### PR TITLE
fix(search): skip monitored items that already have an active download

### DIFF
--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -34,7 +34,7 @@ defmodule Mydia.Jobs.MovieSearch do
   import Ecto.Query, warn: false
 
   alias Mydia.{Repo, Media, Indexers, Downloads, Events, Search}
-  alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.{Blacklists, Download}
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Library.MediaFile
   alias Mydia.Media.MediaItem
@@ -373,17 +373,32 @@ defmodule Mydia.Jobs.MovieSearch do
     enabled_count + cardigann_count
   end
 
-  defp load_monitored_movies_without_files do
+  @doc false
+  # Public for direct testing of the search-selection filter.
+  def load_monitored_movies_without_files do
     movies =
       MediaItem
       |> where([m], m.type == "movie")
       |> where([m], m.monitored == true)
+      |> where([m], m.id not in subquery(active_download_media_item_ids()))
       |> join(:left, [m], mf in MediaFile, on: mf.media_item_id == m.id and is_nil(mf.trashed_at))
       |> group_by([m], m.id)
       |> having([m, mf], count(mf.id) == 0)
       |> Repo.all()
 
     filter_movies_in_backoff(movies)
+  end
+
+  # media_item_ids with an in-flight download (still in client, not failed).
+  # Matches Mydia.Downloads.Queue.check_for_active_download/3 so we skip
+  # indexer calls for items the queue would reject anyway.
+  defp active_download_media_item_ids do
+    from(d in Download,
+      where: is_nil(d.completed_at) and is_nil(d.error_message),
+      where: not is_nil(d.media_item_id),
+      select: d.media_item_id,
+      distinct: true
+    )
   end
 
   defp filter_movies_in_backoff(movies) do

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -54,7 +54,7 @@ defmodule Mydia.Jobs.TVShowSearch do
   import Ecto.Query, warn: false
 
   alias Mydia.{Repo, Media, Indexers, Downloads, Events, Search}
-  alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.{Blacklists, Download}
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Indexers.Structs.SearchResultMetadata
   alias Mydia.Media.{MediaItem, Episode}
@@ -460,7 +460,9 @@ defmodule Mydia.Jobs.TVShowSearch do
     |> Repo.one()
   end
 
-  defp load_monitored_episodes_without_files do
+  @doc false
+  # Public for direct testing of the search-selection filter.
+  def load_monitored_episodes_without_files do
     today = Date.utc_today()
 
     episodes =
@@ -468,6 +470,7 @@ defmodule Mydia.Jobs.TVShowSearch do
       |> join(:inner, [e], m in assoc(e, :media_item))
       |> where([e, m], e.monitored == true and m.monitored == true)
       |> where([e], e.air_date <= ^today)
+      |> where([e], e.id not in subquery(active_episode_download_ids()))
       |> join(:left, [e], mf in MediaFile, on: mf.episode_id == e.id and is_nil(mf.trashed_at))
       |> group_by([e], e.id)
       |> having([_e, _m, mf], count(mf.id) == 0)
@@ -476,8 +479,52 @@ defmodule Mydia.Jobs.TVShowSearch do
 
     # Filter out special episodes (S00) unless configured to monitor them
     episodes
+    |> reject_episodes_in_active_season_packs()
     |> filter_special_episodes()
     |> filter_episodes_in_backoff()
+  end
+
+  # Episodes with an active episode-level download (still in client, not failed).
+  defp active_episode_download_ids do
+    from(d in Download,
+      where: is_nil(d.completed_at) and is_nil(d.error_message),
+      where: not is_nil(d.episode_id),
+      select: d.episode_id,
+      distinct: true
+    )
+  end
+
+  # Drop episodes covered by an active season-pack download. Mirrors the
+  # season-pack arm of Mydia.Downloads.Queue.check_for_active_download/3:
+  # matched by (media_item_id, season_number) on downloads whose metadata
+  # has season_pack=true.
+  defp reject_episodes_in_active_season_packs([]), do: []
+
+  defp reject_episodes_in_active_season_packs(episodes) do
+    media_item_ids =
+      episodes
+      |> Enum.map(& &1.media_item_id)
+      |> Enum.uniq()
+
+    covered =
+      from(d in Download,
+        where: is_nil(d.completed_at) and is_nil(d.error_message),
+        where: d.media_item_id in ^media_item_ids,
+        where: ^Mydia.DB.json_is_true(:metadata, "$.season_pack"),
+        select: %{media_item_id: d.media_item_id, metadata: d.metadata}
+      )
+      |> Repo.all()
+      |> Enum.reduce(MapSet.new(), fn
+        %{media_item_id: mid, metadata: %{"season_number" => sn}}, acc when is_integer(sn) ->
+          MapSet.put(acc, {mid, sn})
+
+        _, acc ->
+          acc
+      end)
+
+    Enum.reject(episodes, fn e ->
+      MapSet.member?(covered, {e.media_item_id, e.season_number})
+    end)
   end
 
   defp load_episodes_for_show(media_item_id) do

