### PR TITLE
test(downloads): de-flake JobManager capacity tests and root-skip permission test

### DIFF
--- a/lib/mydia/downloads/job_manager.ex
+++ b/lib/mydia/downloads/job_manager.ex
@@ -243,7 +243,7 @@ defmodule Mydia.Downloads.JobManager do
           # Only try to stop if process is still alive
           if Process.alive?(job_info.pid) do
             try do
-              FfmpegMp4Transcoder.stop_transcoding(job_info.pid)
+              transcoder().stop_transcoding(job_info.pid)
             catch
               :exit, _ -> :ok
             end
@@ -389,7 +389,7 @@ defmodule Mydia.Downloads.JobManager do
         # Not registered, proceed
 
         # Start the transcoder
-        case FfmpegMp4Transcoder.start_transcoding(opts) do
+        case transcoder().start_transcoding(opts) do
           {:ok, pid} ->
             # Unlink from the transcoder process - we use Process.monitor instead
             # to avoid crashing the JobManager when a transcoder exits abnormally
@@ -406,7 +406,7 @@ defmodule Mydia.Downloads.JobManager do
 
               {:error, {:already_registered, _existing_pid}} ->
                 # Stop the transcoder we just started
-                FfmpegMp4Transcoder.stop_transcoding(pid)
+                transcoder().stop_transcoding(pid)
                 {:error, :already_registered}
             end
 
@@ -463,6 +463,12 @@ defmodule Mydia.Downloads.JobManager do
         # No more queued jobs
         state
     end
+  end
+
+  # Transcoder module, resolvable via config so tests can substitute a
+  # deterministic stand-in. Defaults to the real FFmpeg transcoder.
+  defp transcoder do
+    Application.get_env(:mydia, :transcoder_module, FfmpegMp4Transcoder)
   end
 
   # Log job completion or failure

--- a/test/mydia/downloads/job_manager_test.exs
+++ b/test/mydia/downloads/job_manager_test.exs
@@ -1,16 +1,26 @@
 defmodule Mydia.Downloads.JobManagerTest do
   use Mydia.DataCase, async: false
 
-  # These tests require FFmpeg to be installed
-  @moduletag :requires_ffmpeg
-
+  alias Mydia.Downloads.BlockingTranscoder
   alias Mydia.Downloads.JobManager
 
+  # Drive the JobManager with a deterministic transcoder whose jobs stay alive
+  # until explicitly stopped/finished. With the real FFmpeg transcoder a
+  # 1-second test clip completes faster than a test can fill capacity, so the
+  # slot a queueing assertion expects to be occupied intermittently freed up.
   setup do
+    previous = Application.get_env(:mydia, :transcoder_module)
+    Application.put_env(:mydia, :transcoder_module, BlockingTranscoder)
+
     cleanup_jobs()
 
     on_exit(fn ->
       cleanup_jobs()
+
+      case previous do
+        nil -> Application.delete_env(:mydia, :transcoder_module)
+        mod -> Application.put_env(:mydia, :transcoder_module, mod)
+      end
     end)
 
     :ok
@@ -335,17 +345,15 @@ defmodule Mydia.Downloads.JobManagerTest do
   end
 
   describe "automatic queue processing" do
-    @tag :slow
     test "automatically starts queued jobs when slots become available" do
       test_pid = self()
 
-      # Create very short test videos that transcode quickly
       input1 = create_minimal_test_video()
       input2 = create_minimal_test_video()
       input3 = create_minimal_test_video()
 
       # Start 2 jobs (at capacity)
