### PR TITLE
fix(downloads): enforce ReleaseValidator at grab time (malware .exe torrents)

### DIFF
--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -47,7 +47,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
   require Logger
 
-  alias Mydia.Downloads.TorrentParser
+  alias Mydia.Downloads.{ReleaseValidator, TorrentParser}
   alias Mydia.Indexers.{SearchResult, SearchScorer}
   alias Mydia.Indexers.Structs.{RankedResult, ScoreBreakdown}
   alias Mydia.Settings.QualityProfile
@@ -125,6 +125,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
     ranked =
       results
+      |> reject_invalid_releases()
       |> filter_acceptable(opts)
       |> reject_tv_releases_for_movies(media_type)
       |> reject_title_mismatches(expected_title)
@@ -379,6 +380,32 @@ defmodule Mydia.Indexers.ReleaseRanker do
       tag_bonus: round_score(tag_bonus),
       total: round_score(total_score)
     })
+  end
+
+  ## Private Functions - Release Validation Filtering
+
+  # Drop releases the ReleaseValidator flags as invalid/fake/malicious before
+  # anything else runs. This is the enforcement point for the validator: it only
+  # *detects* bad releases, so without this stage a flagged release (e.g. a
+  # malware torrent named "...h264-ETHEL.exe") still flows through scoring and
+  # can be selected and grabbed. The validator is otherwise consulted deep inside
+  # TorrentParser.parse, where the title-mismatch check discards its error and
+  # keeps the release. Reject here so a suspicious release never reaches a
+  # download client.
+  defp reject_invalid_releases(results) do
+    Enum.filter(results, fn result ->
+      case ReleaseValidator.validate_release(result.title) do
+        {:ok, _name} ->
+          true
+
+        {:error, reason} ->
+          Logger.warning(
+            "[ReleaseRanker] Filtered out (invalid release: #{reason}): #{result.title}"
+          )
+
+          false
+      end
+    end)
   end
 
   ## Private Functions - Media Type Filtering

--- a/test/mydia/indexers/release_ranker_test.exs
+++ b/test/mydia/indexers/release_ranker_test.exs
@@ -148,6 +148,58 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
 
   # Tests for rank_all/2
 
+  describe "rank_all/2 rejects malicious releases" do
+    test "drops a release with a suspicious executable extension before scoring" do
+      # The exact malware filename from the production incident: a 1.3GB PE32
+      # executable padded to look like a 1080p video release. Before this fix it
+      # scored highest and was grabbed; the validator only logged a warning.
+      malware =
+        build_result(%{
+          title: "Your.Friends.and.Neighbors.S02E05.1080p.WEB.h264-ETHEL.exe",
+          seeders: 500
+        })
+
+      legit =
+        build_result(%{
+          title: "Your.Friends.and.Neighbors.S02E05.1080p.WEB.h264-GROUP.mkv",
+          seeders: 5
+        })
+
+      ranked = ReleaseRanker.rank_all([malware, legit])
+
+      titles = Enum.map(ranked, & &1.result.title)
+      refute "Your.Friends.and.Neighbors.S02E05.1080p.WEB.h264-ETHEL.exe" in titles
+      assert "Your.Friends.and.Neighbors.S02E05.1080p.WEB.h264-GROUP.mkv" in titles
+    end
+
+    test "select_best_result never returns a suspicious executable release" do
+      malware =
+        build_result(%{
+          title: "Your.Friends.and.Neighbors.S02E08.1080p.WEB.h264-ETHEL.scr",
+          seeders: 999
+        })
+
+      legit =
+        build_result(%{
+          title: "Your.Friends.and.Neighbors.S02E08.1080p.WEB.h264-GROUP.mkv",
+          seeders: 1
+        })
+
+      best = ReleaseRanker.select_best_result([malware, legit])
+
+      assert best.result.title == "Your.Friends.and.Neighbors.S02E08.1080p.WEB.h264-GROUP.mkv"
+    end
+
+    test "returns empty when every candidate is a suspicious executable" do
+      results = [
+        build_result(%{title: "From.S04E06.1080p.WEB.h264-ETHEL.exe", seeders: 500}),
+        build_result(%{title: "From.S04E06.1080p.WEB.h264-ETHEL.scr", seeders: 400})
+      ]
+
+      assert ReleaseRanker.rank_all(results) == []
+    end
+  end
+
   describe "rank_all/2" do
     test "returns all results sorted by score" do
       results = build_results()


### PR DESCRIPTION
## Summary

Malware torrents named like `Your.Friends.and.Neighbors.S02E05.1080p.WEB.h264-ETHEL.exe` were being **grabbed and fully downloaded** despite `ReleaseValidator` flagging them. This was detection without enforcement.

Found in production (galactica): the file that triggered this PR is a real **1.3 GB PE32 Windows executable** padded to look like a 1080p video. At least 9 such `.exe`/`.scr` releases had been grabbed since mid-May. None reached the media library (the import-time video-extension whitelist from #3ee6a130 correctly refused them), but rqbit still downloaded the full payload and seeded it.

## Root cause

The `ReleaseValidator` is only consulted deep inside `TorrentParser.parse`. The one place that calls it in the ranking pipeline, `ReleaseRanker.parse_and_compare/2`, discards the error:

```elixir
case TorrentParser.parse(result.title) do
  {:ok, %{title: parsed_title}} -> # title-distance check
  _ -> :ok   # {:error, :suspicious_extension} lands here -> "keep it"
end
```

So the validator's `{:error, :suspicious_extension}` was swallowed. With no extension penalty in scoring, the `.exe` actually scored **highest** (67.6 in the production logs) and was selected for download. The `Rejecting release with suspicious executable extension` log line was purely cosmetic; nothing downstream acted on it.

Production log excerpt:

```
[warning] Rejecting release with suspicious executable extension: ...ETHEL.exe
[info]   - [idx=0] 1080p | score=67.6 | ...ETHEL.exe   <- highest score
[info] Selected best result for episode  ->  result_title=...ETHEL.exe
[info] Successfully initiated download for episode
```

## Fix

Add a `reject_invalid_releases` stage as the **first** step of `rank_all/2` that calls `ReleaseValidator.validate_release/1` and drops any release that doesn't return `{:ok, _}`. This enforces every validator rule (suspicious extension, hashed, numeric-only, password-protected, reversed, yenc, no-meaningful-content) before a release can be scored, selected, or grabbed. `select_best_result/2` routes through `rank_all/2`, so the grab path is covered.

This is intentionally broader than just executables: the validator was always meant to gate grabs, and every rule it has targets fake/garbage/malicious releases that should never be downloaded.

## Tests

Adds a `rank_all/2 rejects malicious releases` describe block using the exact ETHEL filenames from the incident:

- `.exe` release is dropped from `rank_all` even with 500 seeders, while the legit `.mkv` survives with 5
- `select_best_result` never returns a `.scr` release even when it has the most seeders
- all-malware candidate list returns `[]`

Full suite for the touched modules passes: `129 tests, 0 failures` (ranker + validator).

## Notes

- This only closes the **grab** hole. The earlier fix (#3ee6a130) closed the import/retry hole. Together: suspicious releases are now never grabbed, and if one ever does land it still won't be imported.
- Existing malware already on disk / seeding in rqbit is operational cleanup, not addressed here.