--- a/test/mydia/jobs/movie_search_test.exs
+++ b/test/mydia/jobs/movie_search_test.exs
@@ -12,6 +12,9 @@ defmodule Mydia.Jobs.MovieSearchTest do
   import Mydia.MediaFixtures
   import Mydia.SettingsFixtures
   import Mydia.AccountsFixtures
+  import Mydia.DownloadsFixtures
+
+  alias Mydia.Repo
 
   # Mock download client adapter for testing
   defmodule MockDownloadAdapter do
@@ -257,6 +260,53 @@ defmodule Mydia.Jobs.MovieSearchTest do
 
       # Job should process all movies with mocked indexer
       assert :ok = perform_job(MovieSearch, %{"mode" => "all_monitored"})
+    end
+  end
+
+  describe "load_monitored_movies_without_files/0" do
+    test "skips movies with an active download" do
+      queued = media_item_fixture(%{type: "movie", title: "Already Queued", monitored: true})
+      _ = download_fixture(%{media_item_id: queued.id, title: "Already.Queued.2024.1080p"})
+
+      needs_search = media_item_fixture(%{type: "movie", title: "Needs Search", monitored: true})
+
+      ids = Enum.map(MovieSearch.load_monitored_movies_without_files(), & &1.id)
+
+      refute queued.id in ids
+      assert needs_search.id in ids
+    end
+
+    test "still selects a movie when its prior download failed" do
+      movie = media_item_fixture(%{type: "movie", title: "Failed Once", monitored: true})
+
+      download = download_fixture(%{media_item_id: movie.id, title: "Failed.Once.2024.1080p"})
+
+      {:ok, _} =
+        download
+        |> Ecto.Changeset.change(error_message: "client reported failure")
+        |> Repo.update()
+
+      ids = Enum.map(MovieSearch.load_monitored_movies_without_files(), & &1.id)
+
+      assert movie.id in ids
+    end
+
+    test "still selects a movie when its prior download completed" do
+      # Edge case: completed_at set but no media_file yet. Search may run again;
+      # the queue layer will dedup if appropriate. We mirror queue.ex semantics:
+      # only `completed_at IS NULL AND error_message IS NULL` counts as in-flight.
+      movie = media_item_fixture(%{type: "movie", title: "Completed", monitored: true})
+
+      download = download_fixture(%{media_item_id: movie.id, title: "Completed.2024.1080p"})
+
+      {:ok, _} =
+        download
+        |> Ecto.Changeset.change(completed_at: DateTime.utc_now() |> DateTime.truncate(:second))
+        |> Repo.update()
+
+      ids = Enum.map(MovieSearch.load_monitored_movies_without_files(), & &1.id)
+
+      assert movie.id in ids
     end
   end
 

--- a/test/mydia/jobs/tv_show_search_test.exs
+++ b/test/mydia/jobs/tv_show_search_test.exs
@@ -12,6 +12,7 @@ defmodule Mydia.Jobs.TVShowSearchTest do
   import Mydia.MediaFixtures
   import Mydia.SettingsFixtures
   import Mydia.AccountsFixtures
+  import Mydia.DownloadsFixtures
 
   # Mock download client adapter for testing
   defmodule MockDownloadAdapter do
@@ -623,6 +624,116 @@ defmodule Mydia.Jobs.TVShowSearchTest do
 
       # Applies smart logic per season with mocked indexer
       assert :ok = perform_job(TVShowSearch, %{"mode" => "all_monitored"})
