### PR TITLE
feat(ui): show a movie's franchise on its detail page

### DIFF
--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -648,6 +648,34 @@ defmodule Mydia.Media do
     end)
   end
 
+  @doc """
+  Returns library status for a specific set of TMDB movie ids.
+
+  Same value shape as `get_library_status_map/0`, but scoped to the ids asked
+  for. Use this when checking a handful of ids (a franchise's members, say)
+  rather than loading the whole library.
+
+  Movies only. A TV row that happens to share a TMDB id with a movie is not a
+  match for a franchise member.
+
+  ## Examples
+
+      iex> library_status_for_tmdb_ids([671, 672])
+      %{671 => %{in_library: true, monitored: true, type: "movie", id: "..."}}
+  """
+  @spec library_status_for_tmdb_ids([integer()]) :: map()
+  def library_status_for_tmdb_ids([]), do: %{}
+
+  def library_status_for_tmdb_ids(tmdb_ids) when is_list(tmdb_ids) do
+    MediaItem
+    |> where([m], m.type == "movie" and m.tmdb_id in ^tmdb_ids)
+    |> select([m], {m.tmdb_id, m.monitored, m.type, m.id})
+    |> Repo.all()
+    |> Map.new(fn {tmdb_id, monitored, type, id} ->
+      {tmdb_id, %{in_library: true, monitored: monitored, type: type, id: id}}
+    end)
+  end
+
   ## Episodes
 
   @doc """

--- a/lib/mydia/media/franchise.ex
+++ b/lib/mydia/media/franchise.ex
@@ -1,0 +1,21 @@
+defmodule Mydia.Media.Franchise do
+  @moduledoc """
+  A movie's franchise, as shown on its detail page.
+
+  Named "franchise" rather than "collection" so it does not collide with
+  `Mydia.Collections`, which means user-curated lists. The provider-shape
+  equivalent is `Mydia.Metadata.Structs.Collection`.
+  """
+
+  alias Mydia.Media.FranchiseEntry
+
+  @enforce_keys [:name, :entries, :owned_count, :total_count]
+  defstruct [:name, :entries, :owned_count, :total_count]
+
+  @type t :: %__MODULE__{
+          name: String.t() | nil,
+          entries: [FranchiseEntry.t()],
+          owned_count: non_neg_integer(),
+          total_count: non_neg_integer()
+        }
+end

--- a/lib/mydia/media/franchise_entry.ex
+++ b/lib/mydia/media/franchise_entry.ex
@@ -1,0 +1,31 @@
+defmodule Mydia.Media.FranchiseEntry do
+  @moduledoc """
+  One movie in a franchise, joined against the library.
+
+  `release_date` is carried alongside `year` because entries are ordered by full
+  date, not by year alone.
+  """
+
+  @enforce_keys [:tmdb_id]
+  defstruct [
+    :tmdb_id,
+    :title,
+    :year,
+    :release_date,
+    :poster_path,
+    :media_item_id,
+    in_library?: false,
+    current?: false
+  ]
+
+  @type t :: %__MODULE__{
+          tmdb_id: integer(),
+          title: String.t() | nil,
+          year: integer() | nil,
+          release_date: Date.t() | nil,
+          poster_path: String.t() | nil,
+          media_item_id: binary() | nil,
+          in_library?: boolean(),
+          current?: boolean()
+        }
+end

--- a/lib/mydia/media/franchises.ex
+++ b/lib/mydia/media/franchises.ex
@@ -60,8 +60,10 @@ defmodule Mydia.Media.Franchises do
       {:ok, _no_franchise} ->
         :none
 
-      # A relay that predates this endpoint is the normal state today; nothing
-      # to warn about.
+      # This is the long-standing movie-details endpoint, not the new collections
+      # one: a 404 means TMDB has no movie under this id, which is a stale or
+      # wrong tmdb_id on the row rather than anything to alarm the operator
+      # about. There is no franchise to show either way.
       {:error, %Error{type: :not_found}} ->
         :none
 

--- a/lib/mydia/media/franchises.ex
+++ b/lib/mydia/media/franchises.ex
@@ -1,0 +1,169 @@
+defmodule Mydia.Media.Franchises do
+  @moduledoc """
+  Resolves a movie's TMDB collection (franchise) and joins it against the library.
+
+  The franchise pointer stored on a movie's metadata is treated as a cache, never
+  as the source of truth: when it is absent, a cached movie-details fetch supplies
+  it and the value is written back. That makes the feature work on libraries whose
+  movies were added before the pointer existed, without a migration or a backfill
+  job.
+
+  Every failure — an old relay, an unreachable relay, a movie with no franchise —
+  returns `:none`, so the caller has exactly one thing to check.
+  """
+
+  require Logger
+
+  import Ecto.Query, warn: false
+
+  alias Mydia.{Media, Metadata, Repo}
+  alias Mydia.Media.{Franchise, FranchiseEntry, MediaItem}
+
+  @doc """
+  Returns the franchise for a movie, or `:none`.
+
+  `config` is the relay configuration; it defaults to
+  `Metadata.default_relay_config/0` and exists so tests can inject a stub without
+  touching global environment.
+  """
+  @spec for_media_item(MediaItem.t(), map() | nil) :: {:ok, Franchise.t()} | :none
+  def for_media_item(media_item, config \\ nil)
+
+  def for_media_item(%MediaItem{type: "movie", tmdb_id: tmdb_id} = item, config)
+      when is_integer(tmdb_id) do
+    config = config || Metadata.default_relay_config()
+
+    with {:ok, collection_id} <- resolve_collection_id(item, config),
+         {:ok, collection} <- fetch_collection(collection_id, config) do
+      build(collection, item)
+    else
+      :none -> :none
+    end
+  end
+
+  def for_media_item(_media_item, _config), do: :none
+
+  ## Pointer resolution
+
+  defp resolve_collection_id(%MediaItem{metadata: %{collection_id: id}}, _config)
+       when is_integer(id),
+       do: {:ok, id}
+
+  defp resolve_collection_id(%MediaItem{tmdb_id: tmdb_id} = item, config) do
+    case Metadata.fetch_by_id_cached(config, to_string(tmdb_id), media_type: :movie) do
+      {:ok, %{collection_id: id} = fresh} when is_integer(id) ->
+        persist_pointer(item, fresh)
+        {:ok, id}
+
+      {:ok, _no_franchise} ->
+        :none
+
+      {:error, reason} ->
+        Logger.warning("Franchise pointer lookup failed for tmdb #{tmdb_id}: #{inspect(reason)}")
+
+        :none
+    end
+  end
+
+  # Writes the pointer back with a bare changeset rather than
+  # Media.update_media_item/3, which emits a timeline event on every call. This
+  # runs on page views; it must stay silent.
+  defp persist_pointer(%MediaItem{metadata: nil}, _fresh), do: :ok
+
+  defp persist_pointer(%MediaItem{} = item, fresh) do
+    updated = %{
+      item.metadata
+      | collection_id: fresh.collection_id,
+        collection_name: fresh.collection_name
+    }
+
+    item
+    |> MediaItem.changeset(%{metadata: updated})
+    |> Repo.update()
+    |> case do
+      {:ok, _} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.warning("Could not persist franchise pointer: #{inspect(changeset.errors)}")
+        :ok
+    end
+  end
+
+  ## Parts
+
+  defp fetch_collection(collection_id, config) do
+    case Metadata.fetch_collection_cached(config, collection_id) do
+      {:ok, collection} ->
+        {:ok, collection}
+
+      {:error, reason} ->
+        Logger.warning(
+          "Franchise lookup failed for collection #{collection_id}: #{inspect(reason)}"
+        )
+
+        :none
+    end
+  end
+
+  ## Assembly
+
+  defp build(collection, %MediaItem{} = item) do
+    entries =
+      collection.parts
+      |> Enum.map(&to_entry/1)
+      |> Enum.reject(&is_nil/1)
+
+    # A franchise of one is the movie you are already looking at.
+    if length(entries) < 2 do
+      :none
+    else
+      status = Media.library_status_for_tmdb_ids(Enum.map(entries, & &1.tmdb_id))
+
+      entries =
+        entries
+        |> Enum.map(&decorate(&1, status, item))
+        |> Enum.sort(&by_release_date/2)
+
+      {:ok,
+       %Franchise{
+         name: collection.name,
+         entries: entries,
+         owned_count: Enum.count(entries, & &1.in_library?),
+         total_count: length(entries)
+       }}
+    end
+  end
+
+  defp to_entry(part) do
+    case Integer.parse(part.provider_id || "") do
+      {tmdb_id, ""} ->
+        %FranchiseEntry{
+          tmdb_id: tmdb_id,
+          title: part.title,
+          year: part.release_date && part.release_date.year,
+          release_date: part.release_date,
+          poster_path: part.poster_path
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  defp decorate(entry, status, %MediaItem{tmdb_id: current_tmdb_id}) do
+    entry = %{entry | current?: entry.tmdb_id == current_tmdb_id}
+
+    case Map.get(status, entry.tmdb_id) do
+      %{id: media_item_id} -> %{entry | in_library?: true, media_item_id: media_item_id}
+      nil -> entry
+    end
+  end
+
+  # Date structs compare as maps under the default term order (:calendar, :day,
+  # :month, :year), which is not chronological. Date.compare/2 is required.
+  defp by_release_date(%{release_date: nil}, %{release_date: nil}), do: true
+  defp by_release_date(%{release_date: nil}, _b), do: false
+  defp by_release_date(_a, %{release_date: nil}), do: true
+  defp by_release_date(a, b), do: Date.compare(a.release_date, b.release_date) != :gt
+end

--- a/lib/mydia/media/franchises.ex
+++ b/lib/mydia/media/franchises.ex
@@ -8,16 +8,18 @@ defmodule Mydia.Media.Franchises do
   movies were added before the pointer existed, without a migration or a backfill
   job.
 
-  Every failure — an old relay, an unreachable relay, a movie with no franchise —
-  returns `:none`, so the caller has exactly one thing to check.
+  Every failure, whether the relay predates the endpoint, is unreachable, or the
+  movie simply has no franchise, returns `:none`, so the caller has exactly one
+  thing to check. A relay that predates the endpoint is the normal, expected
+  state of the world right now and stays quiet in the logs; anything else that
+  goes wrong is logged as a warning.
   """
 
   require Logger
 
-  import Ecto.Query, warn: false
-
   alias Mydia.{Media, Metadata, Repo}
   alias Mydia.Media.{Franchise, FranchiseEntry, MediaItem}
+  alias Mydia.Metadata.Provider.Error
 
   @doc """
   Returns the franchise for a movie, or `:none`.
@@ -58,6 +60,11 @@ defmodule Mydia.Media.Franchises do
       {:ok, _no_franchise} ->
         :none
 
+      # A relay that predates this endpoint is the normal state today; nothing
+      # to warn about.
+      {:error, %Error{type: :not_found}} ->
+        :none
+
       {:error, reason} ->
         Logger.warning("Franchise pointer lookup failed for tmdb #{tmdb_id}: #{inspect(reason)}")
 
@@ -96,6 +103,11 @@ defmodule Mydia.Media.Franchises do
     case Metadata.fetch_collection_cached(config, collection_id) do
       {:ok, collection} ->
         {:ok, collection}
+
+      # A relay that predates this endpoint is the normal state today; nothing
+      # to warn about.
+      {:error, %Error{type: :not_found}} ->
+        :none
 
       {:error, reason} ->
         Logger.warning(

--- a/lib/mydia/media/metadata_type.ex
+++ b/lib/mydia/media/metadata_type.ex
@@ -127,6 +127,8 @@ defmodule Mydia.Media.MetadataType do
       videos: parse_videos_list(data[:videos]),
       origin_country: data[:origin_country],
       original_language: data[:original_language],
+      collection_id: data[:collection_id],
+      collection_name: data[:collection_name],
       number_of_seasons: data[:number_of_seasons],
       number_of_episodes: data[:number_of_episodes],
       episode_run_time: data[:episode_run_time],

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -245,18 +245,25 @@ defmodule Mydia.Metadata do
   `fetch_by_id_cached/3` — a non-English library must not read English-cached
   titles.
 
+  Relay-only, unlike its provider-agnostic siblings above: a TMDB collection has
+  no equivalent in the other registered provider types (`:music_relay`,
+  `:open_library`), so those are rejected with an `:invalid_config` error rather
+  than routed to the relay adapter under a cache key that names a provider which
+  never served the response.
+
   ## Examples
 
       iex> Mydia.Metadata.fetch_collection_cached(config, 1241)
       {:ok, %Mydia.Metadata.Structs.Collection{name: "Harry Potter Collection", ...}}
   """
-  def fetch_collection_cached(%{type: type} = config, collection_id, opts \\ [])
-      when is_atom(type) do
+  def fetch_collection_cached(config, collection_id, opts \\ [])
+
+  def fetch_collection_cached(%{type: :metadata_relay} = config, collection_id, opts) do
     alias Mydia.Metadata.Cache
     alias Mydia.Metadata.Provider.Relay
 
     language = Keyword.get(opts, :language, config_language(config))
