### PR TITLE
fix(nfo): write NFO files when items are imported via library scan

### DIFF
--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -11,6 +11,7 @@ defmodule Mydia.Library.MetadataEnricher do
 
   require Logger
   alias Mydia.{Media, Metadata, Repo, Settings}
+  alias Mydia.Metadata.NfoWriter
 
   @doc """
   Enriches a media item with full metadata from the provider.
@@ -91,6 +92,8 @@ defmodule Mydia.Library.MetadataEnricher do
               enrich_episodes(media_item, provider_id, config, match_result_with_file_id)
             end
           end
+
+          NfoWriter.maybe_write_nfos(media_item.id)
 
           {:ok, media_item}
 

--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -93,7 +93,7 @@ defmodule Mydia.Library.MetadataEnricher do
             end
           end
 
-          NfoWriter.maybe_write_nfos(media_item.id)
+          NfoWriter.maybe_write_nfos(media_item)
 
           {:ok, media_item}
 


### PR DESCRIPTION
## Summary

The "Write NFO Files" per-library toggle silently did nothing when items were brought into the library by folder scanning. `NfoWriter.maybe_write_nfos/1` was only wired into the download import job, the metadata refresh job, and manual refresh, so users who populate their library by dropping files into a watched path never got `.nfo` files generated.

This hooks `NfoWriter.maybe_write_nfos/1` into `MetadataEnricher.enrich/2` after file/episode association, so every import path honors the setting. The writer is best-effort (rescues its own exceptions) and a no-op when no library path has the toggle on, so this is safe to run on every enrich.

Fixes part of #152.

## Test plan

- [x] `./dev mix test test/mydia/library/metadata_enricher_test.exs` passes
- [x] `./dev mix test test/mydia/metadata/nfo_writer_test.exs` passes
- [ ] Manual: enable Write NFO on a library path, drop a file in, confirm a sibling `.nfo` appears