### PR TITLE
fix(metadata-relay): de-collapse crash report fingerprints

### DIFF
--- a/metadata-relay/lib/metadata_relay/router.ex
+++ b/metadata-relay/lib/metadata_relay/router.ex
@@ -739,12 +739,8 @@ defmodule MetadataRelay.Router do
 
   defp metadata_stack_frame(_), do: nil
 
-  defp parse_stacktrace_entry(%{"file" => file, "line" => line, "function" => function}) do
-    crash_frame(nil, function, file, line)
-  end
-
-  defp parse_stacktrace_entry(%{"file" => file, "line" => line}) do
-    crash_frame(nil, nil, file, line)
+  defp parse_stacktrace_entry(%{"file" => file, "line" => line} = entry) do
+    crash_frame(Map.get(entry, "module"), Map.get(entry, "function"), file, line)
   end
 
   defp parse_stacktrace_entry(_), do: nil

--- a/metadata-relay/lib/metadata_relay/router.ex
+++ b/metadata-relay/lib/metadata_relay/router.ex
@@ -685,7 +685,8 @@ defmodule MetadataRelay.Router do
   defp validate_crash_report(_), do: {:error, :invalid_json}
 
   defp store_crash_report(body) do
-    # Create a runtime error from the crash report data
+    # Use the reported error type as the ErrorTracker kind so different error
+    # types are not collapsed together. The message is kept as the reason.
     error_type = Map.get(body, "error_type", "RuntimeError")
     error_message = Map.get(body, "error_message", "Unknown error")
 
@@ -696,6 +697,16 @@ defmodule MetadataRelay.Router do
       |> Enum.map(&parse_stacktrace_entry/1)
       |> Enum.filter(& &1)
 
+    # Clients typically send an empty stacktrace and describe the crash site in
+    # `metadata`. Without any source info, ErrorTracker derives the same
+    # fingerprint for every report and collapses them into a single error.
+    # Synthesize a frame from `metadata` so each crash site stays distinct.
+    stacktrace =
+      case stacktrace do
+        [] -> List.wrap(metadata_stack_frame(Map.get(body, "metadata")))
+        frames -> frames
+      end
+
     # Create context from additional metadata
     context = %{
       version: Map.get(body, "version"),
@@ -704,11 +715,9 @@ defmodule MetadataRelay.Router do
       metadata: Map.get(body, "metadata", %{})
     }
 
-    # Create exception struct
-    exception = %RuntimeError{message: "#{error_type}: #{error_message}"}
-
-    # Report to ErrorTracker
-    case ErrorTracker.report(exception, stacktrace, context) do
+    # Report to ErrorTracker as a {kind, reason} tuple so the reported
+    # error_type is preserved as the error kind.
+    case ErrorTracker.report({error_type, error_message}, stacktrace, context) do
       :noop ->
         {:error, :error_tracker_disabled}
 
@@ -717,20 +726,66 @@ defmodule MetadataRelay.Router do
     end
   end
 
+  # Build a synthetic stacktrace frame from the crash report `metadata` map.
+  # Returns nil when there is no usable source information.
+  defp metadata_stack_frame(metadata) when is_map(metadata) do
+    file = Map.get(metadata, "file")
+    line = Map.get(metadata, "line")
+
+    if file || line do
+      crash_frame(Map.get(metadata, "module"), Map.get(metadata, "function"), file, line)
+    end
+  end
+
+  defp metadata_stack_frame(_), do: nil
+
   defp parse_stacktrace_entry(%{"file" => file, "line" => line, "function" => function}) do
-    # Convert crash report format to Elixir stacktrace format
-    # Format: {module, function, arity, [file: path, line: number]}
-    location = build_location(file, line)
-    {String.to_atom(function), 0, location}
+    crash_frame(nil, function, file, line)
   end
 
   defp parse_stacktrace_entry(%{"file" => file, "line" => line}) do
-    # Minimal format without function
-    location = build_location(file, line)
-    {:unknown, 0, location}
+    crash_frame(nil, nil, file, line)
   end
 
   defp parse_stacktrace_entry(_), do: nil
