### PR TITLE
feat(downloads): editable match correction across the download lifecycle

### DIFF
--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -333,6 +333,14 @@ defmodule Mydia.Downloads do
   defdelegate resolve_file_mappings(download, mappings), to: Mydia.Downloads.Queue
 
   @doc """
+  Re-matches an already-imported download to a corrected movie or episode,
+  enqueuing a MediaRematch job to move + relink the file. See
+  `Mydia.Downloads.Queue.rematch_imported_download/3` for return values.
+  """
+  defdelegate rematch_imported_download(download, media_item_id, episode_id \\ nil),
+    to: Mydia.Downloads.Queue
+
+  @doc """
   Dismisses (deletes) a download from the Issues tab.
   """
   defdelegate dismiss_download(download), to: Mydia.Downloads.Queue

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -486,6 +486,112 @@ defmodule Mydia.Downloads.Queue do
     end
   end
 
+  @doc """
+  Re-matches an already-imported download to a corrected movie or episode.
+
+  Validates lifecycle, scope, and library-type compatibility before any mutation,
+  then enqueues `Mydia.Jobs.MediaRematch` to move + relink the file. Single-target
+  only: a download whose provenance resolves to multiple imported files (a pack)
+  is refused.
+
+  Returns:
+    * `{:ok, :enqueued}` — a re-match job was scheduled
+    * `{:ok, :unchanged}` — the target already matches; nothing to do
+    * `{:error, :not_imported}` — not imported yet (use in-flight correction)
+    * `{:error, :not_single_target}` — partial_pack / unresolved_files / unmatched
+    * `{:error, :multiple_files}` — pack: per-file re-match not supported
+    * `{:error, :no_imported_file}` — could not locate the imported file
+    * `{:error, :no_library_path}` — no monitored, compatible destination library
+    * `{:error, :library_type_mismatch}` — target type incompatible with library
+  """
+  def rematch_imported_download(%Download{} = download, media_item_id, episode_id \\ nil) do
+    cond do
+      is_nil(download.imported_at) ->
+        {:error, :not_imported}
+
+      not is_nil(download.match_status) ->
+        {:error, :not_single_target}
+
+      download.media_item_id == media_item_id and download.episode_id == episode_id ->
+        {:ok, :unchanged}
+
+      true ->
+        do_rematch(download, media_item_id, episode_id)
+    end
+  end
+
+  defp do_rematch(download, media_item_id, episode_id) do
+    media_item = media_item_id && Repo.get(MediaItem, media_item_id)
+    episode = episode_id && Repo.get(Episode, episode_id)
+
+    with {:ok, _file} <- locate_single_imported_file(download),
+         {:ok, library_path} <- resolve_rematch_destination(media_item, episode),
+         :ok <- ensure_type_compatible(library_path, media_item, episode_id) do
+      case History.update_download(download, %{
+             media_item_id: media_item_id,
+             episode_id: episode_id
+           }) do
+        {:ok, updated} ->
+          %{"download_id" => updated.id}
+          |> Mydia.Jobs.MediaRematch.new()
+          |> insert_job()
+
+          {:ok, :enqueued}
+
+        {:error, _changeset} = error ->
+          error
+      end
+    end
+  end
+
+  # Insert an Oban job, falling back to a direct Repo insert when Oban's engine
+  # is disabled (test mode). Mirrors the pattern in DownloadMonitor.
+  defp insert_job(changeset) do
+    Oban.insert(changeset)
+  rescue
+    RuntimeError -> Repo.insert(changeset)
+  end
+
+  defp locate_single_imported_file(download) do
+    case Mydia.Library.list_media_files_for_download(download) do
+      [%MediaFile{} = file] -> {:ok, file}
+      [] -> {:error, :no_imported_file}
+      _multiple -> {:error, :multiple_files}
+    end
+  end
+
+  defp resolve_rematch_destination(media_item, episode) do
+    # Build a probe reflecting the NEW target so determine_library_path resolves
+    # the correct destination (the download row still holds the old target here).
+    probe = %Download{
+      media_item_id: media_item && media_item.id,
+      media_item: media_item,
+      episode_id: episode && episode.id,
+      episode: episode,
+      library_path: nil,
+      library_path_id: nil
+    }
+
+    case Mydia.Jobs.MediaImport.determine_library_path(probe) do
+      nil -> {:error, :no_library_path}
+      library_path -> {:ok, library_path}
+    end
+  end
+
+  defp ensure_type_compatible(library_path, media_item, episode_id) do
+    media_item_type = media_item && media_item.type
+
+    if MediaFile.library_type_compatible?(
+         library_path.type,
+         media_item_type,
+         not is_nil(episode_id)
+       ) do
+      :ok
+    else
+      {:error, :library_type_mismatch}
+    end
+  end
+
   def dismiss_download(%Download{} = download) do
     History.delete_download(download)
   end

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -414,17 +414,21 @@ defmodule Mydia.Downloads.Queue do
 
     case History.update_download(download, attrs) do
       {:ok, updated} ->
-        %{
-          "download_id" => updated.id,
-          "save_path" => save_path,
-          "cleanup_client" => true,
-          "use_hardlinks" => true,
-          "move_files" => false
-        }
-        |> Mydia.Jobs.MediaImport.new()
-        |> insert_job()
+        job_result =
+          %{
+            "download_id" => updated.id,
+            "save_path" => save_path,
+            "cleanup_client" => true,
+            "use_hardlinks" => true,
+            "move_files" => false
+          }
+          |> Mydia.Jobs.MediaImport.new()
+          |> insert_job()
 
-        {:ok, updated}
+        case job_result do
+          {:ok, _job} -> {:ok, updated}
+          {:error, _changeset} = error -> error
+        end
 
       {:error, _changeset} = error ->
         error
@@ -532,11 +536,12 @@ defmodule Mydia.Downloads.Queue do
              episode_id: episode_id
            }) do
         {:ok, updated} ->
-          %{"download_id" => updated.id}
-          |> Mydia.Jobs.MediaRematch.new()
-          |> insert_job()
-
-          {:ok, :enqueued}
+          case %{"download_id" => updated.id}
+               |> Mydia.Jobs.MediaRematch.new()
+               |> insert_job() do
+            {:ok, _job} -> {:ok, :enqueued}
+            {:error, _changeset} = error -> error
+          end
 
         {:error, _changeset} = error ->
           error

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -422,7 +422,7 @@ defmodule Mydia.Downloads.Queue do
           "move_files" => false
         }
         |> Mydia.Jobs.MediaImport.new()
-        |> Oban.insert()
+        |> insert_job()
 
         {:ok, updated}
 
@@ -480,7 +480,7 @@ defmodule Mydia.Downloads.Queue do
            "move_files" => false
          }
          |> Mydia.Jobs.MediaImport.new()
-         |> Oban.insert() do
+         |> insert_job() do
       {:ok, _job} -> {:ok, download}
       {:error, changeset} -> {:error, changeset}
     end

--- a/lib/mydia/downloads/structs/enriched_download.ex
+++ b/lib/mydia/downloads/structs/enriched_download.ex
@@ -55,7 +55,12 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
     # true  = client confirmed the torrent is there
     # false = client confirmed the torrent is gone
     # nil   = client unreachable; presence unknown
