### PR TITLE
fix(release): repair macOS Sparkle appcast so auto-update works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -964,7 +964,15 @@ jobs:
             cat appcast.xml
             exit 1
           fi
-          echo "appcast.xml passed publish-gate validation."
+
+          # Mirror the macOS-job check: sparkle:version must be the integer build
+          # number, or Sparkle never offers the update even though the release ships.
+          sparkle_version=$(sed -n 's#.*<sparkle:version>\(.*\)</sparkle:version>.*#\1#p' appcast.xml)
+          if ! printf '%s' "$sparkle_version" | grep -Eq '^[0-9]+$'; then
+            echo "::error::Refusing to publish: sparkle:version must be an integer build number, got '$sparkle_version'"
+            exit 1
+          fi
+          echo "appcast.xml passed publish-gate validation (sparkle:version=$sparkle_version)."
 
       - name: Upload release assets
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -649,14 +649,29 @@ jobs:
         working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
+          VERSION_CODE="${{ needs.prepare.outputs.version_code }}"
           DMG_FILE="Mydia Player.dmg"
           DMG_URL="https://github.com/getmydia/mydia/releases/download/v${VERSION}/mydia-player-macos-v${VERSION}.dmg"
 
-          # Sign the DMG and get the EdDSA signature
+          # sign_update prints a ready-to-paste XML attribute fragment, e.g.
+          #   sparkle:edSignature="…" length="71098585"
+          # It must be embedded in the enclosure verbatim. Do NOT wrap it in
+          # another sparkle:edSignature="…" or add a separate length=, or the
+          # enclosure ends up with a duplicated length attribute and a signature
+          # value that is not valid base64 — which Sparkle rejects.
           SIGNATURE=$(echo "$SPARKLE_EDDSA_KEY" | $GITHUB_WORKSPACE/sparkle-tools/bin/sign_update "$DMG_FILE" --ed-key-file -)
-          FILE_SIZE=$(stat -f%z "$DMG_FILE")
 
-          # Generate appcast.xml
+          # Catch any future sign_update output-format drift before it reaches the
+          # XML (cheap, no dependency).
+          if ! printf '%s' "$SIGNATURE" | grep -Eq '^sparkle:edSignature="[^"]+" length="[0-9]+"$'; then
+            echo "::error::Unexpected sign_update output, refusing to build appcast: $SIGNATURE"
+            exit 1
+          fi
+
+          # sparkle:version must be the integer CFBundleVersion (VERSION_CODE) that
+          # `flutter build macos` writes into the bundle — Sparkle compares
+          # <sparkle:version> against the installed app's CFBundleVersion. The
+          # marketing string stays in <sparkle:shortVersionString> for display only.
           cat > appcast.xml << EOF
           <?xml version="1.0" encoding="utf-8"?>
           <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -664,17 +679,59 @@ jobs:
               <title>Mydia Player</title>
               <item>
                 <title>Version ${VERSION}</title>
-                <sparkle:version>${VERSION}</sparkle:version>
+                <sparkle:version>${VERSION_CODE}</sparkle:version>
                 <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
                 <pubDate>$(date -R)</pubDate>
                 <enclosure url="${DMG_URL}"
-                           sparkle:edSignature="${SIGNATURE}"
-                           length="${FILE_SIZE}"
+                           ${SIGNATURE}
                            type="application/octet-stream" />
               </item>
             </channel>
           </rss>
           EOF
+
+      - name: Validate appcast
+        if: steps.check_macos.outputs.enabled == 'true' && env.SPARKLE_EDDSA_KEY != ''
+        env:
+          SPARKLE_EDDSA_KEY: ${{ secrets.SPARKLE_EDDSA_KEY }}
+        working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
+        run: |
+          # Fail the release here rather than ship an appcast Sparkle can't read.
+          # xmllint is the load-bearing check — it catches the malformed-XML class
+          # (e.g. the historical double-wrapped enclosure with a duplicated length
+          # attribute). Shipped on GitHub macos runners, but don't silently no-op
+          # if it is ever absent.
+          if ! command -v xmllint >/dev/null 2>&1; then
+            echo "::error::xmllint not found on runner; cannot validate appcast"
+            exit 1
+          fi
+
+          xmllint --noout appcast.xml
+
+          # Exactly one signature and one length attribute in the enclosure
+          # (guards against re-nesting / sign_update output drift).
+          ed_count=$(grep -o 'sparkle:edSignature="' appcast.xml | wc -l | tr -d ' ' || true)
+          len_count=$(grep -o 'length="' appcast.xml | wc -l | tr -d ' ' || true)
+          if [ "$ed_count" -ne 1 ] || [ "$len_count" -ne 1 ]; then
+            echo "::error::appcast enclosure malformed: edSignature=$ed_count length=$len_count (expected 1 each)"
+            cat appcast.xml
+            exit 1
+          fi
+
+          # sparkle:version must be the integer build number, not the marketing
+          # string, or Sparkle's newer-than comparison never offers the update.
+          sparkle_version=$(sed -n 's#.*<sparkle:version>\(.*\)</sparkle:version>.*#\1#p' appcast.xml)
+          if ! printf '%s' "$sparkle_version" | grep -Eq '^[0-9]+$'; then
+            echo "::error::sparkle:version must be an integer build number, got '$sparkle_version'"
+            exit 1
+          fi
+
+          # NOTE: a cryptographic self-verify (sign_update --verify) is deliberately
+          # NOT wired here — the 2.x verify invocation and key material (it checks
+          # against a public key; the pipeline holds the private one) are unresolved
+          # on the pinned 2.8.1 toolchain. The guard therefore proves well-formedness
+          # and enclosure shape, not signature validity. See the plan's KTD3 / R4.
+          echo "appcast.xml validated (well-formed, single signature/length, sparkle:version=$sparkle_version)"
 
       - name: Upload DMG artifact
         if: steps.check_macos.outputs.enabled == 'true'
