### PR TITLE
fix(downloads): stop hourly re-download loop for season packs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -348,7 +348,13 @@ config :mydia, :auto_search,
   # Set to 0 for Usenet compatibility (Usenet indexers report 0 seeders)
   # Set to 3-5 for torrent-only setups to filter out dead torrents
   # This setting only affects automatic background searches, not manual searches
-  min_seeders: 0
+  min_seeders: 0,
+  # Case-insensitive substring tokens that disqualify a release title.
+  # Default is empty — opt in by overriding in runtime.exs or releases.exs.
+  # Examples for English-only libraries:
+  #   blocked_release_tokens: ["UkrEng", "[DUB]", "Dragon Money", "Dual-Audio Russian"]
+  # Tokens merge with any per-job `blocked_tags` passed in job args.
+  blocked_release_tokens: []
 
 # Indexer search throttling
 # Controls concurrency and rate limiting for indexer queries

--- a/lib/mydia/downloads/download.ex
+++ b/lib/mydia/downloads/download.ex
@@ -84,7 +84,7 @@ defmodule Mydia.Downloads.Download do
       :import_failed_at
     ])
     |> validate_required([:title])
-    |> validate_inclusion(:match_status, ["unmatched", "unresolved_files"])
+    |> validate_inclusion(:match_status, ["unmatched", "unresolved_files", "partial_pack"])
     |> foreign_key_constraint(:media_item_id)
     |> foreign_key_constraint(:episode_id)
     |> foreign_key_constraint(:library_path_id)

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -20,6 +20,11 @@ defmodule Mydia.Downloads.Queue do
   ## Public Functions
 
   def initiate_download(%SearchResult{} = search_result, opts \\ []) do
+    # Normalize metadata: callers (e.g. TVShowSearch) may pass a plain map.
+    # Coerce to %SearchResultMetadata{} so downstream pattern matches and
+    # persistence in create_download_record/4 work uniformly.
+    search_result = %{search_result | metadata: normalize_metadata(search_result.metadata)}
+
     # Use protocol from search result
     download_type = search_result.download_protocol
     Logger.info("Download protocol: #{inspect(download_type)} for #{search_result.title}")
@@ -189,6 +194,23 @@ defmodule Mydia.Downloads.Queue do
     success_count = Enum.count(results, &(&1 == :ok))
     {:ok, success_count}
   end
+
+  # Normalizes search-result metadata into a SearchResultMetadata struct.
+  # Some call sites (e.g. tv_show_search.ex) historically passed a plain
+  # map, which silently bypassed every season-pack-aware guard below.
+  defp normalize_metadata(%SearchResultMetadata{} = m), do: m
+  defp normalize_metadata(nil), do: nil
+
+  defp normalize_metadata(%{} = m) do
+    SearchResultMetadata.new(
+      season_pack: m[:season_pack] || m["season_pack"],
+      season_number: m[:season_number] || m["season_number"],
+      episode_count: m[:episode_count] || m["episode_count"],
+      episode_ids: m[:episode_ids] || m["episode_ids"]
+    )
+  end
+
+  defp normalize_metadata(_), do: nil
 
   def check_for_duplicate_download(search_result, opts) do
     media_item_id = Keyword.get(opts, :media_item_id)
@@ -681,10 +703,12 @@ defmodule Mydia.Downloads.Queue do
     # Add season pack metadata if present
     metadata_attrs =
       case search_result.metadata do
-        %SearchResultMetadata{season_pack: true, season_number: season_number} ->
+        %SearchResultMetadata{season_pack: true, season_number: season_number} = m ->
           Map.merge(metadata_attrs, %{
             season_pack: true,
-            season_number: season_number
+            season_number: season_number,
+            episode_count: m.episode_count,
+            episode_ids: m.episode_ids
           })
 
         _ ->

--- a/lib/mydia/downloads/structs/download_metadata.ex
+++ b/lib/mydia/downloads/structs/download_metadata.ex
@@ -18,6 +18,8 @@ defmodule Mydia.Downloads.Structs.DownloadMetadata do
     :quality,
     :season_pack,
     :season_number,
+    :episode_count,
+    :episode_ids,
     :download_protocol
   ]
 
@@ -28,6 +30,8 @@ defmodule Mydia.Downloads.Structs.DownloadMetadata do
           quality: QualityInfo.t() | nil,
           season_pack: boolean() | nil,
           season_number: integer() | nil,
+          episode_count: integer() | nil,
+          episode_ids: [String.t()] | nil,
           download_protocol: :torrent | :nzb | nil
         }
 
