### PR TITLE
feat(infra): wire relay SMTP config without committing it

### DIFF
--- a/infra/config.yaml.example
+++ b/infra/config.yaml.example
@@ -23,8 +23,16 @@ relay_tvdb_api_key: "your-tvdb-api-key"
 # TMDB API key from: https://www.themoviedb.org/settings/api
 relay_tmdb_api_key: "your-tmdb-api-key"
 
-# SMTP password for metadata-relay feedback email notifications
-relay_smtp_password: "your-smtp-password"
+# Feedback email notifications (optional)
+# All six fields below must be set together for the relay to send feedback emails.
+# Leave blank to disable. Stored locally only — never committed to git.
+relay_smtp_host: ""
+relay_smtp_port: "587"
+relay_smtp_username: ""
+relay_smtp_password: ""
+relay_feedback_email_to: ""
+relay_feedback_email_from: ""
+relay_feedback_dashboard_url: ""
 
 # Monitoring
 # Leave empty to auto-generate on first deploy

--- a/infra/config.yaml.example
+++ b/infra/config.yaml.example
@@ -23,6 +23,9 @@ relay_tvdb_api_key: "your-tvdb-api-key"
 # TMDB API key from: https://www.themoviedb.org/settings/api
 relay_tmdb_api_key: "your-tmdb-api-key"
 
+# SMTP password for metadata-relay feedback email notifications
+relay_smtp_password: "your-smtp-password"
+
 # Monitoring
 # Leave empty to auto-generate on first deploy
 grafana_admin_password: ""

--- a/infra/deploy
+++ b/infra/deploy
@@ -96,6 +96,14 @@ class Config:
     relay_tmdb_api_key: str = ""
     relay_smtp_password: str = ""
 
+    # Feedback email notifications (optional; leave blank to disable)
+    relay_smtp_host: str = ""
+    relay_smtp_port: str = ""
+    relay_smtp_username: str = ""
+    relay_feedback_email_to: str = ""
+    relay_feedback_email_from: str = ""
+    relay_feedback_dashboard_url: str = ""
+
     # CoTURN
     coturn_secret: str = ""
 
@@ -174,6 +182,12 @@ class Config:
             "relay_tvdb_api_key": self.relay_tvdb_api_key,
             "relay_tmdb_api_key": self.relay_tmdb_api_key,
             "relay_smtp_password": self.relay_smtp_password,
+            "relay_smtp_host": self.relay_smtp_host,
+            "relay_smtp_port": self.relay_smtp_port,
+            "relay_smtp_username": self.relay_smtp_username,
+            "relay_feedback_email_to": self.relay_feedback_email_to,
+            "relay_feedback_email_from": self.relay_feedback_email_from,
+            "relay_feedback_dashboard_url": self.relay_feedback_dashboard_url,
             "coturn_secret": self.coturn_secret,
             "grafana_admin_password": self.grafana_admin_password,
             "oauth2_proxy_client_id": self.oauth2_proxy_client_id,
@@ -945,17 +959,58 @@ def phase_app(config: Config, dry_run: bool = False) -> bool:
         console.print("  [green]✓[/green] Secret created")
 
     # --- Apply manifests ---
+    configmap_overrides = metadata_relay_configmap_data(config)
+
     if dry_run:
         console.print("  [yellow]Would apply:[/yellow] All metadata-relay manifests")
+        if configmap_overrides:
+            console.print(
+                f"  [yellow]Would patch:[/yellow] ConfigMap 'metadata-relay-config' "
+                f"with {len(configmap_overrides)} operator-specific key(s)"
+            )
     else:
         console.print("  [dim]Applying manifests...[/dim]")
         for manifest in ["configmap.yaml", "pvc.yaml", "deployment.yaml", "service.yaml", "ingress.yaml"]:
             manifest_path = metadata_relay_dir / manifest
             if manifest_path.exists():
                 run(["kubectl", "apply", "-f", str(manifest_path)])
+
+        if configmap_overrides:
+            console.print("  [dim]Patching ConfigMap with operator-specific values...[/dim]")
+            run([
+                "kubectl",
+                "patch",
+                "configmap",
+                "metadata-relay-config",
+                "-n",
+                namespace,
+                "--type",
+                "merge",
+                "-p",
+                json.dumps({"data": configmap_overrides}),
+            ])
+
         console.print("  [green]✓[/green] Application deployed")
 
     return True
+
+
+def metadata_relay_configmap_data(config: Config) -> dict[str, str]:
+    """Operator-specific ConfigMap values layered on top of the committed configmap.yaml.
+
+    Kept out of git so personal info (email, SMTP host) doesn't leak. Applied via
+    `kubectl patch --type merge`, which adds/updates keys without removing the
+    baseline keys defined in configmap.yaml.
+    """
+    fields = {
+        "SMTP_HOST": config.relay_smtp_host,
+        "SMTP_PORT": str(config.relay_smtp_port) if config.relay_smtp_port else "",
+        "SMTP_USERNAME": config.relay_smtp_username,
+        "FEEDBACK_EMAIL_TO": config.relay_feedback_email_to,
+        "FEEDBACK_EMAIL_FROM": config.relay_feedback_email_from,
+        "FEEDBACK_DASHBOARD_URL": config.relay_feedback_dashboard_url,
+    }
+    return {key: value for key, value in fields.items() if value}
 
 
 def metadata_relay_secret_data(config: Config) -> dict[str, str]:

--- a/infra/deploy
+++ b/infra/deploy
@@ -94,6 +94,7 @@ class Config:
     relay_secret_key_base: str = ""
     relay_tvdb_api_key: str = ""
     relay_tmdb_api_key: str = ""
+    relay_smtp_password: str = ""
 
     # CoTURN
     coturn_secret: str = ""
