### PR TITLE
fix(downloads): resilient stall-detection (observed-time clock + recoverable soft-stall)

### DIFF
--- a/lib/mydia/downloads/download.ex
+++ b/lib/mydia/downloads/download.ex
@@ -29,6 +29,8 @@ defmodule Mydia.Downloads.Download do
           import_failed_at: DateTime.t() | nil,
           last_progress_at: DateTime.t() | nil,
           last_known_bytes: integer(),
+          last_observed_at: DateTime.t() | nil,
+          stalled_since: DateTime.t() | nil,
           bytes_pulled: integer() | nil,
           media_item: Mydia.Media.MediaItem.t() | Ecto.Association.NotLoaded.t(),
           episode: Mydia.Media.Episode.t() | nil | Ecto.Association.NotLoaded.t(),
@@ -67,6 +69,15 @@ defmodule Mydia.Downloads.Download do
     # breaker to avoid polling stuck downloads forever.
     field :last_progress_at, :utc_datetime_usec
     field :last_known_bytes, :integer, default: 0
+
+    # Observation + soft-stall tracking. `last_observed_at` is the timestamp of
+    # the last poll in which this download was observed actively downloading; a
+    # gap since this value resets the stall clock (so an outage/restart can't
+    # false-stall a live torrent). `stalled_since` marks a recoverable soft
+    # stall, kept distinct from the terminal `import_failed_at` so the episode
+    # stays occupied until escalation. See `Mydia.Downloads.StallDetector`.
+    field :last_observed_at, :utc_datetime_usec
+    field :stalled_since, :utc_datetime_usec
 
     # Bytes streamed locally into staging by the debrid Fetcher (or any future
     # adapter that performs a separate post-completion local pull). Updated
@@ -140,6 +151,8 @@ defmodule Mydia.Downloads.Download do
       :import_failed_at,
       :last_progress_at,
       :last_known_bytes,
+      :last_observed_at,
+      :stalled_since,
       :bytes_pulled
     ])
     |> validate_required([:title])

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -395,8 +395,10 @@ defmodule Mydia.Downloads.History do
       import_failed_at: download.import_failed_at,
       last_progress_at: download.last_progress_at,
       last_known_bytes: download.last_known_bytes,
-      # Carry the persisted stall state through an outage so the LiveView can
-      # still render a soft-stall warning while the client is unreachable.
+      # Carry the persisted stall state through an outage. The soft-stall badge
+      # itself is gated on status == "downloading", so it isn't shown while the
+      # client is unreachable (status "unknown"); preserving these fields keeps
+      # the state intact for clearing/recovery once the client is reachable again.
       last_observed_at: download.last_observed_at,
       stalled_since: download.stalled_since,
       # Client unreachable — presence indeterminate.

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -347,6 +347,8 @@ defmodule Mydia.Downloads.History do
       import_failed_at: download.import_failed_at,
       last_progress_at: download.last_progress_at,
       last_known_bytes: download.last_known_bytes,
+      last_observed_at: download.last_observed_at,
+      stalled_since: download.stalled_since,
       in_client?: true
     })
   end
@@ -393,6 +395,10 @@ defmodule Mydia.Downloads.History do
       import_failed_at: download.import_failed_at,
       last_progress_at: download.last_progress_at,
       last_known_bytes: download.last_known_bytes,
+      # Carry the persisted stall state through an outage so the LiveView can
+      # still render a soft-stall warning while the client is unreachable.
+      last_observed_at: download.last_observed_at,
+      stalled_since: download.stalled_since,
       # Client unreachable — presence indeterminate.
       in_client?: nil
     })
@@ -451,6 +457,8 @@ defmodule Mydia.Downloads.History do
       import_failed_at: download.import_failed_at,
       last_progress_at: download.last_progress_at,
       last_known_bytes: download.last_known_bytes,
+      last_observed_at: download.last_observed_at,
+      stalled_since: download.stalled_since,
       in_client?: in_client?
     })
   end

--- a/lib/mydia/downloads/stall_detector.ex
+++ b/lib/mydia/downloads/stall_detector.ex
@@ -34,6 +34,8 @@ defmodule Mydia.Downloads.StallDetector do
   in `Mydia.Jobs.DownloadMonitor`.
   """
 
+  alias Mydia.Downloads.StallDetector.Thresholds
+
   @type decision ::
           :no_change
           | {:initialize, now :: DateTime.t()}
@@ -57,17 +59,16 @@ defmodule Mydia.Downloads.StallDetector do
     * `stalled_since` — timestamp the current soft-stall began, or `nil` if not
       soft-stalled.
     * `observed_bytes` — bytes-downloaded reported by the client right now.
-    * `grace_minutes` — per-client incomplete grace window (positive integer).
-    * `escalation_minutes` — how long a soft-stall may persist before escalating
-      to a terminal failure (positive integer, larger than `grace_minutes`).
-    * `gap_threshold_seconds` — an observation gap larger than this resets the
-      stall clock (positive integer).
+    * `thresholds` — a `Thresholds` struct carrying the `grace_minutes`,
+      `escalation_minutes`, and `gap_threshold_seconds` tuning knobs.
     * `now` — the current `DateTime` (injected for test determinism).
 
   ## Returned decisions
 
-    * `:no_change` — nothing to persist beyond the monitor's unconditional
-      `last_observed_at = now` stamp (includes holding an immature soft-stall).
+    * `:no_change` — no stall-state transition to persist. The monitor still
+      records that it observed the download (a throttled `last_observed_at = now`
+      refresh — see `DownloadMonitor`), which keeps the gap reset from firing on
+      the next poll. Includes holding an immature soft-stall.
     * `{:initialize, now}` — first observation. Set `last_progress_at = now` and
       `last_known_bytes = observed_bytes`.
     * `{:reset, now}` — observation gap. Set `last_progress_at = now`, clear
@@ -90,9 +91,7 @@ defmodule Mydia.Downloads.StallDetector do
           DateTime.t() | nil,
           DateTime.t() | nil,
           non_neg_integer(),
-          pos_integer(),
-          pos_integer(),
-          pos_integer(),
+          Thresholds.t(),
           DateTime.t()
         ) :: decision()
   def evaluate(
@@ -101,9 +100,11 @@ defmodule Mydia.Downloads.StallDetector do
         last_observed_at,
         stalled_since,
         observed_bytes,
-        grace_minutes,
-        escalation_minutes,
-        gap_threshold_seconds,
+        %Thresholds{
+          grace_minutes: grace_minutes,
+          escalation_minutes: escalation_minutes,
+          gap_threshold_seconds: gap_threshold_seconds
+        },
         now
       )
       when is_integer(observed_bytes) and observed_bytes >= 0 and

--- a/lib/mydia/downloads/stall_detector.ex
+++ b/lib/mydia/downloads/stall_detector.ex
@@ -1,7 +1,7 @@
 defmodule Mydia.Downloads.StallDetector do
   @moduledoc """
   Pure progress-tracking logic for the `DownloadMonitor` stall-detection circuit
