### PR TITLE
fix(downloads): carry provider-native failure detail into debrid blacklist reasons

### DIFF
--- a/lib/mydia/downloads/client/debrid/provider_job.ex
+++ b/lib/mydia/downloads/client/debrid/provider_job.ex
@@ -9,7 +9,15 @@ defmodule Mydia.Downloads.Client.Debrid.ProviderJob do
   of which debrid service the operator picked.
 
   See `t:state/0` for the unified state taxonomy.
+
+  Terminal jobs (`state: :error`) also carry `:failure_category` and
+  `:failure_detail` — the provider's own answer to *why*, normalised into
+  the shared vocabulary in `Mydia.Downloads.Client.FailureCategory`. Both
+  are `nil` for every non-terminal state and for terminal states a provider
+  has not mapped.
   """
+
+  alias Mydia.Downloads.Client.FailureCategory
 
   @type state :: :queued | :downloading | :finalizing | :ready | :error
 
@@ -22,7 +30,9 @@ defmodule Mydia.Downloads.Client.Debrid.ProviderJob do
     :total_bytes,
     :files,
     :hoster_links,
-    :raw_status
+    :raw_status,
+    :failure_category,
+    :failure_detail
   ]
 
   @type file_entry :: %{
@@ -41,7 +51,9 @@ defmodule Mydia.Downloads.Client.Debrid.ProviderJob do
           total_bytes: non_neg_integer() | nil,
           files: [file_entry()] | nil,
           hoster_links: [String.t()] | nil,
-          raw_status: term() | nil
+          raw_status: term() | nil,
+          failure_category: FailureCategory.t() | nil,
+          failure_detail: String.t() | nil
         }
 
   @doc """

--- a/lib/mydia/downloads/client/debrid/providers/all_debrid.ex
+++ b/lib/mydia/downloads/client/debrid/providers/all_debrid.ex
@@ -25,6 +25,7 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.AllDebrid do
 
   alias Mydia.Downloads.Client.Debrid.{ProviderJob, Shared}
   alias Mydia.Downloads.Client.Error
+  alias Mydia.Downloads.Client.Helpers
   alias Mydia.Downloads.Structs.ClientInfo
 
   @default_base_url "https://api.alldebrid.com"
@@ -272,6 +273,7 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.AllDebrid do
 
   defp parse_magnet(%{} = m) do
     state = map_status_code(m["statusCode"])
+    {category, detail} = classify_failure(state, m)
 
     %ProviderJob{
       provider_id: to_string(m["id"]),
@@ -281,7 +283,9 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.AllDebrid do
       total_bytes: m["size"] || 0,
       files: m["files"] || [],
       hoster_links: [],
-      raw_status: m
+      raw_status: m,
+      failure_category: category,
+      failure_detail: detail
     }
   end
 
@@ -296,6 +300,31 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.AllDebrid do
   defp map_status_code(4), do: :ready
   defp map_status_code(code) when is_integer(code) and code >= 5, do: :error
   defp map_status_code(_), do: :queued
+
+  defp classify_failure(:error, %{} = m) do
+    {failure_category(m["statusCode"]), failure_detail(m)}
+  end
+
+  defp classify_failure(_state, _m), do: {nil, nil}
+
+  # Documented AllDebrid terminal codes. `map_status_code/1` already treats
+  # anything >= 5 as terminal, so codes beyond this table stay terminal and
+  # simply carry no category rather than a guessed one.
+  defp failure_category(code) when code in [5, 6, 9], do: :provider_error
+  defp failure_category(code) when code in [7, 10], do: :no_peers
+  defp failure_category(8), do: :rejected_content
+  defp failure_category(11), do: :missing_files
+  defp failure_category(_), do: nil
+
+  defp failure_detail(%{"status" => status}) when is_binary(status) and status != "" do
+    Helpers.sanitize_failure_detail(status)
+  end
+
+  defp failure_detail(%{"statusCode" => code}) when is_integer(code) do
+    Helpers.sanitize_failure_detail("statusCode #{code}")
+  end
+
+  defp failure_detail(_), do: nil
 
   ## ── 200-on-error wrapper ────────────────────────────────────────────
 

--- a/lib/mydia/downloads/client/debrid/providers/premiumize.ex
+++ b/lib/mydia/downloads/client/debrid/providers/premiumize.ex
@@ -24,6 +24,7 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.Premiumize do
 
   alias Mydia.Downloads.Client.Debrid.{ProviderJob, Shared}
   alias Mydia.Downloads.Client.Error
+  alias Mydia.Downloads.Client.Helpers
   alias Mydia.Downloads.Structs.ClientInfo
 
   @default_base_url "https://www.premiumize.me/api"
@@ -285,15 +286,20 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.Premiumize do
   ## ── Parsing helpers ─────────────────────────────────────────────────
 
   defp parse_transfer(%{} = t) do
+    state = map_status(t["status"])
+    {category, detail} = classify_failure(state, t)
+
     %ProviderJob{
       provider_id: to_string(t["id"]),
-      state: map_status(t["status"]),
+      state: state,
       progress: (t["progress"] || 0.0) * 100.0,
       name: t["name"],
       total_bytes: t["size"] || 0,
       files: [],
       hoster_links: [],
-      raw_status: t
+      raw_status: t,
+      failure_category: category,
+      failure_detail: detail
     }
   end
 
@@ -304,6 +310,17 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.Premiumize do
   defp map_status("finished"), do: :ready
   defp map_status("error"), do: :error
   defp map_status(_), do: :queued
+
+  # Premiumize exposes exactly one terminal status, so there is nothing
+  # finer to distinguish. `message` is free text from the provider, which
+  # is why it goes through the shared sanitiser.
+  defp classify_failure(:error, %{} = t) do
+    detail = t["message"] || t["status"] || "error"
+
+    {:provider_error, Helpers.sanitize_failure_detail(to_string(detail))}
+  end
+
+  defp classify_failure(_state, _t), do: {nil, nil}
 
   ## ── Envelope wrapper ────────────────────────────────────────────────
 

--- a/lib/mydia/downloads/client/debrid/providers/real_debrid.ex
+++ b/lib/mydia/downloads/client/debrid/providers/real_debrid.ex
@@ -32,6 +32,7 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.RealDebrid do
 
   alias Mydia.Downloads.Client.Debrid.{ProviderJob, Shared}
   alias Mydia.Downloads.Client.Error
+  alias Mydia.Downloads.Client.Helpers
   alias Mydia.Downloads.Structs.ClientInfo
 
   @default_base_url "https://api.real-debrid.com/rest/1.0"
@@ -244,19 +245,21 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.RealDebrid do
   ## ── Parsing ─────────────────────────────────────────────────────────
 
   defp parse_torrent_info(id, body) do
-    state = map_status(body["status"])
-    progress = body["progress"] || 0.0
-    bytes = body["bytes"] || 0
+    native_status = body["status"]
+    state = map_status(native_status)
+    {category, detail} = classify_failure(state, native_status)
 
     %ProviderJob{
       provider_id: id,
       state: state,
-      progress: progress * 1.0,
+      progress: (body["progress"] || 0.0) * 1.0,
       name: body["filename"],
-      total_bytes: bytes,
+      total_bytes: body["bytes"] || 0,
       files: body["files"] || [],
       hoster_links: body["links"] || [],
-      raw_status: body
+      raw_status: body,
+      failure_category: category,
+      failure_detail: detail
     }
   end
 
@@ -272,6 +275,20 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.RealDebrid do
   defp map_status("dead"), do: :error
   defp map_status("magnet_error"), do: :error
   defp map_status(_), do: :queued