-      {:ok, _pid1} =
+      {:ok, pid1} =
         JobManager.start_or_queue_job(
           media_file_id: "file1",
           resolution: :p720,
@@ -376,19 +384,17 @@ defmodule Mydia.Downloads.JobManagerTest do
       # Third job should be queued
       assert {:ok, :queued} = JobManager.get_job_status("file3", :p720)
 
-      # Wait for one of the first jobs to complete
-      assert_receive {:completed, completed_id}, 10_000
-      assert completed_id in ["file1", "file2"]
+      # Finish the first job, freeing a slot
+      BlockingTranscoder.finish(pid1)
+      assert_receive {:completed, "file1"}, 5_000
 
       # Give the manager a moment to process the queue
-      Process.sleep(200)
+      Process.sleep(100)
 
-      # Third job should now be running (or completed if it was very fast)
-      status = JobManager.get_job_status("file3", :p720)
-      assert status == {:ok, :running} or status == {:error, :not_found}
+      # Third job should now be promoted from the queue to running
+      assert {:ok, :running} = JobManager.get_job_status("file3", :p720)
 
-      # Clean up (files that might still be running)
-      JobManager.cancel_job("file1", :p720)
+      # Clean up still-running jobs
       JobManager.cancel_job("file2", :p720)
       JobManager.cancel_job("file3", :p720)
 
@@ -401,38 +407,16 @@ defmodule Mydia.Downloads.JobManagerTest do
 
   # Helper functions
 
+  # The JobManager test transcoder (BlockingTranscoder) ignores the input
+  # contents, so an empty placeholder file is enough — no FFmpeg required.
   defp create_test_video do
     create_minimal_test_video()
   end
 
   defp create_minimal_test_video do
-    # Create a minimal 1-second test video for actual transcoding tests
-    output_path = "/tmp/test_video_#{System.unique_integer([:positive])}.mp4"
-
-    # Use FFmpeg to create a 1-second test video
-    # This is a solid color video with no audio, very quick to create and transcode
-    System.cmd("ffmpeg", [
-      "-f",
-      "lavfi",
-      "-i",
-      "color=c=blue:s=320x240:d=1",
-      "-f",
-      "lavfi",
-      "-i",
-      "anullsrc=r=48000:cl=stereo",
-      "-t",
-      "1",
-      "-c:v",
-      "libx264",
-      "-preset",
-      "ultrafast",
-      "-c:a",
-      "aac",
-      "-y",
-      output_path
-    ])
-
-    output_path
+    path = "/tmp/test_video_#{System.unique_integer([:positive])}.mp4"
+    File.write!(path, "")
+    path
   end
 
   defp create_temp_output_path do

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -10,6 +10,15 @@ defmodule Mydia.Jobs.MediaImportTest do
 
   @moduletag :tmp_dir
 
+  # `chmod 000` does not restrict the root user, so a permission-denied path is
+  # unobservable when the suite runs as root (as it does in some Docker images).
+  # Tests that depend on it are skipped there rather than asserting behaviour
+  # that cannot occur.
+  @running_as_root (case System.cmd("id", ["-u"]) do
+                      {out, 0} -> String.trim(out) == "0"
+                      _ -> false
+                    end)
+
   describe "Args.parse/1" do
     test "parses save_path from job args" do
       args = MediaImport.Args.parse(%{"download_id" => "123", "save_path" => "/downloads/movie"})
@@ -690,6 +699,7 @@ defmodule Mydia.Jobs.MediaImportTest do
     end
 
     @tag :tmp_dir
+    @tag skip: @running_as_root and "chmod 000 does not restrict root; path stays accessible"
     test "cancels inaccessible path after the third attempt and clears retry metadata",
          %{tmp_dir: tmp_dir} do
       media_item =

--- a/test/support/blocking_transcoder.ex
+++ b/test/support/blocking_transcoder.ex
@@ -1,0 +1,50 @@
+defmodule Mydia.Downloads.BlockingTranscoder do
+  @moduledoc """
+  Deterministic stand-in for `Mydia.Downloads.FfmpegMp4Transcoder` used by
+  `JobManager` tests.
+
+  A started job stays alive (occupying a capacity slot) until it is explicitly
+  stopped via `stop_transcoding/1` or told to finish via `finish/1`. This lets
+  capacity and queueing assertions hold without racing real FFmpeg timing —
+  a 1-second test clip otherwise transcodes faster than a test can fill
+  capacity, intermittently freeing the slot the test expects to be occupied.
+
+  Implements the same surface `JobManager` calls on the transcoder:
+  `start_transcoding/1` and `stop_transcoding/1`.
+  """
+
+  use GenServer
+
+  @doc "Starts a blocking transcoder process that stays alive until stopped."
+  @spec start_transcoding(keyword()) :: GenServer.on_start()
+  def start_transcoding(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc "Stops the transcoder process (simulates a cancelled job)."
+  @spec stop_transcoding(pid()) :: :ok
+  def stop_transcoding(pid) do
+    GenServer.stop(pid, :normal)
+  end
+
+  @doc """
+  Simulates a finished transcode: invokes the `:on_complete` callback (if any)
+  and exits normally, so `JobManager` frees the slot and starts the next
+  queued job.
+  """
+  @spec finish(pid()) :: :ok
+  def finish(pid) do
+    GenServer.cast(pid, :finish)
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok, %{on_complete: Keyword.get(opts, :on_complete)}}
+  end
+
+  @impl true
+  def handle_cast(:finish, %{on_complete: on_complete} = state) do
+    if is_function(on_complete, 0), do: on_complete.()
+    {:stop, :normal, state}
+  end
+end


### PR DESCRIPTION
Fixes two environment/timing-dependent test flakes (surfaced while stabilizing CI for #173).

## 1. JobManager capacity tests (timing flake)

`JobManagerTest` filled the 2-slot concurrency limit with real FFmpeg jobs, then asserted the next job **queued**. A 1-second test clip transcodes faster than the test can fill capacity, so a slot intermittently freed and the third job ran immediately instead of queueing — e.g. `job_manager_test.exs:236` failed on PR #173's CI run.

**Fix:** `JobManager` now resolves its transcoder module from config (`:transcoder_module`, defaulting to `FfmpegMp4Transcoder`). The tests inject `Mydia.Downloads.BlockingTranscoder`, a stand-in whose jobs stay alive until explicitly stopped/finished, so capacity and queueing are deterministic. The manager test no longer depends on FFmpeg at all (the manager's job is slot accounting, not transcoding).

## 2. Media-import "inaccessible path" test (root bypass)

The test relies on `chmod 000` denying directory listing to trigger `:path_not_accessible`. The **root** user bypasses permission bits, so the path stays accessible and the test failed when the suite runs as root (some Docker images). It passes in CI (non-root).

**Fix:** skip that single test when running as root, where the permission-denied path it asserts cannot occur. It runs normally as a non-root user.

## Verification

- `JobManagerTest` alone: 0 failures across seeds 0, 5, 7, 22, 99 (previously 1–2 failures every run locally).
- Full suite at seed 22 (the original CI-flake reproducer) and seed 314: **0 failures**, media-import test correctly skipped as root.