### PR TITLE
ci: add player E2E integration test workflow

### DIFF
--- a/.github/workflows/ci-player-e2e.yml
+++ b/.github/workflows/ci-player-e2e.yml
@@ -1,0 +1,66 @@
+name: CI / Player E2E
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    paths:
+      - "player/**"
+      - "lib/**"
+      - "native/**"
+      - "metadata-relay/**"
+      - "config/**"
+      - "Dockerfile.e2e"
+      - "compose.player-e2e.yml"
+      - ".github/workflows/ci-player-e2e.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-player-e2e:
+    name: Test / Player E2E
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: Build E2E images
+        run: DOCKER_BUILDKIT=1 docker compose -f compose.player-e2e.yml build
+
+      - name: Run player E2E tests
+        run: |
+          docker compose -f compose.player-e2e.yml up \
+            --abort-on-container-exit \
+            --exit-code-from test
+        env:
+          E2E_TEST_TARGET: integration_test/pairing_flow_test.dart
+
+      - name: Collect service logs
+        if: failure()
+        run: |
+          docker compose -f compose.player-e2e.yml logs mydia > mydia-logs.txt 2>&1 || true
+          docker compose -f compose.player-e2e.yml logs relay > relay-logs.txt 2>&1 || true
+          docker compose -f compose.player-e2e.yml logs test > test-logs.txt 2>&1 || true
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-e2e-logs
+          path: |
+            mydia-logs.txt
+            relay-logs.txt
+            test-logs.txt
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f compose.player-e2e.yml down -v


### PR DESCRIPTION
## Summary
- Add a dedicated GitHub Actions workflow (`ci-player-e2e.yml`) that runs player E2E integration tests
- Builds all 3 Docker services (metadata-relay, mydia server, Flutter test runner) and runs the pairing flow test
- Collects container logs and uploads as artifacts on failure (7-day retention)

## Test plan
- [ ] Workflow triggers on this PR (matches `.github/workflows/ci-player-e2e.yml` path filter)
- [ ] All 3 E2E images build successfully
- [ ] Pairing flow test passes
- [ ] Verify failure mode: logs would be uploaded as artifacts if tests fail