### PR TITLE
ci(release): route Docker Hub pulls through mirror.gcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Route Docker Hub pulls through Google's pull-through cache to avoid
+      # anonymous rate-limit timeouts. The daemon mirror covers the BuildKit
+      # image pull during buildx setup; buildkitd-config-inline covers the
+      # base-image FROM pulls inside the build.
+      - name: Configure Docker Hub mirror
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Login to registry
         uses: docker/login-action@v3
@@ -166,8 +180,18 @@ jobs:
       id-token: write
 
     steps:
+      - name: Configure Docker Hub mirror
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Login to registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Problem

Anonymous Docker Hub pulls from GitHub Actions runners intermittently time out under rate limits. On the v0.11.1 release run, `Docker / sqlite / amd64` failed at **Setup Docker Buildx**:

```
ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

The release builds push to ghcr.io, but still touch docker.io in two places:
1. **buildx setup** — the host daemon pulls `moby/buildkit` from Docker Hub.
2. **base-image FROM pulls** — the build pulls `elixir`/`erlang` alpine images (unqualified `docker.io/library/...`).

## Fix

Route both phases through `mirror.gcr.io` (Google's free pull-through cache of Docker Hub):
- **Host daemon registry-mirror** via `daemon.json` before buildx setup → covers the BuildKit image pull.
- **`buildkitd-config-inline`** on `setup-buildx-action` → covers the in-build base-image pulls.

Applied to both the `docker-build` matrix job and the `docker-merge` job.

## Notes

- Adds a ~5-10s daemon restart per Docker job.
- A complementary hardening (not included here) is authenticating to Docker Hub for higher rate limits; the mirror and auth compose well.