### PR TITLE
feat(media): bulk auto search from the selection toolbar

### DIFF
--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1929,6 +1929,12 @@ defmodule Mydia.Media do
   part of the movie rule: `Mydia.Jobs.MovieSearch` in `"specific"` mode does not
   check it either, so an unmonitored movie is still searchable on request.
 
+  A TV show needs a search when at least one of its episodes is monitored (show
+  and episode), has aired, has no untrashed media file, and has no occupying
+  download, excluding S00 specials unless `:monitor_special_episodes` is set.
+  That is the same set `Mydia.Jobs.TVShowSearch` searches in `"show"` mode, so
+  the caller's queued/skipped counts match what the job will actually do.
+
   Ids that no longer exist are counted in neither the returned list nor the
   skipped count, so a stale selection still reports truthful numbers.
 
@@ -1938,7 +1944,7 @@ defmodule Mydia.Media do
   def partition_for_auto_search([]), do: {[], 0}
 
   def partition_for_auto_search(ids) when is_list(ids) do
-    items = movies_needing_search(ids)
+    items = movies_needing_search(ids) ++ shows_needing_search(ids)
 
     existing_count =
       MediaItem
@@ -1964,6 +1970,50 @@ defmodule Mydia.Media do
     Mydia.Downloads.Download.occupying()
     |> where([d], not is_nil(d.media_item_id))
     |> select([d], d.media_item_id)
+    |> distinct(true)
+  end
+
+  defp shows_needing_search(ids) do
+    show_ids =
+      Episode
+      |> join(:inner, [e], m in assoc(e, :media_item))
+      |> where([e, m], e.media_item_id in ^ids and m.type == "tv_show")
+      |> where([e, m], e.monitored == true and m.monitored == true)
+      |> where([e], e.air_date <= ^Date.utc_today())
+      |> exclude_special_episodes()
+      |> where([e], e.id not in subquery(occupying_download_episode_ids()))
+      |> join(:left, [e], mf in Mydia.Library.MediaFile,
+        on: mf.episode_id == e.id and is_nil(mf.trashed_at)
+      )
+      |> group_by([e], e.id)
+      |> having([_e, _m, mf], count(mf.id) == 0)
+      |> select([e], e.media_item_id)
+      |> Repo.all()
+      |> Enum.uniq()
+
+    MediaItem
+    |> where([m], m.id in ^show_ids)
+    |> Repo.all()
+  end
+
+  defp exclude_special_episodes(query) do
+    if monitor_special_episodes?() do
+      query
+    else
+      where(query, [e], e.season_number != 0)
+    end
+  end
+
+  defp monitor_special_episodes? do
+    :mydia
+    |> Application.get_env(:episode_monitor, [])
+    |> Keyword.get(:monitor_special_episodes, false)
+  end
+
+  defp occupying_download_episode_ids do
+    Mydia.Downloads.Download.occupying()
+    |> where([d], not is_nil(d.episode_id))
+    |> select([d], d.episode_id)
     |> distinct(true)
   end
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1988,8 +1988,8 @@ defmodule Mydia.Media do
       |> group_by([e], e.id)
       |> having([_e, _m, mf], count(mf.id) == 0)
       |> select([e], e.media_item_id)
+      |> distinct(true)
       |> Repo.all()
-      |> Enum.uniq()
 
     MediaItem
     |> where([m], m.id in ^show_ids)

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1920,6 +1920,53 @@ defmodule Mydia.Media do
     {:ok, summary}
   end
 
+  @doc """
+  Partitions selected media item ids into those needing an automatic release
+  search and a count of those that do not need one.
+
+  A movie needs a search when it has no untrashed media file and no occupying
+  download (see `Mydia.Downloads.Download.occupying/1`). Monitored status is not
+  part of the movie rule: `Mydia.Jobs.MovieSearch` in `"specific"` mode does not
+  check it either, so an unmonitored movie is still searchable on request.
+
+  Ids that no longer exist are counted in neither the returned list nor the
+  skipped count, so a stale selection still reports truthful numbers.
+
+  Returns `{items_needing_search, skipped_count}`.
+  """
+  @spec partition_for_auto_search([binary()]) :: {[MediaItem.t()], non_neg_integer()}
+  def partition_for_auto_search([]), do: {[], 0}
+
+  def partition_for_auto_search(ids) when is_list(ids) do
+    items = movies_needing_search(ids)
+
+    existing_count =
+      MediaItem
+      |> where([m], m.id in ^ids)
+      |> Repo.aggregate(:count)
+
+    {items, existing_count - length(items)}
+  end
+
+  defp movies_needing_search(ids) do
+    MediaItem
+    |> where([m], m.id in ^ids and m.type == "movie")
+    |> where([m], m.id not in subquery(occupying_download_media_item_ids()))
+    |> join(:left, [m], mf in Mydia.Library.MediaFile,
+      on: mf.media_item_id == m.id and is_nil(mf.trashed_at)
+    )
+    |> group_by([m], m.id)
+    |> having([_m, mf], count(mf.id) == 0)
+    |> Repo.all()
+  end
+
+  defp occupying_download_media_item_ids do
+    Mydia.Downloads.Download.occupying()
+    |> where([d], not is_nil(d.media_item_id))
+    |> select([d], d.media_item_id)
+    |> distinct(true)
+  end
+
   # Auto-classify a newly created media item
   defp auto_classify_media_item(%MediaItem{} = media_item) do
     category = CategoryClassifier.classify(media_item)

