### PR TITLE
fix(downloads): stop active season download blocking other seasons

### DIFF
--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -262,11 +262,13 @@ defmodule Mydia.Downloads.Queue do
 
         # Unscoped TV show request (no episode_id, not a season pack): a TV show
         # legitimately has many concurrent downloads across seasons/episodes, so
-        # an active download for the show doesn't make THIS request a duplicate.
-        # Without season/episode scoping we can't prove a conflict, so allow it.
-        # Mirrors the tv_show carve-out in check_for_existing_media_files/3.
+        # an active download for a *different* season/episode doesn't make THIS
+        # request a duplicate. Dedupe by the exact release URL instead of by
+        # media_item: different seasons have different torrent hashes (so
+        # cross-season requests are allowed), while re-submitting the same
+        # release (e.g. a double-clicked manual result) is still blocked.
         media_item_id && tv_show?(media_item_id) ->
-          :allow
+          where(base_query, [d], d.download_url == ^search_result.download_url)
 
         # For movies or other media, check if there's an active download for this media_item
         media_item_id ->
@@ -278,21 +280,6 @@ defmodule Mydia.Downloads.Queue do
           where(base_query, [d], d.download_url == ^search_result.download_url)
       end
 
-    if query == :allow do
-      :ok
-    else
-      check_active_downloads(query, search_result, media_item_id, episode_id)
-    end
-  end
-
-  defp tv_show?(media_item_id) do
-    case Repo.get(MediaItem, media_item_id) do
-      %MediaItem{type: "tv_show"} -> true
-      _ -> false
-    end
-  end
-
-  defp check_active_downloads(query, search_result, media_item_id, episode_id) do
     active_downloads = Repo.all(query)
 
     if active_downloads == [] do
@@ -318,6 +305,13 @@ defmodule Mydia.Downloads.Queue do
 
           {:error, :duplicate_download}
       end
+    end
+  end
+
+  defp tv_show?(media_item_id) do
+    case Repo.get(MediaItem, media_item_id) do
+      %MediaItem{type: "tv_show"} -> true
+      _ -> false
     end
   end
 

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -260,6 +260,14 @@ defmodule Mydia.Downloads.Queue do
             ^Mydia.DB.json_integer_equals(:metadata, "$.season_number", season_number)
           )
 
+        # Unscoped TV show request (no episode_id, not a season pack): a TV show
+        # legitimately has many concurrent downloads across seasons/episodes, so
+        # an active download for the show doesn't make THIS request a duplicate.
+        # Without season/episode scoping we can't prove a conflict, so allow it.
+        # Mirrors the tv_show carve-out in check_for_existing_media_files/3.
+        media_item_id && tv_show?(media_item_id) ->
+          :allow
+
         # For movies or other media, check if there's an active download for this media_item
         media_item_id ->
           where(base_query, [d], d.media_item_id == ^media_item_id)
@@ -270,6 +278,21 @@ defmodule Mydia.Downloads.Queue do
           where(base_query, [d], d.download_url == ^search_result.download_url)
       end
 
+    if query == :allow do
+      :ok
+    else
+      check_active_downloads(query, search_result, media_item_id, episode_id)
+    end
+  end
+
+  defp tv_show?(media_item_id) do
+    case Repo.get(MediaItem, media_item_id) do
+      %MediaItem{type: "tv_show"} -> true
+      _ -> false
+    end
+  end
+
+  defp check_active_downloads(query, search_result, media_item_id, episode_id) do
     active_downloads = Repo.all(query)
 
     if active_downloads == [] do

--- a/lib/mydia_web/live/media_live/show/search_events.ex
+++ b/lib/mydia_web/live/media_live/show/search_events.ex
@@ -7,6 +7,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
   alias Mydia.Media
   alias Mydia.Downloads
   alias Mydia.Indexers.SearchResult
+  alias Mydia.Indexers.Structs.SearchResultMetadata
   alias MydiaWeb.Live.Authorization
 
   import MydiaWeb.MediaLive.Show.Loaders,
@@ -244,16 +245,21 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
       media_item = socket.assigns.media_item
       context = socket.assigns.manual_search_context
 
-      {media_item_id, episode_id} =
+      {media_item_id, episode_id, metadata} =
         case context do
           %{type: :episode, episode_id: ep_id} ->
-            {media_item.id, ep_id}
+            {media_item.id, ep_id, nil}
 