+
+  # The detail is the native status string alone — never the body, whose
+  # `links` are credentialed CDN URLs.
+  defp classify_failure(:error, native_status) when is_binary(native_status) do
+    {failure_category(native_status), Helpers.sanitize_failure_detail(native_status)}
+  end
+
+  defp classify_failure(_state, _native_status), do: {nil, nil}
+
+  defp failure_category("dead"), do: :no_peers
+  defp failure_category("virus"), do: :rejected_content
+  defp failure_category("magnet_error"), do: :rejected_content
+  defp failure_category("error"), do: :provider_error
+  defp failure_category(_), do: nil
 
   ## ── Error mapping ────────────────────────────────────────────────────
 

--- a/lib/mydia/downloads/client/debrid/providers/tor_box.ex
+++ b/lib/mydia/downloads/client/debrid/providers/tor_box.ex
@@ -35,6 +35,7 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.TorBox do
 
   alias Mydia.Downloads.Client.Debrid.{ProviderJob, Shared}
   alias Mydia.Downloads.Client.Error
+  alias Mydia.Downloads.Client.Helpers
   alias Mydia.Downloads.Structs.ClientInfo
 
   @default_base_url "https://api.torbox.app/v1/api"
@@ -241,12 +242,16 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.TorBox do
   ## ── Parsing ─────────────────────────────────────────────────────────
 
   defp parse_torrent(%{} = t) do
+    native_state = t["download_state"]
+
     state =
       if t["download_finished"] == true and t["download_present"] == true do
         :ready
       else
-        map_download_state(t["download_state"])
+        map_download_state(native_state)
       end
+
+    {category, detail} = classify_failure(state, native_state)
 
     %ProviderJob{
       provider_id: to_string(t["id"]),
@@ -256,7 +261,9 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.TorBox do
       total_bytes: t["size"] || 0,
       files: t["files"] || [],
       hoster_links: [],
-      raw_status: t
+      raw_status: t,
+      failure_category: category,
+      failure_detail: detail
     }
   end
 
@@ -275,6 +282,19 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.TorBox do
   defp map_download_state("error"), do: :error
   defp map_download_state("missingFiles"), do: :error
   defp map_download_state(_), do: :queued
+
+  # Only terminal states carry a classification. The detail is the native
+  # `download_state` string itself — never the surrounding payload, whose
+  # `files` entries carry credentialed CDN URLs.
+  defp classify_failure(:error, native_state) when is_binary(native_state) do
+    {failure_category(native_state), Helpers.sanitize_failure_detail(native_state)}
+  end
+
+  defp classify_failure(_state, _native_state), do: {nil, nil}
+
+  defp failure_category("missingFiles"), do: :missing_files
+  defp failure_category("error"), do: :provider_error
+  defp failure_category(_), do: nil
 
   defp parse_int(n) when is_integer(n), do: n
 

--- a/lib/mydia/downloads/client/debrid/shared.ex
+++ b/lib/mydia/downloads/client/debrid/shared.ex
@@ -405,8 +405,19 @@ defmodule Mydia.Downloads.Client.Debrid.Shared do
   defp apply_state(base, %ProviderJob{state: :ready}, _fetcher_state, _download),
     do: %{base | state: :queued, progress: 0.0, downloaded: 0}
 
-  defp apply_state(base, %ProviderJob{state: :error}, _fs, _dl),
-    do: %{base | state: :error, progress: 0.0, downloaded: 0}
+  # A terminal provider failure. `failure_category` / `failure_detail` are
+  # whatever the provider managed to classify; both may be nil, which the
+  # monitor renders as the pre-#237 generic message.
+  defp apply_state(base, %ProviderJob{state: :error} = job, _fs, _dl) do
+    %{
+      base
+      | state: :error,
+        progress: 0.0,
+        downloaded: 0,
+        failure_category: job.failure_category,
+        failure_detail: job.failure_detail
+    }
+  end
 
   defp mirror_downloaded(%ProviderJob{total_bytes: total, progress: p})
        when is_integer(total) and total > 0 and is_number(p) do

--- a/lib/mydia/downloads/client/debrid/shared.ex
+++ b/lib/mydia/downloads/client/debrid/shared.ex
@@ -12,20 +12,16 @@ defmodule Mydia.Downloads.Client.Debrid.Shared do
       into `Mydia.Downloads.Client.Error` types. Each provider also has
       its own per-code translation table; this module covers the cases
       shared across all four.
-    * **Security primitives**: `redact_url/1`, `validate_download_url/1`,
-      and `sanitize_error_body/2`. These wrap every URL or response body
-      the providers see *before* it flows into a log line, an `Error`
-      envelope, or `Download.metadata`.
+    * **Security primitives**: `redact_url/1` (delegated to
+      `Mydia.Downloads.Client.Helpers`), `validate_download_url/1`, and
+      `sanitize_error_body/2`.
   """
 
   alias Mydia.Downloads.Client.Debrid.ProviderJob
   alias Mydia.Downloads.Client.Error
+  alias Mydia.Downloads.Client.Helpers
   alias Mydia.Downloads.Download
   alias Mydia.Downloads.Structs.DownloadStatus
-
-  # Query-param keys that *may* carry an operator credential. Lowercased
-  # comparison is used so `Token=` and `TOKEN=` are caught too.
-  @sensitive_url_params ~w(token auth apikey api_key agent _apikey password)
 
   # JSON object keys we drop entirely from response bodies before they
   # land in `Error.details`. Lowercased comparison.
@@ -52,40 +48,15 @@ defmodule Mydia.Downloads.Client.Debrid.Shared do
   # ── URL safety ────────────────────────────────────────────────────────
 
   @doc """
-  Strips credential-bearing query parameters from a URL. Used everywhere
-  a URL might end up in a `Logger` line or an `Error` envelope.
+  Strips credential-bearing query parameters from a URL.
 
-  Returns the URL unchanged if parsing fails (safer to log a half-redacted
-  string than to crash inside an error-handling path).
+  Delegated to `Mydia.Downloads.Client.Helpers` — `failure_detail`
+  sanitisation needs the same redaction from adapters that have no business
+  reaching into the debrid namespace, so the implementation lives with the
+  adapter-agnostic helpers. Kept here as a delegate because the four call
+  sites in this module and the provider modules all reference it unqualified.
   """
-  @spec redact_url(String.t() | nil) :: String.t() | nil
-  def redact_url(nil), do: nil
-
-  def redact_url(url) when is_binary(url) do
-    case URI.parse(url) do
-      %URI{query: nil} ->
-        url
-
-      %URI{query: query} = uri ->
-        scrubbed =
-          query
-          |> URI.decode_query()
-          |> Enum.map(fn {k, v} ->
-            if String.downcase(k) in @sensitive_url_params do
-              {k, "[REDACTED]"}
-            else
-              {k, v}
-            end
-          end)
-          |> Enum.map_join("&", fn {k, v} ->
-            "#{URI.encode_www_form(k)}=#{URI.encode_www_form(v)}"
-          end)
-
-        URI.to_string(%{uri | query: scrubbed})
-    end
-  rescue
-    _ -> url
-  end
+  defdelegate redact_url(url), to: Helpers
 
   @doc """
   Enforces that a provider-returned URL is HTTPS and not pointing at

