### PR TITLE
feat(relay): serve TMDB movie collections at /tmdb/collections/:id

### DIFF
--- a/metadata-relay/lib/metadata_relay/router.ex
+++ b/metadata-relay/lib/metadata_relay/router.ex
@@ -160,6 +160,12 @@ defmodule MetadataRelay.Router do
     handle_tmdb_request(conn, fn -> Handler.get_list(id, params) end)
   end
 
+  # TMDB Collection Details (franchise metadata)
+  get "/tmdb/collections/:id" do
+    params = extract_query_params(conn)
+    handle_tmdb_request(conn, fn -> Handler.get_collection(id, params) end)
+  end
+
   # TMDB Movie Details
   get "/tmdb/movies/:id" do
     params = extract_query_params(conn)

--- a/metadata-relay/lib/metadata_relay/tmdb/client.ex
+++ b/metadata-relay/lib/metadata_relay/tmdb/client.ex
@@ -5,6 +5,15 @@ defmodule MetadataRelay.TMDB.Client do
   This module provides a thin wrapper around the TMDB API using Req.
   It handles authentication and forwards requests to TMDB, returning
   the raw API responses.
+
+  ## Testing
+
+  For testing, you can configure a custom HTTP adapter via application config:
+
+      config :metadata_relay, :tmdb_http_adapter, fn request ->
+        {request, Req.Response.new(status: 200, body: %{})}
+      end
+
   """
 
   @base_url "https://api.themoviedb.org/3"
@@ -17,14 +26,19 @@ defmodule MetadataRelay.TMDB.Client do
   def new do
     api_key = get_api_key()
 
-    Req.new(
+    base_opts = [
       base_url: @base_url,
       params: [api_key: api_key],
       headers: [
         {"accept", "application/json"},
         {"content-type", "application/json"}
       ]
-    )
+    ]
+
+    adapter = Application.get_env(:metadata_relay, :tmdb_http_adapter)
+    opts = if adapter, do: Keyword.put(base_opts, :adapter, adapter), else: base_opts
+
+    Req.new(opts)
   end
 
   @doc """

--- a/metadata-relay/lib/metadata_relay/tmdb/handler.ex
+++ b/metadata-relay/lib/metadata_relay/tmdb/handler.ex
@@ -175,4 +175,12 @@ defmodule MetadataRelay.TMDB.Handler do
   def get_list(id, params) do
     Client.get("/list/#{id}", params: params)
   end
+
+  @doc """
+  GET /tmdb/collections/{id}
+  Get a movie collection (franchise) by ID.
+  """
+  def get_collection(id, params) do
+    Client.get("/collection/#{id}", params: params)
+  end
 end