-    :in_client?
+    :in_client?,
+    # Whether a completed download is eligible for post-import re-match: exactly
+    # one non-trashed imported file (packs resolve to several and can't be
+    # re-matched as a unit). Computed per-tab in the LiveView; nil when not
+    # evaluated (e.g. queue/issues rows, where the action isn't offered).
+    :rematch_eligible?
   ]
 
   @type t :: %__MODULE__{
@@ -96,7 +101,8 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
           import_failed_at: DateTime.t() | nil,
           last_progress_at: DateTime.t() | nil,
           last_known_bytes: integer() | nil,
-          in_client?: boolean() | nil
+          in_client?: boolean() | nil,
+          rematch_eligible?: boolean() | nil
         }
 
   @doc """

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -770,7 +770,8 @@ defmodule Mydia.Jobs.MediaImport do
     end
   end
 
-  defp build_destination_path(download, library_path) when is_struct(library_path, LibraryPath) do
+  @doc false
+  def build_destination_path(download, library_path) when is_struct(library_path, LibraryPath) do
     # Use FileOrganizer for category-aware destination paths when auto_organize is enabled
     cond do
       # Movie with auto_organize enabled
@@ -819,7 +820,7 @@ defmodule Mydia.Jobs.MediaImport do
   end
 
   # Legacy clause for string library_root (used internally)
-  defp build_destination_path(download, library_root) when is_binary(library_root) do
+  def build_destination_path(download, library_root) when is_binary(library_root) do
     cond do
       # TV episode
       download.episode && download.media_item ->
@@ -852,7 +853,8 @@ defmodule Mydia.Jobs.MediaImport do
   end
 
   # Helper to build category-aware base path for TV series
-  defp build_series_base_path(media_item, library_path) do
+  @doc false
+  def build_series_base_path(media_item, library_path) do
     if library_path.auto_organize do
       FileOrganizer.destination_path(media_item, library_path)
     else
@@ -1186,7 +1188,7 @@ defmodule Mydia.Jobs.MediaImport do
     File.mkdir_p!(dest_dir)
 
     # Generate filename (optionally renamed with TRaSH format)
-    final_filename = generate_filename(download, episode, file.name, args)
+    final_filename = generate_filename(download, episode, file.name, args.rename_files)
     dest_path = Path.join(dest_dir, final_filename)
 
     # Check if file already exists
@@ -1258,61 +1260,27 @@ defmodule Mydia.Jobs.MediaImport do
   end
 
   defp copy_or_move_file(source, dest, %Args{} = args) do
-    # Priority: hardlink > move > copy
-    cond do
-      # Try hardlink first if enabled and on same filesystem
-      args.use_hardlinks && same_filesystem?(source, dest) ->
-        case File.ln(source, dest) do
-          :ok ->
-            Logger.debug("Created hardlink", from: source, to: dest)
-            :ok
+    # Import keeps the source file (seeding) after a hardlink, so
+    # remove_source_after_hardlink stays false. Non-hardlink fallback is move
+    # only when move_files is set, otherwise copy.
+    case FileOrganizer.place_file(source, dest,
+           use_hardlinks: args.use_hardlinks,
+           fallback: if(args.move_files, do: :move, else: :copy)
+         ) do
+      {:ok, action} ->
+        Logger.debug("Placed file", from: source, to: dest, action: action)
+        :ok
 
-          {:error, reason} ->
-            Logger.warning("Hardlink failed, falling back to copy",
-              from: source,
-              to: dest,
-              reason: inspect(reason)
-            )
-
-            # Fallback to copy
-            File.cp(source, dest)
-        end
-
-      # Move file if requested
-      args.move_files ->
-        case File.rename(source, dest) do
-          :ok ->
-            Logger.debug("Moved file", from: source, to: dest)
-            :ok
-
-          {:error, :exdev} ->
-            # Cross-device move not supported, fall back to copy + delete
-            with :ok <- File.cp(source, dest),
-                 :ok <- File.rm(source) do
-              Logger.debug("Moved file via copy+delete", from: source, to: dest)
-              :ok
-            end
-
-          error ->
-            error
-        end
-
-      # Default to copy
-      true ->
-        case File.cp(source, dest) do
-          :ok ->
-            Logger.debug("Copied file", from: source, to: dest)
-            :ok
-
-          error ->
-            error
-        end
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  defp generate_filename(download, episode, original_filename, %Args{} = args) do
+  @doc false
+  def generate_filename(download, episode, original_filename, rename_files?)
+      when is_boolean(rename_files?) do
     # Only rename if explicitly enabled (default: false for safety)
-    if args.rename_files do
+    if rename_files? do
       # Parse quality information from download title or original filename
       quality_info =
         QualityParser.parse(download.title || original_filename)
@@ -1344,41 +1312,6 @@ defmodule Mydia.Jobs.MediaImport do
     else
       # Renaming disabled - use original filename
       original_filename
-    end
-  end
-
-  defp same_filesystem?(path1, path2) do
-    # Use File.stat!/1 to check if both paths are on the same device
-    # path2 might not exist yet, so check its parent directory
-    with %{device: dev1} <- File.stat(path1),
-         parent_path2 = Path.dirname(path2),
-         %{device: dev2} <- File.stat(parent_path2) do
-      same = dev1 == dev2
-
-      if same do
-        Logger.debug("Paths on same filesystem",
-          path1: path1,
-          path2: path2,
-          device: dev1
-        )
-      else
-        Logger.debug("Paths on different filesystems, hardlink not possible",
-          path1: path1,
-          path2: path2,
-          device1: dev1,
-          device2: dev2
-        )
-      end
-
-      same
-    else
-      _ ->
-        Logger.debug("Could not determine filesystem, assuming different",
-          path1: path1,
-          path2: path2
-        )
-
-        false
     end
   end
 

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -593,7 +593,8 @@ defmodule Mydia.Jobs.MediaImport do
     end)
   end
 
-  defp determine_library_path(download) do
+  @doc false
+  def determine_library_path(download) do
     # If download has a direct library_path association (specialized libraries),
     # use that directly
     if download.library_path do

--- a/lib/mydia/jobs/media_rematch.ex
+++ b/lib/mydia/jobs/media_rematch.ex
@@ -174,8 +174,12 @@ defmodule Mydia.Jobs.MediaRematch do
 
     case Library.update_media_file(current, attrs) do
       {:ok, updated} ->
-        stamp_provenance(download, old_media_file)
-        updated
+        # Provenance is part of the re-match contract; a failed stamp must roll
+        # back the relink so callers can retry rather than half-update.
+        case stamp_provenance(download, old_media_file) do
+          {:ok, _} -> updated
+          {:error, changeset} -> Repo.rollback({:provenance_failed, changeset})
+        end
 
       {:error, changeset} ->
         Repo.rollback({:relink_failed, changeset})

--- a/lib/mydia/jobs/media_rematch.ex
+++ b/lib/mydia/jobs/media_rematch.ex
@@ -1,0 +1,247 @@
+defmodule Mydia.Jobs.MediaRematch do
+  @moduledoc """
+  Background job that applies a post-import re-match.
+
+  Moves an already-imported file to the correct library location, re-links its
+  `MediaFile` to the corrected media item / episode, and re-notifies media
+  servers. The target was already persisted on the download row by
+  `Mydia.Downloads.Queue.rematch_imported_download/3` before this job was
+  enqueued; this job carries out the filesystem + DB reconciliation.
+
+  ## Safety ordering
+
+  Ecto has no filesystem transaction, so the sequence is built to never leave the
+  DB pointing at a missing file and never let a racing `LibraryScanner` strand a
+  duplicate:
+
+    1. Copy / hardlink the file to the destination (never `rename`), verifying
+       size; the source is kept until after the commit.
+    2. In one `Repo.transaction`: re-read the source row and abort if it was
+       trashed or its path drifted; adopt any duplicate row a concurrent scan
+       created at the destination; relink the row (parent-flip) and stamp
+       provenance.
+    3. Only after the commit, delete the source.
+
+  Re-match is move-optional: when the file is already at the computed
+  destination, only the DB relink runs. Idempotent on retry.
+  """
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 10,
+    unique: [
+      period: :infinity,
+      keys: [:download_id],
+      states: [:available, :scheduled, :retryable, :executing]
+    ]
+
+  require Logger
+
+  alias Mydia.{Downloads, Library, Repo}
+  alias Mydia.Library.{FileOrganizer, MediaFile}
+  alias Mydia.Jobs.MediaImport
+  alias Mydia.MediaServer.Notifier, as: MediaServerNotifier
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"download_id" => download_id}}) do
+    case fetch_download(download_id) do
+      nil ->
+        Logger.info("Re-match short-circuit: download row no longer exists",
+          download_id: download_id
+        )
+
+        :ok
+
+      download ->
+        run(download)
+    end
+  end
+
+  defp fetch_download(download_id) do
+    Downloads.get_download!(download_id,
+      preload: [:media_item, :episode, :library_path]
+    )
+  rescue
+    Ecto.NoResultsError -> nil
+  end
+
+  defp run(download) do
+    with :ok <- validate_rematchable(download),
+         {:ok, media_file} <- locate_file(download),
+         {:ok, library_path} <- resolve_destination(download),
+         {dest_path, new_rel} <- compute_destination(download, media_file, library_path),
+         {:ok, _action} <- place(media_file, library_path, dest_path, new_rel),
+         {:ok, _updated} <- relink(download, media_file, library_path, new_rel) do
+      # Commit succeeded — now it is safe to remove the source path.
+      cleanup_source(download, media_file, dest_path)
+      MediaServerNotifier.notify_all(path: dest_path)
+      Downloads.broadcast_download_update(download.id)
+
+      Logger.info("Re-match complete", download_id: download.id, dest: dest_path)
+      {:ok, :rematched}
+    else
+      {:error, reason} ->
+        Logger.error("Re-match failed", download_id: download.id, reason: inspect(reason))
+        mark_failed(download, reason)
+        {:error, reason}
+    end
+  end
+
+  defp validate_rematchable(download) do
+    cond do
+      is_nil(download.imported_at) -> {:error, :not_imported}
+      not is_nil(download.match_status) -> {:error, :not_single_target}
+      true -> :ok
+    end
+  end
+
+  defp locate_file(download) do
+    case Library.list_media_files_for_download(download, preload: [:library_path]) do
+      [%MediaFile{} = file] -> {:ok, file}
+      [] -> {:error, :no_imported_file}
+      _multiple -> {:error, :multiple_files}
+    end
+  end
+
+  defp resolve_destination(download) do
+    case MediaImport.determine_library_path(download) do
+      nil -> {:error, :no_library_path}
+      library_path -> {:ok, library_path}
+    end
+  end
+
+  defp compute_destination(download, media_file, library_path) do
+    dest_dir = MediaImport.build_destination_path(download, library_path)
+    original = Path.basename(media_file.relative_path)
+    rename? = library_path.auto_rename || false
+    filename = MediaImport.generate_filename(download, download.episode, original, rename?)
+    dest_path = Path.join(dest_dir, filename)
+    new_rel = Path.relative_to(dest_path, library_path.path)
+    {dest_path, new_rel}
+  end
+
+  defp place(media_file, library_path, dest_path, _new_rel) do
+    source_path = MediaFile.absolute_path(media_file)
+
+    cond do
+      is_nil(source_path) ->
+        {:error, :no_source_path}
+
+      not File.exists?(source_path) and not File.exists?(dest_path) ->
+        {:error, :source_missing}
+
+      true ->
+        # fallback: :copy (never rename) keeps the source until after the commit.
+        FileOrganizer.place_file(source_path, dest_path,
+          use_hardlinks: true,
+          fallback: :copy,
+          confine_to: library_path.path,
+          expected_size: media_file.size
+        )
+    end
+  end
+
+  defp relink(download, media_file, library_path, new_rel) do
+    Repo.transaction(fn ->
+      current = Repo.get(MediaFile, media_file.id)
+
+      cond do
+        is_nil(current) ->
+          Repo.rollback(:media_file_gone)
+
+        not is_nil(current.trashed_at) ->
+          Repo.rollback(:media_file_trashed)
+
+        current.relative_path != media_file.relative_path or
+            current.library_path_id != media_file.library_path_id ->
+          Repo.rollback(:media_file_moved)
+
+        true ->
+          # A racing scan may have created a row at the destination path; adopt it
+          # (delete the duplicate) so we do not leave two rows for one file.
+          adopt_destination_duplicate(library_path.id, new_rel, current.id)
+
+          parent =
+            if download.episode_id do
+              %{episode_id: download.episode_id, media_item_id: nil}
+            else
+              %{media_item_id: download.media_item_id, episode_id: nil}
+            end
+
+          attrs =
+            Map.merge(%{relative_path: new_rel, library_path_id: library_path.id}, parent)
+
+          case Library.update_media_file(current, attrs) do
+            {:ok, updated} ->
+              stamp_provenance(download, media_file)
+              updated
+
+            {:error, changeset} ->
+              Repo.rollback({:relink_failed, changeset})
+          end
+      end
+    end)
+  end
+
+  defp adopt_destination_duplicate(library_path_id, relative_path, keep_id) do
+    case Library.get_media_file_by_relative_path(library_path_id, relative_path,
+           include_trashed: true
+         ) do
+      %MediaFile{id: ^keep_id} -> :ok
+      %MediaFile{} = duplicate -> Repo.delete(duplicate)
+      nil -> :ok
+    end
+  end
+
+  defp stamp_provenance(download, old_media_file) do
+    metadata = download.metadata || %{}
+
+    stamped =
+      metadata
+      |> Map.put("rematched_from_media_item_id", old_media_file.media_item_id)
+      |> Map.put("rematched_from_episode_id", old_media_file.episode_id)
+      |> Map.put("rematched_at", DateTime.utc_now() |> DateTime.to_iso8601())
+
+    Downloads.update_download(download, %{metadata: stamped})
+  end
+
+  defp cleanup_source(download, media_file, dest_path) do
+    source_path = MediaFile.absolute_path(media_file)
+
+    if source_path && source_path != dest_path && File.exists?(source_path) do
+      case File.rm(source_path) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("Re-match source delete failed; recording for cleanup sweep",
+            source: source_path,
+            reason: inspect(reason)
+          )
+
+          # Record the pending path so a retry's idempotent short-circuit doesn't
+          # strand the orphan (a later sweep removes it). Best-effort.
+          record_pending_source_delete(download.id, source_path)
+      end
+    else
+      :ok
+    end
+  end
+
+  defp record_pending_source_delete(download_id, source_path) do
+    with %_{} = download <- Downloads.get_download!(download_id) do
+      metadata = Map.put(download.metadata || %{}, "rematch_pending_source_delete", source_path)
+      Downloads.update_download(download, %{metadata: metadata})
+    end
+  rescue
+    _ -> :ok
+  end
+
+  defp mark_failed(download, reason) do
+    Downloads.update_download(download, %{
+      import_failed_at: DateTime.utc_now(),
+      import_last_error: "re-match failed: #{inspect(reason)}"
+    })
+
+    Downloads.broadcast_download_update(download.id)
+  end
+end

--- a/lib/mydia/jobs/media_rematch.ex
+++ b/lib/mydia/jobs/media_rematch.ex
@@ -37,8 +37,8 @@ defmodule Mydia.Jobs.MediaRematch do
   require Logger
 
   alias Mydia.{Downloads, Library, Repo}
-  alias Mydia.Library.{FileOrganizer, MediaFile}
   alias Mydia.Jobs.MediaImport
+  alias Mydia.Library.{FileOrganizer, MediaFile}
   alias Mydia.MediaServer.Notifier, as: MediaServerNotifier
 
   @impl Oban.Worker
@@ -145,41 +145,41 @@ defmodule Mydia.Jobs.MediaRematch do
       current = Repo.get(MediaFile, media_file.id)
 
       cond do
-        is_nil(current) ->
-          Repo.rollback(:media_file_gone)
-
-        not is_nil(current.trashed_at) ->
-          Repo.rollback(:media_file_trashed)
-
-        current.relative_path != media_file.relative_path or
-            current.library_path_id != media_file.library_path_id ->
-          Repo.rollback(:media_file_moved)
-
-        true ->
-          # A racing scan may have created a row at the destination path; adopt it
-          # (delete the duplicate) so we do not leave two rows for one file.
-          adopt_destination_duplicate(library_path.id, new_rel, current.id)
-
-          parent =
-            if download.episode_id do
-              %{episode_id: download.episode_id, media_item_id: nil}
-            else
-              %{media_item_id: download.media_item_id, episode_id: nil}
-            end
-
-          attrs =
-            Map.merge(%{relative_path: new_rel, library_path_id: library_path.id}, parent)
-
-          case Library.update_media_file(current, attrs) do
-            {:ok, updated} ->
-              stamp_provenance(download, media_file)
-              updated
-
-            {:error, changeset} ->
-              Repo.rollback({:relink_failed, changeset})
-          end
+        is_nil(current) -> Repo.rollback(:media_file_gone)
+        not is_nil(current.trashed_at) -> Repo.rollback(:media_file_trashed)
+        path_drifted?(current, media_file) -> Repo.rollback(:media_file_moved)
+        true -> apply_relink(download, current, media_file, library_path, new_rel)
       end
     end)
+  end
+
+  defp path_drifted?(current, snapshot) do
+    current.relative_path != snapshot.relative_path or
+      current.library_path_id != snapshot.library_path_id
+  end
+
+  defp apply_relink(download, current, old_media_file, library_path, new_rel) do
+    # A racing scan may have created a row at the destination path; adopt it
+    # (delete the duplicate) so we do not leave two rows for one file.
+    adopt_destination_duplicate(library_path.id, new_rel, current.id)
+
+    parent =
+      if download.episode_id do
+        %{episode_id: download.episode_id, media_item_id: nil}
+      else
+        %{media_item_id: download.media_item_id, episode_id: nil}
+      end
+
+    attrs = Map.merge(%{relative_path: new_rel, library_path_id: library_path.id}, parent)
+
+    case Library.update_media_file(current, attrs) do
+      {:ok, updated} ->
+        stamp_provenance(download, old_media_file)
+        updated
+
+      {:error, changeset} ->
+        Repo.rollback({:relink_failed, changeset})
+    end
   end
 
   defp adopt_destination_duplicate(library_path_id, relative_path, keep_id) do

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -2025,6 +2025,31 @@ defmodule Mydia.Library do
   end
 
   @doc """
