### PR TITLE
docs: document rqbit download client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Open http://localhost:4000 and create your admin account.
 
 - **Unified Media Management** - Movies + TV shows with TMDB/TVDB metadata
 - **Automated Downloads** - Quality profiles, smart release ranking
-- **Download Clients** - qBittorrent, Transmission, SABnzbd, NZBGet
+- **Download Clients** - qBittorrent, Transmission, rqbit, SABnzbd, NZBGet
 - **Indexers** - Prowlarr, Jackett, built-in Cardigann (experimental)
 - **Multi-User** - Admin/guest roles with request workflow
 - **SSO** - Local auth + OIDC/OpenID Connect

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -258,6 +258,21 @@ download_clients:
   #   password: "transmission"
   #   download_directory: "/downloads"
 
+  # rqbit example (commented out)
+  # Mydia connects to a separately running `rqbit server` over HTTP.
+  # rqbit has no category, label, or tag support.
+  # - name: "rqbit"
+  #   type: "rqbit"
+  #   enabled: true
+  #   priority: 2
+  #   host: "localhost"
+  #   port: 3030
+  #   use_ssl: false
+  #   # Optional: HTTP basic auth, when enabled on the rqbit server
+  #   username: "admin"
+  #   password: "adminpass"
+  #   download_directory: "/downloads"
+
   # HTTP download client example (commented out)
   # - name: "HTTP Downloader"
   #   type: "http"

--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -23,6 +23,7 @@ Navigate to **Admin > Download Clients** to add your download clients.
 
 - qBittorrent
 - Transmission
+- rqbit
 
 **Usenet Clients:**
 

--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -19,6 +19,8 @@ Navigate to **Admin > Download Clients** to add your download clients.
 
 ### Supported Clients
 
+This list highlights common client types. The Admin UI also supports rTorrent, Blackhole, and Debrid clients.
+
 **Torrent Clients:**
 
 - qBittorrent

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -70,7 +70,7 @@ On first visit, you'll be guided through creating the initial admin user.
 
 ## Step 5: Configure Your Setup
 
-1. **Add Download Clients** - Configure qBittorrent, Transmission, SABnzbd, or NZBGet
+1. **Add Download Clients** - Configure qBittorrent, Transmission, rqbit, SABnzbd, or NZBGet
 2. **Add Indexers** - Set up Prowlarr or Jackett for searching releases
 3. **Scan Your Library** - Let Mydia discover your existing media
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -107,7 +107,7 @@ Configure multiple clients using numbered variables (`<N>` = 1, 2, 3, etc.):
 | `DOWNLOAD_CLIENT_<N>_CATEGORY` | Default category | - |
 | `DOWNLOAD_CLIENT_<N>_DOWNLOAD_DIRECTORY` | Download directory | - |
 
-**Client Types:** `qbittorrent`, `transmission`, `rqbit`, `sabnzbd`, `nzbget`
+**Client Types:** `qbittorrent`, `transmission`, `rqbit`, `rtorrent`, `sabnzbd`, `nzbget`
 
 Example rqbit client:
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -107,7 +107,19 @@ Configure multiple clients using numbered variables (`<N>` = 1, 2, 3, etc.):
 | `DOWNLOAD_CLIENT_<N>_CATEGORY` | Default category | - |
 | `DOWNLOAD_CLIENT_<N>_DOWNLOAD_DIRECTORY` | Download directory | - |
 
-**Client Types:** `qbittorrent`, `transmission`, `sabnzbd`, `nzbget`
+**Client Types:** `qbittorrent`, `transmission`, `rqbit`, `sabnzbd`, `nzbget`
+
+Example rqbit client:
+
+```bash
+DOWNLOAD_CLIENT_1_NAME=rqbit
+DOWNLOAD_CLIENT_1_TYPE=rqbit
+DOWNLOAD_CLIENT_1_HOST=rqbit
+DOWNLOAD_CLIENT_1_PORT=3030
+# Optional, when rqbit HTTP basic auth is enabled
+DOWNLOAD_CLIENT_1_USERNAME=admin
+DOWNLOAD_CLIENT_1_PASSWORD=adminpass
+```
 
 ## Indexers
 

--- a/docs/user-guide/download-clients.md
+++ b/docs/user-guide/download-clients.md
@@ -4,6 +4,8 @@ Download clients handle the actual downloading of media files. Mydia supports bo
 
 ## Supported Clients
 
+This table highlights the most common client types. The Admin UI also supports rTorrent, Blackhole, and Debrid clients.
+
 ### Torrent Clients
 
 | Client | Protocol | Features |

