### PR TITLE
ci(relay): stop publishing GitHub releases for metadata-relay

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,4 +1,4 @@
-name: Release / Relay
+name: Deploy / Relay
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/metadata-relay-v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Releasing version: $VERSION"
+          echo "Deploying version: $VERSION"
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -72,49 +72,3 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-
-  publish:
-    name: Publish Release
-    runs-on: ubuntu-latest
-    needs: docker
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Create release notes
-        id: release_notes
-        run: |
-          VERSION=${{ needs.docker.outputs.version }}
-          cat > release_notes.md << EOF
-          # Metadata Relay v${VERSION}
-
-          ## Docker Image
-
-          - **Image**: \`${{ needs.docker.outputs.image }}\`
-
-          ## Installation
-
-          Pull the Docker image:
-          \`\`\`bash
-          docker pull ghcr.io/${{ github.repository }}/metadata-relay:${VERSION}
-          \`\`\`
-
-          ## Changes
-
-          See commit history for detailed changes in this release.
-          EOF
-
-          cat release_notes.md
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: Metadata Relay v${{ needs.docker.outputs.version }}
-          body_path: release_notes.md
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/metadata-relay/CLAUDE.md
+++ b/metadata-relay/CLAUDE.md
@@ -28,9 +28,9 @@ mix format
 
 Environment variables: `PORT` (default 4001), `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` (required in production for `/errors` and `/feedback` dashboards), `TMDB_API_KEY`, `TVDB_API_KEY`, `REDIS_URL` (optional).
 
-## Releasing a New Version
+## Deploying a New Version
 
-The release process is tag-driven and fully automated via GitHub Actions.
+The deployment process is tag-driven and automated via GitHub Actions.
 
 ### Steps
 
@@ -45,7 +45,7 @@ The release process is tag-driven and fully automated via GitHub Actions.
    git commit -m "feat(metadata-relay): prepare vX.Y.Z release"
    ```
 
-3. **Create and push a version tag**:
+3. **Create and push a deployment tag**:
    ```bash
    git tag metadata-relay-vX.Y.Z
    git push origin metadata-relay-vX.Y.Z
@@ -53,12 +53,11 @@ The release process is tag-driven and fully automated via GitHub Actions.
 
 ### What Happens Automatically
 
-The `release-relay.yml` workflow triggers on tags matching `metadata-relay-v*` and:
+The `deploy-relay.yml` workflow triggers on tags matching `metadata-relay-v*` and:
 
 1. Builds **multi-platform Docker images** (linux/amd64 + linux/arm64)
 2. Pushes to **GHCR** at `ghcr.io/getmydia/mydia/metadata-relay` with semver tags (`latest`, `X.Y.Z`, `X.Y`, `X`)
 3. Generates build attestations for supply chain security
-4. Creates a **GitHub Release** with deployment notes
 
 ### Auto-Deployment
 

--- a/metadata-relay/README.md
+++ b/metadata-relay/README.md
@@ -294,18 +294,17 @@ fly secrets unset SECRET_NAME
 
 ## Deployment
 
-### Automated Releases (Recommended)
+### Automated Deployments (Recommended)
 
 The metadata-relay service uses GitHub Actions for automated CI/CD. When you push a version tag, it automatically:
 
 1. ✅ Runs tests and builds the Docker image
 2. 📦 Pushes the image to GitHub Container Registry (GHCR)
-3. 🚀 Deploys to Fly.io production
-4. 📝 Creates a GitHub release with notes
+3. 🚀 Makes the new image available for your deployment target to roll out
 
-#### Creating a Release
+#### Creating a Deployment Build
 
-To release a new version:
+To publish a new deployable image:
 
 1. **Update the version** in `mix.exs` (if desired):
 
@@ -333,32 +332,15 @@ To release a new version:
    git push origin metadata-relay-v0.2.0
    ```
 
-4. **Monitor the release**:
+4. **Monitor the deployment build**:
    - Go to GitHub Actions to watch the build and deployment
-   - The workflow will automatically deploy to Fly.io
-   - A GitHub release will be created with deployment details
+   - Your deployment target can pull the new image once it is published
 
-#### Prerequisites for Automated Releases
+#### Prerequisites for Automated Deployments
 
-**One-time setup** - Add the Fly.io API token to GitHub secrets:
+No extra deployment secret is required for the GitHub workflow itself. It only needs the default `GITHUB_TOKEN` to publish the metadata-relay image to GHCR.
 
-Using the GitHub CLI (recommended):
-
-```bash
-# Quick one-liner setup
-flyctl auth token | gh secret set FLY_API_TOKEN
-
-# Verify it was set
-gh secret list
-```
-
-Or manually via the web UI:
-
-1. Get token: `flyctl auth token`
-2. Go to: Settings → Secrets and variables → Actions
-3. Add secret: Name=`FLY_API_TOKEN`, Value=token from step 1
-
-**That's it!** All releases will now deploy automatically.
+In production, the relay is rolled out separately by infrastructure automation after the new image is published.
 
 **Validate your setup:**
 
@@ -371,19 +353,16 @@ cd metadata-relay
 **Helpful commands:**
 
 ```bash
-# Monitor a release in real-time
+# Monitor a deployment build in real-time
 gh run watch
 
 # View recent workflow runs
-gh run list --workflow=metadata-relay-release.yml
-
-# Check Fly.io deployment logs
-flyctl logs -a metadata-relay -f
+gh run list --workflow=deploy-relay.yml
 ```
 
 #### What Gets Built
 
-Each release creates multi-platform Docker images:
+Each deployment build creates multi-platform Docker images:
 
 - **Platforms**: `linux/amd64`, `linux/arm64`
 - **Registry**: GitHub Container Registry (GHCR)
@@ -864,14 +843,13 @@ Automatically runs on changes to the `metadata-relay/` directory:
 - 📝 **Formatting**: Ensures code follows project standards
 - 🐳 **Docker Build**: Verifies Docker image builds successfully
 
-### Release Workflow (Runs on version tags)
+### Deployment Workflow (Runs on version tags)
 
 Triggered when pushing tags matching `metadata-relay-v*`:
 
 - 🏗️ **Build**: Creates multi-platform Docker images (amd64, arm64)
 - 📦 **Publish**: Pushes to GitHub Container Registry
-- 🚀 **Deploy**: Automatically deploys to Fly.io production
-- 📝 **Release**: Creates GitHub release with deployment notes
+- 🚀 **Deploy**: Makes a new semver-tagged image available for infrastructure automation to roll out
 
 All workflows must pass before code can be merged, ensuring production stability.
 


### PR DESCRIPTION
## Summary

The metadata-relay tag workflow was creating a GitHub Release every time a `metadata-relay-v*` tag was pushed, which ended up taking over the repository's \"Latest release\" slot. This trims the workflow down to just building and pushing the GHCR image, and renames it from \`release-relay.yml\` to \`deploy-relay.yml\` to match what it actually does. The relay still rolls out via image-based automation, so no deploy path changes.

README and CLAUDE.md for metadata-relay are updated to match the new behavior (no more GitHub release, no more Fly.io step, no \`FLY_API_TOKEN\` setup section).

## Test plan

- [ ] Push a \`metadata-relay-v*\` tag (or trigger the workflow manually) and confirm the image lands on GHCR with the expected semver tags
- [ ] Confirm no new GitHub Release is created for that tag