-  breaker (see issue #126 and the 2026-06-16 stall-resilience rework).
+  breaker (see issue #126).
 
   The stall clock only accrues over *observed, actively-downloading* time. On
   each poll cycle the monitor passes in the download's persisted progress state
@@ -118,14 +118,14 @@ defmodule Mydia.Downloads.StallDetector do
 
       # Observation gap — the download was not observed for a stretch (outage,
       # restart, paused/queued). Reset the baseline rather than attribute the
-      # gap to a stall, and clear any in-flight soft-stall (R2/R3).
+      # gap to a stall, and clear any in-flight soft-stall.
       is_nil(last_observed_at) or
           DateTime.diff(now, last_observed_at, :second) > gap_threshold_seconds ->
         {:reset, now}
 
       # Bytes changed — progress (or a regression from a client restart). Either
       # way reset the clock so we never false-trip the stall window, and
-      # auto-clear an in-flight soft-stall (R7).
+      # auto-clear an in-flight soft-stall.
       observed_bytes != known ->
         {:progress, observed_bytes, now}
 

--- a/lib/mydia/downloads/stall_detector.ex
+++ b/lib/mydia/downloads/stall_detector.ex
@@ -1,32 +1,46 @@
 defmodule Mydia.Downloads.StallDetector do
   @moduledoc """
   Pure progress-tracking logic for the `DownloadMonitor` stall-detection circuit
-  breaker (see issue #126).
+  breaker (see issue #126 and the 2026-06-16 stall-resilience rework).
 
-  On each poll cycle the monitor compares the bytes-downloaded reported by the
-  client against the `last_known_bytes` stored on the `Download` row:
+  The stall clock only accrues over *observed, actively-downloading* time. On
+  each poll cycle the monitor passes in the download's persisted progress state
+  plus the bytes-downloaded reported by the client, and this module returns a
+  decision the monitor persists:
 
-    * If the client reports MORE bytes, the download made progress — bump
-      `last_progress_at` and `last_known_bytes`.
-    * If the client reports the SAME bytes AND `(now - last_progress_at)` has
-      exceeded the per-client `incomplete_grace_minutes`, the download is
-      considered stalled. We flag it with `import_failed_at` + a
-      `"stalled after Nm without progress"` error message. The `:status` column
-      is intentionally NOT updated — that field is not cast on
-      `Download.changeset/2` (known bug, out of scope for #126).
-    * If `last_progress_at` is `nil` (a fresh download we have not observed
-      yet), initialize it to `now`. We never flag a download as stalled on
-      first sight; the grace window has to elapse.
+    * **Observation gap → reset.** If too much wall-clock has elapsed since the
+      last observation (`last_observed_at`), the download was *not* observed for
+      a stretch — a client outage, a Mydia restart, or a paused/queued torrent.
+      We can't attribute that gap to a stall, so we reset the baseline
+      (`last_progress_at = now`) and clear any in-flight soft-stall. This is the
+      single mechanism that makes stall-detection resilient to outages.
+    * **Progress → advance.** If the client reports a different byte count
+      (more, or a regression from a client restart), the download made progress;
+      advance `last_progress_at`/`last_known_bytes` and clear any soft-stall.
+    * **Soft-stall.** If bytes are unchanged, the download was observed
+      continuously (no gap), and `(now - last_progress_at)` exceeded the
+      per-client grace window, we record a *recoverable* soft-stall
+      (`stalled_since = now`). A soft-stall keeps occupying its episode — it is
+      NOT a terminal `import_failed_at` failure — and auto-clears on resumed
+      progress or a gap reset.
+    * **Escalate.** A download that stays continuously soft-stalled past a
+      separate, longer escalation threshold escalates to a terminal failure
+      (the monitor sets `import_failed_at`, releasing the episode for re-search).
+    * **Initialize.** First time we see a download (`last_progress_at` nil) we
+      set the baseline and never flag stalled on first sight.
 
   This module is deliberately decoupled from Ecto / Oban so it can be unit
-  tested with pure data.
+  tested with pure data. Persistence, escalation writes, and event emission stay
+  in `Mydia.Jobs.DownloadMonitor`.
   """
 
   @type decision ::
           :no_change
-          | {:progress, new_bytes :: non_neg_integer(), now :: DateTime.t()}
           | {:initialize, now :: DateTime.t()}
-          | {:stalled, error_message :: String.t(), now :: DateTime.t()}
+          | {:reset, now :: DateTime.t()}
+          | {:progress, new_bytes :: non_neg_integer(), now :: DateTime.t()}
+          | {:soft_stall, message :: String.t(), now :: DateTime.t()}
+          | {:escalate, message :: String.t(), now :: DateTime.t()}
 
   @doc """
   Decide what to do with a download whose progress we just observed.
@@ -36,70 +50,120 @@ defmodule Mydia.Downloads.StallDetector do
     * `last_progress_at` — timestamp of the last bytes-downloaded increment, or
       `nil` for a download we have not tracked yet.
     * `last_known_bytes` — bytes-downloaded count at `last_progress_at`. May be
-      `nil` if the row was created before the column existed; treated as `0`.
+      `nil` if the row predates the column; treated as `0`.
+    * `last_observed_at` — timestamp of the last poll in which this download was
+      observed actively downloading, or `nil` for a row that predates the column
+      (treated as a gap → reset).
+    * `stalled_since` — timestamp the current soft-stall began, or `nil` if not
+      soft-stalled.
     * `observed_bytes` — bytes-downloaded reported by the client right now.
     * `grace_minutes` — per-client incomplete grace window (positive integer).
+    * `escalation_minutes` — how long a soft-stall may persist before escalating
+      to a terminal failure (positive integer, larger than `grace_minutes`).
+    * `gap_threshold_seconds` — an observation gap larger than this resets the
+      stall clock (positive integer).
     * `now` — the current `DateTime` (injected for test determinism).
 
   ## Returned decisions
 
-    * `:no_change` — bytes unchanged and within grace window. Caller should do
-      nothing.
-    * `{:initialize, now}` — first observation of this download. Caller should
-      set `last_progress_at = now` and `last_known_bytes = observed_bytes`.
-    * `{:progress, observed_bytes, now}` — bytes increased. Caller should set
-      `last_progress_at = now` and `last_known_bytes = observed_bytes`.
-    * `{:stalled, error_message, now}` — bytes unchanged AND
-      `now - last_progress_at > grace_minutes`. Caller should set
-      `import_failed_at = now` and `import_last_error = error_message`.
+    * `:no_change` — nothing to persist beyond the monitor's unconditional
+      `last_observed_at = now` stamp (includes holding an immature soft-stall).
+    * `{:initialize, now}` — first observation. Set `last_progress_at = now` and
+      `last_known_bytes = observed_bytes`.
+    * `{:reset, now}` — observation gap. Set `last_progress_at = now`, clear
+      `stalled_since`. The byte baseline is left as-is (bytes were unchanged).
+    * `{:progress, observed_bytes, now}` — bytes changed. Set
+      `last_progress_at = now`, `last_known_bytes = observed_bytes`, clear
+      `stalled_since`.
+    * `{:soft_stall, message, now}` — bytes unchanged past the grace window. Set
+      `stalled_since = now`; leave `import_failed_at` nil (episode retained).
+    * `{:escalate, message, now}` — soft-stalled past the escalation threshold.
+      Set `import_failed_at = now` + `import_last_error = message` (terminal).
 
-  Boundary semantics: a download whose `last_progress_at` is EXACTLY
-  `grace_minutes` old is *not yet* stalled. The check uses strict `>`.
+  Boundary semantics: a download whose baseline is EXACTLY `grace_minutes` old is
+  *not yet* soft-stalled, and one stalled EXACTLY `escalation_minutes` is *not
+  yet* escalated. Both checks use strict `>`.
   """
   @spec evaluate(
           DateTime.t() | nil,
           non_neg_integer() | nil,
+          DateTime.t() | nil,
+          DateTime.t() | nil,
           non_neg_integer(),
+          pos_integer(),
+          pos_integer(),
           pos_integer(),
           DateTime.t()
         ) :: decision()
-  def evaluate(last_progress_at, last_known_bytes, observed_bytes, grace_minutes, now)
+  def evaluate(
+        last_progress_at,
+        last_known_bytes,
+        last_observed_at,
+        stalled_since,
+        observed_bytes,
+        grace_minutes,
+        escalation_minutes,
+        gap_threshold_seconds,
+        now
+      )
       when is_integer(observed_bytes) and observed_bytes >= 0 and
-             is_integer(grace_minutes) and grace_minutes > 0 do
+             is_integer(grace_minutes) and grace_minutes > 0 and
+             is_integer(escalation_minutes) and escalation_minutes > 0 and
+             is_integer(gap_threshold_seconds) and gap_threshold_seconds > 0 do
     known = last_known_bytes || 0
 
     cond do
       is_nil(last_progress_at) ->
         {:initialize, now}
 
-      observed_bytes > known ->
+      # Observation gap — the download was not observed for a stretch (outage,
+      # restart, paused/queued). Reset the baseline rather than attribute the
+      # gap to a stall, and clear any in-flight soft-stall (R2/R3).
+      is_nil(last_observed_at) or
+          DateTime.diff(now, last_observed_at, :second) > gap_threshold_seconds ->
+        {:reset, now}
+
+      # Bytes changed — progress (or a regression from a client restart). Either
+      # way reset the clock so we never false-trip the stall window, and
+      # auto-clear an in-flight soft-stall (R7).
+      observed_bytes != known ->
         {:progress, observed_bytes, now}
 
-      observed_bytes < known ->
-        # Bytes regressed (rare: client restart, file replaced). Treat as fresh
-        # progress so we don't false-trip the stall window.
-        {:progress, observed_bytes, now}
-
-      true ->
-        elapsed_seconds = DateTime.diff(now, last_progress_at, :second)
-        grace_seconds = grace_minutes * 60
-
-        if elapsed_seconds > grace_seconds do
-          {:stalled, stalled_message(grace_minutes), now}
+      # Currently soft-stalled and observed continuously: either escalate (past
+      # the longer threshold) or hold the soft-stall.
+      not is_nil(stalled_since) ->
+        if DateTime.diff(now, stalled_since, :second) > escalation_minutes * 60 do
+          {:escalate, escalation_message(escalation_minutes), now}
         else
           :no_change
         end
+
+      # Not yet stalled: enter a soft-stall once the grace window has elapsed.
+      DateTime.diff(now, last_progress_at, :second) > grace_minutes * 60 ->
+        {:soft_stall, stalled_message(grace_minutes), now}
+
+      true ->
+        :no_change
     end
   end
 
   @doc """
-  Build the standardised stalled error message. Other modules (notably the
-  Downloads LiveView) match on the leading `"stalled "` substring to surface
-  the badge.
+  Build the standardised soft-stall error message. The Downloads LiveView matches
+  on the leading `"stalled"` substring to surface the badge.
   """
   @spec stalled_message(pos_integer()) :: String.t()
   def stalled_message(grace_minutes) when is_integer(grace_minutes) and grace_minutes > 0 do
     "stalled after #{grace_minutes}m without progress"
+  end
+
+  @doc """
+  Build the terminal-escalation error message. Kept with a leading `"stalled"`
+  prefix so `stalled?/1` and the LiveView badge continue to recognise it.
+  """
+  @spec escalation_message(pos_integer()) :: String.t()
+  def escalation_message(escalation_minutes)
+      when is_integer(escalation_minutes) and escalation_minutes > 0 do
+    "stalled after #{escalation_minutes}m without progress — escalated to failure"
   end
 
   @doc """

--- a/lib/mydia/downloads/stall_detector/thresholds.ex
+++ b/lib/mydia/downloads/stall_detector/thresholds.ex
@@ -1,0 +1,24 @@
+defmodule Mydia.Downloads.StallDetector.Thresholds do
+  @moduledoc """
+  Config thresholds for `Mydia.Downloads.StallDetector.evaluate/7`.
+
+  Bundles the three per-poll tuning knobs so the evaluator keeps a small arity
+  and callers pass an explicit, self-documenting config value:
+
+    * `grace_minutes` — per-client incomplete grace window before a continuously
+      observed, byte-stalled download enters a recoverable soft-stall.
+    * `escalation_minutes` — how long a soft-stall may persist before escalating
+      to a terminal failure (larger than `grace_minutes`).
+    * `gap_threshold_seconds` — an observation gap larger than this resets the
+      stall clock (outage / restart / paused torrent).
+  """
+
+  @enforce_keys [:grace_minutes, :escalation_minutes, :gap_threshold_seconds]
+  defstruct [:grace_minutes, :escalation_minutes, :gap_threshold_seconds]
+
+  @type t :: %__MODULE__{
+          grace_minutes: pos_integer(),
+          escalation_minutes: pos_integer(),
+          gap_threshold_seconds: pos_integer()
+        }
+end

--- a/lib/mydia/downloads/structs/enriched_download.ex
+++ b/lib/mydia/downloads/structs/enriched_download.ex
@@ -56,6 +56,8 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
     # Stall-detection / progress tracking (mirrored from Download DB row)
     :last_progress_at,
     :last_known_bytes,
+    :last_observed_at,
+    :stalled_since,
     # Whether the torrent is currently present in its download client.
     # true  = client confirmed the torrent is there
     # false = client confirmed the torrent is gone
@@ -110,6 +112,8 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
           path_mapping_affected_count: integer() | nil,
           last_progress_at: DateTime.t() | nil,
           last_known_bytes: integer() | nil,
+          last_observed_at: DateTime.t() | nil,
+          stalled_since: DateTime.t() | nil,
           in_client?: boolean() | nil,
           rematch_eligible?: boolean() | nil
         }

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -608,6 +608,86 @@ defmodule Mydia.Events do
   end
 
   @doc """
+  Records a download.stalled event — a recoverable *soft* stall detected by the
+  `DownloadMonitor`. Unlike `download_failed/3` this is a warning: the download
+  keeps occupying its episode and may auto-clear on resumed progress.
+
+  ## Parameters
+    - `download` - The Download struct
+    - `message` - The stall message describing the soft-stall
+    - `opts` - Additional options (e.g., media_item for context)
+  """
+  def download_stalled(download, message, opts \\ []) do
+    media_item = opts[:media_item]
+
+    {resource_type, resource_id} =
+      if media_item do
+        {"media_item", media_item.id}
+      else
+        {"download", download.id}
+      end
+
+    metadata =
+      %{
+        "title" => download.title,
+        "download_client" => download.download_client,
+        "message" => message,
+        "download_id" => download.id
+      }
+      |> maybe_add_media_context(media_item)
+
+    create_event_async(%{
+      category: "downloads",
+      type: "download.stalled",
+      actor_type: :system,
+      actor_id: "download_monitor",
+      resource_type: resource_type,
+      resource_id: resource_id,
+      severity: :warning,
+      metadata: metadata
+    })
+  end
+
+  @doc """
+  Records a download.unstalled event — a soft-stall that recovered (the client
+  reported progress, or an observation-gap reset cleared the stall). Ensures a
+  recovered stall does not leave a `download.stalled` event as the last word.
+
+  ## Parameters
+    - `download` - The Download struct
+    - `opts` - Additional options (e.g., media_item for context)
+  """
+  def download_unstalled(download, opts \\ []) do
+    media_item = opts[:media_item]
+
+    {resource_type, resource_id} =
+      if media_item do
+        {"media_item", media_item.id}
+      else
+        {"download", download.id}
+      end
+
+    metadata =
+      %{
+        "title" => download.title,
+        "download_client" => download.download_client,
+        "download_id" => download.id
+      }
+      |> maybe_add_media_context(media_item)
+
+    create_event_async(%{
+      category: "downloads",
+      type: "download.unstalled",
+      actor_type: :system,
+      actor_id: "download_monitor",
+      resource_type: resource_type,
+      resource_id: resource_id,
+      severity: :info,
+      metadata: metadata
+    })
+  end
+
+  @doc """
   Records a download.cancelled event.
 
   ## Parameters

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -479,8 +479,9 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
   # Iterate active downloads and apply the StallDetector decision. Returns the
   # number of downloads newly entering a stalled state (soft-stall or escalation)
-  # this poll. Every observed download has `last_observed_at` stamped to `now`
-  # regardless of decision.
+  # this poll. Every observed download has `last_observed_at` refreshed to `now`
+  # (throttled — see `apply_progress_decision/3` for `:no_change`) so the gap
+  # reset doesn't fire on the next poll.
   defp check_progress(active_downloads, grace_map, now) do
     Enum.reduce(active_downloads, 0, fn download, stalled_acc ->
       grace = grace_minutes_for(download.download_client, grace_map)
@@ -493,9 +494,11 @@ defmodule Mydia.Jobs.DownloadMonitor do
           download.last_observed_at,
           download.stalled_since,
           download.downloaded || 0,
-          grace,
-          escalation,
-          @observation_gap_seconds,
+          %StallDetector.Thresholds{
+            grace_minutes: grace,
+            escalation_minutes: escalation,
+            gap_threshold_seconds: @observation_gap_seconds
+          },
           now
         )
 

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -499,15 +499,37 @@ defmodule Mydia.Jobs.DownloadMonitor do
           now
         )
 
-      apply_progress_decision(download, decision, now) + stalled_acc
+      increment =
+        try do
+          apply_progress_decision(download, decision, now)
+        rescue
+          # The row was deleted between the poll's status snapshot and this
+          # write (e.g. a concurrent import that deletes the download, or a
+          # manual delete). Skip it — the rest of the poll must still run.
+          Ecto.NoResultsError ->
+            Logger.debug("Download disappeared mid-poll; skipping stall update",
+              download_id: download.id
+            )
+
+            0
+        end
+
+      increment + stalled_acc
     end)
   end
 
