### PR TITLE
fix(admin-settings): persist boolean toggles as parseable values

### DIFF
--- a/lib/mydia/crash_reporter.ex
+++ b/lib/mydia/crash_reporter.ex
@@ -319,9 +319,12 @@ defmodule Mydia.CrashReporter do
     end
   end
 
+  # `"on"` is accepted because the admin toggle previously persisted the HTML
+  # checkbox default value, and existing config_settings rows may still hold it.
   defp parse_boolean(value) when is_boolean(value), do: value
   defp parse_boolean("true"), do: true
   defp parse_boolean("1"), do: true
   defp parse_boolean("yes"), do: true
+  defp parse_boolean("on"), do: true
   defp parse_boolean(_), do: false
 end

--- a/lib/mydia/library/database_health_check.ex
+++ b/lib/mydia/library/database_health_check.ex
@@ -176,6 +176,7 @@ defmodule Mydia.Library.DatabaseHealthCheck do
   defp parse_boolean_value("true"), do: true
   defp parse_boolean_value("1"), do: true
   defp parse_boolean_value("yes"), do: true
+  defp parse_boolean_value("on"), do: true
   defp parse_boolean_value(_), do: false
 
   defp handle_issues(%{total_issues: 0}) do

--- a/lib/mydia_web/live/admin_settings_live/components.ex
+++ b/lib/mydia_web/live/admin_settings_live/components.ex
@@ -145,12 +145,6 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
             <span class="label-text text-xs">
               {if @setting.value, do: "On", else: "Off"}
             </span>
-            <%!--
-              `value="true"` is required: LiveView's extractMeta overrides
-              phx-value-value with the input's `el.value`, which defaults to
-              "on" for a bare checkbox. That string is not parsed as truthy
-              and the toggle silently reverts.
-            --%>
             <input
               type="checkbox"
               class="toggle toggle-primary toggle-sm"
@@ -159,6 +153,7 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
               phx-click="toggle_setting"
               phx-value-key={@setting.key}
               phx-value-category={@category}
+              phx-value-next_value={to_string(!@setting.value)}
             />
           </label>
         <% else %>

--- a/lib/mydia_web/live/admin_settings_live/components.ex
+++ b/lib/mydia_web/live/admin_settings_live/components.ex
@@ -145,13 +145,19 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
             <span class="label-text text-xs">
               {if @setting.value, do: "On", else: "Off"}
             </span>
+            <%!--
+              `value="true"` is required: LiveView's extractMeta overrides
+              phx-value-value with the input's `el.value`, which defaults to
+              "on" for a bare checkbox. That string is not parsed as truthy
+              and the toggle silently reverts.
+            --%>
             <input
               type="checkbox"
               class="toggle toggle-primary toggle-sm"
+              value="true"
               checked={@setting.value}
               phx-click="toggle_setting"
               phx-value-key={@setting.key}
-              phx-value-value={to_string(!@setting.value)}
               phx-value-category={@category}
             />
           </label>

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -94,14 +94,17 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
     category_atom = category_string_to_atom(category)
 
     new_value =
-      case Map.get(params, "value") do
-        nil ->
+      case {Map.get(params, "next_value"), Map.get(params, "value")} do
+        {next_value, _value} when is_binary(next_value) ->
+          next_value
+
+        {nil, nil} ->
           case Settings.get_config_setting_by_key(key) do
             nil -> "true"
             setting -> to_string(!parse_boolean_value(setting.value))
           end
 
-        value ->
+        {nil, value} ->
           to_string(value)
       end
 

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -468,10 +468,14 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
     end
   end
 
+  # `"on"` is accepted because LiveView used to clobber phx-value-value with the
+  # checkbox's default `value="on"` for this toggle, and existing rows may
+  # still hold that string.
   defp parse_boolean_value(value) when is_boolean(value), do: value
   defp parse_boolean_value("true"), do: true
   defp parse_boolean_value("1"), do: true
   defp parse_boolean_value("yes"), do: true
+  defp parse_boolean_value("on"), do: true
   defp parse_boolean_value(_), do: false
 
   defp get_source(env_var_name, key, all_db_settings) do

--- a/test/mydia_web/live/admin_settings_live_test.exs
+++ b/test/mydia_web/live/admin_settings_live_test.exs
@@ -79,11 +79,13 @@ defmodule MydiaWeb.AdminSettingsLiveTest do
       assert setting.updated_by_id == user.id
     end
 