--- a/lib/mydia/downloads/client/failure_category.ex
+++ b/lib/mydia/downloads/client/failure_category.ex
@@ -1,0 +1,104 @@
+defmodule Mydia.Downloads.Client.FailureCategory do
+  @moduledoc """
+  The shared vocabulary for *why* a download client reported a terminal
+  failure (issue #237).
+
+  Download clients report failure at wildly different granularities: TorBox
+  gives a `download_state` string, AllDebrid a numeric `statusCode`,
+  Premiumize a single `"error"` for everything. Each adapter collapses its
+  native detail into one of the categories here, and this module owns the
+  three renderings that vocabulary needs:
+
+    * `slug/1` — the stable string written to `release_blacklist.failure_reason`
+    * `label/1` — the human phrase shown in the admin UI and failure messages
+    * `message/3` — the operator-facing sentence stored on the
+      `download.failed` event
+
+  Categories are deliberately *diagnostic only*. Nothing here influences
+  whether a release is blacklisted or for how long — see the non-goals in
+  `docs/superpowers/specs/2026-07-29-debrid-failure-detail-design.md`.
+
+  `nil` is a valid input everywhere: it means "the client reported a failure
+  but we could not classify it", which covers every non-debrid adapter today
+  as well as any provider state we have not mapped. It renders as the
+  pre-existing `"client_reported_failure"` slug so rows written before this
+  module existed stay valid.
+  """
+
+  @type t :: :no_peers | :missing_files | :rejected_content | :provider_error
+
+  # The slug used before this module existed. Retained as the fallback so
+  # historical rows keep rendering and the admin filter keeps working.
+  @fallback_slug "client_reported_failure"
+
+  @default_message "Download failed in client"
+
+  @labels %{
+    no_peers: "no peers",
+    missing_files: "missing files",
+    rejected_content: "rejected content",
+    provider_error: "provider error"
+  }
+
+  # Slug -> label, resolved at compile time. Deliberately NOT
+  # `String.to_atom/1` at runtime: slugs arrive from the database, and
+  # atom conversion on stored input is a memory-leak vector.
+  @slug_labels @labels
+               |> Map.new(fn {category, label} -> {Atom.to_string(category), label} end)
+               |> Map.put(@fallback_slug, "client reported failure")
+
+  @doc """
+  The four classifiable categories, sorted. Excludes the `nil` fallback,
+  which is an absence rather than a category.
+  """
+  @spec categories() :: [t()]
+  def categories, do: @labels |> Map.keys() |> Enum.sort()
+
+  @doc """
+  The string written to `release_blacklist.failure_reason`.
+  """
+  @spec slug(t() | nil) :: String.t()
+  def slug(nil), do: @fallback_slug
+  def slug(category) when is_map_key(@labels, category), do: Atom.to_string(category)
+
+  @doc """
+  The human phrase for a category atom, or for a slug read back out of the
+  database. Unrecognised slugs are humanized rather than raising, so a row
+  written by a future version doesn't break the admin page.
+  """
+  @spec label(t() | String.t() | nil) :: String.t()
+  def label(nil), do: Map.fetch!(@slug_labels, @fallback_slug)
+
+  def label(category) when is_atom(category) do
+    Map.get_lazy(@labels, category, fn -> humanize(Atom.to_string(category)) end)
+  end
+
+  def label(slug) when is_binary(slug) do
+    Map.get_lazy(@slug_labels, slug, fn -> humanize(slug) end)
+  end
+
+  @doc """
+  The operator-facing failure sentence, e.g.
+  `"torbox reported missing files: missingFiles"`.
+
+  With neither a category nor a detail there is nothing to add, so this
+  returns the constant used before #237 rather than an emptier sentence.
+  """
+  @spec message(String.t() | nil, t() | nil, String.t() | nil) :: String.t()
+  def message(client, category, detail) do
+    if is_nil(category) and blank?(detail) do
+      @default_message
+    else
+      subject = if blank?(client), do: "Download client", else: client
+      base = "#{subject} reported #{label(category)}"
+
+      if blank?(detail), do: base, else: "#{base}: #{detail}"
+    end
+  end
+
+  defp humanize(slug), do: String.replace(slug, "_", " ")
+
+  defp blank?(nil), do: true
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?(_), do: false
+end

--- a/lib/mydia/downloads/client/failure_category.ex
+++ b/lib/mydia/downloads/client/failure_category.ex
@@ -48,13 +48,6 @@ defmodule Mydia.Downloads.Client.FailureCategory do
                |> Map.put(@fallback_slug, "client reported failure")
 
   @doc """
-  The four classifiable categories, sorted. Excludes the `nil` fallback,
-  which is an absence rather than a category.
-  """
-  @spec categories() :: [t()]
-  def categories, do: @labels |> Map.keys() |> Enum.sort()
-
-  @doc """
   The string written to `release_blacklist.failure_reason`.
   """
   @spec slug(t() | nil) :: String.t()
@@ -83,16 +76,28 @@ defmodule Mydia.Downloads.Client.FailureCategory do
 
   With neither a category nor a detail there is nothing to add, so this
   returns the constant used before #237 rather than an emptier sentence.
+
+  When there is a detail but no category — an adapter surfaced a native
+  detail string it couldn't classify — the category label is dropped
+  rather than rendered as the generic "client reported failure", which
+  would read as a redundant "reported client reported failure: ...".
   """
   @spec message(String.t() | nil, t() | nil, String.t() | nil) :: String.t()
   def message(client, category, detail) do
-    if is_nil(category) and blank?(detail) do
-      @default_message
-    else
-      subject = if blank?(client), do: "Download client", else: client
-      base = "#{subject} reported #{label(category)}"
+    subject = if blank?(client), do: "Download client", else: client
 
-      if blank?(detail), do: base, else: "#{base}: #{detail}"
+    cond do
+      is_nil(category) and blank?(detail) ->
+        @default_message
+
+      is_nil(category) ->
+        "#{subject} reported: #{detail}"
+
+      blank?(detail) ->
+        "#{subject} reported #{label(category)}"
+
+      true ->
+        "#{subject} reported #{label(category)}: #{detail}"
     end
   end
 

--- a/lib/mydia/downloads/client/helpers.ex
+++ b/lib/mydia/downloads/client/helpers.ex
@@ -16,6 +16,15 @@ defmodule Mydia.Downloads.Client.Helpers do
   # `FileSizeMB` field (both report mebibytes, not megabytes).
   @bytes_per_mib 1_048_576
 
+  # Query-param keys that *may* carry an operator credential. Lowercased
+  # comparison is used so `Token=` and `TOKEN=` are caught too.
+  @sensitive_url_params ~w(token auth apikey api_key agent _apikey password)
+
+  # Upper bound on a `DownloadStatus.failure_detail`. Provider detail is a
+  # short native token; anything longer is a payload dump that has no
+  # business in a log line, an event, or the database.
+  @failure_detail_max_length 200
+
   @doc """
   Converts a value expressed in mebibytes (MiB) into bytes.
 
@@ -123,6 +132,66 @@ defmodule Mydia.Downloads.Client.Helpers do
   def priority_profile(config) do
     Map.get(config, :priority_profile) || get_in(config, [:options, :priority_profile]) ||
       %{}
