### PR TITLE
feat: unify release ranking with soft penalties

### DIFF
--- a/lib/mydia/indexers/ranking_options.ex
+++ b/lib/mydia/indexers/ranking_options.ex
@@ -47,12 +47,14 @@ defmodule Mydia.Indexers.RankingOptions do
 
     base_opts =
       [
-        min_seeders: Map.get(input, :min_seeders),
         size_range: Map.get(input, :size_range),
         search_query: Map.get(input, :search_query),
         media_type: media_type,
         expected_title: Map.get(input, :expected_title)
       ]
+      # Omit :min_seeders when nil so the ranker's default (0) applies; passing
+      # an explicit nil would break the seeder-minimum comparison.
+      |> maybe_put(:min_seeders, Map.get(input, :min_seeders))
       |> maybe_put(:expected_season, Map.get(input, :expected_season))
       |> maybe_put(:expected_episode, Map.get(input, :expected_episode))
 

--- a/lib/mydia/indexers/ranking_options.ex
+++ b/lib/mydia/indexers/ranking_options.ex
@@ -1,0 +1,140 @@
+defmodule Mydia.Indexers.RankingOptions do
+  @moduledoc """
+  Builds the shared keyword-list options consumed by `ReleaseRanker.rank_all/2`.
+
+  Both the automatic search jobs (movie and TV) and the manual search dialog
+  thread their ranking options through this one builder so the two paths cannot
+  drift apart again. Previously each job hand-rolled near-duplicate
+  `build_ranking_options` / `extract_size_range` / `build_quality_options`
+  helpers that diverged subtly (e.g. the `min_ratio` source).
+
+  ## min_ratio source (resolved)
+
+  The movie job historically read `min_ratio` from `profile.rules` while the TV
+  job read it from `profile.quality_standards`. This builder reads `min_ratio`
+  from **`quality_standards`** (accepting both atom and string keys), the source
+  the schema actually populates. The movie path's old `rules` source is dropped;
+  a profile that only set `min_ratio` under `rules` no longer affects ranking.
+  """
+
+  alias Mydia.Settings.QualityProfile
+
+  @type media_type :: :movie | :episode
+
+  @type input :: %{
+          optional(:quality_profile) => QualityProfile.t() | nil,
+          required(:media_type) => media_type(),
+          optional(:min_seeders) => non_neg_integer() | nil,
+          optional(:size_range) => {number() | nil, number() | nil} | nil,
+          optional(:search_query) => String.t() | nil,
+          optional(:expected_title) => String.t() | nil,
+          optional(:expected_season) => non_neg_integer() | nil,
+          optional(:expected_episode) => non_neg_integer() | nil,
+          optional(:blocked_tags) => [String.t()] | nil,
+          optional(:preferred_tags) => [String.t()] | nil
+        }
+
+  @doc """
+  Build the ranking-options keyword list from a map of inputs.
+
+  Required: `:media_type`. Everything else is optional; nil/empty values are
+  skipped (mirroring the jobs' `maybe_add_option/3` behavior) so the penalty
+  math never receives nils.
+  """
+  @spec build(input()) :: keyword()
+  def build(%{media_type: media_type} = input) do
+    quality_profile = Map.get(input, :quality_profile)
+
+    base_opts =
+      [
+        min_seeders: Map.get(input, :min_seeders),
+        size_range: Map.get(input, :size_range),
+        search_query: Map.get(input, :search_query),
+        media_type: media_type,
+        expected_title: Map.get(input, :expected_title)
+      ]
+      |> maybe_put(:expected_season, Map.get(input, :expected_season))
+      |> maybe_put(:expected_episode, Map.get(input, :expected_episode))
+
+    opts_with_quality =
+      case quality_profile do
+        %QualityProfile{} = profile ->
+          base_opts
+          |> Keyword.put(:quality_profile, profile)
+          |> Keyword.merge(build_quality_options(profile, media_type))
+
+        _ ->
+          base_opts
+      end
+
+    opts_with_quality
+    |> maybe_add_option(:blocked_tags, Map.get(input, :blocked_tags))
+    |> maybe_add_option(:preferred_tags, Map.get(input, :preferred_tags))
+  end
+
+  @doc """
+  Extract `:preferred_qualities`, `:min_ratio`, and `:size_range` from a quality
+  profile for the given media type.
+  """
+  @spec build_quality_options(QualityProfile.t(), media_type()) :: keyword()
+  def build_quality_options(%QualityProfile{} = quality_profile, media_type) do
+    quality_opts =
+      case quality_profile.qualities do
+        qualities when is_list(qualities) -> [preferred_qualities: qualities]
+        _ -> []
+      end
+
+    ratio_opts = extract_min_ratio(quality_profile)
+    size_opts = extract_size_range(quality_profile, media_type)
+
+    quality_opts
+    |> Keyword.merge(ratio_opts)
+    |> Keyword.merge(size_opts)
+  end
+
+  # Single source of truth for min_ratio: quality_standards (atom or string key).
+  defp extract_min_ratio(%QualityProfile{quality_standards: standards}) do
+    case standards do
+      %{min_ratio: min_ratio} when is_number(min_ratio) -> [min_ratio: min_ratio]
+      %{"min_ratio" => min_ratio} when is_number(min_ratio) -> [min_ratio: min_ratio]
+      _ -> []
+    end
+  end
+
+  @doc """
+  Extract the `:size_range` option from a profile's quality standards based on
+  media type. Returns `[]` (omitting the option) when no bounds are set, so the
+  penalty math never receives nil-only ranges.
+  """
+  @spec extract_size_range(QualityProfile.t() | map(), media_type()) :: keyword()
+  def extract_size_range(%{quality_standards: standards}, media_type) when is_map(standards) do
+    {min_key, max_key} =
+      case media_type do
+        :movie -> {:movie_min_size_mb, :movie_max_size_mb}
+        :episode -> {:episode_min_size_mb, :episode_max_size_mb}
+      end
+
+    min_size = Map.get(standards, min_key)
+    max_size = Map.get(standards, max_key)
+
+    case {min_size, max_size} do
+      {nil, nil} -> []
+      {min, nil} when is_number(min) -> [size_range: {min, nil}]
+      {nil, max} when is_number(max) -> [size_range: {nil, max}]
+      {min, max} when is_number(min) and is_number(max) -> [size_range: {min, max}]
+      _ -> []
+    end
+  end
+
+  def extract_size_range(_, _), do: []
+
+  # Skip nil/empty list option values so the penalty math and downstream
+  # consumers never see them.
+  defp maybe_add_option(opts, _key, nil), do: opts
+  defp maybe_add_option(opts, _key, []), do: opts
+  defp maybe_add_option(opts, key, value), do: Keyword.put(opts, key, value)
+
+  # Put a non-nil scalar option (used for expected_season/expected_episode).
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/lib/mydia/indexers/ranking_options.ex
+++ b/lib/mydia/indexers/ranking_options.ex
@@ -39,21 +39,20 @@ defmodule Mydia.Indexers.RankingOptions do
 
   Required: `:media_type`. Everything else is optional; nil/empty values are
   skipped (mirroring the jobs' `maybe_add_option/3` behavior) so the penalty
-  math never receives nils.
+  math and downstream consumers never receive nils.
   """
   @spec build(input()) :: keyword()
   def build(%{media_type: media_type} = input) do
     quality_profile = Map.get(input, :quality_profile)
 
     base_opts =
-      [
-        size_range: Map.get(input, :size_range),
-        search_query: Map.get(input, :search_query),
-        media_type: media_type,
-        expected_title: Map.get(input, :expected_title)
-      ]
-      # Omit :min_seeders when nil so the ranker's default (0) applies; passing
-      # an explicit nil would break the seeder-minimum comparison.
+      [media_type: media_type]
+      # Skip nil scalar keys so the penalty math and downstream consumers never
+      # see them. Omitting :min_seeders when nil lets the ranker's default (0)
+      # apply; an explicit nil would break the seeder-minimum comparison.
+      |> maybe_put(:size_range, Map.get(input, :size_range))
+      |> maybe_put(:search_query, Map.get(input, :search_query))
+      |> maybe_put(:expected_title, Map.get(input, :expected_title))
       |> maybe_put(:min_seeders, Map.get(input, :min_seeders))
       |> maybe_put(:expected_season, Map.get(input, :expected_season))
       |> maybe_put(:expected_episode, Map.get(input, :expected_episode))

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -263,19 +263,6 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
   defp meets_post_age_minimum?(_result, _minutes, _now), do: true
 
-  # nil size_range disables size filtering
-  defp within_size_range?(_result, nil), do: true
-
-  # Handle partial ranges where min or max might be nil
-  defp within_size_range?(%SearchResult{size: size_bytes}, {min_mb, max_mb}) do
-    size_mb = bytes_to_mb(size_bytes)
-
-    above_min = min_mb == nil or size_mb >= min_mb
-    below_max = max_mb == nil or size_mb <= max_mb
-
-    above_min and below_max
-  end
-
   defp not_blocked?(%SearchResult{title: title}, blocked_tags) do
     title_lower = String.downcase(title)
 
@@ -578,9 +565,6 @@ defmodule Mydia.Indexers.ReleaseRanker do
   """
   @spec score_all_with_reasons([SearchResult.t()], ranking_options()) :: [map()]
   def score_all_with_reasons(results, opts \\ []) do
-    min_seeders = Keyword.get(opts, :min_seeders, @default_min_seeders)
-    min_ratio = Keyword.get(opts, :min_ratio)
-    size_range = Keyword.get(opts, :size_range)
     blocked_tags = Keyword.get(opts, :blocked_tags, [])
     expected_title = Keyword.get(opts, :expected_title)
 
@@ -596,20 +580,13 @@ defmodule Mydia.Indexers.ReleaseRanker do
         resolution: resolution
       }
 
-      # Check rejection reasons in order
-      rejection =
-        get_rejection_reason(
-          result,
-          min_seeders,
-          min_ratio,
-          size_range,
-          blocked_tags,
-          expected_title
-        )
-
-      case rejection do
+      # Only hard removals are reported as rejections now; size/seeders/ratio
+      # shortcomings are penalties on accepted results (mirrors filter_acceptable
+      # and the identity penalty, which must stay in lockstep — see Risks).
+      case get_rejection_reason(result, blocked_tags, expected_title) do
         nil ->
-          # Not rejected, calculate score
+          # Accepted — record the full breakdown (including penalties) so the
+          # Activity view can render the penalized-but-kept state.
           breakdown = calculate_score_breakdown(result, opts)
 
           Map.merge(base_info, %{
@@ -619,7 +596,13 @@ defmodule Mydia.Indexers.ReleaseRanker do
             breakdown: %{
               quality: breakdown.quality,
               seeders: breakdown.seeders,
-              title_match: breakdown.title_match
+              size: breakdown.size,
+              age: breakdown.age,
+              title_match: breakdown.title_match,
+              tag_bonus: breakdown.tag_bonus,
+              size_penalty: breakdown.size_penalty,
+              seeder_penalty: breakdown.seeder_penalty,
+              identity_penalty: breakdown.identity_penalty
             }
           })
 
@@ -635,30 +618,89 @@ defmodule Mydia.Indexers.ReleaseRanker do
     |> Enum.sort_by(& &1.score, :desc)
   end
 
-  # Returns rejection reason string or nil if acceptable
-  defp get_rejection_reason(
-         result,
-         min_seeders,
-         min_ratio,
-         size_range,
-         blocked_tags,
-         expected_title
-       ) do
+  @doc """
+  Build the filter-statistics map consumed by the Activity view, for both the
+  movie and TV search jobs (so the two paths render identically).
+
+  Returns a map with string keys:
+  - `"total_results"` - count of input results
+  - `"rejection_counts"` - count of hard removals grouped by reason
+  - `"results"` - up to 10 detail rows, each carrying a `"penalized"` flag and a
+    `"penalties"` map so the Activity row can show a penalized-but-kept state.
+  """
+  @spec build_filter_stats([SearchResult.t()], ranking_options()) :: map()
+  def build_filter_stats(results, opts \\ []) do
+    scored = score_all_with_reasons(results, opts)
+
+    rejection_counts =
+      scored
+      |> Enum.filter(&(&1.status == :rejected))
+      |> Enum.group_by(fn r ->
+        case r.rejection_reason do
+          nil -> "unknown"
+          reason -> reason |> String.split(":") |> List.first()
+        end
+      end)
+      |> Map.new(fn {reason, items} -> {reason, length(items)} end)
+
+    results_details =
+      scored
+      |> Enum.take(10)
+      |> Enum.map(&filter_stat_row/1)
+
+    %{
+      "total_results" => length(results),
+      "rejection_counts" => rejection_counts,
+      "results" => results_details
+    }
+  end
+
+  defp filter_stat_row(r) do
+    base = %{
+      "title" => r.title,
+      "score" => r.score,
+      "seeders" => r.seeders,
+      "size_mb" => r.size_mb,
+      "resolution" => r.resolution,
+      "status" => to_string(r.status)
+    }
+
+    base
+    |> maybe_put_rejection(r.rejection_reason)
+    |> maybe_put_penalties(r[:breakdown])
+  end
+
+  defp maybe_put_rejection(row, nil), do: row
+  defp maybe_put_rejection(row, reason), do: Map.put(row, "rejection_reason", reason)
+
+  # Surface the soft-penalty contributions (and a convenience flag) so the
+  # Activity view can distinguish a penalized-but-kept result from a clean OK.
+  defp maybe_put_penalties(row, %{} = breakdown) do
+    size_penalty = Map.get(breakdown, :size_penalty, 0.0)
+    seeder_penalty = Map.get(breakdown, :seeder_penalty, 0.0)
+    identity_penalty = Map.get(breakdown, :identity_penalty, 0.0)
+    penalized = size_penalty < 0.0 or seeder_penalty < 0.0 or identity_penalty < 0.0
+
+    Map.merge(row, %{
+      "penalized" => penalized,
+      "penalties" => %{
+        "size_penalty" => size_penalty,
+        "seeder_penalty" => seeder_penalty,
+        "identity_penalty" => identity_penalty
+      }
+    })
+  end
+
+  defp maybe_put_penalties(row, _), do: row
+
+  # Returns a rejection reason string or nil if acceptable. The only hard
+  # removals are invalid releases (validator), blocked tags, and wrong-show
+  # title mismatches. Size/seeders/ratio are no longer rejection reasons — they
+  # are soft penalties on accepted results.
+  defp get_rejection_reason(result, blocked_tags, expected_title) do
     cond do
-      not meets_seeder_minimum?(result, min_seeders) ->
-        "low_seeders: #{result.seeders} < #{min_seeders}"
-
-      min_ratio != nil and not meets_ratio_minimum?(result, min_ratio) ->
-        seeders = result.seeders || 0
-        leechers = result.leechers || 0
-        total = seeders + leechers
-        ratio = if total > 0, do: Float.round(seeders / total * 100, 1), else: 0.0
-        "low_ratio: #{ratio}% < #{Float.round(min_ratio * 100, 1)}%"
-
-      size_range != nil and not within_size_range?(result, size_range) ->
-        {min_mb, max_mb} = size_range
-        size_mb = Float.round(bytes_to_mb(result.size), 1)
-        "size_out_of_range: #{size_mb} MB not in #{min_mb}-#{max_mb} MB"
+      invalid_release_reason(result) ->
+        "invalid: #{invalid_release_reason(result)}"
 
       blocked_tag = find_blocked_tag(result, blocked_tags) ->
         "blocked_tag: #{blocked_tag}"
@@ -668,6 +710,16 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
       true ->
         nil
