### PR TITLE
fix(player): one cast control surface, reachable from any screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ docs/superpowers/
 
 # Subagent-driven-development scratch (ledger, briefs, review packages)
 .superpowers/
+player/ios/scripts/test-ci-signing.sh

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -28,20 +28,20 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.8.1",
+      "version": "1.8.8",
       "license": "MIT",
       "devDependencies": {
-        "@babel/cli": "7.28.3",
-        "@babel/core": "7.28.3",
-        "@babel/preset-env": "7.28.3",
-        "@eslint/js": "^9.28.0",
+        "@babel/cli": "7.28.6",
+        "@babel/core": "7.29.0",
+        "@babel/preset-env": "7.29.3",
+        "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.0.0",
         "documentation": "^14.0.3",
-        "eslint": "9.34.0",
-        "eslint-plugin-jest": "29.0.1",
+        "eslint": "10.2.1",
+        "eslint-plugin-jest": "29.15.2",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
-        "jsdom": "^26.1.0",
+        "jsdom": "^29.0.1",
         "mock-socket": "^9.3.1"
       }
     },
@@ -49,10 +49,10 @@
       "version": "4.3.0"
     },
     "../deps/phoenix_live_view": {
-      "version": "1.1.16",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "morphdom": "2.7.7"
+        "morphdom": "2.7.8"
       },
       "devDependencies": {
         "@babel/cli": "7.27.2",
@@ -60,7 +60,7 @@
         "@babel/preset-env": "7.27.2",
         "@babel/preset-typescript": "^7.27.1",
         "@eslint/js": "^9.29.0",
-        "@playwright/test": "^1.56.1",
+        "@playwright/test": "^1.60.0",
         "@types/jest": "^30.0.0",
         "@types/phoenix": "^1.6.6",
         "css.escape": "^1.5.1",
@@ -75,6 +75,8 @@
         "phoenix": "1.7.21",
         "prettier": "3.5.3",
         "ts-jest": "^29.4.0",
+        "typedoc": "^0.28.19",
+        "typedoc-plugin-missing-exports": "^4.1.3",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
       }

--- a/dev
+++ b/dev
@@ -471,6 +471,29 @@ case "$COMMAND" in
                 esac
                 shift 2
 
+                # Escape the devenv/Nix environment. direnv loads devenv on cd
+                # into the worktree, so by the time this branch runs the shell
+                # already exports a Nix clang/cctools PATH, DEVELOPER_DIR and
+                # SDKROOT pointing at nixpkgs' apple-sdk, NIX_CFLAGS_COMPILE,
+                # and a Nix-wrapped Flutter. That last one is fatal, not merely
+                # wrong: its engine artifacts live read-only in /nix/store, so
+                # Flutter copies FlutterMacOS.framework out as dr-xr-xr-x and
+                # `lipo` dies with "can't create temporary output file
+                # ... (Permission denied)" during debug_unpack_macos. Xcode must
+                # see the host toolchain, so strip the Nix layer back off.
+                if [ -n "${IN_NIX_SHELL:-}${DEVENV_ROOT:-}" ]; then
+                    PATH="$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '^/nix/store/' | paste -sd: -)"
+                    export PATH
+                    # NIX_SSL_CERT_FILE stays: rustup and CocoaPods fetch over
+                    # TLS and Nix-installed curl has no other CA bundle.
+                    for nix_var in $(compgen -v | grep '^NIX_'); do
+                        [ "$nix_var" = "NIX_SSL_CERT_FILE" ] || unset "$nix_var"
+                    done
+                    unset DEVELOPER_DIR SDKROOT MACOSX_DEPLOYMENT_TARGET IN_NIX_SHELL \
+                          LD_DYLD_PATH LD_FOR_BUILD PKG_CONFIG_PATH CC CXX AR LD \
+                          CFLAGS LDFLAGS CPATH LIBRARY_PATH
+                fi
+
                 # Preflight the host toolchain so a missing prerequisite fails
                 # here with a fix, not 200 lines into an Xcode build log.
                 missing_tools=""

--- a/nix/packages/flake-module.nix
+++ b/nix/packages/flake-module.nix
@@ -167,7 +167,7 @@
       # Pre-fetch npm dependencies (required for sandbox build)
       npmDeps = pkgs.fetchNpmDeps {
         src = ../../assets;
-        hash = "sha256-uphoD/oJoGADVR6cTdW+Pah4pLkCS1cKFc5Dp5ZAY4o=";
+        hash = "sha256-hkcy/pcrWC8dtDwx+9wmHPAiI3rT9eZTQfIxafkztos=";
       };
 
       # Tailwind CSS v4 binary (not yet in nixpkgs)

--- a/player/lib/core/cast/cast_seek.dart
+++ b/player/lib/core/cast/cast_seek.dart
@@ -1,0 +1,53 @@
+/// Seek arithmetic for the cast controls.
+///
+/// Split out of `PlayerScreen` because every one of these functions has to
+/// cope with a duration the receiver never told us, and that case is only
+/// reachable on real hardware — a Chromecast fed a live-style HLS playlist
+/// reports `duration: -1`, which is what made the scrub bar and the
+/// skip-ahead button both seek to zero.
+library;
+
+/// Whether [duration] is a real runtime rather than a receiver placeholder.
+///
+/// Chromecast reports `-1` for a stream whose length it cannot determine —
+/// which is every HLS playlist Mydia serves before FFmpeg writes
+/// `#EXT-X-ENDLIST` (see `ffmpeg_hls_transcoder.ex`, which deliberately runs
+/// without `-hls_playlist_type` so playback can start before the whole file
+/// is processed). `dart_cast` forwards that `-1` verbatim, so *every*
+/// consumer has to treat non-positive as "unknown" rather than as a bound.
+bool hasKnownDuration(Duration duration) => duration > Duration.zero;
+
+/// The position a scrub bar at [fraction] of its travel refers to, or null
+/// when [duration] is unknown and the fraction therefore means nothing.
+///
+/// Returning null rather than [Duration.zero] is the whole point: multiplying
+/// a fraction by an unknown duration silently produces zero, which reads to
+/// the user as "seeking sends me back to the start".
+Duration? seekTargetForFraction(double fraction, Duration duration) {
+  if (!hasKnownDuration(duration)) return null;
+
+  final clamped = fraction.clamp(0.0, 1.0);
+  return Duration(milliseconds: (clamped * duration.inMilliseconds).round());
+}
+
+/// Confines a relative skip to the playable range.
+///
+/// The upper bound is applied only when [duration] is known. Clamping against
+/// an unknown duration is what turned "skip forward 10s" into "seek to -1s",
+/// i.e. back to the beginning.
+Duration clampSeekTarget(Duration target, Duration duration) {
+  if (target < Duration.zero) return Duration.zero;
+  if (hasKnownDuration(duration) && target > duration) return duration;
+  return target;
+}
+
+/// How far through [duration] the receiver is, as a 0..1 scrub-bar value.
+///
+/// Zero when the duration is unknown — the bar cannot describe progress
+/// through a length nobody knows.
+double castProgressFraction(Duration position, Duration duration) {
+  if (!hasKnownDuration(duration)) return 0.0;
+
+  final fraction = position.inMilliseconds / duration.inMilliseconds;
+  return fraction.clamp(0.0, 1.0);
+}

