### PR TITLE
feat(metadata): configurable language for TMDB/TVDB requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,11 @@ SQLITE_BUSY_TIMEOUT=5000
 # Defaults to https://metadata-relay.fly.dev if not set
 # METADATA_RELAY_URL=https://metadata-relay.fly.dev
 
+# Language sent to TMDB/TVDB through the metadata relay (ISO 639-1 or BCP 47).
+# Affects displayed titles, descriptions, and posters. Defaults to en-US.
+# Can also be set from Settings → Configuration → Metadata in the admin UI.
+# METADATA_LANGUAGE=en-US
+
 # Authentication Configuration
 # ----------------------------
 # Enable local username/password authentication

--- a/compose.yml
+++ b/compose.yml
@@ -40,6 +40,7 @@ services:
 
       # Metadata relay configuration
       METADATA_RELAY_URL: ${METADATA_RELAY_URL:-https://relay.mydia.dev}
+      METADATA_LANGUAGE: ${METADATA_LANGUAGE:-en-US}
 
       # P2P bind port for direct connections (iroh hole punching)
       # Must match the exposed UDP port below

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -156,8 +156,11 @@ For PostgreSQL deployments (using `latest-pg` image):
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `METADATA_RELAY_URL` | URL for the metadata relay service | `https://relay.mydia.dev` |
+| `METADATA_LANGUAGE` | Language sent to TMDB/TVDB for titles, descriptions, and posters. Accepts ISO 639-1 codes (`de`) or BCP 47 tags (`de-DE`, `pt-BR`). | `en-US` |
 
 The metadata relay proxies requests to TVDB/TMDB and handles remote access relay connections. See [Architecture](../development/architecture.md) for details.
+
+`METADATA_LANGUAGE` can also be set per-instance from **Settings → Configuration → Metadata** in the admin UI; the env var overrides the database value when both are set.
 
 ## FlareSolverr
 

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -122,6 +122,7 @@ defmodule Mydia.Config.Loader do
       database: load_database_env(),
       auth: load_auth_env(),
       media: load_media_env(),
+      metadata: load_metadata_env(),
       downloads: load_downloads_env(),
       logging: load_logging_env(),
       oban: load_oban_env(),
@@ -191,6 +192,11 @@ defmodule Mydia.Config.Loader do
     )
     |> put_if_present(:auto_search_on_add, System.get_env("AUTO_SEARCH_ON_ADD"), &parse_boolean/1)
     |> put_if_present(:monitor_by_default, System.get_env("MONITOR_BY_DEFAULT"), &parse_boolean/1)
+  end
+
+  defp load_metadata_env do
+    %{}
+    |> put_if_present(:language, System.get_env("METADATA_LANGUAGE"))
   end
 
   defp load_downloads_env do

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -14,6 +14,7 @@ defmodule Mydia.Config.Schema do
           database: __MODULE__.Database.t() | nil,
           auth: __MODULE__.Auth.t() | nil,
           media: __MODULE__.Media.t() | nil,
+          metadata: __MODULE__.Metadata.t() | nil,
           downloads: __MODULE__.Downloads.t() | nil,
           logging: __MODULE__.Logging.t() | nil,
           oban: __MODULE__.Oban.t() | nil,
@@ -69,6 +70,12 @@ defmodule Mydia.Config.Schema do
       field :monitor_by_default, :boolean, default: true
       field :season_refresh_threshold_hours, :integer, default: 24
       field :completed_show_refresh_threshold_hours, :integer, default: 168
+    end
+
+    embeds_one :metadata, Metadata, on_replace: :update, primary_key: false do
+      # Language sent to TMDB/TVDB through metadata-relay. Accepts ISO 639-1
+      # codes ("de") or BCP 47 language tags ("de-DE", "pt-BR").
+      field :language, :string, default: "en-US"
     end
 
     embeds_one :downloads, Downloads, on_replace: :update, primary_key: false do
@@ -159,6 +166,7 @@ defmodule Mydia.Config.Schema do
     |> cast_embed(:database, with: &database_changeset/2)
     |> cast_embed(:auth, with: &auth_changeset/2)
     |> cast_embed(:media, with: &media_changeset/2)
