### PR TITLE
docs(player): add TestFlight beta link and auto-distribute builds to Beta group

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Test & Quality](https://github.com/getmydia/mydia/actions/workflows/test.yml/badge.svg)](https://github.com/getmydia/mydia/actions/workflows/test.yml)
 [![Documentation](https://github.com/getmydia/mydia/actions/workflows/docs.yml/badge.svg)](https://docs.mydia.dev)
+[![TestFlight](https://img.shields.io/badge/TestFlight-Join%20iOS%20Beta-0D96F6?logo=apple&logoColor=white)](https://testflight.apple.com/join/KFSYxaQP)
 
 **Your personal media companion, built with Phoenix LiveView**
 
@@ -64,6 +65,14 @@ Open http://localhost:4000 and create your admin account.
 - **SSO** - Local auth + OIDC/OpenID Connect
 - **Import Lists** - Sync from TMDB watchlists, popular, trending (experimental)
 - **Real-Time UI** - Phoenix LiveView with instant updates
+
+## Mobile App (iOS Beta)
+
+The Mydia player is in open beta on TestFlight. On an iPhone or iPad with the [TestFlight app](https://apps.apple.com/app/testflight/id899247664) installed:
+
+**[Join the iOS Beta →](https://testflight.apple.com/join/KFSYxaQP)**
+
+New builds reach testers automatically as they ship.
 
 ## Documentation
 

--- a/docs/reference/remote-access.md
+++ b/docs/reference/remote-access.md
@@ -2,6 +2,12 @@
 
 Remote access allows the Mydia mobile app to connect to your Mydia instance from anywhere, even when your server is behind NAT or a firewall.
 
+## Get the Mobile App (iOS Beta)
+
+The Mydia player is in open beta on TestFlight. Install the [TestFlight app](https://apps.apple.com/app/testflight/id899247664) on your iPhone or iPad, then join the beta. New builds reach you automatically as they ship.
+
+[Join the iOS Beta](https://testflight.apple.com/join/KFSYxaQP){ .md-button .md-button--primary }
+
 ## How It Works
 
 Mydia uses **p2p** for decentralized peer-to-peer connectivity:

--- a/player/ios/fastlane/Fastfile
+++ b/player/ios/fastlane/Fastfile
@@ -22,9 +22,15 @@ platform :ios do
       output_name: "Mydia Player.ipa"
     )
 
-    # Upload to TestFlight
+    # Upload to TestFlight and distribute to the public "Beta" external group.
+    # External distribution requires the build to finish processing, so we can't
+    # skip waiting here. The first build of each new version goes through Apple's
+    # Beta App Review before public-link testers can install it.
     upload_to_testflight(
-      skip_waiting_for_build_processing: true
+      distribute_external: true,
+      groups: ["Beta"],
+      changelog: "Automated beta build.",
+      notify_external_testers: false
     )
   end
 


### PR DESCRIPTION
## What

- Add a TestFlight join button to the README (header badge + dedicated Mobile App section).
- Add a "Join the iOS Beta" button to the Remote Access docs page.
- Configure the Fastlane `beta` lane to distribute each uploaded build to the public **Beta** external group automatically.

## Notes

- TestFlight public link: https://testflight.apple.com/join/KFSYxaQP
- The Fastfile change drops `skip_waiting_for_build_processing` (external distribution requires the build to finish processing) and sets `distribute_external: true`, `groups: ["Beta"]`.
- The first build of each new version still passes Apple Beta App Review before public-link testers can install it; subsequent builds of the same version typically skip re-review.
- Takes effect on the next release run (iOS player builds only run in `release.yml`, not on master pushes).