-    cache_key = "collection:#{type}:#{collection_id}:#{language}"
+    cache_key = "collection:metadata_relay:#{collection_id}:#{language}"
 
     Cache.fetch(
       cache_key,
@@ -265,6 +272,13 @@ defmodule Mydia.Metadata do
       end,
       ttl: :timer.hours(24)
     )
+  end
+
+  def fetch_collection_cached(%{type: type}, _collection_id, _opts) when is_atom(type) do
+    {:error,
+     Provider.Error.invalid_config(
+       "Collections are only available through the metadata relay, got: #{inspect(type)}"
+     )}
   end
 
   @doc """

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -236,6 +236,38 @@ defmodule Mydia.Metadata do
   end
 
   @doc """
+  Fetches a movie collection (franchise) with its member movies, cached in ETS.
+
+  Cached for 24 hours: franchises gain a member every few years, and the page
+  that reads this is opened often.
+
+  The language is part of the cache key for the same reason it is in
+  `fetch_by_id_cached/3` — a non-English library must not read English-cached
+  titles.
+
+  ## Examples
+
+      iex> Mydia.Metadata.fetch_collection_cached(config, 1241)
+      {:ok, %Mydia.Metadata.Structs.Collection{name: "Harry Potter Collection", ...}}
+  """
+  def fetch_collection_cached(%{type: type} = config, collection_id, opts \\ [])
+      when is_atom(type) do
+    alias Mydia.Metadata.Cache
+    alias Mydia.Metadata.Provider.Relay
+
+    language = Keyword.get(opts, :language, config_language(config))
+    cache_key = "collection:#{type}:#{collection_id}:#{language}"
+
+    Cache.fetch(
+      cache_key,
+      fn ->
+        Relay.fetch_collection(config, collection_id, opts)
+      end,
+      ttl: :timer.hours(24)
+    )
+  end
+
+  @doc """
   Fetches images for a specific media item.
 
   ## Parameters

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -74,7 +74,8 @@ defmodule Mydia.Metadata.Provider.Relay do
     SearchResult,
     MediaMetadata,
     SeasonData,
-    ImagesResponse
+    ImagesResponse,
+    Collection
   }
 
   @default_language "en-US"
@@ -798,6 +799,42 @@ defmodule Mydia.Metadata.Provider.Relay do
 
       {:ok, %{status: status, body: body}} ->
         {:error, Error.api_error("Discover failed with status #{status}", %{body: body})}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @doc """
+  Fetches a TMDB movie collection (franchise) and its member movies.
+
+  Not a `Mydia.Metadata.Provider` callback: TVDB has no equivalent concept, so
+  this stays specific to the relay adapter.
+
+  A relay deployment that predates this endpoint answers 404, which surfaces as
+  `{:error, %Error{type: :not_found}}` and is treated by callers as "no franchise
+  data available".
+
+  Returns `{:ok, %Collection{}}`.
+  """
+  def fetch_collection(config, collection_id, opts \\ []) do
+    language = resolve_language(config, opts)
+    endpoint = "/tmdb/collections/#{collection_id}"
+
+    req = HTTP.new_request(config)
+
+    case HTTP.get(req, endpoint, params: [language: language]) do
+      {:ok, %{status: 200, body: body}} when is_map(body) ->
+        {:ok, Collection.from_api_response(body)}
+
+      {:ok, %{status: 200, body: _}} ->
+        {:error, Error.api_error("Collection response was not an object")}
+
+      {:ok, %{status: 404}} ->
+        {:error, Error.not_found("Collection not found: #{collection_id}")}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, Error.api_error("Fetch collection failed with status #{status}", %{body: body})}
 
       {:error, error} ->
         {:error, error}

--- a/lib/mydia/metadata/structs/collection.ex
+++ b/lib/mydia/metadata/structs/collection.ex
@@ -1,0 +1,43 @@
+defmodule Mydia.Metadata.Structs.Collection do
+  @moduledoc """
+  A TMDB movie collection: the franchise a movie belongs to, plus its members.
+
+  Named for the provider's vocabulary, matching its siblings in this directory.
+  The library-facing view model is `Mydia.Media.Franchise`, which is deliberately
+  named differently so it does not collide with `Mydia.Collections` (user-curated
+  lists).
+  """
+
+  alias Mydia.Metadata.Structs.CollectionPart
+
+  @enforce_keys [:provider_id]
+  defstruct [:provider_id, :name, :overview, :poster_path, :backdrop_path, parts: []]
+
+  @type t :: %__MODULE__{
+          provider_id: String.t(),
+          name: String.t() | nil,
+          overview: String.t() | nil,
+          poster_path: String.t() | nil,
+          backdrop_path: String.t() | nil,
+          parts: [CollectionPart.t()]
+        }
+
+  @doc """
+  Creates a Collection from a raw TMDB `/collection/{id}` response.
+  """
+  def from_api_response(data) when is_map(data) do
+    %__MODULE__{
+      provider_id: to_string(data["id"]),
+      name: data["name"],
+      overview: data["overview"],
+      poster_path: data["poster_path"],
+      backdrop_path: data["backdrop_path"],
+      parts: parse_parts(data["parts"])
+    }
+  end
+
+  defp parse_parts(parts) when is_list(parts),
+    do: Enum.map(parts, &CollectionPart.from_api_response/1)
+
+  defp parse_parts(_), do: []
+end

--- a/lib/mydia/metadata/structs/collection_part.ex
+++ b/lib/mydia/metadata/structs/collection_part.ex
@@ -1,0 +1,56 @@
+defmodule Mydia.Metadata.Structs.CollectionPart do
+  @moduledoc """
+  One member movie of a TMDB collection (franchise).
+
+  This is the trimmed shape TMDB returns inside a collection's `parts` list. It
+  is not full movie metadata; fetch `MediaMetadata` by id for that.
+  """
+
+  @enforce_keys [:provider_id]
+  defstruct [
+    :provider_id,
+    :title,
+    :original_title,
+    :overview,
+    :release_date,
+    :poster_path,
+    :backdrop_path,
+    :vote_average
+  ]
+
+  @type t :: %__MODULE__{
+          provider_id: String.t(),
+          title: String.t() | nil,
+          original_title: String.t() | nil,
+          overview: String.t() | nil,
+          release_date: Date.t() | nil,
+          poster_path: String.t() | nil,
+          backdrop_path: String.t() | nil,
+          vote_average: float() | nil
+        }
+
+  @doc """
+  Creates a CollectionPart from a raw entry in a TMDB collection's `parts` list.
+  """
+  def from_api_response(data) when is_map(data) do
+    %__MODULE__{
+      provider_id: to_string(data["id"]),
+      title: data["title"] || data["name"],
+      original_title: data["original_title"],
+      overview: data["overview"],
+      release_date: parse_date(data["release_date"]),
+      poster_path: data["poster_path"],
+      backdrop_path: data["backdrop_path"],
+      vote_average: data["vote_average"]
+    }
+  end
+
+  defp parse_date(date_string) when is_binary(date_string) do
+    case Date.from_iso8601(date_string) do
+      {:ok, date} -> date
+      _ -> nil
+    end
+  end
+
+  defp parse_date(_), do: nil
+end

--- a/lib/mydia/metadata/structs/media_metadata.ex
+++ b/lib/mydia/metadata/structs/media_metadata.ex
@@ -44,6 +44,9 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
     # Classification fields (for category auto-detection)
     :origin_country,
     :original_language,
+    # Franchise membership (movies only; TMDB never sends this for TV)
+    :collection_id,
+    :collection_name,
     # TV show specific fields
     :number_of_seasons,
     :number_of_episodes,
@@ -84,6 +87,8 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
           videos: [Video.t()] | nil,
           origin_country: [String.t()] | nil,
           original_language: String.t() | nil,
+          collection_id: integer() | nil,
+          collection_name: String.t() | nil,
           number_of_seasons: integer() | nil,
           number_of_episodes: integer() | nil,
           episode_run_time: [integer()] | nil,
@@ -105,6 +110,7 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
     title = get_title(data, media_type)
     year = extract_year(data, media_type)
     release_date = parse_date(get_release_date(data, media_type))
+    {collection_id, collection_name} = parse_collection(data["belongs_to_collection"])
 
     base_metadata = %__MODULE__{
       id: data["id"],
@@ -135,7 +141,9 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
       alternative_titles: parse_alternative_titles(data["alternative_titles"]),
       videos: parse_videos(data["videos"]),
       origin_country: parse_origin_country(data["origin_country"]),
-      original_language: data["original_language"]
+      original_language: data["original_language"],
+      collection_id: collection_id,
+      collection_name: collection_name
     }
 
     case media_type do
@@ -243,6 +251,13 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
   defp parse_origin_country(nil), do: []
   defp parse_origin_country(countries) when is_list(countries), do: countries
   defp parse_origin_country(_), do: []
+
+  # TMDB nests franchise membership under "belongs_to_collection" on movie
+  # details. The key is absent for TV and null for standalone movies.
+  defp parse_collection(%{"id" => id, "name" => name}) when is_integer(id),
+    do: {id, name}
+
+  defp parse_collection(_), do: {nil, nil}
 
   defp parse_cast(nil), do: []
 

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -47,7 +47,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       Recorded for TV shows only; movies always leave it nil.
     * `:monitored` - Monitored flag for the new item (default: `true`)
     * `:quality_profile_id` - Quality profile to assign. Omitted from the attrs
-      entirely when nil, so `Media.create_media_item/2` applies its own default.
+      entirely when nil.
 
   If neither id is given, falls back to parsing `metadata.provider_id` as tmdb_id.
   """

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -45,6 +45,9 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
     * `:tvdb_id` - Explicit TVDB ID to use
     * `:metadata_source` - Provenance to stamp (`:tvdb` | `:tmdb` | `nil`).
       Recorded for TV shows only; movies always leave it nil.
+    * `:monitored` - Monitored flag for the new item (default: `true`)
+    * `:quality_profile_id` - Quality profile to assign. Omitted from the attrs
+      entirely when nil, so `Media.create_media_item/2` applies its own default.
 
   If neither id is given, falls back to parsing `metadata.provider_id` as tmdb_id.
   """
@@ -71,8 +74,10 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       tvdb_id: tvdb_id,
       imdb_id: metadata.imdb_id,
       metadata: metadata,
-      monitored: true
+      monitored: Keyword.get(opts, :monitored, true)
     }
+
+    attrs = maybe_put_quality_profile(attrs, opts[:quality_profile_id])
 
     # Record provenance for TV shows only; movies leave metadata_source nil.
     if media_type == :movie do
@@ -81,6 +86,9 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       Map.put(attrs, :metadata_source, opts[:metadata_source])
     end
   end
+
+  defp maybe_put_quality_profile(attrs, nil), do: attrs
+  defp maybe_put_quality_profile(attrs, id), do: Map.put(attrs, :quality_profile_id, id)
 
   @doc """
   Looks up TVDB ID for a TV show by searching TVDB by title+year.
@@ -120,8 +128,18 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
   An optional `config` (relay config map) can be injected for testing; it
   defaults to `Metadata.default_relay_config()`.
+
+  `opts` are forwarded to `build_media_item_attrs/3`; `:monitored` and
+  `:quality_profile_id` let a caller inherit settings from an item the user is
+  already looking at. TV shows ignore them today.
   """
-  def handle_add_media_to_library(provider_id, media_type, library_status_map, config \\ nil) do
+  def handle_add_media_to_library(
+        provider_id,
+        media_type,
+        library_status_map,
+        config \\ nil,
+        opts \\ []
+      ) do
     provider_id_int = parse_provider_id(provider_id)
     config = config || Metadata.default_relay_config()
 
@@ -129,7 +147,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       if media_type == :tv_show do
         add_tv_show_to_library(provider_id, provider_id_int, config)
       else
-        add_movie_to_library(provider_id, provider_id_int, config)
+        add_movie_to_library(provider_id, provider_id_int, config, opts)
       end
 
     case result do
@@ -192,10 +210,15 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
   # Private helpers
 
-  defp add_movie_to_library(provider_id, provider_id_int, config) do
+  defp add_movie_to_library(provider_id, provider_id_int, config, opts) do
     case Metadata.fetch_by_id(config, provider_id, media_type: :movie, provider: :tmdb) do
       {:ok, metadata} ->
-        attrs = build_media_item_attrs(metadata, :movie, tmdb_id: provider_id_int)
+        attrs =
+          build_media_item_attrs(
+            metadata,
+            :movie,
+            Keyword.put(opts, :tmdb_id, provider_id_int)
+          )
 
         case Media.create_media_item(attrs) do
           {:ok, media_item} -> {:ok, media_item}

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -4,6 +4,7 @@ defmodule MydiaWeb.MediaLive.Show do
   alias Mydia.Settings
   alias MydiaWeb.MediaLive.Show.Modals
   alias MydiaWeb.MediaLive.Show.Components
