### PR TITLE
fix: downgrade Logger.error to Logger.warning for known path-not-found failures in MediaImport

### DIFF
--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -272,7 +272,11 @@ defmodule Mydia.Jobs.MediaImport do
           process_import(download, files, args)
 
         {:ok, []} ->
-          Logger.error("No files found for download", download_id: download.id)
+          Logger.warning("No files found for download",
+            download_id: download.id,
+            operational: true
+          )
+
           {:error, :no_files}
 
         {:error, error} ->
@@ -293,18 +297,20 @@ defmodule Mydia.Jobs.MediaImport do
                 process_import(download, files, args)
 
               {:ok, []} ->
-                Logger.error("No files found at save_path",
+                Logger.warning("No files found at save_path",
                   download_id: download.id,
-                  save_path: args.save_path
+                  save_path: args.save_path,
+                  operational: true
                 )
 
                 {:error, :no_files}
 
               {:error, path_error} ->
-                Logger.error("save_path fallback also failed",
+                Logger.warning("save_path fallback also failed",
                   download_id: download.id,
                   save_path: args.save_path,
-                  error: inspect(path_error)
+                  error: inspect(path_error),
+                  operational: true
                 )
 
                 {:error, path_error}
@@ -564,13 +570,28 @@ defmodule Mydia.Jobs.MediaImport do
         end
 
       File.exists?(Path.dirname(path)) ->
+        Logger.warning("Path not found (parent exists, leaf missing)",
+          path: path,
+          operational: true
+        )
+
         {:error, {:path_not_found, path}}
 
       true ->
+        Logger.warning("Path not found (parent directory not visible)",
+          path: path,
+          operational: true
+        )
+
         {:error, {:path_not_found, path}}
     end
   rescue
     _e in File.Error ->
+      Logger.warning("Path not accessible",
+        path: path,
+        operational: true
+      )
+
       {:error, {:path_not_accessible, path}}
   end
 


### PR DESCRIPTION
## Summary

- Downgrade `Logger.error` to `Logger.warning` on four call sites in `MediaImport` that handle known operational path-failure conditions: empty file list from client, empty save_path result, save_path fallback failure, and the `:path_not_found`/`:path_not_accessible` branches inside `list_files_in_path/1`.
- Add `operational: true` structured metadata key to each warning so operators can filter them in log aggregators and distinguish them from genuine code failures.
- Leave `Logger.error` in place on actual code defects: failed client info lookup and unhandled import exceptions.

## Why this matters

Closes #189. Live instances report ~3,800 `:path_not_found` telemetry events in a 14-day window. The root cause is the classic self-hosted volume-mount mismatch — the torrent client reports a path like `/downloads/complete/<release>` that does not exist inside Mydia's container filesystem view. The retry loop (up to 3 attempts) multiplies each underlying failure into several telemetry reports. These are expected operational misconfiguration events, not code defects, and `Logger.error` is the wrong level for them. Downgrading to `Logger.warning` keeps the information visible in logs while stopping these known conditions from reaching crash telemetry.

Fixes #189
