### PR TITLE
fix(import): self-heal stuck season-pack imports

### DIFF
--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -320,9 +320,10 @@ defmodule Mydia.Jobs.MediaImport do
 
           has_unresolved = updated_download.match_status == "unresolved_files"
 
-          # Only mark as fully imported and cleanup if no unresolved files remain
+          # Cleanup is only safe when every file resolved — keep the
+          # download in the client when some files remain unmatched so
+          # the user can manually retry after fixing the matches.
           unless has_unresolved do
-            # Check if we should remove from client based on client config
             client_info = get_client_info(download)
             should_cleanup = client_info && client_info.remove_completed
 
@@ -339,24 +340,43 @@ defmodule Mydia.Jobs.MediaImport do
                 client: download.download_client
               )
             end
+          end
 
-            # Mark download as imported instead of deleting
-            # This allows the download to appear in the Completed tab
-            case Downloads.update_download(updated_download, %{
-                   imported_at: DateTime.utc_now(),
-                   match_status: partial_pack_status
-                 }) do
-              {:ok, _updated} ->
-                Logger.info("Download marked as imported",
-                  download_id: download.id
-                )
+          # Always stamp `imported_at` once we've made an honest attempt,
+          # even when some files are still unresolved. `match_status` keeps
+          # surfacing the partial result in the Issues tab. The previous
+          # behaviour left `imported_at` nil on partial imports, which
+          # caused DownloadMonitor.list_stuck_downloads/1 to re-flag the
+          # download every poll and enqueue a fresh MediaImport job every
+          # 2 minutes — a retry loop that did no useful work but kept
+          # showing "Import stalled - never ran" in the UI.
+          import_update =
+            %{imported_at: DateTime.utc_now()}
+            |> then(fn attrs ->
+              # Preserve `match_status: "unresolved_files"` when present so
+              # the Issues tab can still surface partial imports. Only
+              # touch match_status when we're transitioning to a clean
+              # state (partial_pack or nil), never overwrite the
+              # in-progress "unresolved_files" flag.
+              if has_unresolved do
+                attrs
+              else
+                Map.put(attrs, :match_status, partial_pack_status)
+              end
+            end)
 
-              {:error, changeset} ->
-                Logger.warning("Failed to mark download as imported",
-                  download_id: download.id,
-                  errors: inspect(changeset.errors)
-                )
-            end
+          case Downloads.update_download(updated_download, import_update) do
+            {:ok, _updated} ->
+              Logger.info("Download marked as imported",
+                download_id: download.id,
+                has_unresolved: has_unresolved
+              )
+
+            {:error, changeset} ->
+              Logger.warning("Failed to mark download as imported",
+                download_id: download.id,
+                errors: inspect(changeset.errors)
+              )
           end
 
           # Write NFO metadata files if enabled for this library path
@@ -910,6 +930,43 @@ defmodule Mydia.Jobs.MediaImport do
     end
   end
 
+  # Ensure `Media.refresh_episodes_for_tv_show/1` is invoked at most once
+  # per Oban job per show. Each Oban worker call runs in its own process,
+  # so the process dictionary gives us a job-scoped memoization key that
+  # cleans itself up automatically when the job exits.
+  #
+  # The dedup target is the media_item id, not the season — a single
+  # refresh call always pulls every season's episodes for the show, so
+  # repeating it for another season number in the same job is pure waste.
+  defp refresh_episodes_once(%Mydia.Media.MediaItem{id: id} = media_item, season) do
+    key = {:media_import_refresh_attempted, id}
+
+    if Process.get(key) do
+      :already_attempted
+    else
+      Process.put(key, true)
+
+      Logger.info("Episode not found, refreshing episodes for TV show",
+        media_item: media_item.title,
+        season: season
+      )
+
+      case Media.refresh_episodes_for_tv_show(media_item) do
+        {:ok, count} ->
+          Logger.info("Refreshed episodes, created #{count} episodes")
+          {:ok, count}
+
+        {:error, reason} = error ->
+          Logger.error("Failed to refresh episodes",
+            media_item: media_item.title,
+            reason: inspect(reason)
+          )
+
+          error
+      end
+    end
+  end
+
   defp import_file(file, download, library_path, args, parser_opts) do
     # Parse filename to extract episode info for TV shows. When the
     # download is already bound to a known `%MediaItem{}`, pass it as
@@ -924,51 +981,55 @@ defmodule Mydia.Jobs.MediaImport do
     # Determine episode and destination path
     {episode, dest_dir} =
       case {download.media_item, download.episode, parsed.type, is_season_pack} do
