### PR TITLE
fix(downloads): two production download-failure bugs found on a live instance

### DIFF
--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -396,14 +396,14 @@ defmodule Mydia.Jobs.DownloadMonitor do
       "Removed from download client '#{download_map.download_client}' before import completed. " <>
         "The download may have been manually deleted, or the client may have encountered an error."
 
-    case Downloads.update_download(download, %{
-           status: "missing",
-           error_message: error_msg
-         }) do
-      {:ok, updated} ->
+    # `Download` has no `:status` field — status is derived at read time from the
+    # client poll (see `Downloads.list_downloads_with_status/1`). Persisting
+    # `error_message` is what moves the row into the Issues tab.
+    case Downloads.update_download(download, %{error_message: error_msg}) do
+      {:ok, _updated} ->
         Logger.info("Download marked as missing (preserved for Issues tab)",
           download_id: download_map.id,
-          status: updated.status
+          client: download_map.download_client
         )
 
         # Track event for user visibility

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -209,6 +209,14 @@ defmodule Mydia.Jobs.MediaImport do
   # gets the same answer; only an operator changing the client's layout (or
   # adding a path mapping) fixes it.
   defp terminal_failure?({:save_path_is_download_root, _path}, _attempt), do: true
+  # The download names a client that is no longer in the configuration — the
+  # operator retired or renamed it. Every retry re-reads the same config, so
+  # with max_attempts: 1000 the row retried effectively forever, and because
+  # `Download.occupying/1` treats a pending `import_next_retry_at` as work still
+  # in flight, the episode stayed occupied and was never re-searched. Allow a
+  # small budget first: config is applied at boot, so a job that runs during a
+  # restart can legitimately see no client for a cycle.
+  defp terminal_failure?(:no_client, attempt) when attempt >= 3, do: true
   # A partial import means some files landed and some failed. A couple of
   # retries can pick up a transient per-file failure, but with max_attempts:
   # 1000 an unfixable one re-walks (and historically re-copied) the whole

--- a/test/mydia/jobs/download_monitor_logging_test.exs
+++ b/test/mydia/jobs/download_monitor_logging_test.exs
@@ -1,0 +1,105 @@
+defmodule Mydia.Jobs.DownloadMonitorLoggingTest do
+  # async: false — this raises the *global* Logger level to :info so Logger macro
+  # arguments are actually evaluated.
+  #
+  # The rest of the suite runs at :warning (config/test.exs), and `Logger.info/2`
+  # is a macro that skips evaluating its arguments entirely when the level is
+  # above the configured one. That is how a `Logger.info` referencing a
+  # non-existent struct key reached production: green here, KeyError on prod
+  # (config/prod.exs sets :info).
+  use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  import ExUnit.CaptureLog
+  import Mydia.DownloadsFixtures
+  import Mydia.MediaFixtures
+
+  alias Mydia.Downloads
+  alias Mydia.Events
+  alias Mydia.Jobs.DownloadMonitor
+
+  setup do
+    previous_level = Logger.level()
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: previous_level) end)
+    :ok
+  end
+
+  describe "handle_missing/1 with info logging enabled" do
+    test "marks a download missing without raising" do
+      setup_runtime_config([build_test_client_config()])
+      media_item = media_item_fixture()
+      download = download_fixture(%{media_item_id: media_item.id})
+
+      capture_log(fn ->
+        assert :ok = perform_job(DownloadMonitor, %{})
+      end)
+
+      updated = Downloads.get_download!(download.id)
+      assert updated.error_message =~ "Removed from download client"
+    end
+
+    test "marks every missing download in the batch and emits an event for each" do
+      setup_runtime_config([build_test_client_config()])
+      media_item = media_item_fixture()
+
+      downloads =
+        for n <- 1..3, do: download_fixture(%{media_item_id: media_item.id, title: "Grab #{n}"})
+
+      capture_log(fn ->
+        assert :ok = perform_job(DownloadMonitor, %{})
+      end)
+
+      # A raise inside the Enum.each over `missing` used to abort the pass after
+      # the first row, so later downloads went unmarked and no event ever fired.
+      for download <- downloads do
+        assert Downloads.get_download!(download.id).error_message =~
+                 "Removed from download client"
+      end
+
+      assert length(Events.list_events(type: "download.failed")) == 3
+    end
+  end
+
+  defp setup_runtime_config(download_clients) do
+    config = %Mydia.Config.Schema{
+      server: %Mydia.Config.Schema.Server{},
+      database: %Mydia.Config.Schema.Database{},
+      auth: %Mydia.Config.Schema.Auth{},
+      media: %Mydia.Config.Schema.Media{},
+      downloads: %Mydia.Config.Schema.Downloads{},
+      logging: %Mydia.Config.Schema.Logging{},
+      oban: %Mydia.Config.Schema.Oban{},
+      download_clients: download_clients
+    }
+
+    previous = Application.get_env(:mydia, :runtime_config)
+    Application.put_env(:mydia, :runtime_config, config)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:mydia, :runtime_config)
+        value -> Application.put_env(:mydia, :runtime_config, value)
+      end
+    end)
+  end
+
+  defp build_test_client_config(overrides \\ %{}) do
+    defaults = %{
+      name: "TestClient",
+      type: :qbittorrent,
+      enabled: true,
+      priority: 1,
+      host: "localhost",
+      port: 8080,
+      username: "admin",
+      password: "admin",
+      use_ssl: false,
+      url_base: nil,
+      category: nil,
+      download_directory: nil
+    }
+
+    struct!(Mydia.Config.Schema.DownloadClient, Map.merge(defaults, overrides))
+  end
+end

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -1595,4 +1595,58 @@ defmodule Mydia.Jobs.MediaImportTest do
       |> Enum.sort()
     end
   end