+  Counts non-trashed imported files per download, keyed by `imported_from_download_id`.
+
+  Batched companion to `list_media_files_for_download/1` for callers that need to
+  know how many files a set of downloads imported without an N+1 query — e.g. the
+  Downloads LiveView deciding whether a completed row is single-file (re-match
+  eligible) or a pack. Returns `%{download_id => count}`; downloads with no
+  imported files are simply absent from the map.
+  """
+  @spec count_imported_files_by_download([binary()]) :: %{binary() => non_neg_integer()}
+  def count_imported_files_by_download([]), do: %{}
+
+  def count_imported_files_by_download(download_ids) when is_list(download_ids) do
+    ids = Enum.map(download_ids, &to_string/1)
+
+    from(f in MediaFile,
+      where: is_nil(f.trashed_at),
+      where: json_extract(f.metadata, "$.imported_from_download_id") in ^ids,
+      group_by: json_extract(f.metadata, "$.imported_from_download_id"),
+      select: {json_extract(f.metadata, "$.imported_from_download_id"), count(f.id)}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
   Refreshes file metadata for all media files in the library.
 
   This can be a long-running operation. Returns the count of successfully refreshed files.

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -2002,6 +2002,29 @@ defmodule Mydia.Library do
   end
 
   @doc """
+  Lists the media files imported from a given download.
+
+  Located by the collision-free `imported_from_download_id` provenance key — the
+  download's primary key, written into `metadata` at import time. The
+  `(download_client, download_client_id)` pair is deliberately NOT used as the
+  key: download clients recycle torrent/nzb IDs, so that pair is unique only at a
+  single instant, not over the file's lifetime, and would surface the wrong file.
+
+  Excludes trashed files. Pass `preload:` to preload associations.
+  """
+  @spec list_media_files_for_download(Mydia.Downloads.Download.t(), keyword()) :: [MediaFile.t()]
+  def list_media_files_for_download(download, opts \\ []) do
+    query =
+      from f in MediaFile,
+        where: ^Mydia.DB.json_equals(:metadata, "$.imported_from_download_id", download.id),
+        where: is_nil(f.trashed_at)
+
+    query
+    |> maybe_preload(opts[:preload])
+    |> Repo.all()
+  end
+
+  @doc """
   Refreshes file metadata for all media files in the library.
 
   This can be a long-running operation. Returns the count of successfully refreshed files.

--- a/lib/mydia/library/file_organizer.ex
+++ b/lib/mydia/library/file_organizer.ex
@@ -242,7 +242,113 @@ defmodule Mydia.Library.FileOrganizer do
     end
   end
 