+  alias MydiaWeb.MediaLive.Show.FranchiseComponents
   alias MydiaWeb.MediaLive.Show.EpisodeEvents
   alias MydiaWeb.MediaLive.Show.DownloadEvents
   alias MydiaWeb.MediaLive.Show.MediaItemEvents
@@ -12,6 +13,7 @@ defmodule MydiaWeb.MediaLive.Show do
   alias MydiaWeb.MediaLive.Show.SubtitleEvents
   alias MydiaWeb.MediaLive.Show.FileEvents
   alias MydiaWeb.MediaLive.Show.SearchEvents
+  alias MydiaWeb.MediaLive.Show.FranchiseEvents
 
   # Import helper modules
   import MydiaWeb.MediaLive.Show.Formatters
@@ -130,6 +132,14 @@ defmodule MydiaWeb.MediaLive.Show do
      # Feature flags
      |> assign(:playback_enabled, playback_enabled?())
      |> assign(:subtitle_feature_enabled, subtitle_feature_enabled?())
+     # Franchise section state
+     |> assign(:franchise, nil)
+     |> assign(:adding_franchise_tmdb_id, nil)
+     |> assign(:metadata_config, Mydia.Metadata.default_relay_config())
+     |> assign(
+       :can_create_media,
+       Mydia.Accounts.Authorization.can_create_media?(socket.assigns.current_user)
+     )
      |> assign(:raw_search_results, [])
      # Category modal state
      |> assign(:show_category_modal, false)
@@ -139,6 +149,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:show_trailer_modal, false)
      # Collection state
      |> CollectionEvents.load_collection_data(media_item)
+     |> FranchiseEvents.maybe_load()
      |> stream_configure(:search_results, dom_id: &generate_positioned_id/1)
      |> stream(:search_results, [])}
   end
@@ -363,6 +374,11 @@ defmodule MydiaWeb.MediaLive.Show do
   def handle_event("remove_from_collection", params, socket),
     do: CollectionEvents.remove_from_collection(params, socket)
 
+  # Franchise events
+
+  def handle_event("add_franchise_movie", params, socket),
+    do: FranchiseEvents.add_franchise_movie(params, socket)
+
   @impl true
   def handle_info({:download_created, download}, socket) do
     if download_for_media?(download, socket.assigns.media_item) do
@@ -554,6 +570,12 @@ defmodule MydiaWeb.MediaLive.Show do
 
   def handle_async(:download_subtitle, result, socket),
     do: SubtitleEvents.handle_download_subtitle_async(result, socket)
+
+  def handle_async(:load_franchise, result, socket),
+    do: FranchiseEvents.handle_load_result(result, socket)
+
+  def handle_async(:add_franchise_movie, result, socket),
+    do: FranchiseEvents.handle_add_result(result, socket)
 
   # Private helpers
 

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -134,8 +134,8 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:subtitle_feature_enabled, subtitle_feature_enabled?())
      # Franchise section state
      |> assign(:franchise, nil)
