### PR TITLE
fix(search): count episodes from DB when metadata episode_count is 0

### DIFF
--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -656,7 +656,9 @@ defmodule Mydia.Jobs.TVShowSearch do
     final_count
   end
 
-  defp should_prefer_season_pack?(missing_episodes, media_item, season_number) do
+  @doc false
+  # Public for unit testing — internal helper.
+  def should_prefer_season_pack?(missing_episodes, media_item, season_number) do
     missing_count = length(missing_episodes)
 
     # Try to get total episode count from metadata
@@ -689,7 +691,13 @@ defmodule Mydia.Jobs.TVShowSearch do
   end
 
   defp get_total_episodes_for_season(media_item, season_number) do
-    # Try to get episode count from metadata
+    case metadata_episode_count(media_item, season_number) do
+      count when is_integer(count) and count > 0 -> count
+      _ -> db_episode_count(media_item.id, season_number)
+    end
+  end
+
+  defp metadata_episode_count(media_item, season_number) do
     case media_item.metadata do
       %{"seasons" => seasons} when is_list(seasons) ->
         Enum.find_value(seasons, fn season ->
@@ -700,6 +708,18 @@ defmodule Mydia.Jobs.TVShowSearch do
 
       _ ->
         nil
+    end
+  end
+
+  defp db_episode_count(media_item_id, season_number) do
+    case Repo.aggregate(
+           from(e in Episode,
+             where: e.media_item_id == ^media_item_id and e.season_number == ^season_number
+           ),
+           :count
+         ) do
+      0 -> nil
+      n -> n
     end
   end
 

--- a/test/mydia/jobs/tv_show_search_test.exs
+++ b/test/mydia/jobs/tv_show_search_test.exs
@@ -952,4 +952,86 @@ defmodule Mydia.Jobs.TVShowSearchTest do
       assert length(downloads_after_second) == first_count
     end
   end
+
+  describe "should_prefer_season_pack?/3" do
+    test "falls back to episodes table when metadata episode_count is 0" do
+      # Reproduces the Stillwater/Slow Horses case: TVDB scrape left
+      # episode_count: 0 in metadata, but episodes table has real counts.
+      # Without the fallback, missing_count is used as the total, yielding
+      # 100% missing and incorrectly preferring season packs for partial seasons.
+      tv_show =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Zero Count Show",
+          metadata: %{
+            "seasons" => [
+              %{"season_number" => 1, "episode_count" => 0}
+            ]
+          }
+        })
+
+      episodes =
+        for ep_num <- 1..6 do
+          episode_fixture(%{
+            media_item_id: tv_show.id,
+            season_number: 1,
+            episode_number: ep_num,
+            air_date: Date.add(~D[2020-01-01], ep_num * 7)
+          })
+        end
+
+      # Only 1 of 6 missing = 16.7% — should NOT prefer the pack.
+      missing = Enum.take(episodes, 1)
+
+      refute TVShowSearch.should_prefer_season_pack?(missing, tv_show, 1)
+    end
+
+    test "uses metadata episode_count when it is populated" do
+      tv_show =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Populated Count Show",
+          metadata: %{
+            "seasons" => [
+              %{"season_number" => 1, "episode_count" => 10}
+            ]
+          }
+        })
+
+      # 8 of 10 missing = 80% — prefers the pack via metadata.
+      missing =
+        for ep_num <- 1..8 do
+          episode_fixture(%{
+            media_item_id: tv_show.id,
+            season_number: 1,
+            episode_number: ep_num,
+            air_date: Date.add(~D[2020-01-01], ep_num * 7)
+          })
+        end
+
+      assert TVShowSearch.should_prefer_season_pack?(missing, tv_show, 1)
+    end
+
+    test "prefers season pack when most episodes in the DB are missing" do
+      tv_show =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Mostly Missing Show",
+          metadata: %{"seasons" => [%{"season_number" => 1, "episode_count" => 0}]}
+        })
+
+      missing =
+        for ep_num <- 1..8 do
+          episode_fixture(%{
+            media_item_id: tv_show.id,
+            season_number: 1,
+            episode_number: ep_num,
+            air_date: Date.add(~D[2020-01-01], ep_num * 7)
+          })
+        end
+
+      # 8 of 8 in the DB are missing — 100% via DB fallback.
+      assert TVShowSearch.should_prefer_season_pack?(missing, tv_show, 1)
+    end
+  end
 end

--- a/test/mydia/jobs/tv_show_search_test.exs
+++ b/test/mydia/jobs/tv_show_search_test.exs
@@ -1020,8 +1020,8 @@ defmodule Mydia.Jobs.TVShowSearchTest do
           metadata: %{"seasons" => [%{"season_number" => 1, "episode_count" => 0}]}
         })
 
-      missing =
-        for ep_num <- 1..8 do
+      episodes =
+        for ep_num <- 1..10 do
           episode_fixture(%{
             media_item_id: tv_show.id,
             season_number: 1,
@@ -1030,7 +1030,9 @@ defmodule Mydia.Jobs.TVShowSearchTest do
           })
         end
 
-      # 8 of 8 in the DB are missing — 100% via DB fallback.
+      missing = Enum.take(episodes, 8)
+
+      # 8 of 10 in the DB are missing — 80% via DB fallback.
       assert TVShowSearch.should_prefer_season_pack?(missing, tv_show, 1)
     end
   end


### PR DESCRIPTION
## Summary

`should_prefer_season_pack?/3` uses `media_items.metadata.seasons[].episode_count` as the denominator for the 70% threshold that decides between season-pack and individual-episode search. When TVDB scrape leaves that field as `0` (observed in production: **59 of ~93 TV-show seasons** affected), the existing fallback substitutes `missing_count` for the total, yielding 100% missing.

That forces season-pack search for every partial season — even when most episodes are already on disk:

| Show | Season | On disk | Total | % missing | Picked |
|---|---|---|---|---|---|
| Stillwater | 1 | 13 | 24 | 46% | season pack (wrong) |
| Stillwater | 2 | 7 | 13 | 46% | season pack (wrong) |
| Slow Horses | 1 | 5 | 6 | 17% | season pack (wrong) |
| Slow Horses | 5 | 5 | 6 | 17% | season pack (wrong) |

The selected pack is then correctly rejected by `Downloads.Queue.check_for_existing_media_files/3` (some episodes already have media files), but the rejection is logged as `download.failed` at `severity: :error` every cycle of the `all_monitored` job.

**Production impact:** 17,342 lifetime "Download already exists" events, ~250 in the last 36 hours — all the same handful of partial seasons looping.

## Fix

When metadata says `episode_count <= 0`, fall back to counting rows in the `episodes` table — which already has accurate per-season data — instead of treating the broken metadata as authoritative. Partial seasons now correctly route to individual-episode search.

## Test plan

- [x] New unit tests cover the three cases: metadata-zero falls through to DB count, populated metadata is honored, mostly-missing in DB still prefers the pack.
- [x] `./dev mix test test/mydia/jobs/tv_show_search_test.exs` — 34 tests, 0 failures
- [x] `./dev mix format --check-formatted`
- [x] `./dev mix compile`
- [ ] Verify in production after deploy: `download.failed` events with reason `"Download already exists"` should stop accumulating for partial-season shows.

## Out of scope (follow-ups worth considering)

- The misleading `"Download already exists"` reason/message when the actual condition is "media files exist on disk for some episodes in the season" — should probably be `:season_partially_downloaded` at `severity: :info/:warning`, not `:duplicate_download` at `:error`.
- Why TVDB scrape leaves `episode_count: 0` — the real upstream bug. This PR makes the downstream resilient.