### PR TITLE
fix: widen long metadata columns to TEXT and surface import truncation errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,10 +413,10 @@ Components follow a three-tier system:
 
 ### Database
 
-- This project uses **SQLite exclusively** for all environments (development, test, and production)
-- **Never** use PostgreSQL-specific features, syntax, or extensions
-- **Never** suggest or implement PostgreSQL migrations or configurations
-- Use SQLite-compatible syntax for all queries and migrations
+- This project supports **both SQLite and PostgreSQL**. SQLite is the default adapter (development, test, and the typical self-hosted deployment); PostgreSQL is selected via the `DATABASE_TYPE` env var (`postgres`/`postgresql`). See `config/config.exs`.
+- **Prefer portable, adapter-agnostic SQL** for everyday queries and migrations so the same code runs on both adapters.
+- **Migrations that change column types, nullability, or constraints must handle both adapters.** PostgreSQL supports `ALTER COLUMN` directly; SQLite generally requires a table rebuild (rename → create → copy → drop) or is a no-op when the change is meaningless on SQLite (e.g. `varchar(255)` vs `text`, which SQLite stores identically). Use `Mydia.Repo.Migrations.Helpers` (`postgres?/0`, `sqlite?/0`, `recreate_table/1`, etc.) and branch on the adapter — see `priv/repo/migrations/20260223100000_fix_array_columns_for_postgres.exs` for the Postgres-only / SQLite no-op pattern.
+- **Avoid PostgreSQL-only features** (e.g. extensions, advanced types) unless they degrade gracefully or are guarded behind an adapter check, since SQLite remains the default.
 
 ### General Guidelines
 

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -1971,7 +1971,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       end
 
     "A metadata value is too long to store#{location}. " <>
-      "This title or path exceeds the database column limit."
+      "If your database schema is out of date, run database migrations to widen the affected column."
   end
 
   def friendly_db_error(error) do
@@ -2013,7 +2013,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
         "File type doesn't match the library type"
 
       has_truncation_error?(changeset) ->
-        "A metadata value is too long to store. This title or path exceeds the database column limit."
+        "A metadata value is too long to store. If your database schema is out of date, run database migrations to widen the affected column."
 
       true ->
         "Database error: #{format_changeset_errors(changeset)}"

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -1942,10 +1942,40 @@ defmodule MydiaWeb.ImportMediaLive.Index do
         file_name: Path.basename(file.path),
         status: :failed,
         media_item_title: match_result && match_result.title,
-        error_message: "Unexpected error: #{Exception.message(error)}",
+        error_message: friendly_db_error(error),
         action_taken: nil,
         metadata: %{size: file.size}
       }
+  end
+
+  @doc false
+  # Maps a raised exception to a user-friendly per-file error message.
+  #
+  # A `varchar(255)` overflow on PostgreSQL raises a `Postgrex.Error` with
+  # pg_code `:string_data_right_truncation` (22001) from `Repo.insert` rather
+  # than returning an `{:error, %Ecto.Changeset{}}` — Ecto only maps *declared*
+  # constraint violations to changeset errors, and these free-text columns
+  # declare no length constraint. Referencing the `Postgrex.Error` struct is
+  # safe under SQLite (the dep is compiled in; the match simply never succeeds).
+  #
+  # Public (with `@doc false`) so it can be unit-tested without a live Postgres
+  # connection by synthesizing a `%Postgrex.Error{}`.
+  def friendly_db_error(%Postgrex.Error{postgres: %{code: :string_data_right_truncation} = pg}) do
+    location =
+      case {Map.get(pg, :table), Map.get(pg, :column)} do
+        {table, column} when is_binary(table) and is_binary(column) ->
+          " (#{table}.#{column})"
+
+        _ ->
+          ""
+      end
+
+    "A metadata value is too long to store#{location}. " <>
+      "This title or path exceeds the database column limit."
+  end
+
+  def friendly_db_error(error) do
+    "Unexpected error: #{Exception.message(error)}"
   end
 
   defp build_success_message(match_result, _is_orphaned) do
