### PR TITLE
test(downloads): use valid metainfo body in URL download fixture

### DIFF
--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -230,9 +230,15 @@ defmodule Mydia.DownloadsTest do
       end)
 
       Bypass.stub(bypass, "GET", "/file.torrent", fn conn ->
+        # Minimal valid torrent metainfo: announce + info dict with name/length.
+        # ContentType.detect/1 requires a structurally valid bencode metainfo
+        # (must contain an `info` dict), not just a `d8:announce…` prefix.
+        torrent_body =
+          "d8:announce0:4:infod6:lengthi42e4:name8:test.binee"
+
         conn
         |> Plug.Conn.put_resp_content_type("application/x-bittorrent")
-        |> Plug.Conn.resp(200, "d8:announce0:e")
+        |> Plug.Conn.resp(200, torrent_body)
       end)
 
       url_result = %{search_result | download_url: "http://localhost:#{bypass.port}/file.torrent"}


### PR DESCRIPTION
## Summary

The `Mydia.DownloadsTest "handles URL download links"` test has been failing on master since 38dcdec (`fix(downloads): detect trackerless torrents structurally`). The bypass stub returns `"d8:announce0:e"` — a bencode dict with an empty announce string and no `info` dict — which the new structural classifier (`ContentType.detect/1` → `TorrentHash.valid_metainfo?/1`) correctly rejects as `:unknown`.

This blocks both `Test` and `Test / PostgreSQL` jobs on every PR.

## Fix

Replace the stub body with a minimal but structurally valid metainfo dict: `"d8:announce0:4:infod6:lengthi42e4:name8:test.binee"` (announce + info{length, name}).

## Test plan

- [ ] CI: `Test` and `Test / PostgreSQL` go green
- [ ] `mix test test/mydia/downloads_test.exs` passes the URL-download test