--- a/metadata-relay/test/metadata_relay/tmdb/handler_test.exs
+++ b/metadata-relay/test/metadata_relay/tmdb/handler_test.exs
@@ -1,0 +1,161 @@
+defmodule MetadataRelay.TMDB.HandlerTest do
+  use ExUnit.Case, async: false
+
+  alias MetadataRelay.Router
+  alias MetadataRelay.TMDB.Handler
+  alias MetadataRelay.Test.TMDBHelpers
+
+  @moduletag :capture_log
+
+  setup do
+    # Set a test API key to avoid the missing key error
+    System.put_env("TMDB_API_KEY", "test_api_key_12345")
+
+    # Avoid cross-test pollution: the router pipeline caches successful GET
+    # responses in a shared ETS table, keyed by method:path:query_string.
+    MetadataRelay.Cache.clear()
+
+    on_exit(fn ->
+      TMDBHelpers.clear_tmdb_adapter()
+      System.delete_env("TMDB_API_KEY")
+    end)
+
+    :ok
+  end
+
+  # A verbatim TMDB `/3/collection/{id}` response body. mydia's
+  # `Mydia.Metadata.Structs.Collection.from_api_response/1` parses this exact
+  # shape, so the relay must forward it untouched.
+  defp collection_fixture do
+    %{
+      "id" => 10,
+      "name" => "Star Wars Collection",
+      "overview" => "The Star Wars saga.",
+      "poster_path" => "/collection-poster.jpg",
+      "backdrop_path" => "/collection-backdrop.jpg",
+      "parts" => [
+        %{
+          "id" => 11,
+          "title" => "Star Wars",
+          "original_title" => "Star Wars",
+          "overview" => "A long time ago...",
+          "release_date" => "1977-05-25",
+          "poster_path" => "/part-11-poster.jpg",
+          "backdrop_path" => "/part-11-backdrop.jpg",
+          "vote_average" => 8.6
+        },
+        %{
+          "id" => 1891,
+          "title" => "The Empire Strikes Back",
+          "original_title" => "The Empire Strikes Back",
+          "overview" => "The Empire strikes back.",
+          "release_date" => "1980-05-17",
+          "poster_path" => "/part-1891-poster.jpg",
+          "backdrop_path" => "/part-1891-backdrop.jpg",
+          "vote_average" => 8.4
+        }
+      ]
+    }
+  end
+
+  describe "get_collection/2" do
+    test "retrieves a collection by ID" do
+      TMDBHelpers.set_tmdb_adapter(
+        TMDBHelpers.mock_adapter_with_routes(%{
+          "/3/collection/10" => {200, collection_fixture()}
+        })
+      )
+
+      assert {:ok, body} = Handler.get_collection("10", [])
+      assert body["id"] == 10
+      assert body["name"] == "Star Wars Collection"
+    end
+
+    test "forwards the language query param to TMDB" do
+      test_pid = self()
+
+      TMDBHelpers.set_tmdb_adapter(fn request ->
+        send(test_pid, {:request_url, request.url})
+        {request, Req.Response.new(status: 200, body: collection_fixture())}
+      end)
+
+      assert {:ok, _body} = Handler.get_collection("10", language: "fr-FR")
+
+      assert_received {:request_url, url}
+
+      assert URI.decode_query(url.query || "") == %{
+               "language" => "fr-FR",
+               "api_key" => "test_api_key_12345"
+             }
+    end
+
+    test "returns the TMDB body unmodified, including nested parts" do
+      fixture = collection_fixture()
+
+      TMDBHelpers.set_tmdb_adapter(
+        TMDBHelpers.mock_adapter_with_routes(%{
+          "/3/collection/10" => {200, fixture}
+        })
+      )
+
+      assert {:ok, body} = Handler.get_collection("10", [])
+
+      # Regression guard: reshaping/wrapping the response would silently
+      # yield an empty parts list on the mydia side.
+      assert body == fixture
+      assert length(body["parts"]) == 2
+      assert Enum.map(body["parts"], & &1["id"]) == [11, 1891]
+    end
+
+    test "handles collection not found" do
+      TMDBHelpers.set_tmdb_adapter(
+        TMDBHelpers.mock_adapter_with_routes(%{
+          "/3/collection/999999999" =>
+            {404, %{"status_message" => "The resource could not be found."}}
+        })
+      )
+
+      assert {:error, {:http_error, 404, %{"status_message" => _}}} =
+               Handler.get_collection("999999999", [])
+    end
+  end
+
+  describe "GET /tmdb/collections/:id" do
+    test "dispatches to the handler and returns the TMDB body verbatim" do
+      TMDBHelpers.set_tmdb_adapter(
+        TMDBHelpers.mock_adapter_with_routes(%{
+          "/3/collection/10" => {200, collection_fixture()}
+        })
+      )
+
+      conn =
+        Plug.Test.conn(:get, "/tmdb/collections/10?language=en-US")
+        |> Router.call([])
+
+      assert conn.status == 200
+      response = Jason.decode!(conn.resp_body)
+
+      assert response["id"] == 10
+      assert response["name"] == "Star Wars Collection"
+      assert length(response["parts"]) == 2
+      assert Enum.map(response["parts"], & &1["id"]) == [11, 1891]
+    end
+
+    test "forwards the language query param through the route to TMDB" do
+      test_pid = self()
+
+      TMDBHelpers.set_tmdb_adapter(fn request ->
+        send(test_pid, {:request_url, request.url})
+        {request, Req.Response.new(status: 200, body: collection_fixture())}
+      end)
+
+      conn =
+        Plug.Test.conn(:get, "/tmdb/collections/10?language=fr-FR")
+        |> Router.call([])
+
+      assert conn.status == 200
+      assert_received {:request_url, url}
+      assert URI.decode_query(url.query || "")["language"] == "fr-FR"
+    end
+  end
+end