-     |> assign(:adding_franchise_tmdb_id, nil)
-     |> assign(:metadata_config, Mydia.Metadata.default_relay_config())
+     |> assign(:adding_franchise_tmdb_ids, MapSet.new())
+     |> assign_new(:metadata_config, fn -> Mydia.Metadata.default_relay_config() end)
      |> assign(
        :can_create_media,
        Mydia.Accounts.Authorization.can_create_media?(socket.assigns.current_user)
@@ -574,8 +574,8 @@ defmodule MydiaWeb.MediaLive.Show do
   def handle_async(:load_franchise, result, socket),
     do: FranchiseEvents.handle_load_result(result, socket)
 
-  def handle_async(:add_franchise_movie, result, socket),
-    do: FranchiseEvents.handle_add_result(result, socket)
+  def handle_async({:add_franchise_movie, tmdb_id}, result, socket),
+    do: FranchiseEvents.handle_add_result(tmdb_id, result, socket)
 
   # Private helpers
 

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -162,7 +162,7 @@
             :if={@franchise}
             franchise={@franchise}
             can_add={@can_create_media}
-            adding_tmdb_id={@adding_franchise_tmdb_id}
+            adding_tmdb_ids={@adding_franchise_tmdb_ids}
           />
           <%!-- Episodes Section (TV Shows Only) --%>
           <Components.episodes_section

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -157,6 +157,13 @@
           <% end %>
           <%!-- Overview Section --%>
           <Components.overview_section media_item={@media_item} />
+          <%!-- Franchise Section (Movies in the same TMDB collection) --%>
+          <FranchiseComponents.franchise_section
+            :if={@franchise}
+            franchise={@franchise}
+            can_add={@can_create_media}
+            adding_tmdb_id={@adding_franchise_tmdb_id}
+          />
           <%!-- Episodes Section (TV Shows Only) --%>
           <Components.episodes_section
             media_item={@media_item}

--- a/lib/mydia_web/live/media_live/show/franchise_components.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_components.ex
@@ -1,0 +1,157 @@
+defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
+  @moduledoc """
+  The franchise strip on a movie's detail page: every movie in the same TMDB
+  collection, marked owned or missing.
+  """
+  use MydiaWeb, :html
+
+  alias Mydia.Metadata.ImageUrl
+
+  @doc """
+  Renders the franchise strip.
+
+  The heading is the franchise's own name. TMDB already suffixes these with
+  "Collection", so no generic label is added; that also keeps the section from
+  reading as one of the user's own collections.
+  """
+  attr :franchise, :map, required: true
+  attr :can_add, :boolean, required: true
+  attr :adding_tmdb_id, :integer, default: nil
+
+  def franchise_section(assigns) do
+    ~H"""
+    <div id="franchise-section" class="mb-6 md:mb-8">
+      <div class="flex items-center justify-between gap-3 mb-3">
+        <h2 class="text-lg md:text-xl font-semibold truncate">{@franchise.name}</h2>
+        <span class={[
+          "badge badge-sm flex-shrink-0",
+          if(@franchise.owned_count == @franchise.total_count,
+            do: "badge-success",
+            else: "badge-ghost"
+          )
+        ]}>
+          {@franchise.owned_count} of {@franchise.total_count}
+        </span>
+      </div>
+
+      <div class="flex gap-3 overflow-x-auto snap-x scroll-smooth pb-2">
+        <.franchise_entry
+          :for={entry <- @franchise.entries}
+          entry={entry}
+          can_add={@can_add}
+          adding={@adding_tmdb_id == entry.tmdb_id}
+        />
+      </div>
+    </div>
+    """
+  end
+
+  attr :entry, :map, required: true
+  attr :can_add, :boolean, required: true
+  attr :adding, :boolean, default: false
+
+  defp franchise_entry(%{entry: %{current?: true}} = assigns) do
+    ~H"""
+    <div id={"franchise-entry-#{@entry.tmdb_id}"} class="snap-start flex-shrink-0 w-28">
+      <div class="rounded-lg overflow-hidden ring-2 ring-primary">
+        <.entry_poster entry={@entry} />
+      </div>
+      <.entry_caption entry={@entry} />
+    </div>
+    """
+  end
+
+  defp franchise_entry(%{entry: %{in_library?: true}} = assigns) do
+    ~H"""
+    <.link
+      id={"franchise-entry-#{@entry.tmdb_id}"}
+      navigate={~p"/media/#{@entry.media_item_id}"}
+      class="snap-start flex-shrink-0 w-28 group"
+    >
+      <div class="rounded-lg overflow-hidden transition duration-200 group-hover:ring-2 group-hover:ring-primary">
+        <.entry_poster entry={@entry} />
+      </div>
+      <.entry_caption entry={@entry} />
+    </.link>
+    """
+  end
+
+  defp franchise_entry(%{can_add: true} = assigns) do
+    ~H"""
+    <button
+      type="button"
+      id={"franchise-entry-#{@entry.tmdb_id}"}
+      phx-click="add_franchise_movie"
+      phx-value-tmdb_id={@entry.tmdb_id}
+      disabled={@adding}
+      title={"Add #{@entry.title} to your library"}
+      class="snap-start flex-shrink-0 w-28 group text-left"
+    >
+      <div class="relative rounded-lg overflow-hidden">
+        <.entry_poster
+          entry={@entry}
+          class="grayscale opacity-50 transition duration-200 group-hover:opacity-75"
+        />
+        <div class="absolute inset-0 flex items-center justify-center">
+          <span :if={@adding} class="loading loading-spinner loading-md text-primary"></span>
+          <.icon
+            :if={!@adding}
+            name="hero-plus-circle-solid"
+            class="w-8 h-8 text-primary opacity-0 transition duration-200 group-hover:opacity-100"
+          />
+        </div>
+      </div>
+      <.entry_caption entry={@entry} />
+    </button>
+    """
+  end
+
+  defp franchise_entry(assigns) do
+    ~H"""
+    <div id={"franchise-entry-#{@entry.tmdb_id}"} class="snap-start flex-shrink-0 w-28">
+      <div class="rounded-lg overflow-hidden">
+        <.entry_poster entry={@entry} class="grayscale opacity-50" />
+      </div>
+      <.entry_caption entry={@entry} />
+    </div>
+    """
+  end
+
+  attr :entry, :map, required: true
+  attr :class, :string, default: nil
+
+  defp entry_poster(%{entry: %{poster_path: nil}} = assigns) do
+    ~H"""
+    <div class={[
+      "aspect-[2/3] w-full bg-base-300 flex items-center justify-center",
+      @class
+    ]}>
+      <.icon name="hero-film" class="w-8 h-8 text-base-content/30" />
+    </div>
+    """
+  end
+
+  defp entry_poster(assigns) do
+    assigns = assign(assigns, :url, ImageUrl.poster_url(assigns.entry.poster_path, "w185"))
+
+    ~H"""
+    <img
+      src={@url}
+      alt={@entry.title}
+      loading="lazy"
+      class={["aspect-[2/3] w-full object-cover", @class]}
+    />
+    """
+  end
+
+  attr :entry, :map, required: true
+
+  defp entry_caption(assigns) do
+    ~H"""
+    <div class="mt-1.5">
+      <p class="text-xs font-medium leading-tight line-clamp-2">{@entry.title}</p>
+      <p :if={@entry.year} class="text-xs text-base-content/60">{@entry.year}</p>
+    </div>
+    """
+  end
+end

--- a/lib/mydia_web/live/media_live/show/franchise_components.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_components.ex
@@ -16,7 +16,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
   """
   attr :franchise, :map, required: true
   attr :can_add, :boolean, required: true
-  attr :adding_tmdb_id, :integer, default: nil
+  attr :adding_tmdb_ids, MapSet, required: true
 
   def franchise_section(assigns) do
     ~H"""
@@ -39,7 +39,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
           :for={entry <- @franchise.entries}
           entry={entry}
           can_add={@can_add}
-          adding={@adding_tmdb_id == entry.tmdb_id}
+          adding={MapSet.member?(@adding_tmdb_ids, entry.tmdb_id)}
         />
       </div>
     </div>

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -1,0 +1,145 @@
+defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
+  @moduledoc false
+
+  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.LiveView, only: [start_async: 3, put_flash: 3, connected?: 1]
+
+  alias Mydia.Media.Franchises
+  alias MydiaWeb.Live.Helpers.MediaAddHelpers
+
+  require Logger
+
+  @doc """
+  Starts the franchise lookup for movies on the connected mount.
+
+  A no-op on the dead render (the lookup makes an HTTP call and the dead render
+  must not pay for it) and for anything that is not a movie with a TMDB id.
+  """
+  def maybe_load(socket) do
+    media_item = socket.assigns.media_item
+    config = socket.assigns.metadata_config
+
+    if connected?(socket) && media_item.type == "movie" && is_integer(media_item.tmdb_id) do
+      start_async(socket, :load_franchise, fn ->
+        Franchises.for_media_item(media_item, config)
+      end)
+    else
+      socket
+    end
+  end
+
+  def handle_load_result({:ok, {:ok, franchise}}, socket) do
+    {:noreply, assign(socket, :franchise, franchise)}
+  end
+
+  def handle_load_result({:ok, :none}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_load_result({:exit, reason}, socket) do
+    Logger.warning("Franchise lookup crashed: #{inspect(reason)}")
+    {:noreply, socket}
+  end
+
+  @doc """
+  Adds a missing franchise member, inheriting the viewed movie's quality profile
+  and monitored flag.
+
+  Permission is enforced against the `:can_create_media` assign computed once at
+  mount, mirroring what already governs whether the add button renders at all;
+  a crafted request against a hidden button still gets refused here.
+  """
+  def add_franchise_movie(%{"tmdb_id" => tmdb_id}, socket) do
+    if socket.assigns.can_create_media do
+      start_add(tmdb_id, socket)
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp start_add(tmdb_id, socket) do
+    case Integer.parse(tmdb_id) do
+      {tmdb_id, ""} ->
+        media_item = socket.assigns.media_item
+        config = socket.assigns.metadata_config
+
+        socket =
+          socket
+          |> assign(:adding_franchise_tmdb_id, tmdb_id)
+          |> start_async(:add_franchise_movie, fn ->
+            perform_add(media_item, tmdb_id, config)
+          end)
+
+        {:noreply, socket}
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  @doc """
+  Performs the add. Public so it can be exercised directly in tests without a
+  live process.
+  """
+  def perform_add(media_item, tmdb_id, config) do
+    MediaAddHelpers.handle_add_media_to_library(
+      to_string(tmdb_id),
+      :movie,
+      %{},
+      config,
+      monitored: media_item.monitored,
+      quality_profile_id: media_item.quality_profile_id
+    )
+    |> case do
+      {:ok, added, _status_map} -> {:ok, added}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def handle_add_result({:ok, {:ok, added}}, socket) do
+    {:noreply,
+     socket
+     |> assign(:adding_franchise_tmdb_id, nil)
+     |> assign(:franchise, mark_owned(socket.assigns.franchise, added))
+     |> put_flash(:info, "Added #{added.title} to your library")}
+  end
+
+  def handle_add_result({:ok, {:error, reason}}, socket) do
+    {:noreply,
+     socket
+     |> assign(:adding_franchise_tmdb_id, nil)
+     |> put_flash(:error, "Could not add that movie: #{describe(reason)}")}
+  end
+
+  def handle_add_result({:exit, reason}, socket) do
+    Logger.warning("Franchise add crashed: #{inspect(reason)}")
+
+    {:noreply,
+     socket
+     |> assign(:adding_franchise_tmdb_id, nil)
+     |> put_flash(:error, "Could not add that movie")}
+  end
+
+  ## Private
+
+  defp mark_owned(nil, _added), do: nil
+
+  defp mark_owned(franchise, added) do
+    entries =
+      Enum.map(franchise.entries, fn entry ->
+        if entry.tmdb_id == added.tmdb_id do
+          %{entry | in_library?: true, media_item_id: added.id}
+        else
+          entry
+        end
+      end)
+
+    %{franchise | entries: entries, owned_count: Enum.count(entries, & &1.in_library?)}
+  end
+
+  defp describe({:changeset, changeset}),
+    do: MediaAddHelpers.format_changeset_errors(changeset)
+
+  defp describe({:metadata, reason}), do: "metadata lookup failed (#{inspect(reason)})"
+  defp describe(reason), do: inspect(reason)
+end

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -42,9 +42,23 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
     {:noreply, socket}
   end
 
+  # Defensive: an unmatched shape would otherwise raise in the LiveView process,
+  # and the client would reconnect, re-mount and crash again, taking the whole
+  # movie page down for a section that is meant to be silently absent when the
+  # lookup does not work out.
+  def handle_load_result(other, socket) do
+    Logger.warning("Franchise lookup returned an unexpected result: #{inspect(other)}")
+    {:noreply, socket}
+  end
+
   @doc """
   Adds a missing franchise member, inheriting the viewed movie's quality profile
   and monitored flag.
+
+  Adds are keyed per TMDB id so several can be in flight at once: a franchise is
+  usually missing more than one entry, and `start_async/3` overwrites rather than
+  cancels a task under an existing key, which would silently drop the first
+  result.
   """
   def add_franchise_movie(%{"tmdb_id" => tmdb_id}, socket) do
     with :ok <- Authorization.authorize_create_media(socket) do
@@ -56,21 +70,29 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
 
   defp start_add(tmdb_id, socket) do
     case Integer.parse(tmdb_id) do
-      {tmdb_id, ""} ->
-        media_item = socket.assigns.media_item
-        config = socket.assigns.metadata_config
+      {tmdb_id, ""} -> dispatch_add(tmdb_id, socket)
+      _ -> {:noreply, socket}
+    end
+  end
 
-        socket =
-          socket
-          |> assign(:adding_franchise_tmdb_id, tmdb_id)
-          |> start_async(:add_franchise_movie, fn ->
-            perform_add(media_item, tmdb_id, config)
-          end)
+  # An impatient double-click sends the event twice. The second add would hit the
+  # tmdb_id unique index and flash a failure for a row the first add just
+  # created, so a repeat for an id already in flight is dropped.
+  defp dispatch_add(tmdb_id, socket) do
+    if MapSet.member?(socket.assigns.adding_franchise_tmdb_ids, tmdb_id) do
+      {:noreply, socket}
+    else
+      media_item = socket.assigns.media_item
+      config = socket.assigns.metadata_config
 
-        {:noreply, socket}
+      socket =
+        socket
+        |> mark_in_flight(tmdb_id)
+        |> start_async({:add_franchise_movie, tmdb_id}, fn ->
+          perform_add(media_item, tmdb_id, config)
+        end)
 
-      _ ->
-        {:noreply, socket}
+      {:noreply, socket}
     end
   end
 
@@ -93,31 +115,49 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
     end
   end
 
-  def handle_add_result({:ok, {:ok, added}}, socket) do
+  def handle_add_result(tmdb_id, {:ok, {:ok, added}}, socket) do
     {:noreply,
      socket
-     |> assign(:adding_franchise_tmdb_id, nil)
+     |> clear_in_flight(tmdb_id)
      |> assign(:franchise, mark_owned(socket.assigns.franchise, added))
      |> put_flash(:info, "Added #{added.title} to your library")}
   end
 
-  def handle_add_result({:ok, {:error, reason}}, socket) do
+  def handle_add_result(tmdb_id, {:ok, {:error, reason}}, socket) do
+    Logger.warning("Franchise add failed for tmdb #{tmdb_id}: #{inspect(reason)}")
+
     {:noreply,
      socket
-     |> assign(:adding_franchise_tmdb_id, nil)
+     |> clear_in_flight(tmdb_id)
      |> put_flash(:error, "Could not add that movie: #{describe(reason)}")}
   end
 
-  def handle_add_result({:exit, reason}, socket) do
+  def handle_add_result(tmdb_id, {:exit, reason}, socket) do
     Logger.warning("Franchise add crashed: #{inspect(reason)}")
 
     {:noreply,
      socket
-     |> assign(:adding_franchise_tmdb_id, nil)
+     |> clear_in_flight(tmdb_id)
      |> put_flash(:error, "Could not add that movie")}
   end
 
   ## Private
+
+  defp mark_in_flight(socket, tmdb_id) do
+    assign(
+      socket,
+      :adding_franchise_tmdb_ids,
+      MapSet.put(socket.assigns.adding_franchise_tmdb_ids, tmdb_id)
+    )
+  end
+
+  defp clear_in_flight(socket, tmdb_id) do
+    assign(
+      socket,
+      :adding_franchise_tmdb_ids,
+      MapSet.delete(socket.assigns.adding_franchise_tmdb_ids, tmdb_id)
+    )
+  end
 
   defp mark_owned(nil, _added), do: nil
 
@@ -137,6 +177,6 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   defp describe({:changeset, changeset}),
     do: MediaAddHelpers.format_changeset_errors(changeset)
 
-  defp describe({:metadata, reason}), do: "metadata lookup failed (#{inspect(reason)})"
+  defp describe({:metadata, _reason}), do: "the metadata service could not be reached"
   defp describe(reason), do: inspect(reason)
 end

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   import Phoenix.LiveView, only: [start_async: 3, put_flash: 3, connected?: 1]
 
   alias Mydia.Media.Franchises
+  alias MydiaWeb.Live.Authorization
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
 
   require Logger
@@ -44,16 +45,12 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   @doc """
   Adds a missing franchise member, inheriting the viewed movie's quality profile
   and monitored flag.
-
-  Permission is enforced against the `:can_create_media` assign computed once at
-  mount, mirroring what already governs whether the add button renders at all;
-  a crafted request against a hidden button still gets refused here.
   """
   def add_franchise_movie(%{"tmdb_id" => tmdb_id}, socket) do
-    if socket.assigns.can_create_media do
+    with :ok <- Authorization.authorize_create_media(socket) do
       start_add(tmdb_id, socket)
     else
-      {:noreply, socket}
+      {:unauthorized, socket} -> {:noreply, socket}
     end
   end
 

--- a/test/mydia/media/franchises_test.exs
+++ b/test/mydia/media/franchises_test.exs
@@ -1,0 +1,310 @@
+defmodule Mydia.Media.FranchisesTest do
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Media
+  alias Mydia.Media.{Franchise, FranchiseEntry, Franchises}
+  alias Mydia.Metadata.Cache
+
+  setup do
+    bypass = Bypass.open()
+
+    config = %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false}
+    }
+
+    %{bypass: bypass, config: config}
+  end
+
+  defp movie_with_pointer(tmdb_id, collection_id, attrs \\ %{}) do
+    attrs
+    |> Enum.into(%{
+      type: "movie",
+      title: "Movie #{tmdb_id}",
+      year: 2001,
+      tmdb_id: tmdb_id,
+      metadata: %{
+        "provider_id" => to_string(tmdb_id),
+        "provider" => "metadata_relay",
+        "media_type" => "movie",
+        "title" => "Movie #{tmdb_id}",
+        "collection_id" => collection_id,
+        "collection_name" => "Collection #{collection_id}"
+      }
+    })
+    |> media_item_fixture()
+  end
+
+  defp stub_collection(bypass, collection_id, parts) do
+    on_exit(fn -> Cache.delete("collection:metadata_relay:#{collection_id}:en-US") end)
+
+    Bypass.stub(bypass, "GET", "/tmdb/collections/#{collection_id}", fn conn ->
+      body = %{
+        "id" => collection_id,
+        "name" => "Collection #{collection_id}",
+        "parts" => parts
+      }
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+  end
+
+  defp part(id, title, date), do: %{"id" => id, "title" => title, "release_date" => date}
+
+  describe "for_media_item/2 happy path" do
+    test "marks owned, missing, and current entries", %{bypass: bypass, config: config} do
+      cid = System.unique_integer([:positive])
+      current = movie_with_pointer(801, cid)
+      owned = movie_with_pointer(802, cid, %{title: "Sequel"})
+
+      stub_collection(bypass, cid, [
+        part(801, "First", "2001-01-01"),
+        part(802, "Second", "2004-01-01"),
+        part(803, "Third", "2007-01-01")
+      ])
+
+      assert {:ok, %Franchise{} = franchise} = Franchises.for_media_item(current, config)
+
+      assert franchise.name == "Collection #{cid}"
+      assert franchise.total_count == 3
+      assert franchise.owned_count == 2
+
+      assert [first, second, third] = franchise.entries
+
+      assert %FranchiseEntry{tmdb_id: 801, current?: true, in_library?: true} = first
+      assert first.media_item_id == current.id
+      assert first.year == 2001
+
+      assert %FranchiseEntry{tmdb_id: 802, current?: false, in_library?: true} = second
+      assert second.media_item_id == owned.id
+
+      assert %FranchiseEntry{tmdb_id: 803, current?: false, in_library?: false} = third
+      assert third.media_item_id == nil
+    end
+
+    test "orders entries by release date, undated last", %{bypass: bypass, config: config} do
+      cid = System.unique_integer([:positive])
+      current = movie_with_pointer(811, cid)
+
+      stub_collection(bypass, cid, [
+        %{"id" => 813, "title" => "Undated"},
+        part(812, "Later", "2010-06-01"),
+        part(811, "Earlier", "2002-03-01")
+      ])
+
+      assert {:ok, franchise} = Franchises.for_media_item(current, config)
+      assert Enum.map(franchise.entries, & &1.tmdb_id) == [811, 812, 813]
+    end
+
+    test "orders by full date, not by map term order on Date structs",
+         %{bypass: bypass, config: config} do
+      # Same year, descending day/month in the payload. A naive Enum.sort_by on
+      # %Date{} compares :day before :month before :year and gets this wrong.
+      cid = System.unique_integer([:positive])
+      current = movie_with_pointer(821, cid)
+
+      stub_collection(bypass, cid, [
+        part(822, "December", "2005-12-01"),
+        part(821, "January", "2005-01-30")
+      ])
+
+      assert {:ok, franchise} = Franchises.for_media_item(current, config)
+      assert Enum.map(franchise.entries, & &1.tmdb_id) == [821, 822]
+    end
+  end
+
+  describe "for_media_item/2 pointer resolution" do
+    test "falls back to a details fetch and persists the pointer",
+         %{bypass: bypass, config: config} do
+      cid = System.unique_integer([:positive])
+
+      movie =
+        media_item_fixture(%{
+          type: "movie",
+          title: "No Pointer Yet",
+          year: 2001,
+          tmdb_id: 831,
+          metadata: %{
+            "provider_id" => "831",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "No Pointer Yet"
+          }
+        })
+
+      on_exit(fn -> Cache.delete("fetch_by_id:metadata_relay:831:movie:en-US:") end)
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/831", fn conn ->
+        body = %{
+          "id" => 831,
+          "title" => "No Pointer Yet",
+          "release_date" => "2001-01-01",
+          "credits" => %{"cast" => [], "crew" => []},
+          "belongs_to_collection" => %{"id" => cid, "name" => "Collection #{cid}"}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      stub_collection(bypass, cid, [
+        part(831, "First", "2001-01-01"),
+        part(832, "Second", "2004-01-01")
+      ])
+
+      assert {:ok, %Franchise{}} = Franchises.for_media_item(movie, config)
+
+      reloaded = Media.get_media_item!(movie.id)
+      assert reloaded.metadata.collection_id == cid
+      assert reloaded.metadata.collection_name == "Collection #{cid}"
+    end
+
+    test "persisting the pointer does not append a timeline event",
+         %{bypass: bypass, config: config} do
+      cid = System.unique_integer([:positive])
+
+      movie =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Quiet Persist",
+          year: 2001,
+          tmdb_id: 841,
+          metadata: %{
+            "provider_id" => "841",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "Quiet Persist"
+          }
+        })
+
+      on_exit(fn -> Cache.delete("fetch_by_id:metadata_relay:841:movie:en-US:") end)
+
+      before_count = length(Mydia.Events.get_resource_events("media_item", movie.id, limit: 100))
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/841", fn conn ->
+        body = %{
+          "id" => 841,
+          "title" => "Quiet Persist",
+          "release_date" => "2001-01-01",
+          "credits" => %{"cast" => [], "crew" => []},
+          "belongs_to_collection" => %{"id" => cid, "name" => "Collection #{cid}"}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      stub_collection(bypass, cid, [
+        part(841, "First", "2001-01-01"),
+        part(842, "Second", "2004-01-01")
+      ])
+
+      assert {:ok, _} = Franchises.for_media_item(movie, config)
+
+      after_count = length(Mydia.Events.get_resource_events("media_item", movie.id, limit: 100))
+      assert after_count == before_count
+    end
+  end
+
+  describe "for_media_item/2 returns :none" do
+    test "for a TV show", %{config: config} do
+      show = media_item_fixture(%{type: "tv_show", title: "A Show", tmdb_id: 851, year: 2010})
+      assert Franchises.for_media_item(show, config) == :none
+    end
+
+    test "for a movie with no tmdb_id", %{config: config} do
+      movie = media_item_fixture(%{type: "movie", title: "No Id", year: 2001})
+      assert Franchises.for_media_item(movie, config) == :none
+    end
+
+    test "when the movie has no franchise", %{bypass: bypass, config: config} do
+      movie =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Standalone",
+          year: 1999,
+          tmdb_id: 861,
+          metadata: %{
+            "provider_id" => "861",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "Standalone"
+          }
+        })
+
+      on_exit(fn -> Cache.delete("fetch_by_id:metadata_relay:861:movie:en-US:") end)
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/861", fn conn ->
+        body = %{
+          "id" => 861,
+          "title" => "Standalone",
+          "release_date" => "1999-01-01",
+          "credits" => %{"cast" => [], "crew" => []},
+          "belongs_to_collection" => nil
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      assert Franchises.for_media_item(movie, config) == :none
+    end
+
+    test "when the relay predates the endpoint", %{bypass: bypass, config: config} do
+      cid = System.unique_integer([:positive])
+      movie = movie_with_pointer(871, cid)
+
+      on_exit(fn -> Cache.delete("collection:metadata_relay:#{cid}:en-US") end)
+
+      Bypass.stub(bypass, "GET", "/tmdb/collections/#{cid}", fn conn ->
+        Plug.Conn.resp(conn, 404, "Not Found")
+      end)
+
+      assert Franchises.for_media_item(movie, config) == :none
+    end
+
+    test "when the relay is unreachable", %{bypass: bypass, config: config} do
+      cid = System.unique_integer([:positive])
+      movie = movie_with_pointer(881, cid)
+
+      on_exit(fn -> Cache.delete("collection:metadata_relay:#{cid}:en-US") end)
+      Bypass.down(bypass)
+
+      assert Franchises.for_media_item(movie, config) == :none
+    end
+
+    test "when the franchise has only one member", %{bypass: bypass, config: config} do
+      cid = System.unique_integer([:positive])
+      movie = movie_with_pointer(891, cid)
+
+      stub_collection(bypass, cid, [part(891, "Only", "2001-01-01")])
+
+      assert Franchises.for_media_item(movie, config) == :none
+    end
+  end
+
+  describe "for_media_item/2 malformed parts" do
+    test "drops a part whose id is not an integer", %{bypass: bypass, config: config} do
+      cid = System.unique_integer([:positive])
+      movie = movie_with_pointer(901, cid)
+
+      stub_collection(bypass, cid, [
+        part(901, "First", "2001-01-01"),
+        part(902, "Second", "2004-01-01"),
+        %{"id" => "not-a-number", "title" => "Broken"}
+      ])
+
+      assert {:ok, franchise} = Franchises.for_media_item(movie, config)
+      assert franchise.total_count == 2
+      assert Enum.map(franchise.entries, & &1.tmdb_id) == [901, 902]
+    end
+  end
+end

--- a/test/mydia/media/franchises_test.exs
+++ b/test/mydia/media/franchises_test.exs
@@ -2,6 +2,7 @@ defmodule Mydia.Media.FranchisesTest do
   use Mydia.DataCase, async: false
 
   import Mydia.MediaFixtures
+  import ExUnit.CaptureLog
 
   alias Mydia.Media
   alias Mydia.Media.{Franchise, FranchiseEntry, Franchises}
@@ -268,9 +269,19 @@ defmodule Mydia.Media.FranchisesTest do
         Plug.Conn.resp(conn, 404, "Not Found")
       end)
 