-          %{type: :season, season_number: _season_num} ->
-            {media_item.id, nil}
+          %{type: :season, season_number: season_num} ->
+            # Tag the request as a season pack so duplicate detection and
+            # category routing are scoped to this season rather than the whole
+            # show. Without this, an active download for a *different* season
+            # falsely reports :duplicate_download.
+            {media_item.id, nil,
+             %SearchResultMetadata{season_pack: true, season_number: season_num}}
 
           _ ->
-            {media_item.id, nil}
+            {media_item.id, nil, nil}
         end
 
       search_result = %SearchResult{
@@ -263,7 +269,8 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
         size: parse_int(size),
         seeders: parse_int(seeders),
         leechers: parse_int(leechers),
-        quality: quality
+        quality: quality,
+        metadata: metadata
       }
 
       opts =

--- a/test/mydia/downloads/queue_test.exs
+++ b/test/mydia/downloads/queue_test.exs
@@ -217,6 +217,116 @@ defmodule Mydia.Downloads.QueueTest do
     end
   end
 
+  describe "check_for_active_download/3 — cross-season duplicate blocking" do
+    # Regression for the production bug where starting a Season 3 download for a
+    # show reported `:duplicate_download` because an unrelated, still-active
+    # Season 2 download existed. A TV show legitimately has many concurrent
+    # downloads across seasons/episodes, so an active download for the show must
+    # not, by itself, make a *different* request a duplicate. This mirrors the
+    # tv_show carve-out already present in check_for_existing_media_files/3.
+    #
+    # download_fixture/1 uses download_client: "test-client", which has no
+    # registered client config, so verify_single_download_in_client/1 treats it
+    # as :active (assume-active-on-unknown-client). That makes these fixtures a
+    # faithful stand-in for a genuinely in-progress download.
+
+    alias Mydia.Indexers.SearchResult
+    alias Mydia.Indexers.Structs.SearchResultMetadata
+
+    defp search_result(metadata) do
+      %SearchResult{
+        download_url: "magnet:?xt=urn:btih:req-#{System.unique_integer([:positive])}",
+        title: "Requested Release",
+        indexer: "test",
+        size: 1_000_000_000,
+        seeders: 10,
+        leechers: 5,
+        metadata: metadata
+      }
+    end
+
+    defp active_download(media_item_id, attrs) do
+      download_fixture(Map.merge(%{media_item_id: media_item_id}, attrs))
+    end
+
+    test "an active unscoped TV download does NOT block another unscoped request for the same show" do
+      show = media_item_fixture(%{type: "tv_show", title: "The Boys"})
+
+      active_download(show.id, %{title: "The Boys Season 2 S02 1080p", metadata: %{}})
+
+      # Mirrors the season-download UI path before it tagged season metadata:
+      # episode_id nil, no season_pack metadata.
+      assert Queue.check_for_active_download(search_result(nil), show.id, nil) == :ok
+    end
+
+    test "an active S02 season-pack download does NOT block an S03 season-pack request" do
+      show = media_item_fixture(%{type: "tv_show", title: "The Boys"})
+
+      active_download(show.id, %{
+        title: "The Boys S02 COMPLETE 1080p",
+        metadata: %{season_pack: true, season_number: 2}
+      })
+
+      result = search_result(%SearchResultMetadata{season_pack: true, season_number: 3})
+
+      assert Queue.check_for_active_download(result, show.id, nil) == :ok
+    end
+
+    test "an active S03 season-pack download DOES block a duplicate S03 season-pack request" do
+      show = media_item_fixture(%{type: "tv_show", title: "The Boys"})
+
+      active_download(show.id, %{
+        title: "The Boys S03 COMPLETE 1080p",
+        metadata: %{season_pack: true, season_number: 3}
+      })
+
+      result = search_result(%SearchResultMetadata{season_pack: true, season_number: 3})
+
+      assert Queue.check_for_active_download(result, show.id, nil) ==
+               {:error, :duplicate_download}
+    end
+
+    test "an active download for one episode does NOT block a different episode" do
+      show = media_item_fixture(%{type: "tv_show"})
+      ep_a = episode_fixture(%{media_item_id: show.id, season_number: 3, episode_number: 1})
+      ep_b = episode_fixture(%{media_item_id: show.id, season_number: 3, episode_number: 2})
+
+      active_download(show.id, %{title: "S03E01", episode_id: ep_a.id})
+
+      assert Queue.check_for_active_download(search_result(nil), show.id, ep_b.id) == :ok
+    end
+
+    test "an active download for an episode DOES block a duplicate request for the same episode" do
+      show = media_item_fixture(%{type: "tv_show"})
+      ep = episode_fixture(%{media_item_id: show.id, season_number: 3, episode_number: 1})
+
+      active_download(show.id, %{title: "S03E01", episode_id: ep.id})
+
+      assert Queue.check_for_active_download(search_result(nil), show.id, ep.id) ==
+               {:error, :duplicate_download}
+    end
+
+    test "an active movie download DOES block another request for the same movie" do
+      movie = media_item_fixture(%{type: "movie"})
+
+      active_download(movie.id, %{title: "The Movie 1080p", metadata: %{}})
+
+      assert Queue.check_for_active_download(search_result(nil), movie.id, nil) ==
+               {:error, :duplicate_download}
+    end
+
+    test "a completed download does NOT block a new request (only active ones count)" do
+      movie = media_item_fixture(%{type: "movie"})
+
+      active_download(movie.id, %{
+        title: "The Movie 1080p",
+        completed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+      assert Queue.check_for_active_download(search_result(nil), movie.id, nil) == :ok
+    end
+  end
+
   # Adapter that records the opts passed to remove_torrent/3 so we can prove the
   # delete_files flag reaches the client. The existing MockAdapter in
   # downloads_test.exs discards opts, so we need our own capturing stub here.

--- a/test/mydia/downloads/queue_test.exs
+++ b/test/mydia/downloads/queue_test.exs
@@ -259,6 +259,28 @@ defmodule Mydia.Downloads.QueueTest do
       assert Queue.check_for_active_download(search_result(nil), show.id, nil) == :ok
     end
 
+    test "an active unscoped TV download DOES block re-submitting the same release URL" do
+      show = media_item_fixture(%{type: "tv_show", title: "The Boys"})
+      url = "magnet:?xt=urn:btih:same-release-#{System.unique_integer([:positive])}"
+
+      active_download(show.id, %{title: "The Boys S03 1080p", download_url: url, metadata: %{}})
+
+      # Same release double-clicked: episode_id nil, no season metadata, but the
+      # exact download_url already has an active download.
+      result = %SearchResult{
+        download_url: url,
+        title: "The Boys S03 1080p",
+        indexer: "test",
+        size: 1_000_000_000,
+        seeders: 10,
+        leechers: 5,
+        metadata: nil
+      }
+
+      assert Queue.check_for_active_download(result, show.id, nil) ==
+               {:error, :duplicate_download}
+    end
+
     test "an active S02 season-pack download does NOT block an S03 season-pack request" do
       show = media_item_fixture(%{type: "tv_show", title: "The Boys"})
 


### PR DESCRIPTION
## Problem

Starting a download for a TV show season reported `Failed to start download: :duplicate_download` when an unrelated download for the **same show** was already in progress (e.g. an active Season 2 download blocked a Season 3 request).

Diagnosed on a live instance: the show had one active, in-progress S02 download (no season/episode scoping in its metadata) and zero media files for S03. The block came from the active-download duplicate check, not from existing files.

## Root cause (two combined defects)

1. **`check_for_active_download/3`** blocked on *any* active download for the `media_item`. For TV shows this is wrong: a show legitimately has many concurrent downloads across seasons/episodes. Movies want this behavior; TV shows don't.

2. **The per-show season download path** (`search_events.ex`) built a `SearchResult` with `metadata: nil`, so the request fell through to that overly-broad branch instead of the season-scoped one.

## Fix

- Add a `tv_show?` carve-out to `check_for_active_download/3` for unscoped requests, mirroring the carve-out already in `check_for_existing_media_files/3`. An unscoped TV request can't be proven a duplicate, so it's allowed. Movie dedup is unchanged.
- Tag season download requests with `%SearchResultMetadata{season_pack: true, season_number: ...}` so duplicate detection **and** category routing are scoped to the season. A genuine duplicate of the same season is still caught; a different season is not.

## Tests

TDD: added 7 tests under `check_for_active_download/3 — cross-season duplicate blocking`. Before the fix, exactly the cross-season repro failed (`{:error, :duplicate_download}` instead of `:ok`); the season-pack, per-episode, movie, and completed-download cases already passed, confirming the bug was narrowly the unscoped-TV case.

- `mix test test/mydia/downloads/queue_test.exs` — 34 tests, 0 failures
- downloads + show-search suites — 819 tests, 0 failures