@@ -88,6 +92,8 @@ defmodule Mydia.Downloads.Structs.DownloadMetadata do
       quality: quality,
       season_pack: metadata.season_pack,
       season_number: metadata.season_number,
+      episode_count: metadata.episode_count,
+      episode_ids: metadata.episode_ids,
       download_protocol: metadata.download_protocol
     }
   end
@@ -128,6 +134,8 @@ defmodule Mydia.Downloads.Structs.DownloadMetadata do
       quality: quality,
       season_pack: map["season_pack"] || map[:season_pack],
       season_number: map["season_number"] || map[:season_number],
+      episode_count: map["episode_count"] || map[:episode_count],
+      episode_ids: map["episode_ids"] || map[:episode_ids],
       download_protocol: map["download_protocol"] || map[:download_protocol]
     })
   end

--- a/lib/mydia/indexers/structs/search_result_metadata.ex
+++ b/lib/mydia/indexers/structs/search_result_metadata.ex
@@ -25,7 +25,7 @@ defmodule Mydia.Indexers.Structs.SearchResultMetadata do
           season_pack: boolean() | nil,
           season_number: integer() | nil,
           episode_count: integer() | nil,
-          episode_ids: [integer()] | nil
+          episode_ids: [String.t()] | nil
         }
 
   @doc """
@@ -48,8 +48,8 @@ defmodule Mydia.Indexers.Structs.SearchResultMetadata do
 
   ## Examples
 
-      iex> season_pack(1, 10, [1, 2, 3])
-      %SearchResultMetadata{season_pack: true, season_number: 1, episode_count: 10, episode_ids: [1, 2, 3]}
+      iex> season_pack(1, 10, ["uuid-1", "uuid-2", "uuid-3"])
+      %SearchResultMetadata{season_pack: true, season_number: 1, episode_count: 10, episode_ids: ["uuid-1", "uuid-2", "uuid-3"]}
   """
   def season_pack(season_number, episode_count, episode_ids \\ []) do
     %__MODULE__{

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -234,6 +234,11 @@ defmodule Mydia.Jobs.MediaImport do
             file_count: length(imported_files)
           )
 
+          # Detect partial season packs: a download that claimed to deliver N
+          # episodes but actually matched fewer. Sets match_status accordingly
+          # so future re-imports and reporting can recognize it.
+          partial_pack_status = detect_partial_pack(download, imported_files)
+
           # Reload download to check if it was flagged as having unresolved files
           updated_download =
             Downloads.get_download!(download.id, preload: [:media_item, :episode, :library_path])
@@ -264,7 +269,7 @@ defmodule Mydia.Jobs.MediaImport do
             # This allows the download to appear in the Completed tab
             case Downloads.update_download(updated_download, %{
                    imported_at: DateTime.utc_now(),
-                   match_status: nil
+                   match_status: partial_pack_status
                  }) do
               {:ok, _updated} ->
                 Logger.info("Download marked as imported",
@@ -566,6 +571,40 @@ defmodule Mydia.Jobs.MediaImport do
         true ->
           {:error, :partial_import}
       end
+    end
+  end
+
+  # Returns "partial_pack" if a season-pack download delivered fewer distinct
+  # episodes than the search-time metadata promised; otherwise nil. The infinite
+  # re-download loop we hit in prod was bogus "season packs" that contained a
+  # single episode file — without this check, the download was marked as
+  # successfully imported and the next hourly search re-grabbed it.
+  defp detect_partial_pack(download, imported_files) do
+    metadata = download.metadata || %{}
+    expected_count = metadata["episode_count"]
+
+    cond do
+      not is_integer(expected_count) or expected_count <= 0 ->
+        nil
+
+      true ->
+        actual_count =
+          imported_files
+          |> Enum.map(& &1.episode_id)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.uniq()
+          |> length()
+
+        if actual_count < expected_count do
+          Logger.warning("Season pack delivered fewer episodes than promised",
+            download_id: download.id,
+            title: download.title,
+            expected_episode_count: expected_count,
+            matched_episode_count: actual_count
+          )
+
+          "partial_pack"
+        end
     end
   end
 

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -579,7 +579,8 @@ defmodule Mydia.Jobs.MediaImport do
   # re-download loop we hit in prod was bogus "season packs" that contained a
   # single episode file — without this check, the download was marked as
   # successfully imported and the next hourly search re-grabbed it.
-  defp detect_partial_pack(download, imported_files) do
+  @doc false
+  def detect_partial_pack(download, imported_files) do
     metadata = download.metadata || %{}
     expected_count = metadata["episode_count"]
 

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -86,6 +86,18 @@ defmodule Mydia.Jobs.MovieSearch do
     Application.get_env(:mydia, :auto_search, [])[:min_seeders] || 0
   end
 
+  # Merge user-supplied job-arg blocked_tags with the globally configured
+  # blocked_release_tokens so language/dub tokens applied via config flow
+  # into every auto-search without callers having to pass them.
+  defp merged_blocked_tags(args_blocked) do
+    config_tokens = Application.get_env(:mydia, :auto_search, [])[:blocked_release_tokens] || []
+
+    case (args_blocked || []) ++ config_tokens do
+      [] -> nil
+      tags -> Enum.uniq(tags)
+    end
+  end
+
   @spec perform(Oban.Job.t()) :: :ok | {:ok, term()} | {:error, term()} | {:snooze, pos_integer()}
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"mode" => "all_monitored"} = raw_args}) do
@@ -522,9 +534,9 @@ defmodule Mydia.Jobs.MovieSearch do
           |> Keyword.merge(build_quality_options(quality_profile, :movie))
       end
 
