### PR TITLE
feat(downloads): add rqbit torrent download client

### DIFF
--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -114,7 +114,7 @@ defmodule Mydia.Config.Schema do
       field :name, :string
 
       field :type, Ecto.Enum,
-        values: [:qbittorrent, :transmission, :rtorrent, :http, :sabnzbd, :nzbget]
+        values: [:qbittorrent, :transmission, :rqbit, :rtorrent, :http, :sabnzbd, :nzbget]
 
       field :enabled, :boolean, default: true
       field :priority, :integer, default: 1
@@ -332,6 +332,7 @@ defmodule Mydia.Config.Schema do
     |> validate_inclusion(:type, [
       :qbittorrent,
       :transmission,
+      :rqbit,
       :rtorrent,
       :http,
       :sabnzbd,

--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -26,6 +26,7 @@ defmodule Mydia.Downloads do
     # Register available client adapters
     Registry.register(:qbittorrent, Mydia.Downloads.Client.QBittorrent)
     Registry.register(:transmission, Mydia.Downloads.Client.Transmission)
+    Registry.register(:rqbit, Mydia.Downloads.Client.Rqbit)
     Registry.register(:rtorrent, Mydia.Downloads.Client.Rtorrent)
     Registry.register(:blackhole, Mydia.Downloads.Client.Blackhole)
     Registry.register(:sabnzbd, Mydia.Downloads.Client.Sabnzbd)

--- a/lib/mydia/downloads/client.ex
+++ b/lib/mydia/downloads/client.ex
@@ -304,9 +304,23 @@ defmodule Mydia.Downloads.Client do
 
   ## Convenience Functions
 
+  # Adapter resolution flows through Client.Registry.lookup/1, which returns nil
+  # for any client type that is not registered (an unknown type, or a type that
+  # has been unregistered). A nil adapter is `is_atom/1`, so without an explicit
+  # clause it would fall through to `adapter.fun(...)` and crash with
+  # `nil.fun/n is undefined`. Every convenience function below short-circuits a
+  # nil adapter into a descriptive error so callers (history, untracked_matcher,
+  # client_health, media_import) degrade the client to unreachable/failed instead
+  # of crashing the calling process.
+  defp no_adapter_error do
+    {:error, Error.invalid_config("No adapter registered for client type")}
+  end
+
   @doc """
   Tests connection to a download client using the specified adapter.
   """
+  def test_connection(nil, _config), do: no_adapter_error()
+
   def test_connection(adapter, config) when is_atom(adapter) do
     adapter.test_connection(config)
   end
@@ -314,13 +328,19 @@ defmodule Mydia.Downloads.Client do
   @doc """
   Adds a torrent using the specified adapter.
   """
-  def add_torrent(adapter, config, torrent, opts \\ []) when is_atom(adapter) do
+  def add_torrent(adapter, config, torrent, opts \\ [])
+
+  def add_torrent(nil, _config, _torrent, _opts), do: no_adapter_error()
+
+  def add_torrent(adapter, config, torrent, opts) when is_atom(adapter) do
     adapter.add_torrent(config, torrent, opts)
   end
 
   @doc """
   Gets torrent status using the specified adapter.
   """
+  def get_status(nil, _config, _client_id), do: no_adapter_error()
+
   def get_status(adapter, config, client_id) when is_atom(adapter) do
     adapter.get_status(config, client_id)
   end
@@ -328,20 +348,30 @@ defmodule Mydia.Downloads.Client do
   @doc """
   Lists all torrents using the specified adapter.
   """
-  def list_torrents(adapter, config, opts \\ []) when is_atom(adapter) do
+  def list_torrents(adapter, config, opts \\ [])
+
+  def list_torrents(nil, _config, _opts), do: no_adapter_error()
+
+  def list_torrents(adapter, config, opts) when is_atom(adapter) do
     adapter.list_torrents(config, opts)
   end
 
   @doc """
   Removes a torrent/download using the specified adapter.
   """
-  def remove_download(adapter, config, client_id, opts \\ []) when is_atom(adapter) do
+  def remove_download(adapter, config, client_id, opts \\ [])
+
+  def remove_download(nil, _config, _client_id, _opts), do: no_adapter_error()
+
+  def remove_download(adapter, config, client_id, opts) when is_atom(adapter) do
     adapter.remove_torrent(config, client_id, opts)
   end
 
   @doc """
   Pauses a torrent using the specified adapter.
   """
+  def pause_torrent(nil, _config, _client_id), do: no_adapter_error()
+
   def pause_torrent(adapter, config, client_id) when is_atom(adapter) do
     adapter.pause_torrent(config, client_id)
   end
@@ -349,6 +379,8 @@ defmodule Mydia.Downloads.Client do
   @doc """
   Resumes a torrent using the specified adapter.
   """
+  def resume_torrent(nil, _config, _client_id), do: no_adapter_error()
+
   def resume_torrent(adapter, config, client_id) when is_atom(adapter) do
     adapter.resume_torrent(config, client_id)
   end

--- a/lib/mydia/downloads/client/ADAPTER_GUIDE.md
+++ b/lib/mydia/downloads/client/ADAPTER_GUIDE.md
@@ -314,18 +314,25 @@ end
 
 ### Step 8: Register the Adapter
 
-Register your adapter during application startup in `lib/mydia/application.ex`:
+The `Registry` is the **single source of truth** for `type -> adapter module`. Every
+resolution site (`queue`, `history`, `untracked_matcher`, `client_health`,
+`media_import`) calls `Registry.lookup/1` or `Registry.get_adapter/1`, so registering
+once is all that is needed — there are no per-module dispatch tables to update.
+
+Add one line to `Mydia.Downloads.register_clients/0` in `lib/mydia/downloads.ex`:
 
 ```elixir
-def start(_type, _args) do
-  # ... existing children ...
-
-  # Register download client adapters
-  :ok = Mydia.Downloads.Client.Registry.register(:my_client, Mydia.Downloads.Client.MyClient)
-
-  # ... continue with supervision tree ...
+def register_clients do
+  # ... existing registrations ...
+  Registry.register(:my_client, Mydia.Downloads.Client.MyClient)
+  :ok
 end
 ```
+
+`register_clients/0` runs at application startup (via the supervision tree), so the
+adapter is available in every environment. You also need to add `:my_client` to the
+config enum (`lib/mydia/settings/download_client_config.ex`) and the admin UI type
+dropdown so operators can select it — see the existing client entries for the pattern.
 
 ### Step 9: Write Tests
 

--- a/lib/mydia/downloads/client/registry.ex
+++ b/lib/mydia/downloads/client/registry.ex
@@ -126,6 +126,28 @@ defmodule Mydia.Downloads.Client.Registry do
   end
 
   @doc """
+  Looks up the adapter module for a client type, returning `nil` when unknown.
+
+  This is the plain `module | nil` counterpart to `get_adapter/1`. It exists so
+  call sites that previously kept their own hardcoded `type -> module` dispatch
+  tables can resolve adapters from this single source of truth without unwrapping
+  an `{:ok, _}` tuple.
+
+  ## Examples
+
+      iex> Registry.register(:qbittorrent, Mydia.Downloads.Client.QBittorrent)
+      iex> Registry.lookup(:qbittorrent)
+      Mydia.Downloads.Client.QBittorrent
+
+      iex> Registry.lookup(:unknown_client)
+      nil
+  """
+  @spec lookup(adapter_type()) :: adapter_module() | nil
+  def lookup(type) when is_atom(type) do
+    Agent.get(__MODULE__, &Map.get(&1, type))
+  end
+
+  @doc """
   Lists all registered adapters.
 
   Returns a keyword list of adapter types and their corresponding modules.

--- a/lib/mydia/downloads/client/rqbit.ex
+++ b/lib/mydia/downloads/client/rqbit.ex
@@ -1,0 +1,383 @@
+defmodule Mydia.Downloads.Client.Rqbit do
+  @moduledoc """
+  rqbit download client adapter.
+
+  Implements the download client behaviour for [rqbit](https://github.com/ikatson/rqbit),
+  a lightweight bittorrent client written in Rust that exposes a JSON HTTP API.
+  Mydia talks to a user-run `rqbit server` instance; it does not embed or manage
+  the rqbit process.
+
+  ## Configuration
+
+      config = %{
+        type: :rqbit,
+        host: "localhost",
+        port: 3030,            # rqbit's default HTTP port
+        username: "user",      # optional, HTTP basic auth
+        password: "pass",      # optional, HTTP basic auth
+        use_ssl: false,
+        options: %{
+          timeout: 30_000,
+          connect_timeout: 5_000
+        }
+      }
+
+  ## Identifiers
+
+  rqbit assigns a numeric `id` that is **not stable across server restarts** (it is
+  reassigned in load order). The 40-character hex `info_hash` is stable and is
+  accepted in every `/torrents/{id}` path, so this adapter uses the info hash as the
+  `client_id` returned from `add_torrent/3` and as `DownloadStatus.id`, and addresses
+  all per-torrent endpoints by info hash.
+
+  ## State mapping
+
+  rqbit reports a small `state` enum plus a top-level `finished` boolean. There is no
+  separate "seeding" state — a completed torrent that is still seeding reports
+  `state: "live"` with `finished: true`. Because `Mydia.Jobs.DownloadMonitor` only
+  triggers import once a download reaches `:seeding`/`:completed`, the
+  `live + finished` case maps to `:seeding`:
+
+    * `"error"` -> `:error`
+    * `"initializing"` -> `:checking` (metadata/hash verification)
+    * `"paused"` -> `:paused`
+    * `"live"` with `finished: true` -> `:seeding`
+    * `"live"` with `finished: false` -> `:downloading`
+    * anything else -> `:unknown`
+
+  ## Categories
+
+  rqbit has no category/label concept. Like the Transmission adapter, this adapter
+  ignores `opts[:category]`/`opts[:tags]` on add and treats `list_torrents` category
+  and tag filters as no-ops. Final on-disk organization happens at the import step.
+
+  ## Pause on add
+
+  rqbit's HTTP API does not expose the `paused` add option as a query parameter, so
+  when `opts[:paused]` is set the adapter adds the torrent and then issues a separate
+  pause request. A failure to pause a freshly-added torrent is logged but not fatal.
+  """
+
+  @behaviour Mydia.Downloads.Client
+
+  @impl true
+  def supported_protocols, do: [:torrent]
+
+  require Logger
+
+  alias Mydia.Downloads.Client.{Error, HTTP}
+  alias Mydia.Downloads.Structs.{ClientInfo, DownloadStatus}
+
+  # rqbit reports speeds in mebibytes per second (MiB/s).
+  @bytes_per_mib 1_048_576
+
+  @impl true
+  def test_connection(config) do
+    req = HTTP.new_request(config)
+
+    case HTTP.get(req, "/torrents") do
+      {:ok, %{status: status}} when status in 200..299 ->
+        {:ok, ClientInfo.new(version: "rqbit")}
+
+      {:ok, response} ->
+        {:error, api_error_from(response)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @impl true
+  def add_torrent(config, torrent, opts \\ []) do
+    req = HTTP.new_request(config)
+    {body, params} = build_add_request(torrent, opts)
+
+    case HTTP.post(req, "/torrents", params: params, body: body) do
+      {:ok, %{status: status, body: resp_body}} when status in 200..299 ->
+        case extract_info_hash(resp_body) do
+          nil ->
+            {:error,
+             Error.parse_error("rqbit add response missing info_hash", %{body: resp_body})}
+
+          info_hash ->
+            maybe_pause_after_add(config, info_hash, opts)
+            {:ok, info_hash}
+        end
+
+      {:ok, response} ->
+        {:error, api_error_from(response)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @impl true
+  def get_status(config, client_id) do
+    req = HTTP.new_request(config)
+
+    with {:ok, details} <- fetch_details(req, client_id),
+         {:ok, stats} <- fetch_stats(req, client_id) do
+      {:ok, build_status(details, stats)}
+    end
+  end
+
+  @impl true
+  def list_torrents(config, opts \\ []) do
+    req = HTTP.new_request(config)
+
+    case HTTP.get(req, "/torrents", params: %{with_stats: true}) do
+      {:ok, %{status: status, body: %{"torrents" => torrents}}} when status in 200..299 ->
+        parsed =
+          torrents
+          |> Enum.map(fn torrent -> build_status(torrent, torrent["stats"] || %{}) end)
+          |> apply_filters(opts)
+
+        {:ok, parsed}
+
+      {:ok, %{status: status}} when status in 200..299 ->
+        {:ok, []}
+
+      {:ok, response} ->
+        {:error, api_error_from(response)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @impl true
+  def remove_torrent(config, client_id, opts \\ []) do
+    req = HTTP.new_request(config)
+    action = if Keyword.get(opts, :delete_files, false), do: "delete", else: "forget"
+
+    case HTTP.post(req, "/torrents/#{client_id}/#{action}", []) do
+      {:ok, %{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, response} ->
+        {:error, api_error_from(response)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @impl true
+  def pause_torrent(config, client_id) do
+    control(config, client_id, "pause")
+  end
+
+  @impl true
+  def resume_torrent(config, client_id) do
+    control(config, client_id, "start")
+  end
+
+  ## Private Functions
+
+  defp control(config, client_id, action) do
+    req = HTTP.new_request(config)
+
+    case HTTP.post(req, "/torrents/#{client_id}/#{action}", []) do
+      {:ok, %{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, response} ->
+        {:error, api_error_from(response)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # Builds the {body, query_params} pair for POST /torrents.
+  #
+  # rqbit reads the raw request body as either a URL/magnet string or `.torrent`
+  # bytes. `is_url` disambiguates explicitly; `output_folder` overrides the session
+  # default when the pipeline supplies a save_path. Category/tags are intentionally
+  # dropped (rqbit has no such concept).
+  defp build_add_request({:magnet, magnet}, opts) do
+    {magnet, add_params(opts, is_url: true)}
+  end
+
+  defp build_add_request({:url, url}, opts) do
+    {url, add_params(opts, is_url: true)}
+  end
+
+  defp build_add_request({:file, contents}, opts) do
+    {contents, add_params(opts, is_url: false)}
+  end
+
+  defp add_params(opts, is_url: is_url) do
+    %{is_url: is_url}
+    |> maybe_put(:output_folder, opts[:save_path])
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp maybe_pause_after_add(config, info_hash, opts) do
+    if Keyword.get(opts, :paused, false) do
+      case pause_torrent(config, info_hash) do
+        :ok ->
+          :ok
+
+        {:error, error} ->
+          Logger.warning("Failed to pause rqbit torrent after add",
+            info_hash: info_hash,
+            error: inspect(error)
+          )
+
+          :ok
+      end
+    end
+  end
+
+  defp fetch_details(req, client_id) do
+    case HTTP.get(req, "/torrents/#{client_id}") do
+      {:ok, %{status: status, body: body}} when status in 200..299 and is_map(body) ->
+        {:ok, body}
+
+      {:ok, %{status: 404} = response} ->
+        {:error, api_error_from(response)}
+
+      {:ok, response} ->
+        {:error, api_error_from(response)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp fetch_stats(req, client_id) do
+    case HTTP.get(req, "/torrents/#{client_id}/stats/v1") do
+      {:ok, %{status: status, body: body}} when status in 200..299 and is_map(body) ->
+        {:ok, body}
+
+      {:ok, response} ->
+        {:error, api_error_from(response)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # Builds a DownloadStatus from a torrent details map and a stats map. Both the
+  # list endpoint (stats embedded per item) and the single-status path (details +
+  # stats/v1) converge here.
+  defp build_status(details, stats) do
+    finished = stats["finished"] == true
+    total_bytes = stats["total_bytes"] || 0
+
+    DownloadStatus.new(%{
+      id: details["info_hash"],
+      name: details["name"] || "",
+      state: parse_state(stats),
+      progress: progress(finished, stats["progress_bytes"], total_bytes),
+      download_speed: speed_bytes(stats, "download_speed"),
+      upload_speed: speed_bytes(stats, "upload_speed"),
+      downloaded: stats["progress_bytes"] || 0,
+      uploaded: stats["uploaded_bytes"] || 0,
+      size: total_bytes,
+      eta: parse_eta(stats),
+      ratio: ratio(stats["uploaded_bytes"], total_bytes),
+      save_path: details["output_folder"] || "",
+      added_at: nil,
+      completed_at: nil
+    })
+  end
+
+  defp parse_state(%{"state" => "error"}), do: :error
+  defp parse_state(%{"state" => "initializing"}), do: :checking
+  defp parse_state(%{"state" => "paused"}), do: :paused
+  defp parse_state(%{"state" => "live", "finished" => true}), do: :seeding
+  defp parse_state(%{"state" => "live"}), do: :downloading
+  defp parse_state(_), do: :unknown
+
+  defp progress(true, _progress_bytes, _total), do: 100.0
+  defp progress(false, _progress_bytes, total) when not is_integer(total) or total <= 0, do: 0.0
+
+  defp progress(false, progress_bytes, total) do
+    (progress_bytes || 0) / total * 100.0
+  end
+
+  # rqbit reports download_speed/upload_speed as %{"mbps" => float} in MiB/s under
+  # the `live` sub-object, which is null when not actively transferring.
+  defp speed_bytes(stats, key) do
+    case get_in(stats, ["live", key, "mbps"]) do
+      mbps when is_number(mbps) -> round(mbps * @bytes_per_mib)
+      _ -> 0
+    end
+  end
+
+  defp parse_eta(stats) do
+    case get_in(stats, ["live", "time_remaining", "duration", "secs"]) do
+      secs when is_integer(secs) and secs >= 0 -> secs
+      _ -> nil
+    end
+  end
+
+  defp ratio(uploaded, total) when is_integer(uploaded) and is_integer(total) and total > 0 do
+    uploaded / total
+  end
+
+  defp ratio(_uploaded, _total), do: 0.0
+
+  defp extract_info_hash(body) when is_map(body) do
+    get_in(body, ["details", "info_hash"]) || body["info_hash"]
+  end
+
+  defp extract_info_hash(_), do: nil
+
+  # rqbit error bodies are JSON: %{"error_kind" => ..., "human_readable" => ..., "status" => ...}.
+  defp api_error_from(response) do
+    body = response.body
+    msg = human_readable(body) || "rqbit API error (HTTP #{response.status})"
+
+    cond do
+      error_kind(body) == "torrent_not_found" or response.status == 404 ->
+        Error.not_found(msg)
+
+      error_kind(body) == "unauthorized" or response.status == 401 ->
+        Error.authentication_failed(msg)
+
+      true ->
+        Error.api_error(msg, %{status: response.status})
+    end
+  end
+
+  defp error_kind(body) when is_map(body), do: body["error_kind"]
+  defp error_kind(_), do: nil
+
+  defp human_readable(body) when is_map(body), do: body["human_readable"]
+  defp human_readable(_), do: nil
+
+  # Category and tag filters are no-ops: rqbit has no such concept, and Mydia tracks
+  # its own downloads by info hash. Mirrors the Transmission adapter.
+  defp apply_filters(torrents, opts) do
+    torrents
+    |> filter_by_state(opts[:filter])
+    |> filter_by_category(opts[:category])
+    |> filter_by_tag(opts[:tag])
+  end
+
+  defp filter_by_state(torrents, nil), do: torrents
+  defp filter_by_state(torrents, :all), do: torrents
+
+  defp filter_by_state(torrents, filter) do
+    Enum.filter(torrents, fn torrent ->
+      case filter do
+        :downloading -> torrent.state == :downloading
+        :seeding -> torrent.state == :seeding
+        :paused -> torrent.state == :paused
+        :completed -> torrent.progress >= 100.0
+        :active -> torrent.download_speed > 0 || torrent.upload_speed > 0
+        :inactive -> torrent.download_speed == 0 && torrent.upload_speed == 0
+        _ -> true
+      end
+    end)
+  end
+
+  defp filter_by_category(torrents, _category), do: torrents
+  defp filter_by_tag(torrents, _tag), do: torrents
+end

--- a/lib/mydia/downloads/client_health.ex
+++ b/lib/mydia/downloads/client_health.ex
@@ -158,7 +158,7 @@ defmodule Mydia.Downloads.ClientHealth do
   end
 
   defp do_health_check(config) do
-    adapter = get_adapter(config.type)
+    adapter = Client.Registry.lookup(config.type)
     client_config = config_to_map(config)
 
     result =
@@ -238,15 +238,6 @@ defmodule Mydia.Downloads.ClientHealth do
   defp schedule_health_check do
     Process.send_after(self(), :perform_health_checks, @check_interval)
   end
-
-  defp get_adapter(:qbittorrent), do: Mydia.Downloads.Client.QBittorrent
-  defp get_adapter(:transmission), do: Mydia.Downloads.Client.Transmission
-  defp get_adapter(:rtorrent), do: Mydia.Downloads.Client.Rtorrent
-  defp get_adapter(:blackhole), do: Mydia.Downloads.Client.Blackhole
-  defp get_adapter(:sabnzbd), do: Mydia.Downloads.Client.Sabnzbd
-  defp get_adapter(:nzbget), do: Mydia.Downloads.Client.Nzbget
-  defp get_adapter(:http), do: Mydia.Downloads.Client.HTTP
-  defp get_adapter(:debrid), do: Mydia.Downloads.Client.Debrid
 
   defp config_to_map(config) do
     %{

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -175,7 +175,7 @@ defmodule Mydia.Downloads.History do
     clients
     |> Task.async_stream(
       fn client_config ->
-        adapter = get_adapter_module(client_config.type)
+        adapter = Client.Registry.lookup(client_config.type)
         config = config_to_map(client_config)
         client_downloads = Map.get(downloads_by_client, client_config.name, %{})
 
@@ -450,16 +450,6 @@ defmodule Mydia.Downloads.History do
       d.match_status == "unresolved_files"
     end)
   end
-
-  defp get_adapter_module(:qbittorrent), do: Mydia.Downloads.Client.QBittorrent
-  defp get_adapter_module(:transmission), do: Mydia.Downloads.Client.Transmission
-  defp get_adapter_module(:rtorrent), do: Mydia.Downloads.Client.Rtorrent
-  defp get_adapter_module(:blackhole), do: Mydia.Downloads.Client.Blackhole
-  defp get_adapter_module(:http), do: Mydia.Downloads.Client.HTTP
-  defp get_adapter_module(:sabnzbd), do: Mydia.Downloads.Client.Sabnzbd
-  defp get_adapter_module(:nzbget), do: Mydia.Downloads.Client.Nzbget
-  defp get_adapter_module(:debrid), do: Mydia.Downloads.Client.Debrid
-  defp get_adapter_module(_), do: nil
 
   defp config_to_map(config) do
     %{

--- a/lib/mydia/downloads/untracked_matcher.ex
+++ b/lib/mydia/downloads/untracked_matcher.ex
@@ -71,7 +71,7 @@ defmodule Mydia.Downloads.UntrackedMatcher do
       # Only fetch torrents from torrent clients (not Usenet or HTTP clients)
       torrent_clients =
         Enum.filter(clients, fn client ->
-          client.type in [:qbittorrent, :transmission]
+          client.type in [:qbittorrent, :transmission, :rqbit]
         end)
 
       torrent_clients

--- a/lib/mydia/downloads/untracked_matcher.ex
+++ b/lib/mydia/downloads/untracked_matcher.ex
@@ -88,7 +88,7 @@ defmodule Mydia.Downloads.UntrackedMatcher do
   end
 
   defp fetch_client_torrents(client_config) do
-    adapter = get_adapter_module(client_config.type)
+    adapter = Downloads.Client.Registry.lookup(client_config.type)
     config = config_to_map(client_config)
 
     case Downloads.Client.list_torrents(adapter, config, []) do
@@ -293,16 +293,6 @@ defmodule Mydia.Downloads.UntrackedMatcher do
     Settings.list_download_client_configs()
     |> Enum.filter(& &1.enabled)
   end
-
-  defp get_adapter_module(:qbittorrent), do: Mydia.Downloads.Client.QBittorrent
-  defp get_adapter_module(:transmission), do: Mydia.Downloads.Client.Transmission
-  defp get_adapter_module(:rtorrent), do: Mydia.Downloads.Client.Rtorrent
-  defp get_adapter_module(:blackhole), do: Mydia.Downloads.Client.Blackhole
-  defp get_adapter_module(:http), do: Mydia.Downloads.Client.HTTP
-  defp get_adapter_module(:sabnzbd), do: Mydia.Downloads.Client.Sabnzbd
-  defp get_adapter_module(:nzbget), do: Mydia.Downloads.Client.Nzbget
-  defp get_adapter_module(:debrid), do: Mydia.Downloads.Client.Debrid
-  defp get_adapter_module(_), do: nil
 
   defp config_to_map(config) do
     %{

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -514,7 +514,7 @@ defmodule Mydia.Jobs.MediaImport do
         |> Enum.find(&(&1.name == download.download_client))
 
       if client_config do
-        adapter = get_adapter_module(client_config.type)
+        adapter = Client.Registry.lookup(client_config.type)
 
         %{
           adapter: adapter,
@@ -1526,16 +1526,6 @@ defmodule Mydia.Jobs.MediaImport do
       end
     end
   end
-
-  defp get_adapter_module(:qbittorrent), do: Mydia.Downloads.Client.QBittorrent
-  defp get_adapter_module(:transmission), do: Mydia.Downloads.Client.Transmission
-  defp get_adapter_module(:rtorrent), do: Mydia.Downloads.Client.Rtorrent
-  defp get_adapter_module(:blackhole), do: Mydia.Downloads.Client.Blackhole
-  defp get_adapter_module(:http), do: Mydia.Downloads.Client.HTTP
-  defp get_adapter_module(:sabnzbd), do: Mydia.Downloads.Client.Sabnzbd
-  defp get_adapter_module(:nzbget), do: Mydia.Downloads.Client.Nzbget
-  defp get_adapter_module(:debrid), do: Mydia.Downloads.Client.Debrid
-  defp get_adapter_module(_), do: nil
 
   defp build_client_config(client_config) do
     case client_config.type do

--- a/lib/mydia/settings/download_client_config.ex
+++ b/lib/mydia/settings/download_client_config.ex
@@ -52,6 +52,7 @@ defmodule Mydia.Settings.DownloadClientConfig do
   @client_types [
     :qbittorrent,
     :transmission,
+    :rqbit,
     :rtorrent,
     :blackhole,
     :http,

--- a/lib/mydia_web/live/admin_download_clients_live/components.ex
+++ b/lib/mydia_web/live/admin_download_clients_live/components.ex
@@ -346,6 +346,7 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
                   options={[
                     {"qBittorrent", "qbittorrent"},
                     {"Transmission", "transmission"},
+                    {"rqbit", "rqbit"},
                     {"rTorrent", "rtorrent"},
                     {"Blackhole", "blackhole"},
                     {"SABnzbd", "sabnzbd"},

--- a/nix/packages/flake-module.nix
+++ b/nix/packages/flake-module.nix
@@ -14,10 +14,16 @@
         sha256 = "be3324cc454a42d80951cf6023b9954e9ff27c6daa255483b3e8d608670303f5";
       };
 
-      # Pre-fetch Rust/Cargo dependencies for the p2p NIF (required for sandbox build)
-      cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
-        src = ../../native/mydia_p2p;
-        hash = "sha256-mwciW6cx+n26KEQYv3rJi4ceq+sKhy6rBaTMOC7/8Is=";
+      # Pre-fetch Rust/Cargo dependencies for the p2p NIF (required for sandbox build).
+      #
+      # Uses importCargoLock rather than fetchCargoVendor: fetchCargoVendor's
+      # `fetch-cargo-vendor-util` downloads crates with a `python-requests/<ver>`
+      # User-Agent, which crates.io now rejects with HTTP 403 (rust-lang/crates.io#13482),
+      # breaking the build. importCargoLock fetches each crate via nix's fetchurl
+      # (curl UA, not blocked) and derives hashes from Cargo.lock, so no vendor hash
+      # to maintain. The lock is pure crates.io (no git deps), so no outputHashes needed.
+      cargoDeps = pkgs.rustPlatform.importCargoLock {
+        lockFile = ../../native/mydia_p2p/Cargo.lock;
       };
 
       # Import Mix dependencies from deps.nix with overrides for Nix sandbox builds

--- a/player/lib/core/theme/app_theme.dart
+++ b/player/lib/core/theme/app_theme.dart
@@ -399,12 +399,15 @@ class AppTheme {
       // Page Transitions - Material 3 style (slide + fade)
       pageTransitionsTheme: const PageTransitionsTheme(
         builders: {
-          // Use FadeForwardsPageTransitionsBuilder for all platforms
-          // This provides a smooth slide-in from right with fade effect
+          // FadeForwardsPageTransitionsBuilder for every platform: a smooth
+          // slide-in from the right with a fade. Used uniformly (rather than
+          // CupertinoPageTransitionsBuilder on Apple platforms) because that
+          // builder moved from material.dart to cupertino.dart across Flutter
+          // versions, and FadeForwards lives in material.dart on all of them.
           TargetPlatform.android: FadeForwardsPageTransitionsBuilder(),
-          TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+          TargetPlatform.iOS: FadeForwardsPageTransitionsBuilder(),
           TargetPlatform.linux: FadeForwardsPageTransitionsBuilder(),
-          TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
+          TargetPlatform.macOS: FadeForwardsPageTransitionsBuilder(),
           TargetPlatform.windows: FadeForwardsPageTransitionsBuilder(),
           TargetPlatform.fuchsia: FadeForwardsPageTransitionsBuilder(),
         },

--- a/test/mydia/downloads/client/registry_test.exs
+++ b/test/mydia/downloads/client/registry_test.exs
@@ -63,6 +63,12 @@ defmodule Mydia.Downloads.Client.RegistryTest do
   setup do
     # Clear registry before each test to ensure clean state
     Registry.clear()
+
+    # Every resolution site (queue, history, client_health, untracked_matcher,
+    # media_import) now resolves adapters through this Registry. Clearing it here
+    # would leave the production adapters unregistered for any test file that runs
+    # afterward, so restore them once this file's tests complete.
+    on_exit(fn -> Mydia.Downloads.register_clients() end)
     :ok
   end
 
@@ -105,6 +111,53 @@ defmodule Mydia.Downloads.Client.RegistryTest do
 
       assert error.message =~ "unknown_client"
       assert error.message =~ "Unknown client type"
+    end
+  end
+
+  describe "lookup/1" do
+    test "returns adapter module when registered" do
+      Registry.register(:test_client, TestAdapter)
+
+      assert Registry.lookup(:test_client) == TestAdapter
+    end
+
+    test "returns nil when adapter not registered" do
+      assert Registry.lookup(:unknown_client) == nil
+    end
+  end
+
+  describe "consolidated adapter resolution (single source of truth)" do
+    # Characterizes that register_clients/0 is the one place mapping client type
+    # to adapter module, replacing the four private dispatch tables that formerly
+    # lived in history.ex, untracked_matcher.ex, client_health.ex, and
+    # media_import.ex. Every production type must resolve to its adapter via the
+    # Registry, since those call sites now depend on it.
+    @production_adapters %{
+      qbittorrent: Mydia.Downloads.Client.QBittorrent,
+      transmission: Mydia.Downloads.Client.Transmission,
+      rqbit: Mydia.Downloads.Client.Rqbit,
+      rtorrent: Mydia.Downloads.Client.Rtorrent,
+      blackhole: Mydia.Downloads.Client.Blackhole,
+      http: Mydia.Downloads.Client.HTTP,
+      sabnzbd: Mydia.Downloads.Client.Sabnzbd,
+      nzbget: Mydia.Downloads.Client.Nzbget,
+      debrid: Mydia.Downloads.Client.Debrid
+    }
+
+    setup do
+      Mydia.Downloads.register_clients()
+      :ok
+    end
+
+    test "every production client type resolves to its adapter module" do
+      for {type, module} <- @production_adapters do
+        assert Registry.lookup(type) == module,
+               "expected #{type} to resolve to #{inspect(module)}"
+      end
+    end
+
+    test "unknown type resolves to nil (matches former dispatch-table fallback)" do
+      assert Registry.lookup(:no_such_client) == nil
     end
   end
 

--- a/test/mydia/downloads/client/rqbit_test.exs
+++ b/test/mydia/downloads/client/rqbit_test.exs
@@ -1,0 +1,447 @@
+defmodule Mydia.Downloads.Client.RqbitTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.Client.Rqbit
+
+  @hash "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+  @config %{
+    type: :rqbit,
+    host: "localhost",
+    port: 3030,
+    username: nil,
+    password: nil,
+    use_ssl: false,
+    options: %{}
+  }
+
+  describe "module behaviour" do
+    test "implements all callbacks from Mydia.Downloads.Client behaviour" do
+      behaviours = Rqbit.__info__(:attributes)[:behaviour] || []
+      assert Mydia.Downloads.Client in behaviours
+    end
+
+    test "supports only the torrent protocol" do
+      assert Rqbit.supported_protocols() == [:torrent]
+    end
+  end
+
+  describe "unreachable host" do
+    setup do
+      unreachable = %{@config | host: "nonexistent.invalid", port: 9999}
+      {:ok, config: put_in(unreachable, [:options, :connect_timeout], 100)}
+    end
+
+    test "test_connection returns a connection error", %{config: config} do
+      assert {:error, error} = Rqbit.test_connection(config)
+      assert error.type in [:connection_failed, :network_error, :timeout]
+    end
+
+    test "add_torrent returns a connection error", %{config: config} do
+      assert {:error, error} =
+               Rqbit.add_torrent(config, {:magnet, "magnet:?xt=urn:btih:#{@hash}"})
+
+      assert error.type in [:connection_failed, :network_error, :timeout]
+    end
+
+    test "list_torrents returns a connection error", %{config: config} do
+      assert {:error, error} = Rqbit.list_torrents(config, [])
+      assert error.type in [:connection_failed, :network_error, :timeout]
+    end
+
+    test "pause/resume/remove return connection errors", %{config: config} do
+      assert {:error, _} = Rqbit.pause_torrent(config, @hash)
+      assert {:error, _} = Rqbit.resume_torrent(config, @hash)
+      assert {:error, _} = Rqbit.remove_torrent(config, @hash, delete_files: false)
+    end
+  end
+
+  describe "test_connection/1 (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "returns ClientInfo on success", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "GET", "/torrents", fn conn ->
+        json_resp(conn, 200, %{"torrents" => []})
+      end)
+
+      assert {:ok, info} = Rqbit.test_connection(config)
+      assert info.version == "rqbit"
+    end
+
+    test "maps 401 to authentication_failed", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "GET", "/torrents", fn conn ->
+        json_resp(conn, 401, %{"error_kind" => "unauthorized", "human_readable" => "unauthorized"})
+      end)
+
+      assert {:error, error} = Rqbit.test_connection(config)
+      assert error.type == :authentication_failed
+    end
+  end
+
+  describe "add_torrent/3 (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "adds a magnet with is_url=true and returns the info hash", %{
+      bypass: bypass,
+      config: config
+    } do
+      magnet = "magnet:?xt=urn:btih:#{@hash}"
+
+      Bypass.expect(bypass, "POST", "/torrents", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["is_url"] == "true"
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert body == magnet
+        json_resp(conn, 200, add_response(@hash))
+      end)
+
+      assert {:ok, @hash} = Rqbit.add_torrent(config, {:magnet, magnet})
+    end
+
+    test "uploads .torrent bytes raw with is_url=false", %{bypass: bypass, config: config} do
+      torrent_bytes = <<1, 2, 3, 4, 5>>
+
+      Bypass.expect(bypass, "POST", "/torrents", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["is_url"] == "false"
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert body == torrent_bytes
+        json_resp(conn, 200, add_response(@hash))
+      end)
+
+      assert {:ok, @hash} = Rqbit.add_torrent(config, {:file, torrent_bytes})
+    end
+
+    test "passes save_path as output_folder", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/torrents", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["output_folder"] == "/data/movies"
+        json_resp(conn, 200, add_response(@hash))
+      end)
+
+      assert {:ok, @hash} =
+               Rqbit.add_torrent(config, {:magnet, "magnet:?x"}, save_path: "/data/movies")
+    end
+
+    test "omits output_folder when no save_path is given", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/torrents", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        refute Map.has_key?(conn.query_params, "output_folder")
+        json_resp(conn, 200, add_response(@hash))
+      end)
+
+      assert {:ok, @hash} = Rqbit.add_torrent(config, {:magnet, "magnet:?x"})
+    end
+
+    test "ignores category — no category param is sent to rqbit", %{
+      bypass: bypass,
+      config: config
+    } do
+      Bypass.expect(bypass, "POST", "/torrents", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        refute Map.has_key?(conn.query_params, "category")
+        refute Map.has_key?(conn.query_params, "tags")
+        json_resp(conn, 200, add_response(@hash))
+      end)
+
+      assert {:ok, @hash} =
+               Rqbit.add_torrent(config, {:magnet, "magnet:?x"}, category: "movies", tags: ["x"])
+    end
+
+    test "treats an already-managed torrent as success", %{bypass: bypass, config: config} do
+      # rqbit returns the same shape for AlreadyManaged as for a fresh add.
+      Bypass.expect(bypass, "POST", "/torrents", fn conn ->
+        json_resp(conn, 200, add_response(@hash))
+      end)
+
+      assert {:ok, @hash} = Rqbit.add_torrent(config, {:magnet, "magnet:?x"})
+    end
+
+    test "when paused: true, adds then issues a pause request", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/torrents", fn conn ->
+        json_resp(conn, 200, add_response(@hash))
+      end)
+
+      pause_called = :counters.new(1, [])
+
+      Bypass.expect(bypass, "POST", "/torrents/#{@hash}/pause", fn conn ->
+        :counters.add(pause_called, 1, 1)
+        json_resp(conn, 200, %{})
+      end)
+
+      assert {:ok, @hash} = Rqbit.add_torrent(config, {:magnet, "magnet:?x"}, paused: true)
+      assert :counters.get(pause_called, 1) == 1
+    end
+
+    test "a failed pause after add is non-fatal", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/torrents", fn conn ->
+        json_resp(conn, 200, add_response(@hash))
+      end)
+
+      Bypass.expect(bypass, "POST", "/torrents/#{@hash}/pause", fn conn ->
+        json_resp(conn, 400, %{"error_kind" => "internal_error", "human_readable" => "nope"})
+      end)
+
+      assert {:ok, @hash} = Rqbit.add_torrent(config, {:magnet, "magnet:?x"}, paused: true)
+    end
+  end
+
+  describe "get_status/2 state mapping (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "live + finished maps to :seeding at 100% progress", %{bypass: bypass, config: config} do
+      stub_details(bypass)
+
+      stub_stats(
+        bypass,
+        stats(state: "live", finished: true, progress_bytes: 1000, total_bytes: 1000)
+      )
+
+      assert {:ok, status} = Rqbit.get_status(config, @hash)
+      assert status.state == :seeding
+      assert status.progress == 100.0
+      assert status.id == @hash
+    end
+
+    test "live + not finished maps to :downloading with computed progress", %{
+      bypass: bypass,
+      config: config
+    } do
+      stub_details(bypass)
+
+      stub_stats(
+        bypass,
+        stats(state: "live", finished: false, progress_bytes: 500, total_bytes: 1000)
+      )
+
+      assert {:ok, status} = Rqbit.get_status(config, @hash)
+      assert status.state == :downloading
+      assert status.progress == 50.0
+    end
+
+    test "initializing maps to :checking", %{bypass: bypass, config: config} do
+      stub_details(bypass)
+      stub_stats(bypass, stats(state: "initializing", finished: false))
+
+      assert {:ok, status} = Rqbit.get_status(config, @hash)
+      assert status.state == :checking
+    end
+
+    test "paused maps to :paused", %{bypass: bypass, config: config} do
+      stub_details(bypass)
+      stub_stats(bypass, stats(state: "paused", finished: false))
+
+      assert {:ok, status} = Rqbit.get_status(config, @hash)
+      assert status.state == :paused
+    end
+
+    test "error maps to :error", %{bypass: bypass, config: config} do
+      stub_details(bypass)
+      stub_stats(bypass, stats(state: "error", finished: false))
+
+      assert {:ok, status} = Rqbit.get_status(config, @hash)
+      assert status.state == :error
+    end
+
+    test "converts MiB/s speeds to integer bytes/sec", %{bypass: bypass, config: config} do
+      stub_details(bypass)
+
+      stub_stats(
+        bypass,
+        stats(state: "live", finished: false, progress_bytes: 1, total_bytes: 1000)
+        |> Map.put("live", %{
+          "download_speed" => %{"mbps" => 12.5},
+          "upload_speed" => %{"mbps" => 0.0},
+          "time_remaining" => nil
+        })
+      )
+
+      assert {:ok, status} = Rqbit.get_status(config, @hash)
+      assert status.download_speed == round(12.5 * 1_048_576)
+      assert status.upload_speed == 0
+    end
+
+    test "unknown info hash (404) maps to not_found", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "GET", "/torrents/#{@hash}", fn conn ->
+        json_resp(conn, 404, %{
+          "error_kind" => "torrent_not_found",
+          "human_readable" => "torrent not found"
+        })
+      end)
+
+      assert {:error, error} = Rqbit.get_status(config, @hash)
+      assert error.type == :not_found
+    end
+  end
+
+  describe "list_torrents/2 (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "requests with_stats and parses embedded stats", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "GET", "/torrents", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["with_stats"] == "true"
+
+        json_resp(conn, 200, %{
+          "torrents" => [
+            %{
+              "id" => 0,
+              "info_hash" => @hash,
+              "name" => "Movie",
+              "output_folder" => "/downloads",
+              "stats" => stats(state: "live", finished: true, progress_bytes: 10, total_bytes: 10)
+            }
+          ]
+        })
+      end)
+
+      assert {:ok, [status]} = Rqbit.list_torrents(config, [])
+      assert status.id == @hash
+      assert status.state == :seeding
+      assert status.save_path == "/downloads"
+    end
+
+    test "category filter is a no-op — all torrents returned", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "GET", "/torrents", fn conn ->
+        json_resp(conn, 200, %{
+          "torrents" => [
+            %{
+              "id" => 0,
+              "info_hash" => @hash,
+              "name" => "A",
+              "output_folder" => "/d",
+              "stats" => stats()
+            },
+            %{
+              "id" => 1,
+              "info_hash" => "ff",
+              "name" => "B",
+              "output_folder" => "/d",
+              "stats" => stats()
+            }
+          ]
+        })
+      end)
+
+      assert {:ok, torrents} = Rqbit.list_torrents(config, category: "anything")
+      assert length(torrents) == 2
+    end
+  end
+
+  describe "remove/pause/resume (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "remove_torrent with delete_files: true hits /delete", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/torrents/#{@hash}/delete", fn conn ->
+        json_resp(conn, 200, %{})
+      end)
+
+      assert :ok = Rqbit.remove_torrent(config, @hash, delete_files: true)
+    end
+
+    test "remove_torrent without delete_files hits /forget", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/torrents/#{@hash}/forget", fn conn ->
+        json_resp(conn, 200, %{})
+      end)
+
+      assert :ok = Rqbit.remove_torrent(config, @hash, delete_files: false)
+    end
+
+    test "pause_torrent hits /pause", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/torrents/#{@hash}/pause", fn conn ->
+        json_resp(conn, 200, %{})
+      end)
+
+      assert :ok = Rqbit.pause_torrent(config, @hash)
+    end
+
+    test "resume_torrent hits /start", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/torrents/#{@hash}/start", fn conn ->
+        json_resp(conn, 200, %{})
+      end)
+
+      assert :ok = Rqbit.resume_torrent(config, @hash)
+    end
+  end
+
+  ## Helpers
+
+  defp bypass_config(bypass) do
+    %{
+      type: :rqbit,
+      host: "localhost",
+      port: bypass.port,
+      username: nil,
+      password: nil,
+      use_ssl: false,
+      options: %{timeout: 5_000, connect_timeout: 2_000}
+    }
+  end
+
+  defp json_resp(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(status, Jason.encode!(body))
+  end
+
+  defp add_response(hash) do
+    %{
+      "id" => 0,
+      "output_folder" => "/downloads/Movie",
+      "details" => %{
+        "id" => 0,
+        "info_hash" => hash,
+        "name" => "Movie",
+        "output_folder" => "/downloads/Movie",
+        "total_pieces" => 100
+      }
+    }
+  end
+
+  defp stats(overrides \\ []) do
+    base = %{
+      "state" => "live",
+      "finished" => false,
+      "error" => nil,
+      "progress_bytes" => 0,
+      "uploaded_bytes" => 0,
+      "total_bytes" => 1000,
+      "live" => nil
+    }
+
+    Map.merge(base, Map.new(overrides, fn {k, v} -> {to_string(k), v} end))
+  end
+
+  defp stub_details(bypass) do
+    Bypass.stub(bypass, "GET", "/torrents/#{@hash}", fn conn ->
+      json_resp(conn, 200, %{
+        "id" => 0,
+        "info_hash" => @hash,
+        "name" => "Movie",
+        "output_folder" => "/downloads",
+        "total_pieces" => 100
+      })
+    end)
+  end
+
+  defp stub_stats(bypass, stats) do
+    Bypass.stub(bypass, "GET", "/torrents/#{@hash}/stats/v1", fn conn ->
+      json_resp(conn, 200, stats)
+    end)
+  end
+end

--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -1,5 +1,10 @@
 defmodule Mydia.DownloadsTest do
-  use Mydia.DataCase, async: true
+  # async: false — this suite overrides the global download-client Registry
+  # (registers MockAdapter for :qbittorrent, unregisters :qbittorrent). Since
+  # production adapter resolution now reads that Registry live, running async
+  # would race concurrent readers (media_import, download_monitor) and make them
+  # resolve MockAdapter mid-test. Every Registry-mutating suite runs sync.
+  use Mydia.DataCase, async: false
 
   import Mydia.AccountsFixtures
   import Mydia.SettingsFixtures

--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -261,8 +261,12 @@ defmodule Mydia.DownloadsTest do
         end
       end)
 
-      # Also unregister the mock adapter so no clients are available at all
+      # Also unregister the mock adapter so no clients are available at all.
+      # All resolution sites (queue, history, client_health, untracked_matcher,
+      # media_import) now resolve through the Registry, so restore it after this
+      # test to avoid leaving later tests without the production adapters.
       Mydia.Downloads.Client.Registry.unregister(:qbittorrent)
+      on_exit(fn -> Mydia.Downloads.register_clients() end)
 
       search_result = %SearchResult{
         title: "Test",

--- a/test/mydia/jobs/tv_show_search_test.exs
+++ b/test/mydia/jobs/tv_show_search_test.exs
@@ -1,5 +1,9 @@
 defmodule Mydia.Jobs.TVShowSearchTest do
-  use Mydia.DataCase, async: true
+  # async: false — this suite overrides the global download-client Registry
+  # (registers MockDownloadAdapter for :transmission). Production adapter
+  # resolution now reads that Registry live, so running async would race
+  # concurrent readers. Every Registry-mutating suite runs sync.
+  use Mydia.DataCase, async: false
   use Oban.Testing, repo: Mydia.Repo
 
   alias Mydia.Jobs.TVShowSearch

--- a/test/mydia/settings/download_client_config_test.exs
+++ b/test/mydia/settings/download_client_config_test.exs
@@ -15,6 +15,33 @@ defmodule Mydia.Settings.DownloadClientConfigTest do
     api_key: "test-api-key"
   }
 
+  describe "rqbit client type" do
+    @rqbit_attrs %{
+      name: "test-rqbit",
+      type: :rqbit,
+      enabled: true,
+      priority: 1,
+      host: "localhost",
+      port: 3030,
+      use_ssl: false
+    }
+
+    test "a rqbit config with host and port is valid" do
+      {:ok, config} = Settings.create_download_client_config(@rqbit_attrs)
+      assert config.type == :rqbit
+      assert config.host == "localhost"
+      assert config.port == 3030
+    end
+
+    test "rqbit requires host and port (network client validation)" do
+      changeset =
+        DownloadClientConfig.changeset(%DownloadClientConfig{}, %{@rqbit_attrs | host: nil})
+
+      refute changeset.valid?
+      assert %{host: _} = errors_on(changeset)
+    end
+  end
+
   describe "wave-2 schema additions" do
     test "inserting with a categories map round-trips correctly" do
       categories = %{"movie" => "movies", "tv" => "tv", "music" => "music"}

--- a/test/mydia_web/live/admin_download_clients_live_test.exs
+++ b/test/mydia_web/live/admin_download_clients_live_test.exs
@@ -50,6 +50,8 @@ defmodule MydiaWeb.AdminDownloadClientsLiveTest do
       end)
 
       Mydia.Downloads.Client.Registry.unregister(:transmission)
+      # Resolution sites now depend on the Registry; restore it after this test.
+      on_exit(fn -> Mydia.Downloads.register_clients() end)
 
       conn =
         conn
@@ -184,6 +186,36 @@ defmodule MydiaWeb.AdminDownloadClientsLiveTest do
       html = render(view)
       assert html =~ ~s{value="debrid"}
       assert html =~ "Debrid"
+    end
+
+    test "rqbit option appears in the type select", %{view: view} do
+      view
+      |> element(~s{button[phx-click="new_download_client"]})
+      |> render_click()
+
+      html = render(view)
+      assert html =~ ~s{value="rqbit"}
+    end
+
+    test "rqbit type renders host/port fields and hides categories", %{view: view} do
+      view
+      |> element(~s{button[phx-click="new_download_client"]})
+      |> render_click()
+
+      html =
+        view
+        |> form("#download-client-form", %{
+          "download_client_config" => %{"type" => "rqbit"}
+        })
+        |> render_change()
+
+      # rqbit is a standard network client: host/port are rendered.
+      assert html =~ "Host"
+      assert html =~ "Port"
+
+      # rqbit has no category or priority-profile concept.
+      refute has_element?(view, "#download-client-categories")
+      refute has_element?(view, "#download-client-priority-profile")
     end
 
     test "legacy single-category clients prefill all three content-type inputs", %{conn: conn} do


### PR DESCRIPTION
## Summary

Mydia can now drive [rqbit](https://github.com/ikatson/rqbit) as a torrent download client. Operators who run rqbit (a small single-binary Rust client) can select it in the download-client settings and get the full search → download → monitor → import pipeline that the other clients already have, instead of being forced onto qBittorrent or Transmission.

rqbit runs as a separate process the operator manages; Mydia talks to its HTTP API and does not embed or supervise it.

## rqbit specifics worth knowing

rqbit's API differs from the other torrent clients in ways the adapter has to absorb, so behavior stays consistent across clients:

- **No "seeding" state.** A finished-and-seeding torrent reports `state: "live"` with `finished: true`. Since the download monitor only triggers import once a download reaches `:seeding`/`:completed`, the adapter maps `live + finished → :seeding` — otherwise completed downloads would never import.
- **No categories.** Like the Transmission adapter, category/tag options are ignored on add and the list filters are no-ops. On-disk organization happens at the existing import step.
- **Stable identifier.** rqbit's numeric id is reassigned across restarts, so the adapter uses the 40-char info hash as the client id (and to address every per-torrent endpoint).
- **No paused-on-add.** rqbit's HTTP API has no paused query param, so when a paused add is requested the adapter adds, then issues a separate pause (non-fatal on failure).
- Speeds reported in MiB/s are converted to integer bytes/sec for the shared status struct.

## Adapter resolution consolidation (bundled refactor)

Wiring a new client used to mean editing five places: the runtime Registry plus four private `type → adapter module` dispatch tables that had drifted into `history`, `untracked_matcher`, `client_health`, and `media_import`. Missing one silently half-wired a client (addable but not pollable, health-checked, or removable on import).

This PR routes all four through the Registry (`Registry.lookup/1`), making `register_clients/0` the single source of truth. Adding rqbit — and any future client — is now a one-line registration. The Registry already registered the full client set, so resolution behavior is unchanged for every existing client; a parity test pins that.

## Tests

- rqbit adapter suite (Bypass-based): all eight callbacks, the completion-critical `live + finished → :seeding` mapping, the category no-op, add-then-pause, MiB/s→bytes conversion, error-kind mapping, and unreachable-host error paths.
- Registry resolution parity across all client types (incl. rqbit), config-changeset validity, and admin-UI selectability.
- One pre-existing, environment-specific test failure (`media_import` `path_not_accessible`) is unrelated to this change — it requires `chmod 000` to block directory reads, which the Docker `/app` volume does not enforce; it reproduces on master and is independent of the one-line resolution swap.

## Known follow-ups

- The adapter is coded against rqbit's source-verified API shapes but has not yet been confirmed against a live `rqbit server` (no rqbit instance in the dev environment). Recommend one verification pass against a running instance before relying on it in production.
- The untracked-matcher's torrent-client filter also omits `:rtorrent` (a real torrent client) — a pre-existing gap, left out of scope here.

## Post-Deploy Monitoring & Validation

- **Validate:** configure a rqbit client in admin settings against a running rqbit; confirm test-connection succeeds, a monitored search adds a torrent, the monitor reflects live progress, and on completion `MediaImport` fires and the file lands in the library.
- **Healthy signals:** `Mydia.Jobs.DownloadMonitor` reports rqbit torrents transitioning `:downloading → :seeding`; imports complete.
- **Failure signals to watch in logs:** `Failed to pause rqbit torrent after add`, repeated `rqbit API error` / `:connection_failed` from the rqbit host, or downloads stuck in `:checking`/`:downloading` past completion (would indicate a state-mapping mismatch against the deployed rqbit version).
- **Rollback:** disable or remove the rqbit client config in settings; no migrations or data changes are involved, so removal is immediate and non-destructive.
- **Window/owner:** first successful end-to-end rqbit import.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
