### PR TITLE
fix(test): restore indexer adapter registry after RegistryTest

### DIFF
--- a/test/mydia/indexers/adapter/registry_test.exs
+++ b/test/mydia/indexers/adapter/registry_test.exs
@@ -54,6 +54,16 @@ defmodule Mydia.Indexers.Adapter.RegistryTest do
   setup do
     # Clear registry before each test to ensure clean state
     Registry.clear()
+
+    # This registry is a single global Agent shared across the whole test run.
+    # Restore the real adapters afterward so other async: false suites that rely
+    # on them (e.g. Mydia.Jobs.TVShowSearchTest) don't run against an emptied
+    # registry and fail with "Unknown indexer type: prowlarr".
+    on_exit(fn ->
+      Registry.clear()
+      Mydia.Indexers.register_adapters()
+    end)
+
     :ok
   end
 


### PR DESCRIPTION
## Problem

The `Mydia.Jobs.TVShowSearchTest` tests under **"season pack filtering in episode search"** fail in CI (both the SQLite and PostgreSQL jobs) with:

```
assert length(downloads) == 1
left:  0
right: 1
```

They pass when the file is run in isolation but fail in the full suite — the classic signature of **cross-test global-state contamination**, not a network/timing flake.

## Root cause

`Mydia.Indexers.Adapter.Registry` is a **single global `Agent`**, seeded once at application startup by `Mydia.Indexers.register_adapters/0` (`:prowlarr`, `:jackett`, `:nzbhydra2`, `:cardigann`).

`Mydia.Indexers.Adapter.RegistryTest` is `async: false` and calls `Registry.clear()` in its `setup` before **every** test — but never restores the real adapters. When it runs before `TVShowSearchTest` in the same `mix test` run, `:prowlarr` is no longer registered. Indexer resolution then fails with:

```
%Mydia.Indexers.Adapter.Error{type: :invalid_config, message: "Unknown indexer type: prowlarr"}
```

so the Bypass mock is never even contacted, `Mydia.Indexers.search_all/2` yields no results ("No results found for episode"), no download is created, and the count assertion sees `0`.

`MydiaWeb.AdminIndexersLiveTest` already worked around this by calling `register_adapters/0` in its own `setup` (with a comment naming `RegistryTest` as the culprit); `TVShowSearchTest` had no such guard.

## Fix

`RegistryTest` now restores the real adapters in `on_exit` (`Registry.clear()` + `Mydia.Indexers.register_adapters/0`), leaving the global registry in the state it found it. This fixes the leak at its source, so any downstream suite that relies on the real adapters is unaffected — no per-suite defensive re-registration needed.

Test-support only; no production code touched, no assertions weakened.

## Verification

Reproduced deterministically by forcing the order in a single run:

```
mix test test/mydia/indexers/adapter/registry_test.exs \
         test/mydia/jobs/tv_show_search_test.exs --seed 0
```

- **Before the fix:** `53 tests, 2 failures` (the two season-pack tests).
- **After the fix:** `53 tests, 0 failures`.

## Note

`Mydia.Downloads.Client.Registry` and `Mydia.Metadata.Provider.Registry` follow the same global-Agent pattern and are likewise `clear()`-ed by their own registry tests. They aren't causing the current failure (`TVShowSearchTest` re-registers its download-client mock in setup), but the same "restore in `on_exit`" hardening could be applied to those registry tests as a follow-up to prevent future order-dependent flakes.
