### PR TITLE
Fix: speed up test suite by ~42% (221s → 127s)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -84,6 +84,9 @@ config :mydia,
   # timer-triggered re-renders from clearing flash messages during tests
   admin_refresh_interval: :timer.minutes(10)
 
+# Disable search delay in tests (production uses 3000ms to throttle API calls)
+config :mydia, :episode_monitor, search_delay_ms: 0
+
 # Guardian JWT configuration for tests
 config :mydia, Mydia.Auth.Guardian,
   issuer: "mydia",

--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -221,23 +221,25 @@ defmodule Mydia.DownloadsTest do
     end
 
     test "handles URL download links", %{search_result: search_result} do
-      url_result = %{search_result | download_url: "https://example.com/file.torrent"}
+      # Use Bypass to serve a mock torrent file instead of hitting a real URL
+      bypass = Bypass.open()
 
-      # Note: This test will fail to download the file (connection refused)
-      # since the URL doesn't exist. We accept this failure for now.
-      # In a real scenario, the download would succeed and return {:file, body}
-      result = Downloads.initiate_download(url_result)
+      # HEAD for redirect check, then GET for actual download
+      Bypass.stub(bypass, "HEAD", "/file.torrent", fn conn ->
+        Plug.Conn.resp(conn, 200, "")
+      end)
 
-      case result do
-        {:ok, download} ->
-          assert download.download_url == url_result.download_url
-          # After downloading and detecting file type, it uses {:file, body}
-          assert download.download_client_id == "mock-file-id"
+      Bypass.stub(bypass, "GET", "/file.torrent", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/x-bittorrent")
+        |> Plug.Conn.resp(200, "d8:announce0:e")
+      end)
 
-        {:error, {:download_failed, _reason}} ->
-          # Expected when the URL can't be reached
-          assert true
-      end
+      url_result = %{search_result | download_url: "http://localhost:#{bypass.port}/file.torrent"}
+
+      assert {:ok, download} = Downloads.initiate_download(url_result)
+      assert download.download_url == url_result.download_url
+      assert download.download_client_id == "mock-file-id"
     end
 
     test "returns error when no clients are configured" do

--- a/test/mydia/indexers/adapter/cardigann_test.exs
+++ b/test/mydia/indexers/adapter/cardigann_test.exs
@@ -6,46 +6,48 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
   alias Mydia.Indexers.CardigannDefinition
   alias Mydia.Repo
 
-  @sample_yaml """
-  id: test-indexer
-  name: Test Indexer
-  description: A test indexer for unit tests
-  language: en-US
-  type: public
-  encoding: UTF-8
-  links:
-    - https://test-indexer.example.com
-  caps:
-    modes:
-      search: {search-type: q}
-      tv-search: {search-type: q, tv-attributes: q, season, ep}
-      movie-search: {search-type: q, movie-attributes: q, imdbid}
-    categories:
-      2000: Movies
-      5000: TV
-    categorymappings:
-      - {id: 2000, cat: Movies, desc: "Movies"}
-      - {id: 5000, cat: TV, desc: "TV Shows"}
-  search:
-    path: /search/{{ .Keywords }}/
-    rows:
-      selector: "table.results tr"
-      after: 1
-    fields:
-      title:
-        selector: "td.title a"
-      download:
-        selector: "td.download a"
-        attribute: href
-      size:
-        selector: "td.size"
-      seeders:
-        selector: "td.seeders"
-      leechers:
-        selector: "td.leechers"
-      category:
-        selector: "td.category"
-  """
+  defp sample_yaml(base_url) do
+    """
+    id: test-indexer
+    name: Test Indexer
+    description: A test indexer for unit tests
+    language: en-US
+    type: public
+    encoding: UTF-8
+    links:
+      - #{base_url}
+    caps:
+      modes:
+        search: {search-type: q}
+        tv-search: {search-type: q, tv-attributes: q, season, ep}
+        movie-search: {search-type: q, movie-attributes: q, imdbid}
+      categories:
+        2000: Movies
+        5000: TV
+      categorymappings:
+        - {id: 2000, cat: Movies, desc: "Movies"}
+        - {id: 5000, cat: TV, desc: "TV Shows"}
+    search:
+      path: /search/{{ .Keywords }}/
+      rows:
+        selector: "table.results tr"
+        after: 1
+      fields:
+        title:
+          selector: "td.title a"
+        download:
+          selector: "td.download a"
+          attribute: href
+        size:
+          selector: "td.size"
+        seeders:
+          selector: "td.seeders"
+        leechers:
+          selector: "td.leechers"
+        category:
+          selector: "td.category"
+    """
+  end
 
   setup do
     # Clear any existing definitions
