### PR TITLE
fix: stop retry loop on unimportable malware downloads

### DIFF
--- a/lib/mydia/downloads/release_validator.ex
+++ b/lib/mydia/downloads/release_validator.ex
@@ -109,7 +109,12 @@ defmodule Mydia.Downloads.ReleaseValidator do
   @suspicious_extensions ~w(.exe .scr .bat .cmd .com .msi .vbs .js .jar .pif)
 
   defp suspicious_extension?(name) do
-    ext = name |> Path.extname() |> String.downcase()
+    ext =
+      name
+      |> String.trim()
+      |> Path.extname()
+      |> String.downcase()
+
     ext in @suspicious_extensions
   end
 

--- a/lib/mydia/downloads/release_validator.ex
+++ b/lib/mydia/downloads/release_validator.ex
@@ -28,6 +28,12 @@ defmodule Mydia.Downloads.ReleaseValidator do
      - Example: `yenc movie title`
      - These are raw usenet posts, not proper releases
 
+  6. **Suspicious executable extensions** - Release name ends in an executable
+     extension (.exe, .scr, .bat, .cmd, .com, .msi, .vbs, .js, .jar, .pif)
+     - Example: `From.S04E05.1080p.WEB.h264-ETHEL.exe`
+     - These are malware torrents disguised as 1080p video releases. A
+       legitimate video release never carries an executable extension.
+
   ## Usage
 
       iex> ReleaseValidator.validate_release("The.Matrix.1999.1080p.BluRay.x264")
@@ -56,10 +62,15 @@ defmodule Mydia.Downloads.ReleaseValidator do
   - `:reversed_pattern` - Strange reversed naming
   - `:yenc_pattern` - Raw usenet binary encoding
   - `:no_meaningful_content` - No extractable title content
