### PR TITLE
fix(metadata): match both por and pt TVDB translation codes for Portuguese

### DIFF
--- a/lib/mydia/metadata/language_code.ex
+++ b/lib/mydia/metadata/language_code.ex
@@ -55,37 +55,35 @@ defmodule Mydia.Metadata.LanguageCode do
   def to_tvdb_code(_), do: nil
 
   @doc """
-  Normalizes a language code that may be either a 2-letter (ISO 639-1, possibly
-  region-suffixed) or an already-3-letter (ISO 639-2/T) value into the TVDB
-  3-letter form. Use for values whose width depends on their source — e.g. a
-  show's `original_language`, which TVDB stores as `"jpn"` but TMDB stores as
-  `"ja"`. Returns `nil` for blank or unrecognized input.
+  Returns the ordered list of TVDB language codes to try for a configured or
+  original-language value. TVDB's translation keys are mostly ISO 639-2/T
+  3-letter codes, but it is inconsistent — Portuguese appears as both `"por"`
+  and `"pt"`, and some shows carry only one of them. So each language expands to
+  both its 3-letter and 2-letter forms; the form TVDB didn't use simply never
+  matches. Accepts 2-letter (`"pt-BR"`, TMDB) or 3-letter (`"jpn"`, TVDB) input.
+  Returns `[]` for blank or `nil` input.
 
   ## Examples
 
-      iex> Mydia.Metadata.LanguageCode.normalize_tvdb_code("jpn")
-      "jpn"
+      iex> Mydia.Metadata.LanguageCode.tvdb_candidates("pt-BR")
+      ["por", "pt"]
 
-      iex> Mydia.Metadata.LanguageCode.normalize_tvdb_code("ja")
-      "jpn"
+      iex> Mydia.Metadata.LanguageCode.tvdb_candidates("jpn")
+      ["jpn"]
   """
-  def normalize_tvdb_code(code) when is_binary(code) do
+  def tvdb_candidates(code) when is_binary(code) do
     primary =
       code
       |> String.downcase()
       |> String.split(["-", "_"], parts: 2)
       |> List.first()
 
-    cond do
-      primary == "" -> nil
-      # Already a 3-letter ISO 639-2 code (e.g. TVDB's "jpn"); pass through.
-      String.length(primary) == 3 -> primary
-      # Otherwise treat as a 2-letter ISO 639-1 code and map it.
-      true -> to_tvdb_code(primary)
-    end
+    [to_tvdb_code(primary), primary]
+    |> Enum.reject(fn c -> is_nil(c) or c == "" end)
+    |> Enum.uniq()
   end
 
