### PR TITLE
ci(player-e2e): always run, skip work via path filter step

### DIFF
--- a/.github/workflows/ci-player-e2e.yml
+++ b/.github/workflows/ci-player-e2e.yml
@@ -4,15 +4,6 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    paths:
-      - "player/**"
-      - "lib/**"
-      - "native/**"
-      - "metadata-relay/**"
-      - "config/**"
-      - "Dockerfile.e2e"
-      - "compose.player-e2e.yml"
-      - ".github/workflows/ci-player-e2e.yml"
   workflow_dispatch:
 
 concurrency:
@@ -29,13 +20,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect relevant changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'player/**'
+              - 'lib/**'
+              - 'native/**'
+              - 'metadata-relay/**'
+              - 'config/**'
+              - 'Dockerfile.e2e'
+              - 'compose.player-e2e.yml'
+              - '.github/workflows/ci-player-e2e.yml'
+
+      - name: Decide whether to run
+        id: should
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ] || [ "${{ steps.filter.outputs.relevant }}" = "true" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No player/relay/lib/native/config changes; skipping E2E build."
+          fi
+
       - name: Setup Docker Buildx
+        if: steps.should.outputs.run == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build E2E images
+        if: steps.should.outputs.run == 'true'
         run: DOCKER_BUILDKIT=1 docker compose -f compose.player-e2e.yml build
 
       - name: Run player E2E tests
+        if: steps.should.outputs.run == 'true'
         run: |
           docker compose -f compose.player-e2e.yml up \
             --abort-on-container-exit \
@@ -44,14 +64,14 @@ jobs:
           E2E_TEST_TARGET: integration_test/pairing_flow_test.dart
 
       - name: Collect service logs
-        if: failure()
+        if: failure() && steps.should.outputs.run == 'true'
         run: |
           docker compose -f compose.player-e2e.yml logs mydia > mydia-logs.txt 2>&1 || true
           docker compose -f compose.player-e2e.yml logs relay > relay-logs.txt 2>&1 || true
           docker compose -f compose.player-e2e.yml logs test > test-logs.txt 2>&1 || true
 
       - name: Upload logs on failure
-        if: failure()
+        if: failure() && steps.should.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: player-e2e-logs
@@ -62,5 +82,5 @@ jobs:
           retention-days: 7
 
       - name: Cleanup
-        if: always()
+        if: always() && steps.should.outputs.run == 'true'
         run: docker compose -f compose.player-e2e.yml down -v


### PR DESCRIPTION
## Why

The `Test / Player E2E` check is required on master, but the workflow used a `pull_request: paths:` filter. PRs that don't touch player/lib/native/metadata-relay/config get the workflow skipped entirely, which means the check is absent from the rollup, which means branch protection refuses the merge.

We hit this on #150 (infra-only). The temporary fix was to relax the ruleset to merge that PR. This is the permanent fix.

## What

- Drop the workflow-level `paths:` filter from `pull_request:`.
- Inside the job, add a `dorny/paths-filter@v3` step that detects whether the same set of paths changed.
- Gate the heavy steps (Buildx setup, build, run, logs, upload, cleanup) on `steps.should.outputs.run == 'true'`.
- Pushes to master and `workflow_dispatch` always run the full E2E.

When the paths don't match, the job completes in seconds with a SUCCESS conclusion, satisfying branch protection without burning CI minutes.

## Self-test

This PR itself touches `.github/workflows/ci-player-e2e.yml`, which is in the filter list — so the full E2E runs on this PR. To verify the skip path, the next infra-only or docs-only PR should show this job completing quickly with SUCCESS instead of being absent.

## Test plan

- [ ] This PR's Player E2E runs the full pipeline (paths matched)
- [ ] After merge, open a throwaway PR touching only `README.md` and confirm Player E2E reports SUCCESS in under ~30s