@@ -1970,8 +2000,10 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   defp library_type_label(:adult), do: "Adult"
   defp library_type_label(type), do: to_string(type)
 
-  # Formats changeset errors with user-friendly messages for known issues
-  defp format_changeset_errors_friendly(%Ecto.Changeset{} = changeset) do
+  @doc false
+  # Formats changeset errors with user-friendly messages for known issues.
+  # Public (with `@doc false`) so the friendly-error mapping can be unit-tested.
+  def format_changeset_errors_friendly(%Ecto.Changeset{} = changeset) do
     # Check for specific known error patterns
     cond do
       has_size_error?(changeset) ->
@@ -1980,17 +2012,33 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       has_library_type_mismatch?(changeset) ->
         "File type doesn't match the library type"
 
+      has_truncation_error?(changeset) ->
+        "A metadata value is too long to store. This title or path exceeds the database column limit."
+
       true ->
         "Database error: #{format_changeset_errors(changeset)}"
     end
   end
 
-  defp format_changeset_errors_friendly(other), do: format_error(other)
+  def format_changeset_errors_friendly(other), do: format_error(other)
 
   defp has_size_error?(changeset) do
     Enum.any?(changeset.errors, fn
       {:size, {_msg, _opts}} -> true
       _ -> false
+    end)
+  end
+
+  # Defends the `{:error, changeset}` branch in case any path ever surfaces a
+  # length overflow as a changeset error (e.g. a value-too-long validation
+  # rather than a raised Postgrex.Error). Matches Ecto's `:length` validation
+  # metadata or a message mentioning the value being too long.
+  defp has_truncation_error?(changeset) do
+    Enum.any?(changeset.errors, fn {_field, {msg, opts}} ->
+      Keyword.get(opts, :validation) == :length or
+        Keyword.has_key?(opts, :count) or
+        String.contains?(msg, "too long") or
+        String.contains?(msg, "should be at most")
     end)
   end
 

--- a/priv/repo/migrations/20260616120000_widen_metadata_text_columns.exs
+++ b/priv/repo/migrations/20260616120000_widen_metadata_text_columns.exs
@@ -1,0 +1,54 @@
+defmodule Mydia.Repo.Migrations.WidenMetadataTextColumns do
+  use Ecto.Migration
+  import Mydia.Repo.Migrations.Helpers
+
+  @moduledoc """
+  Widen long-capable metadata columns from VARCHAR(255) to TEXT on PostgreSQL.
+
+  In Ecto a bare `:string` column compiles to `varchar(255)` on PostgreSQL but to
+  unconstrained `TEXT` affinity on SQLite. Provider-supplied metadata (long
+  localized episode titles, full original titles) and filesystem paths (deeply
+  nested libraries) legitimately exceed 255 characters, so the same import that
+  succeeds on SQLite fails on PostgreSQL with `ERROR 22001
+  (string_data_right_truncation)`. This widens the affected columns to `TEXT`.
+
+  On SQLite this migration is a no-op: `:string` and `:text` are both stored as
+  unconstrained `TEXT` affinity, so the declared `varchar` length is ignored and
+  no table rebuild is required.
+
+  The UNIQUE btree index on `media_files.path` and the index on
+  `media_items.title` are preserved automatically by `ALTER COLUMN ... TYPE` — no
+  index drop/recreate is needed.
+
+  Note on reversibility: the up direction (`VARCHAR(255)` -> `TEXT`) is widening
+  and non-lossy. The down direction (`TEXT` -> `VARCHAR(255)`) is written for a
+  rollback executed *before* any value exceeds 255 chars; once long values are
+  stored, the narrowing will hard-fail on PostgreSQL. Rollback is therefore
+  effectively one-way after the fix is in use.
+  """
+
+  @columns [
+    {:media_items, :title},
+    {:media_items, :original_title},
+    {:episodes, :title},
+    {:media_files, :path},
+    {:media_files, :relative_path},
+    {:media_files, :last_analysis_error}
+  ]
+
+  def up do
+    if postgres?() do
+      for {table, column} <- @columns do
+        execute "ALTER TABLE #{table} ALTER COLUMN #{column} TYPE TEXT"
+      end
+    end
+  end
+
+  def down do
+    if postgres?() do
+      for {table, column} <- @columns do
+        execute "ALTER TABLE #{table} ALTER COLUMN #{column} TYPE VARCHAR(255)"
+      end
+    end
+  end
+end