+    end
+  end
+
+  describe "load_monitored_episodes_without_files/0" do
+    test "skips an episode with an active episode-level download" do
+      tv_show = media_item_fixture(%{type: "tv_show", title: "Mixed Show", monitored: true})
+
+      queued =
+        episode_fixture(%{
+          media_item_id: tv_show.id,
+          season_number: 1,
+          episode_number: 1,
+          air_date: ~D[2020-01-01]
+        })
+
+      needs_search =
+        episode_fixture(%{
+          media_item_id: tv_show.id,
+          season_number: 1,
+          episode_number: 2,
+          air_date: ~D[2020-01-08]
+        })
+
+      _download =
+        download_fixture(%{
+          media_item_id: tv_show.id,
+          episode_id: queued.id,
+          title: "Mixed.Show.S01E01.1080p"
+        })
+
+      ids = Enum.map(TVShowSearch.load_monitored_episodes_without_files(), & &1.id)
+
+      refute queued.id in ids
+      assert needs_search.id in ids
+    end
+
+    test "skips every episode covered by an active season-pack download" do
+      tv_show = media_item_fixture(%{type: "tv_show", title: "Pack Show", monitored: true})
+
+      s1e1 =
+        episode_fixture(%{
+          media_item_id: tv_show.id,
+          season_number: 1,
+          episode_number: 1,
+          air_date: ~D[2020-01-01]
+        })
+
+      s1e2 =
+        episode_fixture(%{
+          media_item_id: tv_show.id,
+          season_number: 1,
+          episode_number: 2,
+          air_date: ~D[2020-01-08]
+        })
+
+      s2e1 =
+        episode_fixture(%{
+          media_item_id: tv_show.id,
+          season_number: 2,
+          episode_number: 1,
+          air_date: ~D[2021-01-01]
+        })
+
+      _season_pack =
+        download_fixture(%{
+          media_item_id: tv_show.id,
+          title: "Pack.Show.S01.1080p",
+          metadata: %{"season_pack" => true, "season_number" => 1}
+        })
+
+      ids = Enum.map(TVShowSearch.load_monitored_episodes_without_files(), & &1.id)
+
+      refute s1e1.id in ids
+      refute s1e2.id in ids
+      assert s2e1.id in ids
+    end
+
+    test "does not treat a non-season-pack download as covering other episodes" do
+      # A download with season_pack=false (or missing) on the same season must not
+      # skip sibling episodes — only an explicit season pack does.
+      tv_show = media_item_fixture(%{type: "tv_show", title: "Single Ep Show", monitored: true})
+
+      ep1 =
+        episode_fixture(%{
+          media_item_id: tv_show.id,
+          season_number: 1,
+          episode_number: 1,
+          air_date: ~D[2020-01-01]
+        })
+
+      ep2 =
+        episode_fixture(%{
+          media_item_id: tv_show.id,
+          season_number: 1,
+          episode_number: 2,
+          air_date: ~D[2020-01-08]
+        })
+
+      _download =
+        download_fixture(%{
+          media_item_id: tv_show.id,
+          episode_id: ep1.id,
+          title: "Single.Ep.Show.S01E01.1080p",
+          metadata: %{"season_pack" => false, "season_number" => 1}
+        })
+
+      ids = Enum.map(TVShowSearch.load_monitored_episodes_without_files(), & &1.id)
+
+      refute ep1.id in ids
+      assert ep2.id in ids
     end
   end
 


### PR DESCRIPTION
## Summary

`MovieSearch` and `TVShowSearch` in `all_monitored` mode pick up any monitored item without a `MediaFile` — including items whose download is already in flight in the client. The job hits every indexer, ranks releases, and only then does `Downloads.Queue.check_for_duplicate_download/2` reject the queue attempt with `:duplicate_download`. This wastes indexer queries on every scheduled cycle and emits noisy `download.failed` events for releases that aren't actually failing.

Observed in production: a single show with three season-pack downloads in flight produced ~10 `download.failed` events with reason "Download already exists" in a 90-second window.

## Fix

Filter at the selection step in both jobs using the same predicate `Downloads.Queue.check_for_active_download/3` uses for dedup: `completed_at IS NULL AND error_message IS NULL`.

- **Movies** (`load_monitored_movies_without_files/0`): exclude `media_item_id`s with any active download row.
- **Episodes** (`load_monitored_episodes_without_files/0`):
  - exclude `episode_id`s with an active episode-level download via subquery
  - drop episodes covered by an active season-pack download (matched by `media_item_id` + `metadata.season_pack=true` + `metadata.season_number`), mirroring the season-pack arm of the queue dedup

UI-triggered `specific` / `show` / `season` modes are unchanged. An explicit user click still flows through the queue dedup so the user gets a real error if there's a conflict.

The search filter is best-effort: a stale `downloads` row that doesn't reflect client state will incorrectly keep an item out of automatic search. That's tracked separately as a self-healing fix for unmatched/orphaned downloads.

## Test plan

- [x] `./dev mix test test/mydia/jobs/movie_search_test.exs test/mydia/jobs/tv_show_search_test.exs` — 45 tests, 0 failures
- [x] `./dev mix test test/mydia/downloads/` — 623 tests, 0 failures (verified no regressions in queue/dedup paths)
- [x] `./dev mix compile` — clean
- [ ] After deploy, watch activity log for absence of `download.failed` with reason `"Download already exists"` from scheduled `all_monitored` runs