--- a/player/lib/core/cast/cast_session_manager.dart
+++ b/player/lib/core/cast/cast_session_manager.dart
@@ -20,6 +20,15 @@ class CastLaunchRequest {
   final Duration? startPosition;
   final List<CastSubtitleTrack> subtitles;
 
+  /// The item's runtime, as the app already knows it.
+  ///
+  /// Required for a usable scrub bar: a Chromecast fed one of Mydia's
+  /// live-style HLS playlists answers `duration: -1` forever, so the receiver
+  /// is not a source of truth for length. Null means the caller genuinely
+  /// does not know it yet, and the UI degrades to controls that only move
+  /// relative to the current position.
+  final Duration? duration;
+
   const CastLaunchRequest({
     required this.fileId,
     required this.mediaId,
@@ -29,6 +38,7 @@ class CastLaunchRequest {
     this.imageUrl,
     this.startPosition,
     this.subtitles = const [],
+    this.duration,
   });
 }
 
@@ -103,7 +113,8 @@ class CastSessionManager {
 
     CastRoute? route;
     try {
-      route = await _resolveRoute(resolver, request, device, startedHlsSessions);
+      route =
+          await _resolveRoute(resolver, request, device, startedHlsSessions);
     } catch (e) {
       await _abandonStart(lanEnabledBeforeCall, startedHlsSessions);
       rethrow;
@@ -321,7 +332,8 @@ class CastSessionManager {
         // Usually AP isolation, a VLAN, or guest wifi. Serve it ourselves.
         if (attempted.kind == CastRouteKind.localBridge) return null;
 
-        debugPrint('[CastSessionManager] Direct route failed, retrying via bridge');
+        debugPrint(
+            '[CastSessionManager] Direct route failed, retrying via bridge');
         return _resolveRoute(
           resolver,
           request,
@@ -364,7 +376,8 @@ class CastSessionManager {
         // Escalate to a full transcode.
         if (attempted.mediaUrl.contains('strategy=TRANSCODE')) return null;
 
-        debugPrint('[CastSessionManager] Media rejected, retrying with TRANSCODE');
+        debugPrint(
+            '[CastSessionManager] Media rejected, retrying with TRANSCODE');
         return _resolveRoute(
           resolver,
           request,
@@ -389,7 +402,8 @@ class CastSessionManager {
     final subtitles = route.subtitlesSupported
         ? request.subtitles
             .map((track) => CastSubtitleTrack(
-                  url: resolver.resolveSubtitleUrl(route, track.url) ?? track.url,
+                  url: resolver.resolveSubtitleUrl(route, track.url) ??
+                      track.url,
                   label: track.label,
                   language: track.language,
                 ))
@@ -416,6 +430,7 @@ class CastSessionManager {
       routeKind: route.kind,
       savedAt: _clock(),
       mediaUrl: route.mediaUrl,
+      duration: request.duration ?? Duration.zero,
     );
     await _store.save(_persisted!);
 
@@ -426,7 +441,9 @@ class CastSessionManager {
         title: request.title,
         subtitle: request.subtitleLabel,
         imageUrl: request.imageUrl,
-        duration: Duration.zero,
+        // Seeded from what the app knows, not left at zero to wait on the
+        // receiver: on HLS the receiver never reports a length at all.
+        duration: request.duration ?? Duration.zero,
         position: request.startPosition ?? Duration.zero,
       ),
     ));
@@ -461,10 +478,17 @@ class CastSessionManager {
     // Otherwise the first position event for the new item can sync against
     // a stale duration, writing a wrong durationSeconds (and potentially a
     // false "watched" verdict) to the user's history.
-    _lastDuration = Duration.zero;
+    _lastDuration = request.duration ?? Duration.zero;
     _lastProgressSync = null;
 
     _durationSub = _backend.durationStream.listen((duration) {
+      // Non-positive is the receiver saying "I don't know" (Chromecast sends
+      // -1 for the live-style HLS playlists Mydia serves), not a length.
+      // `DartCastBackend` already filters these; the guard is repeated here
+      // because the manager is backend-agnostic and a bad duration corrupts
+      // both the scrub bar and the watch-history sync below.
+      if (duration <= Duration.zero) return;
+
       _lastDuration = duration;
       _updateMediaInfo(duration: duration);
     });
@@ -497,8 +521,13 @@ class CastSessionManager {
     });
   }
 
-  Future<void> _syncProgress(CastLaunchRequest request, Duration position) async {
-    if (_lastDuration == Duration.zero) return;
+  Future<void> _syncProgress(
+      CastLaunchRequest request, Duration position) async {
+    // `<=` rather than `== Duration.zero`: a receiver that reports -1 would
+    // otherwise clear this guard and write `durationSeconds: -1` into the
+    // user's watch history, along with whatever watched verdict follows from
+    // dividing by it.
+    if (_lastDuration <= Duration.zero) return;
 
     final now = _clock();
     final last = _lastProgressSync;
@@ -561,6 +590,7 @@ class CastSessionManager {
         mediaType: stored.mediaType,
         title: stored.title,
         startPosition: stored.position,
+        duration: stored.duration,
       ),
     );
   }
@@ -636,6 +666,7 @@ class CastSessionManager {
       mediaType: stored.mediaType,
       title: stored.title,
       startPosition: stored.position,
+      duration: stored.duration,
     );
     _listenToBackend(request);
 
@@ -656,7 +687,7 @@ class CastSessionManager {
       playbackState: CastPlaybackState.buffering,
       mediaInfo: CastMediaInfo(
         title: stored.title,
-        duration: Duration.zero,
+        duration: stored.duration,
         position: stored.position,
       ),
     ));
@@ -767,7 +798,8 @@ class CastSessionManager {
       try {
         await _backend.disconnect();
       } catch (e) {
-        debugPrint('[CastSessionManager] Ignoring disconnect error on dispose: $e');
+        debugPrint(
+            '[CastSessionManager] Ignoring disconnect error on dispose: $e');
       }
     }
 

--- a/player/lib/core/cast/cast_session_store.dart
+++ b/player/lib/core/cast/cast_session_store.dart
@@ -15,6 +15,14 @@ class PersistedCastSession {
   final CastRouteKind routeKind;
   final DateTime savedAt;
 
+  /// The item's runtime as the *app* knows it, not as the receiver reports it.
+  ///
+  /// Persisted because a Chromecast never learns the length of the live-style
+  /// HLS playlists Mydia serves — so a reconnect that did not carry this
+  /// across would come back with an unknown duration and a scrub bar that
+  /// cannot be dragged. Zero means "was not known when this was saved".
+  final Duration duration;
+
   /// The exact URL handed to the receiver.
   ///
   /// Persisted so a restore can ask the receiver what it is playing and
@@ -32,6 +40,7 @@ class PersistedCastSession {
     required this.routeKind,
     required this.savedAt,
     this.mediaUrl = '',
+    this.duration = Duration.zero,
   });
 
   /// Sessions older than this are discarded without a reconnect attempt.
@@ -50,6 +59,7 @@ class PersistedCastSession {
             routeKind == CastRouteKind.localBridge ? 'bridge' : 'direct',
         'savedAt': savedAt.toIso8601String(),
         'mediaUrl': mediaUrl,
+        'durationSeconds': duration.inSeconds,
       };
 
   factory PersistedCastSession.fromMap(Map<dynamic, dynamic> map) {
@@ -70,10 +80,17 @@ class PersistedCastSession {
       // carry no URL; an empty one can never match, so they are discarded
       // rather than restored blind.
       mediaUrl: map['mediaUrl'] as String? ?? '',
+      // Records written before the cast session carried a duration have no
+      // such key; zero reads as "unknown", which the UI already handles.
+      duration: Duration(seconds: map['durationSeconds'] as int? ?? 0),
     );
   }
 
-  PersistedCastSession copyWith({Duration? position, DateTime? savedAt}) {
+  PersistedCastSession copyWith({
+    Duration? position,
+    DateTime? savedAt,
+    Duration? duration,
+  }) {
     return PersistedCastSession(
       device: device,
       mediaId: mediaId,
@@ -84,6 +101,7 @@ class PersistedCastSession {
       routeKind: routeKind,
       savedAt: savedAt ?? this.savedAt,
       mediaUrl: mediaUrl,
+      duration: duration ?? this.duration,
     );
   }
 }

--- a/player/lib/core/cast/cast_target.dart
+++ b/player/lib/core/cast/cast_target.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/models/cast_device.dart';
+
+/// The device the user has chosen to cast to, before anything is playing.
+///
+/// Deliberately *not* a connection. Setting a target contacts nothing and
+/// launches no receiver app — it only records an intent, which `PlayerScreen`
+/// reads when playback starts so the media opens on the receiver instead of
+/// locally. Modelling it this way keeps `CastSessionManager` owning exactly
+/// one concept (an active session with media) rather than growing a
+/// media-less idle state that the session store, LAN gating and the progress
+/// pump would all have to learn.
+class CastTargetNotifier extends Notifier<CastDevice?> {
+  @override
+  CastDevice? build() => null;
+
+  void set(CastDevice device) => state = device;
+
+  void clear() => state = null;
+}
+
+final castTargetProvider =
+    NotifierProvider<CastTargetNotifier, CastDevice?>(CastTargetNotifier.new);

--- a/player/lib/core/cast/dart_cast_backend.dart
+++ b/player/lib/core/cast/dart_cast_backend.dart
@@ -117,8 +117,31 @@ CastFailureKind failureKindFor(dc.CastException e) {
 /// composition wiring [BonsoirChromecastDiscovery.failures] into
 /// [CastBackend.failureStream] is unit-testable without a real `CastService`.
 @visibleForTesting
-Stream<CastFailureKind> mapDiscoveryFailures(Stream<dc.CastException> failures) {
+Stream<CastFailureKind> mapDiscoveryFailures(
+    Stream<dc.CastException> failures) {
   return failures.map(failureKindFor);
+}
+
+/// Drops receiver "durations" that are not durations.
+///
+/// A Chromecast reports `duration: -1` for any stream whose length it cannot
+/// determine, which is every HLS playlist Mydia serves: the server runs
+/// FFmpeg without `-hls_playlist_type` on purpose (see
+/// `ffmpeg_hls_transcoder.ex`) so playback can start before the whole file is
+/// remuxed, which means no `#EXT-X-ENDLIST` and therefore no advertised
+/// length. `dart_cast` only null-checks the field
+/// (`chromecast_session.dart`'s `status.duration != null`), so the `-1`
+/// arrives here verbatim.
+///
+/// This is the single point where that placeholder is stopped. Letting it
+/// past made the cast scrub bar render `00:-1`, made the slider seek to
+/// `fraction * -1s` — i.e. the start of the video — and made the skip-ahead
+/// button clamp every target against a `-1s` "end", also landing at the
+/// start. Zero is filtered for the same reason: it is the pre-first-status
+/// placeholder, never a real runtime.
+@visibleForTesting
+Stream<Duration> sanitizeDurations(Stream<Duration> durations) {
+  return durations.where((duration) => duration > Duration.zero);
 }
 
 /// Builds the protocol-specific `dart_cast` session for a discovered device.
@@ -167,8 +190,8 @@ class DartCastBackend implements CastBackend {
     // it never forwards them (see discovery_manager.dart) — so a discovery
     // denial would otherwise surface as a silently empty device list rather
     // than reaching the UI. This is the only path that gets it there.
-    _discoveryFailureSub =
-        mapDiscoveryFailures(_chromecastDiscovery.failures).listen(_failures.add);
+    _discoveryFailureSub = mapDiscoveryFailures(_chromecastDiscovery.failures)
+        .listen(_failures.add);
   }
 
   factory DartCastBackend() {
@@ -292,7 +315,8 @@ class DartCastBackend implements CastBackend {
       }
     });
     _positionSub = session.positionStream.listen(_positions.add);
-    _durationSub = session.durationStream.listen(_durations.add);
+    _durationSub =
+        sanitizeDurations(session.durationStream).listen(_durations.add);
   }
 
   /// Always null: `dart_cast` 0.7.x offers no way to ask a receiver what it is

--- a/player/lib/presentation/screens/downloads/downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/downloads_screen.dart
@@ -4,6 +4,8 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/cache/poster_cache_manager.dart';
 import '../../widgets/ambient_backdrop_provider.dart';
+import '../../widgets/cast_actions.dart';
+import '../../widgets/cast_button.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/downloads/download_providers.dart';
 import '../../../core/downloads/download_queue_providers.dart';
@@ -762,45 +764,53 @@ class DownloadsScreen extends ConsumerWidget {
     return PreferredSize(
       preferredSize: const Size.fromHeight(kToolbarHeight),
       child: GlassSurface.appBar(
-          opacity: 0.85,
-          child: SafeArea(
-              child: SizedBox(
-                height: kToolbarHeight,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: Row(
-                    children: [
-                      const Icon(
-                        Icons.download_rounded,
-                        color: AppColors.primary,
-                        size: 24,
-                      ),
-                      const SizedBox(width: 10),
-                      Text(
-                        'Downloads',
-                        style:
-                            Theme.of(context).textTheme.headlineSmall?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  letterSpacing: -0.3,
-                                ),
-                      ),
-                      const Spacer(),
-                      if (queuedCount > 0)
-                        IconButton(
-                          onPressed: () => _showCancelAllQueuedDialog(
-                              context, ref, queuedCount),
-                          tooltip: 'Cancel all queued',
-                          icon: const Icon(
-                            Icons.clear_all_rounded,
-                            color: AppColors.textSecondary,
-                          ),
-                        ),
-                    ],
+        opacity: 0.85,
+        child: SafeArea(
+          child: SizedBox(
+            height: kToolbarHeight,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  const Icon(
+                    Icons.download_rounded,
+                    color: AppColors.primary,
+                    size: 24,
                   ),
-                ),
+                  const SizedBox(width: 10),
+                  Text(
+                    'Downloads',
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          letterSpacing: -0.3,
+                        ),
+                  ),
+                  const Spacer(),
+                  if (queuedCount > 0) ...[
+                    IconButton(
+                      onPressed: () =>
+                          _showCancelAllQueuedDialog(context, ref, queuedCount),
+                      tooltip: 'Cancel all queued',
+                      icon: const Icon(
+                        Icons.clear_all_rounded,
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                  ],
+                  // DownloadsScreen's app bar is always visible (no
+                  // desktop suppression), so it carries its own cast
+                  // affordance instead of the shell's overlay — see
+                  // AppShell._hasOwnCastButton.
+                  CastButton(
+                    onPressed: () => pickCastDevice(context, ref),
+                  ),
+                ],
               ),
             ),
+          ),
         ),
+      ),
     );
   }
 

--- a/player/lib/presentation/screens/episode/episode_detail_screen.dart
+++ b/player/lib/presentation/screens/episode/episode_detail_screen.dart
@@ -13,6 +13,8 @@ import '../../../core/downloads/download_job_providers.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../domain/models/download.dart';
 import '../../../core/theme/colors.dart';
+import '../../widgets/cast_actions.dart';
+import '../../widgets/cast_button.dart';
 import '../../widgets/smart_play_button.dart';
 
 class EpisodeDetailScreen extends ConsumerWidget {
@@ -181,7 +183,7 @@ class EpisodeDetailScreen extends ConsumerWidget {
       BuildContext context, WidgetRef ref, EpisodeDetail episode) {
     return CustomScrollView(
       slivers: [
-        _buildHeroSection(context, episode),
+        _buildHeroSection(context, ref, episode),
         SliverToBoxAdapter(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -251,7 +253,8 @@ class EpisodeDetailScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildHeroSection(BuildContext context, EpisodeDetail episode) {
+  Widget _buildHeroSection(
+      BuildContext context, WidgetRef ref, EpisodeDetail episode) {
     // Use episode thumbnail if available, otherwise fall back to show backdrop
     final imageUrl = episode.thumbnailUrl ?? episode.show.artwork.backdropUrl;
 
@@ -261,6 +264,13 @@ class EpisodeDetailScreen extends ConsumerWidget {
       stretch: true,
       backgroundColor: AppColors.background,
       leading: _buildBackButton(context),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: CastButton(onPressed: () => pickCastDevice(context, ref)),
+        ),
+        const SizedBox(width: 8),
+      ],
       flexibleSpace: FlexibleSpaceBar(
         stretchModes: const [
           StretchMode.zoomBackground,

--- a/player/lib/presentation/screens/library/library_screen.dart
+++ b/player/lib/presentation/screens/library/library_screen.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'library_controller.dart';
 import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/app_shell.dart';
+import '../../widgets/cast_actions.dart';
+import '../../widgets/cast_button.dart';
 import '../../widgets/freshness_header.dart';
 import '../../widgets/glass_surface.dart';
 import '../../widgets/media_poster.dart';
@@ -246,6 +248,14 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                             : Icons.grid_view_rounded,
                         onPressed: _toggleViewMode,
                         tooltip: 'Toggle view',
+                      ),
+                      const SizedBox(width: 4),
+                      // LibraryScreen keeps a real app bar on every platform
+                      // (unlike the desktop-suppressed browse screens), so it
+                      // carries its own cast affordance instead of the
+                      // shell's overlay — see AppShell._hasOwnCastButton.
+                      CastButton(
+                        onPressed: () => pickCastDevice(context, ref),
                       ),
                     ],
                   ),

--- a/player/lib/presentation/screens/movie/movie_detail_screen.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_screen.dart
@@ -12,6 +12,8 @@ import '../../../core/downloads/download_job_providers.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../domain/models/download.dart';
 import '../../../core/theme/colors.dart';
+import '../../widgets/cast_actions.dart';
+import '../../widgets/cast_button.dart';
 import '../../widgets/smart_play_button.dart';
 
 class MovieDetailScreen extends ConsumerWidget {
@@ -256,6 +258,10 @@ class MovieDetailScreen extends ConsumerWidget {
               ),
             ),
           ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: CastButton(onPressed: () => pickCastDevice(context, ref)),
         ),
         const SizedBox(width: 8),
       ],

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -30,6 +30,7 @@ import '../../widgets/subtitle_track_selector.dart';
 import '../../widgets/audio_track_selector.dart';
 import '../../widgets/hls_quality_selector.dart';
 import '../../widgets/gesture_controls.dart';
+import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
 import '../../widgets/cast_device_picker.dart';
 import '../../widgets/video_controls/custom_video_controls.dart';
@@ -1841,7 +1842,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     } on CastBackendException catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(_castErrorMessage(e)),
+        content: Text(castErrorMessage(e, ref: ref)),
         backgroundColor: Colors.red,
       ));
     } catch (e) {
@@ -1866,7 +1867,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     } on CastBackendException catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(_castErrorMessage(e)),
+        content: Text(castErrorMessage(e, ref: ref)),
         backgroundColor: Colors.red,
       ));
     } catch (e) {
@@ -1891,32 +1892,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         content: Text('Failed to stop casting: $e'),
         backgroundColor: Colors.red,
       ));
-    }
-  }
-
-  /// Turn a cast failure into something the user can act on. A bare
-  /// "cast failed" leaves a firewall or codec problem undiagnosable, so the
-  /// unreachable case names the actual port that needs to be open.
-  String _castErrorMessage(CastBackendException e) {
-    final proxy = ref.read(localProxyServiceProvider);
-
-    switch (e.kind) {
-      case CastFailureKind.unreachable:
-        final port = proxy.isLanAccessible ? proxy.port : null;
-        final portHint =
-            port == null ? '' : ' Allow incoming connections on port $port.';
-        return 'The device could not reach your media. Check that both are on '
-            'the same network and that your firewall is not blocking '
-            'Mydia.$portHint';
-      case CastFailureKind.mediaLoadFailed:
-        return 'The device could not play this file. It may not support the '
-            'video or audio format.';
-      case CastFailureKind.connectionLost:
-        return 'Lost the connection to the device.';
-      case CastFailureKind.discoveryDenied:
-        return 'Mydia needs local network permission to find cast devices.';
-      case CastFailureKind.unknown:
-        return 'Casting failed: ${e.message}';
     }
   }
 

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -19,6 +19,7 @@ import '../../../core/player/progress_service.dart';
 import '../../../core/utils/file_utils.dart' as file_utils;
 import '../../../core/utils/web_lifecycle.dart' as web_lifecycle;
 import '../../../core/player/platform_features.dart';
+import '../../../core/cast/cast_seek.dart';
 import '../../../core/player/duration_override.dart';
 import '../../../core/cast/cast_backend.dart';
 import '../../../core/cast/cast_providers.dart';
@@ -1811,6 +1812,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           title: widget.title ?? 'Untitled',
           subtitleLabel: widget.mediaType == 'episode' ? 'Episode' : 'Movie',
           startPosition: _player?.state.position,
+          // The receiver cannot work this out for itself: Mydia's HLS
+          // playlists carry no `#EXT-X-ENDLIST` until FFmpeg finishes, so a
+          // Chromecast reports `duration: -1` for the whole session. Hand it
+          // the runtime the server already told us (`_totalDuration`, set
+          // from the candidates metadata), falling back to whatever the local
+          // player managed to work out.
+          duration: _knownCastDuration(),
           subtitles: _subtitleTracks
               .where((track) => track.url != null)
               .map((track) => CastSubtitleTrack(
@@ -1963,9 +1971,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
     final isPlaying = playbackState == CastPlaybackState.playing;
     final isBuffering = playbackState == CastPlaybackState.buffering;
-    final progress = mediaInfo.duration.inSeconds > 0
-        ? mediaInfo.position.inSeconds / mediaInfo.duration.inSeconds
-        : 0.0;
+    // A receiver that cannot report a length (every HLS cast — see
+    // `cast_seek.dart`) leaves this false, and the scrub bar goes read-only
+    // rather than seeking to a position computed from a bogus duration.
+    final durationKnown = hasKnownDuration(mediaInfo.duration);
+    final progress =
+        castProgressFraction(mediaInfo.position, mediaInfo.duration);
 
     return Stack(
       children: [
@@ -2022,14 +2033,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
                 Column(
                   children: [
                     Slider(
-                      value: progress.clamp(0.0, 1.0),
-                      onChanged: (value) async {
-                        final newPosition = Duration(
-                          seconds:
-                              (value * mediaInfo.duration.inSeconds).round(),
-                        );
-                        await manager.seek(newPosition);
-                      },
+                      value: progress,
+                      // Null disables the slider outright. Leaving it live
+                      // with an unknown duration is the bug this replaces:
+                      // every drag resolved to `fraction * -1s` and threw the
+                      // receiver back to the start of the video.
+                      onChanged: !durationKnown
+                          ? null
+                          : (value) async {
+                              final newPosition = seekTargetForFraction(
+                                value,
+                                mediaInfo.duration,
+                              );
+                              if (newPosition == null) return;
+                              await manager.seek(newPosition);
+                            },
                       activeColor: Colors.red,
                       inactiveColor: Colors.grey[800],
                     ),
@@ -2046,7 +2064,11 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
                                     ),
                           ),
                           Text(
-                            _formatDuration(mediaInfo.duration),
+                            // `_formatDuration` renders a -1s duration as
+                            // "00:-1"; an unknown length gets a placeholder.
+                            durationKnown
+                                ? _formatDuration(mediaInfo.duration)
+                                : '--:--',
                             style:
                                 Theme.of(context).textTheme.bodySmall?.copyWith(
                                       color: Colors.grey[400],
@@ -2067,11 +2089,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
                       icon: const Icon(Icons.replay_10, color: Colors.white),
                       iconSize: 40,
                       onPressed: () async {
-                        final newPosition =
-                            mediaInfo.position - const Duration(seconds: 10);
-                        await manager.seek(
-                          newPosition.isNegative ? Duration.zero : newPosition,
-                        );
+                        await manager.seek(clampSeekTarget(
+                          mediaInfo.position - const Duration(seconds: 10),
+                          mediaInfo.duration,
+                        ));
                       },
                     ),
                     const SizedBox(width: 24),
@@ -2108,12 +2129,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
                       icon: const Icon(Icons.forward_10, color: Colors.white),
                       iconSize: 40,
                       onPressed: () async {
-                        final newPosition =
-                            mediaInfo.position + const Duration(seconds: 10);
-                        final maxPosition = mediaInfo.duration;
-                        await manager.seek(
-                          newPosition > maxPosition ? maxPosition : newPosition,
-                        );
+                        // Clamping only applies when the duration is real;
+                        // clamping against the receiver's -1 placeholder is
+                        // what turned "skip ahead" into "back to the start".
+                        await manager.seek(clampSeekTarget(
+                          mediaInfo.position + const Duration(seconds: 10),
+                          mediaInfo.duration,
+                        ));
                       },
                     ),
                   ],
@@ -2155,6 +2177,23 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         ),
       ],
     );