--- a/test/mydia_web/live/import_media_live_test.exs
+++ b/test/mydia_web/live/import_media_live_test.exs
@@ -1429,4 +1429,89 @@ defmodule MydiaWeb.ImportMediaLiveTest do
       Mydia.Repo.delete(session)
     end
   end
+
+  describe "friendly DB-error formatting" do
+    alias MydiaWeb.ImportMediaLive.Index, as: ImportIndex
+
+    test "friendly_db_error/1 maps a value-too-long Postgrex.Error to a clear message" do
+      error = %Postgrex.Error{
+        postgres: %{
+          code: :string_data_right_truncation,
+          table: "media_items",
+          column: "title"
+        }
+      }
+
+      message = ImportIndex.friendly_db_error(error)
+
+      assert message =~ "too long to store"
+      assert message =~ "media_items.title"
+      refute message =~ "Unexpected error"
+    end
+
+    test "friendly_db_error/1 still names the value-too-long case without table/column metadata" do
+      error = %Postgrex.Error{postgres: %{code: :string_data_right_truncation}}
+
+      message = ImportIndex.friendly_db_error(error)
+
+      assert message =~ "too long to store"
+      refute message =~ "Unexpected error"
+    end
+
+    test "friendly_db_error/1 maps a non-truncation exception to the Unexpected error catch-all" do
+      message = ImportIndex.friendly_db_error(%RuntimeError{message: "boom"})
+
+      assert message =~ "Unexpected error: boom"
+      refute message =~ "too long to store"
+    end
+
+    test "format_changeset_errors_friendly/1 maps a too-long changeset error to the value-too-long message" do
+      changeset =
+        %Mydia.Media.MediaItem{}
+        |> Ecto.Changeset.change(%{})
+        |> Ecto.Changeset.add_error(:title, "should be at most %{count} character(s)",
+          count: 255,
+          validation: :length
+        )
+
+      message = ImportIndex.format_changeset_errors_friendly(changeset)
+
+      assert message =~ "too long to store"
+      refute message =~ "Database error"
+    end
+
+    test "format_changeset_errors_friendly/1 preserves the size-error message" do
+      changeset =
+        %Mydia.Library.MediaFile{}
+        |> Ecto.Changeset.change(%{})
+        |> Ecto.Changeset.add_error(:size, "must be greater than 0")
+
+      message = ImportIndex.format_changeset_errors_friendly(changeset)
+
+      assert message =~ "empty or incomplete"
+    end
+
+    test "format_changeset_errors_friendly/1 preserves the library-type-mismatch message" do
+      changeset =
+        %Mydia.Library.MediaFile{}
+        |> Ecto.Changeset.change(%{})
+        |> Ecto.Changeset.add_error(:media_item_id, "does not match the library type")
+
+      message = ImportIndex.format_changeset_errors_friendly(changeset)
+
+      assert message =~ "doesn't match the library type"
+    end
+
+    test "format_changeset_errors_friendly/1 falls through to Database error for unrelated validation errors" do
+      changeset =
+        %Mydia.Media.MediaItem{}
+        |> Ecto.Changeset.change(%{})
+        |> Ecto.Changeset.add_error(:title, "is invalid")
+
+      message = ImportIndex.format_changeset_errors_friendly(changeset)
+
+      assert message =~ "Database error"
+      refute message =~ "too long to store"
+    end
+  end
 end


### PR DESCRIPTION
## Why