@@ -55,7 +57,28 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
     original_features = Application.get_env(:mydia, :features, [])
     Application.put_env(:mydia, :features, cardigann_enabled: true)
 
-    # Insert test definition
+    # Use Bypass to avoid real HTTP connections during test_connection/search
+    bypass = Bypass.open()
+    base_url = "http://localhost:#{bypass.port}"
+
+    # Stub the root path for test_connection reachability check
+    Bypass.stub(bypass, "GET", "/", fn conn ->
+      Plug.Conn.resp(conn, 200, "OK")
+    end)
+
+    # Stub search paths with empty HTML table (Cardigann parses HTML from search results)
+    for query <- ["test+query", "test%20query", "query"] do
+      Bypass.stub(bypass, "GET", "/search/#{query}/", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("text/html")
+        |> Plug.Conn.resp(
+          200,
+          "<html><body><table class=\"results\"><tr><th>Header</th></tr></table></body></html>"
+        )
+      end)
+    end
+
+    # Insert test definition with Bypass URL
     {:ok, definition} =
       %CardigannDefinition{}
       |> CardigannDefinition.changeset(%{
@@ -65,7 +88,7 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
         language: "en-US",
         type: "public",
         encoding: "UTF-8",
-        links: %{"0" => "https://test-indexer.example.com"},
+        links: %{"0" => base_url},
         capabilities: %{
           modes: %{"search" => %{}, "tv-search" => %{}, "movie-search" => %{}},
           categories: %{"2000" => "Movies", "5000" => "TV"},
@@ -74,7 +97,7 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
             %{"id" => 5000, "cat" => "TV", "desc" => "TV Shows"}
           ]
         },
-        definition: @sample_yaml,
+        definition: sample_yaml(base_url),
         schema_version: "v11",
         enabled: true,
         last_synced_at: DateTime.utc_now()
@@ -85,7 +108,7 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
       Application.put_env(:mydia, :features, original_features)
     end)
 
-    %{definition: definition}
+    %{definition: definition, bypass: bypass}
   end
 
   describe "test_connection/1" do
@@ -96,24 +119,9 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
         indexer_id: "test-indexer"
       }
 
-      # Mock HTTP request to base URL
-      # In a real test we'd use a mocking library or bypass
-      # For now, we'll test that the adapter at least attempts to connect
-      result = Cardigann.test_connection(config)
-
-      # Should either succeed or fail with connection error (not config error)
-      case result do
-        {:ok, info} ->
-          assert info.name == "Test Indexer"
-          assert info.indexer_id == "test-indexer"
-
-        {:error, %Error{type: :connection_failed}} ->
-          # This is expected if the test indexer is not actually running
-          assert true
-
-        other ->
-          flunk("Unexpected result: #{inspect(other)}")
-      end
+      assert {:ok, info} = Cardigann.test_connection(config)
+      assert info.name == "Test Indexer"
+      assert info.indexer_id == "test-indexer"
     end
 
     test "fails with missing indexer_id" do
@@ -150,22 +158,11 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
         indexer_id: "test-indexer"
       }
 
-      # This will fail during HTTP request, but we can verify it processes config correctly
-      result = Cardigann.search(config, "test query", categories: [2000], min_seeders: 5)
+      # Bypass returns an empty HTML table, so search should succeed with no results
+      assert {:ok, results} =
+               Cardigann.search(config, "test query", categories: [2000], min_seeders: 5)
 
-      # Should fail with connection error (not config error)
-      case result do
-        {:ok, _results} ->
-          # If somehow it succeeds (unlikely in test env), that's fine
-          assert true
-
-        {:error, %Error{type: error_type}} ->
-          # Should fail with connection/search error, not config error
-          assert error_type in [:connection_failed, :search_failed]
-
-        other ->
-          flunk("Unexpected result: #{inspect(other)}")
-      end
+      assert is_list(results)
     end
 
     test "fails with missing indexer_id" do