+    |> cast_embed(:metadata, with: &metadata_changeset/2)
     |> cast_embed(:downloads, with: &downloads_changeset/2)
     |> cast_embed(:logging, with: &logging_changeset/2)
     |> cast_embed(:oban, with: &oban_changeset/2)
@@ -242,6 +250,13 @@ defmodule Mydia.Config.Schema do
     |> validate_number(:scan_interval_hours, greater_than: 0)
     |> validate_number(:season_refresh_threshold_hours, greater_than: 0)
     |> validate_number(:completed_show_refresh_threshold_hours, greater_than: 0)
+  end
+
+  defp metadata_changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:language])
+    |> validate_required([:language])
+    |> validate_length(:language, min: 2, max: 16)
   end
 
   defp downloads_changeset(schema, attrs) do
@@ -436,6 +451,7 @@ defmodule Mydia.Config.Schema do
       database: %__MODULE__.Database{},
       auth: %__MODULE__.Auth{},
       media: %__MODULE__.Media{},
+      metadata: %__MODULE__.Metadata{},
       downloads: %__MODULE__.Downloads{},
       logging: %__MODULE__.Logging{},
       oban: %__MODULE__.Oban{},

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -342,13 +342,38 @@ defmodule Mydia.Metadata do
   end
 
   @doc """
+  Gets the configured metadata language.
+
+  The language is sent to TMDB/TVDB through the metadata-relay so titles,
+  descriptions, and image translations come back in the user's preferred locale.
+  Resolved through the standard 4-layer config precedence:
+  `METADATA_LANGUAGE` env var → admin DB setting (`metadata.language`) → YAML
+  config (`metadata.language`) → schema default (`"en-US"`).
+
+  Accepts any value the underlying provider understands — typically an ISO 639-1
+  code (`"de"`) or BCP 47 language tag (`"de-DE"`, `"pt-BR"`).
+
+  ## Examples
+
+      iex> Mydia.Metadata.metadata_language()
+      "en-US"
+  """
+  def metadata_language do
+    case Mydia.Settings.get_metadata_config() do
+      %{language: lang} when is_binary(lang) and lang != "" -> lang
+      _ -> "en-US"
+    end
+  end
+
+  @doc """
   Gets the default metadata relay configuration.
 
   This provides a ready-to-use configuration for the metadata-relay service
   that doesn't require an API key.
 
   The base URL can be configured via the METADATA_RELAY_URL environment variable,
-  defaulting to the self-hosted relay on Fly.io if not set.
+  defaulting to the self-hosted relay on Fly.io if not set. The metadata language
+  can be configured via the METADATA_LANGUAGE environment variable.
 
   ## Examples
 
@@ -364,7 +389,7 @@ defmodule Mydia.Metadata do
       type: :metadata_relay,
       base_url: metadata_relay_url(),
       options: %{
-        language: "en-US",
+        language: metadata_language(),
         include_adult: false,
         timeout: 30_000
       }
@@ -375,7 +400,8 @@ defmodule Mydia.Metadata do
   Gets the default TVDB relay configuration.
 
   The base URL can be configured via the METADATA_RELAY_URL environment variable,
-  defaulting to the self-hosted relay on Fly.io if not set.
+  defaulting to the self-hosted relay on Fly.io if not set. The metadata language
+  can be configured via the METADATA_LANGUAGE environment variable.
 
   ## Examples
 
@@ -391,7 +417,7 @@ defmodule Mydia.Metadata do
       type: :metadata_relay,
       base_url: metadata_relay_url(),
       options: %{
-        language: "en-US",
+        language: metadata_language(),
         timeout: 30_000
       }
     }

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -78,6 +78,20 @@ defmodule Mydia.Metadata.Provider.Relay do
 
   @default_language "en-US"
 
+  # Resolves the language to use for a request: explicit per-call opt wins,
+  # then the language configured on the provider config (typically populated
+  # from `Mydia.Metadata.metadata_language/0`), then the module default.
+  defp config_language(config) do
+    case config do
+      %{options: %{language: lang}} when is_binary(lang) and lang != "" -> lang
+      _ -> @default_language
+    end
+  end
+
+  defp resolve_language(config, opts) do
+    Keyword.get(opts, :language, config_language(config))
+  end
+
   @impl true
   def test_connection(config) do
     req = HTTP.new_request(config)
@@ -110,7 +124,7 @@ defmodule Mydia.Metadata.Provider.Relay do
   defp search_tmdb(config, query, opts) do
     media_type = Keyword.get(opts, :media_type)
     year = Keyword.get(opts, :year)
-    language = Keyword.get(opts, :language, @default_language)
+    language = resolve_language(config, opts)
     include_adult = Keyword.get(opts, :include_adult, false)
     page = Keyword.get(opts, :page, 1)
 
@@ -201,7 +215,7 @@ defmodule Mydia.Metadata.Provider.Relay do
 
   # Perform the actual TMDB fetch after validation
   defp perform_tmdb_fetch(config, provider_id, media_type, opts) do
-    language = Keyword.get(opts, :language, @default_language)
+    language = resolve_language(config, opts)
     append = Keyword.get(opts, :append_to_response, ["credits", "alternative_titles", "videos"])
 
     endpoint = build_details_endpoint(media_type, provider_id)
@@ -583,7 +597,7 @@ defmodule Mydia.Metadata.Provider.Relay do
   end
 
   defp fetch_season_tmdb(config, provider_id, season_number, opts) do
-    language = Keyword.get(opts, :language, @default_language)
+    language = resolve_language(config, opts)
 
     endpoint = "/tmdb/tv/shows/#{provider_id}/#{season_number}"
     params = [language: language]
@@ -677,7 +691,7 @@ defmodule Mydia.Metadata.Provider.Relay do
   @impl true
   def fetch_trending(config, opts \\ []) do
     media_type = Keyword.get(opts, :media_type)
-    language = Keyword.get(opts, :language, @default_language)
+    language = resolve_language(config, opts)
     page = Keyword.get(opts, :page, 1)
 
     endpoint = build_trending_endpoint(media_type)
@@ -709,7 +723,7 @@ defmodule Mydia.Metadata.Provider.Relay do
   """
   def fetch_curated(config, list_type, opts \\ []) do
     media_type = Keyword.get(opts, :media_type, :movie)
