### PR TITLE
fix(import): handle word-form Season/Episode filenames

### DIFF
--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -938,7 +938,8 @@ defmodule Mydia.Jobs.MediaImport do
           end
 
         # TV show with parsed episode info - look up the episode
-        {%{type: "tv_show"} = media_item, _, :tv_show, _} when not is_nil(parsed.season) ->
+        {%{type: "tv_show"} = media_item, _, :tv_show, _}
+        when not is_nil(parsed.season) and not is_nil(parsed.episodes) ->
           episode_number = List.first(parsed.episodes) || 1
 
           episode =
@@ -975,6 +976,28 @@ defmodule Mydia.Jobs.MediaImport do
             dest_dir = build_destination_path(download, library_path)
             {download.episode, dest_dir}
           end
+
+        # TV show file where the parser found a season but no episode
+        # number (e.g. `Show.S01.mkv`, or season-pack files that don't
+        # carry an `SxxEyy` marker). Don't silently default to episode 1
+        # — return :unresolved so the file shows up in the issues queue
+        # for manual resolution.
+        {%{type: "tv_show"} = media_item, _, :tv_show, _}
+        when not is_nil(parsed.season) and is_nil(parsed.episodes) ->
+          Logger.warning("TV file has parseable season but no episode number — skipping",
+            file: file.name,
+            season: parsed.season,
+            media_item: media_item.title
+          )
+
+          {:unresolved,
+           %{
+             path: file.path,
+             name: file.name,
+             size: file.size,
+             parsed_season: parsed.season,
+             parsed_episode: nil
+           }}
 
         # TV show but no parsed info - use download episode
         {%{type: "tv_show"}, episode, _, _} when not is_nil(episode) ->

--- a/lib/mydia/library/release_parser/resolver.ex
+++ b/lib/mydia/library/release_parser/resolver.ex
@@ -367,9 +367,13 @@ defmodule Mydia.Library.ReleaseParser.Resolver do
   end
 
   defp verbose_episode_extract([%Token{value: word} | [%Token{value: ep_str} | _]]) do
+    # The episode-number token may have trailing punctuation (e.g.
+    # "Episode 1- The Deal" leaves "1-" attached because the tokenizer
+    # only splits on whitespace / dot / underscore). Match the leading
+    # digit run instead of demanding a clean integer.
     if String.downcase(word) == "episode" do
-      case Integer.parse(ep_str) do
-        {ep, ""} -> {:ok, [ep]}
+      case Regex.run(~r/^(\d+)/, ep_str) do
+        [_, digits] -> {:ok, [String.to_integer(digits)]}
         _ -> :error
       end
     else

--- a/lib/mydia/library/release_parser/resolver.ex
+++ b/lib/mydia/library/release_parser/resolver.ex
@@ -372,7 +372,7 @@ defmodule Mydia.Library.ReleaseParser.Resolver do
     # only splits on whitespace / dot / underscore). Match the leading
     # digit run instead of demanding a clean integer.
     if String.downcase(word) == "episode" do
-      case Regex.run(~r/^(\d+)/, ep_str) do
+      case Regex.run(~r/^(\d+)(?![a-zA-Z\d])/, ep_str) do
         [_, digits] -> {:ok, [String.to_integer(digits)]}
         _ -> :error
       end

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -468,6 +468,70 @@ defmodule Mydia.Jobs.MediaImportTest do
     end
 
     @tag :tmp_dir
+    test "TV file with parsable season but nil episodes is flagged as unresolved", %{
+      tmp_dir: tmp_dir
+    } do
+      # Regression: a file whose name parses to season=N but no episode
+      # number (e.g. `Show.S01.mkv` or `Show Season 1 Foo.mkv`) used to
+      # crash `import_file/5` with `FunctionClauseError` in `List.first/2`
+      # because the clause did `List.first(parsed.episodes) || 1` without
+      # guarding for nil. The job must route the file to the Issues tab
+      # (via match_status: "unresolved_files") instead of raising or
+      # silently importing as episode 1.
+      _library_path = create_test_library_path(tmp_dir, :series)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+
+      # `Mystery.Show.S01.mkv` parses to season=1, episodes=nil.
+      video_file = Path.join(download_dir, "Mystery.Show.S01.mkv")
+      File.write!(video_file, "fake video content")
+
+      media_item = media_item_fixture(%{type: "tv_show", title: "Mystery Show"})
+
+      _episode =
+        episode_fixture(%{
+          media_item_id: media_item.id,
+          season_number: 1,
+          episode_number: 1
+        })
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "NilEpisodesClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "NilEpisodesClient",
+          download_client_id: "nilep123"
+        })
+
+      assert {:error, :all_files_unresolved} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      updated = Mydia.Downloads.get_download!(download.id)
+      assert updated.match_status == "unresolved_files"
+      assert [unresolved] = updated.metadata["unresolved_files"]
+      assert unresolved["name"] == "Mystery.Show.S01.mkv"
+      assert unresolved["parsed_season"] == 1
+      assert unresolved["parsed_episode"] == nil
+    end
+
+    @tag :tmp_dir
     test "returns error when save_path points to non-existent path", %{tmp_dir: _tmp_dir} do
       media_item =
         media_item_fixture(%{type: "movie", title: "Bad Path Movie", year: 2024})

