### PR TITLE
fix(downloads): round progress percentages to one decimal place

### DIFF
--- a/lib/mydia_web/helpers/formatters.ex
+++ b/lib/mydia_web/helpers/formatters.ex
@@ -62,12 +62,12 @@ defmodule MydiaWeb.Formatters do
       iex> MydiaWeb.Formatters.format_progress(0.899999999999)
       "0.9"
 
-      iex> MydiaWeb.Formatters.format_progress(nil)
+      iex> MydiaWeb.Formatters.format_progress(0)
       "0.0"
 
   """
   def format_progress(nil), do: "0.0"
 
   def format_progress(progress) when is_number(progress),
-    do: :erlang.float_to_binary(progress, decimals: 1)
+    do: :erlang.float_to_binary(progress * 1.0, decimals: 1)
 end

--- a/lib/mydia_web/helpers/formatters.ex
+++ b/lib/mydia_web/helpers/formatters.ex
@@ -47,4 +47,27 @@ defmodule MydiaWeb.Formatters do
       "#{field}: #{Enum.join(errors, ", ")}"
     end)
   end
+
+  @doc """
+  Formats a download progress percentage (0.0..100.0) for display.
+
+  Returns a string with one decimal place, guaranteed clean of
+  floating-point noise (unlike Float.round/2 + interpolation).
+
+  ## Examples
+
+      iex> MydiaWeb.Formatters.format_progress(45.5)
+      "45.5"
+
+      iex> MydiaWeb.Formatters.format_progress(0.899999999999)
+      "0.9"
+
+      iex> MydiaWeb.Formatters.format_progress(nil)
+      "0.0"
+
+  """
+  def format_progress(nil), do: "0.0"
+
+  def format_progress(progress) when is_number(progress),
+    do: :erlang.float_to_binary(progress, decimals: 1)
 end

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -7,6 +7,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
   alias Mydia.Media
   alias Phoenix.PubSub
   alias MydiaWeb.Live.Authorization
+  import MydiaWeb.Formatters
 
   @items_per_page 50
 
@@ -1085,9 +1086,6 @@ defmodule MydiaWeb.DownloadsLive.Index do
       true -> "#{div(seconds, 86400)}d"
     end
   end
-
-  defp format_progress(nil), do: 0.0
-  defp format_progress(progress), do: Float.round(progress * 1.0, 1)
 
   # A percentage is only meaningful when the client is reporting a real
   # byte-for-byte transfer. Provider-side waits — debrid magnet conversion,

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -15,6 +15,7 @@ defmodule MydiaWeb.MediaLive.Show do
 
   # Import helper modules
   import MydiaWeb.MediaLive.Show.Formatters
+  import MydiaWeb.Formatters, only: [format_progress: 1]
   import MydiaWeb.MediaLive.Show.Helpers
   import MydiaWeb.MediaLive.Show.SearchHelpers
   import MydiaWeb.MediaLive.Show.Loaders

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -149,7 +149,7 @@
                 <div class="text-sm">
                   {format_download_status(download.status)}
                   <%= if download.progress do %>
-                    - {download.progress}%
+                    - {format_progress(download.progress)}%
                   <% end %>
                 </div>
               </div>

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -7,6 +7,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
 
   # Import the formatting and search helper functions
   import MydiaWeb.MediaLive.Show.Formatters
+  import MydiaWeb.Formatters, only: [format_progress: 1]
   import MydiaWeb.MediaLive.Show.SearchHelpers
 
   @doc """
@@ -359,7 +360,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
           <% end %>
           <%= if @download_to_cancel.progress do %>
             <p class="text-sm text-base-content/70 mt-1">
-              Progress: {@download_to_cancel.progress}%
+              Progress: {format_progress(@download_to_cancel.progress)}%
             </p>
           <% end %>
         </div>
@@ -482,7 +483,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                   max="100"
                 >
                 </progress>
-                <span class="text-sm font-mono">{@download_details.progress}%</span>
+                <span class="text-sm font-mono">{format_progress(@download_details.progress)}%</span>
               </div>
             </div>
           <% end %>


### PR DESCRIPTION
## Summary

Fix download progress display to show cleanly rounded percentages (e.g., `0.9%` instead of `0.899999999999%`).

Moves `format_progress/1` from a private helper in `DownloadsLive.Index` to `MydiaWeb.Formatters` as a public function, switches from `Float.round/2` to `:erlang.float_to_binary/2` for guaranteed-clean output, and uses it in the three media-show template locations that previously rendered raw floats.

Closes #202

## Changes

- `lib/mydia_web/helpers/formatters.ex` — add public `format_progress/1` with `:erlang.float_to_binary/2`
- `lib/mydia_web/live/downloads_live/index.ex` — remove private `format_progress/1`, import `MydiaWeb.Formatters`
- `lib/mydia_web/live/media_live/show.ex` — import `MydiaWeb.Formatters, only: [format_progress: 1]`
- `lib/mydia_web/live/media_live/show/modals.ex` — import `MydiaWeb.Formatters, only: [format_progress: 1]`
- `lib/mydia_web/live/media_live/show.html.heex` — `{download.progress}%` → `{format_progress(download.progress)}%`
- `lib/mydia_web/live/media_live/show/modals.ex` — two progress labels switched to `format_progress/1`

## Testing

- DownloadsLive index tests: 23/23 pass
- MediaLive show tests: 41/41 pass
- Compile, format, deps check: all green

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a presentation-only change affecting template string interpolation. No backend logic, API contracts, or data shape changes.