-  # No stall transition, but still record that we observed this download now so
-  # the gap reset doesn't fire on the next poll. This also lets a
-  # held soft-stall mature toward escalation without self-resetting.
+  # No stall transition, but record that we observed this download so the gap
+  # reset doesn't fire on the next poll, and a held soft-stall keeps maturing
+  # toward escalation without self-resetting. Throttled: refreshing on every
+  # poll would issue a write + PubSub broadcast (which re-polls the client for
+  # every open Downloads view) for an otherwise-idle download. A refresh only
+  # has to keep `now - last_observed_at` under @observation_gap_seconds, so
+  # writing once it is half-stale is sufficient and far cheaper.
   defp apply_progress_decision(download, :no_change, now) do
-    update_progress(download, %{last_observed_at: now})
+    if observation_stale?(download.last_observed_at, now) do
+      update_progress(download, %{last_observed_at: now})
+    end
+
     0
   end
 
@@ -635,6 +657,16 @@ defmodule Mydia.Jobs.DownloadMonitor do
           :ok
       end
     end
+  end
+
+  # Whether `last_observed_at` is stale enough to be worth refreshing on an
+  # otherwise-idle poll. Half the gap threshold leaves ample margin: even with
+  # the slowest (cron) poll spacing, the next observation stays well under
+  # @observation_gap_seconds, so the gap reset never false-fires.
+  defp observation_stale?(nil, _now), do: true
+
+  defp observation_stale?(last_observed_at, now) do
+    DateTime.diff(now, last_observed_at, :second) > div(@observation_gap_seconds, 2)
   end
 
   defp update_progress(download, attrs) do

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -41,14 +41,14 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
   # A soft-stall escalates to a terminal failure only after it has persisted for
   # `grace_minutes × @stall_escalation_multiplier` (default 60 × 3 = 180 min).
-  # A dedicated per-client knob is deferred (see plan KTD5).
+  # A dedicated per-client knob is deferred.
   @stall_escalation_multiplier 3
 
   # An observation gap larger than this resets the stall clock instead of
   # accruing stall time — covers client outages, Mydia restarts, and torrents
   # that sat paused/queued. 360s is ~3 cron cycles at the 120s DownloadMonitor
   # interval; the 15s adaptive fast-followup chain keeps live polling well
-  # inside this window (see plan KTD6).
+  # inside this window.
   @observation_gap_seconds 360
 
   # Adaptive polling: when downloads are actively running, the cron plugin's
@@ -112,7 +112,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
     # Active downloads we should track for stall detection. Only genuinely
     # *downloading* torrents accrue stall time — paused/queued/checking/seeding
     # are not observed, so their stale clock is neutralised by the gap reset on
-    # resume (plan KTD4, R4). Terminal rows (import_failed_at set) stay excluded
+    # resume. Terminal rows (import_failed_at set) stay excluded
     # so an escalated stall isn't re-evaluated; soft-stalled rows keep
     # import_failed_at nil and so remain in the set for auto-clear/escalation.
     active_for_stall_check =
@@ -480,7 +480,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # Iterate active downloads and apply the StallDetector decision. Returns the
   # number of downloads newly entering a stalled state (soft-stall or escalation)
   # this poll. Every observed download has `last_observed_at` stamped to `now`