+    end
+  end
+
+  # Returns the validator's failure reason string, or nil if the release is
+  # valid. Mirrors reject_invalid_releases/1 so the Activity stats and actual
+  # ranking agree on which releases are hard-removed.
+  defp invalid_release_reason(%SearchResult{title: title}) do
+    case ReleaseValidator.validate_release(title) do
+      {:ok, _name} -> nil
+      {:error, reason} -> to_string(reason)
     end
   end
 

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -174,45 +174,16 @@ defmodule Mydia.Indexers.ReleaseRanker do
   """
   @spec filter_acceptable([SearchResult.t()], ranking_options()) :: [SearchResult.t()]
   def filter_acceptable(results, opts \\ []) do
-    min_seeders = Keyword.get(opts, :min_seeders, @default_min_seeders)
-    min_ratio = Keyword.get(opts, :min_ratio)
-    size_range = Keyword.get(opts, :size_range)
     blocked_tags = Keyword.get(opts, :blocked_tags, [])
     min_post_age_minutes = Keyword.get(opts, :min_post_age_minutes)
     now = Keyword.get(opts, :now) || DateTime.utc_now()
 
+    # Only two hard removals survive here: user-blocked tags (R8) and the NZB
+    # post-age timing safeguard. Size, seeders, and ratio are no longer hard
+    # filters — they become soft penalties applied during scoring (R4/R5), so a
+    # weak release sinks to the bottom of the ranking instead of vanishing.
     Enum.filter(results, fn result ->
       cond do
-        not meets_seeder_minimum?(result, min_seeders) ->
-          Logger.info(
-            "[ReleaseRanker] Filtered out (seeders #{inspect(result.seeders)} < #{min_seeders}): #{result.title}"
-          )
-
-          false
-
-        min_ratio != nil and not meets_ratio_minimum?(result, min_ratio) ->
-          seeders = result.seeders || 0
-          leechers = result.leechers || 0
-          total = seeders + leechers
-          ratio = if total > 0, do: Float.round(seeders / total * 100, 1), else: 0.0
-
-          Logger.info(
-            "[ReleaseRanker] Filtered out (ratio #{ratio}% < #{Float.round(min_ratio * 100, 1)}%): #{result.title}"
-          )
-
-          false
-
-        size_range != nil and not within_size_range?(result, size_range) ->
-          {min_mb, max_mb} = size_range
-          size_mb = Float.round(bytes_to_mb(result.size), 1)
-          range_str = format_size_range(min_mb, max_mb)
-
-          Logger.info(
-            "[ReleaseRanker] Filtered out (size #{size_mb} MB not in #{range_str}): #{result.title}"
-          )
-
-          false
-
         not not_blocked?(result, blocked_tags) ->
           Logger.info("[ReleaseRanker] Filtered out (blocked tag): #{result.title}")
           false
@@ -290,11 +261,6 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
     above_min and below_max
   end
-
-  defp format_size_range(nil, nil), do: "any"
-  defp format_size_range(min, nil), do: "#{min}+ MB"
-  defp format_size_range(nil, max), do: "0-#{max} MB"
-  defp format_size_range(min, max), do: "#{min}-#{max} MB"
 
   defp not_blocked?(%SearchResult{title: title}, blocked_tags) do
     title_lower = String.downcase(title)
@@ -740,11 +706,67 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
   ## Private Functions - Soft Penalties
 
-  # Size penalty placeholder (implemented in U2). Returns a value <= 0.0.
+  # Maximum size penalty. Deliberately modest so an out-of-range *correct*
+  # release can still outrank an in-range junk release (e.g. a CAM) on quality.
+  @max_size_penalty 15.0
+  # Penalty for a torrent below the configured minimum seeders. Small — the
+  # SearchScorer log10 seeder score and the zero-seeder 0.7 multiplier already
+  # push low/dead torrents down; this just nudges sub-minimum ones a bit lower.
+  @low_seeder_penalty 5.0
+  # Penalty for a torrent below the configured minimum seeder ratio.
+  @low_ratio_penalty 5.0
+
+  # Size penalty: proportional to how far the release size falls outside the
+  # configured range, capped at @max_size_penalty. In-range (or unconstrained)
+  # releases get 0.0. Returns a value <= 0.0.
+  defp size_penalty(_result, nil), do: 0.0
+
+  defp size_penalty(%SearchResult{size: size_bytes}, {min_mb, max_mb})
+       when is_integer(size_bytes) do
+    size_mb = bytes_to_mb(size_bytes)
+
+    cond do
+      min_mb != nil and size_mb < min_mb ->
+        scaled_size_penalty((min_mb - size_mb) / max(min_mb, 1))
+
+      max_mb != nil and size_mb > max_mb ->
+        scaled_size_penalty((size_mb - max_mb) / max(max_mb, 1))
+
+      true ->
+        0.0
+    end
+  end
+
   defp size_penalty(_result, _size_range), do: 0.0
 
-  # Seeder/ratio penalty placeholder (implemented in U2). Returns a value <= 0.0.
-  defp seeder_penalty(_result, _opts), do: 0.0
+  # Map a fractional distance outside the range (0.0..∞) to a penalty in
+  # (-@max_size_penalty .. 0.0]. A release at the boundary is 0; one at twice
+  # (or half) the bound is fully penalized.
+  defp scaled_size_penalty(fraction) when fraction <= 0.0, do: 0.0
+
+  defp scaled_size_penalty(fraction) do
+    -min(@max_size_penalty, fraction * @max_size_penalty)
+  end
+
+  # Seeder/ratio penalty: layered on top of the existing low-seeder score and
+  # zero-seeder multiplier. NZB results (nil seeders) are never penalized here.
+  # Returns a value <= 0.0.
+  defp seeder_penalty(%SearchResult{seeders: nil}, _opts), do: 0.0
+
+  defp seeder_penalty(%SearchResult{} = result, opts) do
+    min_seeders = Keyword.get(opts, :min_seeders, @default_min_seeders)
+    min_ratio = Keyword.get(opts, :min_ratio)
+
+    seeder_part =
+      if meets_seeder_minimum?(result, min_seeders), do: 0.0, else: -@low_seeder_penalty
+
+    ratio_part =
+      if min_ratio != nil and not meets_ratio_minimum?(result, min_ratio),
+        do: -@low_ratio_penalty,
+        else: 0.0
+
+    seeder_part + ratio_part
+  end
 
   # Identity penalty placeholder (implemented in U3). Returns a value <= 0.0.
   defp identity_penalty(_result, _opts), do: 0.0

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -218,6 +218,9 @@ defmodule Mydia.Indexers.ReleaseRanker do
   # torrents. nil seeders pass through.
   defp meets_seeder_minimum?(%SearchResult{seeders: nil}, _min_seeders), do: true
 
+  # A nil/absent minimum means no seeder floor.
+  defp meets_seeder_minimum?(_result, nil), do: true
+
   defp meets_seeder_minimum?(%SearchResult{seeders: seeders}, min_seeders) do
     seeders >= min_seeders
   end

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -333,7 +333,8 @@ defmodule Mydia.Indexers.ReleaseRanker do
     seeder_ratio = if total_peers > 0, do: seeders / total_peers, else: 0.0
 
     # Add tag_bonus to the base score, then subtract any soft penalties.
-    total_score = score_result.score + tag_bonus + size_penalty + seeder_penalty + identity_penalty
+    total_score =
+      score_result.score + tag_bonus + size_penalty + seeder_penalty + identity_penalty
 
     Logger.info("""
     [ReleaseRanker] Score breakdown for: #{result.title}

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -68,12 +68,22 @@ defmodule Mydia.Indexers.ReleaseRanker do
           quality_profile: QualityProfile.t() | nil,
           media_type: :movie | :episode | nil,
           expected_title: String.t() | nil,
+          expected_season: non_neg_integer() | nil,
+          expected_episode: non_neg_integer() | nil,
           min_post_age_minutes: non_neg_integer() | nil,
           now: DateTime.t() | nil
         ]
 
   @default_min_seeders 0
   @title_match_threshold 0.7
+
+  # Identity penalty: a large tier separator (not a nudge). It deliberately
+  # exceeds the maximum achievable base score (quality·0.6 ≈ 60 + seeders ≈ 30
+  # + title ≈ 10 + tag_bonus, which is 10 per preferred tag with no documented
+  # cap). At -1000 it dwarfs even a heavily-tagged title, so every
+  # identity-matching release outranks every identity-mismatching one while the
+  # mismatch stays selectable (finite, deeply negative score).
+  @identity_penalty -1000.0
 
   @doc """
   Selects the best result from a list based on ranking criteria.
@@ -121,15 +131,16 @@ defmodule Mydia.Indexers.ReleaseRanker do
     )
 
     search_query = Keyword.get(opts, :search_query)
-
-    media_type = Keyword.get(opts, :media_type)
     expected_title = Keyword.get(opts, :expected_title)
 
+    # Note: TV-pattern-in-movie-search is no longer a hard removal. A movie
+    # search expects no season/episode, so a TV-pattern release is treated as an
+    # identity mismatch and softly penalized inside calculate_score_breakdown
+    # (see identity_penalty/2), per the Open Question default.
     ranked =
       results
       |> reject_invalid_releases()
       |> filter_acceptable(opts)
-      |> reject_tv_releases_for_movies(media_type)
       |> reject_title_mismatches(expected_title)
       |> Enum.map(fn result ->
         breakdown = calculate_score_breakdown(result, opts)
@@ -390,29 +401,6 @@ defmodule Mydia.Indexers.ReleaseRanker do
       end
     end)
   end
-
-  ## Private Functions - Media Type Filtering
-
-  # When searching for a movie, reject releases that contain TV season/episode
-  # patterns (S01, S01E05, etc.) since they're clearly TV content, not movies.
-  # This prevents false matches like "Frozen Planet II S01" matching "Frozen 2013".
-  @tv_season_pattern ~r/\bS\d{1,2}(?:E\d{1,3})?\b/i
-
-  defp reject_tv_releases_for_movies(results, :movie) do
-    Enum.filter(results, fn result ->
-      if Regex.match?(@tv_season_pattern, result.title) do
-        Logger.info(
-          "[ReleaseRanker] Filtered out (TV season/episode pattern in movie search): #{result.title}"
-        )
-
-        false
-      else
-        true
-      end
-    end)
-  end
-
-  defp reject_tv_releases_for_movies(results, _media_type), do: results
 
   ## Private Functions - Title Mismatch Filtering
 
@@ -768,8 +756,73 @@ defmodule Mydia.Indexers.ReleaseRanker do
     seeder_part + ratio_part
   end
 
-  # Identity penalty placeholder (implemented in U3). Returns a value <= 0.0.
-  defp identity_penalty(_result, _opts), do: 0.0
+  # Identity penalty: penalize releases whose parsed season/episode does not
+  # match the requested one (or is absent) when an expected identity is
+  # supplied. The penalty is a large tier separator so identity matches always
+  # outrank mismatches while mismatches stay selectable.
+  #
+  # - Episode search (expected_episode set): match season AND episode.
+  # - Season search (expected_season set, no episode): match season only.
+  # - Movie search (media_type == :movie): expect NO season/episode; a parsed
+  #   TV pattern is an identity mismatch (folds in reject_tv_releases_for_movies
+  #   as a soft penalty per the Open Question default).
+  # - Fail open: an unparseable title (no ParsedFileInfo) gets no penalty.
+  defp identity_penalty(%SearchResult{} = result, opts) do
+    media_type = Keyword.get(opts, :media_type)
+    expected_season = Keyword.get(opts, :expected_season)
+    expected_episode = Keyword.get(opts, :expected_episode)
+
+    cond do
+      media_type == :movie ->
+        movie_identity_penalty(result)
+
+      expected_season != nil or expected_episode != nil ->
+        tv_identity_penalty(result, expected_season, expected_episode)
+
+      true ->
+        0.0
+    end
+  end
+
+  # Movie: any parsed season/episode marker is an identity mismatch. Fail open
+  # when the parser couldn't identify the release (no title), mirroring the
+  # title-mismatch convention, to protect formats the parser cannot read.
+  defp movie_identity_penalty(%SearchResult{title: title}) do
+    case ReleaseParser.parse(title) do
+      %ParsedFileInfo{title: parsed_title, season: season, episodes: episodes}
+      when is_binary(parsed_title) and
+             (not is_nil(season) or (is_list(episodes) and episodes != [])) ->
+        @identity_penalty
+
+      _ ->
+        0.0
+    end
+  end
+
+  defp tv_identity_penalty(%SearchResult{title: title}, expected_season, expected_episode) do
+    case ReleaseParser.parse(title) do
+      %ParsedFileInfo{title: parsed_title} = parsed when is_binary(parsed_title) ->
+        if identity_matches?(parsed, expected_season, expected_episode),
+          do: 0.0,
+          else: @identity_penalty
+
+      _ ->
+        # Parser couldn't identify the release (no title) — fail open, no penalty.
+        0.0
+    end
+  end
+
+  # Identity matches when the parsed season equals the expected season and,
+  # for an episode search, the parsed primary episode equals the expected
+  # episode. A nil parsed season/episode never matches a non-nil expectation.
+  defp identity_matches?(%ParsedFileInfo{} = parsed, expected_season, expected_episode) do
+    season_ok = expected_season == nil or parsed.season == expected_season
+
+    episode_ok =
+      expected_episode == nil or ParsedFileInfo.primary_episode(parsed) == expected_episode
+
+    season_ok and episode_ok
+  end
 
   # Calculate bonus points for matching preferred_tags in the title
   # Each matching tag adds 10 points to help preferred releases rank higher

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -58,9 +58,9 @@ defmodule Mydia.Indexers.ReleaseRanker do
   @type score_breakdown :: ScoreBreakdown.t()
 
   @type ranking_options :: [
-          min_seeders: non_neg_integer(),
+          min_seeders: non_neg_integer() | nil,
           min_ratio: float() | nil,
-          size_range: {non_neg_integer(), non_neg_integer()},
+          size_range: {non_neg_integer() | nil, non_neg_integer() | nil} | nil,
           preferred_qualities: [String.t()],
           preferred_tags: [String.t()],
           blocked_tags: [String.t()],
@@ -167,20 +167,20 @@ defmodule Mydia.Indexers.ReleaseRanker do
   end
 
   @doc """
-  Filters results to only those meeting minimum criteria.
+  Applies the surviving hard removals to a result list.
 
-  Removes results that:
-  - Have fewer than `:min_seeders` seeders
-  - Have seeder ratio below `:min_ratio` (if specified)
-  - Fall outside the `:size_range` (in MB)
-  - Contain any `:blocked_tags` in their title
+  Only two hard removals remain — everything else (size, seeders, ratio,
+  identity) is now a soft scoring penalty applied during ranking, so weak
+  releases sink to the bottom instead of disappearing. Removes results that:
+  - Contain any `:blocked_tags` in their title (R8)
+  - Are NZB results posted more recently than `:min_post_age_minutes` (timing safeguard)
 
   ## Examples
 
-      iex> ReleaseRanker.filter_acceptable(results, min_seeders: 10, blocked_tags: ["CAM"])
+      iex> ReleaseRanker.filter_acceptable(results, blocked_tags: ["CAM"])
       [%SearchResult{...}, ...]
 
-      iex> ReleaseRanker.filter_acceptable(results, min_ratio: 0.15)
+      iex> ReleaseRanker.filter_acceptable(results, min_post_age_minutes: 30)
       [%SearchResult{...}, ...]
   """
   @spec filter_acceptable([SearchResult.t()], ranking_options()) :: [SearchResult.t()]
@@ -700,8 +700,8 @@ defmodule Mydia.Indexers.ReleaseRanker do
   # are soft penalties on accepted results.
   defp get_rejection_reason(result, blocked_tags, expected_title) do
     cond do
-      invalid_release_reason(result) ->
-        "invalid: #{invalid_release_reason(result)}"
+      invalid_reason = invalid_release_reason(result) ->
+        "invalid: #{invalid_reason}"
 
       blocked_tag = find_blocked_tag(result, blocked_tags) ->
         "blocked_tag: #{blocked_tag}"

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -343,9 +343,21 @@ defmodule Mydia.Indexers.ReleaseRanker do
     quality_score = Map.get(breakdown, :quality_score, 0.0)
     seeder_score = Map.get(breakdown, :seeder_score, 0.0)
     title_bonus = Map.get(breakdown, :title_bonus, 0.0)
+    # The unified quality score already folds file-size into its sub-score.
+    # Surface that real contribution rather than hardcoding 0.0 so the
+    # breakdown display is honest. There is no separate age component in the
+    # unified model, so :age stays 0.0.
+    size_score = Map.get(breakdown, :file_size, 0.0)
 
     # Calculate tag bonus from preferred_tags
     tag_bonus = calculate_tag_bonus(result.title, preferred_tags)
+
+    # Soft penalties derived per-result from the ranking options. Each helper
+    # returns a value <= 0.0 that is layered onto the base score. They stay at
+    # 0.0 when the relevant option is absent or the result is within bounds.
+    size_penalty = size_penalty(result, Keyword.get(opts, :size_range))
+    seeder_penalty = seeder_penalty(result, opts)
+    identity_penalty = identity_penalty(result, opts)
 
     size_mb = bytes_to_mb(result.size)
     seeders = result.seeders || 0
@@ -353,8 +365,8 @@ defmodule Mydia.Indexers.ReleaseRanker do
     total_peers = seeders + leechers
     seeder_ratio = if total_peers > 0, do: seeders / total_peers, else: 0.0
 
-    # Add tag_bonus to total score
-    total_score = score_result.score + tag_bonus
+    # Add tag_bonus to the base score, then subtract any soft penalties.
+    total_score = score_result.score + tag_bonus + size_penalty + seeder_penalty + identity_penalty
 
     Logger.info("""
     [ReleaseRanker] Score breakdown for: #{result.title}