+  end
+
+  @doc """
+  Strips credential-bearing query parameters from a URL. Used everywhere a
+  URL might end up in a `Logger` line or an `Error` envelope.
+
+  Returns the URL unchanged if parsing fails (safer to log a half-redacted
+  string than to crash inside an error-handling path).
+  """
+  @spec redact_url(String.t() | nil) :: String.t() | nil
+  def redact_url(nil), do: nil
+
+  def redact_url(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{query: nil} ->
+        url
+
+      %URI{query: query} = uri ->
+        scrubbed =
+          query
+          |> URI.decode_query()
+          |> Enum.map(fn {k, v} ->
+            if String.downcase(k) in @sensitive_url_params do
+              {k, "[REDACTED]"}
+            else
+              {k, v}
+            end
+          end)
+          |> Enum.map_join("&", fn {k, v} ->
+            "#{URI.encode_www_form(k)}=#{URI.encode_www_form(v)}"
+          end)
+
+        URI.to_string(%{uri | query: scrubbed})
+    end
+  rescue
+    _ -> url
+  end
+
+  @doc """
+  Normalises a client-reported failure detail before it reaches a log line,
+  a `download.failed` event, or the database.
+
+  Every adapter routes its detail through here rather than sanitising
+  locally, so a future adapter cannot quietly skip the redaction step.
+  """
+  @spec sanitize_failure_detail(String.t() | nil) :: String.t() | nil
+  def sanitize_failure_detail(nil), do: nil
+
+  def sanitize_failure_detail(detail) when is_binary(detail) do
+    detail
+    |> redact_url()
+    |> truncate_detail()
+  end
+
+  defp truncate_detail(detail) when is_binary(detail) do
+    if String.length(detail) > @failure_detail_max_length do
+      String.slice(detail, 0, @failure_detail_max_length)
+    else
+      detail
+    end
   end
 
   # Floors strings/numbers to a float; defaults unparseable input to 0.0.

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -337,6 +337,8 @@ defmodule Mydia.Downloads.History do
       save_path: torrent_status.save_path,
       completed_at: download.completed_at || torrent_status.completed_at,
       error_message: download.error_message,
+      client_failure_category: torrent_status.failure_category,
+      client_error_detail: torrent_status.failure_detail,
       db_completed_at: download.completed_at,
       imported_at: download.imported_at,
       import_retry_count: download.import_retry_count,

--- a/lib/mydia/downloads/structs/download_status.ex
+++ b/lib/mydia/downloads/structs/download_status.ex
@@ -28,6 +28,8 @@ defmodule Mydia.Downloads.Structs.DownloadStatus do
     * `:unknown` — fallback for unrecognised values
   """
 
+  alias Mydia.Downloads.Client.FailureCategory
+
   @enforce_keys [:id, :name, :state, :progress]
 
   defstruct [
@@ -45,6 +47,11 @@ defmodule Mydia.Downloads.Structs.DownloadStatus do
     :save_path,
     :added_at,
     :completed_at,
+    # Why the client reported a terminal failure, in its own words. Both are
+    # nil unless `state == :error`, and stay nil for adapters that don't yet
+    # classify their failures. See `Mydia.Downloads.Client.FailureCategory`.
+    :failure_category,
+    :failure_detail,
     # Absolute paths of files that belong to THIS torrent/NZB only.
     # When present and non-empty, MediaImport must import these paths
     # instead of recursively listing `save_path` — clients like rqbit
@@ -89,7 +96,9 @@ defmodule Mydia.Downloads.Structs.DownloadStatus do
           save_path: String.t(),
           files: [String.t()] | nil,
           added_at: DateTime.t() | nil,
-          completed_at: DateTime.t() | nil
+          completed_at: DateTime.t() | nil,
+          failure_category: FailureCategory.t() | nil,
+          failure_detail: String.t() | nil
         }
 
   @doc """

--- a/lib/mydia/downloads/structs/enriched_download.ex
+++ b/lib/mydia/downloads/structs/enriched_download.ex
@@ -9,6 +9,8 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
   and represents the current state of a download at any given moment.
   """
 
+  alias Mydia.Downloads.Client.FailureCategory
+
   @enforce_keys [:id, :title, :download_client, :status]
 
   defstruct [
@@ -41,6 +43,13 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
     :save_path,
     :completed_at,
     :error_message,
+    # Client-reported failure detail. Deliberately SEPARATE from
+    # `error_message`, which is bound to the database column: DownloadMonitor
+    # uses `is_nil(error_message)` to find failures it hasn't handled yet
+    # (lib/mydia/jobs/download_monitor.ex:91), so folding client detail into
+    # it would make every failed download look already-handled.
+    :client_failure_category,
+    :client_error_detail,
     :db_completed_at,
     :imported_at,
     # Import retry tracking (displayed in Issues tab)
@@ -100,6 +109,8 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
           save_path: String.t() | nil,
           completed_at: DateTime.t() | nil,
           error_message: String.t() | nil,
+          client_failure_category: FailureCategory.t() | nil,
+          client_error_detail: String.t() | nil,
           db_completed_at: DateTime.t() | nil,
           imported_at: DateTime.t() | nil,
           import_retry_count: integer() | nil,

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -30,6 +30,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   require Logger
   alias Mydia.Downloads
   alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.Client.FailureCategory
   alias Mydia.Downloads.StallDetector
   alias Mydia.Downloads.UntrackedMatcher
   alias Mydia.Events
@@ -277,23 +278,38 @@ defmodule Mydia.Jobs.DownloadMonitor do
   end
 
   defp handle_failure(download_map) do
+    # `error_message` is nil by construction here — the caller's filter only
+    # selects failures we haven't handled yet. The `||` is belt-and-braces
+    # for any future caller.
+    error_msg =
+      download_map.error_message ||
+        FailureCategory.message(
+          download_map.download_client,
+          download_map.client_failure_category,
+          download_map.client_error_detail
+        )
+
     Logger.info("Handling failed download",
       download_id: download_map.id,
       title: download_map.title,
-      error: download_map.error_message
+      failure_category: download_map.client_failure_category,
+      failure_detail: download_map.client_error_detail,
+      error: error_msg
     )
 
     # Get the download struct from database (with media_item preloaded)
     download = Downloads.get_download!(download_map.id, preload: [:media_item])
 
-    error_msg = download_map.error_message || "Download failed in client"
-
-    # Track failure event before deletion
+    # Track failure event before deletion. This metadata is what the activity
+    # feed and the media-item history render, so the composed message is the
+    # operator's only lasting record — the Download row is deleted below.
     Events.download_failed(download, error_msg, media_item: download.media_item)
 
     # Blacklist the release so the next search excludes it (issue #123).
+    # The reason is the provider's own classification when we have one
+    # (issue #237), falling back to the pre-existing generic slug.
     # This MUST NOT block failure handling — wrap in try/rescue and log.
-    record_blacklist_entry(download, "client_reported_failure")
+    record_blacklist_entry(download, FailureCategory.slug(download_map.client_failure_category))
 
     # Delete the download record - downloads table is ephemeral
     case Downloads.delete_download(download) do

--- a/lib/mydia_web/live/admin_release_blacklist_live/index.ex
+++ b/lib/mydia_web/live/admin_release_blacklist_live/index.ex
@@ -16,6 +16,7 @@ defmodule MydiaWeb.AdminReleaseBlacklistLive.Index do
   use MydiaWeb, :live_view
 
   alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.Client.FailureCategory
 
   @page_size 25
 
@@ -141,4 +142,8 @@ defmodule MydiaWeb.AdminReleaseBlacklistLive.Index do
 
   defp total_pages(0, _page_size), do: 1
   defp total_pages(total, page_size), do: max(1, ceil(total / page_size))
+
+  # Slugs are stable identifiers; the operator reads the label. Unknown
+  # slugs (rows written by a newer version) humanize rather than raise.
+  defp reason_label(slug), do: FailureCategory.label(slug)
 end

--- a/lib/mydia_web/live/admin_release_blacklist_live/index.html.heex
+++ b/lib/mydia_web/live/admin_release_blacklist_live/index.html.heex
@@ -26,7 +26,7 @@
             <option value="">All</option>
             <%= for reason <- @failure_reasons do %>
               <option value={reason} selected={reason == @failure_reason_filter}>
-                {reason}
+                {reason_label(reason)}
               </option>
             <% end %>
           </select>
@@ -78,7 +78,9 @@
                   {row.guid}
                 </td>
                 <td>
-                  <span class="badge badge-warning badge-sm">{row.failure_reason}</span>
+                  <span class="badge badge-warning badge-sm" title={row.failure_reason}>
+                    {reason_label(row.failure_reason)}
+                  </span>
                 </td>
                 <td class="text-xs">{format_datetime(row.inserted_at)}</td>
                 <td class="text-xs">

--- a/test/mydia/downloads/client/debrid/providers/all_debrid_test.exs
+++ b/test/mydia/downloads/client/debrid/providers/all_debrid_test.exs
@@ -174,6 +174,89 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.AllDebridTest do
     end
   end
 
+  describe "failure classification" do
+    defp magnet_payload(status_code, status_text) do
+      %{
+        "id" => 99,
+        "filename" => "Some.Release.1080p",
+        "statusCode" => status_code,
+        "status" => status_text,
+        "size" => 100,
+        "downloaded" => 0,
+        "files" => []
+      }
+    end
+
+    defp fetch_magnet(bypass, config, payload) do
+      Bypass.expect(bypass, "POST", "/v4.1/magnet/status", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, success_envelope(%{"magnets" => payload}))
+      end)
+
+      AllDebrid.get_job(config, "99")
+    end
+
+    # Generated one-test-per-code, mirroring the `describe "get_job/2 status
+    # code mapping"` block at line 108 — a loop inside a single test would
+    # stop at the first bad code and hide the rest.
+    for {code, category} <- [
+          {5, :provider_error},
+          {6, :provider_error},
+          {7, :no_peers},
+          {8, :rejected_content},
+          {9, :provider_error},
+          {10, :no_peers},
+          {11, :missing_files}
+        ] do
+      test "statusCode #{code} classifies as #{inspect(category)}",
+           %{bypass: bypass, config: config} do
+        assert {:ok, %ProviderJob{} = job} =
+                 fetch_magnet(bypass, config, magnet_payload(unquote(code), "Some failure"))
+
+        assert job.state == :error
+        assert job.failure_category == unquote(category)
+      end
+    end
+
+    test "prefers the payload's status text as the detail",
+         %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} =
+               fetch_magnet(bypass, config, magnet_payload(7, "Not downloaded in 20 min"))
+
+      assert job.failure_detail == "Not downloaded in 20 min"
+    end
+
+    test "falls back to the numeric code when no status text is present",
+         %{bypass: bypass, config: config} do
+      payload = magnet_payload(9, nil) |> Map.delete("status")
+
+      assert {:ok, %ProviderJob{} = job} = fetch_magnet(bypass, config, payload)
+
+      assert job.failure_detail == "statusCode 9"
+    end
+
+    test "an undocumented code stays terminal but unclassified",
+         %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} =
+               fetch_magnet(bypass, config, magnet_payload(12, "Something new"))
+
+      assert job.state == :error
+      assert job.failure_category == nil
+      assert job.failure_detail == "Something new"
+    end
+
+    test "a healthy magnet carries no failure fields",
+         %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} =
+               fetch_magnet(bypass, config, magnet_payload(1, "Downloading"))
+
+      assert job.state == :downloading
+      assert job.failure_category == nil
+      assert job.failure_detail == nil
+    end
+  end
+
   describe "list_jobs/2" do
     test "empty input returns empty map", %{config: config} do
       assert {:ok, %{}} = AllDebrid.list_jobs(config, [])

--- a/test/mydia/downloads/client/debrid/providers/premiumize_test.exs
+++ b/test/mydia/downloads/client/debrid/providers/premiumize_test.exs
@@ -172,6 +172,20 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.PremiumizeTest do
       assert job.failure_category == nil
       assert job.failure_detail == nil
     end
+
+    test "redacts credentials leaking through the free-text message", %{
+      bypass: bypass,
+      config: config
+    } do
+      assert {:ok, %ProviderJob{} = job} =
+               fetch_transfer(bypass, config, %{
+                 "status" => "error",
+                 "message" => "failed https://cdn.example.com/f?token=SECRET"
+               })
+
+      assert job.failure_category == :provider_error
+      refute job.failure_detail =~ "SECRET"
+    end
   end
 
   describe "list_jobs/2" do

--- a/test/mydia/downloads/client/debrid/providers/premiumize_test.exs
+++ b/test/mydia/downloads/client/debrid/providers/premiumize_test.exs
@@ -121,6 +121,59 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.PremiumizeTest do
     end
   end
 
+  describe "failure classification" do
+    defp fetch_transfer(bypass, config, overrides) do
+      transfer =
+        Map.merge(
+          %{
+            "id" => "t1",
+            "name" => "Some.Release.1080p",
+            "progress" => 0.0,
+            "size" => 100
+          },
+          overrides
+        )
+
+      Bypass.expect(bypass, "GET", "/transfer/list", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, success(%{"transfers" => [transfer]}))
+      end)
+
+      Premiumize.get_job(config, "t1")
+    end
+
+    test "an error transfer classifies as :provider_error with its message",
+         %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} =
+               fetch_transfer(bypass, config, %{
+                 "status" => "error",
+                 "message" => "torrent not available"
+               })
+
+      assert job.state == :error
+      assert job.failure_category == :provider_error
+      assert job.failure_detail == "torrent not available"
+    end
+
+    test "falls back to the status string when there is no message",
+         %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} =
+               fetch_transfer(bypass, config, %{"status" => "error"})
+
+      assert job.failure_category == :provider_error
+      assert job.failure_detail == "error"
+    end
+
+    test "a running transfer carries no failure fields", %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} =
+               fetch_transfer(bypass, config, %{"status" => "running"})
+
+      assert job.failure_category == nil
+      assert job.failure_detail == nil
+    end
+  end
+
   describe "list_jobs/2" do
     test "filters to requested ids", %{bypass: bypass, config: config} do
       Bypass.expect(bypass, "GET", "/transfer/list", fn conn ->

--- a/test/mydia/downloads/client/debrid/providers/real_debrid_test.exs
+++ b/test/mydia/downloads/client/debrid/providers/real_debrid_test.exs
@@ -245,6 +245,54 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.RealDebridTest do
     end
   end
 
+  describe "failure classification" do
+    defp fetch_info(bypass, config, status) do
+      Bypass.expect(bypass, "GET", "/torrents/info/RD123", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{
+            "id" => "RD123",
+            "filename" => "Some.Release.1080p",
+            "status" => status,
+            "progress" => 0.0,
+            "bytes" => 1_000_000,
+            "files" => [],
+            "links" => []
+          })
+        )
+      end)
+
+      RealDebrid.get_job(config, "RD123")
+    end
+
+    # One generated test per status, so a single bad mapping doesn't mask
+    # the others.
+    for {status, category} <- [
+          {"dead", :no_peers},
+          {"virus", :rejected_content},
+          {"magnet_error", :rejected_content},
+          {"error", :provider_error}
+        ] do
+      test "status #{status} classifies as #{inspect(category)}",
+           %{bypass: bypass, config: config} do
+        assert {:ok, %ProviderJob{} = job} = fetch_info(bypass, config, unquote(status))
+
+        assert job.state == :error
+        assert job.failure_category == unquote(category)
+        assert job.failure_detail == unquote(status)
+      end
+    end
+
+    test "a healthy torrent carries no failure fields", %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} = fetch_info(bypass, config, "downloading")
+
+      assert job.failure_category == nil
+      assert job.failure_detail == nil
+    end
+  end
+
   describe "get_download_urls/2" do
     test "issues N /unrestrict/link calls and returns URLs in order", %{
       bypass: bypass,

--- a/test/mydia/downloads/client/debrid/providers/tor_box_test.exs
+++ b/test/mydia/downloads/client/debrid/providers/tor_box_test.exs
@@ -186,6 +186,63 @@ defmodule Mydia.Downloads.Client.Debrid.Providers.TorBoxTest do
     end
   end
 
+  describe "failure classification" do
+    defp failure_payload(download_state) do
+      %{
+        "id" => 7,
+        "name" => "Some.Release.1080p",
+        "download_state" => download_state,
+        "download_finished" => false,
+        "download_present" => false,
+        "progress" => 0.0,
+        "size" => 100,
+        "files" => []
+      }
+    end
+
+    defp fetch_job(bypass, config, download_state) do
+      Bypass.expect(bypass, "GET", "/torrents/mylist", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, success(failure_payload(download_state)))
+      end)
+
+      TorBox.get_job(config, "7")
+    end
+
+    test "missingFiles classifies as :missing_files", %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} = fetch_job(bypass, config, "missingFiles")
+
+      assert job.state == :error
+      assert job.failure_category == :missing_files
+      assert job.failure_detail == "missingFiles"
+    end
+
+    test "error classifies as :provider_error", %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} = fetch_job(bypass, config, "error")
+
+      assert job.state == :error
+      assert job.failure_category == :provider_error
+      assert job.failure_detail == "error"
+    end
+
+    test "a non-terminal state carries no failure fields", %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} = fetch_job(bypass, config, "downloading")
+
+      assert job.state == :downloading
+      assert job.failure_category == nil
+      assert job.failure_detail == nil
+    end
+
+    test "stalled (no seeds) stays non-terminal and unclassified (PR #221)",
+         %{bypass: bypass, config: config} do
+      assert {:ok, %ProviderJob{} = job} = fetch_job(bypass, config, "stalled (no seeds)")
+
+      assert job.state == :downloading
+      assert job.failure_category == nil
+    end
+  end
+
   describe "get_download_urls/2 (descriptors)" do
     test "returns tokenless descriptors with provider/torrent_id/file_id", %{config: config} do
       job = %ProviderJob{

--- a/test/mydia/downloads/client/debrid/shared_test.exs
+++ b/test/mydia/downloads/client/debrid/shared_test.exs
@@ -272,6 +272,36 @@ defmodule Mydia.Downloads.Client.Debrid.SharedTest do
       assert status.state == :queued
       refute status.save_path
     end
+
+    test "carries failure category and detail through the :error clause" do
+      status =
+        Shared.synthesize_status(
+          job(:error, %{failure_category: :missing_files, failure_detail: "missingFiles"}),
+          :not_started,
+          nil
+        )
+
+      assert status.state == :error
+      assert status.failure_category == :missing_files
+      assert status.failure_detail == "missingFiles"
+    end
+
+    test "leaves failure fields nil on an unclassified error" do
+      status = Shared.synthesize_status(job(:error), :not_started, nil)
+
+      assert status.state == :error
+      assert status.failure_category == nil
+      assert status.failure_detail == nil
+    end
+
+    test "never sets failure fields on a non-error state" do
+      for state <- [:queued, :downloading, :finalizing, :ready] do
+        status = Shared.synthesize_status(job(state), :not_started, nil)
+
+        assert status.failure_category == nil, "#{state} leaked a failure_category"
+        assert status.failure_detail == nil, "#{state} leaked a failure_detail"
+      end
+    end
   end
 
   describe "map_error/2" do

--- a/test/mydia/downloads/client/debrid/shared_test.exs
+++ b/test/mydia/downloads/client/debrid/shared_test.exs
@@ -296,7 +296,10 @@ defmodule Mydia.Downloads.Client.Debrid.SharedTest do
 
     test "never sets failure fields on a non-error state" do
       for state <- [:queued, :downloading, :finalizing, :ready] do
-        status = Shared.synthesize_status(job(state), :not_started, nil)
+        leaky =
+          job(state, %{failure_category: :missing_files, failure_detail: "missingFiles"})
+
+        status = Shared.synthesize_status(leaky, :not_started, nil)
 
         assert status.failure_category == nil, "#{state} leaked a failure_category"
         assert status.failure_detail == nil, "#{state} leaked a failure_detail"

--- a/test/mydia/downloads/client/failure_category_test.exs
+++ b/test/mydia/downloads/client/failure_category_test.exs
@@ -1,0 +1,74 @@
+defmodule Mydia.Downloads.Client.FailureCategoryTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.Client.FailureCategory
+
+  describe "categories/0" do
+    test "lists the four real categories, excluding the nil fallback" do
+      assert FailureCategory.categories() == [
+               :missing_files,
+               :no_peers,
+               :provider_error,
+               :rejected_content
+             ]
+    end
+  end
+
+  describe "slug/1" do
+    test "nil maps to the pre-existing fallback slug" do
+      assert FailureCategory.slug(nil) == "client_reported_failure"
+    end
+
+    test "each category stringifies to its own slug" do
+      assert FailureCategory.slug(:no_peers) == "no_peers"
+      assert FailureCategory.slug(:missing_files) == "missing_files"
+      assert FailureCategory.slug(:rejected_content) == "rejected_content"
+      assert FailureCategory.slug(:provider_error) == "provider_error"
+    end
+  end
+
+  describe "label/1" do
+    test "humanizes a category atom" do
+      assert FailureCategory.label(:missing_files) == "missing files"
+      assert FailureCategory.label(:no_peers) == "no peers"
+    end
+
+    test "humanizes the fallback slug read back from the database" do
+      assert FailureCategory.label("client_reported_failure") == "client reported failure"
+    end
+
+    test "humanizes an unknown legacy slug rather than raising" do
+      assert FailureCategory.label("some_legacy_value") == "some legacy value"
+    end
+
+    test "nil is treated as the fallback" do
+      assert FailureCategory.label(nil) == "client reported failure"
+    end
+  end
+
+  describe "message/3" do
+    test "composes client, label and native detail" do
+      assert FailureCategory.message("torbox", :missing_files, "missingFiles") ==
+               "torbox reported missing files: missingFiles"
+    end
+
+    test "falls back to the pre-existing constant when there is nothing to say" do
+      assert FailureCategory.message("qbittorrent", nil, nil) == "Download failed in client"
+    end
+
+    test "omits the detail suffix when only a category is known" do
+      assert FailureCategory.message("premiumize", :provider_error, nil) ==
+               "premiumize reported provider error"
+    end
+
+    test "substitutes a generic subject when the client name is missing" do
+      assert FailureCategory.message(nil, :no_peers, "dead") ==
+               "Download client reported no peers: dead"
+    end
+
+    test "treats a blank detail as absent" do
+      assert FailureCategory.message("torbox", :provider_error, "   ") ==
+               "torbox reported provider error"
+    end
+  end
+end

--- a/test/mydia/downloads/client/failure_category_test.exs
+++ b/test/mydia/downloads/client/failure_category_test.exs
@@ -3,17 +3,6 @@ defmodule Mydia.Downloads.Client.FailureCategoryTest do
 
   alias Mydia.Downloads.Client.FailureCategory
 
-  describe "categories/0" do
-    test "lists the four real categories, excluding the nil fallback" do
-      assert FailureCategory.categories() == [
-               :missing_files,
-               :no_peers,
-               :provider_error,
-               :rejected_content
-             ]
-    end
-  end
-
   describe "slug/1" do
     test "nil maps to the pre-existing fallback slug" do
       assert FailureCategory.slug(nil) == "client_reported_failure"
@@ -69,6 +58,20 @@ defmodule Mydia.Downloads.Client.FailureCategoryTest do
     test "treats a blank detail as absent" do
       assert FailureCategory.message("torbox", :provider_error, "   ") ==
                "torbox reported provider error"
+    end
+
+    # This is the shape AllDebrid actually produces for undocumented
+    # `statusCode >= 12` values: no category, but a native status text
+    # worth surfacing. The category label must not appear, or the
+    # sentence reads as the redundant "reported client reported failure".
+    test "drops the redundant label when there is a detail but no category" do
+      assert FailureCategory.message("my-debrid", nil, "Something new") ==
+               "my-debrid reported: Something new"
+    end
+
+    test "substitutes a generic subject when client is blank, with a detail but no category" do
+      assert FailureCategory.message(nil, nil, "Something new") ==
+               "Download client reported: Something new"
     end
   end
 end

--- a/test/mydia/downloads/client/helpers_test.exs
+++ b/test/mydia/downloads/client/helpers_test.exs
@@ -1,0 +1,46 @@
+defmodule Mydia.Downloads.Client.HelpersTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.Client.Helpers
+
+  describe "redact_url/1" do
+    test "strips credential-bearing query params" do
+      redacted = Helpers.redact_url("https://example.com/f?token=ABC&safe=keep")
+
+      refute redacted =~ "ABC"
+      assert redacted =~ "safe=keep"
+    end
+
+    test "returns nil for nil" do
+      assert Helpers.redact_url(nil) == nil
+    end
+  end
+
+  describe "sanitize_failure_detail/1" do
+    test "passes an ordinary provider token through untouched" do
+      assert Helpers.sanitize_failure_detail("missingFiles") == "missingFiles"
+    end
+
+    test "redacts a credential that leaked into the detail" do
+      detail = Helpers.sanitize_failure_detail("https://cdn.example.com/x?token=SECRET")
+
+      refute detail =~ "SECRET"
+    end
+
+    test "truncates to 200 characters" do
+      detail = Helpers.sanitize_failure_detail(String.duplicate("a", 500))
+
+      assert String.length(detail) == 200
+    end
+
+    test "leaves a detail of exactly 200 characters alone" do
+      input = String.duplicate("b", 200)
+
+      assert Helpers.sanitize_failure_detail(input) == input
+    end
+
+    test "returns nil for nil" do
+      assert Helpers.sanitize_failure_detail(nil) == nil
+    end
+  end
+end

--- a/test/mydia/downloads/history_failure_detail_test.exs
+++ b/test/mydia/downloads/history_failure_detail_test.exs
@@ -1,0 +1,61 @@
+defmodule Mydia.Downloads.HistoryFailureDetailTest do
+  @moduledoc """
+  Guards the field separation that #237 depends on: `error_message` stays
+  bound to the database column, while client-reported failure detail
+  travels in its own fields.
+
+  `DownloadMonitor` selects unhandled failures with `is_nil(error_message)`
+  (lib/mydia/jobs/download_monitor.ex:91). If client detail ever leaks into
+  `error_message`, every failed download looks already-handled and stops
+  being processed — silently. That is what the last test here prevents.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.Structs.EnrichedDownload
+
+  describe "EnrichedDownload failure fields" do
+    test "carries a client failure category and detail" do
+      enriched =
+        EnrichedDownload.new(%{
+          id: "d-1",
+          title: "Some.Release",
+          download_client: "torbox",
+          status: "failed",
+          client_failure_category: :missing_files,
+          client_error_detail: "missingFiles"
+        })
+
+      assert enriched.client_failure_category == :missing_files
+      assert enriched.client_error_detail == "missingFiles"
+    end
+
+    test "error_message stays nil when only client detail is present" do
+      enriched =
+        EnrichedDownload.new(%{
+          id: "d-2",
+          title: "Some.Release",
+          download_client: "torbox",
+          status: "failed",
+          client_failure_category: :no_peers,
+          client_error_detail: "dead"
+        })
+
+      # If this ever fails, the DownloadMonitor unhandled-failure guard is
+      # broken and failed downloads will stop being blacklisted at all.
+      assert enriched.error_message == nil
+    end
+
+    test "defaults both fields to nil for clients that do not classify" do
+      enriched =
+        EnrichedDownload.new(%{
+          id: "d-3",
+          title: "Some.Release",
+          download_client: "qbittorrent",
+          status: "failed"
+        })
+
+      assert enriched.client_failure_category == nil
+      assert enriched.client_error_detail == nil
+    end
+  end
+end

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1204,6 +1204,20 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       assert [row] = Blacklists.list(failure_reason: "missing_files")
       assert row.guid == "guid-1"
       assert row.indexer == "prowlarr"
+
+      # The composed operator message is what the activity feed and the
+      # media-item history render (Events.download_failed/3 stores it under
+      # metadata["error_message"] — see lib/mydia/events.ex:593). Assert on
+      # all three ingredients so a transposed argument or a dropped client
+      # name in the FailureCategory.message/3 call would fail this test.
+      Process.sleep(100)
+
+      assert [event] = Events.list_events(type: "download.failed")
+      message = event.metadata["error_message"]
+
+      assert message =~ "my-debrid"
+      assert message =~ "missing files"
+      assert message =~ "missingFiles"
     end
 
     test "an unclassified failure still uses the pre-existing fallback slug" do

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1208,16 +1208,16 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       # The composed operator message is what the activity feed and the
       # media-item history render (Events.download_failed/3 stores it under
       # metadata["error_message"] — see lib/mydia/events.ex:593). Assert on
-      # all three ingredients so a transposed argument or a dropped client
-      # name in the FailureCategory.message/3 call would fail this test.
+      # the exact composed sentence, not just substring membership, so a
+      # transposed argument at the FailureCategory.message/3 call site
+      # (e.g. swapping client and detail) would fail this test even though
+      # each individual value still appears somewhere in the string.
       Process.sleep(100)
 
       assert [event] = Events.list_events(type: "download.failed")
       message = event.metadata["error_message"]
 
-      assert message =~ "my-debrid"
-      assert message =~ "missing files"
-      assert message =~ "missingFiles"
+      assert message == "my-debrid reported missing files: missingFiles"
     end
 
     test "an unclassified failure still uses the pre-existing fallback slug" do

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1123,6 +1123,190 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
     end
   end
 
+  describe "handle_failure/1 with a classified debrid failure" do
+    setup do
+      alias Mydia.Downloads.Client.Debrid.StubProvider
+
+      StubProvider.ensure_started!()
+      StubProvider.reset()
+      on_exit(fn -> StubProvider.reset() end)
+
+      ensure_started!(
+        {Registry, [keys: :unique, name: Mydia.Downloads.Client.Debrid.FetcherRegistry]}
+      )
+
+      ensure_started!(
+        {DynamicSupervisor,
+         [name: Mydia.Downloads.Client.Debrid.FetcherSupervisor, strategy: :one_for_one]}
+      )
+
+      ensure_started!(Mydia.Downloads.Client.Debrid.RateLimiter)
+
+      prior = Application.get_env(:mydia, :debrid_provider_overrides, %{})
+
+      Application.put_env(:mydia, :debrid_provider_overrides, %{
+        "tor_box" => StubProvider
+      })
+
+      on_exit(fn -> Application.put_env(:mydia, :debrid_provider_overrides, prior) end)
+
+      :ok
+    end
+
+    test "blacklists under the category slug and records the native detail" do
+      alias Mydia.Downloads.Blacklists
+      alias Mydia.Downloads.Client.Debrid.{ProviderJob, StubProvider}
+
+      setup_runtime_config([
+        build_test_client_config(%{
+          name: "my-debrid",
+          type: :debrid,
+          api_key: "tb-key",
+          connection_settings: %{"provider" => "tor_box"}
+        })
+      ])
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "my-debrid",
+          download_client_id: "job-1",
+          indexer: "prowlarr",
+          metadata: %{"guid" => "guid-1"}
+        })
+
+      StubProvider.set(
+        :list_jobs,
+        {:ok,
+         %{
+           "job-1" => %ProviderJob{
+             provider_id: "job-1",
+             state: :error,
+             progress: 0.0,
+             name: "Some.Release.1080p",
+             total_bytes: 1000,
+             files: [],
+             hoster_links: [],
+             raw_status: %{},
+             failure_category: :missing_files,
+             failure_detail: "missingFiles"
+           }
+         }}
+      )
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      # The download row is ephemeral and deleted on failure.
+      assert_raise Ecto.NoResultsError, fn -> Downloads.get_download!(download.id) end
+
+      assert [row] = Blacklists.list(failure_reason: "missing_files")
+      assert row.guid == "guid-1"
+      assert row.indexer == "prowlarr"
+    end
+
+    test "an unclassified failure still uses the pre-existing fallback slug" do
+      alias Mydia.Downloads.Blacklists
+      alias Mydia.Downloads.Client.Debrid.{ProviderJob, StubProvider}
+
+      setup_runtime_config([
+        build_test_client_config(%{
+          name: "my-debrid",
+          type: :debrid,
+          api_key: "tb-key",
+          connection_settings: %{"provider" => "tor_box"}
+        })
+      ])
+
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "my-debrid",
+        download_client_id: "job-2",
+        indexer: "prowlarr",
+        metadata: %{"guid" => "guid-2"}
+      })
+
+      StubProvider.set(
+        :list_jobs,
+        {:ok,
+         %{
+           "job-2" => %ProviderJob{
+             provider_id: "job-2",
+             state: :error,
+             progress: 0.0,
+             name: "Other.Release.1080p",
+             total_bytes: 1000,
+             files: [],
+             hoster_links: [],
+             raw_status: %{},
+             failure_category: nil,
+             failure_detail: nil
+           }
+         }}
+      )
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      assert [row] = Blacklists.list(failure_reason: "client_reported_failure")
+      assert row.guid == "guid-2"
+    end
+
+    test "client failure detail does not leak into error_message during enrichment" do
+      # Guards DownloadMonitor's unhandled-failure filter (download_monitor.ex:91).
+      # If error_message ever falls back to client detail, failed downloads look
+      # already-handled and stop being processed entirely — silently.
+      alias Mydia.Downloads.Client.Debrid.{ProviderJob, StubProvider}
+
+      setup_runtime_config([
+        build_test_client_config(%{
+          name: "my-debrid",
+          type: :debrid,
+          api_key: "tb-key",
+          connection_settings: %{"provider" => "tor_box"}
+        })
+      ])
+
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "my-debrid",
+        download_client_id: "job-3",
+        indexer: "prowlarr",
+        metadata: %{"guid" => "guid-3"}
+      })
+
+      StubProvider.set(
+        :list_jobs,
+        {:ok,
+         %{
+           "job-3" => %ProviderJob{
+             provider_id: "job-3",
+             state: :error,
+             progress: 0.0,
+             name: "Some.Release.1080p",
+             total_bytes: 1000,
+             files: [],
+             hoster_links: [],
+             raw_status: %{},
+             failure_category: :missing_files,
+             failure_detail: "missingFiles"
+           }
+         }}
+      )
+
+      assert [enriched] = Downloads.list_downloads_with_status(filter: :all)
+
+      assert enriched.status == "failed"
+      assert enriched.error_message == nil
+      assert enriched.client_failure_category == :missing_files
+      assert enriched.client_error_detail == "missingFiles"
+    end
+  end
+
   # Acceptance examples carried from the stall-resilience plan. AE1 (outage
   # recovery) and AE3 (genuine soft-stall) are additionally exercised by the
   # "stall detection" describe block and AE7 below; here we lock the multi-poll
