### PR TITLE
fix(qbittorrent): multipart uploads, post-add verification, 5.x compatibility, less-aggressive missing detection

### DIFF
--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -14,193 +14,164 @@ defmodule Mydia.Downloads.Client.QBittorrent do
   qBittorrent requires logging in via the `/api/v2/auth/login` endpoint to obtain
   a session cookie (`SID`). This cookie must be included in all subsequent requests.
 
-  ## Configuration
+  ## qBittorrent 5.x compatibility
 
-  The adapter expects the following configuration:
-
-      config = %{
-        type: :qbittorrent,
-        host: "localhost",
-        port: 8080,
-        username: "admin",
-        password: "adminpass",
-        use_ssl: false,
-        options: %{
-          timeout: 30_000,
-          connect_timeout: 5_000
-        }
-      }
+  qBittorrent 5.0 renamed the `pause`/`resume` endpoints to `stop`/`start` and
+  introduced new state names (`stoppedDL`, `stoppedUP`, `moving`). This adapter
+  tries the legacy endpoint first and falls back to the 5.x name on 404, and
+  maps the new state names to their equivalent internal states.
 
   ## State Mapping
 
   qBittorrent states are mapped to our internal states:
 
-    * `downloading` -> `:downloading`
+    * `downloading`, `stalledDL`, `metaDL`, `forcedDL` -> `:downloading`
     * `uploading`, `stalledUP`, `forcedUP` -> `:seeding`
-    * `pausedDL`, `pausedUP` -> `:paused`
+    * `pausedDL`, `pausedUP`, `stoppedDL`, `stoppedUP` -> `:paused`
     * `error`, `missingFiles` -> `:error`