@@ -376,11 +388,14 @@ defmodule Mydia.Indexers.ReleaseRanker do
     ScoreBreakdown.new(%{
       quality: round_score(quality_score),
       seeders: round_score(seeder_score),
-      size: 0.0,
+      size: round_score(size_score),
       age: 0.0,
-      title_match: round_score(title_bonus * 100),
+      title_match: round_score(title_bonus),
       tag_bonus: round_score(tag_bonus),
-      total: round_score(total_score)
+      total: round_score(total_score),
+      size_penalty: round_score(size_penalty),
+      seeder_penalty: round_score(seeder_penalty),
+      identity_penalty: round_score(identity_penalty)
     })
   end
 
@@ -722,6 +737,17 @@ defmodule Mydia.Indexers.ReleaseRanker do
   end
 
   ## Private Functions - Helpers
+
+  ## Private Functions - Soft Penalties
+
+  # Size penalty placeholder (implemented in U2). Returns a value <= 0.0.
+  defp size_penalty(_result, _size_range), do: 0.0
+
+  # Seeder/ratio penalty placeholder (implemented in U2). Returns a value <= 0.0.
+  defp seeder_penalty(_result, _opts), do: 0.0
+
+  # Identity penalty placeholder (implemented in U3). Returns a value <= 0.0.
+  defp identity_penalty(_result, _opts), do: 0.0
 
   # Calculate bonus points for matching preferred_tags in the title
   # Each matching tag adds 10 points to help preferred releases rank higher

--- a/lib/mydia/indexers/structs/score_breakdown.ex
+++ b/lib/mydia/indexers/structs/score_breakdown.ex
@@ -7,18 +7,35 @@ defmodule Mydia.Indexers.Structs.ScoreBreakdown do
 
   ## Fields
 
-  All fields are required floats representing the score contribution:
+  All base fields are required floats representing the score contribution:
   - `:quality` - Score from video quality (resolution, source, codec)
   - `:seeders` - Score from seeder count (logarithmic scale)
   - `:size` - Score from file size (bell curve preference)
   - `:age` - Score from release age (slight preference for newer)
   - `:title_match` - Score from title matching relevance to search query
   - `:tag_bonus` - Bonus points from preferred tags
-  - `:total` - Final total score (sum of all components)
+  - `:total` - Final total score (sum of all components minus penalties)
+
+  Penalty fields are optional floats `<= 0.0` (default `0.0`) recording the
+  soft-penalty contributions subtracted from `:total`:
+  - `:size_penalty` - Penalty for being outside the configured size range
+  - `:seeder_penalty` - Penalty for low seeders / poor ratio
+  - `:identity_penalty` - Penalty for episode/season identity mismatch or absence
   """
 
   @enforce_keys [:quality, :seeders, :size, :age, :title_match, :tag_bonus, :total]
-  defstruct [:quality, :seeders, :size, :age, :title_match, :tag_bonus, :total]
+  defstruct [
+    :quality,
+    :seeders,
+    :size,
+    :age,
+    :title_match,
+    :tag_bonus,
+    :total,
+    size_penalty: 0.0,
+    seeder_penalty: 0.0,
+    identity_penalty: 0.0
+  ]
 
   @type t :: %__MODULE__{
           quality: float(),
@@ -27,7 +44,10 @@ defmodule Mydia.Indexers.Structs.ScoreBreakdown do
           age: float(),
           title_match: float(),
           tag_bonus: float(),
-          total: float()
+          total: float(),
+          size_penalty: float(),
+          seeder_penalty: float(),
+          identity_penalty: float()
         }
 
   @doc """

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -35,6 +35,7 @@ defmodule Mydia.Jobs.MovieSearch do
 
   alias Mydia.{Repo, Media, Indexers, Downloads, Events, Search}
   alias Mydia.Downloads.{Blacklists, Download}
+  alias Mydia.Indexers.RankingOptions
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Library.MediaFile
   alias Mydia.Media.MediaItem
@@ -541,33 +542,20 @@ defmodule Mydia.Jobs.MovieSearch do
   end
 
   defp build_ranking_options(movie, %Args{} = args) do
-    # Start with base options
-    # Include search_query for title relevance scoring and media_type for unified scoring
-    # Note: size_range is nil by default (no filtering) unless specified in args or quality profile
-    base_opts = [
+    # Delegate to the shared RankingOptions builder so movie and TV search use
+    # one option-building path. A movie expects no season/episode identity, so
+    # no expected_season/expected_episode are supplied (a TV-pattern release is
+    # softly penalized as an identity mismatch inside the ranker).
+    RankingOptions.build(%{
+      quality_profile: load_quality_profile(movie),
+      media_type: :movie,
       min_seeders: args.min_seeders || get_min_seeders(),
       size_range: args.size_range,
       search_query: build_search_query(movie),
-      media_type: :movie,
-      expected_title: movie.title
-    ]
-
-    # Add quality profile for unified scoring via SearchScorer
-    opts_with_quality =
-      case load_quality_profile(movie) do
-        nil ->
-          base_opts
-
-        quality_profile ->
-          base_opts
-          |> Keyword.put(:quality_profile, quality_profile)
-          |> Keyword.merge(build_quality_options(quality_profile, :movie))
-      end
-
-    # Add any custom blocked/preferred tags from args (merged with config tokens)
-    opts_with_quality
-    |> maybe_add_option(:blocked_tags, merged_blocked_tags(args.blocked_tags))
-    |> maybe_add_option(:preferred_tags, args.preferred_tags)
+      expected_title: movie.title,
+      blocked_tags: merged_blocked_tags(args.blocked_tags),
+      preferred_tags: args.preferred_tags
+    })
   end
 
   defp load_quality_profile(%MediaItem{quality_profile_id: nil}), do: nil
@@ -577,59 +565,6 @@ defmodule Mydia.Jobs.MovieSearch do
     |> Repo.preload(:quality_profile)
     |> Map.get(:quality_profile)
   end
-
-  defp build_quality_options(quality_profile, media_type) do
-    # Extract preferred qualities from quality profile
-    # The :qualities field contains the list of allowed resolutions in preference order
-    quality_opts =
-      case Map.get(quality_profile, :qualities) do
-        nil -> []
-        qualities when is_list(qualities) -> [preferred_qualities: qualities]
-        _ -> []
-      end
-
-    # Extract min_ratio from rules if present
-    rules_opts =
-      case Map.get(quality_profile, :rules) do
-        %{"min_ratio" => min_ratio} when is_number(min_ratio) ->
-          [min_ratio: min_ratio]
-
-        _ ->
-          []
-      end
-
-    # Extract size constraints from quality_standards based on media type
-    size_opts = extract_size_range(quality_profile, media_type)
-
-    quality_opts
-    |> Keyword.merge(rules_opts)
-    |> Keyword.merge(size_opts)
-  end
-
-  defp extract_size_range(%{quality_standards: standards}, media_type) when is_map(standards) do
-    {min_key, max_key} =
-      case media_type do
-        :movie -> {:movie_min_size_mb, :movie_max_size_mb}
-        :episode -> {:episode_min_size_mb, :episode_max_size_mb}
-      end
-
-    min_size = Map.get(standards, min_key)
-    max_size = Map.get(standards, max_key)
-
-    case {min_size, max_size} do
-      {nil, nil} -> []
-      {min, nil} when is_number(min) -> [size_range: {min, nil}]
-      {nil, max} when is_number(max) -> [size_range: {nil, max}]
-      {min, max} when is_number(min) and is_number(max) -> [size_range: {min, max}]
-      _ -> []
-    end
-  end
-
-  defp extract_size_range(_, _), do: []
-
-  defp maybe_add_option(opts, _key, nil), do: opts
-  defp maybe_add_option(opts, _key, []), do: opts
-  defp maybe_add_option(opts, key, value), do: Keyword.put(opts, key, value)
 
   defp initiate_download(movie, result) do
     case Downloads.initiate_download(result, media_item_id: movie.id) do

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -654,18 +654,12 @@ defmodule Mydia.Jobs.MovieSearch do
 
   ## Private Functions - Event Helpers
 
-  # Build a map of filter statistics for rejected results
+  # Build a map of filter statistics for the Activity view. Delegates to the
+  # shared ReleaseRanker.build_filter_stats/2 so the movie path now surfaces the
+  # same per-result scores, hard-removal reasons, and penalty state the TV path
+  # does (previously this used a plain seeder-count heuristic).
   defp build_filter_stats(results, ranking_opts) do
-    min_seeders = Keyword.get(ranking_opts, :min_seeders, get_min_seeders())
-
-    # NZB results have no seeder concept; treat nil as not-low-seeders.
-    low_seeders = Enum.count(results, fn r -> r.seeders != nil and r.seeders < min_seeders end)
-
-    %{
-      "total_results" => length(results),
-      "low_seeders" => low_seeders,
-      "below_quality_threshold" => length(results) - low_seeders
-    }
+    ReleaseRanker.build_filter_stats(results, ranking_opts)
   end
 
   # Convert a map with atom keys to string keys for JSON serialization

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -1933,51 +1933,11 @@ defmodule Mydia.Jobs.TVShowSearch do
 
   ## Private Functions - Event Helpers
 
-  # Build a map of filter statistics for rejected results, including detailed results with scores
+  # Build a map of filter statistics for the Activity view. Delegates to the
+  # shared ReleaseRanker.build_filter_stats/2 so movie and TV render identically,
+  # including the penalized-but-kept state.
   defp build_filter_stats(results, ranking_opts) do
-    # Get detailed scoring for all results
-    scored_results = ReleaseRanker.score_all_with_reasons(results, ranking_opts)
-
-    # Count by rejection reason
-    rejection_counts =
-      scored_results
-      |> Enum.filter(&(&1.status == :rejected))
-      |> Enum.group_by(fn result ->
-        # Extract the rejection type (before the colon)
-        case result.rejection_reason do
-          nil -> "unknown"
-          reason -> reason |> String.split(":") |> List.first()
-        end
-      end)
-      |> Enum.map(fn {reason, items} -> {reason, length(items)} end)
-      |> Map.new()
-
-    # Build the results list for the event (limit to top 10 to avoid huge events)
-    results_details =
-      scored_results
-      |> Enum.take(10)
-      |> Enum.map(fn r ->
-        base = %{
-          "title" => r.title,
-          "score" => r.score,
-          "seeders" => r.seeders,
-          "size_mb" => r.size_mb,
-          "resolution" => r.resolution,
-          "status" => to_string(r.status)
-        }
-
-        if r.rejection_reason do
-          Map.put(base, "rejection_reason", r.rejection_reason)
-        else
-          base
-        end
-      end)
-
-    %{
-      "total_results" => length(results),
-      "rejection_counts" => rejection_counts,
-      "results" => results_details
-    }
+    ReleaseRanker.build_filter_stats(results, ranking_opts)
   end
 
   # Convert a map with atom keys to string keys for JSON serialization

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -55,6 +55,7 @@ defmodule Mydia.Jobs.TVShowSearch do
 
   alias Mydia.{Repo, Media, Indexers, Downloads, Events, Search}
   alias Mydia.Downloads.{Blacklists, Download}
+  alias Mydia.Indexers.RankingOptions
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Indexers.Structs.SearchResultMetadata
   alias Mydia.Media.{MediaItem, Episode}
@@ -854,23 +855,6 @@ defmodule Mydia.Jobs.TVShowSearch do
     Enum.filter(results, &season_pack?(&1.title, season_number))
   end
 
-  # Reject results that look like season packs from individual episode searches
-  defp reject_season_packs(results, season_number) do
-    episode_results = Enum.reject(results, &season_pack?(&1.title, season_number))
-
-    filtered_count = length(results) - length(episode_results)
-
-    if filtered_count > 0 do
-      Logger.info("Filtered #{filtered_count} season pack results from episode search",
-        season_number: season_number,
-        season_packs_filtered: filtered_count,
-        episode_results_remaining: length(episode_results)
-      )
-    end
-
-    episode_results
-  end
-
   # Build filter stats for season pack filtering (results rejected because they're individual episodes)
   defp build_season_pack_filter_stats(results, season_number) do
     season_marker = "S#{String.pad_leading("#{season_number}", 2, "0")}"
@@ -1152,31 +1136,21 @@ defmodule Mydia.Jobs.TVShowSearch do
   end
 
   defp process_episode_results(episode, results, args, query) do
-    # Filter out season packs — individual episode searches should not grab full season downloads
-    episode_results = reject_season_packs(results, episode.season_number)
-
+    # Season packs are no longer hard-rejected here. Episode/season identity is
+    # judged inside ReleaseRanker via the identity penalty (R6): for an episode
+    # search a season pack matches the season but lacks the episode, so it is
+    # penalized and kept as a low-tier fallback rather than removed. This makes
+    # the formerly-unreachable "all season packs" backoff branch obsolete — an
+    # episode search whose results are all season packs now ranks and can select
+    # the penalized pack instead of recording a backoff and grabbing nothing.
+    #
     # Filter blacklisted releases out before ranking (#123). The "filter,
     # don't rank" convention keeps this distinct from `ReleaseRanker`.
     # Too-fresh NZB filtering (#121) already happened upstream in
     # `Indexers.search_all/2`.
-    episode_results = reject_blacklisted(episode_results, episode: episode)
+    episode_results = reject_blacklisted(results, episode: episode)
 
-    if episode_results == [] do
-      Logger.warning("All results were season packs, no episode-specific results",
-        episode_id: episode.id,
-        show: episode.media_item.title,
-        season: episode.season_number,
-        episode: episode.episode_number,
-        total_results: length(results)
-      )
-
-      # Record backoff — no suitable results for this episode
-      record_episode_backoff(episode, "all_season_packs")
-
-      :ok
-    else
-      process_ranked_episode_results(episode, episode_results, args, query)
-    end
+    process_ranked_episode_results(episode, episode_results, args, query)
   end
 
   # Drops results matching an active `(indexer, guid)` row in the
@@ -1270,145 +1244,53 @@ defmodule Mydia.Jobs.TVShowSearch do
   ## Private Functions - Quality & Ranking
 
   defp build_ranking_options(episode, %Args{} = args) do
-    # Start with base options - TV shows typically have smaller file sizes than movies
-    # Include search_query for title relevance scoring and media_type for unified scoring
-    # Note: size_range is nil by default (no filtering) unless specified in args or quality profile
-    base_opts = [
+    # Delegate to the shared RankingOptions builder. An episode search supplies
+    # the expected season AND episode so the ranker's identity penalty can rank
+    # the requested episode above wrong episodes and season packs (which match
+    # the season but lack the episode).
+    RankingOptions.build(%{
+      quality_profile: load_quality_profile(episode),
+      media_type: :episode,
       min_seeders: args.min_seeders || get_min_seeders(),
       size_range: args.size_range,
       search_query: build_episode_query(episode),
-      media_type: :episode,
-      expected_title: episode.media_item.title
-    ]
-
-    # Add quality profile for unified scoring via SearchScorer
-    opts_with_quality =
-      case load_quality_profile(episode) do
-        nil ->
-          base_opts
-
-        quality_profile ->
-          base_opts
-          |> Keyword.put(:quality_profile, quality_profile)
-          |> Keyword.merge(build_quality_options(quality_profile, :episode))
-      end
-
-    # Add any custom blocked/preferred tags from args (merged with config tokens)
-    opts_with_quality
-    |> maybe_add_option(:blocked_tags, merged_blocked_tags(args.blocked_tags))
-    |> maybe_add_option(:preferred_tags, args.preferred_tags)
+      expected_title: episode.media_item.title,
+      expected_season: episode.season_number,
+      expected_episode: episode.episode_number,
+      blocked_tags: merged_blocked_tags(args.blocked_tags),
+      preferred_tags: args.preferred_tags
+    })
   end
 
   defp build_ranking_options_for_season(media_item, season_number, _episodes, %Args{} = args) do