@@ -1367,6 +1551,14 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
   end
 
   ## Helper Functions
+
+  defp ensure_started!(child_spec) do
+    case start_supervised(child_spec) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      {:error, :already_started} -> :ok
+    end
+  end
 
   defp occupying_ids do
     Download.occupying() |> Repo.all() |> Enum.map(& &1.id)

--- a/test/mydia_web/live/admin_release_blacklist_live_test.exs
+++ b/test/mydia_web/live/admin_release_blacklist_live_test.exs
@@ -122,4 +122,39 @@ defmodule MydiaWeb.AdminReleaseBlacklistLiveTest do
       assert has_element?(view, "#blacklist-row-#{row_stalled.id}")
     end
   end
+
+  describe "failure reason rendering" do
+    setup %{conn: conn, token: token} do
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      %{conn: conn}
+    end
+
+    test "renders a humanized label in the badge, keeping the slug as a tooltip",
+         %{conn: conn} do
+      Blacklists.add("prowlarr", "guid-1", "Some.Release", "missing_files")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/release-blacklist")
+
+      assert has_element?(view, "#blacklist-rows span[title='missing_files']", "missing files")
+    end
+
+    test "keeps the filter option value as the raw slug", %{conn: conn} do
+      # The option VALUE must stay the slug so the phx-change filter still
+      # matches stored rows; only the visible text is humanized.
+      Blacklists.add("prowlarr", "guid-2", "Other.Release", "client_reported_failure")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/release-blacklist")
+
+      assert has_element?(
+               view,
+               "#failure-reason-filter option[value='client_reported_failure']",
+               "client reported failure"
+             )
+    end
+  end
 end


