### PR TITLE
fix(metadata): respect configured language for TV series, seasons, and episodes

### DIFF
--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -396,6 +396,11 @@ defmodule Mydia.Library.MetadataEnricher do
     # Get seasons list from metadata (includes tvdb_season_id if from TVDB)
     seasons = get_seasons_list(media_item.metadata)
 
+    # The show's original language lets the TVDB season/episode fetch prefer the
+    # original-language translation before falling back to English (TVDB stores
+    # it as a 3-letter code, matching the translation bundle's keys).
+    original_language = metadata_original_language(media_item.metadata)
+
     if seasons != [] do
       # Fetch and create/update all episodes
       Enum.each(seasons, fn season ->
@@ -403,11 +408,8 @@ defmodule Mydia.Library.MetadataEnricher do
         tvdb_season_id = Map.get(season, :tvdb_season_id)
 
         fetch_opts =
-          if tvdb_season_id do
-            [tvdb_season_id: tvdb_season_id]
-          else
-            []
-          end
+          [tvdb_season_id: tvdb_season_id, original_language: original_language]
+          |> Enum.reject(fn {_key, value} -> is_nil(value) end)
 
         case Metadata.fetch_season_cached(config, provider_id, season_num, fetch_opts) do
           {:ok, season_data} ->
@@ -444,6 +446,12 @@ defmodule Mydia.Library.MetadataEnricher do
   end
 
   defp get_seasons_list(_), do: []
+
+  defp metadata_original_language(%{original_language: lang})
+       when is_binary(lang) and lang != "",
+       do: lang
+
+  defp metadata_original_language(_), do: nil
 
   defp create_episodes_for_season(media_item, season_data) do
     {:ok, count} = Media.upsert_episodes_from_season(media_item, season_data)

--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -11,6 +11,7 @@ defmodule Mydia.Library.MetadataEnricher do
 
   require Logger
   alias Mydia.{Media, Metadata, Repo, Settings}
+  alias Mydia.Metadata.LanguageCode
   alias Mydia.Metadata.NfoWriter
 
   @doc """
@@ -397,9 +398,8 @@ defmodule Mydia.Library.MetadataEnricher do
     seasons = get_seasons_list(media_item.metadata)
 
     # The show's original language lets the TVDB season/episode fetch prefer the
-    # original-language translation before falling back to English (TVDB stores
-    # it as a 3-letter code, matching the translation bundle's keys).
-    original_language = metadata_original_language(media_item.metadata)
+    # original-language translation before falling back to English.
+    original_language = LanguageCode.original_language_from(media_item.metadata)
 
     if seasons != [] do
       # Fetch and create/update all episodes
@@ -446,12 +446,6 @@ defmodule Mydia.Library.MetadataEnricher do
   end
 
   defp get_seasons_list(_), do: []
-
-  defp metadata_original_language(%{original_language: lang})
-       when is_binary(lang) and lang != "",
-       do: lang
-
-  defp metadata_original_language(_), do: nil
 
   defp create_episodes_for_season(media_item, season_data) do
     {:ok, count} = Media.upsert_episodes_from_season(media_item, season_data)

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1225,11 +1225,14 @@ defmodule Mydia.Media do
               tvdb_season_id =
                 if has_tvdb, do: Map.get(season, :tvdb_season_id), else: nil
 
+              # Use the configured language so the deleted key matches the one
+              # fetch_season_cached writes under (it now keys by configured
+              # language, not a hardcoded "en-US").
               cache_key =
                 Metadata.build_season_cache_key(
                   provider_id,
                   season.season_number,
-                  "en-US",
+                  Metadata.metadata_language(),
                   tvdb_season_id
                 )
 
@@ -1491,13 +1494,18 @@ defmodule Mydia.Media do
           end
       end
 
-    # Pass tvdb_season_id only if we have a tvdb_id (otherwise season IDs are TMDB)
+    # Pass tvdb_season_id only if we have a tvdb_id (otherwise season IDs are TMDB).
+    # Thread the show's original language so episode selection can fall back to it
+    # before English, matching the enricher path.
+    original_language = Metadata.LanguageCode.original_language_from(media_item.metadata)
+
     fetch_opts =
       if has_tvdb do
-        case Map.get(season, :tvdb_season_id) do
-          nil -> []
-          tvdb_season_id -> [tvdb_season_id: tvdb_season_id]
-        end
+        [
+          tvdb_season_id: Map.get(season, :tvdb_season_id),
+          original_language: original_language
+        ]
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
       else
         []
       end

--- a/lib/mydia/media/provider_switch.ex
+++ b/lib/mydia/media/provider_switch.ex
@@ -212,7 +212,13 @@ defmodule Mydia.Media.ProviderSwitch do
              append_to_response: ["credits", "images", "videos", "keywords"]
            ),
          {:ok, season_datas, expected_episode_count} <-
-           prefetch_provider_seasons(new_id, target_provider, metadata.seasons || [], config) do
+           prefetch_provider_seasons(
+             new_id,
+             target_provider,
+             metadata.seasons || [],
+             config,
+             metadata.original_language
+           ) do
       # Step 3 (transactional, no network): wipe + swap + recreate + re-link.
       result =
         Repo.transaction(fn ->
@@ -280,7 +286,7 @@ defmodule Mydia.Media.ProviderSwitch do
     {:error, {:invalid_type, "Expected tv_show, got #{type}"}}
   end
 
-  defp prefetch_provider_seasons(provider_id, target_provider, seasons, config) do
+  defp prefetch_provider_seasons(provider_id, target_provider, seasons, config, original_language) do
     has_tvdb = target_provider == :tvdb
 
     # All-or-nothing: abort the whole switch if ANY season fails to fetch. A
@@ -294,8 +300,15 @@ defmodule Mydia.Media.ProviderSwitch do
             # endpoint with a TVDB id (wrong data / 404), so treat it as a hard
             # failure rather than silently fetching from the wrong provider.
             case Map.get(season, :tvdb_season_id) do
-              nil -> :error
-              tvdb_season_id -> {:ok, [tvdb_season_id: tvdb_season_id]}
+              nil ->
+                :error
+
+              tvdb_season_id ->
+                opts =
+                  [tvdb_season_id: tvdb_season_id, original_language: original_language]
+                  |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+
+                {:ok, opts}
             end
           else
             {:ok, []}

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -211,7 +211,9 @@ defmodule Mydia.Metadata do
 
     media_type = Keyword.get(opts, :media_type, :movie)
     append = Keyword.get(opts, :append_to_response, []) |> Enum.sort() |> Enum.join(",")
-    language = Keyword.get(opts, :language, "en-US")
+    # Default to the configured language (not a literal "en-US") so cache keys
+    # vary by language and non-English libraries don't read English-cached entries.
+    language = Keyword.get(opts, :language, config_language(config))
     # Include the provider so numerically-overlapping TVDB/TMDB ids never share a
     # cache entry (e.g. TVDB series 603 vs TMDB movie 603).
     provider = Keyword.get(opts, :provider, type)
@@ -304,7 +306,9 @@ defmodule Mydia.Metadata do
       when is_atom(type) do
     alias Mydia.Metadata.Cache
 
-    language = Keyword.get(opts, :language, "en-US")
+    # Default to the configured language so a non-English library does not read
+    # the English library's cached season (see fetch_by_id_cached/3).
+    language = Keyword.get(opts, :language, config_language(config))
     tvdb_season_id = Keyword.get(opts, :tvdb_season_id)
     cache_key = build_season_cache_key(provider_id, season_number, language, tvdb_season_id)
 
@@ -368,6 +372,17 @@ defmodule Mydia.Metadata do
   def metadata_language do
     case Mydia.Settings.get_metadata_config() do
       %{language: lang} when is_binary(lang) and lang != "" -> lang
+      _ -> "en-US"
+    end
+  end
+
+  # Reads the language carried on a provider config (populated from
+  # metadata_language/0 via default_relay_config/0), falling back to "en-US"
+  # for bare configs. Used to default cache-key language so entries vary by the
+  # configured language. Mirrors Relay's private config_language/1.
+  defp config_language(config) do
+    case config do
+      %{options: %{language: lang}} when is_binary(lang) and lang != "" -> lang
       _ -> "en-US"
     end
   end

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -146,7 +146,9 @@ defmodule Mydia.Metadata do
     # Build cache key including all relevant search parameters
     media_type = Keyword.get(opts, :media_type)
     year = Keyword.get(opts, :year)
-    language = Keyword.get(opts, :language, "en-US")
+    # Default to the configured language so searches don't read English-cached
+    # results (mirrors fetch_by_id_cached/3 and fetch_season_cached/4).
+    language = Keyword.get(opts, :language, config_language(config))
     page = Keyword.get(opts, :page, 1)
     # Include the provider so a TV title searched under TVDB and under TMDB
     # never share a cache entry (per-library provider routing). Mirrors the

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -36,6 +36,10 @@ defmodule Mydia.Metadata do
 
   require Logger
 
+  # Fallback language when neither opts nor the provider config specify one.
+  # Must agree with the relay provider's default so cache keys and fetches align.
+  @default_language "en-US"
+
   alias Mydia.Metadata.Provider
 
   @doc """
@@ -372,7 +376,7 @@ defmodule Mydia.Metadata do
   def metadata_language do
     case Mydia.Settings.get_metadata_config() do
       %{language: lang} when is_binary(lang) and lang != "" -> lang
-      _ -> "en-US"
+      _ -> @default_language
     end
   end
 
@@ -383,7 +387,7 @@ defmodule Mydia.Metadata do
   defp config_language(config) do
     case config do
       %{options: %{language: lang}} when is_binary(lang) and lang != "" -> lang
-      _ -> "en-US"
+      _ -> @default_language
     end
   end
 

--- a/lib/mydia/metadata/language_code.ex
+++ b/lib/mydia/metadata/language_code.ex
@@ -96,6 +96,11 @@ defmodule Mydia.Metadata.LanguageCode do
       when is_binary(lang) and lang != "",
       do: lang
 
+  # Some paths carry metadata as a string-key map rather than a MediaMetadata struct.
+  def original_language_from(%{"original_language" => lang})
+      when is_binary(lang) and lang != "",
+      do: lang
+
   def original_language_from(_), do: nil
 
   @doc """

--- a/lib/mydia/metadata/language_code.ex
+++ b/lib/mydia/metadata/language_code.ex
@@ -55,6 +55,50 @@ defmodule Mydia.Metadata.LanguageCode do
   def to_tvdb_code(_), do: nil
 
   @doc """
+  Normalizes a language code that may be either a 2-letter (ISO 639-1, possibly
+  region-suffixed) or an already-3-letter (ISO 639-2/T) value into the TVDB
+  3-letter form. Use for values whose width depends on their source — e.g. a
+  show's `original_language`, which TVDB stores as `"jpn"` but TMDB stores as
+  `"ja"`. Returns `nil` for blank or unrecognized input.
+
+  ## Examples
+
+      iex> Mydia.Metadata.LanguageCode.normalize_tvdb_code("jpn")
+      "jpn"
+
+      iex> Mydia.Metadata.LanguageCode.normalize_tvdb_code("ja")
+      "jpn"
+  """
+  def normalize_tvdb_code(code) when is_binary(code) do
+    primary =
+      code
+      |> String.downcase()
+      |> String.split(["-", "_"], parts: 2)
+      |> List.first()
+
+    cond do
+      primary == "" -> nil
+      # Already a 3-letter ISO 639-2 code (e.g. TVDB's "jpn"); pass through.
+      String.length(primary) == 3 -> primary
+      # Otherwise treat as a 2-letter ISO 639-1 code and map it.
+      true -> to_tvdb_code(primary)
+    end
+  end
+
+  def normalize_tvdb_code(_), do: nil
+
+  @doc """
+  Extracts a show's original-language code from a metadata struct or map,
+  returning `nil` when absent or blank. Nil-safe so callers can thread it into
+  fetch options without guarding the metadata themselves.
+  """
+  def original_language_from(%{original_language: lang})
+      when is_binary(lang) and lang != "",
+      do: lang
+
+  def original_language_from(_), do: nil
+
+  @doc """
   Selects a field value from a TVDB translation list by trying each preferred
   language code in order. TVDB translation entries look like
   `%{"language" => "eng", "name" => "..."}`. Returns the first non-empty match,

--- a/lib/mydia/metadata/language_code.ex
+++ b/lib/mydia/metadata/language_code.ex
@@ -1,0 +1,82 @@
+defmodule Mydia.Metadata.LanguageCode do
+  @moduledoc """
+  Maps configured language codes to the form TVDB uses, and selects a
+  translation from a TVDB translation bundle by an ordered preference list.
+
+  The configured metadata language arrives as a BCP-47 / ISO 639-1 value
+  (e.g. `"en-US"`, `"de"`, `"ja-JP"`), while TVDB extended endpoints key
+  their translation arrays off ISO 639-2/T 3-letter codes (`"eng"`, `"deu"`,
+  `"jpn"`). This module bridges the two and centralizes the selection logic
+  that was previously duplicated (and hardcoded to English) across the relay
+  transform and the season/episode structs.
+  """
+
+  # ISO 639-1 (primary subtag) -> ISO 639-2/T, covering the metadata config's
+  # supported language set. TVDB v4 uses the /T ("terminological") variant.
+  @iso_639_1_to_639_2 %{
+    "en" => "eng",
+    "es" => "spa",
+    "fr" => "fra",
+    "de" => "deu",
+    "it" => "ita",
+    "pt" => "por",
+    "ja" => "jpn",
+    "zh" => "zho",
+    "ko" => "kor",
+    "ru" => "rus"
+  }
+
+  @doc """
+  Maps a BCP-47 / ISO 639-1 language code to its TVDB (ISO 639-2/T) 3-letter
+  code, stripping any region suffix. Returns `nil` for unknown or blank input
+  so callers can skip that tier of the fallback chain.
+
+  ## Examples
+
+      iex> Mydia.Metadata.LanguageCode.to_tvdb_code("en-US")
+      "eng"
+
+      iex> Mydia.Metadata.LanguageCode.to_tvdb_code("de")
+      "deu"
+
+      iex> Mydia.Metadata.LanguageCode.to_tvdb_code("xx")
+      nil
+  """
+  def to_tvdb_code(code) when is_binary(code) do
+    primary =
+      code
+      |> String.downcase()
+      |> String.split(["-", "_"], parts: 2)
+      |> List.first()
+
+    Map.get(@iso_639_1_to_639_2, primary)
+  end
+
+  def to_tvdb_code(_), do: nil
+
+  @doc """
+  Selects a field value from a TVDB translation list by trying each preferred
+  language code in order. TVDB translation entries look like
+  `%{"language" => "eng", "name" => "..."}`. Returns the first non-empty match,
+  or `nil` when no preferred code has a usable value (callers fall back to the
+  raw field).
+
+  `preferred_codes` is an ordered list of 3-letter codes, e.g.
+  `["spa", "jpn", "eng"]` for "Spanish, then original, then English".
+  """
+  def select_translation(translations, field, preferred_codes)
+      when is_list(translations) and is_list(preferred_codes) do
+    Enum.find_value(preferred_codes, fn code ->
+      case Enum.find(translations, fn t -> t["language"] == code end) do
+        %{} = translation ->
+          value = translation[field]
+          if is_binary(value) and value != "", do: value
+
+        _ ->
+          nil
+      end
+    end)
+  end
+
+  def select_translation(_translations, _field, _preferred_codes), do: nil
+end

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -624,8 +624,10 @@ defmodule Mydia.Metadata.Provider.Relay do
     end
   end
 
-  defp fetch_season_tvdb(config, tvdb_season_id, _opts) do
+  defp fetch_season_tvdb(config, tvdb_season_id, opts) do
     endpoint = "/tvdb/seasons/#{tvdb_season_id}/extended"
+    language = resolve_language(config, opts)
+    preferred = tvdb_preferred_codes(language, Keyword.get(opts, :original_language))
 
     req = HTTP.new_request(config)
 
@@ -635,7 +637,7 @@ defmodule Mydia.Metadata.Provider.Relay do
         # Episodes in the season response don't include translation text,
         # only language code arrays. Fetch each episode's translations individually.
         data = enrich_tvdb_episodes_with_translations(req, data)
-        season = SeasonData.from_tvdb_response(data)
+        season = SeasonData.from_tvdb_response(data, preferred)
         {:ok, season}
 
       {:ok, %{status: 404}} ->
@@ -650,7 +652,7 @@ defmodule Mydia.Metadata.Provider.Relay do
   end
 
   # TVDB season extended responses include episodes but without translation text.
-  # Fetch each episode's extended data to get translations (name/overview in English).
+  # Fetch each episode's extended data to get its translation bundle (all languages).
   defp enrich_tvdb_episodes_with_translations(req, data) do
     episodes = data["episodes"] || []
 
@@ -674,7 +676,8 @@ defmodule Mydia.Metadata.Provider.Relay do
   end
 
   # Fetch an individual episode's extended data to get its translations.
-  # Merges the translations key into the episode map so from_tvdb_response can extract English text.
+  # Merges the translations key into the episode map so from_tvdb_response can
+  # select the configured language.
   defp fetch_tvdb_episode_translations(req, episode) do
     ep_id = episode["id"]
 

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -66,6 +66,7 @@ defmodule Mydia.Metadata.Provider.Relay do
 
   require Logger
   alias Mydia.Metadata.Provider.{Error, HTTP}
+  alias Mydia.Metadata.LanguageCode
   alias Mydia.Metadata.ProviderIDRegistry
 
   alias Mydia.Metadata.Structs.{
@@ -90,6 +91,15 @@ defmodule Mydia.Metadata.Provider.Relay do
 
   defp resolve_language(config, opts) do
     Keyword.get(opts, :language, config_language(config))
+  end
+
+  # Ordered list of TVDB (ISO 639-2/T) codes to try when selecting a
+  # translation: configured language, then the show's original language,
+  # then English. `original_language` is already a TVDB 3-letter code (or nil).
+  defp tvdb_preferred_codes(language, original_language) do
+    [LanguageCode.to_tvdb_code(language), original_language, "eng"]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
   end
 
   @impl true
@@ -276,9 +286,10 @@ defmodule Mydia.Metadata.Provider.Relay do
   end
 
   # Perform the actual TVDB fetch after validation
-  defp perform_tvdb_fetch(config, provider_id, media_type, _opts) do
+  defp perform_tvdb_fetch(config, provider_id, media_type, opts) do
     # Use extended endpoint to get more details including seasons
     endpoint = "/tvdb/series/#{provider_id}/extended"
+    language = resolve_language(config, opts)
 
     req = HTTP.new_request(config)
 
@@ -289,7 +300,7 @@ defmodule Mydia.Metadata.Provider.Relay do
         # TVDB wraps response in "data" key
         data = body["data"] || body
         # Transform TVDB response to TMDB-like format for parsing
-        transformed = transform_tvdb_to_tmdb_format(data, media_type)
+        transformed = transform_tvdb_to_tmdb_format(data, media_type, language)
         metadata = parse_metadata(transformed, media_type, provider_id)
         # Override provider to :tvdb
         metadata = %{metadata | provider: :tvdb}
@@ -307,7 +318,7 @@ defmodule Mydia.Metadata.Provider.Relay do
   end
 
   # Transform TVDB API response to match TMDB format for consistent parsing
-  defp transform_tvdb_to_tmdb_format(data, _media_type) when is_map(data) do
+  defp transform_tvdb_to_tmdb_format(data, _media_type, language) when is_map(data) do
     # Extract year from firstAired date or year field
     year = extract_tvdb_year(data)
 
@@ -317,21 +328,23 @@ defmodule Mydia.Metadata.Provider.Relay do
     # Transform genres
     genres = transform_tvdb_genres(data["genres"])
 
-    # Extract English translations (extended endpoint returns translation arrays)
+    # Select localized title/overview from the translation bundle, preferring
+    # the configured language, then the show's original language, then English.
     translations = data["translations"] || %{}
+    preferred = tvdb_preferred_codes(language, data["originalLanguage"])
 
-    english_name =
-      extract_tvdb_english_translation(translations["nameTranslations"], "name")
+    localized_name =
+      LanguageCode.select_translation(translations["nameTranslations"], "name", preferred)
 
-    english_overview =
-      extract_tvdb_english_translation(translations["overviewTranslations"], "overview")
+    localized_overview =
+      LanguageCode.select_translation(translations["overviewTranslations"], "overview", preferred)
 
     # Build TMDB-like response
     %{
       "id" => data["id"],
-      "name" => english_name || data["name"],
+      "name" => localized_name || data["name"],
       "original_name" => data["originalName"] || data["name"],
-      "overview" => english_overview || data["overview"],
+      "overview" => localized_overview || data["overview"],
       "first_air_date" => data["firstAired"],
       "last_air_date" => data["lastAired"],
       "status" => get_in(data, ["status", "name"]),
@@ -352,7 +365,7 @@ defmodule Mydia.Metadata.Provider.Relay do
     }
   end
 
-  defp transform_tvdb_to_tmdb_format(data, _media_type), do: data
+  defp transform_tvdb_to_tmdb_format(data, _media_type, _language), do: data
 
   defp extract_tvdb_year(%{"year" => year}) when is_binary(year) do
     case Integer.parse(year) do
@@ -412,19 +425,6 @@ defmodule Mydia.Metadata.Provider.Relay do
   defp transform_tvdb_origin_country(country) when is_binary(country), do: [country]
   defp transform_tvdb_origin_country(countries) when is_list(countries), do: countries
   defp transform_tvdb_origin_country(_), do: []
-
-  # Extract English translation from TVDB translation arrays
-  # TVDB extended endpoints return translations as lists of %{"language" => "eng", "name" => "..."}
-  defp extract_tvdb_english_translation(nil, _field), do: nil
-
-  defp extract_tvdb_english_translation(translations, field) when is_list(translations) do
-    case Enum.find(translations, fn t -> t["language"] == "eng" end) do
-      nil -> nil
-      translation -> translation[field]
-    end
-  end
-
-  defp extract_tvdb_english_translation(_, _), do: nil
 
   # TVDB images are full URLs or relative paths
   defp transform_tvdb_image(nil), do: nil

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -95,9 +95,14 @@ defmodule Mydia.Metadata.Provider.Relay do
 
   # Ordered list of TVDB (ISO 639-2/T) codes to try when selecting a
   # translation: configured language, then the show's original language,
-  # then English. `original_language` is already a TVDB 3-letter code (or nil).
+  # then English. `original_language` may be 2-letter (TMDB) or 3-letter
+  # (TVDB), so it is normalized rather than trusted to be a TVDB code.
   defp tvdb_preferred_codes(language, original_language) do
-    [LanguageCode.to_tvdb_code(language), original_language, "eng"]
+    [
+      LanguageCode.to_tvdb_code(language),
+      LanguageCode.normalize_tvdb_code(original_language),
+      "eng"
+    ]
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
   end

--- a/lib/mydia/metadata/structs/episode_data.ex
+++ b/lib/mydia/metadata/structs/episode_data.ex
@@ -6,6 +6,8 @@ defmodule Mydia.Metadata.Structs.EpisodeData do
   plain map access that can silently return nil.
   """
 
+  alias Mydia.Metadata.LanguageCode
+
   @enforce_keys [:season_number, :episode_number]
   defstruct [
     # Required fields
@@ -60,37 +62,36 @@ defmodule Mydia.Metadata.Structs.EpisodeData do
 
   TVDB uses different field names: `seasonNumber`, `number`, `name`,
   `overview`, `aired`, `runtime`, `image`.
-  """
-  def from_tvdb_response(data) when is_map(data) do
-    # Extract English translations if available (episodes within season responses
-    # may not include translations — falls back gracefully)
-    translations = data["translations"] || %{}
-    english_name = extract_english_translation(translations["nameTranslations"], "name")
 
-    english_overview =
-      extract_english_translation(translations["overviewTranslations"], "overview")
+  `preferred_codes` is an ordered list of TVDB (ISO 639-2/T) language codes to
+  try when selecting the localized name/overview, falling back to the raw
+  fields. Defaults to `["eng"]` to preserve prior English-only behavior.
+  """
+  def from_tvdb_response(data, preferred_codes \\ ["eng"]) when is_map(data) do
+    # Episodes within season responses may not include translations — falls
+    # back gracefully to the raw name/overview.
+    translations = data["translations"] || %{}
+
+    localized_name =
+      LanguageCode.select_translation(translations["nameTranslations"], "name", preferred_codes)
+
+    localized_overview =
+      LanguageCode.select_translation(
+        translations["overviewTranslations"],
+        "overview",
+        preferred_codes
+      )
 
     %__MODULE__{
       season_number: data["seasonNumber"],
       episode_number: data["number"],
-      name: english_name || data["name"],
-      overview: english_overview || data["overview"],
+      name: localized_name || data["name"],
+      overview: localized_overview || data["overview"],
       air_date: parse_date(data["aired"]),
       runtime: data["runtime"],
       still_path: data["image"]
     }
   end
-
-  defp extract_english_translation(nil, _field), do: nil
-
-  defp extract_english_translation(translations, field) when is_list(translations) do
-    case Enum.find(translations, fn t -> t["language"] == "eng" end) do
-      nil -> nil
-      translation -> translation[field]
-    end
-  end
-
-  defp extract_english_translation(_, _), do: nil
 
   defp parse_date(nil), do: nil
   defp parse_date(""), do: nil

--- a/lib/mydia/metadata/structs/season_data.ex
+++ b/lib/mydia/metadata/structs/season_data.ex
@@ -6,6 +6,7 @@ defmodule Mydia.Metadata.Structs.SeasonData do
   plain map access that can silently return nil.
   """
 
+  alias Mydia.Metadata.LanguageCode
   alias Mydia.Metadata.Structs.EpisodeData
 
   @enforce_keys [:season_number]
@@ -59,48 +60,41 @@ defmodule Mydia.Metadata.Structs.SeasonData do
   TVDB season extended endpoint returns season details with episodes
   nested under the `"episodes"` key. Translations are in TranslationExtended
   format: `%{"nameTranslations" => [...], "overviewTranslations" => [...]}`.
+
+  `preferred_codes` is an ordered list of TVDB (ISO 639-2/T) language codes to
+  try when selecting the localized name/overview; it is also forwarded to each
+  episode. Defaults to `["eng"]` to preserve prior English-only behavior.
   """
-  def from_tvdb_response(data) when is_map(data) do
+  def from_tvdb_response(data, preferred_codes \\ ["eng"]) when is_map(data) do
     episodes = data["episodes"] || []
 
-    # Extract English translations if available.
-    # TVDB season extended returns translations in TranslationExtended format:
-    #   %{"nameTranslations" => [%{"language" => "eng", "name" => "..."}, ...],
-    #     "overviewTranslations" => [%{"language" => "eng", "overview" => "..."}, ...]}
-    {english_name, english_overview} = extract_english_from_translations(data["translations"])
+    {localized_name, localized_overview} =
+      select_from_translations(data["translations"], preferred_codes)
 
     %__MODULE__{
       season_number: data["number"],
-      name: english_name || data["name"] || "Season #{data["number"]}",
-      overview: english_overview || data["overview"],
+      name: localized_name || data["name"] || "Season #{data["number"]}",
+      overview: localized_overview || data["overview"],
       air_date: nil,
       poster_path: data["image"],
       episode_count: length(episodes),
-      episodes: Enum.map(episodes, &EpisodeData.from_tvdb_response/1)
+      episodes: Enum.map(episodes, &EpisodeData.from_tvdb_response(&1, preferred_codes))
     }
   end
 
-  # Handle TranslationExtended format (TVDB season/series extended):
+  # Select localized name/overview from TVDB TranslationExtended format:
   #   %{"nameTranslations" => [%{"language" => "eng", "name" => "..."}, ...],
   #     "overviewTranslations" => [%{"language" => "eng", "overview" => "..."}, ...]}
-  defp extract_english_from_translations(%{} = t) do
-    english_name = find_english_in_list(t["nameTranslations"], "name")
-    english_overview = find_english_in_list(t["overviewTranslations"], "overview")
-    {english_name, english_overview}
+  defp select_from_translations(%{} = t, preferred_codes) do
+    name = LanguageCode.select_translation(t["nameTranslations"], "name", preferred_codes)
+
+    overview =
+      LanguageCode.select_translation(t["overviewTranslations"], "overview", preferred_codes)
+
+    {name, overview}
   end
 
-  defp extract_english_from_translations(_), do: {nil, nil}
-
-  defp find_english_in_list(nil, _field), do: nil
-
-  defp find_english_in_list(translations, field) when is_list(translations) do
-    case Enum.find(translations, fn t -> t["language"] == "eng" end) do
-      nil -> nil
-      translation -> translation[field]
-    end
-  end
-
-  defp find_english_in_list(_, _), do: nil
+  defp select_from_translations(_translations, _preferred_codes), do: {nil, nil}
 
   defp parse_date(nil), do: nil
   defp parse_date(""), do: nil

--- a/test/mydia/library/metadata_enricher_test.exs
+++ b/test/mydia/library/metadata_enricher_test.exs
@@ -4,7 +4,7 @@ defmodule Mydia.Library.MetadataEnricherTest do
   import Mydia.MediaFixtures
 
   alias Mydia.Library.MetadataEnricher
-  alias Mydia.{Library, Settings}
+  alias Mydia.{Library, Media, Settings}
   alias Mydia.Media.MediaItem
 
   describe "enrich/2 with invalid input" do
@@ -636,6 +636,99 @@ defmodule Mydia.Library.MetadataEnricherTest do
 
       assert updated.id == item.id
       assert is_nil(updated.metadata_source)
+    end
+  end
+
+  describe "episode enrichment threads original language (U5)" do
+    setup do
+      bypass = Bypass.open()
+
+      config = %{
+        type: :metadata_relay,
+        base_url: "http://localhost:#{bypass.port}",
+        # Korean has no translation in the stubbed bundle, so selection must
+        # fall back to the show's original language (Japanese), not English.
+        options: %{language: "ko", include_adult: false}
+      }
+
+      %{bypass: bypass, config: config}
+    end
+
+    test "episodes use the original language when the configured language is missing",
+         %{bypass: bypass, config: config} do
+      series_id = System.unique_integer([:positive])
+      season_id = System.unique_integer([:positive])
+      episode_id = System.unique_integer([:positive])
+
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Original Lang Show",
+        tvdb_id: series_id,
+        metadata_source: :tvdb
+      })
+      |> backdate()
+
+      # Series extended: carries the original language and one official season.
+      Bypass.stub(bypass, "GET", "/tvdb/series/#{series_id}/extended", fn conn ->
+        respond_json(conn, %{
+          "data" => %{
+            "id" => series_id,
+            "name" => "Original Lang Show",
+            "overview" => "ov",
+            "originalLanguage" => "jpn",
+            "firstAired" => "2010-01-01",
+            "genres" => [],
+            "seasons" => [
+              %{
+                "id" => season_id,
+                "number" => 1,
+                "type" => %{"type" => "official"},
+                "name" => "Season 1"
+              }
+            ]
+          }
+        })
+      end)
+
+      # Season extended: episodes without translation text (only ids).
+      Bypass.stub(bypass, "GET", "/tvdb/seasons/#{season_id}/extended", fn conn ->
+        respond_json(conn, %{
+          "data" => %{
+            "number" => 1,
+            "name" => "Season 1",
+            "episodes" => [
+              %{"id" => episode_id, "seasonNumber" => 1, "number" => 1, "name" => "Raw Episode"}
+            ]
+          }
+        })
+      end)
+
+      # Episode extended: translation bundle with Japanese + English, no Korean.
+      Bypass.stub(bypass, "GET", "/tvdb/episodes/#{episode_id}/extended", fn conn ->
+        respond_json(conn, %{
+          "data" => %{
+            "translations" => %{
+              "nameTranslations" => [
+                %{"language" => "jpn", "name" => "日本語タイトル"},
+                %{"language" => "eng", "name" => "English Title"}
+              ],
+              "overviewTranslations" => [
+                %{"language" => "jpn", "overview" => "概要"},
+                %{"language" => "eng", "overview" => "English overview"}
+              ]
+            }
+          }
+        })
+      end)
+
+      match = tv_match(series_id, :tvdb, "Original Lang Show")
+
+      assert {:ok, updated} = MetadataEnricher.enrich(match, config: config, fetch_episodes: true)
+
+      [episode] = Media.list_episodes(updated.id)
+      # Without original-language threading these would be the English values.
+      assert episode.title == "日本語タイトル"
+      assert episode.metadata.overview == "概要"
     end
   end
 

--- a/test/mydia/metadata/cache_language_key_test.exs
+++ b/test/mydia/metadata/cache_language_key_test.exs
@@ -1,0 +1,78 @@
+defmodule Mydia.Metadata.CacheLanguageKeyTest do
+  @moduledoc """
+  Verifies that the cached metadata entry points key by the configured language
+  so non-English libraries do not read English-cached entries, and libraries on
+  different languages do not collide. See U4 of the TV-metadata-language plan.
+  """
+  use ExUnit.Case, async: false
+
+  alias Mydia.Metadata
+  alias Mydia.Metadata.Cache
+
+  setup do
+    Cache.clear()
+    :ok
+  end
+
+  defp config(language) do
+    %{
+      type: :metadata_relay,
+      base_url: "https://example.test",
+      options: %{language: language, include_adult: false}
+    }
+  end
+
+  describe "fetch_season_cached/4 cache key" do
+    test "varies by the config's language so two languages don't collide" do
+      es_key = Metadata.build_season_cache_key("100", 1, "es-ES", nil)
+      en_key = Metadata.build_season_cache_key("100", 1, "en-US", nil)
+
+      assert es_key != en_key
+
+      Cache.put(es_key, :spanish_season)
+      Cache.put(en_key, :english_season)
+
+      # Each config reads its own language's entry (cache hit, no fetch).
+      assert {:ok, :spanish_season} =
+               Metadata.fetch_season_cached(config("es-ES"), "100", 1, [])
+
+      assert {:ok, :english_season} =
+               Metadata.fetch_season_cached(config("en-US"), "100", 1, [])
+    end
+
+    test "an explicit :language opt still overrides the config default" do
+      es_key = Metadata.build_season_cache_key("100", 1, "es-ES", nil)
+      Cache.put(es_key, :spanish_season)
+
+      # Config says en-US, but the explicit opt wins and hits the es entry.
+      assert {:ok, :spanish_season} =
+               Metadata.fetch_season_cached(config("en-US"), "100", 1, language: "es-ES")
+    end
+
+    test "a bare config (no options.language) falls back to en-US" do
+      en_key = Metadata.build_season_cache_key("100", 1, "en-US", nil)
+      Cache.put(en_key, :english_season)
+
+      bare_config = %{type: :metadata_relay, base_url: "https://example.test"}
+
+      assert {:ok, :english_season} =
+               Metadata.fetch_season_cached(bare_config, "100", 1, [])
+    end
+  end
+
+  describe "fetch_by_id_cached/3 cache key" do
+    test "varies by the config's language" do
+      es_key = "fetch_by_id:metadata_relay:603:tv_show:es-ES:"
+      en_key = "fetch_by_id:metadata_relay:603:tv_show:en-US:"
+
+      Cache.put(es_key, :spanish_show)
+      Cache.put(en_key, :english_show)
+
+      assert {:ok, :spanish_show} =
+               Metadata.fetch_by_id_cached(config("es-ES"), "603", media_type: :tv_show)
+
+      assert {:ok, :english_show} =
+               Metadata.fetch_by_id_cached(config("en-US"), "603", media_type: :tv_show)
+    end
+  end
+end

--- a/test/mydia/metadata/language_code_test.exs
+++ b/test/mydia/metadata/language_code_test.exs
@@ -1,0 +1,68 @@
+defmodule Mydia.Metadata.LanguageCodeTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.LanguageCode
+
+  describe "to_tvdb_code/1" do
+    test "maps supported ISO 639-1 codes to ISO 639-2/T" do
+      assert LanguageCode.to_tvdb_code("en-US") == "eng"
+      assert LanguageCode.to_tvdb_code("de") == "deu"
+      assert LanguageCode.to_tvdb_code("ja-JP") == "jpn"
+      assert LanguageCode.to_tvdb_code("es") == "spa"
+      assert LanguageCode.to_tvdb_code("zh") == "zho"
+    end
+
+    test "is case-insensitive and tolerates underscore separators" do
+      assert LanguageCode.to_tvdb_code("EN-us") == "eng"
+      assert LanguageCode.to_tvdb_code("pt_BR") == "por"
+    end
+
+    test "returns nil for blank, nil, and unknown codes" do
+      assert LanguageCode.to_tvdb_code("") == nil
+      assert LanguageCode.to_tvdb_code(nil) == nil
+      assert LanguageCode.to_tvdb_code("xx") == nil
+      assert LanguageCode.to_tvdb_code(123) == nil
+    end
+  end
+
+  describe "select_translation/3" do
+    setup do
+      translations = [
+        %{"language" => "eng", "name" => "The Show", "overview" => "English overview"},
+        %{"language" => "spa", "name" => "El Show", "overview" => "Resumen en español"},
+        %{"language" => "fra", "name" => "", "overview" => "Résumé"}
+      ]
+
+      {:ok, translations: translations}
+    end
+
+    test "returns the first matching code's field in preference order", %{
+      translations: translations
+    } do
+      assert LanguageCode.select_translation(translations, "name", ["spa", "eng"]) == "El Show"
+      assert LanguageCode.select_translation(translations, "name", ["eng", "spa"]) == "The Show"
+    end
+
+    test "skips a requested code that is absent and falls to the next", %{
+      translations: translations
+    } do
+      assert LanguageCode.select_translation(translations, "name", ["deu", "eng"]) == "The Show"
+    end
+
+    test "returns nil when no preferred code matches", %{translations: translations} do
+      assert LanguageCode.select_translation(translations, "name", ["deu", "ita"]) == nil
+    end
+
+    test "treats an empty-string field as no match and continues", %{translations: translations} do
+      # French name is "" — should fall through to English rather than return ""
+      assert LanguageCode.select_translation(translations, "name", ["fra", "eng"]) == "The Show"
+      # but French overview is present
+      assert LanguageCode.select_translation(translations, "overview", ["fra", "eng"]) == "Résumé"
+    end
+
+    test "returns nil for nil or non-list translations" do
+      assert LanguageCode.select_translation(nil, "name", ["eng"]) == nil
+      assert LanguageCode.select_translation(%{}, "name", ["eng"]) == nil
+    end
+  end
+end

--- a/test/mydia/metadata/language_code_test.exs
+++ b/test/mydia/metadata/language_code_test.exs
@@ -25,6 +25,37 @@ defmodule Mydia.Metadata.LanguageCodeTest do
     end
   end
 
+  describe "normalize_tvdb_code/1" do
+    test "passes through an already-3-letter ISO 639-2 code" do
+      assert LanguageCode.normalize_tvdb_code("jpn") == "jpn"
+      assert LanguageCode.normalize_tvdb_code("ENG") == "eng"
+    end
+
+    test "maps a 2-letter ISO 639-1 code (with optional region) to 3-letter" do
+      assert LanguageCode.normalize_tvdb_code("ja") == "jpn"
+      assert LanguageCode.normalize_tvdb_code("pt-BR") == "por"
+    end
+
+    test "returns nil for blank, nil, and unmappable 2-letter codes" do
+      assert LanguageCode.normalize_tvdb_code("") == nil
+      assert LanguageCode.normalize_tvdb_code(nil) == nil
+      assert LanguageCode.normalize_tvdb_code("xx") == nil
+    end
+  end
+
+  describe "original_language_from/1" do
+    test "extracts a non-empty original_language" do
+      assert LanguageCode.original_language_from(%{original_language: "jpn"}) == "jpn"
+    end
+
+    test "returns nil for absent, empty, or non-binary values" do
+      assert LanguageCode.original_language_from(%{original_language: nil}) == nil
+      assert LanguageCode.original_language_from(%{original_language: ""}) == nil
+      assert LanguageCode.original_language_from(%{}) == nil
+      assert LanguageCode.original_language_from(nil) == nil
+    end
+  end
+
   describe "select_translation/3" do
     setup do
       translations = [

--- a/test/mydia/metadata/language_code_test.exs
+++ b/test/mydia/metadata/language_code_test.exs
@@ -48,6 +48,11 @@ defmodule Mydia.Metadata.LanguageCodeTest do
       assert LanguageCode.original_language_from(%{original_language: "jpn"}) == "jpn"
     end
 
+    test "extracts from a string-key map too" do
+      assert LanguageCode.original_language_from(%{"original_language" => "jpn"}) == "jpn"
+      assert LanguageCode.original_language_from(%{"original_language" => ""}) == nil
+    end
+
     test "returns nil for absent, empty, or non-binary values" do
       assert LanguageCode.original_language_from(%{original_language: nil}) == nil
       assert LanguageCode.original_language_from(%{original_language: ""}) == nil

--- a/test/mydia/metadata/provider/relay_test.exs
+++ b/test/mydia/metadata/provider/relay_test.exs
@@ -319,6 +319,21 @@ defmodule Mydia.Metadata.Provider.RelayTest do
       assert is_binary(metadata.title)
       assert is_binary(metadata.overview)
     end
+
+    test "fetches TVDB series metadata in the configured language" do
+      # Stranger Things (TVDB 305288) has Spanish translations. The TVDB path
+      # selects from the returned translation bundle rather than hardcoding English.
+      assert {:ok, metadata} =
+               Relay.fetch_by_id(@config, "305288",
+                 media_type: :tv_show,
+                 provider: :tvdb,
+                 language: "es"
+               )
+
+      assert metadata.provider == :tvdb
+      assert is_binary(metadata.title)
+      assert is_binary(metadata.overview)
+    end
   end
 
   describe "pagination" do

--- a/test/mydia/metadata/structs/tvdb_translation_selection_test.exs
+++ b/test/mydia/metadata/structs/tvdb_translation_selection_test.exs
@@ -1,0 +1,124 @@
+defmodule Mydia.Metadata.Structs.TvdbTranslationSelectionTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.Structs.{EpisodeData, SeasonData}
+
+  defp season_translations do
+    %{
+      "nameTranslations" => [
+        %{"language" => "eng", "name" => "Season 1"},
+        %{"language" => "spa", "name" => "Temporada 1"}
+      ],
+      "overviewTranslations" => [
+        %{"language" => "eng", "overview" => "English season overview"},
+        %{"language" => "spa", "overview" => "Resumen de la temporada"}
+      ]
+    }
+  end
+
+  defp episode_translations do
+    %{
+      "nameTranslations" => [
+        %{"language" => "eng", "name" => "Pilot"},
+        %{"language" => "fra", "name" => "Pilote"}
+      ],
+      "overviewTranslations" => [
+        %{"language" => "eng", "overview" => "English episode overview"},
+        %{"language" => "fra", "overview" => "Résumé de l'épisode"}
+      ]
+    }
+  end
+
+  describe "SeasonData.from_tvdb_response/2" do
+    test "selects the configured language when present" do
+      data = %{"number" => 1, "translations" => season_translations(), "episodes" => []}
+
+      season = SeasonData.from_tvdb_response(data, ["spa", "eng"])
+
+      assert season.name == "Temporada 1"
+      assert season.overview == "Resumen de la temporada"
+    end
+
+    test "falls back to English then raw when configured language absent" do
+      data = %{"number" => 2, "translations" => season_translations(), "episodes" => []}
+
+      season = SeasonData.from_tvdb_response(data, ["deu", "eng"])
+
+      assert season.name == "Season 1"
+      assert season.overview == "English season overview"
+    end
+
+    test "default arity preserves English-only behavior" do
+      data = %{"number" => 1, "translations" => season_translations(), "episodes" => []}
+
+      season = SeasonData.from_tvdb_response(data)
+
+      assert season.name == "Season 1"
+    end
+
+    test "forwards preferred codes to nested episodes" do
+      data = %{
+        "number" => 1,
+        "translations" => season_translations(),
+        "episodes" => [
+          %{
+            "seasonNumber" => 1,
+            "number" => 1,
+            "name" => "raw",
+            "translations" => episode_translations()
+          }
+        ]
+      }
+
+      season = SeasonData.from_tvdb_response(data, ["fra", "eng"])
+      [episode] = season.episodes
+
+      assert episode.name == "Pilote"
+    end
+
+    test "falls back to raw season name when no translations present" do
+      data = %{"number" => 3, "name" => "Specials", "episodes" => []}
+
+      season = SeasonData.from_tvdb_response(data, ["spa", "eng"])
+
+      assert season.name == "Specials"
+    end
+  end
+
+  describe "EpisodeData.from_tvdb_response/2" do
+    test "selects the configured language when present" do
+      data = %{
+        "seasonNumber" => 1,
+        "number" => 1,
+        "name" => "raw name",
+        "translations" => episode_translations()
+      }
+
+      episode = EpisodeData.from_tvdb_response(data, ["fra", "eng"])
+
+      assert episode.name == "Pilote"
+      assert episode.overview == "Résumé de l'épisode"
+    end
+
+    test "falls back through English to raw when configured language absent" do
+      data = %{
+        "seasonNumber" => 1,
+        "number" => 1,
+        "name" => "raw name",
+        "translations" => episode_translations()
+      }
+
+      episode = EpisodeData.from_tvdb_response(data, ["spa", "eng"])
+
+      assert episode.name == "Pilot"
+    end
+
+    test "falls back to raw fields when episode has no translations" do
+      data = %{"seasonNumber" => 1, "number" => 2, "name" => "Raw Episode"}
+
+      episode = EpisodeData.from_tvdb_response(data, ["fra", "eng"])
+
+      assert episode.name == "Raw Episode"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Fixes #194 — movies correctly use the configured metadata language, but TV series, seasons, and episodes always rendered in English.

## Root cause

Movies and TV use different providers and select language differently:

- **Movies → TMDB:** language selected server-side (`language=` query param). Worked.
- **TV → TVDB:** TVDB returns *all* translations in one bundle (`meta=translations`) and the client picks one. That selection was hardcoded to English (`language == "eng"`) in three places, and the configured language was never threaded into the TVDB fetch path (the `opts` arg was ignored).

## Changes

- **`Mydia.Metadata.LanguageCode`** (new): maps the configured BCP-47/ISO 639-1 value (`en-US`, `de`) to TVDB's ISO 639-2/T 3-letter codes (`eng`, `deu`), and provides a shared, ordered translation selector — replacing three duplicated hardcoded-English extractors.
- Threads the configured language into the TVDB series, season, and episode fetch paths.
- Selection follows the fallback chain **configured language → original language → English → raw field**.
- **Cache correctness:** the metadata cache (`fetch_by_id_cached`, `fetch_season_cached`) and the refresh-path cache invalidation now key by the configured language instead of defaulting to `en-US`, so non-English libraries no longer read English-cached entries and mixed-language libraries don't collide.
- Original language is threaded through all three season-fetch paths (enricher, `Media.create_episodes_for_season`, `ProviderSwitch`) for consistent fallback.

The TMDB/movie path, the language-setting UI, and subtitle language are untouched.

## Testing

- New unit tests for `LanguageCode` (mapping, normalization, selection), the season/episode struct selection, and cache-key-by-language behavior.
- An end-to-end integration test: a Korean-configured show whose TVDB record has only Japanese + English translations correctly falls back to **Japanese** (the original language), proving the threading works across the full enrich path.
- `mix format`, `credo --strict`, and `compile --warnings-as-errors` all clean.

## Post-Deploy Monitoring & Validation

No special monitoring required. This is read-path metadata selection. The visible signal: non-English libraries see localized TV titles/overviews after their next metadata refresh. Entries cached under `en-US` before this change age out at their 24h TTL (no forced backfill); if a library should update sooner, a manual refresh re-fetches under the correct language.