+  }
+
+  /// The item's runtime, from the most trustworthy source available.
+  ///
+  /// Prefers `_totalDuration` (the server's own figure, from the candidates
+  /// metadata) over the local player's, because on an HLS stream media_kit is
+  /// working from the same incomplete playlist the receiver is. Returns null
+  /// when neither knows yet, which the cast UI renders as an unknown length
+  /// rather than as zero.
+  Duration? _knownCastDuration() {
+    final fromServer = _totalDuration;
+    if (fromServer != null && fromServer > Duration.zero) return fromServer;
+
+    final fromPlayer = _player?.state.duration;
+    if (fromPlayer != null && fromPlayer > Duration.zero) return fromPlayer;
+
+    return null;
   }
 
   /// Format duration as HH:MM:SS or MM:SS.

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -19,7 +19,6 @@ import '../../../core/player/progress_service.dart';
 import '../../../core/utils/file_utils.dart' as file_utils;
 import '../../../core/utils/web_lifecycle.dart' as web_lifecycle;
 import '../../../core/player/platform_features.dart';
-import '../../../core/cast/cast_seek.dart';
 import '../../../core/player/duration_override.dart';
 import '../../../core/cast/cast_backend.dart';
 import '../../../core/cast/cast_providers.dart';
@@ -1422,7 +1421,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     });
 
     final isCasting = ref.watch(isCastingProvider);
-    Widget body = isCasting ? _buildCastRemoteControlUI() : _buildBody();
+    final castDevice = ref.watch(currentCastDeviceProvider);
+    Widget body = isCasting && castDevice != null
+        ? _buildCastPlaceholder(castDevice)
+        : _buildBody();
 
     // Wrap with keyboard listener for desktop
     if (PlatformFeatures.supportsKeyboardShortcuts && !isCasting) {
@@ -1811,7 +1813,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           mediaId: widget.mediaId,
           mediaType: widget.mediaType,
           title: widget.title ?? 'Untitled',
-          subtitleLabel: widget.mediaType == 'episode' ? 'Episode' : 'Movie',
           startPosition: _player?.state.position,
           // The receiver cannot work this out for itself: Mydia's HLS
           // playlists carry no `#EXT-X-ENDLIST` until FFmpeg finishes, so a
@@ -1859,280 +1860,51 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     }
   }
 
-  /// Re-cast the media the stored (now stale) session was playing.
-  Future<void> _reconnectStaleSession() async {
-    try {
-      final manager = await ref.read(castSessionManagerProvider.future);
-      await manager.reconnectStoredSession();
-    } on CastBackendException catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(castErrorMessage(e, ref: ref)),
-        backgroundColor: Colors.red,
-      ));
-    } catch (e) {
-      debugPrint('[PlayerScreen] Unexpected error reconnecting cast: $e');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text('Failed to reconnect: $e'),
-        backgroundColor: Colors.red,
-      ));
-    }
-  }
-
-  /// Drop the cast session and fall back to local playback.
-  Future<void> _stopCasting() async {
-    try {
-      final manager = await ref.read(castSessionManagerProvider.future);
-      await manager.stopCast();
-    } catch (e) {
-      debugPrint('[PlayerScreen] Unexpected error stopping cast: $e');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text('Failed to stop casting: $e'),
-        backgroundColor: Colors.red,
-      ));
-    }
-  }
-
-  /// Build the remote control UI when casting.
-  Widget _buildCastRemoteControlUI() {
-    final session = ref.watch(castSessionProvider).value;
-    if (session != null && session.isStale) {
-      return Center(
-        key: const Key('cast-session-stale'),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.cast_outlined, size: 48, color: Colors.white70),
-            const SizedBox(height: 16),
-            Text(
-              'Lost connection to ${session.device.name}',
-              style: const TextStyle(color: Colors.white),
-            ),
-            const SizedBox(height: 16),
-            FilledButton(
-              key: const Key('cast-stale-reconnect'),
-              // Re-cast what the *stale session* was playing. Opening the
-              // picker here would silently start whatever file this screen
-              // happens to be showing instead.
-              onPressed: _reconnectStaleSession,
-              child: const Text('Reconnect'),
-            ),
-            const SizedBox(height: 8),
-            // Without this the screen is a dead end: `isCastingProvider`
-            // stays true while the session is stale, so the normal player
-            // body never renders and there is no way back.
-            TextButton(
-              key: const Key('cast-stale-stop'),
-              onPressed: _stopCasting,
-              child: const Text('Stop casting'),
-            ),
-          ],
-        ),
-      );
-    }
-
-    final mediaInfo = ref.watch(castMediaInfoProvider);
-    final playbackState = ref.watch(castPlaybackStateProvider);
-    final castDevice = ref.watch(currentCastDeviceProvider);
-    final manager = ref.watch(castSessionManagerProvider).value;
-
-    if (mediaInfo == null || castDevice == null || manager == null) {
-      return const Center(
-        child: CircularProgressIndicator(color: Colors.red),
-      );
-    }
-
-    final isPlaying = playbackState == CastPlaybackState.playing;
-    final isBuffering = playbackState == CastPlaybackState.buffering;
-    // A receiver that cannot report a length (every HLS cast — see
-    // `cast_seek.dart`) leaves this false, and the scrub bar goes read-only
-    // rather than seeking to a position computed from a bogus duration.
-    final durationKnown = hasKnownDuration(mediaInfo.duration);
-    final progress =
-        castProgressFraction(mediaInfo.position, mediaInfo.duration);
-
+  /// What the player screen shows while the media is on a receiver.
+  ///
+  /// Deliberately inert: every control lives in `CastMiniController`, which is
+  /// mounted over this screen by `app.dart`. Duplicating them here is the
+  /// confusion this replaced — two surfaces showing the same title, device,
+  /// play/pause and stop, with the bar clipping the remote's stop button.
+  Widget _buildCastPlaceholder(CastDevice device) {
     return Stack(
       children: [
         Center(
           child: Padding(
-            padding: const EdgeInsets.all(32),
+            // Bottom inset keeps the text clear of the mini bar.
+            padding: const EdgeInsets.only(
+              left: 32,
+              right: 32,
+              top: 32,
+              bottom: 120,
+            ),
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
               children: [
-                // Cast icon
-                const Icon(
-                  Icons.cast_connected,
-                  size: 120,
-                  color: Colors.blue,
-                ),
-                const SizedBox(height: 32),
-                // Device name
+                const Icon(Icons.cast_connected, size: 96, color: Colors.blue),
+                const SizedBox(height: 24),
                 Text(
-                  'Casting to',
+                  'Playing on ${device.name}',
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: Colors.grey[400],
+                        color: Colors.white,
                       ),
+                  textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  castDevice.name,
-                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                      ),
-                ),
-                const SizedBox(height: 48),
-                // Media title
-                Text(
-                  mediaInfo.title,
-                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                        color: Colors.white,
+                  widget.title ?? 'Untitled',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Colors.grey[400],
                       ),
                   textAlign: TextAlign.center,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                 ),
-                if (mediaInfo.subtitle != null) ...[
-                  const SizedBox(height: 8),
-                  Text(
-                    mediaInfo.subtitle!,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Colors.grey[400],
-                        ),
-                  ),
-                ],
-                const SizedBox(height: 48),
-                // Progress bar
-                Column(
-                  children: [
-                    Slider(
-                      value: progress,
-                      // Null disables the slider outright. Leaving it live
-                      // with an unknown duration is the bug this replaces:
-                      // every drag resolved to `fraction * -1s` and threw the
-                      // receiver back to the start of the video.
-                      onChanged: !durationKnown
-                          ? null
-                          : (value) async {
-                              final newPosition = seekTargetForFraction(
-                                value,
-                                mediaInfo.duration,
-                              );
-                              if (newPosition == null) return;
-                              await manager.seek(newPosition);
-                            },
-                      activeColor: Colors.red,
-                      inactiveColor: Colors.grey[800],
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 24),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(
-                            _formatDuration(mediaInfo.position),
-                            style:
-                                Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: Colors.grey[400],
-                                    ),
-                          ),
-                          Text(
-                            // `_formatDuration` renders a -1s duration as
-                            // "00:-1"; an unknown length gets a placeholder.
-                            durationKnown
-                                ? _formatDuration(mediaInfo.duration)
-                                : '--:--',
-                            style:
-                                Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: Colors.grey[400],
-                                    ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 32),
-                // Playback controls
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    // Rewind 10s
-                    IconButton(
-                      icon: const Icon(Icons.replay_10, color: Colors.white),
-                      iconSize: 40,
-                      onPressed: () async {
-                        await manager.seek(clampSeekTarget(
-                          mediaInfo.position - const Duration(seconds: 10),
-                          mediaInfo.duration,
-                        ));
-                      },
-                    ),
-                    const SizedBox(width: 24),
-                    // Play/Pause
-                    if (isBuffering)
-                      const SizedBox(
-                        width: 64,
-                        height: 64,
-                        child: CircularProgressIndicator(
-                          color: Colors.red,
-                          strokeWidth: 4,
-                        ),
-                      )
-                    else
-                      IconButton(
-                        icon: Icon(
-                          isPlaying
-                              ? Icons.pause_circle_filled
-                              : Icons.play_circle_filled,
-                          color: Colors.white,
-                        ),
-                        iconSize: 64,
-                        onPressed: () async {
-                          if (isPlaying) {
-                            await manager.pause();
-                          } else {
-                            await manager.play();
-                          }
-                        },
-                      ),
-                    const SizedBox(width: 24),
-                    // Forward 10s
-                    IconButton(
-                      icon: const Icon(Icons.forward_10, color: Colors.white),
-                      iconSize: 40,
-                      onPressed: () async {
-                        // Clamping only applies when the duration is real;
-                        // clamping against the receiver's -1 placeholder is
-                        // what turned "skip ahead" into "back to the start".
-                        await manager.seek(clampSeekTarget(
-                          mediaInfo.position + const Duration(seconds: 10),
-                          mediaInfo.duration,
-                        ));
-                      },
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 32),
-                // Stop casting button
-                OutlinedButton.icon(
-                  icon: const Icon(Icons.stop),
-                  label: const Text('Stop Casting'),
-                  onPressed: () async {
-                    await manager.stopCast();
-                  },
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: Colors.white,
-                    side: const BorderSide(color: Colors.white),
-                  ),
-                ),
               ],
             ),
           ),
         ),
-        // Back button
         Positioned(
           top: 8,
           left: 8,
@@ -2169,18 +1941,5 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     if (fromPlayer != null && fromPlayer > Duration.zero) return fromPlayer;
 
     return null;
-  }
-
-  /// Format duration as HH:MM:SS or MM:SS.
-  String _formatDuration(Duration duration) {
-    final hours = duration.inHours;
-    final minutes = duration.inMinutes.remainder(60);
-    final seconds = duration.inSeconds.remainder(60);
-
-    if (hours > 0) {
-      return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
-    } else {
-      return '${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
-    }
   }
 }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -23,6 +23,7 @@ import '../../../core/player/duration_override.dart';
 import '../../../core/cast/cast_backend.dart';
 import '../../../core/cast/cast_providers.dart';
 import '../../../core/cast/cast_session_manager.dart';
+import '../../../core/cast/cast_target.dart';
 import '../../../core/downloads/download_providers.dart';
 import '../../widgets/resume_dialog.dart';
 import '../../widgets/subtitle_track_selector.dart';
@@ -157,6 +158,80 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     }
   }
 
+  /// Start on the receiver instead of locally, when a device was chosen
+  /// before playback began.
+  ///
+  /// Returns true when a cast was started, in which case the caller must not
+  /// build a local `Player` — the point of choosing a device up front is that
+  /// the file never opens on this machine. Called from three points inside
+  /// [_initializePlayer], each immediately before it would otherwise start
+  /// local-only setup (HLS session negotiation, the P2P proxy, or opening a
+  /// downloaded file): the offline-playback branch, the "already downloaded,
+  /// still online" branch, and the network streaming branch. Checking before
+  /// that setup — rather than once at the top of [_initializePlayer], or once
+  /// right before each `Player` is constructed — means a chosen cast target
+  /// never pays for local streaming infrastructure it immediately throws
+  /// away, while still reaching the metadata fetch that populates
+  /// `_totalDuration` on the streaming path.
+  ///
+  /// `castNotifier` is read once, up front: `castTargetProvider` is a
+  /// keep-alive root provider, like `invalidatorProvider` (see
+  /// [_invalidator]), so the notifier itself stays valid to call even if this
+  /// widget is disposed while `startCast` is awaited. `ref.read` itself is
+  /// not safe to call again at that point, which is why the notifier is
+  /// captured before any `await` rather than re-read after one.
+  Future<bool> _castToTargetIfSet() async {
+    final target = ref.read(castTargetProvider);
+    if (target == null) return false;
+
+    final castNotifier = ref.read(castTargetProvider.notifier);
+
+    // Downloaded media lives only on this device; the route resolver has no
+    // server-side file to hand the receiver. Playing locally is the useful
+    // outcome, but silently ignoring the chosen device is not, so say why.
+    if (widget.fileId == 'offline') {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text('Downloads cannot be cast — playing on this device.'),
+        ));
+      }
+      return false;
+    }
+
+    try {
+      final manager = await ref.read(castSessionManagerProvider.future);
+      await manager.startCast(
+        device: target,
+        request: CastLaunchRequest(
+          fileId: widget.fileId,
+          mediaId: widget.mediaId,
+          mediaType: widget.mediaType,
+          title: widget.title ?? 'Untitled',
+          duration: _knownCastDuration(),
+        ),
+      );
+      // The session now owns the device; currentCastDeviceProvider reports
+      // it from here on. Leaving the target set would make every future
+      // playback cast forever with no way to opt out.
+      castNotifier.clear();
+      return true;
+    } catch (e) {
+      // A dead screen is the one outcome worse than not casting: clear the
+      // target and fall through so the user still gets their episode.
+      debugPrint('[PlayerScreen] Cast target failed, playing locally: $e');
+      castNotifier.clear();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(e is CastBackendException
+              ? castErrorMessage(e, ref: ref)
+              : 'Failed to start casting: $e'),
+          backgroundColor: Colors.red,
+        ));
+      }
+      return false;
+    }
+  }
+
   Future<void> _initializePlayer() async {
     try {
       setState(() {
@@ -198,6 +273,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           return;
         }
 
+        if (await _castToTargetIfSet()) return;
+
         // Play downloaded content in offline mode
         await _initializeOfflinePlayback(offlinePath);
         return;
@@ -210,6 +287,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
             await _resolveDownloadedFilePath(downloadedMedia.filePath);
         if (localPath != null) {
           debugPrint('Playing from local file: $localPath');
+
+          if (await _castToTargetIfSet()) return;
 
           // Try to initialize progress sync (optional - local playback
           // works even if server is unreachable)
@@ -310,6 +389,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
               '[PlayerScreen] Total duration from candidates: $_totalDuration');
         }
       }
+
+      if (await _castToTargetIfSet()) return;
 
       String mediaSource;
       Map<String, String> httpHeaders = {};

--- a/player/lib/presentation/screens/search/search_screen.dart
+++ b/player/lib/presentation/screens/search/search_screen.dart
@@ -6,6 +6,8 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/search_result.dart';
+import '../../widgets/cast_actions.dart';
+import '../../widgets/cast_button.dart';
 import 'search_controller.dart';
 import 'widgets/episode_result_row.dart';
 import 'widgets/search_filter_chip.dart';
@@ -155,6 +157,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
               onPressed: _onClear,
               tooltip: 'Clear',
             ),