--- a/docs/user-guide/download-clients.md
+++ b/docs/user-guide/download-clients.md
@@ -10,6 +10,7 @@ Download clients handle the actual downloading of media files. Mydia supports bo
 |--------|----------|----------|
 | qBittorrent | HTTP API | Categories, labels, seeding |
 | Transmission | RPC | Categories, seeding |
+| rqbit | HTTP API | Lightweight torrent client, seeding |
 
 ### Usenet Clients
 
@@ -50,20 +51,29 @@ DOWNLOAD_CLIENT_2_PORT=9091
 DOWNLOAD_CLIENT_2_USERNAME=admin
 DOWNLOAD_CLIENT_2_PASSWORD=adminpass
 
+# rqbit
+DOWNLOAD_CLIENT_3_NAME=rqbit
+DOWNLOAD_CLIENT_3_TYPE=rqbit
+DOWNLOAD_CLIENT_3_HOST=rqbit
+DOWNLOAD_CLIENT_3_PORT=3030
+# Optional, when rqbit HTTP basic auth is enabled
+DOWNLOAD_CLIENT_3_USERNAME=admin
+DOWNLOAD_CLIENT_3_PASSWORD=adminpass
+
 # SABnzbd
-DOWNLOAD_CLIENT_3_NAME=SABnzbd
-DOWNLOAD_CLIENT_3_TYPE=sabnzbd
-DOWNLOAD_CLIENT_3_HOST=sabnzbd
-DOWNLOAD_CLIENT_3_PORT=8080
-DOWNLOAD_CLIENT_3_API_KEY=your-sabnzbd-api-key
+DOWNLOAD_CLIENT_4_NAME=SABnzbd
+DOWNLOAD_CLIENT_4_TYPE=sabnzbd
+DOWNLOAD_CLIENT_4_HOST=sabnzbd
+DOWNLOAD_CLIENT_4_PORT=8080
+DOWNLOAD_CLIENT_4_API_KEY=your-sabnzbd-api-key
 
 # NZBGet
-DOWNLOAD_CLIENT_4_NAME=NZBGet
-DOWNLOAD_CLIENT_4_TYPE=nzbget
-DOWNLOAD_CLIENT_4_HOST=nzbget
-DOWNLOAD_CLIENT_4_PORT=6789
-DOWNLOAD_CLIENT_4_USERNAME=nzbget
-DOWNLOAD_CLIENT_4_PASSWORD=tegbzn6789
+DOWNLOAD_CLIENT_5_NAME=NZBGet
+DOWNLOAD_CLIENT_5_TYPE=nzbget
+DOWNLOAD_CLIENT_5_HOST=nzbget
+DOWNLOAD_CLIENT_5_PORT=6789
+DOWNLOAD_CLIENT_5_USERNAME=nzbget
+DOWNLOAD_CLIENT_5_PASSWORD=tegbzn6789
 ```
 
 ## Configuration Options
@@ -82,6 +92,18 @@ DOWNLOAD_CLIENT_4_PASSWORD=tegbzn6789
 | Priority | Client priority | `1` |
 | Download Directory | Output directory | `/downloads` |
 
+## rqbit
+
+Mydia connects to a separately running `rqbit server` over rqbit's HTTP API. Mydia does not install, start, or supervise the rqbit process.
+
+Use these connection values when adding rqbit:
+
+- Type: `rqbit`
+- Port: `3030` by default
+- Username/password: optional, only when rqbit HTTP basic auth is enabled
+
+rqbit supports torrents only. It does not support categories, labels, tags, or Usenet downloads, so Mydia ignores category settings for rqbit clients. Final organization still happens during import when Mydia moves or links completed files into the configured library.
+
 ## Client Priority
 
 When multiple clients are configured, priority determines which client is used:
@@ -96,6 +118,8 @@ Categories help organize downloads:
 - Configure a category in your download client
 - Set the same category in Mydia
 - Downloads are tagged with this category
+
+rqbit does not have categories or labels. For rqbit clients, leave category fields empty and use the download directory plus Mydia's import step for final organization.
 
 ## Download Directory
 


### PR DESCRIPTION
## Summary

rqbit users can now find setup guidance in the active Mydia docs instead of only in the implementation and planning artifacts. The public docs now list rqbit with the other supported download clients, show environment/YAML examples, and call out the two operational constraints that matter for setup: Mydia connects to a separately running `rqbit server`, and rqbit does not support categories or labels.

## Verification

- Checked active docs for stale supported-client lists with `rg`.
- `uv run --project docs mkdocs build` succeeded. MkDocs still reports existing archival docs/nav/link warnings unrelated to this change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