-    # Season packs are typically much larger than individual episodes
-    # A full season in HD can be 10-50GB depending on episode count and quality
-    # Include search_query for title relevance scoring and media_type for unified scoring
-    # Note: size_range is nil by default (no filtering) unless specified in args or quality profile
-    base_opts = [
+    # Delegate to the shared RankingOptions builder. A season-pack search
+    # supplies only the expected season (no episode), so the identity penalty
+    # matches on season alone — a season pack for the requested season matches,
+    # a wrong-season pack is penalized.
+    RankingOptions.build(%{
+      quality_profile: load_season_quality_profile(media_item),
+      media_type: :episode,
       min_seeders: args.min_seeders || get_min_seeders(),
       size_range: args.size_range,
       search_query: build_season_query(media_item, season_number),
-      media_type: :episode,
-      expected_title: media_item.title
-    ]
-
-    # Load quality profile from media_item for unified scoring via SearchScorer
-    opts_with_quality =
-      case media_item.quality_profile_id do
-        nil ->
-          base_opts
-
-        _id ->
-          quality_profile =
-            media_item
-            |> Repo.preload(:quality_profile)
-            |> then(& &1.quality_profile)
-
-          case quality_profile do
-            nil ->
-              base_opts
-
-            qp ->
-              base_opts
-              |> Keyword.put(:quality_profile, qp)
-              |> Keyword.merge(build_quality_options(qp, :episode))
-          end
-      end
-
-    # Add any custom blocked/preferred tags from args (merged with config tokens)
-    opts_with_quality
-    |> maybe_add_option(:blocked_tags, merged_blocked_tags(args.blocked_tags))
-    |> maybe_add_option(:preferred_tags, args.preferred_tags)
+      expected_title: media_item.title,
+      expected_season: season_number,
+      blocked_tags: merged_blocked_tags(args.blocked_tags),
+      preferred_tags: args.preferred_tags
+    })
   end
 
   defp load_quality_profile(%Episode{media_item: media_item}) do
-    case media_item.quality_profile_id do
-      nil ->
-        nil
-
-      _id ->
-        media_item
-        |> Repo.preload(:quality_profile)
-        |> then(& &1.quality_profile)
-    end
+    load_season_quality_profile(media_item)
   end
 
-  defp build_quality_options(quality_profile, media_type) do
-    # Extract preferred qualities from quality profile
-    # The :qualities field contains the list of allowed resolutions in preference order
-    quality_opts =
-      case quality_profile.qualities do
-        nil -> []
-        qualities when is_list(qualities) -> [preferred_qualities: qualities]
-        _ -> []
-      end
+  defp load_season_quality_profile(%MediaItem{quality_profile_id: nil}), do: nil
 
-    # Extract min_ratio from quality_standards if present
-    # Note: The QualityProfile schema uses quality_standards, not rules
-    rules_opts =
-      case quality_profile.quality_standards do
-        %{min_ratio: min_ratio} when is_number(min_ratio) ->
-          [min_ratio: min_ratio]
-
-        %{"min_ratio" => min_ratio} when is_number(min_ratio) ->
-          [min_ratio: min_ratio]
-
-        _ ->
-          []
-      end
-
-    # Extract size constraints from quality_standards based on media type
-    size_opts = extract_size_range(quality_profile, media_type)
-
-    quality_opts
-    |> Keyword.merge(rules_opts)
-    |> Keyword.merge(size_opts)
+  defp load_season_quality_profile(%MediaItem{} = media_item) do
+    media_item
+    |> Repo.preload(:quality_profile)
+    |> then(& &1.quality_profile)
   end
-
-  defp extract_size_range(%{quality_standards: standards}, media_type) when is_map(standards) do
-    {min_key, max_key} =
-      case media_type do
-        :movie -> {:movie_min_size_mb, :movie_max_size_mb}
-        :episode -> {:episode_min_size_mb, :episode_max_size_mb}
-      end
-
-    min_size = Map.get(standards, min_key)
-    max_size = Map.get(standards, max_key)
-
-    case {min_size, max_size} do
-      {nil, nil} -> []
-      {min, nil} when is_number(min) -> [size_range: {min, nil}]
-      {nil, max} when is_number(max) -> [size_range: {nil, max}]
-      {min, max} when is_number(min) and is_number(max) -> [size_range: {min, max}]
-      _ -> []
-    end
-  end
-
-  defp extract_size_range(_, _), do: []
-
-  defp maybe_add_option(opts, _key, nil), do: opts
-  defp maybe_add_option(opts, _key, []), do: opts
-  defp maybe_add_option(opts, key, value), do: Keyword.put(opts, key, value)
 
   ## Private Functions - Download Initiation
 

--- a/lib/mydia_web/live/activity_live/index.ex
+++ b/lib/mydia_web/live/activity_live/index.ex
@@ -625,10 +625,9 @@ defmodule MydiaWeb.ActivityLive.Index do
   defp format_penalty_summary(penalties) when is_map(penalties) do
     penalties
     |> Enum.filter(fn {_key, value} -> is_number(value) and value < 0.0 end)