@@ -880,6 +937,34 @@ jobs:
 
           [ -d "mydia-player-macos-appcast" ] && \
             mv mydia-player-macos-appcast/appcast.xml . || true
+
+      - name: Validate appcast (publish gate)
+        working-directory: artifacts
+        run: |
+          # The player-macos job is gated by `always()` in this job's needs, so a
+          # failed appcast validation there does not by itself block publish. Re-run
+          # the well-formedness/shape checks here against the artifact actually about
+          # to ship, so a malformed appcast fails the release instead of publishing.
+          if [ ! -f appcast.xml ]; then
+            echo "No appcast.xml in artifacts — nothing to validate (non-macOS or fork run)."
+            exit 0
+          fi
+
+          if ! command -v xmllint >/dev/null 2>&1; then
+            echo "Installing libxml2-utils for xmllint"
+            sudo apt-get update -qq && sudo apt-get install -y -qq libxml2-utils
+          fi
+
+          xmllint --noout appcast.xml
+
+          ed_count=$(grep -o 'sparkle:edSignature="' appcast.xml | wc -l | tr -d ' ' || true)
+          len_count=$(grep -o 'length="' appcast.xml | wc -l | tr -d ' ' || true)
+          if [ "$ed_count" -ne 1 ] || [ "$len_count" -ne 1 ]; then
+            echo "::error::Refusing to publish malformed appcast: edSignature=$ed_count length=$len_count (expected 1 each)"
+            cat appcast.xml
+            exit 1
+          fi
+          echo "appcast.xml passed publish-gate validation."
 
       - name: Upload release assets
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -947,9 +947,17 @@ jobs:
           # malformed appcast never becomes an artifact and never reaches here. This
           # re-runs the same well-formedness/shape checks against the downloaded
           # artifact to catch corruption-in-transit (or a well-formed-but-wrong
-          # appcast) before upload — failing publish rather than shipping it. Because
-          # this job runs under `always()`, a macOS build that fails validation simply
-          # omits the macOS assets from the release; it does not block other platforms.
+          # appcast) before upload — failing publish rather than shipping it.
+          #
+          # `always()` only governs whether this job runs when an upstream build
+          # failed; it does NOT make this check non-blocking. Two outcomes:
+          #   - No appcast present (fork run, missing secret, or a failed macOS
+          #     job that produced no artifact): the guard below exits 0, so the
+          #     other platforms still publish.
+          #   - An appcast IS present but fails these checks: this step fails the
+          #     entire `publish` job. That is intentional — we refuse to ship a
+          #     release with a broken auto-update feed rather than silently
+          #     dropping just the macOS assets.
           if [ ! -f appcast.xml ]; then
             echo "No appcast.xml in artifacts — nothing to validate (non-macOS or fork run)."
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -941,10 +941,15 @@ jobs:
       - name: Validate appcast (publish gate)
         working-directory: artifacts
         run: |
-          # The player-macos job is gated by `always()` in this job's needs, so a
-          # failed appcast validation there does not by itself block publish. Re-run
-          # the well-formedness/shape checks here against the artifact actually about
-          # to ship, so a malformed appcast fails the release instead of publishing.
+          # Defense-in-depth gate on the appcast actually about to ship. Generation-
+          # time malformation is already caught upstream: the player-macos "Validate
+          # appcast" step fails the job before "Upload appcast artifact" runs, so a
+          # malformed appcast never becomes an artifact and never reaches here. This
+          # re-runs the same well-formedness/shape checks against the downloaded
+          # artifact to catch corruption-in-transit (or a well-formed-but-wrong
+          # appcast) before upload — failing publish rather than shipping it. Because
+          # this job runs under `always()`, a macOS build that fails validation simply
+          # omits the macOS assets from the release; it does not block other platforms.
           if [ ! -f appcast.xml ]; then
             echo "No appcast.xml in artifacts — nothing to validate (non-macOS or fork run)."
             exit 0


