### PR TITLE
fix(metadata-relay): deliver feedback email over Resend SMTP with verified TLS

### DIFF
--- a/infra/kubernetes/apps/metadata-relay/configmap.yaml
+++ b/infra/kubernetes/apps/metadata-relay/configmap.yaml
@@ -17,3 +17,12 @@ data:
 
   # Redis cache for distributed/persistent caching
   REDIS_URL: "redis://redis:6379"
+
+  # Feedback email notifications (delivered via Resend SMTP).
+  # The matching SMTP_PASSWORD (Resend API key) lives in the secret.
+  FEEDBACK_EMAIL_TO: "feedback@mydia.dev"
+  FEEDBACK_EMAIL_FROM: "feedback@mydia.dev"
+  FEEDBACK_DASHBOARD_URL: "https://relay.mydia.dev"
+  SMTP_HOST: "smtp.resend.com"
+  SMTP_PORT: "587"
+  SMTP_USERNAME: "resend"

--- a/infra/kubernetes/apps/metadata-relay/secret.yaml.example
+++ b/infra/kubernetes/apps/metadata-relay/secret.yaml.example
@@ -20,8 +20,10 @@ stringData:
   # Generate with: openssl rand -hex 32
   RENDEZVOUS_MASTER_PEPPER: "your-secure-random-pepper-here"
 
-  # REQUIRED when feedback email notifications are enabled
-  SMTP_PASSWORD: "your-smtp-password"
+  # REQUIRED when feedback email notifications are enabled.
+  # Using Resend SMTP (host/user/port are set in the configmap): this is the
+  # Resend API key (re_...). For any other SMTP provider, use its password.
+  SMTP_PASSWORD: "your-smtp-password-or-resend-api-key"
 
   # OPTIONAL: OpenSubtitles credentials (if subtitle support is needed)
   # OPENSUBTITLES_API_KEY: "your-opensubtitles-api-key"

--- a/metadata-relay/config/runtime.exs
+++ b/metadata-relay/config/runtime.exs
@@ -74,6 +74,15 @@ if config_env() != :test do
         password: smtp_password,
         auth: if(smtp_username && smtp_password, do: :always, else: :never),
         tls: :always,
+        tls_options: [
+          verify: :verify_peer,
+          cacerts: :public_key.cacerts_get(),
+          server_name_indication: String.to_charlist(smtp_host),
+          depth: 99,
+          customize_hostname_check: [
+            match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+          ]
+        ],
         retries: 2,
         no_mx_lookups: true
     else

--- a/metadata-relay/mix.exs
+++ b/metadata-relay/mix.exs
@@ -4,7 +4,7 @@ defmodule MetadataRelay.MixProject do
   def project do
     [
       app: :metadata_relay,
-      version: "0.10.0",
+      version: "0.10.1",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## What

The relay's SMTP mailer had no `tls_options`, so gen_smtp's STARTTLS handshake failed with `:tls_failed` on modern OTP (no CA trust, no hostname match). Feedback submissions were stored but the notification email **never sent** (this was pre-existing, not specific to Resend).

## Changes

- Add `tls_options` to the mailer SMTP config: `verify: :verify_peer`, system CA store via `:public_key.cacerts_get/0`, SNI, and the `:https` hostname match fun. Verified live via `rpc` that this delivers (`{:ok, ...}`) where the prior config returned `:tls_failed`.
- Point relay infra at Resend SMTP (`smtp.resend.com` / `feedback@mydia.dev`); `SMTP_PASSWORD` carries the Resend API key (stored in the k8s secret, not committed).
- Bump to 0.10.1.

## Deploy

Configmap + secret already applied to the cluster. Image deploying via tag `metadata-relay-v0.10.1`.