### PR TITLE
chore(metadata-relay): bump version to 0.10.0

### DIFF
--- a/metadata-relay/mix.exs
+++ b/metadata-relay/mix.exs
@@ -4,7 +4,7 @@ defmodule MetadataRelay.MixProject do
   def project do
     [
       app: :metadata_relay,
-      version: "0.9.0",
+      version: "0.10.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Summary
Cuts a new minor release. Tag `metadata-relay-v0.10.0` will be pushed once this lands to trigger the GHCR build, which Keel then rolls out to the cluster.

Unreleased commits since v0.9.0:
- `7db262b` feat(relay): add feedback inbox dashboard
- `20f7eff` feat(relay): improve feedback triage
- `284fd71` test(ci): fix feedback formatting and ffmpeg fixtures
- `01b334c` fix(feedback): align validation and error handling
- `910e7d9` fix(relay): harden feedback triage flow

## Test plan
- [ ] CI green
- [ ] After merge, push `metadata-relay-v0.10.0`; the deploy-relay workflow publishes to GHCR
- [ ] Keel rolls the new image out to `metadata-relay/metadata-relay`