### PR DESCRIPTION
Closes #237.

## Problem

When a debrid provider hard-fails a job, the provider already tells us why — TorBox's `download_state`, AllDebrid's `statusCode`, Real-Debrid's `status`, Premiumize's transfer `message`. None of it reached the operator. `DownloadMonitor` saw a generic `"failed"`, deleted the queue row, and blacklisted the release as `client_reported_failure` with no indication of the cause.

The structural reason: `DownloadStatus` had no field for failure detail at all, so a provider had nowhere to put it even if it extracted one. `client_reported_failure` was the only blacklist reason produced anywhere in the codebase.

## What changed

A small vocabulary (`Mydia.Downloads.Client.FailureCategory`) with four categories plus the pre-existing fallback:

| Category | Meaning |
|---|---|
| `no_peers` | Nothing to download from — swarm dead or timed out |
| `missing_files` | Provider had it, then didn't |
| `rejected_content` | Provider refused it — virus, bad magnet, over size limit |
| `provider_error` | The provider's own infrastructure broke; the release may be fine |
| `client_reported_failure` | Unmapped — the existing slug, unchanged |

Each provider classifies its own terminal states, and the category plus a short native detail string travel on `ProviderJob` → `DownloadStatus` → `EnrichedDownload` to `DownloadMonitor`, which writes the category as the blacklist reason and composes the operator-facing message.

