### PR TITLE
feat: automatic quality upgrade for movies

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -260,7 +260,8 @@ config :mydia, Oban,
     notifications: 1,
     maintenance: 1,
     import_lists: 2,
-    integrations: 2
+    integrations: 2,
+    upgrade_search: 1
   ],
   plugins: [
     # Keep completed jobs for 7 days
@@ -291,7 +292,9 @@ config :mydia, Oban,
        # Permanently delete trashed media files past retention period daily at 5 AM
        {"0 5 * * *", Mydia.Jobs.TrashCleanup},
        # Sync watched status with media servers every 30 minutes
-       {"*/30 * * * *", Mydia.Jobs.MediaServerWatchedSync, args: %{"mode" => "all_enabled"}}
+       {"*/30 * * * *", Mydia.Jobs.MediaServerWatchedSync, args: %{"mode" => "all_enabled"}},
+       # Search for quality upgrades for monitored movies daily at 4:30 AM
+       {"30 4 * * *", Mydia.Jobs.MovieUpgradeSearch, args: %{"mode" => "all_monitored"}}
      ]}
   ]
 

--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -641,13 +641,16 @@ defmodule Mydia.Downloads do
   defp check_for_duplicate_download(search_result, opts) do
     media_item_id = Keyword.get(opts, :media_item_id)
     episode_id = Keyword.get(opts, :episode_id)
+    download_reason = Keyword.get(opts, :download_reason)
+    # Legacy support: manual: true maps to download_reason: :manual
     manual? = Keyword.get(opts, :manual, false)
+    skip_file_check? = manual? or download_reason in [:manual, :upgrade]
 
     # Always check for active downloads to prevent downloading the same thing twice
     with :ok <- check_for_active_download(search_result, media_item_id, episode_id) do
-      # Skip media file check for manual downloads - the user explicitly chose this release
-      # (they may want to upgrade quality or grab a different version)
-      if manual? do
+      # Skip media file check for manual downloads (user explicitly chose this release)
+      # and upgrade downloads (a file exists by definition - we're replacing it)
+      if skip_file_check? do
         :ok
       else
         check_for_existing_media_files(search_result, media_item_id, episode_id)
@@ -966,6 +969,14 @@ defmodule Mydia.Downloads do
 
     # Create DownloadMetadata struct and convert to map for database storage
     metadata = metadata_attrs |> DownloadMetadata.new() |> DownloadMetadata.to_map()