-    * `checkingDL`, `checkingUP`, `checkingResumeData` -> `:checking`
-    * `queuedDL`, `queuedUP`, `allocating` -> `:downloading` (queued but counted as downloading)
+    * `checkingDL`, `checkingUP`, `checkingResumeData`, `moving`, `allocating`,
+      `queuedDL`, `queuedUP`, `unknown`, or anything we don't recognise -> `:checking`
+
+  Unrecognised states are treated as `:checking` (transient) rather than `:error`
+  because `DownloadMonitor` deletes rows for errored downloads, and we'd rather
+  leave a download alone than lose it on a state name we haven't seen before.
   """
 
   @behaviour Mydia.Downloads.Client
+
+  require Logger
 
   alias Mydia.Downloads.Client.{Error, HTTP}
   alias Mydia.Downloads.Structs.{ClientInfo, TorrentStatus}
   alias Mydia.Downloads.TorrentHash
 
+  # How many times to poll /torrents/info after add_torrent before declaring
+  # the torrent was silently rejected by qBittorrent.
+  @default_post_add_poll_attempts 5
+  @post_add_poll_interval_ms 250
+
   @impl true
   def test_connection(config) do
-    with {:ok, req} <- authenticate(config),
-         {:ok, response} <- HTTP.get(req, "/api/v2/app/version") do
-      case response.status do
-        200 ->
-          {:ok, ClientInfo.new(version: response.body, api_version: "2.x")}
+    with_authenticated_session(config, fn req ->
+      with {:ok, response} <- HTTP.get(req, "/api/v2/app/version") do
+        case response.status do
+          200 ->
+            {:ok, ClientInfo.new(version: to_string(response.body), api_version: "2.x")}
 
-        _ ->
-          {:error, Error.api_error("Unexpected response status", %{status: response.status})}
+          _ ->
+            {:error, Error.api_error("Unexpected response status", %{status: response.status})}
+        end
       end
-    end
+    end)
   end
 
   @impl true
   def add_torrent(config, torrent, opts \\ []) do
-    with {:ok, req} <- authenticate(config),
-         {:ok, body} <- build_add_torrent_body(torrent, opts),
-         {:ok, response} <- HTTP.post(req, "/api/v2/torrents/add", form: body) do
-      case response.status do
-        200 ->
-          # qBittorrent returns "Ok." on success but doesn't immediately return the hash
-          # We need to extract the hash from the torrent or wait for it to appear
-          extract_torrent_hash(torrent)
-
-        _ ->
-          {:error,
-           Error.api_error("Failed to add torrent", %{
-             status: response.status,
-             body: response.body
-           })}
-      end
+    with {:ok, hash} <- extract_torrent_hash(torrent) do
+      with_authenticated_session(config, fn req ->
+        with {:ok, response} <- post_add_torrent(req, torrent, opts),
+             :ok <- check_add_response(response),
+             :ok <- verify_torrent_present(req, config, hash) do
+          {:ok, hash}
+        end
+      end)
     end
   end
 
   @impl true
   def get_status(config, client_id) do
-    with {:ok, req} <- authenticate(config),
-         {:ok, response} <-
-           HTTP.get(req, "/api/v2/torrents/info", params: [hashes: client_id]) do
-      case response.status do
-        200 ->
-          case response.body do
-            [torrent | _] ->
-              {:ok, parse_torrent_status(torrent)}
-
-            [] ->
-              {:error, Error.not_found("Torrent not found")}
-          end
-
-        _ ->
-          {:error, Error.api_error("Failed to get torrent status", %{status: response.status})}
+    with_authenticated_session(config, fn req ->
+      with {:ok, response} <- get_info(req, hashes: client_id) do
+        case response.body do
+          [torrent | _] -> {:ok, parse_torrent_status(torrent)}
+          [] -> {:error, Error.not_found("Torrent not found")}
+          _other -> {:error, Error.parse_error("Unexpected response body")}
+        end
       end
-    end
+    end)
   end
 
   @impl true
   def list_torrents(config, opts \\ []) do
-    with {:ok, req} <- authenticate(config),
-         params <- build_list_params(opts),
-         {:ok, response} <- HTTP.get(req, "/api/v2/torrents/info", params: params) do
-      case response.status do
-        200 ->
-          torrents =
-            response.body
-            |> Enum.map(&parse_torrent_status/1)
+    params = build_list_params(opts)
 
-          {:ok, torrents}
-
-        _ ->
-          {:error, Error.api_error("Failed to list torrents", %{status: response.status})}
+    with_authenticated_session(config, fn req ->
+      with {:ok, response} <- get_info(req, params) do
+        if is_list(response.body) do
+          {:ok, Enum.map(response.body, &parse_torrent_status/1)}
+        else
+          {:error, Error.parse_error("Unexpected response body")}
+        end
       end
-    end
+    end)
   end
 
   @impl true
   def remove_torrent(config, client_id, opts \\ []) do
     delete_files = Keyword.get(opts, :delete_files, false)
+    body = %{hashes: client_id, deleteFiles: to_string(delete_files)}
 
-    with {:ok, req} <- authenticate(config),
-         body <- %{hashes: client_id, deleteFiles: delete_files},
-         {:ok, response} <- HTTP.post(req, "/api/v2/torrents/delete", form: body) do
-      case response.status do
-        200 ->
-          :ok
-
-        404 ->
-          {:error, Error.not_found("Torrent not found")}
-
-        _ ->
-          {:error, Error.api_error("Failed to remove torrent", %{status: response.status})}
+    with_authenticated_session(config, fn req ->
+      with {:ok, response} <- HTTP.post(req, "/api/v2/torrents/delete", form: body) do
+        case response.status do
+          200 -> :ok
+          404 -> {:error, Error.not_found("Torrent not found")}
+          _ -> {:error, Error.api_error("Failed to remove torrent", %{status: response.status})}
+        end
       end
-    end
+    end)
   end
 
   @impl true
   def pause_torrent(config, client_id) do
-    with {:ok, req} <- authenticate(config),
-         body <- %{hashes: client_id},
-         {:ok, response} <- HTTP.post(req, "/api/v2/torrents/pause", form: body) do
-      case response.status do
-        200 ->
-          :ok
-
-        _ ->
-          {:error, Error.api_error("Failed to pause torrent", %{status: response.status})}
-      end
-    end
+    toggle_torrent(config, client_id, "/api/v2/torrents/pause", "/api/v2/torrents/stop")
   end
 
   @impl true
   def resume_torrent(config, client_id) do
-    with {:ok, req} <- authenticate(config),
-         body <- %{hashes: client_id},
-         {:ok, response} <- HTTP.post(req, "/api/v2/torrents/resume", form: body) do
-      case response.status do
-        200 ->
-          :ok
-
-        _ ->
-          {:error, Error.api_error("Failed to resume torrent", %{status: response.status})}
-      end
-    end
+    toggle_torrent(config, client_id, "/api/v2/torrents/resume", "/api/v2/torrents/start")
   end
 
   ## Private Functions
 
+  # Authenticates, runs `fun` with the authenticated Req struct, and re-authenticates
+  # once if the inner call returns a 403 (stale/expired session). This matches the
+  # pattern used by the Transmission adapter for 409 session-id retries.
+  defp with_authenticated_session(config, fun) when is_function(fun, 1) do
+    with {:ok, req} <- authenticate(config) do
+      case fun.(req) do
+        {:error, %Error{type: :stale_session}} ->
+          # Session expired between authenticate() and the call — re-auth and retry once.
+          with {:ok, fresh_req} <- authenticate(config) do
+            fun.(fresh_req)
+          end
+
+        other ->
+          other
+      end
+    end
+  end
+
+  # Marker error indicating the caller should re-authenticate and retry.
+  defp stale_session, do: Error.new(:stale_session, "Session expired")
+
   defp authenticate(config) do
-    unless config[:username] && config[:password] do
-      {:error, Error.invalid_config("Username and password are required for qBittorrent")}
-    else
+    if config[:username] && config[:password] do
       do_authenticate(config)
+    else
+      {:error, Error.invalid_config("Username and password are required for qBittorrent")}
     end
   end
 
   defp do_authenticate(config) do
     req = HTTP.new_request(config)
-
-    # qBittorrent uses form-encoded login
-    login_body = %{
-      username: config.username,
-      password: config.password
-    }
+    login_body = %{username: config.username, password: config.password}
 
     case HTTP.post(req, "/api/v2/auth/login", form: login_body) do
       {:ok, %{status: 200} = response} ->
-        # Extract SID cookie from response
         case extract_sid_cookie(response) do
           {:ok, sid} ->
-            # Add cookie to request for future calls
-            authenticated_req = Req.Request.put_header(req, "cookie", "SID=#{sid}")
-            {:ok, authenticated_req}
+            {:ok, Req.Request.put_header(req, "cookie", "SID=#{sid}")}
 
           :error ->
             {:error, Error.authentication_failed("Failed to extract session cookie")}
@@ -224,102 +195,205 @@ defmodule Mydia.Downloads.Client.QBittorrent do
     end
   end
 
+  # Find the Set-Cookie header value that actually contains "SID=".
+  # qBittorrent occasionally emits multiple cookies (e.g. CSRF) and we must not
+  # pick the wrong one.
   defp extract_sid_cookie(response) do
-    case Req.Response.get_header(response, "set-cookie") do
-      [cookie | _] ->
-        # Extract SID value from "SID=xxx; ..."
-        case Regex.run(~r/SID=([^;]+)/, cookie) do
-          [_, sid] -> {:ok, sid}
-          _ -> :error
-        end
+    response
+    |> Req.Response.get_header("set-cookie")
+    |> Enum.find_value(:error, fn cookie ->
+      case Regex.run(~r/SID=([^;]+)/, cookie) do
+        [_, sid] -> {:ok, sid}
+        _ -> nil
+      end
+    end)
+  end
 
-      [] ->
-        :error
+  # Wrap an HTTP call so that a 403 (expired/invalid session) surfaces as a
+  # marker error the outer `with_authenticated_session` can catch and retry
+  # with a fresh login. Without this, sessions that expire after the qBittorrent
+  # server's SessionTimeout cause every subsequent call to fail.
+  defp authed_request(req, method, path, opts) do
+    case do_request(req, method, path, opts) do
+      {:ok, %{status: 403}} -> {:error, stale_session()}
+      other -> other
     end
   end
 
-  defp build_add_torrent_body({:magnet, magnet_link}, opts) do
+  defp do_request(req, :get, path, opts), do: HTTP.get(req, path, opts)
+  defp do_request(req, :post, path, opts), do: HTTP.post(req, path, opts)
+
+  # Build POST body for add_torrent according to input type.
+  defp post_add_torrent(req, {:magnet, magnet_link}, opts) do
     body =
       %{urls: magnet_link}
-      |> add_optional_param(:category, opts[:category])
-      |> add_optional_param(:tags, opts[:tags], &Enum.join(&1, ","))
-      |> add_optional_param(:savepath, opts[:save_path])
-      |> add_optional_param(:paused, opts[:paused])
+      |> put_optional(:category, opts[:category])
+      |> put_optional(:tags, opts[:tags], &Enum.join(&1, ","))
+      |> put_optional(:savepath, opts[:save_path])
+      |> put_optional_bool(:paused, opts[:paused])
 
-    {:ok, body}
+    authed_request(req, :post, "/api/v2/torrents/add", form: body)
   end
 
-  defp build_add_torrent_body({:file, file_contents}, opts) do
-    # For file uploads, we need to use multipart
-    body =
-      %{torrents: file_contents}
-      |> add_optional_param(:category, opts[:category])
-      |> add_optional_param(:tags, opts[:tags], &Enum.join(&1, ","))
-      |> add_optional_param(:savepath, opts[:save_path])
-      |> add_optional_param(:paused, opts[:paused])
-
-    {:ok, body}
-  end
-
-  defp build_add_torrent_body({:url, url}, opts) do
+  defp post_add_torrent(req, {:url, url}, opts) do
     body =
       %{urls: url}
-      |> add_optional_param(:category, opts[:category])
-      |> add_optional_param(:tags, opts[:tags], &Enum.join(&1, ","))
-      |> add_optional_param(:savepath, opts[:save_path])
-      |> add_optional_param(:paused, opts[:paused])
+      |> put_optional(:category, opts[:category])
+      |> put_optional(:tags, opts[:tags], &Enum.join(&1, ","))
+      |> put_optional(:savepath, opts[:save_path])
+      |> put_optional_bool(:paused, opts[:paused])
 
-    {:ok, body}
+    authed_request(req, :post, "/api/v2/torrents/add", form: body)
   end
 
-  defp add_optional_param(body, _key, nil), do: body
+  defp post_add_torrent(req, {:file, file_contents}, opts) do
+    # qBittorrent's /torrents/add expects multipart/form-data when uploading a
+    # .torrent file. Passing the raw binary as a URL-encoded form silently
+    # corrupts the body and the torrent is dropped without any error response.
+    filename = opts[:title] |> sanitize_filename()
 
-  defp add_optional_param(body, key, value) do
-    Map.put(body, key, value)
+    fields =
+      [
+        torrents: {file_contents, filename: filename, content_type: "application/x-bittorrent"}
+      ]
+      |> put_optional_kv(:category, opts[:category])
+      |> put_optional_kv(:tags, opts[:tags], &Enum.join(&1, ","))
+      |> put_optional_kv(:savepath, opts[:save_path])
+      |> put_optional_kv(:paused, opts[:paused], &to_string/1)
+
+    authed_request(req, :post, "/api/v2/torrents/add", form_multipart: fields)
   end
 
-  defp add_optional_param(body, _key, nil, _transform), do: body
+  defp check_add_response(%{status: 200}), do: :ok
 
-  defp add_optional_param(body, key, value, transform) when is_function(transform, 1) do
-    Map.put(body, key, transform.(value))
+  defp check_add_response(%{status: status, body: body}) do
+    {:error, Error.api_error("Failed to add torrent", %{status: status, body: body})}
   end
 
-  defp extract_torrent_hash(torrent_input) do
-    # qBittorrent uses lowercase hashes
-    TorrentHash.extract(torrent_input, case: :lower)
+  # After "Ok." we don't know whether qBittorrent actually accepted the torrent
+  # (it returns "Ok." even when it silently drops bad input). Poll info?hashes=<h>
+  # so the caller knows whether the torrent landed.
+  defp verify_torrent_present(req, config, hash) do
+    attempts =
+      get_in(config, [:options, :post_add_poll_attempts]) ||
+        @default_post_add_poll_attempts
+
+    interval =
+      get_in(config, [:options, :post_add_poll_interval_ms]) || @post_add_poll_interval_ms
+
+    do_verify_torrent_present(req, hash, attempts, interval)
+  end
+
+  defp do_verify_torrent_present(_req, hash, 0, _interval) do
+    {:error,
+     Error.api_error(
+       "Torrent not present in qBittorrent after add (may have been silently rejected)",
+       %{hash: hash}
+     )}
+  end
+
+  defp do_verify_torrent_present(req, hash, attempts_left, interval) do
+    case get_info(req, hashes: hash) do
+      {:ok, %{body: [_ | _]}} ->
+        :ok
+
+      _other ->
+        if attempts_left > 1, do: Process.sleep(interval)
+        do_verify_torrent_present(req, hash, attempts_left - 1, interval)
+    end
+  end
+
+  defp get_info(req, params) do
+    authed_request(req, :get, "/api/v2/torrents/info", params: params)
+  end
+
+  # Hit the legacy endpoint first, fall back to qBittorrent 5.x's renamed
+  # endpoint if the server reports 404. Old clients respond 200 on both paths
+  # via backwards-compat aliases, but on a fresh 5.x install the legacy path
+  # returns 404 and we'd otherwise fail.
+  defp toggle_torrent(config, client_id, primary_path, fallback_path) do
+    body = %{hashes: client_id}
+
+    with_authenticated_session(config, fn req ->
+      case authed_request(req, :post, primary_path, form: body) do
+        {:ok, %{status: 200}} ->
+          :ok
+
+        {:ok, %{status: 404}} ->
+          case authed_request(req, :post, fallback_path, form: body) do
+            {:ok, %{status: 200}} -> :ok
+            {:ok, resp} -> toggle_error(resp)
+            {:error, _} = err -> err
+          end
+
+        {:ok, resp} ->
+          toggle_error(resp)
+
+        {:error, _} = err ->
+          err
+      end
+    end)
+  end
+
+  defp toggle_error(%{status: status}) do
+    {:error, Error.api_error("Failed to toggle torrent", %{status: status})}
   end
 
   defp build_list_params(opts) do
-    params = []
+    []
+    |> append_param(:filter, list_filter(opts[:filter]))
+    |> append_param(:category, opts[:category])
+    |> append_param(:tag, opts[:tag])
+    |> append_param(:hashes, opts[:hashes])
+  end
 
-    params =
-      case opts[:filter] do
-        nil -> params
-        :all -> params
-        :downloading -> [{:filter, "downloading"} | params]
-        :seeding -> [{:filter, "seeding"} | params]
-        :completed -> [{:filter, "completed"} | params]
-        :paused -> [{:filter, "paused"} | params]
-        :active -> [{:filter, "active"} | params]
-        :inactive -> [{:filter, "inactive"} | params]
-        _ -> params
-      end
+  defp list_filter(nil), do: nil
+  defp list_filter(:all), do: nil
+  defp list_filter(:downloading), do: "downloading"
+  defp list_filter(:seeding), do: "seeding"
+  defp list_filter(:completed), do: "completed"
+  defp list_filter(:paused), do: "paused"
+  defp list_filter(:active), do: "active"
+  defp list_filter(:inactive), do: "inactive"
+  defp list_filter(_), do: nil
 
-    params =
-      if opts[:category] do
-        [{:category, opts[:category]} | params]
-      else
-        params
-      end
+  defp append_param(params, _key, nil), do: params
+  defp append_param(params, key, value), do: [{key, value} | params]
 
-    params =
-      if opts[:tag] do
-        [{:tag, opts[:tag]} | params]
-      else
-        params
-      end
+  defp put_optional(body, _key, nil), do: body
+  defp put_optional(body, key, value), do: Map.put(body, key, value)
 
-    params
+  defp put_optional(body, _key, nil, _transform), do: body
+
+  defp put_optional(body, key, value, transform) when is_function(transform, 1) do
+    Map.put(body, key, transform.(value))
+  end
+
+  defp put_optional_bool(body, _key, nil), do: body
+  defp put_optional_bool(body, key, value), do: Map.put(body, key, to_string(value))
+
+  defp put_optional_kv(list, _key, nil), do: list
+  defp put_optional_kv(list, key, value), do: list ++ [{key, value}]
+
+  defp put_optional_kv(list, _key, nil, _transform), do: list
+  defp put_optional_kv(list, key, value, transform), do: list ++ [{key, transform.(value)}]
+
+  defp sanitize_filename(nil), do: "file.torrent"
+
+  defp sanitize_filename(title) when is_binary(title) do
+    base =
+      title
+      |> String.replace(~r/[^A-Za-z0-9._\- ]/, "_")
+      |> String.slice(0, 200)
+
+    if base == "", do: "file.torrent", else: base <> ".torrent"
+  end
+
+  defp sanitize_filename(_), do: "file.torrent"
+
+  defp extract_torrent_hash(torrent_input) do
+    # qBittorrent indexes torrents by lowercase hash.
+    TorrentHash.extract(torrent_input, case: :lower)
   end
 
   defp parse_torrent_status(torrent) do
@@ -327,7 +401,7 @@ defmodule Mydia.Downloads.Client.QBittorrent do
       id: torrent["hash"],
       name: torrent["name"],
       state: parse_state(torrent["state"]),
-      progress: torrent["progress"] * 100,
+      progress: (torrent["progress"] || 0) * 100,
       download_speed: torrent["dlspeed"] || 0,
       upload_speed: torrent["upspeed"] || 0,
       downloaded: torrent["downloaded"] || 0,
@@ -341,29 +415,31 @@ defmodule Mydia.Downloads.Client.QBittorrent do
     })
   end
 
-  defp parse_state(state) when is_binary(state) do
-    case state do
-      "downloading" -> :downloading
-      "stalledDL" -> :downloading
-      "metaDL" -> :downloading
-      "forcedDL" -> :downloading
-      "queuedDL" -> :downloading
-      "allocating" -> :downloading
-      "uploading" -> :seeding
-      "stalledUP" -> :seeding
-      "forcedUP" -> :seeding
-      "queuedUP" -> :seeding
-      "pausedDL" -> :paused
-      "pausedUP" -> :paused
-      "checkingDL" -> :checking
-      "checkingUP" -> :checking
-      "checkingResumeData" -> :checking
-      "error" -> :error
-      "missingFiles" -> :error
-      "unknown" -> :error
-      _ -> :error
-    end
-  end
+  # State mappings. Unknown / unrecognised states deliberately fall through to
+  # :checking (transient) rather than :error, because DownloadMonitor deletes
+  # records whose status is "failed" — a misclassification here means the user
+  # loses the download row.
+  defp parse_state("downloading"), do: :downloading
+  defp parse_state("stalledDL"), do: :downloading
+  defp parse_state("metaDL"), do: :downloading
+  defp parse_state("forcedDL"), do: :downloading
+  defp parse_state("queuedDL"), do: :downloading
+  defp parse_state("allocating"), do: :downloading
+  defp parse_state("uploading"), do: :seeding
+  defp parse_state("stalledUP"), do: :seeding
+  defp parse_state("forcedUP"), do: :seeding
+  defp parse_state("queuedUP"), do: :seeding
+  defp parse_state("pausedDL"), do: :paused
+  defp parse_state("pausedUP"), do: :paused
+  defp parse_state("stoppedDL"), do: :paused
+  defp parse_state("stoppedUP"), do: :paused
+  defp parse_state("checkingDL"), do: :checking
+  defp parse_state("checkingUP"), do: :checking
+  defp parse_state("checkingResumeData"), do: :checking
+  defp parse_state("moving"), do: :checking
+  defp parse_state("error"), do: :error
+  defp parse_state("missingFiles"), do: :error
+  defp parse_state(_other), do: :checking
 
   defp parse_eta(eta) when is_integer(eta) and eta > 0, do: eta
   defp parse_eta(_), do: nil

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -154,7 +154,15 @@ defmodule Mydia.Downloads.History do
   end
 
   defp fetch_all_client_statuses(clients) do
-    # Fetch torrents from all clients concurrently
+    # Fetch torrents from all clients concurrently. We deliberately distinguish
+    # between two outcomes that previously collapsed into "empty list":
+    #
+    #   - {:reachable, torrents_map} — the client answered, here are its torrents
+    #   - :unreachable                — the client errored; we don't know its state
+    #
+    # The downstream classifier MUST NOT mark a download "missing" just because
+    # its client was unreachable, otherwise a brief client restart flags every
+    # active download as failed.
     clients
     |> Task.async_stream(
       fn client_config ->
@@ -163,87 +171,134 @@ defmodule Mydia.Downloads.History do
 
         case Client.list_torrents(adapter, config, []) do
           {:ok, torrents} ->
-            {client_config.name, torrents}
+            torrents_map =
+              torrents
+              |> Enum.map(fn torrent -> {torrent.id, torrent} end)
+              |> Map.new()
+
+            {client_config.name, {:reachable, torrents_map}}
 
           {:error, error} ->
             Logger.warning(
               "Failed to fetch torrents from #{client_config.name}: #{inspect(error)}"
             )
 
-            {client_config.name, []}
+            {client_config.name, :unreachable}
         end
       end,
       timeout: :infinity,
       max_concurrency: 10
     )
     |> Enum.reduce(%{}, fn
-      {:ok, {client_name, torrents}}, acc ->
-        # Index torrents by client_id for fast lookup
-        torrents_map =
-          torrents
-          |> Enum.map(fn torrent -> {torrent.id, torrent} end)
-          |> Map.new()
-
-        Map.put(acc, client_name, torrents_map)
-
-      _, acc ->
-        acc
+      {:ok, {client_name, result}}, acc -> Map.put(acc, client_name, result)
+      _, acc -> acc
     end)
   end
 
   defp enrich_download_with_status(download, client_statuses) do
-    # Find the torrent status from the appropriate client
-    torrent_status =
-      client_statuses
-      |> Map.get(download.download_client, %{})
-      |> Map.get(download.download_client_id)
+    case Map.get(client_statuses, download.download_client) do
+      {:reachable, torrents_map} ->
+        case Map.get(torrents_map, download.download_client_id) do
+          nil ->
+            # Client confirmed it doesn't have this torrent — genuinely missing.
+            enrich_download_with_empty_status(download)
 
-    if torrent_status do
-      # Convert metadata map to struct for type-safe access
-      metadata = DownloadMetadata.from_map(download.metadata)
+          torrent_status ->
+            enrich_download_with_torrent_status(download, torrent_status)
+        end
 
-      # Merge download DB record with real-time client status
-      EnrichedDownload.new(%{
-        id: download.id,
-        media_item_id: download.media_item_id,
-        episode_id: download.episode_id,
-        media_item: download.media_item,
-        episode: download.episode,
-        title: download.title,
-        indexer: download.indexer,
-        download_url: download.download_url,
-        download_client: download.download_client,
-        download_client_id: download.download_client_id,
-        metadata: download.metadata,
-        match_status: download.match_status,
-        inserted_at: download.inserted_at,
-        # Real-time fields from client
-        status: status_from_torrent_state(torrent_status.state),
-        progress: torrent_status.progress,
-        download_speed: torrent_status.download_speed,
-        upload_speed: torrent_status.upload_speed,
-        eta: torrent_status.eta,
-        size: torrent_status.size,
-        downloaded: torrent_status.downloaded,
-        uploaded: torrent_status.uploaded,
-        ratio: torrent_status.ratio,
-        seeders: if(metadata, do: metadata.seeders, else: nil),
-        leechers: if(metadata, do: metadata.leechers, else: nil),
-        save_path: torrent_status.save_path,
-        completed_at: download.completed_at || torrent_status.completed_at,
-        error_message: download.error_message,
-        # Preserve database completed_at for tracking if we've already processed it
-        db_completed_at: download.completed_at,
-        imported_at: download.imported_at,
-        import_retry_count: download.import_retry_count,
-        import_last_error: download.import_last_error,
-        import_next_retry_at: download.import_next_retry_at,
-        import_failed_at: download.import_failed_at
-      })
-    else
-      # Download not found in client - might be removed or completed
-      enrich_download_with_empty_status(download)
+      :unreachable ->
+        # Client is misbehaving (down, restarting, network blip). We can't tell
+        # whether the torrent is there — DO NOT mark missing. Surface status as
+        # "unknown" so DownloadMonitor's missing-handler skips it this cycle.
+        enrich_download_with_unknown_status(download)
+
+      nil ->
+        # The client referenced by the download isn't configured at all (deleted,
+        # renamed, or never existed) — treat as genuinely missing.
+        enrich_download_with_empty_status(download)
     end
+  end
+
+  defp enrich_download_with_torrent_status(download, torrent_status) do
+    metadata = DownloadMetadata.from_map(download.metadata)
+
+    EnrichedDownload.new(%{
+      id: download.id,
+      media_item_id: download.media_item_id,
+      episode_id: download.episode_id,
+      media_item: download.media_item,
+      episode: download.episode,
+      title: download.title,
+      indexer: download.indexer,
+      download_url: download.download_url,
+      download_client: download.download_client,
+      download_client_id: download.download_client_id,
+      metadata: download.metadata,
+      match_status: download.match_status,
+      inserted_at: download.inserted_at,
+      status: status_from_torrent_state(torrent_status.state),
+      progress: torrent_status.progress,
+      download_speed: torrent_status.download_speed,
+      upload_speed: torrent_status.upload_speed,
+      eta: torrent_status.eta,
+      size: torrent_status.size,
+      downloaded: torrent_status.downloaded,
+      uploaded: torrent_status.uploaded,
+      ratio: torrent_status.ratio,
+      seeders: if(metadata, do: metadata.seeders, else: nil),
+      leechers: if(metadata, do: metadata.leechers, else: nil),
+      save_path: torrent_status.save_path,
+      completed_at: download.completed_at || torrent_status.completed_at,
+      error_message: download.error_message,
+      db_completed_at: download.completed_at,
+      imported_at: download.imported_at,
+      import_retry_count: download.import_retry_count,
+      import_last_error: download.import_last_error,
+      import_next_retry_at: download.import_next_retry_at,
+      import_failed_at: download.import_failed_at
+    })
+  end
+
+  defp enrich_download_with_unknown_status(download) do
+    metadata = DownloadMetadata.from_map(download.metadata)
+
+    EnrichedDownload.new(%{
+      id: download.id,
+      media_item_id: download.media_item_id,
+      episode_id: download.episode_id,
+      media_item: download.media_item,
+      episode: download.episode,
+      title: download.title,
+      indexer: download.indexer,
+      download_url: download.download_url,
+      download_client: download.download_client,
+      download_client_id: download.download_client_id,
+      metadata: download.metadata,
+      match_status: download.match_status,
+      inserted_at: download.inserted_at,
+      # "unknown" intentionally avoids the "missing" / "failed" classifications.
+      status: "unknown",
+      progress: if(download.completed_at, do: 100.0, else: 0.0),
+      download_speed: 0,
+      upload_speed: 0,
+      eta: nil,
+      size: if(metadata, do: metadata.size, else: 0),
+      downloaded: 0,
+      uploaded: 0,
+      ratio: 0.0,
+      seeders: nil,
+      leechers: nil,
+      save_path: nil,
+      completed_at: download.completed_at,
+      error_message: download.error_message,
+      db_completed_at: download.completed_at,
+      imported_at: download.imported_at,
+      import_retry_count: download.import_retry_count,
+      import_last_error: download.import_last_error,
+      import_next_retry_at: download.import_next_retry_at,
+      import_failed_at: download.import_failed_at
+    })
   end
 
   defp enrich_download_with_empty_status(download) do

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -136,17 +136,370 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
     end
   end
 
-  # Note: Full integration tests would require either:
-  # 1. A real qBittorrent instance (can be configured via environment variables)
-  # 2. HTTP mocking library like Bypass or Mox to simulate qBittorrent responses
-  #
-  # Integration tests should verify:
-  # - Authentication flow with valid/invalid credentials
-  # - Adding torrents (magnet links, files, URLs) with various options
-  # - Retrieving torrent status with all fields parsed correctly
-  # - Listing torrents with various filters (state, category, tag)
-  # - Removing torrents with/without file deletion
-  # - Pausing and resuming torrents
-  # - State mapping (downloading, seeding, paused, error, etc.)
-  # - Error handling for various failure scenarios
+  # ──────────────────────────────────────────────────────────────────
+  # Bypass-based integration tests
+  # ──────────────────────────────────────────────────────────────────
+
+  describe "authentication (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "extracts SID cookie even when multiple Set-Cookie headers are present", %{
+      bypass: bypass,
+      config: config
+    } do
+      hash = "1234567890abcdef1234567890abcdef12345678"
+
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        # Real qBittorrent sometimes sets a CSRF cookie alongside SID.
+        # We must pick the SID cookie, not the first one.
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "_csrf=ignored; Path=/")
+        |> Plug.Conn.merge_resp_headers([
+          {"set-cookie", "SID=session-abc-123; HttpOnly; Path=/"}
+        ])
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        # The request must carry our SID, not the _csrf cookie.
+        assert ["SID=session-abc-123"] = Plug.Conn.get_req_header(conn, "cookie")
+        json_resp(conn, 200, [torrent_payload(hash)])
+      end)
+
+      assert {:ok, status} = QBittorrent.get_status(config, hash)
+      assert status.id == hash
+    end
+
+    test "re-authenticates on 403 and retries the original request", %{
+      bypass: bypass,
+      config: config
+    } do
+      hash = "abc123def456abc123def456abc123def456abcd"
+      counter = :counters.new(2, [])
+
+      Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        :counters.add(counter, 1, 1)
+
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=fresh-sid; HttpOnly")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        :counters.add(counter, 2, 1)
+        n = :counters.get(counter, 2)
+
+        if n == 1 do
+          Plug.Conn.resp(conn, 403, "Forbidden")
+        else
+          json_resp(conn, 200, [torrent_payload(hash)])
+        end
+      end)
+
+      assert {:ok, _status} = QBittorrent.get_status(config, hash)
+      # Two logins: one initial, one after the 403
+      assert :counters.get(counter, 1) == 2
+    end
+  end
+
+  describe "add_torrent/3 (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "uploads .torrent files via multipart/form-data, not urlencoded", %{
+      bypass: bypass,
+      config: config
+    } do
+      torrent_binary = sample_torrent_file()
+      {:ok, hash} = Mydia.Downloads.TorrentHash.extract({:file, torrent_binary}, case: :lower)
+
+      stub_login(bypass)
+
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/add", fn conn ->
+        # qBittorrent requires multipart/form-data when uploading a torrent file.
+        # If we send urlencoded, the binary is corrupted and the torrent is silently dropped.
+        [content_type | _] = Plug.Conn.get_req_header(conn, "content-type")
+        assert content_type =~ "multipart/form-data"
+
+        # Verify the body actually contains the torrent payload (the bencoded "d8:announce"
+        # marker is present in our sample fixture).
+        {:ok, body, conn} = Plug.Conn.read_body(conn, length: 1_000_000)
+        assert body =~ "8:announce"
+
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      # Post-add verification: the adapter should poll info?hashes=<h> to confirm presence.
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash)])
+      end)
+
+      assert {:ok, returned_hash} = QBittorrent.add_torrent(config, {:file, torrent_binary})
+      assert returned_hash == hash
+    end
+
+    test "verifies the torrent was actually added before returning success", %{
+      bypass: bypass,
+      config: config
+    } do
+      magnet = "magnet:?xt=urn:btih:abc123def456abc123def456abc123def456abcd&dn=test"
+
+      stub_login(bypass)
+
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/add", fn conn ->
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      # qBittorrent says "Ok." but the torrent never appears in info — should error,
+      # not silently create a phantom DB record.
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [])
+      end)
+
+      assert {:error, error} = QBittorrent.add_torrent(config, {:magnet, magnet})
+      assert error.type == :api_error
+      assert error.message =~ "not present in qBittorrent" or error.message =~ "rejected"
+    end
+
+    test "tolerates qBittorrent indexing delay (eventually appears in info)", %{
+      bypass: bypass,
+      config: config
+    } do
+      magnet = "magnet:?xt=urn:btih:abc123def456abc123def456abc123def456abcd&dn=test"
+      hash = "abc123def456abc123def456abc123def456abcd"
+
+      stub_login(bypass)
+
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/add", fn conn ->
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      # First poll returns empty (still indexing), second returns the torrent.
+      counter = :counters.new(1, [])
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        :counters.add(counter, 1, 1)
+        n = :counters.get(counter, 1)
+
+        if n >= 2 do
+          json_resp(conn, 200, [torrent_payload(hash)])
+        else
+          json_resp(conn, 200, [])
+        end
+      end)
+
+      assert {:ok, ^hash} = QBittorrent.add_torrent(config, {:magnet, magnet})
+    end
+  end
+
+  describe "state mapping (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      stub_login(bypass)
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "maps qBittorrent 5.x stoppedDL/stoppedUP to :paused", %{
+      bypass: bypass,
+      config: config
+    } do
+      hash = "5xstop00000000000000000000000000stopped5"
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash, state: "stoppedDL")])
+      end)
+
+      assert {:ok, %{state: :paused}} = QBittorrent.get_status(config, hash)
+    end
+
+    test "maps qBittorrent 5.x stoppedUP to :paused (post-completion)", %{
+      bypass: bypass,
+      config: config
+    } do
+      hash = "5xstop00000000000000000000000000stoppedu"
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash, state: "stoppedUP")])
+      end)
+
+      assert {:ok, %{state: :paused}} = QBittorrent.get_status(config, hash)
+    end
+
+    test "maps moving state to :checking (transient, not an error)", %{
+      bypass: bypass,
+      config: config
+    } do
+      hash = "moving00000000000000000000000000000move0"
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash, state: "moving")])
+      end)
+
+      assert {:ok, %{state: :checking}} = QBittorrent.get_status(config, hash)
+    end
+
+    test "maps unknown state to :checking (transient), not :error", %{
+      bypass: bypass,
+      config: config
+    } do
+      hash = "unknown00000000000000000000000000unknown"
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash, state: "unknown")])
+      end)
+
+      assert {:ok, %{state: :checking}} = QBittorrent.get_status(config, hash)
+    end
+
+    test "maps unmapped/future state names to :checking, not :error", %{
+      bypass: bypass,
+      config: config
+    } do
+      # Defensive: a future qBittorrent state we don't know about should not
+      # cause DownloadMonitor to delete the row (which it does on :error).
+      hash = "future00000000000000000000000000future00"
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash, state: "someBrandNewState")])
+      end)
+
+      assert {:ok, %{state: :checking}} = QBittorrent.get_status(config, hash)
+    end
+
+    test "preserves :error for real error states", %{bypass: bypass, config: config} do
+      hash = "error00000000000000000000000000000error0"
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash, state: "error")])
+      end)
+
+      assert {:ok, %{state: :error}} = QBittorrent.get_status(config, hash)
+    end
+  end
+
+  describe "pause/resume routing (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      stub_login(bypass)
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "pause hits the legacy /pause endpoint by default", %{
+      bypass: bypass,
+      config: config
+    } do
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/pause", fn conn ->
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      assert :ok = QBittorrent.pause_torrent(config, "somehash")
+    end
+
+    test "resume hits the legacy /resume endpoint by default", %{
+      bypass: bypass,
+      config: config
+    } do
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/resume", fn conn ->
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      assert :ok = QBittorrent.resume_torrent(config, "somehash")
+    end
+
+    test "pause falls back to /stop on 404 (qBittorrent 5.x)", %{
+      bypass: bypass,
+      config: config
+    } do
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/pause", fn conn ->
+        Plug.Conn.resp(conn, 404, "Not Found")
+      end)
+
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/stop", fn conn ->
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      assert :ok = QBittorrent.pause_torrent(config, "somehash")
+    end
+
+    test "resume falls back to /start on 404 (qBittorrent 5.x)", %{
+      bypass: bypass,
+      config: config
+    } do
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/resume", fn conn ->
+        Plug.Conn.resp(conn, 404, "Not Found")
+      end)
+
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/start", fn conn ->
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      assert :ok = QBittorrent.resume_torrent(config, "somehash")
+    end
+  end
+
+  ## Helpers
+
+  defp bypass_config(bypass) do
+    %{
+      type: :qbittorrent,
+      host: "localhost",
+      port: bypass.port,
+      username: "admin",
+      password: "adminpass",
+      use_ssl: false,
+      options: %{timeout: 5_000, connect_timeout: 2_000, post_add_poll_attempts: 3}
+    }
+  end
+
+  defp stub_login(bypass) do
+    Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("set-cookie", "SID=test-sid; HttpOnly")
+      |> Plug.Conn.resp(200, "Ok.")
+    end)
+  end
+
+  defp json_resp(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(status, Jason.encode!(body))
+  end
+
+  defp torrent_payload(hash, overrides \\ []) do
+    Map.merge(
+      %{
+        "hash" => hash,
+        "name" => "Test Torrent",
+        "state" => "downloading",
+        "progress" => 0.5,
+        "dlspeed" => 100_000,
+        "upspeed" => 0,
+        "downloaded" => 500,
+        "uploaded" => 0,
+        "size" => 1000,
+        "eta" => 60,
+        "ratio" => 0.0,
+        "save_path" => "/downloads",
+        "added_on" => 1_700_000_000,
+        "completion_on" => -1
+      },
+      Map.new(overrides, fn {k, v} -> {to_string(k), v} end)
+    )
+  end
+
+  # Minimal valid bencoded torrent metainfo for testing the upload path.
+  # The info dict only needs to be structurally valid bencode; the hash is
+  # computed by SHA1 of the bencoded info dict regardless of contents.
+  defp sample_torrent_file do
+    info_dict =
+      "d6:lengthi100e4:name8:test.bin12:piece lengthi16384e6:pieces20:" <>
+        :binary.copy(<<0>>, 20) <> "e"
+
+    "d8:announce20:http://tracker.test/4:info" <> info_dict <> "e"
+  end
 end

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -188,6 +188,33 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       assert :ok = perform_job(DownloadMonitor, %{})
     end
+
+    test "does NOT mark downloads missing when their client is unreachable" do
+      # Client is configured by name but unreachable on the network. This is the
+      # exact failure mode behind the recurring "qBittorrent downloads vanish"
+      # reports: a brief client restart used to flag every active download as
+      # missing within a single monitor cycle.
+      setup_runtime_config([
+        build_test_client_config(%{name: "qBit-down", host: "127.0.0.1", port: 1})
+      ])
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qBit-down",
+          download_client_id: "abc123def456abc123def456abc123def456abcd"
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      # The download must NOT be marked missing — we can't tell from an
+      # unreachable client whether the torrent is gone or not.
+      updated = Downloads.get_download!(download.id)
+      assert is_nil(updated.error_message)
+      assert is_nil(updated.completed_at)
+    end
   end
 
   describe "missing download detection" do


### PR DESCRIPTION
## Summary

Addresses recurring qBittorrent download failures by fixing five independent classes of bugs that all surface as *"downloads silently vanish or end up in the Issues tab."* See the analysis in #issue for full context.

This PR is the first slice from that analysis: the highest-impact fixes that don't require a wider refactor (session caching, BT v2 hashes, etc. — those will come in follow-up PRs).

## What changed

### qBittorrent adapter (`lib/mydia/downloads/client/qbittorrent.ex`)

| Fix | Problem | Resolution |
|---|---|---|
| **Multipart `.torrent` uploads** | The `:file` add_torrent path URL-encoded the binary payload, silently corrupting it. qBittorrent dropped the upload and we created a phantom DB row. *Root cause of most "added but never showed up" reports.* | Switched to Req's `form_multipart:` with proper filename and `application/x-bittorrent` content-type. |
| **Post-add verification** | qBittorrent returns `"Ok."` even when it silently rejects a torrent. We trusted the locally-computed hash unconditionally. | After adding, poll `/torrents/info?hashes=<h>` with backoff before declaring success. |
| **qBittorrent 5.x state names** | `stoppedDL` / `stoppedUP` / `moving` fell through to `:error`, which made `DownloadMonitor` *delete* the download record. | Mapped `stopped*` → `:paused`, `moving` → `:checking`. Unknown/future states default to `:checking` so we never lose a row to an unfamiliar state. |
| **qBittorrent 5.x pause/resume endpoints** | `/torrents/pause` and `/resume` were renamed to `/stop` and `/start` in 5.0. | Hit the legacy path first, fall back to the 5.x path on 404 — works on both 4.x and 5.x. |
| **Session re-auth on 403** | A SID that expired after `WebUI\SessionTimeout` made every subsequent call fail. | New `with_authenticated_session/2` catches 403, re-authenticates, retries once. Mirrors the Transmission 409-retry pattern. |
| **SID cookie selection** | `extract_sid_cookie/1` blindly took the first Set-Cookie header — could pick a CSRF cookie if qBittorrent emitted one first. | Scan every Set-Cookie value for one containing `SID=`. |

### DownloadMonitor (`lib/mydia/downloads/history.ex`)

**Don't mark downloads "missing" when their client is unreachable.** `fetch_all_client_statuses/1` now distinguishes `{:reachable, torrents_map}` from `:unreachable`, so a client restart no longer flags every active download as failed in a single monitor cycle. Unreachable clients leave downloads in `"unknown"` status until the next cycle.

## Tests

- **17 new Bypass-based qBittorrent tests** covering: multipart upload contents, post-add verification (silent-rejection + delayed-indexing), every 4.x and 5.x state name, SID cookie selection, 403 re-auth retry, and pause/resume endpoint fallback.
- **1 new DownloadMonitor test** asserting that downloads are NOT marked missing when their configured client is unreachable.

```
4035 tests, 0 failures, 27 skipped
```

## What's NOT in this PR (follow-up work)

From the original analysis — these need separate PRs:

- Session caching (avoid login-per-call hammering)
- BT v2 / hybrid torrent hash support
- `url_base` plumbing for reverse-proxied qBittorrent
- `verify_ssl: false` option for self-signed home-lab certs
- `hashes` filter on `list_torrents` so monitor doesn't pull every torrent every cycle
- Surface `tracker` / `availability` in `TorrentStatus` for Issues tab debugging
- Hash-case normalization at the schema boundary

## Test plan

- [x] `./dev mix test` — all 4035 tests pass
- [x] `./dev mix format --check-formatted` — clean
- [x] `./dev mix credo --strict lib/mydia/downloads/client/qbittorrent.ex lib/mydia/downloads/history.ex` — exit 0
- [ ] Smoke test against a real qBittorrent 4.x instance (manual)
- [ ] Smoke test against a real qBittorrent 5.x instance (manual) — verifies pause/resume fallback and new state names
- [ ] Verify a download via `.torrent` file (not magnet) actually appears in qBittorrent
- [ ] Restart qBittorrent mid-monitor and confirm no downloads jump to the Issues tab