### PR TITLE
fix(indexers): collapse expired FlareSolverr session into :not_found

### DIFF
--- a/lib/mydia/indexers/adapter/cardigann.ex
+++ b/lib/mydia/indexers/adapter/cardigann.ex
@@ -365,9 +365,11 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
       session ->
         # Check if session is expired
         if CardigannSearchSession.expired?(session) do
-          # Delete expired session
+          # Delete the stale row and treat it as absent. Callers only need to
+          # distinguish "usable session" from "no usable session", so expired
+          # collapses into :not_found rather than exposing a third return value.
           Repo.delete(session)
-          {:error, :expired}
+          {:error, :not_found}
         else
           {:ok, session}
         end

--- a/test/mydia/indexers/adapter/cardigann_test.exs
+++ b/test/mydia/indexers/adapter/cardigann_test.exs
@@ -4,6 +4,7 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
   alias Mydia.Indexers.Adapter.Cardigann
   alias Mydia.Indexers.Adapter.Error
   alias Mydia.Indexers.CardigannDefinition
+  alias Mydia.Indexers.CardigannSearchSession
   alias Mydia.Repo
 
   defp sample_yaml(base_url) do
@@ -184,6 +185,37 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
       # Bypass returns empty results, verifying config processing doesn't error
       assert {:ok, results} = Cardigann.search(config, "query", min_seeders: 10, limit: 5)
       assert is_list(results)
+    end
+
+    # Regression for #192: an expired FlareSolverr session row used to make
+    # get_flaresolverr_session/1 return {:error, :expired}, a value the cookie
+    # store call site had no clause for (CaseClauseError). The session lookup now
+    # collapses expired into :not_found, so an expired row is silently purged and
+    # the search proceeds instead of crashing.
+    test "search purges an expired FlareSolverr session and does not crash", %{
+      definition: definition
+    } do
+      {:ok, expired_session} =
+        %CardigannSearchSession{}
+        |> CardigannSearchSession.changeset(%{
+          cardigann_definition_id: definition.id,
+          cookies: [%{"name" => "cf_clearance", "value" => "stale"}],
+          expires_at:
+            DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+        })
+        |> Repo.insert()
+
+      config = %{
+        type: :cardigann,
+        name: "Test Indexer",
+        indexer_id: "test-indexer"
+      }
+
+      assert {:ok, results} = Cardigann.search(config, "test query")
+      assert is_list(results)
+
+      # The expired row was deleted by the session lookup during the search.
+      refute Repo.get(CardigannSearchSession, expired_session.id)
     end
   end
 


### PR DESCRIPTION
## What

Fixes the `CaseClauseError` reported in #192. Cardigann searches that use FlareSolverr crashed once an indexer's stored session expired.

## Root cause

`get_flaresolverr_session/1` returned three values: `{:ok, session}`, `{:error, :not_found}`, and `{:error, :expired}`. The cookie store call site at `cardigann.ex:302` (`store_flaresolverr_cookies/2`) only had clauses for the first two, so an expired session raised `CaseClauseError` and killed the search task (also surfaced to the relay as `Mydia.CrashReporter.ExitError`).

The expired branch already **deletes** the stale row before returning, so to the caller "expired" and "absent" are the same state.

## Fix

Narrow the private contract: when the lookup finds an expired row it deletes it (as before) and now returns `{:error, :not_found}` instead of `{:error, :expired}`. `:expired` no longer exists as a return value of this function, so the store `case` is exhaustive over the only two values it can produce, and the same gap can't recur at either call site.

The other `:expired` references in the file belong to the separate `CardigannAuth.get_stored_session/1` contract and are untouched.

## Test

Added a regression test that inserts an expired `CardigannSearchSession`, runs a search, and asserts the search succeeds and the expired row is purged. It drives the shared lookup through the read path (which runs on every search); reproducing the exact store-site crash would require a live FlareSolverr solve, which needs global runtime-config mutation disallowed in this `async: true` file. The contract narrowing is the real guard.

All 15 tests in `test/mydia/indexers/adapter/cardigann_test.exs` pass.

Closes #192