@@ -178,26 +175,15 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
     end
 
     test "applies search filters correctly" do
-      # Test that filters would be applied if we had results
-      # This is more of a unit test of the filter logic
-
       config = %{
         type: :cardigann,
         name: "Test Indexer",
         indexer_id: "test-indexer"
       }
 
-      # The search will fail at HTTP stage, but config processing should work
-      result = Cardigann.search(config, "query", min_seeders: 10, limit: 5)
-
-      # Verify it doesn't fail with invalid config
-      case result do
-        {:error, %Error{type: error_type}} ->
-          assert error_type in [:connection_failed, :search_failed]
-
-        _ ->
-          assert true
-      end
+      # Bypass returns empty results, verifying config processing doesn't error
+      assert {:ok, results} = Cardigann.search(config, "query", min_seeders: 10, limit: 5)
+      assert is_list(results)
     end
   end
 
@@ -292,17 +278,9 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
           indexer_id: "test-indexer"
         }
 
-        # Should proceed to search (will fail with connection error in test env)
-        result = Cardigann.search(config, "test query")
-
-        case result do
-          {:ok, _results} ->
-            assert true
-
-          {:error, %Error{type: error_type}} ->
-            # Should fail with connection/search error, not config error
-            assert error_type in [:connection_failed, :search_failed]
-        end
+        # Should proceed to search (Bypass returns empty results)
+        assert {:ok, results} = Cardigann.search(config, "test query")
+        assert is_list(results)
       after
         Application.put_env(:mydia, :features, original)
       end
@@ -345,14 +323,9 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
           indexer_id: "test-indexer"
         }
 
-        # Should proceed to test connection (will fail with connection error in test env)
-        result = Cardigann.test_connection(config)
-
-        case result do
-          {:ok, _info} -> assert true
-          {:error, %Error{type: :connection_failed}} -> assert true
-          other -> flunk("Unexpected result: #{inspect(other)}")
-        end
+        # Should proceed to test connection (Bypass returns 200)
+        assert {:ok, info} = Cardigann.test_connection(config)
+        assert info.name == "Test Indexer"
       after
         Application.put_env(:mydia, :features, original)
       end

--- a/test/mydia/jobs/movie_search_test.exs
+++ b/test/mydia/jobs/movie_search_test.exs
@@ -74,9 +74,9 @@ defmodule Mydia.Jobs.MovieSearchTest do
     # Create test library path for media files
     library_path = library_path_fixture(%{path: "/test/library", type: "movies"})
 
-    # Disable all existing indexer configs from test database
+    # Disable all existing DB indexer configs so only our Bypass mock is used
     Settings.list_indexer_configs()
-    |> Enum.filter(fn config -> not is_nil(config.inserted_at) end)
+    |> Enum.reject(&Mydia.Settings.runtime_config?/1)
     |> Enum.each(fn config ->
       Settings.update_indexer_config(config, %{enabled: false})
     end)

--- a/test/mydia/jobs/tv_show_search_test.exs
+++ b/test/mydia/jobs/tv_show_search_test.exs
@@ -74,9 +74,9 @@ defmodule Mydia.Jobs.TVShowSearchTest do
     # Create test library path for media files
     library_path = library_path_fixture(%{path: "/test/library", type: "series"})
 
-    # Disable all existing indexer configs from test database
+    # Disable all existing DB indexer configs so only our Bypass mock is used
     Settings.list_indexer_configs()
-    |> Enum.filter(fn config -> not is_nil(config.inserted_at) end)
+    |> Enum.reject(&Mydia.Settings.runtime_config?/1)
     |> Enum.each(fn config ->
       Settings.update_indexer_config(config, %{enabled: false})
     end)

--- a/test/mydia_web/plugs/media_auth_test.exs
+++ b/test/mydia_web/plugs/media_auth_test.exs
@@ -136,7 +136,8 @@ defmodule MydiaWeb.Plugs.MediaAuthTest do
       user = create_user()
       device = create_device(user)
       {:ok, token, _claims} = MediaToken.create_token(device, ttl: {1, :second})
