### PR TITLE
fix(downloads): self-heal unmatched orphans and stop MediaImport retry loop

### DIFF
--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -258,7 +258,8 @@ defmodule Mydia.Downloads.History do
       import_next_retry_at: download.import_next_retry_at,
       import_failed_at: download.import_failed_at,
       last_progress_at: download.last_progress_at,
-      last_known_bytes: download.last_known_bytes
+      last_known_bytes: download.last_known_bytes,
+      in_client?: true
     })
   end
 
@@ -301,7 +302,9 @@ defmodule Mydia.Downloads.History do
       import_next_retry_at: download.import_next_retry_at,
       import_failed_at: download.import_failed_at,
       last_progress_at: download.last_progress_at,
-      last_known_bytes: download.last_known_bytes
+      last_known_bytes: download.last_known_bytes,
+      # Client unreachable — presence indeterminate.
+      in_client?: nil
     })
   end
 
@@ -355,7 +358,8 @@ defmodule Mydia.Downloads.History do
       import_next_retry_at: download.import_next_retry_at,
       import_failed_at: download.import_failed_at,
       last_progress_at: download.last_progress_at,
-      last_known_bytes: download.last_known_bytes
+      last_known_bytes: download.last_known_bytes,
+      in_client?: false
     })
   end
 

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -201,7 +201,7 @@ defmodule Mydia.Downloads.History do
         case Map.get(torrents_map, download.download_client_id) do
           nil ->
             # Client confirmed it doesn't have this torrent — genuinely missing.
-            enrich_download_with_empty_status(download)
+            enrich_download_with_empty_status(download, false)
 
           torrent_status ->
             enrich_download_with_torrent_status(download, torrent_status)
@@ -308,7 +308,7 @@ defmodule Mydia.Downloads.History do
     })
   end
 
-  defp enrich_download_with_empty_status(download) do
+  defp enrich_download_with_empty_status(download, in_client? \\ nil) do
     # Download exists in DB but not in client
     # Could be completed and removed, or manually deleted from client
     status =
@@ -359,7 +359,7 @@ defmodule Mydia.Downloads.History do
       import_failed_at: download.import_failed_at,
       last_progress_at: download.last_progress_at,
       last_known_bytes: download.last_known_bytes,
-      in_client?: false
+      in_client?: in_client?
     })
   end
 

--- a/lib/mydia/downloads/structs/enriched_download.ex
+++ b/lib/mydia/downloads/structs/enriched_download.ex
@@ -50,7 +50,12 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
     :import_failed_at,
     # Stall-detection / progress tracking (mirrored from Download DB row)
     :last_progress_at,