### PR DESCRIPTION
## Summary

macOS auto-update has never actually worked. The player ships a complete Sparkle 2.8.1 stack, but the `appcast.xml` the release pipeline publishes is malformed, so every installed client either rejects the update or is never offered one. This repairs the appcast generation and adds guards so a broken appcast fails the release instead of shipping silently.

Two defects in the `Generate appcast` step, both visible in the live published feed:

- **Double-wrapped signature.** `sign_update` already prints a ready-to-paste fragment (`sparkle:edSignature="…" length="…"`). The workflow wrapped that whole fragment in *another* `sparkle:edSignature="…"` and emitted a second `length=`, producing invalid XML with a duplicated attribute and a non-base64 signature value Sparkle rejects.
- **Wrong comparison version.** `<sparkle:version>` was set to the marketing string (`0.11.1`), but Sparkle compares it against the installed app's integer `CFBundleVersion` (`VERSION_CODE`, e.g. `10043`). Comparing `0.11.1` to `10043`, Sparkle concluded the installed build was newer and never offered the update.

```
before:  sparkle:edSignature="sparkle:edSignature="f4…Bw==" length="71098585"" length="71098585"
         <sparkle:version>0.11.1</sparkle:version>
after:   sparkle:edSignature="f4…Bw==" length="71098585"
         <sparkle:version>10043</sparkle:version>   (shortVersionString keeps 0.11.1 for display)
```

## Validation guards

So this class of bug can't silently ship again:

- A **`Validate appcast`** step in the `player-macos` job runs before the artifact upload: `xmllint` well-formedness, an exactly-one-`edSignature`/`length` shape assertion, and an integer-`sparkle:version` check. A failure fails the job, so the bad appcast never becomes an artifact.
- A **publish-gate** in the `publish` job re-runs the same checks against the downloaded artifact as defense-in-depth (catches corruption-in-transit of an otherwise-valid appcast) before the release upload.

## Key decisions

- Kept the `sign_update` + hand-template approach and fixed it, rather than migrating to `generate_appcast` (which would need runner Keychain setup) — smaller, scoped change.
- Embed the `sign_update` fragment verbatim and drop the manual `length` computation — Sparkle's documented usage, no fragile regex.
- **Cryptographic self-verify (`sign_update --verify`) is deliberately not wired.** The 2.x verify invocation and key material (it checks against a *public* key; the pipeline holds the *private* one) are unresolved on the pinned 2.8.1 toolchain. The guard therefore proves well-formedness and shape, **not** signature validity — documented in-code (plan KTD3 / R4).

## Test plan

Release-pipeline shell config, so no app unit tests. Validated locally:

- The corrected template is well-formed XML and passes all three guard layers (`edSignature` count 1, `length` count 1, `sparkle:version=10043` integer).
- The historical double-wrapped appcast is rejected at all three layers (malformed XML, counts 2/2, non-integer `0.11.1`).
- `release.yml` parses as valid YAML.

End-to-end (an old build self-updating) is only provable by cutting a real release — see below.

## Known limitation / deferred follow-ups

- **Sandbox / Sparkle XPC entitlements.** The app is sandboxed but lacks the `mach-lookup` exception for Sparkle's installer XPC service. Even with a valid appcast, the download may succeed while the in-place install fails. Verify on the first corrected release; address in a follow-up if the install step fails.
- Migrating to `generate_appcast`; documenting an EdDSA key-rotation runbook.

## Post-Deploy Monitoring & Validation

- After the next release publishes, fetch `https://github.com/getmydia/mydia/releases/latest/download/appcast.xml` and confirm: well-formed XML, exactly one `sparkle:edSignature` and one `length` in the enclosure, and `<sparkle:version>` is the integer build number (not `0.x.y`).
- **Healthy signal:** an installed macOS build at version N is offered the N+1 update, downloads, passes Sparkle signature verification, and relaunches updated.
- **Failure signal / rollback trigger:** Sparkle logs a signature-verification failure (→ appcast/signing problem), or the download succeeds but the in-place install/relaunch fails (→ the deferred sandbox/XPC-entitlements blocker, not the appcast).
- The fix-carrying release **must** be published as a normal (non-draft, non-prerelease) `latest` release, or clients keep reading the old broken appcast.
- **Owner:** release author. **Window:** first release after merge.
