### PR TITLE
feat(admin): surface real error count and dashboard link in crash widget

### DIFF
--- a/lib/mydia/crash_reporter.ex
+++ b/lib/mydia/crash_reporter.ex
@@ -55,6 +55,7 @@ defmodule Mydia.CrashReporter do
 
   require Logger
 
+  alias ErrorTracker.Error
   alias Mydia.CrashReporter.{Sanitizer, Queue, Sender}
 
   @doc """
@@ -133,10 +134,14 @@ defmodule Mydia.CrashReporter do
   @doc """
   Returns statistics about the crash reporter.
 
+  `tracked_errors` is the number of errors stored locally by ErrorTracker (the
+  same total shown on the `/admin/errors` dashboard), not a count of reports
+  sent to the metadata relay.
+
   ## Examples
 
       iex> Mydia.CrashReporter.stats()
-      %{enabled: false, queued_reports: 0, sent_reports: 42}
+      %{enabled: false, queued_reports: 0, tracked_errors: 42, metadata_relay_url: "https://relay.mydia.dev"}
 
   """
   @spec stats() :: map()
@@ -144,8 +149,19 @@ defmodule Mydia.CrashReporter do
     %{
       enabled: enabled?(),
       queued_reports: Queue.count(),
+      tracked_errors: tracked_error_count(),
       metadata_relay_url: Mydia.Metadata.metadata_relay_url()
     }
+  end
+
+  # Count of errors stored locally by ErrorTracker. Mirrors the dashboard's own
+  # `Repo.aggregate(_, :count)` over grouped error records. Guarded like
+  # `Queue.count/0` so a momentarily-unavailable DB renders 0 instead of crashing
+  # the settings page.
+  defp tracked_error_count do
+    Mydia.Repo.aggregate(Error, :count)
+  rescue
+    _ -> 0
   end
 
   @doc """

--- a/lib/mydia_web/live/admin_settings_live/components.ex
+++ b/lib/mydia_web/live/admin_settings_live/components.ex
@@ -83,16 +83,23 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
           </span>
         </div>
       </div>
-      <div class="stat">
-        <div class="stat-figure text-success">
-          <.icon name="hero-check-circle" class="w-8 h-8" />
+      <.link
+        navigate={~p"/admin/errors"}
+        id="tracked-errors-link"
+        class="stat hover:bg-base-300 transition-colors cursor-pointer"
+      >
+        <div class="stat-figure text-info">
+          <.icon name="hero-magnifying-glass" class="w-8 h-8" />
         </div>
-        <div class="stat-title">Sent</div>
-        <div class="stat-value text-success">
-          {Map.get(@stats, :sent_reports, 0)}
+        <div class="stat-title">Tracked</div>
+        <div class="stat-value text-info">
+          {@stats.tracked_errors}
+          <span class="text-base font-normal">
+            {if @stats.tracked_errors == 1, do: "error", else: "errors"}
+          </span>
         </div>
-        <div class="stat-desc">Successfully reported</div>
-      </div>
+        <div class="stat-desc link link-info">View all →</div>
+      </.link>
       <%= if @stats.queued_reports > 0 do %>
         <div class="stat">
           <div class="stat-figure">

--- a/lib/mydia_web/live/admin_settings_live/components.ex
+++ b/lib/mydia_web/live/admin_settings_live/components.ex
@@ -72,16 +72,7 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
         </div>
         <div class="stat-title">Crash Reports</div>
         <div class="stat-value text-warning">{@stats.queued_reports}</div>
-        <div class="stat-desc">
-          Queued →
-          <span
-            class="font-mono truncate max-w-xs inline-block align-bottom"
-            title={@stats.metadata_relay_url}
-            aria-label={"Relay URL: #{@stats.metadata_relay_url}"}
-          >
-            {@stats.metadata_relay_url}
-          </span>
-        </div>
+        <div class="stat-desc">Queued</div>
       </div>
       <.link
         navigate={~p"/admin/errors"}

--- a/test/mydia/crash_reporter_test.exs
+++ b/test/mydia/crash_reporter_test.exs
@@ -37,7 +37,9 @@ defmodule Mydia.CrashReporterTest do
       source_line: "lib/foo.ex:1",
       source_function: "Foo.bar/0",
       status: :unresolved,
-      fingerprint: :crypto.strong_rand_bytes(8),
+      # ErrorTracker stores the fingerprint as a Base16 string (the column is a
+      # NOT NULL unique string); raw bytes break Postgres' UTF-8 encoding.
+      fingerprint: Base.encode16(:crypto.strong_rand_bytes(8)),
       last_occurrence_at: DateTime.utc_now()
     })
   end