+  - `:suspicious_extension` - Release name ends in an executable extension
   """
   @spec validate_release(String.t()) :: {:ok, String.t()} | {:error, atom()}
   def validate_release(name) when is_binary(name) do
     cond do
+      suspicious_extension?(name) ->
+        Logger.warning("Rejecting release with suspicious executable extension: #{name}")
+        {:error, :suspicious_extension}
+
       is_hashed_release?(name) ->
         Logger.debug("Rejecting hashed release: #{name}")
         {:error, :hashed_release}
@@ -90,6 +101,17 @@ defmodule Mydia.Downloads.ReleaseValidator do
   end
 
   ## Private Functions - Validation Patterns
+
+  # Release filenames that end in a Windows executable extension are malware
+  # — a legitimate 1080p video release never has a .exe extension. These show
+  # up periodically from public indexers using real-looking release-group
+  # names (e.g. "ETHEL") to slip past automatic-grab filters.
+  @suspicious_extensions ~w(.exe .scr .bat .cmd .com .msi .vbs .js .jar .pif)
+
+  defp suspicious_extension?(name) do
+    ext = name |> Path.extname() |> String.downcase()
+    ext in @suspicious_extensions
+  end
 
   # Detects hashed releases with long hex strings in brackets
   # Example: [A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6] Movie Title

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -155,13 +155,47 @@ defmodule Mydia.Jobs.MediaImport do
             clear_retry_metadata(download)
             {:ok, result}
 
-          {:error, reason} = error ->
-            # Failure - update retry metadata and schedule next retry
-            handle_import_failure(download, reason, attempt)
-            error
+          {:error, reason} ->
+            # Failure - update retry metadata. If the failure is structurally
+            # unfixable (e.g. a completed torrent contains zero importable
+            # media files, or its save path has been gone for several
+            # attempts), stop Oban's retry loop so the row doesn't keep
+            # re-scanning for days.
+            terminal? = terminal_failure?(reason, attempt)
+            handle_import_failure(download, reason, attempt, terminal?: terminal?)
+
+            if terminal? do
+              Logger.warning("Media import giving up — terminal failure",
+                download_id: download_id,
+                attempt: attempt,
+                reason: inspect(reason)
+              )
+
+              {:cancel, reason}
+            else
+              {:error, reason}
+            end
         end
     end
   end
+
+  # Classifies failures whose state will not change by retrying.
+  #
+  # `:no_importable_files` fires only after a *completed* torrent has been
+  # scanned and zero files matched the video-extension whitelist. Re-scanning
+  # the same finished torrent will deterministically produce the same result,
+  # so retrying is pointless. The common cause in production is malware
+  # torrents named `*.1080p.WEB.h264-<group>.exe` — the importer correctly
+  # rejects them, then they sit in the retry queue for weeks.
+  #
+  # Filesystem-availability errors (`:path_not_found`, `:path_not_accessible`)
+  # can legitimately be transient — a remote mount blip, a torrent client
+  # that hasn't finished moving files yet — so they get a small budget of
+  # retries before we give up.
+  defp terminal_failure?(:no_importable_files, _attempt), do: true
+  defp terminal_failure?({:path_not_found, _path}, attempt) when attempt >= 3, do: true
+  defp terminal_failure?({:path_not_accessible, _path}, attempt) when attempt >= 3, do: true
+  defp terminal_failure?(_reason, _attempt), do: false
 
   defp fetch_download(download_id) do
     {:ok,
@@ -1582,15 +1616,20 @@ defmodule Mydia.Jobs.MediaImport do
     end
   end
 
-  # Update download record with retry metadata after a failed attempt
-  defp handle_import_failure(download, reason, attempt) do
-    backoff_seconds = calculate_backoff(attempt)
-    next_retry_at = DateTime.add(DateTime.utc_now(), backoff_seconds, :second)
+  # Update download record with retry metadata after a failed attempt.
+  # When `terminal?: true` is passed, clears `import_next_retry_at` so the
+  # UI can show "gave up" instead of advertising a retry that will never fire.
+  defp handle_import_failure(download, reason, attempt, opts \\ []) do
+    terminal? = Keyword.get(opts, :terminal?, false)
 
-    # Format error message with actionable context
+    next_retry_at =
+      if terminal? do
+        nil
+      else
+        DateTime.add(DateTime.utc_now(), calculate_backoff(attempt), :second)
+      end
+
     error_message = format_import_error(reason, download)
-
-    # Track first failure timestamp
     import_failed_at = download.import_failed_at || DateTime.utc_now()
 
     attrs = %{
@@ -1602,13 +1641,20 @@ defmodule Mydia.Jobs.MediaImport do
 
     case Downloads.update_download(download, attrs) do
       {:ok, _updated} ->
-        Logger.warning("Import failed, will retry",
-          download_id: download.id,
-          attempt: attempt,
-          reason: error_message,
-          next_retry_at: next_retry_at,
-          backoff_seconds: backoff_seconds
-        )
+        if terminal? do
+          Logger.warning("Import failed terminally — no further retries",
+            download_id: download.id,
+            attempt: attempt,
+            reason: error_message
+          )
+        else
+          Logger.warning("Import failed, will retry",
+            download_id: download.id,
+            attempt: attempt,
+            reason: error_message,
+            next_retry_at: next_retry_at
+          )
+        end
 
         :ok
 

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -165,12 +165,6 @@ defmodule Mydia.Jobs.MediaImport do
             handle_import_failure(download, reason, attempt, terminal?: terminal?)
 
             if terminal? do
-              Logger.warning("Media import giving up — terminal failure",
-                download_id: download_id,
-                attempt: attempt,
-                reason: inspect(reason)
-              )
-
               {:cancel, reason}
             else
               {:error, reason}

--- a/test/mydia/downloads/release_validator_test.exs
+++ b/test/mydia/downloads/release_validator_test.exs
@@ -182,6 +182,12 @@ defmodule Mydia.Downloads.ReleaseValidatorTest do
       assert {:error, :suspicious_extension} = ReleaseValidator.validate_release(name)
     end
 
+    test "rejects executable extension with trailing whitespace" do
+      name = "Movie.2024.1080p.BluRay.x264.exe "
+
+      assert {:error, :suspicious_extension} = ReleaseValidator.validate_release(name)
+    end
+
     test "rejects other Windows executable extensions" do
       for ext <- ~w(.scr .bat .cmd .com .msi .vbs .js .jar .pif) do
         name = "Movie.Title.2020.1080p.BluRay.x264#{ext}"

--- a/test/mydia/downloads/release_validator_test.exs
+++ b/test/mydia/downloads/release_validator_test.exs
@@ -163,6 +163,45 @@ defmodule Mydia.Downloads.ReleaseValidatorTest do
     end
   end
 
+  describe "validate_release/1 - suspicious executable extensions" do
+    test "rejects .exe release disguised as 1080p TV episode" do
+      name = "From.S04E05.1080p.WEB.h264-ETHEL.exe"
+
+      assert {:error, :suspicious_extension} = ReleaseValidator.validate_release(name)
+    end
+
+    test "rejects .exe release disguised as movie" do
+      name = "The.Matrix.1999.1080p.BluRay.x264.exe"
+
+      assert {:error, :suspicious_extension} = ReleaseValidator.validate_release(name)
+    end
+
+    test "rejects uppercase .EXE extension" do
+      name = "Your.Friends.and.Neighbors.S02E07.1080p.WEB.h264-ETHEL.EXE"
+
+      assert {:error, :suspicious_extension} = ReleaseValidator.validate_release(name)
+    end
+
+    test "rejects other Windows executable extensions" do
+      for ext <- ~w(.scr .bat .cmd .com .msi .vbs .js .jar .pif) do
+        name = "Movie.Title.2020.1080p.BluRay.x264#{ext}"
+        assert {:error, :suspicious_extension} = ReleaseValidator.validate_release(name)
+      end
+    end
+
+    test "accepts release without an extension" do
+      name = "From.S04E05.1080p.WEB.h264-ETHEL"
+
+      assert {:ok, ^name} = ReleaseValidator.validate_release(name)
+    end
+
+    test "accepts release with legitimate .mkv extension" do
+      name = "From.S04E05.1080p.WEB.h264-ETHEL.mkv"
+
+      assert {:ok, ^name} = ReleaseValidator.validate_release(name)
+    end
+  end
+
   describe "validate_release/1 - no meaningful content" do
     test "rejects release with only brackets and quality markers" do
       name = "[Tracker] (2020) 1080p BluRay x264"

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -647,6 +647,96 @@ defmodule Mydia.Jobs.MediaImportTest do
       updated = Mydia.Downloads.get_download!(download.id)
       assert updated.import_last_error =~ "Download path not found"
     end
+
+    test "cancels missing path after the third attempt and clears retry metadata" do
+      media_item =
+        media_item_fixture(%{type: "movie", title: "Bad Path Movie", year: 2024})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "MissingPathTerminalClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "MissingPathTerminalClient",
+          download_client_id: "missing-path-terminal"
+        })
+
+      assert {:cancel, {:path_not_found, "/no/such/path/exists"}} =
+               perform_job(
+                 MediaImport,
+                 %{
+                   "download_id" => download.id,
+                   "save_path" => "/no/such/path/exists"
+                 },
+                 attempt: 3
+               )
+
+      updated = Mydia.Downloads.get_download!(download.id)
+      assert updated.import_retry_count == 3
+      assert is_nil(updated.import_next_retry_at)
+      assert updated.import_last_error =~ "Download path not found"
+    end
+
+    @tag :tmp_dir
+    test "cancels inaccessible path after the third attempt and clears retry metadata",
+         %{tmp_dir: tmp_dir} do
+      media_item =
+        media_item_fixture(%{type: "movie", title: "Restricted Path Movie", year: 2024})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "RestrictedPathTerminalClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      restricted_dir = Path.join(tmp_dir, "restricted-download")
+      File.mkdir_p!(restricted_dir)
+      File.write!(Path.join(restricted_dir, "movie.mkv"), "video")
+      File.chmod!(restricted_dir, 0o000)
+      on_exit(fn -> File.chmod!(restricted_dir, 0o755) end)
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "RestrictedPathTerminalClient",
+          download_client_id: "restricted-path-terminal"
+        })
+
+      assert {:cancel, {:path_not_accessible, ^restricted_dir}} =
+               perform_job(
+                 MediaImport,
+                 %{
+                   "download_id" => download.id,
+                   "save_path" => restricted_dir
+                 },
+                 attempt: 3
+               )
+
+      updated = Mydia.Downloads.get_download!(download.id)
+      assert updated.import_retry_count == 3
+      assert is_nil(updated.import_next_retry_at)
+      assert updated.import_last_error =~ "Download path is not accessible"
+    end
   end
 
   # Helper functions

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -254,6 +254,62 @@ defmodule Mydia.Jobs.MediaImportTest do
                perform_job(MediaImport, %{"download_id" => download.id})
     end
 
+    @tag :tmp_dir
+    test "cancels (no retry) when completed torrent has no importable files",
+         %{tmp_dir: tmp_dir} do
+      # Real bug from production: malware torrents named
+      # `From.S04E05.1080p.WEB.h264-ETHEL.exe` slip past the indexer, finish
+      # downloading, and then sit in the retry queue forever because the
+      # importer keeps rejecting them with `:no_importable_files`. Re-scanning
+      # the same finished torrent will deterministically produce the same
+      # result — there's no recovery path, so the job must `:cancel` on the
+      # first attempt instead of burning days of exponential backoff.
+      _library_path = create_test_library_path(tmp_dir, :movies)
+
+      download_dir = Path.join(tmp_dir, "ethel-malware")
+      File.mkdir_p!(download_dir)
+      File.write!(Path.join(download_dir, "Movie.2024.1080p.exe"), "not a video")
+
+      media_item = media_item_fixture(%{type: "movie", title: "Malware Movie", year: 2024})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "MalwareClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "MalwareClient",
+          download_client_id: "ethel-1"
+        })
+
+      assert {:cancel, :no_importable_files} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      updated = Mydia.Downloads.get_download!(download.id)
+
+      assert updated.import_failed_at != nil,
+             "Terminal failures must still record import_failed_at for the Issues tab"
+
+      assert is_nil(updated.import_next_retry_at),
+             "Terminal failures must clear import_next_retry_at so the UI doesn't advertise a retry that won't fire"
+
+      assert updated.import_last_error =~ "No importable files"
+    end
+
     test "returns error if download has no client info", %{tmp_dir: tmp_dir} do
       # Create a library path
       create_test_library_path(tmp_dir, :movies)


### PR DESCRIPTION
## Summary

Two compounding bugs let malware torrents named like `From.S04E05.1080p.WEB.h264-ETHEL.exe` sit in the import retry queue for days. With `max_attempts: 1000` and 24-hour backoff past attempt 7, a single bad grab can rack up double-digit retries before anyone notices. Spotted in production with four such rows on one host, the worst at `retry_count: 11`.

### Two root causes

1. **`ReleaseValidator` didn't recognize executable extensions as a malware tell.** Torrents whose name ended in `.exe` parsed cleanly and entered the queue.
2. **`:no_importable_files` was treated as a transient failure.** The importer correctly rejected the `.exe` payload every time, but the retry loop never gave up.

### Changes

- **`ReleaseValidator`** rejects release names ending in `.exe .scr .bat .cmd .com .msi .vbs .js .jar .pif` as `:suspicious_extension`. A legitimate video release never carries one of these, and several public indexers periodically post malware under real-looking release-group names (e.g. `ETHEL`) to slip past automatic-grab filters.
- **`MediaImport`** gains a `terminal_failure?/2` classifier. When a failure is structurally unfixable, `perform/1` returns `{:cancel, reason}` (same escape hatch already used for unmatched orphans) and clears `import_next_retry_at` so the UI shows "gave up" instead of advertising a retry that will not fire:
  - `:no_importable_files` is terminal on the **first** attempt. The error only fires after a *completed* torrent has been scanned and zero files matched the video-extension whitelist. Re-scanning the same finished torrent will deterministically produce the same result.
  - `{:path_not_found, _}` and `{:path_not_accessible, _}` are terminal after **3** attempts so a transient mount blip still gets a chance to recover.
  - Every other failure keeps current backoff behavior.

### Behavior on already-stuck rows

No data migration needed. On each affected row's next scheduled retry, MediaImport will hit the same error, classify it terminal, return `{:cancel, ...}`, and Oban will discard the job. The download row stays (with `import_next_retry_at = nil`) so it surfaces in the Issues tab as a permanent failure to be cleared manually, instead of quietly retrying for weeks.

## Test plan

- [x] `mix test test/mydia/downloads/release_validator_test.exs` (48 tests, 9 new for `.exe` and friends)
- [x] `mix test test/mydia/jobs/media_import_test.exs` (33 tests, 1 new end-to-end terminal-failure case that drops a `.exe` in a save_path dir and asserts `{:cancel, :no_importable_files}` plus `import_next_retry_at: nil`)
- [x] Full `mix precommit` (4506 tests, 0 failures)