### PR TITLE
test(downloads): restore runtime_config after job tests to stop client leak

### DIFF
--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1153,7 +1153,19 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       download_clients: download_clients
     }
 
+    # Capture and restore the prior value. `:runtime_config` is global
+    # Application state (test_helper.exs forces empty download_clients at boot);
+    # leaving an enabled client here leaks into later tests, e.g. DownloadsLive,
+    # whose queue-tab filter then hides the completed downloads they seed.
+    previous = Application.get_env(:mydia, :runtime_config)
     Application.put_env(:mydia, :runtime_config, config)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:mydia, :runtime_config)
+        value -> Application.put_env(:mydia, :runtime_config, value)
+      end
+    end)
   end
 
   defp build_test_client_config(overrides \\ %{}) do

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -767,7 +767,19 @@ defmodule Mydia.Jobs.MediaImportTest do
       download_clients: download_clients
     }
 
+    # Capture and restore the prior value. `:runtime_config` is global
+    # Application state (test_helper.exs forces empty download_clients at boot);
+    # leaving an enabled client here leaks into later tests, e.g. DownloadsLive,
+    # whose queue-tab filter then hides the completed downloads they seed.
+    previous = Application.get_env(:mydia, :runtime_config)
     Application.put_env(:mydia, :runtime_config, config)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:mydia, :runtime_config)
+        value -> Application.put_env(:mydia, :runtime_config, value)
+      end
+    end)
   end
 
   defp build_test_client_config do


### PR DESCRIPTION
## Problem

`DownloadsLive.IndexTest` flakes in CI (~50%) — the sort control `#downloads-sort-form` renders absent and 5 tests fail with `expected selector "#downloads-sort-form" to return a single element, but got none`. It has hit both the PostgreSQL and SQLite test jobs on `master`.

## Root cause

`download_monitor_test.exs` and `media_import_test.exs` configure an **enabled** download client via `Application.put_env(:mydia, :runtime_config, ...)` in `setup_runtime_config/1` with **no restore** (29 call sites between them).

`:runtime_config` is global Application state; `test_helper.exs` boots it with `download_clients: []`. The unrestored `put_env` replaces that with an enabled client that persists into later tests. When `DownloadsLive.IndexTest` runs afterward (seed-dependent module ordering), `list_downloads_with_status` sees a configured client and applies the queue tab's `:active` filter — which excludes the completed (`imported_at`-set) downloads these tests seed. The list renders empty and the sort control (gated on rows existing) never appears.

`#172`'s `async: false` change addressed a genuine but **unrelated** connected-mount sandbox concern, which is why it never fixed this flake.

## Fix

`setup_runtime_config/1` now captures the prior `:runtime_config` and restores it in `on_exit`, so no test leaks an enabled client past its own lifetime.

## Verification

Reproduced deterministically against the full suite at **seed 22**:

| | downloads failures |
|---|---|
| without fix | **5** |
| with fix | **0** |

- Confirmed the mechanism independently by injecting an enabled runtime client into the downloads test setup → all 15 tests fail.
- `download_monitor`/`media_import` still pass with the fix (the `on_exit` restore runs only at teardown).