### PR TITLE
feat(player): liquid-glass depth pass — ambient backdrop, GlassSurface, sheen & parallax

### DIFF
--- a/player/lib/core/ui/reduced_motion.dart
+++ b/player/lib/core/ui/reduced_motion.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/widgets.dart';
+
+/// Helpers for honoring the user's reduced-motion / accessibility preferences
+/// when deciding whether to play decorative animations.
+///
+/// On Flutter web (SDK >= 3.38) `MediaQuery.disableAnimationsOf` is backed by
+/// the browser's `prefers-reduced-motion` media query, so reading it reactively
+/// in `build` lets widgets respond to OS/browser changes at runtime.
+///
+/// Consumers should read [ReducedMotion.of] in their `build` method (so the
+/// dependency is registered and the widget rebuilds when the preference flips)
+/// and then choose `Duration.zero` / a final-state render when motion is
+/// suppressed. See [ReducedMotionContext] for the extension form.
+abstract final class ReducedMotion {
+  /// Whether decorative motion should be suppressed for the current context.
+  ///
+  /// Returns `true` when the platform requests disabled animations or when
+  /// accessible navigation (e.g. a screen reader / switch access) is active.
+  /// Reads `MediaQuery` reactively, so callers rebuild when the value changes.
+  static bool of(BuildContext context) {
+    return MediaQuery.disableAnimationsOf(context) ||
+        MediaQuery.accessibleNavigationOf(context);
+  }
+
+  /// Returns [duration] when motion is allowed, otherwise [Duration.zero].
+  ///
+  /// Convenience for gating animation/crossfade durations.
+  static Duration duration(BuildContext context, Duration duration) {
+    return of(context) ? Duration.zero : duration;
+  }
+}
+
+/// Context extension mirroring [ReducedMotion] for ergonomic call sites.
+extension ReducedMotionContext on BuildContext {
+  /// Whether decorative motion should be suppressed. See [ReducedMotion.of].
+  bool get reduceMotion => ReducedMotion.of(this);
+
+  /// See [ReducedMotion.duration].
+  Duration reducedMotionDuration(Duration duration) =>
+      ReducedMotion.duration(this, duration);
+}

--- a/player/lib/presentation/screens/collections/collections_screen.dart
+++ b/player/lib/presentation/screens/collections/collections_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'collections_controller.dart';
 import '../../../domain/models/collection.dart';
 import '../../widgets/app_shell.dart';
+import '../../widgets/glass_surface.dart';
 import '../../../core/layout/breakpoints.dart';
 import '../../../core/theme/colors.dart';
 
@@ -45,11 +45,9 @@ class CollectionsScreen extends ConsumerWidget {
     }
     return PreferredSize(
       preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: ClipRRect(
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+      child: GlassSurface.appBar(
           child: AppBar(
-            backgroundColor: AppColors.background.withValues(alpha: 0.8),
+            backgroundColor: Colors.transparent,
             elevation: 0,
             leading: IconButton(
               icon: const Icon(Icons.menu_rounded),
@@ -95,7 +93,6 @@ class CollectionsScreen extends ConsumerWidget {
             ],
           ),
         ),
-      ),
     );
   }
 

--- a/player/lib/presentation/screens/collections/collections_screen.dart
+++ b/player/lib/presentation/screens/collections/collections_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'collections_controller.dart';
 import '../../../domain/models/collection.dart';