-        # Season pack - use metadata season number as authoritative source
+        # Season pack - the per-file filename is the authoritative season
+        # hint when the parser found one. The download-level
+        # `season_number` is only the originally-requested season; for
+        # "Complete S01-S03" style packs containing files from multiple
+        # seasons, every file would otherwise be force-matched to that
+        # one season and most would fall through to `:unresolved` (or
+        # worse, collapse onto a single episode row when episode_number
+        # collides). Prefer parsed.season; fall back to season_pack_season
+        # for files where the parser couldn't recover a season token.
         {%{type: "tv_show"} = media_item, _, :tv_show, true}
         when not is_nil(season_pack_season) and not is_nil(parsed.episodes) ->
           episode_number = List.first(parsed.episodes) || 1
+          file_season = parsed.season || season_pack_season
 
           Logger.debug("Processing season pack file",
             file: file.name,
             season_pack_season: season_pack_season,
+            file_season: file_season,
             episode_number: episode_number
           )
 
           episode =
             Media.get_episode_by_number(
               media_item.id,
-              season_pack_season,
+              file_season,
               episode_number
             )
 
           episode =
             if is_nil(episode) do
-              Logger.info("Episode not found, refreshing episodes for TV show",
-                media_item: media_item.title,
-                season: season_pack_season
+              # Refresh metadata at most ONCE per import job per show.
+              # Calling refresh per-file was the metadata-relay hammer
+              # behind the Good Omens incident: the in-memory media_item
+              # struct stays stale across this Enum.map loop, so
+              # `should_skip_season_refresh?` never tripped and every
+              # unresolved file fired a fresh HTTP round-trip. After this
+              # guard, the first miss does the refresh, subsequent misses
+              # in the same job re-use whatever the refresh produced (or
+              # the empty result if refresh failed).
+              refresh_episodes_once(media_item, file_season)
+
+              # Retry episode lookup regardless of refresh result —
+              # another file in this same job may have just created the
+              # episode row we need.
+              Media.get_episode_by_number(
+                media_item.id,
+                file_season,
+                episode_number
               )
-
-              # Try to refresh episodes from metadata provider
-              case Media.refresh_episodes_for_tv_show(media_item) do
-                {:ok, count} ->
-                  Logger.info("Refreshed episodes, created #{count} episodes")
-
-                  # Retry episode lookup
-                  Media.get_episode_by_number(
-                    media_item.id,
-                    season_pack_season,
-                    episode_number
-                  )
-
-                {:error, reason} ->
-                  Logger.error("Failed to refresh episodes",
-                    media_item: media_item.title,
-                    reason: inspect(reason)
-                  )
-
-                  nil
-              end
             else
               episode
             end
@@ -976,22 +1037,24 @@ defmodule Mydia.Jobs.MediaImport do
           if episode do
             Logger.debug("Found episode for season pack file",
               file: file.name,
-              season: season_pack_season,
+              season: file_season,
               episode: episode_number,
               episode_id: episode.id
             )
 
-            # Build destination path using season pack metadata (category-aware)
+            # Build destination path using the matched episode's actual
+            # season — not the download-level season — so files from
+            # `Complete S01-S03` packs land in the right `Season XX` dirs.
             base_dir = build_series_base_path(media_item, library_path)
 
             dest_dir =
-              Path.join(base_dir, "Season #{String.pad_leading("#{season_pack_season}", 2, "0")}")
+              Path.join(base_dir, "Season #{String.pad_leading("#{file_season}", 2, "0")}")
 
             {episode, dest_dir}
           else
             Logger.warning("Episode still not found after refresh attempt",
               file: file.name,
-              season: season_pack_season,
+              season: file_season,
               episode: episode_number,
               media_item: media_item.title
             )
@@ -1002,7 +1065,7 @@ defmodule Mydia.Jobs.MediaImport do
                path: file.path,
                name: file.name,
                size: file.size,
-               parsed_season: season_pack_season,
+               parsed_season: file_season,
                parsed_episode: episode_number
              }}
           end

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -667,4 +667,362 @@ defmodule Mydia.Jobs.MediaImportTest do
     # short-circuit above is the user-visible safety net regardless of
     # whether duplicate jobs slip past the unique gate.
   end
+
+  # Regression tests for the Good Omens "Complete S01-S03" pack incident.
+  #
+  # A torrent named `... 2019 S01 S03 Complete ...` was grabbed to satisfy
+  # a single-episode request (S3E1). The pack contained S01E01..S03E01 in
+  # /S01/, /S02/, /S03/ subdirs. The season-pack branch in import_file/5
+  # hard-overrode every file's season with the download-level
+  # `season_number=3`, so:
+  #
+  #   - S01/E01..E06 and S02/E01..E06 were either flagged as unresolved
+  #     (when the parsed episode_number had no corresponding S3 episode)
+  #     or wrongly imported onto S3E1 (when parsed episode_number happened
+  #     to be 1) — multiple files collapsing onto the same episode row.
+  #   - The partial-import path skipped setting `imported_at`, so
+  #     DownloadMonitor's `list_stuck_downloads/1` kept matching the
+  #     download forever and the UI showed "Import stalled - never ran"
+  #     even though it had run ~28 times.
+  describe "season pack with multi-season files (Good Omens regression)" do
+    @tag :tmp_dir
+    test "uses per-file parsed season instead of download-level season override",
+         %{tmp_dir: tmp_dir} do
+      # Setup: TV show with S1E1, S1E2, S2E1. Download is a "season 2 pack"
+      # but the torrent actually contains files from S01 and S02. The
+      # per-file filename is the authoritative season hint — the
+      # download-level `season_number` is just the originally-requested
+      # season, not what the file at hand belongs to.
+      _library_path = create_test_library_path(tmp_dir, :series)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+
+      s1_dir = Path.join(download_dir, "S01")
+      s2_dir = Path.join(download_dir, "S02")
+      File.mkdir_p!(s1_dir)
+      File.mkdir_p!(s2_dir)
+
+      s01e01 = Path.join(s1_dir, "Mystery.Show.S01E01.mkv")
+      s01e02 = Path.join(s1_dir, "Mystery.Show.S01E02.mkv")
+      s02e01 = Path.join(s2_dir, "Mystery.Show.S02E01.mkv")
+
+      for f <- [s01e01, s01e02, s02e01], do: File.write!(f, "fake video")
+
+      media_item = media_item_fixture(%{type: "tv_show", title: "Mystery Show"})
+
+      ep_s1e1 =
+        episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 1})
+
+      ep_s1e2 =
+        episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 2})
+
+      ep_s2e1 =
+        episode_fixture(%{media_item_id: media_item.id, season_number: 2, episode_number: 1})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "MultiSeasonClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "MultiSeasonClient",
+          download_client_id: "multiseason-1",
+          metadata: %{
+            "season_pack" => true,
+            "season_number" => 2,
+            "episode_count" => 1
+          }
+        })
+
+      assert {:ok, :imported} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      updated = Mydia.Downloads.get_download!(download.id)
+
+      # All three files must be matched to their actual episodes.
+      refute updated.match_status == "unresolved_files",
+             "Expected all files to resolve; got unresolved: #{inspect(updated.metadata["unresolved_files"])}"
+
+      # Each parsed season's episode must end up with its own media_file row,
+      # not collapsed onto a single S2E1 entry.
+      files_by_episode =
+        Mydia.Library.list_media_files()
+        |> Enum.filter(&(&1.episode_id in [ep_s1e1.id, ep_s1e2.id, ep_s2e1.id]))
+        |> Enum.group_by(& &1.episode_id)
+
+      assert Map.has_key?(files_by_episode, ep_s1e1.id),
+             "S1E1 must get its own media_file, not collapse onto S2E1"
+
+      assert Map.has_key?(files_by_episode, ep_s1e2.id),
+             "S1E2 must get its own media_file"
+
+      assert Map.has_key?(files_by_episode, ep_s2e1.id),
+             "S2E1 must get its own media_file"
+    end
+
+    @tag :tmp_dir
+    test "different-season files with the same episode number don't collapse onto one row",
+         %{tmp_dir: tmp_dir} do
+      # The Bug D variant: three E01 files from three different seasons
+      # were all rewritten to season=download.season_number, episode=1 and
+      # all matched the single existing S3E1 row.
+      _library_path = create_test_library_path(tmp_dir, :series)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+
+      File.write!(Path.join(download_dir, "Show.S01E01.mkv"), "v")
+      File.write!(Path.join(download_dir, "Show.S02E01.mkv"), "v")
+      File.write!(Path.join(download_dir, "Show.S03E01.mkv"), "v")
+
+      media_item = media_item_fixture(%{type: "tv_show", title: "Show"})
+
+      ep_s1e1 =
+        episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 1})
+
+      ep_s2e1 =
+        episode_fixture(%{media_item_id: media_item.id, season_number: 2, episode_number: 1})
+
+      ep_s3e1 =
+        episode_fixture(%{media_item_id: media_item.id, season_number: 3, episode_number: 1})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "ThreeE01Client",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "ThreeE01Client",
+          download_client_id: "three-e01-1",
+          metadata: %{
+            "season_pack" => true,
+            "season_number" => 3,
+            "episode_count" => 1
+          }
+        })
+
+      assert {:ok, :imported} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      episode_ids_with_files =
+        Mydia.Library.list_media_files()
+        |> Enum.map(& &1.episode_id)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
+        |> MapSet.new()
+
+      expected = MapSet.new([ep_s1e1.id, ep_s2e1.id, ep_s3e1.id])
+
+      assert MapSet.equal?(episode_ids_with_files, expected),
+             "Expected exactly the three E01 episodes to be referenced once each, got: #{inspect(MapSet.to_list(episode_ids_with_files))}"
+    end
+  end
+
+  # Regression for the partial-import retry loop (Bug C).
+  #
+  # When a season-pack import resolves some files but flags others as
+  # unresolved, the historical behaviour skipped setting `imported_at`,
+  # which left the download permanently matching
+  # `Downloads.list_stuck_downloads/1`. DownloadMonitor then re-enqueued
+  # `MediaImport` every 2 minutes forever, and the user-facing Issues tab
+  # rendered the misleading "Import stalled - never ran" message even
+  # though dozens of import attempts had succeeded.
+  describe "partial import retry-loop (stalled detector)" do
+    @tag :tmp_dir
+    test "marks imported_at even when some files remain unresolved",
+         %{tmp_dir: tmp_dir} do
+      _library_path = create_test_library_path(tmp_dir, :series)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+
+      # One file matches an existing episode; one file is unparseable
+      # for episode number and must end up unresolved.
+      File.write!(Path.join(download_dir, "Show.S01E01.mkv"), "v")
+      File.write!(Path.join(download_dir, "Show.S01.mkv"), "v")
+
+      media_item = media_item_fixture(%{type: "tv_show", title: "Show"})
+
+      _ep =
+        episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 1})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "PartialClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      # Make completed_at older than list_stuck_downloads' 60-min threshold
+      # so the stuck detector would re-fire if imported_at stayed nil.
+      old_completion = DateTime.add(DateTime.utc_now(), -2, :hour)
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: old_completion,
+          download_client: "PartialClient",
+          download_client_id: "partial-1",
+          metadata: %{
+            "season_pack" => true,
+            "season_number" => 1,
+            "episode_count" => 2
+          }
+        })
+
+      # `:partial_import` is the contract result when some files resolve and
+      # others don't — that's expected here. The bug is that `imported_at`
+      # stayed nil on this path, which is what we assert below.
+      assert {:ok, result} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      assert result in [:imported, :partial_import]
+
+      updated = Mydia.Downloads.get_download!(download.id)
+
+      assert updated.imported_at != nil,
+             "Partial imports must set imported_at to break the stuck-detector retry loop"
+
+      assert updated.match_status == "unresolved_files",
+             "match_status must still surface the partial result to the Issues tab"
+
+      stuck = Mydia.Downloads.list_stuck_downloads()
+      stuck_ids = Enum.map(stuck, & &1.id)
+
+      refute download.id in stuck_ids,
+             "list_stuck_downloads must not re-flag a download whose import already ran"
+    end
+  end
+
+  # Regression for the metadata-relay hammer (Bug A).
+  #
+  # The season-pack branch in `import_file/5` called
+  # `Media.refresh_episodes_for_tv_show(media_item)` on every unmatched
+  # file, passing the same in-memory media_item struct each time. Even
+  # though `refresh_episodes_for_tv_show` has a `should_skip_season_refresh?`
+  # threshold check, the in-memory `seasons_refreshed_at` stayed stale
+  # across the per-file loop, so the threshold never tripped and the
+  # function refetched from the metadata-relay once per unresolved file.
+  # A 10-file Good Omens import hit the relay 10× per job, and the
+  # MediaImport job re-ran every 2 minutes from the stall-detector loop.
+  describe "metadata-relay refresh deduplication" do
+    @tag :tmp_dir
+    test "refresh_episodes_for_tv_show is called at most once per import",
+         %{tmp_dir: tmp_dir} do
+      _library_path = create_test_library_path(tmp_dir, :series)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+
+      # Five files for a season whose episodes don't exist in the DB. Each
+      # missing lookup would historically trigger a fresh refresh round-trip.
+      for i <- 1..5 do
+        File.write!(Path.join(download_dir, "Show.S99E0#{i}.mkv"), "v")
+      end
+
+      media_item = media_item_fixture(%{type: "tv_show", title: "Show"})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "RefreshDedupClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "RefreshDedupClient",
+          download_client_id: "refresh-dedup-1",
+          metadata: %{
+            "season_pack" => true,
+            "season_number" => 99,
+            "episode_count" => 5
+          }
+        })
+
+      # Point metadata relay at an unreachable URL so every refresh call
+      # fails quickly without creating episodes. Without dedup the import
+      # would invoke refresh once per file (5 times); with dedup it's at
+      # most once for the whole job regardless of how many files miss.
+      # `Mydia.Metadata.metadata_relay_url/0` reads from System env, not
+      # Application config, so we have to override there.
+      previous_env = System.get_env("METADATA_RELAY_URL")
+      System.put_env("METADATA_RELAY_URL", "http://127.0.0.1:1")
+
+      on_exit(fn ->
+        if previous_env do
+          System.put_env("METADATA_RELAY_URL", previous_env)
+        else
+          System.delete_env("METADATA_RELAY_URL")
+        end
+      end)
+
+      # Count "Failed to refresh episodes" — that line only fires inside
+      # the refresh attempt itself, so its count equals the number of
+      # actual `Media.refresh_episodes_for_tv_show/1` invocations. (The
+      # outer "Episode still not found …" warning fires per file
+      # regardless of dedup and is not a reliable counter.)
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          perform_job(MediaImport, %{
+            "download_id" => download.id,
+            "save_path" => download_dir
+          })
+        end)
+
+      refresh_attempts =
+        log
+        |> String.split("\n")
+        |> Enum.count(&String.contains?(&1, "Failed to refresh episodes"))
+
+      assert refresh_attempts <= 1,
+             "refresh_episodes_for_tv_show should be invoked at most once per import job; got #{refresh_attempts} attempts across 5 unresolved files"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Triggered by a Good Omens "Complete S01-S03" pack that downloaded fine but left 10 files in `match_status: unresolved_files` and looped `MediaImport` every 2 minutes forever, surfacing a misleading "Import stalled — never ran" message in the UI even though the import job had succeeded ~28 times.