-  # regardless of decision (plan KTD7).
+  # regardless of decision.
   defp check_progress(active_downloads, grace_map, now) do
     Enum.reduce(active_downloads, 0, fn download, stalled_acc ->
       grace = grace_minutes_for(download.download_client, grace_map)
@@ -504,7 +504,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   end
 
   # No stall transition, but still record that we observed this download now so
-  # the gap reset doesn't fire on the next poll (plan KTD7). This also lets a
+  # the gap reset doesn't fire on the next poll. This also lets a
   # held soft-stall mature toward escalation without self-resetting.
   defp apply_progress_decision(download, :no_change, now) do
     update_progress(download, %{last_observed_at: now})
@@ -546,7 +546,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   end
 
   # A recoverable soft-stall: keep `import_failed_at` nil so the episode stays
-  # occupied (plan KTD2), record `stalled_since`, and emit a warning event.
+  # occupied, record `stalled_since`, and emit a warning event.
   defp apply_progress_decision(download, {:soft_stall, message, now}, _now) do
     Logger.warning("Download soft-stalled — no progress within grace window",
       download_id: download.id,
@@ -614,7 +614,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   end
 
   # Persist a progress/reset decision that clears any in-flight soft-stall,
-  # emitting a recovery event only when a soft-stall was actually cleared (R10).
+  # emitting a recovery event only when a soft-stall was actually cleared.
   defp apply_recovery(download, attrs) do
     if is_nil(download.stalled_since) do
       update_progress(download, attrs)

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -39,6 +39,18 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # config. The DB schema's default is also 60; this just guards against a nil.
   @default_grace_minutes 60
 
+  # A soft-stall escalates to a terminal failure only after it has persisted for
+  # `grace_minutes × @stall_escalation_multiplier` (default 60 × 3 = 180 min).
+  # A dedicated per-client knob is deferred (see plan KTD5).
+  @stall_escalation_multiplier 3
+
+  # An observation gap larger than this resets the stall clock instead of
+  # accruing stall time — covers client outages, Mydia restarts, and torrents
+  # that sat paused/queued. 360s is ~3 cron cycles at the 120s DownloadMonitor
+  # interval; the 15s adaptive fast-followup chain keeps live polling well
+  # inside this window (see plan KTD6).
+  @observation_gap_seconds 360
+
   # Adaptive polling: when downloads are actively running, the cron plugin's
   # 2-minute interval is too slow — completed downloads land in the library
   # 0–120s after the client says so. To shorten that gap without configuring
@@ -97,13 +109,15 @@ defmodule Mydia.Jobs.DownloadMonitor do
         d.match_status == "unmatched" and d.in_client? == false
       end)
 
-    # Active downloads we should track for stall detection. Skip terminal
-    # states (completed/seeding/failed/missing/imported) and anything already
-    # flagged as import_failed_at — the latter prevents stomping a previous
-    # stall annotation on every subsequent poll.
+    # Active downloads we should track for stall detection. Only genuinely
+    # *downloading* torrents accrue stall time — paused/queued/checking/seeding
+    # are not observed, so their stale clock is neutralised by the gap reset on
+    # resume (plan KTD4, R4). Terminal rows (import_failed_at set) stay excluded
+    # so an escalated stall isn't re-evaluated; soft-stalled rows keep
+    # import_failed_at nil and so remain in the set for auto-clear/escalation.
     active_for_stall_check =
       Enum.filter(downloads, fn d ->
-        d.status in ["downloading", "checking"] and
+        d.status == "downloading" and
           is_nil(d.import_failed_at) and
           is_nil(d.imported_at)
       end)
@@ -464,74 +478,162 @@ defmodule Mydia.Jobs.DownloadMonitor do
   end
 
   # Iterate active downloads and apply the StallDetector decision. Returns the
-  # number of downloads newly flagged as stalled.
+  # number of downloads newly entering a stalled state (soft-stall or escalation)
+  # this poll. Every observed download has `last_observed_at` stamped to `now`
+  # regardless of decision (plan KTD7).
   defp check_progress(active_downloads, grace_map, now) do
     Enum.reduce(active_downloads, 0, fn download, stalled_acc ->
       grace = grace_minutes_for(download.download_client, grace_map)
+      escalation = grace * @stall_escalation_multiplier
 
       decision =
         StallDetector.evaluate(
           download.last_progress_at,
           download.last_known_bytes,
+          download.last_observed_at,
+          download.stalled_since,
           download.downloaded || 0,
           grace,
+          escalation,
+          @observation_gap_seconds,
           now
         )
 
-      apply_progress_decision(download, decision) + stalled_acc
+      apply_progress_decision(download, decision, now) + stalled_acc
     end)
   end
 
-  defp apply_progress_decision(_download, :no_change), do: 0
+  # No stall transition, but still record that we observed this download now so
+  # the gap reset doesn't fire on the next poll (plan KTD7). This also lets a
+  # held soft-stall mature toward escalation without self-resetting.
+  defp apply_progress_decision(download, :no_change, now) do
+    update_progress(download, %{last_observed_at: now})
+    0
+  end
 
-  defp apply_progress_decision(download, {:initialize, now}) do
+  defp apply_progress_decision(download, {:initialize, now}, _now) do
     update_progress(download, %{
       last_progress_at: now,
-      last_known_bytes: download.downloaded || 0
+      last_known_bytes: download.downloaded || 0,
+      last_observed_at: now,
+      stalled_since: nil
     })
 
     0
   end
 
-  defp apply_progress_decision(download, {:progress, new_bytes, now}) do
-    update_progress(download, %{
+  # Observation gap — fresh baseline, clears any in-flight soft-stall. Bytes were
+  # unchanged so `last_known_bytes` is left as-is.
+  defp apply_progress_decision(download, {:reset, now}, _now) do
+    apply_recovery(download, %{
       last_progress_at: now,
-      last_known_bytes: new_bytes
+      last_observed_at: now,
+      stalled_since: nil
     })
 
     0
   end
 
-  defp apply_progress_decision(download, {:stalled, error_message, now}) do
-    Logger.warning("Download stalled — no progress within grace window",
+  defp apply_progress_decision(download, {:progress, new_bytes, now}, _now) do
+    apply_recovery(download, %{
+      last_progress_at: now,
+      last_known_bytes: new_bytes,
+      last_observed_at: now,
+      stalled_since: nil
+    })
+
+    0
+  end
+
+  # A recoverable soft-stall: keep `import_failed_at` nil so the episode stays
+  # occupied (plan KTD2), record `stalled_since`, and emit a warning event.
+  defp apply_progress_decision(download, {:soft_stall, message, now}, _now) do
+    Logger.warning("Download soft-stalled — no progress within grace window",
       download_id: download.id,
       download_client: download.download_client,
       last_progress_at: download.last_progress_at,
       last_known_bytes: download.last_known_bytes,
       downloaded: download.downloaded,
+      message: message
+    )
+
+    db_download = Downloads.get_download!(download.id, preload: [:media_item])
+
+    case Downloads.update_download(db_download, %{
+           stalled_since: now,
+           last_observed_at: now
+         }) do
+      {:ok, updated} ->
+        Events.download_stalled(updated, message, media_item: updated.media_item)
+        1
+
+      {:error, changeset} ->
+        Logger.error("Failed to flag soft-stalled download",
+          download_id: download.id,
+          errors: inspect(changeset.errors)
+        )
+
+        0
+    end
+  end
+
+  # Escalation — a soft-stall that outlasted the longer threshold becomes a
+  # terminal failure, releasing the episode for re-search (today's terminal
+  # behaviour, now reached only after escalation).
+  #
+  # IMPORTANT: do NOT cast `:status` here — `Download.changeset/2` silently
+  # drops it (known bug, tracked separately). Use `import_failed_at` +
+  # `import_last_error` as the terminal signal.
+  defp apply_progress_decision(download, {:escalate, error_message, now}, _now) do
+    Logger.warning("Download stall escalated to terminal failure",
+      download_id: download.id,
+      download_client: download.download_client,
+      stalled_since: download.stalled_since,
       error: error_message
     )
 
-    # IMPORTANT: do NOT cast `:status` here — `Download.changeset/2` silently
-    # drops it (known bug, tracked separately). Use `import_failed_at` +
-    # `import_last_error` as the stalled signal.
     db_download = Downloads.get_download!(download.id, preload: [:media_item])
 
     case Downloads.update_download(db_download, %{
            import_failed_at: now,
-           import_last_error: error_message
+           import_last_error: error_message,
+           last_observed_at: now
          }) do
       {:ok, updated} ->
         Events.download_failed(updated, error_message, media_item: updated.media_item)
         1
 
       {:error, changeset} ->
-        Logger.error("Failed to flag stalled download",
+        Logger.error("Failed to escalate stalled download",
           download_id: download.id,
           errors: inspect(changeset.errors)
         )
 
         0
+    end
+  end
+
+  # Persist a progress/reset decision that clears any in-flight soft-stall,
+  # emitting a recovery event only when a soft-stall was actually cleared (R10).
+  defp apply_recovery(download, attrs) do
+    if is_nil(download.stalled_since) do
+      update_progress(download, attrs)
+    else
+      db_download = Downloads.get_download!(download.id, preload: [:media_item])
+
+      case Downloads.update_download(db_download, attrs) do
+        {:ok, updated} ->
+          Events.download_unstalled(updated, media_item: updated.media_item)
+          :ok
+
+        {:error, changeset} ->
+          Logger.warning("Failed to clear soft-stall on download",
+            download_id: download.id,
+            errors: inspect(changeset.errors)
+          )
+
+          :ok
+      end
     end
   end
 

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -1150,8 +1150,8 @@ defmodule MydiaWeb.DownloadsLive.Index do
     # Stall state overrides the client status for sorting: a soft-stall groups
     # with warnings, a terminal stall failure groups with errors.
     cond do
-      stalled?(download) -> Map.fetch!(@status_rank, "failed")
       soft_stalled?(download) -> Map.fetch!(@status_rank, "stalled")
+      stalled?(download) -> Map.fetch!(@status_rank, "failed")
       true -> Map.get(@status_rank, download.status, 99)
     end
   end

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -1146,7 +1146,15 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   defp sort_name(download), do: String.downcase(get_display_title(download) || "")
 
-  defp status_rank(download), do: Map.get(@status_rank, download.status, 99)
+  defp status_rank(download) do
+    # Stall state overrides the client status for sorting: a soft-stall groups
+    # with warnings, a terminal stall failure groups with errors.
+    cond do
+      stalled?(download) -> Map.fetch!(@status_rank, "failed")
+      soft_stalled?(download) -> Map.fetch!(@status_rank, "stalled")
+      true -> Map.get(@status_rank, download.status, 99)
+    end
+  end
 
   # ETA may be nil, an integer (seconds remaining), or a DateTime. Normalize to
   # an integer so a single comparator works; nil sorts last (soonest first).
@@ -1262,6 +1270,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
       "queued" -> "badge-info"
       "paused" -> "badge-warning"
       "stalled" -> "badge-warning"
+      "stall_failed" -> "badge-error"
       _ -> "badge-ghost"
     end
   end
@@ -1299,24 +1308,49 @@ defmodule MydiaWeb.DownloadsLive.Index do
   # green) client status.
   defp row_status_dot_class(_download, :failed), do: "status-error"
   defp row_status_dot_class(_download, :retrying), do: "status-warning"
-  defp row_status_dot_class(download, nil), do: status_dot_class(download.status)
+
+  defp row_status_dot_class(download, nil) do
+    # A soft-stall keeps import_failed_at nil (so import_issue is nil), but the
+    # row should still read as a warning rather than a healthy green.
+    if soft_stalled?(download) do
+      "status-warning"
+    else
+      status_dot_class(download.status)
+    end
+  end
 
   defp import_issue_label(:failed), do: "Import failed"
   defp import_issue_label(:retrying), do: "Import retrying"
 
   @doc false
-  # Returns `{class, label}` for the download's status badge.
-  # When the download has been flagged stalled by `DownloadMonitor` (see #126),
-  # we override the underlying client status with a yellow "Stalled" badge so
-  # the user can tell at a glance that progress has stopped.
-  defp status_badge(download) do
-    if stalled?(download) do
-      {status_badge_class("stalled"), "Stalled"}
-    else
-      {status_badge_class(download.status), String.capitalize(download.status)}
+  # Returns `{class, label}` for the download's status badge. A stall has two
+  # distinct states (see DownloadMonitor stall-resilience rework):
+  #
+  #   * soft-stall — recoverable warning; progress has stopped but the download
+  #     still occupies its episode and may auto-clear. Yellow "Stalled" badge.
+  #   * terminal stall failure — escalated past the longer threshold; the
+  #     episode has been released for re-search. Red "Stall failed" badge.
+  def status_badge(download) do
+    cond do
+      soft_stalled?(download) ->
+        {status_badge_class("stalled"), "Stalled"}
+
+      stalled?(download) ->
+        {status_badge_class("stall_failed"), "Stall failed"}
+
+      true ->
+        {status_badge_class(download.status), String.capitalize(download.status)}
     end
   end
 
+  # A recoverable soft-stall: `stalled_since` set but not yet escalated to a
+  # terminal `import_failed_at` failure.
+  defp soft_stalled?(download) do
+    not is_nil(download.stalled_since) and is_nil(download.import_failed_at)
+  end
+
+  # A terminal stall failure: escalated to `import_failed_at` with a stalled
+  # message.
   defp stalled?(download) do
     not is_nil(download.import_failed_at) and
       Mydia.Downloads.StallDetector.stalled?(download.import_last_error)

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -1344,9 +1344,14 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   # A recoverable soft-stall: `stalled_since` set but not yet escalated to a
-  # terminal `import_failed_at` failure.
+  # terminal `import_failed_at` failure. Gated on the live "downloading" status
+  # so a download that pauses, completes, or goes client-unreachable after a
+  # soft-stall does not keep rendering a stale warning — `stalled_since` is only
+  # cleared while the download is observed downloading, so it can linger on a row
+  # that has since moved on.
   defp soft_stalled?(download) do
-    not is_nil(download.stalled_since) and is_nil(download.import_failed_at)
+    download.status == "downloading" and
+      not is_nil(download.stalled_since) and is_nil(download.import_failed_at)
   end
 
   # A terminal stall failure: escalated to `import_failed_at` with a stalled

--- a/priv/repo/migrations/20260616040800_add_stall_observation_fields_to_downloads.exs
+++ b/priv/repo/migrations/20260616040800_add_stall_observation_fields_to_downloads.exs
@@ -1,0 +1,21 @@
+defmodule Mydia.Repo.Migrations.AddStallObservationFieldsToDownloads do
+  use Ecto.Migration
+
+  def change do
+    alter table(:downloads) do
+      # Timestamp of the most recent poll in which this download was both
+      # observable (client reachable) and actively downloading. The stall clock
+      # only accrues over observed, active time; a gap since this value resets
+      # the clock so a client outage or Mydia restart can't false-stall a live
+      # torrent. Nil for rows created before this column existed.
+      add :last_observed_at, :utc_datetime_usec
+
+      # Marks a recoverable *soft* stall: set when a download is first detected
+      # stalled, cleared on resumed progress or an observation-gap reset. Kept
+      # distinct from the terminal `import_failed_at` so a soft stall keeps
+      # occupying its episode and only escalates to a terminal failure after a
+      # longer threshold. Nil when not soft-stalled.
+      add :stalled_since, :utc_datetime_usec
+    end
+  end
+end

--- a/test/mydia/downloads/download_test.exs
+++ b/test/mydia/downloads/download_test.exs
@@ -109,4 +109,63 @@ defmodule Mydia.Downloads.DownloadTest do
       assert reloaded.bytes_pulled == 1024
     end
   end
+
+  describe "stall observation fields (last_observed_at / stalled_since)" do
+    test "both default to nil when not provided" do
+      {:ok, download} =
+        %Download{}
+        |> Download.changeset(@valid_attrs)
+        |> Repo.insert()
+
+      assert download.last_observed_at == nil
+      assert download.stalled_since == nil
+    end
+
+    test "last_observed_at and stalled_since round-trip through the changeset" do
+      now = DateTime.utc_now()
+
+      attrs =
+        @valid_attrs
+        |> Map.put(:last_observed_at, now)
+        |> Map.put(:stalled_since, now)
+
+      download =
+        %Download{}
+        |> Download.changeset(attrs)
+        |> Ecto.Changeset.apply_changes()
+
+      assert DateTime.compare(download.last_observed_at, now) == :eq
+      assert DateTime.compare(download.stalled_since, now) == :eq
+    end
+
+    test "accepts nil for both (existing-row compatibility)" do
+      now = DateTime.utc_now()
+
+      {:ok, download} =
+        %Download{}
+        |> Download.changeset(Map.put(@valid_attrs, :stalled_since, now))
+        |> Repo.insert()
+
+      {:ok, cleared} =
+        download
+        |> Download.changeset(%{last_observed_at: nil, stalled_since: nil})
+        |> Repo.update()
+
+      reloaded = Repo.get!(Download, cleared.id)
+      assert reloaded.last_observed_at == nil
+      assert reloaded.stalled_since == nil
+    end
+
+    test "a soft-stalled row (stalled_since set, import_failed_at nil) is still occupying" do
+      now = DateTime.utc_now()
+
+      {:ok, download} =
+        %Download{}
+        |> Download.changeset(Map.put(@valid_attrs, :stalled_since, now))
+        |> Repo.insert()
+
+      occupying_ids = Download.occupying() |> Repo.all() |> Enum.map(& &1.id)
+      assert download.id in occupying_ids
+    end
+  end
 end

--- a/test/mydia/downloads/stall_detector_test.exs
+++ b/test/mydia/downloads/stall_detector_test.exs
@@ -4,118 +4,231 @@ defmodule Mydia.Downloads.StallDetectorTest do
   alias Mydia.Downloads.StallDetector
 
   @grace_minutes 60
+  @escalation_minutes 180
+  @gap_seconds 360
   @base_time ~U[2026-01-01 12:00:00.000000Z]
 
-  describe "evaluate/5 — first observation" do
-    test "initializes last_progress_at when it is nil" do
+  # Convenience wrapper so each test only varies the inputs it cares about.
+  defp evaluate(opts) do
+    StallDetector.evaluate(
+      Keyword.get(opts, :last_progress_at, @base_time),
+      Keyword.get(opts, :last_known_bytes, 200_000_000),
+      Keyword.get(opts, :last_observed_at, @base_time),
+      Keyword.get(opts, :stalled_since, nil),
+      Keyword.get(opts, :observed_bytes, 200_000_000),
+      Keyword.get(opts, :grace_minutes, @grace_minutes),
+      Keyword.get(opts, :escalation_minutes, @escalation_minutes),
+      Keyword.get(opts, :gap_threshold_seconds, @gap_seconds),
+      Keyword.fetch!(opts, :now)
+    )
+  end
+
+  describe "evaluate/9 — first observation" do
+    test "initializes when last_progress_at is nil" do
       assert {:initialize, @base_time} =
-               StallDetector.evaluate(nil, 0, 0, @grace_minutes, @base_time)
+               evaluate(last_progress_at: nil, last_observed_at: nil, now: @base_time)
     end
 
     test "initializes even when bytes are already non-zero (fresh row mid-download)" do
       assert {:initialize, @base_time} =
-               StallDetector.evaluate(nil, nil, 1_000_000, @grace_minutes, @base_time)
-    end
-
-    test "treats nil last_known_bytes the same as 0" do
-      one_minute_later = DateTime.add(@base_time, 60, :second)
-
-      assert {:progress, 500, ^one_minute_later} =
-               StallDetector.evaluate(@base_time, nil, 500, @grace_minutes, one_minute_later)
+               evaluate(
+                 last_progress_at: nil,
+                 last_known_bytes: nil,
+                 observed_bytes: 1_000_000,
+                 now: @base_time
+               )
     end
   end
 
-  describe "evaluate/5 — progress" do
-    test "returns :progress when bytes increased" do
-      one_minute_later = DateTime.add(@base_time, 60, :second)
+  describe "evaluate/9 — observation gap reset (AE1, AE2)" do
+    test "nil last_observed_at (post-migration row) resets, not stalls" do
+      # Even far past the grace window, a row never observed yet just resets.
+      way_past = DateTime.add(@base_time, (@grace_minutes + 30) * 60, :second)
 
-      assert {:progress, 200_000_000, ^one_minute_later} =
-               StallDetector.evaluate(
-                 @base_time,
-                 100_000_000,
-                 200_000_000,
-                 @grace_minutes,
-                 one_minute_later
+      assert {:reset, ^way_past} =
+               evaluate(last_observed_at: nil, now: way_past)
+    end
+
+    test "gap larger than threshold resets, even with bytes unchanged past grace" do
+      # last_observed_at is ~10h stale (outage), elapsed since baseline also huge.
+      now = DateTime.add(@base_time, 10 * 60 * 60, :second)
+      stale_observed = DateTime.add(@base_time, -(10 * 60 * 60), :second)
+
+      assert {:reset, ^now} =
+               evaluate(
+                 last_progress_at: @base_time,
+                 last_observed_at: stale_observed,
+                 now: now
                )
     end
 
-    test "returns :progress even after a long pause if bytes finally increased" do
-      two_hours_later = DateTime.add(@base_time, 2 * 60 * 60, :second)
+    test "gap within threshold does not reset" do
+      # Observed 1 poll (~2min) ago, bytes unchanged but still within grace.
+      now = DateTime.add(@base_time, 120, :second)
+      observed = DateTime.add(@base_time, 0, :second)
 
-      assert {:progress, 250, ^two_hours_later} =
-               StallDetector.evaluate(@base_time, 100, 250, @grace_minutes, two_hours_later)
+      assert :no_change =
+               evaluate(last_observed_at: observed, now: now)
+    end
+
+    test "a soft-stalled row that then hits a gap resets and clears the stall" do
+      now = DateTime.add(@base_time, 10 * 60 * 60, :second)
+      stale_observed = DateTime.add(@base_time, -(10 * 60 * 60), :second)
+
+      assert {:reset, ^now} =
+               evaluate(
+                 last_observed_at: stale_observed,
+                 stalled_since: @base_time,
+                 now: now
+               )
+    end
+  end
+
+  describe "evaluate/9 — progress" do
+    test "returns :progress when bytes increased (gap within threshold)" do
+      now = DateTime.add(@base_time, 120, :second)
+
+      assert {:progress, 300_000_000, ^now} =
+               evaluate(
+                 last_observed_at: @base_time,
+                 last_known_bytes: 200_000_000,
+                 observed_bytes: 300_000_000,
+                 now: now
+               )
     end
 
     test "treats a byte regression as progress (resets the clock, never stalls)" do
-      one_minute_later = DateTime.add(@base_time, 60, :second)
+      now = DateTime.add(@base_time, 120, :second)
 
-      # Bytes went DOWN (client restart, file replaced). We never want this to
-      # be misread as a stall — reset the progress clock so the new lower
-      # baseline is what we measure against.
-      assert {:progress, 50, ^one_minute_later} =
-               StallDetector.evaluate(@base_time, 100, 50, @grace_minutes, one_minute_later)
+      assert {:progress, 50, ^now} =
+               evaluate(
+                 last_observed_at: @base_time,
+                 last_known_bytes: 100,
+                 observed_bytes: 50,
+                 now: now
+               )
+    end
+
+    test "bytes increase on a soft-stalled row auto-clears via :progress (AE4)" do
+      now = DateTime.add(@base_time, 120, :second)
+
+      assert {:progress, 250_000_000, ^now} =
+               evaluate(
+                 last_observed_at: @base_time,
+                 stalled_since: @base_time,
+                 last_known_bytes: 200_000_000,
+                 observed_bytes: 250_000_000,
+                 now: now
+               )
+    end
+
+    test "treats nil last_known_bytes the same as 0" do
+      now = DateTime.add(@base_time, 120, :second)
+
+      assert {:progress, 500, ^now} =
+               evaluate(
+                 last_observed_at: @base_time,
+                 last_known_bytes: nil,
+                 observed_bytes: 500,
+                 now: now
+               )
     end
   end
 
-  describe "evaluate/5 — stall window" do
+  describe "evaluate/9 — soft-stall window (AE3)" do
     test "no change when bytes unchanged within grace window" do
       five_minutes_later = DateTime.add(@base_time, 5 * 60, :second)
+      observed = DateTime.add(@base_time, 4 * 60, :second)
 
       assert :no_change =
-               StallDetector.evaluate(
-                 @base_time,
-                 200_000_000,
-                 200_000_000,
-                 @grace_minutes,
-                 five_minutes_later
-               )
+               evaluate(last_observed_at: observed, now: five_minutes_later)
     end
 
     test "no change at the exact grace boundary (strict >, not >=)" do
-      # Exactly @grace_minutes elapsed — not yet stalled.
       exactly_grace = DateTime.add(@base_time, @grace_minutes * 60, :second)
+      observed = DateTime.add(@base_time, @grace_minutes * 60 - 60, :second)
 
       assert :no_change =
-               StallDetector.evaluate(
-                 @base_time,
-                 200_000_000,
-                 200_000_000,
-                 @grace_minutes,
-                 exactly_grace
-               )
+               evaluate(last_observed_at: observed, now: exactly_grace)
     end
 
-    test "stalled one second past the grace boundary" do
+    test "soft-stalls one second past the grace boundary, observed continuously" do
       just_past_grace = DateTime.add(@base_time, @grace_minutes * 60 + 1, :second)
+      # Observed recently (no gap) so the gap reset does not pre-empt the stall.
+      observed = DateTime.add(@base_time, @grace_minutes * 60 - 60, :second)
 
-      assert {:stalled, msg, ^just_past_grace} =
-               StallDetector.evaluate(
-                 @base_time,
-                 200_000_000,
-                 200_000_000,
-                 @grace_minutes,
-                 just_past_grace
-               )
+      assert {:soft_stall, msg, ^just_past_grace} =
+               evaluate(last_observed_at: observed, now: just_past_grace)
 
       assert msg == "stalled after 60m without progress"
     end
 
-    test "stalled message reflects the configured grace window" do
-      grace = 15
-      past_grace = DateTime.add(@base_time, grace * 60 + 1, :second)
+    test "soft-stall message reflects the configured grace window" do
+      past_grace = DateTime.add(@base_time, 15 * 60 + 1, :second)
+      observed = DateTime.add(@base_time, 15 * 60 - 30, :second)
 
-      assert {:stalled, "stalled after 15m without progress", ^past_grace} =
-               StallDetector.evaluate(@base_time, 500, 500, grace, past_grace)
+      assert {:soft_stall, "stalled after 15m without progress", ^past_grace} =
+               evaluate(
+                 grace_minutes: 15,
+                 last_known_bytes: 500,
+                 observed_bytes: 500,
+                 last_observed_at: observed,
+                 now: past_grace
+               )
+    end
+  end
+
+  describe "evaluate/9 — escalation (AE6)" do
+    test "holds the soft-stall within the escalation window" do
+      # Stalled 2h, escalation threshold is 3h; observed recently (no gap).
+      now = DateTime.add(@base_time, 2 * 60 * 60, :second)
+      observed = DateTime.add(now, -120, :second)
+
+      assert :no_change =
+               evaluate(
+                 last_progress_at: @base_time,
+                 stalled_since: @base_time,
+                 last_observed_at: observed,
+                 now: now
+               )
+    end
+
+    test "no escalation at the exact escalation boundary (strict >)" do
+      exactly = DateTime.add(@base_time, @escalation_minutes * 60, :second)
+      observed = DateTime.add(exactly, -120, :second)
+
+      assert :no_change =
+               evaluate(
+                 last_progress_at: @base_time,
+                 stalled_since: @base_time,
+                 last_observed_at: observed,
+                 now: exactly
+               )
+    end
+
+    test "escalates one second past the escalation threshold" do
+      past = DateTime.add(@base_time, @escalation_minutes * 60 + 1, :second)
+      observed = DateTime.add(past, -120, :second)
+
+      assert {:escalate, msg, ^past} =
+               evaluate(
+                 last_progress_at: @base_time,
+                 stalled_since: @base_time,
+                 last_observed_at: observed,
+                 now: past
+               )
+
+      assert StallDetector.stalled?(msg)
     end
   end
 
   describe "stalled?/1" do
-    test "true for the canonical error message" do
+    test "true for the canonical soft-stall message" do
       assert StallDetector.stalled?("stalled after 60m without progress")
     end
 
-    test "true for any message starting with 'stalled'" do
-      assert StallDetector.stalled?("stalled after 15m without progress")
+    test "true for the escalation message" do
+      assert StallDetector.stalled?(StallDetector.escalation_message(180))
     end
 
     test "false for unrelated error messages" do
@@ -128,10 +241,16 @@ defmodule Mydia.Downloads.StallDetectorTest do
     end
   end
 
-  describe "stalled_message/1" do
-    test "interpolates the grace minutes" do
+  describe "stalled_message/1 and escalation_message/1" do
+    test "stalled_message interpolates the grace minutes" do
       assert StallDetector.stalled_message(60) == "stalled after 60m without progress"
       assert StallDetector.stalled_message(5) == "stalled after 5m without progress"
+    end
+
+    test "escalation_message interpolates and is recognised as stalled" do
+      msg = StallDetector.escalation_message(180)
+      assert String.contains?(msg, "180m")
+      assert StallDetector.stalled?(msg)
     end
   end
 end

--- a/test/mydia/downloads/stall_detector_test.exs
+++ b/test/mydia/downloads/stall_detector_test.exs
@@ -2,6 +2,7 @@ defmodule Mydia.Downloads.StallDetectorTest do
   use ExUnit.Case, async: true
 
   alias Mydia.Downloads.StallDetector
+  alias Mydia.Downloads.StallDetector.Thresholds
 
   @grace_minutes 60
   @escalation_minutes 180
@@ -16,14 +17,16 @@ defmodule Mydia.Downloads.StallDetectorTest do
       Keyword.get(opts, :last_observed_at, @base_time),
       Keyword.get(opts, :stalled_since, nil),
       Keyword.get(opts, :observed_bytes, 200_000_000),
-      Keyword.get(opts, :grace_minutes, @grace_minutes),
-      Keyword.get(opts, :escalation_minutes, @escalation_minutes),
-      Keyword.get(opts, :gap_threshold_seconds, @gap_seconds),
+      %Thresholds{
+        grace_minutes: Keyword.get(opts, :grace_minutes, @grace_minutes),
+        escalation_minutes: Keyword.get(opts, :escalation_minutes, @escalation_minutes),
+        gap_threshold_seconds: Keyword.get(opts, :gap_threshold_seconds, @gap_seconds)
+      },
       Keyword.fetch!(opts, :now)
     )
   end
 
-  describe "evaluate/9 — first observation" do
+  describe "evaluate/7 — first observation" do
     test "initializes when last_progress_at is nil" do
       assert {:initialize, @base_time} =
                evaluate(last_progress_at: nil, last_observed_at: nil, now: @base_time)
@@ -40,7 +43,7 @@ defmodule Mydia.Downloads.StallDetectorTest do
     end
   end
 
-  describe "evaluate/9 — observation gap reset (AE1, AE2)" do
+  describe "evaluate/7 — observation gap reset (AE1, AE2)" do
     test "nil last_observed_at (post-migration row) resets, not stalls" do
       # Even far past the grace window, a row never observed yet just resets.
       way_past = DateTime.add(@base_time, (@grace_minutes + 30) * 60, :second)
@@ -84,7 +87,7 @@ defmodule Mydia.Downloads.StallDetectorTest do
     end
   end
 
-  describe "evaluate/9 — progress" do
+  describe "evaluate/7 — progress" do
     test "returns :progress when bytes increased (gap within threshold)" do
       now = DateTime.add(@base_time, 120, :second)
 
@@ -135,7 +138,7 @@ defmodule Mydia.Downloads.StallDetectorTest do
     end
   end
 
-  describe "evaluate/9 — soft-stall window (AE3)" do
+  describe "evaluate/7 — soft-stall window (AE3)" do
     test "no change when bytes unchanged within grace window" do
       five_minutes_later = DateTime.add(@base_time, 5 * 60, :second)
       observed = DateTime.add(@base_time, 4 * 60, :second)
@@ -178,7 +181,7 @@ defmodule Mydia.Downloads.StallDetectorTest do
     end
   end
 
-  describe "evaluate/9 — escalation (AE6)" do
+  describe "evaluate/7 — escalation (AE6)" do
     test "holds the soft-stall within the escalation window" do
       # Stalled 2h, escalation threshold is 3h; observed recently (no gap).
       now = DateTime.add(@base_time, 2 * 60 * 60, :second)

--- a/test/mydia/events_test.exs
+++ b/test/mydia/events_test.exs
@@ -677,6 +677,40 @@ defmodule Mydia.EventsTest do
       assert event.metadata["title"] == "Failed Download"
     end
 
+    test "download_stalled/3 creates a warning event distinct from download.failed" do
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Stalled Download",
+        download_client: "transmission"
+      }
+
+      Events.download_stalled(download, "stalled after 60m without progress")
+      Process.sleep(100)
+
+      assert [] = Events.list_events(type: "download.failed")
+      [event] = Events.list_events(type: "download.stalled")
+      assert event.category == "downloads"
+      assert event.actor_type == :system
+      assert event.severity == :warning
+      assert event.metadata["title"] == "Stalled Download"
+    end
+
+    test "download_unstalled/2 creates a recovery event referencing the download" do
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Recovered Download",
+        download_client: "transmission"
+      }
+
+      Events.download_unstalled(download)
+      Process.sleep(100)
+
+      [event] = Events.list_events(type: "download.unstalled")
+      assert event.category == "downloads"
+      assert event.severity == :info
+      assert event.metadata["download_id"] == download.id
+    end
+
     test "download_cancelled/3 creates correct event" do
       user_id = Ecto.UUID.generate()
 

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -744,7 +744,9 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
           download_client_id: "nzo-stuck-1",
           last_progress_at: first_seen,
           last_known_bytes: same_bytes,
-          last_observed_at: ~U[2026-05-14 11:58:00.000000Z]
+          # Half-stale (5 min > the 180s refresh threshold) so the no-change
+          # path refreshes last_observed_at this poll.
+          last_observed_at: ~U[2026-05-14 11:55:00.000000Z]
         })
 
       # 30 minutes after first_seen — still within the 60-minute grace window.
@@ -754,8 +756,42 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       updated = Downloads.get_download!(download.id)
       assert updated.last_progress_at == first_seen
       assert updated.last_known_bytes == same_bytes
-      # last_observed_at is stamped every poll even when nothing else changes.
+      # last_observed_at refreshed because it was half-stale.
       assert updated.last_observed_at == now
+      assert is_nil(updated.import_failed_at)
+      assert is_nil(updated.stalled_since)
+    end
+
+    test "does not rewrite last_observed_at on a no-change poll when it is still fresh" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+
+      same_bytes = round(50.0 * 1024 * 1024)
+
+      mock_sabnzbd_queue(bypass, [
+        sabnzbd_queue_item("nzo-fresh-1", "test.nzb", size_mb: 100.0, mb_left: 50.0)
+      ])
+
+      media_item = media_item_fixture()
+
+      # Observed 1 minute ago — well inside the 180s refresh threshold, so the
+      # idle poll must not issue a redundant write/broadcast.
+      fresh_observed = ~U[2026-05-14 11:59:00.000000Z]
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-fresh-1",
+          last_progress_at: ~U[2026-05-14 11:30:00.000000Z],
+          last_known_bytes: same_bytes,
+          last_observed_at: fresh_observed
+        })
+
+      now = ~U[2026-05-14 12:00:00.000000Z]
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
+
+      updated = Downloads.get_download!(download.id)
+      assert updated.last_observed_at == fresh_observed
       assert is_nil(updated.import_failed_at)
       assert is_nil(updated.stalled_since)
     end
