### PR TITLE
fix: self-heal cropped 1080p media analysis

### DIFF
--- a/lib/mydia/jobs/file_analysis.ex
+++ b/lib/mydia/jobs/file_analysis.ex
@@ -35,6 +35,7 @@ defmodule Mydia.Jobs.FileAnalysis do
     ]
 
   import Ecto.Query
+  import Mydia.DB
 
   require Logger
 
@@ -93,11 +94,8 @@ defmodule Mydia.Jobs.FileAnalysis do
         not is_nil(mf.analyzed_at) and is_nil(mf.trashed_at) and
           mf.analysis_attempts < ^max_attempts and
           not is_nil(mf.codec) and not is_nil(mf.resolution) and
-          fragment(
-            "json_extract(?, '$.width') IS NULL OR json_extract(?, '$.height') IS NULL",
-            mf.metadata,
-            mf.metadata
-          ) and
+          (is_nil(json_extract(mf.metadata, "$.width")) or
+             is_nil(json_extract(mf.metadata, "$.height"))) and
           mf.id not in ^exclude_ids,
       order_by: [asc: mf.updated_at, asc: mf.id],
       limit: ^overscan_limit,

--- a/lib/mydia/jobs/file_analysis.ex
+++ b/lib/mydia/jobs/file_analysis.ex
@@ -1,7 +1,8 @@
 defmodule Mydia.Jobs.FileAnalysis do
   @moduledoc """
   Recurring worker that fills in tech metadata for `MediaFile` rows the
-  import path leaves at `analyzed_at IS NULL`.
+  import path leaves at `analyzed_at IS NULL`, then uses spare capacity to
+  repair legacy analyzed rows that are missing persisted dimensions.
 
   Selection is by row state, so the worker is naturally idempotent: every
   tick pulls a bounded batch of un-analyzed rows whose `analysis_attempts`
@@ -39,6 +40,7 @@ defmodule Mydia.Jobs.FileAnalysis do
 
   alias Mydia.Library
   alias Mydia.Library.{FileAnalyzer, MediaFile}
+  alias Mydia.Library.Structs.FileMetadata
   alias Mydia.Repo
 
   @default_batch_size 50
@@ -50,14 +52,13 @@ defmodule Mydia.Jobs.FileAnalysis do
     batch_size = Application.get_env(:mydia, :file_analysis_batch_size, @default_batch_size)
     max_attempts = Application.get_env(:mydia, :file_analysis_max_attempts, @default_max_attempts)
 
-    rows =
-      from(mf in MediaFile,
-        where: is_nil(mf.analyzed_at) and mf.analysis_attempts < ^max_attempts,
-        order_by: [asc: mf.inserted_at],
-        limit: ^batch_size,
-        preload: :library_path
-      )
-      |> Repo.all()
+    analyze_rows = fetch_unanalyzed_rows(batch_size, max_attempts)
+    remaining_slots = max(batch_size - length(analyze_rows), 0)
+
+    repair_rows =
+      fetch_repair_rows(remaining_slots, max_attempts, Enum.map(analyze_rows, & &1.id))
+
+    rows = Enum.map(analyze_rows, &{:analyze, &1}) ++ Enum.map(repair_rows, &{:repair, &1})
 
     case rows do
       [] ->
@@ -66,11 +67,54 @@ defmodule Mydia.Jobs.FileAnalysis do
       rows ->
         Logger.debug("FileAnalysis worker processing batch", count: length(rows))
 
-        Enum.each(rows, &analyze_one/1)
+        Enum.each(rows, &process_row/1)
 
         :ok
     end
   end
+
+  defp fetch_unanalyzed_rows(batch_size, max_attempts) do
+    from(mf in MediaFile,
+      where: is_nil(mf.analyzed_at) and mf.analysis_attempts < ^max_attempts,
+      order_by: [asc: mf.inserted_at],
+      limit: ^batch_size,
+      preload: :library_path
+    )
+    |> Repo.all()
+  end
+
+  defp fetch_repair_rows(0, _max_attempts, _exclude_ids), do: []
+
+  defp fetch_repair_rows(limit, max_attempts, exclude_ids) do
+    overscan_limit = max(limit * 5, 20)
+
+    from(mf in MediaFile,
+      where:
+        is_nil(mf.trashed_at) and mf.analysis_attempts < ^max_attempts and
+          mf.id not in ^exclude_ids,
+      order_by: [asc: mf.updated_at, asc: mf.id],
+      limit: ^overscan_limit,
+      preload: :library_path
+    )
+    |> Repo.all()
+    |> Enum.filter(&repair_candidate?/1)
+    |> Enum.take(limit)
+  end
+
+  defp repair_candidate?(%MediaFile{
+         analyzed_at: %DateTime{},
+         codec: codec,
+         resolution: resolution,
+         metadata: %FileMetadata{} = metadata
+       })
+       when not is_nil(codec) and not is_nil(resolution) do
+    is_nil(metadata.width) or is_nil(metadata.height)
+  end
+
+  defp repair_candidate?(_), do: false
+
+  defp process_row({:analyze, media_file}), do: analyze_one(media_file)
+  defp process_row({:repair, media_file}), do: repair_one(media_file)
 
   defp analyze_one(%MediaFile{} = media_file) do
     case MediaFile.absolute_path(media_file) do
@@ -85,6 +129,21 @@ defmodule Mydia.Jobs.FileAnalysis do
         result = FileAnalyzer.analyze(absolute_path)
         outcome = Library.apply_analysis(media_file, result)
         log_outcome(media_file, absolute_path, result, outcome)
+    end
+
+    :ok
+  end
+
+  defp repair_one(%MediaFile{} = media_file) do
+    case Library.repair_file_metadata(media_file) do
+      {:ok, _updated} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to repair media file metadata",
+          file_id: media_file.id,
+          reason: inspect(reason)
+        )
     end
 
     :ok

--- a/lib/mydia/jobs/file_analysis.ex
+++ b/lib/mydia/jobs/file_analysis.ex
@@ -90,7 +90,14 @@ defmodule Mydia.Jobs.FileAnalysis do
 
     from(mf in MediaFile,
       where:
-        is_nil(mf.trashed_at) and mf.analysis_attempts < ^max_attempts and
+        not is_nil(mf.analyzed_at) and is_nil(mf.trashed_at) and
+          mf.analysis_attempts < ^max_attempts and
+          not is_nil(mf.codec) and not is_nil(mf.resolution) and
+          fragment(
+            "json_extract(?, '$.width') IS NULL OR json_extract(?, '$.height') IS NULL",
+            mf.metadata,
+            mf.metadata
+          ) and
           mf.id not in ^exclude_ids,
       order_by: [asc: mf.updated_at, asc: mf.id],
       limit: ^overscan_limit,
@@ -101,13 +108,7 @@ defmodule Mydia.Jobs.FileAnalysis do
     |> Enum.take(limit)
   end
 
-  defp repair_candidate?(%MediaFile{
-         analyzed_at: %DateTime{},
-         codec: codec,
-         resolution: resolution,
-         metadata: %FileMetadata{} = metadata
-       })
-       when not is_nil(codec) and not is_nil(resolution) do
+  defp repair_candidate?(%MediaFile{metadata: %FileMetadata{} = metadata}) do
     is_nil(metadata.width) or is_nil(metadata.height)
   end
 

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -312,6 +312,8 @@ defmodule Mydia.Library do
         current_metadata
         |> maybe_put_struct_field(:duration, result.duration)
         |> maybe_put_struct_field(:container, result.container)
+        |> maybe_put_struct_field(:width, result.width)
+        |> maybe_put_struct_field(:height, result.height)
 
       write_analysis_success(
         media_file,
@@ -418,6 +420,90 @@ defmodule Mydia.Library do
 
   defp maybe_put_struct_field(struct, _field, nil), do: struct
   defp maybe_put_struct_field(struct, field, value), do: Map.put(struct, field, value)
+
+  defp record_repair_failure(%MediaFile{} = media_file, reason) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    reason_text = format_analysis_error(reason)
+
+    query = from(mf in MediaFile, where: mf.id == ^media_file.id)
+
+    Repo.update_all(query,
+      inc: [analysis_attempts: 1],
+      set: [last_analysis_error: reason_text, updated_at: now]
+    )
+  end
+
+  defp apply_repair_analysis(%MediaFile{} = media_file, result) do
+    apply_repair_analysis(media_file, result, 3)
+  end
+
+  defp apply_repair_analysis(%MediaFile{} = media_file, result, retries_remaining) do
+    alias Mydia.Library.Structs.FileMetadata
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    current =
+      Repo.one(
+        from(mf in MediaFile,
+          where: mf.id == ^media_file.id,
+          select: %{
+            metadata: mf.metadata,
+            updated_at: mf.updated_at
+          }
+        )
+      )
+
+    case current do
+      nil ->
+        {:error, :not_found}
+
+      current ->
+        metadata =
+          current.metadata
+          |> Kernel.||(FileMetadata.empty())
+          |> maybe_put_struct_field(:duration, result.duration)
+          |> maybe_put_struct_field(:container, result.container)
+          |> maybe_put_struct_field(:width, result.width)
+          |> maybe_put_struct_field(:height, result.height)
+
+        set = build_analysis_success_set(result, metadata, now)
+
+        query =
+          from(mf in MediaFile,
+            where: mf.id == ^media_file.id and mf.updated_at == ^current.updated_at
+          )
+
+        case Repo.update_all(query, set: set) do
+          {1, _} ->
+            :ok
+
+          {0, _} when retries_remaining > 0 ->
+            apply_repair_analysis(media_file, result, retries_remaining - 1)
+
+          {0, _} ->
+            {:error, :not_found}
+        end
+    end
+  end
+
+  defp build_analysis_success_set(result, metadata, now) do
+    alias Mydia.Streaming.Codec
+
+    set = [
+      codec: Codec.normalize_video_codec(result.codec),
+      audio_codec: Codec.normalize_audio_codec(result.audio_codec),
+      resolution: result.resolution,
+      bitrate: result.bitrate,
+      hdr_format: result.hdr_format,
+      metadata: metadata,
+      analyzed_at: now,
+      analysis_attempts: 0,
+      last_analysis_error: nil,
+      updated_at: now
+    ]
+
+    if result.size, do: Keyword.put(set, :size, result.size), else: set
+  end
 
   @max_analysis_error_length 2048
 
@@ -1831,6 +1917,66 @@ defmodule Mydia.Library do
   def refresh_file_metadata_by_id(media_file_id) do
     media_file = get_media_file!(media_file_id, preload: [:library_path])
     refresh_file_metadata(media_file)
+  end
+
+  @doc """
+  Re-analyzes an already-analyzed file in place without clearing the existing
+  analysis state first.
+
+  Intended for self-healing passes that backfill newly tracked metadata fields
+  or repair legacy analyzer mistakes while preserving the old row on failure.
+  """
+  @spec repair_file_metadata(MediaFile.t()) :: {:ok, MediaFile.t()} | {:error, term()}
+  def repair_file_metadata(%MediaFile{} = media_file) do
+    case MediaFile.absolute_path(media_file) do
+      nil ->
+        Logger.error("Cannot repair file metadata - path could not be resolved",
+          file_id: media_file.id
+        )
+
+        {:error, :path_not_resolved}
+
+      absolute_path ->
+        if File.exists?(absolute_path) do
+          case FileAnalyzer.analyze(absolute_path) do
+            {:ok, result} ->
+              case apply_repair_analysis(media_file, result) do
+                :ok ->
+                  updated_file = get_media_file!(media_file.id, preload: [:library_path])
+
+                  Logger.info("Repaired file metadata",
+                    file_id: media_file.id,
+                    path: absolute_path,
+                    resolution: updated_file.resolution,
+                    codec: updated_file.codec,
+                    audio: updated_file.audio_codec
+                  )
+
+                  {:ok, updated_file}
+
+                {:error, :not_found} = error ->
+                  error
+              end
+
+            {:error, reason} ->
+              record_repair_failure(media_file, reason)
+
+              Logger.warning("FFprobe analysis failed during repair",
+                file_id: media_file.id,
+                reason: inspect(reason)
+              )
+
+              {:error, reason}
+          end
+        else
+          Logger.warning("File does not exist, cannot repair metadata",
+            file_id: media_file.id,
+            path: absolute_path
+          )
+
+          {:error, :file_not_found}
+        end
+    end
   end
 
   @doc """

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -4,6 +4,7 @@ defmodule Mydia.Library do
   """
 
   import Ecto.Query, warn: false
+  import Mydia.DB
   import Mydia.QueryHelpers
   alias Mydia.Repo
   alias Mydia.Library.{MediaFile, FileAnalyzer, PhashGenerator}
@@ -474,11 +475,8 @@ defmodule Mydia.Library do
             where:
               mf.id == ^media_file.id and mf.updated_at == ^current.updated_at and
                 mf.analyzed_at == ^current.analyzed_at and
-                fragment(
-                  "json_extract(?, '$.width') IS NULL OR json_extract(?, '$.height') IS NULL",
-                  mf.metadata,
-                  mf.metadata
-                )
+                (is_nil(json_extract(mf.metadata, "$.width")) or
+                   is_nil(json_extract(mf.metadata, "$.height")))
           )
 
         case Repo.update_all(query, set: set) do

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -448,6 +448,7 @@ defmodule Mydia.Library do
           where: mf.id == ^media_file.id,
           select: %{
             metadata: mf.metadata,
+            analyzed_at: mf.analyzed_at,
             updated_at: mf.updated_at
           }
         )
@@ -470,7 +471,14 @@ defmodule Mydia.Library do
 
         query =
           from(mf in MediaFile,
-            where: mf.id == ^media_file.id and mf.updated_at == ^current.updated_at
+            where:
+              mf.id == ^media_file.id and mf.updated_at == ^current.updated_at and
+                mf.analyzed_at == ^current.analyzed_at and
+                fragment(
+                  "json_extract(?, '$.width') IS NULL OR json_extract(?, '$.height') IS NULL",
+                  mf.metadata,
+                  mf.metadata
+                )
           )
 
         case Repo.update_all(query, set: set) do

--- a/lib/mydia/library/file_analyzer.ex
+++ b/lib/mydia/library/file_analyzer.ex
@@ -246,6 +246,8 @@ defmodule Mydia.Library.FileAnalyzer do
     metadata =
       FileAnalysisResult.new(%{
         resolution: extract_resolution(video_stream),
+        width: video_stream && video_stream["width"],
+        height: video_stream && video_stream["height"],
         codec: extract_video_codec(video_stream),
         audio_codec: extract_audio_codec(audio_stream),
         bitrate: extract_bitrate(video_stream, format),
@@ -316,37 +318,53 @@ defmodule Mydia.Library.FileAnalyzer do
   defp extract_resolution(video_stream) do
     height = video_stream["height"]
     width = video_stream["width"]
+    effective_height = effective_resolution_height(width, height)
 
     cond do
       # 4K / UHD / 2160p
-      height >= 2000 ->
+      effective_height >= 2000 ->
         if width >= 3800, do: "4K", else: "2160p"
 
       # 1440p
-      height >= 1400 ->
+      effective_height >= 1400 ->
         "1440p"
 
       # 1080p / Full HD
-      height >= 1000 ->
+      effective_height >= 1000 ->
         "1080p"
 
       # 720p / HD
-      height >= 700 ->
+      effective_height >= 700 ->
         "720p"
 
       # 480p / SD
-      height >= 450 ->
+      effective_height >= 450 ->
         "480p"
 
       # 360p
-      height >= 300 ->
+      effective_height >= 300 ->
         "360p"
 
       true ->
         # Unknown or very low resolution
-        if height, do: "#{height}p", else: nil
+        if effective_height, do: "#{effective_height}p", else: nil
     end
   end
+
+  # Cropped cinemascope encodes often keep the source width (for example
+  # 1920x800) while trimming black bars from the stored frame height. Use the
+  # implied 16:9 height as a floor for widescreen landscape video so 1080p
+  # sources are not downgraded to 720p purely because of active-image crops.
+  defp effective_resolution_height(width, height)
+       when is_integer(width) and is_integer(height) and width > 0 and height > 0 do
+    if width > height and width / height >= 16 / 9 do
+      max(height, round(width * 9 / 16))
+    else
+      height
+    end
+  end
+
+  defp effective_resolution_height(_width, height), do: height
 
   defp extract_video_codec(nil), do: nil
 

--- a/lib/mydia/library/file_analyzer.ex
+++ b/lib/mydia/library/file_analyzer.ex
@@ -353,18 +353,38 @@ defmodule Mydia.Library.FileAnalyzer do
 
   # Cropped cinemascope encodes often keep the source width (for example
   # 1920x800) while trimming black bars from the stored frame height. Use the
-  # implied 16:9 height as a floor for widescreen landscape video so 1080p
-  # sources are not downgraded to 720p purely because of active-image crops.
+  # encoded width as a fallback only when the stored height is not already near
+  # a standard tier. That fixes 1920x800 -> 1080p and 1280x534 -> 720p while
+  # leaving true ultrawide sources like 2560x1080 at their actual 1080p tier.
   defp effective_resolution_height(width, height)
        when is_integer(width) and is_integer(height) and width > 0 and height > 0 do
-    if width > height and width / height >= 16 / 9 do
-      max(height, round(width * 9 / 16))
-    else
-      height
+    cond do
+      standard_resolution_height?(height) ->
+        height
+
+      width > height ->
+        inferred_resolution_height_from_width(width) || height
+
+      true ->
+        height
     end
   end
 
   defp effective_resolution_height(_width, height), do: height
+
+  @resolution_height_tolerance 24
+
+  defp standard_resolution_height?(height) do
+    Enum.any?([2160, 1440, 1080, 720, 480, 360], fn standard_height ->
+      abs(height - standard_height) <= @resolution_height_tolerance
+    end)
+  end
+
+  defp inferred_resolution_height_from_width(width) when width >= 3800, do: 2160
+  defp inferred_resolution_height_from_width(width) when width >= 2500, do: 1440
+  defp inferred_resolution_height_from_width(width) when width >= 1900, do: 1080
+  defp inferred_resolution_height_from_width(width) when width >= 1200, do: 720
+  defp inferred_resolution_height_from_width(_width), do: nil
 
   defp extract_video_codec(nil), do: nil
 

--- a/lib/mydia/library/structs/file_analysis_result.ex
+++ b/lib/mydia/library/structs/file_analysis_result.ex
@@ -24,6 +24,8 @@ defmodule Mydia.Library.Structs.FileAnalysisResult do
 
   defstruct [
     :resolution,
+    :width,
+    :height,
     :codec,
     :audio_codec,
     :bitrate,
@@ -35,6 +37,8 @@ defmodule Mydia.Library.Structs.FileAnalysisResult do
 
   @type t :: %__MODULE__{
           resolution: String.t() | nil,
+          width: integer() | nil,
+          height: integer() | nil,
           codec: String.t() | nil,
           audio_codec: String.t() | nil,
           bitrate: integer() | nil,

--- a/test/mydia/jobs/file_analysis_test.exs
+++ b/test/mydia/jobs/file_analysis_test.exs
@@ -10,6 +10,7 @@ defmodule Mydia.Jobs.FileAnalysisTest do
   alias Mydia.Jobs.FileAnalysis
   alias Mydia.Library
   alias Mydia.Library.MediaFile
+  alias Mydia.Library.Structs.FileMetadata
   alias Mydia.Repo
 
   setup do
@@ -135,6 +136,41 @@ defmodule Mydia.Jobs.FileAnalysisTest do
         File.rm(shim)
       end
     end
+
+    test "repairs analyzed rows that are missing persisted dimensions" do
+      {_library_path, [{media_file, path}]} = seed_real_files(1, "u5_repair")
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(mf in MediaFile, where: mf.id == ^media_file.id),
+        set: [
+          analyzed_at: now,
+          resolution: "720p",
+          codec: "hevc",
+          audio_codec: "aac",
+          metadata: %FileMetadata{container: "mkv", duration: 60.0}
+        ]
+      )
+
+      shim = write_cropped_1080_shim(path)
+
+      try do
+        Application.put_env(:mydia, :ffprobe_path, shim)
+
+        assert :ok = perform_job(FileAnalysis, %{})
+
+        reloaded = Repo.get!(MediaFile, media_file.id)
+        assert reloaded.resolution == "1080p"
+        assert reloaded.metadata.width == 1920
+        assert reloaded.metadata.height == 800
+        assert %DateTime{} = reloaded.analyzed_at
+        assert is_nil(reloaded.last_analysis_error)
+      after
+        File.rm(shim)
+        File.rm(path)
+      end
+    end
   end
 
   describe "configuration wiring (source config/config.exs)" do
@@ -210,6 +246,23 @@ defmodule Mydia.Jobs.FileAnalysisTest do
       ~s({"streams":[{"codec_type":"video","codec_name":"h264","width":1920,"height":1080,"bit_rate":"8000000"},{"codec_type":"audio","codec_name":"aac"}],"format":{"duration":"5400.5","format_name":"matroska,webm","size":"#{size}","bit_rate":"8000000"}})
 
     path = Path.join(System.tmp_dir!(), "u5_ffprobe_ok_#{:rand.uniform(10_000_000)}.sh")
+    escaped = String.replace(json, "'", "'\\''")
+    File.write!(path, "#!/bin/sh\nprintf '%s' '#{escaped}'\n")
+    File.chmod!(path, 0o755)
+    path
+  end
+
+  defp write_cropped_1080_shim(reference_path) do
+    size =
+      case File.stat(reference_path) do
+        {:ok, %{size: s}} -> s
+        _ -> 1024
+      end
+
+    json =
+      ~s({"streams":[{"codec_type":"video","codec_name":"hevc","width":1920,"height":800,"bit_rate":"8000000"},{"codec_type":"audio","codec_name":"aac"}],"format":{"duration":"5400.5","format_name":"matroska,webm","size":"#{size}","bit_rate":"8000000"}})
+
+    path = Path.join(System.tmp_dir!(), "u5_ffprobe_repair_#{:rand.uniform(10_000_000)}.sh")
     escaped = String.replace(json, "'", "'\\''")
     File.write!(path, "#!/bin/sh\nprintf '%s' '#{escaped}'\n")
     File.chmod!(path, 0o755)

--- a/test/mydia/library/file_analyzer_test.exs
+++ b/test/mydia/library/file_analyzer_test.exs
@@ -51,19 +51,69 @@ defmodule Mydia.Library.FileAnalyzerTest do
   end
 
   describe "resolution extraction" do
-    test "correctly categorizes common resolutions" do
-      # These would need actual FFprobe integration to test properly
-      # For now, we document the expected behavior
+    setup do
+      target_file = write_temp_file("fake video content")
 
-      # 4K: height >= 2000, width >= 3800
-      # 2160p: height >= 2000
-      # 1440p: height >= 1400
-      # 1080p: height >= 1000
-      # 720p: height >= 700
-      # 480p: height >= 450
-      # 360p: height >= 300
+      on_exit(fn ->
+        Application.delete_env(:mydia, :ffprobe_path)
+        File.rm(target_file)
+      end)
 
-      assert true
+      %{target_file: target_file}
+    end
+
+    test "keeps standard 1080p video at 1080p", %{target_file: target_file} do
+      shim =
+        write_json_shim(
+          ~s({"streams":[{"codec_type":"video","codec_name":"h264","width":1920,"height":1080},{"codec_type":"audio","codec_name":"aac"}],"format":{"duration":"60.0","format_name":"matroska"}})
+        )
+
+      try do
+        Application.put_env(:mydia, :ffprobe_path, shim)
+
+        assert {:ok, result} = FileAnalyzer.analyze(target_file)
+        assert result.resolution == "1080p"
+        assert result.width == 1920
+        assert result.height == 1080
+      after
+        File.rm(shim)
+      end
+    end
+
+    test "treats cropped 1920x800 widescreen encodes as 1080p", %{target_file: target_file} do
+      shim =
+        write_json_shim(
+          ~s({"streams":[{"codec_type":"video","codec_name":"hevc","width":1920,"height":800},{"codec_type":"audio","codec_name":"aac"}],"format":{"duration":"60.0","format_name":"matroska"}})
+        )
+
+      try do
+        Application.put_env(:mydia, :ffprobe_path, shim)
+
+        assert {:ok, result} = FileAnalyzer.analyze(target_file)
+        assert result.resolution == "1080p"
+        assert result.width == 1920
+        assert result.height == 800
+      after
+        File.rm(shim)
+      end
+    end
+
+    test "does not up-rank true 720p widescreen encodes", %{target_file: target_file} do
+      shim =
+        write_json_shim(
+          ~s({"streams":[{"codec_type":"video","codec_name":"h264","width":1280,"height":534},{"codec_type":"audio","codec_name":"aac"}],"format":{"duration":"60.0","format_name":"matroska"}})
+        )
+
+      try do
+        Application.put_env(:mydia, :ffprobe_path, shim)
+
+        assert {:ok, result} = FileAnalyzer.analyze(target_file)
+        assert result.resolution == "720p"
+        assert result.width == 1280
+        assert result.height == 534
+      after
+        File.rm(shim)
+      end
     end
   end
 
@@ -198,5 +248,10 @@ defmodule Mydia.Library.FileAnalyzerTest do
     File.write!(path, script_body)
     File.chmod!(path, 0o755)
     path
+  end
+
+  defp write_json_shim(json) do
+    escaped = String.replace(json, "'", "'\\''")
+    write_shim("#!/bin/sh\nprintf '%s' '#{escaped}'\n")
   end
 end

--- a/test/mydia/library/file_analyzer_test.exs
+++ b/test/mydia/library/file_analyzer_test.exs
@@ -115,6 +115,24 @@ defmodule Mydia.Library.FileAnalyzerTest do
         File.rm(shim)
       end
     end
+
+    test "does not up-rank true ultrawide sources", %{target_file: target_file} do
+      shim =
+        write_json_shim(
+          ~s({"streams":[{"codec_type":"video","codec_name":"hevc","width":2560,"height":1080},{"codec_type":"audio","codec_name":"aac"}],"format":{"duration":"60.0","format_name":"matroska"}})
+        )
+
+      try do
+        Application.put_env(:mydia, :ffprobe_path, shim)
+
+        assert {:ok, result} = FileAnalyzer.analyze(target_file)
+        assert result.resolution == "1080p"
+        assert result.width == 2560
+        assert result.height == 1080
+      after
+        File.rm(shim)
+      end
+    end
   end
 
   describe "codec mapping" do

--- a/test/mydia/library_test.exs
+++ b/test/mydia/library_test.exs
@@ -438,6 +438,8 @@ defmodule Mydia.LibraryTest do
 
       result = %FileAnalysisResult{
         resolution: "1080p",
+        width: 1920,
+        height: 1080,
         codec: "H.264 (High)",
         audio_codec: "AAC Stereo",
         bitrate: 8_000_000,
@@ -462,7 +464,14 @@ defmodule Mydia.LibraryTest do
       assert reloaded.bitrate == 8_000_000
       assert is_nil(reloaded.hdr_format)
       assert reloaded.size == 2_147_483_648
-      assert %FileMetadata{container: "mkv", duration: 5400.5} = reloaded.metadata
+
+      assert %FileMetadata{
+               container: "mkv",
+               duration: 5400.5,
+               width: 1920,
+               height: 1080
+             } = reloaded.metadata
+
       assert %DateTime{} = reloaded.analyzed_at
       assert reloaded.last_analysis_error == nil
     end


### PR DESCRIPTION
## Summary
- classify cropped widescreen encodes by effective source height so 1920x800-style releases keep their 1080p tier instead of being downgraded to 720p
- persist analyzed video width and height in `media_files.metadata` and add a safe in-place repair path for already-analyzed rows missing those dimensions
- teach the recurring file analysis worker to spend spare batch capacity self-healing legacy analyzed rows, with focused regression coverage for the new repair flow

## Testing
- `mix test test/mydia/library/file_analyzer_test.exs test/mydia/library_test.exs test/mydia/jobs/file_analysis_test.exs`
- `mix precommit` currently reports existing repo-wide Credo warnings outside this diff