--- a/metadata-relay/test/metadata_relay/tmdb/handler_test.exs
+++ b/metadata-relay/test/metadata_relay/tmdb/handler_test.exs
@@ -122,9 +122,11 @@ defmodule MetadataRelay.TMDB.HandlerTest do
 
   describe "GET /tmdb/collections/:id" do
     test "dispatches to the handler and returns the TMDB body verbatim" do
+      fixture = collection_fixture()
+
       TMDBHelpers.set_tmdb_adapter(
         TMDBHelpers.mock_adapter_with_routes(%{
-          "/3/collection/10" => {200, collection_fixture()}
+          "/3/collection/10" => {200, fixture}
         })
       )
 
@@ -135,8 +137,10 @@ defmodule MetadataRelay.TMDB.HandlerTest do
       assert conn.status == 200
       response = Jason.decode!(conn.resp_body)
 
-      assert response["id"] == 10
-      assert response["name"] == "Star Wars Collection"
+      # Whole-body equality, not a field spot-check: anything the pipeline adds,
+      # drops, or renames would hide the franchise on the mydia side rather than
+      # fail, so a partial assertion is not enough to catch it.
+      assert response == fixture
       assert length(response["parts"]) == 2
       assert Enum.map(response["parts"], & &1["id"]) == [11, 1891]
     end
@@ -156,6 +160,28 @@ defmodule MetadataRelay.TMDB.HandlerTest do
       assert conn.status == 200
       assert_received {:request_url, url}
       assert URI.decode_query(url.query || "")["language"] == "fr-FR"
+    end
+
+    test "propagates a TMDB 404 with its status and error body" do
+      error_body = %{
+        "status_code" => 34,
+        "status_message" => "The resource you requested could not be found."
+      }
+
+      TMDBHelpers.set_tmdb_adapter(
+        TMDBHelpers.mock_adapter_with_routes(%{
+          "/3/collection/999999999" => {404, error_body}
+        })
+      )
+
+      conn =
+        Plug.Test.conn(:get, "/tmdb/collections/999999999?language=en-US")
+        |> Router.call([])
+
+      # mydia turns this 404 into a silently absent section, so the status has to
+      # survive the pipeline rather than being collapsed into a 500.
+      assert conn.status == 404
+      assert Jason.decode!(conn.resp_body) == error_body
     end
   end
 end

--- a/metadata-relay/test/support/tmdb_helpers.ex
+++ b/metadata-relay/test/support/tmdb_helpers.ex
@@ -1,0 +1,53 @@
+defmodule MetadataRelay.Test.TMDBHelpers do
+  @moduledoc """
+  Test helpers for TMDB module testing.
+
+  Provides utilities for creating mock HTTP adapters for the TMDB client.
+  """
+
+  @doc """
+  Creates a mock HTTP adapter that returns different responses based on URL.
+
+  ## Examples
+
+      adapter = mock_adapter_with_routes(%{
+        "/3/collection/10" => {200, %{"id" => 10, "name" => "Star Wars Collection"}}
+      })
+  """
+  def mock_adapter_with_routes(routes) do
+    fn request ->
+      url = request.url |> URI.to_string()
+
+      # Find matching route
+      {status, body} =
+        Enum.find_value(routes, {404, %{"error" => "Not found"}}, fn {pattern, response} ->
+          if String.contains?(url, pattern), do: response
+        end)
+
+      {request, Req.Response.new(status: status, body: body)}
+    end
+  end
+
+  @doc """
+  Sets up the TMDB HTTP adapter for testing.
+
+  Should be called in test setup and cleaned up with `clear_tmdb_adapter/0`.
+  """
+  def set_tmdb_adapter(adapter) do
+    # Wrap the adapter to also disable Req's retry mechanism for faster tests
+    wrapped_adapter = fn request ->
+      # Remove retry step from request options to speed up tests
+      request = %{request | options: Map.put(request.options, :retry, false)}
+      adapter.(request)
+    end
+
+    Application.put_env(:metadata_relay, :tmdb_http_adapter, wrapped_adapter)
+  end
+
+  @doc """
+  Clears the TMDB HTTP adapter after testing.
+  """
+  def clear_tmdb_adapter do
+    Application.delete_env(:metadata_relay, :tmdb_http_adapter)
+  end
+end

