### PR TITLE
ci(player-e2e): free host disk space before the E2E build

### DIFF
--- a/.github/workflows/ci-player-e2e.yml
+++ b/.github/workflows/ci-player-e2e.yml
@@ -46,6 +46,23 @@ jobs:
             echo "::notice::No player/relay/lib/native/config changes; skipping E2E build."
           fi
 
+      - name: Free up disk space
+        if: steps.should.outputs.run == 'true'
+        run: |
+          echo "Disk before cleanup:"
+          df -h /
+          # The E2E build runs entirely in Docker (the Android emulator is built
+          # inside the container from Dockerfile.e2e), so the host's preinstalled
+          # toolchains are unused. Remove them to avoid "No space left on device"
+          # while compiling the Rust p2p NIF + Android image.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/powershell /usr/local/share/chromium \
+            /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune --all --force || true
+          echo "Disk after cleanup:"
+          df -h /
+
       - name: Setup Docker Buildx
         if: steps.should.outputs.run == 'true'
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Problem

The **`Test / Player E2E`** job intermittently fails with:

```
rustc-LLVM ERROR: IO failure on output stream: No space left on device
error: couldn't create a temp dir: No space left on device (os error 28)
** (RuntimeError) Rust NIF compile error (rustc exit code 101)
target mydia: failed to solve: process "/bin/sh -c mix compile" ... exit code: 1
```

The runner exhausts its disk while compiling the Rust p2p NIF and building the Android emulator image. This is a required check, so when it hits the disk wall it blocks otherwise-green PRs (it just blocked #225, whose only change was favicon HTML).

## Fix

The entire E2E stack builds and runs **inside Docker** — the Android SDK/emulator comes from `Dockerfile.e2e`, not the host — so the runner's preinstalled toolchains are unused. A new **"Free up disk space"** step removes them (.NET, host Android SDK, GHC/ghcup, CodeQL, PowerShell, Chromium, Boost, the hosted tool cache) and prunes dangling Docker images before the build, reclaiming ~20–30 GB. `df -h` is printed before and after for visibility.

Implemented with transparent inline `rm` commands (no new third-party action). Only the workflow file changes; the fix is exercised by this PR's own Player E2E run.