Importing a media file with a >255-character episode title or filesystem path fails on **PostgreSQL** with `ERROR 22001 (string_data_right_truncation)`. In Ecto a bare `:string` column compiles to `varchar(255)` on Postgres but to unconstrained `TEXT` affinity on SQLite, so the *same* import succeeds on SQLite and fails on Postgres. Long localized episode titles, full original titles, and deeply nested library paths legitimately exceed 255 characters. The file is rejected outright and the surfaced error is the raw Postgres code.

Fixes #177.

## What

Three units, per `docs/plans/2026-06-16-003-fix-long-metadata-truncation-plan.md`:

- **U1 — Migration (`20260616120000_widen_metadata_text_columns.exs`).** Postgres-only migration widening six long-capable columns to `TEXT`: `media_items.title`, `media_items.original_title`, `episodes.title`, `media_files.path`, `media_files.relative_path`, `media_files.last_analysis_error`. Guarded by `if postgres?()`, so it is a true **no-op on SQLite** (which stores `:string` and `:text` identically — no table rebuild). Bounded columns (`imdb_id`, `type`, fixed-width blob keys, etc.) are untouched. Schema field declarations stay `:string`. The UNIQUE btree index on `media_files.path` and the index on `media_items.title` are preserved automatically by `ALTER COLUMN ... TYPE`.

- **U2 — Import safety net (`import_media_live/index.ex`).** A `varchar(255)` overflow raises a `Postgrex.Error` (not an `Ecto.Changeset` — these fields declare no length constraint), which lands in the per-file rescue and previously rendered as `"Unexpected error: ..."`. Factored a testable `friendly_db_error/1` that maps a `Postgrex.Error` with pg_code `:string_data_right_truncation` to a clear value-too-long message (naming `table.column` when available); all other exceptions keep the existing catch-all. Added a secondary `has_truncation_error?/1` guard in `format_changeset_errors_friendly/1` for the rare changeset path. Batch-continue (one bad file doesn't abort the rest) is preserved.

- **U3 — Docs (`AGENTS.md`).** Corrected the stale "SQLite exclusively / never implement PostgreSQL migrations" claim to reflect the dual-adapter reality (SQLite default, Postgres via `DATABASE_TYPE`); migrations that change column types/constraints must handle both adapters via `Mydia.Repo.Migrations.Helpers`. The `:string` field convention line is preserved.

## Testing

- `./dev mix test test/mydia_web/live/import_media_live_test.exs` — **28 tests, 0 failures** (7 new formatter/exception-mapping tests synthesizing a `Postgrex.Error` and length-error changesets, so they exercise the real production mapping on the default SQLite suite).
- Migration verified on default SQLite: `ecto.migrate` runs clean as a no-op; `ecto.migrate → ecto.rollback → ecto.migrate` all exit 0 (`down/0` and `up/0` both run cleanly), confirming reversibility on SQLite.
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, and `mix credo --strict` all pass on the changed files.

## Notes / risks (per plan)

- **Postgres-only effect.** The bug and the migration's column-type effect only manifest on Postgres; the default suite runs on SQLite. U2's logic is tested adapter-independently. No Postgres-backed CI job gates this (deferred follow-up).
- **One-way rollback after adoption.** `varchar(255) → TEXT` is widening and non-lossy. The `down` direction narrows back to `VARCHAR(255)` and will hard-fail on Postgres once any stored value exceeds 255 chars — rollback is effectively one-way after the fix is in use. The `down` branch is written for a pre-adoption rollback.
- **Btree size limit.** `media_files.path` (unique) and `media_items.title` are btree-indexed; Postgres caps a btree entry at ~2704 bytes regardless of `TEXT`. A value past that limit fails INSERT with a btree-size error that U2's `22001` matcher does not recognize (falls through to "Unexpected error"). Realistic paths/titles are far under this; reconsidering the `path` index is deferred follow-up.

Plan: `docs/plans/2026-06-16-003-fix-long-metadata-truncation-plan.md`