### PR TITLE
fix(library): sort library grid dates by value, not term order

### DIFF
--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -751,10 +751,10 @@ defmodule MydiaWeb.MediaLive.Index do
         Enum.sort_by(items, &(&1.year || 0), :desc)
 
       "added_asc" ->
-        Enum.sort_by(items, & &1.inserted_at, :asc)
+        Enum.sort_by(items, & &1.inserted_at, {:asc, DateTime})
 
       "added_desc" ->
-        Enum.sort_by(items, & &1.inserted_at, :desc)
+        Enum.sort_by(items, & &1.inserted_at, {:desc, DateTime})
 
       "rating_asc" ->
         Enum.sort_by(items, &get_rating(&1), :asc)
@@ -763,16 +763,16 @@ defmodule MydiaWeb.MediaLive.Index do
         Enum.sort_by(items, &get_rating(&1), :desc)
 
       "last_aired_asc" ->
-        Enum.sort_by(items, &get_last_aired_date(&1), {:asc, NaiveDateTime})
+        Enum.sort_by(items, &get_last_aired_date(&1), {:asc, Date})
 
       "last_aired_desc" ->
-        Enum.sort_by(items, &get_last_aired_date(&1), {:desc, NaiveDateTime})
+        Enum.sort_by(items, &get_last_aired_date(&1), {:desc, Date})
 
       "next_aired_asc" ->
-        Enum.sort_by(items, &get_next_aired_date(&1), {:asc, NaiveDateTime})
+        Enum.sort_by(items, &get_next_aired_date(&1), {:asc, Date})
 
       "next_aired_desc" ->
-        Enum.sort_by(items, &get_next_aired_date(&1), {:desc, NaiveDateTime})
+        Enum.sort_by(items, &get_next_aired_date(&1), {:desc, Date})
 
       "episode_count_asc" ->
         Enum.sort_by(items, &get_episode_count(&1), :asc)
@@ -793,38 +793,43 @@ defmodule MydiaWeb.MediaLive.Index do
     end
   end
 
+  # Episode `air_date` is a Date, so these sentinels and comparisons stay in Date
+  # terms: sorting them as NaiveDateTime raises, since a Date has no time fields.
+  @never_aired ~D[1970-01-01]
+  @no_upcoming_airing ~D[2999-12-31]
+
   defp get_last_aired_date(media_item) do
     if media_item.type == "tv_show" && Ecto.assoc_loaded?(media_item.episodes) do
       media_item.episodes
       |> Enum.map(& &1.air_date)
       |> Enum.reject(&is_nil/1)
-      |> Enum.sort({:desc, NaiveDateTime})
+      |> Enum.sort({:desc, Date})
       |> List.first()
       |> case do
-        nil -> ~N[1970-01-01 00:00:00]
+        nil -> @never_aired
         date -> date
       end
     else
-      ~N[1970-01-01 00:00:00]
+      @never_aired
     end
   end
 
   defp get_next_aired_date(media_item) do
     if media_item.type == "tv_show" && Ecto.assoc_loaded?(media_item.episodes) do
-      now = NaiveDateTime.utc_now()
+      today = Date.utc_today()
 
       media_item.episodes
       |> Enum.map(& &1.air_date)
       |> Enum.reject(&is_nil/1)
-      |> Enum.filter(&(NaiveDateTime.compare(&1, now) == :gt))
-      |> Enum.sort({:asc, NaiveDateTime})
+      |> Enum.filter(&(Date.compare(&1, today) == :gt))
+      |> Enum.sort({:asc, Date})
       |> List.first()
       |> case do
-        nil -> ~N[2999-12-31 23:59:59]
+        nil -> @no_upcoming_airing
         date -> date
       end
     else
-      ~N[2999-12-31 23:59:59]
+      @no_upcoming_airing
     end
   end
 

--- a/test/mydia_web/live/media_live/index_test.exs
+++ b/test/mydia_web/live/media_live/index_test.exs
@@ -1,6 +1,7 @@
 defmodule MydiaWeb.MediaLive.IndexTest do
   use MydiaWeb.ConnCase
 
+  import Ecto.Query
   import Phoenix.LiveViewTest
   import Mydia.MediaFixtures
   import Mydia.AccountsFixtures
@@ -321,6 +322,83 @@ defmodule MydiaWeb.MediaLive.IndexTest do
                view,
                "#test-debug-info[data-search-query='Unmonitored'][data-stream-count='0']"
              )
