### PR TITLE
feat(downloads): sortable list, opt-in delete of completed files, compact layout

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6,6 +6,11 @@
 @source "../js";
 @source "../../lib/mydia_web";
 
+/* DaisyUI `status` dot colors are selected at runtime (downloads_live status
+   indicator), so the variant classes never appear literally in markup the
+   scanner can see. Safelist them so they're always built. */
+@source inline("status-{success,error,warning,info,neutral}");
+
 /* A Tailwind plugin that makes "hero-#{ICON}" classes available.
    The heroicons installation itself is managed by your mix.exs */
 @plugin "../vendor/heroicons";

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -264,8 +264,20 @@ defmodule Mydia.Config.Loader do
       |> put_if_present(:api_key, System.get_env("#{prefix}API_KEY"))
       |> put_if_present(:category, System.get_env("#{prefix}CATEGORY"))
       |> put_if_present(:download_directory, System.get_env("#{prefix}DOWNLOAD_DIRECTORY"))
+      |> put_download_client_connection_settings(prefix)
     end)
     |> Enum.reject(&(&1 == %{}))
+  end
+
+  # Assemble the `connection_settings` map from env vars. Some adapters store
+  # config here rather than in top-level columns — notably debrid clients,
+  # whose provider lives at `connection_settings["provider"]`
+  # (DOWNLOAD_CLIENT_<N>_PROVIDER). Add further keys here as adapters need them.
+  # Keys are strings to match how adapters and validations read the map.
+  defp put_download_client_connection_settings(map, prefix) do
+    settings = put_if_present(%{}, "provider", System.get_env("#{prefix}PROVIDER"))
+
+    if settings == %{}, do: map, else: Map.put(map, :connection_settings, settings)
   end
 
   defp load_indexers_env do

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -114,7 +114,17 @@ defmodule Mydia.Config.Schema do
       field :name, :string
 
       field :type, Ecto.Enum,
-        values: [:qbittorrent, :transmission, :rqbit, :rtorrent, :http, :sabnzbd, :nzbget]
+        values: [
+          :qbittorrent,
+          :transmission,
+          :rqbit,
+          :rtorrent,
+          :http,
+          :sabnzbd,
+          :nzbget,
+          :blackhole,
+          :debrid
+        ]
 
       field :enabled, :boolean, default: true
       field :priority, :integer, default: 1
@@ -127,6 +137,7 @@ defmodule Mydia.Config.Schema do
       field :api_key, :string
       field :category, :string
       field :download_directory, :string
+      field :connection_settings, :map, default: %{}
     end
 
     embeds_many :indexers, Indexer, on_replace: :delete, primary_key: false do
@@ -326,9 +337,10 @@ defmodule Mydia.Config.Schema do
       :password,
       :api_key,
       :category,
-      :download_directory
+      :download_directory,
+      :connection_settings
     ])
-    |> validate_required([:name, :type, :host, :port])
+    |> validate_required([:name, :type])
     |> validate_inclusion(:type, [
       :qbittorrent,
       :transmission,
@@ -336,10 +348,45 @@ defmodule Mydia.Config.Schema do
       :rtorrent,
       :http,
       :sabnzbd,
-      :nzbget
+      :nzbget,
+      :blackhole,
+      :debrid
     ])
+    |> validate_download_client_by_type()
     |> validate_number(:port, greater_than: 0, less_than: 65536)
     |> validate_number(:priority, greater_than: 0)
+  end
+
+  # Network clients need host/port; hostless ones (blackhole, debrid) don't.
+  # Debrid additionally needs an api_key and a recognised provider.
+  defp validate_download_client_by_type(changeset) do
+    case get_field(changeset, :type) do
+      :debrid ->
+        changeset
+        |> validate_required([:api_key])
+        |> validate_debrid_provider()
+
+      :blackhole ->
+        changeset
+
+      _network_client ->
+        validate_required(changeset, [:host, :port])
+    end
+  end
+
+  defp validate_debrid_provider(changeset) do
+    providers = Mydia.Settings.DownloadClientConfig.debrid_providers()
+    provider = get_field(changeset, :connection_settings)["provider"]
+
+    if provider in providers do
+      changeset
+    else
+      add_error(
+        changeset,
+        :connection_settings,
+        "must include provider (one of: #{Enum.join(providers, ", ")})"
+      )
+    end
   end
 
   defp indexer_changeset(schema, attrs) do

--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -289,6 +289,12 @@ defmodule Mydia.Downloads do
   defdelegate clear_all_completed(opts \\ []), to: Mydia.Downloads.Queue
 
   @doc """
+  Counts imported downloads that `clear_all_completed/1` would clear.
+  """
+  @spec count_completed() :: non_neg_integer()
+  defdelegate count_completed(), to: Mydia.Downloads.History
+
+  @doc """
   Checks for duplicate downloads (active downloads or existing media files).
   """
   defdelegate check_for_duplicate_download(search_result, opts), to: Mydia.Downloads.Queue

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -30,6 +30,18 @@ defmodule Mydia.Downloads.History do
     |> Repo.all()
   end
 
+  @doc """
+  Counts imported downloads — the set `clear_all_completed/1` would remove.
+
+  Used to show a scope-accurate blast radius before the user confirms a
+  destructive "delete files from disk" clear.
+  """
+  def count_completed do
+    Download
+    |> where([d], not is_nil(d.imported_at))
+    |> Repo.aggregate(:count)
+  end
+
   def list_downloads_with_status(opts \\ []) do
     # Get all download records from database
     # Preload episode.media_item to get parent show info for episode downloads

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -191,18 +191,32 @@ defmodule Mydia.Downloads.History do
         config = config_to_map(client_config)
         client_downloads = Map.get(downloads_by_client, client_config.name, %{})
 
-        case Client.list_torrents(adapter, config, downloads: client_downloads) do
-          {:ok, torrents} ->
-            torrents_map =
-              torrents
-              |> Enum.map(fn torrent -> {torrent.id, torrent} end)
-              |> Map.new()
+        try do
+          case Client.list_torrents(adapter, config, downloads: client_downloads) do
+            {:ok, torrents} ->
+              torrents_map =
+                torrents
+                |> Enum.map(fn torrent -> {torrent.id, torrent} end)
+                |> Map.new()
 
-            {client_config.name, {:reachable, torrents_map}}
+              {client_config.name, {:reachable, torrents_map}}
 