-    # Add any custom blocked/preferred tags from args
+    # Add any custom blocked/preferred tags from args (merged with config tokens)
     opts_with_quality
-    |> maybe_add_option(:blocked_tags, args.blocked_tags)
+    |> maybe_add_option(:blocked_tags, merged_blocked_tags(args.blocked_tags))
     |> maybe_add_option(:preferred_tags, args.preferred_tags)
   end
 

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -55,6 +55,7 @@ defmodule Mydia.Jobs.TVShowSearch do
 
   alias Mydia.{Repo, Media, Indexers, Downloads, Events, Search}
   alias Mydia.Indexers.ReleaseRanker
+  alias Mydia.Indexers.Structs.SearchResultMetadata
   alias Mydia.Media.{MediaItem, Episode}
   alias Mydia.Library.MediaFile
   alias Phoenix.PubSub
@@ -141,6 +142,18 @@ defmodule Mydia.Jobs.TVShowSearch do
   # Get min_seeders from config (defaults to 0 for Usenet compatibility)
   defp get_min_seeders do
     Application.get_env(:mydia, :auto_search, [])[:min_seeders] || 0
+  end
+
+  # Merge user-supplied job-arg blocked_tags with the globally configured
+  # blocked_release_tokens so language/dub tokens applied via config flow
+  # into every auto-search without callers having to pass them.
+  defp merged_blocked_tags(args_blocked) do
+    config_tokens = Application.get_env(:mydia, :auto_search, [])[:blocked_release_tokens] || []
+
+    case (args_blocked || []) ++ config_tokens do
+      [] -> nil
+      tags -> Enum.uniq(tags)
+    end
   end
 
   @spec perform(Oban.Job.t()) :: :ok | {:ok, term()} | {:error, term()} | {:snooze, pos_integer()}
@@ -1193,9 +1206,9 @@ defmodule Mydia.Jobs.TVShowSearch do
           |> Keyword.merge(build_quality_options(quality_profile, :episode))
       end
 
-    # Add any custom blocked/preferred tags from args
+    # Add any custom blocked/preferred tags from args (merged with config tokens)
     opts_with_quality
-    |> maybe_add_option(:blocked_tags, args.blocked_tags)
+    |> maybe_add_option(:blocked_tags, merged_blocked_tags(args.blocked_tags))
     |> maybe_add_option(:preferred_tags, args.preferred_tags)
   end
 
@@ -1235,9 +1248,9 @@ defmodule Mydia.Jobs.TVShowSearch do
           end
       end
 
-    # Add any custom blocked/preferred tags from args
+    # Add any custom blocked/preferred tags from args (merged with config tokens)
     opts_with_quality
-    |> maybe_add_option(:blocked_tags, args.blocked_tags)
+    |> maybe_add_option(:blocked_tags, merged_blocked_tags(args.blocked_tags))
     |> maybe_add_option(:preferred_tags, args.preferred_tags)
   end
 
@@ -1347,15 +1360,15 @@ defmodule Mydia.Jobs.TVShowSearch do
     # The download will include metadata about the season pack
     # The import job will later match files to individual episodes
 
-    # Build metadata with season pack information
-    metadata = %{
-      season_pack: true,
-      season_number: season_number,
-      episode_count: length(episodes),
-      episode_ids: Enum.map(episodes, & &1.id)
-    }
+    # Build season pack metadata struct so dedup pattern matches in
+    # Mydia.Downloads.Queue and persistence in DownloadMetadata work correctly.
+    metadata =
+      SearchResultMetadata.season_pack(
+        season_number,
+        length(episodes),
+        Enum.map(episodes, & &1.id)
+      )
 