-      assert Franchises.for_media_item(movie, config) == :none
+      # A 404 is the normal state of the world until the relay ships this
+      # endpoint. It must not log a warning: an operator on a pre-upgrade
+      # relay would otherwise get a fresh warning line on every movie page
+      # view, indistinguishable from a genuinely broken relay.
+      log =
+        capture_log(fn ->
+          assert Franchises.for_media_item(movie, config) == :none
+        end)
+
+      refute log =~ "Franchise lookup failed"
     end
 
+    @tag :capture_log
     test "when the relay is unreachable", %{bypass: bypass, config: config} do
       cid = System.unique_integer([:positive])
       movie = movie_with_pointer(881, cid)

--- a/test/mydia/media/library_status_test.exs
+++ b/test/mydia/media/library_status_test.exs
@@ -1,0 +1,51 @@
+defmodule Mydia.Media.LibraryStatusTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Media
+
+  test "returns an entry for each requested id that is in the library" do
+    owned = media_item_fixture(%{type: "movie", title: "Owned", year: 2001, tmdb_id: 671})
+    _other = media_item_fixture(%{type: "movie", title: "Other", year: 2002, tmdb_id: 672})
+
+    status = Media.library_status_for_tmdb_ids([671, 999_001])
+
+    assert %{671 => entry} = status
+    assert entry.in_library == true
+    assert entry.monitored == owned.monitored
+    assert entry.type == "movie"
+    assert entry.id == owned.id
+    refute Map.has_key?(status, 999_001)
+    refute Map.has_key?(status, 672)
+  end
+
+  test "returns an empty map for an empty id list" do
+    assert Media.library_status_for_tmdb_ids([]) == %{}
+  end
+
+  test "returns an empty map when nothing matches" do
+    assert Media.library_status_for_tmdb_ids([999_002, 999_003]) == %{}
+  end
+
+  test "ignores TV rows sharing a tmdb id with a franchise member" do
+    _show =
+      media_item_fixture(%{type: "tv_show", title: "Collides", tmdb_id: 999_004, year: 2010})
+
+    assert Media.library_status_for_tmdb_ids([999_004]) == %{}
+  end
+
+  test "reflects the monitored flag" do
+    unmonitored =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Unmonitored",
+        year: 2003,
+        tmdb_id: 673,
+        monitored: false
+      })
+
+    assert %{673 => %{monitored: false, id: id}} = Media.library_status_for_tmdb_ids([673])
+    assert id == unmonitored.id
+  end
+end

--- a/test/mydia/media/metadata_type_test.exs
+++ b/test/mydia/media/metadata_type_test.exs
@@ -143,6 +143,51 @@ defmodule Mydia.Media.MetadataTypeTest do
       assert is_nil(reloaded.metadata.cast)
       assert is_nil(reloaded.metadata.crew)
     end
+
+    test "collection pointer survives a database round trip" do
+      {:ok, media_item} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: "Harry Potter and the Philosopher's Stone",
+          year: 2001,
+          tmdb_id: 671,
+          metadata: %{
+            "provider_id" => "671",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "Harry Potter and the Philosopher's Stone",
+            "collection_id" => 1241,
+            "collection_name" => "Harry Potter Collection"
+          }
+        })
+
+      reloaded = Media.get_media_item!(media_item.id)
+
+      assert %MediaMetadata{} = reloaded.metadata
+      assert reloaded.metadata.collection_id == 1241
+      assert reloaded.metadata.collection_name == "Harry Potter Collection"
+    end
+
+    test "collection pointer is nil when the movie has no franchise" do
+      {:ok, media_item} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: "Standalone Movie",
+          year: 1999,
+          tmdb_id: 603,
+          metadata: %{
+            "provider_id" => "603",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "Standalone Movie"
+          }
+        })
+
+      reloaded = Media.get_media_item!(media_item.id)
+
+      assert reloaded.metadata.collection_id == nil
+      assert reloaded.metadata.collection_name == nil
+    end
   end
 
   describe "Ecto.Type callbacks" do

--- a/test/mydia/metadata/collection_fetch_test.exs
+++ b/test/mydia/metadata/collection_fetch_test.exs
@@ -1,0 +1,106 @@
+defmodule Mydia.Metadata.CollectionFetchTest do
+  use ExUnit.Case, async: false
+
+  alias Mydia.Metadata
+  alias Mydia.Metadata.Cache
+  alias Mydia.Metadata.Structs.Collection
+
+  setup do
+    bypass = Bypass.open()
+
+    config = %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false}
+    }
+
+    %{bypass: bypass, config: config}
+  end
+
+  defp collection_body(id) do
+    %{
+      "id" => id,
+      "name" => "Test Collection #{id}",
+      "parts" => [
+        %{"id" => id + 1, "title" => "First", "release_date" => "2001-01-01"},
+        %{"id" => id + 2, "title" => "Second", "release_date" => "2004-01-01"}
+      ]
+    }
+  end
+
+  test "fetches and parses a collection", %{bypass: bypass, config: config} do
+    id = System.unique_integer([:positive])
+    on_exit(fn -> Cache.delete("collection:metadata_relay:#{id}:en-US") end)
+
+    Bypass.expect_once(bypass, "GET", "/tmdb/collections/#{id}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(collection_body(id)))
+    end)
+
+    assert {:ok, %Collection{} = collection} = Metadata.fetch_collection_cached(config, id)
+    assert collection.name == "Test Collection #{id}"
+    assert length(collection.parts) == 2
+  end
+
+  test "serves the second call from cache", %{bypass: bypass, config: config} do
+    id = System.unique_integer([:positive])
+    on_exit(fn -> Cache.delete("collection:metadata_relay:#{id}:en-US") end)
+
+    # expect_once fails the test if the endpoint is hit twice
+    Bypass.expect_once(bypass, "GET", "/tmdb/collections/#{id}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(collection_body(id)))
+    end)
+
+    assert {:ok, first} = Metadata.fetch_collection_cached(config, id)
+    assert {:ok, second} = Metadata.fetch_collection_cached(config, id)
+    assert first == second
+  end
+
+  test "different languages do not share a cache entry", %{bypass: bypass, config: config} do
+    id = System.unique_integer([:positive])
+
+    on_exit(fn ->
+      Cache.delete("collection:metadata_relay:#{id}:en-US")
+      Cache.delete("collection:metadata_relay:#{id}:fr-FR")
+    end)
+
+    Bypass.expect(bypass, "GET", "/tmdb/collections/#{id}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(collection_body(id)))
+    end)
+
+    assert {:ok, _} = Metadata.fetch_collection_cached(config, id)
+    assert {:ok, _} = Metadata.fetch_collection_cached(config, id, language: "fr-FR")
+
+    # Both keys are populated independently
+    assert {:ok, _} = Cache.get("collection:metadata_relay:#{id}:en-US")
+    assert {:ok, _} = Cache.get("collection:metadata_relay:#{id}:fr-FR")
+  end
+
+  test "a relay without the endpoint returns not_found", %{bypass: bypass, config: config} do
+    id = System.unique_integer([:positive])
+    on_exit(fn -> Cache.delete("collection:metadata_relay:#{id}:en-US") end)
+
+    Bypass.expect_once(bypass, "GET", "/tmdb/collections/#{id}", fn conn ->
+      Plug.Conn.resp(conn, 404, "Not Found")
+    end)
+
+    assert {:error, %{type: :not_found}} = Metadata.fetch_collection_cached(config, id)
+  end
+
+  test "a server error is not cached", %{bypass: bypass, config: config} do
+    id = System.unique_integer([:positive])
+    on_exit(fn -> Cache.delete("collection:metadata_relay:#{id}:en-US") end)
+
+    Bypass.expect(bypass, "GET", "/tmdb/collections/#{id}", fn conn ->
+      Plug.Conn.resp(conn, 500, "boom")
+    end)
+
+    assert {:error, _} = Metadata.fetch_collection_cached(config, id)
+    assert {:error, :not_found} = Cache.get("collection:metadata_relay:#{id}:en-US")
+  end
+end

