### PR TITLE
fix(parser): correct byte-offset slicing for Unicode filenames

### DIFF
--- a/lib/mydia/library/file_parser.ex
+++ b/lib/mydia/library/file_parser.ex
@@ -293,7 +293,7 @@ defmodule Mydia.Library.FileParser do
       |> Enum.reject(&(&1 == {-1, 0}))
       |> Enum.map(fn {start, length} ->
         text
-        |> String.slice(start, length)
+        |> :binary.part(start, length)
         |> String.to_integer()
       end)
 
@@ -319,7 +319,7 @@ defmodule Mydia.Library.FileParser do
     year = extract_year(text)
 
     text
-    |> String.slice(0, match_index)
+    |> :binary.part(0, match_index)
     |> remove_year_from_title(year)
     |> clean_title()
   end

--- a/lib/mydia/library/file_parser_v2.ex
+++ b/lib/mydia/library/file_parser_v2.ex
@@ -611,13 +611,23 @@ defmodule Mydia.Library.FileParser.V2 do
     {Map.delete(metadata, :_original_text), remaining}
   end
 
+  # Slice text using byte offsets from Regex.run(..., return: :index).
+  # Regex returns byte positions, but String.slice expects character positions.
+  # For multi-byte UTF-8 strings these diverge, so we use :binary.part which
+  # operates on bytes directly.
+  defp byte_slice(text, start, length), do: :binary.part(text, start, length)
+  defp byte_slice_before(text, byte_pos), do: :binary.part(text, 0, byte_pos)
+
+  defp byte_slice_after(text, byte_pos),
+    do: :binary.part(text, byte_pos, byte_size(text) - byte_pos)
+
   defp extract_pattern(%{regex: :tv_patterns}, metadata, text) do
     # Special case: TV patterns use a list of regexes
     case match_tv_patterns(text) do
       {:ok, tv_metadata, match_start, match_length} ->
         # Remove the matched TV pattern from text and everything after it until a quality marker
-        before = String.slice(text, 0, match_start)
-        after_match = String.slice(text, match_start + match_length, String.length(text))
+        before = byte_slice_before(text, match_start)
+        after_match = byte_slice_after(text, match_start + match_length)
 
         # Discard text between episode marker and first quality marker to remove episode titles
         after_match_cleaned = discard_until_quality_marker(after_match)
@@ -654,15 +664,15 @@ defmodule Mydia.Library.FileParser.V2 do
 
       [{start, length} | _captures] ->
         # Extract the matched portion
-        match = String.slice(text, start, length)
+        match = byte_slice(text, start, length)
 
         # Call the handler to extract value
         value = pattern.handler.(match, text, metadata)
 
         # Remove matched portion from text (replace with space to preserve word boundaries)
         new_text =
-          String.slice(text, 0, start) <>
-            " " <> String.slice(text, start + length, String.length(text))
+          byte_slice_before(text, start) <>
+            " " <> byte_slice_after(text, start + length)
 
         # Update metadata if value is not nil (noise patterns return nil)
         new_metadata =