+
+  # Build a stacktrace frame in the {module, function, arity, location} shape that
+  # ErrorTracker.Stacktrace.new/1 expects. The module position is always `nil`
+  # (a safe atom) because ErrorTracker passes it to Application.get_application/1,
+  # which requires an atom; we never call String.to_atom/1 on untrusted module
+  # names (atom-table exhaustion risk). The readable module name is folded into
+  # the function descriptor instead, and the file:line drives the fingerprint.
+  defp crash_frame(module, function, file, line) do
+    {name, arity} = parse_function(function)
+    {nil, qualify(module, name), arity, build_location(file, line)}
+  end
+
+  defp qualify(nil, name), do: name
+
+  defp qualify(module, name) do
+    case to_string(module) |> String.replace_prefix("Elixir.", "") do
+      "" -> name
+      mod -> "#{mod}.#{name}"
+    end
+  end
+
+  # Split a "name/arity" function descriptor (e.g. "import_download/2") into its
+  # name and integer arity. Falls back to arity 0 when the format is unexpected.
+  defp parse_function(function) when is_binary(function) do
+    case String.split(function, "/", parts: 2) do
+      [name, arity] ->
+        case Integer.parse(arity) do
+          {n, ""} -> {name, n}
+          _ -> {function, 0}
+        end
+
+      [name] ->
+        {name, 0}
+    end
+  end
+
+  defp parse_function(nil), do: {"unknown", 0}
+  defp parse_function(function), do: {to_string(function), 0}
 
   defp build_location(nil, nil), do: []
   defp build_location(nil, line), do: [line: line]