Per-provider mapping, from each API's documented terminal states:

- **TorBox** — `missingFiles` → `missing_files`; `error` → `provider_error`. (`stalled (no seeds)` stays `:downloading` per #221 and is covered by a regression test.)
- **AllDebrid** — codes 5/6/9 → `provider_error`; 7/10 → `no_peers`; 8 → `rejected_content`; 11 → `missing_files`. Codes ≥12 are undocumented, so they stay terminal but carry no guessed category.
- **Real-Debrid** — `dead` → `no_peers`; `virus`/`magnet_error` → `rejected_content`; `error` → `provider_error`.
- **Premiumize** — one terminal status, so everything is `provider_error`; the transfer's `message` carries the detail.

## Where it shows up

The activity feed and the media-item history already render `metadata["error_message"]` from the `download.failed` event, so both improve with no UI changes — a TorBox failure now reads `my-debrid reported missing files: missingFiles` instead of `Download failed in client`. The admin blacklist page renders humanized labels with the raw slug kept in a `title` attribute; option *values* stay slugs so existing rows remain filterable.

## Notes for review

**No behavior change to blacklisting.** Categories are diagnostic only. Every hard failure still blacklists with the same default TTL — `Blacklists.add/5` is called at the same arity with no TTL options. A future change can make TTL or skip decisions a pure function of the category without re-plumbing.

**No migration.** `failure_reason` was already a free string column. Existing `client_reported_failure` rows stay valid and filterable.

**Backward compatible.** Non-debrid clients and unmapped provider states produce byte-identical output to master: the slug `client_reported_failure` and the message `Download failed in client` are both preserved verbatim.

**One load-bearing invariant.** `DownloadMonitor` selects unhandled failures with `is_nil(error_message)`, so `EnrichedDownload.error_message` stays bound to the DB column alone and the client detail travels in separate fields. Folding it in would make every failed download look already-handled and silently stop blacklisting entirely. There's a dedicated test driving the real enrichment path to pin this.

**Security.** Provider payloads carry credentialed CDN URLs (TorBox `files`, Real-Debrid `links`), so each provider extracts one short native token rather than the payload, and all details route through a shared sanitizer that redacts credential-bearing query params and truncates to 200 chars. `redact_url/1` moved from the debrid-specific `Shared` down to the adapter-agnostic `Client.Helpers` (with a `defdelegate` preserving the old call sites) so the next adapter can reach it. A Premiumize test proves a credential in its free-text `message` doesn't survive.

## Known limitation

Premiumize exposes a single terminal status, so its failures can only ever be `provider_error` — filtering by "no peers" under-reports for that provider. Its native message still carries the truth in the detail. Not fixable without a finer signal from the provider.

## Verification

- 964 tests across the affected surface (`test/mydia/downloads/`, download monitor, blacklist admin): 0 failures.
- `mix precommit` — compile, `deps.unlock --unused`, `format --check-formatted`, `credo --strict` all pass.
- Full suite: 5401 tests, 4 failures — all 4 in `MydiaWeb.DownloadsLive.PathMappingIssueTest`, verified pre-existing by running that file on the clean merge base `eebd5cb8` via detached checkout (same 4 failures, same names). Unrelated to this branch.