+  @doc """
+  Places a file at `dest` from `source` without touching the database.
+
+  Chooses the cheapest safe operation — a hardlink on the same filesystem, then a
+  configurable move/copy fallback — and returns the action taken. Performs **no**
+  database writes; callers own the `MediaFile` record. This is the shared
+  primitive behind both import (keep the source for seeding) and reorganize /
+  re-match (move the file into place), so the two paths cannot drift.
+
+  ## Options
+
+    * `:use_hardlinks` (default `true`) — try a hardlink first on the same filesystem.
+    * `:fallback` (`:move` | `:copy`, default `:copy`) — operation used when a
+      hardlink is not taken. `:move` renames (cross-device falls back to copy+delete);
+      `:copy` leaves the source in place.
+    * `:remove_source_after_hardlink` (default `false`) — when a hardlink succeeds,
+      remove the source so a single path remains. Import keeps the source (seeding);
+      reorganize removes it.
+    * `:confine_to` — when set to a directory, the expanded `dest` must be a
+      descendant of it, otherwise `{:error, {:path_escape, dest}}` is returned
+      before any filesystem mutation.
+    * `:expected_size` — when set, an existing `dest` whose size matches is treated
+      as already-placed (`{:ok, :exists}`); a size mismatch (e.g. a truncated file
+      from a crashed copy) removes the stale file and re-places.
+
+  ## Returns
+
+    * `{:ok, :hardlink | :move | :copy}` — the file was placed
+    * `{:ok, :skip}` — `source` and `dest` are the same path
+    * `{:ok, :exists}` — `dest` already present with a matching `:expected_size`
+    * `{:error, reason}`
+  """
+  @spec place_file(String.t(), String.t(), keyword()) ::
+          {:ok, :hardlink | :move | :copy | :skip | :exists} | {:error, any()}
+  def place_file(source, dest, opts \\ []) do
+    with :ok <- confine(dest, Keyword.get(opts, :confine_to)) do
+      cond do
+        source == dest ->
+          {:ok, :skip}
+
+        Keyword.has_key?(opts, :expected_size) and File.exists?(dest) ->
+          if file_size(dest) == Keyword.fetch!(opts, :expected_size) do
+            {:ok, :exists}
+          else
+            # Stale/partial destination (e.g. a crashed copy) — drop it and re-place.
+            _ = File.rm(dest)
+            do_place(source, dest, opts)
+          end
+
+        true ->
+          do_place(source, dest, opts)
+      end
+    end
+  end
+
   # Private functions
+
+  defp do_place(source, dest, opts) do
+    use_hardlinks = Keyword.get(opts, :use_hardlinks, true)
+    fallback = Keyword.get(opts, :fallback, :copy)
+    remove_source? = Keyword.get(opts, :remove_source_after_hardlink, false)
+
+    with :ok <- File.mkdir_p(Path.dirname(dest)) do
+      if use_hardlinks and same_filesystem?(source, dest) do
+        case File.ln(source, dest) do
+          :ok ->
+            if remove_source?, do: File.rm(source)
+            {:ok, :hardlink}
+
+          {:error, _reason} ->
+            # Hardlink failed despite same-filesystem detection — fall back safely.
+            do_fallback(source, dest, fallback)
+        end
+      else
+        do_fallback(source, dest, fallback)
+      end
+    end
+  end
+
+  defp do_fallback(source, dest, :move), do: do_move_file(source, dest)
+
+  defp do_fallback(source, dest, :copy) do
+    case File.cp(source, dest) do
+      :ok -> {:ok, :copy}
+      {:error, reason} -> {:error, {:copy_failed, reason}}
+    end
+  end
+
+  defp confine(_dest, nil), do: :ok
+
+  defp confine(dest, root) do
+    expanded = Path.expand(dest)
+    root_expanded = Path.expand(root)
+
+    if expanded == root_expanded or String.starts_with?(expanded, root_expanded <> "/") do
+      :ok
+    else
+      {:error, {:path_escape, dest}}
+    end
+  end
+
+  defp file_size(path) do
+    case File.stat(path) do
+      {:ok, %{size: size}} -> size
+      _ -> nil
+    end
+  end
 
   defp preload_associations(%MediaFile{} = media_file) do
     media_file
@@ -342,34 +448,13 @@ defmodule Mydia.Library.FileOrganizer do
   end
 
   defp move_or_copy_file(source, dest, use_hardlinks, force_move) do
-    cond do
-      # Try hardlink first if enabled and on same filesystem
-      use_hardlinks && same_filesystem?(source, dest) ->
-        case File.ln(source, dest) do
-          :ok ->
-            # Remove original file after successful hardlink
-            File.rm(source)
-            {:ok, :hardlink}
-
-          {:error, _reason} when force_move ->
-            # Fallback to move
-            do_move_file(source, dest)
-
-          {:error, reason} ->
-            {:error, {:hardlink_failed, reason}}
-        end
-
-      # Move file
-      force_move ->
-        do_move_file(source, dest)
-
-      # Copy only
-      true ->
-        case File.cp(source, dest) do
-          :ok -> {:ok, :copy}
-          {:error, reason} -> {:error, {:copy_failed, reason}}
-        end
-    end
+    # Reorganize removes the source after a successful hardlink (single path),
+    # and uses move (not copy) as the non-hardlink fallback when force_move.
+    place_file(source, dest,
+      use_hardlinks: use_hardlinks,
+      fallback: if(force_move, do: :move, else: :copy),
+      remove_source_after_hardlink: true
+    )
   end
 
   defp do_move_file(source, dest) do

--- a/lib/mydia/library/file_organizer.ex
+++ b/lib/mydia/library/file_organizer.ex
@@ -283,12 +283,21 @@ defmodule Mydia.Library.FileOrganizer do
           {:ok, :skip}
 
         Keyword.has_key?(opts, :expected_size) and File.exists?(dest) ->
-          if file_size(dest) == Keyword.fetch!(opts, :expected_size) do
-            {:ok, :exists}
-          else
-            # Stale/partial destination (e.g. a crashed copy) — drop it and re-place.
-            _ = File.rm(dest)
-            do_place(source, dest, opts)
+          cond do
+            file_size(dest) == Keyword.fetch!(opts, :expected_size) ->
+              {:ok, :exists}
+
+            not File.exists?(source) ->
+              # Stale/partial dest but the source is gone (e.g. a retry where only
+              # dest survived) — refuse rather than delete the only remaining copy.
+              {:error, {:size_mismatch_no_source, dest}}
+
+            true ->
+              # Stale/partial destination (e.g. a crashed copy) — drop it and re-place.
+              case File.rm(dest) do
+                :ok -> do_place(source, dest, opts)
+                {:error, reason} -> {:error, {:rm_failed, dest, reason}}
+              end
           end
 
         true ->
@@ -308,8 +317,14 @@ defmodule Mydia.Library.FileOrganizer do
       if use_hardlinks and same_filesystem?(source, dest) do
         case File.ln(source, dest) do
           :ok ->
-            if remove_source?, do: File.rm(source)
-            {:ok, :hardlink}
+            if remove_source? do
+              case File.rm(source) do
+                :ok -> {:ok, :hardlink}
+                {:error, reason} -> {:error, {:source_rm_failed, source, reason}}
+              end
+            else
+              {:ok, :hardlink}
+            end
 
           {:error, _reason} ->
             # Hardlink failed despite same-filesystem detection — fall back safely.

--- a/lib/mydia/library/media_file.ex
+++ b/lib/mydia/library/media_file.ex
@@ -98,6 +98,21 @@ defmodule Mydia.Library.MediaFile do
   def absolute_path(%__MODULE__{}), do: nil
 
   @doc """
+  Returns true when a media item / episode is compatible with a library path type.
+
+  Shared rule behind both the changeset-level validation and pre-flight checks
+  (e.g. download re-match), so the two cannot drift. `media_item_type` is the
+  item's `type` ("movie" / "tv_show") or nil; `has_episode?` is whether an
+  `episode_id` is being set. `:mixed` accepts everything; movies are rejected
+  from `:series` paths and episodes from `:movies` paths.
+  """
+  @spec library_type_compatible?(atom(), String.t() | nil, boolean()) :: boolean()
+  def library_type_compatible?(:mixed, _media_item_type, _has_episode?), do: true
+  def library_type_compatible?(:movies, _media_item_type, true), do: false
+  def library_type_compatible?(:series, "movie", _has_episode?), do: false
+  def library_type_compatible?(_library_type, _media_item_type, _has_episode?), do: true
+
+  @doc """
   Changeset for creating or updating a media file.
   """
   def changeset(media_file, attrs) do
@@ -282,36 +297,31 @@ defmodule Mydia.Library.MediaFile do
         changeset
 
       library_path ->
-        cond do
-          # If library is :mixed, allow both types
-          library_path.type == :mixed ->
-            changeset
+        media_item_type = media_item_id && get_media_type_for_item(media_item_id)
 
-          # Movie in :series library
-          not is_nil(media_item_id) and library_path.type == :series ->
-            media_type = get_media_type_for_item(media_item_id)
-
-            if media_type == "movie" do
+        if library_type_compatible?(library_path.type, media_item_type, not is_nil(episode_id)) do
+          changeset
+        else
+          cond do
+            # Movie in :series library
+            not is_nil(media_item_id) and library_path.type == :series ->
               add_error(
                 changeset,
                 :media_item_id,
                 "cannot add movies to a library path configured for TV series only (path: #{library_path.path})"
               )
-            else
+
+            # TV episode in :movies library
+            not is_nil(episode_id) and library_path.type == :movies ->
+              add_error(
+                changeset,
+                :episode_id,
+                "cannot add TV episodes to a library path configured for movies only (path: #{library_path.path})"
+              )
+
+            true ->
               changeset
-            end
-
-          # TV show in :movies library
-          not is_nil(episode_id) and library_path.type == :movies ->
-            add_error(
-              changeset,
-              :episode_id,
-              "cannot add TV episodes to a library path configured for movies only (path: #{library_path.path})"
-            )
-
-          # All other cases are valid
-          true ->
-            changeset
+          end
         end
     end
   end

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -3,6 +3,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
   alias Mydia.Downloads
   alias Mydia.Downloads.Structs.DownloadMetadata
   alias Mydia.Indexers.Structs.QualityInfo
