### PR TITLE
fix(qbittorrent): support qBittorrent 5.2+ (204 login, renamed session cookie) and add API-key auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,8 @@ TV_PATH=/media/tv
 # DOWNLOAD_CLIENT_1_URL_BASE=
 # DOWNLOAD_CLIENT_1_USERNAME=admin
 # DOWNLOAD_CLIENT_1_PASSWORD=adminpass
+# Alternative to username/password on qBittorrent 5.2 and newer.
+# DOWNLOAD_CLIENT_1_API_KEY=
 # DOWNLOAD_CLIENT_1_CATEGORY=mydia
 # DOWNLOAD_CLIENT_1_DOWNLOAD_DIRECTORY=/downloads/complete
 #

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ mydia-*.tar
 # In case you use Node.js/npm, you want to ignore these.
 npm-debug.log
 /assets/node_modules/
+/test/mock_services/*/node_modules/
 
 # Playwright E2E test results
 /assets/e2e-results/

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -103,7 +103,7 @@ Configure multiple clients using numbered variables (`<N>` = 1, 2, 3, etc.):
 | `DOWNLOAD_CLIENT_<N>_USE_SSL` | Use SSL/TLS | `false` |
 | `DOWNLOAD_CLIENT_<N>_USERNAME` | Auth username | - |
 | `DOWNLOAD_CLIENT_<N>_PASSWORD` | Auth password | - |
-| `DOWNLOAD_CLIENT_<N>_API_KEY` | API key (SABnzbd, debrid) | - |
+| `DOWNLOAD_CLIENT_<N>_API_KEY` | API key (SABnzbd, debrid, qBittorrent 5.2+) | - |
 | `DOWNLOAD_CLIENT_<N>_CATEGORY` | Default category | - |
 | `DOWNLOAD_CLIENT_<N>_DOWNLOAD_DIRECTORY` | Download directory | - |
 | `DOWNLOAD_CLIENT_<N>_PROVIDER` | Debrid provider (debrid only) | `real_debrid` |

--- a/docs/user-guide/download-clients.md
+++ b/docs/user-guide/download-clients.md
@@ -52,6 +52,10 @@ DOWNLOAD_CLIENT_1_HOST=qbittorrent
 DOWNLOAD_CLIENT_1_PORT=8080
 DOWNLOAD_CLIENT_1_USERNAME=admin
 DOWNLOAD_CLIENT_1_PASSWORD=adminpass
+# Alternative to username/password on qBittorrent 5.2 and newer. Generate the
+# key in qBittorrent under Preferences, WebUI, API Key. When set, it takes
+# precedence over the username and password.
+# DOWNLOAD_CLIENT_1_API_KEY=qbt_yourkeyhere
 
 # Transmission
 DOWNLOAD_CLIENT_2_NAME=Transmission
@@ -119,7 +123,7 @@ variable, so a block without one is silently ignored.
 | Port | Client port | `8080` |
 | Username | Auth username | `admin` |
 | Password | Auth password | `secret` |
-| API Key | API key (SABnzbd, debrid) | `abc123` |
+| API Key | API key (SABnzbd, debrid, qBittorrent 5.2+) | `abc123` |
 | Provider | Debrid provider (debrid only) | `real_debrid` |
 | Use SSL | Enable HTTPS | `true` |
 | Category | Default category | `mydia` |

--- a/docs/user-guide/download-clients.md
+++ b/docs/user-guide/download-clients.md
@@ -54,7 +54,9 @@ DOWNLOAD_CLIENT_1_USERNAME=admin
 DOWNLOAD_CLIENT_1_PASSWORD=adminpass
 # Alternative to username/password on qBittorrent 5.2 and newer. Generate the
 # key in qBittorrent under Preferences, WebUI, API Key. When set, it takes
-# precedence over the username and password.
+# precedence over the username and password. qBittorrent holds exactly one
+# API key at a time, so generating a new one immediately invalidates the
+# previous one and breaks any other integration still using it.
 # DOWNLOAD_CLIENT_1_API_KEY=qbt_yourkeyhere
 
 # Transmission

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -220,7 +220,13 @@ defmodule Mydia.Downloads.Client.QBittorrent do
             {:ok, Req.Request.put_header(req, "cookie", cookie)}
 
           :error ->
-            {:error, Error.authentication_failed("Failed to extract session cookie")}
+            {:error,
+             Error.authentication_failed("Failed to extract session cookie", %{
+               hint:
+                 "qBittorrent returned no recognisable session cookie " <>
+                   "(expected SID or QBT_SID_<port>)",
+               cookies_seen: observed_cookie_names(response)
+             })}
         end
 
       {:ok, %{status: 403}} ->
@@ -263,6 +269,17 @@ defmodule Mydia.Downloads.Client.QBittorrent do
         [_, pair] -> {:ok, pair}
         _ -> nil
       end
+    end)
+  end
+
+  # Names only, never values: this lands in logs and the admin UI, and the
+  # value is a live session token.
+  defp observed_cookie_names(response) do
+    headers = Req.Response.get_header(response, "set-cookie")
+    headers_list = if is_list(headers), do: headers, else: (headers && [headers]) || []
+
+    Enum.map(headers_list, fn cookie ->
+      cookie |> String.split("=", parts: 2) |> hd() |> String.trim()
     end)
   end
 

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -272,13 +272,12 @@ defmodule Mydia.Downloads.Client.QBittorrent do
     end)
   end
 
-  # Names only, never values: this lands in logs and the admin UI, and the
-  # value is a live session token.
+  # Names only, never values: this lands in logs, and the value is a live
+  # session token.
   defp observed_cookie_names(response) do
-    headers = Req.Response.get_header(response, "set-cookie")
-    headers_list = if is_list(headers), do: headers, else: (headers && [headers]) || []
-
-    Enum.map(headers_list, fn cookie ->
+    response
+    |> Req.Response.get_header("set-cookie")
+    |> Enum.map(fn cookie ->
       cookie |> String.split("=", parts: 2) |> hd() |> String.trim()
     end)
   end

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -187,16 +187,38 @@ defmodule Mydia.Downloads.Client.QBittorrent do
     with {:ok, req} <- authenticate(config) do
       case fun.(req) do
         {:error, %Error{type: :stale_session}} ->
-          # Session expired between authenticate() and the call — re-auth and retry once.
-          with {:ok, fresh_req} <- authenticate(config) do
-            fun.(fresh_req)
-          end
+          retry_after_stale_session(config, fun)
 
         other ->
           other
       end
     end
   end
+
+  # API-key auth has no session to refresh: a 403 means the key was rejected.
+  # Re-running `fun` would also resend mutating requests such as
+  # POST /torrents/add, so fail fast rather than retrying.
+  defp retry_after_stale_session(config, fun) do
+    if api_key?(config) do
+      {:error,
+       Error.authentication_failed("qBittorrent rejected the API key", %{
+         hint: "Regenerate the key in qBittorrent under Preferences, WebUI, API Key"
+       })}
+    else
+      with {:ok, fresh_req} <- authenticate(config) do
+        case fun.(fresh_req) do
+          # Never leak the internal marker: it is meaningless to an operator.
+          {:error, %Error{type: :stale_session}} ->
+            {:error, Error.authentication_failed("qBittorrent session could not be established")}
+
+          other ->
+            other
+        end
+      end
+    end
+  end
+
+  defp api_key?(config), do: is_binary(config[:api_key]) and config[:api_key] != ""
 
   # Marker error indicating the caller should re-authenticate and retry.
   defp stale_session, do: Error.new(:stale_session, "Session expired")

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -21,6 +21,26 @@ defmodule Mydia.Downloads.Client.QBittorrent do
   tries the legacy endpoint first and falls back to the 5.x name on 404, and
   maps the new state names to their equivalent internal states.
 
+  qBittorrent 5.2 changed authentication in two ways. `/api/v2/auth/login` now
+  answers 204 with an empty body instead of 200 `Ok.`, so any 2xx is treated as
+  success. The session cookie was renamed from `SID` to `QBT_SID_<port>`, where
+  the port is the server's own WebUI port rather than the port we dial, so the
+  cookie name is read from `Set-Cookie` and echoed back verbatim instead of
+  being reconstructed. The old `SID` name is rejected outright by 5.2.
+
+  ## Authentication modes
+
+  Either an API key or a username and password is required.
+
+  An `api_key` (qBittorrent 5.2+) is sent as `Authorization: Bearer <key>` on
+  every request, with no login round trip and no session to expire. Keys are
+  generated inside qBittorrent under Preferences, WebUI, API Key. qBittorrent
+  holds exactly one key at a time and generating a new one immediately
+  invalidates the previous one, so mydia never generates keys itself.
+
+  Otherwise the adapter logs in with the username and password and maintains
+  the session cookie, re-authenticating once when a request comes back 403.
+
   ## State Mapping
 
   qBittorrent states are mapped to our internal states:
@@ -180,9 +200,12 @@ defmodule Mydia.Downloads.Client.QBittorrent do
 
   ## Private Functions
 
-  # Authenticates, runs `fun` with the authenticated Req struct, and re-authenticates
-  # once if the inner call returns a 403 (stale/expired session). This matches the
-  # pattern used by the Transmission adapter for 409 session-id retries.
+  # Authenticates, runs `fun` with the authenticated Req struct, and handles a
+  # 403 from the inner call. In cookie mode this is a stale/expired session, so
+  # we re-authenticate once and retry (matching the pattern used by the
+  # Transmission adapter for 409 session-id retries). Under API-key auth a 403
+  # means the key itself was rejected, so it is terminal: see
+  # `retry_after_stale_session/2`.
   defp with_authenticated_session(config, fun) when is_function(fun, 1) do
     with {:ok, req} <- authenticate(config) do
       case fun.(req) do

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -160,9 +160,9 @@ defmodule Mydia.Downloads.Client.QBittorrent do
     with_authenticated_session(config, fn req ->
       with {:ok, response} <- HTTP.post(req, "/api/v2/torrents/delete", form: body) do
         case response.status do
-          200 -> :ok
+          status when status in 200..299 -> :ok
           404 -> {:error, Error.not_found("Torrent not found")}
-          _ -> {:error, Error.api_error("Failed to remove torrent", %{status: response.status})}
+          status -> {:error, Error.api_error("Failed to remove torrent", %{status: status})}
         end
       end
     end)
@@ -337,7 +337,7 @@ defmodule Mydia.Downloads.Client.QBittorrent do
     authed_request(req, :post, "/api/v2/torrents/add", form_multipart: fields)
   end
 
-  defp check_add_response(%{status: 200}), do: :ok
+  defp check_add_response(%{status: status}) when status in 200..299, do: :ok
 
   defp check_add_response(%{status: status, body: body}) do
     {:error, Error.api_error("Failed to add torrent", %{status: status, body: body})}
@@ -389,12 +389,12 @@ defmodule Mydia.Downloads.Client.QBittorrent do
 
     with_authenticated_session(config, fn req ->
       case authed_request(req, :post, primary_path, form: body) do
-        {:ok, %{status: 200}} ->
+        {:ok, %{status: status}} when status in 200..299 ->
           :ok
 
         {:ok, %{status: 404}} ->
           case authed_request(req, :post, fallback_path, form: body) do
-            {:ok, %{status: 200}} -> :ok
+            {:ok, %{status: status}} when status in 200..299 -> :ok
             {:ok, resp} -> toggle_error(resp)
             {:error, _} = err -> err
           end

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -9,11 +9,6 @@ defmodule Mydia.Downloads.Client.QBittorrent do
 
   qBittorrent Web API: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)
 
-  ## Authentication
-
-  qBittorrent requires logging in via the `/api/v2/auth/login` endpoint to obtain
-  a session cookie (`SID`). This cookie must be included in all subsequent requests.
-
   ## qBittorrent 5.x compatibility
 
   qBittorrent 5.0 renamed the `pause`/`resume` endpoints to `stop`/`start` and
@@ -90,7 +85,7 @@ defmodule Mydia.Downloads.Client.QBittorrent do
   @impl true
   def test_connection(config) do
     with_authenticated_session(config, fn req ->
-      with {:ok, response} <- HTTP.get(req, "/api/v2/app/version") do
+      with {:ok, response} <- authed_request(req, :get, "/api/v2/app/version", []) do
         case response.status do
           200 ->
             {:ok, ClientInfo.new(version: to_string(response.body), api_version: "2.x")}
@@ -178,7 +173,7 @@ defmodule Mydia.Downloads.Client.QBittorrent do
     body = %{hashes: client_id, deleteFiles: to_string(delete_files)}
 
     with_authenticated_session(config, fn req ->
-      with {:ok, response} <- HTTP.post(req, "/api/v2/torrents/delete", form: body) do
+      with {:ok, response} <- authed_request(req, :post, "/api/v2/torrents/delete", form: body) do
         case response.status do
           status when status in 200..299 -> :ok
           404 -> {:error, Error.not_found("Torrent not found")}
@@ -274,19 +269,26 @@ defmodule Mydia.Downloads.Client.QBittorrent do
 
     case HTTP.post(req, "/api/v2/auth/login", form: login_body) do
       {:ok, %{status: status} = response} when status in 200..299 ->
-        case extract_session_cookie(response) do
-          {:ok, cookie} ->
-            {:ok, Req.Request.put_header(req, "cookie", cookie)}
+        if login_rejected_body?(response.body) do
+          {:error, Error.authentication_failed("Invalid username or password")}
+        else
+          case extract_session_cookie(response) do
+            {:ok, cookie} ->
+              {:ok, Req.Request.put_header(req, "cookie", cookie)}
 
-          :error ->
-            {:error,
-             Error.authentication_failed("Failed to extract session cookie", %{
-               hint:
-                 "qBittorrent returned no recognisable session cookie " <>
-                   "(expected SID or QBT_SID_<port>)",
-               cookies_seen: observed_cookie_names(response)
-             })}
+            :error ->
+              {:error,
+               Error.authentication_failed("Failed to extract session cookie", %{
+                 hint:
+                   "qBittorrent returned no recognisable session cookie " <>
+                     "(expected SID or QBT_SID_<port>)",
+                 cookies_seen: observed_cookie_names(response)
+               })}
+          end
         end
+
+      {:ok, %{status: 401}} ->
+        {:error, Error.authentication_failed("Invalid username or password")}
 
       {:ok, %{status: 403}} ->
         {:error,
@@ -305,6 +307,13 @@ defmodule Mydia.Downloads.Client.QBittorrent do
         {:error, error}
     end
   end
+
+  # qBittorrent <= 5.1 answers a wrong-password login with HTTP 200 and body
+  # "Fails." instead of an error status, so a 2xx alone doesn't mean success.
+  # Checked before cookie extraction so this doesn't get misreported as a
+  # missing/unrecognised session cookie.
+  defp login_rejected_body?(body) when is_binary(body), do: String.trim(body) == "Fails."
+  defp login_rejected_body?(_body), do: false
 
   # Session cookie under any qBittorrent naming scheme:
   #   <= 5.1  ->  SID=<value>

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -214,10 +214,10 @@ defmodule Mydia.Downloads.Client.QBittorrent do
     login_body = %{username: config.username, password: config.password}
 
     case HTTP.post(req, "/api/v2/auth/login", form: login_body) do
-      {:ok, %{status: 200} = response} ->
-        case extract_sid_cookie(response) do
-          {:ok, sid} ->
-            {:ok, Req.Request.put_header(req, "cookie", "SID=#{sid}")}
+      {:ok, %{status: status} = response} when status in 200..299 ->
+        case extract_session_cookie(response) do
+          {:ok, cookie} ->
+            {:ok, Req.Request.put_header(req, "cookie", cookie)}
 
           :error ->
             {:error, Error.authentication_failed("Failed to extract session cookie")}
@@ -241,15 +241,26 @@ defmodule Mydia.Downloads.Client.QBittorrent do
     end
   end
 
-  # Find the Set-Cookie header value that actually contains "SID=".
-  # qBittorrent occasionally emits multiple cookies (e.g. CSRF) and we must not
-  # pick the wrong one.
-  defp extract_sid_cookie(response) do
+  # Session cookie under any qBittorrent naming scheme:
+  #   <= 5.1  ->  SID=<value>
+  #   >= 5.2  ->  QBT_SID_<webui_port>=<value>
+  #
+  # The port suffix is qBittorrent's OWN listening port, not the port we dial:
+  # a 5.2 server listening on 8282 still issues QBT_SID_8282 when reached
+  # through a proxy on another port. So the name cannot be derived from config
+  # and must be read off Set-Cookie, then echoed back verbatim.
+  #
+  # Anchoring on (?:^|[\s;]) keeps unrelated cookies out: qBittorrent sometimes
+  # emits a _csrf cookie alongside the session one, and a name like MYSID= must
+  # not match either.
+  @session_cookie ~r/(?:^|[\s;])((?:QBT_)?SID(?:_\d+)?=[^;]+)/
+
+  defp extract_session_cookie(response) do
     response
     |> Req.Response.get_header("set-cookie")
     |> Enum.find_value(:error, fn cookie ->
-      case Regex.run(~r/SID=([^;]+)/, cookie) do
-        [_, sid] -> {:ok, sid}
+      case Regex.run(@session_cookie, cookie) do
+        [_, pair] -> {:ok, pair}
         _ -> nil
       end
     end)

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -201,11 +201,25 @@ defmodule Mydia.Downloads.Client.QBittorrent do
   # Marker error indicating the caller should re-authenticate and retry.
   defp stale_session, do: Error.new(:stale_session, "Session expired")
 
+  # An API key (qBittorrent 5.2+, WebAPI 2.14.1+) authenticates every request
+  # directly, so there is no login round trip and no session to maintain.
+  # put_header replaces, so this Bearer header wins over the Basic header that
+  # HTTP.new_request/1 sets when credentials are also present.
+  defp authenticate(%{api_key: key} = config) when is_binary(key) and key != "" do
+    {:ok,
+     config
+     |> HTTP.new_request()
+     |> Req.Request.put_header("authorization", "Bearer " <> key)}
+  end
+
   defp authenticate(config) do
     if config[:username] && config[:password] do
       do_authenticate(config)
     else
-      {:error, Error.invalid_config("Username and password are required for qBittorrent")}
+      {:error,
+       Error.invalid_config(
+         "qBittorrent requires either an API key (5.2+) or a username and password"
+       )}
     end
   end
 

--- a/test/mock_services/qbittorrent/server.js
+++ b/test/mock_services/qbittorrent/server.js
@@ -7,6 +7,15 @@ const PORT = process.env.PORT || 8080;
 const USERNAME = process.env.USERNAME || "admin";
 const PASSWORD = process.env.PASSWORD || "adminpass";
 
+// Which qBittorrent WebAPI dialect to emulate.
+//   5.1 -> login returns 200 "Ok."  and sets SID
+//   5.2 -> login returns 204 empty  and sets QBT_SID_<port>
+// 5.2 is the default because that is what current installs speak. The port in
+// the cookie name is the server's own listening port, matching real behaviour.
+const DIALECT = process.env.QB_DIALECT || "5.2";
+const SESSION_COOKIE = DIALECT === "5.1" ? "SID" : `QBT_SID_${PORT}`;
+const APP_VERSION = DIALECT === "5.1" ? "v5.1.2-mock" : "v5.2.0-mock";
+
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.use(cookieParser());
@@ -22,7 +31,7 @@ function generateSessionId() {
 
 // Middleware to check authentication
 const requireAuth = (req, res, next) => {
-  const sid = req.cookies.SID;
+  const sid = req.cookies[SESSION_COOKIE];
   if (!sid || !sessions.has(sid)) {
     return res.status(403).send("Forbidden");
   }
@@ -41,8 +50,8 @@ app.post("/api/v2/auth/login", (req, res) => {
   if (username === USERNAME && password === PASSWORD) {
     const sid = generateSessionId();
     sessions.set(sid, { username, loginTime: Date.now() });
-    res.cookie("SID", sid, { httpOnly: true });
-    return res.send("Ok.");
+    res.cookie(SESSION_COOKIE, sid, { httpOnly: true, sameSite: "Strict" });
+    return DIALECT === "5.1" ? res.send("Ok.") : res.status(204).end();
   }
 
   res.status(401).send("Fails.");
@@ -50,17 +59,17 @@ app.post("/api/v2/auth/login", (req, res) => {
 
 // Logout endpoint
 app.post("/api/v2/auth/logout", (req, res) => {
-  const sid = req.cookies.SID;
+  const sid = req.cookies[SESSION_COOKIE];
   if (sid) {
     sessions.delete(sid);
-    res.clearCookie("SID");
+    res.clearCookie(SESSION_COOKIE);
   }
   res.send("Ok.");
 });
 
 // Get application version
 app.get("/api/v2/app/version", (req, res) => {
-  res.send("v4.5.0-mock");
+  res.send(APP_VERSION);
 });
 
 // Get application preferences

--- a/test/mock_services/qbittorrent/server.js
+++ b/test/mock_services/qbittorrent/server.js
@@ -7,11 +7,15 @@ const PORT = process.env.PORT || 8080;
 const USERNAME = process.env.USERNAME || "admin";
 const PASSWORD = process.env.PASSWORD || "adminpass";
 
-// Which qBittorrent WebAPI dialect to emulate.
-//   5.1 -> login returns 200 "Ok."  and sets SID
-//   5.2 -> login returns 204 empty  and sets QBT_SID_<port>
-// 5.2 is the default because that is what current installs speak. The port in
-// the cookie name is the server's own listening port, matching real behaviour.
+// Which qBittorrent WebAPI dialect to emulate. Captured from real servers:
+//   5.1 -> login OK returns 200 "Ok."  and sets SID
+//          login FAIL returns 200 "Fails."
+//   5.2 -> login OK returns 204 empty  and sets QBT_SID_<port>
+//          login FAIL returns 401 "Unauthorized"
+// Note the rejection shapes differ as much as the success ones: 5.1 reports a
+// bad password with a 2xx and only the body distinguishes it. 5.2 is the
+// default because that is what current installs speak. The port in the cookie
+// name is the server's own listening port, matching real behaviour.
 const DIALECT = process.env.QB_DIALECT || "5.2";
 const SESSION_COOKIE = DIALECT === "5.1" ? "SID" : `QBT_SID_${PORT}`;
 const APP_VERSION = DIALECT === "5.1" ? "v5.1.2-mock" : "v5.2.0-mock";
@@ -54,7 +58,11 @@ app.post("/api/v2/auth/login", (req, res) => {
     return DIALECT === "5.1" ? res.send("Ok.") : res.status(204).end();
   }
 
-  res.status(401).send("Fails.");
+  // Rejection shape is dialect-specific. 5.1 answers 200 with a "Fails." body,
+  // so a client that only checks the status code sees a success.
+  return DIALECT === "5.1"
+    ? res.status(200).send("Fails.")
+    : res.status(401).send("Unauthorized");
 });
 
 // Logout endpoint

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -261,6 +261,23 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
         assert {:ok, _} = QBittorrent.get_status(config, hash)
       end
     end
+
+    test "reports the cookie names it actually saw when none is a session cookie", %{
+      bypass: bypass,
+      config: config
+    } do
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "_csrf=ignored; Path=/")
+        |> Plug.Conn.merge_resp_headers([{"set-cookie", "NEWNAME_9=abc; Path=/"}])
+        |> Plug.Conn.resp(204, "")
+      end)
+
+      assert {:error, error} = QBittorrent.test_connection(config)
+      assert error.type == :authentication_failed
+      assert error.message =~ "session cookie"
+      assert "NEWNAME_9" in error.details.cookies_seen
+    end
   end
 
   describe "add_torrent/3 (Bypass)" do

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -218,6 +218,25 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
       assert :counters.get(counter, 1) == 2
     end
 
+    test "never leaks the internal stale_session marker when the retry also fails", %{
+      bypass: bypass,
+      config: config
+    } do
+      Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=always-stale; HttpOnly")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        Plug.Conn.resp(conn, 403, "Forbidden")
+      end)
+
+      assert {:error, error} = QBittorrent.list_torrents(config)
+      assert error.type == :authentication_failed
+      refute error.type == :stale_session
+    end
+
     for {version, login_status, login_body, set_cookie, expected_cookie} <- @dialects do
       test "authenticates and echoes the session cookie on qBittorrent #{version}", %{
         bypass: bypass,
@@ -611,6 +630,30 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
       assert {:error, error} = QBittorrent.test_connection(bare)
       assert error.type == :invalid_config
       assert error.message =~ "API key"
+    end
+
+    test "a 403 does not trigger a login retry and does not resend the request", %{
+      bypass: bypass,
+      config: config
+    } do
+      logins = :counters.new(1, [])
+      infos = :counters.new(1, [])
+
+      Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        :counters.add(logins, 1, 1)
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        :counters.add(infos, 1, 1)
+        Plug.Conn.resp(conn, 403, "Forbidden")
+      end)
+
+      assert {:error, error} = QBittorrent.list_torrents(config)
+      assert error.type == :authentication_failed
+      assert error.message =~ "API key"
+      assert :counters.get(logins, 1) == 0
+      assert :counters.get(infos, 1) == 1
     end
   end
 

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -301,6 +301,60 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
       assert error.message =~ "session cookie"
       assert Enum.sort(error.details.cookies_seen) == ["NEWNAME_9", "_csrf"]
     end
+
+    test "reports invalid credentials (not a cookie error) on the qBittorrent 5.1 'Fails.' rejection",
+         %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        Plug.Conn.resp(conn, 200, "Fails.")
+      end)
+
+      assert {:error, error} = QBittorrent.test_connection(config)
+      assert error.type == :authentication_failed
+      assert error.message =~ "Invalid username or password"
+      refute error.message =~ "session cookie"
+    end
+
+    test "reports invalid credentials on the qBittorrent 5.2 401 rejection", %{
+      bypass: bypass,
+      config: config
+    } do
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        Plug.Conn.resp(conn, 401, "Unauthorized")
+      end)
+
+      assert {:error, error} = QBittorrent.test_connection(config)
+      assert error.type == :authentication_failed
+      assert error.message =~ "Invalid username or password"
+      refute error.message =~ "session cookie"
+    end
+
+    test "does not match a cookie that merely contains SID as a substring (e.g. MYSID)", %{
+      bypass: bypass,
+      config: config
+    } do
+      hash = "1234567890abcdef1234567890abcdef12345678"
+
+      # Note: Plug/Cowboy relay these to the wire in the opposite order to how
+      # they're passed to prepend_resp_headers/2, so SID is listed first here
+      # to make MYSID arrive first over the wire, the position that actually
+      # exercises the anchor against a false match.
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.prepend_resp_headers([
+          {"set-cookie", "SID=session-abc-123; HttpOnly; Path=/"},
+          {"set-cookie", "MYSID=nope; Path=/"}
+        ])
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        assert ["SID=session-abc-123"] == Plug.Conn.get_req_header(conn, "cookie")
+        json_resp(conn, 200, [torrent_payload(hash)])
+      end)
+
+      assert {:ok, status} = QBittorrent.get_status(config, hash)
+      assert status.id == hash
+    end
   end
 
   describe "add_torrent/3 (Bypass)" do
@@ -389,6 +443,26 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
         else
           json_resp(conn, 200, [])
         end
+      end)
+
+      assert {:ok, ^hash} = QBittorrent.add_torrent(config, {:magnet, magnet})
+    end
+
+    test "accepts a 204 from the add endpoint, not just 200", %{
+      bypass: bypass,
+      config: config
+    } do
+      magnet = "magnet:?xt=urn:btih:abc123def456abc123def456abc123def456abcd&dn=test"
+      hash = "abc123def456abc123def456abc123def456abcd"
+
+      stub_login(bypass)
+
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/add", fn conn ->
+        Plug.Conn.resp(conn, 204, "")
+      end)
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash)])
       end)
 
       assert {:ok, ^hash} = QBittorrent.add_torrent(config, {:magnet, magnet})
@@ -654,6 +728,49 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
       assert error.message =~ "API key"
       assert :counters.get(logins, 1) == 0
       assert :counters.get(infos, 1) == 1
+    end
+
+    test "test_connection maps a 403 to the API-key error too, and never hits /auth/login", %{
+      bypass: bypass,
+      config: config
+    } do
+      logins = :counters.new(1, [])
+
+      Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        :counters.add(logins, 1, 1)
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      Bypass.stub(bypass, "GET", "/api/v2/app/version", fn conn ->
+        Plug.Conn.resp(conn, 403, "Forbidden")
+      end)
+
+      assert {:error, error} = QBittorrent.test_connection(config)
+      assert error.type == :authentication_failed
+      assert error.message =~ "API key"
+      assert :counters.get(logins, 1) == 0
+    end
+
+    test "Bearer wins over Basic when an api_key and a username/password are all set", %{
+      bypass: bypass,
+      config: config
+    } do
+      logins = :counters.new(1, [])
+
+      Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        :counters.add(logins, 1, 1)
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      full_config = Map.merge(config, %{username: "admin", password: "adminpass"})
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        assert ["Bearer " <> @api_key] == Plug.Conn.get_req_header(conn, "authorization")
+        json_resp(conn, 200, [])
+      end)
+
+      assert {:ok, []} = QBittorrent.list_torrents(full_config)
+      assert :counters.get(logins, 1) == 0
     end
   end
 

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -170,8 +170,8 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
         # Real qBittorrent sometimes sets a CSRF cookie alongside SID.
         # We must pick the SID cookie, not the first one.
         conn
-        |> Plug.Conn.put_resp_header("set-cookie", "_csrf=ignored; Path=/")
-        |> Plug.Conn.merge_resp_headers([
+        |> Plug.Conn.prepend_resp_headers([
+          {"set-cookie", "_csrf=ignored; Path=/"},
           {"set-cookie", "SID=session-abc-123; HttpOnly; Path=/"}
         ])
         |> Plug.Conn.resp(200, "Ok.")
@@ -248,8 +248,10 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
 
         Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
           conn
-          |> Plug.Conn.put_resp_header("set-cookie", "_csrf=ignored; Path=/")
-          |> Plug.Conn.merge_resp_headers([{"set-cookie", unquote(set_cookie)}])
+          |> Plug.Conn.prepend_resp_headers([
+            {"set-cookie", "_csrf=ignored; Path=/"},
+            {"set-cookie", unquote(set_cookie)}
+          ])
           |> Plug.Conn.resp(unquote(login_status), unquote(login_body))
         end)
 
@@ -268,15 +270,17 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
     } do
       Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
         conn
-        |> Plug.Conn.put_resp_header("set-cookie", "_csrf=ignored; Path=/")
-        |> Plug.Conn.merge_resp_headers([{"set-cookie", "NEWNAME_9=abc; Path=/"}])
+        |> Plug.Conn.prepend_resp_headers([
+          {"set-cookie", "_csrf=ignored; Path=/"},
+          {"set-cookie", "NEWNAME_9=abc; Path=/"}
+        ])
         |> Plug.Conn.resp(204, "")
       end)
 
       assert {:error, error} = QBittorrent.test_connection(config)
       assert error.type == :authentication_failed
       assert error.message =~ "session cookie"
-      assert "NEWNAME_9" in error.details.cookies_seen
+      assert Enum.sort(error.details.cookies_seen) == ["NEWNAME_9", "_csrf"]
     end
   end
 

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -521,6 +521,55 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
     end
   end
 
+  describe "2xx success handling (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      stub_login(bypass)
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "remove_torrent accepts a 204", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/delete", fn conn ->
+        Plug.Conn.resp(conn, 204, "")
+      end)
+
+      assert :ok = QBittorrent.remove_torrent(config, "abc123")
+    end
+
+    test "pause falls back to stop and accepts a 204", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/pause", fn conn ->
+        Plug.Conn.resp(conn, 404, "Not Found")
+      end)
+
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/stop", fn conn ->
+        Plug.Conn.resp(conn, 204, "")
+      end)
+
+      assert :ok = QBittorrent.pause_torrent(config, "abc123")
+    end
+
+    test "resume falls back to start and accepts a 204", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/resume", fn conn ->
+        Plug.Conn.resp(conn, 404, "Not Found")
+      end)
+
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/start", fn conn ->
+        Plug.Conn.resp(conn, 204, "")
+      end)
+
+      assert :ok = QBittorrent.resume_torrent(config, "abc123")
+    end
+
+    test "remove_torrent still reports a 404 as not_found", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "POST", "/api/v2/torrents/delete", fn conn ->
+        Plug.Conn.resp(conn, 404, "Not Found")
+      end)
+
+      assert {:error, error} = QBittorrent.remove_torrent(config, "abc123")
+      assert error.type == :not_found
+    end
+  end
+
   describe "priority profile resolution (Bypass)" do
     setup do
       bypass = Bypass.open()

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -140,6 +140,20 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
   # Bypass-based integration tests
   # ──────────────────────────────────────────────────────────────────
 
+  # Login dialects observed from real servers.
+  # 5.1.2 -> 200 "Ok."  + SID=<v>
+  # 5.2.0 -> 204 ""     + QBT_SID_<webui_port>=<v>
+  # The 5.2 cookie's port (8080) is deliberately NOT the port Bypass listens on,
+  # which is what makes the echo assertion meaningful: the name cannot be
+  # reconstructed from our config, it must be read off Set-Cookie.
+  @dialects [
+    {"5.1", 200, "Ok.", "SID=session-abc-123; HttpOnly; SameSite=Strict; path=/",
+     "SID=session-abc-123"},
+    {"5.2", 204, "",
+     "QBT_SID_8080=session-abc-123; HttpOnly; SameSite=Strict; " <>
+       "expires=Wed, 29-Jul-2026 01:06:04 GMT; path=/", "QBT_SID_8080=session-abc-123"}
+  ]
+
   describe "authentication (Bypass)" do
     setup do
       bypass = Bypass.open()
@@ -202,6 +216,50 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
       assert {:ok, _status} = QBittorrent.get_status(config, hash)
       # Two logins: one initial, one after the 403
       assert :counters.get(counter, 1) == 2
+    end
+
+    for {version, login_status, login_body, set_cookie, expected_cookie} <- @dialects do
+      test "authenticates and echoes the session cookie on qBittorrent #{version}", %{
+        bypass: bypass,
+        config: config
+      } do
+        hash = "1234567890abcdef1234567890abcdef12345678"
+
+        Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("set-cookie", unquote(set_cookie))
+          |> Plug.Conn.resp(unquote(login_status), unquote(login_body))
+        end)
+
+        Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+          assert [unquote(expected_cookie)] == Plug.Conn.get_req_header(conn, "cookie")
+          json_resp(conn, 200, [torrent_payload(hash)])
+        end)
+
+        assert {:ok, download_status} = QBittorrent.get_status(config, hash)
+        assert download_status.id == hash
+      end
+
+      test "skips the _csrf cookie on qBittorrent #{version}", %{
+        bypass: bypass,
+        config: config
+      } do
+        hash = "1234567890abcdef1234567890abcdef12345678"
+
+        Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("set-cookie", "_csrf=ignored; Path=/")
+          |> Plug.Conn.merge_resp_headers([{"set-cookie", unquote(set_cookie)}])
+          |> Plug.Conn.resp(unquote(login_status), unquote(login_body))
+        end)
+
+        Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+          assert [unquote(expected_cookie)] == Plug.Conn.get_req_header(conn, "cookie")
+          json_resp(conn, 200, [torrent_payload(hash)])
+        end)
+
+        assert {:ok, _} = QBittorrent.get_status(config, hash)
+      end
     end
   end
 

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -27,7 +27,7 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
 
       {:error, error} = QBittorrent.test_connection(config_without_username)
       assert error.type == :invalid_config
-      assert error.message =~ "Username and password are required"
+      assert error.message =~ "API key"
     end
 
     test "test_connection fails with unreachable host" do
@@ -567,6 +567,50 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
 
       assert {:error, error} = QBittorrent.remove_torrent(config, "abc123")
       assert error.type == :not_found
+    end
+  end
+
+  describe "API-key authentication (Bypass)" do
+    @api_key "qbt_TESTKEY0123456789abcdefghij"
+
+    setup do
+      bypass = Bypass.open()
+
+      config =
+        bypass
+        |> bypass_config()
+        |> Map.merge(%{api_key: @api_key, username: nil, password: nil})
+
+      {:ok, bypass: bypass, config: config}
+    end
+
+    test "sends Bearer auth and never calls the login endpoint", %{
+      bypass: bypass,
+      config: config
+    } do
+      logins = :counters.new(1, [])
+
+      Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        :counters.add(logins, 1, 1)
+        Plug.Conn.resp(conn, 200, "Ok.")
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        assert ["Bearer " <> @api_key] == Plug.Conn.get_req_header(conn, "authorization")
+        assert [] == Plug.Conn.get_req_header(conn, "cookie")
+        json_resp(conn, 200, [])
+      end)
+
+      assert {:ok, []} = QBittorrent.list_torrents(config)
+      assert :counters.get(logins, 1) == 0
+    end
+
+    test "requires an API key or a username and password", %{config: config} do
+      bare = Map.merge(config, %{api_key: nil, username: nil, password: nil})
+
+      assert {:error, error} = QBittorrent.test_connection(bare)
+      assert error.type == :invalid_config
+      assert error.message =~ "API key"
     end
   end
 


### PR DESCRIPTION
## Problem

Users reported that mydia could not connect to qBittorrent 5.2+, while 5.1 worked fine.

Reproduced against real servers (`linuxserver/qbittorrent:5.1.2` and `:5.2.0`). There were **two stacked defects**, so fixing either one alone still left 5.2 broken:

**1. Login now answers 204.** qBittorrent 5.2.0 release note: "WEBAPI: Send 204 when WebAPI response contains no data". The login response has no body, so it returns `204`. The adapter matched only `200` and fell through to:

```
{:error, %Error{type: :authentication_failed,
                message: "Login failed",
                details: %{status: 204, body: ""}}}
```

**2. The session cookie was renamed.** 5.2 issues `QBT_SID_<port>` instead of `SID`, and rejects the legacy name outright with 403. There is no server-side back-compat.

Critically, the port in that name is **the server's own WebUI port, not the port we dial**. Verified by proxying a server listening on 8282 through port 8383: it still issued `QBT_SID_8282`. So the name cannot be reconstructed from config, or anyone behind a reverse proxy or Docker port mapping breaks. It has to be read off `Set-Cookie` and echoed back verbatim.

Empirically the 204 change is narrower than the release note implies: of the endpoints this adapter uses, only `auth/login` flipped. `delete`, `start`, and `stop` still return 200 on 5.2.0.

## Changes

- **Version-agnostic session cookie.** Capture the whole `name=value` pair from `Set-Cookie` and replay it. No version detection, no port arithmetic, proxy-safe.
- **Accept any 2xx** at the adapter's four success checks. Scoped to this adapter deliberately: Transmission signals failure as `200` with `{"result": "error: ..."}` and SABnzbd as `200` with `{"status": false}`, so a shared 2xx predicate would mask real failures there.
- **Optional API-key auth** (`Authorization: Bearer`), which qBittorrent 5.2 introduced. No config plumbing was needed: `api_key` already existed in the schema, the YAML/env loader (`DOWNLOAD_CLIENT_<N>_API_KEY`), the adapter config map, and the admin UI.
- **Don't retry under Bearer.** A 403 there means the key was rejected, and `auth/login` itself 403s under Bearer, so retrying cannot help. Worse, the old retry re-invoked the request function, which for `add_torrent` meant a second `POST /torrents/add` and a possible duplicate torrent.
- **Stop leaking `:stale_session`**, an internal marker, to callers and the admin UI.
- **Clearer credential errors.** Wrong-password behaviour differs by version (5.1 answers `200` with body `Fails.`; 5.2 answers `401`). Both previously produced misleading messages, with 5.1 reporting "Failed to extract session cookie ... expected QBT_SID_&lt;port&gt;" which reads as "5.2 is still broken" to someone who simply typo'd their password. Both now report `Invalid username or password`.
- **Mock service** now speaks the 5.2 dialect by default, with `QB_DIALECT=5.1` to fall back.

## Not done, deliberately

**Auto-generating an API key.** `POST /api/v2/app/rotateAPIKey` works, but qBittorrent holds exactly one key and rotating immediately invalidates the previous one, which would silently break whatever else the operator has using it. Operators paste a key, the same way indexer API keys already work.

## Verification

Full round trip against **real** qBittorrent 5.1.2 and 5.2.0 (`test_connection` → `list_torrents` → `add_torrent` → `pause` → `resume` → `remove`) across all three auth paths: 5.1 password, 5.2 password, 5.2 API key. All succeeded; `add_torrent` returned the genuine Debian ISO infohash.

Test suite: 3204 tests, 0 failures. The adapter file goes from 29 to 48 tests.

Three test-quality problems were found and fixed during review:

- Several `_csrf`-skipping tests were **vacuous**, including one predating this branch. `Plug.Conn.merge_resp_headers/2` uses `List.keystore/4`, which *replaces* same-key headers, so the second `Set-Cookie` never existed and the regex guard had zero real coverage. Now built with `prepend_resp_headers/2`; breaking the extractor deliberately turns 6 tests red.
- Mutation testing found the widened `check_add_response/1`, the regex anchor, and Bearer-over-Basic precedence were entirely unpinned. Each now has a test verified to fail under its mutation.
- `test_connection` and `remove_torrent` bypassed `authed_request/4`, so a rejected API key surfaced as a bare 403 from the Test Connection button rather than the actionable message.

## Compatibility

Client-side only. One build works against 4.x, 5.0, 5.1, and 5.2+ simultaneously. No schema change, no migration, no config change. Existing username/password setups keep working untouched; the API key is purely additive and optional.

One thing worth knowing: the admin form has always rendered an API Key field for qBittorrent and previously ignored it. It now takes precedence, so a stray value there would break a working 4.x/5.0/5.1 client (those reject Bearer). Impact is bounded and the resulting error is self-diagnosing.