--- a/lib/mydia/search.ex
+++ b/lib/mydia/search.ex
@@ -35,6 +35,7 @@ defmodule Mydia.Search do
   import Ecto.Query, warn: false
   require Logger
 
+  alias Mydia.Media.MediaItem
   alias Mydia.Repo
   alias Mydia.Search.SearchBackoff
 
@@ -287,6 +288,54 @@ defmodule Mydia.Search do
       seconds < 86_400 -> "#{div(seconds, 3600)} hours"
       true -> "#{div(seconds, 86_400)} days"
     end
+  end
+
+  @doc """
+  Queues automatic release searches for the given media items.
+
+  Movies queue `Mydia.Jobs.MovieSearch` in `"specific"` mode and TV shows queue
+  `Mydia.Jobs.TVShowSearch` in `"show"` mode, the same jobs and modes the media
+  detail page queues.
+
+  Both workers declare `unique: [period: 60, fields: [:args]]`, which
+  `Oban.insert_all/1` honors, so repeated clicks cannot double-queue.
+
+  Callers are expected to have filtered the list already, typically with
+  `Mydia.Media.partition_for_auto_search/1`.
+
+  Returns `{:ok, count}` with the number of jobs inserted.
+  """
+  @spec queue_auto_searches([MediaItem.t()]) :: {:ok, non_neg_integer()} | {:error, term()}
+  def queue_auto_searches([]), do: {:ok, 0}
+
+  def queue_auto_searches(items) when is_list(items) do
+    jobs =
+      items
+      |> Enum.map(&auto_search_job/1)
+      |> insert_all_jobs()
+
+    {:ok, length(jobs)}
+  rescue
+    error ->
+      Logger.error("Failed to queue automatic searches: #{inspect(error)}")
+      {:error, error}
+  end
+
+  defp auto_search_job(%MediaItem{type: "movie", id: id}) do
+    Mydia.Jobs.MovieSearch.new(%{mode: "specific", media_item_id: id})
+  end
+
+  defp auto_search_job(%MediaItem{type: "tv_show", id: id}) do
+    Mydia.Jobs.TVShowSearch.new(%{mode: "show", media_item_id: id})
+  end
+
+  # Insert Oban jobs in one round trip, falling back to direct Repo inserts
+  # when Oban's engine is disabled (test mode). Mirrors the pattern in
+  # DownloadMonitor and Downloads.Queue.
+  defp insert_all_jobs(changesets) do
+    Oban.insert_all(changesets)
+  rescue
+    RuntimeError -> Enum.map(changesets, &Repo.insert!/1)
   end
 
   ## Private Functions

--- a/lib/mydia/search.ex
+++ b/lib/mydia/search.ex
@@ -297,28 +297,48 @@ defmodule Mydia.Search do
   `Mydia.Jobs.TVShowSearch` in `"show"` mode, the same jobs and modes the media
   detail page queues.
 
-  Both workers declare `unique: [period: 60, fields: [:args]]`, which
-  `Oban.insert_all/1` honors, so repeated clicks cannot double-queue.
+  Jobs are inserted one at a time with singular `Oban.insert/1`, not
+  `Oban.insert_all/1`. On this project's engines (`Oban.Engines.Basic` for
+  Postgres, `Oban.Engines.Lite` for SQLite, configured in `config/config.exs`)
+  `insert_all/1` performs a raw bulk insert and never checks the workers'
+  `unique: [period: 60, fields: [:args]]` option — bulk unique-job support is
+  an Oban Pro (Smart Engine) feature this project does not use. Only the
+  singular `insert/1` path checks uniqueness before inserting, so repeated
+  calls within the window cannot double-queue. Do not change this back to
+  `insert_all/1` as a "one round trip" optimization: that reintroduces
+  duplicate-queuing on repeated clicks.
+
+  Media items whose `type` is neither `"movie"` nor `"tv_show"` are skipped
+  (and logged) rather than raising, so one unsupported item cannot fail the
+  whole batch.
 
   Callers are expected to have filtered the list already, typically with
   `Mydia.Media.partition_for_auto_search/1`.
 