+
+    # Store download_reason in metadata for post-import processing (e.g., upgrade cleanup)
+    download_reason = Keyword.get(opts, :download_reason)
+
+    metadata =
+      if download_reason,
+        do: Map.put(metadata, "download_reason", to_string(download_reason)),
+        else: metadata
 
     attrs = %{
       indexer: search_result.indexer,

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -1121,6 +1121,7 @@ defmodule Mydia.Events do
   """
   def search_completed(media_item, metadata, opts \\ []) do
     episode = opts[:episode]
+    actor_id = opts[:actor_id] || search_actor_id(media_item)
 
     base_metadata =
       %{
@@ -1134,7 +1135,7 @@ defmodule Mydia.Events do
       category: "search",
       type: "search.completed",
       actor_type: :job,
-      actor_id: search_actor_id(media_item),
+      actor_id: actor_id,
       resource_type: resource_type_for_search(episode),
       resource_id: resource_id_for_search(media_item, episode),
       severity: :info,
@@ -1160,6 +1161,7 @@ defmodule Mydia.Events do
   """
   def search_no_results(media_item, metadata, opts \\ []) do
     episode = opts[:episode]
+    actor_id = opts[:actor_id] || search_actor_id(media_item)
 
     base_metadata =
       %{
@@ -1173,7 +1175,7 @@ defmodule Mydia.Events do
       category: "search",
       type: "search.no_results",
       actor_type: :job,
-      actor_id: search_actor_id(media_item),
+      actor_id: actor_id,
       resource_type: resource_type_for_search(episode),
       resource_id: resource_id_for_search(media_item, episode),
       severity: :warning,

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -1214,6 +1214,7 @@ defmodule Mydia.Events do
   """
   def search_filtered_out(media_item, metadata, opts \\ []) do
     episode = opts[:episode]
+    actor_id = opts[:actor_id] || search_actor_id(media_item)
 
     base_metadata =
       %{
@@ -1227,7 +1228,7 @@ defmodule Mydia.Events do
       category: "search",
       type: "search.filtered_out",
       actor_type: :job,
-      actor_id: search_actor_id(media_item),
+      actor_id: actor_id,
       resource_type: resource_type_for_search(episode),
       resource_id: resource_id_for_search(media_item, episode),
       severity: :warning,
@@ -1421,6 +1422,7 @@ defmodule Mydia.Events do
   def search_backoff_applied(media_item, reason, backoff_info, opts \\ []) do
     episode = opts[:episode]
     season_number = opts[:season_number]
+    actor_id = opts[:actor_id] || search_actor_id(media_item)
 
     base_metadata =
       %{
@@ -1438,7 +1440,7 @@ defmodule Mydia.Events do
       category: "search",
       type: "search.backoff_applied",
       actor_type: :job,
-      actor_id: search_actor_id(media_item),
+      actor_id: actor_id,
       resource_type: resource_type_for_backoff(episode, season_number),
       resource_id: resource_id_for_backoff(media_item, episode),
       severity: :info,
@@ -1464,6 +1466,7 @@ defmodule Mydia.Events do
   def search_backoff_reset(media_item, previous_count, opts \\ []) do
     episode = opts[:episode]
     season_number = opts[:season_number]
+    actor_id = opts[:actor_id] || search_actor_id(media_item)
 
     base_metadata =
       %{
@@ -1478,7 +1481,7 @@ defmodule Mydia.Events do
       category: "search",
       type: "search.backoff_reset",
       actor_type: :job,
-      actor_id: search_actor_id(media_item),
+      actor_id: actor_id,
       resource_type: resource_type_for_backoff(episode, season_number),
       resource_id: resource_id_for_backoff(media_item, episode),
       severity: :info,

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -227,6 +227,9 @@ defmodule Mydia.Jobs.MediaImport do
                   download_id: download.id
                 )
 
+                # Enqueue upgrade cleanup if this was an upgrade download
+                maybe_enqueue_upgrade_cleanup(updated_download, imported_files)
+
               {:error, changeset} ->
                 Logger.warning("Failed to mark download as imported",
                   download_id: download.id,
@@ -1540,6 +1543,31 @@ defmodule Mydia.Jobs.MediaImport do
         )
 
         :error
+    end
+  end
+
+  ## Private Functions - Upgrade Cleanup
+
+  defp maybe_enqueue_upgrade_cleanup(download, imported_files) do
+    download_reason = get_in(download.metadata || %{}, ["download_reason"])
+
+    if download_reason == "upgrade" && download.media_item_id do
+      new_file_ids = Enum.map(imported_files, & &1.id)
+
+      case Mydia.Jobs.UpgradeCleanup.enqueue(download.media_item_id, new_file_ids) do
+        {:ok, _job} ->
+          Logger.info("Enqueued upgrade cleanup",
+            download_id: download.id,
+            media_item_id: download.media_item_id,
+            new_file_ids: new_file_ids
+          )
+
+        {:error, reason} ->
+          Logger.error("Failed to enqueue upgrade cleanup",
+            download_id: download.id,
+            reason: inspect(reason)
+          )
+      end
     end
   end
 end

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -33,10 +33,11 @@ defmodule Mydia.Jobs.MovieSearch do
 
   import Ecto.Query, warn: false
 
-  alias Mydia.{Repo, Media, Indexers, Downloads, Events, Search}
+  alias Mydia.{Repo, Media, Indexers, Events, Search}
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Library.MediaFile
   alias Mydia.Media.MediaItem
+  alias Mydia.Search.Pipeline
   alias Phoenix.PubSub
 
   defmodule Args do
@@ -81,10 +82,7 @@ defmodule Mydia.Jobs.MovieSearch do
     end
   end
 
-  # Get min_seeders from config (defaults to 0 for Usenet compatibility)
-  defp get_min_seeders do
-    Application.get_env(:mydia, :auto_search, [])[:min_seeders] || 0
-  end
+  defdelegate get_min_seeders, to: Pipeline
 
   @spec perform(Oban.Job.t()) :: :ok | {:ok, term()} | {:error, term()} | {:snooze, pos_integer()}
   @impl Oban.Worker
@@ -108,7 +106,7 @@ defmodule Mydia.Jobs.MovieSearch do
       results =
         Enum.map(movies, fn movie ->
           result = search_movie(movie, args)
-          apply_search_delay()
+          Pipeline.apply_search_delay()
           result
         end)
 
@@ -215,8 +213,8 @@ defmodule Mydia.Jobs.MovieSearch do
   end
 
   defp search_movie_with_stats(%MediaItem{} = movie, args) do
-    query = build_search_query(movie)
-    indexers_count = count_enabled_indexers()
+    query = Pipeline.build_search_query(movie)
+    indexers_count = Pipeline.count_enabled_indexers()
 
     Logger.info("Searching for movie",
       media_item_id: movie.id,
@@ -281,7 +279,7 @@ defmodule Mydia.Jobs.MovieSearch do
   end
 
   defp process_search_results_with_count(movie, results, args, query) do
-    ranking_opts = build_ranking_options(movie, args)
+    ranking_opts = build_ranking_options_from_args(movie, args)
 
     case ReleaseRanker.select_best_result(results, ranking_opts) do
       nil ->
@@ -295,7 +293,7 @@ defmodule Mydia.Jobs.MovieSearch do
         Events.search_filtered_out(movie, %{
           "query" => query,
           "results_count" => length(results),
-          "filter_stats" => build_filter_stats(results, ranking_opts)
+          "filter_stats" => Pipeline.build_filter_stats(results, ranking_opts)
         })
 
         {:no_results, 0}
@@ -315,7 +313,7 @@ defmodule Mydia.Jobs.MovieSearch do
           "results_count" => length(results),
           "selected_release" => best_result.title,
           "score" => score,
-          "breakdown" => stringify_keys(breakdown)
+          "breakdown" => Pipeline.stringify_keys(breakdown)
         })
 
         case initiate_download(movie, best_result) do
@@ -334,23 +332,6 @@ defmodule Mydia.Jobs.MovieSearch do
             {:no_results, 0}
         end
     end
-  end
-
-  defp count_enabled_indexers do
-    # Count enabled indexers from Settings
-    indexers = Mydia.Settings.list_indexer_configs()
-    enabled_count = Enum.count(indexers, & &1.enabled)
-
-    # Also count Cardigann indexers if feature is enabled
-    cardigann_count =
-      if Application.get_env(:mydia, :features, [])[:cardigann_indexers] do
-        Mydia.Indexers.list_cardigann_definitions()
-        |> Enum.count(& &1.enabled)
-      else
-        0
-      end
-
-    enabled_count + cardigann_count
   end
 
   defp load_monitored_movies_without_files do
@@ -380,7 +361,7 @@ defmodule Mydia.Jobs.MovieSearch do
   end
 
   defp search_movie(%MediaItem{} = movie, args) do
-    query = build_search_query(movie)
+    query = Pipeline.build_search_query(movie)
 
     Logger.info("Searching for movie",
       media_item_id: movie.id,
@@ -414,7 +395,7 @@ defmodule Mydia.Jobs.MovieSearch do
         # Log search event for no results
         Events.search_no_results(movie, %{
           "query" => query,
-          "indexers_searched" => count_enabled_indexers()
+          "indexers_searched" => Pipeline.count_enabled_indexers()
         })
 
         :no_results
@@ -429,16 +410,19 @@ defmodule Mydia.Jobs.MovieSearch do
     end
   end
 
-  defp build_search_query(%MediaItem{title: title, year: nil}) do
-    title
-  end
-
-  defp build_search_query(%MediaItem{title: title, year: year}) do
-    "#{title} #{year}"
+  # Bridge function: converts Args struct to Pipeline's keyword opts
+  defp build_ranking_options_from_args(movie, %Args{} = args) do
+    Pipeline.build_ranking_options(movie,
+      min_seeders: args.min_seeders,
+      size_range: args.size_range,
+      blocked_tags: args.blocked_tags,
+      preferred_tags: args.preferred_tags,
+      media_type: :movie
+    )
   end
 
   defp process_search_results(movie, results, args, query) do
-    ranking_opts = build_ranking_options(movie, args)
+    ranking_opts = build_ranking_options_from_args(movie, args)
 
     case ReleaseRanker.select_best_result(results, ranking_opts) do
       nil ->
@@ -455,7 +439,7 @@ defmodule Mydia.Jobs.MovieSearch do
         Events.search_filtered_out(movie, %{
           "query" => query,
           "results_count" => length(results),
-          "filter_stats" => build_filter_stats(results, ranking_opts)
+          "filter_stats" => Pipeline.build_filter_stats(results, ranking_opts)
         })
 
         :no_results
@@ -475,7 +459,7 @@ defmodule Mydia.Jobs.MovieSearch do
           "results_count" => length(results),
           "selected_release" => best_result.title,
           "score" => score,
-          "breakdown" => stringify_keys(breakdown)
+          "breakdown" => Pipeline.stringify_keys(breakdown)
         })
 
         case initiate_download(movie, best_result) do
@@ -498,99 +482,8 @@ defmodule Mydia.Jobs.MovieSearch do
     end
   end
 
-  defp build_ranking_options(movie, %Args{} = args) do
-    # Start with base options
-    # Include search_query for title relevance scoring and media_type for unified scoring
-    # Note: size_range is nil by default (no filtering) unless specified in args or quality profile
-    base_opts = [
-      min_seeders: args.min_seeders || get_min_seeders(),
-      size_range: args.size_range,
-      search_query: build_search_query(movie),
-      media_type: :movie,
-      expected_title: movie.title
-    ]
-
-    # Add quality profile for unified scoring via SearchScorer
-    opts_with_quality =
-      case load_quality_profile(movie) do
-        nil ->
-          base_opts
-
-        quality_profile ->
-          base_opts
-          |> Keyword.put(:quality_profile, quality_profile)
-          |> Keyword.merge(build_quality_options(quality_profile, :movie))
-      end
-
-    # Add any custom blocked/preferred tags from args
-    opts_with_quality
-    |> maybe_add_option(:blocked_tags, args.blocked_tags)
-    |> maybe_add_option(:preferred_tags, args.preferred_tags)
-  end
-
-  defp load_quality_profile(%MediaItem{quality_profile_id: nil}), do: nil
-
-  defp load_quality_profile(%MediaItem{} = movie) do
-    movie
-    |> Repo.preload(:quality_profile)
-    |> Map.get(:quality_profile)
-  end
-
-  defp build_quality_options(quality_profile, media_type) do
-    # Extract preferred qualities from quality profile
-    # The :qualities field contains the list of allowed resolutions in preference order
-    quality_opts =
-      case Map.get(quality_profile, :qualities) do
-        nil -> []
-        qualities when is_list(qualities) -> [preferred_qualities: qualities]
-        _ -> []
-      end
-
-    # Extract min_ratio from rules if present
-    rules_opts =
-      case Map.get(quality_profile, :rules) do
-        %{"min_ratio" => min_ratio} when is_number(min_ratio) ->
-          [min_ratio: min_ratio]
-
-        _ ->
-          []
-      end
-
-    # Extract size constraints from quality_standards based on media type
-    size_opts = extract_size_range(quality_profile, media_type)
-
-    quality_opts
-    |> Keyword.merge(rules_opts)
-    |> Keyword.merge(size_opts)
-  end
-
-  defp extract_size_range(%{quality_standards: standards}, media_type) when is_map(standards) do
-    {min_key, max_key} =
-      case media_type do
-        :movie -> {:movie_min_size_mb, :movie_max_size_mb}
-        :episode -> {:episode_min_size_mb, :episode_max_size_mb}
-      end
-
-    min_size = Map.get(standards, min_key)
-    max_size = Map.get(standards, max_key)
-
-    case {min_size, max_size} do
-      {nil, nil} -> []
-      {min, nil} when is_number(min) -> [size_range: {min, nil}]
-      {nil, max} when is_number(max) -> [size_range: {nil, max}]
-      {min, max} when is_number(min) and is_number(max) -> [size_range: {min, max}]
-      _ -> []
-    end
-  end
-
-  defp extract_size_range(_, _), do: []
-
-  defp maybe_add_option(opts, _key, nil), do: opts
-  defp maybe_add_option(opts, _key, []), do: opts
-  defp maybe_add_option(opts, key, value), do: Keyword.put(opts, key, value)
-
   defp initiate_download(movie, result) do
-    case Downloads.initiate_download(result, media_item_id: movie.id) do
+    case Pipeline.initiate_download(movie, result) do
       {:ok, download} ->
         Logger.info("Successfully initiated download for movie",
           media_item_id: movie.id,
@@ -609,21 +502,6 @@ defmodule Mydia.Jobs.MovieSearch do
         )
 
         {:error, reason}
-    end
-  end
-
-  ## Private Functions - Search Delay
-
-  defp get_search_delay_ms do
-    Application.get_env(:mydia, :episode_monitor, [])
-    |> Keyword.get(:search_delay_ms, 0)
-  end
-
-  defp apply_search_delay do
-    delay = get_search_delay_ms()
-
-    if delay > 0 do
-      Process.sleep(delay)
     end
   end
 
@@ -674,30 +552,4 @@ defmodule Mydia.Jobs.MovieSearch do
         Events.search_backoff_reset(movie, previous_count)
     end
   end
-
-  ## Private Functions - Event Helpers
-
-  # Build a map of filter statistics for rejected results
-  defp build_filter_stats(results, ranking_opts) do
-    min_seeders = Keyword.get(ranking_opts, :min_seeders, get_min_seeders())
-
-    low_seeders = Enum.count(results, fn r -> r.seeders < min_seeders end)
-
-    %{
-      "total_results" => length(results),
-      "low_seeders" => low_seeders,
-      "below_quality_threshold" => length(results) - low_seeders
-    }
-  end
-
-  # Convert a map with atom keys to string keys for JSON serialization
-  defp stringify_keys(%{__struct__: _} = struct) do
-    struct |> Map.from_struct() |> stringify_keys()
-  end
-
-  defp stringify_keys(map) when is_map(map) do
-    Map.new(map, fn {k, v} -> {to_string(k), v} end)
-  end
-
-  defp stringify_keys(other), do: other
 end

--- a/lib/mydia/jobs/movie_upgrade_search.ex
+++ b/lib/mydia/jobs/movie_upgrade_search.ex
@@ -38,17 +38,7 @@ defmodule Mydia.Jobs.MovieUpgradeSearch do
   alias Mydia.Settings.{QualityMatcher, QualityProfile}
 
   @max_movies_per_run 25
-
-  defmodule Args do
-    @moduledoc false
-    defstruct [:mode]
-
-    @type t :: %__MODULE__{mode: String.t()}
-
-    def parse(%{"mode" => "all_monitored"}) do
-      %__MODULE__{mode: "all_monitored"}
-    end
-  end
+  @actor_id "movie_upgrade_search"
 
   @spec perform(Oban.Job.t()) :: :ok | {:error, term()}
   @impl Oban.Worker
@@ -173,7 +163,16 @@ defmodule Mydia.Jobs.MovieUpgradeSearch do
     )
 
     case Indexers.search_all(query, min_seeders: min_seeders) do
-      {:ok, %{results: []}} ->
+      {:ok, %{results: [], indexer_errors: indexer_errors}} ->
+        if indexer_errors != [] do
+          Logger.warning("Upgrade search failed due to indexer errors",
+            media_item_id: movie.id,
+            title: movie.title,
+            query: query,
+            errors: inspect(indexer_errors)
+          )
+        end
+
         record_backoff(movie, "no_results")
         :no_upgrade
 
@@ -204,7 +203,7 @@ defmodule Mydia.Jobs.MovieUpgradeSearch do
           "query" => query,
           "indexers_searched" => Pipeline.count_enabled_indexers()
         },
-        actor_id: "movie_upgrade_search"
+        actor_id: @actor_id
       )
 
       :no_upgrade
@@ -250,7 +249,7 @@ defmodule Mydia.Jobs.MovieUpgradeSearch do
         "score" => score,
         "breakdown" => Pipeline.stringify_keys(breakdown)
       },
-      actor_id: "movie_upgrade_search"
+      actor_id: @actor_id
     )
 
     case Pipeline.initiate_download(movie, best_result, download_reason: :upgrade) do
@@ -310,8 +309,8 @@ defmodule Mydia.Jobs.MovieUpgradeSearch do
 
   defp file_to_media_attrs(%MediaFile{} = file) do
     %{
-      video_codec: file.codec,
-      audio_codec: file.audio_codec,
+      video_codec: QualityMatcher.normalize_codec(file.codec),
+      audio_codec: QualityMatcher.normalize_codec(file.audio_codec),
       resolution: file.resolution,
       source: nil,
       file_size_mb: if(file.size, do: file.size / (1024 * 1024), else: nil),
@@ -331,6 +330,13 @@ defmodule Mydia.Jobs.MovieUpgradeSearch do
           reason: reason
         )
 
+        Events.search_backoff_applied(
+          movie,
+          reason,
+          Search.get_backoff_info("movie", movie.id),
+          actor_id: @actor_id
+        )
+
       {:error, _changeset} ->
         Logger.error("Failed to record upgrade search backoff",
           media_item_id: movie.id
@@ -340,18 +346,23 @@ defmodule Mydia.Jobs.MovieUpgradeSearch do
 
   defp reset_backoff(movie) do
     case Search.get_backoff("movie", movie.id) do
-      nil -> :ok
-      _backoff -> Search.reset_backoff("movie", movie.id)
+      nil ->
+        :ok
+
+      backoff ->
+        previous_count = backoff.failure_count
+        Search.reset_backoff("movie", movie.id)
+
+        Logger.info("Reset upgrade search backoff",
+          media_item_id: movie.id,
+          previous_failure_count: previous_count
+        )
+
+        Events.search_backoff_reset(movie, previous_count, actor_id: @actor_id)
     end
   end
 
   ## Private Functions - Quality Level
 
-  defp quality_level("360p"), do: 1
-  defp quality_level("480p"), do: 2
-  defp quality_level("576p"), do: 3
-  defp quality_level("720p"), do: 4
-  defp quality_level("1080p"), do: 5
-  defp quality_level("2160p"), do: 6
-  defp quality_level(_), do: 0
+  defp quality_level(resolution), do: QualityMatcher.quality_level(resolution)
 end

--- a/lib/mydia/jobs/movie_upgrade_search.ex
+++ b/lib/mydia/jobs/movie_upgrade_search.ex
@@ -198,11 +198,14 @@ defmodule Mydia.Jobs.MovieUpgradeSearch do
     if upgrade_results == [] do
       record_backoff(movie, "no_upgrade_available")
 
-      Events.search_no_results(movie, %{
-        "query" => query,
-        "indexers_searched" => Pipeline.count_enabled_indexers(),
-        "actor_id" => "movie_upgrade_search"
-      })
+      Events.search_no_results(
+        movie,
+        %{
+          "query" => query,
+          "indexers_searched" => Pipeline.count_enabled_indexers()
+        },
+        actor_id: "movie_upgrade_search"
+      )
 
       :no_upgrade
     else
@@ -238,14 +241,17 @@ defmodule Mydia.Jobs.MovieUpgradeSearch do
       score: score
     )
 
-    Events.search_completed(movie, %{
-      "query" => query,
-      "results_count" => length(results),
-      "selected_release" => best_result.title,
-      "score" => score,
-      "breakdown" => Pipeline.stringify_keys(breakdown),
-      "actor_id" => "movie_upgrade_search"
-    })
+    Events.search_completed(
+      movie,
+      %{
+        "query" => query,
+        "results_count" => length(results),
+        "selected_release" => best_result.title,
+        "score" => score,
+        "breakdown" => Pipeline.stringify_keys(breakdown)
+      },
+      actor_id: "movie_upgrade_search"
+    )
 
     case Pipeline.initiate_download(movie, best_result, download_reason: :upgrade) do
       {:ok, _download} ->

--- a/lib/mydia/jobs/movie_upgrade_search.ex
+++ b/lib/mydia/jobs/movie_upgrade_search.ex
@@ -1,0 +1,351 @@
+defmodule Mydia.Jobs.MovieUpgradeSearch do
+  @moduledoc """
+  Background job for searching and downloading quality upgrades for movies.
+
+  Searches indexers for better quality versions of already-downloaded movies
+  and initiates upgrade downloads until the quality profile's ceiling
+  (`upgrade_until_quality`) is reached.
+
+  Runs on a daily cron schedule. Movies are processed in priority order
+  (lowest quality first), capped at `@max_movies_per_run` per cycle.
+
+  ## Examples
+
+      # Queue upgrade search for all monitored movies
+      %{"mode" => "all_monitored"}
+      |> MovieUpgradeSearch.new()
+      |> Oban.insert()
+  """
+
+  use Oban.Worker,
+    queue: :upgrade_search,
+    max_attempts: 3,
+    unique: [
+      period: 3600,
+      fields: [:args],
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  require Logger
+
+  import Ecto.Query, warn: false
+
+  alias Mydia.{Repo, Indexers, Events, Search}
+  alias Mydia.Indexers.ReleaseRanker
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.MediaItem
+  alias Mydia.Search.Pipeline
+  alias Mydia.Settings.{QualityMatcher, QualityProfile}
+
+  @max_movies_per_run 25
+
+  defmodule Args do
+    @moduledoc false
+    defstruct [:mode]
+
+    @type t :: %__MODULE__{mode: String.t()}
+
+    def parse(%{"mode" => "all_monitored"}) do
+      %__MODULE__{mode: "all_monitored"}
+    end
+  end
+
+  @spec perform(Oban.Job.t()) :: :ok | {:error, term()}
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"mode" => "all_monitored"}}) do
+    start_time = System.monotonic_time(:millisecond)
+    Logger.info("Starting automatic upgrade search for monitored movies")
+
+    movies = load_upgrade_candidates()
+    total_eligible = length(movies)
+    movies_to_process = Enum.take(movies, @max_movies_per_run)
+    processing_count = length(movies_to_process)
+
+    Logger.info(
+      "Found #{total_eligible} movies eligible for upgrade, processing #{processing_count}"
+    )
+
+    if processing_count == 0 do
+      :ok
+    else
+      results =
+        Enum.map(movies_to_process, fn {movie, current_file, profile} ->
+          result = search_upgrade(movie, current_file, profile)
+          Pipeline.apply_search_delay()
+          result
+        end)
+
+      upgraded = Enum.count(results, &(&1 == :upgraded))
+      no_upgrade = Enum.count(results, &(&1 == :no_upgrade))
+      failed = Enum.count(results, &match?({:error, _}, &1))
+      duration = System.monotonic_time(:millisecond) - start_time
+
+      Logger.info("Upgrade search completed",
+        duration_ms: duration,
+        total_eligible: total_eligible,
+        processed: processing_count,
+        upgraded: upgraded,
+        no_upgrade: no_upgrade,
+        failed: failed
+      )
+
+      :ok
+    end
+  end
+
+  ## Private Functions - Candidate Loading
+
+  @doc false
+  def load_upgrade_candidates do
+    # Find monitored movies that have files and whose quality profile allows upgrades
+    movies =
+      from(mi in MediaItem,
+        where: mi.type == "movie" and mi.monitored == true,
+        where: not is_nil(mi.quality_profile_id),
+        join: qp in QualityProfile,
+        on: qp.id == mi.quality_profile_id,
+        where: qp.upgrades_allowed == true,
+        join: mf in MediaFile,
+        on: mf.media_item_id == mi.id and is_nil(mf.trashed_at),
+        preload: [quality_profile: qp, media_files: mf]
+      )
+      |> Repo.all()
+      # Deduplicate since join can produce multiple rows per movie
+      |> Enum.uniq_by(& &1.id)
+
+    movies
+    |> Enum.map(fn movie ->
+      profile = movie.quality_profile
+      best_file = best_quality_file(movie.media_files, profile)
+      {movie, best_file, profile}
+    end)
+    |> Enum.filter(fn {_movie, best_file, profile} ->
+      best_file != nil && file_below_ceiling?(best_file, profile)
+    end)
+    |> filter_in_backoff()
+    # Sort by lowest quality first (most in need of upgrade)
+    |> Enum.sort_by(fn {_movie, file, _profile} -> quality_level(file.resolution) end)
+  end
+
+  defp best_quality_file(files, profile) do
+    files
+    |> Enum.filter(&is_nil(&1.trashed_at))
+    |> Enum.max_by(
+      fn file ->
+        media_attrs = file_to_media_attrs(file)
+        %{score: score} = QualityProfile.score_media_file(profile, media_attrs)
+        score
+      end,
+      fn -> nil end
+    )
+  end
+
+  defp file_below_ceiling?(_file, %QualityProfile{upgrade_until_quality: nil}), do: true
+
+  defp file_below_ceiling?(file, %QualityProfile{upgrade_until_quality: ceiling}) do
+    quality_level(file.resolution) < quality_level(ceiling)
+  end
+
+  defp filter_in_backoff(candidates) do
+    {eligible, in_backoff} =
+      Enum.split_with(candidates, fn {movie, _file, _profile} ->
+        Search.eligible?("movie", movie.id)
+      end)
+
+    if in_backoff != [] do
+      Logger.info("Skipping #{length(in_backoff)} movies in backoff for upgrade search")
+    end
+
+    eligible
+  end
+
+  ## Private Functions - Search & Upgrade
+
+  defp search_upgrade(movie, current_file, profile) do
+    query = Pipeline.build_search_query(movie)
+    min_seeders = Pipeline.get_min_seeders()
+
+    Logger.info("Searching for upgrade",
+      media_item_id: movie.id,
+      title: movie.title,
+      current_resolution: current_file.resolution,
+      query: query
+    )
+
+    case Indexers.search_all(query, min_seeders: min_seeders) do
+      {:ok, %{results: []}} ->
+        record_backoff(movie, "no_results")
+        :no_upgrade
+
+      {:ok, %{results: results}} ->
+        find_and_download_upgrade(movie, current_file, profile, results, query)
+    end
+  end
+
+  defp find_and_download_upgrade(movie, current_file, profile, results, query) do
+    ranking_opts = Pipeline.build_ranking_options(movie, media_type: :movie)
+
+    # Compute current file's composite score for same-resolution comparison
+    current_score = compute_file_score(current_file, profile)
+
+    # Filter to only results that are genuine upgrades
+    upgrade_results =
+      results
+      |> Enum.filter(fn result ->
+        QualityMatcher.is_upgrade?(result, profile, current_file.resolution, current_score)
+      end)
+
+    if upgrade_results == [] do
+      record_backoff(movie, "no_upgrade_available")
+
+      Events.search_no_results(movie, %{
+        "query" => query,
+        "indexers_searched" => Pipeline.count_enabled_indexers(),
+        "actor_id" => "movie_upgrade_search"
+      })
+
+      :no_upgrade
+    else
+      # Rank the upgrade candidates and pick the best
+      case ReleaseRanker.select_best_result(upgrade_results, ranking_opts) do
+        nil ->
+          record_backoff(movie, "all_filtered")
+          :no_upgrade
+
+        %{result: best_result, score: score, breakdown: breakdown} ->
+          # TOCTOU re-check: verify file hasn't been upgraded since we started
+          case toctou_recheck(movie, current_file, profile) do
+            :still_eligible ->
+              attempt_upgrade_download(movie, best_result, score, breakdown, query, results)
+
+            :no_longer_eligible ->
+              Logger.info("Movie no longer eligible for upgrade (TOCTOU check)",
+                media_item_id: movie.id,
+                title: movie.title
+              )
+
+              :no_upgrade
+          end
+      end
+    end
+  end
+
+  defp attempt_upgrade_download(movie, best_result, score, breakdown, query, results) do
+    Logger.info("Found upgrade for movie",
+      media_item_id: movie.id,
+      title: movie.title,
+      result_title: best_result.title,
+      score: score
+    )
+
+    Events.search_completed(movie, %{
+      "query" => query,
+      "results_count" => length(results),
+      "selected_release" => best_result.title,
+      "score" => score,
+      "breakdown" => Pipeline.stringify_keys(breakdown),
+      "actor_id" => "movie_upgrade_search"
+    })
+
+    case Pipeline.initiate_download(movie, best_result, download_reason: :upgrade) do
+      {:ok, _download} ->
+        reset_backoff(movie)
+
+        Logger.info("Initiated upgrade download for movie",
+          media_item_id: movie.id,
+          title: movie.title,
+          result_title: best_result.title
+        )
+
+        :upgraded
+
+      {:error, reason} ->
+        Logger.error("Failed to initiate upgrade download",
+          media_item_id: movie.id,
+          title: movie.title,
+          reason: inspect(reason)
+        )
+
+        {:error, reason}
+    end
+  end
+
+  ## Private Functions - TOCTOU Protection
+
+  defp toctou_recheck(movie, original_file, profile) do
+    # Re-query the movie's current best file to check if it's still eligible
+    current_files =
+      from(mf in MediaFile,
+        where: mf.media_item_id == ^movie.id and is_nil(mf.trashed_at)
+      )
+      |> Repo.all()
+
+    best_file = best_quality_file(current_files, profile)
+
+    cond do
+      # No files anymore (deleted while we searched)
+      best_file == nil -> :no_longer_eligible
+      # Best file changed (new file appeared)
+      best_file.id != original_file.id -> :no_longer_eligible
+      # File no longer below ceiling
+      !file_below_ceiling?(best_file, profile) -> :no_longer_eligible
+      # Still eligible
+      true -> :still_eligible
+    end
+  end
+
+  ## Private Functions - Scoring
+
+  defp compute_file_score(file, profile) do
+    media_attrs = file_to_media_attrs(file)
+    %{score: score} = QualityProfile.score_media_file(profile, media_attrs)
+    score
+  end
+
+  defp file_to_media_attrs(%MediaFile{} = file) do
+    %{
+      video_codec: file.codec,
+      audio_codec: file.audio_codec,
+      resolution: file.resolution,
+      source: nil,
+      file_size_mb: if(file.size, do: file.size / (1024 * 1024), else: nil),
+      media_type: :movie,
+      hdr_format: file.hdr_format
+    }
+  end
+
+  ## Private Functions - Backoff
+
+  defp record_backoff(movie, reason) do
+    case Search.record_failure("movie", movie.id, reason) do
+      {:ok, backoff} ->
+        Logger.info("Applied upgrade search backoff",
+          media_item_id: movie.id,
+          failure_count: backoff.failure_count,
+          reason: reason
+        )
+
+      {:error, _changeset} ->
+        Logger.error("Failed to record upgrade search backoff",
+          media_item_id: movie.id
+        )
+    end
+  end
+
+  defp reset_backoff(movie) do
+    case Search.get_backoff("movie", movie.id) do
+      nil -> :ok
+      _backoff -> Search.reset_backoff("movie", movie.id)
+    end
+  end
+
+  ## Private Functions - Quality Level
+
+  defp quality_level("360p"), do: 1
+  defp quality_level("480p"), do: 2
+  defp quality_level("576p"), do: 3
+  defp quality_level("720p"), do: 4
+  defp quality_level("1080p"), do: 5
+  defp quality_level("2160p"), do: 6
+  defp quality_level(_), do: 0
+end

--- a/lib/mydia/jobs/upgrade_cleanup.ex
+++ b/lib/mydia/jobs/upgrade_cleanup.ex
@@ -1,0 +1,114 @@
+defmodule Mydia.Jobs.UpgradeCleanup do
+  @moduledoc """
+  Handles old file cleanup after a quality upgrade download is imported.
+
+  Enqueued by MediaImport when a download with `download_reason: "upgrade"`
+  completes successfully. Queries old media files for the movie, validates
+  ownership, and applies the configured file policy (replace or keep).
+
+  This is a separate job from MediaImport to:
+  - Keep MediaImport focused on import logic
+  - Make cleanup independently retryable
+  - Ensure the new file is fully available before acting on old files
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3
+
+  require Logger
+
+  import Ecto.Query, warn: false
+
+  alias Mydia.{Repo, Library}
+  alias Mydia.Library.MediaFile
+
+  @doc """
+  Enqueues an upgrade cleanup job for a completed upgrade import.
+
+  ## Parameters
+    - `media_item_id` - The media item that was upgraded
+    - `new_media_file_ids` - List of newly imported media file IDs to preserve
+  """
+  def enqueue(media_item_id, new_media_file_ids) when is_list(new_media_file_ids) do
+    %{
+      "media_item_id" => media_item_id,
+      "new_media_file_ids" => new_media_file_ids
+    }
+    |> new()
+    |> Oban.insert()
+  end
+
+  @spec perform(Oban.Job.t()) :: :ok | {:error, term()}
+  @impl Oban.Worker
+  def perform(%Oban.Job{
+        args: %{
+          "media_item_id" => media_item_id,
+          "new_media_file_ids" => new_media_file_ids
+        }
+      }) do
+    policy = get_file_policy()
+
+    Logger.info("Running upgrade cleanup",
+      media_item_id: media_item_id,
+      new_file_ids: new_media_file_ids,
+      policy: policy
+    )
+
+    case policy do
+      "keep" ->
+        Logger.info("Upgrade file policy is 'keep', skipping old file cleanup",
+          media_item_id: media_item_id
+        )
+
+        :ok
+
+      "replace" ->
+        trash_old_files(media_item_id, new_media_file_ids)
+    end
+  end
+
+  defp trash_old_files(media_item_id, new_media_file_ids) do
+    # Query old files: same media_item, not trashed, not the newly imported files
+    old_files =
+      from(mf in MediaFile,
+        where: mf.media_item_id == ^media_item_id,
+        where: mf.id not in ^new_media_file_ids,
+        where: is_nil(mf.trashed_at)
+      )
+      |> Repo.all()
+
+    if old_files == [] do
+      Logger.info("No old files to clean up", media_item_id: media_item_id)
+      :ok
+    else
+      Logger.info("Trashing #{length(old_files)} old files after upgrade",
+        media_item_id: media_item_id,
+        old_file_ids: Enum.map(old_files, & &1.id)
+      )
+
+      Enum.each(old_files, fn file ->
+        case Library.trash_media_file(file) do
+          {:ok, _trashed} ->
+            Logger.info("Trashed old media file",
+              media_file_id: file.id,
+              media_item_id: media_item_id
+            )
+
+          {:error, reason} ->
+            Logger.error("Failed to trash old media file",
+              media_file_id: file.id,
+              media_item_id: media_item_id,
+              reason: inspect(reason)
+            )
+        end
+      end)
+
+      :ok
+    end
+  end
+
+  defp get_file_policy do
+    Mydia.Settings.get_config([:downloads, :upgrade_file_policy], "replace")
+  end
+end

--- a/lib/mydia/jobs/upgrade_cleanup.ex
+++ b/lib/mydia/jobs/upgrade_cleanup.ex
@@ -87,24 +87,35 @@ defmodule Mydia.Jobs.UpgradeCleanup do
         old_file_ids: Enum.map(old_files, & &1.id)
       )
 
-      Enum.each(old_files, fn file ->
-        case Library.trash_media_file(file) do
-          {:ok, _trashed} ->
-            Logger.info("Trashed old media file",
-              media_file_id: file.id,
-              media_item_id: media_item_id
-            )
+      results =
+        Enum.map(old_files, fn file ->
+          case Library.trash_media_file(file) do
+            {:ok, _trashed} ->
+              Logger.info("Trashed old media file",
+                media_file_id: file.id,
+                media_item_id: media_item_id
+              )
 
-          {:error, reason} ->
-            Logger.error("Failed to trash old media file",
-              media_file_id: file.id,
-              media_item_id: media_item_id,
-              reason: inspect(reason)
-            )
-        end
-      end)
+              :ok
 
-      :ok
+            {:error, reason} ->
+              Logger.error("Failed to trash old media file",
+                media_file_id: file.id,
+                media_item_id: media_item_id,
+                reason: inspect(reason)
+              )
+
+              {:error, reason}
+          end
+        end)
+
+      failed = Enum.count(results, &match?({:error, _}, &1))
+
+      if failed > 0 do
+        {:error, "Failed to trash #{failed} of #{length(old_files)} old files"}
+      else
+        :ok
+      end
     end
   end
 

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -352,12 +352,25 @@ defmodule Mydia.Library do
       |> Repo.all()
 
     # Delete physical files from disk before removing DB records
-    delete_media_files_from_disk(files)
+    # Only remove DB records for files successfully deleted from disk
+    results =
+      Enum.map(files, fn file ->
+        {file.id, delete_media_file_from_disk(file)}
+      end)
 
-    ids = Enum.map(files, & &1.id)
+    successfully_deleted_ids =
+      results
+      |> Enum.filter(fn {_id, result} -> result == :ok end)
+      |> Enum.map(fn {id, _} -> id end)
+
+    failed_count = length(results) - length(successfully_deleted_ids)
+
+    if failed_count > 0 do
+      Logger.warning("Failed to delete #{failed_count} files from disk, keeping their DB records")
+    end
 
     {count, _} =
-      from(f in MediaFile, where: f.id in ^ids)
+      from(f in MediaFile, where: f.id in ^successfully_deleted_ids)
       |> Repo.delete_all()
 
     {:ok, count}

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -344,10 +344,20 @@ defmodule Mydia.Library do
   def purge_old_trashed_media_files(days \\ 30) do
     cutoff = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.add(-days, :day)
 
-    {count, _} =
+    files =
       from(f in MediaFile,
-        where: not is_nil(f.trashed_at) and f.trashed_at < ^cutoff
+        where: not is_nil(f.trashed_at) and f.trashed_at < ^cutoff,
+        preload: [:library_path]
       )
+      |> Repo.all()
+
+    # Delete physical files from disk before removing DB records
+    delete_media_files_from_disk(files)
+
+    ids = Enum.map(files, & &1.id)
+
+    {count, _} =
+      from(f in MediaFile, where: f.id in ^ids)
       |> Repo.delete_all()
 
     {:ok, count}

--- a/lib/mydia/search/pipeline.ex
+++ b/lib/mydia/search/pipeline.ex
@@ -1,0 +1,236 @@
+defmodule Mydia.Search.Pipeline do
+  @moduledoc """
+  Shared search-and-rank pipeline used by MovieSearch, MovieUpgradeSearch,
+  and future search jobs.
+
+  Contains the common primitives for building search queries, loading quality
+  profiles, building ranking options, and initiating downloads. Orchestration
+  (backoff, events, what to do with results) is left to each job.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Mydia.{Repo, Indexers, Downloads}
+  alias Mydia.Media.MediaItem
+
+  # -- Search Query Building --
+
+  @doc """
+  Builds a search query string from a media item's title and year.
+  """
+  @spec build_search_query(MediaItem.t()) :: String.t()
+  def build_search_query(%MediaItem{title: title, year: nil}), do: title
+  def build_search_query(%MediaItem{title: title, year: year}), do: "#{title} #{year}"
+
+  # -- Indexer Helpers --
+
+  @doc """
+  Returns the configured minimum seeders threshold (defaults to 0 for Usenet compatibility).
+  """
+  @spec get_min_seeders() :: non_neg_integer()
+  def get_min_seeders do
+    Application.get_env(:mydia, :auto_search, [])[:min_seeders] || 0
+  end
+
+  @doc """
+  Counts all enabled indexers (standard + Cardigann).
+  """
+  @spec count_enabled_indexers() :: non_neg_integer()
+  def count_enabled_indexers do
+    indexers = Mydia.Settings.list_indexer_configs()
+    enabled_count = Enum.count(indexers, & &1.enabled)
+
+    cardigann_count =
+      if Application.get_env(:mydia, :features, [])[:cardigann_indexers] do
+        Indexers.list_cardigann_definitions()
+        |> Enum.count(& &1.enabled)
+      else
+        0
+      end
+
+    enabled_count + cardigann_count
+  end
+
+  @doc """
+  Applies the configured search delay between searches to avoid indexer rate limiting.
+  """
+  @spec apply_search_delay() :: :ok
+  def apply_search_delay do
+    delay = get_search_delay_ms()
+
+    if delay > 0 do
+      Process.sleep(delay)
+    end
+
+    :ok
+  end
+
+  defp get_search_delay_ms do
+    Application.get_env(:mydia, :episode_monitor, [])
+    |> Keyword.get(:search_delay_ms, 0)
+  end
+
+  # -- Quality Profile --
+
+  @doc """
+  Loads the quality profile for a media item, if one is assigned.
+  """
+  @spec load_quality_profile(MediaItem.t()) :: Mydia.Settings.QualityProfile.t() | nil
+  def load_quality_profile(%MediaItem{quality_profile_id: nil}), do: nil
+
+  def load_quality_profile(%MediaItem{} = media_item) do
+    media_item
+    |> Repo.preload(:quality_profile)
+    |> Map.get(:quality_profile)
+  end
+
+  # -- Ranking Options --
+
+  @doc """
+  Builds ranking options for `ReleaseRanker.select_best_result/2`.
+
+  Accepts explicit options that override defaults:
+    - `:min_seeders` - minimum seeder count
+    - `:size_range` - `{min_mb, max_mb}` tuple
+    - `:blocked_tags` - list of blocked tag strings
+    - `:preferred_tags` - list of preferred tag strings
+    - `:media_type` - `:movie` or `:episode`
+  """
+  @spec build_ranking_options(MediaItem.t(), keyword()) :: keyword()
+  def build_ranking_options(%MediaItem{} = media_item, opts \\ []) do
+    media_type = Keyword.get(opts, :media_type, :movie)
+
+    base_opts = [
+      min_seeders: Keyword.get(opts, :min_seeders, get_min_seeders()),
+      size_range: Keyword.get(opts, :size_range),
+      search_query: build_search_query(media_item),
+      media_type: media_type,
+      expected_title: media_item.title
+    ]
+
+    opts_with_quality =
+      case load_quality_profile(media_item) do
+        nil ->
+          base_opts
+
+        quality_profile ->
+          base_opts
+          |> Keyword.put(:quality_profile, quality_profile)
+          |> Keyword.merge(build_quality_options(quality_profile, media_type))
+      end
+
+    opts_with_quality
+    |> maybe_add_option(:blocked_tags, Keyword.get(opts, :blocked_tags))
+    |> maybe_add_option(:preferred_tags, Keyword.get(opts, :preferred_tags))
+  end
+
+  @doc """
+  Extracts quality filtering options from a quality profile.
+  """
+  @spec build_quality_options(map(), atom()) :: keyword()
+  def build_quality_options(quality_profile, media_type) do
+    quality_opts =
+      case Map.get(quality_profile, :qualities) do
+        nil -> []
+        qualities when is_list(qualities) -> [preferred_qualities: qualities]
+        _ -> []
+      end
+
+    rules_opts =
+      case Map.get(quality_profile, :rules) do
+        %{"min_ratio" => min_ratio} when is_number(min_ratio) ->
+          [min_ratio: min_ratio]
+
+        _ ->
+          []
+      end
+
+    size_opts = extract_size_range(quality_profile, media_type)
+
+    quality_opts
+    |> Keyword.merge(rules_opts)
+    |> Keyword.merge(size_opts)
+  end
+
+  @doc """
+  Extracts size range constraints from quality standards based on media type.
+  """
+  @spec extract_size_range(map(), atom()) :: keyword()
+  def extract_size_range(%{quality_standards: standards}, media_type)
+      when is_map(standards) do
+    {min_key, max_key} =
+      case media_type do
+        :movie -> {:movie_min_size_mb, :movie_max_size_mb}
+        :episode -> {:episode_min_size_mb, :episode_max_size_mb}
+      end
+
+    min_size = Map.get(standards, min_key)
+    max_size = Map.get(standards, max_key)
+
+    case {min_size, max_size} do
+      {nil, nil} -> []
+      {min, nil} when is_number(min) -> [size_range: {min, nil}]
+      {nil, max} when is_number(max) -> [size_range: {nil, max}]
+      {min, max} when is_number(min) and is_number(max) -> [size_range: {min, max}]
+      _ -> []
+    end
+  end
+
+  def extract_size_range(_, _), do: []
+
+  # -- Download Initiation --
+
+  @doc """
+  Initiates a download for a media item with the given search result.
+
+  Accepts additional options to pass to `Downloads.initiate_download/2`,
+  such as `download_reason: :upgrade`.
+  """
+  @spec initiate_download(MediaItem.t(), map(), keyword()) ::
+          {:ok, map()} | {:error, term()}
+  def initiate_download(%MediaItem{} = media_item, result, opts \\ []) do
+    download_opts = Keyword.merge([media_item_id: media_item.id], opts)
+
+    case Downloads.initiate_download(result, download_opts) do
+      {:ok, download} -> {:ok, download}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # -- Event/Stats Helpers --
+
+  @doc """
+  Builds filter statistics for search events when all results are filtered out.
+  """
+  @spec build_filter_stats(list(), keyword()) :: map()
+  def build_filter_stats(results, ranking_opts) do
+    min_seeders = Keyword.get(ranking_opts, :min_seeders, get_min_seeders())
+    low_seeders = Enum.count(results, fn r -> r.seeders < min_seeders end)
+
+    %{
+      "total_results" => length(results),
+      "low_seeders" => low_seeders,
+      "below_quality_threshold" => length(results) - low_seeders
+    }
+  end
+
+  @doc """
+  Converts a map with atom keys to string keys for JSON serialization.
+  """
+  @spec stringify_keys(map()) :: map()
+  def stringify_keys(%{__struct__: _} = struct) do
+    struct |> Map.from_struct() |> stringify_keys()
+  end
+
+  def stringify_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), v} end)
+  end
+
+  def stringify_keys(other), do: other
+
+  # -- Private Helpers --
+
+  defp maybe_add_option(opts, _key, nil), do: opts
+  defp maybe_add_option(opts, _key, []), do: opts
+  defp maybe_add_option(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/lib/mydia/settings/quality_matcher.ex
+++ b/lib/mydia/settings/quality_matcher.ex
@@ -107,6 +107,45 @@ defmodule Mydia.Settings.QualityMatcher do
   end
 
   def is_upgrade?(%SearchResult{} = result, %QualityProfile{} = profile, current_quality) do
+    is_upgrade?(result, profile, current_quality, nil)
+  end
+
+  @doc """
+  Checks if a result would be an upgrade, with composite score comparison
+  for same-resolution upgrades.
+
+  When `current_score` is provided (a float from 0.0-100.0), same-resolution
+  results are compared by composite quality score. This allows detecting upgrades
+  like 1080p Telesync → 1080p BluRay where the resolution is the same but the
+  overall quality is significantly better.
+
+  The `current_score` should be computed via `QualityProfile.score_media_file/2`
+  on the existing file's attributes.
+
+  ## Examples
+
+      iex> QualityMatcher.is_upgrade?(bluray_result, profile, "1080p", 45.0)
+      true  # BluRay scores higher than the current 45.0 (e.g., telesync)
+
+      iex> QualityMatcher.is_upgrade?(similar_result, profile, "1080p", 80.0)
+      false  # Similar quality, not worth upgrading
+  """
+  @spec is_upgrade?(SearchResult.t(), QualityProfile.t(), String.t() | nil, float() | nil) ::
+          boolean()
+  def is_upgrade?(_result, %QualityProfile{upgrades_allowed: false}, _current_quality, _score) do
+    false
+  end
+
+  def is_upgrade?(%SearchResult{quality: nil}, _profile, _current_quality, _score) do
+    false
+  end
+
+  def is_upgrade?(
+        %SearchResult{} = result,
+        %QualityProfile{} = profile,
+        current_quality,
+        current_score
+      ) do
     result_quality = result.quality.resolution
 
     cond do
@@ -122,9 +161,18 @@ defmodule Mydia.Settings.QualityMatcher do
       profile.upgrade_until_quality && current_quality == profile.upgrade_until_quality ->
         false
 
-      # Compare quality levels
+      # Higher resolution is always an upgrade
+      quality_level(result_quality) > quality_level(current_quality) ->
+        true
+
+      # Same resolution: compare composite scores if current_score is available
+      quality_level(result_quality) == quality_level(current_quality) && current_score != nil ->
+        candidate_score = calculate_score(result, profile)
+        candidate_score > current_score
+
+      # Same or lower resolution without score comparison
       true ->
-        quality_level(result_quality) > quality_level(current_quality)
+        false
     end
   end
 

--- a/lib/mydia/settings/quality_matcher.ex
+++ b/lib/mydia/settings/quality_matcher.ex
@@ -97,6 +97,10 @@ defmodule Mydia.Settings.QualityMatcher do
       iex> QualityMatcher.is_upgrade?(result, profile, "2160p")
       false  # Already at max quality
   """
+  # Minimum composite score improvement required for same-resolution upgrades.
+  # Prevents upgrade churn from downloading marginally-better files.
+  @min_upgrade_margin 10.0
+
   @spec is_upgrade?(SearchResult.t(), QualityProfile.t(), String.t() | nil) :: boolean()
   def is_upgrade?(_result, %QualityProfile{upgrades_allowed: false}, _current_quality) do
     false
@@ -166,14 +170,56 @@ defmodule Mydia.Settings.QualityMatcher do
         true
 
       # Same resolution: compare composite scores if current_score is available
-      quality_level(result_quality) == quality_level(current_quality) && current_score != nil ->
+      # Require a minimum margin to prevent upgrade churn
+      quality_level(result_quality) == quality_level(current_quality) &&
+          is_number(current_score) ->
         candidate_score = calculate_score(result, profile)
-        candidate_score > current_score
+        threshold = (current_score || 0.0) + @min_upgrade_margin
+        candidate_score > threshold
 
       # Same or lower resolution without score comparison
       true ->
         false
     end
+  end
+
+  ## Public Helpers
+
+  @doc """
+  Maps a resolution string to a numeric quality level for ordering.
+
+  Returns 0 for unknown resolutions.
+
+  ## Examples
+
+      iex> QualityMatcher.quality_level("1080p")
+      5
+
+      iex> QualityMatcher.quality_level("unknown")
+      0
+  """
+  @spec quality_level(String.t()) :: non_neg_integer()
+  def quality_level("360p"), do: 1
+  def quality_level("480p"), do: 2
+  def quality_level("576p"), do: 3
+  def quality_level("720p"), do: 4
+  def quality_level("1080p"), do: 5
+  def quality_level("2160p"), do: 6
+  def quality_level(_), do: 0
+
+  @doc """
+  Normalizes a codec string for consistent comparison.
+
+  Downcases and strips dots and hyphens (e.g., "H.265" -> "h265").
+  """
+  @spec normalize_codec(String.t() | nil) :: String.t() | nil
+  def normalize_codec(nil), do: nil
+
+  def normalize_codec(codec) when is_binary(codec) do
+    codec
+    |> String.downcase()
+    |> String.replace(".", "")
+    |> String.replace("-", "")
   end
 
   ## Private Functions
@@ -208,7 +254,7 @@ defmodule Mydia.Settings.QualityMatcher do
       quality ->
         %{
           video_codec: normalize_codec(quality.codec),
-          audio_codec: normalize_audio_codec(quality.audio),
+          audio_codec: normalize_codec(quality.audio),
           resolution: quality.resolution,
           source: quality.source,
           file_size_mb: size_mb,
@@ -218,25 +264,7 @@ defmodule Mydia.Settings.QualityMatcher do
     end
   end
 
-  # Normalize video codec to match QualityProfile's expected format
-  defp normalize_codec(nil), do: nil
-
-  defp normalize_codec(codec) when is_binary(codec) do
-    codec
-    |> String.downcase()
-    |> String.replace(".", "")
-    |> String.replace("-", "")
-  end
-
-  # Normalize audio codec to match QualityProfile's expected format
-  defp normalize_audio_codec(nil), do: nil
-
-  defp normalize_audio_codec(codec) when is_binary(codec) do
-    codec
-    |> String.downcase()
-    |> String.replace(".", "")
-    |> String.replace("-", "")
-  end
+  # normalize_codec/1 and normalize_audio_codec/1 unified as public normalize_codec/1 above
 
   # Check quality allowed using legacy qualities field for backward compatibility
   defp check_quality_allowed(%SearchResult{quality: nil}, _profile) do
@@ -253,12 +281,5 @@ defmodule Mydia.Settings.QualityMatcher do
     end
   end
 
-  # Map quality strings to numeric levels for comparison
-  defp quality_level("360p"), do: 1
-  defp quality_level("480p"), do: 2
-  defp quality_level("576p"), do: 3
-  defp quality_level("720p"), do: 4
-  defp quality_level("1080p"), do: 5
-  defp quality_level("2160p"), do: 6
-  defp quality_level(_), do: 0
+  # quality_level/1 is now a public function defined above
 end

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -144,6 +144,7 @@ defmodule MydiaWeb.LibraryComponents do
   attr :progress, :map, default: nil
   attr :status, :any, default: nil
   attr :quality, :string, default: nil
+  attr :upgrade_target, :string, default: nil
 
   slot :badges
   slot :footer
@@ -201,10 +202,17 @@ defmodule MydiaWeb.LibraryComponents do
             <%!-- Progress indicators --%>
             <.progress_bar :if={@progress} progress={@progress} />
             <.progress_badge :if={@progress} progress={@progress} />
-            <%!-- Quality badge --%>
+            <%!-- Quality badge with optional upgrade indicator --%>
             <%= if @quality do %>
-              <div class="badge badge-primary badge-sm absolute top-2 right-2 z-10 shadow-md">
-                {@quality}
+              <div class={[
+                "badge badge-sm absolute top-2 right-2 z-10 shadow-md",
+                if(@upgrade_target, do: "badge-warning", else: "badge-primary")
+              ]}>
+                <%= if @upgrade_target do %>
+                  {@quality} → {@upgrade_target}
+                <% else %>
+                  {@quality}
+                <% end %>
               </div>
             <% end %>
             <%!-- Custom badges slot --%>

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -870,16 +870,9 @@ defmodule MydiaWeb.MediaLive.Index do
     end
   end
 
-  @quality_levels %{
-    "360p" => 1,
-    "480p" => 2,
-    "576p" => 3,
-    "720p" => 4,
-    "1080p" => 5,
-    "2160p" => 6
-  }
-
   defp upgrade_target(media_item) do
+    alias Mydia.Settings.QualityMatcher
+
     profile = media_item.quality_profile
     current = get_quality_badge(media_item)
 
@@ -896,8 +889,8 @@ defmodule MydiaWeb.MediaLive.Index do
       is_nil(profile.upgrade_until_quality) ->
         nil
 
-      Map.get(@quality_levels, current, 0) >=
-          Map.get(@quality_levels, profile.upgrade_until_quality, 0) ->
+      QualityMatcher.quality_level(current) >=
+          QualityMatcher.quality_level(profile.upgrade_until_quality) ->
         nil
 
       true ->

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -663,6 +663,7 @@ defmodule MydiaWeb.MediaLive.Index do
     |> maybe_add_filter(:library_path_type, assigns[:filter_library_type])
     |> Keyword.put(:preload, [
       :downloads,
+      :quality_profile,
       media_files: active_files_query,
       playback_progress: progress_query,
       episodes: [media_files: active_files_query, downloads: []]
@@ -866,6 +867,41 @@ defmodule MydiaWeb.MediaLive.Index do
         |> Enum.reject(&is_nil/1)
         |> Enum.sort(:desc)
         |> List.first()
+    end
+  end
+
+  @quality_levels %{
+    "360p" => 1,
+    "480p" => 2,
+    "576p" => 3,
+    "720p" => 4,
+    "1080p" => 5,
+    "2160p" => 6
+  }
+
+  defp upgrade_target(media_item) do
+    profile = media_item.quality_profile
+    current = get_quality_badge(media_item)
+
+    cond do
+      is_nil(profile) ->
+        nil
+
+      !profile.upgrades_allowed ->
+        nil
+
+      is_nil(current) ->
+        nil
+
+      is_nil(profile.upgrade_until_quality) ->
+        nil
+
+      Map.get(@quality_levels, current, 0) >=
+          Map.get(@quality_levels, profile.upgrade_until_quality, 0) ->
+        nil
+
+      true ->
+        profile.upgrade_until_quality
     end
   end
 

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -357,10 +357,18 @@
                   <% progress = get_progress(item) %>
                   <.progress_bar :if={progress} progress={progress} class="hide-on-select" />
                   <.progress_badge :if={progress} progress={progress} class="hide-on-select" />
-                  <%!-- Quality badge --%>
+                  <%!-- Quality badge with upgrade indicator --%>
                   <%= if quality = get_quality_badge(item) do %>
-                    <div class="badge badge-primary badge-sm absolute top-2 right-2 z-10 shadow-md hide-on-select">
-                      {quality}
+                    <% target = upgrade_target(item) %>
+                    <div class={[
+                      "badge badge-sm absolute top-2 right-2 z-10 shadow-md hide-on-select",
+                      if(target, do: "badge-warning", else: "badge-primary")
+                    ]}>
+                      <%= if target do %>
+                        {quality} → {target}
+                      <% else %>
+                        {quality}
+                      <% end %>
                     </div>
                   <% end %>
                 </figure>
@@ -536,9 +544,14 @@
               </div>
             </div>
             <%!-- Quality column --%>
-            <div class="w-20 hidden lg:block text-center flex-shrink-0">
+            <div class="w-24 hidden lg:block text-center flex-shrink-0">
               <%= if quality = get_quality_badge(item) do %>
-                <span class="badge badge-primary badge-sm">{quality}</span>
+                <% target = upgrade_target(item) %>
+                <%= if target do %>
+                  <span class="badge badge-warning badge-sm">{quality} → {target}</span>
+                <% else %>
+                  <span class="badge badge-primary badge-sm">{quality}</span>
+                <% end %>
               <% else %>
                 <span class="text-base-content/40">—</span>
               <% end %>

--- a/test/mydia/jobs/upgrade_cleanup_test.exs
+++ b/test/mydia/jobs/upgrade_cleanup_test.exs
@@ -1,0 +1,161 @@
+defmodule Mydia.Jobs.UpgradeCleanupTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Jobs.UpgradeCleanup
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.MediaItem
+  alias Mydia.Settings.LibraryPath
+
+  describe "perform/1" do
+    setup do
+      # Create a library path
+      {:ok, library_path} =
+        %LibraryPath{}
+        |> Ecto.Changeset.change(%{
+          path: "/media/movies",
+          type: :movies,
+          disabled: false
+        })
+        |> Repo.insert()
+
+      # Create a media item
+      {:ok, media_item} =
+        %MediaItem{}
+        |> Ecto.Changeset.change(%{
+          title: "Test Movie",
+          type: "movie",
+          monitored: true
+        })
+        |> Repo.insert()
+
+      # Create the "old" file (should be trashed on upgrade)
+      {:ok, old_file} =
+        %MediaFile{}
+        |> Ecto.Changeset.change(%{
+          media_item_id: media_item.id,
+          library_path_id: library_path.id,
+          path: "/media/movies/Test Movie/test.720p.mkv",
+          relative_path: "Test Movie/test.720p.mkv",
+          size: 2_000_000_000,
+          resolution: "720p"
+        })
+        |> Repo.insert()
+
+      # Create the "new" file (just imported from upgrade)
+      {:ok, new_file} =
+        %MediaFile{}
+        |> Ecto.Changeset.change(%{
+          media_item_id: media_item.id,
+          library_path_id: library_path.id,
+          path: "/media/movies/Test Movie/test.1080p.mkv",
+          relative_path: "Test Movie/test.1080p.mkv",
+          size: 4_000_000_000,
+          resolution: "1080p"
+        })
+        |> Repo.insert()
+
+      {:ok,
+       media_item: media_item, old_file: old_file, new_file: new_file, library_path: library_path}
+    end
+
+    test "trashes old files and preserves new files", %{
+      media_item: media_item,
+      old_file: old_file,
+      new_file: new_file
+    } do
+      # Default policy is "replace" — old files should be trashed
+      job =
+        UpgradeCleanup.new(%{
+          "media_item_id" => media_item.id,
+          "new_media_file_ids" => [new_file.id]
+        })
+
+      assert :ok = UpgradeCleanup.perform(%Oban.Job{args: job.changes.args})
+
+      # Old file should be trashed
+      old_file_reloaded = Repo.get!(MediaFile, old_file.id)
+      assert old_file_reloaded.trashed_at != nil
+
+      # New file should NOT be trashed
+      new_file_reloaded = Repo.get!(MediaFile, new_file.id)
+      assert new_file_reloaded.trashed_at == nil
+    end
+
+    test "does not trash already-trashed files", %{
+      media_item: media_item,
+      old_file: old_file,
+      new_file: new_file
+    } do
+      # Pre-trash the old file
+      old_file
+      |> Ecto.Changeset.change(trashed_at: DateTime.utc_now() |> DateTime.truncate(:second))
+      |> Repo.update!()
+
+      job =
+        UpgradeCleanup.new(%{
+          "media_item_id" => media_item.id,
+          "new_media_file_ids" => [new_file.id]
+        })
+
+      # Should succeed — no un-trashed old files to process
+      assert :ok = UpgradeCleanup.perform(%Oban.Job{args: job.changes.args})
+    end
+
+    test "handles case when no old files exist", %{
+      media_item: media_item,
+      new_file: new_file,
+      old_file: old_file
+    } do
+      # Delete the old file entirely
+      Repo.delete!(old_file)
+
+      job =
+        UpgradeCleanup.new(%{
+          "media_item_id" => media_item.id,
+          "new_media_file_ids" => [new_file.id]
+        })
+
+      assert :ok = UpgradeCleanup.perform(%Oban.Job{args: job.changes.args})
+    end
+
+    test "does not trash files from other media items", %{
+      media_item: media_item,
+      new_file: new_file,
+      library_path: library_path
+    } do
+      # Create another media item with a file
+      {:ok, other_item} =
+        %MediaItem{}
+        |> Ecto.Changeset.change(%{
+          title: "Other Movie",
+          type: "movie",
+          monitored: true
+        })
+        |> Repo.insert()
+
+      {:ok, other_file} =
+        %MediaFile{}
+        |> Ecto.Changeset.change(%{
+          media_item_id: other_item.id,
+          library_path_id: library_path.id,
+          path: "/media/movies/Other Movie/other.720p.mkv",
+          relative_path: "Other Movie/other.720p.mkv",
+          size: 2_000_000_000,
+          resolution: "720p"
+        })
+        |> Repo.insert()
+
+      job =
+        UpgradeCleanup.new(%{
+          "media_item_id" => media_item.id,
+          "new_media_file_ids" => [new_file.id]
+        })
+
+      assert :ok = UpgradeCleanup.perform(%Oban.Job{args: job.changes.args})
+
+      # Other movie's file should NOT be trashed
+      other_file_reloaded = Repo.get!(MediaFile, other_file.id)
+      assert other_file_reloaded.trashed_at == nil
+    end
+  end
+end

--- a/test/mydia/search/pipeline_test.exs
+++ b/test/mydia/search/pipeline_test.exs
@@ -1,0 +1,59 @@
+defmodule Mydia.Search.PipelineTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Search.Pipeline
+  alias Mydia.Media.MediaItem
+
+  describe "build_search_query/1" do
+    test "returns title and year for movies with year" do
+      media_item = %MediaItem{title: "The Matrix", year: 1999}
+      assert Pipeline.build_search_query(media_item) == "The Matrix 1999"
+    end
+
+    test "returns just title when year is nil" do
+      media_item = %MediaItem{title: "Untitled Film"}
+      assert Pipeline.build_search_query(media_item) == "Untitled Film"
+    end
+  end
+
+  describe "get_min_seeders/0" do
+    test "returns configured value or default 0" do
+      result = Pipeline.get_min_seeders()
+      assert is_integer(result)
+      assert result >= 0
+    end
+  end
+
+  describe "stringify_keys/1" do
+    test "converts atom keys to string keys" do
+      result = Pipeline.stringify_keys(%{quality: "1080p", score: 85.0})
+      assert result == %{"quality" => "1080p", "score" => 85.0}
+    end
+
+    test "handles struct maps by converting from struct first" do
+      result = Pipeline.stringify_keys(%URI{host: "example.com", port: 443})
+      assert is_map(result)
+      assert Map.has_key?(result, "host")
+    end
+
+    test "passes through non-map values" do
+      assert Pipeline.stringify_keys("hello") == "hello"
+      assert Pipeline.stringify_keys(42) == 42
+    end
+  end
+
+  describe "build_filter_stats/2" do
+    test "builds stats with correct counts" do
+      results = [
+        %{seeders: 1, title: "low"},
+        %{seeders: 100, title: "high"},
+        %{seeders: 0, title: "zero"}
+      ]
+
+      stats = Pipeline.build_filter_stats(results, min_seeders: 5)
+      assert stats["total_results"] == 3
+      assert stats["low_seeders"] == 2
+      assert stats["below_quality_threshold"] == 1
+    end
+  end
+end

--- a/test/mydia/settings/quality_matcher_test.exs
+++ b/test/mydia/settings/quality_matcher_test.exs
@@ -430,4 +430,152 @@ defmodule Mydia.Settings.QualityMatcherTest do
       refute QualityMatcher.is_upgrade?(result, profile, "720p")
     end
   end
+
+  describe "is_upgrade?/4 (same-resolution composite scoring)" do
+    setup do
+      profile = %QualityProfile{
+        name: "Test Profile",
+        qualities: ["720p", "1080p", "2160p"],
+        upgrades_allowed: true,
+        upgrade_until_quality: "2160p",
+        quality_standards: %{
+          preferred_video_codecs: ["h265", "h264"],
+          preferred_audio_codecs: ["atmos", "truehd", "ac3", "aac"],
+          preferred_resolutions: ["2160p", "1080p"],
+          preferred_sources: ["BluRay", "REMUX", "WEB-DL", "HDTV"],
+          min_video_bitrate_mbps: 5.0,
+          max_video_bitrate_mbps: 50.0,
+          movie_min_size_mb: 2048,
+          movie_max_size_mb: 15360
+        }
+      }
+
+      {:ok, profile: profile}
+    end
+
+    test "returns true for same-resolution upgrade with higher score (e.g., TS -> BluRay)", %{
+      profile: profile
+    } do
+      # BluRay result at 1080p
+      bluray_result = %SearchResult{
+        title: "Test Movie 2024 1080p BluRay x265 AC3",
+        size: 8 * 1024 * 1024 * 1024,
+        seeders: 100,
+        leechers: 10,
+        download_url: "magnet:?xt=...",
+        indexer: "Test",
+        quality: %QualityInfo{
+          resolution: "1080p",
+          source: "BluRay",
+          codec: "x265",
+          audio: "AC3",
+          hdr: false,
+          proper: false,
+          repack: false
+        }
+      }
+
+      # Current file is a low-quality 1080p telesync (low composite score)
+      low_score = 25.0
+
+      assert QualityMatcher.is_upgrade?(bluray_result, profile, "1080p", low_score)
+    end
+
+    test "returns false for same-resolution with similar or lower score", %{profile: profile} do
+      # Another WEB-DL at 1080p
+      webdl_result = %SearchResult{
+        title: "Test Movie 2024 1080p WEB-DL x264 AAC",
+        size: 4 * 1024 * 1024 * 1024,
+        seeders: 50,
+        leechers: 5,
+        download_url: "magnet:?xt=...",
+        indexer: "Test",
+        quality: %QualityInfo{
+          resolution: "1080p",
+          source: "WEB-DL",
+          codec: "x264",
+          audio: "AAC",
+          hdr: false,
+          proper: false,
+          repack: false
+        }
+      }
+
+      # Current file already has a high score (e.g., already a BluRay)
+      high_score = 90.0
+
+      refute QualityMatcher.is_upgrade?(webdl_result, profile, "1080p", high_score)
+    end
+
+    test "returns false for same-resolution when current_score is nil (falls back to resolution only)",
+         %{profile: profile} do
+      result = %SearchResult{
+        title: "Test Movie 2024 1080p BluRay",
+        size: 8 * 1024 * 1024 * 1024,
+        seeders: 100,
+        leechers: 10,
+        download_url: "magnet:?xt=...",
+        indexer: "Test",
+        quality: %QualityInfo{
+          resolution: "1080p",
+          source: "BluRay",
+          codec: "x265",
+          audio: "AC3",
+          hdr: false,
+          proper: false,
+          repack: false
+        }
+      }
+
+      # Without current_score, same resolution is not an upgrade
+      refute QualityMatcher.is_upgrade?(result, profile, "1080p", nil)
+    end
+
+    test "higher resolution is always an upgrade regardless of score", %{profile: profile} do
+      result_2160p = %SearchResult{
+        title: "Test Movie 2024 2160p WEB-DL",
+        size: 12 * 1024 * 1024 * 1024,
+        seeders: 50,
+        leechers: 5,
+        download_url: "magnet:?xt=...",
+        indexer: "Test",
+        quality: %QualityInfo{
+          resolution: "2160p",
+          source: "WEB-DL",
+          codec: "x264",
+          audio: "AAC",
+          hdr: false,
+          proper: false,
+          repack: false
+        }
+      }
+
+      # Even with a very high current score, higher resolution wins
+      assert QualityMatcher.is_upgrade?(result_2160p, profile, "1080p", 95.0)
+    end
+
+    test "respects upgrades_allowed: false even with score", %{profile: profile} do
+      no_upgrade_profile = %{profile | upgrades_allowed: false}
+
+      result = %SearchResult{
+        title: "Test Movie 2024 1080p BluRay",
+        size: 8 * 1024 * 1024 * 1024,
+        seeders: 100,
+        leechers: 10,
+        download_url: "magnet:?xt=...",
+        indexer: "Test",
+        quality: %QualityInfo{
+          resolution: "1080p",
+          source: "BluRay",
+          codec: "x265",
+          audio: "AC3",
+          hdr: false,
+          proper: false,
+          repack: false
+        }
+      }
+
+      refute QualityMatcher.is_upgrade?(result, no_upgrade_profile, "720p", 30.0)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds automatic quality upgrade for movies: Mydia periodically re-searches indexers for better quality versions of already-downloaded movies and auto-downloads upgrades until the quality profile ceiling is reached
- New `MovieUpgradeSearch` Oban worker runs daily on a dedicated `upgrade_search` queue, processing up to 25 movies per run
- Extends `is_upgrade?` with composite quality scoring for same-resolution upgrades (e.g., 1080p Telesync → 1080p BluRay)
- New `UpgradeCleanup` job handles old file trashing after upgrade import, with configurable policy (replace/keep)
- Shared `Search.Pipeline` module extracted from `MovieSearch` to avoid code duplication
- Fixes pre-existing bug: `purge_old_trashed_media_files` was not deleting physical files from disk

## Key design decisions
- **Fixed daily cron** instead of configurable interval — release cycles are days/weeks apart
- **Query-at-import-time** for old files instead of storing IDs in metadata — eliminates security risk of unvalidated file deletion
- **Separate `UpgradeCleanup` job** — independently retryable, keeps `MediaImport` focused
- **Dedicated `:upgrade_search` queue** (concurrency: 1) — natural mutual exclusion without polling
- **Unified `download_reason` option** — replaces boolean `manual: true` pattern for extensibility
- **TOCTOU re-check** before download initiation — prevents stale quality comparisons

## Commits
1. `fix:` Delete physical files from disk before purging trashed media file records
2. `refactor:` Extract shared search pipeline from MovieSearch
3. `feat:` Extend is_upgrade? for same-resolution composite scoring
4. `feat:` Add MovieUpgradeSearch Oban worker for automatic quality upgrades
5. `feat:` Add download_reason option to initiate_download for upgrade bypass
6. `feat:` Add UpgradeCleanup job and MediaImport integration
7. `feat:` Support actor_id override in search events for upgrade distinction
8. `test:` Add tests for is_upgrade?/4 same-resolution composite scoring

## Testing
- 5 new tests for `is_upgrade?/4` composite scoring (all pass)
- 10 existing `MovieSearch` tests pass (pipeline extraction is behavior-preserving)
- Full compilation clean with no warnings

## Post-Deploy Monitoring & Validation
- **What to monitor**
  - Logs: `MovieUpgradeSearch` and `UpgradeCleanup` job execution logs
  - Oban dashboard: `upgrade_search` queue activity
  - Events: filter by `actor_id: "movie_upgrade_search"` in activity feed
- **Expected healthy behavior**
  - Daily job at 4:30 AM, processes ≤25 movies, completes in 5-10 min
  - Upgrade downloads appear in download queue with `download_reason: "upgrade"` in metadata
  - Old files trashed after successful import (visible in trash)
- **Failure signals / rollback trigger**
  - Indexer rate limiting (429 errors) — reduce `max_movies_per_run`
  - Unexpected file deletion — check `UpgradeCleanup` logs, verify `media_item_id` ownership
  - Job stuck in `executing` — check `upgrade_search` queue concurrency
- **Validation window & owner**
  - Window: 7 days after deploy
  - Owner: @arosenfeld