-    language = Keyword.get(opts, :language, @default_language)
+    language = resolve_language(config, opts)
     page = Keyword.get(opts, :page, 1)
 
     endpoint = build_curated_endpoint(list_type, media_type)
@@ -743,7 +757,7 @@ defmodule Mydia.Metadata.Provider.Relay do
   Returns `{:ok, %{results: [SearchResult], page: int, total_pages: int}}`.
   """
   def fetch_discover(config, media_type, opts \\ []) do
-    language = Keyword.get(opts, :language, @default_language)
+    language = resolve_language(config, opts)
     page = Keyword.get(opts, :page, 1)
     genres = Keyword.get(opts, :genres)
     original_language = Keyword.get(opts, :original_language)

--- a/lib/mydia/settings.ex
+++ b/lib/mydia/settings.ex
@@ -770,6 +770,12 @@ defmodule Mydia.Settings do
   defdelegate get_media_config(), to: Mydia.Settings.RuntimeConfig
 
   @doc """
+  Gets metadata provider configuration.
+  """
+  @spec get_metadata_config() :: Mydia.Config.Schema.Metadata.t()
+  defdelegate get_metadata_config(), to: Mydia.Settings.RuntimeConfig
+
+  @doc """
   Gets downloads configuration.
   """
   @spec get_downloads_config() :: Mydia.Config.Schema.Downloads.t() | nil

--- a/lib/mydia/settings/config_setting.ex
+++ b/lib/mydia/settings/config_setting.ex
@@ -67,6 +67,7 @@ defmodule Mydia.Settings.ConfigSetting do
     :server,
     :auth,
     :media,
+    :metadata,
     :downloads,
     :notifications,
     :crash_reporting,

--- a/lib/mydia/settings/runtime_config.ex
+++ b/lib/mydia/settings/runtime_config.ex
@@ -96,6 +96,13 @@ defmodule Mydia.Settings.RuntimeConfig do
     get_runtime_config().media
   end
 
+  def get_metadata_config do
+    case get_runtime_config() do
+      %{metadata: %_{} = metadata} -> metadata
+      _ -> %Mydia.Config.Schema.Metadata{}
+    end
+  end
+
   def get_downloads_config do
     get_runtime_config().downloads
   end

--- a/lib/mydia_web/live/admin_settings_live/components.ex
+++ b/lib/mydia_web/live/admin_settings_live/components.ex
@@ -196,6 +196,7 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
   defp category_icon("Database"), do: "hero-circle-stack"
   defp category_icon("Authentication"), do: "hero-finger-print"
   defp category_icon("Media"), do: "hero-film"
+  defp category_icon("Metadata"), do: "hero-language"
   defp category_icon("Downloads"), do: "hero-arrow-down-tray"
   defp category_icon("Crash Reporting"), do: "hero-bug-ant"
   defp category_icon("Notifications"), do: "hero-bell"

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -218,6 +218,7 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
       end
 
     flaresolverr = config.flaresolverr || %Mydia.Config.Schema.FlareSolverr{}
+    metadata = config.metadata || %Mydia.Config.Schema.Metadata{}
 
     # Fetch all DB settings in one query to avoid N+1 per-key lookups
     all_db_settings = Settings.list_config_settings() |> Map.new(&{&1.key, &1})
@@ -307,6 +308,18 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
           value: config.media.scan_interval_hours,
           source:
             get_source("MEDIA_SCAN_INTERVAL_HOURS", "media.scan_interval_hours", all_db_settings)
+        }
+      ],
+      "Metadata" => [
+        %{
+          key: "metadata.language",
+          label: "Language",
+          description:
+            "Locale sent to TMDB/TVDB through the metadata relay (ISO 639-1 like \"de\" or BCP 47 like \"de-DE\"). Affects displayed titles, descriptions, and posters.",
+          type: :string,
+          value: metadata.language,
+          placeholder: "en-US",
+          source: get_source("METADATA_LANGUAGE", "metadata.language", all_db_settings)
         }
       ],
       "Downloads" => [
@@ -488,6 +501,7 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
       "Database" -> :general
       "Authentication" -> :auth
       "Media" -> :media
+      "Metadata" -> :metadata
       "Downloads" -> :downloads
       "Crash Reporting" -> :crash_reporting
       "Notifications" -> :notifications

--- a/test/mydia/config/loader_test.exs
+++ b/test/mydia/config/loader_test.exs
@@ -35,6 +35,7 @@ defmodule Mydia.Config.LoaderTest do
         "OIDC_CLIENT_SECRET",
         "MOVIES_PATH",
         "TV_PATH",
+        "METADATA_LANGUAGE",
         "LOG_LEVEL",
         "OBAN_POLL_INTERVAL"
       ] ++ download_client_vars
@@ -213,6 +214,15 @@ defmodule Mydia.Config.LoaderTest do
       assert config.server.port == 5000
       assert config.database.pool_size == 15
       assert config.oban.poll_interval == 2000
+    end
+
+    test "metadata language defaults to en-US and is overridden by METADATA_LANGUAGE env var" do
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+      assert config.metadata.language == "en-US"
+
+      System.put_env("METADATA_LANGUAGE", "pt-BR")
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+      assert config.metadata.language == "pt-BR"
     end
 
     test "returns error for invalid configuration" do

--- a/test/mydia/metadata_test.exs
+++ b/test/mydia/metadata_test.exs
@@ -385,4 +385,39 @@ defmodule Mydia.MetadataTest do
       assert config.base_url == "https://relay.mydia.dev"
     end
   end
+
+  describe "metadata_language/0" do
+    setup do
+      original = Application.get_env(:mydia, :runtime_config)
+      on_exit(fn -> Application.put_env(:mydia, :runtime_config, original) end)
+      :ok
+    end
+
+    test "reads the language from the merged runtime config" do
+      Application.put_env(
+        :mydia,
+        :runtime_config,
+        %Mydia.Config.Schema{metadata: %Mydia.Config.Schema.Metadata{language: "de-DE"}}
+      )
+
+      assert Metadata.metadata_language() == "de-DE"
+      assert Metadata.default_relay_config().options.language == "de-DE"
+      assert Metadata.default_tvdb_relay_config().options.language == "de-DE"
+    end
+
+    test "falls back to en-US when no language is configured" do
+      Application.put_env(
+        :mydia,
+        :runtime_config,
+        %Mydia.Config.Schema{metadata: %Mydia.Config.Schema.Metadata{language: nil}}
+      )
+
+      assert Metadata.metadata_language() == "en-US"
+    end
+
+    test "falls back to en-US when runtime_config is unset" do
+      Application.delete_env(:mydia, :runtime_config)
+      assert Metadata.metadata_language() == "en-US"
+    end
+  end
 end

--- a/test/mydia/metadata_test.exs
+++ b/test/mydia/metadata_test.exs
@@ -389,15 +389,25 @@ defmodule Mydia.MetadataTest do
   describe "metadata_language/0" do
     setup do
       original = Application.get_env(:mydia, :runtime_config)
-      on_exit(fn -> Application.put_env(:mydia, :runtime_config, original) end)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:mydia, :runtime_config, original)
+        else
+          Application.delete_env(:mydia, :runtime_config)
+        end
+      end)
+
       :ok
     end
 
     test "reads the language from the merged runtime config" do
+      base = Mydia.Config.Schema.defaults()
+
       Application.put_env(
         :mydia,
         :runtime_config,
-        %Mydia.Config.Schema{metadata: %Mydia.Config.Schema.Metadata{language: "de-DE"}}
+        %{base | metadata: %Mydia.Config.Schema.Metadata{language: "de-DE"}}
       )
 
       assert Metadata.metadata_language() == "de-DE"
@@ -406,10 +416,12 @@ defmodule Mydia.MetadataTest do
     end
 
     test "falls back to en-US when no language is configured" do
+      base = Mydia.Config.Schema.defaults()
+
       Application.put_env(
         :mydia,
         :runtime_config,
-        %Mydia.Config.Schema{metadata: %Mydia.Config.Schema.Metadata{language: nil}}
+        %{base | metadata: %Mydia.Config.Schema.Metadata{language: nil}}
       )
 
       assert Metadata.metadata_language() == "en-US"


### PR DESCRIPTION
## Summary

- Adds a `metadata.language` setting that controls the language sent to TMDB/TVDB through the metadata relay (titles, descriptions, posters).
- Plumbs it through the standard 4-layer config: `METADATA_LANGUAGE` env var > admin DB setting (Settings → Configuration → Metadata) > `metadata.language` in `config.yml` > schema default `"en-US"`.
- Wires the previously-unused `config.options.language` field into `Mydia.Metadata.Provider.Relay` so per-call opts still win, but `default_relay_config/0` now actually drives the language used for search, fetch_by_id, fetch_season, trending, curated, and discover.

Closes #111.

## What changed

- New `embeds_one :metadata` schema (`Mydia.Config.Schema.Metadata`) with a `language` field.
- `Mydia.Config.Loader.load_metadata_env/0` reads `METADATA_LANGUAGE`.
- `Mydia.Settings.get_metadata_config/0` exposes the merged config.
- `Mydia.Metadata.metadata_language/0` reads from the runtime config (so all four layers work) and feeds `default_relay_config/0` and `default_tvdb_relay_config/0`.
- `Mydia.Metadata.Provider.Relay` adds `resolve_language/2`: per-call opt > `config.options.language` > module default — so calls that don't pass `:language` (most of them) now respect the configured locale.
- New `:metadata` category on `ConfigSetting`; admin Settings UI gains a "Metadata" section showing source (ENV / DB / Default).
- Docs (`docs/reference/environment-variables.md`), `.env.example`, and `compose.yml` updated.

TMDB **image fetches** intentionally keep their opt-in behavior (only sending `language` when explicitly passed) — auto-filling it would change which poster/backdrop sets the relay returns and risks regressions for existing users. The primary movie/show poster comes from the main details endpoint, which now respects the locale.

TVDB extended-series fetches still prefer English in the parser (`transform_tvdb_to_tmdb_format`) — out of scope for this change; that requires a deeper translation-selection refactor.

## Test plan

- [ ] CI green (full test suite)
- [x] `./dev mix test test/mydia/metadata_test.exs test/mydia/config/loader_test.exs` — 48 passing
- [x] `./dev mix test test/mydia/settings_test.exs test/mydia/config/ test/mydia/metadata_test.exs test/mydia/metadata/` — 314 passing
- [x] `./dev mix test test/mydia_web/live/admin_settings_live_test.exs` — 3 passing
- [ ] Manual: set `METADATA_LANGUAGE=de-DE`, search/add a movie, verify German title + description + poster come back from the relay
- [ ] Manual: clear env var, set "Metadata > Language" to `pt-BR` in admin UI, restart, verify Portuguese metadata flows through