-      # Sleep long enough for token to expire (add extra margin for test reliability)
+      # Wait for token to expire (allowed_drift is 0 in test config,
+      # 2000ms for reliable expiry through the TokenCache path)
       Process.sleep(2000)
 
       %{token: token}

--- a/test/mydia_web/remote_access/media_token_test.exs
+++ b/test/mydia_web/remote_access/media_token_test.exs
@@ -83,8 +83,9 @@ defmodule Mydia.RemoteAccess.MediaTokenTest do
       # Verify the TTL was applied (exp should be about 1 second after iat)
       assert claims["exp"] - claims["iat"] <= 2
 
-      # Wait longer than TTL + allowed_drift (2 seconds drift configured) + margin
-      Process.sleep(4000)
+      # Wait for token to expire (allowed_drift is 0 in test config,
+      # 2000ms for reliable expiry with second-precision JWT timestamps)
+      Process.sleep(2000)
 
       assert {:error, :token_expired} = MediaToken.verify_token(token)
     end
@@ -145,8 +146,9 @@ defmodule Mydia.RemoteAccess.MediaTokenTest do
       # Verify the TTL was applied (exp should be about 1 second after iat)
       assert claims["exp"] - claims["iat"] <= 2
 
-      # Wait longer than TTL + allowed_drift (2 seconds drift configured) + margin
-      Process.sleep(4000)
+      # Wait for token to expire (allowed_drift is 0 in test config,
+      # 2000ms for reliable expiry with second-precision JWT timestamps)
+      Process.sleep(2000)
 
       assert {:error, :token_expired} = MediaToken.refresh_token(expired_token)
     end

--- a/test/mydia_web/schema/remote_access_test.exs
+++ b/test/mydia_web/schema/remote_access_test.exs
@@ -51,8 +51,9 @@ defmodule MydiaWeb.Schema.RemoteAccessTest do
       # Verify the TTL was applied (exp should be about 1 second after iat)
       assert claims["exp"] - claims["iat"] <= 2
 
-      # Wait for token to expire (TTL + allowed_drift of 2 seconds + margin)
-      Process.sleep(4000)
+      # Wait for token to expire (allowed_drift is 0 in test config,
+      # 2000ms for reliable expiry with second-precision JWT timestamps)
+      Process.sleep(2000)
 
       variables = %{"token" => expired_token}
       result = run_query(@refresh_media_token_mutation, variables)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -15,6 +15,21 @@ max_cases =
 ExUnit.start(max_cases: max_cases, exclude: [:external, :feature, :requires_relay])
 Ecto.Adapters.SQL.Sandbox.mode(Mydia.Repo, :manual)
 
+# Clear runtime config indexers, download clients, and media servers so tests
+# never accidentally hit real external services (e.g. Prowlarr from Docker env vars).
+# Tests that need indexers should create their own via Bypass + Settings.create_indexer_config.
+case Application.get_env(:mydia, :runtime_config) do
+  %{} = config ->
+    Application.put_env(
+      :mydia,
+      :runtime_config,
+      %{config | indexers: [], download_clients: [], media_servers: []}
+    )
+
+  _ ->
+    :ok
+end
+
 # Configure ExMachina
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 


### PR DESCRIPTION
## Summary

- **Disable `search_delay_ms` in test config** — production uses 3s sleep between search API calls to avoid rate limiting. Tests were sleeping 3s × N searches = ~75s wasted. Set to 0 in `config/test.exs`.
- **Clear runtime indexer/download configs in `test_helper.exs`** — Docker Compose env vars inject a "Local Prowlarr" indexer pointing to `http://prowlarr:9696`. Tests hitting this got `:nxdomain` + Req retry backoff (~6s per search call).
- **Replace real HTTP connections with Bypass** — Cardigann tests hit `https://test-indexer.example.com` (10s timeout). Downloads test hit `https://example.com/file.torrent` (7s timeout). Both now use Bypass for instant responses.
- **Reduce token expiry sleeps** — Test config already sets `allowed_drift: 0` but tests slept 4s assuming 2s drift. Reduced to 2s.

## Test plan

- [ ] CI passes with no new test failures
- [ ] Full suite completes in ~130s (was ~220s)