+  alias Mydia.Library
   alias Mydia.Media
   alias Phoenix.PubSub
   alias MydiaWeb.Live.Authorization
@@ -835,7 +836,13 @@ defmodule MydiaWeb.DownloadsLive.Index do
         # Apply pagination
         page = socket.assigns.page
         offset = page * @items_per_page
-        paginated_downloads = all_downloads |> Enum.drop(offset) |> Enum.take(@items_per_page)
+
+        paginated_downloads =
+          all_downloads
+          |> Enum.drop(offset)
+          |> Enum.take(@items_per_page)
+          |> annotate_rematch_eligibility(tab)
+
         has_more = length(all_downloads) > offset + @items_per_page
 
         # Determine if we need to append or reset stream
@@ -950,7 +957,26 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
     Downloads.list_downloads_with_status(filter: filter)
     |> apply_sorting(socket.assigns.sort_by)
+    |> annotate_rematch_eligibility(socket.assigns.active_tab)
   end
+
+  # Stamps `rematch_eligible?` on completed-tab rows: a row is eligible only when
+  # it resolves to exactly one non-trashed imported file. Packs resolve to several
+  # files and can't be re-matched as a unit, so the Completed-tab action must stay
+  # hidden for them even though their `match_status` is nil. Other tabs don't offer
+  # the action, so the flag is left nil to avoid a needless query.
+  defp annotate_rematch_eligibility(downloads, :completed) do
+    counts =
+      downloads
+      |> Enum.map(& &1.id)
+      |> Library.count_imported_files_by_download()
+
+    Enum.map(downloads, fn download ->
+      %{download | rematch_eligible?: Map.get(counts, download.id, 0) == 1}
+    end)
+  end
+
+  defp annotate_rematch_eligibility(downloads, _tab), do: downloads
 
   # Sorts the enriched download list by the active `sort_by` selection. Runs in
   # the LiveView (not the DB) because real-time keys (progress, speeds, ETA,

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -93,6 +93,8 @@ defmodule MydiaWeb.DownloadsLive.Index do
      |> assign(:library_search_value, "")
      |> assign(:library_search_results, [])
      |> assign(:episodes_by_media_item, %{})
+     # Match / re-match modal state (in-flight correction + post-import re-match)
+     |> assign(:match_modal, nil)
      # Initialize all streams
      |> stream(:downloads, [])
      |> stream(:unmatched_downloads, [])
@@ -607,6 +609,67 @@ defmodule MydiaWeb.DownloadsLive.Index do
     end
   end
 