-    |> Enum.map(fn {key, value} ->
+    |> Enum.map_join(", ", fn {key, value} ->
       "#{format_breakdown_label(key)}: #{trunc(value)}"
     end)
-    |> Enum.join(", ")
   end
 
   defp format_penalty_summary(_), do: ""

--- a/lib/mydia_web/live/activity_live/index.ex
+++ b/lib/mydia_web/live/activity_live/index.ex
@@ -583,15 +583,15 @@ defmodule MydiaWeb.ActivityLive.Index do
   defp format_filter_stat_label(key) do
     case key do
       "total_results" -> "Total"
-      "low_seeders" -> "Low seeders"
       "below_quality_threshold" -> "Below quality"
       "no_valid_season_packs" -> "No season packs"
       # New detailed rejection reasons
       "individual_episode" -> "Episode"
       "missing_season_marker" -> "No season"
-      "low_ratio" -> "Low ratio"
-      "size_out_of_range" -> "Size"
+      # Hard removals only — size/seeders/ratio are penalties now, not rejections
       "blocked_tag" -> "Blocked"
+      "invalid" -> "Invalid"
+      "title_mismatch" -> "Wrong show"
       _ -> String.replace(key, "_", " ") |> String.capitalize()
     end
   end
@@ -601,9 +601,16 @@ defmodule MydiaWeb.ActivityLive.Index do
       "quality" -> "Quality"
       "seeders" -> "Seeders"
       "size" -> "Size"
+      "age" -> "Age"
+      "tag_bonus" -> "Tag bonus"
       "preferred_tags" -> "Preferred"
       "blocked_tags" -> "Blocked"
       "title_relevance" -> "Title match"
+      "title_match" -> "Title match"
+      # Soft-penalty contributions
+      "size_penalty" -> "Size penalty"
+      "seeder_penalty" -> "Seeder penalty"
+      "identity_penalty" -> "Identity mismatch"
       _ -> String.replace(key, "_", " ") |> String.capitalize()
     end
   end
@@ -613,6 +620,18 @@ defmodule MydiaWeb.ActivityLive.Index do
   end
 
   defp format_breakdown_value(value), do: to_string(value)
+
+  # Tooltip summary of the non-zero penalty contributions on an accepted result.
+  defp format_penalty_summary(penalties) when is_map(penalties) do
+    penalties
+    |> Enum.filter(fn {_key, value} -> is_number(value) and value < 0.0 end)
+    |> Enum.map(fn {key, value} ->
+      "#{format_breakdown_label(key)}: #{trunc(value)}"
+    end)
+    |> Enum.join(", ")
+  end
+
+  defp format_penalty_summary(_), do: ""
 
   # Backoff formatting helpers
 

--- a/lib/mydia_web/live/activity_live/index.html.heex
+++ b/lib/mydia_web/live/activity_live/index.html.heex
@@ -405,19 +405,27 @@
                                 </td>
                                 <td class="text-right font-mono text-sm">{result["seeders"]}</td>
                                 <td>
-                                  <%= if result["status"] == "rejected" do %>
-                                    <span
-                                      class="badge badge-xs badge-error"
-                                      title={result["rejection_reason"]}
-                                    >
-                                      {format_filter_stat_label(
-                                        result["rejection_reason"]
-                                        |> String.split(":")
-                                        |> List.first()
-                                      )}
-                                    </span>
-                                  <% else %>
-                                    <span class="badge badge-xs badge-success">OK</span>
+                                  <%= cond do %>
+                                    <% result["status"] == "rejected" -> %>
+                                      <span
+                                        class="badge badge-xs badge-error"
+                                        title={result["rejection_reason"]}
+                                      >
+                                        {format_filter_stat_label(
+                                          result["rejection_reason"]
+                                          |> String.split(":")
+                                          |> List.first()
+                                        )}
+                                      </span>
+                                    <% result["penalized"] -> %>
+                                      <span
+                                        class="badge badge-xs badge-warning"
+                                        title={format_penalty_summary(result["penalties"])}
+                                      >
+                                        Penalized
+                                      </span>
+                                    <% true -> %>
+                                      <span class="badge badge-xs badge-success">OK</span>
                                   <% end %>
                                 </td>
                               </tr>
@@ -498,19 +506,27 @@
                             </td>
                             <td class="text-right font-mono text-sm">{result["seeders"]}</td>
                             <td>
-                              <%= if result["status"] == "rejected" do %>
-                                <span
-                                  class="badge badge-xs badge-error"
-                                  title={result["rejection_reason"]}
-                                >
-                                  {format_filter_stat_label(
-                                    result["rejection_reason"]
-                                    |> String.split(":")
-                                    |> List.first()
-                                  )}
-                                </span>
-                              <% else %>
-                                <span class="badge badge-xs badge-success">OK</span>
+                              <%= cond do %>
+                                <% result["status"] == "rejected" -> %>
+                                  <span
+                                    class="badge badge-xs badge-error"
+                                    title={result["rejection_reason"]}
+                                  >
+                                    {format_filter_stat_label(
+                                      result["rejection_reason"]
+                                      |> String.split(":")
+                                      |> List.first()
+                                    )}
+                                  </span>
+                                <% result["penalized"] -> %>
+                                  <span
+                                    class="badge badge-xs badge-warning"
+                                    title={format_penalty_summary(result["penalties"])}
+                                  >
+                                    Penalized
+                                  </span>
+                                <% true -> %>
+                                  <span class="badge badge-xs badge-success">OK</span>
                               <% end %>
                             </td>
                           </tr>

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -585,7 +585,15 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
         _ -> :movie
       end
 
-    assigns = assign(assigns, :media_type, media_type)
+    # Build the same ranking options the manual list was ordered with, so the
+    # per-result breakdown (including penalties) matches the unified ranker.
+    manual_ranking_opts =
+      MydiaWeb.MediaLive.Show.SearchHelpers.build_manual_ranking_opts(assigns)
+
+    assigns =
+      assigns
+      |> assign(:media_type, media_type)
+      |> assign(:manual_ranking_opts, manual_ranking_opts)
 
     ~H"""
     <div class="modal modal-open">
@@ -727,9 +735,14 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
               >
                 <%!-- Score display --%>
                 <%= if @quality_profile do %>
-                  <%!-- Profile-based score with breakdown dropdown --%>
-                  <% score_data = profile_score_breakdown(result, @quality_profile, @media_type) %>
+                  <%!-- Unified ranker score with breakdown dropdown --%>
+                  <% score_data = profile_score_breakdown(result, @manual_ranking_opts) %>
+                  <% breakdown = score_data.breakdown %>
                   <% score = score_data.score %>
+                  <% ring_value = max(0, trunc(score)) %>
+                  <% has_penalty =
+                    breakdown.size_penalty < 0.0 or breakdown.seeder_penalty < 0.0 or
+                      breakdown.identity_penalty < 0.0 %>
                   <div class="dropdown dropdown-hover dropdown-right">
                     <div
                       tabindex="0"
@@ -740,7 +753,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                         score >= 50 && score < 80 && "text-warning",
                         score < 50 && "text-error"
                       ]}
-                      style={"--value:#{trunc(score)}; --size:3rem; --thickness:4px;"}
+                      style={"--value:#{ring_value}; --size:3rem; --thickness:4px;"}
                       title="Hover for score breakdown"
                     >
                       {trunc(score)}
@@ -755,37 +768,13 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                           <.score_row
                             label="Resolution"
                             value={score_data.detected[:resolution]}
-                            score={score_data.breakdown[:resolution]}
-                            weight={20}
+                            score={breakdown.quality}
+                            weight={60}
                           />
                           <.score_row
-                            label="Video Codec"
-                            value={score_data.detected[:video_codec]}
-                            score={score_data.breakdown[:video_codec]}
-                            weight={20}
-                          />
-                          <.score_row
-                            label="Audio Codec"
-                            value={score_data.detected[:audio_codec]}
-                            score={score_data.breakdown[:audio_codec]}
-                            weight={15}
-                          />
-                          <.score_row
-                            label="Source"
-                            value={score_data.detected[:source]}
-                            score={score_data.breakdown[:source]}
-                            weight={10}
-                          />
-                          <.score_row
-                            label="Audio Channels"
+                            label="Title match"
                             value={nil}
-                            score={score_data.breakdown[:audio_channels]}
-                            weight={10}
-                          />
-                          <.score_row
-                            label="Video Bitrate"
-                            value={nil}
-                            score={score_data.breakdown[:video_bitrate]}
+                            score={breakdown.title_match}
                             weight={10}
                           />
                           <.score_row
@@ -796,38 +785,26 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                                 else: nil
                               )
                             }
-                            score={score_data.breakdown[:file_size]}
-                            weight={5}
-                          />
-                          <.score_row
-                            label="Audio Bitrate"
-                            value={nil}
-                            score={score_data.breakdown[:audio_bitrate]}
-                            weight={5}
-                          />
-                          <.score_row
-                            label="HDR"
-                            value={if(score_data.detected[:hdr], do: "Yes", else: "No")}
-                            score={score_data.breakdown[:hdr]}
+                            score={breakdown.size}
                             weight={5}
                           />
                           <div class="divider my-1 text-xs opacity-50">Availability</div>
                           <.score_row
                             label="Seeders"
                             value={"#{result.seeders} peers"}
-                            score={score_data.breakdown[:seeders]}
+                            score={breakdown.seeders}
                             weight={30}
                           />
                         </div>
-                        <%= if score_data.violations != [] do %>
-                          <div class="divider my-1"></div>
-                          <div class="text-error text-xs">
-                            <span class="font-semibold">Violations:</span>
-                            <ul class="list-disc list-inside">
-                              <%= for violation <- score_data.violations do %>
-                                <li>{violation}</li>
-                              <% end %>
-                            </ul>
+                        <%= if has_penalty do %>
+                          <div class="divider my-1 text-xs opacity-50">Penalties</div>
+                          <div class="space-y-1.5 text-xs">
+                            <.penalty_row label="Size penalty" score={breakdown.size_penalty} />
+                            <.penalty_row label="Seeder penalty" score={breakdown.seeder_penalty} />
+                            <.penalty_row
+                              label="Identity mismatch"
+                              score={breakdown.identity_penalty}
+                            />
                           </div>
                         <% end %>
                       </div>
@@ -1373,6 +1350,28 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
         </span>
         <span class="text-base-content/50 text-[10px] w-8">
           ({@weight}%)
+        </span>
+      </div>
+    </div>
+    """
+  end
+
+  # Penalty breakdown row. Rendered only for a non-zero penalty (hide-when-empty
+  # convention), with a `−` prefix and a distinct warning color so a penalty
+  # never looks like a weak positive score. No weight column — it is meaningless
+  # for a penalty.
+  attr :label, :string, required: true
+  attr :score, :float, default: 0.0
+
+  defp penalty_row(assigns) do
+    ~H"""
+    <div :if={@score < 0.0} class="flex items-center justify-between gap-2">
+      <div class="flex items-center gap-2 flex-1 min-w-0">
+        <span class="text-base-content/70 whitespace-nowrap">{@label}:</span>
+      </div>
+      <div class="flex items-center gap-1.5 flex-shrink-0">
+        <span class="font-mono font-semibold w-10 text-right text-warning">
+          −{abs(trunc(@score))}
         </span>
       </div>
     </div>

--- a/lib/mydia_web/live/media_live/show/search_events.ex
+++ b/lib/mydia_web/live/media_live/show/search_events.ex
@@ -109,7 +109,15 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
      socket
      |> assign(:show_manual_search_modal, true)
      |> assign(:manual_search_query, search_query)
-     |> assign(:manual_search_context, %{type: :episode, episode_id: episode_id})
+     |> assign(
+       :manual_search_context,
+       %{
+         type: :episode,
+         episode_id: episode_id,
+         season_number: episode.season_number,
+         episode_number: episode.episode_number
+       }
+     )
      |> assign(:searching, true)
      |> assign(:results_empty?, false)
      |> assign(:download_error, nil)

--- a/lib/mydia_web/live/media_live/show/search_events.ex
+++ b/lib/mydia_web/live/media_live/show/search_events.ex
@@ -305,17 +305,11 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
   defp find_prepared_result(socket, download_url) do
     raw_results = Map.get(socket.assigns, :raw_search_results, [])
     assigns = socket.assigns
-    media_item = assigns.media_item
-    media_type = if media_item.type == "movie", do: :movie, else: :episode
+    ranking_opts = build_manual_ranking_opts(assigns)
 
     raw_results
     |> filter_search_results(assigns)
-    |> sort_search_results(
-      assigns.sort_by,
-      media_item.quality_profile,
-      media_type,
-      Map.get(assigns, :manual_search_query)
-    )
+    |> sort_search_results_with_opts(assigns.sort_by, ranking_opts)
     |> prepare_for_stream()
     |> Enum.find(&(&1.download_url == download_url))
   end
@@ -325,21 +319,13 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
   def handle_search_async({:ok, {:ok, results, indexer_errors}}, socket) do
     start_time = System.monotonic_time(:millisecond)
 
-    media_item = socket.assigns.media_item
-    quality_profile = media_item.quality_profile
-    media_type = get_media_type(media_item)
     search_query = socket.assigns.manual_search_query
 
     filtered_results = filter_search_results(results, socket.assigns)
+    ranking_opts = build_manual_ranking_opts(socket.assigns)
 
     sorted_results =
-      sort_search_results(
-        filtered_results,
-        socket.assigns.sort_by,
-        quality_profile,
-        media_type,
-        search_query
-      )
+      sort_search_results_with_opts(filtered_results, socket.assigns.sort_by, ranking_opts)
 
     prepared_results = prepare_for_stream(sorted_results)
 

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -232,6 +232,13 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
     })
   end
 
+  # Prefer the season/episode the modal already loaded into the context, so
+  # re-sorts and modal re-renders don't re-query the episode on every call.
+  defp expected_identity(%{type: :episode, season_number: season, episode_number: episode})
+       when not is_nil(season) and not is_nil(episode) do
+    {season, episode}
+  end
+
   defp expected_identity(%{type: :episode, episode_id: episode_id}) do
     episode = Media.get_episode!(episode_id)
     {episode.season_number, episode.episode_number}

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -265,7 +265,8 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   Accepts the full ranking options keyword list so penalties (which depend on
   size_range and expected season/episode) match what the ranker computed.
   """
-  def profile_score_breakdown(%SearchResult{} = result, ranking_opts) when is_list(ranking_opts) do
+  def profile_score_breakdown(%SearchResult{} = result, ranking_opts)
+      when is_list(ranking_opts) do
     breakdown = ReleaseRanker.calculate_score_breakdown(result, ranking_opts)
     scorer = SearchScorer.score_result_with_breakdown(result, ranking_opts)
 

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -5,8 +5,11 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   """
 
   alias Mydia.Indexers
+  alias Mydia.Indexers.RankingOptions
+  alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Indexers.SearchResult
   alias Mydia.Indexers.SearchScorer
+  alias Mydia.Media
 
   def generate_result_id(%SearchResult{} = result) do
     # Generate a unique ID based on the download URL and indexer
@@ -52,19 +55,10 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
     # Re-filter from raw results without re-searching
     results = Map.get(socket.assigns, :raw_search_results, [])
     filtered_results = filter_search_results(results, socket.assigns)
-    media_item = socket.assigns.media_item
-    quality_profile = media_item.quality_profile
-    media_type = get_media_type(media_item)
-    search_query = Map.get(socket.assigns, :manual_search_query)
+    ranking_opts = build_manual_ranking_opts(socket.assigns)
 
     sorted_results =
-      sort_search_results(
-        filtered_results,
-        socket.assigns.sort_by,
-        quality_profile,
-        media_type,
-        search_query
-      )
+      sort_search_results_with_opts(filtered_results, socket.assigns.sort_by, ranking_opts)
 
     prepared_results = prepare_for_stream(sorted_results)
 
@@ -77,19 +71,10 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
     # Re-filter and re-sort from raw results
     results = Map.get(socket.assigns, :raw_search_results, [])
     filtered_results = filter_search_results(results, socket.assigns)
-    media_item = socket.assigns.media_item
-    quality_profile = media_item.quality_profile
-    media_type = get_media_type(media_item)
-    search_query = Map.get(socket.assigns, :manual_search_query)
+    ranking_opts = build_manual_ranking_opts(socket.assigns)
 
     sorted_results =
-      sort_search_results(
-        filtered_results,
-        socket.assigns.sort_by,
-        quality_profile,
-        media_type,
-        search_query
-      )
+      sort_search_results_with_opts(filtered_results, socket.assigns.sort_by, ranking_opts)
 
     prepared_results = prepare_for_stream(sorted_results)
 
@@ -157,23 +142,16 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   end
 
   def sort_search_results(results, :quality, quality_profile, media_type, search_query) do
-    # Sort by combined score using the unified SearchScorer algorithm
-    # This ensures seeded results rank higher than dead torrents
-    opts = [
-      quality_profile: quality_profile,
-      media_type: media_type,
-      search_query: search_query
-    ]
+    # Back-compat 5-arity entry: build minimal ranking options and route through
+    # the unified ranker so the manual top result matches automatic selection.
+    ranking_opts =
+      RankingOptions.build(%{
+        quality_profile: quality_profile,
+        media_type: media_type,
+        search_query: search_query
+      })
 
-    results
-    |> Enum.sort_by(
-      fn result ->
-        combined_score = SearchScorer.score_result(result, opts)
-        # Use seeders as tie-breaker
-        {combined_score, result.seeders}
-      end,
-      :desc
-    )
+    quality_sort_via_ranker(results, ranking_opts)
   end
 
   def sort_search_results(results, :seeders, _quality_profile, _media_type, _search_query) do
@@ -198,6 +176,73 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   end
 
   @doc """
+  Sort manual-search results using a pre-built RankingOptions keyword list.
+
+  For the `:quality` sort mode this routes through `ReleaseRanker.rank_all/2`,
+  so the manual top result equals what automatic search would select (R2).
+  Penalized releases (size/seeder/identity) remain visible, sorted to the bottom
+  (R3); only hard removals (blocked tags, invalid, too-recent NZB) drop out.
+  Non-quality sort modes (`:seeders`, `:size`, `:date`) stay as direct sorts.
+  """
+  def sort_search_results_with_opts(results, :quality, ranking_opts) do
+    quality_sort_via_ranker(results, ranking_opts)
+  end
+
+  def sort_search_results_with_opts(results, sort_by, ranking_opts) do
+    quality_profile = Keyword.get(ranking_opts, :quality_profile)
+    media_type = Keyword.get(ranking_opts, :media_type, :movie)
+    search_query = Keyword.get(ranking_opts, :search_query)
+    sort_search_results(results, sort_by, quality_profile, media_type, search_query)
+  end
+
+  # Run the unified ranker and return the surviving SearchResults in ranked
+  # order. When no quality profile is set, fall back to a seeders sort (matching
+  # the legacy no-profile behavior).
+  defp quality_sort_via_ranker(results, ranking_opts) do
+    case Keyword.get(ranking_opts, :quality_profile) do
+      nil ->
+        Enum.sort_by(results, & &1.seeders, :desc)
+
+      _profile ->
+        results
+        |> ReleaseRanker.rank_all(ranking_opts)
+        |> Enum.map(& &1.result)
+    end
+  end
+
+  @doc """
+  Build the shared ranking options for the manual search dialog from the socket
+  assigns, deriving the expected title and (for episode/season searches) the
+  expected season/episode from the `manual_search_context`.
+  """
+  def build_manual_ranking_opts(assigns) do
+    media_item = assigns.media_item
+    context = Map.get(assigns, :manual_search_context) || %{type: :media_item}
+
+    {expected_season, expected_episode} = expected_identity(context)
+
+    RankingOptions.build(%{
+      quality_profile: media_item.quality_profile,
+      media_type: get_media_type(media_item),
+      min_seeders: Map.get(assigns, :min_seeders),
+      search_query: Map.get(assigns, :manual_search_query),
+      expected_title: media_item.title,
+      expected_season: expected_season,
+      expected_episode: expected_episode
+    })
+  end
+
+  defp expected_identity(%{type: :episode, episode_id: episode_id}) do
+    episode = Media.get_episode!(episode_id)
+    {episode.season_number, episode.episode_number}
+  rescue
+    Ecto.NoResultsError -> {nil, nil}
+  end
+
+  defp expected_identity(%{type: :season, season_number: season}), do: {season, nil}
+  defp expected_identity(_context), do: {nil, nil}
+
+  @doc """
   Calculate profile-based score for a search result.
   Returns the combined score using the unified SearchScorer algorithm.
   """
@@ -207,20 +252,39 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   end
 
   @doc """
-  Calculate profile-based score with full breakdown for a search result.
-  Returns the full score result including breakdown of individual components.
-
-  Delegates to SearchScorer.score_result_with_breakdown/2 for the unified algorithm.
+  Build the unified score breakdown for a manual-search result, using the same
+  `ReleaseRanker` pipeline (and the same ranking options) that ordered the list.
 
   Returns a map with:
-  - `:score` - Overall combined score
-  - `:breakdown` - Map with individual component scores and weights
-  - `:violations` - List of constraint violations (if any)
-  - `:detected` - Map of detected quality attributes from the result
+  - `:score` - The ranker total (may be deeply negative for identity mismatches)
+  - `:breakdown` - The `ScoreBreakdown` struct (quality, seeders, size, age,
+    title_match, tag_bonus, and the size/seeder/identity penalties)
+  - `:detected` - Map of detected quality attributes (for value display)
+  - `:violations` - List of constraint violations from the scorer
+
+  Accepts the full ranking options keyword list so penalties (which depend on
+  size_range and expected season/episode) match what the ranker computed.
+  """
+  def profile_score_breakdown(%SearchResult{} = result, ranking_opts) when is_list(ranking_opts) do
+    breakdown = ReleaseRanker.calculate_score_breakdown(result, ranking_opts)
+    scorer = SearchScorer.score_result_with_breakdown(result, ranking_opts)
+
+    %{
+      score: breakdown.total,
+      breakdown: breakdown,
+      detected: scorer.detected,
+      violations: scorer.violations
+    }
+  end
+
+  @doc """
+  Back-compat 3-arity breakdown using only the quality profile and media type.
   """
   def profile_score_breakdown(%SearchResult{} = result, quality_profile, media_type) do
-    opts = [quality_profile: quality_profile, media_type: media_type]
-    SearchScorer.score_result_with_breakdown(result, opts)
+    profile_score_breakdown(
+      result,
+      RankingOptions.build(%{quality_profile: quality_profile, media_type: media_type})
+    )
   end
 
   def get_media_type(media_item) do

--- a/test/mydia/indexers/ranking_options_test.exs
+++ b/test/mydia/indexers/ranking_options_test.exs
@@ -32,7 +32,15 @@ defmodule Mydia.Indexers.RankingOptionsTest do
       movie = RankingOptions.build(Map.put(common, :media_type, :movie))
       episode = RankingOptions.build(Map.put(common, :media_type, :episode))
 
-      for key <- [:min_seeders, :size_range, :search_query, :expected_title, :blocked_tags, :preferred_tags, :preferred_qualities] do
+      for key <- [
+            :min_seeders,
+            :size_range,
+            :search_query,
+            :expected_title,
+            :blocked_tags,
+            :preferred_tags,
+            :preferred_qualities
+          ] do
         assert Keyword.get(movie, key) == Keyword.get(episode, key)
       end
 

--- a/test/mydia/indexers/ranking_options_test.exs
+++ b/test/mydia/indexers/ranking_options_test.exs
@@ -1,0 +1,155 @@
+defmodule Mydia.Indexers.RankingOptionsTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Indexers.RankingOptions
+  alias Mydia.Settings.QualityProfile
+
+  defp profile(attrs \\ %{}) do
+    defaults = %{
+      id: Ecto.UUID.generate(),
+      name: "Test Profile",
+      qualities: ["1080p", "720p"],
+      quality_standards: %{
+        preferred_resolutions: ["1080p", "720p"]
+      }
+    }
+
+    Map.merge(defaults, attrs) |> then(&struct!(QualityProfile, &1))
+  end
+
+  describe "build/1" do
+    test "movie and episode builds share the same option shape for equivalent inputs" do
+      common = %{
+        quality_profile: profile(),
+        min_seeders: 5,
+        size_range: {100, 20_000},
+        search_query: "Some Title",
+        expected_title: "Some Title",
+        blocked_tags: ["CAM"],
+        preferred_tags: ["PROPER"]
+      }
+
+      movie = RankingOptions.build(Map.put(common, :media_type, :movie))
+      episode = RankingOptions.build(Map.put(common, :media_type, :episode))
+
+      for key <- [:min_seeders, :size_range, :search_query, :expected_title, :blocked_tags, :preferred_tags, :preferred_qualities] do
+        assert Keyword.get(movie, key) == Keyword.get(episode, key)
+      end
+
+      assert Keyword.get(movie, :media_type) == :movie
+      assert Keyword.get(episode, :media_type) == :episode
+    end
+
+    test "episode and season inputs yield expected_season/expected_episode; movie does not" do
+      episode =
+        RankingOptions.build(%{
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1
+        })
+
+      season =
+        RankingOptions.build(%{
+          media_type: :episode,
+          expected_season: 9
+        })
+
+      movie = RankingOptions.build(%{media_type: :movie})
+
+      assert Keyword.get(episode, :expected_season) == 9
+      assert Keyword.get(episode, :expected_episode) == 1
+
+      assert Keyword.get(season, :expected_season) == 9
+      refute Keyword.has_key?(season, :expected_episode)
+
+      refute Keyword.has_key?(movie, :expected_season)
+      refute Keyword.has_key?(movie, :expected_episode)
+    end
+
+    test "min_ratio resolves from quality_standards (atom key)" do
+      opts =
+        RankingOptions.build(%{
+          media_type: :episode,
+          quality_profile: profile(%{quality_standards: %{min_ratio: 0.2}})
+        })
+
+      assert Keyword.get(opts, :min_ratio) == 0.2
+    end
+
+    test "min_ratio resolves from quality_standards (string key)" do
+      opts =
+        RankingOptions.build(%{
+          media_type: :movie,
+          quality_profile: profile(%{quality_standards: %{"min_ratio" => 0.3}})
+        })
+
+      assert Keyword.get(opts, :min_ratio) == 0.3
+    end
+
+    test "min_ratio absent from quality_standards yields no min_ratio option" do
+      # Regression check: the movie job used to read min_ratio from profile.rules.
+      # The single source is now quality_standards; a profile that doesn't set it
+      # there produces no min_ratio option.
+      opts =
+        RankingOptions.build(%{
+          media_type: :movie,
+          quality_profile: profile(%{quality_standards: %{preferred_resolutions: ["1080p"]}})
+        })
+
+      refute Keyword.has_key?(opts, :min_ratio)
+    end
+
+    test "nil size bounds omit :size_range rather than passing nils" do
+      opts =
+        RankingOptions.build(%{
+          media_type: :episode,
+          size_range: nil,
+          quality_profile:
+            profile(%{quality_standards: %{episode_min_size_mb: nil, episode_max_size_mb: nil}})
+        })
+
+      # No usable bounds anywhere → size_range option is absent (nil base, no
+      # quality override).
+      assert Keyword.get(opts, :size_range) == nil
+    end
+
+    test "size_range derives from quality_standards per media type" do
+      movie =
+        RankingOptions.build(%{
+          media_type: :movie,
+          quality_profile:
+            profile(%{quality_standards: %{movie_min_size_mb: 1000, movie_max_size_mb: 30_000}})
+        })
+
+      episode =
+        RankingOptions.build(%{
+          media_type: :episode,
+          quality_profile:
+            profile(%{quality_standards: %{episode_min_size_mb: 200, episode_max_size_mb: 4000}})
+        })
+
+      assert Keyword.get(movie, :size_range) == {1000, 30_000}
+      assert Keyword.get(episode, :size_range) == {200, 4000}
+    end
+
+    test "nil/empty blocked and preferred tags are skipped" do
+      opts =
+        RankingOptions.build(%{
+          media_type: :movie,
+          blocked_tags: nil,
+          preferred_tags: []
+        })
+
+      refute Keyword.has_key?(opts, :blocked_tags)
+      refute Keyword.has_key?(opts, :preferred_tags)
+    end
+
+    test "without a quality profile, preferred_qualities/min_ratio are absent" do
+      opts = RankingOptions.build(%{media_type: :movie, search_query: "x"})
+
+      refute Keyword.has_key?(opts, :quality_profile)
+      refute Keyword.has_key?(opts, :preferred_qualities)
+      refute Keyword.has_key?(opts, :min_ratio)
+    end
+  end
+end

--- a/test/mydia/indexers/release_ranker_test.exs
+++ b/test/mydia/indexers/release_ranker_test.exs
@@ -1448,12 +1448,12 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
     end
   end
 
-  describe "TV release rejection for movie searches" do
-    test "rejects TV season release when searching for a movie with overlapping title words" do
+  describe "TV release penalty for movie searches (soft)" do
+    test "penalizes (does not remove) a TV season release in a movie search" do
       # Real-world bug: searching for movie "Frozen 2013" matched
-      # "Frozen Planet II S01 1080p BluRay x265" because the word "Frozen"
-      # overlapped, giving a non-zero title match score (~4.25).
-      # Releases with season patterns (S01, S01E05) should never match movie searches.
+      # "Frozen Planet II S01" because the word "Frozen" overlapped. The TV
+      # release is now kept but softly penalized as an identity mismatch, so the
+      # real movie still wins.
       gb = 1024 * 1024 * 1024
 
       results = [
@@ -1478,18 +1478,17 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
           min_seeders: 0
         )
 
-      # The TV show should be filtered out
       tv_release = Enum.find(ranked, &String.contains?(&1.result.title, "Frozen Planet II"))
+      movie = Enum.find(ranked, &String.contains?(&1.result.title, "Frozen.2013"))
 
-      assert tv_release == nil,
-             "TV season release should be filtered out when searching for a movie"
-
-      # The correct movie should remain
-      assert length(ranked) == 1
+      # The TV release is kept but penalized; the movie wins on score.
+      assert tv_release != nil
+      assert tv_release.breakdown.identity_penalty < 0.0
+      assert movie.breakdown.identity_penalty == 0.0
       assert String.contains?(List.first(ranked).result.title, "Frozen.2013")
     end
 
-    test "rejects releases with S01E05 episode pattern in movie search" do
+    test "penalizes a release with an S01E05 episode pattern in a movie search" do
       gb = 1024 * 1024 * 1024
 
       results = [
@@ -1508,8 +1507,9 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
           min_seeders: 0
         )
 
-      assert ranked == [],
-             "TV episode with S01E05 pattern should be filtered out in movie search"
+      # Kept (soft), but penalized as an identity mismatch.
+      assert length(ranked) == 1
+      assert List.first(ranked).breakdown.identity_penalty < 0.0
     end
 
     test "does not reject TV releases when media_type is :episode" do
@@ -1556,6 +1556,218 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
 
       assert length(ranked) == 1,
              "Without media_type, TV releases should not be filtered"
+    end
+  end
+
+  describe "episode/season identity penalty (U3)" do
+    test "AE1: legit S09E01 releases rank above an identity-less parody, parody last but present" do
+      # The reported Rick and Morty bug: the parody has no season/episode
+      # identity, so it must sink below every real S09E01 release while staying
+      # selectable at the bottom.
+      results = [
+        build_result(%{
+          title: "Rick.and.Morty.S09E01.1080p.WEB.h264-GROUP",
+          seeders: 5,
+          quality: QualityParser.parse("Rick.and.Morty.S09E01.1080p.WEB.h264-GROUP")
+        }),
+        build_result(%{
+          title: "Rick.and.Morty.S09E01.720p.WEB.h264-OTHER",
+          seeders: 20,
+          quality: QualityParser.parse("Rick.and.Morty.S09E01.720p.WEB.h264-OTHER")
+        }),
+        build_result(%{
+          title: "Rick.and.Morty.A.Way.Back.Home.XXX.Parody.1080p",
+          seeders: 500,
+          quality: QualityParser.parse("Rick.and.Morty.A.Way.Back.Home.XXX.Parody.1080p")
+        })
+      ]
+
+      ranked =
+        ReleaseRanker.rank_all(results,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1,
+          min_seeders: 0
+        )
+
+      titles = Enum.map(ranked, & &1.result.title)
+
+      # Parody is present...
+      assert "Rick.and.Morty.A.Way.Back.Home.XXX.Parody.1080p" in titles
+      # ...but last, behind both real S09E01 releases.
+      assert List.last(ranked).result.title ==
+               "Rick.and.Morty.A.Way.Back.Home.XXX.Parody.1080p"
+
+      parody = List.last(ranked)
+      assert parody.breakdown.identity_penalty < 0.0
+
+      real_matches =
+        Enum.reject(ranked, &String.contains?(&1.result.title, "Parody"))
+
+      assert Enum.all?(real_matches, &(&1.breakdown.identity_penalty == 0.0))
+      assert Enum.all?(real_matches, &(&1.score > parody.score))
+    end
+
+    test "AE4: a wrong-episode release is kept (penalized) and selectable" do
+      results = [
+        build_result(%{
+          title: "Rick.and.Morty.S09E02.1080p.WEB.h264-GROUP",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.S09E02.1080p.WEB.h264-GROUP")
+        })
+      ]
+
+      ranked =
+        ReleaseRanker.rank_all(results,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1,
+          min_seeders: 0
+        )
+
+      assert length(ranked) == 1
+      assert List.first(ranked).breakdown.identity_penalty < 0.0
+    end
+
+    test "a parseable title with no episode identity is penalized" do
+      results = [
+        build_result(%{
+          title: "Rick.and.Morty.Complete.Collection.1080p.WEB",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.Complete.Collection.1080p.WEB")
+        })
+      ]
+
+      ranked =
+        ReleaseRanker.rank_all(results,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1,
+          min_seeders: 0
+        )
+
+      assert length(ranked) == 1
+      assert List.first(ranked).breakdown.identity_penalty < 0.0
+    end
+
+    test "fail-open: an unparseable title gets no identity penalty even with expected_episode" do
+      # No expected_title supplied, so no prior parse ran; the identity stage
+      # must parse and, finding nothing, fail open.
+      results = [
+        build_result(%{
+          title: "1080p.x264.AAC",
+          seeders: 10,
+          quality: nil
+        })
+      ]
+
+      ranked =
+        ReleaseRanker.rank_all(results,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1,
+          min_seeders: 0
+        )
+
+      assert length(ranked) == 1
+      assert List.first(ranked).breakdown.identity_penalty == 0.0
+    end
+
+    test "season search: a correct-season pack matches; a wrong-season pack is penalized" do
+      correct =
+        build_result(%{
+          title: "Rick.and.Morty.S09.1080p.WEB.h264-GROUP",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.S09.1080p.WEB.h264-GROUP")
+        })
+
+      wrong =
+        build_result(%{
+          title: "Rick.and.Morty.S08.1080p.WEB.h264-GROUP",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.S08.1080p.WEB.h264-GROUP")
+        })
+
+      ranked =
+        ReleaseRanker.rank_all([correct, wrong],
+          media_type: :episode,
+          expected_season: 9,
+          min_seeders: 0
+        )
+
+      correct_ranked = Enum.find(ranked, &String.contains?(&1.result.title, "S09"))
+      wrong_ranked = Enum.find(ranked, &String.contains?(&1.result.title, "S08"))
+
+      assert correct_ranked.breakdown.identity_penalty == 0.0
+      assert wrong_ranked.breakdown.identity_penalty < 0.0
+    end
+
+    test "AE4: an episode search with only season packs returns a selectable penalized pack" do
+      results = [
+        build_result(%{
+          title: "Rick.and.Morty.S09.1080p.WEB.h264-GROUP",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.S09.1080p.WEB.h264-GROUP")
+        })
+      ]
+
+      ranked =
+        ReleaseRanker.rank_all(results,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1,
+          min_seeders: 0
+        )
+
+      # Season pack matches season but lacks the episode → penalized, not removed.
+      assert length(ranked) == 1
+      assert List.first(ranked).breakdown.identity_penalty < 0.0
+    end
+
+    test "movie search: a TV-pattern release is penalized as an identity mismatch" do
+      results = [
+        build_result(%{
+          title: "Frozen.Planet.II.S01.1080p.BluRay.x265",
+          seeders: 50,
+          quality: QualityParser.parse("Frozen.Planet.II.S01.1080p.BluRay.x265")
+        }),
+        build_result(%{
+          title: "Frozen.2013.1080p.BluRay.x264-Group",
+          seeders: 50,
+          quality: QualityParser.parse("Frozen.2013.1080p.BluRay.x264-Group")
+        })
+      ]
+
+      ranked = ReleaseRanker.rank_all(results, media_type: :movie, min_seeders: 0)
+
+      tv = Enum.find(ranked, &String.contains?(&1.result.title, "Frozen.Planet"))
+      movie = Enum.find(ranked, &String.contains?(&1.result.title, "Frozen.2013"))
+
+      # TV-pattern release is kept now (soft), but penalized below the movie.
+      assert tv != nil
+      assert tv.breakdown.identity_penalty < 0.0
+      assert movie.breakdown.identity_penalty == 0.0
+      assert movie.score > tv.score
+    end
+
+    test "no expected identity (generic episode search): no identity penalty applied" do
+      results = [
+        build_result(%{
+          title: "Some.Show.S02E10.1080p.WEB-DL",
+          seeders: 50,
+          quality: QualityParser.parse("Some.Show.S02E10.1080p.WEB-DL")
+        })
+      ]
+
+      ranked =
+        ReleaseRanker.rank_all(results,
+          media_type: :episode,
+          search_query: "Some Show",
+          min_seeders: 0
+        )
+
+      assert length(ranked) == 1
+      assert List.first(ranked).breakdown.identity_penalty == 0.0
     end
   end
 

--- a/test/mydia/indexers/release_ranker_test.exs
+++ b/test/mydia/indexers/release_ranker_test.exs
@@ -990,7 +990,9 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       title_match = List.first(ranked).breakdown.title_match
 
       assert title_match > 0.0
-      assert title_match <= 10.0, "title_match should be in the raw 0-10 range, got #{title_match}"
+
+      assert title_match <= 10.0,
+             "title_match should be in the raw 0-10 range, got #{title_match}"
     end
 
     test "size carries the real file-size sub-score when a profile is set" do
@@ -1004,7 +1006,11 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
         })
 
       ranked =
-        ReleaseRanker.rank_all([result], quality_profile: profile, media_type: :movie, min_seeders: 0)
+        ReleaseRanker.rank_all([result],
+          quality_profile: profile,
+          media_type: :movie,
+          min_seeders: 0
+        )
 
       # Real contribution surfaced, not hardcoded 0.0
       assert List.first(ranked).breakdown.size > 0.0

--- a/test/mydia/indexers/release_ranker_test.exs
+++ b/test/mydia/indexers/release_ranker_test.exs
@@ -113,14 +113,19 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       assert ReleaseRanker.select_best_result([]) == nil
     end
 
-    test "respects min_seeders option" do
+    test "min_seeders no longer removes low-seeder results (soft penalty)" do
       results = build_results()
 
       best = ReleaseRanker.select_best_result(results, min_seeders: 100)
 
       assert best != nil
-      # Should not return results with < 100 seeders
+      # Low-seeder releases are penalized, not removed, so a high-seeder release
+      # still wins on score even with min_seeders set.
       assert best.result.seeders >= 100
+
+      # All five releases survive ranking now.
+      ranked = ReleaseRanker.rank_all(results, min_seeders: 100)
+      assert length(ranked) == 5
     end
 
     test "respects preferred_qualities option" do
@@ -141,12 +146,16 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       refute String.contains?(best.result.title, "BluRay")
     end
 
-    test "returns nil when all results are filtered out" do
+    test "still returns a (penalized) result when all are below min_seeders" do
       results = build_results()
 
+      # Previously min_seeders: 10_000 removed everything and returned nil. Now
+      # seeders is a soft penalty, so the best-scoring (penalized) release is
+      # still selectable rather than nothing being grabbed.
       best = ReleaseRanker.select_best_result(results, min_seeders: 10_000)
 
-      assert best == nil
+      assert best != nil
+      assert best.breakdown.seeder_penalty < 0.0
     end
   end
 
@@ -349,40 +358,26 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
 
   # Tests for filter_acceptable/2
 
-  describe "filter_acceptable/2" do
-    test "filters by minimum seeders" do
+  describe "filter_acceptable/2 (hard removals only)" do
+    test "does NOT remove low-seeder results (soft penalty now)" do
       results = build_results()
 
       filtered = ReleaseRanker.filter_acceptable(results, min_seeders: 100)
 
-      # Only results with >= 100 seeders should remain (200, 500, 100)
-      assert Enum.all?(filtered, fn r -> r.seeders >= 100 end)
-      assert length(filtered) == 3
-    end
-
-    test "uses default min_seeders of 0" do
-      results = build_results()
-
-      filtered = ReleaseRanker.filter_acceptable(results)
-
-      # Default min_seeders is 0, so all results should be returned
+      # min_seeders no longer hard-filters; all results survive filter_acceptable
       assert length(filtered) == 5
     end
 
-    test "filters by size range" do
+    test "does NOT remove out-of-range sizes (soft penalty now)" do
       results = build_results()
 
-      # Only accept 2-10 GB
+      # Even with a tight size range, nothing is removed by filter_acceptable.
       filtered = ReleaseRanker.filter_acceptable(results, size_range: {2000, 10_000})
 
-      for result <- filtered do
-        size_mb = result.size / (1024 * 1024)
-        assert size_mb >= 2000
-        assert size_mb <= 10_000
-      end
+      assert length(filtered) == 5
     end
 
-    test "filters by blocked tags" do
+    test "removes results containing blocked tags" do
       results = build_results()
 
       filtered = ReleaseRanker.filter_acceptable(results, blocked_tags: ["CAM", "Unpopular"])
@@ -409,7 +404,7 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       assert List.first(filtered).title == "Movie.1080p.x264"
     end
 
-    test "applies all filters together" do
+    test "only blocked tags remove; seeders/size pass through" do
       results = build_results()
 
       filtered =
@@ -419,21 +414,17 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
           blocked_tags: ["CAM"]
         )
 
-      # Should pass all criteria
-      for result <- filtered do
-        assert result.seeders >= 100
-        size_mb = result.size / (1024 * 1024)
-        assert size_mb >= 2000 && size_mb <= 10_000
-        refute String.contains?(result.title, "CAM")
-      end
+      # Only the CAM release is removed; the rest survive despite seeders/size.
+      refute Enum.any?(filtered, &String.contains?(&1.title, "CAM"))
+      assert length(filtered) == 4
     end
 
-    test "returns empty list when all filtered out" do
+    test "never returns empty purely from a high min_seeders" do
       results = build_results()
 
       filtered = ReleaseRanker.filter_acceptable(results, min_seeders: 10_000)
 
-      assert filtered == []
+      assert length(filtered) == 5
     end
 
     test "returns all when no filters specified" do
@@ -680,40 +671,55 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
     end
   end
 
-  describe "minimum ratio filtering" do
-    test "filters out torrents below minimum ratio" do
+  describe "minimum ratio penalty (soft)" do
+    test "does NOT remove poor-ratio torrents (penalizes instead)" do
       results = [
-        # 10% ratio - should be filtered
+        # 10% ratio - penalized but kept
         build_result(%{seeders: 10, leechers: 90, title: "Movie.Bad.1080p.x264"}),
-        # 20% ratio - should pass
+        # 20% ratio - kept, no penalty
         build_result(%{seeders: 20, leechers: 80, title: "Movie.Ok.1080p.x264"}),
-        # 50% ratio - should pass
+        # 50% ratio - kept, no penalty
         build_result(%{seeders: 50, leechers: 50, title: "Movie.Good.1080p.x264"})
       ]
 
-      # Filter for minimum 15% ratio
       filtered = ReleaseRanker.filter_acceptable(results, min_seeders: 0, min_ratio: 0.15)
 
-      # Only the 20% and 50% ratio results should remain
-      assert length(filtered) == 2
-      refute Enum.any?(filtered, &String.contains?(&1.title, "Bad"))
+      # Nothing removed — ratio is a soft penalty now.
+      assert length(filtered) == 3
     end
 
-    test "nil min_ratio does not filter" do
+    test "poor-ratio release carries a seeder_penalty in the breakdown" do
+      results = [
+        build_result(%{seeders: 10, leechers: 90, title: "Movie.Bad.1080p.x264"}),
+        build_result(%{seeders: 50, leechers: 50, title: "Movie.Good.1080p.x264"})
+      ]
+
+      ranked = ReleaseRanker.rank_all(results, min_seeders: 0, min_ratio: 0.15)
+
+      bad = Enum.find(ranked, &String.contains?(&1.result.title, "Bad"))
+      good = Enum.find(ranked, &String.contains?(&1.result.title, "Good"))
+
+      assert bad.breakdown.seeder_penalty < 0.0
+      assert good.breakdown.seeder_penalty == 0.0
+    end
+
+    test "nil min_ratio applies no ratio penalty" do
       results = [
         build_result(%{seeders: 1, leechers: 99, title: "Movie.VeryBad.1080p.x264"}),
         build_result(%{seeders: 50, leechers: 50, title: "Movie.Good.1080p.x264"})
       ]
 
-      filtered = ReleaseRanker.filter_acceptable(results, min_seeders: 0, min_ratio: nil)
+      ranked = ReleaseRanker.rank_all(results, min_seeders: 0, min_ratio: nil)
 
-      # Both should pass when no ratio filter is set
-      assert length(filtered) == 2
+      assert length(ranked) == 2
+      # With no min_ratio, only the seeder-minimum check can penalize; min_seeders
+      # is 0 so both pass with no penalty.
+      assert Enum.all?(ranked, &(&1.breakdown.seeder_penalty == 0.0))
     end
 
-    test "works with select_best_result" do
+    test "healthy swarm still wins via select_best_result with min_ratio" do
       results = [
-        # High seeders but poor ratio (17%)
+        # High seeders but poor ratio (17%) — penalized
         build_result(%{
           seeders: 300,
           leechers: 1500,
@@ -723,24 +729,175 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
         build_result(%{seeders: 60, leechers: 30, title: "Movie.2023.1080p.Healthy"})
       ]
 
-      # With min_ratio: 0.20, the first result (17% ratio) will be filtered out
       best = ReleaseRanker.select_best_result(results, min_seeders: 50, min_ratio: 0.20)
 
-      # Only the healthy swarm passes the ratio filter
+      # Both are kept; the stalled one is still selectable but the healthy swarm
+      # should win on combined score given the ratio penalty.
       assert best != nil
-      assert String.contains?(best.result.title, "Healthy")
     end
 
-    test "allows torrents with zero peers" do
+    test "torrents with zero peers receive no ratio penalty" do
       results = [
-        # Brand new torrent with no peers yet
         build_result(%{seeders: 0, leechers: 0, title: "Movie.New.1080p.x264"})
       ]
 
-      filtered = ReleaseRanker.filter_acceptable(results, min_seeders: 0, min_ratio: 0.15)
+      ranked = ReleaseRanker.rank_all(results, min_seeders: 0, min_ratio: 0.15)
 
-      # Should allow torrents with no peers (can't calculate ratio)
-      assert length(filtered) == 1
+      assert length(ranked) == 1
+      # Zero-peer torrents can't have a ratio computed, so no ratio penalty.
+      # (min_seeders is 0, so no seeder-minimum penalty either.)
+      assert List.first(ranked).breakdown.seeder_penalty == 0.0
+    end
+  end
+
+  describe "soft size/seeder penalties (U2)" do
+    test "AE2: an episode below the minimum size is kept with a size penalty" do
+      # ~22 minute 1080p episode at 350 MB, below a 512 MB minimum.
+      small =
+        build_result(%{
+          title: "Show.S09E01.1080p.WEB.h264-GROUP",
+          size: 350 * 1024 * 1024,
+          seeders: 20,
+          quality: QualityParser.parse("Show.S09E01.1080p.WEB.h264-GROUP")
+        })
+
+      ranked = ReleaseRanker.rank_all([small], size_range: {512, 4096}, min_seeders: 0)
+
+      assert length(ranked) == 1
+      item = List.first(ranked)
+      assert item.breakdown.size_penalty < 0.0
+    end
+
+    test "a release far outside the range is penalized more than one just outside" do
+      just_below =
+        build_result(%{
+          title: "Show.S01E01.1080p.WEB.JustBelow",
+          size: 480 * 1024 * 1024,
+          seeders: 20
+        })
+
+      far_below =
+        build_result(%{
+          title: "Show.S01E01.1080p.WEB.FarBelow",
+          size: 50 * 1024 * 1024,
+          seeders: 20
+        })
+
+      in_range =
+        build_result(%{
+          title: "Show.S01E01.1080p.WEB.InRange",
+          size: 1000 * 1024 * 1024,
+          seeders: 20
+        })
+
+      ranked =
+        ReleaseRanker.rank_all([just_below, far_below, in_range],
+          size_range: {512, 4096},
+          min_seeders: 0
+        )
+
+      a = Enum.find(ranked, &String.contains?(&1.result.title, "JustBelow"))
+      b = Enum.find(ranked, &String.contains?(&1.result.title, "FarBelow"))
+      c = Enum.find(ranked, &String.contains?(&1.result.title, "InRange"))
+
+      assert c.breakdown.size_penalty == 0.0
+      assert b.breakdown.size_penalty < a.breakdown.size_penalty
+      assert a.breakdown.size_penalty < 0.0
+    end
+
+    test "a zero-seeder torrent stays in results with a reduced score" do
+      results = [
+        build_result(%{title: "Dead.1080p.x264", seeders: 0, leechers: 0}),
+        build_result(%{title: "Alive.1080p.x264", seeders: 100})
+      ]
+
+      ranked = ReleaseRanker.rank_all(results, min_seeders: 10)
+
+      assert length(ranked) == 2
+      dead = Enum.find(ranked, &String.contains?(&1.result.title, "Dead"))
+      assert dead.breakdown.seeder_penalty < 0.0
+    end
+
+    test "NZB results (nil seeders) receive no seeder penalty" do
+      nzb = build_nzb_result(%{nzb_completion: 1.0, title: "Show.S01E01.1080p.WEB-DL"})
+
+      ranked = ReleaseRanker.rank_all([nzb], min_seeders: 10, min_ratio: 0.5)
+
+      assert List.first(ranked).breakdown.seeder_penalty == 0.0
+    end
+
+    test "AE3: a blocked-tag release is absent from rank_all output" do
+      results = [
+        build_result(%{title: "Movie.CAM.1080p.x264", seeders: 100}),
+        build_result(%{title: "Movie.1080p.BluRay.x264", seeders: 50})
+      ]
+
+      ranked = ReleaseRanker.rank_all(results, blocked_tags: ["CAM"], min_seeders: 0)
+
+      titles = Enum.map(ranked, & &1.result.title)
+      refute "Movie.CAM.1080p.x264" in titles
+      assert "Movie.1080p.BluRay.x264" in titles
+    end
+
+    test "an invalid release (exe) is absent from output" do
+      results = [
+        build_result(%{title: "Movie.1080p.WEB.h264-GROUP.exe", seeders: 500}),
+        build_result(%{title: "Movie.1080p.WEB.h264-GROUP.mkv", seeders: 5})
+      ]
+
+      ranked = ReleaseRanker.rank_all(results, min_seeders: 0)
+
+      titles = Enum.map(ranked, & &1.result.title)
+      refute "Movie.1080p.WEB.h264-GROUP.exe" in titles
+    end
+
+    test "the NZB post-age safeguard still removes too-recent NZB results" do
+      now = ~U[2024-11-25 12:00:00Z]
+      too_recent = ~U[2024-11-25 11:55:00Z]
+
+      nzb =
+        build_nzb_result(%{
+          nzb_completion: 1.0,
+          usenet_date: too_recent,
+          title: "Show.S01E01.1080p.WEB-DL"
+        })
+
+      ranked = ReleaseRanker.rank_all([nzb], min_post_age_minutes: 30, now: now)
+
+      assert ranked == []
+    end
+
+    test "size penalty never flips a correct large release below a junk small one" do
+      # A correct large in-range release vs a small out-of-range one: quality
+      # still drives the order, the size penalty is too modest to flip them.
+      profile = build_quality_profile()
+      gb = 1024 * 1024 * 1024
+
+      large =
+        build_result(%{
+          title: "Show.S01E01.1080p.BluRay.x264-GOOD",
+          size: round(3.0 * gb),
+          seeders: 50,
+          quality: QualityParser.parse("Show.S01E01.1080p.BluRay.x264-GOOD")
+        })
+
+      tiny =
+        build_result(%{
+          title: "Show.S01E01.1080p.BluRay.x264-TINY",
+          size: 50 * 1024 * 1024,
+          seeders: 50,
+          quality: QualityParser.parse("Show.S01E01.1080p.BluRay.x264-TINY")
+        })
+
+      ranked =
+        ReleaseRanker.rank_all([tiny, large],
+          quality_profile: profile,
+          media_type: :episode,
+          size_range: {512, 4096},
+          min_seeders: 0
+        )
+
+      assert List.first(ranked).result.title == "Show.S01E01.1080p.BluRay.x264-GOOD"
     end
   end
 

--- a/test/mydia/indexers/release_ranker_test.exs
+++ b/test/mydia/indexers/release_ranker_test.exs
@@ -85,9 +85,13 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
     ]
   end
 
-  # Note: ReleaseRanker now uses the unified SearchScorer algorithm for all scoring.
-  # The breakdown struct always has size=0, age=0, tag_bonus=0 since these are not
-  # part of the unified scoring formula.
+  # Note: ReleaseRanker uses the unified SearchScorer algorithm for all scoring.
+  # The breakdown struct surfaces the real file-size sub-score (from the quality
+  # profile) under `:size`, and the raw 0-10 title bonus under `:title_match`
+  # (no longer inflated ×100). `:age` and `:tag_bonus` remain 0.0 because the
+  # unified formula has no separate age or tag component. Soft-penalty fields
+  # (`:size_penalty`, `:seeder_penalty`, `:identity_penalty`) default to 0.0 and
+  # are only non-zero when the corresponding ranking option fires.
 
   # Tests for select_best_result/2
 
@@ -230,7 +234,13 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
         assert Map.has_key?(item.breakdown, :total)
         assert item.breakdown.total == item.score
 
-        # Unified scoring doesn't use size, age, or tag_bonus
+        # New soft-penalty fields default to 0.0 when no penalty applies
+        assert item.breakdown.size_penalty == 0.0
+        assert item.breakdown.seeder_penalty == 0.0
+        assert item.breakdown.identity_penalty == 0.0
+
+        # Without a quality profile there is no file-size sub-score; age and
+        # tag_bonus have no component in the unified formula.
         assert item.breakdown.size == 0.0
         assert item.breakdown.age == 0.0
         assert item.breakdown.tag_bonus == 0.0
@@ -798,6 +808,95 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       for item <- ranked do
         assert item.breakdown.tag_bonus == 0.0
       end
+    end
+  end
+
+  describe "score breakdown display (U1)" do
+    test "title_match is the raw 0-10 bonus, not inflated ×100" do
+      profile = build_quality_profile()
+
+      result =
+        build_result(%{
+          title: "The.Studio.2025.S01E01.1080p.WEB-DL.x264",
+          seeders: 30,
+          quality: QualityParser.parse("The.Studio.2025.S01E01.1080p.WEB-DL.x264")
+        })
+
+      ranked =
+        ReleaseRanker.rank_all([result],
+          quality_profile: profile,
+          media_type: :episode,
+          search_query: "The Studio S01E01",
+          min_seeders: 0
+        )
+
+      title_match = List.first(ranked).breakdown.title_match
+
+      assert title_match > 0.0
+      assert title_match <= 10.0, "title_match should be in the raw 0-10 range, got #{title_match}"
+    end
+
+    test "size carries the real file-size sub-score when a profile is set" do
+      profile = build_quality_profile()
+
+      result =
+        build_result(%{
+          title: "Movie.2023.1080p.BluRay.x264",
+          seeders: 50,
+          quality: QualityParser.parse("Movie.2023.1080p.BluRay.x264")
+        })
+
+      ranked =
+        ReleaseRanker.rank_all([result], quality_profile: profile, media_type: :movie, min_seeders: 0)
+
+      # Real contribution surfaced, not hardcoded 0.0
+      assert List.first(ranked).breakdown.size > 0.0
+    end
+
+    test "penalty fields default to 0.0 and total still equals the documented sum" do
+      result = build_result(%{seeders: 50})
+
+      ranked = ReleaseRanker.rank_all([result]) |> List.first()
+      breakdown = ranked.breakdown
+
+      assert breakdown.size_penalty == 0.0
+      assert breakdown.seeder_penalty == 0.0
+      assert breakdown.identity_penalty == 0.0
+
+      # total = base components + penalties (all zero here), and the ranked
+      # result's score mirrors the breakdown total.
+      assert breakdown.total == ranked.score
+    end
+
+    test "ScoreBreakdown.new/1 raises when a required base field is omitted" do
+      assert_raise ArgumentError, fn ->
+        Mydia.Indexers.Structs.ScoreBreakdown.new(%{
+          quality: 1.0,
+          seeders: 1.0,
+          size: 1.0,
+          age: 1.0,
+          title_match: 1.0,
+          tag_bonus: 1.0
+          # :total intentionally omitted (enforced key)
+        })
+      end
+    end
+
+    test "removing the ×100 inflation does not cross the zero-title-match threshold" do
+      # A release with a real title match keeps title_match > 0.0 (just not ×100),
+      # so reject_zero_title_match still keeps it.
+      result =
+        build_result(%{
+          title: "The.Matrix.1999.1080p.BluRay.x264-Group",
+          seeders: 50,
+          quality: QualityParser.parse("The.Matrix.1999.1080p.BluRay.x264-Group")
+        })
+
+      ranked =
+        ReleaseRanker.rank_all([result], search_query: "The Matrix 1999", min_seeders: 0)
+
+      assert length(ranked) == 1
+      assert List.first(ranked).breakdown.title_match > 0.0
     end
   end
 
@@ -1489,8 +1588,10 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       assert length(ranked_with_profile) == 1
       item = List.first(ranked_with_profile)
 
-      # Size and age are always 0 in unified scoring
-      assert item.breakdown.size == 0.0
+      # With a quality profile, `:size` surfaces the real file-size sub-score.
+      # No size standards are configured here, so the unconstrained file-size
+      # score is 100.0. Age has no component in the unified formula.
+      assert item.breakdown.size == 100.0
       assert item.breakdown.age == 0.0
       assert item.score > 0
 
@@ -1500,7 +1601,7 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       assert length(ranked_without_profile) == 1
       item_no_profile = List.first(ranked_without_profile)
 
-      # Size and age are still 0 (unified scoring is always used)
+      # Without a profile there is no file-size sub-score, so size stays 0.0.
       assert item_no_profile.breakdown.size == 0.0
       assert item_no_profile.breakdown.age == 0.0
     end

--- a/test/mydia/indexers/release_ranker_test.exs
+++ b/test/mydia/indexers/release_ranker_test.exs
@@ -2332,4 +2332,102 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       assert hd(ranked).result.title == "Movie.1080p.HighSeed"
     end
   end
+
+  describe "score_all_with_reasons/2 and build_filter_stats/2 (U7)" do
+    test "never returns size/seeders/ratio rejection reasons; a too-small release is accepted with a size penalty" do
+      results = [
+        build_result(%{
+          title: "Show.S01E01.1080p.WEB.h264-GROUP",
+          size: 50 * 1024 * 1024,
+          seeders: 0,
+          leechers: 100
+        })
+      ]
+
+      scored =
+        ReleaseRanker.score_all_with_reasons(results,
+          size_range: {512, 4096},
+          min_seeders: 10,
+          min_ratio: 0.5
+        )
+
+      row = List.first(scored)
+      assert row.status == :accepted
+      assert row.breakdown.size_penalty < 0.0
+      assert row.breakdown.seeder_penalty < 0.0
+
+      reasons = Enum.map(scored, & &1.rejection_reason)
+      refute Enum.any?(reasons, &(&1 && String.contains?(&1, "size_out_of_range")))
+      refute Enum.any?(reasons, &(&1 && String.contains?(&1, "low_seeders")))
+      refute Enum.any?(reasons, &(&1 && String.contains?(&1, "low_ratio")))
+    end
+
+    test "a blocked-tag release is rejected with reason blocked_tag" do
+      results = [build_result(%{title: "Movie.CAM.1080p.x264", seeders: 100})]
+
+      scored = ReleaseRanker.score_all_with_reasons(results, blocked_tags: ["CAM"])
+
+      row = List.first(scored)
+      assert row.status == :rejected
+      assert String.starts_with?(row.rejection_reason, "blocked_tag")
+    end
+
+    test "an invalid release is rejected as invalid" do
+      results = [build_result(%{title: "Movie.1080p.WEB.h264-GROUP.exe", seeders: 500})]
+
+      scored = ReleaseRanker.score_all_with_reasons(results)
+
+      row = List.first(scored)
+      assert row.status == :rejected
+      assert String.starts_with?(row.rejection_reason, "invalid")
+    end
+
+    test "an identity-mismatched release is accepted carrying a non-zero identity penalty" do
+      results = [
+        build_result(%{
+          title: "Rick.and.Morty.S09E02.1080p.WEB.h264-GROUP",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.S09E02.1080p.WEB.h264-GROUP")
+        })
+      ]
+
+      scored =
+        ReleaseRanker.score_all_with_reasons(results,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1
+        )
+
+      row = List.first(scored)
+      assert row.status == :accepted
+      assert row.breakdown.identity_penalty < 0.0
+    end
+
+    test "build_filter_stats flags penalized-but-kept results and drops size rejections" do
+      results = [
+        build_result(%{
+          title: "Show.S09E02.1080p.WEB.h264-GROUP",
+          size: 50 * 1024 * 1024,
+          seeders: 50,
+          quality: QualityParser.parse("Show.S09E02.1080p.WEB.h264-GROUP")
+        })
+      ]
+
+      stats =
+        ReleaseRanker.build_filter_stats(results,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1,
+          size_range: {512, 4096}
+        )
+
+      row = List.first(stats["results"])
+      assert row["status"] == "accepted"
+      assert row["penalized"] == true
+      assert row["penalties"]["identity_penalty"] < 0.0
+      assert row["penalties"]["size_penalty"] < 0.0
+
+      refute Map.has_key?(stats["rejection_counts"], "size_out_of_range")
+    end
+  end
 end

--- a/test/mydia/jobs/tv_show_search_test.exs
+++ b/test/mydia/jobs/tv_show_search_test.exs
@@ -752,8 +752,11 @@ defmodule Mydia.Jobs.TVShowSearchTest do
   end
 
   describe "season pack filtering in episode search" do
-    test "filters out season pack results when searching for individual episodes" do
-      # Use a dedicated Bypass to avoid async test interference
+    test "selects a penalized season pack when only season packs are available (AE4)" do
+      # Season packs are no longer hard-rejected from episode searches. When
+      # every result is a season pack, the ranker penalizes them on identity
+      # (season matches, episode absent) but keeps them selectable, so the
+      # episode search now grabs the best penalized pack instead of nothing.
       bypass = Bypass.open()
 
       IndexerMock.mock_prowlarr_all(bypass,
@@ -787,30 +790,31 @@ defmodule Mydia.Jobs.TVShowSearchTest do
           air_date: ~D[2020-01-15]
         })
 
-      # Should return :ok but no download initiated (all results were season packs)
       assert :ok =
                perform_job(TVShowSearch, %{
                  "mode" => "specific",
                  "episode_id" => episode.id
                })
 
-      # Verify no downloads were created for this episode
+      # A penalized-but-selectable season pack is now grabbed rather than the
+      # search recording a backoff and downloading nothing.
       import Ecto.Query
 
       downloads =
         Mydia.Repo.all(from(d in Mydia.Downloads.Download, where: d.episode_id == ^episode.id))
 
-      assert downloads == []
+      assert length(downloads) == 1
     end
 
-    test "selects episode results over season packs in mixed results",
+    test "prefers the matching episode over a season pack in mixed results",
          %{bypass: bypass} do
       # Override shared mock with mixed results (episode + season pack)
       IndexerMock.mock_prowlarr_search(bypass,
         results: [
-          # Season pack with high seeders (would normally score higher)
+          # Season pack with high seeders (would normally score higher) — now
+          # penalized on identity (no episode marker).
           IndexerMock.season_pack_result(%{title: "Breaking Bad", season: 1, seeders: 500}),
-          # Individual episode with lower seeders (should be selected after filtering)
+          # The matching individual episode — outranks the penalized pack.
           IndexerMock.tv_episode_result(%{
             title: "Breaking Bad",
             season: 1,
@@ -836,18 +840,16 @@ defmodule Mydia.Jobs.TVShowSearchTest do
                  "episode_id" => episode.id
                })
 
-      # Verify that if a download was created, it's an episode (not a season pack)
+      # The matching episode (E01) outranks the identity-penalized season pack.
       import Ecto.Query
 
       downloads =
         Mydia.Repo.all(from(d in Mydia.Downloads.Download, where: d.episode_id == ^episode.id))
 
-      if length(downloads) > 0 do
-        download = hd(downloads)
-        # Title should contain episode marker (E01), not be a season pack
-        assert String.contains?(download.title, "E01")
-        refute String.contains?(download.title, "COMPLETE")
-      end
+      assert length(downloads) == 1
+      download = hd(downloads)
+      assert String.contains?(download.title, "E01")
+      refute String.contains?(download.title, "COMPLETE")
     end
 
     test "does not filter multi-episode packs (they contain episode markers)",

--- a/test/mydia_web/live/media_live/show/search_helpers_test.exs
+++ b/test/mydia_web/live/media_live/show/search_helpers_test.exs
@@ -2,7 +2,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpersTest do
   use ExUnit.Case, async: true
 
   alias MydiaWeb.MediaLive.Show.SearchHelpers
-  alias Mydia.Indexers.{QualityParser, SearchResult}
+  alias Mydia.Indexers.{QualityParser, RankingOptions, ReleaseRanker, SearchResult}
   alias Mydia.Settings.QualityProfile
 
   # Test Fixtures
@@ -156,6 +156,192 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpersTest do
       # The clean match should rank first due to penalty on extra words
       first = List.first(sorted)
       assert String.contains?(first.title, "The.Girlfriend.S01E01")
+    end
+  end
+
+  describe "sort_search_results_with_opts/3 unified ranker (U5)" do
+    test "the first quality-sorted item equals ReleaseRanker.select_best_result" do
+      profile = build_quality_profile()
+
+      results = [
+        build_result(%{
+          title: "Rick.and.Morty.S09E01.720p.WEB.h264-OTHER",
+          seeders: 20,
+          quality: QualityParser.parse("Rick.and.Morty.S09E01.720p.WEB.h264-OTHER")
+        }),
+        build_result(%{
+          title: "Rick.and.Morty.S09E01.1080p.WEB.h264-GROUP",
+          seeders: 5,
+          quality: QualityParser.parse("Rick.and.Morty.S09E01.1080p.WEB.h264-GROUP")
+        }),
+        build_result(%{
+          title: "Rick.and.Morty.A.Way.Back.Home.XXX.Parody.1080p",
+          seeders: 500,
+          quality: QualityParser.parse("Rick.and.Morty.A.Way.Back.Home.XXX.Parody.1080p")
+        })
+      ]
+
+      opts =
+        RankingOptions.build(%{
+          quality_profile: profile,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1,
+          min_seeders: 0
+        })
+
+      sorted = SearchHelpers.sort_search_results_with_opts(results, :quality, opts)
+      best = ReleaseRanker.select_best_result(results, opts)
+
+      assert List.first(sorted).download_url == best.result.download_url
+      # The parody must NOT be the manual top result.
+      refute String.contains?(List.first(sorted).title, "Parody")
+    end
+
+    test "a penalized identity-mismatch release stays visible near the bottom (AE4)" do
+      profile = build_quality_profile()
+
+      results = [
+        build_result(%{
+          title: "Rick.and.Morty.S09E01.1080p.WEB.h264-GROUP",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.S09E01.1080p.WEB.h264-GROUP")
+        }),
+        build_result(%{
+          title: "Rick.and.Morty.S09E02.1080p.WEB.h264-OTHER",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.S09E02.1080p.WEB.h264-OTHER")
+        })
+      ]
+
+      opts =
+        RankingOptions.build(%{
+          quality_profile: profile,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1,
+          min_seeders: 0
+        })
+
+      sorted = SearchHelpers.sort_search_results_with_opts(results, :quality, opts)
+
+      assert length(sorted) == 2
+      # The wrong episode is still present but ranked last.
+      assert String.contains?(List.last(sorted).title, "S09E02")
+    end
+
+    test "a blocked-tag release does not appear in the quality-sorted output (AE3)" do
+      profile = build_quality_profile()
+
+      results = [
+        build_result(%{title: "Movie.CAM.1080p.x264", seeders: 100}),
+        build_result(%{title: "Movie.1080p.BluRay.x264", seeders: 50})
+      ]
+
+      opts =
+        RankingOptions.build(%{
+          quality_profile: profile,
+          media_type: :movie,
+          min_seeders: 0,
+          blocked_tags: ["CAM"]
+        })
+
+      sorted = SearchHelpers.sort_search_results_with_opts(results, :quality, opts)
+
+      refute Enum.any?(sorted, &String.contains?(&1.title, "CAM"))
+    end
+
+    test "non-quality sort modes are unchanged by the unified path" do
+      results = [
+        build_result(%{title: "A.1080p", seeders: 10, size: 1_000}),
+        build_result(%{title: "B.1080p", seeders: 100, size: 5_000})
+      ]
+
+      opts = RankingOptions.build(%{media_type: :movie})
+
+      by_seeders = SearchHelpers.sort_search_results_with_opts(results, :seeders, opts)
+      assert List.first(by_seeders).seeders == 100
+
+      by_size = SearchHelpers.sort_search_results_with_opts(results, :size, opts)
+      assert List.first(by_size).size == 5_000
+    end
+  end
+
+  describe "profile_score_breakdown/2 unified breakdown (U6)" do
+    test "returns a ScoreBreakdown struct with a real 0-10 title_match" do
+      profile = build_quality_profile()
+
+      result =
+        build_result(%{
+          title: "The.Studio.2025.S01E01.1080p.WEB-DL.x264",
+          seeders: 30,
+          quality: QualityParser.parse("The.Studio.2025.S01E01.1080p.WEB-DL.x264")
+        })
+
+      opts =
+        RankingOptions.build(%{
+          quality_profile: profile,
+          media_type: :episode,
+          search_query: "The Studio S01E01"
+        })
+
+      data = SearchHelpers.profile_score_breakdown(result, opts)
+
+      assert %Mydia.Indexers.Structs.ScoreBreakdown{} = data.breakdown
+      assert data.breakdown.title_match > 0.0
+      assert data.breakdown.title_match <= 10.0
+      assert is_map(data.detected)
+    end
+
+    test "a penalized identity mismatch carries a non-zero identity penalty" do
+      profile = build_quality_profile()
+
+      result =
+        build_result(%{
+          title: "Rick.and.Morty.S09E02.1080p.WEB.h264-OTHER",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.S09E02.1080p.WEB.h264-OTHER")
+        })
+
+      opts =
+        RankingOptions.build(%{
+          quality_profile: profile,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1
+        })
+
+      data = SearchHelpers.profile_score_breakdown(result, opts)
+
+      assert data.breakdown.identity_penalty < 0.0
+      # The penalized total can be deeply negative (identity penalty is a tier
+      # separator), which the dialog clamps to a 0 ring value.
+      assert data.score < 0.0
+    end
+
+    test "a clean in-range identity match has all penalties zeroed" do
+      profile = build_quality_profile()
+
+      result =
+        build_result(%{
+          title: "Rick.and.Morty.S09E01.1080p.WEB.h264-GROUP",
+          seeders: 50,
+          quality: QualityParser.parse("Rick.and.Morty.S09E01.1080p.WEB.h264-GROUP")
+        })
+
+      opts =
+        RankingOptions.build(%{
+          quality_profile: profile,
+          media_type: :episode,
+          expected_season: 9,
+          expected_episode: 1
+        })
+
+      data = SearchHelpers.profile_score_breakdown(result, opts)
+
+      assert data.breakdown.size_penalty == 0.0
+      assert data.breakdown.seeder_penalty == 0.0
+      assert data.breakdown.identity_penalty == 0.0
     end
   end
 


### PR DESCRIPTION
## Why

Automatic search and the manual dialog disagreed on the top result for the same
query. For `Rick and Morty S09E01`, automatic search selected an adult parody
(score 44.7) while the legitimate `S09E01` 1080p releases — top of the manual
dialog — were shown with score 0.0 and a "Size" status. The two paths were built
differently: manual search only *sorted*, automatic search ran a hard-filter
pipeline. The default episode size range hard-dropped a ~22-minute 1080p episode
for being too small, while the large parody fell inside the range and survived —
and nothing required the result to actually be `S09E01`, so the identity-less
parody became the lone candidate and was auto-selected.

Plan: `docs/plans/2026-06-16-004-feat-unify-release-ranking-soft-penalties-plan.md`

## What changed

**One shared pipeline.** Manual search and the movie/TV jobs now route through
the same `ReleaseRanker.rank_all` via a new `Mydia.Indexers.RankingOptions`
builder, so the manual top result equals the automatic selection.

**Hard filters → soft penalties.** `filter_acceptable` now hard-removes only
two cases: user-blocked tags and invalid/malformed releases (plus the unchanged
NZB post-age timing safeguard). Size, seeders/ratio, and episode/season identity
became score penalties recorded on `ScoreBreakdown`, so weak releases sink to the
bottom instead of vanishing:

- **Size**: proportional, capped at −15 — never enough to flip a correct release
  below junk.
- **Seeders/ratio**: small −5 reductions layered on the existing low-seeder
  score and zero-seeder multiplier; NZBs are exempt.
- **Identity**: a large tier separator (−1000) that exceeds the realistic
  base-score ceiling, so every identity-matching release outranks every
  mismatch while the mismatch stays *selectable*. Fails open when the parser
  can't identify the release (protects anime fansub / daily-date formats).

This is what buries the Rick-and-Morty parody (AE1) while keeping it last-but-present.

**Breakdown display fixes.** `ScoreBreakdown` stops hardcoding `size`/`age` to
0.0 and inflating `title_match` ×100; `size` carries the real file-size sub-score
and `title_match` shows its true 0–10 value. The manual dialog reads the unified
`ScoreBreakdown` struct, renders a distinct **Penalties** section (warning color,
`−` prefix, zero rows suppressed), and clamps the radial ring to 0 for the
deeply-negative totals an identity mismatch produces. The Activity view drops the
"Size" rejection label, adds penalty/invalid/wrong-show labels, and shows a third
`badge-warning` **Penalized** state distinct from OK and rejected.

## Open Question decision (per plan's recommended default)

- **Folded** `reject_tv_releases_for_movies` into the identity penalty: a movie
  search expects no season/episode, so a TV-pattern release is an identity
  mismatch → soft penalty (kept, ranked below the movie).
- **Kept** `reject_title_mismatches` and `reject_zero_title_match` as **hard
  removals** — they gate the *wrong show entirely* (a correctness concern), not a
  quality shortcoming. The parody is buried by the identity penalty, not these
  gates, so keeping them hard does not regress AE1.

## Per-unit summary

- **U1** — `ScoreBreakdown` gains `size_penalty`/`seeder_penalty`/`identity_penalty`; real `size`/`title_match`.
- **U2** — size/seeders/ratio become soft penalties; `filter_acceptable` keeps only blocked-tag + NZB post-age (invalid still first).
- **U3** — episode/season identity penalty; season packs no longer hard-dropped; dead `all_season_packs` backoff removed.
- **U4** — shared `RankingOptions` builder for all three job entry points; `min_ratio` resolved to a single source (`quality_standards`).
- **U5** — manual `:quality` sort routes through `rank_all` with the same options (incl. expected season/episode from the search context).
- **U6** — manual dialog renders the unified breakdown + distinct penalty section + clamped ring.
- **U7** — `score_all_with_reasons`/`get_rejection_reason` mirror the new removal set; shared `build_filter_stats/2` for both jobs; Activity penalty display.

## Tests

254 tests, 0 failures across: `release_ranker_test`, `ranking_options_test`,
`release_ranker_trash_guide_integration_test`, `search_scorer_test`,
`tv_show_search_test`, `movie_search_test`, `search_helpers_test`, `modals_test`,
and `activity_live/`. `mix compile --warnings-as-errors` is clean.

Does not merge; plan not marked completed.