-    # Add metadata to the result
     result_with_metadata = Map.put(result, :metadata, metadata)
 
     case Downloads.initiate_download(result_with_metadata, media_item_id: media_item.id) do

--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -230,9 +230,15 @@ defmodule Mydia.DownloadsTest do
       end)
 
       Bypass.stub(bypass, "GET", "/file.torrent", fn conn ->
+        # Minimal valid torrent metainfo: announce + info dict with name/length.
+        # ContentType.detect/1 requires a structurally valid bencode metainfo
+        # (must contain an `info` dict), not just a `d8:announce…` prefix.
+        torrent_body =
+          "d8:announce0:4:infod6:lengthi42e4:name8:test.binee"
+
         conn
         |> Plug.Conn.put_resp_content_type("application/x-bittorrent")
-        |> Plug.Conn.resp(200, "d8:announce0:e")
+        |> Plug.Conn.resp(200, torrent_body)
       end)
 
       url_result = %{search_result | download_url: "http://localhost:#{bypass.port}/file.torrent"}

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -130,7 +130,7 @@ defmodule Mydia.Jobs.MediaImportTest do
     end
   end
 
-
+  describe "perform/1" do
     test "schedules retry when download is not completed (first snooze)" do
       media_item = media_item_fixture()
 

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -462,9 +462,9 @@ defmodule Mydia.Jobs.MediaImportTest do
 
       assert {:error, :client_error} =
                perform_job(MediaImport, %{
-                  "download_id" => download.id,
-                  "save_path" => ""
-                })
+                 "download_id" => download.id,
+                 "save_path" => ""
+               })
     end
 
     @tag :tmp_dir
@@ -495,9 +495,9 @@ defmodule Mydia.Jobs.MediaImportTest do
 
       assert {:error, {:path_not_found, "/no/such/path/exists"}} =
                perform_job(MediaImport, %{
-                  "download_id" => download.id,
-                  "save_path" => "/no/such/path/exists"
-                })
+                 "download_id" => download.id,
+                 "save_path" => "/no/such/path/exists"
+               })
 
       updated = Mydia.Downloads.get_download!(download.id)
       assert updated.import_last_error =~ "Download path not found"

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -45,7 +45,92 @@ defmodule Mydia.Jobs.MediaImportTest do
     end
   end
 
-  describe "perform/1" do
+  describe "detect_partial_pack/2" do
+    test "returns 'partial_pack' when fewer episodes are imported than promised" do
+      episode_id = Ecto.UUID.generate()
+
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Test.Show.S01.Pack",
+        metadata: %{"episode_count" => 3}
+      }
+
+      # Only 1 distinct episode imported, but 3 were promised
+      imported_files = [%{episode_id: episode_id}]
+
+      assert "partial_pack" == MediaImport.detect_partial_pack(download, imported_files)
+    end
+
+    test "returns nil when all promised episodes are delivered" do
+      ids = Enum.map(1..3, fn _ -> Ecto.UUID.generate() end)
+
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Test.Show.S01.Pack",
+        metadata: %{"episode_count" => 3}
+      }
+
+      imported_files = Enum.map(ids, fn id -> %{episode_id: id} end)
+
+      assert nil == MediaImport.detect_partial_pack(download, imported_files)
+    end
+
+    test "returns nil when metadata has no episode_count" do
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Test.Show.S01E01",
+        metadata: %{}
+      }
+
+      imported_files = [%{episode_id: Ecto.UUID.generate()}]
+
+      assert nil == MediaImport.detect_partial_pack(download, imported_files)
+    end
+
+    test "returns nil when download has no metadata" do
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Test.Show.S01E01",
+        metadata: nil
+      }
+
+      imported_files = [%{episode_id: Ecto.UUID.generate()}]
+
+      assert nil == MediaImport.detect_partial_pack(download, imported_files)
+    end
+
+    test "deduplicates episode_ids before comparing counts" do
+      episode_id = Ecto.UUID.generate()
+
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Test.Show.S01.Pack",
+        metadata: %{"episode_count" => 1}
+      }
+
+      # Two files pointing to the same episode — should count as 1 distinct episode
+      imported_files = [%{episode_id: episode_id}, %{episode_id: episode_id}]
+
+      assert nil == MediaImport.detect_partial_pack(download, imported_files)
+    end
+
+    test "ignores imported files without an episode_id (e.g. extras)" do
+      episode_id = Ecto.UUID.generate()
+
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Test.Show.S01.Pack",
+        metadata: %{"episode_count" => 2}
+      }
+
+      # One real episode + one file with no episode_id (extra/featurette)
+      imported_files = [%{episode_id: episode_id}, %{episode_id: nil}]
+
+      assert "partial_pack" == MediaImport.detect_partial_pack(download, imported_files)
+    end
+  end
+
+
     test "schedules retry when download is not completed (first snooze)" do
       media_item = media_item_fixture()
 