-          {:error, error} ->
-            Logger.warning(
-              "Failed to fetch torrents from #{client_config.name}: #{inspect(error)}"
+            {:error, error} ->
+              Logger.warning(
+                "Failed to fetch torrents from #{client_config.name}: #{inspect(error)}"
+              )
+
+              {client_config.name, :unreachable}
+          end
+        rescue
+          # A buggy or mis-registered adapter (e.g. a module that doesn't
+          # implement list_torrents/2) must not crash the caller — that would
+          # take down the whole Downloads LiveView for every other client too.
+          # Degrade to :unreachable, same as an explicit {:error, _}.
+          exception ->
+            Logger.error(
+              "Adapter #{inspect(adapter)} for client #{client_config.name} " <>
+                "(type=#{client_config.type}) raised: #{Exception.message(exception)}"
             )
 
             {client_config.name, :unreachable}

--- a/lib/mydia_web/live/admin_system_live/components.ex
+++ b/lib/mydia_web/live/admin_system_live/components.ex
@@ -430,10 +430,14 @@ defmodule MydiaWeb.AdminSystemLive.Components do
           "Unknown Media"
       end
 
+    user = assigns.progress.user
+
     assigns =
       assigns
       |> assign(:poster_path, poster_path)
       |> assign(:title, title)
+      |> assign(:username, (user && user.username) || "Unknown")
+      |> assign(:avatar_url, user && user.avatar_url)
 
     ~H"""
     <div class="p-3 flex items-center gap-3 hover:bg-base-200/50 transition-colors">
@@ -447,7 +451,7 @@ defmodule MydiaWeb.AdminSystemLive.Components do
         <div class="avatar placeholder">
           <div class="bg-base-300 text-base-content rounded-full w-8">
             <span class="text-xs">
-              {(@progress.user.username || "?") |> String.slice(0, 1) |> String.upcase()}
+              {@username |> String.slice(0, 1) |> String.upcase()}
             </span>
           </div>
         </div>
@@ -455,14 +459,14 @@ defmodule MydiaWeb.AdminSystemLive.Components do
       <div class="flex-1 min-w-0">
         <div class="text-sm font-medium truncate" title={@title}>{@title}</div>
         <div class="text-xs opacity-50 flex items-center gap-1">
-          <%= if @progress.user.avatar_url do %>
+          <%= if @avatar_url do %>
             <div class="avatar">
               <div class="w-4 rounded-full">
-                <img src={@progress.user.avatar_url} alt={@progress.user.username} />
+                <img src={@avatar_url} alt={@username} />
               </div>
             </div>
           <% end %>
-          <span>{@progress.user.username || "Unknown"}</span>
+          <span>{@username}</span>
         </div>
       </div>
       <div class="text-xs opacity-40 whitespace-nowrap">

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -9,6 +9,56 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   @items_per_page 50
 
+  @default_sort "added_desc"
+
+  # Sort options offered per tab. Real-time keys (progress, speeds, ETA, ratio)
+  # only exist after client-status enrichment, so sorting runs in the LiveView
+  # over the enriched list (see apply_sorting/2), not in the DB query.
+  @shared_sort_options [
+    {"added_desc", "Newest first"},
+    {"added_asc", "Oldest first"},
+    {"name_asc", "Name (A-Z)"},
+    {"name_desc", "Name (Z-A)"},
+    {"status_asc", "Status"},
+    {"size_desc", "Size (largest)"},
+    {"size_asc", "Size (smallest)"}
+  ]
+
+  @queue_sort_options [
+    {"progress_desc", "Progress (most)"},
+    {"progress_asc", "Progress (least)"},
+    {"dlspeed_desc", "Download speed"},
+    {"eta_asc", "ETA (soonest)"}
+  ]
+
+  @completed_sort_options [
+    {"ratio_desc", "Ratio (highest)"},
+    {"ratio_asc", "Ratio (lowest)"},
+    {"ulspeed_desc", "Upload speed"},
+    {"imported_desc", "Imported (newest)"},
+    {"imported_asc", "Imported (oldest)"}
+  ]
+
+  @allowed_sort_fields (@shared_sort_options ++ @queue_sort_options ++ @completed_sort_options)
+                       |> Enum.map(&elem(&1, 0))
+
+  # Rank for status sorting so states group sensibly (active work first) rather
+  # than sorting alphabetically. Unknown statuses fall to the end.
+  @status_rank %{
+    "downloading" => 0,
+    "checking" => 1,
+    "queued" => 2,
+    "paused" => 3,
+    "stalled" => 4,
+    "seeding" => 5,
+    "completed" => 6,
+    "imported" => 7,
+    "cancelled" => 8,
+    "failed" => 9,
+    "missing" => 10,
+    "unknown" => 11
+  }
+
   @impl true
   def mount(_params, _session, socket) do
     # Subscribe to download updates for real-time progress
@@ -20,6 +70,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
      socket
      |> assign(:page_title, "Activity")
      |> assign(:active_tab, :queue)
+     |> assign(:sort_by, @default_sort)
      |> assign(:selected_ids, MapSet.new())
      |> assign(:selection_mode, false)
      |> assign(:page, 0)
@@ -52,11 +103,26 @@ defmodule MydiaWeb.DownloadsLive.Index do
     {:noreply,
      socket
      |> assign(:active_tab, tab_atom)
+     # Reset to the default sort: a tab-specific sort (e.g. ratio on completed)
+     # is not a valid option on the new tab.
+     |> assign(:sort_by, @default_sort)
      |> assign(:selected_ids, MapSet.new())
      |> assign(:selection_mode, false)
      |> assign(:page, 0)
      |> load_downloads()}
   end
+
+  def handle_event("sort", %{"sort_by" => sort_by}, socket)
+      when sort_by in @allowed_sort_fields do
+    {:noreply,
+     socket
+     |> assign(:sort_by, sort_by)
+     |> assign(:page, 0)
+     |> load_downloads()}
+  end
+
+  # Unknown sort value: fall back to the current sort rather than raising.
+  def handle_event("sort", _params, socket), do: {:noreply, socket}
 
   def handle_event("toggle_select", %{"id" => id}, socket) do
     selected_ids =
@@ -612,7 +678,9 @@ defmodule MydiaWeb.DownloadsLive.Index do
           end
 
         # Get all matching downloads for the current tab with real-time status from clients
-        all_downloads = Downloads.list_downloads_with_status(filter: filter)
+        all_downloads =
+          Downloads.list_downloads_with_status(filter: filter)
+          |> apply_sorting(socket.assigns.sort_by)
 
         # Apply pagination
         page = socket.assigns.page
@@ -679,7 +747,58 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
 
     Downloads.list_downloads_with_status(filter: filter)
+    |> apply_sorting(socket.assigns.sort_by)
   end
+
+  # Sorts the enriched download list by the active `sort_by` selection. Runs in
+  # the LiveView (not the DB) because real-time keys (progress, speeds, ETA,
+  # ratio) only exist after client-status enrichment. Missing values are guarded
+  # so they group deterministically rather than scatter or raise.
+  defp apply_sorting(downloads, sort_by) do
+    case sort_by do
+      "added_desc" -> Enum.sort_by(downloads, & &1.inserted_at, {:desc, DateTime})
+      "added_asc" -> Enum.sort_by(downloads, & &1.inserted_at, {:asc, DateTime})
+      "name_asc" -> Enum.sort_by(downloads, &sort_name/1, :asc)
+      "name_desc" -> Enum.sort_by(downloads, &sort_name/1, :desc)
+      "status_asc" -> Enum.sort_by(downloads, &status_rank/1, :asc)
+      "size_desc" -> Enum.sort_by(downloads, &(&1.size || 0), :desc)
+      "size_asc" -> Enum.sort_by(downloads, &(&1.size || 0), :asc)
+      "progress_desc" -> Enum.sort_by(downloads, &(&1.progress || 0.0), :desc)
+      "progress_asc" -> Enum.sort_by(downloads, &(&1.progress || 0.0), :asc)
+      "dlspeed_desc" -> Enum.sort_by(downloads, &(&1.download_speed || 0), :desc)
+      "ulspeed_desc" -> Enum.sort_by(downloads, &(&1.upload_speed || 0), :desc)
+      "ratio_desc" -> Enum.sort_by(downloads, &(&1.ratio || 0.0), :desc)
+      "ratio_asc" -> Enum.sort_by(downloads, &(&1.ratio || 0.0), :asc)
+      "eta_asc" -> Enum.sort_by(downloads, &eta_sort_key/1, :asc)
+      "imported_desc" -> Enum.sort_by(downloads, &imported_sort_key/1, {:desc, DateTime})
+      "imported_asc" -> Enum.sort_by(downloads, &imported_sort_key/1, {:asc, DateTime})
+      _ -> Enum.sort_by(downloads, & &1.inserted_at, {:desc, DateTime})
+    end
+  end
+
+  defp sort_name(download), do: String.downcase(get_display_title(download) || "")
+
+  defp status_rank(download), do: Map.get(@status_rank, download.status, 99)
+
+  # ETA may be nil, an integer (seconds remaining), or a DateTime. Normalize to
+  # an integer so a single comparator works; nil sorts last (soonest first).
+  defp eta_sort_key(download) do
+    case download.eta do
+      nil -> 9_999_999_999
+      %DateTime{} = dt -> DateTime.diff(dt, DateTime.utc_now(), :second)
+      seconds when is_integer(seconds) -> seconds
+      _ -> 9_999_999_999
+    end
+  end
+
+  # imported_at is always present on the completed tab, but guard nil so the
+  # comparator never raises if called on a mixed list.
+  defp imported_sort_key(download), do: download.imported_at || download.inserted_at
+
+  # Sort options available for the given tab. Shared keys apply to every tab;
+  # queue- and completed-specific keys are only meaningful there.
+  defp sort_options(:completed), do: @shared_sort_options ++ @completed_sort_options
+  defp sort_options(_tab), do: @shared_sort_options ++ @queue_sort_options
 
   # View helpers
 

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -330,98 +330,106 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   def handle_event("batch_retry", _params, socket) do
-    selected_ids = MapSet.to_list(socket.assigns.selected_ids)
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      selected_ids = MapSet.to_list(socket.assigns.selected_ids)
 
-    results =
-      Enum.map(selected_ids, fn id ->
-        try do
-          download = Downloads.get_download!(id, preload: [:media_item, :episode])
+      results =
+        Enum.map(selected_ids, fn id ->
+          try do
+            download = Downloads.get_download!(id, preload: [:media_item, :episode])
 
-          # Check if this is an import failure or download failure
-          if download.import_last_error do
-            # Import failure - retry import
-            case Downloads.update_download(download, %{
-                   import_retry_count: 0,
-                   import_last_error: nil,
-                   import_next_retry_at: nil,
-                   import_failed_at: nil
-                 }) do
-              {:ok, updated} ->
-                %{
-                  "download_id" => updated.id,
-                  "save_path" => nil,
-                  "cleanup_client" => true,
-                  "use_hardlinks" => true,
-                  "move_files" => false
-                }
-                |> Mydia.Jobs.MediaImport.new()
-                |> Oban.insert()
+            # Check if this is an import failure or download failure
+            if download.import_last_error do
+              # Import failure - retry import
+              case Downloads.update_download(download, %{
+                     import_retry_count: 0,
+                     import_last_error: nil,
+                     import_next_retry_at: nil,
+                     import_failed_at: nil
+                   }) do
+                {:ok, updated} ->
+                  %{
+                    "download_id" => updated.id,
+                    "save_path" => nil,
+                    "cleanup_client" => true,
+                    "use_hardlinks" => true,
+                    "move_files" => false
+                  }
+                  |> Mydia.Jobs.MediaImport.new()
+                  |> Oban.insert()
 
-              error ->
-                error
+                error ->
+                  error
+              end
+            else
+              # Download failure - retry download
+              metadata = DownloadMetadata.from_map(download.metadata)
+
+              search_result = %Mydia.Indexers.SearchResult{
+                download_url: download.download_url,
+                title: download.title,
+                indexer: download.indexer,
+                size: metadata.size,
+                seeders: metadata.seeders,
+                leechers: metadata.leechers,
+                quality: metadata.quality
+              }
+
+              opts =
+                []
+                |> maybe_add_opt(:media_item_id, download.media_item_id)
+                |> maybe_add_opt(:episode_id, download.episode_id)
+                |> maybe_add_opt(:client_name, download.download_client)
+
+              Downloads.delete_download(download)
+              Downloads.initiate_download(search_result, opts)
             end
-          else
-            # Download failure - retry download
-            metadata = DownloadMetadata.from_map(download.metadata)
-
-            search_result = %Mydia.Indexers.SearchResult{
-              download_url: download.download_url,
-              title: download.title,
-              indexer: download.indexer,
-              size: metadata.size,
-              seeders: metadata.seeders,
-              leechers: metadata.leechers,
-              quality: metadata.quality
-            }
-
-            opts =
-              []
-              |> maybe_add_opt(:media_item_id, download.media_item_id)
-              |> maybe_add_opt(:episode_id, download.episode_id)
-              |> maybe_add_opt(:client_name, download.download_client)
-
-            Downloads.delete_download(download)
-            Downloads.initiate_download(search_result, opts)
+          rescue
+            _ -> {:error, :failed}
           end
-        rescue
-          _ -> {:error, :failed}
-        end
-      end)
+        end)
 
-    success_count = Enum.count(results, fn {status, _} -> status == :ok end)
+      success_count = Enum.count(results, fn {status, _} -> status == :ok end)
 
-    {:noreply,
-     socket
-     |> assign(:selected_ids, MapSet.new())
-     |> assign(:selection_mode, false)
-     |> put_flash(:info, "#{success_count} item(s) retried")
-     |> load_downloads()}
+      {:noreply,
+       socket
+       |> assign(:selected_ids, MapSet.new())
+       |> assign(:selection_mode, false)
+       |> put_flash(:info, "#{success_count} item(s) retried")
+       |> load_downloads()}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
   end
 
   def handle_event("batch_delete", _params, socket) do
-    selected_ids = MapSet.to_list(socket.assigns.selected_ids)
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      selected_ids = MapSet.to_list(socket.assigns.selected_ids)
 
-    results =
-      Enum.map(selected_ids, fn id ->
-        try do
-          download = Downloads.get_download!(id)
-          # Try to remove from client (ignore errors)
-          _ = Downloads.cancel_download(download, delete_files: true)
-          # Delete from database
-          Downloads.delete_download(download)
-        rescue
-          _ -> {:error, :failed}
-        end
-      end)
+      results =
+        Enum.map(selected_ids, fn id ->
+          try do
+            download = Downloads.get_download!(id)
+            # Try to remove from client (ignore errors)
+            _ = Downloads.cancel_download(download, delete_files: true)
+            # Delete from database
+            Downloads.delete_download(download)
+          rescue
+            _ -> {:error, :failed}
+          end
+        end)
 
-    success_count = Enum.count(results, fn {status, _} -> status == :ok end)
+      success_count = Enum.count(results, fn {status, _} -> status == :ok end)
 
-    {:noreply,
-     socket
-     |> assign(:selected_ids, MapSet.new())
-     |> assign(:selection_mode, false)
-     |> put_flash(:info, "#{success_count} download(s) removed")
-     |> load_downloads()}
+      {:noreply,
+       socket
+       |> assign(:selected_ids, MapSet.new())
+       |> assign(:selection_mode, false)
+       |> put_flash(:info, "#{success_count} download(s) removed")
+       |> load_downloads()}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
   end
 
   def handle_event("open_clear_completed_modal", _params, socket) do

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -450,14 +450,14 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   def handle_event("toggle_delete_files", params, socket) do
-    {:noreply, assign(socket, :delete_files, Map.get(params, "delete_files") == "true")}
+    {:noreply, assign(socket, :delete_files, delete_files?(params))}
   end
 
   def handle_event("clear_completed", params, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
       # Phoenix checkboxes submit the string "true" (or omit the key); coerce to
       # a real boolean so the adapter's [delete_files: boolean()] contract holds.
-      delete_files = Map.get(params, "delete_files") == "true"
+      delete_files = delete_files?(params)
       {:ok, count} = Downloads.clear_all_completed(delete_files: delete_files)
 
       message =
@@ -687,14 +687,23 @@ defmodule MydiaWeb.DownloadsLive.Index do
   def handle_info({:download_updated, _download_id}, socket) do
     # Reload downloads when we receive an update
     # In a real implementation, we might want to just update the specific download
-    {:noreply, load_downloads(socket)}
+    {:noreply, socket |> maybe_refresh_clearable_count() |> load_downloads()}
   end
 
   def handle_info({:search_completed, _media_item_id, _stats}, socket) do
-    {:noreply, load_downloads(socket)}
+    {:noreply, socket |> maybe_refresh_clearable_count() |> load_downloads()}
   end
 
   # Private functions
+
+  # Keeps the Clear Completed modal's blast-radius count fresh if a background
+  # update lands while the (destructive) modal is open. The submit flash always
+  # reports the authoritative recomputed count regardless.
+  defp maybe_refresh_clearable_count(%{assigns: %{show_clear_modal: true}} = socket) do
+    assign(socket, :clearable_count, Downloads.count_completed())
+  end
+
+  defp maybe_refresh_clearable_count(socket), do: socket
 
   defp reload_stream(socket) do
     case socket.assigns.active_tab do
@@ -709,6 +718,9 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   defp maybe_add_opt(opts, _key, nil), do: opts
   defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  # Phoenix checkboxes submit "true" when checked and omit the key when not.
+  defp delete_files?(params), do: Map.get(params, "delete_files") == "true"
 
   defp load_downloads(socket) do
     case socket.assigns.active_tab do

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -75,6 +75,10 @@ defmodule MydiaWeb.DownloadsLive.Index do
      |> assign(:selection_mode, false)
      |> assign(:page, 0)
      |> assign(:has_more, true)
+     # Clear-completed modal state
+     |> assign(:show_clear_modal, false)
+     |> assign(:delete_files, false)
+     |> assign(:clearable_count, 0)
      # Issues tab state
      |> assign(:issues_counts, %{unmatched: 0, unresolved: 0, other: 0})
      |> assign(:search_open_for, nil)
@@ -420,16 +424,49 @@ defmodule MydiaWeb.DownloadsLive.Index do
      |> load_downloads()}
   end
 
-  def handle_event("clear_completed", _params, socket) do
+  def handle_event("open_clear_completed_modal", _params, socket) do
+    # Opening the modal is non-destructive, so it is ungated (the button renders
+    # for everyone, matching prior behavior). The destructive submit is gated.
+    {:noreply,
+     socket
+     |> assign(:show_clear_modal, true)
+     |> assign(:delete_files, false)
+     |> assign(:clearable_count, Downloads.count_completed())}
+  end
+
+  def handle_event("close_clear_completed_modal", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:show_clear_modal, false)
+     |> assign(:delete_files, false)}
+  end
+
+  def handle_event("toggle_delete_files", params, socket) do
+    {:noreply, assign(socket, :delete_files, Map.get(params, "delete_files") == "true")}
+  end
+
+  def handle_event("clear_completed", params, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      {:ok, count} = Downloads.clear_all_completed()
+      # Phoenix checkboxes submit the string "true" (or omit the key); coerce to
+      # a real boolean so the adapter's [delete_files: boolean()] contract holds.
+      delete_files = Map.get(params, "delete_files") == "true"
+      {:ok, count} = Downloads.clear_all_completed(delete_files: delete_files)
+
+      message =
+        if delete_files do
+          "#{count} completed download(s) cleared and files deleted from disk"
+        else
+          "#{count} completed download(s) cleared"
+        end
 
       {:noreply,
        socket
-       |> put_flash(:info, "#{count} completed download(s) cleared")
+       |> assign(:show_clear_modal, false)
+       |> assign(:delete_files, false)
+       |> put_flash(:info, message)
        |> load_downloads()}
     else
-      {:unauthorized, socket} -> {:noreply, socket}
+      {:unauthorized, socket} -> {:noreply, assign(socket, :show_clear_modal, false)}
     end
   end
 

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -11,6 +11,13 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   @default_sort "added_desc"
 
+  # While a download is in flight, its progress (debrid swarm %, local fetch %)
+  # is synthesized live from the client/provider on each poll and is NOT
+  # persisted to the DB. PubSub broadcasts only fire on DB row changes, so
+  # without a periodic re-render the bar freezes at whatever it showed at page
+  # load. This timer re-polls + re-renders the Queue while work is active.
+  @progress_refresh_interval_ms 3_000
+
   # Sort options offered per tab. Real-time keys (progress, speeds, ETA, ratio)
   # only exist after client-status enrichment, so sorting runs in the LiveView
   # over the enriched list (see apply_sorting/2), not in the DB query.
@@ -64,6 +71,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
     # Subscribe to download updates for real-time progress
     if connected?(socket) do
       PubSub.subscribe(Mydia.PubSub, "downloads")
+      schedule_progress_refresh()
     end
 
     {:ok,
@@ -694,7 +702,29 @@ defmodule MydiaWeb.DownloadsLive.Index do
     {:noreply, socket |> maybe_refresh_clearable_count() |> load_downloads()}
   end
 
+  # Periodic live-progress refresh. Reschedules unconditionally so it resumes
+  # when the operator switches back to the Queue or a new download starts, but
+  # only re-polls clients when the Queue tab actually has active work — idle
+  # tabs cost nothing.
+  def handle_info(:refresh_progress, socket) do
+    schedule_progress_refresh()
+
+    socket =
+      if socket.assigns.active_tab == :queue and not socket.assigns.downloads_empty? and
+           not socket.assigns.selection_mode do
+        load_downloads(socket)
+      else
+        socket
+      end
+
+    {:noreply, socket}
+  end
+
   # Private functions
+
+  defp schedule_progress_refresh do
+    Process.send_after(self(), :refresh_progress, @progress_refresh_interval_ms)
+  end
 
   # Keeps the Clear Completed modal's blast-radius count fresh if a background
   # update lands while the (destructive) modal is open. The submit flash always
@@ -918,6 +948,14 @@ defmodule MydiaWeb.DownloadsLive.Index do
   defp format_progress(nil), do: 0.0
   defp format_progress(progress), do: Float.round(progress * 1.0, 1)
 
+  # A percentage is only meaningful when the client is reporting a real
+  # byte-for-byte transfer. Provider-side waits — debrid magnet conversion,
+  # queueing for a download slot ("queued"), or remote packaging
+  # ("checking") — have no measurable percentage. Rendering a 0%-filled bar
+  # there reads as "stuck"; these phases get an indeterminate (animated) bar
+  # plus the phase label instead of a frozen "0%".
+  defp progress_indeterminate?(download), do: download.status in ["queued", "checking"]
+
   defp get_metadata_value(download, key) do
     metadata_map = download.metadata || %{}
 
@@ -947,6 +985,17 @@ defmodule MydiaWeb.DownloadsLive.Index do
       "paused" -> "badge-warning"
       "stalled" -> "badge-warning"
       _ -> "badge-ghost"
+    end
+  end
+
+  # Color modifier for the DaisyUI `status` dot shown at the start of each row.
+  defp status_dot_class(status) do
+    case status do
+      s when s in ["downloading", "seeding", "completed", "imported"] -> "status-success"
+      s when s in ["failed", "missing"] -> "status-error"
+      s when s in ["cancelled", "stalled", "paused"] -> "status-warning"
+      s when s in ["checking", "queued"] -> "status-info"
+      _ -> "status-neutral"
     end
   end
 

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -41,38 +41,38 @@
       </div>
     </div>
 
-    <%!-- Tabs --%>
-    <div role="tablist" class="tabs tabs-border mb-6">
-      <button
-        role="tab"
-        class={["tab", @active_tab == :queue && "tab-active"]}
-        phx-click="switch_tab"
-        phx-value-tab="queue"
-      >
-        <.icon name="hero-arrow-down-tray" class="w-4 h-4 mr-1" /> Queue
-      </button>
-      <button
-        role="tab"
-        class={["tab", @active_tab == :completed && "tab-active"]}
-        phx-click="switch_tab"
-        phx-value-tab="completed"
-      >
-        <.icon name="hero-check-circle" class="w-4 h-4 mr-1" /> Completed
-      </button>
-      <button
-        role="tab"
-        class={["tab", @active_tab == :issues && "tab-active"]}
-        phx-click="switch_tab"
-        phx-value-tab="issues"
-      >
-        <.icon name="hero-exclamation-triangle" class="w-4 h-4 mr-1" /> Issues
-      </button>
-    </div>
+    <%!-- Toolbar: tabs + sort on one row --%>
+    <div class="flex items-end justify-between gap-4 flex-wrap mb-4 border-b border-base-300">
+      <div role="tablist" class="tabs tabs-border -mb-px">
+        <button
+          role="tab"
+          class={["tab", @active_tab == :queue && "tab-active"]}
+          phx-click="switch_tab"
+          phx-value-tab="queue"
+        >
+          <.icon name="hero-arrow-down-tray" class="w-4 h-4 mr-1" /> Queue
+        </button>
+        <button
+          role="tab"
+          class={["tab", @active_tab == :completed && "tab-active"]}
+          phx-click="switch_tab"
+          phx-value-tab="completed"
+        >
+          <.icon name="hero-check-circle" class="w-4 h-4 mr-1" /> Completed
+        </button>
+        <button
+          role="tab"
+          class={["tab", @active_tab == :issues && "tab-active"]}
+          phx-click="switch_tab"
+          phx-value-tab="issues"
+        >
+          <.icon name="hero-exclamation-triangle" class="w-4 h-4 mr-1" /> Issues
+        </button>
+      </div>
 
-    <%!-- Sort control (Queue/Completed tabs, non-empty only) --%>
-    <%= if @active_tab != :issues and not @downloads_empty? do %>
-      <div class="flex justify-end mb-4">
-        <form phx-change="sort" id="downloads-sort-form">
+      <%!-- Sort control (Queue/Completed tabs, non-empty only) --%>
+      <%= if @active_tab != :issues and not @downloads_empty? do %>
+        <form phx-change="sort" id="downloads-sort-form" class="pb-2">
           <label class="sr-only" for="downloads-sort">Sort downloads</label>
           <select
             id="downloads-sort"
@@ -89,8 +89,8 @@
             </option>
           </select>
         </form>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
 
     <%!-- Batch action bar --%>
     <%= if MapSet.size(@selected_ids) > 0 do %>
@@ -152,11 +152,15 @@
         phx-viewport-bottom="load_more"
         class="list bg-base-100 rounded-box shadow-lg"
       >
-        <li :for={{id, download} <- @streams.downloads} id={id} class="list-row py-2">
+        <li
+          :for={{id, download} <- @streams.downloads}
+          id={id}
+          class="list-row items-center gap-3 py-2.5 hover:bg-base-300/40 transition-colors"
+        >
           <%!-- Checkbox (only shown in selection mode) --%>
           <div class={[
             "transition-all",
-            (@selection_mode && "w-auto") || "w-0 opacity-0 overflow-hidden"
+            (@selection_mode && "w-auto opacity-100") || "w-0 opacity-0 overflow-hidden"
           ]}>
             <input
               type="checkbox"
@@ -168,181 +172,167 @@
             />
           </div>
           <%!-- Content --%>
-          <div class="list-col-grow">
-            <div class="font-medium text-sm truncate">
-              <%= if media_type_badge(download) do %>
-                <% {icon, _label, _badge_class} = media_type_badge(download) %>
-                <span class="text-xs opacity-50 mr-1">{icon}</span>
-              <% end %>
-              {download.title}
-            </div>
-            <%= if get_display_title(download) != download.title do %>
-              <div class="text-xs text-base-content/50 truncate">
-                {get_display_title(download)}
-                <%= if get_episode_details(download) do %>
-                  <span>- {get_episode_details(download)}</span>
-                <% end %>
-              </div>
-            <% end %>
-            <div class="text-xs opacity-60 flex flex-wrap items-center gap-1.5">
-              <% {badge_class, badge_label} = status_badge(download) %>
-              <span class={"badge badge-xs #{badge_class}"}>
-                {badge_label}
+          <div class="list-col-grow min-w-0">
+            <%!-- Line 1: status dot + title + episode --%>
+            <div class="flex items-center gap-2 min-w-0">
+              <% {_badge_class, status_label} = status_badge(download) %>
+              <span
+                class={["status status-md shrink-0", status_dot_class(download.status)]}
+                title={status_label}
+                aria-label={status_label}
+              >
               </span>
-              <%= if download.indexer do %>
-                <span>{download.indexer}</span>
+              <span class="font-medium text-sm truncate">{get_display_title(download)}</span>
+              <%= if get_episode_details(download) do %>
+                <span class="text-xs text-base-content/50 shrink-0 truncate">
+                  {get_episode_details(download)}
+                </span>
               <% end %>
+            </div>
+            <%!-- Line 2: release title (muted), only when it differs from the display title --%>
+            <%= if get_display_title(download) != download.title do %>
+              <div class="text-xs text-base-content/40 truncate">{download.title}</div>
+            <% end %>
+            <%!-- Line 3: compact metadata cluster (every metric carries an icon) --%>
+            <div class="flex items-center gap-x-3 gap-y-1 flex-wrap mt-1 text-xs text-base-content/60">
+              <% quality_str = QualityInfo.format(get_metadata_value(download, "quality")) %>
+              <span :if={quality_str && quality_str != ""} class="badge badge-ghost badge-sm">
+                {quality_str}
+              </span>
+              <% protocol = format_protocol(get_metadata_value(download, "download_protocol")) %>
+              <span :if={protocol} class="badge badge-ghost badge-sm">{protocol}</span>
+
               <%= if @active_tab == :queue do %>
-                <span>•</span>
-                <span>{format_progress(download.progress)}%</span>
-                <span>•</span>
-                <span>Speed: {format_speed(download.download_speed)}</span>
-                <span>•</span>
-                <span>{format_size(download.size)}</span>
-                <span>•</span>
-                <span>ETA: {format_eta(download.eta)}</span>
-                <%= if get_metadata_value(download, "seeders") do %>
-                  <span>•</span>
-                  <span>{get_metadata_value(download, "seeders")} seeds</span>
-                <% end %>
+                <span class="inline-flex items-center gap-1" title="Download speed">
+                  <.icon name="hero-arrow-down-tray" class="size-3 opacity-70" />{format_speed(
+                    download.download_speed
+                  )}
+                </span>
+                <span class="inline-flex items-center gap-1 tabular-nums" title="Size">
+                  <.icon name="hero-circle-stack" class="size-3 opacity-70" />{format_size(
+                    download.size
+                  )}
+                </span>
+                <span class="inline-flex items-center gap-1" title="Time remaining">
+                  <.icon name="hero-clock" class="size-3 opacity-70" />{format_eta(download.eta)}
+                </span>
+                <span
+                  :if={get_metadata_value(download, "seeders")}
+                  class="inline-flex items-center gap-1"
+                  title="Seeders"
+                >
+                  <.icon name="hero-users" class="size-3 opacity-70" />{get_metadata_value(
+                    download,
+                    "seeders"
+                  )}
+                </span>
               <% end %>
               <%= if @active_tab == :completed do %>
-                <span>•</span>
-                <span>Ratio: {format_ratio(download.ratio)}</span>
-                <span>•</span>
-                <span>↑ {format_speed(download.upload_speed)}</span>
-                <span>•</span>
-                <span>Uploaded: {format_size(download.uploaded)}</span>
-                <span>•</span>
-                <span>{format_size(download.size)}</span>
-                <%= if download.imported_at do %>
-                  <span>•</span>
-                  <span>Imported: {format_relative_time(download.imported_at)}</span>
-                <% end %>
+                <span class="inline-flex items-center gap-1" title="Upload speed">
+                  <.icon name="hero-arrow-up-tray" class="size-3 opacity-70" />{format_speed(
+                    download.upload_speed
+                  )}
+                </span>
+                <span class="inline-flex items-center gap-1" title="Share ratio">
+                  <.icon name="hero-scale" class="size-3 opacity-70" />{format_ratio(
+                    download.ratio
+                  )}
+                </span>
+                <span class="inline-flex items-center gap-1 tabular-nums" title="Size">
+                  <.icon name="hero-circle-stack" class="size-3 opacity-70" />{format_size(
+                    download.size
+                  )}
+                </span>
+                <span
+                  :if={download.imported_at}
+                  class="inline-flex items-center gap-1 text-success/80"
+                  title="Imported"
+                >
+                  <.icon name="hero-check-circle" class="size-3" />{format_relative_time(
+                    download.imported_at
+                  )}
+                </span>
               <% end %>
-            </div>
-            <%= if @active_tab == :queue do %>
-              <progress
-                class="progress progress-primary w-full h-1 mt-0.5"
-                value={format_progress(download.progress)}
-                max="100"
+              <span
+                :if={download.download_client}
+                class="inline-flex items-center gap-1"
+                title="Download client"
               >
-              </progress>
+                <.icon name="hero-server" class="size-3 opacity-70" />{download.download_client}
+              </span>
+            </div>
+            <%!-- Line 4: thin inline progress (queue only) --%>
+            <%= if @active_tab == :queue do %>
+              <div class="flex items-center gap-2 mt-1.5">
+                <%= if progress_indeterminate?(download) do %>
+                  <%!-- No measurable %: animated bar + phase label, not a frozen 0% --%>
+                  <% {_class, phase_label} = status_badge(download) %>
+                  <progress class="progress h-1.5 flex-1"></progress>
+                  <span class="text-xs text-base-content/60 shrink-0 whitespace-nowrap w-16 text-right">
+                    {phase_label}
+                  </span>
+                <% else %>
+                  <progress
+                    class="progress progress-primary h-1.5 flex-1"
+                    value={format_progress(download.progress)}
+                    max="100"
+                  >
+                  </progress>
+                  <span class="text-xs tabular-nums text-base-content/70 shrink-0 whitespace-nowrap w-12 text-right">
+                    {format_progress(download.progress)}%
+                  </span>
+                <% end %>
+              </div>
             <% end %>
           </div>
           <%!-- Action buttons --%>
-          <div>
+          <div class="flex items-center gap-1 shrink-0">
             <%= cond do %>
               <% @active_tab == :queue -> %>
-                <div class="flex gap-1">
-                  <%= if download.status == "paused" do %>
-                    <button
-                      type="button"
-                      class="btn btn-square btn-ghost btn-sm"
-                      phx-click="resume_download"
-                      phx-value-id={download.id}
-                      title="Resume download"
-                    >
-                      <.icon name="hero-play" class="size-4" />
-                    </button>
-                  <% else %>
-                    <button
-                      type="button"
-                      class="btn btn-square btn-ghost btn-sm"
-                      phx-click="pause_download"
-                      phx-value-id={download.id}
-                      title="Pause download"
-                    >
-                      <.icon name="hero-pause" class="size-4" />
-                    </button>
-                  <% end %>
+                <%= if download.status == "paused" do %>
                   <button
                     type="button"
                     class="btn btn-square btn-ghost btn-sm"
-                    phx-click="cancel_download"
+                    phx-click="resume_download"
                     phx-value-id={download.id}
-                    data-confirm="Cancel this download?"
-                    title="Cancel download"
+                    title="Resume download"
                   >
-                    <.icon name="hero-x-mark" class="size-4" />
+                    <.icon name="hero-play" class="size-4" />
                   </button>
-                </div>
+                <% else %>
+                  <button
+                    type="button"
+                    class="btn btn-square btn-ghost btn-sm"
+                    phx-click="pause_download"
+                    phx-value-id={download.id}
+                    title="Pause download"
+                  >
+                    <.icon name="hero-pause" class="size-4" />
+                  </button>
+                <% end %>
+                <button
+                  type="button"
+                  class="btn btn-square btn-ghost btn-sm hover:btn-error"
+                  phx-click="cancel_download"
+                  phx-value-id={download.id}
+                  data-confirm="Cancel this download?"
+                  title="Cancel download"
+                >
+                  <.icon name="hero-x-mark" class="size-4" />
+                </button>
               <% @active_tab == :completed -> %>
-                <div class="flex gap-1">
-                  <button
-                    type="button"
-                    class="btn btn-square btn-ghost btn-sm"
-                    phx-click="clear_single_completed"
-                    phx-value-id={download.id}
-                    data-confirm="Remove from client and clear from history?"
-                    title="Clear completed download"
-                  >
-                    <.icon name="hero-trash" class="size-4" />
-                  </button>
-                </div>
+                <button
+                  type="button"
+                  class="btn btn-square btn-ghost btn-sm hover:btn-error"
+                  phx-click="clear_single_completed"
+                  phx-value-id={download.id}
+                  data-confirm="Remove from client and clear from history?"
+                  title="Clear completed download"
+                >
+                  <.icon name="hero-trash" class="size-4" />
+                </button>
               <% true -> %>
-                <div></div>
             <% end %>
-          </div>
-          <%!-- Expandable raw details --%>
-          <div class="list-col-wrap col-span-full">
-            <details class="group w-full">
-              <summary class="text-sm text-base-content/70 cursor-pointer hover:text-base-content flex items-center gap-1.5 py-1">
-                <.icon
-                  name="hero-chevron-right"
-                  class="w-3.5 h-3.5 transition-transform group-open:rotate-90"
-                /> Details
-              </summary>
-              <div class="flex flex-col gap-1.5 mt-1 text-sm text-base-content pb-1">
-                <%= if download.download_client do %>
-                  <div>
-                    <span class="text-base-content/60">Client</span>
-                    <p class="mt-0.5">{download.download_client}</p>
-                  </div>
-                <% end %>
-                <% protocol = format_protocol(get_metadata_value(download, "download_protocol")) %>
-                <%= if protocol do %>
-                  <div>
-                    <span class="text-base-content/60">Protocol</span>
-                    <p class="mt-0.5">
-                      <span class="badge badge-xs badge-outline">{protocol}</span>
-                    </p>
-                  </div>
-                <% end %>
-                <% quality = get_metadata_value(download, "quality") %>
-                <% quality_str = QualityInfo.format(quality) %>
-                <%= if quality_str && quality_str != "" do %>
-                  <div>
-                    <span class="text-base-content/60">Quality</span>
-                    <p class="mt-0.5">
-                      <span class="badge badge-xs badge-outline">{quality_str}</span>
-                    </p>
-                  </div>
-                <% end %>
-                <%= if download.save_path do %>
-                  <div>
-                    <span class="text-base-content/60">Save Path</span>
-                    <p class="font-mono text-base-content/80 break-all mt-0.5">
-                      {download.save_path}
-                    </p>
-                  </div>
-                <% end %>
-                <%= if download.download_client_id do %>
-                  <div>
-                    <span class="text-base-content/60">Client ID</span>
-                    <p class="font-mono text-base-content/80 break-all mt-0.5">
-                      {download.download_client_id}
-                    </p>
-                  </div>
-                <% end %>
-                <%= if download.inserted_at do %>
-                  <div>
-                    <span class="text-base-content/60">Added</span>
-                    <p class="mt-0.5">{format_relative_time(download.inserted_at)}</p>
-                  </div>
-                <% end %>
-              </div>
-            </details>
           </div>
         </li>
       </ul>

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -70,6 +70,29 @@
       </button>
     </div>
 
+    <%!-- Sort control (Queue/Completed tabs, non-empty only) --%>
+    <%= if @active_tab != :issues and not @downloads_empty? do %>
+      <div class="flex justify-end mb-4">
+        <form phx-change="sort" id="downloads-sort-form">
+          <label class="sr-only" for="downloads-sort">Sort downloads</label>
+          <select
+            id="downloads-sort"
+            name="sort_by"
+            class="select select-bordered select-sm w-full sm:w-auto"
+            title="Sort downloads"
+          >
+            <option
+              :for={{value, label} <- sort_options(@active_tab)}
+              value={value}
+              selected={@sort_by == value}
+            >
+              {label}
+            </option>
+          </select>
+        </form>
+      </div>
+    <% end %>
+
     <%!-- Batch action bar --%>
     <%= if MapSet.size(@selected_ids) > 0 do %>
       <div class="alert mb-4 shadow-lg">

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -33,8 +33,7 @@
         <button
           type="button"
           class="btn btn-sm btn-ghost"
-          phx-click="clear_completed"
-          data-confirm="Clear all completed downloads from history?"
+          phx-click="open_clear_completed_modal"
         >
           <.icon name="hero-trash" class="w-4 h-4" />
           <span class="hidden sm:inline ml-1">Clear Completed</span>
@@ -687,5 +686,50 @@
         </div>
       </div>
     <% end %>
+
+    <%!-- Clear Completed modal (with opt-in delete-from-disk) --%>
+    <.modal
+      id="clear-completed-modal"
+      show={@show_clear_modal}
+      on_cancel="close_clear_completed_modal"
+    >
+      <:title>Clear completed downloads</:title>
+      <form
+        id="clear-completed-form"
+        phx-change="toggle_delete_files"
+        phx-submit="clear_completed"
+      >
+        <p class="text-base-content/80">
+          This clears {@clearable_count} completed download(s) from the queue and
+          removes them from the download client.
+        </p>
+        <label class="label cursor-pointer justify-start gap-3 mt-4">
+          <input
+            type="checkbox"
+            name="delete_files"
+            value="true"
+            checked={@delete_files}
+            class="checkbox checkbox-error"
+          />
+          <span class="label-text">Also permanently delete the downloaded files from disk</span>
+        </label>
+        <p :if={@delete_files} class="text-error text-sm mt-2 flex items-center gap-1">
+          <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
+          This permanently deletes files for {@clearable_count} download(s) from disk. This cannot be undone.
+        </p>
+      </form>
+      <:actions>
+        <button type="button" class="btn btn-ghost" phx-click="close_clear_completed_modal">
+          Cancel
+        </button>
+        <button
+          type="submit"
+          form="clear-completed-form"
+          class={["btn", (@delete_files && "btn-error") || "btn-primary"]}
+        >
+          {if @delete_files, do: "Clear and Delete Files", else: "Clear Completed"}
+        </button>
+      </:actions>
+    </.modal>
   </div>
 </Layouts.app>

--- a/test/mydia/downloads/queue_test.exs
+++ b/test/mydia/downloads/queue_test.exs
@@ -9,9 +9,14 @@ defmodule Mydia.Downloads.QueueTest do
   use Mydia.DataCase, async: false
 
   alias Mydia.Downloads.Queue
+  alias Mydia.Downloads.Client.Registry
+  alias Mydia.Downloads.Download
+  alias Mydia.Repo
   alias Mydia.Settings.DownloadClientConfig
 
   import Mydia.MediaFixtures
+  import Mydia.DownloadsFixtures
+  import Mydia.SettingsFixtures
 
   describe "resolve_content_type/1" do
     test "episode_id present -> tv" do
@@ -209,6 +214,124 @@ defmodule Mydia.Downloads.QueueTest do
       Mydia.Downloads.Client in behaviours
     rescue
       _ -> false
+    end
+  end
+
+  # Adapter that records the opts passed to remove_torrent/3 so we can prove the
+  # delete_files flag reaches the client. The existing MockAdapter in
+  # downloads_test.exs discards opts, so we need our own capturing stub here.
+  defmodule CaptureAdapter do
+    @behaviour Mydia.Downloads.Client
+
+    @impl true
+    def supported_protocols, do: [:torrent]
+    @impl true
+    def test_connection(_config), do: {:ok, %{version: "1.0.0", api_version: "1.0"}}
+    @impl true
+    def add_torrent(_config, _torrent, _opts), do: {:ok, "capture-id"}
+    @impl true
+    def get_status(_config, _client_id), do: {:ok, %{}}
+    @impl true
+    def list_torrents(_config, _opts), do: {:ok, []}
+    @impl true
+    def pause_torrent(_config, _client_id), do: :ok
+    @impl true
+    def resume_torrent(_config, _client_id), do: :ok
+
+    @impl true
+    def remove_torrent(_config, client_id, opts) do
+      if pid = Application.get_env(:mydia, :queue_capture_pid) do
+        send(pid, {:remove_torrent_called, client_id, opts})
+      end
+
+      :ok
+    end
+  end
+
+  describe "clear_completed/2 + clear_all_completed/1 delete_files plumbing" do
+    setup do
+      original =
+        case Registry.get_adapter(:qbittorrent) do
+          {:ok, adapter} -> adapter
+          {:error, _} -> nil
+        end
+
+      Registry.register(:qbittorrent, CaptureAdapter)
+      Application.put_env(:mydia, :queue_capture_pid, self())
+
+      on_exit(fn ->
+        Application.delete_env(:mydia, :queue_capture_pid)
+        if original, do: Registry.register(:qbittorrent, original)
+      end)
+
+      config =
+        download_client_config_fixture(%{
+          name: "capture-client",
+          type: "qbittorrent",
+          enabled: true
+        })
+
+      %{config: config}
+    end
+
+    defp imported_download(config) do
+      download_fixture(%{
+        download_client: config.name,
+        imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+    end
+
+    test "clear_completed/2 with delete_files: true sets the delete flag on the adapter", %{
+      config: config
+    } do
+      download = imported_download(config)
+
+      assert {:ok, _} = Queue.clear_completed(download, delete_files: true)
+
+      assert_received {:remove_torrent_called, _client_id, opts}
+      assert Keyword.get(opts, :delete_files) == true
+    end
+
+    test "clear_completed/2 without delete_files does not set the delete flag", %{config: config} do
+      download = imported_download(config)
+
+      assert {:ok, _} = Queue.clear_completed(download)
+
+      assert_received {:remove_torrent_called, _client_id, opts}
+      refute Keyword.get(opts, :delete_files) == true
+    end
+
+    test "clear_completed/2 deletes the DB record even when delete_files is true", %{
+      config: config
+    } do
+      download = imported_download(config)
+
+      assert {:ok, _} = Queue.clear_completed(download, delete_files: true)
+      assert Repo.get(Download, download.id) == nil
+    end
+
+    test "clear_all_completed/1 forwards delete_files to each imported download", %{
+      config: config
+    } do
+      _d1 = imported_download(config)
+      _d2 = imported_download(config)
+
+      assert {:ok, 2} = Queue.clear_all_completed(delete_files: true)
+
+      assert_received {:remove_torrent_called, _id1, opts1}
+      assert_received {:remove_torrent_called, _id2, opts2}
+      assert Keyword.get(opts1, :delete_files) == true
+      assert Keyword.get(opts2, :delete_files) == true
+    end
+
+    test "clear_all_completed/1 only targets imported downloads", %{config: config} do
+      imported = imported_download(config)
+      active = download_fixture(%{download_client: config.name})
+
+      assert {:ok, 1} = Queue.clear_all_completed(delete_files: true)
+
+      assert Repo.get(Download, imported.id) == nil
+      assert Repo.get(Download, active.id) != nil
     end
   end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -6,6 +6,8 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
   import Mydia.DownloadsFixtures
   import Mydia.MediaFixtures
 
+  alias Mydia.Downloads
+
   setup %{conn: conn} do
     admin = admin_user_fixture()
     %{conn: log_in_user(conn, admin), admin: admin}
@@ -112,6 +114,99 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       html = view |> element("#downloads-sort-form") |> render_change(%{"sort_by" => "bogus"})
       assert html =~ ~s(value="added_desc")
       assert has_element?(view, "#downloads-sort option[value='added_desc'][selected]")
+    end
+  end
+
+  describe "clear completed modal" do
+    test "opens with the delete-files checkbox off and a scope-accurate count", %{conn: conn} do
+      completed_download("Alpha Movie")
+      completed_download("Beta Movie")
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      refute has_element?(view, "#clear-completed-modal[open]")
+
+      html =
+        view |> element("button[phx-click='open_clear_completed_modal']") |> render_click()
+
+      assert has_element?(view, "#clear-completed-modal[open]")
+      assert html =~ "2 completed download(s)"
+      # Default (unchecked) confirm button is non-destructive.
+      assert html =~ "Clear Completed"
+      refute html =~ "Clear and Delete Files"
+    end
+
+    test "checking the box switches the confirm button to destructive", %{conn: conn} do
+      completed_download("Alpha Movie")
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      view |> element("button[phx-click='open_clear_completed_modal']") |> render_click()
+
+      html =
+        view |> element("#clear-completed-form") |> render_change(%{"delete_files" => "true"})
+
+      assert html =~ "Clear and Delete Files"
+      assert html =~ "btn-error"
+      assert html =~ "cannot be undone"
+    end
+
+    test "reopening the modal resets the checkbox", %{conn: conn} do
+      completed_download("Alpha Movie")
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      view |> element("button[phx-click='open_clear_completed_modal']") |> render_click()
+      view |> element("#clear-completed-form") |> render_change(%{"delete_files" => "true"})
+
+      view
+      |> element(".modal-action button[phx-click='close_clear_completed_modal']")
+      |> render_click()
+
+      html =
+        view |> element("button[phx-click='open_clear_completed_modal']") |> render_click()
+
+      assert html =~ "Clear and Delete Files" == false
+      assert html =~ "Clear Completed"
+    end
+
+    test "submitting without the box clears without deleting files", %{conn: conn} do
+      completed_download("Alpha Movie")
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      view |> element("button[phx-click='open_clear_completed_modal']") |> render_click()
+
+      html = view |> element("#clear-completed-form") |> render_submit(%{})
+
+      assert html =~ "completed download(s) cleared"
+      refute html =~ "files deleted from disk"
+      assert Downloads.count_completed() == 0
+    end
+
+    test "submitting with the box checked reports files deleted", %{conn: conn} do
+      completed_download("Alpha Movie")
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      view |> element("button[phx-click='open_clear_completed_modal']") |> render_click()
+
+      html =
+        view |> element("#clear-completed-form") |> render_submit(%{"delete_files" => "true"})
+
+      assert html =~ "cleared and files deleted from disk"
+      assert Downloads.count_completed() == 0
+    end
+
+    test "a readonly user cannot clear completed downloads", %{conn: conn} do
+      completed_download("Alpha Movie")
+      readonly = user_fixture(%{role: "readonly"})
+      conn = log_in_user(conn, readonly)
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      view |> element("button[phx-click='open_clear_completed_modal']") |> render_click()
+
+      html =
+        view |> element("#clear-completed-form") |> render_submit(%{"delete_files" => "true"})
+
+      assert html =~ "do not have permission"
+      assert Downloads.count_completed() == 1
     end
   end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -209,4 +209,31 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       assert Downloads.count_completed() == 1
     end
   end
+
+  describe "batch action authorization" do
+    test "a readonly user cannot batch-delete downloads", %{conn: conn} do
+      download = completed_download("Alpha Movie")
+      readonly = user_fixture(%{role: "readonly"})
+      conn = log_in_user(conn, readonly)
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      render_click(view, "toggle_select", %{"id" => download.id})
+      render_click(view, "batch_delete", %{})
+
+      # The download is untouched — the gate blocked the destructive handler.
+      assert Downloads.count_completed() == 1
+    end
+
+    test "an admin can batch-delete downloads", %{conn: conn} do
+      download = completed_download("Alpha Movie")
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      render_click(view, "toggle_select", %{"id" => download.id})
+      render_click(view, "batch_delete", %{})
+
+      assert Downloads.count_completed() == 0
+    end
+  end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -1,0 +1,117 @@
+defmodule MydiaWeb.DownloadsLive.IndexTest do
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.DownloadsFixtures
+  import Mydia.MediaFixtures
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin), admin: admin}
+  end
+
+  # No download client is configured in these tests, so list_downloads_with_status
+  # returns every download regardless of tab filter. That's fine here — we assert
+  # on sort ordering and control state, not on tab filtering or live client fields.
+
+  defp completed_download(title, attrs \\ %{}) do
+    media_item = media_item_fixture(%{title: title})
+
+    download_fixture(
+      Map.merge(
+        %{
+          media_item_id: media_item.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        },
+        attrs
+      )
+    )
+  end
+
+  # Returns the given substrings ordered by where they appear in the html.
+  defp order_in(html, substrings) do
+    substrings
+    |> Enum.map(fn s ->
+      {pos, _len} = :binary.match(html, s)
+      {s, pos}
+    end)
+    |> Enum.sort_by(fn {_s, pos} -> pos end)
+    |> Enum.map(fn {s, _pos} -> s end)
+  end
+
+  describe "sort control" do
+    test "defaults to newest-first and renders the control when rows exist", %{conn: conn} do
+      completed_download("Alpha Movie")
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      assert has_element?(view, "#downloads-sort")
+      assert has_element?(view, "#downloads-sort option[value='added_desc'][selected]")
+    end
+
+    test "is hidden when the active tab has no rows", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      refute has_element?(view, "#downloads-sort")
+    end
+
+    test "offers tab-appropriate options", %{conn: conn} do
+      completed_download("Alpha Movie")
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      # Queue tab: ETA is meaningful, ratio is not.
+      assert has_element?(view, "#downloads-sort option[value='eta_asc']")
+      refute has_element?(view, "#downloads-sort option[value='ratio_desc']")
+
+      html = view |> element("button[phx-value-tab='completed']") |> render_click()
+
+      # Completed tab: ratio/imported are meaningful, ETA is not.
+      assert html =~ "ratio_desc"
+      assert has_element?(view, "#downloads-sort option[value='ratio_desc']")
+      refute has_element?(view, "#downloads-sort option[value='eta_asc']")
+    end
+  end
+
+  describe "sorting rows" do
+    setup do
+      completed_download("Gamma Movie", %{metadata: %{size: 3_000_000_000}})
+      completed_download("Alpha Movie", %{metadata: %{size: 1_000_000_000}})
+      completed_download("Beta Movie", %{metadata: %{size: 2_000_000_000}})
+      :ok
+    end
+
+    test "sorts by name ascending and descending", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      titles = ["Alpha Movie", "Beta Movie", "Gamma Movie"]
+
+      html = view |> element("#downloads-sort-form") |> render_change(%{"sort_by" => "name_asc"})
+      assert order_in(html, titles) == ["Alpha Movie", "Beta Movie", "Gamma Movie"]
+      assert has_element?(view, "#downloads-sort option[value='name_asc'][selected]")
+
+      html = view |> element("#downloads-sort-form") |> render_change(%{"sort_by" => "name_desc"})
+      assert order_in(html, titles) == ["Gamma Movie", "Beta Movie", "Alpha Movie"]
+    end
+
+    test "sorts by size descending (largest first)", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      html = view |> element("#downloads-sort-form") |> render_change(%{"sort_by" => "size_desc"})
+
+      assert order_in(html, ["Alpha Movie", "Beta Movie", "Gamma Movie"]) ==
+               ["Gamma Movie", "Beta Movie", "Alpha Movie"]
+
+      assert has_element?(view, "#downloads-sort option[value='size_desc'][selected]")
+    end
+
+    test "an unknown sort value leaves the current sort unchanged", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      # No crash, default remains selected.
+      html = view |> element("#downloads-sort-form") |> render_change(%{"sort_by" => "bogus"})
+      assert html =~ ~s(value="added_desc")
+      assert has_element?(view, "#downloads-sort option[value='added_desc'][selected]")
+    end
+  end
+end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -164,7 +164,7 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       html =
         view |> element("button[phx-click='open_clear_completed_modal']") |> render_click()
 
-      assert html =~ "Clear and Delete Files" == false
+      refute html =~ "Clear and Delete Files"
       assert html =~ "Clear Completed"
     end
 
@@ -234,6 +234,21 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       render_click(view, "batch_delete", %{})
 
       assert Downloads.count_completed() == 0
+    end
+
+    test "a readonly user cannot batch-retry downloads", %{conn: conn} do
+      download = completed_download("Alpha Movie")
+      readonly = user_fixture(%{role: "readonly"})
+      conn = log_in_user(conn, readonly)
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      render_click(view, "toggle_select", %{"id" => download.id})
+      render_click(view, "batch_retry", %{})
+
+      # batch_retry deletes-and-reinitiates on success; the gate must leave the
+      # record untouched for a readonly user.
+      assert Downloads.count_completed() == 1
     end
   end
 end


### PR DESCRIPTION
## Summary

Addresses #171 — the downloads list is now **sortable** and completed files can be **deleted from disk** — and gives the Activity/Downloads page a compact, scannable redesign.

### Downloads (closes #171)
- **Sortable list** — tab-aware sort control (status, progress, size, ratio, speeds, ETA, age) with a visible active sort. Sorting runs over the enriched list so real-time keys are sortable, with deterministic handling of missing values.
- **Opt-in delete from disk** — "Clear Completed" now opens a modal with a default-off "delete files from disk" checkbox. The confirm button turns destructive (`btn-error`, "Clear and Delete Files") only when checked, and states a scope-accurate count. Rides the existing client-adapter `delete_files` plumbing — no adapter changes.
- **Auth hardening** — `batch_retry` / `batch_delete` are now gated behind manage-downloads authorization (they previously weren't, and `batch_delete` deletes files).
- **Compact layout** — each row is a tight block: a DaisyUI `status` dot (color-coded by state), a metadata cluster where every metric carries a consistent icon, inline progress, and quality/protocol as ghost badges. Drops the always-open per-row Details disclosure and merges the sort control onto the tab row.

### Also included (carried from the working tree)
- **config** — file-config support for debrid & blackhole download clients via a `connection_settings` map and `DOWNLOAD_CLIENT_<N>_PROVIDER`.
- **downloads** — status polling no longer crashes the whole Downloads view if one adapter raises; that client degrades to unreachable instead.
- **admin** — the active-stream/transcode card renders "Unknown" instead of raising when a stream has no associated user.

## Testing
- New `test/mydia_web/live/downloads_live/index_test.exs` — sort default / tab-aware options / ordering, clear-completed modal (default-off, destructive state, reopen reset, readonly denial), and batch-action authorization.
- `test/mydia/downloads/queue_test.exs` extended to prove `delete_files` reaches the client adapter and that only imported downloads are cleared.
- Full downloads area green: `./dev mix test test/mydia/downloads test/mydia_web/live/downloads_live` → 817 tests, 0 failures.

## Notes / limitations
- The delete-files option closes the disk-space gap for mydia-tracked imports. With an arr* stack also driving the client, torrents mydia never imported (no `imported_at`) aren't touched — accepted limitation.
- The runtime-selected `status-*` dot colors are safelisted via `@source inline(...)` in `app.css` so they build reliably.