--- a/metadata-relay/test/test_helper.exs
+++ b/metadata-relay/test/test_helper.exs
@@ -1,5 +1,6 @@
 # Load test support modules
 Code.require_file("support/tvdb_helpers.ex", __DIR__)
+Code.require_file("support/tmdb_helpers.ex", __DIR__)
 
 # Ensure the Repo is started and run migrations for in-memory database
 case MetadataRelay.Repo.start_link() do


### PR DESCRIPTION
## What

Adds `GET /tmdb/collections/:id` to metadata-relay, a verbatim passthrough of TMDB's
`/3/collection/{id}`.

This is the endpoint #248's movie franchise section consumes. It was never added, so
that feature has been dark since it merged: the relay 404s, mydia degrades the section
to absent, and nothing is logged. This turns it on.

## Why it was missed

#248 described the relay change as a follow-up "in its own repo". `metadata-relay/` is a
folder in this repo, so the endpoint could have shipped in that same PR. Filing it here
instead of deferring further.

## Verbatim matters here

`Mydia.Metadata.Structs.Collection.from_api_response/1` reads the raw TMDB keys, and
`parse_parts/1` falls back to `[]` on anything it does not recognise. A reshaped or
wrapped payload would therefore *hide* the franchise rather than error, which is the
worst failure mode available: silent, and indistinguishable from "this movie has no
sequels".

So the passthrough is asserted two ways:

- A test pins the response body byte-for-byte against the fixture (`assert body == fixture`),
  not just a field spot-check.
- That same fixture was run through mydia's parser directly, producing 2 parts with real
  `Date` structs — confirming both sides agree on the shape rather than assuming it.

## Changes

- `router.ex` — the route, next to the other single-id TMDB detail routes. `collections`
  is a distinct first path segment, so unlike the `trending`/`popular` routes it cannot
  be shadowed by `/tmdb/movies/:id`; placement is for readability, not correctness.
- `tmdb/handler.ex` — `get_collection/2`, same one-line `Client.get/2` shape as
  `get_movie/2` and `get_list/2`.
- `tmdb/client.ex` — reads `:tmdb_http_adapter` from application config so tests can
  stand in for the network. The TVDB client already did exactly this; the TMDB one had no
  equivalent, which left its handlers testable only against the live API. Mirrors the
  TVDB shape rather than adding a second mocking approach. Separate commit.
- Tests — 7 cases. At the handler level: body verbatim, nested `parts` intact, `language`
  reaching TMDB, 404 passthrough. Through the full router pipeline: body verbatim,
  `language` reaching TMDB, and 404 propagating its status and error body. `setup`
  clears the response cache, since the router memoises successful GETs in a shared ETS
  table keyed by `method:path:query_string` and stale entries would leak between
  router-level tests.

## Testing

Relay CI gates, run in `metadata-relay/`:

```
mix deps.unlock --check-unused    exit 0
mix compile --warnings-as-errors  Generated metadata_relay app
mix format --check-formatted      exit 0
mix test --warnings-as-errors     173 tests, 0 failures
```

Caveat: run on Elixir 1.19.5 / OTP 28, the toolchain available locally. Relay CI pins
1.18 / OTP 27. Nothing in the diff is version-sensitive (no new deps, no 1.19-only
syntax), but CI is the real check on that.

## Note on deploying

Merging this does not make the franchise section live. `deploy-relay.yml` fires on a
`metadata-relay-v*` tag, not on merge to master. The section lights up on the next movie
page view after the relay is deployed, with no mydia restart and no TTL wait, because
`Metadata.Cache.fetch/3` only writes on `{:ok, _}` and never negative-caches the 404.
