### PR TITLE
fix(ui): restore browser favicon

### DIFF
--- a/lib/mydia_web/components/layouts/root.html.heex
+++ b/lib/mydia_web/components/layouts/root.html.heex
@@ -9,11 +9,14 @@
     </.live_title>
     <%!-- PWA Support --%>
     <link rel="manifest" href={~p"/manifest.json"} />
+    <link rel="icon" href={~p"/favicon.ico"} sizes="64x64" />
+    <link rel="icon" type="image/png" sizes="192x192" href={~p"/images/icons/icon-192.png"} />
+    <link rel="mask-icon" href={~p"/images/logo-maskable.svg"} color="#3b82f6" />
     <meta name="theme-color" content="#3b82f6" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Mydia" />
-    <link rel="apple-touch-icon" href={~p"/images/icons/icon-192.png"} />
+    <link rel="apple-touch-icon" sizes="192x192" href={~p"/images/icons/icon-192.png"} />
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
     </script>


### PR DESCRIPTION
Adds explicit favicon, PNG icon, mask icon, and Apple touch icon metadata so browsers can discover the app icon. The PWA manifest alone was not enough for any of the browsers I tested. 
Spot tested this change on a few browsers and devices: Brave(macOS), and Safari(macOS), and Edge(Windows). I don't use chrome, but it should resolve it there as well. 
<img width="157" height="45" alt="image" src="https://github.com/user-attachments/assets/5319f832-018a-4ac6-9e8a-493344b2628f" />