@@ -829,6 +865,11 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       assert updated.last_observed_at == now
       assert is_nil(updated.import_failed_at)
       assert is_nil(updated.import_last_error)
+
+      # A soft-stall emits a warning event, not a terminal failure.
+      Process.sleep(100)
+      assert Events.list_events(type: "download.stalled") != []
+      assert Events.list_events(type: "download.failed") == []
     end
 
     test "respects per-client incomplete_grace_minutes for soft-stall" do
@@ -1208,6 +1249,44 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       assert is_nil(updated.stalled_since)
       assert is_nil(updated.import_failed_at)
       assert updated.last_known_bytes == round(70.0 * 1024 * 1024)
+      assert download.id in occupying_ids()
+
+      Process.sleep(100)
+      assert Events.list_events(type: "download.unstalled") != []
+      assert Events.list_events(type: "download.failed") == []
+    end
+
+    test "a soft-stall cleared by an observation-gap reset emits a recovery event" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+
+      # Same byte count as the baseline — recovery here comes from the gap reset,
+      # not from progress.
+      mock_sabnzbd_queue(bypass, [
+        sabnzbd_queue_item("nzo-reset-recover", "show.nzb", size_mb: 100.0, mb_left: 50.0)
+      ])
+
+      media_item = media_item_fixture()
+
+      # Soft-stalled, but last_observed_at is ~10h stale (outage/restart), so the
+      # next poll takes the gap-reset branch and clears the soft-stall.
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-reset-recover",
+          last_progress_at: ~U[2026-06-16 00:00:00.000000Z],
+          last_known_bytes: round(50.0 * 1024 * 1024),
+          last_observed_at: ~U[2026-06-16 00:00:00.000000Z],
+          stalled_since: ~U[2026-06-16 01:00:00.000000Z]
+        })
+
+      now = ~U[2026-06-16 10:00:00.000000Z]
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
+
+      updated = Downloads.get_download!(download.id)
+      assert is_nil(updated.stalled_since)
+      assert is_nil(updated.import_failed_at)
+      assert updated.last_progress_at == now
       assert download.id in occupying_ids()
 
       Process.sleep(100)

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -4,6 +4,8 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
   alias Mydia.Jobs.DownloadMonitor
   alias Mydia.Downloads