--- a/test/mydia/metadata/collection_fetch_test.exs
+++ b/test/mydia/metadata/collection_fetch_test.exs
@@ -103,4 +103,36 @@ defmodule Mydia.Metadata.CollectionFetchTest do
     assert {:error, _} = Metadata.fetch_collection_cached(config, id)
     assert {:error, :not_found} = Cache.get("collection:metadata_relay:#{id}:en-US")
   end
+
+  # Collections are a TMDB concept served by the relay. Other registered
+  # provider types (:music_relay, :open_library) have no equivalent, so a config
+  # for one of them must be rejected rather than quietly routed to the relay
+  # adapter under a cache key that claims otherwise.
+  test "a non-relay config is rejected without reaching the relay", %{bypass: bypass} do
+    id = System.unique_integer([:positive])
+
+    Bypass.down(bypass)
+
+    config = %{
+      type: :open_library,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US"}
+    }
+
+    assert {:error, %{type: :invalid_config}} = Metadata.fetch_collection_cached(config, id)
+  end
+
+  test "a rejected config is not cached under any key", %{bypass: bypass} do
+    id = System.unique_integer([:positive])
+
+    config = %{
+      type: :music_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US"}
+    }
+
+    assert {:error, %{type: :invalid_config}} = Metadata.fetch_collection_cached(config, id)
+    assert {:error, :not_found} = Cache.get("collection:music_relay:#{id}:en-US")
+    assert {:error, :not_found} = Cache.get("collection:metadata_relay:#{id}:en-US")
+  end
 end

--- a/test/mydia/metadata/structs/collection_test.exs
+++ b/test/mydia/metadata/structs/collection_test.exs
@@ -1,0 +1,77 @@
+defmodule Mydia.Metadata.Structs.CollectionTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.Structs.{Collection, CollectionPart}
+
+  defp body do
+    %{
+      "id" => 1241,
+      "name" => "Harry Potter Collection",
+      "overview" => "A wizarding saga.",
+      "poster_path" => "/eVPs.jpg",
+      "backdrop_path" => "/kmEs.jpg",
+      "parts" => [
+        %{
+          "id" => 671,
+          "title" => "Harry Potter and the Philosopher's Stone",
+          "original_title" => "Harry Potter and the Philosopher's Stone",
+          "overview" => "Harry discovers he is a wizard.",
+          "release_date" => "2001-11-16",
+          "poster_path" => "/wuMc.jpg",
+          "backdrop_path" => "/hzii.jpg",
+          "vote_average" => 7.9
+        },
+        %{
+          "id" => 672,
+          "title" => "Harry Potter and the Chamber of Secrets",
+          "release_date" => "2002-11-13",
+          "poster_path" => "/sdEO.jpg"
+        }
+      ]
+    }
+  end
+
+  test "parses the collection and its parts" do
+    collection = Collection.from_api_response(body())
+
+    assert collection.provider_id == "1241"
+    assert collection.name == "Harry Potter Collection"
+    assert collection.overview == "A wizarding saga."
+    assert collection.poster_path == "/eVPs.jpg"
+    assert collection.backdrop_path == "/kmEs.jpg"
+    assert [%CollectionPart{} = first, %CollectionPart{} = second] = collection.parts
+
+    assert first.provider_id == "671"
+    assert first.title == "Harry Potter and the Philosopher's Stone"
+    assert first.release_date == ~D[2001-11-16]
+    assert first.vote_average == 7.9
+
+    assert second.provider_id == "672"
+    assert second.release_date == ~D[2002-11-13]
+    assert second.vote_average == nil
+  end
+
+  test "handles a missing parts key" do
+    collection = Collection.from_api_response(Map.delete(body(), "parts"))
+    assert collection.parts == []
+  end
+
+  test "handles an empty parts list" do
+    collection = Collection.from_api_response(Map.put(body(), "parts", []))
+    assert collection.parts == []
+  end
+
+  test "tolerates a part with no release date" do
+    part_without_date = %{"id" => 999, "title" => "Untitled Sequel"}
+    collection = Collection.from_api_response(Map.put(body(), "parts", [part_without_date]))
+
+    assert [%CollectionPart{provider_id: "999", release_date: nil}] = collection.parts
+  end
+
+  test "tolerates a malformed release date" do
+    part = %{"id" => 999, "title" => "Untitled Sequel", "release_date" => ""}
+    collection = Collection.from_api_response(Map.put(body(), "parts", [part]))
+
+    assert [%CollectionPart{release_date: nil}] = collection.parts
+  end
+end

--- a/test/mydia/metadata/structs/media_metadata_collection_test.exs
+++ b/test/mydia/metadata/structs/media_metadata_collection_test.exs
@@ -1,0 +1,67 @@
+defmodule Mydia.Metadata.Structs.MediaMetadataCollectionTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.Structs.MediaMetadata
+
+  test "parses belongs_to_collection from a movie response" do
+    body = %{
+      "id" => 671,
+      "title" => "Harry Potter and the Philosopher's Stone",
+      "release_date" => "2001-11-16",
+      "credits" => %{"cast" => [], "crew" => []},
+      "belongs_to_collection" => %{
+        "id" => 1241,
+        "name" => "Harry Potter Collection",
+        "poster_path" => "/eVPs.jpg",
+        "backdrop_path" => "/kmEs.jpg"
+      }
+    }
+
+    metadata = MediaMetadata.from_api_response(body, :movie, "671")
+
+    assert metadata.collection_id == 1241
+    assert metadata.collection_name == "Harry Potter Collection"
+  end
+
+  test "leaves the collection pointer nil when the key is absent" do
+    body = %{
+      "id" => 603,
+      "title" => "The Matrix",
+      "release_date" => "1999-03-30",
+      "credits" => %{"cast" => [], "crew" => []}
+    }
+
+    metadata = MediaMetadata.from_api_response(body, :movie, "603")
+
+    assert metadata.collection_id == nil
+    assert metadata.collection_name == nil
+  end
+
+  test "leaves the collection pointer nil when the key is explicitly null" do
+    body = %{
+      "id" => 603,
+      "title" => "The Matrix",
+      "release_date" => "1999-03-30",
+      "credits" => %{"cast" => [], "crew" => []},
+      "belongs_to_collection" => nil
+    }
+
+    metadata = MediaMetadata.from_api_response(body, :movie, "603")
+
+    assert metadata.collection_id == nil
+  end
+
+  test "leaves the collection pointer nil for TV shows" do
+    body = %{
+      "id" => 1396,
+      "name" => "Breaking Bad",
+      "first_air_date" => "2008-01-20",
+      "credits" => %{"cast" => [], "crew" => []}
+    }
+
+    metadata = MediaMetadata.from_api_response(body, :tv_show, "1396")
+
+    assert metadata.collection_id == nil
+    assert metadata.collection_name == nil
+  end
+end

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -53,6 +53,45 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
     end
   end
 
+  describe "build_media_item_attrs/3 inherited settings" do
+    defp movie_metadata do
+      %MediaMetadata{
+        provider_id: "672",
+        provider: :tmdb,
+        media_type: :movie,
+        title: "Chamber of Secrets",
+        release_date: ~D[2002-11-13]
+      }
+    end
+
+    test "defaults to monitored with no quality profile" do
+      attrs = MediaAddHelpers.build_media_item_attrs(movie_metadata(), :movie)
+
+      assert attrs.monitored == true
+      refute Map.has_key?(attrs, :quality_profile_id)
+    end
+
+    test "honours an explicit monitored flag" do
+      attrs = MediaAddHelpers.build_media_item_attrs(movie_metadata(), :movie, monitored: false)
+
+      assert attrs.monitored == false
+    end
+
+    test "sets the quality profile when one is given" do
+      attrs =
+        MediaAddHelpers.build_media_item_attrs(movie_metadata(), :movie, quality_profile_id: 42)
+
+      assert attrs.quality_profile_id == 42
+    end
+
+    test "omits the quality profile when it is nil" do
+      attrs =
+        MediaAddHelpers.build_media_item_attrs(movie_metadata(), :movie, quality_profile_id: nil)
+
+      refute Map.has_key?(attrs, :quality_profile_id)
+    end
+  end
+
   describe "handle_add_media_to_library/4 derives provider and stamps provenance" do
     setup do
       bypass = Bypass.open()

--- a/test/mydia_web/live/media_live/show/franchise_components_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_components_test.exs
@@ -29,7 +29,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponentsTest do
     render_component(&FranchiseComponents.franchise_section/1, %{
       franchise: franchise,
       can_add: Keyword.get(opts, :can_add, true),
-      adding_tmdb_id: Keyword.get(opts, :adding_tmdb_id)
+      adding_tmdb_ids: MapSet.new(Keyword.get(opts, :adding_tmdb_ids, []))
     })
   end
 
@@ -44,6 +44,8 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponentsTest do
 
     assert html =~ "Harry Potter Collection"
     assert html =~ "1 of 2"
+    assert html =~ "badge-ghost"
+    refute html =~ "badge-success"
     assert html =~ ~s(id="franchise-section")
   end
 
@@ -124,12 +126,29 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponentsTest do
           entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
           entry(%{tmdb_id: 672})
         ]),
-        adding_tmdb_id: 672
+        adding_tmdb_ids: [672]
       )
 
     missing = extract_entry(html, 672)
     assert missing =~ "loading-spinner"
     assert missing =~ "disabled"
+  end
+
+  test "every entry in flight shows a spinner, and only those" do
+    html =
+      render(
+        franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672}),
+          entry(%{tmdb_id: 673}),
+          entry(%{tmdb_id: 674})
+        ]),
+        adding_tmdb_ids: [672, 673]
+      )
+
+    assert extract_entry(html, 672) =~ "loading-spinner"
+    assert extract_entry(html, 673) =~ "loading-spinner"
+    refute extract_entry(html, 674) =~ "loading-spinner"
   end
 
   test "renders a placeholder when a poster is missing" do

