### PR TITLE
fix(ci): strip prerelease suffix from iOS CFBundleShortVersionString

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,7 +421,12 @@ jobs:
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           VERSION_CODE="${{ needs.prepare.outputs.version_code }}"
-          sed -i '' "s/^version: .*/version: ${VERSION}+${VERSION_CODE}/" pubspec.yaml
+          # Apple's CFBundleShortVersionString must be at most three
+          # period-separated integers, so strip any prerelease suffix
+          # (e.g. 0.12.0-beta.2 -> 0.12.0). The unique build number is
+          # carried by VERSION_CODE (CFBundleVersion).
+          MARKETING_VERSION="${VERSION%%-*}"
+          sed -i '' "s/^version: .*/version: ${MARKETING_VERSION}+${VERSION_CODE}/" pubspec.yaml
 
       - name: Install dependencies
         if: steps.check_ios.outputs.enabled == 'true'


### PR DESCRIPTION
## Problem

The `Player / iOS` job in the Release workflow fails on **prerelease tags** (beta/rc) during the App Store / TestFlight upload:

```
This bundle is invalid. The value for key CFBundleShortVersionString '0.12.0.2' ...
must be a period-separated list of at most three non-negative integers. (altool error 90060)
```

The workflow writes the full tag-derived version into `pubspec.yaml` (e.g. `0.12.0-beta.2+N`). Flutter renders that into a **four-segment** `CFBundleShortVersionString` (`0.12.0.2`), which Apple rejects. This only affects prerelease tags, which is why stable releases haven't hit it. macOS notarization does **not** enforce the format, so only the iOS job fails — meanwhile the rest of the release publishes fine (observed on `v0.12.0-beta.2`).

## Fix

In the iOS job's "Update version" step, strip the prerelease suffix to a clean marketing version:

```
MARKETING_VERSION="${VERSION%%-*}"   # 0.12.0-beta.2 -> 0.12.0
```

Build-number uniqueness is unchanged (still carried by `VERSION_CODE` → `CFBundleVersion`). The change is **iOS-only**: Docker image labels, release asset filenames, and Android `versionName` keep the full `-beta.N` version.

## Scope / notes

- macOS `.dmg` still embeds the 4-segment string cosmetically, but Sparkle keys off the build number and notarization accepts it, so it is left untouched to avoid disturbing appcast/update detection.
- No functional change for stable tags (`${VERSION%%-*}` is a no-op when there is no suffix).