### PR TITLE
Fix PostgreSQL migration: Change quality_profile_id from TEXT to UUID

### DIFF
--- a/priv/repo/migrations/20251128014213_add_specialized_library_types.exs
+++ b/priv/repo/migrations/20251128014213_add_specialized_library_types.exs
@@ -23,7 +23,7 @@ defmodule Mydia.Repo.Migrations.AddSpecializedLibraryTypes do
               last_scan_at TEXT,
               last_scan_status TEXT CHECK(last_scan_status IS NULL OR last_scan_status IN ('success', 'failed', 'in_progress')),
               last_scan_error TEXT,
-              quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL,
+              quality_profile_id UUID REFERENCES quality_profiles(id) ON DELETE SET NULL,
               updated_by_id TEXT REFERENCES users(id) ON DELETE SET NULL,
               inserted_at TEXT NOT NULL,
               updated_at TEXT NOT NULL
@@ -39,7 +39,7 @@ defmodule Mydia.Repo.Migrations.AddSpecializedLibraryTypes do
               last_scan_at TEXT,
               last_scan_status TEXT CHECK(last_scan_status IS NULL OR last_scan_status IN ('success', 'failed', 'in_progress')),
               last_scan_error TEXT,
-              quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL,
+              quality_profile_id UUID REFERENCES quality_profiles(id) ON DELETE SET NULL,
               updated_by_id TEXT REFERENCES users(id) ON DELETE SET NULL,
               inserted_at TEXT NOT NULL,
               updated_at TEXT NOT NULL


### PR DESCRIPTION
- Fixes foreign key type mismatch error in PostgreSQL
- Changes quality_profile_id column from TEXT to UUID type
- Ensures type compatibility with quality_profiles.id (binary_id/UUID)
- Tested with PostgreSQL 15, 16, and 18 - all failed before this fix
- No impact on SQLite version (continues to work)

Root Cause:
Migration 20251128014213 creates quality_profile_id as TEXT type but references quality_profiles.id which is defined as :binary_id (UUID). PostgreSQL enforces strict foreign key type matching, while SQLite allows this mismatch due to loose type checking.

Error Fixed:
ERROR 42804 (datatype_mismatch) foreign key constraint "library_paths_new_quality_profile_id_fkey" cannot be implemented Key columns "quality_profile_id" and "id" are of incompatible types: text and uuid.