@@ -172,6 +173,7 @@ class Config:
             "relay_secret_key_base": self.relay_secret_key_base,
             "relay_tvdb_api_key": self.relay_tvdb_api_key,
             "relay_tmdb_api_key": self.relay_tmdb_api_key,
+            "relay_smtp_password": self.relay_smtp_password,
             "coturn_secret": self.coturn_secret,
             "grafana_admin_password": self.grafana_admin_password,
             "oauth2_proxy_client_id": self.oauth2_proxy_client_id,
@@ -920,31 +922,26 @@ def phase_app(config: Config, dry_run: bool = False) -> bool:
         console.print("  [green]✓[/green] Secret 'metadata-relay-secrets' exists")
         # Update secret if not in dry run
         if not dry_run:
-             console.print("  [dim]Updating secret...[/dim]")
-             # Generate yaml and pipe to apply
-             proc = subprocess.Popen(
-                ["kubectl", "create", "secret", "generic", "metadata-relay-secrets",
-                "-n", namespace,
-                "--dry-run=client", "-o", "yaml",
-                f"--from-literal=RELAY_TOKEN_SECRET={config.relay_secret_key_base}",
-                f"--from-literal=TMDB_API_KEY={config.relay_tmdb_api_key}",
-                f"--from-literal=TVDB_API_KEY={config.relay_tvdb_api_key}"],
-                stdout=subprocess.PIPE
-             )
-             subprocess.run(["kubectl", "apply", "-f", "-"], stdin=proc.stdout)
-             console.print("  [green]✓[/green] Secret updated")
+            console.print("  [dim]Updating secret...[/dim]")
+            run([
+                "kubectl",
+                "patch",
+                "secret",
+                "metadata-relay-secrets",
+                "-n",
+                namespace,
+                "--type",
+                "merge",
+                "-p",
+                json.dumps({"stringData": metadata_relay_secret_data(config)}),
+            ])
+            console.print("  [green]✓[/green] Secret updated")
 
     elif dry_run:
         console.print("  [yellow]Would create:[/yellow] Secret with API keys")
     else:
         console.print("  [dim]Creating secret...[/dim]")
-        run([
-            "kubectl", "create", "secret", "generic", "metadata-relay-secrets",
-            "-n", namespace,
-            f"--from-literal=RELAY_TOKEN_SECRET={config.relay_secret_key_base}",
-            f"--from-literal=TMDB_API_KEY={config.relay_tmdb_api_key}",
-            f"--from-literal=TVDB_API_KEY={config.relay_tvdb_api_key}",
-        ])
+        run(metadata_relay_secret_args(config, namespace))
         console.print("  [green]✓[/green] Secret created")
 
     # --- Apply manifests ---
@@ -959,6 +956,36 @@ def phase_app(config: Config, dry_run: bool = False) -> bool:
         console.print("  [green]✓[/green] Application deployed")
 
     return True
+
+
+def metadata_relay_secret_data(config: Config) -> dict[str, str]:
+    data = {
+        "RELAY_TOKEN_SECRET": config.relay_secret_key_base,
+        "TMDB_API_KEY": config.relay_tmdb_api_key,
+        "TVDB_API_KEY": config.relay_tvdb_api_key,
+    }
+
+    if config.relay_smtp_password:
+        data["SMTP_PASSWORD"] = config.relay_smtp_password
+
+    return data
+
+
+def metadata_relay_secret_args(config: Config, namespace: str) -> list[str]:
+    args = [
+        "kubectl",
+        "create",
+        "secret",
+        "generic",
+        "metadata-relay-secrets",
+        "-n",
+        namespace,
+    ]
+
+    for key, value in metadata_relay_secret_data(config).items():
+        args.append(f"--from-literal={key}={value}")
+
+    return args
 
 
 def phase_monitoring(config: Config, dry_run: bool = False) -> bool:

--- a/infra/kubernetes/apps/metadata-relay/secret.yaml.example
+++ b/infra/kubernetes/apps/metadata-relay/secret.yaml.example
@@ -20,6 +20,9 @@ stringData:
   # Generate with: openssl rand -hex 32
   RENDEZVOUS_MASTER_PEPPER: "your-secure-random-pepper-here"
 
+  # REQUIRED when feedback email notifications are enabled
+  SMTP_PASSWORD: "your-smtp-password"
+
   # OPTIONAL: OpenSubtitles credentials (if subtitle support is needed)
   # OPENSUBTITLES_API_KEY: "your-opensubtitles-api-key"
   # OPENSUBTITLES_USERNAME: "your-opensubtitles-username"


### PR DESCRIPTION
## Summary
- Adds `SMTP_PASSWORD` to `metadata-relay-secrets` so feedback email notifications can authenticate.
- Switches the relay secret update path to `kubectl patch ... --type merge`, so individual keys can be added or rotated without clobbering unrelated fields.
- Templates the SMTP host/port/username, feedback from/to, and dashboard URL out of the committed ConfigMap and into `config.yaml`. After `kubectl apply -f configmap.yaml`, the deploy script does `kubectl patch configmap metadata-relay-config --type merge` with whichever fields the operator has set, so the operator's email and SMTP host stay local.

## Test plan
- [ ] `./infra/deploy --dry-run` reports the patch step (and the count of keys it would apply) without touching the cluster
- [ ] `./infra/deploy` applies `configmap.yaml`, then merges the operator's SMTP keys on top — `kubectl get configmap metadata-relay-config -o yaml` shows both the baseline keys (PORT, PHX_HOST, …) and the SMTP keys
- [ ] With all SMTP fields blank in `config.yaml`, the patch step is skipped and the ConfigMap matches the committed baseline
- [ ] Relay pod restarts and successfully sends a feedback notification email