--- a/test/mydia_web/live/media_live/show/franchise_components_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_components_test.exs
@@ -1,0 +1,182 @@
+defmodule MydiaWeb.MediaLive.Show.FranchiseComponentsTest do
+  use ExUnit.Case, async: true
+
+  # `render/1` is excluded: our own `render/2` (with its `opts \\ []` default)
+  # collides with `Phoenix.LiveViewTest.render/1`, and this suite only ever
+  # needs `render_component/2`.
+  import Phoenix.LiveViewTest, except: [render: 1]
+
+  alias Mydia.Media.{Franchise, FranchiseEntry}
+  alias MydiaWeb.MediaLive.Show.FranchiseComponents
+
+  defp entry(attrs) do
+    struct!(
+      %FranchiseEntry{tmdb_id: 1, title: "Untitled", year: 2001, poster_path: "/p.jpg"},
+      attrs
+    )
+  end
+
+  defp franchise(entries) do
+    %Franchise{
+      name: "Harry Potter Collection",
+      entries: entries,
+      owned_count: Enum.count(entries, & &1.in_library?),
+      total_count: length(entries)
+    }
+  end
+
+  defp render(franchise, opts \\ []) do
+    render_component(&FranchiseComponents.franchise_section/1, %{
+      franchise: franchise,
+      can_add: Keyword.get(opts, :can_add, true),
+      adding_tmdb_id: Keyword.get(opts, :adding_tmdb_id)
+    })
+  end
+
+  test "renders the franchise name and the owned count" do
+    html =
+      render(
+        franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672})
+        ])
+      )
+
+    assert html =~ "Harry Potter Collection"
+    assert html =~ "1 of 2"
+    assert html =~ ~s(id="franchise-section")
+  end
+
+  test "marks the count as complete when everything is owned" do
+    html =
+      render(
+        franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672, in_library?: true, media_item_id: "b"})
+        ])
+      )
+
+    assert html =~ "2 of 2"
+    assert html =~ "badge-success"
+  end
+
+  test "the current entry is neither a link nor a button" do
+    html =
+      render(
+        franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672})
+        ])
+      )
+
+    current = extract_entry(html, 671)
+    refute current =~ "<a "
+    refute current =~ "<button"
+    assert current =~ "ring-primary"
+  end
+
+  test "an owned entry links to its media page" do
+    html =
+      render(
+        franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672, in_library?: true, media_item_id: "b7d3"})
+        ])
+      )
+
+    owned = extract_entry(html, 672)
+    assert owned =~ ~s(href="/media/b7d3")
+  end
+
+  test "a missing entry is an add button when the user may add" do
+    html =
+      render(
+        franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672})
+        ])
+      )
+
+    missing = extract_entry(html, 672)
+    assert missing =~ ~s(phx-click="add_franchise_movie")
+    assert missing =~ ~s(phx-value-tmdb_id="672")
+  end
+
+  test "a missing entry is inert without permission" do
+    html =
+      render(
+        franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672})
+        ]),
+        can_add: false
+      )
+
+    missing = extract_entry(html, 672)
+    refute missing =~ "phx-click"
+    refute missing =~ "<button"
+  end
+
+  test "the entry being added shows a spinner and is disabled" do
+    html =
+      render(
+        franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672})
+        ]),
+        adding_tmdb_id: 672
+      )
+
+    missing = extract_entry(html, 672)
+    assert missing =~ "loading-spinner"
+    assert missing =~ "disabled"
+  end
+
+  test "renders a placeholder when a poster is missing" do
+    html =
+      render(
+        franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672, poster_path: nil})
+        ])
+      )
+
+    missing = extract_entry(html, 672)
+    refute missing =~ "<img"
+    assert missing =~ "hero-film"
+  end
+
+  test "renders the title and year for each entry" do
+    html =
+      render(
+        franchise([
+          entry(%{
+            tmdb_id: 671,
+            title: "Philosopher's Stone",
+            year: 2001,
+            in_library?: true,
+            current?: true,
+            media_item_id: "a"
+          }),
+          entry(%{tmdb_id: 672, title: "Chamber of Secrets", year: 2002})
+        ])
+      )
+
+    assert html =~ "Chamber of Secrets"
+    assert html =~ "2002"
+  end
+
+  # Slices the markup for one entry out of the full section so assertions cannot
+  # accidentally match a sibling entry's attributes.
+  #
+  # `LazyHTML.filter/2` only matches root-level nodes, but the entries are
+  # nested inside `#franchise-section`, so it must be `query/2`, which
+  # searches descendants (see `index_test.exs` for the same pattern).
+  defp extract_entry(html, tmdb_id) do
+    doc = LazyHTML.from_fragment(html)
+
+    doc
+    |> LazyHTML.query(~s(#franchise-entry-#{tmdb_id}))
+    |> LazyHTML.to_html()
+  end
+end

--- a/test/mydia_web/live/media_live/show/franchise_events_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_events_test.exs
@@ -3,8 +3,8 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
 
   import Mydia.MediaFixtures
   import Mydia.AccountsFixtures
+  import ExUnit.CaptureLog
 
-  alias Mydia.Media
   alias Mydia.Media.{Franchise, FranchiseEntry}
   alias MydiaWeb.MediaLive.Show.FranchiseEvents
 
@@ -20,20 +20,35 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
     %{bypass: bypass, config: config}
   end
 
-  defp stub_socket(assigns) do
+  # `start_async/3` is a no-op on a socket that is not connected, so the
+  # connected variant is what the dispatch tests need: it records the running
+  # task under `private.live_async`, which is where a second task for the same
+  # key would show up.
+  defp stub_socket(assigns, opts \\ []) do
     defaults = %{
       __changed__: %{},
       flash: %{},
       franchise: nil,
-      adding_franchise_tmdb_id: nil,
+      adding_franchise_tmdb_ids: MapSet.new(),
       can_create_media: true,
       current_user: user_fixture()
     }
 
     %Phoenix.LiveView.Socket{
       assigns: Map.merge(defaults, assigns),
-      private: %{live_temp: %{}}
+      private: %{live_temp: %{}},
+      transport_pid: if(opts[:connected], do: self())
     }
+  end
+
+  defp in_flight_tasks(socket), do: socket.private[:live_async] || %{}
+
+  # Answers a TMDB movie lookup with a 404 so `perform_add/3` fails fast without
+  # touching the database.
+  defp stub_missing(bypass, tmdb_id) do
+    Bypass.stub(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+      Plug.Conn.resp(conn, 404, "Not Found")
+    end)
   end
 
   defp franchise_with_missing(current_item, missing_tmdb_id) do
@@ -59,6 +74,17 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
         }
       ]
     }
+  end
+
+  defp with_extra_missing(franchise, tmdb_id) do
+    extra = %FranchiseEntry{
+      tmdb_id: tmdb_id,
+      title: "Third",
+      year: 2007,
+      release_date: ~D[2007-01-01]
+    }
+
+    %{franchise | entries: franchise.entries ++ [extra], total_count: franchise.total_count + 1}
   end
 
   describe "add_franchise_movie/2" do
@@ -99,7 +125,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
       {:noreply, socket} =
         FranchiseEvents.add_franchise_movie(%{"tmdb_id" => "1002"}, socket)
 
-      assert socket.assigns.adding_franchise_tmdb_id == 1002
+      assert MapSet.member?(socket.assigns.adding_franchise_tmdb_ids, 1002)
 
       # The async body is what performs the add; run it directly.
       {:ok, media_item} = FranchiseEvents.perform_add(current, 1002, config)
@@ -125,12 +151,96 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
       {:noreply, socket} =
         FranchiseEvents.add_franchise_movie(%{"tmdb_id" => "1012"}, socket)
 
-      assert socket.assigns.adding_franchise_tmdb_id == nil
-      assert Media.get_media_item_by_tmdb(1012) == nil
+      assert MapSet.size(socket.assigns.adding_franchise_tmdb_ids) == 0
+    end
+
+    test "a repeat click on an id already in flight does not start a second task",
+         %{bypass: bypass, config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1101})
+
+      # The dispatched task runs for real on a connected socket. A 404 keeps it
+      # short and off the database, so it cannot outlive the sandbox owner.
+      stub_missing(bypass, 1102)
+
+      socket =
+        stub_socket(
+          %{
+            media_item: current,
+            metadata_config: config,
+            franchise: franchise_with_missing(current, 1102)
+          },
+          connected: true
+        )
+
+      {:noreply, socket} = FranchiseEvents.add_franchise_movie(%{"tmdb_id" => "1102"}, socket)
+      first = in_flight_tasks(socket)
+      assert Map.keys(first) == [{:add_franchise_movie, 1102}]
+
+      {:noreply, socket} = FranchiseEvents.add_franchise_movie(%{"tmdb_id" => "1102"}, socket)
+
+      # An overwritten entry would carry a different ref and pid, and the first
+      # task's result would then be discarded by LiveView.
+      assert in_flight_tasks(socket) == first
+      assert MapSet.size(socket.assigns.adding_franchise_tmdb_ids) == 1
+    end
+
+    test "two different ids can be in flight at the same time",
+         %{bypass: bypass, config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1201})
+
+      stub_missing(bypass, 1202)
+      stub_missing(bypass, 1203)
+
+      franchise =
+        current
+        |> franchise_with_missing(1202)
+        |> with_extra_missing(1203)
+
+      socket =
+        stub_socket(
+          %{media_item: current, metadata_config: config, franchise: franchise},
+          connected: true
+        )
+
+      {:noreply, socket} = FranchiseEvents.add_franchise_movie(%{"tmdb_id" => "1202"}, socket)
+      first = in_flight_tasks(socket)[{:add_franchise_movie, 1202}]
+
+      {:noreply, socket} = FranchiseEvents.add_franchise_movie(%{"tmdb_id" => "1203"}, socket)
+
+      tasks = in_flight_tasks(socket)
+
+      assert Enum.sort(Map.keys(tasks)) == [
+               {:add_franchise_movie, 1202},
+               {:add_franchise_movie, 1203}
+             ]
+
+      assert tasks[{:add_franchise_movie, 1202}] == first
+
+      assert socket.assigns.adding_franchise_tmdb_ids == MapSet.new([1202, 1203])
+
+      # Both results land, in either order, because each is routed by its own id.
+      second_added =
+        media_item_fixture(%{type: "movie", title: "Second", year: 2004, tmdb_id: 1202})
+
+      third_added =
+        media_item_fixture(%{type: "movie", title: "Third", year: 2007, tmdb_id: 1203})
+
+      {:noreply, socket} =
+        FranchiseEvents.handle_add_result(1203, {:ok, {:ok, third_added}}, socket)
+
+      {:noreply, socket} =
+        FranchiseEvents.handle_add_result(1202, {:ok, {:ok, second_added}}, socket)
+
+      assert MapSet.size(socket.assigns.adding_franchise_tmdb_ids) == 0
+      assert socket.assigns.franchise.owned_count == 3
+
+      assert Enum.all?(socket.assigns.franchise.entries, & &1.in_library?)
     end
   end
 
-  describe "handle_add_result/2" do
+  describe "handle_add_result/3" do
     test "flips the entry to owned and bumps the count", %{config: config} do
       current =
         media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1021})
@@ -142,13 +252,13 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
         stub_socket(%{
           media_item: current,
           metadata_config: config,
-          adding_franchise_tmdb_id: 1022,
+          adding_franchise_tmdb_ids: MapSet.new([1022]),
           franchise: franchise_with_missing(current, 1022)
         })
 
-      {:noreply, socket} = FranchiseEvents.handle_add_result({:ok, {:ok, added}}, socket)
+      {:noreply, socket} = FranchiseEvents.handle_add_result(1022, {:ok, {:ok, added}}, socket)
 
-      assert socket.assigns.adding_franchise_tmdb_id == nil
+      assert MapSet.size(socket.assigns.adding_franchise_tmdb_ids) == 0
       assert socket.assigns.franchise.owned_count == 2
 
       entry = Enum.find(socket.assigns.franchise.entries, &(&1.tmdb_id == 1022))
@@ -156,6 +266,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
       assert entry.media_item_id == added.id
     end
 
+    @tag :capture_log
     test "clears the spinner on failure", %{config: config} do
       current =
         media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1031})
@@ -164,15 +275,43 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
         stub_socket(%{
           media_item: current,
           metadata_config: config,
-          adding_franchise_tmdb_id: 1032,
+          adding_franchise_tmdb_ids: MapSet.new([1032]),
           franchise: franchise_with_missing(current, 1032)
         })
 
       {:noreply, socket} =
-        FranchiseEvents.handle_add_result({:ok, {:error, {:metadata, :timeout}}}, socket)
+        FranchiseEvents.handle_add_result(1032, {:ok, {:error, {:metadata, :timeout}}}, socket)
 
-      assert socket.assigns.adding_franchise_tmdb_id == nil
+      assert MapSet.size(socket.assigns.adding_franchise_tmdb_ids) == 0
       assert socket.assigns.franchise.owned_count == 1
+    end
+
+    test "the flash for a metadata failure carries no internal struct", %{config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1071})
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          metadata_config: config,
+          adding_franchise_tmdb_ids: MapSet.new([1072]),
+          franchise: franchise_with_missing(current, 1072)
+        })
+
+      error = %Mydia.Metadata.Provider.Error{type: :timeout, message: "timed out"}
+
+      log =
+        capture_log(fn ->
+          {:noreply, socket} =
+            FranchiseEvents.handle_add_result(1072, {:ok, {:error, {:metadata, error}}}, socket)
+
+          flash = socket.assigns.flash["error"]
+          assert flash == "Could not add that movie: the metadata service could not be reached"
+          refute flash =~ "Mydia.Metadata.Provider.Error"
+        end)
+
+      # The detail is not lost, it moves to the log.
+      assert log =~ "Mydia.Metadata.Provider.Error"
     end
   end
 
@@ -200,6 +339,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
       assert socket.assigns.franchise == nil
     end
 
+    @tag :capture_log
     test "leaves the franchise nil when the async task crashed", %{config: config} do
       current =
         media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1061})
@@ -207,6 +347,19 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
       socket = stub_socket(%{media_item: current, metadata_config: config})
 
       {:noreply, socket} = FranchiseEvents.handle_load_result({:exit, :boom}, socket)
+
+      assert socket.assigns.franchise == nil
+    end
+
+    @tag :capture_log
+    test "an unexpected result is ignored instead of raising in the LiveView",
+         %{config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1081})
+
+      socket = stub_socket(%{media_item: current, metadata_config: config})
+
+      {:noreply, socket} = FranchiseEvents.handle_load_result(:something_unexpected, socket)
 
       assert socket.assigns.franchise == nil
     end