@@ -721,7 +731,7 @@ defmodule Mydia.Library.FileParser.V2 do
       |> Enum.reject(&(&1 == {-1, 0}))
       |> Enum.map(fn {start, length} ->
         text
-        |> String.slice(start, length)
+        |> byte_slice(start, length)
         |> Integer.parse()
       end)
       |> Enum.map(fn
@@ -784,16 +794,16 @@ defmodule Mydia.Library.FileParser.V2 do
 
       {{year_start, year_length}, nil} ->
         # Year found but no quality marker - preserve only the year
-        String.slice(text, year_start, year_length)
+        byte_slice(text, year_start, year_length)
 
       {nil, position} ->
         # No year, but quality marker found - keep from quality marker onward
-        String.slice(text, position, String.length(text))
+        byte_slice_after(text, position)
 
       {{year_start, year_length}, position} ->
         # Both year and quality marker found - preserve year and everything from quality marker
-        year_text = String.slice(text, year_start, year_length)
-        quality_text = String.slice(text, position, String.length(text))
+        year_text = byte_slice(text, year_start, year_length)
+        quality_text = byte_slice_after(text, position)
         year_text <> " " <> quality_text
     end
   end

--- a/test/mydia/library/file_parser_test.exs
+++ b/test/mydia/library/file_parser_test.exs
@@ -779,4 +779,17 @@ defmodule Mydia.Library.FileParserTest do
       assert result2.quality.audio == "AAC-LC"
     end
   end
+
+  describe "multi-byte UTF-8 filenames" do
+    test "Japanese anime fansub with kanji/katakana before SxxExx" do
+      result =
+        FileParser.parse(
+          "[H3LL] Frieren ~ Beyond Journey's End (葬送のフリーレン ) - S02E02 [1080p][x264 10bits][AAC][Multiple Subtitles].mkv"
+        )
+
+      assert result.type == :tv_show
+      assert result.season == 2
+      assert result.episodes == [2]
+    end
+  end
 end

--- a/test/mydia/library/file_parser_v2_test.exs
+++ b/test/mydia/library/file_parser_v2_test.exs
@@ -1679,4 +1679,84 @@ defmodule Mydia.Library.FileParser.V2Test do
       assert result.episodes == [4]
     end
   end
+
+  describe "multi-byte UTF-8 filenames" do
+    test "Japanese anime fansub with kanji/katakana before SxxExx" do
+      result =
+        FileParser.parse(
+          "[H3LL] Frieren ~ Beyond Journey's End (葬送のフリーレン ) - S02E02 [1080p][x264 10bits][AAC][Multiple Subtitles].mkv"
+        )
+
+      assert result.type == :tv_show
+      assert result.season == 2
+      assert result.episodes == [2]
+    end
+
+    test "Japanese anime fansub S02E03 variant" do
+      result =
+        FileParser.parse(
+          "[H3LL] Frieren ~ Beyond Journey's End (葬送のフリーレン ) - S02E03 [1080p][x264 10bits][AAC][Multiple Subtitles].mkv"
+        )
+
+      assert result.type == :tv_show
+      assert result.season == 2
+      assert result.episodes == [3]
+    end
+
+    test "Japanese anime with season indicator in title" do
+      result =
+        FileParser.parse(
+          "[H3LL] Frieren (葬送のフリーレン 第2期) - Beyond Journey's End - S02E01 [1080p][x264 10bits][AAC][Multiple Subtitles].mkv"
+        )
+
+      assert result.type == :tv_show
+      assert result.season == 2
+      assert result.episodes == [1]
+    end
+
+    test "Japanese anime with parenthesized title" do
+      result =
+        FileParser.parse("[Group] Show (日本語タイトル) - S01E05 [720p].mkv")
+
+      assert result.type == :tv_show
+      assert result.season == 1
+      assert result.episodes == [5]
+    end
+
+    test "Korean drama with hangul title" do
+      result = FileParser.parse("쇼이름 - S01E08 [1080p].mkv")
+
+      assert result.type == :tv_show
+      assert result.season == 1
+      assert result.episodes == [8]
+    end
+
+    test "accented characters in title" do
+      result = FileParser.parse("Ángel.De.La.Noche.S03E12.720p.mkv")
+
+      assert result.type == :tv_show
+      assert result.season == 3
+      assert result.episodes == [12]
+    end
+
+    test "parse_with_path with Japanese chars in folder and filename" do
+      result =
+        FileParser.parse_with_path(
+          "/media/Series/Frieren Beyond Journey's End/Season 02/[H3LL] Frieren ~ Beyond Journey's End (葬送のフリーレン ) - S02E04 [1080p][x264 10bits][AAC][Multiple Subtitles].mkv"
+        )
+
+      assert result.type == :tv_show
+      assert result.season == 2
+      assert result.episodes == [4]
+    end
+
+    test "quality info extracted correctly with multi-byte chars before it" do
+      result =
+        FileParser.parse(
+          "[H3LL] Frieren ~ Beyond Journey's End (葬送のフリーレン ) - S02E02 [1080p][x264 10bits][AAC][Multiple Subtitles].mkv"
+        )
+
+      assert result.quality.resolution == "1080p"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **Root cause:** `Regex.run(pattern, text, return: :index)` returns byte offsets, but `String.slice/3` expects character offsets. For multi-byte UTF-8 filenames (Japanese, Korean, accented chars), this caused the parser to read from wrong string positions.
- **Production impact:** Frieren S02E02-E04 files (H3LL fansub with Japanese `葬送のフリーレン` in filename) were all incorrectly matched to S02E10 — the byte drift landed on `"64"` from `x264` (season) and `"10"` from `10bits` (episode).
- **Fix:** Replace `String.slice` with `:binary.part` (which operates on byte offsets) at all 7 affected locations across V1 and V2 parsers. Added `byte_slice` helper functions and 8 new Unicode filename tests.

## Test plan

- [x] 234 parser tests pass (including 8 new Unicode tests)
- [x] Japanese anime fansub patterns (the exact production filenames)
- [x] Korean, accented character filenames
- [x] `parse_with_path` with Unicode folder + filename
- [x] Quality info extraction with multi-byte chars before markers
- [x] All existing tests pass (no regressions)

## Post-Deploy Monitoring & Validation

- **What to monitor:** Library scanner logs for file-to-episode association. Check that newly scanned files with non-ASCII filenames get correct episode associations.
- **Validation:** After deploy, trigger a rescan of the Frieren show. Verify S02E02-E04 files get reassociated to the correct episodes (currently stuck on S02E10).
- **Failure signal:** Files still mapping to wrong episodes after rescan → rollback.