--- a/test/mydia/library/release_parser/resolver_test.exs
+++ b/test/mydia/library/release_parser/resolver_test.exs
@@ -55,6 +55,22 @@ defmodule Mydia.Library.ReleaseParser.ResolverTest do
       assert result.season == 1
       assert result.episodes == [5]
     end
+
+    test "verbose 'Season N Episode M' produces season + episodes" do
+      result = resolve("Off Campus (2026) Season 1 Episode 1 The Deal")
+      assert result.season == 1
+      assert result.episodes == [1]
+    end
+
+    test "verbose 'Season N Episode M-' with trailing punctuation still extracts episode" do
+      # Regression: filenames like "Season 1 Episode 1- The Deal - PrimeWire.mp4"
+      # leave a trailing dash on the episode-number token. The episode integer
+      # must still be parsed instead of falling through to nil and crashing
+      # downstream import code.
+      result = resolve("Off Campus (2026) Season 1 Episode 1- The Deal - PrimeWire")
+      assert result.season == 1
+      assert result.episodes == [1]
+    end
   end
 
   describe "unbound movie" do

--- a/test/mydia/library/release_parser_test.exs
+++ b/test/mydia/library/release_parser_test.exs
@@ -41,6 +41,20 @@ defmodule Mydia.Library.ReleaseParserTest do
       assert result.quality.source == "WEB-DL"
     end
 
+    test "verbose 'Season N Episode M' release name with trailing punctuation" do
+      # Regression for the Off Campus PrimeWire-style filenames: the parser
+      # must extract both season and episode (not nil) so MediaImport can
+      # match each file to its episode without crashing.
+      result =
+        ReleaseParser.parse("Off Campus (2026) Season 1 Episode 1- The Deal - PrimeWire.mp4")
+
+      assert result.type == :tv_show
+      assert result.title == "Off Campus"
+      assert result.year == 2026
+      assert result.season == 1
+      assert result.episodes == [1]
+    end
+
     test "exposes field_confidence as a non-empty map" do
       result = ReleaseParser.parse("Movie.Name.2020.1080p.BluRay.mkv")
 


### PR DESCRIPTION
## Summary

- Release parser now extracts episode numbers from filenames like `Show Season 1 Episode 1- Title.mp4` — previously the trailing punctuation caused `parsed.episodes` to come back `nil`.
- `MediaImport.import_file/5` no longer crashes with `FunctionClauseError` in `List.first/2` when `parsed.episodes` is nil; the file is routed to the Issues tab via `match_status: "unresolved_files"`.

## Bug

A user-reported import failure on a TV-show season pack (Off Campus 2026 S01 from PrimeWire). The release-name tokenizer kept the `1-` from `Episode 1- The Deal` as a single token; the verbose-form extractor in `resolver.ex` required a clean integer (`Integer.parse/1 == {n, ""}`) and rejected `"1-"`, leaving `parsed.episodes = nil`. Then `import_file/5` did `List.first(parsed.episodes) || 1` without guarding for nil, so every retry crashed:

    ** (FunctionClauseError) no function clause matching in List.first/2
        # 1: nil
        # 2: nil
        (mydia 0.0.0-dev) lib/mydia/jobs/media_import.ex:942: Mydia.Jobs.MediaImport.import_file/5

After three attempts the Oban job sat in `retryable` state and the download never imported.

## Fix

- `lib/mydia/library/release_parser/resolver.ex`: `verbose_episode_extract/1` matches the leading digit run with a regex so trailing punctuation no longer eats the episode number.
- `lib/mydia/jobs/media_import.ex`: the TV-show branch now requires `parsed.episodes` to be non-nil. A new clause for `season != nil and episodes == nil` returns `{:unresolved, file_info}`, which flows through the existing `flag_unresolved_files/2` path and surfaces the file in the Downloads → Issues tab instead of silently importing as episode 1 or crashing.

## Test plan

- [x] `./dev mix test test/mydia/library/release_parser/` — 361/361 pass
- [x] `./dev mix test test/mydia/library/release_parser_test.exs` — facade test for the full Off Campus filename passes
- [x] `./dev mix test test/mydia/jobs/media_import_test.exs` — 26/26 pass, new regression test verifies match_status: "unresolved_files" and stored parsed metadata
- [ ] Verify on storage: re-trigger MediaImport for the existing stuck Off Campus download (id 2bef0f45) and confirm it either imports (with parser fix) or lands in the Issues tab