-  Returns `{:ok, count}` with the number of jobs inserted.
+  Returns `{:ok, count}` with the number of jobs inserted, or `{:error,
+  reason}` if any insert failed.
   """
   @spec queue_auto_searches([MediaItem.t()]) :: {:ok, non_neg_integer()} | {:error, term()}
   def queue_auto_searches([]), do: {:ok, 0}
 
   def queue_auto_searches(items) when is_list(items) do
-    jobs =
-      items
-      |> Enum.map(&auto_search_job/1)
-      |> insert_all_jobs()
-
-    {:ok, length(jobs)}
+    items
+    |> Enum.map(&auto_search_job/1)
+    |> Enum.reject(&is_nil/1)
+    |> insert_jobs(0)
   rescue
     error ->
       Logger.error("Failed to queue automatic searches: #{inspect(error)}")
       {:error, error}
+  end
+
+  defp insert_jobs([], count), do: {:ok, count}
+
+  defp insert_jobs([changeset | rest], count) do
+    case insert_job(changeset) do
+      {:ok, _job} -> insert_jobs(rest, count + 1)
+      {:error, _reason} = error -> error
+    end
   end
 
   defp auto_search_job(%MediaItem{type: "movie", id: id}) do
@@ -329,13 +349,26 @@ defmodule Mydia.Search do
     Mydia.Jobs.TVShowSearch.new(%{mode: "show", media_item_id: id})
   end
 
-  # Insert Oban jobs in one round trip, falling back to direct Repo inserts
-  # when Oban's engine is disabled (test mode). Mirrors the pattern in
-  # DownloadMonitor and Downloads.Queue.
-  defp insert_all_jobs(changesets) do
-    Oban.insert_all(changesets)
+  defp auto_search_job(%MediaItem{id: id, type: type}) do
+    Logger.warning("Skipping auto search for unsupported media type",
+      media_item_id: id,
+      type: type
+    )
+
+    nil
+  end
+
+  # Insert an Oban job, falling back to a direct Repo insert when Oban's engine
+  # is disabled (test mode). Mirrors the pattern in Downloads.Queue and
+  # DownloadMonitor.
+  #
+  # This repo's test config sets `engine: false` (see config/test.exs), so
+  # this fallback branch is the only one the test suite exercises. It gives
+  # no signal on the real `Oban.insert/1` path or its uniqueness behavior.
+  defp insert_job(changeset) do
+    Oban.insert(changeset)
   rescue
-    RuntimeError -> Enum.map(changesets, &Repo.insert!/1)
+    RuntimeError -> Repo.insert(changeset)
   end
 
   ## Private Functions

--- a/lib/mydia/search.ex
+++ b/lib/mydia/search.ex
@@ -335,7 +335,13 @@ defmodule Mydia.Search do
   defp insert_jobs([], count), do: {:ok, count}
 
   defp insert_jobs([changeset | rest], count) do
+    # A deduped insert returns {:ok, %Oban.Job{conflict?: true}} rather than an
+    # error, so it must not bump the "queued" count. This branch cannot be
+    # regression-tested here: config/test.exs sets `engine: false`, so
+    # insert_job/1 always falls through to the Repo.insert/1 rescue clause
+    # below, which never sets conflict?: true.
     case insert_job(changeset) do
+      {:ok, %Oban.Job{conflict?: true}} -> insert_jobs(rest, count)
       {:ok, _job} -> insert_jobs(rest, count + 1)
       {:error, _reason} = error -> error
     end

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -5,6 +5,8 @@ defmodule MydiaWeb.MediaLive.Index do
   alias Mydia.Metadata.Structs.MediaMetadata
   alias Mydia.Settings
   alias Mydia.Collections
+  alias Mydia.Search
+  alias MydiaWeb.Live.Authorization
 
   require Logger
 
@@ -301,10 +303,30 @@ defmodule MydiaWeb.MediaLive.Index do
     end
   end
 
-  def handle_event("batch_download", _params, socket) do
-    # TODO: Implement download functionality
-    # For now, just show a placeholder message
-    {:noreply, put_flash(socket, :info, "Download functionality coming soon")}
+  def handle_event("batch_auto_search", _params, socket) do
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      ids = MapSet.to_list(socket.assigns.selected_ids)
+      {items, skipped} = Media.partition_for_auto_search(ids)
+
+      case Search.queue_auto_searches(items) do
+        {:ok, queued} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, auto_search_flash(queued, skipped))
+           |> assign(:selection_mode, false)
+           |> assign(:selected_ids, MapSet.new())}
+
+        {:error, reason} ->
+          Logger.error("Failed to queue bulk auto search",
+            media_item_ids: ids,
+            reason: inspect(reason)
+          )
+
+          {:noreply, put_flash(socket, :error, "Failed to queue searches")}
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
   end
 
   def handle_event("batch_reclassify", _params, socket) do
@@ -902,6 +924,23 @@ defmodule MydiaWeb.MediaLive.Index do
 
   defp pluralize_files(1), do: "file"
   defp pluralize_files(_), do: "files"
+
+  defp auto_search_flash(0, 0), do: "Nothing to search"
+
+  defp auto_search_flash(0, skipped) do
+    "Nothing to search. All #{skipped} selected #{pluralize_items(skipped)} already have files or downloads in progress."
+  end
+
+  defp auto_search_flash(queued, 0) do
+    "Queued #{queued} #{pluralize_searches(queued)}"
+  end
+
+  defp auto_search_flash(queued, skipped) do
+    "Queued #{queued} #{pluralize_searches(queued)}, skipped #{skipped} already complete"
+  end
+
+  defp pluralize_searches(1), do: "search"
+  defp pluralize_searches(_), do: "searches"
 
   defp maybe_add_attr(attrs, _key, nil), do: attrs
   defp maybe_add_attr(attrs, _key, ""), do: attrs

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -12,6 +12,7 @@ defmodule MydiaWeb.MediaLive.Index do
 
   @items_per_page 50
   @items_per_scroll 25
+  @auto_search_confirm_threshold 50
 
   @impl true
   def mount(_params, _session, socket) do
@@ -34,6 +35,7 @@ defmodule MydiaWeb.MediaLive.Index do
      |> assign(:show_delete_modal, false)
      |> assign(:delete_files, false)
      |> assign(:show_batch_edit_modal, false)
+     |> assign(:show_auto_search_confirm_modal, false)
      |> assign(:quality_profiles, [])
      |> assign(:batch_edit_form, to_form(%{}, as: :batch_edit))
      |> assign(:scanning, false)
@@ -305,28 +307,29 @@ defmodule MydiaWeb.MediaLive.Index do
 
   def handle_event("batch_auto_search", _params, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      ids = MapSet.to_list(socket.assigns.selected_ids)
-      {items, skipped} = Media.partition_for_auto_search(ids)
-
-      case Search.queue_auto_searches(items) do
-        {:ok, queued} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, auto_search_flash(queued, skipped))
-           |> assign(:selection_mode, false)
-           |> assign(:selected_ids, MapSet.new())}
-
-        {:error, reason} ->
-          Logger.error("Failed to queue bulk auto search",
-            media_item_ids: ids,
-            reason: inspect(reason)
-          )
-
-          {:noreply, put_flash(socket, :error, "Failed to queue searches")}
+      if MapSet.size(socket.assigns.selected_ids) > @auto_search_confirm_threshold do
+        {:noreply, assign(socket, :show_auto_search_confirm_modal, true)}
+      else
+        {:noreply, run_batch_auto_search(socket)}
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
+  end
+
+  def handle_event("confirm_batch_auto_search", _params, socket) do
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      {:noreply,
+       socket
+       |> assign(:show_auto_search_confirm_modal, false)
+       |> run_batch_auto_search()}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("cancel_batch_auto_search", _params, socket) do
+    {:noreply, assign(socket, :show_auto_search_confirm_modal, false)}
   end
 
   def handle_event("batch_reclassify", _params, socket) do
@@ -629,6 +632,27 @@ defmodule MydiaWeb.MediaLive.Index do
     {:noreply, socket}
   end
 
+  defp run_batch_auto_search(socket) do
+    ids = MapSet.to_list(socket.assigns.selected_ids)
+    {items, skipped} = Media.partition_for_auto_search(ids)
+
+    case Search.queue_auto_searches(items) do
+      {:ok, queued} ->
+        socket
+        |> put_flash(:info, auto_search_flash(queued, skipped))
+        |> assign(:selection_mode, false)
+        |> assign(:selected_ids, MapSet.new())
+
+      {:error, reason} ->
+        Logger.error("Failed to queue bulk auto search",
+          media_item_ids: ids,
+          reason: inspect(reason)
+        )
+
+        put_flash(socket, :error, "Failed to queue searches")
+    end
+  end
+
   defp load_media_items(socket, opts) do
     reset? = Keyword.get(opts, :reset, false)
     page = if reset?, do: 0, else: socket.assigns.page
@@ -928,7 +952,7 @@ defmodule MydiaWeb.MediaLive.Index do
   defp auto_search_flash(0, 0), do: "Nothing to search"
 
   defp auto_search_flash(0, skipped) do
-    "Nothing to search. All #{skipped} selected #{pluralize_items(skipped)} already have files or downloads in progress."
+    "Nothing to search. None of the #{skipped} selected #{pluralize_items(skipped)} need a search."
   end
 
   defp auto_search_flash(queued, 0) do
@@ -936,7 +960,7 @@ defmodule MydiaWeb.MediaLive.Index do
   end
 
   defp auto_search_flash(queued, skipped) do
-    "Queued #{queued} #{pluralize_searches(queued)}, skipped #{skipped} already complete"
+    "Queued #{queued} #{pluralize_searches(queued)}, skipped #{skipped} that do not need one"
   end
 
   defp pluralize_searches(1), do: "search"

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -951,12 +951,18 @@ defmodule MydiaWeb.MediaLive.Index do
 
   defp auto_search_flash(0, 0), do: "Nothing to search"
 
+  defp auto_search_flash(0, 1), do: "Nothing to search. The selected item does not need a search."
+
   defp auto_search_flash(0, skipped) do
-    "Nothing to search. None of the #{skipped} selected #{pluralize_items(skipped)} need a search."
+    "Nothing to search. None of the #{skipped} selected items need a search."
   end
 
   defp auto_search_flash(queued, 0) do
     "Queued #{queued} #{pluralize_searches(queued)}"
+  end
+
+  defp auto_search_flash(queued, 1) do
+    "Queued #{queued} #{pluralize_searches(queued)}, skipped 1 that does not need one"
   end
 
   defp auto_search_flash(queued, skipped) do

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -594,6 +594,18 @@
 
             <%!-- Primary action buttons (icon only with tooltips) --%>
             <div class="flex items-center">
+              <div class="tooltip tooltip-top" data-tip="Auto Search">
+                <button
+                  id="batch-auto-search-btn"
+                  type="button"
+                  class={["btn btn-sm btn-ghost btn-square", !has_selection && "btn-disabled"]}
+                  phx-click="batch_auto_search"
+                  disabled={!has_selection}
+                >
+                  <.icon name="hero-magnifying-glass" class="w-4 h-4" />
+                </button>
+              </div>
+
               <div class="tooltip tooltip-top" data-tip="Monitor">
                 <button
                   type="button"

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -770,6 +770,36 @@
       </:actions>
     </.modal>
 
+    <%!-- Bulk Auto Search Confirmation Modal --%>
+    <.modal
+      id="auto-search-confirm-modal"
+      show={@show_auto_search_confirm_modal}
+      on_cancel="cancel_batch_auto_search"
+    >
+      <:title>Search for many items?</:title>
+
+      <p>
+        This will queue searches for <strong>{MapSet.size(@selected_ids)}</strong>
+        selected {if MapSet.size(@selected_ids) == 1, do: "item", else: "items"}.
+        Searches run two at a time, so a batch this size can take hours of indexer requests
+        to work through.
+      </p>
+
+      <:actions>
+        <button type="button" class="btn btn-ghost" phx-click="cancel_batch_auto_search">
+          Cancel
+        </button>
+        <button
+          type="button"
+          id="confirm-batch-auto-search-btn"
+          class="btn btn-primary"
+          phx-click="confirm_batch_auto_search"
+        >
+          <.icon name="hero-magnifying-glass" class="w-4 h-4" /> Queue searches
+        </button>
+      </:actions>
+    </.modal>
+
     <%!-- Add to Collection Modal --%>
     <.modal
       id="add-to-collection-modal"

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -1893,4 +1893,68 @@ defmodule Mydia.MediaTest do
       assert File.exists?(abs)
     end
   end
+
+  describe "partition_for_auto_search/1 with movies" do
+    test "returns a movie with no files and no downloads" do
+      movie = insert(:media_item, type: "movie")
+
+      assert {[found], 0} = Media.partition_for_auto_search([movie.id])
+      assert found.id == movie.id
+    end
+
+    test "skips a movie with an untrashed media file" do
+      movie = insert(:media_item, type: "movie")
+      insert(:media_file, media_item: movie, episode: nil)
+
+      assert {[], 1} = Media.partition_for_auto_search([movie.id])
+    end
+
+    test "returns a movie whose only media file is trashed" do
+      movie = insert(:media_item, type: "movie")
+
+      insert(:media_file,
+        media_item: movie,
+        episode: nil,
+        trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+      assert {[found], 0} = Media.partition_for_auto_search([movie.id])
+      assert found.id == movie.id
+    end
+
+    test "skips a movie with an occupying download" do
+      movie = insert(:media_item, type: "movie")
+      insert(:download, media_item: movie)
+
+      assert {[], 1} = Media.partition_for_auto_search([movie.id])
+    end
+
+    test "returns a movie whose only download failed terminally" do
+      movie = insert(:media_item, type: "movie")
+
+      insert(:download,
+        media_item: movie,
+        import_failed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        import_next_retry_at: nil
+      )
+
+      assert {[found], 0} = Media.partition_for_auto_search([movie.id])
+      assert found.id == movie.id
+    end
+
+    test "returns an unmonitored movie with no files" do
+      movie = insert(:media_item, type: "movie", monitored: false)
+
+      assert {[found], 0} = Media.partition_for_auto_search([movie.id])
+      assert found.id == movie.id
+    end
+
+    test "ignores ids that do not exist" do
+      assert {[], 0} = Media.partition_for_auto_search([Ecto.UUID.generate()])
+    end
+
+    test "returns an empty result for an empty id list" do
+      assert {[], 0} = Media.partition_for_auto_search([])
+    end
+  end
 end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -1957,4 +1957,135 @@ defmodule Mydia.MediaTest do
       assert {[], 0} = Media.partition_for_auto_search([])
     end
   end
+
+  describe "partition_for_auto_search/1 with TV shows" do
+    setup do
+      %{yesterday: Date.add(Date.utc_today(), -1), tomorrow: Date.add(Date.utc_today(), 1)}
+    end
+
+    test "returns a show with an aired monitored episode that has no file", %{
+      yesterday: yesterday
+    } do
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, air_date: yesterday)
+
+      assert {[found], 0} = Media.partition_for_auto_search([show.id])
+      assert found.id == show.id
+    end
+
+    test "skips a show whose only aired episode already has a file", %{yesterday: yesterday} do
+      show = insert(:tv_show)
+      episode = insert(:episode, media_item: show, air_date: yesterday)
+      insert(:media_file, episode: episode, media_item: nil)
+
+      assert {[], 1} = Media.partition_for_auto_search([show.id])
+    end
+
+    test "returns a show whose episode file is trashed", %{yesterday: yesterday} do
+      show = insert(:tv_show)
+      episode = insert(:episode, media_item: show, air_date: yesterday)
+
+      insert(:media_file,
+        episode: episode,
+        media_item: nil,
+        trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+      assert {[found], 0} = Media.partition_for_auto_search([show.id])
+      assert found.id == show.id
+    end
+
+    test "skips a show whose only missing episode has not aired", %{tomorrow: tomorrow} do
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, air_date: tomorrow)
+
+      assert {[], 1} = Media.partition_for_auto_search([show.id])
+    end
+
+    test "skips a show whose only missing episode has no air date" do
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, air_date: nil)
+
+      assert {[], 1} = Media.partition_for_auto_search([show.id])
+    end
+
+    test "skips a show whose only missing episode is unmonitored", %{yesterday: yesterday} do
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, air_date: yesterday, monitored: false)
+
+      assert {[], 1} = Media.partition_for_auto_search([show.id])
+    end
+
+    test "skips an unmonitored show with missing episodes", %{yesterday: yesterday} do
+      show = insert(:tv_show, monitored: false)
+      insert(:episode, media_item: show, air_date: yesterday)
+
+      assert {[], 1} = Media.partition_for_auto_search([show.id])
+    end
+
+    test "skips a show whose only missing episode has an occupying download", %{
+      yesterday: yesterday
+    } do
+      show = insert(:tv_show)
+      episode = insert(:episode, media_item: show, air_date: yesterday)
+      insert(:download, media_item: show, episode: episode)
+
+      assert {[], 1} = Media.partition_for_auto_search([show.id])
+    end
+
+    test "skips a show whose only missing episode is a special", %{yesterday: yesterday} do
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, air_date: yesterday, season_number: 0)
+
+      assert {[], 1} = Media.partition_for_auto_search([show.id])
+    end
+
+    test "returns a show with a missing special when specials are monitored", %{
+      yesterday: yesterday
+    } do
+      original = Application.get_env(:mydia, :episode_monitor, [])
+
+      Application.put_env(
+        :mydia,
+        :episode_monitor,
+        Keyword.put(original, :monitor_special_episodes, true)
+      )
+
+      on_exit(fn -> Application.put_env(:mydia, :episode_monitor, original) end)
+
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, air_date: yesterday, season_number: 0)
+
+      assert {[found], 0} = Media.partition_for_auto_search([show.id])
+      assert found.id == show.id
+    end
+
+    test "returns a show once even when several episodes are missing", %{yesterday: yesterday} do
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, air_date: yesterday, episode_number: 1)
+      insert(:episode, media_item: show, air_date: yesterday, episode_number: 2)
+
+      assert {[found], 0} = Media.partition_for_auto_search([show.id])
+      assert found.id == show.id
+    end
+
+    test "counts movies and shows together", %{yesterday: yesterday} do
+      movie = insert(:media_item, type: "movie")
+      complete_movie = insert(:media_item, type: "movie")
+      insert(:media_file, media_item: complete_movie, episode: nil)
+
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, air_date: yesterday)
+
+      complete_show = insert(:tv_show)
+      complete_episode = insert(:episode, media_item: complete_show, air_date: yesterday)
+      insert(:media_file, episode: complete_episode, media_item: nil)
+
+      ids = [movie.id, complete_movie.id, show.id, complete_show.id]
+      {items, skipped} = Media.partition_for_auto_search(ids)
+
+      assert skipped == 2
+      assert Enum.sort(Enum.map(items, & &1.id)) == Enum.sort([movie.id, show.id])
+    end
+  end
 end

--- a/test/mydia/search_test.exs
+++ b/test/mydia/search_test.exs
@@ -1,0 +1,47 @@
+defmodule Mydia.SearchTest do
+  use Mydia.DataCase
+  use Oban.Testing, repo: Mydia.Repo
+
+  alias Mydia.Search
+
+  describe "queue_auto_searches/1" do
+    test "queues a specific-mode MovieSearch for a movie" do
+      movie = insert(:media_item, type: "movie")
+
+      assert {:ok, 1} = Search.queue_auto_searches([movie])
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MovieSearch,
+        args: %{mode: "specific", media_item_id: movie.id}
+      )
+    end
+
+    test "queues a show-mode TVShowSearch for a TV show" do
+      show = insert(:tv_show)
+
+      assert {:ok, 1} = Search.queue_auto_searches([show])
+
+      assert_enqueued(
+        worker: Mydia.Jobs.TVShowSearch,
+        args: %{mode: "show", media_item_id: show.id}
+      )
+    end
+
+    test "queues one job per item for a mixed list" do
+      movie = insert(:media_item, type: "movie")
+      show = insert(:tv_show)
+
+      assert {:ok, 2} = Search.queue_auto_searches([movie, show])
+
+      assert_enqueued(worker: Mydia.Jobs.MovieSearch, args: %{media_item_id: movie.id})
+      assert_enqueued(worker: Mydia.Jobs.TVShowSearch, args: %{media_item_id: show.id})
+    end
+
+    test "queues nothing for an empty list" do
+      assert {:ok, 0} = Search.queue_auto_searches([])
+
+      refute_enqueued(worker: Mydia.Jobs.MovieSearch)
+      refute_enqueued(worker: Mydia.Jobs.TVShowSearch)
+    end
+  end
+end

--- a/test/mydia/search_test.exs
+++ b/test/mydia/search_test.exs
@@ -43,5 +43,16 @@ defmodule Mydia.SearchTest do
       refute_enqueued(worker: Mydia.Jobs.MovieSearch)
       refute_enqueued(worker: Mydia.Jobs.TVShowSearch)
     end
+
+    test "skips an item with an unsupported type instead of failing the batch" do
+      movie = insert(:media_item, type: "movie")
+      unsupported = insert(:media_item, type: "documentary")
+
+      assert {:ok, 1} = Search.queue_auto_searches([movie, unsupported])
+
+      assert_enqueued(worker: Mydia.Jobs.MovieSearch, args: %{media_item_id: movie.id})
+      refute_enqueued(worker: Mydia.Jobs.MovieSearch, args: %{media_item_id: unsupported.id})
+      refute_enqueued(worker: Mydia.Jobs.TVShowSearch, args: %{media_item_id: unsupported.id})
+    end
   end
 end

--- a/test/mydia_web/live/media_live/index_test.exs
+++ b/test/mydia_web/live/media_live/index_test.exs
@@ -377,7 +377,7 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       view |> element("#batch-auto-search-btn") |> render_click()
 
       assert view |> element("#flash-info") |> render() =~
-               "Queued 1 search, skipped 1 that do not need one"
+               "Queued 1 search, skipped 1 that does not need one"
 
       assert [job] = Mydia.Repo.all(Oban.Job)
       assert job.worker == "Mydia.Jobs.MovieSearch"
@@ -409,8 +409,13 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       render_click(view, "toggle_selection_mode", %{})
       render_click(view, "toggle_select", %{"id" => needs_search.id})
 
-      for i <- 1..50 do
-        render_click(view, "toggle_select", %{"id" => "fake-id-#{i}"})
+      # Real UUIDs for rows that do not exist: `binary_id` is a plain string on
+      # SQLite but a genuine uuid column on Postgres, so a synthetic id like
+      # "fake-id-1" casts fine on one adapter and raises Ecto.Query.CastError on
+      # the other. partition_for_auto_search/1 counts absent ids in neither
+      # number, which is what keeps the assertions below stable.
+      for _ <- 1..50 do
+        render_click(view, "toggle_select", %{"id" => Ecto.UUID.generate()})
       end
 
       refute has_element?(view, "#auto-search-confirm-modal[open]")
@@ -439,8 +444,13 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       render_click(view, "toggle_selection_mode", %{})
       render_click(view, "toggle_select", %{"id" => needs_search.id})
 
-      for i <- 1..50 do
-        render_click(view, "toggle_select", %{"id" => "fake-id-#{i}"})
+      # Real UUIDs for rows that do not exist: `binary_id` is a plain string on
+      # SQLite but a genuine uuid column on Postgres, so a synthetic id like
+      # "fake-id-1" casts fine on one adapter and raises Ecto.Query.CastError on
+      # the other. partition_for_auto_search/1 counts absent ids in neither
+      # number, which is what keeps the assertions below stable.
+      for _ <- 1..50 do
+        render_click(view, "toggle_select", %{"id" => Ecto.UUID.generate()})
       end
 
       view |> element("#batch-auto-search-btn") |> render_click()

--- a/test/mydia_web/live/media_live/index_test.exs
+++ b/test/mydia_web/live/media_live/index_test.exs
@@ -340,4 +340,77 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       assert socket.assigns.delete_files == true
     end
   end
+
+  describe "bulk auto search" do
+    setup %{conn: conn} do
+      %{conn: log_in_user(conn, admin_user_fixture())}
+    end
+
+    test "renders the auto search button in selection mode", %{conn: conn} do
+      insert(:media_item, type: "movie")
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      refute has_element?(view, "#batch-auto-search-btn")
+
+      render_click(view, "toggle_selection_mode", %{})
+
+      assert has_element?(view, "#batch-auto-search-btn")
+    end
+
+    test "queues searches for selected items and reports skipped ones", %{conn: conn} do
+      needs_search = insert(:media_item, type: "movie", title: "Needs A Search")
+      already_have = insert(:media_item, type: "movie", title: "Already Downloaded")
+      insert(:media_file, media_item: already_have, episode: nil)
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      render_click(view, "toggle_selection_mode", %{})
+      render_click(view, "toggle_select", %{"id" => needs_search.id})
+      render_click(view, "toggle_select", %{"id" => already_have.id})
+
+      view |> element("#batch-auto-search-btn") |> render_click()
+
+      assert view |> element("#flash-info") |> render() =~
+               "Queued 1 search, skipped 1 already complete"
+
+      assert [job] = Mydia.Repo.all(Oban.Job)
+      assert job.worker == "Mydia.Jobs.MovieSearch"
+      assert job.args["mode"] == "specific"
+      assert job.args["media_item_id"] == needs_search.id
+    end
+
+    test "reports when nothing in the selection needs a search", %{conn: conn} do
+      already_have = insert(:media_item, type: "movie", title: "Already Downloaded")
+      insert(:media_file, media_item: already_have, episode: nil)
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      render_click(view, "toggle_selection_mode", %{})
+      render_click(view, "toggle_select", %{"id" => already_have.id})
+
+      view |> element("#batch-auto-search-btn") |> render_click()
+
+      assert view |> element("#flash-info") |> render() =~ "Nothing to search"
+      assert Mydia.Repo.all(Oban.Job) == []
+    end
+
+    test "denies a user without download permission", %{conn: conn} do
+      readonly = user_fixture(%{role: "readonly"})
+      conn = log_in_user(conn, readonly)
+      movie = insert(:media_item, type: "movie")
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      render_click(view, "toggle_selection_mode", %{})
+      render_click(view, "toggle_select", %{"id" => movie.id})
+
+      view |> element("#batch-auto-search-btn") |> render_click()
+
+      assert view |> element("#flash-error") |> render() =~
+               "You do not have permission to manage downloads"
+
+      assert Mydia.Repo.all(Oban.Job) == []
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/index_test.exs
+++ b/test/mydia_web/live/media_live/index_test.exs
@@ -346,8 +346,8 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       %{conn: log_in_user(conn, admin_user_fixture())}
     end
 
-    test "renders the auto search button in selection mode", %{conn: conn} do
-      insert(:media_item, type: "movie")
+    test "renders the auto search button disabled until something is selected", %{conn: conn} do
+      movie = insert(:media_item, type: "movie")
 
       {:ok, view, _html} = live(conn, ~p"/movies")
 
@@ -356,6 +356,11 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       render_click(view, "toggle_selection_mode", %{})
 
       assert has_element?(view, "#batch-auto-search-btn")
+      assert has_element?(view, "#batch-auto-search-btn[disabled]")
+
+      render_click(view, "toggle_select", %{"id" => movie.id})
+
+      refute has_element?(view, "#batch-auto-search-btn[disabled]")
     end
 
     test "queues searches for selected items and reports skipped ones", %{conn: conn} do
@@ -372,7 +377,7 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       view |> element("#batch-auto-search-btn") |> render_click()
 
       assert view |> element("#flash-info") |> render() =~
-               "Queued 1 search, skipped 1 already complete"
+               "Queued 1 search, skipped 1 that do not need one"
 
       assert [job] = Mydia.Repo.all(Oban.Job)
       assert job.worker == "Mydia.Jobs.MovieSearch"
@@ -393,6 +398,63 @@ defmodule MydiaWeb.MediaLive.IndexTest do
 
       assert view |> element("#flash-info") |> render() =~ "Nothing to search"
       assert Mydia.Repo.all(Oban.Job) == []
+    end
+
+    test "selecting more than the threshold shows a confirmation modal and queues nothing until confirmed",
+         %{conn: conn} do
+      needs_search = insert(:media_item, type: "movie", title: "Needs A Search")
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      render_click(view, "toggle_selection_mode", %{})
+      render_click(view, "toggle_select", %{"id" => needs_search.id})
+
+      for i <- 1..50 do
+        render_click(view, "toggle_select", %{"id" => "fake-id-#{i}"})
+      end
+
+      refute has_element?(view, "#auto-search-confirm-modal[open]")
+
+      view |> element("#batch-auto-search-btn") |> render_click()
+
+      assert has_element?(view, "#auto-search-confirm-modal[open]")
+      assert Mydia.Repo.all(Oban.Job) == []
+
+      view |> element("#confirm-batch-auto-search-btn") |> render_click()
+
+      refute has_element?(view, "#auto-search-confirm-modal[open]")
+
+      assert view |> element("#flash-info") |> render() =~ "Queued 1 search"
+      assert [job] = Mydia.Repo.all(Oban.Job)
+      assert job.args["media_item_id"] == needs_search.id
+    end
+
+    test "cancelling the confirmation modal queues nothing and keeps the selection", %{
+      conn: conn
+    } do
+      needs_search = insert(:media_item, type: "movie", title: "Needs A Search")
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      render_click(view, "toggle_selection_mode", %{})
+      render_click(view, "toggle_select", %{"id" => needs_search.id})
+
+      for i <- 1..50 do
+        render_click(view, "toggle_select", %{"id" => "fake-id-#{i}"})
+      end
+
+      view |> element("#batch-auto-search-btn") |> render_click()
+      assert has_element?(view, "#auto-search-confirm-modal[open]")
+
+      render_click(view, "cancel_batch_auto_search", %{})
+
+      refute has_element?(view, "#auto-search-confirm-modal[open]")
+      assert Mydia.Repo.all(Oban.Job) == []
+
+      # Selection survives the cancel: the toolbar is still in selection mode
+      # with the same count shown.
+      assert has_element?(view, "#batch-auto-search-btn")
+      assert has_element?(view, ".tabular-nums", "51")
     end
 
     test "denies a user without download permission", %{conn: conn} do


### PR DESCRIPTION
Adds a magnifying-glass button to the multi-select toolbar on `/movies` and `/tv`. Clicking it queues the same background release searches the detail page's "Auto Search" queues, for every selected item that still needs one, and reports how many were queued versus skipped.

This also removes the dead `batch_download` handler that flashed "Download functionality coming soon" and was wired to no button.

## What counts as needing a search

A **movie** needs one when it has no untrashed media file and no occupying download. "Occupying" reuses `Downloads.Download.occupying/1`, the same scope `Downloads.Queue.check_for_active_download/3` uses, so the skip rule and the queue's own duplicate rejection cannot drift apart.

A **show** needs one when at least one episode is monitored (show and episode), has aired, has no untrashed file, and has no occupying download, excluding S00 specials unless `monitor_special_episodes` is set. That is deliberately the same set `TVShowSearch` searches in `"show"` mode, so the queued and skipped counts cannot claim searches the job then silently no-ops.

One asymmetry worth knowing: unmonitored movies are still searched, matching the detail-page button, but unmonitored shows are skipped, because `TVShowSearch` `"show"` mode requires `monitored == true` internally and would do nothing anyway.

## Structure

- `Mydia.Media.partition_for_auto_search/1` splits the selected ids into items needing a search plus a skipped count. Ids for items deleted since the page rendered land in neither number, so a stale selection still reports truthfully.
- `Mydia.Search.queue_auto_searches/1` turns those items into Oban jobs.
- `handle_event("batch_auto_search", ...)` in `MediaLive.Index` authorizes, calls both, flashes, and exits selection mode.

## Two things review caught

**Bulk insert silently bypassed job uniqueness.** The first implementation used `Oban.insert_all/1` for one round trip. Verified against Oban 2.20.1's source: `Engines.Basic.insert_all_jobs/3` is a bare `Repo.insert_all` with `on_conflict: :nothing` and never runs the unique path, and `Lite` delegates to it. Bulk unique jobs are an Oban Pro feature. Jobs are now inserted one at a time via `Oban.insert/1`, which does honor the workers' `unique: [period: 60]`, so a double-click cannot double-queue. A deduped job comes back `conflict?: true` and is not counted as queued.

**Select All is unbounded.** It selects everything matching the current filters, not just the loaded page, so on a large library one click could queue thousands of jobs against a `:search` queue that runs two at a time. Above 50 selected items the button now opens a confirmation modal stating the count first. Authorization runs before the modal appears, and the confirm handler re-authorizes independently so a forged event cannot bypass it.

## Authorization

This handler queues downloads, so it checks `authorize_manage_downloads/1` server-side. Note the other bulk handlers in this LiveView have no authorization check at all; retrofitting them was left out of scope and is worth a separate look.

## Testing

`5364 tests, 4 failures.` The 4 failures are `DownloadsLive.PathMappingIssueTest` timeouts and are pre-existing, not introduced here: reverting `lib/` and `test/` to the fork point with this feature entirely absent reproduces the identical SIGKILL, and there is no code linkage between that page and anything this branch touches. Credo `--strict`, format, unused deps, and warnings-as-errors compile are clean.

Coverage added: the movie and show partition rules including trashed files, terminally-failed downloads, unaired and undated episodes, unmonitored shows and episodes, and specials; the job dispatch for both media types; and the toolbar behaviour including the disabled state, the confirmation threshold, cancelling, and permission denial.

Two known gaps:

- No manual browser verification was performed. The confirmation modal has not been seen rendered in a real browser.
- `config/test.exs` sets `engine: false`, so the search tests exercise the `Repo.insert` fallback and never Oban's real uniqueness path. This affects every Oban-inserting module in the repo, not just this change, so the uniqueness behaviour was verified from Oban's source rather than from a test.
