### PR TITLE
fix(accounts): allow admins to update roles for OIDC users

### DIFF
--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -151,6 +151,19 @@ defmodule Mydia.Accounts do
   end
 
   @doc """
+  Updates only a user's role.
+
+  Unlike `update_user/2`, this does not re-validate the full local
+  changeset, so it works for OIDC-created users (which have a `nil`
+  username). Intended for admin-driven role changes.
+  """
+  def update_user_role(%User{} = user, attrs) do
+    user
+    |> User.role_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
   Updates user's last login timestamp.
   """
   def update_last_login(%User{} = user) do

--- a/lib/mydia/accounts/user.ex
+++ b/lib/mydia/accounts/user.ex
@@ -108,6 +108,20 @@ defmodule Mydia.Accounts.User do
   end
 
   @doc """
+  Changeset for updating only a user's role.
+
+  Used by admins to change a user's role without re-validating other
+  fields. This is required for OIDC-created users, which have a `nil`
+  username and would otherwise fail the local `changeset/2` validations.
+  """
+  def role_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:role])
+    |> validate_required([:role])
+    |> validate_inclusion(:role, @role_values)
+  end
+
+  @doc """
   Returns the list of valid role values.
   """
   def valid_roles, do: @role_values

--- a/lib/mydia_web/live/admin_users_live/index.ex
+++ b/lib/mydia_web/live/admin_users_live/index.ex
@@ -175,7 +175,7 @@ defmodule MydiaWeb.AdminUsersLive.Index do
     if changeset.valid? do
       validated_data = Ecto.Changeset.apply_changes(changeset)
 
-      case Accounts.update_user(user, %{role: validated_data.role}) do
+      case Accounts.update_user_role(user, %{role: validated_data.role}) do
         {:ok, _updated_user} ->
           {:noreply,
            socket

--- a/test/mydia/accounts/update_user_role_test.exs
+++ b/test/mydia/accounts/update_user_role_test.exs
@@ -1,0 +1,55 @@
+defmodule Mydia.Accounts.UpdateUserRoleTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.User
+
+  describe "update_user_role/2" do
+    test "updates the role of an OIDC user that has a nil username" do
+      # OIDC users are created without a username, which the full
+      # changeset/2 requires. update_user_role/2 must not trip on that.
+      {:ok, oidc_user} =
+        %User{}
+        |> User.oidc_changeset(%{
+          oidc_sub: "oidc-sub-role",
+          oidc_issuer: "google",
+          email: "oidc_role@example.com",
+          display_name: "OIDC User",
+          role: "user"
+        })
+        |> Repo.insert()
+
+      assert is_nil(oidc_user.username)
+
+      assert {:ok, updated} = Accounts.update_user_role(oidc_user, %{role: "admin"})
+      assert updated.role == "admin"
+      assert updated.id == oidc_user.id
+    end
+
+    test "updates the role of a local user" do
+      {:ok, user} =
+        Accounts.create_user(%{
+          username: "localuser",
+          email: "local@example.com",
+          password: "password123",
+          role: "user"
+        })
+
+      assert {:ok, updated} = Accounts.update_user_role(user, %{role: "readonly"})
+      assert updated.role == "readonly"
+    end
+
+    test "rejects an invalid role" do
+      {:ok, user} =
+        Accounts.create_user(%{
+          username: "localuser2",
+          email: "local2@example.com",
+          password: "password123",
+          role: "user"
+        })
+
+      assert {:error, changeset} = Accounts.update_user_role(user, %{role: "superuser"})
+      assert %{role: ["is invalid"]} = errors_on(changeset)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #159

## The bug

Admins could not remap the role of any user created automatically by OIDC/SSO. Every attempt failed with the flash `Failed to update user role`.

## Root cause

The admin edit-role flow (`MydiaWeb.AdminUsersLive.Index`) called `Accounts.update_user/2`, which always runs the full local `User.changeset/2`. That changeset does `validate_required([:username, :email, :role])`. OIDC users are created via `oidc_changeset/2` and never get a `username`, so a role-only update was rejected on the missing `username` before the change could persist.

## The fix

- Add `User.role_changeset/2` that casts and validates only `:role` (presence + `validate_inclusion` against the allowed roles).
- Add `Accounts.update_user_role/2` that writes through it.
- Point the admin `submit_edit_role` handler at `update_user_role/2` instead of `update_user/2`.

Role changes now work for both local and OIDC users, and the admin role update no longer re-validates identity fields it is not touching.

## Test plan

New `test/mydia/accounts/update_user_role_test.exs`:

- Updating the role of an OIDC user with a `nil` username succeeds (the regression).
- Updating a local user`s role still succeeds.
- An invalid role is rejected by `validate_inclusion`.

Full precommit run on PostgreSQL: compile, format, and the new tests pass. (One unrelated, pre-existing failure in `Mydia.Jobs.MediaImportTest` reproduces on `master` in isolation and is untouched by this change.)