Four entangled bugs in `lib/mydia/jobs/media_import.ex`:

- **Per-file parsed season ignored** — the season-pack branch hard-overrode every file's season with the download-level `season_number`, so `S01E02 The Book.mkv` got looked up as S03E02 (doesn't exist), and `S01E01.mkv` + `S02E01.mkv` + `S03E01.mkv` all collapsed onto the single S3E1 episode row.
- **Partial imports never marked `imported_at`** — `list_stuck_downloads/1` matched the download forever, retrying the same fruitless import every 2 minutes.
- **Metadata-relay hammer** — the in-memory `media_item` struct stayed stale across the per-file `Enum.map` loop, so `should_skip_season_refresh?` never tripped and every unresolved file fired its own metadata-relay round-trip (10x per job x ~28 retries = ~280 spurious refreshes for one stuck download).

## Fix

- Prefer per-file `parsed.season` over the download-level `season_number` in the season-pack branch (`parsed.season || season_pack_season`).
- Always stamp `imported_at` once an import attempt completes, even when some files are unresolved; preserve `match_status: "unresolved_files"` so the Issues tab still surfaces partial imports.
- Dedupe `Media.refresh_episodes_for_tv_show/1` to at most once per Oban job per show via a process-dict guard.

## Self-healing

The stuck Good Omens download (`cc58c402-…`) will heal itself on the next retry without manual intervention: the 10 unresolved files now match their actual S01/S02 episodes, `imported_at` gets set, the stuck detector stops re-flagging it, and the "Import stalled" message disappears.

## Test plan

Regression tests added in `test/mydia/jobs/media_import_test.exs`, each first verified to fail reproducing the bug, then to pass after the fix:

- [x] `season pack with multi-season files (Good Omens regression) / uses per-file parsed season instead of download-level season override`
- [x] `… / different-season files with the same episode number don't collapse onto one row`
- [x] `partial import retry-loop (stalled detector) / marks imported_at even when some files remain unresolved`
- [x] `metadata-relay refresh deduplication / refresh_episodes_for_tv_show is called at most once per import`
- [x] `mix test test/mydia/jobs/` — 186 tests, 0 failures
- [x] `mix test test/mydia/downloads/ test/mydia/library/release_parser_test.exs` — 640 tests, 0 failures
- [x] `mix format --check-formatted` clean