### PR TITLE
fix: stop three tests depending on real host state (#242, #243)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -49,7 +49,10 @@ end
 # The server is enabled by default. Individual tests that don't need it
 # won't be affected since they use Phoenix.ConnTest directly.
 config :mydia, MydiaWeb.Endpoint,
-  http: [ip: {127, 0, 0, 1}, port: 4002],
+  # port: 0 asks the OS for a free ephemeral port, so concurrent test runs in
+  # different worktrees can never collide. test_helper.exs resolves the real
+  # port once the endpoint is listening and hands it to Wallaby.
+  http: [ip: {127, 0, 0, 1}, port: 0],
   secret_key_base: "CuiGpJ9j+jd1Xb0aq51rBSKLxBYwqr3tvwvMyS2aXBUAlHRtSCT3/GX8fxFcV6UE",
   server: true
 
@@ -146,7 +149,6 @@ chrome_capabilities =
 
 config :wallaby,
   driver: Wallaby.Chrome,
-  base_url: "http://localhost:4002",
   screenshot_on_failure: true,
   screenshot_dir: "tmp/wallaby_screenshots",
   chromedriver: wallaby_chromedriver_opts,

--- a/lib/mydia/library/mount_roots.ex
+++ b/lib/mydia/library/mount_roots.ex
@@ -7,8 +7,10 @@ defmodule Mydia.Library.MountRoots do
   ones that share a top-level directory with a configured library path, so
   suggestions resolve to directories the operator actually recognizes (rather
   than VM-internal binds on Docker Desktop, for example). Returns `[]` on
-  non-Linux hosts, in tests, or when `/proc/mounts` can't be read — in which case
-  auto-suggestion degrades to plain guidance.
+  non-Linux hosts, when no library paths are configured, or
+  when `/proc/mounts` can't be read — in which case auto-suggestion degrades
+  to plain guidance. Mount probes are time-boxed so an unresponsive network or
+  FUSE mount can't stall the caller.
   """
 
   alias Mydia.Settings
@@ -23,12 +25,18 @@ defmodule Mydia.Library.MountRoots do
   # System path prefixes a data mount would never legitimately live under.
   @system_prefixes ~w(/proc /sys /dev /run /etc /boot /usr /bin /sbin /lib /var)
 
+  # Wall-clock budget for probing all candidate mounts, total rather than per
+  # mount (they are probed concurrently).
+  @probe_timeout_ms 250
+
   @doc """
   Returns the detected, operator-meaningful mount roots.
 
   Options (for testing):
     - `:mounts_path` — path to read mounts from (default `/proc/mounts`)
     - `:library_paths` — list of library path strings (default: configured paths)
+    - `:probe_fun` — 1-arity directory check (default `&File.dir?/1`)
+    - `:probe_timeout_ms` — total budget for the probes (default #{@probe_timeout_ms})
   """
   @spec detect(keyword()) :: [String.t()]
   def detect(opts \\ []) do
@@ -41,8 +49,8 @@ defmodule Mydia.Library.MountRoots do
         |> Enum.filter(&data_like?/1)
         |> Enum.map(fn {mount_point, _fstype} -> mount_point end)
         |> intersect_with_libraries(library_top_levels(opts))
-        |> Enum.filter(&File.dir?/1)
         |> Enum.uniq()
+        |> reachable_dirs(opts)
 
       _ ->
         []
@@ -71,11 +79,44 @@ defmodule Mydia.Library.MountRoots do
   end
 
   # Keep mounts whose top-level segment matches a configured library path's
-  # top-level segment. With no library paths configured, keep them all.
-  defp intersect_with_libraries(mount_points, []), do: mount_points
+  # top-level segment.
+  #
+  # With no library paths configured there is no mapping worth suggesting, and
+  # keeping every mount would mean probing arbitrary filesystems. Degrade to
+  # plain guidance instead.
+  defp intersect_with_libraries(_mount_points, []), do: []
 
   defp intersect_with_libraries(mount_points, library_tops) do
     Enum.filter(mount_points, &(top_level(&1) in library_tops))
+  end
+
+  # A wedged NFS or FUSE mount makes File.dir?/1 block in the kernel with no
+  # timeout, which would stall the caller (in production, a LiveView event).
+  # Probe every candidate concurrently under one wall-clock budget and drop
+  # whatever has not answered.
+  #
+  # Caveat: killing the task unblocks this process, not the dirty IO scheduler
+  # thread the probe is stuck on, which stays blocked until the kernel gives
+  # up. With the probe-everything fallback removed the candidate set is
+  # typically one to three mounts, so this is bounded in practice.
+  defp reachable_dirs([], _opts), do: []
+
+  defp reachable_dirs(mount_points, opts) do
+    probe = Keyword.get(opts, :probe_fun, &File.dir?/1)
+    timeout = Keyword.get(opts, :probe_timeout_ms, @probe_timeout_ms)
+
+    mount_points
+    |> Task.async_stream(probe,
+      max_concurrency: length(mount_points),
+      timeout: timeout,
+      on_timeout: :kill_task,
+      ordered: true
+    )
+    |> Enum.zip(mount_points)
+    |> Enum.flat_map(fn
+      {{:ok, true}, mount_point} -> [mount_point]
+      {_result, _mount_point} -> []
+    end)
   end
 
   defp library_top_levels(opts) do

--- a/lib/mydia/library/mount_roots.ex
+++ b/lib/mydia/library/mount_roots.ex
@@ -90,15 +90,21 @@ defmodule Mydia.Library.MountRoots do
     Enum.filter(mount_points, &(top_level(&1) in library_tops))
   end
 
-  # A wedged NFS or FUSE mount makes File.dir?/1 block in the kernel with no
-  # timeout, which would stall the caller (in production, a LiveView event).
+  # A wedged NFS or FUSE mount makes File.dir?/1 block indefinitely. Without
+  # `raw: true`, the underlying `:file.read_file_info/2` is a synchronous
+  # `gen_server.call` into the VM-global `file_server_2` process, so the probe
+  # blocks in a `receive`, not in a dirty NIF thread. That means one wedged
+  # probe wedges `file_server_2` for the whole VM: every later non-`raw`
+  # `File.*` call anywhere queues behind it indefinitely, not just this one.
   # Probe every candidate concurrently under one wall-clock budget and drop
   # whatever has not answered.
   #
-  # Caveat: killing the task unblocks this process, not the dirty IO scheduler
-  # thread the probe is stuck on, which stays blocked until the kernel gives
-  # up. With the probe-everything fallback removed the candidate set is
-  # typically one to three mounts, so this is bounded in practice.
+  # Invariant: the timeout only works because the probe stays non-`raw`. A
+  # `raw: true` probe would run the syscall on the task's own dirty IO
+  # scheduler, where `on_timeout: :kill_task`'s `Process.exit(pid, :kill)` is
+  # deferred until the NIF returns — silently restoring an unbounded hang
+  # that these tests cannot catch (`Process.sleep(:infinity)` is trivially
+  # killable either way).
   defp reachable_dirs([], _opts), do: []
 
   defp reachable_dirs(mount_points, opts) do
@@ -107,6 +113,10 @@ defmodule Mydia.Library.MountRoots do
 
     mount_points
     |> Task.async_stream(probe,
+      # max_concurrency == length(mount_points) so every probe starts its
+      # clock at the same time and `timeout` is a total budget, not a
+      # per-mount one. Capping concurrency below the candidate count would
+      # silently turn this into waves of `timeout` each.
       max_concurrency: length(mount_points),
       timeout: timeout,
       on_timeout: :kill_task,

--- a/test/mydia/library/mount_roots_test.exs
+++ b/test/mydia/library/mount_roots_test.exs
@@ -54,5 +54,54 @@ defmodule Mydia.Library.MountRootsTest do
       assert MountRoots.detect(mounts_path: mounts_file, library_paths: ["/elsewhere/media"]) ==
                []
     end
+
+    test "returns [] when no library paths are configured", %{data: data} do
+      mounts_file = Path.join(data, "mounts")
+      File.write!(mounts_file, "/dev/sda1 #{data} ext4 rw 0 0\n")
+
+      # With nothing configured there is no meaningful mapping to suggest, and
+      # keeping every mount means probing arbitrary filesystems (a wedged NFS
+      # or FUSE mount then blocks the caller in the kernel).
+      assert MountRoots.detect(mounts_path: mounts_file, library_paths: []) == []
+    end
+
+    test "drops a mount point that is not a directory on disk", %{data: data} do
+      mounts_file = Path.join(data, "mounts")
+      missing = Path.join(data, "not_mounted")
+
+      File.write!(mounts_file, """
+      /dev/sda1 #{data} ext4 rw 0 0
+      /dev/sdb1 #{missing} ext4 rw 0 0
+      """)
+
+      assert MountRoots.detect(mounts_path: mounts_file, library_paths: [data]) == [data]
+    end
+
+    test "drops mounts whose probe does not answer within the budget", %{data: data} do
+      mounts_file = Path.join(data, "mounts")
+      slow = Path.join(data, "slow")
+      File.mkdir_p!(slow)
+
+      File.write!(mounts_file, """
+      /dev/sda1 #{data} ext4 rw 0 0
+      /dev/sdb1 #{slow} ext4 rw 0 0
+      """)
+
+      # Stands in for a wedged NFS/FUSE mount, where File.dir?/1 blocks in the
+      # kernel indefinitely.
+      probe = fn path ->
+        if path == slow, do: Process.sleep(:infinity), else: File.dir?(path)
+      end
+
+      roots =
+        MountRoots.detect(
+          mounts_path: mounts_file,
+          library_paths: [data],
+          probe_fun: probe,
+          probe_timeout_ms: 50
+        )
+
+      assert roots == [data]
+    end
   end
 end

--- a/test/mydia/library/mount_roots_test.exs
+++ b/test/mydia/library/mount_roots_test.exs
@@ -98,7 +98,7 @@ defmodule Mydia.Library.MountRootsTest do
           mounts_path: mounts_file,
           library_paths: [data],
           probe_fun: probe,
-          probe_timeout_ms: 50
+          probe_timeout_ms: 500
         )
 
       assert roots == [data]

--- a/test/mydia_web/controllers/api/stream_controller_test.exs
+++ b/test/mydia_web/controllers/api/stream_controller_test.exs
@@ -191,7 +191,7 @@ defmodule MydiaWeb.Api.StreamControllerTest do
             relative_path: test_file_name,
             codec: codec,
             audio_codec: audio_codec,
-            metadata: %{"container" => container}
+            metadata: %{"container" => container, "duration" => 120.5}
           })
 
         conn =
@@ -334,7 +334,7 @@ defmodule MydiaWeb.Api.StreamControllerTest do
           media_item_id: media_item.id,
           codec: "h264",
           audio_codec: "aac",
-          metadata: %{"container" => "mkv"}
+          metadata: %{"container" => "mkv", "duration" => 120.5}
         })
 
       conn =

--- a/test/mydia_web/controllers/api/stream_controller_test.exs
+++ b/test/mydia_web/controllers/api/stream_controller_test.exs
@@ -149,6 +149,26 @@ defmodule MydiaWeb.Api.StreamControllerTest do
       assert conn.status in [401, 302]
     end
 
+    test "streaming a fixture file runs no ffprobe analysis", %{
+      conn: conn,
+      token: token,
+      media_file: media_file
+    } do
+      conn
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/v1/stream/#{media_file.id}")
+
+      reloaded = Mydia.Repo.get!(MediaFile, media_file.id)
+
+      # A fixture file is 10KB of random bytes. If the request analyzes it,
+      # ffprobe's reading of noise replaces the codec fields the test set up
+      # and the streaming decision stops being deterministic.
+      assert reloaded.analyzed_at == media_file.analyzed_at
+      assert reloaded.analysis_attempts == media_file.analysis_attempts
+      assert reloaded.codec == media_file.codec
+      assert reloaded.audio_codec == media_file.audio_codec
+    end
+
     test "sets correct MIME type for different file extensions", %{conn: _conn, token: token} do
       test_files = [
         {".mp4", "mp4", "h264", "aac", "video/mp4"},

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -94,7 +94,8 @@ defmodule MydiaWeb.FeatureCase do
   ## Notes
 
   - Feature tests use the Ecto sandbox with allowances for browser connections
-  - The test server runs on port 4002 (configured in test.exs)
+  - The test server binds an ephemeral port; test_helper.exs resolves it and
+    sets Wallaby's base_url
   - Screenshots are automatically captured on test failure to tmp/wallaby_screenshots
   - Set `async: false` since SQLite doesn't handle concurrent writes well
   """

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -103,7 +103,14 @@ defmodule Mydia.MediaFixtures do
       resolution: "1080p",
       codec: "h264",
       audio_codec: "aac",
-      metadata: %{"container" => "mp4"}
+      # Default to an already-analyzed row so no test accidentally shells out
+      # to ffprobe. Candidates.ensure_codec_info/1 only short-circuits when
+      # analyzed_at is set AND metadata carries a duration: with analyzed_at
+      # alone it falls to the second clause (candidates.ex:197), which calls
+      # ThumbnailGenerator.get_duration/1 and shells out anyway. Tests that
+      # exercise analysis pass analyzed_at: nil explicitly.
+      analyzed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+      metadata: %{"container" => "mp4", "duration" => 120.5}
     }
 
     # Merge attrs with defaults

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -109,6 +109,12 @@ defmodule Mydia.MediaFixtures do
       # alone it falls to the second clause (candidates.ex:197), which calls
       # ThumbnailGenerator.get_duration/1 and shells out anyway. Tests that
       # exercise analysis pass analyzed_at: nil explicitly.
+      #
+      # Merging below (Enum.into(attrs, default_attrs)) replaces :metadata
+      # wholesale rather than deep-merging it: a caller that passes its own
+      # `metadata:` overrides this entire map, including the "duration" key,
+      # not just the keys it sets. Any override MUST include "duration" (or
+      # set analyzed_at: nil) or that row will still ffprobe.
       analyzed_at: DateTime.utc_now() |> DateTime.truncate(:second),
       metadata: %{"container" => "mp4", "duration" => 120.5}
     }

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -59,3 +59,14 @@ else
     - Or set config :wallaby, :chromedriver, path: "/path/to/chromedriver"
   """)
 end
+
+# The endpoint binds an OS-assigned ephemeral port (config/test.exs) so
+# concurrent worktree runs cannot collide. Wallaby needs the real port, which
+# is only knowable once the endpoint is listening.
+{:ok, {_ip, resolved_port}} = MydiaWeb.Endpoint.server_info(:http)
+
+if resolved_port == 0 do
+  raise "test endpoint reported port 0; Wallaby would be pointed at localhost:0"
+end
+
+Application.put_env(:wallaby, :base_url, "http://localhost:#{resolved_port}")


### PR DESCRIPTION
Three failures that looked unrelated turned out to share one cause: the tests reach for real host state that a CI runner happens not to have. CI runners are uniform and empty; developer machines and concurrent worktree runs are neither.

| Symptom | Host state depended on |
|---|---|
| Two worktrees can't run tests at once | A fixed global TCP port |
| `StreamControllerTest` fails intermittently in CI (#242) | The real `ffprobe` binary |
| `path_mapping_issue_test.exs` hangs 60s locally (#243) | Real `/proc/mounts` plus real mounts |

One of them is also a user-facing bug, not just a test bug.

## Ephemeral test port

`config/test.exs` hardcoded the endpoint on port 4002 with `server: true`. That port is global, so only one worktree on a machine could run the suite at a time; the second died at boot with `:eaddrinuse`. It was bound for nothing in almost every run, since feature tests are excluded by default and the four Wallaby files are the only consumer of a running server.

Now binds `port: 0` and resolves the real port for Wallaby in `test_helper.exs` via `Endpoint.server_info(:http)`, raising rather than silently pointing Wallaby at `localhost:0`.

## StreamControllerTest no longer depends on ffprobe (#242)

Root-caused rather than papered over. `stream_media_file` calls `Candidates.ensure_codec_info/1` **synchronously** on every request. For a row with `analyzed_at: nil` that shells out to ffprobe, then `Library.apply_analysis/2` writes the result to the database and re-reads the row. The fixture writes 10KB of random bytes to a `.mp4`, so ffprobe was guessing at noise, and that guess (not the test's setup) decided the response path. Different guesses, different failures: a missing `content-type` on the MIME test, a 302 instead of a 206 on the range test.

`media_file_fixture` never set `analyzed_at`, so **every** fixture media file in the suite triggered this.

The fixture now defaults to an already-analyzed row. Both `analyzed_at` and a metadata `"duration"` are needed: with `analyzed_at` alone, execution falls to the second clause of `maybe_extract_codec_info/2`, which calls `ThumbnailGenerator.get_duration/1` and shells out anyway. Tests that genuinely exercise analysis opt in with `analyzed_at: nil`.

A second commit covers two tests that overrode `metadata:` without a `"duration"` key. `Enum.into` replaces that map wholesale rather than merging, so they lost the default and still spawned ffprobe. This was invisible to normal verification because the failure path logs at `:debug` while the test logger is `:warning`; confirmed by toggling the level (3 `FFprobe failed` lines before, 0 after) and documented at the fixture so the next person doesn't step in it.

## Mount detection no longer probes every mount (#243)

Two production-behaviour changes in `MountRoots.detect/1`:

- **Dropped the probe-everything fallback.** With no library paths configured the intersection filter kept *every* data-like mount instead of narrowing, so it probed the whole machine. It now returns `[]`, degrading to plain guidance, which is what the moduledoc already claimed happened.
- **Time-boxed the probes.** `File.dir?/1` against a wedged NFS or FUSE mount blocks with no timeout. Probes now run concurrently under a total 250ms wall-clock budget and anything that hasn't answered is dropped.

This is a real bug, not only a test problem: a self-hoster with a stalled mount hangs their Downloads Issues tab exactly the way the suite hung. Locally, `path_mapping_issue_test.exs` goes from four 60-second timeouts (and an intermittent exit-137 OOM) to **4/4 passing in 1.3 seconds**.

Worth knowing for anyone touching this later, and recorded in the code: `File.dir?/1` doesn't pass `raw`, so it's a `gen_server:call(file_server_2, …, :infinity)` and a wedged mount blocks the VM-global file server, meaning one wedged probe is enough and the candidate count bounds nothing. The timeout works *because* the call is non-`raw` and therefore killable. Switching to `raw: true` would move it to a dirty IO scheduler where the kill is deferred and restore an unbounded hang, and no test could catch that, since a test's stand-in probe is always killable.

## Verification

- `mount_roots_test.exs` 7/7
- `stream_controller_test.exs` 17/17, run three times consecutively (one green run proves nothing on a flake)
- `path_mapping_issue_test.exs` 4/4, 1.3s, exit 0
- Fixture-consumer and analysis-path suites green
- `format --check-formatted` and `credo --strict` clean
- Concurrency: the ephemeral-port change was verified green *while another worktree still held 4002*

Full-suite and PostgreSQL runs are what CI is for here.

## Deliberate follow-ups, not in this PR

- `reachable_dirs/2` silently drops non-`{:ok, true}` results, so a self-hoster with a wedged mount gets no diagnostic at all. A `Logger.warning` is the obvious fix, but the budget test deliberately trips that branch, so it needs a considered answer on log level or `capture_log` rather than a reflex.
- `test_helper.exs` hard-matches `{:ok, {_ip, port}}` from `server_info/1`; an `{:error, _}` would raise a bare `MatchError`.
- `./dev shell -- <cmd>` silently discards trailing arguments.

Closes #242
Closes #243