+          // SearchScreen's app bar is always visible (no desktop
+          // suppression), so it carries its own cast affordance instead of
+          // the shell's overlay — see AppShell._hasOwnCastButton.
+          CastButton(onPressed: () => pickCastDevice(context, ref)),
           const SizedBox(width: 8),
         ],
       ),

--- a/player/lib/presentation/screens/settings_screen.dart
+++ b/player/lib/presentation/screens/settings_screen.dart
@@ -9,6 +9,8 @@ import '../../core/graphql/graphql_provider.dart';
 import '../../core/update/update_provider.dart';
 import '../../core/update/updaters/macos_updater.dart';
 import '../widgets/ambient_backdrop_provider.dart';
+import '../widgets/cast_actions.dart';
+import '../widgets/cast_button.dart';
 import '../widgets/connection_status_indicator.dart';
 import '../widgets/update_tile.dart';
 import 'settings/settings_controller.dart';
@@ -61,6 +63,13 @@ class SettingsScreen extends ConsumerWidget {
       appBar: AppBar(
         backgroundColor: Colors.transparent,
         title: const Text('Settings'),
+        // SettingsScreen's app bar is always visible (no desktop
+        // suppression), so it carries its own cast affordance instead of
+        // the shell's overlay — see AppShell._hasOwnCastButton.
+        actions: [
+          CastButton(onPressed: () => pickCastDevice(context, ref)),
+          const SizedBox(width: 8),
+        ],
       ),
       body: settingsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -18,6 +18,8 @@ import '../../widgets/quality_download_dialog.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/player/media_file_selector.dart';
 import '../../../core/theme/colors.dart';
+import '../../widgets/cast_actions.dart';
+import '../../widgets/cast_button.dart';
 import '../../widgets/smart_play_button.dart';
 
 class ShowDetailScreen extends ConsumerWidget {
@@ -264,6 +266,10 @@ class ShowDetailScreen extends ConsumerWidget {
               ),
             ),
           ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: CastButton(onPressed: () => pickCastDevice(context, ref)),
         ),
         const SizedBox(width: 8),
       ],

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -17,6 +17,7 @@ import '../../core/theme/colors.dart';
 import '../../core/theme/depth_tokens.dart';
 import 'ambient_backdrop.dart';
 import 'ambient_backdrop_provider.dart';
+import 'cast_actions.dart';
 import 'glass_surface.dart';
 import 'offline_banner.dart';
 
@@ -415,6 +416,7 @@ class _AppShellState extends ConsumerState<AppShell> {
                 ),
               ],
             ),
+            CastOverlayButton(topInset: _macOSTitleBarPadding + 12),
           ],
         ),
       );
@@ -447,6 +449,7 @@ class _AppShellState extends ConsumerState<AppShell> {
               Expanded(child: widget.child),
             ],
           ),
+          const CastOverlayButton(topInset: kToolbarHeight + 8),
         ],
       ),
       bottomNavigationBar: _ModernBottomNav(

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -167,6 +167,31 @@ class AppShell extends ConsumerStatefulWidget {
     required this.location,
   });
 
+  /// Routes whose own screen already renders a [CastButton] in a real,
+  /// always-visible app bar.
+  ///
+  /// [CastOverlayButton] exists only for screens with nowhere else to put the
+  /// affordance — the desktop browse screens that suppress their app bar
+  /// entirely (Home/Unwatched/Favorites/RecentlyAdded/Collections). Library,
+  /// Downloads, Settings and Search all keep a real app bar on every
+  /// platform, with their own action buttons (sort/view-toggle, cancel-all,
+  /// clear, etc.) living in the exact top-right band this overlay paints
+  /// into. Rendering the overlay there too would sit on top of — and
+  /// intercept taps for — those existing buttons. Do not delete this check
+  /// "to simplify": it is what keeps the overlay from colliding with a
+  /// screen's own app bar the next time one grows an action.
+  ///
+  /// Public (rather than a private helper on [_AppShellState]) and annotated
+  /// `@visibleForTesting` purely so a test can assert the routing decision
+  /// directly, without reconstructing the shell's full provider graph.
+  @visibleForTesting
+  static bool hasOwnCastButton(String location) =>
+      location.startsWith('/movies') ||
+      location.startsWith('/shows') ||
+      location.startsWith('/downloads') ||
+      location.startsWith('/settings') ||
+      location.startsWith('/search');
+
   @override
   ConsumerState<AppShell> createState() => _AppShellState();
 }
@@ -376,6 +401,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     // proper repaint propagation on mobile when combined with GlobalKey
     // on the Scaffold (causing the "stuck navigation" bug).
     final isDesktop = Breakpoints.isDesktop(context);
+    final showCastOverlay = !AppShell.hasOwnCastButton(location);
 
     // Shell-level ambient backdrop, fed by the active browse screen. Sits behind
     // the (now transparent) in-shell Scaffolds for all browse screens (plan U5).
@@ -416,7 +442,8 @@ class _AppShellState extends ConsumerState<AppShell> {
                 ),
               ],
             ),
-            CastOverlayButton(topInset: _macOSTitleBarPadding + 12),
+            if (showCastOverlay)
+              CastOverlayButton(topInset: _macOSTitleBarPadding + 12),
           ],
         ),
       );
@@ -449,7 +476,8 @@ class _AppShellState extends ConsumerState<AppShell> {
               Expanded(child: widget.child),
             ],
           ),
-          const CastOverlayButton(topInset: kToolbarHeight + 8),
+          if (showCastOverlay)
+            const CastOverlayButton(topInset: kToolbarHeight + 8),
         ],
       ),
       bottomNavigationBar: _ModernBottomNav(

--- a/player/lib/presentation/widgets/cast_actions.dart
+++ b/player/lib/presentation/widgets/cast_actions.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/cast/cast_backend.dart';
+import '../../core/cast/cast_providers.dart';
+import '../../core/cast/cast_session_manager.dart';
+import '../../core/cast/cast_target.dart';
+import '../../core/p2p/local_proxy_service.dart';
+import 'cast_device_picker.dart';
+
+/// Turn a cast failure into something the user can act on.
+///
+/// Was private to `PlayerScreen`. It now has multiple callers — the player
+/// screen's device picker, the player screen's failed-target fallback, and
+/// every other cast affordance's [pickCastDevice] — so it lives here.
+///
+/// A bare "cast failed" leaves a firewall or codec problem undiagnosable, so
+/// the unreachable case names the actual port that needs to be open. That
+/// port comes from [LocalProxyService], which requires a [WidgetRef] to
+/// look up — callers that have one (anything running inside a widget tree)
+/// should pass it; callers that don't (like this file's own tests) get the
+/// same message minus the port hint, matching what the original method did
+/// whenever the proxy wasn't LAN-accessible.
+String castErrorMessage(CastBackendException e, {WidgetRef? ref}) {
+  final proxy = ref?.read(localProxyServiceProvider);
+
+  switch (e.kind) {
+    case CastFailureKind.unreachable:
+      final port = proxy != null && proxy.isLanAccessible ? proxy.port : null;
+      final portHint =
+          port == null ? '' : ' Allow incoming connections on port $port.';
+      return 'The device could not reach your media. Check that both are on '
+          'the same network and that your firewall is not blocking '
+          'Mydia.$portHint';
+    case CastFailureKind.mediaLoadFailed:
+      return 'The device could not play this file. It may not support the '
+          'video or audio format.';
+    case CastFailureKind.connectionLost:
+      return 'Lost the connection to the device.';
+    case CastFailureKind.discoveryDenied:
+      return 'Mydia needs local network permission to find cast devices.';
+    case CastFailureKind.unknown:
+      return 'Casting failed: ${e.message}';
+  }
+}
+
+/// The shared "user tapped a cast affordance" entry point, for every screen
+/// except the player.
+///
+/// Branches on what is playing rather than on which screen called it:
+/// re-target a live session, or record an intent for the next playback.
+/// `PlayerScreen` keeps its own picker because it holds the loaded media and
+/// can therefore cast immediately.
+Future<void> pickCastDevice(BuildContext context, WidgetRef ref) async {
+  final device = await showCastDevicePicker(context);
+  if (device == null || !context.mounted) return;
+
+  final session = ref.read(castSessionProvider).value;
+
+  // Nothing playing: record the intent and stop. Connecting here would launch
+  // a receiver app with no media to show.
+  if (session == null) {
+    ref.read(castTargetProvider.notifier).set(device);
+    return;
+  }
+
+  // Already on that receiver — picking it again should do nothing rather than
+  // tear down and rebuild the session the user is watching.
+  if (session.device.id == device.id) return;
+
+  final persisted =
+      ref.read(castSessionManagerProvider).value?.persistedSession;
+  if (persisted == null) {
+    // A live session with nothing persisted behind it cannot be moved; fall
+    // back to recording the intent so the next play lands on the new device.
+    ref.read(castTargetProvider.notifier).set(device);
+    return;
+  }
+
+  try {
+    final manager = await ref.read(castSessionManagerProvider.future);
+    await manager.startCast(
+      device: device,
+      request: CastLaunchRequest(
+        fileId: persisted.fileId,
+        mediaId: persisted.mediaId,
+        mediaType: persisted.mediaType,
+        title: persisted.title,
+        startPosition: persisted.position,
+        duration: persisted.duration,
+      ),
+    );
+  } on CastBackendException catch (e) {
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(castErrorMessage(e, ref: ref)),
+      backgroundColor: Colors.red,
+    ));
+  }
+}

--- a/player/lib/presentation/widgets/cast_actions.dart
+++ b/player/lib/presentation/widgets/cast_actions.dart
@@ -6,6 +6,7 @@ import '../../core/cast/cast_providers.dart';
 import '../../core/cast/cast_session_manager.dart';
 import '../../core/cast/cast_target.dart';
 import '../../core/p2p/local_proxy_service.dart';
+import 'cast_button.dart';
 import 'cast_device_picker.dart';
 
 /// Turn a cast failure into something the user can act on.
@@ -96,5 +97,33 @@ Future<void> pickCastDevice(BuildContext context, WidgetRef ref) async {
       content: Text(castErrorMessage(e, ref: ref)),
       backgroundColor: Colors.red,
     ));
+  }
+}
+
+/// The cast affordance for screens with no app bar to put it in.
+///
+/// `AppShell` has no app bar of its own, and on desktop the browse screens
+/// deliberately suppress theirs (`HomeScreen` passes `appBar: null`;
+/// `UnwatchedScreen` and friends return a zero-height `SizedBox.shrink()`).
+/// An app-bar-only affordance would therefore be invisible on macOS across
+/// most of the app, so the shell pins this into its existing `Stack`.
+class CastOverlayButton extends ConsumerWidget {
+  /// Distance from the top of the safe area.
+  ///
+  /// Mobile browse screens *do* render an app bar with its own actions, so
+  /// this clears it rather than sitting on top of it.
+  final double topInset;
+
+  const CastOverlayButton({super.key, required this.topInset});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Positioned(
+      top: topInset,
+      right: 12,
+      child: SafeArea(
+        child: CastButton(onPressed: () => pickCastDevice(context, ref)),
+      ),
+    );
   }
 }

--- a/player/lib/presentation/widgets/cast_actions.dart
+++ b/player/lib/presentation/widgets/cast_actions.dart
@@ -97,6 +97,17 @@ Future<void> pickCastDevice(BuildContext context, WidgetRef ref) async {
       content: Text(castErrorMessage(e, ref: ref)),
       backgroundColor: Colors.red,
     ));
+  } catch (e) {
+    // Anything that isn't a CastBackendException: the session manager
+    // itself resolving (Hive, GraphQL client), or a non-typed failure from
+    // _setLanAccess/_store.save inside startCast. Without this, those
+    // failures would close the picker with no snackbar and no log.
+    debugPrint('[cast_actions] Unexpected error starting cast: $e');
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text('Failed to start casting: $e'),
+      backgroundColor: Colors.red,
+    ));
   }
 }
 

--- a/player/lib/presentation/widgets/cast_button.dart
+++ b/player/lib/presentation/widgets/cast_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/cast/cast_providers.dart';
+import '../../core/cast/cast_target.dart';
 
 /// Cast button for the player's top bar.
 ///
@@ -20,20 +21,29 @@ class CastButton extends ConsumerWidget {
 
     final isCasting = ref.watch(isCastingProvider);
     final castDevice = ref.watch(currentCastDeviceProvider);
+    final target = ref.watch(castTargetProvider);
+    final active = isCasting || target != null;
+
+    final String tooltip;
+    if (isCasting && castDevice != null) {
+      tooltip = 'Casting to ${castDevice.name}';
+    } else if (target != null) {
+      tooltip = 'Will play on ${target.name}';
+    } else {
+      tooltip = 'Cast to device';
+    }
 
     return IconButton(
       key: const Key('cast-button'),
       icon: Icon(
-        isCasting ? Icons.cast_connected : Icons.cast,
-        color: isCasting ? Colors.blue : Colors.white,
+        active ? Icons.cast_connected : Icons.cast,
+        color: active ? Colors.blue : Colors.white,
       ),
       onPressed: onPressed,
       style: IconButton.styleFrom(
         backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
-      tooltip: isCasting && castDevice != null
-          ? 'Casting to ${castDevice.name}'
-          : 'Cast to device',
+      tooltip: tooltip,
     );
   }
 }

--- a/player/lib/presentation/widgets/cast_mini_controller.dart
+++ b/player/lib/presentation/widgets/cast_mini_controller.dart
@@ -85,6 +85,11 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
             IconButton(
               key: const Key('cast-bar-idle-clear'),
               icon: const Icon(Icons.close),
+              // This bar is the only cast surface in the app, so an unlabelled
+              // icon here leaves a screen-reader user no route to the control
+              // at all — there is no longer a full-screen remote to fall back
+              // to. Same reasoning for every button below.
+              tooltip: 'Cancel casting to ${device.name}',
               onPressed: () => ref.read(castTargetProvider.notifier).clear(),
             ),
           ],
