### PR TITLE
ci(release): flip to release-first flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,16 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g., v1.0.0)'
+        description: 'Version tag of an existing release (e.g., v1.0.0)'
         required: true
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event.release.tag_name || github.event.inputs.version || github.ref }}
   cancel-in-progress: false
 
 env:
@@ -25,6 +24,7 @@ jobs:
     name: Prepare
     runs-on: ubuntu-latest
     outputs:
+      tag: ${{ steps.get_version.outputs.tag }}
       version: ${{ steps.get_version.outputs.version }}
       version_code: ${{ steps.get_version.outputs.version_code }}
       is_prerelease: ${{ steps.get_version.outputs.is_prerelease }}
@@ -35,7 +35,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TAG="${{ github.event.inputs.version }}"
           else
-            TAG="${{ github.ref_name }}"
+            TAG="${{ github.event.release.tag_name }}"
           fi
 
           # Remove 'v' prefix for version number
@@ -54,6 +54,7 @@ jobs:
             IS_PRERELEASE=false
           fi
 
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT
           echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
           echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
@@ -807,9 +808,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -840,48 +838,36 @@ jobs:
           [ -d "mydia-player-macos-appcast" ] && \
             mv mydia-player-macos-appcast/appcast.xml . || true
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: Mydia Player v${{ needs.prepare.outputs.version }}
-          tag_name: ${{ github.ref_name }}
-          draft: false
-          prerelease: ${{ needs.prepare.outputs.is_prerelease }}
-          generate_release_notes: true
-          body: |
-            ## Docker Images
-
-            ```bash
-            # SQLite (recommended for most users)
-            docker pull ghcr.io/getmydia/mydia:${{ needs.prepare.outputs.version }}
-
-            # PostgreSQL
-            docker pull ghcr.io/getmydia/mydia:${{ needs.prepare.outputs.version }}-pg
-            ```
-
-            ## Player Downloads
-
-            Platform-specific player downloads are available as release assets below.
-
-            | Platform | Notes |
-            |----------|-------|
-            | **Android** | APK for direct installation |
-            | **iOS** | Available on TestFlight (if configured) |
-            | **macOS** | DMG disk image |
-            | **Windows** | Installer (.exe) |
-            | **Linux** | Bundle in tar.gz archive |
-            | **Web** | Integrated at `/player` on your Mydia server |
-
-            ---
-
-          files: |
-            artifacts/mydia-player-android-*.apk
-            artifacts/mydia-player-macos-*.dmg
-            artifacts/mydia-player-windows-*.exe
-            artifacts/mydia-player-linux-*.tar.gz
-            artifacts/appcast.xml
+      - name: Upload release assets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        working-directory: artifacts
+        run: |
+          shopt -s nullglob
+          FILES=()
+          for pattern in \
+            "mydia-player-android-*.apk" \
+            "mydia-player-macos-*.dmg" \
+            "mydia-player-windows-*.exe" \
+            "mydia-player-linux-*.tar.gz" \
+            "appcast.xml"; do
+            for f in $pattern; do
+              FILES+=("$f")
+            done
+          done
+
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No release artifacts found"
+            exit 1
+          fi
+
+          echo "Uploading to release ${TAG}:"
+          printf '  %s\n' "${FILES[@]}"
+
+          gh release upload "${TAG}" "${FILES[@]}" \
+            --clobber \
+            --repo "${{ github.repository }}"
 
   docs:
     name: Deploy Docs


### PR DESCRIPTION
## Summary

- Trigger the Release workflow on `release: published` instead of `push: tags`
- Author releases first: `gh release create vX.Y.Z --notes-file notes.md --prerelease` creates the tag, release, and notes atomically; that publish event kicks off the build
- Upload artifacts to the existing release via `gh release upload --clobber` so author-set notes and prerelease state are never overwritten

## Why

Today's `push: tags` flow forces human-authored release notes to land **after** a ~40-min build. During that window, the release page shows the workflow's generic Docker/Player template, and the curated notes have to be patched in by editing the release after the fact (or by a follow-up automation step). Reviewers, early testers, and the docs deploy all see a half-baked release until the edit lands.

Release-first inverts that: notes exist from second zero. The build just decorates the release with artifacts when it's done. Same total work, but the user-visible artifact is correct from the start.

## New release procedure

```bash
# 1. Draft notes locally
$EDITOR notes.md

# 2. Create the release (also creates the tag)
gh release create v0.10.1-beta1 \
  --target master \
  --notes-file notes.md \
  --prerelease   # or omit for a stable release

# 3. Workflow auto-fires; watch in Actions tab
gh run watch
```

If a build fails partway, fix the issue, then rerun via Actions UI or `workflow_dispatch` with the existing tag as the `version` input. The release stays put.

## Concrete diff highlights

- `on: push.tags` → `on: release.types: [published]`
- Concurrency group now keyed on the release tag (resilient to dispatch reruns)
- `prepare` exposes a `tag` output (`vX.Y.Z` form) for the upload step
- `publish` drops `softprops/action-gh-release@v2` and the hardcoded Docker/Player body template; uploads files directly with `gh release upload --clobber` via a `nullglob` loop that tolerates platform-specific builds being absent

## Test plan

- [ ] Cut the next release (e.g. `v0.10.0`) using the new procedure and confirm: release notes stay intact, artifacts attach, prerelease flag preserved
- [ ] Verify `workflow_dispatch` rerun still works against an existing release tag
- [ ] Sanity-check the docs deploy job still fires only for non-prereleases

No new release needed to validate — the next one naturally exercises this path.

## Out of scope (followups)

- A `RELEASING.md` capturing the procedure above; left out to keep this diff surgical
- Drafting notes from a committed `release-notes/vX.Y.Z.md` file so they're reviewable in a PR before publish (orthogonal improvement)