+import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/app_shell.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/layout/breakpoints.dart';
@@ -17,7 +18,11 @@ class CollectionsScreen extends ConsumerWidget {
     final collectionsData = ref.watch(collectionsControllerProvider);
     final isDesktop = Breakpoints.isDesktop(context);
 
+    // Grid screens use the calm static backdrop (no per-title artwork).
+    publishBackdropSource(ref, BackdropSource.none);
+
     return Scaffold(
+      backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: true,
       appBar: _buildAppBar(context, isDesktop),
       body: RefreshIndicator(

--- a/player/lib/presentation/screens/downloads/downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/downloads_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/cache/poster_cache_manager.dart';
+import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/downloads/download_providers.dart';
 import '../../../core/downloads/download_queue_providers.dart';
@@ -22,6 +23,9 @@ class DownloadsScreen extends ConsumerWidget {
     final downloadedMediaAsync = ref.watch(downloadedMediaProvider);
     final downloadQueueAsync = ref.watch(downloadQueueProvider);
     final failedDownloadsAsync = ref.watch(failedDownloadsProvider);
+
+    // Downloads uses the calm static backdrop (no per-title artwork).
+    publishBackdropSource(ref, BackdropSource.none);
 
     // Grouping Logic
     final items = <String, DownloadGroup>{};
@@ -84,6 +88,7 @@ class DownloadsScreen extends ConsumerWidget {
       ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
 
     return Scaffold(
+      backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: true,
       appBar: _buildAppBar(context, ref),
       body: CustomScrollView(

--- a/player/lib/presentation/screens/downloads/downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/downloads_screen.dart
@@ -1,9 +1,9 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/cache/poster_cache_manager.dart';
+import '../../widgets/glass_surface.dart';
 import '../../../core/downloads/download_providers.dart';
 import '../../../core/downloads/download_queue_providers.dart';
 import '../../../core/downloads/storage_quota_providers.dart';
@@ -756,12 +756,9 @@ class DownloadsScreen extends ConsumerWidget {
 
     return PreferredSize(
       preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: ClipRRect(
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-          child: Container(
-            color: AppColors.background.withValues(alpha: 0.85),
-            child: SafeArea(
+      child: GlassSurface.appBar(
+          opacity: 0.85,
+          child: SafeArea(
               child: SizedBox(
                 height: kToolbarHeight,
                 child: Padding(
@@ -798,9 +795,7 @@ class DownloadsScreen extends ConsumerWidget {
                 ),
               ),
             ),
-          ),
         ),
-      ),
     );
   }
 

--- a/player/lib/presentation/screens/favorites/favorites_screen.dart
+++ b/player/lib/presentation/screens/favorites/favorites_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'favorites_controller.dart';
 import '../../widgets/media_poster.dart';
+import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/app_shell.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/layout/breakpoints.dart';
@@ -25,7 +26,11 @@ class FavoritesScreen extends ConsumerWidget {
     final favoritesData = ref.watch(favoritesControllerProvider);
     final isDesktop = Breakpoints.isDesktop(context);
 
+    // Grid screens use the calm static backdrop (no per-title artwork).
+    publishBackdropSource(ref, BackdropSource.none);
+
     return Scaffold(
+      backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: true,
       appBar: _buildAppBar(context, isDesktop),
       body: RefreshIndicator(

--- a/player/lib/presentation/screens/favorites/favorites_screen.dart
+++ b/player/lib/presentation/screens/favorites/favorites_screen.dart
@@ -1,10 +1,10 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'favorites_controller.dart';
 import '../../widgets/media_poster.dart';
 import '../../widgets/app_shell.dart';
+import '../../widgets/glass_surface.dart';
 import '../../../core/layout/breakpoints.dart';
 import '../../../core/theme/colors.dart';
 
@@ -52,11 +52,9 @@ class FavoritesScreen extends ConsumerWidget {
           preferredSize: Size.fromHeight(0), child: SizedBox.shrink());
     return PreferredSize(
       preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: ClipRRect(
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+      child: GlassSurface.appBar(
           child: AppBar(
-            backgroundColor: AppColors.background.withValues(alpha: 0.8),
+            backgroundColor: Colors.transparent,
             elevation: 0,
             leading: IconButton(
               icon: const Icon(Icons.menu_rounded),
@@ -102,7 +100,6 @@ class FavoritesScreen extends ConsumerWidget {
             ],
           ),
         ),
-      ),
     );
   }
 

--- a/player/lib/presentation/screens/home_screen.dart
+++ b/player/lib/presentation/screens/home_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/glass_surface.dart';
 import '../widgets/shimmer_card.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/theme/colors.dart';
+import '../../core/ui/reduced_motion.dart';
 import '../widgets/app_shell.dart';
 import 'home/home_controller.dart';
 
@@ -271,53 +272,68 @@ class _ModernAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     return GlassSurface.appBar(
       child: AppBar(
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-          titleSpacing: 0,
-          leading: IconButton(
-            icon: const Icon(Icons.menu_rounded),
-            onPressed: () {
-              AppShell.scaffoldKey.currentState?.openDrawer();
-            },
-            tooltip: 'Menu',
-          ),
-          title: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              MydiaLogo(size: 32),
-              SizedBox(width: 10),
-              Text(
-                'Mydia Player',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: -0.5,
-                ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        titleSpacing: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.menu_rounded),
+          onPressed: () {
+            AppShell.scaffoldKey.currentState?.openDrawer();
+          },
+          tooltip: 'Menu',
+        ),
+        title: const Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            MydiaLogo(size: 32),
+            SizedBox(width: 10),
+            Text(
+              'Mydia Player',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                letterSpacing: -0.5,
               ),
-            ],
-          ),
-          actions: [
-            IconButton(
-              icon: Container(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: AppColors.surfaceVariant.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: const Icon(Icons.search_rounded, size: 20),
-              ),
-              onPressed: () {
-                context.push('/search');
-              },
-              tooltip: 'Search',
             ),
-            const SizedBox(width: 8),
           ],
         ),
+        actions: [
+          IconButton(
+            icon: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Icon(Icons.search_rounded, size: 20),
+            ),
+            onPressed: () {
+              context.push('/search');
+            },
+            tooltip: 'Search',
+          ),
+          const SizedBox(width: 8),
+        ],
+      ),
     );
   }
 }
 
-class _HeroSection extends StatelessWidget {
+/// Max vertical parallax travel (logical px) for the home hero. The hero image
+/// is over-sized by `2 * homeHeroMaxParallax` and clipped so translation never
+/// reveals an edge gap.
+const double homeHeroMaxParallax = 40;
+
+/// Bounded parallax translation for the home hero at a given [scrollOffset].
+///
+/// Moves the image up at ~30% of scroll speed, clamped to
+/// `±homeHeroMaxParallax`. Returns `0` when [reduceMotion] is true so the hero
+/// stays static (plan U7 / AE4). Pure function, exposed for testing.
+double homeHeroParallaxOffset(double scrollOffset, {required bool reduceMotion}) {
+  if (reduceMotion) return 0;
+  return (-scrollOffset * 0.3).clamp(-homeHeroMaxParallax, homeHeroMaxParallax);
+}
+
+class _HeroSection extends StatefulWidget {
   final dynamic item;
   final VoidCallback onTap;
 
@@ -326,9 +342,45 @@ class _HeroSection extends StatelessWidget {
     required this.onTap,
   });
 
+  @override
+  State<_HeroSection> createState() => _HeroSectionState();
+}
+
+class _HeroSectionState extends State<_HeroSection> {
+  static const double _maxParallax = homeHeroMaxParallax;
+
+  ScrollPosition? _position;
+  double _scrollOffset = 0;
+
   String? get _backdropUrl {
+    final item = widget.item;
     if (item.backdropUrl != null) return item.backdropUrl;
     return item.posterUrl;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final newPosition = Scrollable.maybeOf(context)?.position;
+    if (newPosition != _position) {
+      _position?.removeListener(_onScroll);
+      _position = newPosition;
+      _position?.addListener(_onScroll);
+      _onScroll();
+    }
+  }
+
+  void _onScroll() {
+    final offset = _position?.pixels ?? 0;
+    if (offset != _scrollOffset) {
+      setState(() => _scrollOffset = offset);
+    }
+  }
+
+  @override
+  void dispose() {
+    _position?.removeListener(_onScroll);
+    super.dispose();
   }
 
   @override
@@ -340,40 +392,60 @@ class _HeroSection extends StatelessWidget {
         ? (size.height * 0.45).clamp(300.0, 450.0)
         : size.height * 0.5;
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
+    final reduceMotion = context.reduceMotion;
+    final parallax =
+        homeHeroParallaxOffset(_scrollOffset, reduceMotion: reduceMotion);
 
     return GestureDetector(
-      onTap: onTap,
+      onTap: widget.onTap,
       child: Stack(
         children: [
-          // Background image
-          SizedBox(
-            width: size.width,
-            height: heroHeight,
-            child: _backdropUrl != null
-                ? CachedNetworkImage(
-                    imageUrl: _backdropUrl!,
-                    fit: BoxFit.cover,
-                    cacheManager: BackdropCacheManager(),
-                    placeholder: (context, url) => Container(
-                      color: AppColors.surface,
-                    ),
-                    errorWidget: (context, url, error) => Container(
-                      color: AppColors.surface,
-                      child: const Icon(
-                        Icons.movie_rounded,
-                        size: 64,
-                        color: AppColors.textSecondary,
-                      ),
-                    ),
-                  )
-                : Container(
-                    color: AppColors.surface,
-                    child: const Icon(
-                      Icons.movie_rounded,
-                      size: 64,
-                      color: AppColors.textSecondary,
-                    ),
+          // Background image with bounded parallax. The image is over-sized by
+          // 2 * _maxParallax and clipped to the hero so translation never
+          // reveals a gap.
+          ClipRect(
+            child: SizedBox(
+              width: size.width,
+              height: heroHeight,
+              child: OverflowBox(
+                minWidth: size.width,
+                maxWidth: size.width,
+                minHeight: heroHeight + _maxParallax * 2,
+                maxHeight: heroHeight + _maxParallax * 2,
+                child: Transform.translate(
+                  offset: Offset(0, parallax),
+                  child: SizedBox(
+                    width: size.width,
+                    height: heroHeight + _maxParallax * 2,
+                    child: _backdropUrl != null
+                        ? CachedNetworkImage(
+                            imageUrl: _backdropUrl!,
+                            fit: BoxFit.cover,
+                            cacheManager: BackdropCacheManager(),
+                            placeholder: (context, url) => Container(
+                              color: AppColors.surface,
+                            ),
+                            errorWidget: (context, url, error) => Container(
+                              color: AppColors.surface,
+                              child: const Icon(
+                                Icons.movie_rounded,
+                                size: 64,
+                                color: AppColors.textSecondary,
+                              ),
+                            ),
+                          )
+                        : Container(
+                            color: AppColors.surface,
+                            child: const Icon(
+                              Icons.movie_rounded,
+                              size: 64,
+                              color: AppColors.textSecondary,
+                            ),
+                          ),
                   ),
+                ),
+              ),
+            ),
           ),
 
           // Gradient overlays
@@ -425,7 +497,7 @@ class _HeroSection extends StatelessWidget {
 
                 // Title
                 Text(
-                  item.title,
+                  widget.item.title,
                   style: Theme.of(context).textTheme.headlineMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                     shadows: [
@@ -441,9 +513,9 @@ class _HeroSection extends StatelessWidget {
                 const SizedBox(height: 8),
 
                 // Subtitle/info
-                if (item.showTitle != null)
+                if (widget.item.showTitle != null)
                   Text(
-                    item.showTitle!,
+                    widget.item.showTitle!,
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                           color: AppColors.textSecondary,
                         ),
@@ -456,7 +528,7 @@ class _HeroSection extends StatelessWidget {
                   children: [
                     // Play button
                     FilledButton.icon(
-                      onPressed: onTap,
+                      onPressed: widget.onTap,
                       icon: const Icon(Icons.play_arrow_rounded),
                       label: const Text('Play'),
                       style: FilledButton.styleFrom(
@@ -473,7 +545,7 @@ class _HeroSection extends StatelessWidget {
 
                     // More info button
                     OutlinedButton.icon(
-                      onPressed: onTap,
+                      onPressed: widget.onTap,
                       icon: const Icon(Icons.info_outline_rounded, size: 20),
                       label: const Text('More Info'),
                       style: OutlinedButton.styleFrom(

--- a/player/lib/presentation/screens/home_screen.dart
+++ b/player/lib/presentation/screens/home_screen.dart
@@ -1,10 +1,10 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import '../../core/cache/poster_cache_manager.dart';
 import '../widgets/content_rail.dart';
+import '../widgets/glass_surface.dart';
 import '../widgets/shimmer_card.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/theme/colors.dart';
@@ -237,11 +237,9 @@ class _ModernAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-        child: AppBar(
-          backgroundColor: AppColors.background.withValues(alpha: 0.8),
+    return GlassSurface.appBar(
+      child: AppBar(
+          backgroundColor: Colors.transparent,
           elevation: 0,
           titleSpacing: 0,
           leading: IconButton(
@@ -251,12 +249,12 @@ class _ModernAppBar extends StatelessWidget implements PreferredSizeWidget {
             },
             tooltip: 'Menu',
           ),
-          title: Row(
+          title: const Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const MydiaLogo(size: 32),
-              const SizedBox(width: 10),
-              const Text(
+              MydiaLogo(size: 32),
+              SizedBox(width: 10),
+              Text(
                 'Mydia Player',
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
@@ -283,7 +281,6 @@ class _ModernAppBar extends StatelessWidget implements PreferredSizeWidget {
             const SizedBox(width: 8),
           ],
         ),
-      ),
     );
   }
 }

--- a/player/lib/presentation/screens/home_screen.dart
+++ b/player/lib/presentation/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import '../../core/cache/poster_cache_manager.dart';
+import '../widgets/ambient_backdrop_provider.dart';
 import '../widgets/content_rail.dart';
 import '../widgets/glass_surface.dart';
 import '../widgets/shimmer_card.dart';
@@ -33,6 +34,7 @@ class HomeScreen extends ConsumerWidget {
     final bottomPadding = isDesktop ? 32.0 : 100.0;
 
     return Scaffold(
+      backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: true,
       appBar: isDesktop ? null : _ModernAppBar(),
       body: RefreshIndicator(
@@ -40,12 +42,42 @@ class HomeScreen extends ConsumerWidget {
           await ref.read(homeControllerProvider.notifier).refresh();
         },
         child: homeData.when(
-          loading: () => _buildShimmerLoading(context),
-          error: (error, stackTrace) => _buildErrorView(context, error, ref),
+          loading: () {
+            // No hero pick yet -> calm static fallback.
+            publishBackdropSource(ref, BackdropSource.none);
+            return _buildShimmerLoading(context);
+          },
+          error: (error, stackTrace) {
+            publishBackdropSource(ref, BackdropSource.none);
+            return _buildErrorView(context, error, ref);
+          },
           data: (data) {
             if (data.isEmpty) {
+              publishBackdropSource(ref, BackdropSource.none);
               return _buildEmptyState(context);
             }
+
+            // Feed the shell ambient backdrop from the hero pick:
+            // continueWatching.first ?? recentlyAdded.first, using
+            // backdropUrl ?? posterUrl (plan U5 / AE1). Branch by concrete
+            // type so the getters resolve (the two lists hold different types).
+            final BackdropSource heroSource;
+            if (data.continueWatching.isNotEmpty) {
+              final item = data.continueWatching.first;
+              heroSource = BackdropSource(
+                imageUrl: item.backdropUrl ?? item.posterUrl,
+                id: item.id,
+              );
+            } else if (data.recentlyAdded.isNotEmpty) {
+              final item = data.recentlyAdded.first;
+              heroSource = BackdropSource(
+                imageUrl: item.backdropUrl ?? item.posterUrl,
+                id: item.id,
+              );
+            } else {
+              heroSource = BackdropSource.none;
+            }
+            publishBackdropSource(ref, heroSource);
 
             return CustomScrollView(
               slivers: [

--- a/player/lib/presentation/screens/library/library_screen.dart
+++ b/player/lib/presentation/screens/library/library_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'library_controller.dart';
+import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/app_shell.dart';
 import '../../widgets/glass_surface.dart';
 import '../../widgets/media_poster.dart';
@@ -106,7 +107,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     // On desktop, always show search bar expanded
     final effectiveShowSearch = isDesktop || _showSearch;
 
+    // Library grids use the calm static backdrop (no per-title artwork).
+    publishBackdropSource(ref, BackdropSource.none);
+
     return Scaffold(
+      backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: true,
       appBar: _buildAppBar(title, icon, isDesktop, effectiveShowSearch),
       body: RefreshIndicator(

--- a/player/lib/presentation/screens/library/library_screen.dart
+++ b/player/lib/presentation/screens/library/library_screen.dart
@@ -1,9 +1,9 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'library_controller.dart';
 import '../../widgets/app_shell.dart';
+import '../../widgets/glass_surface.dart';
 import '../../widgets/media_poster.dart';
 import '../../../core/layout/breakpoints.dart';
 import '../../../core/theme/colors.dart';
@@ -151,12 +151,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
 
     return PreferredSize(
       preferredSize: Size.fromHeight(showSearch ? 120 : kToolbarHeight),
-      child: ClipRRect(
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-          child: Container(
-            color: AppColors.background.withValues(alpha: 0.85),
-            child: SafeArea(
+      child: GlassSurface.appBar(
+          opacity: 0.85,
+          child: SafeArea(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -279,9 +276,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                 ],
               ),
             ),
-          ),
         ),
-      ),
     );
   }
 

--- a/player/lib/presentation/screens/login_screen.dart
+++ b/player/lib/presentation/screens/login_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,6 +7,7 @@ import 'package:mobile_scanner/mobile_scanner.dart';
 import '../../core/auth/auth_service.dart';
 import '../../core/p2p/p2p_service.dart' show defaultRelayUrl;
 import '../../core/theme/colors.dart';
+import '../widgets/glass_surface.dart';
 import '../widgets/update_required_dialog.dart';
 import 'login/login_controller.dart';
 
@@ -504,23 +503,12 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
   Widget _buildClaimCodeCard(LoginState loginState, bool isCompact) {
     return Container(
       constraints: const BoxConstraints(maxWidth: 360),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(20),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
-          child: Container(
-            padding: EdgeInsets.all(isCompact ? 20 : 24),
-            decoration: BoxDecoration(
-              color: AppColors.surface.withValues(alpha: 0.6),
-              borderRadius: BorderRadius.circular(20),
-              border: Border.all(
-                color: AppColors.border.withValues(alpha: 0.2),
-              ),
-            ),
-            child: _showDirectConnection
-                ? _buildDirectConnectionContent(loginState, isCompact)
-                : _buildClaimCodeContent(loginState, isCompact),
-          ),
+      child: GlassSurface.modal(
+        child: Padding(
+          padding: EdgeInsets.all(isCompact ? 20 : 24),
+          child: _showDirectConnection
+              ? _buildDirectConnectionContent(loginState, isCompact)
+              : _buildClaimCodeContent(loginState, isCompact),
         ),
       ),
     );

--- a/player/lib/presentation/screens/recently_added/recently_added_screen.dart
+++ b/player/lib/presentation/screens/recently_added/recently_added_screen.dart
@@ -1,10 +1,10 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'recently_added_controller.dart';
 import '../../widgets/media_poster.dart';
 import '../../widgets/app_shell.dart';
+import '../../widgets/glass_surface.dart';
 import '../../../core/layout/breakpoints.dart';
 import '../../../core/theme/colors.dart';
 
@@ -52,11 +52,9 @@ class RecentlyAddedScreen extends ConsumerWidget {
           preferredSize: Size.fromHeight(0), child: SizedBox.shrink());
     return PreferredSize(
       preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: ClipRRect(
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+      child: GlassSurface.appBar(
           child: AppBar(
-            backgroundColor: AppColors.background.withValues(alpha: 0.8),
+            backgroundColor: Colors.transparent,
             elevation: 0,
             leading: IconButton(
               icon: const Icon(Icons.menu_rounded),
@@ -102,7 +100,6 @@ class RecentlyAddedScreen extends ConsumerWidget {
             ],
           ),
         ),
-      ),
     );
   }
 

--- a/player/lib/presentation/screens/recently_added/recently_added_screen.dart
+++ b/player/lib/presentation/screens/recently_added/recently_added_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'recently_added_controller.dart';
 import '../../widgets/media_poster.dart';
+import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/app_shell.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/layout/breakpoints.dart';
@@ -25,7 +26,11 @@ class RecentlyAddedScreen extends ConsumerWidget {
     final data = ref.watch(recentlyAddedControllerProvider);
     final isDesktop = Breakpoints.isDesktop(context);
 
+    // Grid screens use the calm static backdrop (no per-title artwork).
+    publishBackdropSource(ref, BackdropSource.none);
+
     return Scaffold(
+      backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: true,
       appBar: _buildAppBar(context, isDesktop),
       body: RefreshIndicator(

--- a/player/lib/presentation/screens/settings_screen.dart
+++ b/player/lib/presentation/screens/settings_screen.dart
@@ -8,6 +8,7 @@ import '../../core/connection/connection_provider.dart';
 import '../../core/graphql/graphql_provider.dart';
 import '../../core/update/update_provider.dart';
 import '../../core/update/updaters/macos_updater.dart';
+import '../widgets/ambient_backdrop_provider.dart';
 import '../widgets/connection_status_indicator.dart';
 import '../widgets/update_tile.dart';
 import 'settings/settings_controller.dart';
@@ -51,8 +52,14 @@ class SettingsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final settingsAsync = ref.watch(settingsControllerProvider);
 
+    // Settings shows the calm static backdrop, never a stale title image
+    // (plan U5 / AE3).
+    publishBackdropSource(ref, BackdropSource.none);
+
     return Scaffold(
+      backgroundColor: Colors.transparent,
       appBar: AppBar(
+        backgroundColor: Colors.transparent,
         title: const Text('Settings'),
       ),
       body: settingsAsync.when(

--- a/player/lib/presentation/screens/unwatched/unwatched_screen.dart
+++ b/player/lib/presentation/screens/unwatched/unwatched_screen.dart
@@ -1,10 +1,10 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'unwatched_controller.dart';
 import '../../widgets/media_poster.dart';
 import '../../widgets/app_shell.dart';
+import '../../widgets/glass_surface.dart';
 import '../../../core/layout/breakpoints.dart';
 import '../../../core/theme/colors.dart';
 
@@ -52,11 +52,9 @@ class UnwatchedScreen extends ConsumerWidget {
           preferredSize: Size.fromHeight(0), child: SizedBox.shrink());
     return PreferredSize(
       preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: ClipRRect(
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+      child: GlassSurface.appBar(
           child: AppBar(
-            backgroundColor: AppColors.background.withValues(alpha: 0.8),
+            backgroundColor: Colors.transparent,
             elevation: 0,
             leading: IconButton(
               icon: const Icon(Icons.menu_rounded),
@@ -102,7 +100,6 @@ class UnwatchedScreen extends ConsumerWidget {
             ],
           ),
         ),
-      ),
     );
   }
 

--- a/player/lib/presentation/screens/unwatched/unwatched_screen.dart
+++ b/player/lib/presentation/screens/unwatched/unwatched_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'unwatched_controller.dart';
 import '../../widgets/media_poster.dart';
+import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/app_shell.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/layout/breakpoints.dart';
@@ -25,7 +26,11 @@ class UnwatchedScreen extends ConsumerWidget {
     final data = ref.watch(unwatchedControllerProvider);
     final isDesktop = Breakpoints.isDesktop(context);
 
+    // Grid screens use the calm static backdrop (no per-title artwork).
+    publishBackdropSource(ref, BackdropSource.none);
+
     return Scaffold(
+      backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: true,
       appBar: _buildAppBar(context, isDesktop),
       body: RefreshIndicator(

--- a/player/lib/presentation/widgets/ambient_backdrop.dart
+++ b/player/lib/presentation/widgets/ambient_backdrop.dart
@@ -1,0 +1,206 @@
+import 'dart:ui';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../core/cache/poster_cache_manager.dart';
+import '../../core/theme/colors.dart';
+import '../../core/ui/reduced_motion.dart';
+
+/// A shell-level ambient backdrop: a pre-blurred, dimmed copy of the focused
+/// title's artwork that crossfades behind the browse screens.
+///
+/// Performance (plan R2/R11): the blur is a **pre-blurred image layer**
+/// ([ImageFiltered] over a [CachedNetworkImage]), *not* a live full-screen
+/// [BackdropFilter] behind scrolling content. The blurred layer is computed
+/// once and is not recomputed while content scrolls in front of it. The whole
+/// backdrop is wrapped in a [RepaintBoundary] so it repaints independently of
+/// the foreground.
+///
+/// A constant dark base always paints behind the [AnimatedSwitcher] so the
+/// scrim never dips to a brighter color mid-crossfade, and the incoming image
+/// is pre-warmed with [precacheImage] before the key swaps to avoid a decode
+/// hitch.
+///
+/// When [imageUrl] is null (grid/settings screens) a calm static gradient is
+/// shown with no network image. All motion collapses to [Duration.zero] when
+/// the user prefers reduced motion (see [ReducedMotion]).
+class AmbientBackdrop extends StatefulWidget {
+  /// The artwork URL to blur behind content. When null, the static fallback
+  /// gradient is rendered (no image is fetched).
+  final String? imageUrl;
+
+  /// Stable identity of the artwork. Drives the [AnimatedSwitcher] crossfade:
+  /// the layer transitions only when [id] changes. When null, the fallback is
+  /// treated as a single stable layer.
+  final String? id;
+
+  /// Sigma of the gaussian blur applied to the artwork.
+  final double blurSigma;
+
+  /// Crossfade duration when artwork changes (collapsed to zero under reduced
+  /// motion).
+  final Duration crossfadeDuration;
+
+  const AmbientBackdrop({
+    super.key,
+    this.imageUrl,
+    this.id,
+    this.blurSigma = 40,
+    this.crossfadeDuration = const Duration(milliseconds: 600),
+  });
+
+  @override
+  State<AmbientBackdrop> createState() => _AmbientBackdropState();
+}
+
+class _AmbientBackdropState extends State<AmbientBackdrop> {
+  @override
+  void didUpdateWidget(covariant AmbientBackdrop oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Pre-warm the incoming artwork before the AnimatedSwitcher key swaps so
+    // the crossfade does not stall on first decode (plan U4 / R2).
+    final url = widget.imageUrl;
+    if (url != null && url != oldWidget.imageUrl) {
+      precacheImage(
+        CachedNetworkImageProvider(url, cacheManager: BackdropCacheManager()),
+        context,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final reduceMotion = context.reduceMotion;
+    final duration =
+        reduceMotion ? Duration.zero : widget.crossfadeDuration;
+
+    return RepaintBoundary(
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          // Constant dark base so the scrim never brightens mid-crossfade.
+          const ColoredBox(color: AppColors.background),
+          AnimatedSwitcher(
+            duration: duration,
+            // Keep both layers stacked during the fade so the outgoing artwork
+            // does not pop out before the incoming one is opaque.
+            layoutBuilder: (currentChild, previousChildren) => Stack(
+              fit: StackFit.expand,
+              children: [
+                ...previousChildren,
+                if (currentChild != null) currentChild,
+              ],
+            ),
+            child: _buildLayer(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLayer(BuildContext context) {
+    final url = widget.imageUrl;
+    if (url == null || url.isEmpty) {
+      // Calm static fallback — no network image (plan U4 / AE3).
+      return const _StaticFallback(key: ValueKey('ambient-fallback'));
+    }
+
+    return _ArtworkLayer(
+      key: ValueKey('ambient-${widget.id ?? url}'),
+      imageUrl: url,
+      blurSigma: widget.blurSigma,
+    );
+  }
+}
+
+/// A single blurred, dimmed artwork layer. The blur is pre-applied with
+/// [ImageFiltered] (never a live [BackdropFilter]).
+class _ArtworkLayer extends StatelessWidget {
+  final String imageUrl;
+  final double blurSigma;
+
+  const _ArtworkLayer({
+    super.key,
+    required this.imageUrl,
+    required this.blurSigma,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        ImageFiltered(
+          imageFilter: ImageFilter.blur(
+            sigmaX: blurSigma,
+            sigmaY: blurSigma,
+            tileMode: TileMode.decal,
+          ),
+          child: CachedNetworkImage(
+            imageUrl: imageUrl,
+            fit: BoxFit.cover,
+            cacheManager: BackdropCacheManager(),
+            // No placeholder/error chrome: the constant dark base behind the
+            // switcher covers the gap, keeping the scrim color stable.
+            placeholder: (_, __) => const SizedBox.expand(),
+            errorWidget: (_, __, ___) => const SizedBox.expand(),
+          ),
+        ),
+        // Dark scrim guaranteeing text contrast over bright artwork. Alpha is
+        // tuned in U8 against real images.
+        const _BackdropScrim(),
+      ],
+    );
+  }
+}
+
+/// Dark scrim painted over the blurred artwork to guarantee foreground text
+/// contrast (plan R3 / U8). A flat dim plus a slightly stronger bottom gradient
+/// keeps content legible without crushing the artwork to pure black.
+class _BackdropScrim extends StatelessWidget {
+  const _BackdropScrim();
+
+  /// Flat dim applied across the whole backdrop. Tuned in U8 so primary text
+  /// (~15:1) and secondary text (~7:1) hold over worst-case bright artwork.
+  static const double baseDim = 0.78;
+
+  @override
+  Widget build(BuildContext context) {
+    return const DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            Color.fromRGBO(10, 17, 32, baseDim),
+            Color.fromRGBO(10, 17, 32, 0.88),
+          ],
+          stops: [0.0, 1.0],
+        ),
+      ),
+    );
+  }
+}
+
+/// Calm static gradient shown for grids / settings (no per-title artwork).
+class _StaticFallback extends StatelessWidget {
+  const _StaticFallback({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: RadialGradient(
+          center: Alignment(0, -0.6),
+          radius: 1.4,
+          colors: [
+            AppColors.surface,
+            AppColors.background,
+          ],
+          stops: [0.0, 1.0],
+        ),
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/ambient_backdrop.dart
+++ b/player/lib/presentation/widgets/ambient_backdrop.dart
@@ -148,8 +148,8 @@ class _ArtworkLayer extends StatelessWidget {
           ),
         ),
         // Dark scrim guaranteeing text contrast over bright artwork. Alpha is
-        // tuned in U8 against real images.
-        const _BackdropScrim(),
+        // tuned in U8 (see AmbientBackdropScrim.baseDim).
+        const AmbientBackdropScrim(),
       ],
     );
   }
@@ -158,12 +158,20 @@ class _ArtworkLayer extends StatelessWidget {
 /// Dark scrim painted over the blurred artwork to guarantee foreground text
 /// contrast (plan R3 / U8). A flat dim plus a slightly stronger bottom gradient
 /// keeps content legible without crushing the artwork to pure black.
-class _BackdropScrim extends StatelessWidget {
-  const _BackdropScrim();
+///
+/// [baseDim] is the single source of truth for the top-of-scrim alpha and is
+/// asserted against worst-case bright artwork in `ambient_backdrop_contrast_test`.
+class AmbientBackdropScrim extends StatelessWidget {
+  const AmbientBackdropScrim({super.key});
 
-  /// Flat dim applied across the whole backdrop. Tuned in U8 so primary text
-  /// (~15:1) and secondary text (~7:1) hold over worst-case bright artwork.
-  static const double baseDim = 0.78;
+  /// Top-of-scrim dim alpha applied over the blurred artwork. Tuned in U8 so
+  /// primary text clears WCAG AAA (7:1) and secondary text clears AA (4.5:1)
+  /// over worst-case (white) artwork; on the flat theme background they remain
+  /// at their ~15:1 / ~7:1 design targets.
+  static const double baseDim = 0.88;
+
+  /// Bottom-of-scrim dim alpha (slightly stronger to anchor bottom content).
+  static const double bottomDim = 0.94;
 
   @override
   Widget build(BuildContext context) {
@@ -174,7 +182,7 @@ class _BackdropScrim extends StatelessWidget {
           end: Alignment.bottomCenter,
           colors: [
             Color.fromRGBO(10, 17, 32, baseDim),
-            Color.fromRGBO(10, 17, 32, 0.88),
+            Color.fromRGBO(10, 17, 32, bottomDim),
           ],
           stops: [0.0, 1.0],
         ),

--- a/player/lib/presentation/widgets/ambient_backdrop_provider.dart
+++ b/player/lib/presentation/widgets/ambient_backdrop_provider.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'ambient_backdrop_provider.g.dart';
+
+/// The artwork source the shell-level [AmbientBackdrop] should render.
+///
+/// A null [imageUrl] means "no per-title artwork" — the backdrop shows its calm
+/// static fallback (grids, settings). [id] is the stable identity used to key
+/// the crossfade so equal sources don't re-trigger a transition.
+@immutable
+class BackdropSource {
+  final String? imageUrl;
+  final String? id;
+
+  const BackdropSource({this.imageUrl, this.id});
+
+  /// The static-fallback source (no artwork).
+  static const BackdropSource none = BackdropSource();
+
+  @override
+  bool operator ==(Object other) =>
+      other is BackdropSource &&
+      other.imageUrl == imageUrl &&
+      other.id == id;
+
+  @override
+  int get hashCode => Object.hash(imageUrl, id);
+}
+
+/// Carries the current shell backdrop source.
+///
+/// Browse screens publish their source from `build` (home -> its hero pick;
+/// grids/settings -> [BackdropSource.none]). The [AmbientBackdrop] in the shell
+/// watches this and crossfades when it changes.
+///
+/// Screens publish via a post-frame callback so they don't mutate provider
+/// state synchronously during their own build.
+@riverpod
+class AmbientBackdropController extends _$AmbientBackdropController {
+  @override
+  BackdropSource build() => BackdropSource.none;
+
+  /// Sets the backdrop source. No-op when the source is unchanged so we don't
+  /// retrigger the crossfade on every rebuild.
+  void set(BackdropSource source) {
+    if (state != source) {
+      state = source;
+    }
+  }
+
+  /// Clears to the static fallback.
+  void clear() => set(BackdropSource.none);
+}
+
+/// Publishes [source] as the shell backdrop after the current frame.
+///
+/// Browse screens call this from `build` so they don't mutate provider state
+/// synchronously while building (which Riverpod disallows). Grid/settings
+/// screens pass [BackdropSource.none] to show the calm static fallback.
+void publishBackdropSource(WidgetRef ref, BackdropSource source) {
+  SchedulerBinding.instance.addPostFrameCallback((_) {
+    // The ref may have been disposed if the screen left the tree before the
+    // post-frame callback ran; guard against that.
+    if (!ref.context.mounted) return;
+    ref.read(ambientBackdropControllerProvider.notifier).set(source);
+  });
+}

--- a/player/lib/presentation/widgets/ambient_backdrop_provider.dart
+++ b/player/lib/presentation/widgets/ambient_backdrop_provider.dart
@@ -61,6 +61,12 @@ class AmbientBackdropController extends _$AmbientBackdropController {
 /// synchronously while building (which Riverpod disallows). Grid/settings
 /// screens pass [BackdropSource.none] to show the calm static fallback.
 void publishBackdropSource(WidgetRef ref, BackdropSource source) {
+  // Skip scheduling entirely when the published source is already identical.
+  // Many screens call this unconditionally from `build`, so without this guard
+  // every rebuild (scroll, hover, animation) would enqueue a redundant
+  // post-frame callback. A cheap read-and-compare avoids that churn.
+  if (ref.read(ambientBackdropControllerProvider) == source) return;
+
   SchedulerBinding.instance.addPostFrameCallback((_) {
     // The ref may have been disposed if the screen left the tree before the
     // post-frame callback ran; guard against that.

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -14,6 +14,8 @@ import '../screens/collections/collection_detail_controller.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/p2p/p2p_service.dart';
 import '../../core/theme/colors.dart';
+import 'ambient_backdrop.dart';
+import 'ambient_backdrop_provider.dart';
 import 'glass_surface.dart';
 import 'offline_banner.dart';
 
@@ -373,30 +375,44 @@ class _AppShellState extends ConsumerState<AppShell> {
     // on the Scaffold (causing the "stuck navigation" bug).
     final isDesktop = Breakpoints.isDesktop(context);
 
+    // Shell-level ambient backdrop, fed by the active browse screen. Sits behind
+    // the (now transparent) in-shell Scaffolds for all browse screens (plan U5).
+    final backdropSource = ref.watch(ambientBackdropControllerProvider);
+    final backdrop = AmbientBackdrop(
+      imageUrl: backdropSource.imageUrl,
+      id: backdropSource.id,
+    );
+
     if (isDesktop) {
       return Scaffold(
-        body: Row(
+        backgroundColor: Colors.transparent,
+        body: Stack(
           children: [
-            _DesktopSidebar(
-              location: location,
-              onNavigate: _navigateTo,
-              homeExpanded: _homeExpanded,
-              libraryExpanded: _libraryExpanded,
-              onToggleHome: () =>
-                  setState(() => _homeExpanded = !_homeExpanded),
-              onToggleLibrary: () =>
-                  setState(() => _libraryExpanded = !_libraryExpanded),
-              showBackToMydia: showBackToMydia,
-              isOffline: isOffline,
-            ),
-            Expanded(
-              child: Column(
-                children: [
-                  SizedBox(height: _macOSTitleBarPadding),
-                  if (isOffline) const OfflineBanner(),
-                  Expanded(child: widget.child),
-                ],
-              ),
+            Positioned.fill(child: backdrop),
+            Row(
+              children: [
+                _DesktopSidebar(
+                  location: location,
+                  onNavigate: _navigateTo,
+                  homeExpanded: _homeExpanded,
+                  libraryExpanded: _libraryExpanded,
+                  onToggleHome: () =>
+                      setState(() => _homeExpanded = !_homeExpanded),
+                  onToggleLibrary: () =>
+                      setState(() => _libraryExpanded = !_libraryExpanded),
+                  showBackToMydia: showBackToMydia,
+                  isOffline: isOffline,
+                ),
+                Expanded(
+                  child: Column(
+                    children: [
+                      SizedBox(height: _macOSTitleBarPadding),
+                      if (isOffline) const OfflineBanner(),
+                      Expanded(child: widget.child),
+                    ],
+                  ),
+                ),
+              ],
             ),
           ],
         ),
@@ -405,6 +421,7 @@ class _AppShellState extends ConsumerState<AppShell> {
 
     return Scaffold(
       key: AppShell.scaffoldKey,
+      backgroundColor: Colors.transparent,
       extendBody: true,
       drawer: _MobileDrawer(
         location: location,
@@ -420,10 +437,15 @@ class _AppShellState extends ConsumerState<AppShell> {
         showBackToMydia: showBackToMydia,
         isOffline: isOffline,
       ),
-      body: Column(
+      body: Stack(
         children: [
-          if (isOffline) const OfflineBanner(),
-          Expanded(child: widget.child),
+          Positioned.fill(child: backdrop),
+          Column(
+            children: [
+              if (isOffline) const OfflineBanner(),
+              Expanded(child: widget.child),
+            ],
+          ),
         ],
       ),
       bottomNavigationBar: _ModernBottomNav(

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -14,6 +14,7 @@ import '../screens/collections/collection_detail_controller.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/p2p/p2p_service.dart';
 import '../../core/theme/colors.dart';
+import 'glass_surface.dart';
 import 'offline_banner.dart';
 
 /// Connection status badge for the settings icon.
@@ -1008,13 +1009,12 @@ class _ModernBottomNav extends StatelessWidget {
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-        child: Container(
+        child: DecoratedBox(
+          // Drop shadow lives on an outer box; GlassSurface clips its own
+          // blurred fill so the pill now reads as true frosted glass over the
+          // ambient backdrop instead of a near-opaque surface.
           decoration: BoxDecoration(
-            color: AppColors.surface.withValues(alpha: 0.92),
             borderRadius: BorderRadius.circular(22),
-            border: Border.all(
-              color: AppColors.border.withValues(alpha: 0.2),
-            ),
             boxShadow: [
               BoxShadow(
                 color: Colors.black.withValues(alpha: 0.1),
@@ -1024,7 +1024,14 @@ class _ModernBottomNav extends StatelessWidget {
               ),
             ],
           ),
-          child: Padding(
+          child: GlassSurface(
+            blurSigma: 10,
+            fillColor: AppColors.surface.withValues(alpha: 0.7),
+            borderRadius: BorderRadius.circular(22),
+            border: Border.all(
+              color: AppColors.border.withValues(alpha: 0.2),
+            ),
+            child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceAround,
@@ -1085,6 +1092,7 @@ class _ModernBottomNav extends StatelessWidget {
                 ),
               ],
             ),
+          ),
           ),
         ),
       ),

--- a/player/lib/presentation/widgets/episode_card.dart
+++ b/player/lib/presentation/widgets/episode_card.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -9,6 +8,7 @@ import '../../core/downloads/download_service.dart' show isDownloadSupported;
 import '../../core/downloads/download_providers.dart';
 import '../../core/downloads/download_job_providers.dart';
 import '../../core/theme/colors.dart';
+import 'glass_surface.dart';
 import 'quality_download_dialog.dart';
 import 'quality_badge.dart';
 
@@ -194,34 +194,32 @@ class _EpisodeCardState extends ConsumerState<EpisodeCard>
           ),
 
           // Hover overlay with play button
-          AnimatedOpacity(
-            opacity: _isHovered && widget.episode.hasFile ? 1.0 : 0.0,
-            duration: const Duration(milliseconds: 200),
-            child: ClipRRect(
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 2, sigmaY: 2),
-                child: Container(
-                  color: Colors.black.withValues(alpha: 0.5),
-                  child: Center(
-                    child: Container(
-                      width: 48,
-                      height: 48,
-                      decoration: BoxDecoration(
-                        color: AppColors.primary,
-                        shape: BoxShape.circle,
-                        boxShadow: [
-                          BoxShadow(
-                            color: AppColors.primary.withValues(alpha: 0.4),
-                            blurRadius: 12,
-                            offset: const Offset(0, 4),
-                          ),
-                        ],
-                      ),
-                      child: const Icon(
-                        Icons.play_arrow_rounded,
-                        size: 28,
-                        color: Colors.white,
-                      ),
+          Positioned.fill(
+            child: AnimatedOpacity(
+              opacity: _isHovered && widget.episode.hasFile ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: GlassSurface(
+                blurSigma: 2,
+                fillColor: Colors.black.withValues(alpha: 0.5),
+                child: Center(
+                  child: Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      color: AppColors.primary,
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color: AppColors.primary.withValues(alpha: 0.4),
+                          blurRadius: 12,
+                          offset: const Offset(0, 4),
+                        ),
+                      ],
+                    ),
+                    child: const Icon(
+                      Icons.play_arrow_rounded,
+                      size: 28,
+                      color: Colors.white,
                     ),
                   ),
                 ),

--- a/player/lib/presentation/widgets/glass_surface.dart
+++ b/player/lib/presentation/widgets/glass_surface.dart
@@ -1,0 +1,138 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import '../../core/theme/colors.dart';
+
+/// A single reusable frosted-glass surface that subsumes the player's three
+/// ad-hoc `BackdropFilter` variants (app bar, modal, card hover overlay).
+///
+/// Internally this is `RepaintBoundary > ClipRRect > BackdropFilter > fill`,
+/// so live blur stays isolated to small fixed-position chrome (R8/R11) and the
+/// blur region repaints independently of surrounding content.
+///
+/// Use the named constructors ([GlassSurface.appBar], [GlassSurface.modal],
+/// [GlassSurface.hoverOverlay]) to reproduce the existing visual treatments
+/// exactly; the unnamed constructor is available for bespoke surfaces.
+///
+/// When several glass surfaces are visible at once, wrap them in a
+/// [BackdropGroup] and pass `grouped: true` so they share a single backdrop
+/// rendering pass (uses [BackdropFilter.grouped]).
+class GlassSurface extends StatelessWidget {
+  /// Gaussian blur sigma applied behind the surface.
+  final double blurSigma;
+
+  /// Solid fill painted over the blur. Ignored when [gradient] is set.
+  final Color? fillColor;
+
+  /// Optional gradient fill painted over the blur (e.g. the card hover scrim).
+  /// Takes precedence over [fillColor] when both are provided.
+  final Gradient? gradient;
+
+  /// Corner radius for the clip and border.
+  final BorderRadius borderRadius;
+
+  /// Optional border drawn on the fill.
+  final BoxBorder? border;
+
+  /// Whether to participate in an enclosing [BackdropGroup] for a shared
+  /// rendering pass. Requires a [BackdropGroup] ancestor.
+  final bool grouped;
+
+  final Widget? child;
+
+  const GlassSurface({
+    super.key,
+    required this.blurSigma,
+    this.fillColor,
+    this.gradient,
+    this.borderRadius = BorderRadius.zero,
+    this.border,
+    this.grouped = false,
+    this.child,
+  });
+
+  /// App-bar chrome glass: blur sigma 10, [AppColors.background] fill, no
+  /// border, square corners. Pass [opacity] to override the fill alpha
+  /// (0.85 for the library/downloads bars, 0.8 elsewhere).
+  GlassSurface.appBar({
+    Key? key,
+    double opacity = 0.8,
+    bool grouped = false,
+    Widget? child,
+  }) : this(
+          key: key,
+          blurSigma: 10,
+          fillColor: AppColors.background.withValues(alpha: opacity),
+          grouped: grouped,
+          child: child,
+        );
+
+  /// Modal / sheet glass: blur sigma 8, [AppColors.surface] @0.6 fill,
+  /// [AppColors.border] @0.2 border, radius 20.
+  GlassSurface.modal({
+    Key? key,
+    bool grouped = false,
+    Widget? child,
+  }) : this(
+          key: key,
+          blurSigma: 8,
+          fillColor: AppColors.surface.withValues(alpha: 0.6),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: AppColors.border.withValues(alpha: 0.2),
+          ),
+          grouped: grouped,
+          child: child,
+        );
+
+  /// Media-card hover overlay glass: blur sigma 2, vertical black gradient
+  /// (0.3 -> 0.6), radius 12.
+  GlassSurface.hoverOverlay({
+    Key? key,
+    BorderRadius? borderRadius,
+    bool grouped = false,
+    Widget? child,
+  }) : this(
+          key: key,
+          blurSigma: 2,
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Colors.black.withValues(alpha: 0.3),
+              Colors.black.withValues(alpha: 0.6),
+            ],
+          ),
+          borderRadius: borderRadius ?? BorderRadius.circular(12),
+          grouped: grouped,
+          child: child,
+        );
+
+  @override
+  Widget build(BuildContext context) {
+    final filter = ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma);
+    final backdrop = grouped
+        ? BackdropFilter.grouped(filter: filter, child: _fill())
+        : BackdropFilter(filter: filter, child: _fill());
+
+    return RepaintBoundary(
+      child: ClipRRect(
+        borderRadius: borderRadius,
+        child: backdrop,
+      ),
+    );
+  }
+
+  Widget _fill() {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: gradient == null ? fillColor : null,
+        gradient: gradient,
+        borderRadius: borderRadius,
+        border: border,
+      ),
+      child: child,
+    );
+  }
+}

--- a/player/lib/presentation/widgets/media_card.dart
+++ b/player/lib/presentation/widgets/media_card.dart
@@ -7,6 +7,7 @@ import '../../domain/models/media_file.dart';
 import 'glass_surface.dart';
 import 'progress_overlay.dart';
 import 'quality_badge.dart';
+import 'specular_sheen.dart';
 
 class MediaCard extends StatefulWidget {
   final String? posterUrl;
@@ -17,6 +18,7 @@ class MediaCard extends StatefulWidget {
   final double? width;
   final double? height;
   final List<MediaFile>? files;
+
   /// If true, uses responsive sizing based on screen width
   final bool responsive;
 
@@ -162,78 +164,83 @@ class _MediaCardState extends State<MediaCard>
                       child: child,
                     );
                   },
-                  child: ClipRRect(
+                  child: SpecularSheen(
                     borderRadius: BorderRadius.circular(12),
-                    child: Stack(
-                      children: [
-                        // Poster image
-                        SizedBox(
-                          width: cardWidth,
-                          height: cardHeight,
-                          child: widget.posterUrl != null
-                              ? CachedNetworkImage(
-                                  imageUrl: widget.posterUrl!,
-                                  fit: BoxFit.cover,
-                                  cacheManager: PosterCacheManager(),
-                                  placeholder: (context, url) => _buildPlaceholder(),
-                                  errorWidget: (context, url, error) =>
-                                      _buildPlaceholder(),
-                                )
-                              : _buildPlaceholder(),
-                        ),
-
-                        // Progress overlay at bottom
-                        if (widget.progressPercentage != null &&
-                            widget.progressPercentage! > 0)
-                          ProgressOverlay(percentage: widget.progressPercentage!),
-
-                        // Quality badges at top-right
-                        if (quality.hasQuality)
-                          Positioned(
-                            top: 8,
-                            right: 8,
-                            child: QualityBadgeRow(
-                              badges: quality.toBadges(),
-                              spacing: 4.0,
-                            ),
-                          ),
-
-                        // Hover overlay with glassmorphism
-                        AnimatedOpacity(
-                          opacity: _isHovered ? 1.0 : 0.0,
-                          duration: const Duration(milliseconds: 200),
-                          curve: Curves.easeOut,
-                          child: SizedBox(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(12),
+                      child: Stack(
+                        children: [
+                          // Poster image
+                          SizedBox(
                             width: cardWidth,
                             height: cardHeight,
-                            child: GlassSurface.hoverOverlay(
-                              child: Center(
-                                child: Container(
-                                  width: 56,
-                                  height: 56,
-                                  decoration: BoxDecoration(
-                                    color: AppColors.primary,
-                                    shape: BoxShape.circle,
-                                    boxShadow: [
-                                      BoxShadow(
-                                        color: AppColors.primary
-                                            .withValues(alpha: 0.4),
-                                        blurRadius: 16,
-                                        offset: const Offset(0, 4),
-                                      ),
-                                    ],
-                                  ),
-                                  child: const Icon(
-                                    Icons.play_arrow_rounded,
-                                    size: 32,
-                                    color: Colors.white,
+                            child: widget.posterUrl != null
+                                ? CachedNetworkImage(
+                                    imageUrl: widget.posterUrl!,
+                                    fit: BoxFit.cover,
+                                    cacheManager: PosterCacheManager(),
+                                    placeholder: (context, url) =>
+                                        _buildPlaceholder(),
+                                    errorWidget: (context, url, error) =>
+                                        _buildPlaceholder(),
+                                  )
+                                : _buildPlaceholder(),
+                          ),
+
+                          // Progress overlay at bottom
+                          if (widget.progressPercentage != null &&
+                              widget.progressPercentage! > 0)
+                            ProgressOverlay(
+                                percentage: widget.progressPercentage!),
+
+                          // Quality badges at top-right
+                          if (quality.hasQuality)
+                            Positioned(
+                              top: 8,
+                              right: 8,
+                              child: QualityBadgeRow(
+                                badges: quality.toBadges(),
+                                spacing: 4.0,
+                              ),
+                            ),
+
+                          // Hover overlay with glassmorphism
+                          AnimatedOpacity(
+                            opacity: _isHovered ? 1.0 : 0.0,
+                            duration: const Duration(milliseconds: 200),
+                            curve: Curves.easeOut,
+                            child: SizedBox(
+                              width: cardWidth,
+                              height: cardHeight,
+                              child: GlassSurface.hoverOverlay(
+                                child: Center(
+                                  child: Container(
+                                    width: 56,
+                                    height: 56,
+                                    decoration: BoxDecoration(
+                                      color: AppColors.primary,
+                                      shape: BoxShape.circle,
+                                      boxShadow: [
+                                        BoxShadow(
+                                          color: AppColors.primary
+                                              .withValues(alpha: 0.4),
+                                          blurRadius: 16,
+                                          offset: const Offset(0, 4),
+                                        ),
+                                      ],
+                                    ),
+                                    child: const Icon(
+                                      Icons.play_arrow_rounded,
+                                      size: 32,
+                                      color: Colors.white,
+                                    ),
                                   ),
                                 ),
                               ),
                             ),
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/player/lib/presentation/widgets/media_card.dart
+++ b/player/lib/presentation/widgets/media_card.dart
@@ -1,10 +1,10 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import '../../core/cache/poster_cache_manager.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/theme/colors.dart';
 import '../../domain/models/media_file.dart';
+import 'glass_surface.dart';
 import 'progress_overlay.dart';
 import 'quality_badge.dart';
 
@@ -203,44 +203,30 @@ class _MediaCardState extends State<MediaCard>
                           opacity: _isHovered ? 1.0 : 0.0,
                           duration: const Duration(milliseconds: 200),
                           curve: Curves.easeOut,
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(12),
-                            child: BackdropFilter(
-                              filter: ImageFilter.blur(sigmaX: 2, sigmaY: 2),
-                              child: Container(
-                                width: cardWidth,
-                                height: cardHeight,
-                                decoration: BoxDecoration(
-                                  gradient: LinearGradient(
-                                    begin: Alignment.topCenter,
-                                    end: Alignment.bottomCenter,
-                                    colors: [
-                                      Colors.black.withValues(alpha: 0.3),
-                                      Colors.black.withValues(alpha: 0.6),
+                          child: SizedBox(
+                            width: cardWidth,
+                            height: cardHeight,
+                            child: GlassSurface.hoverOverlay(
+                              child: Center(
+                                child: Container(
+                                  width: 56,
+                                  height: 56,
+                                  decoration: BoxDecoration(
+                                    color: AppColors.primary,
+                                    shape: BoxShape.circle,
+                                    boxShadow: [
+                                      BoxShadow(
+                                        color: AppColors.primary
+                                            .withValues(alpha: 0.4),
+                                        blurRadius: 16,
+                                        offset: const Offset(0, 4),
+                                      ),
                                     ],
                                   ),
-                                ),
-                                child: Center(
-                                  child: Container(
-                                    width: 56,
-                                    height: 56,
-                                    decoration: BoxDecoration(
-                                      color: AppColors.primary,
-                                      shape: BoxShape.circle,
-                                      boxShadow: [
-                                        BoxShadow(
-                                          color: AppColors.primary
-                                              .withValues(alpha: 0.4),
-                                          blurRadius: 16,
-                                          offset: const Offset(0, 4),
-                                        ),
-                                      ],
-                                    ),
-                                    child: const Icon(
-                                      Icons.play_arrow_rounded,
-                                      size: 32,
-                                      color: Colors.white,
-                                    ),
+                                  child: const Icon(
+                                    Icons.play_arrow_rounded,
+                                    size: 32,
+                                    color: Colors.white,
                                   ),
                                 ),
                               ),

--- a/player/lib/presentation/widgets/specular_sheen.dart
+++ b/player/lib/presentation/widgets/specular_sheen.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+import '../../core/ui/reduced_motion.dart';
+
+/// Wraps [child] with a subtle cursor-tracking specular highlight for desktop
+/// depth (plan U6 / R9).
+///
+/// The cursor position is pushed into a [ValueNotifier] on hover and only a
+/// thin [RadialGradient] overlay rebuilds via [ValueListenableBuilder] — the
+/// wrapped [child] never rebuilds, and we never `setState` per hover tick. The
+/// sheen layer is isolated in a [RepaintBoundary].
+///
+/// When the user prefers reduced motion the sheen is removed entirely: no
+/// listener is attached and only the flat [child] is rendered (plan AE4).
+///
+/// A [BoxDecoration] radial gradient is used (not a `ShaderMask`) to avoid
+/// `saveLayer` cost across many simultaneously-hoverable cards.
+class SpecularSheen extends StatefulWidget {
+  /// The content the sheen overlays.
+  final Widget child;
+
+  /// Corner radius of the sheen clip, matched to the host (e.g. a card).
+  final BorderRadius borderRadius;
+
+  /// Peak opacity of the sheen highlight at the cursor.
+  final double intensity;
+
+  /// Radius of the radial sheen as a fraction of the shorter side.
+  final double radiusFactor;
+
+  const SpecularSheen({
+    super.key,
+    required this.child,
+    this.borderRadius = BorderRadius.zero,
+    this.intensity = 0.12,
+    this.radiusFactor = 0.6,
+  });
+
+  /// Maps a local cursor [position] inside a box of [size] to the [Alignment]
+  /// used as the radial-gradient center (-1..1 on each axis). Exposed for
+  /// testing the position math independently of pointer simulation.
+  static Alignment alignmentFor(Offset position, Size size) {
+    if (size.width <= 0 || size.height <= 0) return Alignment.center;
+    final dx = (position.dx / size.width) * 2 - 1;
+    final dy = (position.dy / size.height) * 2 - 1;
+    return Alignment(dx.clamp(-1.0, 1.0), dy.clamp(-1.0, 1.0));
+  }
+
+  @override
+  State<SpecularSheen> createState() => _SpecularSheenState();
+}
+
+class _SpecularSheenState extends State<SpecularSheen> {
+  /// Cursor position within the widget, in local logical pixels. Null when the
+  /// pointer is outside (sheen hidden).
+  final ValueNotifier<Offset?> _cursor = ValueNotifier<Offset?>(null);
+
+  @override
+  void dispose() {
+    _cursor.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Reduced motion: render the flat child only, no listener, no sheen.
+    if (context.reduceMotion) {
+      return widget.child;
+    }
+
+    return MouseRegion(
+      onHover: (event) => _cursor.value = event.localPosition,
+      onExit: (_) => _cursor.value = null,
+      child: Stack(
+        children: [
+          widget.child,
+          Positioned.fill(
+            child: RepaintBoundary(
+              child: IgnorePointer(
+                child: ValueListenableBuilder<Offset?>(
+                  valueListenable: _cursor,
+                  builder: (context, cursor, _) {
+                    if (cursor == null) return const SizedBox.shrink();
+                    return LayoutBuilder(
+                      builder: (context, constraints) {
+                        final size = constraints.biggest;
+                        return ClipRRect(
+                          borderRadius: widget.borderRadius,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              gradient: RadialGradient(
+                                center: SpecularSheen.alignmentFor(cursor, size),
+                                radius: widget.radiusFactor,
+                                colors: [
+                                  Colors.white
+                                      .withValues(alpha: widget.intensity),
+                                  Colors.white.withValues(alpha: 0.0),
+                                ],
+                                stops: const [0.0, 1.0],
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/player/test/core/ui/reduced_motion_test.dart
+++ b/player/test/core/ui/reduced_motion_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/ui/reduced_motion.dart';
+
+/// Pumps [child] under a [MediaQuery] with the given accessibility flags and
+/// returns nothing — the child captures the value it reads.
+Widget _wrap({
+  required Widget child,
+  bool disableAnimations = false,
+  bool accessibleNavigation = false,
+}) {
+  return MediaQuery(
+    data: MediaQueryData(
+      disableAnimations: disableAnimations,
+      accessibleNavigation: accessibleNavigation,
+    ),
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: child,
+    ),
+  );
+}
+
+/// Small consumer that records what it read from [ReducedMotion] and how many
+/// times it has rebuilt, so tests can assert on reactivity.
+class _Probe extends StatelessWidget {
+  const _Probe({required this.onBuild});
+
+  final void Function(bool reduceMotion) onBuild;
+
+  @override
+  Widget build(BuildContext context) {
+    onBuild(ReducedMotion.of(context));
+    return const SizedBox.shrink();
+  }
+}
+
+void main() {
+  group('ReducedMotion.of', () {
+    testWidgets('returns true when disableAnimations is true (AE4)',
+        (tester) async {
+      bool? captured;
+      await tester.pumpWidget(
+        _wrap(
+          disableAnimations: true,
+          child: _Probe(onBuild: (v) => captured = v),
+        ),
+      );
+      expect(captured, isTrue);
+    });
+
+    testWidgets(
+        'returns true when accessibleNavigation is true and '
+        'disableAnimations is false', (tester) async {
+      bool? captured;
+      await tester.pumpWidget(
+        _wrap(
+          accessibleNavigation: true,
+          child: _Probe(onBuild: (v) => captured = v),
+        ),
+      );
+      expect(captured, isTrue);
+    });
+
+    testWidgets('returns false under default MediaQueryData', (tester) async {
+      bool? captured;
+      await tester.pumpWidget(
+        _wrap(child: _Probe(onBuild: (v) => captured = v)),
+      );
+      expect(captured, isFalse);
+    });
+
+    testWidgets('rebuilds dependents when MediaQuery flips at runtime',
+        (tester) async {
+      final reads = <bool>[];
+      Widget build(bool disableAnimations) => _wrap(
+            disableAnimations: disableAnimations,
+            child: _Probe(onBuild: reads.add),
+          );
+
+      await tester.pumpWidget(build(false));
+      expect(reads.last, isFalse);
+
+      // Flip the inherited MediaQuery; the consumer must re-read the value.
+      await tester.pumpWidget(build(true));
+      expect(reads.last, isTrue);
+    });
+  });
+
+  group('ReducedMotion.duration', () {
+    testWidgets('passes the duration through when motion is allowed',
+        (tester) async {
+      late Duration captured;
+      await tester.pumpWidget(
+        _wrap(
+          child: Builder(
+            builder: (context) {
+              captured = ReducedMotion.duration(
+                context,
+                const Duration(milliseconds: 300),
+              );
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      expect(captured, const Duration(milliseconds: 300));
+    });
+
+    testWidgets('collapses to zero when motion is suppressed', (tester) async {
+      late Duration captured;
+      await tester.pumpWidget(
+        _wrap(
+          disableAnimations: true,
+          child: Builder(
+            builder: (context) {
+              captured = ReducedMotion.duration(
+                context,
+                const Duration(milliseconds: 300),
+              );
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      expect(captured, Duration.zero);
+    });
+  });
+
+  group('ReducedMotionContext extension', () {
+    testWidgets('reduceMotion mirrors ReducedMotion.of', (tester) async {
+      bool? captured;
+      await tester.pumpWidget(
+        _wrap(
+          disableAnimations: true,
+          child: Builder(
+            builder: (context) {
+              captured = context.reduceMotion;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      expect(captured, isTrue);
+    });
+  });
+}

--- a/player/test/presentation/screens/home_hero_parallax_test.dart
+++ b/player/test/presentation/screens/home_hero_parallax_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/screens/home_screen.dart';
+
+void main() {
+  group('homeHeroParallaxOffset', () {
+    test('shifts proportionally with scroll offset', () {
+      final atZero = homeHeroParallaxOffset(0, reduceMotion: false);
+      final atSome = homeHeroParallaxOffset(50, reduceMotion: false);
+      final atMore = homeHeroParallaxOffset(100, reduceMotion: false);
+
+      expect(atZero, 0);
+      // Image translates upward (negative) as the user scrolls down.
+      expect(atSome, lessThan(0));
+      // More scroll -> more (more-negative) translation, until clamped.
+      expect(atMore, lessThan(atSome));
+    });
+
+    test('is static (zero) across all offsets under reduced motion', () {
+      for (final offset in const [0.0, 50.0, 200.0, 1000.0, -300.0]) {
+        expect(
+          homeHeroParallaxOffset(offset, reduceMotion: true),
+          0,
+          reason: 'offset $offset should not parallax under reduced motion',
+        );
+      }
+    });
+
+    test('is bounded to ±homeHeroMaxParallax so no edge gap is exposed', () {
+      // Extreme positive and negative scroll never exceed the over-size budget.
+      expect(
+        homeHeroParallaxOffset(100000, reduceMotion: false),
+        greaterThanOrEqualTo(-homeHeroMaxParallax),
+      );
+      expect(
+        homeHeroParallaxOffset(-100000, reduceMotion: false),
+        lessThanOrEqualTo(homeHeroMaxParallax),
+      );
+      // At a large positive scroll it saturates at the lower bound.
+      expect(
+        homeHeroParallaxOffset(100000, reduceMotion: false),
+        -homeHeroMaxParallax,
+      );
+    });
+  });
+}

--- a/player/test/presentation/widgets/ambient_backdrop_contrast_test.dart
+++ b/player/test/presentation/widgets/ambient_backdrop_contrast_test.dart
@@ -1,0 +1,100 @@
+// U8 — contrast and performance verification (plan R3, R11; AE1).
+//
+// Contrast is asserted computably below: the dark scrim composited over
+// worst-case bright (white) artwork must keep primary text at WCAG AAA (>=7:1)
+// and secondary text at WCAG AA body (>=4.5:1). With the tuned
+// `AmbientBackdropScrim.baseDim`, the effective background over white artwork is
+// ~rgb(39,46,59): primary ~11.6:1, secondary ~4.7:1. Real artwork (non-white,
+// blurred) yields higher contrast, so these are conservative lower bounds.
+//
+// Frame-rate / scroll performance is MANUAL and cannot run in this headless
+// unit-test environment (no CanvasKit browser). Procedure to run by hand:
+//   1. `./dev up -d` then open http://localhost:4000/player in Chrome.
+//   2. Build/serve the web target (CanvasKit) and open Chrome DevTools
+//      Performance panel (or Flutter DevTools > Performance, "Frame rendering").
+//   3. Record while scrolling (a) the Home screen with the hero parallax and
+//      (b) a dense grid (e.g. Movies/Recently Added) end-to-end.
+//   4. Confirm no sustained frame drops below 60fps attributable to the
+//      backdrop, sheen, or glass. The backdrop is a pre-blurred ImageFiltered
+//      layer (not a live full-screen BackdropFilter behind scroll); each
+//      blur/sheen region is wrapped in a RepaintBoundary.
+// No fabricated frame numbers are recorded here — this requires manual browser
+// profiling.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/theme/colors.dart';
+import 'package:player/presentation/widgets/ambient_backdrop.dart';
+
+/// WCAG relative luminance of an opaque [color].
+double _relativeLuminance(Color color) {
+  double channel(double c) {
+    final s = c; // already 0..1
+    return s <= 0.03928 ? s / 12.92 : math.pow((s + 0.055) / 1.055, 2.4) as double;
+  }
+
+  final r = channel(color.r);
+  final g = channel(color.g);
+  final b = channel(color.b);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/// WCAG contrast ratio between two opaque colors.
+double _contrastRatio(Color a, Color b) {
+  final la = _relativeLuminance(a);
+  final lb = _relativeLuminance(b);
+  final lighter = math.max(la, lb);
+  final darker = math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/// Alpha-composite [fg] (with its own alpha) over an opaque [bg].
+Color _composite(Color fg, Color bg) {
+  final a = fg.a;
+  return Color.from(
+    alpha: 1.0,
+    red: fg.r * a + bg.r * (1 - a),
+    green: fg.g * a + bg.g * (1 - a),
+    blue: fg.b * a + bg.b * (1 - a),
+  );
+}
+
+void main() {
+  // Worst case for contrast: a fully bright (white) backdrop artwork. The dark
+  // scrim composited over it sets the effective background text sits on.
+  const brightArtwork = Color(0xFFFFFFFF);
+
+  // The scrim base color is AppColors.background; its alpha is the tuned dim.
+  final scrim = AppColors.background.withValues(
+    alpha: AmbientBackdropScrim.baseDim,
+  );
+  final effectiveBackground = _composite(scrim, brightArtwork);
+
+  group('AmbientBackdrop scrim contrast over bright artwork', () {
+    test('primary text holds a high contrast ratio (~15:1 target)', () {
+      final ratio = _contrastRatio(AppColors.textPrimary, effectiveBackground);
+      // Over worst-case white artwork the scrim must keep primary text strongly
+      // legible. We require a comfortably-AAA ratio; the theme targets ~15:1 on
+      // the flat background, and the dim keeps it well above the 7:1 AAA bar.
+      expect(ratio, greaterThanOrEqualTo(7.0),
+          reason: 'primary text contrast was $ratio');
+    });
+
+    test('secondary text holds an AA-large / body-legible ratio', () {
+      final ratio =
+          _contrastRatio(AppColors.textSecondary, effectiveBackground);
+      // Secondary text targets ~7:1 on the flat theme; over worst-case bright
+      // artwork it must still clear the WCAG AA 4.5:1 body-text bar.
+      expect(ratio, greaterThanOrEqualTo(4.5),
+          reason: 'secondary text contrast was $ratio');
+    });
+
+    test('the effective background stays dark (luminance well below mid)', () {
+      // A sanity bound: the scrimmed bright artwork must read as a dark surface
+      // so the cinematic look and contrast both hold.
+      expect(_relativeLuminance(effectiveBackground), lessThan(0.25));
+    });
+  });
+}

--- a/player/test/presentation/widgets/ambient_backdrop_test.dart
+++ b/player/test/presentation/widgets/ambient_backdrop_test.dart
@@ -1,0 +1,139 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/ambient_backdrop.dart';
+
+import '../../test_utils/mock_network_images.dart';
+
+Widget _host(
+  Widget child, {
+  bool disableAnimations = false,
+}) {
+  return MaterialApp(
+    home: MediaQuery(
+      data: MediaQueryData(disableAnimations: disableAnimations),
+      child: Scaffold(body: SizedBox.expand(child: child)),
+    ),
+  );
+}
+
+AnimatedSwitcher _switcherOf(WidgetTester tester) {
+  return tester.widget<AnimatedSwitcher>(find.byType(AnimatedSwitcher));
+}
+
+void main() {
+  group('AmbientBackdrop', () {
+    testWidgets('renders the blur via ImageFiltered, not BackdropFilter',
+        (tester) async {
+      await mockNetworkImages(() async {
+        await tester.pumpWidget(
+          _host(const AmbientBackdrop(
+            imageUrl: 'https://example.com/a.jpg',
+            id: 'a',
+          )),
+        );
+        await tester.pump();
+
+        expect(find.byType(ImageFiltered), findsOneWidget);
+        expect(find.byType(BackdropFilter), findsNothing);
+      });
+    });
+
+    testWidgets('null imageUrl renders the static fallback (no image)',
+        (tester) async {
+      await tester.pumpWidget(_host(const AmbientBackdrop()));
+      await tester.pump();
+
+      expect(find.byType(CachedNetworkImage), findsNothing);
+      expect(find.byType(ImageFiltered), findsNothing);
+    });
+
+    testWidgets('changing the id key triggers an AnimatedSwitcher transition',
+        (tester) async {
+      await mockNetworkImages(() async {
+        await tester.pumpWidget(
+          _host(const AmbientBackdrop(
+            imageUrl: 'https://example.com/a.jpg',
+            id: 'a',
+          )),
+        );
+        await tester.pump();
+
+        // Swap the id -> a new keyed child; the switcher keeps both layers
+        // present mid-fade.
+        await tester.pumpWidget(
+          _host(const AmbientBackdrop(
+            imageUrl: 'https://example.com/b.jpg',
+            id: 'b',
+          )),
+        );
+        await tester.pump(const Duration(milliseconds: 100));
+
+        // Two artwork layers exist mid-transition (outgoing + incoming).
+        expect(find.byType(CachedNetworkImage), findsNWidgets(2));
+
+        // Settle to a single layer.
+        await tester.pumpAndSettle();
+        expect(find.byType(CachedNetworkImage), findsOneWidget);
+      });
+    });
+
+    testWidgets('same id with unchanged params does not transition',
+        (tester) async {
+      await mockNetworkImages(() async {
+        await tester.pumpWidget(
+          _host(const AmbientBackdrop(
+            imageUrl: 'https://example.com/a.jpg',
+            id: 'a',
+          )),
+        );
+        await tester.pump();
+
+        // Rebuild with identical id/url.
+        await tester.pumpWidget(
+          _host(const AmbientBackdrop(
+            imageUrl: 'https://example.com/a.jpg',
+            id: 'a',
+          )),
+        );
+        await tester.pump(const Duration(milliseconds: 100));
+
+        // No second layer spawned.
+        expect(find.byType(CachedNetworkImage), findsOneWidget);
+      });
+    });
+
+    testWidgets('with reduced motion on, the crossfade duration is zero',
+        (tester) async {
+      await mockNetworkImages(() async {
+        await tester.pumpWidget(
+          _host(
+            const AmbientBackdrop(
+              imageUrl: 'https://example.com/a.jpg',
+              id: 'a',
+            ),
+            disableAnimations: true,
+          ),
+        );
+        await tester.pump();
+
+        expect(_switcherOf(tester).duration, Duration.zero);
+      });
+    });
+
+    testWidgets('with motion allowed, the crossfade duration is non-zero',
+        (tester) async {
+      await mockNetworkImages(() async {
+        await tester.pumpWidget(
+          _host(const AmbientBackdrop(
+            imageUrl: 'https://example.com/a.jpg',
+            id: 'a',
+          )),
+        );
+        await tester.pump();
+
+        expect(_switcherOf(tester).duration, greaterThan(Duration.zero));
+      });
+    });
+  });
+}

--- a/player/test/presentation/widgets/app_shell_backdrop_test.dart
+++ b/player/test/presentation/widgets/app_shell_backdrop_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/ambient_backdrop.dart';
+import 'package:player/presentation/widgets/ambient_backdrop_provider.dart';
+
+import '../../test_utils/mock_network_images.dart';
+
+/// A minimal stand-in for the shell: it watches the backdrop controller and
+/// renders an [AmbientBackdrop] just like [AppShell] does, while [screen]
+/// publishes a source from its own build.
+Widget _shellHost(Widget screen) {
+  return ProviderScope(
+    child: MaterialApp(
+      home: Consumer(
+        builder: (context, ref, _) {
+          final source = ref.watch(ambientBackdropControllerProvider);
+          return Scaffold(
+            backgroundColor: Colors.transparent,
+            body: Stack(
+              children: [
+                Positioned.fill(
+                  child: AmbientBackdrop(
+                    imageUrl: source.imageUrl,
+                    id: source.id,
+                  ),
+                ),
+                screen,
+              ],
+            ),
+          );
+        },
+      ),
+    ),
+  );
+}
+
+/// A fake browse screen that publishes a fixed source from build.
+class _PublishingScreen extends ConsumerWidget {
+  final BackdropSource source;
+  const _PublishingScreen(this.source);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    publishBackdropSource(ref, source);
+    return const SizedBox.shrink();
+  }
+}
+
+void main() {
+  group('AmbientBackdropController', () {
+    test('starts on the static fallback (none)', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(
+        container.read(ambientBackdropControllerProvider),
+        BackdropSource.none,
+      );
+    });
+
+    test('set updates the source; equal source is a no-op', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(ambientBackdropControllerProvider.notifier);
+
+      const a = BackdropSource(imageUrl: 'u', id: 'a');
+      notifier.set(a);
+      expect(container.read(ambientBackdropControllerProvider), a);
+
+      // Re-setting the same value keeps state identical (no crossfade churn).
+      notifier.set(const BackdropSource(imageUrl: 'u', id: 'a'));
+      expect(container.read(ambientBackdropControllerProvider), a);
+    });
+
+    test('clear returns to the static fallback', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(ambientBackdropControllerProvider.notifier);
+
+      notifier.set(const BackdropSource(imageUrl: 'u', id: 'a'));
+      notifier.clear();
+      expect(
+        container.read(ambientBackdropControllerProvider),
+        BackdropSource.none,
+      );
+    });
+  });
+
+  group('shell backdrop integration', () {
+    testWidgets('a screen publishing artwork feeds the backdrop with the URL',
+        (tester) async {
+      await mockNetworkImages(() async {
+        await tester.pumpWidget(
+          _shellHost(
+            const _PublishingScreen(
+              BackdropSource(imageUrl: 'https://example.com/hero.jpg', id: 'h'),
+            ),
+          ),
+        );
+        // Let the post-frame publish run and rebuild the shell.
+        await tester.pump();
+        await tester.pump();
+
+        final backdrop = tester.widget<AmbientBackdrop>(
+          find.byType(AmbientBackdrop),
+        );
+        expect(backdrop.imageUrl, 'https://example.com/hero.jpg');
+        expect(backdrop.id, 'h');
+      });
+    });
+
+    testWidgets('a screen publishing none renders the static fallback',
+        (tester) async {
+      await tester.pumpWidget(
+        _shellHost(const _PublishingScreen(BackdropSource.none)),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final backdrop = tester.widget<AmbientBackdrop>(
+        find.byType(AmbientBackdrop),
+      );
+      expect(backdrop.imageUrl, isNull);
+      // No artwork image is fetched for the static fallback.
+      expect(find.byType(ImageFiltered), findsNothing);
+    });
+  });
+}

--- a/player/test/presentation/widgets/glass_surface_test.dart
+++ b/player/test/presentation/widgets/glass_surface_test.dart
@@ -1,0 +1,167 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/theme/colors.dart';
+import 'package:player/presentation/widgets/glass_surface.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    );
+
+BackdropFilter _backdropOf(WidgetTester tester) {
+  return tester.widget<BackdropFilter>(find.byType(BackdropFilter));
+}
+
+/// Extracts the blur sigma from a [BackdropFilter]'s image filter by matching
+/// against a freshly built blur filter (ImageFilter equality is value-based).
+bool _hasBlurSigma(BackdropFilter f, double sigma) {
+  return f.filter == ImageFilter.blur(sigmaX: sigma, sigmaY: sigma);
+}
+
+DecoratedBox _decoratedBoxOf(WidgetTester tester) {
+  return tester.widget<DecoratedBox>(
+    find.descendant(
+      of: find.byType(BackdropFilter),
+      matching: find.byType(DecoratedBox),
+    ),
+  );
+}
+
+void main() {
+  group('GlassSurface.appBar', () {
+    testWidgets('renders a BackdropFilter with sigma 10 and the fill opacity',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(GlassSurface.appBar(child: const SizedBox(width: 50, height: 50))),
+      );
+
+      expect(find.byType(BackdropFilter), findsOneWidget);
+      expect(_hasBlurSigma(_backdropOf(tester), 10), isTrue);
+
+      final decoration =
+          _decoratedBoxOf(tester).decoration as BoxDecoration;
+      expect(
+        decoration.color,
+        AppColors.background.withValues(alpha: 0.8),
+      );
+    });
+
+    testWidgets('honors an explicit opacity override (0.85)', (tester) async {
+      await tester.pumpWidget(
+        _host(GlassSurface.appBar(opacity: 0.85, child: const SizedBox())),
+      );
+      final decoration =
+          _decoratedBoxOf(tester).decoration as BoxDecoration;
+      expect(
+        decoration.color,
+        AppColors.background.withValues(alpha: 0.85),
+      );
+    });
+  });
+
+  group('GlassSurface.modal', () {
+    testWidgets('renders border + radius 20 + sigma 8 fill at 0.6',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(GlassSurface.modal(child: const SizedBox())),
+      );
+
+      expect(_hasBlurSigma(_backdropOf(tester), 8), isTrue);
+
+      final decoration =
+          _decoratedBoxOf(tester).decoration as BoxDecoration;
+      expect(decoration.color, AppColors.surface.withValues(alpha: 0.6));
+      expect(decoration.border, isNotNull);
+      expect(decoration.borderRadius, BorderRadius.circular(20));
+    });
+  });
+
+  group('GlassSurface.hoverOverlay', () {
+    testWidgets('renders sigma 2 with a dark gradient and radius 12',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(GlassSurface.hoverOverlay(child: const SizedBox())),
+      );
+
+      expect(_hasBlurSigma(_backdropOf(tester), 2), isTrue);
+
+      final decoration =
+          _decoratedBoxOf(tester).decoration as BoxDecoration;
+      expect(decoration.gradient, isA<LinearGradient>());
+      expect(decoration.borderRadius, BorderRadius.circular(12));
+    });
+
+    testWidgets('honors a custom borderRadius', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          GlassSurface.hoverOverlay(
+            borderRadius: BorderRadius.circular(8),
+            child: const SizedBox(),
+          ),
+        ),
+      );
+      final decoration =
+          _decoratedBoxOf(tester).decoration as BoxDecoration;
+      expect(decoration.borderRadius, BorderRadius.circular(8));
+    });
+  });
+
+  group('grouped rendering', () {
+    testWidgets('a BackdropGroup wrapping two grouped surfaces builds and '
+        'both render', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          BackdropGroup(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                GlassSurface.appBar(
+                  grouped: true,
+                  child: const Text('one'),
+                ),
+                GlassSurface.modal(
+                  grouped: true,
+                  child: const Text('two'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(BackdropGroup), findsOneWidget);
+      expect(find.byType(BackdropFilter), findsNWidgets(2));
+      expect(find.text('one'), findsOneWidget);
+      expect(find.text('two'), findsOneWidget);
+    });
+  });
+
+  group('child rendering', () {
+    testWidgets('renders its child in every preset', (tester) async {
+      for (final surface in [
+        GlassSurface.appBar(child: const Text('appbar')),
+        GlassSurface.modal(child: const Text('modal')),
+        GlassSurface.hoverOverlay(child: const Text('hover')),
+      ]) {
+        await tester.pumpWidget(_host(surface));
+        await tester.pump();
+      }
+      // Last pump is the hover overlay preset.
+      expect(find.text('hover'), findsOneWidget);
+    });
+
+    testWidgets('wraps the blur region in a RepaintBoundary', (tester) async {
+      await tester.pumpWidget(
+        _host(GlassSurface.appBar(child: const SizedBox())),
+      );
+      expect(
+        find.ancestor(
+          of: find.byType(BackdropFilter),
+          matching: find.byType(RepaintBoundary),
+        ),
+        findsWidgets,
+      );
+    });
+  });
+}

--- a/player/test/presentation/widgets/specular_sheen_test.dart
+++ b/player/test/presentation/widgets/specular_sheen_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/specular_sheen.dart';
+
+Widget _host(Widget child, {bool disableAnimations = false}) {
+  return MaterialApp(
+    home: MediaQuery(
+      data: MediaQueryData(disableAnimations: disableAnimations),
+      child: Scaffold(
+        body: Center(
+          child: SizedBox(width: 200, height: 300, child: child),
+        ),
+      ),
+    ),
+  );
+}
+
+/// A child that counts how many times it builds, to prove the sheen does not
+/// rebuild the wrapped subtree on hover.
+class _BuildCounter extends StatelessWidget {
+  final List<int> builds;
+  const _BuildCounter(this.builds);
+
+  @override
+  Widget build(BuildContext context) {
+    builds.add(1);
+    return const ColoredBox(color: Colors.black);
+  }
+}
+
+void main() {
+  group('SpecularSheen.alignmentFor', () {
+    test('maps the center of the box to Alignment.center', () {
+      expect(
+        SpecularSheen.alignmentFor(const Offset(100, 150), const Size(200, 300)),
+        const Alignment(0, 0),
+      );
+    });
+
+    test('maps the top-left corner to (-1, -1)', () {
+      expect(
+        SpecularSheen.alignmentFor(Offset.zero, const Size(200, 300)),
+        const Alignment(-1, -1),
+      );
+    });
+
+    test('maps the bottom-right corner to (1, 1)', () {
+      expect(
+        SpecularSheen.alignmentFor(const Offset(200, 300), const Size(200, 300)),
+        const Alignment(1, 1),
+      );
+    });
+
+    test('clamps out-of-bounds positions to the edge', () {
+      expect(
+        SpecularSheen.alignmentFor(const Offset(400, -50), const Size(200, 300)),
+        const Alignment(1, -1),
+      );
+    });
+
+    test('degenerate size returns center', () {
+      expect(
+        SpecularSheen.alignmentFor(const Offset(10, 10), Size.zero),
+        Alignment.center,
+      );
+    });
+  });
+
+  group('SpecularSheen widget', () {
+    testWidgets('hovering shows a sheen without rebuilding the child',
+        (tester) async {
+      final builds = <int>[];
+      await tester.pumpWidget(_host(SpecularSheen(child: _BuildCounter(builds))));
+      await tester.pump();
+
+      final buildsAfterMount = builds.length;
+
+      // No sheen until the cursor enters.
+      expect(_sheenGradient(tester), isNull);
+
+      final gesture =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(tester.getCenter(find.byType(SpecularSheen)));
+      await tester.pump();
+
+      // Sheen gradient now present.
+      expect(_sheenGradient(tester), isNotNull);
+      // The wrapped child did not rebuild on hover.
+      expect(builds.length, buildsAfterMount);
+    });
+
+    testWidgets('pointer exit clears the sheen', (tester) async {
+      await tester.pumpWidget(_host(const SpecularSheen(child: SizedBox())));
+      await tester.pump();
+
+      final gesture =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(tester.getCenter(find.byType(SpecularSheen)));
+      await tester.pump();
+      expect(_sheenGradient(tester), isNotNull);
+
+      // Move far away -> exit.
+      await gesture.moveTo(const Offset(-500, -500));
+      await tester.pump();
+      expect(_sheenGradient(tester), isNull);
+    });
+
+    testWidgets('reduced motion renders no sheen and ignores hover',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          const SpecularSheen(child: SizedBox()),
+          disableAnimations: true,
+        ),
+      );
+      await tester.pump();
+
+      // No MouseRegion sheen wrapper is attached at all.
+      expect(find.byType(ValueListenableBuilder<Offset?>), findsNothing);
+
+      final gesture =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(tester.getCenter(find.byType(SpecularSheen)));
+      await tester.pump();
+
+      expect(_sheenGradient(tester), isNull);
+    });
+  });
+}
+
+/// Finds the radial sheen gradient if one is currently painted.
+RadialGradient? _sheenGradient(WidgetTester tester) {
+  final decorated = tester
+      .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+      .where((d) => d.decoration is BoxDecoration)
+      .map((d) => (d.decoration as BoxDecoration).gradient)
+      .whereType<RadialGradient>();
+  return decorated.isEmpty ? null : decorated.first;
+}

--- a/player/test/test_utils/mock_network_images.dart
+++ b/player/test/test_utils/mock_network_images.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 

--- a/player/test/test_utils/mock_network_images.dart
+++ b/player/test/test_utils/mock_network_images.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+
+/// A 1x1 transparent PNG used as the canned response for any image request in
+/// widget tests so [CachedNetworkImage] / [NetworkImage] never hit the network.
+final Uint8List _transparentPixelPng = Uint8List.fromList(const <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+  0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+  0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+  0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+]);
+
+/// Runs [body] with all HTTP image requests answered by an in-memory
+/// transparent PNG. Mirrors the common `network_image_mock` pattern without
+/// adding a dependency.
+Future<T> mockNetworkImages<T>(Future<T> Function() body) {
+  return HttpOverrides.runZoned(
+    body,
+    createHttpClient: (_) => _MockHttpClient(),
+  );
+}
+
+class _MockHttpClient implements HttpClient {
+  @override
+  bool autoUncompress = true;
+
+  @override
+  Duration? connectionTimeout;
+
+  @override
+  Duration idleTimeout = const Duration(seconds: 15);
+
+  @override
+  int? maxConnectionsPerHost;
+
+  @override
+  String? userAgent;
+
+  Future<HttpClientRequest> _request() async => _MockHttpClientRequest();
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) => _request();
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) => _request();
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MockHttpClientRequest implements HttpClientRequest {
+  @override
+  final HttpHeaders headers = _MockHttpHeaders();
+
+  @override
+  Future<HttpClientResponse> close() async => _MockHttpClientResponse();
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MockHttpClientResponse implements HttpClientResponse {
+  @override
+  int get statusCode => HttpStatus.ok;
+
+  @override
+  int get contentLength => _transparentPixelPng.length;
+
+  @override
+  HttpClientResponseCompressionState get compressionState =>
+      HttpClientResponseCompressionState.notCompressed;
+
+  @override
+  HttpHeaders get headers => _MockHttpHeaders();
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return Stream<List<int>>.value(_transparentPixelPng).listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MockHttpHeaders implements HttpHeaders {
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
## Player liquid-glass depth pass (v1)

Gives the Flutter player Apple-TV-style depth on desktop web. The browse screens now sit over a shell-level **ambient backdrop** (a blurred, dimmed copy of the home hero's artwork that crossfades behind content), all frosted-glass chrome is consolidated into one reusable `GlassSurface` primitive, and two low-risk motion touches (cursor specular sheen, home-hero parallax) add life — all honoring reduced-motion.

Implements the approved plan `docs/plans/2026-06-16-002-feat-player-liquid-glass-depth-plan.md` (origin brainstorm `docs/brainstorms/2026-06-16-player-liquid-glass-depth-requirements.md`).

### What changed (U1–U8)

- **U1 — Reduced-motion helper** (`core/ui/reduced_motion.dart`): reactive `MediaQuery.disableAnimationsOf` / `accessibleNavigationOf` check, backed by the browser's `prefers-reduced-motion`. Gates every new effect below.
- **U2 — `GlassSurface`** (`presentation/widgets/glass_surface.dart`): one component with `.appBar` / `.modal` / `.hoverOverlay` presets reproducing the prior three ad-hoc blur variants exactly, plus `BackdropGroup` support; each blur region is wrapped in a `RepaintBoundary`.
- **U3 — Chrome migration**: the seven near-identical browse app bars, the login claim-code modal, the media/episode card hover overlays, and the bottom-nav pill now route through `GlassSurface` (the nav pill gains true glass now that a backdrop sits behind it).
- **U4 — `AmbientBackdrop`** (`presentation/widgets/ambient_backdrop.dart`): pre-blurred `ImageFiltered` artwork + dark scrim, `AnimatedSwitcher` keyed by title id with a constant dark base and `precacheImage` to avoid brightness dips / decode hitches. A calm static gradient renders when there's no per-title artwork. **Never** a live full-screen `BackdropFilter` behind scrolling content (R11).
- **U5 — Shell integration**: `AmbientBackdrop` mounted in `AppShell` for both breakpoints; the nine in-shell `Scaffold`s made transparent; a Riverpod controller (`ambient_backdrop_provider.dart`) carries the source. Home publishes its hero pick (`continueWatching.first ?? recentlyAdded.first`, `backdropUrl ?? posterUrl`); grids and settings publish the calm static fallback (never a stale image). Out-of-shell screens (search, detail, players) are untouched.
- **U6 — Cursor specular sheen** (`presentation/widgets/specular_sheen.dart`): `MouseRegion.onHover` → `ValueNotifier` rebuilds only a `RadialGradient` overlay (`BoxDecoration`, not `ShaderMask`), isolated in a `RepaintBoundary`; the wrapped child never rebuilds and there's no `setState` per hover tick. Applied to media-card posters. Removed entirely under reduced motion.
- **U7 — Home-hero parallax**: the hero artwork translates at ~30% of scroll, clamped and clipped against an over-sized image so it never exposes an edge gap; pinned static under reduced motion. Parallax math extracted to a pure, tested function.
- **U8 — Contrast & performance**: scrim alpha tuned (`AmbientBackdropScrim.baseDim = 0.88`) with a computable WCAG contrast assertion. Over worst-case white artwork the effective background is ~`rgb(39,46,59)`: **primary text ~11.6:1 (AAA)**, **secondary ~4.7:1 (AA body)**; real (non-white, blurred) artwork is higher, so these are conservative lower bounds.

### Performance notes (R11)

- Backdrop is a pre-blurred `ImageFiltered` layer + scrim, cached, **not** recomputed while content scrolls in front. Live `BackdropFilter` stays confined to small fixed-position chrome inside `GlassSurface`.
- Blur, sheen, and glass regions are each wrapped in `RepaintBoundary`.

### Verification (automated in this environment via the player Nix flake — Flutter 3.38.5 / Dart 3.10.4, the same toolchain CI uses)

- `flutter pub get` + `flutter pub run build_runner build --delete-conflicting-outputs` (required for the new `@riverpod` provider) — ran clean.
- `flutter analyze`: **0 error/warning-severity issues**. Remaining `info` lints are all pre-existing across the codebase (e.g. `prefer_const`, deprecated members) and predate this branch.
- `flutter test`: **306 tests pass, 0 failures**, including the new `ambient_backdrop_test`, `app_shell_backdrop_test`, `specular_sheen_test`, `home_hero_parallax_test`, and `ambient_backdrop_contrast_test`. A small `mock_network_images` HTTP test helper lets backdrop widget tests run without network IO.

### Manual / not verifiable here

- **Frame-rate scroll profiling (U8)** requires a CanvasKit browser and cannot run in this headless environment. The exact manual procedure (DevTools Performance panel while scrolling Home + a dense grid, watching for drops attributable to backdrop/sheen/glass) is documented at the top of `ambient_backdrop_contrast_test.dart`. No frame numbers were fabricated.
- Visual spot-checks of the crossfade, the nav-pill re-skin, and the per-screen transparent Scaffolds are best confirmed in-browser.

### Deferred follow-ups (per plan Scope Boundaries)

- Per-title color extraction (prefer a backend-computed accent over client-side `palette_generator`).
- Hover-tracked `focusedTitleProvider` so grids react to the card under the cursor (v1 uses the home hero only).
- Poster→detail shared-element (Hero) transition across the shell→root navigator boundary.
- Gating the pre-existing hover/scale animations on reduced motion (v1 gates only the new effects).
- Migrating the remaining out-of-set `BackdropFilter` usages to `GlassSurface`.

Generated `*.g.dart` files are gitignored (CI regenerates them via build_runner), so they are intentionally not committed.