+  # --- Match / re-match modal (in-flight correction + post-import re-match) ---
+
+  def handle_event("open_match_modal", %{"id" => id, "mode" => mode}, socket)
+      when mode in ["inflight", "postimport"] do
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      {:noreply,
+       assign(socket, :match_modal, %{
+         download_id: id,
+         mode: String.to_existing_atom(mode),
+         query: "",
+         results: [],
+         selected: nil,
+         episodes: []
+       })}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("close_match_modal", _params, socket) do
+    {:noreply, assign(socket, :match_modal, nil)}
+  end
+
+  def handle_event("match_modal_search", %{"q" => query}, socket) do
+    results =
+      if String.length(query) >= 2 do
+        Media.list_media_items(search: query) |> Enum.take(10)
+      else
+        []
+      end
+
+    {:noreply,
+     update(socket, :match_modal, fn modal ->
+       %{modal | query: query, results: results}
+     end)}
+  end
+
+  def handle_event(
+        "match_modal_pick_item",
+        %{"media_item_id" => media_item_id, "type" => type, "title" => title},
+        socket
+      ) do
+    if type == "tv_show" do
+      # TV: choose the specific episode in a second step.
+      episodes = Media.list_episodes(media_item_id)
+
+      {:noreply,
+       update(socket, :match_modal, fn modal ->
+         %{modal | selected: %{id: media_item_id, title: title}, episodes: episodes}
+       end)}
+    else
+      # Movie: submit immediately.
+      submit_match(socket, media_item_id, nil)
+    end
+  end
+
+  def handle_event("match_modal_pick_episode", %{"episode_id" => episode_id}, socket) do
+    %{selected: %{id: media_item_id}} = socket.assigns.match_modal
+    submit_match(socket, media_item_id, episode_id)
+  end
+
   def handle_event("refresh_suggestions", %{"id" => download_id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
       download = Downloads.get_download!(download_id)
@@ -824,6 +887,58 @@ defmodule MydiaWeb.DownloadsLive.Index do
     |> stream(:unresolved_downloads, unresolved, reset: true)
     |> stream(:other_issues, other, reset: true)
   end
+
+  defp submit_match(socket, media_item_id, episode_id) do
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      modal = socket.assigns.match_modal
+      download = Downloads.get_download!(modal.download_id)
+
+      {flash_kind, message} =
+        case modal.mode do
+          :inflight ->
+            case Downloads.manually_match_download(download, media_item_id, episode_id) do
+              {:ok, _} -> {:info, "Match updated — the import will use the corrected match."}
+              {:error, _} -> {:error, "Failed to update the match."}
+            end
+
+          :postimport ->
+            case Downloads.rematch_imported_download(download, media_item_id, episode_id) do
+              {:ok, :enqueued} ->
+                {:info, "Re-match queued — the file will be moved and relinked."}
+
+              {:ok, :unchanged} ->
+                {:info, "Already matched to that title."}
+
+              {:error, reason} ->
+                {:error, friendly_rematch_error(reason)}
+            end
+        end
+
+      {:noreply,
+       socket
+       |> assign(:match_modal, nil)
+       |> put_flash(flash_kind, message)
+       |> load_downloads()}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  defp friendly_rematch_error(:not_imported), do: "This download hasn't imported yet."
+
+  defp friendly_rematch_error(reason) when reason in [:not_single_target, :multiple_files],
+    do: "This download has multiple files; per-file re-match isn't supported yet."
+
+  defp friendly_rematch_error(:no_imported_file),
+    do: "Couldn't find the imported file for this download."
+
+  defp friendly_rematch_error(:no_library_path),
+    do: "No matching library is configured for that title's type."
+
+  defp friendly_rematch_error(:library_type_mismatch),
+    do: "That title's type doesn't match an available library."
+
+  defp friendly_rematch_error(_), do: "Re-match failed."
 
   defp get_current_downloads(socket) do
     filter =

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -289,6 +289,16 @@
           <div class="flex items-center gap-1 shrink-0">
             <%= cond do %>
               <% @active_tab == :queue -> %>
+                <button
+                  type="button"
+                  class="btn btn-square btn-ghost btn-sm"
+                  phx-click="open_match_modal"
+                  phx-value-id={download.id}
+                  phx-value-mode="inflight"
+                  title="Change match"
+                >
+                  <.icon name="hero-pencil-square" class="size-4" />
+                </button>
                 <%= if download.status == "paused" do %>
                   <button
                     type="button"
@@ -321,6 +331,17 @@
                   <.icon name="hero-x-mark" class="size-4" />
                 </button>
               <% @active_tab == :completed -> %>
+                <button
+                  :if={is_nil(download.match_status)}
+                  type="button"
+                  class="btn btn-square btn-ghost btn-sm"
+                  phx-click="open_match_modal"
+                  phx-value-id={download.id}
+                  phx-value-mode="postimport"
+                  title="Re-match to the correct title"
+                >
+                  <.icon name="hero-arrow-path" class="size-4" />
+                </button>
                 <button
                   type="button"
                   class="btn btn-square btn-ghost btn-sm hover:btn-error"
@@ -718,6 +739,76 @@
           class={["btn", (@delete_files && "btn-error") || "btn-primary"]}
         >
           {if @delete_files, do: "Clear and Delete Files", else: "Clear Completed"}
+        </button>
+      </:actions>
+    </.modal>
+
+    <%!-- Match / re-match modal (in-flight correction + post-import re-match) --%>
+    <.modal :if={@match_modal} id="match-modal" show={true} on_cancel="close_match_modal">
+      <:title>
+        {if @match_modal.mode == :inflight, do: "Change match", else: "Re-match download"}
+      </:title>
+
+      <%= if @match_modal.selected do %>
+        <p class="text-sm text-base-content/80">
+          Choose the episode for <span class="font-medium">{@match_modal.selected.title}</span>:
+        </p>
+        <div
+          :if={@match_modal.episodes == []}
+          class="text-sm text-base-content/50 mt-2"
+        >
+          No episodes found for this show.
+        </div>
+        <div class="mt-2 max-h-64 overflow-y-auto flex flex-col gap-1">
+          <button
+            :for={ep <- @match_modal.episodes}
+            type="button"
+            class="btn btn-sm btn-ghost justify-start"
+            phx-click="match_modal_pick_episode"
+            phx-value-episode_id={ep.id}
+          >
+            S{String.pad_leading("#{ep.season_number}", 2, "0")}E{String.pad_leading(
+              "#{ep.episode_number}",
+              2,
+              "0"
+            )}
+            <span :if={ep.title} class="text-base-content/60">- {ep.title}</span>
+          </button>
+        </div>
+      <% else %>
+        <form id="match-modal-search-form" phx-change="match_modal_search">
+          <input
+            type="text"
+            name="q"
+            value={@match_modal.query}
+            class="input input-bordered w-full"
+            phx-debounce="300"
+            autocomplete="off"
+            placeholder="Search your library by title..."
+          />
+        </form>
+        <div class="mt-2 max-h-64 overflow-y-auto flex flex-col gap-1">
+          <button
+            :for={item <- @match_modal.results}
+            type="button"
+            class="btn btn-sm btn-ghost justify-start"
+            phx-click="match_modal_pick_item"
+            phx-value-media_item_id={item.id}
+            phx-value-type={item.type}
+            phx-value-title={item.title}
+          >
+            <span class="font-medium">{item.title}</span>
+            <span :if={item.year} class="text-base-content/60">({item.year})</span>
+            <span class="badge badge-xs badge-outline">
+              {if item.type == "tv_show", do: "TV", else: "Movie"}
+            </span>
+          </button>
+        </div>
+      <% end %>
+
+      <:actions>
+        <button type="button" class="btn btn-ghost" phx-click="close_match_modal">
+          Cancel
         </button>
       </:actions>
     </.modal>

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -332,7 +332,7 @@
                 </button>
               <% @active_tab == :completed -> %>
                 <button
-                  :if={is_nil(download.match_status)}
+                  :if={is_nil(download.match_status) and download.rematch_eligible?}
                   type="button"
                   class="btn btn-square btn-ghost btn-sm"
                   phx-click="open_match_modal"

--- a/test/mydia/downloads/queue_test.exs
+++ b/test/mydia/downloads/queue_test.exs
@@ -7,6 +7,7 @@ defmodule Mydia.Downloads.QueueTest do
   they are the unit-of-change for U3 (#124 + #129).
   """
   use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
 
   alias Mydia.Downloads.Queue
   alias Mydia.Downloads.Client.Registry
@@ -332,6 +333,90 @@ defmodule Mydia.Downloads.QueueTest do
 
       assert Repo.get(Download, imported.id) == nil
       assert Repo.get(Download, active.id) != nil
+    end
+  end
+
+  describe "rematch_imported_download/3" do
+    setup do
+      library = library_path_fixture(%{type: "movies", monitored: true})
+      movie = media_item_fixture(%{type: "movie", title: "Right Movie"})
+
+      download =
+        download_fixture(%{
+          media_item_id: movie.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      _media_file =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: library.id,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      %{library: library, movie: movie, download: download}
+    end
+
+    test "rejects a download that is not imported yet", %{movie: movie} do
+      download = download_fixture(%{media_item_id: movie.id, imported_at: nil})
+      assert {:error, :not_imported} = Queue.rematch_imported_download(download, movie.id)
+    end
+
+    test "rejects a partial-pack / unresolved download", %{movie: movie} do
+      download =
+        download_fixture(%{
+          media_item_id: movie.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          match_status: "partial_pack"
+        })
+
+      assert {:error, :not_single_target} = Queue.rematch_imported_download(download, movie.id)
+    end
+
+    test "no-ops when the target is unchanged", %{download: download, movie: movie} do
+      assert {:ok, :unchanged} = Queue.rematch_imported_download(download, movie.id)
+      refute_enqueued(worker: Mydia.Jobs.MediaRematch)
+    end
+
+    test "refuses a pack (provenance resolves to multiple files)", %{
+      library: library,
+      download: download
+    } do
+      other_movie = media_item_fixture(%{type: "movie", title: "Other"})
+
+      # A second imported file under the same download id makes this a pack.
+      media_file_fixture(%{
+        media_item_id: download.media_item_id,
+        library_path_id: library.id,
+        metadata: %{"imported_from_download_id" => download.id}
+      })
+
+      assert {:error, :multiple_files} =
+               Queue.rematch_imported_download(download, other_movie.id)
+
+      refute_enqueued(worker: Mydia.Jobs.MediaRematch)
+    end
+
+    test "errors when no compatible destination library exists", %{download: download} do
+      # Re-match the movie download to a TV episode while only a :movies library
+      # is monitored — there is no series destination, so it is rejected pre-move.
+      episode = episode_fixture(%{season_number: 1, episode_number: 3})
+      show_id = episode.media_item_id
+
+      assert {:error, :no_library_path} =
+               Queue.rematch_imported_download(download, show_id, episode.id)
+
+      refute_enqueued(worker: Mydia.Jobs.MediaRematch)
+    end
+
+    test "enqueues a re-match job and persists the new target", %{download: download} do
+      new_movie = media_item_fixture(%{type: "movie", title: "Corrected Movie"})
+
+      assert {:ok, :enqueued} = Queue.rematch_imported_download(download, new_movie.id)
+      assert_enqueued(worker: Mydia.Jobs.MediaRematch, args: %{"download_id" => download.id})
+
+      reloaded = Repo.get(Download, download.id)
+      assert reloaded.media_item_id == new_movie.id
     end
   end
 end

--- a/test/mydia/jobs/media_rematch_test.exs
+++ b/test/mydia/jobs/media_rematch_test.exs
@@ -1,0 +1,206 @@
+defmodule Mydia.Jobs.MediaRematchTest do
+  @moduledoc """
+  Tests for the post-import re-match job: it moves an already-imported file to
+  the corrected location, relinks the MediaFile (parent-flip), adopts any
+  scanner-created duplicate at the destination, leaves the old item file-less,
+  and is idempotent on retry.
+  """
+  use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  @moduletag :tmp_dir
+
+  alias Mydia.Jobs.MediaRematch
+  alias Mydia.Library
+  alias Mydia.Library.MediaFile
+  alias Mydia.Repo
+
+  import Mydia.MediaFixtures
+  import Mydia.DownloadsFixtures
+  import Mydia.SettingsFixtures
+
+  defp movies_library(tmp) do
+    path = Path.join(tmp, "movies")
+    File.mkdir_p!(path)
+
+    library_path_fixture(%{
+      type: "movies",
+      path: path,
+      monitored: true,
+      auto_organize: false,
+      auto_rename: false
+    })
+  end
+
+  defp series_library(tmp) do
+    path = Path.join(tmp, "series")
+    File.mkdir_p!(path)
+
+    library_path_fixture(%{
+      type: "series",
+      path: path,
+      monitored: true,
+      auto_organize: false,
+      auto_rename: false
+    })
+  end
+
+  defp write_source(library, relative_path, contents) do
+    abs = Path.join(library.path, relative_path)
+    File.mkdir_p!(Path.dirname(abs))
+    File.write!(abs, contents)
+    {abs, byte_size(contents)}
+  end
+
+  describe "movie re-match" do
+    test "moves the file, relinks to the new movie, and leaves the old item file-less", %{
+      tmp_dir: tmp
+    } do
+      library = movies_library(tmp)
+      old_movie = media_item_fixture(%{type: "movie", title: "Wrong Movie", year: 2020})
+      new_movie = media_item_fixture(%{type: "movie", title: "Right Movie", year: 2021})
+
+      {_abs, size} = write_source(library, "Wrong Movie (2020)/movie.mkv", "video-bytes")
+
+      # download already corrected to the new movie (as Queue.rematch_imported_download does)
+      download =
+        download_fixture(%{
+          media_item_id: new_movie.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, media_file} =
+        Library.create_media_file(%{
+          relative_path: "Wrong Movie (2020)/movie.mkv",
+          library_path_id: library.id,
+          media_item_id: old_movie.id,
+          size: size,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      assert {:ok, :rematched} =
+               perform_job(MediaRematch, %{"download_id" => download.id})
+
+      reloaded = Repo.get(MediaFile, media_file.id)
+      assert reloaded.media_item_id == new_movie.id
+      assert reloaded.relative_path == "Right Movie (2021)/movie.mkv"
+
+      assert File.exists?(Path.join(library.path, "Right Movie (2021)/movie.mkv"))
+      refute File.exists?(Path.join(library.path, "Wrong Movie (2020)/movie.mkv"))
+
+      # Old item is left in place but now has no files (no destructive cleanup).
+      assert Repo.get(Mydia.Media.MediaItem, old_movie.id)
+      assert Library.list_media_files(media_item_id: old_movie.id) == []
+    end
+  end
+
+  describe "episode re-match (parent-flip)" do
+    test "moves the file into the correct season folder and flips the parent", %{tmp_dir: tmp} do
+      library = series_library(tmp)
+      show = media_item_fixture(%{type: "tv_show", title: "My Show"})
+      old_ep = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+      new_ep = episode_fixture(%{media_item_id: show.id, season_number: 2, episode_number: 5})
+
+      {_abs, size} = write_source(library, "Wrong/ep.mkv", "ep-bytes")
+
+      download =
+        download_fixture(%{
+          media_item_id: show.id,
+          episode_id: new_ep.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, media_file} =
+        Library.create_media_file(%{
+          relative_path: "Wrong/ep.mkv",
+          library_path_id: library.id,
+          episode_id: old_ep.id,
+          size: size,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      assert {:ok, :rematched} = perform_job(MediaRematch, %{"download_id" => download.id})
+
+      reloaded = Repo.get(MediaFile, media_file.id)
+      assert reloaded.episode_id == new_ep.id
+      assert is_nil(reloaded.media_item_id)
+      assert reloaded.relative_path == "My Show/Season 02/ep.mkv"
+      assert File.exists?(Path.join(library.path, "My Show/Season 02/ep.mkv"))
+    end
+  end
+
+  describe "concurrency + idempotency" do
+    test "adopts a scanner-created duplicate at the destination (no duplicate row)", %{
+      tmp_dir: tmp
+    } do
+      library = movies_library(tmp)
+      old_movie = media_item_fixture(%{type: "movie", title: "Wrong Movie", year: 2020})
+      new_movie = media_item_fixture(%{type: "movie", title: "Right Movie", year: 2021})
+
+      {_abs, size} = write_source(library, "Wrong Movie (2020)/movie.mkv", "video-bytes")
+
+      download =
+        download_fixture(%{
+          media_item_id: new_movie.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, _media_file} =
+        Library.create_media_file(%{
+          relative_path: "Wrong Movie (2020)/movie.mkv",
+          library_path_id: library.id,
+          media_item_id: old_movie.id,
+          size: size,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      # Simulate a racing scan that already created an orphan row at the dest path.
+      {:ok, _orphan} =
+        Library.create_scanned_media_file(%{
+          relative_path: "Right Movie (2021)/movie.mkv",
+          library_path_id: library.id,
+          size: size
+        })
+
+      assert {:ok, :rematched} = perform_job(MediaRematch, %{"download_id" => download.id})
+
+      rows =
+        Library.list_media_files(library_path_id: library.id)
+        |> Enum.filter(&(&1.relative_path == "Right Movie (2021)/movie.mkv"))
+
+      assert length(rows) == 1
+      assert hd(rows).media_item_id == new_movie.id
+    end
+
+    test "is idempotent on retry", %{tmp_dir: tmp} do
+      library = movies_library(tmp)
+      old_movie = media_item_fixture(%{type: "movie", title: "Wrong Movie", year: 2020})
+      new_movie = media_item_fixture(%{type: "movie", title: "Right Movie", year: 2021})
+
+      {_abs, size} = write_source(library, "Wrong Movie (2020)/movie.mkv", "video-bytes")
+
+      download =
+        download_fixture(%{
+          media_item_id: new_movie.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, media_file} =
+        Library.create_media_file(%{
+          relative_path: "Wrong Movie (2020)/movie.mkv",
+          library_path_id: library.id,
+          media_item_id: old_movie.id,
+          size: size,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      assert {:ok, :rematched} = perform_job(MediaRematch, %{"download_id" => download.id})
+      # Second run: the file is already at the destination and the row is relinked.
+      assert {:ok, :rematched} = perform_job(MediaRematch, %{"download_id" => download.id})
+
+      rows = Library.list_media_files(library_path_id: library.id)
+      assert length(rows) == 1
+      assert Repo.get(MediaFile, media_file.id).relative_path == "Right Movie (2021)/movie.mkv"
+    end
+  end
+end

--- a/test/mydia/library/file_organizer_test.exs
+++ b/test/mydia/library/file_organizer_test.exs
@@ -354,4 +354,102 @@ defmodule Mydia.Library.FileOrganizerTest do
       assert {:error, :no_media_item} = FileOrganizer.organize_file(media_file, dry_run: true)
     end
   end
+
+  describe "place_file/3" do
+    @describetag :tmp_dir
+
+    defp write_file(path, contents) do
+      File.mkdir_p!(Path.dirname(path))
+      File.write!(path, contents)
+      path
+    end
+
+    test "hardlink keeps the source by default (import mode)", %{tmp_dir: tmp} do
+      source = write_file(Path.join(tmp, "src/movie.mkv"), "data")
+      dest = Path.join(tmp, "lib/Movie (2020)/movie.mkv")
+
+      assert {:ok, :hardlink} = FileOrganizer.place_file(source, dest, use_hardlinks: true)
+      assert File.exists?(source)
+      assert File.read!(dest) == "data"
+    end
+
+    test "hardlink removes the source when requested (reorganize mode)", %{tmp_dir: tmp} do
+      source = write_file(Path.join(tmp, "src/movie.mkv"), "data")
+      dest = Path.join(tmp, "lib/Movie (2020)/movie.mkv")
+
+      assert {:ok, :hardlink} =
+               FileOrganizer.place_file(source, dest,
+                 use_hardlinks: true,
+                 remove_source_after_hardlink: true
+               )
+
+      refute File.exists?(source)
+      assert File.read!(dest) == "data"
+    end
+
+    test "copy fallback leaves the source in place", %{tmp_dir: tmp} do
+      source = write_file(Path.join(tmp, "src/movie.mkv"), "data")
+      dest = Path.join(tmp, "lib/movie.mkv")
+
+      assert {:ok, :copy} =
+               FileOrganizer.place_file(source, dest, use_hardlinks: false, fallback: :copy)
+
+      assert File.exists?(source)
+      assert File.read!(dest) == "data"
+    end
+
+    test "move fallback removes the source", %{tmp_dir: tmp} do
+      source = write_file(Path.join(tmp, "src/movie.mkv"), "data")
+      dest = Path.join(tmp, "lib/movie.mkv")
+
+      assert {:ok, :move} =
+               FileOrganizer.place_file(source, dest, use_hardlinks: false, fallback: :move)
+
+      refute File.exists?(source)
+      assert File.read!(dest) == "data"
+    end
+
+    test "source == dest short-circuits to :skip", %{tmp_dir: tmp} do
+      source = write_file(Path.join(tmp, "lib/movie.mkv"), "data")
+
+      assert {:ok, :skip} = FileOrganizer.place_file(source, source)
+      assert File.read!(source) == "data"
+    end
+
+    test "expected_size match treats an existing dest as already placed", %{tmp_dir: tmp} do
+      source = write_file(Path.join(tmp, "src/movie.mkv"), "newdata")
+      dest = write_file(Path.join(tmp, "lib/movie.mkv"), "olddata")
+      size = byte_size("olddata")
+
+      assert {:ok, :exists} = FileOrganizer.place_file(source, dest, expected_size: size)
+      # Untouched — same-size existing dest is adopted, not overwritten.
+      assert File.read!(dest) == "olddata"
+    end
+
+    test "expected_size mismatch re-places a stale/partial dest", %{tmp_dir: tmp} do
+      source = write_file(Path.join(tmp, "src/movie.mkv"), "complete-data")
+      dest = write_file(Path.join(tmp, "lib/movie.mkv"), "partial")
+
+      assert {:ok, action} =
+               FileOrganizer.place_file(source, dest,
+                 use_hardlinks: false,
+                 fallback: :copy,
+                 expected_size: byte_size("complete-data")
+               )
+
+      assert action in [:copy, :hardlink, :move]
+      assert File.read!(dest) == "complete-data"
+    end
+
+    test "confine_to rejects a destination outside the library root", %{tmp_dir: tmp} do
+      source = write_file(Path.join(tmp, "src/movie.mkv"), "data")
+      root = Path.join(tmp, "lib")
+      escaping_dest = Path.join(tmp, "lib/../outside/movie.mkv")
+
+      assert {:error, {:path_escape, _}} =
+               FileOrganizer.place_file(source, escaping_dest, confine_to: root)
+
+      refute File.exists?(Path.join(tmp, "outside/movie.mkv"))
+    end
+  end
 end

--- a/test/mydia/library_test.exs
+++ b/test/mydia/library_test.exs
@@ -847,4 +847,65 @@ defmodule Mydia.LibraryTest do
     File.chmod!(path, 0o755)
     path
   end
+
+  describe "list_media_files_for_download/1" do
+    test "locates files by imported_from_download_id, excluding recycled client ids" do
+      lib = library_path_fixture(%{type: "movies"})
+      movie = Mydia.MediaFixtures.media_item_fixture(%{type: "movie"})
+
+      download_id = Ecto.UUID.generate()
+      other_download_id = Ecto.UUID.generate()
+
+      {:ok, ours} =
+        Library.create_media_file(%{
+          relative_path: "ours.mkv",
+          library_path_id: lib.id,
+          media_item_id: movie.id,
+          size: 100,
+          metadata: %{
+            "imported_from_download_id" => download_id,
+            "download_client" => "qbit",
+            "download_client_id" => "7"
+          }
+        })
+
+      # Same recycled client id, different download — must NOT be returned.
+      {:ok, _recycled} =
+        Library.create_media_file(%{
+          relative_path: "recycled.mkv",
+          library_path_id: lib.id,
+          media_item_id: movie.id,
+          size: 100,
+          metadata: %{
+            "imported_from_download_id" => other_download_id,
+            "download_client" => "qbit",
+            "download_client_id" => "7"
+          }
+        })
+
+      download = %Mydia.Downloads.Download{id: download_id}
+      result = Library.list_media_files_for_download(download)
+
+      assert Enum.map(result, & &1.id) == [ours.id]
+    end
+
+    test "excludes trashed files" do
+      lib = library_path_fixture(%{type: "movies"})
+      movie = Mydia.MediaFixtures.media_item_fixture(%{type: "movie"})
+      download_id = Ecto.UUID.generate()
+
+      {:ok, _trashed} =
+        Library.create_media_file(%{
+          relative_path: "trashed.mkv",
+          library_path_id: lib.id,
+          media_item_id: movie.id,
+          size: 100,
+          trashed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          metadata: %{"imported_from_download_id" => download_id}
+        })
+
+      download = %Mydia.Downloads.Download{id: download_id}
+      assert Library.list_media_files_for_download(download) == []
+    end
+  end
 end

--- a/test/mydia/library_test.exs
+++ b/test/mydia/library_test.exs
@@ -908,4 +908,56 @@ defmodule Mydia.LibraryTest do
       assert Library.list_media_files_for_download(download) == []
     end
   end
+
+  describe "count_imported_files_by_download/1" do
+    test "counts non-trashed files per download, omitting downloads with none" do
+      lib = library_path_fixture(%{type: "movies"})
+      movie = Mydia.MediaFixtures.media_item_fixture(%{type: "movie"})
+
+      single = Ecto.UUID.generate()
+      pack = Ecto.UUID.generate()
+      none = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Library.create_media_file(%{
+          relative_path: "single.mkv",
+          library_path_id: lib.id,
+          media_item_id: movie.id,
+          size: 100,
+          metadata: %{"imported_from_download_id" => single}
+        })
+
+      for n <- 1..2 do
+        {:ok, _} =
+          Library.create_media_file(%{
+            relative_path: "pack#{n}.mkv",
+            library_path_id: lib.id,
+            media_item_id: movie.id,
+            size: 100,
+            metadata: %{"imported_from_download_id" => pack}
+          })
+      end
+
+      # A trashed file must not be counted.
+      {:ok, _} =
+        Library.create_media_file(%{
+          relative_path: "pack-trashed.mkv",
+          library_path_id: lib.id,
+          media_item_id: movie.id,
+          size: 100,
+          trashed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          metadata: %{"imported_from_download_id" => pack}
+        })
+
+      counts = Library.count_imported_files_by_download([single, pack, none])
+
+      assert counts[single] == 1
+      assert counts[pack] == 2
+      refute Map.has_key?(counts, none)
+    end
+
+    test "returns an empty map for an empty id list" do
+      assert Library.count_imported_files_by_download([]) == %{}
+    end
+  end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -314,6 +314,39 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
              )
     end
 
+    test "Re-match action is hidden for a fully-imported multi-file pack", %{conn: conn} do
+      # A season pack imports successfully, so MediaImport clears match_status to
+      # nil — but it resolves to several imported files and can't be re-matched as
+      # a unit. The action must stay hidden even though match_status is nil.
+      library = library_path_fixture(%{type: "series", monitored: true})
+      show = media_item_fixture(%{type: "tv_show", title: "Some Show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: show.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      for episode <- 1..2 do
+        {:ok, _file} =
+          Library.create_media_file(%{
+            relative_path: "Some Show/S01E0#{episode}.mkv",
+            library_path_id: library.id,
+            media_item_id: show.id,
+            size: 100,
+            metadata: %{"imported_from_download_id" => download.id}
+          })
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "switch_tab", %{"tab" => "completed"})
+
+      refute has_element?(
+               view,
+               "button[phx-click='open_match_modal'][phx-value-id='#{download.id}'][phx-value-mode='postimport']"
+             )
+    end
+
     test "re-matching a movie enqueues the job and persists the new target", %{conn: conn} do
       download = imported_movie_with_file("Wrong Title")
       new_movie = media_item_fixture(%{type: "movie", title: "Corrected Title"})

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -5,13 +5,16 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
   # empty, and the sort control (gated on rows existing) never appears. Shared
   # mode (the non-async default) makes the inserted rows visible to the mount.
   use MydiaWeb.ConnCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
 
   import Phoenix.LiveViewTest
   import Mydia.AccountsFixtures
   import Mydia.DownloadsFixtures
   import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
 
   alias Mydia.Downloads
+  alias Mydia.Library
 
   setup %{conn: conn} do
     admin = admin_user_fixture()
@@ -254,6 +257,117 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       # batch_retry deletes-and-reinitiates on success; the gate must leave the
       # record untouched for a readonly user.
       assert Downloads.count_completed() == 1
+    end
+  end
+
+  describe "post-import re-match (U4)" do
+    defp imported_movie_with_file(old_title) do
+      library = library_path_fixture(%{type: "movies", monitored: true})
+      old = media_item_fixture(%{type: "movie", title: old_title})
+
+      download =
+        download_fixture(%{
+          media_item_id: old.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, _media_file} =
+        Library.create_media_file(%{
+          relative_path: "#{old_title}/movie.mkv",
+          library_path_id: library.id,
+          media_item_id: old.id,
+          size: 100,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      download
+    end
+
+    test "Re-match action is shown for an eligible imported row", %{conn: conn} do
+      download = imported_movie_with_file("Wrong Title")
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "switch_tab", %{"tab" => "completed"})
+
+      assert has_element?(
+               view,
+               "button[phx-click='open_match_modal'][phx-value-id='#{download.id}'][phx-value-mode='postimport']"
+             )
+    end
+
+    test "Re-match action is hidden for an ineligible (partial_pack) row", %{conn: conn} do
+      movie = media_item_fixture(%{type: "movie", title: "Pack"})
+
+      download =
+        download_fixture(%{
+          media_item_id: movie.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          match_status: "partial_pack"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "switch_tab", %{"tab" => "completed"})
+
+      refute has_element?(
+               view,
+               "button[phx-click='open_match_modal'][phx-value-id='#{download.id}']"
+             )
+    end
+
+    test "re-matching a movie enqueues the job and persists the new target", %{conn: conn} do
+      download = imported_movie_with_file("Wrong Title")
+      new_movie = media_item_fixture(%{type: "movie", title: "Corrected Title"})
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "switch_tab", %{"tab" => "completed"})
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "postimport"})
+
+      assert has_element?(view, "#match-modal")
+
+      render_change(view, "match_modal_search", %{"q" => "Corrected"})
+
+      html =
+        render_click(view, "match_modal_pick_item", %{
+          "media_item_id" => new_movie.id,
+          "type" => "movie",
+          "title" => new_movie.title
+        })
+
+      assert html =~ "Re-match queued"
+      assert_enqueued(worker: Mydia.Jobs.MediaRematch, args: %{"download_id" => download.id})
+      assert Downloads.get_download!(download.id).media_item_id == new_movie.id
+    end
+  end
+
+  describe "in-flight match correction (U3)" do
+    test "Change match action is shown on an active (not-imported) row", %{conn: conn} do
+      movie = media_item_fixture(%{type: "movie", title: "Active Movie"})
+      download = download_fixture(%{media_item_id: movie.id, imported_at: nil})
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      assert has_element?(
+               view,
+               "button[phx-click='open_match_modal'][phx-value-id='#{download.id}'][phx-value-mode='inflight']"
+             )
+    end
+
+    test "changing the match on an in-flight download persists the new target", %{conn: conn} do
+      movie = media_item_fixture(%{type: "movie", title: "Active Movie"})
+      new_movie = media_item_fixture(%{type: "movie", title: "Better Match"})
+      download = download_fixture(%{media_item_id: movie.id, imported_at: nil})
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "inflight"})
+      render_change(view, "match_modal_search", %{"q" => "Better"})
+
+      render_click(view, "match_modal_pick_item", %{
+        "media_item_id" => new_movie.id,
+        "type" => "movie",
+        "title" => new_movie.title
+      })
+
+      assert Downloads.get_download!(download.id).media_item_id == new_movie.id
     end
   end
 end


### PR DESCRIPTION
## Summary

A confident-but-wrong auto-import used to be a dead end: the matcher would clear its threshold, pick the wrong movie or episode, import silently, and leave you to clean up the library by hand. This makes a download's match **editable across its whole lifecycle**. Catch a wrong match while it's still downloading and correct it in the Queue so it imports as the right title. Miss it, and you can re-match the already-imported download from the Completed tab — the file is moved/re-organized to the correct location, the library record is re-linked, and Plex/Jellyfin are re-notified. Auto-import stays on by default; this is the safety net, not a gate.

## What you can now do

- **Change match (Queue):** active downloads show a "Change match" action. Correcting the match persists before completion, so the import uses the corrected target.
- **Re-match (Completed):** imported downloads show a "Re-match" action. Movies re-match directly; picking a TV show prompts for the specific episode.
- Re-match is offered only where it's safe — eligible imported rows (clean match status), single-file downloads. Season packs are refused with a clear message rather than silently collapsing onto one episode.

## Why the implementation is mostly about safety

Re-match physically moves user media and rewrites the DB row that points at it, so the bulk of the work is making that reconciliation crash- and race-safe:

- **Crash-safe ordering.** Copy/hardlink to the destination → verify → relink the row inside a transaction → only then delete the source. The DB never points at a file that isn't there, and a failure mid-way leaves the original intact for a retry.
- **Scanner race closed.** The library scanner trashes rows whose path is missing and creates rows for untracked files. The relink transaction re-reads the source row (aborting if it drifted) and adopts any duplicate row a concurrent scan created at the destination, so a re-match can't strand a trashed original or a duplicate.
- **Collision-free provenance.** The imported file is located by `imported_from_download_id` (the download's primary key), not the `(download_client, download_client_id)` pair — clients recycle those IDs, so the pair would surface the wrong file.
- **Validation before any move.** Library-type compatibility and a monitored destination are checked up front; on failure the file is never touched. A shared predicate backs both this pre-flight and the write-time changeset so they can't drift.
- **Idempotent + deduped enqueue.** The job is move-optional (relink only when the file is already in place), size-verifies before adopting an existing file, and carries an Oban `unique` key so double-triggers and retries collapse.

A wrong import's now-empty media item is intentionally left in place (stamped with provenance) rather than deleted — re-match never destroys data it didn't create.

## Notable refactor

`FileOrganizer` and `MediaImport` previously had two drifted copies of the hardlink/move/copy logic (and two diverged filename sanitizers). Both movers now route through a single `FileOrganizer.place_file/3` primitive — one place for the move semantics, with explicit keep-vs-remove-source, size-verified idempotency, and a path-confinement guard. Import behavior is unchanged (characterization suites green).

## Tests

- `place_file/3`: hardlink keep/remove-source, copy/move fallbacks, skip, size-match idempotency, partial-file re-copy, path-escape rejection.
- Provenance lookup (recycled-ID exclusion, trashed exclusion) and every re-match context guard (not-imported, partial-pack, unchanged, multi-file refusal, no destination).
- The job end-to-end against real temp files: movie re-match, episode parent-flip, scanner-duplicate adoption, idempotent retry, old item left file-less.
- LiveView: action visibility/eligibility, the modal flow, enqueue + persisted target, in-flight correction.

Full affected-area suite passes (1905 tests); `mix compile --warnings-as-errors`, `mix format`, and `credo --strict` are clean on the new code.

## Deferred (follow-ups)

Per-file season-pack re-match (packs are refused for now), a cleanup sweep for the rare post-commit source-delete failure, and re-match of pre-feature imports that lack provenance metadata. The mydia-rs import port should pick up this reorganize-and-re-notify capability later.
