### PR TITLE
test(downloads): fix Postgres CI by running LiveView index test non-async

### DIFF
--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -1,5 +1,10 @@
 defmodule MydiaWeb.DownloadsLive.IndexTest do
-  use MydiaWeb.ConnCase, async: true
+  # Not async: a connected LiveView mount runs in a separate process from the
+  # test. Under PostgreSQL with async: true the sandbox is non-shared, so that
+  # process can't see the rows this test inserts, the download list renders
+  # empty, and the sort control (gated on rows existing) never appears. Shared
+  # mode (the non-async default) makes the inserted rows visible to the mount.
+  use MydiaWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
   import Mydia.AccountsFixtures


### PR DESCRIPTION
## Problem

The `CI / Test / PostgreSQL` job has been failing **5 tests** deterministically on `master` (since PR #172 merged), all in `MydiaWeb.DownloadsLive.IndexTest`:

- `sort control defaults to newest-first and renders the control when rows exist`
- `sort control offers tab-appropriate options`
- `sorting rows sorts by size descending`
- `sorting rows an unknown sort value leaves the current sort unchanged`
- `sorting rows sorts by name ascending and descending`

All fail the same way: `#downloads-sort` isn't in the DOM. The control is gated on `not @downloads_empty?`, so the real symptom is that **no download rows render**. SQLite passes; only Postgres fails. It looks flaky but is fully deterministic.

## Root cause

`test/support/data_case.ex` sets up the sandbox as `start_owner!(repo, shared: not tags[:async])`:

- **SQLite** forces `async: false` → shared mode → the connected LiveView process (separate from the test) sees the inserted rows.
- **Postgres** honors this file's `async: true` → non-shared mode → the LiveView mount process runs on a different connection and can't see the test's uncommitted rows. The list renders empty and the sort control never appears.

This test file was created `async: true` in #172 and has never passed on the Postgres job. Every other connected-LiveView test in the repo is non-async for exactly this reason (the only other `async: true` LiveView test, `authorization_test.exs`, builds a mock socket and never mounts).

## Fix

Flip the file to `async: false` (with an explanatory comment), matching the rest of the suite. Shared mode makes the inserted rows visible to the mount on both engines.

## Verification

Could not run locally (Docker daemon down, and the host rustup toolchain can't link the p2p NIF under `nix develop` — both unrelated environment issues). Relying on CI to confirm green. `mix format --check-formatted` passes on the changed file.