+  alias Mydia.Downloads.Download
+  alias Mydia.Events
   import Mydia.MediaFixtures
   import Mydia.DownloadsFixtures
 
@@ -1080,7 +1082,216 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
     end
   end
 
+  # Acceptance examples carried from the stall-resilience plan. AE1 (outage
+  # recovery) and AE3 (genuine soft-stall) are additionally exercised by the
+  # "stall detection" describe block and AE7 below; here we lock the multi-poll
+  # sequences and the end-to-end incident replay.
+  describe "acceptance examples (AE1–AE7)" do
+    test "AE7: pegasus incident replay — outage then recovery never terminally fails" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+
+      mock_sabnzbd_queue(bypass, [
+        sabnzbd_queue_item("nzo-pegasus", "show.nzb", size_mb: 100.0, mb_left: 50.0)
+      ])
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-pegasus",
+          last_progress_at: nil,
+          last_known_bytes: 0
+        })
+
+      t0 = ~U[2026-06-16 00:00:00.000000Z]
+
+      # Poll 1: first observation initializes tracking.
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(t0)})
+      after1 = Downloads.get_download!(download.id)
+      assert after1.last_progress_at == t0
+      assert after1.last_observed_at == t0
+
+      # Outage: client unreachable for hours. The download reads as "unknown",
+      # is excluded from stall tracking, and last_observed_at stays frozen.
+      Bypass.down(bypass)
+      during = DateTime.add(t0, 5 * 60 * 60, :second)
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(during)})
+      mid = Downloads.get_download!(download.id)
+      assert is_nil(mid.import_failed_at)
+      assert is_nil(mid.stalled_since)
+      assert mid.last_observed_at == t0
+
+      # Recovery ~10h after t0, same byte count. The observation gap (~10h) far
+      # exceeds the threshold → reset, NOT a stall.
+      Bypass.up(bypass)
+      recovery = DateTime.add(t0, 10 * 60 * 60, :second)
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(recovery)})
+      recovered = Downloads.get_download!(download.id)
+      assert is_nil(recovered.import_failed_at)
+      assert is_nil(recovered.stalled_since)
+      assert recovered.last_progress_at == recovery
+      assert recovered.last_observed_at == recovery
+
+      # A follow-up poll shortly after recovery, still same bytes — fresh grace
+      # window, so still not stalled.
+      followup = DateTime.add(recovery, 120, :second)
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(followup)})
+      after_followup = Downloads.get_download!(download.id)
+      assert is_nil(after_followup.import_failed_at)
+      assert is_nil(after_followup.stalled_since)
+
+      # Episode never released: the download still occupies it throughout.
+      assert download.id in occupying_ids()
+
+      Process.sleep(100)
+      assert Events.list_events(type: "download.failed") == []
+    end
+
+    test "AE2: restart with a stale last_observed_at resets rather than false-stalls" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+      same_bytes = round(50.0 * 1024 * 1024)
+
+      mock_sabnzbd_queue(bypass, [
+        sabnzbd_queue_item("nzo-ae2", "show.nzb", size_mb: 100.0, mb_left: 50.0)
+      ])
+
+      media_item = media_item_fixture()
+
+      # last_observed_at is 2h old (2× grace) — the downtime gap resets the clock.
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-ae2",
+          last_progress_at: ~U[2026-06-16 00:00:00.000000Z],
+          last_known_bytes: same_bytes,
+          last_observed_at: ~U[2026-06-16 00:00:00.000000Z]
+        })
+
+      now = ~U[2026-06-16 02:00:00.000000Z]
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
+
+      updated = Downloads.get_download!(download.id)
+      assert is_nil(updated.import_failed_at)
+      assert is_nil(updated.stalled_since)
+      assert updated.last_progress_at == now
+      assert updated.last_observed_at == now
+    end
+
+    test "AE4: soft-stall auto-clears on resumed progress; episode never released" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+
+      # Client now reports MORE bytes (30 MB left vs the 50 MB baseline).
+      mock_sabnzbd_queue(bypass, [
+        sabnzbd_queue_item("nzo-ae4", "show.nzb", size_mb: 100.0, mb_left: 30.0)
+      ])
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-ae4",
+          last_progress_at: ~U[2026-06-16 00:00:00.000000Z],
+          last_known_bytes: round(50.0 * 1024 * 1024),
+          last_observed_at: ~U[2026-06-16 00:58:00.000000Z],
+          stalled_since: ~U[2026-06-16 00:50:00.000000Z]
+        })
+
+      now = ~U[2026-06-16 01:00:00.000000Z]
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
+
+      updated = Downloads.get_download!(download.id)
+      assert is_nil(updated.stalled_since)
+      assert is_nil(updated.import_failed_at)
+      assert updated.last_known_bytes == round(70.0 * 1024 * 1024)
+      assert download.id in occupying_ids()
+
+      Process.sleep(100)
+      assert Events.list_events(type: "download.unstalled") != []
+      assert Events.list_events(type: "download.failed") == []
+    end
+
+    test "AE5: a paused download past the grace window never stalls" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+
+      paused_slot =
+        "nzo-ae5"
+        |> sabnzbd_queue_item("show.nzb", size_mb: 100.0, mb_left: 50.0)
+        |> Map.put("status", "Paused")
+
+      mock_sabnzbd_queue(bypass, [paused_slot])
+
+      media_item = media_item_fixture()
+
+      stale_observed = ~U[2026-06-16 04:58:00.000000Z]
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-ae5",
+          # last_progress_at 5h ago — far past grace, but the torrent is paused.
+          last_progress_at: ~U[2026-06-16 00:00:00.000000Z],
+          last_known_bytes: round(50.0 * 1024 * 1024),
+          last_observed_at: stale_observed
+        })
+
+      now = ~U[2026-06-16 05:00:00.000000Z]
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
+
+      updated = Downloads.get_download!(download.id)
+      assert is_nil(updated.import_failed_at)
+      assert is_nil(updated.stalled_since)
+      # Paused → excluded from the active set → last_observed_at is not advanced.
+      assert updated.last_observed_at == stale_observed
+    end
+
+    test "AE6: a soft-stall past the escalation threshold becomes terminal; episode released" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+      same_bytes = round(50.0 * 1024 * 1024)
+
+      mock_sabnzbd_queue(bypass, [
+        sabnzbd_queue_item("nzo-ae6", "show.nzb", size_mb: 100.0, mb_left: 50.0)
+      ])
+
+      media_item = media_item_fixture()
+
+      # Escalation threshold = grace × 3 = 180 min. stalled_since is 182 min old,
+      # observed continuously (recent last_observed_at), bytes unchanged.
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-ae6",
+          last_progress_at: ~U[2026-06-16 00:00:00.000000Z],
+          last_known_bytes: same_bytes,
+          last_observed_at: ~U[2026-06-16 03:58:00.000000Z],
+          stalled_since: ~U[2026-06-16 00:58:00.000000Z]
+        })
+
+      now = ~U[2026-06-16 04:00:00.000000Z]
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
+
+      updated = Downloads.get_download!(download.id)
+      refute is_nil(updated.import_failed_at)
+      assert updated.import_last_error =~ "stalled"
+      # Terminal failure releases the episode for re-search.
+      refute download.id in occupying_ids()
+
+      Process.sleep(100)
+      assert Events.list_events(type: "download.failed") != []
+    end
+  end
+
   ## Helper Functions
