### PR TITLE
chore(metadata-relay): bump version to 0.11.0

### DIFF
--- a/metadata-relay/mix.exs
+++ b/metadata-relay/mix.exs
@@ -4,7 +4,7 @@ defmodule MetadataRelay.MixProject do
   def project do
     [
       app: :metadata_relay,
-      version: "0.10.2",
+      version: "0.11.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Cuts metadata-relay 0.11.0 so the TMDB collections endpoint from #250 actually gets built and deployed.

## Why minor, not patch

0.11.0 carries a new endpoint (`GET /tmdb/collections/:id`). That matches how the relay has been versioned: 0.10.0 was cut for a `feat`, while 0.10.1 and 0.10.2 were fix-only patches.

## Why this is needed at all

The relay auto-deploys, but only from tagged releases:

```
git tag metadata-relay-v0.11.0  ->  deploy-relay.yml builds ghcr.io/.../metadata-relay:0.11.0
                                ->  Keel polls ghcr.io (@every 5m)  ->  rollout
```

`deploy-relay.yml` triggers on `metadata-relay-v*` tags, not on push to master, so merging #250 produced no image and Keel had nothing newer to find. Verified on can-1: the running pod is 52 days old on `:0.10.2`, and `GET /tmdb/collections/1241` still 404s while `/tmdb/movies/671` returns 200.

Nothing relay-side has been tagged since 0.10.2 on 2026-06-07. This ships the three untagged relay commits, all from today and all covered by green relay CI:

```
64c668a7  test(relay): assert the collections route body verbatim and its 404
89d13b33  feat(relay): serve TMDB movie collections at /tmdb/collections/:id
742777d3  test(relay): allow injecting an HTTP adapter into the TMDB client
```

After merge, the tag goes on the merge commit, matching `metadata-relay-v0.10.0` -> merge `60222be0`.