--- a/test/mydia/crash_reporter_test.exs
+++ b/test/mydia/crash_reporter_test.exs
@@ -1,0 +1,44 @@
+defmodule Mydia.CrashReporterTest do
+  use Mydia.DataCase, async: false
+
+  alias Mydia.CrashReporter
+
+  describe "stats/0" do
+    test "tracked_errors counts errors stored locally by ErrorTracker" do
+      assert CrashReporter.stats().tracked_errors == 0
+
+      insert_error()
+      insert_error()
+
+      assert CrashReporter.stats().tracked_errors == 2
+    end
+
+    test "tracked_errors is 0 when no errors are stored" do
+      assert CrashReporter.stats().tracked_errors == 0
+    end
+
+    test "does not expose a :sent_reports key" do
+      refute Map.has_key?(CrashReporter.stats(), :sent_reports)
+    end
+
+    test "still returns enabled, queued_reports, and metadata_relay_url" do
+      stats = CrashReporter.stats()
+
+      assert is_boolean(stats.enabled)
+      assert is_integer(stats.queued_reports)
+      assert is_binary(stats.metadata_relay_url)
+    end
+  end
+
+  defp insert_error do
+    Mydia.Repo.insert!(%ErrorTracker.Error{
+      kind: "RuntimeError",
+      reason: "boom #{System.unique_integer([:positive])}",
+      source_line: "lib/foo.ex:1",
+      source_function: "Foo.bar/0",
+      status: :unresolved,
+      fingerprint: :crypto.strong_rand_bytes(8),
+      last_occurrence_at: DateTime.utc_now()
+    })
+  end
+end

--- a/test/mydia_web/live/admin_settings_live_test.exs
+++ b/test/mydia_web/live/admin_settings_live_test.exs
@@ -127,4 +127,37 @@ defmodule MydiaWeb.AdminSettingsLiveTest do
       refute has_element?(view, "input[phx-value-key='flaresolverr.url']")
     end
   end
+
+  describe "Crash report widget" do
+    setup %{conn: conn, token: token, user: user} do
+      start_supervised!(Mydia.Indexers.Health)
+
+      # The stats widget only renders when crash reporting is enabled.
+      {:ok, _setting} =
+        Settings.upsert_config_setting(%{
+          key: "crash_reporting.enabled",
+          value: "true",
+          category: :crash_reporting,
+          updated_by_id: user.id
+        })
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/settings")
+      %{view: view}
+    end
+
+    test "renders the tracked-errors count as a link to the error dashboard", %{view: view} do
+      assert has_element?(view, "a#tracked-errors-link[href='/admin/errors']")
+    end
+
+    test "no longer renders the 'Sent' tile", %{view: view} do
+      refute has_element?(view, ".stat-title", "Sent")
+      refute has_element?(view, ".stat-desc", "Successfully reported")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The crash-reporting widget in admin settings showed a "Sent" count that was always 0 — `stats/0` never tracked sent reports, so the number signalled nothing. It now shows a real count of errors tracked locally and links straight to the error dashboard at `/admin/errors`, which until now had no entry point anywhere in the UI.

Operators who opted into crash reporting can finally see how many errors their instance has recorded and click through to read them. The fake "Sent" tile and its dead `sent_reports` docstring/fallback are gone.

### How the count works

The number comes from `Repo.aggregate(ErrorTracker.Error, :count)` — the same grouped-error total ErrorTracker's own dashboard shows — surfaced through `stats/0` behind a `try/rescue → 0` guard (mirroring `Queue.count/0`) so a momentarily-unavailable DB renders `0` instead of crashing the settings page. It counts total stored errors to match the "tracked locally" label; narrowing to unresolved-only later is a one-clause query change.

## Test plan

- `test/mydia/crash_reporter_test.exs` (new): `stats/0` returns a real `tracked_errors` count, `0` when empty, no `:sent_reports` key, and still returns `enabled` / `queued_reports` / `metadata_relay_url`.
- `test/mydia_web/live/admin_settings_live_test.exs`: the widget renders the tracked-errors link to `/admin/errors` and no longer renders a "Sent" tile.
- 59 tests pass across the crash-reporter subsystem and admin settings; no regressions.

## Post-Deploy Monitoring & Validation

Low runtime impact — adds one `COUNT(*)` on `error_tracker_errors` per settings-page render, guarded so a DB failure renders `0` rather than erroring. Validate by opening `/admin/config/settings` with crash reporting enabled: the "Tracked" tile shows the real error count and links to `/admin/errors`. Failure signal: the settings page errors, or the tile shows `0` while errors exist. No migrations and no rollback steps; revert the PR if the count query misbehaves.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