+
+  describe "download client removed from configuration" do
+    # A download whose `download_client` no longer resolves to any configured
+    # client cannot self-heal: every retry re-reads the same config and gets the
+    # same answer. With max_attempts: 1000 the row retried indefinitely, and
+    # because `Download.occupying/1` treats a non-nil `import_next_retry_at` as
+    # "still working", the episode stayed occupied and was never re-searched.
+    # Observed in production after an rqbit client was retired.
+    setup do
+      media_item = media_item_fixture(%{type: "movie", title: "Retired Client Movie", year: 2024})
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          completed_at: DateTime.utc_now(),
+          download_client: "RetiredClient",
+          download_client_id: "retired-client-1"
+        })
+
+      %{download: download}
+    end
+
+    test "retries the first attempts so a config reload can still recover it", %{
+      download: download
+    } do
+      assert {:error, :no_client} =
+               perform_job(MediaImport, %{"download_id" => download.id}, attempt: 1)
+
+      updated = Mydia.Downloads.get_download!(download.id)
+      assert updated.import_failure_reason == "no_client"
+      assert updated.import_next_retry_at != nil
+    end
+
+    test "goes terminal after the third attempt so the episode is released", %{
+      download: download
+    } do
+      assert {:cancel, :no_client} =
+               perform_job(MediaImport, %{"download_id" => download.id}, attempt: 3)
+
+      updated = Mydia.Downloads.get_download!(download.id)
+      assert updated.import_failure_reason == "no_client"
+
+      assert is_nil(updated.import_next_retry_at),
+             "a terminal failure must clear import_next_retry_at so Download.occupying/1 releases the target"
+
+      refute updated.id in occupying_download_ids()
+    end
+
+    defp occupying_download_ids do
+      Mydia.Downloads.Download.occupying()
+      |> Repo.all()
+      |> Enum.map(& &1.id)
+    end
+  end
 end


### PR DESCRIPTION
Two independent defects found while investigating why 47 of 101 downloads on a
live instance never imported. Both are small, both were invisible to the
existing test suite, and both have real user-visible consequences.

## 1. DownloadMonitor crashed on every missing download

`handle_missing/1` logged `updated.status`, but `Downloads.Download` has no
`:status` field — status is derived at read time from the client poll. The same
call also passed `status: "missing"` to `update_download/2`, where the changeset
silently dropped it.

```
** (KeyError) key :status not found in: %Mydia.Downloads.Download{...}
    lib/mydia/jobs/download_monitor.ex:406: Mydia.Jobs.DownloadMonitor.handle_missing/1
    lib/mydia/jobs/download_monitor.ex:136: Mydia.Jobs.DownloadMonitor.perform/1
```

The `error_message` write landed first, then the job raised. So:

- `Events.download_failed/3` never fired, and nothing surfaced to the user
- the `Enum.each` over `missing` aborted, leaving later rows unmarked
- unmatched-orphan cleanup, stall detection, and the adaptive follow-up chain
  never ran in that pass
- Oban burned all five attempts and discarded the job

On the instance this was found on, that produced one marked download per retry
cycle across ~45 minutes, and three discarded `DownloadMonitor` jobs.

### Why the suite did not catch it

`config/test.exs` pins Logger to `:warning`, and `Logger.info/2` is a macro that
skips evaluating its arguments below the configured level. The existing tests
could not reach the offending expression at all. `config/prod.exs` sets `:info`,
so it raised on every missing download in production.

The new test file raises the global Logger level to `:info` (hence
`async: false`) and reproduces the exact production stack frame. It fails on the
parent commit for the right reason.

## 2. `:no_client` retried forever and held episodes hostage

A download whose `download_client` no longer resolves to a configured client
cannot self-heal: every retry re-reads the same config and gets the same answer.
With `MediaImport`'s `max_attempts: 1000` it retried effectively forever.

The wasted attempts were not the problem. `Download.occupying/1` treats a
non-nil `import_next_retry_at` as work still in flight, so the row kept
occupying its episode and no replacement release was ever grabbed. The episode
silently stopped being searched, with nothing surfaced to the user.

Observed after a download client was retired: three episodes sat at attempt 6
with a pending retry against a client that no longer existed.

`:no_client` now goes terminal after three attempts. The small budget is
deliberate — config is applied at boot, so a job running during a restart can
legitimately see no client for a cycle. Past that it clears
`import_next_retry_at`, which releases the target and lands the row in the
Issues tab where an operator can act on it.

## Verification

- Full suite: 2888 tests, 0 failures, 34 skipped
- `mix credo --strict`: no issues across 877 files
- `mix compile --force --warnings-as-errors`: clean
- `mix format --check-formatted`: clean

Both fixes were written test-first and watched fail before implementing. The
batch-completion test for #1 was verified red by temporarily reverting the fix.

## Not included

Existing rows on an affected instance are not migrated by this PR. A download
already stuck with a pending retry against a removed client stays stuck until
its next attempt, at which point the new classification applies and releases it.