--- a/metadata-relay/mix.exs
+++ b/metadata-relay/mix.exs
@@ -4,7 +4,7 @@ defmodule MetadataRelay.MixProject do
   def project do
     [
       app: :metadata_relay,
-      version: "0.10.1",
+      version: "0.10.2",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/metadata-relay/test/metadata_relay/crash_report_test.exs
+++ b/metadata-relay/test/metadata_relay/crash_report_test.exs
@@ -1,6 +1,8 @@
 defmodule MetadataRelay.CrashReportTest do
   use ExUnit.Case, async: false
 
+  import Ecto.Query
+
   alias MetadataRelay.Router
 
   setup do
@@ -17,6 +19,20 @@ defmodule MetadataRelay.CrashReportTest do
     :ets.delete_all_objects(:rate_limiter)
 
     :ok
+  end
+
+  # Submit a crash report through the full router pipeline, mirroring what a
+  # real mydia instance sends: an empty `stacktrace` plus a `metadata` map
+  # describing the crash site.
+  defp report(crash_report) do
+    Plug.Test.conn(:post, "/crashes/report", crash_report)
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Plug.Parsers.call(Plug.Parsers.init(parsers: [:json], json_decoder: Jason))
+    |> Router.call([])
+  end
+
+  defp stored_errors do
+    MetadataRelay.Repo.all(from(e in ErrorTracker.Error, order_by: e.id))
   end
 
   describe "POST /crashes/report" do
@@ -132,6 +148,69 @@ defmodule MetadataRelay.CrashReportTest do
       assert conn.status == 429
       assert %{"error" => "Too many requests"} = Jason.decode!(conn.resp_body)
       assert ["60"] = Plug.Conn.get_resp_header(conn, "retry-after")
+    end
+  end
+
+  describe "crash report fingerprinting" do
+    # Real mydia instances send an empty stacktrace and put the crash site in
+    # `metadata`. These reproduce the production bug where every report collapsed
+    # into a single ErrorTracker record because kind was hardcoded to
+    # "RuntimeError" and no source info was derived from `metadata`.
+    test "distinct crash sites are stored as distinct errors" do
+      assert report(%{
+               "error_type" => "RuntimeError",
+               "error_message" => "{:path_not_found, \"/downloads/complete/foo.mkv\"}",
+               "stacktrace" => [],
+               "metadata" => %{
+                 "file" => "lib/mydia/jobs/media_import.ex",
+                 "function" => "import_download/2",
+                 "line" => 299,
+                 "module" => "Elixir.Mydia.Jobs.MediaImport"
+               },
+               "version" => "0.11.1"
+             }).status == 201
+
+      assert report(%{
+               "error_type" => "RuntimeError",
+               "error_message" => "value too long for type character varying(255)",
+               "stacktrace" => [],
+               "metadata" => %{
+                 "file" => "lib/mydia/jobs/library_scanner.ex",
+                 "function" => "scan/1",
+                 "line" => 248,
+                 "module" => "Elixir.Mydia.Jobs.LibraryScanner"
+               },
+               "version" => "0.11.1"
+             }).status == 201
+
+      errors = stored_errors()
+
+      assert length(errors) == 2,
+             "expected two distinct errors, got #{length(errors)}: " <>
+               inspect(Enum.map(errors, & &1.source_line))
+
+      assert Enum.map(errors, & &1.source_line) |> Enum.uniq() |> length() == 2
+
+      assert Enum.any?(errors, &(&1.source_line =~ "media_import.ex:299"))
+      assert Enum.any?(errors, &(&1.source_line =~ "library_scanner.ex:248"))
+    end
+
+    test "the reported error_type is preserved as the error kind" do
+      assert report(%{
+               "error_type" => "CaseClauseError",
+               "error_message" => "no case clause matching: {:error, :expired}",
+               "stacktrace" => [],
+               "metadata" => %{
+                 "file" => "lib/mydia/indexers/flaresolverr.ex",
+                 "function" => "request/2",
+                 "line" => 232,
+                 "module" => "Elixir.Mydia.Indexers.Flaresolverr"
+               },
+               "version" => "0.11.1"
+             }).status == 201
+
+      assert [error] = stored_errors()
+      assert error.kind == "CaseClauseError"
     end
   end
 end

--- a/metadata-relay/test/metadata_relay/crash_report_test.exs
+++ b/metadata-relay/test/metadata_relay/crash_report_test.exs
@@ -195,6 +195,43 @@ defmodule MetadataRelay.CrashReportTest do
       assert Enum.any?(errors, &(&1.source_line =~ "library_scanner.ex:248"))
     end
 
+    test "client stacktrace module is folded into source_function so same-named functions in different modules stay distinct" do
+      assert report(%{
+               "error_type" => "RuntimeError",
+               "error_message" => "boom",
+               "stacktrace" => [
+                 %{
+                   "file" => "lib/mydia/a.ex",
+                   "line" => 10,
+                   "function" => "handle/1",
+                   "module" => "Elixir.Mydia.A"
+                 }
+               ]
+             }).status == 201
+
+      assert report(%{
+               "error_type" => "RuntimeError",
+               "error_message" => "boom",
+               "stacktrace" => [
+                 %{
+                   "file" => "lib/mydia/b.ex",
+                   "line" => 10,
+                   "function" => "handle/1",
+                   "module" => "Elixir.Mydia.B"
+                 }
+               ]
+             }).status == 201
+
+      errors = stored_errors()
+
+      assert length(errors) == 2,
+             "expected two distinct errors, got #{length(errors)}: " <>
+               inspect(Enum.map(errors, & &1.source_function))
+
+      assert Enum.any?(errors, &(&1.source_function =~ "Mydia.A.handle"))
+      assert Enum.any?(errors, &(&1.source_function =~ "Mydia.B.handle"))
+    end
+
     test "the reported error_type is preserved as the error kind" do
       assert report(%{
                "error_type" => "CaseClauseError",


### PR DESCRIPTION
## Problem

Crash reports submitted by mydia instances to `POST /crashes/report` were all collapsing into a **single** ErrorTracker record. In production, one bucket (`error_tracker_errors` id 2) had **29k+ occurrences spanning many unrelated crashes** — the displayed reason (a client's `String.slice/3` error) had nothing to do with most of the occurrences stacked under it.

### Root cause

ErrorTracker computes its fingerprint from `kind <> source_line <> source_function` — **not** the reason. The handler:

1. Wrapped every report in `%RuntimeError{}`, discarding the client's real `error_type` (it only survived inside the message string), and
2. Ignored the `metadata` map. Real clients send `stacktrace: []` and describe the crash site in `metadata`, so `source_line`/`source_function` were always `"-"`.

Result: `fingerprint = sha256("RuntimeError" <> "-" <> "-")` — constant for every report.

A secondary bug: `parse_stacktrace_entry/1` built 3-tuples, but `ErrorTracker.Stacktrace.new/1` matches on 4-tuples `{module, function, arity, opts}` and silently dropped them — so even client-supplied stacktraces never produced source info.

## Fix

- Report as `{error_type, error_message}` so the client's real error type is preserved as the ErrorTracker kind.
- Synthesize a stacktrace frame from `metadata` (file/function/line/module) when the client stacktrace is empty, so `source_line` becomes e.g. `lib/mydia/jobs/media_import.ex:299` and fingerprints diverge per crash site.
- Emit the correct 4-tuple frame shape so client-supplied stacktraces are honored too.
- The module position is passed as `nil` (a safe atom), **not** via `String.to_atom/1` on untrusted module names — that would be an atom-table exhaustion vector on the public endpoint. The readable module name is folded into the function descriptor instead.
- Bump relay to `0.10.2`.

### Stored output after the fix

```
kind:            RuntimeError
reason:          {:path_not_found, "/downloads/complete/foo.mkv"}
source_line:     lib/mydia/jobs/media_import.ex:299
source_function: .Mydia.Jobs.MediaImport.import_download/2
```

## Tests

TDD: two new tests in `crash_report_test.exs` pin the behavior — distinct crash sites produce distinct error records, and `error_type` survives as `kind`. Both failed before the fix, pass after. Full suite: **165 tests, 0 failures**.

## Notes

- **Forward-only.** This de-collapses *new* reports; the existing merged bucket is not re-fingerprinted (ErrorTracker doesn't rewrite stored rows). Old payloads remain in each occurrence's `context.request.params` if backfill analysis is ever wanted.
- The underlying signal this exposed — ~3,800 instances hitting `media_import.ex` `:path_not_found` — is tracked separately as a mydia bug.