-    :last_known_bytes
+    :last_known_bytes,
+    # Whether the torrent is currently present in its download client.
+    # true  = client confirmed the torrent is there
+    # false = client confirmed the torrent is gone
+    # nil   = client unreachable; presence unknown
+    :in_client?
   ]
 
   @type t :: %__MODULE__{
@@ -90,7 +95,8 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
           import_next_retry_at: DateTime.t() | nil,
           import_failed_at: DateTime.t() | nil,
           last_progress_at: DateTime.t() | nil,
-          last_known_bytes: integer() | nil
+          last_known_bytes: integer() | nil,
+          in_client?: boolean() | nil
         }
 
   @doc """

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -86,6 +86,16 @@ defmodule Mydia.Jobs.DownloadMonitor do
         d.status == "missing" and is_nil(d.db_completed_at) and is_nil(d.error_message)
       end)
 
+    # Self-heal: unmatched downloads whose torrent is no longer in any client
+    # have no recovery path — they were never paired to a media_item and have
+    # no destination library_path. Delete them so MediaImport stops retrying
+    # forever. (Matched downloads keep going through `missing` / `failed`
+    # handlers so the user can investigate them in the Issues tab.)
+    unmatched_orphans =
+      Enum.filter(downloads, fn d ->
+        d.match_status == "unmatched" and d.in_client? == false
+      end)
+
     # Active downloads we should track for stall detection. Skip terminal
     # states (completed/seeding/failed/missing/imported) and anything already
     # flagged as import_failed_at — the latter prevents stomping a previous
@@ -98,7 +108,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
       end)
 
     Logger.info(
-      "Found #{length(completed)} newly completed, #{length(failed)} newly failed, #{length(missing)} missing downloads, #{length(active_for_stall_check)} active for stall check"
+      "Found #{length(completed)} newly completed, #{length(failed)} newly failed, #{length(missing)} missing downloads, #{length(unmatched_orphans)} unmatched orphans, #{length(active_for_stall_check)} active for stall check"
     )
 
     # Handle completions
@@ -109,6 +119,9 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
     # Handle missing downloads
     Enum.each(missing, &handle_missing/1)
+
+    # Self-heal unmatched orphans (delete; never imported, never will be)
+    Enum.each(unmatched_orphans, &handle_unmatched_orphan/1)
 
     # Track progress / flag stalled downloads. Grace minutes are read from each
     # download's configured client (DB or runtime config) — cached per poll.
@@ -131,6 +144,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
       completed_count: length(completed),
       failed_count: length(failed),
       missing_count: length(missing),
+      unmatched_orphans_cleaned: length(unmatched_orphans),
       stalled_count: stalled_count,
       stuck_count: length(stuck),
       untracked_matched: length(untracked_downloads)
@@ -187,19 +201,60 @@ defmodule Mydia.Jobs.DownloadMonitor do
     # Track completion event
     Events.download_completed(download, media_item: download.media_item)
 
-    # Enqueue import job - it will delete the download record after successful import
-    case enqueue_import_job(download, download_map) do
-      {:ok, _job} ->
-        Logger.info("Import job enqueued for completed download",
-          download_id: download.id
-        )
+    if download.match_status == "unmatched" do
+      # Unmatched downloads have no destination library_path and no media_item
+      # to associate files with, so MediaImport can't do anything with them.
+      # Leave the row in place: the user may still match it via the Issues tab
+      # while the torrent is in the client. Once the torrent leaves the client,
+      # handle_unmatched_orphan/1 will delete the row.
+      Logger.info("Completed download is unmatched — skipping MediaImport enqueue",
+        download_id: download.id
+      )
 
+      :ok
+    else
+      # Enqueue import job - it will delete the download record after successful import
+      case enqueue_import_job(download, download_map) do
+        {:ok, _job} ->
+          Logger.info("Import job enqueued for completed download",
+            download_id: download.id
+          )
+
+          :ok
+
+        {:error, reason} ->
+          Logger.error("Failed to enqueue import job",
+            download_id: download.id,
+            reason: inspect(reason)
+          )
+
+          :ok
+      end
+    end
+  end
+
+  # Self-heal: an unmatched download whose torrent is no longer in any client
+  # is unrecoverable — nothing in the system can pair it with a media_item.
+  # Delete the row so MediaImport stops retrying and the queue dedup stops
+  # treating it as "active".
+  defp handle_unmatched_orphan(download_map) do
+    Logger.info(
+      "Self-healing unmatched download — torrent gone from client, no recovery path",
+      download_id: download_map.id,
+      title: download_map.title,
+      client: download_map.download_client
+    )
+
+    download = Downloads.get_download!(download_map.id)
+
+    case Downloads.delete_download(download) do
+      {:ok, _deleted} ->
         :ok
 
-      {:error, reason} ->
-        Logger.error("Failed to enqueue import job",
+      {:error, changeset} ->
+        Logger.warning("Failed to delete unmatched orphan",
           download_id: download.id,
-          reason: inspect(reason)
+          errors: inspect(changeset.errors)
         )
 
         :ok

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -83,7 +83,8 @@ defmodule Mydia.Jobs.DownloadMonitor do
     # Status is "missing" when download exists in DB but not in any client
     missing =
       Enum.filter(downloads, fn d ->
-        d.status == "missing" and is_nil(d.db_completed_at) and is_nil(d.error_message)
+        d.status == "missing" and is_nil(d.db_completed_at) and is_nil(d.error_message) and
+          d.match_status != "unmatched"
       end)
 
     # Self-heal: unmatched downloads whose torrent is no longer in any client

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -102,10 +102,24 @@ defmodule Mydia.Jobs.MediaImport do
       attempt: attempt
     )
 
-    download =
-      Downloads.get_download!(download_id,
-        preload: [{:media_item, :episodes}, :episode, :library_path]
-      )
+    case fetch_download(download_id) do
+      :not_found ->
+        # Self-heal: the row was deleted (likely by DownloadMonitor cleaning up
+        # an unmatched orphan, or by failure handling). No work to do — mark
+        # the job done so Oban stops retrying.
+        Logger.info("Media import short-circuit: download row no longer exists",
+          download_id: download_id
+        )
+
+        :ok
+
+      {:ok, download} ->
+        perform_with_download(download, args, attempt, raw_args)
+    end
+  end
+
+  defp perform_with_download(download, args, attempt, raw_args) do
+    download_id = download.id
 
     cond do
       not is_nil(download.imported_at) ->
@@ -118,6 +132,18 @@ defmodule Mydia.Jobs.MediaImport do
         )
 
         :ok
+
+      orphaned_unmatched?(download) ->
+        # Self-heal: the download has no media_item, no library_path, and is
+        # tagged unmatched. There is no path to a successful import — discard
+        # so Oban stops retrying. The row stays so the user can still match
+        # it manually from the Issues tab while the torrent is in the client.
+        Logger.info("Media import discarded: unmatched download with no destination",
+          download_id: download_id,
+          attempt: attempt
+        )
+
+        {:cancel, :unmatched_no_destination}
 
       is_nil(download.completed_at) ->
         handle_incomplete_download(download, args, attempt, raw_args)
@@ -136,6 +162,21 @@ defmodule Mydia.Jobs.MediaImport do
         end
     end
   end
+
+  defp fetch_download(download_id) do
+    {:ok,
+     Downloads.get_download!(download_id,
+       preload: [{:media_item, :episodes}, :episode, :library_path]
+     )}
+  rescue
+    Ecto.NoResultsError -> :not_found
+  end
+
+  defp orphaned_unmatched?(%{match_status: "unmatched"} = download) do
+    is_nil(download.media_item_id) and is_nil(download.library_path_id)
+  end
+
+  defp orphaned_unmatched?(_download), do: false
 
   defp handle_incomplete_download(download, args, attempt, raw_args) do
     download_id = download.id

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -379,6 +379,98 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
     end
   end
 
+  describe "unmatched orphan self-healing" do
+    test "deletes an unmatched download that is no longer in any client" do
+      setup_runtime_config([])
+
+      orphan =
+        download_fixture(%{
+          match_status: "unmatched",
+          download_client: "test-client",
+          download_client_id: "gone-1"
+        })
+
+      {:ok, _} =
+        orphan
+        |> Ecto.Changeset.change(media_item_id: nil)
+        |> Mydia.Repo.update()
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      refute Mydia.Repo.get(Mydia.Downloads.Download, orphan.id)
+    end
+
+    test "deletes an unmatched + completed download that is no longer in any client" do
+      # The actual production bug: completed_at set, no media_item, no
+      # library_path, sitting in DB forever while MediaImport retries.
+      setup_runtime_config([])
+
+      orphan =
+        download_fixture(%{
+          match_status: "unmatched",
+          completed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          download_client: "test-client",
+          download_client_id: "gone-completed-1"
+        })
+
+      {:ok, _} =
+        orphan
+        |> Ecto.Changeset.change(media_item_id: nil, library_path_id: nil)
+        |> Mydia.Repo.update()
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      refute Mydia.Repo.get(Mydia.Downloads.Download, orphan.id)
+    end
+
+    test "preserves a matched download that goes missing (regression guard)" do
+      # Matched downloads still go through the `missing` handler — the user
+      # may want to investigate why their tracked torrent disappeared.
+      setup_runtime_config([])
+      media_item = media_item_fixture()
+
+      # match_status is nil for normally-matched downloads (the enum is
+      # ["unmatched", "unresolved_files", "partial_pack"]).
+      tracked =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "test-client",
+          download_client_id: "tracked-1"
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      preserved = Mydia.Repo.get(Mydia.Downloads.Download, tracked.id)
+      assert preserved
+      assert preserved.error_message =~ "Removed from download client"
+    end
+
+    test "does not delete unmatched downloads while their client is unreachable" do
+      # When client.list_torrents/2 errors out, presence is unknown and we
+      # MUST NOT treat the row as orphaned. The runtime config below points
+      # at a non-running client, which yields a connection error (not "not
+      # found"), and `enrich_download_with_unknown_status` produces
+      # in_client?=nil.
+      setup_runtime_config([build_test_client_config()])
+
+      orphan =
+        download_fixture(%{
+          match_status: "unmatched",
+          download_client: "TestClient",
+          download_client_id: "unreachable-1"
+        })
+
+      {:ok, _} =
+        orphan
+        |> Ecto.Changeset.change(media_item_id: nil)
+        |> Mydia.Repo.update()
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      assert Mydia.Repo.get(Mydia.Downloads.Download, orphan.id)
+    end
+  end
+
   describe "stuck download detection" do
     test "detects and flags downloads that completed but never imported" do
       setup_runtime_config([])

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -380,7 +380,68 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
   end
 
   describe "unmatched orphan self-healing" do
-    test "deletes an unmatched download that is no longer in any client" do
+    test "deletes an unmatched download when client confirms torrent is gone" do
+      # The client must be reachable and return an empty torrent list to confirm
+      # the torrent is absent (in_client?: false). Only then is the orphan deleted.
+      bypass = Bypass.open()
+      stub_qbit_login(bypass)
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [])
+      end)
+
+      setup_runtime_config([build_test_client_config(%{port: bypass.port})])
+
+      orphan =
+        download_fixture(%{
+          match_status: "unmatched",
+          download_client: "TestClient",
+          download_client_id: "gone-1"
+        })
+
+      {:ok, _} =
+        orphan
+        |> Ecto.Changeset.change(media_item_id: nil)
+        |> Mydia.Repo.update()
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      refute Mydia.Repo.get(Mydia.Downloads.Download, orphan.id)
+    end
+
+    test "deletes an unmatched + completed download when client confirms torrent is gone" do
+      # The actual production bug: completed_at set, no media_item, no
+      # library_path, sitting in DB forever while MediaImport retries.
+      bypass = Bypass.open()
+      stub_qbit_login(bypass)
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [])
+      end)
+
+      setup_runtime_config([build_test_client_config(%{port: bypass.port})])
+
+      orphan =
+        download_fixture(%{
+          match_status: "unmatched",
+          completed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          download_client: "TestClient",
+          download_client_id: "gone-completed-1"
+        })
+
+      {:ok, _} =
+        orphan
+        |> Ecto.Changeset.change(media_item_id: nil, library_path_id: nil)
+        |> Mydia.Repo.update()
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      refute Mydia.Repo.get(Mydia.Downloads.Download, orphan.id)
+    end
+
+    test "does not delete unmatched download when no clients are configured" do
+      # No clients means presence is indeterminate (in_client?: nil).
+      # The orphan must survive so the user can still manually handle it.
       setup_runtime_config([])
 
       orphan =
@@ -397,30 +458,7 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       assert :ok = perform_job(DownloadMonitor, %{})
 
-      refute Mydia.Repo.get(Mydia.Downloads.Download, orphan.id)
-    end
-
-    test "deletes an unmatched + completed download that is no longer in any client" do
-      # The actual production bug: completed_at set, no media_item, no
-      # library_path, sitting in DB forever while MediaImport retries.
-      setup_runtime_config([])
-
-      orphan =
-        download_fixture(%{
-          match_status: "unmatched",
-          completed_at: DateTime.utc_now() |> DateTime.truncate(:second),
-          download_client: "test-client",
-          download_client_id: "gone-completed-1"
-        })
-
-      {:ok, _} =
-        orphan
-        |> Ecto.Changeset.change(media_item_id: nil, library_path_id: nil)
-        |> Mydia.Repo.update()
-
-      assert :ok = perform_job(DownloadMonitor, %{})
-
-      refute Mydia.Repo.get(Mydia.Downloads.Download, orphan.id)
+      assert Mydia.Repo.get(Mydia.Downloads.Download, orphan.id)
     end
 
     test "preserves a matched download that goes missing (regression guard)" do
@@ -1135,5 +1173,19 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
     }
 
     struct!(Mydia.Config.Schema.DownloadClient, Map.merge(defaults, overrides))
+  end
+
+  defp stub_qbit_login(bypass) do
+    Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("set-cookie", "SID=test-sid; HttpOnly")
+      |> Plug.Conn.resp(200, "Ok.")
+    end)
+  end
+
+  defp json_resp(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(status, Jason.encode!(body))
   end
 end

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -3,6 +3,7 @@ defmodule Mydia.Jobs.MediaImportTest do
   use Oban.Testing, repo: Mydia.Repo
 
   alias Mydia.Jobs.MediaImport
+  alias Mydia.Repo
   alias Mydia.Settings
   import Mydia.MediaFixtures
   import Mydia.DownloadsFixtures
@@ -221,12 +222,36 @@ defmodule Mydia.Jobs.MediaImportTest do
                perform_job(MediaImport, %{"download_id" => download.id, "snooze_count" => 1})
     end
 
-    test "returns error if download does not exist" do
+    test "self-heals when the download row has been deleted" do
+      # If DownloadMonitor cleans up an unmatched orphan between when the
+      # MediaImport job was enqueued and when it runs, the row is gone.
+      # Returning :ok lets Oban mark the job done so it stops retrying.
       fake_id = Ecto.UUID.generate()
 
-      assert_raise Ecto.NoResultsError, fn ->
-        perform_job(MediaImport, %{"download_id" => fake_id})
-      end
+      assert :ok = perform_job(MediaImport, %{"download_id" => fake_id})
+    end
+
+    test "cancels (no retry) when the download is unmatched with no destination" do
+      # Unmatched downloads with no media_item_id AND no library_path_id cannot
+      # ever be imported — there's no destination. The job must return
+      # {:cancel, _} so Oban doesn't burn ~1000 retries waiting forever.
+      download =
+        download_fixture(%{
+          match_status: "unmatched",
+          completed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          download_client: "TestClient",
+          download_client_id: "orphan-1"
+        })
+
+      # download_fixture creates a media_item by default; null it out so
+      # this row is a true orphan.
+      {:ok, download} =
+        download
+        |> Ecto.Changeset.change(media_item_id: nil, library_path_id: nil)
+        |> Repo.update()
+
+      assert {:cancel, :unmatched_no_destination} =
+               perform_job(MediaImport, %{"download_id" => download.id})
     end
 
     test "returns error if download has no client info", %{tmp_dir: tmp_dir} do


### PR DESCRIPTION
## Summary

Unmatched downloads created by `UntrackedMatcher` (torrents added directly to the download client and discovered by Mydia) have no `media_item_id` and no `library_path_id`. When the torrent later disappears from the client, the row stayed in the DB forever — `MediaImport` retried up to 1000 times with 24h backoff, emitting `:no_library_path` errors for weeks.

In one production instance the activity table shows ~160 such rows from April still failing in May (attempt 42 of 1000), spamming the events table and the queue dedup table with stale rows.

## Why "self-healing" instead of a one-time cleanup

These rows are produced by the regular `UntrackedMatcher` flow whenever the user adds a manual torrent that doesn't auto-match. Cleaning data once doesn't fix the bug — the same condition will recreate stuck rows the next time a manual torrent comes and goes. The fix has to live in the code that creates and processes them.

## Behavior changes

### `DownloadMonitor.handle_completion/1`
When a completed download is `match_status == "unmatched"`, **skip enqueueing `MediaImport`**. There's no destination, so the import can't do anything useful. The row stays so the user can still manually match it via the Issues tab while the torrent is in the client.

### `DownloadMonitor.perform/1` — new pass
Any unmatched download whose client **confirms** the torrent is gone (`in_client? == false`) is **deleted**, regardless of `completed_at` / `error_message`. Matched downloads still flow through the existing `missing` / `failed` handlers so the user can investigate them in the Issues tab.

### `MediaImport.perform/1`
- If the row no longer exists (`Ecto.NoResultsError`) → return `:ok`. The job is moot; Oban marks it done and the retry loop ends.
- If the row IS there but is an unmatched orphan with no destination → return `{:cancel, :unmatched_no_destination}`. Oban discards the job instead of burning ~1000 retries waiting forever.

### `EnrichedDownload.in_client?`
New field on `EnrichedDownload`. The three enrichment paths in `history.ex` already know whether the torrent is in the client; this field just exposes that fact downstream:

| path                                  | `in_client?` |
| ------------------------------------- | :----------: |
| `enrich_download_with_torrent_status` | `true`       |
| `enrich_download_with_empty_status`   | `false`      |
| `enrich_download_with_unknown_status` | `nil`        |

Without it, the existing `status` field collapsed "client says completed and is still there" with "client says it never had this torrent, but DB has `completed_at`" into the same `"completed"` value — masking exactly the bug we want to catch.

## Safety

- Stale `downloads` rows whose **client is unreachable** stay put (`in_client? == nil`). A network blip cannot trigger mass deletion. Test guards this regression.
- Matched downloads keep their existing missing/failed flow. Only unmatched downloads are auto-deleted.
- The `{:cancel, _}` return for orphan import jobs is the modern Oban discard signal (Oban 2.20+).

## Test plan

- [x] `./dev mix test test/mydia/jobs/download_monitor_test.exs test/mydia/jobs/media_import_test.exs` — 66 tests, 0 failures
- [x] `./dev mix test test/mydia/downloads/ test/mydia/jobs/` — 804 tests, 0 failures
- [x] `mix compile` clean
- [ ] After deploy, confirm activity log no longer shows recurring `Mydia.Jobs.MediaImport failed with {:error, :no_library_path}` events
- [ ] Confirm the existing ~160 unmatched rows drain to zero over the next monitor pass once their client confirms the torrents are gone