--- a/test/mydia/jobs/usenet_import_integration_test.exs
+++ b/test/mydia/jobs/usenet_import_integration_test.exs
@@ -242,7 +242,7 @@ defmodule Mydia.Jobs.UsenetImportIntegrationTest do
           download_client_id: "777"
         })
 
-      assert {:error, :client_error} =
+      assert {:error, {:path_not_found, "/nonexistent/path/that/does/not/exist"}} =
                perform_job(MediaImport, %{
                  "download_id" => download.id,
                  "save_path" => "/nonexistent/path/that/does/not/exist"


### PR DESCRIPTION
## Summary

Production was re-grabbing the same TV "season pack" torrents once per hour, indefinitely. In a 7-day window: `Your.Friends.and.Neighbors.S02.1080p.ATVP.WEB-DL.H.264` was initiated **170 times**, `From.S04.WEB-DL.1080p.UkrEng` **100 times**, `Stillwater.S01.1080p.WEBRip.x265[eztv.re]` **79 times**.

Each cycle the import "succeeded" by matching a single E01 file from a bogus pack, so S04E01 accumulated 3 active media_files (one English HEVC, one Russian dub, one Ukrainian) while E02–E10 stayed at zero files. Next hour's search saw 90% missing, re-selected the same release as best result, and re-imported — duplicate-download guards never tripped.

## Root cause (three compounding bugs)

1. **Plain-map vs struct metadata** — `tv_show_search.ex:1351-1356` wrote season-pack metadata as a plain map, but `queue.ex:225-228, 297-300, 684` pattern-matched `%SearchResultMetadata{}`. Every season-pack-aware code path was unreachable, including the persistence branch in `create_download_record/4` — so DB rows had `season_pack: null` and downstream readers treated them as non-pack downloads.

2. **Generic tv_show fallthrough** — `check_for_existing_media_files` ends in a `media_item_id ->` clause that returns `:ok` unconditionally for `type: "tv_show"`. With #1 in place, season packs always reached this fallthrough.

3. **No coverage verification on import** — `media_import.ex` never read `download.metadata.episode_ids` / `episode_count`. A "season pack" delivering one `.mkv` was marked `imported_at: …, match_status: nil` and considered fully successful.

## Fixes

- `tv_show_search.ex` builds metadata via `SearchResultMetadata.season_pack/3` so the struct survives the trip into `Queue`.
- `Queue.initiate_download/2` normalizes `search_result.metadata` to a struct at entry (defense-in-depth — future callers can pass plain maps without breaking dedup).
- `DownloadMetadata` gains `episode_count` and `episode_ids` fields; both are persisted on season-pack downloads.
- `MediaImport.detect_partial_pack/2` compares matched episode IDs against `metadata.episode_count`; sets `match_status: "partial_pack"` and logs a warning when a pack underdelivers.
- New `config :mydia, :auto_search, blocked_release_tokens: []` feeds into `ReleaseRanker.blocked_tags` for both TV and movie searches. Users can globally reject language/dub tokens (`UkrEng`, `[DUB]`, `Dragon Money`) without setting them per-job.

## Out of scope

**Bug 4** — `import_file_to_destination/6` deduplicates by destination path only, so two release groups produce two `media_files` rows for the same `episode_id`. This needs a proper upgrade policy (replace / keep-both / skip based on quality profile), tracked separately.

## Test plan

- [ ] CI: `mix precommit` (compile + format + credo + test) — couldn't run locally; dev image predates the Rust addition and `./dev` rebuild hits an unrelated PATH bug in `Dockerfile.dev:36`
- [ ] Verify on prod after deploy: in the activity feed, `download.initiated` events for the offending titles (FROM S04, Your Friends & Neighbors S02, Stillwater S01) stop recurring hourly
- [ ] Check `downloads.metadata` JSON for new season-pack rows: should contain `season_pack: true, season_number: N, episode_count: M, episode_ids: [...]`
- [ ] Trigger a known-bad pack manually; confirm `match_status = "partial_pack"` is set and the warning is logged
- [ ] Set `blocked_release_tokens: ["UkrEng", "[DUB]"]` in runtime config; rerun TV auto-search; confirm those releases are filtered from results