-  def normalize_tvdb_code(_), do: nil
+  def tvdb_candidates(_), do: []
 
   @doc """
   Extracts a show's original-language code from a metadata struct or map,

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -93,17 +93,14 @@ defmodule Mydia.Metadata.Provider.Relay do
     Keyword.get(opts, :language, config_language(config))
   end
 
-  # Ordered list of TVDB (ISO 639-2/T) codes to try when selecting a
-  # translation: configured language, then the show's original language,
-  # then English. `original_language` may be 2-letter (TMDB) or 3-letter
-  # (TVDB), so it is normalized rather than trusted to be a TVDB code.
+  # Ordered list of TVDB codes to try when selecting a translation: configured
+  # language, then the show's original language, then English. Each language
+  # expands to its 3-letter and 2-letter candidates because TVDB's translation
+  # keys are inconsistent (e.g. Portuguese as both "por" and "pt").
   defp tvdb_preferred_codes(language, original_language) do
-    [
-      LanguageCode.to_tvdb_code(language),
-      LanguageCode.normalize_tvdb_code(original_language),
-      "eng"
-    ]
-    |> Enum.reject(&is_nil/1)
+    (LanguageCode.tvdb_candidates(language) ++
+       LanguageCode.tvdb_candidates(original_language) ++
+       ["eng"])
     |> Enum.uniq()
   end
 

--- a/test/mydia/metadata/language_code_test.exs
+++ b/test/mydia/metadata/language_code_test.exs
@@ -25,21 +25,29 @@ defmodule Mydia.Metadata.LanguageCodeTest do
     end
   end
 
-  describe "normalize_tvdb_code/1" do
-    test "passes through an already-3-letter ISO 639-2 code" do
-      assert LanguageCode.normalize_tvdb_code("jpn") == "jpn"
-      assert LanguageCode.normalize_tvdb_code("ENG") == "eng"
+  describe "tvdb_candidates/1" do
+    test "expands Portuguese to both por and pt (TVDB uses both inconsistently)" do
+      assert LanguageCode.tvdb_candidates("pt-BR") == ["por", "pt"]
+      assert LanguageCode.tvdb_candidates("pt") == ["por", "pt"]
     end
 
-    test "maps a 2-letter ISO 639-1 code (with optional region) to 3-letter" do
-      assert LanguageCode.normalize_tvdb_code("ja") == "jpn"
-      assert LanguageCode.normalize_tvdb_code("pt-BR") == "por"
+    test "expands a 2-letter code to its 3-letter form plus the 2-letter form" do
+      assert LanguageCode.tvdb_candidates("de") == ["deu", "de"]
+      assert LanguageCode.tvdb_candidates("ja") == ["jpn", "ja"]
+      assert LanguageCode.tvdb_candidates("en-US") == ["eng", "en"]
     end
 
-    test "returns nil for blank, nil, and unmappable 2-letter codes" do
-      assert LanguageCode.normalize_tvdb_code("") == nil
-      assert LanguageCode.normalize_tvdb_code(nil) == nil
-      assert LanguageCode.normalize_tvdb_code("xx") == nil
+    test "passes an already-3-letter code through as the only candidate" do
+      assert LanguageCode.tvdb_candidates("jpn") == ["jpn"]
+      assert LanguageCode.tvdb_candidates("ENG") == ["eng"]
+    end
+
+    test "returns empty for blank/nil; passes an unknown code through harmlessly" do
+      assert LanguageCode.tvdb_candidates("") == []
+      assert LanguageCode.tvdb_candidates(nil) == []
+      # Unknown 2-letter code isn't mapped but is still offered as a candidate;
+      # it simply never matches a TVDB translation key.
+      assert LanguageCode.tvdb_candidates("xx") == ["xx"]
     end
   end
 


### PR DESCRIPTION
## Problem

Follow-up to #196, found by validating against real TVDB data on a live instance.

The merged fix mapped each configured language to a single TVDB (ISO 639-2/T) 3-letter code. But TVDB's translation keys are **inconsistent**: while almost every language uses the 3-letter code, **Portuguese appears as both `por` and `pt`**, and some shows carry only one. For example, *Frieren: Beyond Journey's End* (tvdb `424536`) has only `pt` in its translation bundle — so a Portuguese-configured library requesting `por` matched nothing and fell back to English.

## Validation

Inspected the real `nameTranslations` codes across 5 popular shows on a live instance. Distinct codes:

```
ara cat ces dan deu ell eng fas fin fra heb hin hrv hun ind ita jpn kan kat
kor mal msa nld nor pol por pt ron rus spa srp swe tam tel tgl tha tur ukr
vie zho zhtw
```

`pt` is the **only** 2-letter exception — every other supported language (`es→spa`, `fr→fra`, `de→deu`, `it→ita`, `ja→jpn`, `zh→zho`, `ko→kor`, `ru→rus`, `en→eng`) is confirmed 3-letter. The `deu`/`ger` and `zho`/`chi` variants I'd flagged as risks resolve to `deu` and `zho` — matching the existing mapping.

## Change

Replace the single-code mapping (`to_tvdb_code/1` in the selection path) with `tvdb_candidates/1`, which expands each configured/original language to **both** its 3-letter and 2-letter forms (`pt-BR → ["por", "pt"]`). The form TVDB didn't use simply never matches, so this is harmless for the other nine languages and robust to TVDB's inconsistency going forward.

Verified end-to-end against Frieren's real bundle: a `pt-BR` library now selects `"Frieren e a Jornada para o Além"` instead of the English title.

## Post-Deploy Monitoring & Validation

No special monitoring required (read-path metadata selection). Portuguese libraries will see Portuguese TV titles/overviews after their next refresh, including on `pt`-only shows.