@@ -226,6 +231,7 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
                 IconButton(
                   key: const Key('cast-bar-rewind'),
                   icon: const Icon(Icons.replay_10),
+                  tooltip: 'Back 10 seconds',
                   onPressed: () async {
                     final manager =
                         await ref.read(castSessionManagerProvider.future);
@@ -241,6 +247,7 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
                     isPlaying ? Icons.pause : Icons.play_arrow,
                     size: 28,
                   ),
+                  tooltip: isPlaying ? 'Pause' : 'Play',
                   onPressed: () async {
                     final manager =
                         await ref.read(castSessionManagerProvider.future);
@@ -254,6 +261,7 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
                 IconButton(
                   key: const Key('cast-bar-forward'),
                   icon: const Icon(Icons.forward_10),
+                  tooltip: 'Forward 10 seconds',
                   onPressed: () async {
                     final manager =
                         await ref.read(castSessionManagerProvider.future);
@@ -266,6 +274,7 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
                 IconButton(
                   key: const Key('cast-bar-stop'),
                   icon: const Icon(Icons.stop, size: 28),
+                  tooltip: 'Stop casting',
                   onPressed: _confirmStop,
                 ),
               ],

--- a/player/lib/presentation/widgets/cast_mini_controller.dart
+++ b/player/lib/presentation/widgets/cast_mini_controller.dart
@@ -190,7 +190,7 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
                 Expanded(
                   child: Slider(
                     key: const Key('cast-bar-scrubber'),
-                    value: value.clamp(0.0, 1.0),
+                    value: value,
                     // Null disables the control outright. Leaving it live
                     // against an unknown duration resolves every drag to
                     // `fraction * -1s`, i.e. the start.
@@ -278,6 +278,7 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
 
   /// Re-cast the media the stored (now stale) session was playing.
   Future<void> _reconnectStaleSession() async {
+    if (!mounted) return;
     try {
       final manager = await ref.read(castSessionManagerProvider.future);
       await manager.reconnectStoredSession();
@@ -299,6 +300,7 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
 
   /// Drop the cast session and fall back to local playback.
   Future<void> _stopCasting() async {
+    if (!mounted) return;
     try {
       final manager = await ref.read(castSessionManagerProvider.future);
       await manager.stopCast();

--- a/player/lib/presentation/widgets/cast_mini_controller.dart
+++ b/player/lib/presentation/widgets/cast_mini_controller.dart
@@ -1,20 +1,38 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/auth/auth_status.dart';
+import '../../core/cast/cast_backend.dart';
 import '../../core/cast/cast_providers.dart';
 import '../../core/cast/cast_seek.dart';
+import '../../core/cast/cast_target.dart';
 import '../../core/graphql/graphql_provider.dart';
 import '../../domain/models/cast_device.dart';
+import 'cast_actions.dart';
 
-/// Mini controller that shows at the bottom of the screen during casting.
+/// The sole cast control surface, shown at the bottom of every screen.
 ///
-/// Displays the currently playing media title, progress, and basic controls.
-/// Tapping it navigates to the full player screen with remote controls.
-class CastMiniController extends ConsumerWidget {
+/// Displays the currently playing media title, a draggable scrubber, skip
+/// and play/pause/stop controls, an idle state (a target picked before
+/// anything is playing — see `castTargetProvider`) and the stale-session
+/// state (the receiver dropped off the network). There is no separate
+/// full-screen remote: everything the user can do while casting lives here.
+class CastMiniController extends ConsumerStatefulWidget {
   const CastMiniController({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<CastMiniController> createState() => _CastMiniControllerState();
+}
+
+class _CastMiniControllerState extends ConsumerState<CastMiniController> {
+  /// Where the user has dragged to, while they are dragging.
+  ///
+  /// The position stream keeps arriving mid-drag; without holding the drag
+  /// value locally the thumb snaps back to the receiver's position on every
+  /// tick and the bar becomes impossible to scrub.
+  double? _dragFraction;
+
+  @override
+  Widget build(BuildContext context) {
     final capabilities = ref.watch(castCapabilitiesProvider);
     if (!capabilities.any) return const SizedBox.shrink();
 
@@ -30,89 +48,202 @@ class CastMiniController extends ConsumerWidget {
     final auth = ref.watch(authStateProvider);
     if (auth.value != AuthStatus.authenticated) return const SizedBox.shrink();
 
-    final isCasting = ref.watch(isCastingProvider);
-    if (!isCasting) return const SizedBox.shrink();
+    final session = ref.watch(castSessionProvider).value;
+    final target = ref.watch(castTargetProvider);
 
-    final managerAsync = ref.watch(castSessionManagerProvider);
-    final manager = managerAsync.value;
-    if (manager == null) return const SizedBox.shrink();
-
-    final mediaInfo = ref.watch(castMediaInfoProvider);
-    final playbackState = ref.watch(castPlaybackStateProvider);
-    final device = ref.watch(currentCastDeviceProvider);
-
-    if (mediaInfo == null) {
-      return const SizedBox.shrink();
+    final Widget? content;
+    if (session == null) {
+      content = target == null ? null : _buildIdle(target);
+    } else if (session.isStale) {
+      content = _buildStale(session);
+    } else {
+      content = _buildPlaying(session);
     }
 
-    final isPlaying = playbackState == CastPlaybackState.playing;
-    final progress =
-        castProgressFraction(mediaInfo.position, mediaInfo.duration);
+    if (content == null) return const SizedBox.shrink();
+    return SafeArea(top: false, child: content);
+  }
 
-    // Deliberately not tappable: the full remote lives on the player screen,
-    // and this bar has no media ids to route there with. An affordance that
-    // only apologises for itself is worse than no affordance — the play/pause
-    // and stop buttons below are the real controls.
+  Widget _buildIdle(CastDevice device) {
+    return Material(
+      elevation: 8,
+      color: Theme.of(context).colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            const Icon(Icons.cast, color: Colors.blue, size: 24),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Will play on ${device.name}',
+                style: Theme.of(context).textTheme.bodyMedium,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            IconButton(
+              key: const Key('cast-bar-idle-clear'),
+              icon: const Icon(Icons.close),
+              onPressed: () => ref.read(castTargetProvider.notifier).clear(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStale(CastSession session) {
+    return Material(
+      elevation: 8,
+      color: Theme.of(context).colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            const Icon(Icons.cast_outlined, color: Colors.grey, size: 24),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Lost connection to ${session.device.name}',
+                style: Theme.of(context).textTheme.bodyMedium,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            FilledButton(
+              key: const Key('cast-stale-reconnect'),
+              // Re-cast what the *stale session* was playing. Anything else
+              // here would silently start whatever this screen happens to
+              // be showing instead.
+              onPressed: _reconnectStaleSession,
+              child: const Text('Reconnect'),
+            ),
+            const SizedBox(width: 8),
+            TextButton(
+              key: const Key('cast-stale-stop'),
+              onPressed: _stopCasting,
+              child: const Text('Stop'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPlaying(CastSession session) {
+    final info = session.mediaInfo;
+    if (info == null) return const SizedBox.shrink();
+
+    final durationKnown = hasKnownDuration(info.duration);
+    final value =
+        _dragFraction ?? castProgressFraction(info.position, info.duration);
+    final isPlaying = session.playbackState == CastPlaybackState.playing;
+
     return Material(
       elevation: 8,
       color: Theme.of(context).colorScheme.surface,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          // Progress bar
-          LinearProgressIndicator(
-            value: progress,
-            backgroundColor: Colors.grey[300],
-            valueColor: const AlwaysStoppedAnimation<Color>(Colors.red),
-            minHeight: 2,
-          ),
-          // Controller content
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
             child: Row(
               children: [
-                // Cast icon
-                const Icon(
-                  Icons.cast_connected,
-                  color: Colors.blue,
-                  size: 24,
-                ),
+                const Icon(Icons.cast_connected, color: Colors.blue, size: 24),
                 const SizedBox(width: 12),
-                // Media info
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        mediaInfo.title,
+                        info.title,
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                               fontWeight: FontWeight.w600,
                             ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
-                      if (device != null)
-                        Text(
-                          'Casting to ${device.name}',
-                          style:
-                              Theme.of(context).textTheme.bodySmall?.copyWith(
-                                    color: Colors.grey[600],
-                                  ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
+                      Text(
+                        'Casting to ${session.device.name}',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Colors.grey[600],
+                            ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                     ],
                   ),
                 ),
-                const SizedBox(width: 12),
-                // Play/pause button
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Row(
+              children: [
+                Text(
+                  _formatDuration(info.position),
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                Expanded(
+                  child: Slider(
+                    key: const Key('cast-bar-scrubber'),
+                    value: value.clamp(0.0, 1.0),
+                    // Null disables the control outright. Leaving it live
+                    // against an unknown duration resolves every drag to
+                    // `fraction * -1s`, i.e. the start.
+                    onChanged: durationKnown
+                        ? (v) => setState(() => _dragFraction = v)
+                        : null,
+                    onChangeEnd: durationKnown
+                        ? (v) async {
+                            final target =
+                                seekTargetForFraction(v, info.duration);
+                            setState(() => _dragFraction = null);
+                            if (target == null) return;
+                            final manager = await ref
+                                .read(castSessionManagerProvider.future);
+                            await manager.seek(target);
+                          }
+                        : null,
+                  ),
+                ),
+                Text(
+                  key: const Key('cast-bar-duration'),
+                  durationKnown ? _formatDuration(info.duration) : '--:--',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
                 IconButton(
+                  key: const Key('cast-bar-rewind'),
+                  icon: const Icon(Icons.replay_10),
+                  onPressed: () async {
+                    final manager =
+                        await ref.read(castSessionManagerProvider.future);
+                    await manager.seek(clampSeekTarget(
+                      info.position - const Duration(seconds: 10),
+                      info.duration,
+                    ));
+                  },
+                ),
+                IconButton(
+                  key: const Key('cast-bar-play-pause'),
                   icon: Icon(
                     isPlaying ? Icons.pause : Icons.play_arrow,
                     size: 28,
                   ),
                   onPressed: () async {
+                    final manager =
+                        await ref.read(castSessionManagerProvider.future);
                     if (isPlaying) {
                       await manager.pause();
                     } else {
@@ -120,38 +251,22 @@ class CastMiniController extends ConsumerWidget {
                     }
                   },
                 ),
-                // Stop/disconnect button
                 IconButton(
-                  icon: const Icon(
-                    Icons.stop,
-                    size: 28,
-                  ),
+                  key: const Key('cast-bar-forward'),
+                  icon: const Icon(Icons.forward_10),
                   onPressed: () async {
-                    // Show confirmation dialog
-                    final shouldStop = await showDialog<bool>(
-                      context: context,
-                      builder: (context) => AlertDialog(
-                        title: const Text('Stop Casting'),
-                        content: const Text(
-                          'Do you want to stop casting and disconnect?',
-                        ),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.of(context).pop(false),
-                            child: const Text('Cancel'),
-                          ),
-                          TextButton(
-                            onPressed: () => Navigator.of(context).pop(true),
-                            child: const Text('Stop'),
-                          ),
-                        ],
-                      ),
-                    );
-
-                    if (shouldStop == true) {
-                      await manager.stopCast();
-                    }
+                    final manager =
+                        await ref.read(castSessionManagerProvider.future);
+                    await manager.seek(clampSeekTarget(
+                      info.position + const Duration(seconds: 10),
+                      info.duration,
+                    ));
                   },
+                ),
+                IconButton(
+                  key: const Key('cast-bar-stop'),
+                  icon: const Icon(Icons.stop, size: 28),
+                  onPressed: _confirmStop,
                 ),
               ],
             ),
@@ -159,5 +274,77 @@ class CastMiniController extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  /// Re-cast the media the stored (now stale) session was playing.
+  Future<void> _reconnectStaleSession() async {
+    try {
+      final manager = await ref.read(castSessionManagerProvider.future);
+      await manager.reconnectStoredSession();
+    } on CastBackendException catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(castErrorMessage(e, ref: ref)),
+        backgroundColor: Colors.red,
+      ));
+    } catch (e) {
+      debugPrint('[CastMiniController] Unexpected error reconnecting cast: $e');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('Failed to reconnect: $e'),
+        backgroundColor: Colors.red,
+      ));
+    }
+  }
+
+  /// Drop the cast session and fall back to local playback.
+  Future<void> _stopCasting() async {
+    try {
+      final manager = await ref.read(castSessionManagerProvider.future);
+      await manager.stopCast();
+    } catch (e) {
+      debugPrint('[CastMiniController] Unexpected error stopping cast: $e');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('Failed to stop casting: $e'),
+        backgroundColor: Colors.red,
+      ));
+    }
+  }
+
+  Future<void> _confirmStop() async {
+    final shouldStop = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Stop Casting'),
+        content: const Text('Do you want to stop casting and disconnect?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Stop'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldStop == true) {
+      await _stopCasting();
+    }
+  }
+
+  String _formatDuration(Duration duration) {
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60);
+    final seconds = duration.inSeconds.remainder(60);
+
+    if (hours > 0) {
+      return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+    } else {
+      return '${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+    }
   }
 }

--- a/player/lib/presentation/widgets/cast_mini_controller.dart
+++ b/player/lib/presentation/widgets/cast_mini_controller.dart
@@ -299,11 +299,21 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
   }
 
   /// Drop the cast session and fall back to local playback.
+  ///
+  /// Also clears `castTargetProvider`: stopping a cast is a clear signal
+  /// that the user wants to stop casting, and a lingering target would make
+  /// the *next* playback silently cast again. This is the only place a live
+  /// session's stop reaches the target — `cast_actions.dart` can set a
+  /// target while a session is active (re-targeting with nothing persisted
+  /// behind it), and the idle ✕ is not shown in that window, so this is
+  /// also the only way to clear it until the session ends.
   Future<void> _stopCasting() async {
     if (!mounted) return;
     try {
       final manager = await ref.read(castSessionManagerProvider.future);
       await manager.stopCast();
+      if (!mounted) return;
+      ref.read(castTargetProvider.notifier).clear();
     } catch (e) {
       debugPrint('[CastMiniController] Unexpected error stopping cast: $e');
       if (!mounted) return;

--- a/player/lib/presentation/widgets/cast_mini_controller.dart
+++ b/player/lib/presentation/widgets/cast_mini_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/auth/auth_status.dart';
 import '../../core/cast/cast_providers.dart';
+import '../../core/cast/cast_seek.dart';
 import '../../core/graphql/graphql_provider.dart';
 import '../../domain/models/cast_device.dart';
 
@@ -45,9 +46,8 @@ class CastMiniController extends ConsumerWidget {
     }
 
     final isPlaying = playbackState == CastPlaybackState.playing;
-    final progress = mediaInfo.duration.inSeconds > 0
-        ? mediaInfo.position.inSeconds / mediaInfo.duration.inSeconds
-        : 0.0;
+    final progress =
+        castProgressFraction(mediaInfo.position, mediaInfo.duration);
 
     // Deliberately not tappable: the full remote lives on the player screen,
     // and this bar has no media ids to route there with. An affordance that
@@ -59,104 +59,103 @@ class CastMiniController extends ConsumerWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-            // Progress bar
-            LinearProgressIndicator(
-              value: progress,
-              backgroundColor: Colors.grey[300],
-              valueColor: const AlwaysStoppedAnimation<Color>(Colors.red),
-              minHeight: 2,
-            ),
-            // Controller content
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              child: Row(
-                children: [
-                  // Cast icon
-                  const Icon(
-                    Icons.cast_connected,
-                    color: Colors.blue,
-                    size: 24,
-                  ),
-                  const SizedBox(width: 12),
-                  // Media info
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
+          // Progress bar
+          LinearProgressIndicator(
+            value: progress,
+            backgroundColor: Colors.grey[300],
+            valueColor: const AlwaysStoppedAnimation<Color>(Colors.red),
+            minHeight: 2,
+          ),
+          // Controller content
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                // Cast icon
+                const Icon(
+                  Icons.cast_connected,
+                  color: Colors.blue,
+                  size: 24,
+                ),
+                const SizedBox(width: 12),
+                // Media info
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        mediaInfo.title,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      if (device != null)
                         Text(
-                          mediaInfo.title,
+                          'Casting to ${device.name}',
                           style:
-                              Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
+                              Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Colors.grey[600],
                                   ),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
-                        if (device != null)
-                          Text(
-                            'Casting to ${device.name}',
-                            style:
-                                Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: Colors.grey[600],
-                                    ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                      ],
-                    ),
+                    ],
                   ),
-                  const SizedBox(width: 12),
-                  // Play/pause button
-                  IconButton(
-                    icon: Icon(
-                      isPlaying ? Icons.pause : Icons.play_arrow,
-                      size: 28,
-                    ),
-                    onPressed: () async {
-                      if (isPlaying) {
-                        await manager.pause();
-                      } else {
-                        await manager.play();
-                      }
-                    },
+                ),
+                const SizedBox(width: 12),
+                // Play/pause button
+                IconButton(
+                  icon: Icon(
+                    isPlaying ? Icons.pause : Icons.play_arrow,
+                    size: 28,
                   ),
-                  // Stop/disconnect button
-                  IconButton(
-                    icon: const Icon(
-                      Icons.stop,
-                      size: 28,
-                    ),
-                    onPressed: () async {
-                      // Show confirmation dialog
-                      final shouldStop = await showDialog<bool>(
-                        context: context,
-                        builder: (context) => AlertDialog(
-                          title: const Text('Stop Casting'),
-                          content: const Text(
-                            'Do you want to stop casting and disconnect?',
-                          ),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.of(context).pop(false),
-                              child: const Text('Cancel'),
-                            ),
-                            TextButton(
-                              onPressed: () => Navigator.of(context).pop(true),
-                              child: const Text('Stop'),
-                            ),
-                          ],
+                  onPressed: () async {
+                    if (isPlaying) {
+                      await manager.pause();
+                    } else {
+                      await manager.play();
+                    }
+                  },
+                ),
+                // Stop/disconnect button
+                IconButton(
+                  icon: const Icon(
+                    Icons.stop,
+                    size: 28,
+                  ),
+                  onPressed: () async {
+                    // Show confirmation dialog
+                    final shouldStop = await showDialog<bool>(
+                      context: context,
+                      builder: (context) => AlertDialog(
+                        title: const Text('Stop Casting'),
+                        content: const Text(
+                          'Do you want to stop casting and disconnect?',
                         ),
-                      );
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(false),
+                            child: const Text('Cancel'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(true),
+                            child: const Text('Stop'),
+                          ),
+                        ],
+                      ),
+                    );
 
-                      if (shouldStop == true) {
-                        await manager.stopCast();
-                      }
-                    },
-                  ),
-                ],
-              ),
+                    if (shouldStop == true) {
+                      await manager.stopCast();
+                    }
+                  },
+                ),
+              ],
             ),
+          ),
         ],
       ),
     );

--- a/player/test/core/cast/cast_seek_test.dart
+++ b/player/test/core/cast/cast_seek_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_seek.dart';
+
+/// What a Chromecast reports for a stream whose length it cannot work out.
+/// Every case below that uses it is a regression test for the bug where the
+/// scrub bar and the skip-ahead button both seeked to the start of the video.
+const unknown = Duration(seconds: -1);
+
+void main() {
+  group('hasKnownDuration', () {
+    test('rejects the Chromecast -1 placeholder', () {
+      expect(hasKnownDuration(unknown), isFalse);
+    });
+
+    test('rejects zero, which is the pre-first-status placeholder', () {
+      expect(hasKnownDuration(Duration.zero), isFalse);
+    });
+
+    test('accepts a real runtime', () {
+      expect(hasKnownDuration(const Duration(minutes: 107)), isTrue);
+    });
+  });
+
+  group('seekTargetForFraction', () {
+    test('returns null instead of zero when the duration is unknown', () {
+      expect(seekTargetForFraction(0.5, unknown), isNull);
+    });
+
+    test('returns null when the duration is zero', () {
+      expect(seekTargetForFraction(0.5, Duration.zero), isNull);
+    });
+
+    test('maps a fraction onto a known duration', () {
+      expect(
+        seekTargetForFraction(0.25, const Duration(minutes: 100)),
+        const Duration(minutes: 25),
+      );
+    });
+
+    test('clamps out-of-range fractions', () {
+      const duration = Duration(minutes: 100);
+      expect(seekTargetForFraction(-0.5, duration), Duration.zero);
+      expect(seekTargetForFraction(1.5, duration), duration);
+    });
+  });
+
+  group('clampSeekTarget', () {
+    test('does not clamp a forward skip against an unknown duration', () {
+      // The bug: `target > duration` was true for every position because
+      // duration was -1s, so every skip-ahead collapsed to the start.
+      expect(
+        clampSeekTarget(const Duration(minutes: 12), unknown),
+        const Duration(minutes: 12),
+      );
+    });
+
+    test('clamps a forward skip to a known duration', () {
+      expect(
+        clampSeekTarget(const Duration(minutes: 120), const Duration(hours: 1)),
+        const Duration(hours: 1),
+      );
+    });
+
+    test('floors a rewind at zero', () {
+      expect(
+          clampSeekTarget(const Duration(seconds: -5), unknown), Duration.zero);
+      expect(
+        clampSeekTarget(const Duration(seconds: -5), const Duration(hours: 1)),
+        Duration.zero,
+      );
+    });
+
+    test('leaves an in-range target alone', () {
+      expect(
+        clampSeekTarget(const Duration(minutes: 30), const Duration(hours: 1)),
+        const Duration(minutes: 30),
+      );
+    });
+  });
+
+  group('castProgressFraction', () {
+    test('is zero when the duration is unknown', () {
+      expect(castProgressFraction(const Duration(minutes: 5), unknown), 0.0);
+    });
+
+    test('reports progress through a known duration', () {
+      expect(
+        castProgressFraction(
+            const Duration(minutes: 30), const Duration(hours: 1)),
+        0.5,
+      );
+    });
+
+    test('clamps past-the-end positions', () {
+      expect(
+        castProgressFraction(
+            const Duration(hours: 2), const Duration(hours: 1)),
+        1.0,
+      );
+    });
+  });
+}

--- a/player/test/core/cast/cast_session_manager_test.dart
+++ b/player/test/core/cast/cast_session_manager_test.dart
@@ -222,8 +222,7 @@ void main() {
       expect(backend.connectedDevice, isNull);
     });
 
-    test(
-        'does not retry a codec failure on the bridge route, and rolls back',
+    test('does not retry a codec failure on the bridge route, and rolls back',
         () async {
       final manager = build(isP2pMode: true);
       addTearDown(manager.dispose);
@@ -271,7 +270,8 @@ void main() {
   });
 
   group('codec failure escalation', () {
-    test('retries via the bridge rather than TRANSCODE when a bridge is available',
+    test(
+        'retries via the bridge rather than TRANSCODE when a bridge is available',
         () async {
       final manager = build();
       addTearDown(manager.dispose);
@@ -362,6 +362,63 @@ void main() {
     });
   });
 
+  group('media duration', () {
+    /// The runtime the app already knows locally. Casting has to carry it
+    /// across, because a Chromecast playing one of Mydia's live-style HLS
+    /// playlists reports `duration: -1` and never learns the real length.
+    const knownRuntime = Duration(minutes: 107);
+
+    const launchWithDuration = CastLaunchRequest(
+      fileId: 'file-1',
+      mediaId: 'movie-1',
+      mediaType: 'movie',
+      title: 'Arrival',
+      duration: knownRuntime,
+    );
+
+    test('seeds the published session from the launch request', () async {
+      final manager = build();
+      addTearDown(manager.dispose);
+
+      await manager.startCast(device: device, request: launchWithDuration);
+
+      expect(manager.currentSession?.mediaInfo?.duration, knownRuntime);
+    });
+
+    test('ignores a receiver-reported -1 placeholder', () async {
+      final manager = build();
+      addTearDown(manager.dispose);
+      await manager.startCast(device: device, request: launchWithDuration);
+
+      backend.emitDuration(const Duration(seconds: -1));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(manager.currentSession?.mediaInfo?.duration, knownRuntime);
+    });
+
+    test('accepts a real duration the receiver does report', () async {
+      final manager = build();
+      addTearDown(manager.dispose);
+      await manager.startCast(device: device, request: launchWithDuration);
+
+      backend.emitDuration(const Duration(minutes: 108));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(manager.currentSession?.mediaInfo?.duration,
+          const Duration(minutes: 108));
+    });
+
+    test('persists the duration so a reconnect keeps a usable scrub bar',
+        () async {
+      final manager = build();
+      addTearDown(manager.dispose);
+
+      await manager.startCast(device: device, request: launchWithDuration);
+
+      expect((await store.load())?.duration, knownRuntime);
+    });
+  });
+
   group('progress sync', () {
     test('syncs position to the server as the receiver reports it', () async {
       final manager = build();
@@ -380,6 +437,21 @@ void main() {
       addTearDown(manager.dispose);
       await manager.startCast(device: device, request: launch);
 
+      backend.emitPosition(const Duration(seconds: 100));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      verifyNever(client.mutate(any));
+    });
+
+    /// `-1` is the Chromecast's "I don't know" placeholder, not a length.
+    /// Syncing against it would write `durationSeconds: -1` into the user's
+    /// watch history — and, worse, a nonsense watched verdict derived from it.
+    test('does not sync against the receiver\'s -1 placeholder', () async {
+      final manager = build();
+      addTearDown(manager.dispose);
+      await manager.startCast(device: device, request: launch);
+
+      backend.emitDuration(const Duration(seconds: -1));
       backend.emitPosition(const Duration(seconds: 100));
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
@@ -480,8 +552,7 @@ void main() {
       expect(await store.load(), isNull);
     });
 
-    test('reconnects a recent session the receiver is still playing',
-        () async {
+    test('reconnects a recent session the receiver is still playing', () async {
       await storeSession();
       backend.receiverContentUrl =
           'https://mydia.test/api/v1/stream/file/file-1';

--- a/player/test/core/cast/cast_target_test.dart
+++ b/player/test/core/cast/cast_target_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_target.dart';
+import 'package:player/domain/models/cast_device.dart';
+
+const _device = CastDevice(
+  id: 'device-1',
+  name: 'Cottage Chromecast',
+  protocol: CastProtocolKind.chromecast,
+);
+
+const _other = CastDevice(
+  id: 'device-2',
+  name: 'Bedroom TV',
+  protocol: CastProtocolKind.chromecast,
+);
+
+void main() {
+  group('castTargetProvider', () {
+    test('starts with no target', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(castTargetProvider), isNull);
+    });
+
+    test('set records the device', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(castTargetProvider.notifier).set(_device);
+
+      expect(container.read(castTargetProvider), _device);
+    });
+
+    test('set replaces a previous target', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(castTargetProvider.notifier).set(_device);
+      container.read(castTargetProvider.notifier).set(_other);
+
+      expect(container.read(castTargetProvider), _other);
+    });
+
+    test('clear removes the target', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(castTargetProvider.notifier).set(_device);
+      container.read(castTargetProvider.notifier).clear();
+
+      expect(container.read(castTargetProvider), isNull);
+    });
+  });
+}

--- a/player/test/core/cast/dart_cast_mapping_test.dart
+++ b/player/test/core/cast/dart_cast_mapping_test.dart
@@ -306,7 +306,9 @@ void main() {
         protocol: dc.CastProtocol.dlna,
         address: InternetAddress('192.168.1.51'),
         port: 1900,
-        metadata: const {'avTransportControlUrl': 'http://192.168.1.51:1900/AVTransport'},
+        metadata: const {
+          'avTransportControlUrl': 'http://192.168.1.51:1900/AVTransport'
+        },
       ));
 
       expect(domain.protocol, CastProtocolKind.dlna);
@@ -339,7 +341,8 @@ void main() {
       expect(rebuilt.metadata['md'], 'Chromecast Ultra');
     });
 
-    test('rebuilds a DLNA device including the control-URL metadata '
+    test(
+        'rebuilds a DLNA device including the control-URL metadata '
         'DlnaSession.fromDevice needs', () {
       const domain = CastDevice(
         id: 'uuid:1',
@@ -348,7 +351,8 @@ void main() {
         host: '192.168.1.51',
         port: 1900,
         metadata: {
-          'avTransportControlUrl': 'http://192.168.1.51:1900/AVTransport/control',
+          'avTransportControlUrl':
+              'http://192.168.1.51:1900/AVTransport/control',
         },
       );
 
@@ -415,19 +419,27 @@ void main() {
 
   group('playbackStateFrom', () {
     test('maps every dart_cast session state', () {
-      expect(playbackStateFrom(dc.SessionState.playing), CastPlaybackState.playing);
-      expect(playbackStateFrom(dc.SessionState.paused), CastPlaybackState.paused);
-      expect(playbackStateFrom(dc.SessionState.buffering), CastPlaybackState.buffering);
-      expect(playbackStateFrom(dc.SessionState.loading), CastPlaybackState.buffering);
-      expect(playbackStateFrom(dc.SessionState.connecting), CastPlaybackState.buffering);
+      expect(playbackStateFrom(dc.SessionState.playing),
+          CastPlaybackState.playing);
+      expect(
+          playbackStateFrom(dc.SessionState.paused), CastPlaybackState.paused);
+      expect(playbackStateFrom(dc.SessionState.buffering),
+          CastPlaybackState.buffering);
+      expect(playbackStateFrom(dc.SessionState.loading),
+          CastPlaybackState.buffering);
+      expect(playbackStateFrom(dc.SessionState.connecting),
+          CastPlaybackState.buffering);
       expect(playbackStateFrom(dc.SessionState.idle), CastPlaybackState.idle);
-      expect(playbackStateFrom(dc.SessionState.connected), CastPlaybackState.idle);
-      expect(playbackStateFrom(dc.SessionState.disconnected), CastPlaybackState.idle);
+      expect(
+          playbackStateFrom(dc.SessionState.connected), CastPlaybackState.idle);
+      expect(playbackStateFrom(dc.SessionState.disconnected),
+          CastPlaybackState.idle);
     });
   });
 
   group('failureKindFor', () {
-    test('maps DeviceUnreachableException to unreachable (future-proofing; '
+    test(
+        'maps DeviceUnreachableException to unreachable (future-proofing; '
         'never actually thrown today)', () {
       expect(
         failureKindFor(dc.DeviceUnreachableException('unreachable')),
@@ -435,7 +447,8 @@ void main() {
       );
     });
 
-    test('maps ProxyUpstreamException to unreachable (future-proofing; '
+    test(
+        'maps ProxyUpstreamException to unreachable (future-proofing; '
         'never actually thrown today)', () {
       expect(
         failureKindFor(dc.ProxyUpstreamException('proxy failed')),
@@ -443,7 +456,8 @@ void main() {
       );
     });
 
-    test('maps MediaLoadFailedException (the real Chromecast LOAD failure) '
+    test(
+        'maps MediaLoadFailedException (the real Chromecast LOAD failure) '
         'to mediaLoadFailed', () {
       expect(
         failureKindFor(dc.MediaLoadFailedException('LOAD_FAILED')),
@@ -451,7 +465,8 @@ void main() {
       );
     });
 
-    test('maps ProtocolException (the real DLNA SOAP failure) to '
+    test(
+        'maps ProtocolException (the real DLNA SOAP failure) to '
         'mediaLoadFailed, the same as Chromecast\'s LOAD failure', () {
       expect(
         failureKindFor(dc.ProtocolException('HTTP 500', dc.CastProtocol.dlna)),
@@ -459,7 +474,8 @@ void main() {
       );
     });
 
-    test('maps ConnectionLostException to connectionLost (future-proofing; '
+    test(
+        'maps ConnectionLostException to connectionLost (future-proofing; '
         'never actually thrown today)', () {
       expect(
         failureKindFor(dc.ConnectionLostException('lost')),
@@ -475,12 +491,14 @@ void main() {
     });
 
     test('maps an unrecognized CastException to unknown', () {
-      expect(failureKindFor(dc.CastException('mystery')), CastFailureKind.unknown);
+      expect(
+          failureKindFor(dc.CastException('mystery')), CastFailureKind.unknown);
     });
   });
 
   group('mapDiscoveryFailures', () {
-    test('translates each discovery exception through failureKindFor', () async {
+    test('translates each discovery exception through failureKindFor',
+        () async {
       final controller = StreamController<dc.CastException>();
       addTearDown(controller.close);
 
@@ -491,6 +509,51 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(kinds, [CastFailureKind.discoveryDenied]);
+    });
+  });
+
+  group('sanitizeDurations', () {
+    /// A Chromecast fed one of Mydia's live-style HLS playlists reports
+    /// `duration: -1`, and `dart_cast` forwards it verbatim. Letting that
+    /// through is what made the scrub bar read `00:-1` and both the slider
+    /// and the skip-ahead button seek to the start of the video.
+    test('drops the receiver\'s -1 unknown-duration placeholder', () async {
+      final controller = StreamController<Duration>();
+      addTearDown(controller.close);
+
+      final durations = <Duration>[];
+      sanitizeDurations(controller.stream).listen(durations.add);
+
+      controller.add(const Duration(seconds: -1));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(durations, isEmpty);
+    });
+
+    test('drops zero, which is equally not a runtime', () async {
+      final controller = StreamController<Duration>();
+      addTearDown(controller.close);
+
+      final durations = <Duration>[];
+      sanitizeDurations(controller.stream).listen(durations.add);
+
+      controller.add(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(durations, isEmpty);
+    });
+
+    test('passes a real runtime through', () async {
+      final controller = StreamController<Duration>();
+      addTearDown(controller.close);
+
+      final durations = <Duration>[];
+      sanitizeDurations(controller.stream).listen(durations.add);
+
+      controller.add(const Duration(minutes: 107));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(durations, [const Duration(minutes: 107)]);
     });
   });
 }

--- a/player/test/presentation/screens/search/search_screen_test.dart
+++ b/player/test/presentation/screens/search/search_screen_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/domain/models/search_result.dart';
 import 'package:player/presentation/screens/search/search_controller.dart';
@@ -60,6 +62,9 @@ void main() {
     return ProviderScope(
       overrides: [
         asyncGraphqlClientProvider.overrideWith((ref) async => client),
+        castCapabilitiesProvider.overrideWithValue(
+          const CastCapabilities.full(),
+        ),
       ],
       child: MaterialApp(
         home: SearchScreen(
@@ -286,5 +291,16 @@ void main() {
     for (final label in ['Movies', 'TV Shows', 'Episodes', 'Collections']) {
       expect(find.text(label), findsOneWidget);
     }
+  });
+
+  testWidgets(
+      'carries its own cast button in the app bar '
+      '(the shell overlay skips this route)', (tester) async {
+    await mockNetworkImages(() async {
+      await tester.pumpWidget(host());
+      await tester.pumpAndSettle();
+    });
+
+    expect(find.byKey(const Key('cast-button')), findsOneWidget);
   });
 }

--- a/player/test/presentation/widgets/app_shell_cast_overlay_test.dart
+++ b/player/test/presentation/widgets/app_shell_cast_overlay_test.dart
@@ -1,0 +1,107 @@
+// The shell pins CastOverlayButton into its own Stack so casting is reachable
+// even on desktop screens that suppress their app bar entirely (Home,
+// Unwatched, Favorites, RecentlyAdded, Collections). But some in-shell
+// screens (Library, Downloads, Settings, Search) keep a real, always-visible
+// app bar with their own action buttons in the same top-right band the
+// overlay paints into — those screens carry their own CastButton instead, and
+// the shell must not also paint the overlay there, or the overlay sits on top
+// of and intercepts taps for the screen's own actions.
+//
+// `AppShell.hasOwnCastButton` is the single routing decision that keeps these
+// two mutually exclusive. It's asserted directly here (rather than by
+// mounting the full `AppShell`, which needs a GoRouter ancestor plus the auth/
+// connection/download provider graph — no existing shell test does that; see
+// app_shell_backdrop_test.dart and app_shell_search_nav_test.dart, which both
+// use lightweight stand-ins instead) and then exercised against a Stack that
+// reproduces the shell's exact `if (showCastOverlay) CastOverlayButton(...)`
+// pattern, so a regression in either the predicate or the wiring is caught.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/presentation/widgets/app_shell.dart';
+import 'package:player/presentation/widgets/cast_actions.dart';
+
+void main() {
+  group('AppShell.hasOwnCastButton', () {
+    // Library, Downloads, Settings and Search all keep a real app bar on
+    // every platform (no desktop suppression) and were each given their own
+    // CastButton in this fix — see the corresponding screen files.
+    for (final location in [
+      '/movies',
+      '/shows',
+      '/downloads',
+      '/settings',
+      '/search',
+      // Sub-paths under a route with its own button must also be excluded
+      // from the overlay, matching how `_isHomeSection`/`_isLibrarySection`
+      // already treat these as prefixes, not exact matches.
+      '/search?q=foo&type=movie',
+      '/settings/devices',
+    ]) {
+      test('is true for $location (screen carries its own CastButton)', () {
+        expect(AppShell.hasOwnCastButton(location), isTrue);
+      });
+    }
+
+    // Home, Unwatched, Favorites, RecentlyAdded and Collections all suppress
+    // their app bar entirely on desktop — the overlay is the only cast
+    // affordance they ever get, so it must stay lit for these routes.
+    for (final location in [
+      '/',
+      '/unwatched',
+      '/favorites',
+      '/recently-added',
+      '/collections',
+    ]) {
+      test('is false for $location (overlay is the only affordance)', () {
+        expect(AppShell.hasOwnCastButton(location), isFalse);
+      });
+    }
+  });
+
+  group('the shell Stack, gated by hasOwnCastButton', () {
+    /// Reproduces the exact conditional the shell's own Stack children use:
+    /// `if (!AppShell.hasOwnCastButton(location)) CastOverlayButton(...)`.
+    Widget stackFor(String location) {
+      final showCastOverlay = !AppShell.hasOwnCastButton(location);
+
+      return ProviderScope(
+        overrides: [
+          castCapabilitiesProvider.overrideWithValue(
+            const CastCapabilities.full(),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                const SizedBox.expand(),
+                if (showCastOverlay) const CastOverlayButton(topInset: 40),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders no cast button on a route with its own (e.g. /movies)',
+        (tester) async {
+      await tester.pumpWidget(stackFor('/movies'));
+      await tester.pump();
+
+      expect(find.byKey(const Key('cast-button')), findsNothing);
+    });
+
+    testWidgets(
+        'renders exactly one overlay cast button on a route with no app-bar '
+        'affordance (e.g. /)', (tester) async {
+      await tester.pumpWidget(stackFor('/'));
+      await tester.pump();
+
+      expect(find.byKey(const Key('cast-button')), findsOneWidget);
+    });
+  });
+}

--- a/player/test/presentation/widgets/cast_actions_test.dart
+++ b/player/test/presentation/widgets/cast_actions_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_backend.dart';
+import 'package:player/presentation/widgets/cast_actions.dart';
+
+void main() {
+  group('castErrorMessage', () {
+    test('names the port for an unreachable receiver', () {
+      const e = CastBackendException('nope', CastFailureKind.unreachable);
+
+      expect(castErrorMessage(e), isNot(contains('nope')));
+      expect(castErrorMessage(e), isNotEmpty);
+    });
+
+    test('explains a denied local network permission', () {
+      const e = CastBackendException('denied', CastFailureKind.discoveryDenied);
+
+      expect(castErrorMessage(e), contains('local network'));
+    });
+  });
+
+  group('castErrorMessage covers every failure kind', () {
+    // A missed enum case would fall through to a generic string, losing the
+    // port number or permission hint that makes the error actionable.
+    for (final kind in CastFailureKind.values) {
+      test('produces actionable text for $kind', () {
+        final message = castErrorMessage(CastBackendException('raw', kind));
+
+        expect(message, isNotEmpty);
+        expect(message, isNot(equals('raw')),
+            reason: 'the raw backend string is not user-facing');
+      });
+    }
+  });
+}

--- a/player/test/presentation/widgets/cast_actions_test.dart
+++ b/player/test/presentation/widgets/cast_actions_test.dart
@@ -1,6 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/cast/cast_backend.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/cast/cast_target.dart';
+import 'package:player/domain/models/cast_device.dart';
 import 'package:player/presentation/widgets/cast_actions.dart';
+
+const _device = CastDevice(
+  id: 'device-1',
+  name: 'Living Room TV',
+  protocol: CastProtocolKind.chromecast,
+);
 
 void main() {
   group('castErrorMessage', () {
@@ -30,5 +42,62 @@ void main() {
             reason: 'the raw backend string is not user-facing');
       });
     }
+  });
+
+  group('CastOverlayButton', () {
+    /// [CastOverlayButton] returns a bare [Positioned], so it is only valid
+    /// as a direct child of a [Stack] — matching how `AppShell` mounts it as
+    /// the last child of its own Stack.
+    Widget host({double topInset = 40}) {
+      return ProviderScope(
+        overrides: [
+          castCapabilitiesProvider.overrideWithValue(
+            const CastCapabilities.full(),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                CastOverlayButton(topInset: topInset),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('positions the cast button at the given top inset',
+        (tester) async {
+      await tester.pumpWidget(host(topInset: 52));
+      await tester.pump();
+
+      expect(find.byKey(const Key('cast-button')), findsOneWidget);
+
+      final positioned = tester.widget<Positioned>(find.ancestor(
+        of: find.byKey(const Key('cast-button')),
+        matching: find.byType(Positioned),
+      ));
+      expect(positioned.top, 52);
+      expect(positioned.right, 12);
+    });
+
+    testWidgets('reflects an idle target picked from elsewhere',
+        (tester) async {
+      await tester.pumpWidget(host());
+      await tester.pump();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byKey(const Key('cast-button'))),
+      );
+      container.read(castTargetProvider.notifier).set(_device);
+      await tester.pump();
+
+      final icon = tester.widget<Icon>(find.descendant(
+        of: find.byKey(const Key('cast-button')),
+        matching: find.byType(Icon),
+      ));
+      expect(icon.icon, Icons.cast_connected);
+    });
   });
 }

--- a/player/test/presentation/widgets/cast_button_test.dart
+++ b/player/test/presentation/widgets/cast_button_test.dart
@@ -1,19 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+// `Override` is not re-exported by the main `flutter_riverpod.dart` barrel in
+// Riverpod 3.x; it lives in the `misc.dart` sub-library alongside other
+// advanced/library-author types (see `test/test_utils/riverpod_helpers.dart`).
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/cast/cast_capabilities.dart';
 import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/cast/cast_target.dart';
+import 'package:player/domain/models/cast_device.dart';
 import 'package:player/presentation/widgets/cast_button.dart';
+
+const _device = CastDevice(
+  id: 'device-1',
+  name: 'Living Room TV',
+  protocol: CastProtocolKind.chromecast,
+);
 
 void main() {
   Future<void> pumpButton(
     WidgetTester tester, {
     required CastCapabilities capabilities,
     VoidCallback? onPressed,
+    List<Override> overrides = const [],
   }) async {
     await tester.pumpWidget(ProviderScope(
       overrides: [
         castCapabilitiesProvider.overrideWithValue(capabilities),
+        ...overrides,
       ],
       child: MaterialApp(
         home: Scaffold(
@@ -56,5 +70,72 @@ void main() {
     await tester.pump();
 
     expect(tapped, isTrue);
+  });
+
+  testWidgets('shows the idle icon and neutral tooltip with no target',
+      (tester) async {
+    await pumpButton(tester, capabilities: const CastCapabilities.full());
+
+    final icon = tester.widget<Icon>(find.descendant(
+      of: find.byKey(const Key('cast-button')),
+      matching: find.byType(Icon),
+    ));
+    expect(icon.icon, Icons.cast);
+    expect(icon.color, Colors.white);
+
+    final button = tester.widget<IconButton>(
+      find.byKey(const Key('cast-button')),
+    );
+    expect(button.tooltip, 'Cast to device');
+  });
+
+  testWidgets(
+      'reflects a chosen-but-idle target as active, with a "will play on" tooltip',
+      (tester) async {
+    await pumpButton(tester, capabilities: const CastCapabilities.full());
+
+    // Set the target after the provider is live, matching how pickCastDevice
+    // records an intent for the next playback.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byKey(const Key('cast-button'))),
+    );
+    container.read(castTargetProvider.notifier).set(_device);
+    await tester.pump();
+
+    final icon = tester.widget<Icon>(find.descendant(
+      of: find.byKey(const Key('cast-button')),
+      matching: find.byType(Icon),
+    ));
+    expect(icon.icon, Icons.cast_connected);
+    expect(icon.color, Colors.blue);
+
+    final button = tester.widget<IconButton>(
+      find.byKey(const Key('cast-button')),
+    );
+    expect(button.tooltip, 'Will play on ${_device.name}');
+  });
+
+  testWidgets('an active cast session takes priority over the tooltip text',
+      (tester) async {
+    await pumpButton(
+      tester,
+      capabilities: const CastCapabilities.full(),
+      overrides: [
+        isCastingProvider.overrideWithValue(true),
+        currentCastDeviceProvider.overrideWithValue(_device),
+      ],
+    );
+
+    final icon = tester.widget<Icon>(find.descendant(
+      of: find.byKey(const Key('cast-button')),
+      matching: find.byType(Icon),
+    ));
+    expect(icon.icon, Icons.cast_connected);
+    expect(icon.color, Colors.blue);
+
+    final button = tester.widget<IconButton>(
+      find.byKey(const Key('cast-button')),
+    );
+    expect(button.tooltip, 'Casting to ${_device.name}');
   });
 }

--- a/player/test/presentation/widgets/cast_mini_controller_test.dart
+++ b/player/test/presentation/widgets/cast_mini_controller_test.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/cast/cast_target.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/domain/models/cast_device.dart';
+import 'package:player/presentation/widgets/cast_mini_controller.dart';
+
+class _FakeAuthNotifier extends AuthStateNotifier {
+  _FakeAuthNotifier(this._initial);
+  final AsyncValue<AuthStatus> _initial;
+  @override
+  AsyncValue<AuthStatus> build() => _initial;
+}
+
+const _device = CastDevice(
+  id: 'd1',
+  name: 'Cottage Chromecast',
+  protocol: CastProtocolKind.chromecast,
+);
+
+CastSession _session({
+  required Duration duration,
+  Duration position = const Duration(seconds: 29),
+  bool isStale = false,
+}) {
+  return CastSession(
+    device: _device,
+    playbackState: CastPlaybackState.playing,
+    isStale: isStale,
+    mediaInfo: CastMediaInfo(
+      title: 'Silo - S02E01',
+      duration: duration,
+      position: position,
+    ),
+  );
+}
+
+/// Returns the container so a test can set a cast target after pumping.
+Future<ProviderContainer> _pump(
+  WidgetTester tester, {
+  CastSession? session,
+}) async {
+  final container = ProviderContainer(overrides: [
+    castCapabilitiesProvider.overrideWithValue(const CastCapabilities.full()),
+    authStateProvider.overrideWith(() =>
+        _FakeAuthNotifier(const AsyncValue.data(AuthStatus.authenticated))),
+    asyncGraphqlClientProvider
+        .overrideWith((ref) => Completer<GraphQLClient>().future),
+    castSessionProvider.overrideWith((ref) => Stream.value(session)),
+  ]);
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(UncontrolledProviderScope(
+    container: container,
+    child: const MaterialApp(home: Scaffold(body: CastMiniController())),
+  ));
+  await tester.pump();
+  return container;
+}
+
+void main() {
+  testWidgets('shows title and device while casting', (tester) async {
+    await _pump(tester,
+        session: _session(duration: const Duration(minutes: 44)));
+
+    expect(find.text('Silo - S02E01'), findsOneWidget);
+    expect(find.textContaining('Cottage Chromecast'), findsOneWidget);
+  });
+
+  testWidgets(
+      'renders --:-- and disables the scrubber when duration is unknown',
+      (tester) async {
+    await _pump(tester, session: _session(duration: Duration.zero));
+
+    expect(
+      find.byKey(const Key('cast-bar-duration')),
+      findsOneWidget,
+    );
+    expect(
+      (tester.widget<Text>(find.byKey(const Key('cast-bar-duration')))).data,
+      '--:--',
+    );
+
+    final slider =
+        tester.widget<Slider>(find.byKey(const Key('cast-bar-scrubber')));
+    expect(slider.onChanged, isNull,
+        reason: 'an unknown duration must make the scrubber inert rather than '
+            'seeking to fraction * -1s');
+  });
+
+  testWidgets('renders the stale state with reconnect and stop',
+      (tester) async {
+    await _pump(
+      tester,
+      session: _session(duration: const Duration(minutes: 44), isStale: true),
+    );
+
+    expect(find.byKey(const Key('cast-stale-reconnect')), findsOneWidget);
+    expect(find.byKey(const Key('cast-stale-stop')), findsOneWidget);
+    expect(find.byKey(const Key('cast-bar-scrubber')), findsNothing);
+  });
+
+  testWidgets('renders nothing when there is no session and no target',
+      (tester) async {
+    await _pump(tester);
+
+    expect(find.byKey(const Key('cast-bar-scrubber')), findsNothing);
+    expect(find.textContaining('Cottage Chromecast'), findsNothing);
+  });
+
+  testWidgets('renders the idle state for a target with no session',
+      (tester) async {
+    final container = await _pump(tester);
+
+    container.read(castTargetProvider.notifier).set(_device);
+    await tester.pump();
+
+    expect(find.textContaining('Will play on'), findsOneWidget);
+    expect(find.textContaining('Cottage Chromecast'), findsOneWidget);
+    expect(find.byKey(const Key('cast-bar-scrubber')), findsNothing);
+  });
+
+  testWidgets('the idle clear button drops the target', (tester) async {
+    final container = await _pump(tester);
+
+    container.read(castTargetProvider.notifier).set(_device);
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('cast-bar-idle-clear')));
+    await tester.pump();
+
+    expect(container.read(castTargetProvider), isNull);
+    expect(find.textContaining('Will play on'), findsNothing);
+  });
+}

--- a/player/test/presentation/widgets/cast_mini_controller_test.dart
+++ b/player/test/presentation/widgets/cast_mini_controller_test.dart
@@ -7,10 +7,19 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/cast/cast_capabilities.dart';
 import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/cast/cast_route_resolver.dart';
+import 'package:player/core/cast/cast_seek.dart';
+import 'package:player/core/cast/cast_session_manager.dart';
+import 'package:player/core/cast/cast_session_store.dart';
 import 'package:player/core/cast/cast_target.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/core/player/progress_service.dart';
 import 'package:player/domain/models/cast_device.dart';
 import 'package:player/presentation/widgets/cast_mini_controller.dart';
+
+import '../../test_utils/fake_cast_backend.dart';
+import '../../test_utils/fake_streaming_session_service.dart';
+import '../../test_utils/stub_graphql_client.dart';
 
 class _FakeAuthNotifier extends AuthStateNotifier {
   _FakeAuthNotifier(this._initial);
@@ -54,6 +63,76 @@ Future<ProviderContainer> _pump(
     asyncGraphqlClientProvider
         .overrideWith((ref) => Completer<GraphQLClient>().future),
     castSessionProvider.overrideWith((ref) => Stream.value(session)),
+  ]);
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(UncontrolledProviderScope(
+    container: container,
+    child: const MaterialApp(home: Scaffold(body: CastMiniController())),
+  ));
+  await tester.pump();
+  return container;
+}
+
+/// A real [CastSessionManager] wired to a [FakeCastBackend], so seeks the
+/// widget issues can be observed on `backend.seeks` without a network.
+///
+/// `seek` on the manager just forwards to `backend.seek` (see
+/// `CastSessionManager.seek`), so nothing here needs a live `startCast` —
+/// the manager's other dependencies (store, GraphQL client, route resolver)
+/// only matter for casting/reconnecting, which this test never exercises.
+class _ManagerHarness {
+  _ManagerHarness(this.manager, this.backend);
+
+  final CastSessionManager manager;
+  final FakeCastBackend backend;
+}
+
+_ManagerHarness _buildManagerHarness() {
+  final backend = FakeCastBackend();
+  final sessions = FakeStreamingSessionService();
+  final client = stubClient(
+    StubLink((request, callIndex) => const {'__typename': 'Query'}),
+  );
+
+  final manager = CastSessionManager(
+    backend: backend,
+    store: InMemoryCastSessionStore(),
+    progressService: ProgressService(client),
+    resolverFactory: () => CastRouteResolver(
+      isP2pMode: false,
+      serverUrl: 'https://mydia.test',
+      mediaToken: () async => null,
+      lanBaseUrl: () => null,
+      streamingSessions: sessions,
+    ),
+    streamingSessions: sessions,
+    setLanAccess: (enabled) async {},
+  );
+
+  return _ManagerHarness(manager, backend);
+}
+
+/// Like [_pump], but backs `castSessionManagerProvider` with a real manager
+/// over a [FakeCastBackend] and lets the caller push more than one session
+/// onto `castSessionProvider` (a plain `Stream.value` can only ever emit
+/// one), which the mid-drag-update assertion needs.
+Future<ProviderContainer> _pumpWithManager(
+  WidgetTester tester, {
+  required _ManagerHarness harness,
+  required Stream<CastSession?> sessionStream,
+}) async {
+  final container = ProviderContainer(overrides: [
+    castCapabilitiesProvider.overrideWithValue(const CastCapabilities.full()),
+    authStateProvider.overrideWith(() =>
+        _FakeAuthNotifier(const AsyncValue.data(AuthStatus.authenticated))),
+    asyncGraphqlClientProvider
+        .overrideWith((ref) => Completer<GraphQLClient>().future),
+    castSessionManagerProvider.overrideWith((ref) async {
+      ref.onDispose(harness.manager.dispose);
+      return harness.manager;
+    }),
+    castSessionProvider.overrideWith((ref) => sessionStream),
   ]);
   addTearDown(container.dispose);
 
@@ -138,5 +217,66 @@ void main() {
 
     expect(container.read(castTargetProvider), isNull);
     expect(find.textContaining('Will play on'), findsNothing);
+  });
+
+  testWidgets(
+      'seeks once on release, not during the drag, and the thumb holds the '
+      'dragged position against a stale mid-drag update', (tester) async {
+    final harness = _buildManagerHarness();
+    addTearDown(harness.manager.dispose);
+
+    final sessionController = StreamController<CastSession?>();
+    addTearDown(sessionController.close);
+
+    final initialSession = _session(
+      duration: const Duration(minutes: 44),
+      position: const Duration(seconds: 60),
+    );
+
+    await _pumpWithManager(
+      tester,
+      harness: harness,
+      sessionStream: sessionController.stream,
+    );
+    sessionController.add(initialSession);
+    await tester.pump();
+    await tester.pump();
+
+    final sliderFinder = find.byKey(const Key('cast-bar-scrubber'));
+    expect(sliderFinder, findsOneWidget);
+    final startValue = tester.widget<Slider>(sliderFinder).value;
+
+    // Press down and drag right, but do not release yet.
+    final gesture = await tester.startGesture(tester.getCenter(sliderFinder));
+    await tester.pump();
+    await gesture.moveBy(const Offset(120, 0));
+    await tester.pump();
+
+    final draggedValue = tester.widget<Slider>(sliderFinder).value;
+    expect(draggedValue, isNot(closeTo(startValue, 0.01)),
+        reason: 'the thumb must follow the drag');
+    expect(harness.backend.seeks, isEmpty,
+        reason: 'dragging must not seek on every frame, only on release');
+
+    // The receiver's own position stream keeps ticking during a drag; a new
+    // session update carrying the pre-drag position must not snap the thumb
+    // back to it.
+    sessionController.add(initialSession);
+    await tester.pump();
+
+    final midDragValue = tester.widget<Slider>(sliderFinder).value;
+    expect(midDragValue, draggedValue,
+        reason: 'a position event mid-drag must not override the local '
+            'drag position');
+    expect(harness.backend.seeks, isEmpty);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.backend.seeks, hasLength(1),
+        reason: 'release must seek exactly once');
+    final expectedTarget =
+        seekTargetForFraction(draggedValue, initialSession.mediaInfo!.duration);
+    expect(harness.backend.seeks.single, expectedTarget);
   });
 }

--- a/player/test/presentation/widgets/cast_mini_controller_test.dart
+++ b/player/test/presentation/widgets/cast_mini_controller_test.dart
@@ -279,4 +279,67 @@ void main() {
         seekTargetForFraction(draggedValue, initialSession.mediaInfo!.duration);
     expect(harness.backend.seeks.single, expectedTarget);
   });
+
+  testWidgets(
+      'confirming stop clears a target set while the session was already '
+      'live', (tester) async {
+    final harness = _buildManagerHarness();
+    addTearDown(harness.manager.dispose);
+
+    final sessionController = StreamController<CastSession?>();
+    addTearDown(sessionController.close);
+
+    final container = await _pumpWithManager(
+      tester,
+      harness: harness,
+      sessionStream: sessionController.stream,
+    );
+    sessionController.add(_session(duration: const Duration(minutes: 44)));
+    await tester.pump();
+    await tester.pump();
+
+    // Mirrors cast_actions.dart's re-target fallback: a target can be set
+    // while a session is already live, when nothing is persisted behind it
+    // to re-cast. The idle "x" does not render in that state, so stopping
+    // the session must be the path that clears it.
+    container.read(castTargetProvider.notifier).set(_device);
+
+    await tester.tap(find.byKey(const Key('cast-bar-stop')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Stop'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(castTargetProvider), isNull,
+        reason: 'stopping a cast must clear castTargetProvider, or the '
+            'next playback would silently cast again');
+  });
+
+  testWidgets('the stale-session stop button clears the target',
+      (tester) async {
+    final harness = _buildManagerHarness();
+    addTearDown(harness.manager.dispose);
+
+    final sessionController = StreamController<CastSession?>();
+    addTearDown(sessionController.close);
+
+    final container = await _pumpWithManager(
+      tester,
+      harness: harness,
+      sessionStream: sessionController.stream,
+    );
+    sessionController.add(_session(
+      duration: const Duration(minutes: 44),
+      isStale: true,
+    ));
+    await tester.pump();
+    await tester.pump();
+
+    container.read(castTargetProvider.notifier).set(_device);
+
+    await tester.tap(find.byKey(const Key('cast-stale-stop')));
+    await tester.pumpAndSettle();
+
+    expect(container.read(castTargetProvider), isNull);
+  });
 }


### PR DESCRIPTION
## Problem

Casting rendered two UIs at once. `PlayerScreen` swapped its whole body for a full-screen remote whenever a cast was active, while `CastMiniController` — mounted in the global `MaterialApp.builder` stack — overlaid *every* screen, including the one already showing the remote. Both surfaces displayed the same four things (title, "Casting to <device>", play/pause, stop), and the bar sat on top and clipped the remote's "Stop Casting" button.

Separately, the only cast button in the app lived inside `PlayerScreen`. You had to start local playback before you could hand it off — there was no way to pick a device up front and have playback simply begin on the TV.

## What this does

**One control surface.** The full-screen remote is deleted. `CastMiniController` becomes the sole place casting is controlled, gaining a draggable scrubber, ±10s skips, play/pause, stop-with-confirmation, an idle state, and the stale-session Reconnect/Stop that used to live in the remote. `PlayerScreen` now shows an inert placeholder while casting: icon, "Playing on <device>", title, back button.

**Casting from anywhere.** A new `castTargetProvider` records a device chosen before anything is playing — a preference, not a connection, so `CastSessionManager` keeps owning exactly one concept (an active session with media). `PlayerScreen` reads it before initialising and calls `startCast` instead, never constructing a local player. All seven playback entry points route through `/player/:type/:id`, so this is one interception rather than seven call-site edits.

The affordance itself is an overlay pinned inside `AppShell`'s `Stack`, not an app-bar action: on desktop the browse screens deliberately suppress their app bars (`HomeScreen` passes `appBar: null`; Unwatched/Favorites/RecentlyAdded/Collections return a zero-height `SizedBox.shrink()`), so an app-bar-only button would have been invisible on macOS. Screens that *do* keep an app bar with actions — Library, Downloads, Settings, Search, and the three detail screens — get the button there instead, with `AppShell.hasOwnCastButton` gating the overlay so every route has exactly one affordance.

**Receiver duration fix** (first commit, independent of the UI work). A Chromecast reports `duration: -1` for any stream whose length it cannot determine — which is every HLS playlist Mydia serves, because the server runs FFmpeg without `-hls_playlist_type` on purpose so playback can start before the file is fully remuxed, leaving no `#EXT-X-ENDLIST`. `dart_cast` forwarded that `-1` verbatim. It rendered the scrub bar as `00:-1`, made the slider seek to `fraction × -1s` (the start of the video), and made skip-ahead clamp against a `-1s` "end" — also the start. The placeholder is now stopped at the backend boundary, the session is seeded with the runtime the app already knows, and the shared arithmetic lives in `cast_seek.dart` so every consumer treats non-positive as unknown.

## Testing

732 tests pass; 0 analyzer errors or warnings. New coverage includes the bar's three states, `--:--` with a disabled scrubber on unknown duration, seek-on-release (asserting zero seeks *during* a drag and exactly one on release), the overlay's route gating, and `CastButton`'s idle/casting states.

## Known gaps

- `_castToTargetIfSet` has no test — `player_screen.dart` has no scaffold, and one needs GraphQL, auth, downloads and cast providers plus a `media_kit` Player. Extracting it as a free function over `(Ref, fileId, …)` is the cheap way in if we want the clear-on-success contract pinned.
- `CastButton`'s black-circle styling now appears in four differently-styled app bars, including the light Settings and Search bars where it will look out of place.
- Not yet verified on a real receiver; the flow needs a manual pass on hardware.