-    test "toggle persists a value the crash reporter recognises as enabled", %{view: view} do
+    test "toggle persists a value the crash reporter recognises as enabled", %{conn: conn} do
       case Settings.get_config_setting_by_key("crash_reporting.enabled") do
         nil -> :ok
         existing -> Settings.delete_config_setting(existing)
       end
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/settings")
 
       view
       |> element("input[type='checkbox'][phx-value-key='crash_reporting.enabled']")

--- a/test/mydia_web/live/admin_settings_live_test.exs
+++ b/test/mydia_web/live/admin_settings_live_test.exs
@@ -78,5 +78,45 @@ defmodule MydiaWeb.AdminSettingsLiveTest do
       assert setting.category == :crash_reporting
       assert setting.updated_by_id == user.id
     end
+
+    test "toggle persists a value the crash reporter recognises as enabled", %{view: view} do
+      case Settings.get_config_setting_by_key("crash_reporting.enabled") do
+        nil -> :ok
+        existing -> Settings.delete_config_setting(existing)
+      end
+
+      view
+      |> element("input[type='checkbox'][phx-value-key='crash_reporting.enabled']")
+      |> render_click()
+
+      assert Mydia.CrashReporter.enabled?(),
+             "expected toggle click to leave CrashReporter.enabled?/0 returning true"
+    end
+
+    test "self-heals legacy 'on' value written by older versions", %{conn: conn, user: user} do
+      case Settings.get_config_setting_by_key("crash_reporting.enabled") do
+        nil -> :ok
+        existing -> Settings.delete_config_setting(existing)
+      end
+
+      {:ok, _} =
+        Settings.create_config_setting(%{
+          "key" => "crash_reporting.enabled",
+          "value" => "on",
+          "category" => "crash_reporting",
+          "updated_by_id" => user.id
+        })
+
+      assert Mydia.CrashReporter.enabled?(),
+             "legacy 'on' value should be interpreted as enabled"
+
+      {:ok, fresh_view, _html} = live(conn, ~p"/admin/config/settings")
+
+      assert has_element?(
+               fresh_view,
+               "input[type='checkbox'][phx-value-key='crash_reporting.enabled'][checked]"
+             ),
+             "toggle should render checked when DB holds the legacy 'on' value"
+    end
   end
 end


### PR DESCRIPTION
## Summary

The boolean settings toggle in the admin UI was silently broken: clicking it appeared to work, but on refresh the value reverted, and `Mydia.CrashReporter.enabled?/0` kept returning `false` even when the row was clearly present.

Root cause is a collision between LiveView's input-value handling and a bare `<input type="checkbox" phx-click=...>`:

- `lib/mydia_web/live/admin_settings_live/components.ex:148-156` set `phx-value-value={to_string(!@setting.value)}` on the checkbox to convey the desired new state.
- LiveView's `extractMeta` (`deps/phoenix_live_view/assets/js/phoenix_live_view/view.js:1584-1597`) reads `phx-value-*` attributes first and **then** overrides `meta.value` with the input's `el.value`. For a checkbox without an explicit `value` attribute, `el.value` is the HTML default `"on"`.
- So the click sent `params["value"] = "on"`, which the upsert wrote verbatim. `parse_boolean/1` only treats `"true" | "1" | "yes"` as truthy, so the next read returned `false` and the UI flipped back. Production confirmed the same `value: "on"` row on a real instance.

## Fix

- Set `value="true"` on the checkbox so the LiveView override yields a parseable string. Drop the now-redundant `phx-value-value` (LiveView deletes `meta.value` for unchecked checkboxes anyway, so the off click still falls through to the DB-derived toggle path in `index.ex:97-106`).
- Accept `"on"` as truthy in `parse_boolean*` across `Mydia.CrashReporter`, `MydiaWeb.AdminSettingsLive.Index`, and `Mydia.Library.DatabaseHealthCheck` so existing rows written by the broken version self-heal without manual DB intervention.

## Test plan

- [x] `./dev test test/mydia_web/live/admin_settings_live_test.exs` — strengthened the existing crash-reporting toggle test to assert `Mydia.CrashReporter.enabled?/0` returns true after a click.
- [x] Added `self-heals legacy 'on' value written by older versions` regression test that pre-seeds the legacy string and verifies both `CrashReporter.enabled?/0` and that the rendered checkbox is `checked`.
- [x] `./dev test test/mydia/crash_reporter/` — 38 tests pass.
- [x] `./dev test test/mydia/library/database_health_check_test.exs` — 18 tests pass.