+
+  defp occupying_ids do
+    Download.occupying() |> Repo.all() |> Enum.map(& &1.id)
+  end
 
   defp start_sabnzbd_bypass(opts \\ []) do
     bypass = Bypass.open()

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -704,7 +704,10 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
           download_client: client_config.name,
           download_client_id: "nzo-progress-1",
           last_progress_at: first_seen,
-          last_known_bytes: prev_bytes
+          last_known_bytes: prev_bytes,
+          # Observed one poll ago — within the observation-gap window, so the
+          # gap reset doesn't pre-empt progress evaluation.
+          last_observed_at: ~U[2026-05-14 11:58:00.000000Z]
         })
 
       now = ~U[2026-05-14 12:00:00.000000Z]
@@ -714,7 +717,9 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       # Bytes increased from ~50MB to ~60MB — progress recorded, no stall flag.
       assert updated.last_progress_at == now
       assert updated.last_known_bytes == round(60.0 * 1024 * 1024)
+      assert updated.last_observed_at == now
       assert is_nil(updated.import_failed_at)
+      assert is_nil(updated.stalled_since)
     end
 
     test "leaves last_progress_at unchanged when bytes are unchanged within grace window" do
@@ -736,7 +741,8 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
           download_client: client_config.name,
           download_client_id: "nzo-stuck-1",
           last_progress_at: first_seen,
-          last_known_bytes: same_bytes
+          last_known_bytes: same_bytes,
+          last_observed_at: ~U[2026-05-14 11:58:00.000000Z]
         })
 
       # 30 minutes after first_seen — still within the 60-minute grace window.
@@ -746,7 +752,10 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       updated = Downloads.get_download!(download.id)
       assert updated.last_progress_at == first_seen
       assert updated.last_known_bytes == same_bytes
+      # last_observed_at is stamped every poll even when nothing else changes.
+      assert updated.last_observed_at == now
       assert is_nil(updated.import_failed_at)
+      assert is_nil(updated.stalled_since)
     end
 
     test "does not stall at the exact grace boundary (strict >)" do
@@ -770,7 +779,8 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
           download_client: client_config.name,
           download_client_id: "nzo-boundary-1",
           last_progress_at: first_seen,
-          last_known_bytes: same_bytes
+          last_known_bytes: same_bytes,
+          last_observed_at: ~U[2026-05-14 11:58:00.000000Z]
         })
 
       assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
@@ -778,9 +788,10 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       updated = Downloads.get_download!(download.id)
       assert is_nil(updated.import_failed_at)
       assert is_nil(updated.import_last_error)
+      assert is_nil(updated.stalled_since)
     end
 
-    test "flags as stalled when bytes are unchanged past the grace window" do
+    test "soft-stalls (not terminal) when bytes are unchanged past the grace window" do
       {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
 
       same_bytes = round(50.0 * 1024 * 1024)
@@ -792,7 +803,8 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       media_item = media_item_fixture()
 
       first_seen = ~U[2026-05-14 10:00:00.000000Z]
-      # 61 minutes later — past the 60m grace window by 1 minute.
+      # 61 minutes later — past the 60m grace window by 1 minute. Observed
+      # continuously (recent last_observed_at) so no gap reset.
       now = ~U[2026-05-14 11:01:00.000000Z]
 
       download =
@@ -801,20 +813,23 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
           download_client: client_config.name,
           download_client_id: "nzo-stalled-1",
           last_progress_at: first_seen,
-          last_known_bytes: same_bytes
+          last_known_bytes: same_bytes,
+          last_observed_at: ~U[2026-05-14 10:59:00.000000Z]
         })
 
       assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
 
       updated = Downloads.get_download!(download.id)