--- a/test/mydia_web/live/media_live/show/franchise_events_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_events_test.exs
@@ -1,0 +1,212 @@
+defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Media
+  alias Mydia.Media.{Franchise, FranchiseEntry}
+  alias MydiaWeb.MediaLive.Show.FranchiseEvents
+
+  setup do
+    bypass = Bypass.open()
+
+    config = %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false}
+    }
+
+    %{bypass: bypass, config: config}
+  end
+
+  defp stub_socket(assigns) do
+    defaults = %{
+      __changed__: %{},
+      flash: %{},
+      franchise: nil,
+      adding_franchise_tmdb_id: nil,
+      can_create_media: true
+    }
+
+    %Phoenix.LiveView.Socket{
+      assigns: Map.merge(defaults, assigns),
+      private: %{live_temp: %{}}
+    }
+  end
+
+  defp franchise_with_missing(current_item, missing_tmdb_id) do
+    %Franchise{
+      name: "Test Collection",
+      owned_count: 1,
+      total_count: 2,
+      entries: [
+        %FranchiseEntry{
+          tmdb_id: current_item.tmdb_id,
+          title: current_item.title,
+          year: current_item.year,
+          release_date: ~D[2001-01-01],
+          in_library?: true,
+          current?: true,
+          media_item_id: current_item.id
+        },
+        %FranchiseEntry{
+          tmdb_id: missing_tmdb_id,
+          title: "Missing Sequel",
+          year: 2004,
+          release_date: ~D[2004-01-01]
+        }
+      ]
+    }
+  end
+
+  describe "add_franchise_movie/2" do
+    test "creates the movie inheriting profile and monitored flag",
+         %{bypass: bypass, config: config} do
+      profile = Mydia.SettingsFixtures.quality_profile_fixture()
+
+      current =
+        media_item_fixture(%{
+          type: "movie",
+          title: "First",
+          year: 2001,
+          tmdb_id: 1001,
+          monitored: false,
+          quality_profile_id: profile.id
+        })
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/1002", fn conn ->
+        body = %{
+          "id" => 1002,
+          "title" => "Missing Sequel",
+          "release_date" => "2004-01-01",
+          "credits" => %{"cast" => [], "crew" => []}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          metadata_config: config,
+          franchise: franchise_with_missing(current, 1002)
+        })
+
+      {:noreply, socket} =
+        FranchiseEvents.add_franchise_movie(%{"tmdb_id" => "1002"}, socket)
+
+      assert socket.assigns.adding_franchise_tmdb_id == 1002
+
+      # The async body is what performs the add; run it directly.
+      {:ok, media_item} = FranchiseEvents.perform_add(current, 1002, config)
+
+      assert media_item.tmdb_id == 1002
+      assert media_item.title == "Missing Sequel"
+      assert media_item.monitored == false
+      assert media_item.quality_profile_id == profile.id
+    end
+
+    test "refuses without create permission", %{config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1011})
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          metadata_config: config,
+          can_create_media: false,
+          franchise: franchise_with_missing(current, 1012)
+        })
+
+      {:noreply, socket} =
+        FranchiseEvents.add_franchise_movie(%{"tmdb_id" => "1012"}, socket)
+
+      assert socket.assigns.adding_franchise_tmdb_id == nil
+      assert Media.get_media_item_by_tmdb(1012) == nil
+    end
+  end
+
+  describe "handle_add_result/2" do
+    test "flips the entry to owned and bumps the count", %{config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1021})
+
+      added =
+        media_item_fixture(%{type: "movie", title: "Missing Sequel", year: 2004, tmdb_id: 1022})
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          metadata_config: config,
+          adding_franchise_tmdb_id: 1022,
+          franchise: franchise_with_missing(current, 1022)
+        })
+
+      {:noreply, socket} = FranchiseEvents.handle_add_result({:ok, {:ok, added}}, socket)
+
+      assert socket.assigns.adding_franchise_tmdb_id == nil
+      assert socket.assigns.franchise.owned_count == 2
+
+      entry = Enum.find(socket.assigns.franchise.entries, &(&1.tmdb_id == 1022))
+      assert entry.in_library? == true
+      assert entry.media_item_id == added.id
+    end
+
+    test "clears the spinner on failure", %{config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1031})
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          metadata_config: config,
+          adding_franchise_tmdb_id: 1032,
+          franchise: franchise_with_missing(current, 1032)
+        })
+
+      {:noreply, socket} =
+        FranchiseEvents.handle_add_result({:ok, {:error, {:metadata, :timeout}}}, socket)
+
+      assert socket.assigns.adding_franchise_tmdb_id == nil
+      assert socket.assigns.franchise.owned_count == 1
+    end
+  end
+
+  describe "handle_load_result/2" do
+    test "assigns the franchise on success", %{config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1041})
+
+      franchise = franchise_with_missing(current, 1042)
+      socket = stub_socket(%{media_item: current, metadata_config: config})
+
+      {:noreply, socket} = FranchiseEvents.handle_load_result({:ok, {:ok, franchise}}, socket)
+
+      assert socket.assigns.franchise == franchise
+    end
+
+    test "leaves the franchise nil on :none", %{config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1051})
+
+      socket = stub_socket(%{media_item: current, metadata_config: config})
+
+      {:noreply, socket} = FranchiseEvents.handle_load_result({:ok, :none}, socket)
+
+      assert socket.assigns.franchise == nil
+    end
+
+    test "leaves the franchise nil when the async task crashed", %{config: config} do
+      current =
+        media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1061})
+
+      socket = stub_socket(%{media_item: current, metadata_config: config})
+
+      {:noreply, socket} = FranchiseEvents.handle_load_result({:exit, :boom}, socket)
+
+      assert socket.assigns.franchise == nil
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/franchise_events_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_events_test.exs
@@ -2,6 +2,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
   use Mydia.DataCase, async: false
 
   import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
 
   alias Mydia.Media
   alias Mydia.Media.{Franchise, FranchiseEntry}
@@ -25,7 +26,8 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
       flash: %{},
       franchise: nil,
       adding_franchise_tmdb_id: nil,
-      can_create_media: true
+      can_create_media: true,
+      current_user: user_fixture()
     }
 
     %Phoenix.LiveView.Socket{
@@ -116,7 +118,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
         stub_socket(%{
           media_item: current,
           metadata_config: config,
-          can_create_media: false,
+          current_user: user_fixture(%{role: "readonly"}),
           franchise: franchise_with_missing(current, 1012)
         })
 

--- a/test/mydia_web/live/media_live/show/franchise_section_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_section_test.exs
@@ -1,0 +1,100 @@
+defmodule MydiaWeb.MediaLive.Show.FranchiseSectionTest do
+  # Connected LiveView tests must stay sync: the Postgres sandbox is only shared
+  # with the mount process when the case is not async.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Metadata
+  alias Mydia.Metadata.Cache
+
+  setup %{conn: conn} do
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  test "a TV show page never renders the franchise section", %{conn: conn} do
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "A Show",
+        year: 2010,
+        tmdb_id: System.unique_integer([:positive])
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+
+    refute has_element?(view, "#franchise-section")
+  end
+
+  test "a movie whose franchise resolves renders the strip with its owned count",
+       %{conn: conn} do
+    collection_id = System.unique_integer([:positive])
+    owned_tmdb_id = System.unique_integer([:positive])
+    missing_tmdb_id = System.unique_integer([:positive])
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "First",
+        year: 2001,
+        tmdb_id: owned_tmdb_id,
+        metadata: %{
+          "provider_id" => to_string(owned_tmdb_id),
+          "provider" => "metadata_relay",
+          "media_type" => "movie",
+          "title" => "First",
+          "collection_id" => collection_id,
+          "collection_name" => "Test Collection"
+        }
+      })
+
+    warm_collection_cache(collection_id, [
+      %{"id" => owned_tmdb_id, "title" => "First", "release_date" => "2001-01-01"},
+      %{"id" => missing_tmdb_id, "title" => "Second", "release_date" => "2004-01-01"}
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, "#franchise-section")
+    assert has_element?(view, "#franchise-section .badge", "1 of 2")
+    assert has_element?(view, "#franchise-entry-#{owned_tmdb_id}")
+    assert has_element?(view, "#franchise-entry-#{missing_tmdb_id}")
+
+    # `can_create_media` reaches the component: an admin gets the add affordance
+    # on the missing entry.
+    assert has_element?(
+             view,
+             "#franchise-entry-#{missing_tmdb_id}[phx-click='add_franchise_movie']"
+           )
+  end
+
+  # Populates the shared metadata cache through the real fetch path, with the
+  # relay response coming from Bypass. `fetch_collection_cached/3` keys on the
+  # provider type, collection id and language but not the base URL, so the
+  # LiveView's own default config reads this entry back without any outbound
+  # request: the assertions above passing is itself proof the cache was hit.
+  defp warm_collection_cache(collection_id, parts) do
+    bypass = Bypass.open()
+    relay = Metadata.default_relay_config()
+    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
+
+    on_exit(fn ->
+      Cache.delete("collection:#{relay.type}:#{collection_id}:#{relay.options.language}")
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/tmdb/collections/#{collection_id}", fn conn ->
+      body = %{"id" => collection_id, "name" => "Test Collection", "parts" => parts}
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    {:ok, _collection} = Metadata.fetch_collection_cached(config, collection_id)
+    :ok
+  end
+end


### PR DESCRIPTION
## What

Adds a franchise section to the movie detail page. Opening a movie now shows every film in
the same TMDB collection as a poster strip, marking which are already in your library and
which are missing, with one-click add for a missing entry.

The movie page was noticeably emptier than a TV page (movies skip the Episodes block), and
it answered nothing about sequels. Finding out whether you were missing one meant leaving
the page and searching each title by hand.

```
Harry Potter Collection                          5 of 8
[ x ] [ v ] [ v ] [ . ] [ v ] [ . ] [ v ]  ->
 ^current            ^missing
```

Clicking a missing poster adds it monitored, inheriting the quality profile and monitored
flag of the movie you were looking at. No indexer search fires on add: adding four sequels
should not kick off four searches unannounced, and the hourly `MovieSearch` all-monitored
run picks them up.

## Requires a metadata-relay change

This consumes a new relay endpoint, `GET /tmdb/collections/{id}`, which **does not exist
yet**. It is a verbatim passthrough of TMDB's `/3/collection/{id}`, following the existing
`/tmdb/movies/{id}` convention.

Until an operator's relay ships it, the endpoint 404s and the section simply does not
render: the page looks exactly as it does today, with no error banner and nothing logged.
So there is no deploy ordering in either direction. This can merge now and the section
lights up on its own once the relay catches up.

## How it works

`belongs_to_collection` already arrives in the relay's movie-details response and was being
discarded. It is now parsed into `MediaMetadata` as `collection_id` / `collection_name`, and
treated as a **cache rather than a source of truth**: when absent, a cached details fetch
supplies it and writes it back. That means no migration and no backfill job, and the
feature works on libraries whose movies predate it.

The member list comes from the new endpoint through the existing ETS metadata cache (24h
TTL) and is joined against the library by `tmdb_id`. All of it runs in `start_async` after
mount, and every failure path collapses to a single `:none`, so the section is absent
rather than broken.

Naming: `Mydia.Collections` already means user-curated lists, so the provider-shape structs
are `Metadata.Structs.Collection`/`CollectionPart` and the view model is
`Media.Franchise`/`FranchiseEntry`. The UI heading is the franchise's own name, which TMDB
already suffixes with "Collection".

## Notable details

- Entries sort by full release date via `Date.compare/2`. `%Date{}` structs compare as maps
  (`:calendar`, `:day`, `:month`, `:year`), so a naive `Enum.sort_by` misorders them; there
  is a same-year test that fails under the naive version.
- The pointer write-back uses `MediaItem.changeset/2` + `Repo.update/1` directly rather than
  `Media.update_media_item/3`, which emits a timeline event unconditionally. This runs on
  page views, so it has to stay silent. A test pins the event count.
- Adds are keyed per movie id (`{:add_franchise_movie, tmdb_id}`) with in-flight ids in a
  `MapSet`. Sharing one async key meant a second click discarded the first result: the movie
  was created but its entry never flipped, and a retry then reported "has already been
  taken" for an add that had succeeded.
- A relay 404 returns `:none` silently while genuine failures log at warning. Errors are
  never cached, so logging 404s would mean a warning per movie page view on every
  pre-upgrade relay.
- `MediaAddHelpers` was widened with `:monitored` / `:quality_profile_id` opts rather than
  growing a second add path. Dashboard and Discover call the short-arity form and are
  unaffected.

## Testing

11 commits, TDD throughout, 74 tests across 9 files covering the resolver's five
degradation paths, the ordering trap, the quiet write-back, all four entry render states,
per-id add concurrency, and page-level presence/absence.

Two known-flaky suites are unrelated to this branch: `DownloadsLive.PathMappingIssueTest`
(60s timeouts, verified failing identically at the merge base) and `StreamControllerTest`.

## Follow-ups, deliberately not here

- The relay endpoint itself, in its own repo.
- Routing users without create permission into the existing request flow.
- A library-wide franchises page or "missing across all franchises" report.
- Negative caching for `:not_found`, which would make the pre-upgrade-relay path free.