+    end
+  end
+
+  describe "date sorting" do
+    setup %{conn: conn} do
+      %{conn: log_in_user(conn, admin_user_fixture())}
+    end
+
+    test "Added (Newest) puts the most recently added item first across a month boundary", %{
+      conn: conn
+    } do
+      june = media_item_fixture(%{title: "Added June 30", type: "movie"})
+      july = media_item_fixture(%{title: "Added July 1", type: "movie"})
+
+      set_inserted_at(june, ~U[2026-06-30 12:00:00Z])
+      set_inserted_at(july, ~U[2026-07-01 09:00:00Z])
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      assert sorted_item_ids(view, "added_desc") == [july.id, june.id]
+    end
+
+    test "Added (Oldest) puts the earliest added item first across a month boundary", %{
+      conn: conn
+    } do
+      june = media_item_fixture(%{title: "Added June 30", type: "movie"})
+      july = media_item_fixture(%{title: "Added July 1", type: "movie"})
+
+      set_inserted_at(june, ~U[2026-06-30 12:00:00Z])
+      set_inserted_at(july, ~U[2026-07-01 09:00:00Z])
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      assert sorted_item_ids(view, "added_asc") == [june.id, july.id]
+    end
+
+    test "Last Aired (Recent) orders shows by their most recent episode air date", %{conn: conn} do
+      older = media_item_fixture(%{title: "Aired Long Ago", type: "tv_show"})
+      recent = media_item_fixture(%{title: "Aired Recently", type: "tv_show"})
+
+      episode_fixture(%{media_item_id: older.id, air_date: ~D[2020-01-15]})
+      episode_fixture(%{media_item_id: recent.id, air_date: ~D[2026-01-15]})
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      assert sorted_item_ids(view, "last_aired_desc") == [recent.id, older.id]
+    end
+
+    test "Next Airing (Soon) orders shows by their next upcoming episode", %{conn: conn} do
+      soon = media_item_fixture(%{title: "Airing Soon", type: "tv_show"})
+      later = media_item_fixture(%{title: "Airing Later", type: "tv_show"})
+
+      episode_fixture(%{media_item_id: soon.id, air_date: Date.add(Date.utc_today(), 7)})
+      episode_fixture(%{media_item_id: later.id, air_date: Date.add(Date.utc_today(), 30)})
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      assert sorted_item_ids(view, "next_aired_asc") == [soon.id, later.id]
+    end
+
+    defp set_inserted_at(media_item, %DateTime{} = at) do
+      Mydia.Repo.update_all(
+        from(m in Mydia.Media.MediaItem, where: m.id == ^media_item.id),
+        set: [inserted_at: at]
+      )
+    end
+
+    # Picks `sort_by` in the library toolbar and returns the resulting grid item
+    # ids in DOM order, stripped back to the bare media item id.
+    defp sorted_item_ids(view, sort_by) do
+      view
+      |> element("form#library-filter-form")
+      |> render_change(%{"sort_by" => sort_by})
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query("#media-items > div")
+      |> LazyHTML.attribute("id")
+      |> Enum.map(&String.replace_prefix(&1, "media_items-", ""))
     end
   end
 


### PR DESCRIPTION
Sorting the library grid by **Added (Newest)** did not put the newest item first. The true newest title was pushed down the grid, often to second place.

## Root cause

```elixir
"added_desc" -> Enum.sort_by(items, & &1.inserted_at, :desc)
```

`Enum.sort_by/3` with a bare `:asc`/`:desc` sorter falls back to Erlang term ordering. `%DateTime{}` is a struct, so term order compares its map values in *key* order:

```
calendar, day, hour, microsecond, minute, month, second, std_offset,
time_zone, utc_offset, year, zone_abbr
```

`day` is compared first and `year` is second to last, so the sort effectively ranked by day-of-month and barely looked at the year. Verified against real rows:

```
DB       [{"June", ~U[2026-06-30 12:00:00Z]}, {"July", ~U[2026-07-01 09:00:00Z]}]
TERMDESC ["June", "July"]     # before: older item first
DTDESC   ["July", "June"]     # after
```

Anything added late in a month outranks a genuinely newer item added early in the next one.

## Second bug, same dropdown

**Last Aired (Recent)** and **Next Airing (Soon)** crashed the LiveView for any show with episodes:

```
** (FunctionClauseError) no function clause matching in NaiveDateTime.to_iso_days/1
    NaiveDateTime.to_iso_days(~D[2020-01-15])
```

Episode `air_date` is a `Date`, but `get_last_aired_date/1` and `get_next_aired_date/1` sorted and compared it as a `NaiveDateTime`, which has no time fields to read.

## Fix

- `added_asc`/`added_desc` pass the `DateTime` module as the sorter, so comparison goes through `DateTime.compare/2`. This matches the form already used in `downloads_live`.
- The air-date helpers stay in `Date` terms throughout: `{:asc, Date}` / `{:desc, Date}`, `Date.compare/2` against `Date.utc_today()`, and `Date` sentinels for "never aired" / "no upcoming airing".

## Tests

New `date sorting` block in `test/mydia_web/live/media_live/index_test.exs` covering all four sorts, driven through the real toolbar sort form and asserting the rendered grid order. All four fail on the current code (two with reversed order, two with the crash) and pass with the fix.

```
52 tests, 0 failures   # full media_live suite
```

`mix compile --warnings-as-errors` is clean and Credo `--strict` reports no issues on the changed file.

## Not included

The identical term-order bug exists in the deprecated library pages (`music_live/index.ex`, `books_live/index.ex`, `adult_live/index.ex`). Left untouched here to keep the change scoped.