-      # import_failed_at is :utc_datetime (second precision), so compare via diff.
-      assert updated.import_failed_at != nil
-      assert DateTime.diff(updated.import_failed_at, now, :second) == 0
-      assert updated.import_last_error =~ "stalled"
-      assert updated.import_last_error == "stalled after 60m without progress"
+      # Soft-stall: stalled_since set, but NOT terminal — import_failed_at stays
+      # nil so the episode is still occupied (no re-grab).
+      assert updated.stalled_since != nil
+      assert DateTime.diff(updated.stalled_since, now, :second) == 0
+      assert updated.last_observed_at == now
+      assert is_nil(updated.import_failed_at)
+      assert is_nil(updated.import_last_error)
     end
 
-    test "respects per-client incomplete_grace_minutes" do
+    test "respects per-client incomplete_grace_minutes for soft-stall" do
       {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 15)
 
       same_bytes = round(50.0 * 1024 * 1024)
@@ -835,15 +850,16 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
           download_client: client_config.name,
           download_client_id: "nzo-grace15-1",
           last_progress_at: first_seen,
-          last_known_bytes: same_bytes
+          last_known_bytes: same_bytes,
+          last_observed_at: ~U[2026-05-14 10:14:00.000000Z]
         })
 
       assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
 
       updated = Downloads.get_download!(download.id)
-      assert updated.import_failed_at != nil
-      assert DateTime.diff(updated.import_failed_at, now, :second) == 0
-      assert updated.import_last_error == "stalled after 15m without progress"
+      assert updated.stalled_since != nil
+      assert DateTime.diff(updated.stalled_since, now, :second) == 0
+      assert is_nil(updated.import_failed_at)
     end
 
     test "does not flag stalled in terminal state (completed)" do

--- a/test/mydia/jobs/usenet_import_integration_test.exs
+++ b/test/mydia/jobs/usenet_import_integration_test.exs
@@ -330,7 +330,10 @@ defmodule Mydia.Jobs.UsenetImportIntegrationTest do
           download_client: client_config.name,
           download_client_id: nzo_id,
           last_progress_at: first_seen,
-          last_known_bytes: same_bytes
+          last_known_bytes: same_bytes,
+          # Observed continuously (within the observation-gap window) so the
+          # stall is detected rather than reset away.
+          last_observed_at: ~U[2026-05-14 10:14:00.000000Z]
         })
 
       # 16 minutes after `first_seen` — past the 15-minute grace window.
@@ -339,9 +342,11 @@ defmodule Mydia.Jobs.UsenetImportIntegrationTest do
       assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
 
       updated = Downloads.get_download!(download.id)
-      assert updated.import_failed_at != nil
-      assert DateTime.diff(updated.import_failed_at, now, :second) == 0
-      assert updated.import_last_error == "stalled after 15m without progress"
+      # A newly-detected stall is now a recoverable soft-stall, not a terminal
+      # failure: stalled_since is set but import_failed_at stays nil.
+      assert updated.stalled_since != nil
+      assert DateTime.diff(updated.stalled_since, now, :second) == 0
+      assert is_nil(updated.import_failed_at)
     end
 
     test "DownloadMonitor clears no progress when bytes finally move past the grace window",
@@ -401,7 +406,8 @@ defmodule Mydia.Jobs.UsenetImportIntegrationTest do
           download_client: client_config.name,
           download_client_id: nzo_id,
           last_progress_at: first_seen,
-          last_known_bytes: previous_bytes
+          last_known_bytes: previous_bytes,
+          last_observed_at: ~U[2026-05-14 10:18:00.000000Z]
         })
 
       # 20 minutes later — past the 15-min grace, but bytes increased.

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -501,5 +501,20 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
                  import_last_error: nil
                })
     end
+
+    test "a stale stalled_since on a no-longer-downloading row does not render the warning badge" do
+      # A soft-stall that paused/completed keeps a lingering stalled_since (it is
+      # only cleared while observed downloading). The badge must reflect the
+      # current client status, not a stale warning.
+      now = DateTime.utc_now()
+
+      assert {_class, "Completed"} =
+               Index.status_badge(%{
+                 status: "completed",
+                 stalled_since: now,
+                 import_failed_at: nil,
+                 import_last_error: nil
+               })
+    end
   end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -464,4 +464,42 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       assert html =~ "Attempt #2"
     end
   end
+
+  describe "soft-stall vs terminal stall badge" do
+    alias MydiaWeb.DownloadsLive.Index
+
+    test "a soft-stalled download renders a warning 'Stalled' badge" do
+      now = DateTime.utc_now()
+
+      assert {"badge-warning", "Stalled"} =
+               Index.status_badge(%{
+                 status: "downloading",
+                 stalled_since: now,
+                 import_failed_at: nil,
+                 import_last_error: nil
+               })
+    end
+
+    test "a terminal stall failure renders an error 'Stall failed' badge" do
+      now = DateTime.utc_now()
+
+      assert {"badge-error", "Stall failed"} =
+               Index.status_badge(%{
+                 status: "downloading",
+                 stalled_since: now,
+                 import_failed_at: now,
+                 import_last_error: "stalled after 180m without progress — escalated to failure"
+               })
+    end
+
+    test "a normal download falls through to its client-status badge" do
+      assert {_class, "Downloading"} =
+               Index.status_badge(%{
+                 status: "downloading",
+                 stalled_since: nil,
+                 import_failed_at: nil,
+                 import_last_error: nil
+               })
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Makes download stall-detection resilient to download-client outages, Mydia restarts, and non-downloading torrent states. Two coupled changes:

1. **Observed-time stall clock.** The stall grace window only accrues over time in which a download was *observed actively downloading*. A new `last_observed_at` column tracks the last such poll; an observation gap larger than `@observation_gap_seconds` (360s, ~3 cron cycles) **resets** the clock instead of measuring across it. This single mechanism covers client outages, Mydia restarts, and paused/queued/checking torrents — none can false-stall a live download anymore.

2. **Recoverable soft-stall.** A newly-detected stall is now a *soft-stall* (new `stalled_since` marker) that **keeps occupying its episode** (no re-grab), **auto-clears** on resumed progress or a gap reset, and only **escalates** to a terminal `import_failed_at` failure after a longer threshold (`incomplete_grace_minutes × 3`). The UI distinguishes a soft-stall (warning) from a terminal stall failure (error).

`StallDetector` stays pure (`evaluate/9` is a flat gap-reset + two-threshold state machine); persistence, escalation, and event emission stay in `DownloadMonitor`.

### The incident this fixes (`pegasus`)
A ~10h `transmission-openvpn` outage. On restore, the first post-recovery poll measured elapsed time across the *entire* outage and terminally failed six actively-downloading episodes, dropping them from search (`import_next_retry_at` null). The AE7 regression test replays this timeline end-to-end and asserts zero terminal failures.

## Implementation (plan units U1–U6)
- **U1** — `last_observed_at` + `stalled_since` columns; plumbed through schema cast, `EnrichedDownload`, and all three `history.ex` enrichment paths.
- **U2** — `StallDetector.evaluate/9` reworked into the gap-reset + soft-stall/escalate state machine (pure).
- **U3** — `download.stalled` (warning) and `download.unstalled` (recovery) events.
- **U4** — `DownloadMonitor` orchestration: active set narrowed to `downloading`, `last_observed_at` stamped each poll, decisions mapped to persistence + events.
- **U5** — LiveView soft-stall (warning) vs terminal stall-failure (error) badge/dot/sort.
- **U6** — AE1–AE7 acceptance coverage incl. the `pegasus` incident replay.

## Testing
- `mix precommit` green: **5172 tests, 0 failures**.
- New/updated suites: `stall_detector_test` (full state-machine + strict-`>` boundaries), `download_monitor_test` (AE1–AE7, soft-stall/auto-clear/escalation, gap-reset recovery, observation-write throttle), `events_test`, `download_test`, `downloads_live/index_test` (badge distinction + stale-badge gate), `usenet_import_integration_test` (updated to soft-stall semantics).
- Migration verified up/down clean on SQLite.

## Code review (Tier 2, applied)
A multi-persona review ran (correctness, adversarial, reliability, performance, data-migration, testing, maintainability, project-standards). Fixes applied from the review:
- **Badge gate:** soft-stall warning is gated on live `downloading` status so a stalled download that pauses/completes doesn't render a stale "Stalled" badge.
- **Write throttle:** the per-poll `last_observed_at` stamp now only writes when half-stale (>180s), avoiding a write + PubSub→client-re-poll storm on every idle poll. Gap-reset correctness preserved (180s + worst-case 120s cron = 300s < 360s).
- **Failure isolation:** each per-download apply is wrapped so a row deleted mid-poll (`Ecto.NoResultsError`) can't abort stall checks for the rest of the poll.

## Post-Deploy Monitoring & Validation
- **Healthy signal:** after one poll, existing rows take the `:reset` path (nil `last_observed_at`) — no spurious soft-stalls. Verify:
  `SELECT COUNT(*) FROM downloads WHERE status='downloading' AND import_failed_at IS NULL AND stalled_since IS NOT NULL;` should track only genuinely stalled downloads.
- **Watch:** events of type `download.stalled` (soft) vs `download.failed` from the monitor; a healthy fleet should show few/no terminal stall escalations.
- **Failure signal / rollback trigger:** a spike of `download.failed` with `"escalated to failure"` messages shortly after deploy, or episodes dropping from search during a known client outage → revert this branch (code + migration roll back together; columns are additive/nullable).
- **Validation window:** first 24h with at least one active download; owner: downloads subsystem.

## Known residuals / follow-ups (accepted, not blocking)
These are design tradeoffs (most already noted in the plan's Risks section), recorded here rather than fixed in this PR:
- **Escalation can be starved** by a stuck torrent whose byte counter ticks on discarded pieces (any byte change reads as progress — pre-existing behavior) or by repeated >360s poll gaps resetting the escalation clock. A soft-stall that never escalates stays *occupying* its episode (the safe direction — it never wrongly drops from search), but won't auto-release. Adversarial review, advisory.
- **Concurrent overlapping polls** could double-emit stall/unstall events (the Oban `unique` guard dedups queued, not executing, jobs). Pre-existing architecture; low probability.
- **`evaluate/9`** has nine positional args (three adjacent `DateTime|nil`, three adjacent `pos_integer`); a future `%Observation{}` struct would remove the transposition trap. Single production call site + numeric guard + keyword test wrapper mitigate today.
- A soft-stalled download that completes leaves a lingering `stalled_since` in the DB until the row is deleted post-import; the badge gate hides it in the UI and it self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
