### PR TITLE
fix(auth): disable OIDC pushed authorization requests natively via quirks

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -347,6 +347,17 @@ if oidc_issuer && oidc_client_id && oidc_client_secret do
     %{
       name: :default_issuer,
       issuer: oidc_issuer,
+      # Workaround for Authelia 4.39+ JAR strictness (RFC 9101 cross-jwt-
+      # confusion mitigation): Authelia rejects request objects whose JWT
+      # header lacks `typ` (`JWT` or `oauth-authz-req+jwt`). Erlef oidcc up
+      # to and including v3.7.2 signs JARs without setting that header, so
+      # any flow that builds one fails with `invalid_request_object`.
+      #
+      # Patch the discovery doc so oidcc believes the issuer supports
+      # neither PAR nor the `request` parameter; that short-circuits
+      # `oidcc_authorization:attempt_request_object/3` and falls back to a
+      # plain query-param authorize redirect. Drop these overrides once
+      # upstream oidcc sets `typ` on signed request objects.
       provider_configuration_opts: %{
         quirks: %{
           document_overrides: %{

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -350,7 +350,8 @@ if oidc_issuer && oidc_client_id && oidc_client_secret do
       provider_configuration_opts: %{
         quirks: %{
           document_overrides: %{
-            "pushed_authorization_request_endpoint" => :undefined
+            "pushed_authorization_request_endpoint" => :undefined,
+            "request_parameter_supported" => false
           }
         }
       }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -344,7 +344,17 @@ if oidc_issuer && oidc_client_id && oidc_client_secret do
 
   # Step 1: Configure the OIDC issuer (required by ueberauth_oidcc)
   config :ueberauth_oidcc, :issuers, [
-    %{name: :default_issuer, issuer: oidc_issuer}
+    %{
+      name: :default_issuer,
+      issuer: oidc_issuer,
+      provider_configuration_opts: %{
+        quirks: %{
+          document_overrides: %{
+            "pushed_authorization_request_endpoint" => :undefined
+          }
+        }
+      }
+    }
   ]
 
   # Step 2: Configure Ueberauth provider with inline options

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -502,7 +502,17 @@ if oidc_issuer && oidc_client_id && oidc_client_secret do
 
   # Step 1: Configure the OIDC issuer (required by ueberauth_oidcc)
   config :ueberauth_oidcc, :issuers, [
-    %{name: :default_issuer, issuer: oidc_issuer}
+    %{
+      name: :default_issuer,
+      issuer: oidc_issuer,
+      provider_configuration_opts: %{
+        quirks: %{
+          document_overrides: %{
+            "pushed_authorization_request_endpoint" => :undefined
+          }
+        }
+      }
+    }
   ]
 
   # Step 2: Configure Ueberauth provider with optimal compatibility settings

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -508,7 +508,8 @@ if oidc_issuer && oidc_client_id && oidc_client_secret do
       provider_configuration_opts: %{
         quirks: %{
           document_overrides: %{
-            "pushed_authorization_request_endpoint" => :undefined
+            "pushed_authorization_request_endpoint" => :undefined,
+            "request_parameter_supported" => false
           }
         }
       }

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -505,6 +505,17 @@ if oidc_issuer && oidc_client_id && oidc_client_secret do
     %{
       name: :default_issuer,
       issuer: oidc_issuer,
+      # Workaround for Authelia 4.39+ JAR strictness (RFC 9101 cross-jwt-
+      # confusion mitigation): Authelia rejects request objects whose JWT
+      # header lacks `typ` (`JWT` or `oauth-authz-req+jwt`). Erlef oidcc up
+      # to and including v3.7.2 signs JARs without setting that header, so
+      # any flow that builds one fails with `invalid_request_object`.
+      #
+      # Patch the discovery doc so oidcc believes the issuer supports
+      # neither PAR nor the `request` parameter; that short-circuits
+      # `oidcc_authorization:attempt_request_object/3` and falls back to a
+      # plain query-param authorize redirect. Drop these overrides once
+      # upstream oidcc sets `typ` on signed request objects.
       provider_configuration_opts: %{
         quirks: %{
           document_overrides: %{


### PR DESCRIPTION
Disables PAR endpoint usage in oidcc client library using document_overrides quirk, bypassing Authelia validation failures.