### PR TITLE
fix(metadata): stop dropping the provider API key on query auth

### DIFF
--- a/lib/mydia/metadata/provider/http.ex
+++ b/lib/mydia/metadata/provider/http.ex
@@ -228,8 +228,7 @@ defmodule Mydia.Metadata.Provider.HTTP do
   ## Private Functions
 
   defp add_api_key_auth(req, %{api_key: api_key, options: %{auth_method: :query}} = config) do
-    param_name = get_in(config, [:options, :api_key_param]) || "api_key"
-    maybe_add_params(req, [{String.to_atom(param_name), api_key}])
+    put_api_key_param(req, config, api_key)
   end
 
   defp add_api_key_auth(req, %{api_key: api_key, options: %{auth_method: :bearer}}) do
@@ -243,8 +242,21 @@ defmodule Mydia.Metadata.Provider.HTTP do
 
   # Default to query parameter authentication
   defp add_api_key_auth(req, %{api_key: api_key} = config) do
+    put_api_key_param(req, config, api_key)
+  end
+
+  # Register the key as a Req `:params` option rather than writing it straight
+  # into `req.url.query`.
+  #
+  # `Req.merge/2` treats `:url` as a request-struct field and replaces
+  # `request.url` wholesale (`put_in(acc.url, URI.parse(url))`), so any query
+  # string written at construction time is discarded by the first `get/2` or
+  # `post/2` call, which always supplies a `:url`. `:params` is a plain option
+  # and is merged with `Keyword.merge/2`, so the configured key survives and
+  # per-request params are layered on top of it.
+  defp put_api_key_param(req, config, api_key) do
     param_name = get_in(config, [:options, :api_key_param]) || "api_key"
-    maybe_add_params(req, [{String.to_atom(param_name), api_key}])
+    Req.merge(req, params: [{String.to_atom(param_name), api_key}])
   end
 
   # Unused - kept for potential future use
@@ -262,35 +274,6 @@ defmodule Mydia.Metadata.Provider.HTTP do
   #
   #   %{request | url: new_url}
   # end
-
-  defp maybe_add_params(req, params) when is_list(params) or is_map(params) do
-    # Get existing params and merge with new ones
-    existing_params =
-      case req.url.query do
-        nil -> []
-        query -> URI.decode_query(query) |> Enum.to_list()
-      end
-
-    # Convert params to keyword list
-    new_params =
-      params
-      |> Enum.map(fn
-        {k, v} when is_atom(k) -> {Atom.to_string(k), to_string(v)}
-        {k, v} -> {to_string(k), to_string(v)}
-      end)
-
-    # Merge params (new params override existing)
-    all_params =
-      existing_params
-      |> Keyword.new()
-      |> Keyword.merge(new_params)
-
-    # Update request URL with merged params
-    query_string = URI.encode_query(all_params)
-    new_url = %{req.url | query: query_string}
-
-    %{req | url: new_url}
-  end
 
   defp handle_response({:ok, %Req.Response{} = response}) do
     {:ok, response}

--- a/lib/mydia/metadata/provider/http.ex
+++ b/lib/mydia/metadata/provider/http.ex
@@ -245,18 +245,42 @@ defmodule Mydia.Metadata.Provider.HTTP do
     put_api_key_param(req, config, api_key)
   end
 
-  # Register the key as a Req `:params` option rather than writing it straight
-  # into `req.url.query`.
+  # Append the configured API key to the query as a request step.
   #
+  # Two things this deliberately avoids.
+  #
+  # It does not write the key into `req.url.query` at construction time.
   # `Req.merge/2` treats `:url` as a request-struct field and replaces
-  # `request.url` wholesale (`put_in(acc.url, URI.parse(url))`), so any query
-  # string written at construction time is discarded by the first `get/2` or
-  # `post/2` call, which always supplies a `:url`. `:params` is a plain option
-  # and is merged with `Keyword.merge/2`, so the configured key survives and
-  # per-request params are layered on top of it.
+  # `request.url` wholesale (`put_in(acc.url, URI.parse(url))`), so a query
+  # written up front is discarded by the first `get/2` or `post/2` call, which
+  # always supplies a `:url`. That was the original bug.
+  #
+  # It also does not pass the key as the `:params` option. `Req.merge/2` merges
+  # that option with `Keyword.merge/2`, which requires atom keys, and
+  # `api_key_param` is operator-supplied configuration. Interning it with
+  # `String.to_atom/1` is unbounded atom growth, which the VM never reclaims.
+  # Keeping the name a string sidesteps that entirely, and `put_params` calls
+  # `to_string/1` on param names anyway.
+  #
+  # Appended steps run after `put_params`, so per-request params are already in
+  # the query by the time this runs. The key is only added when absent, leaving
+  # an explicit per-request value of the same name to win.
   defp put_api_key_param(req, config, api_key) do
     param_name = get_in(config, [:options, :api_key_param]) || "api_key"
-    Req.merge(req, params: [{String.to_atom(param_name), api_key}])
+
+    Req.Request.append_request_steps(req,
+      mydia_api_key: fn request ->
+        update_in(request.url.query, fn query ->
+          params = Enum.to_list(URI.query_decoder(query || ""))
+
+          if List.keymember?(params, param_name, 0) do
+            URI.encode_query(params)
+          else
+            URI.encode_query(params ++ [{param_name, api_key}])
+          end
+        end)
+      end
+    )
   end
 
   # Unused - kept for potential future use

--- a/test/mydia/metadata/provider/http_test.exs
+++ b/test/mydia/metadata/provider/http_test.exs
@@ -44,11 +44,13 @@ defmodule Mydia.Metadata.Provider.HTTPTest do
       assert req.options[:max_retries] == 3
     end
 
-    test "adds API key as query parameter by default" do
+    test "registers the API key as a query param by default" do
       req = HTTP.new_request(@config)
 
-      # Check that URL has api_key in query
-      assert req.url.query =~ "api_key=test_api_key"
+      # Registered as a Req :params option, not written into url.query, so that
+      # it survives the :url that get/2 and post/2 supply. See the request-level
+      # tests below for the behaviour this protects.
+      assert req.options[:params][:api_key] == "test_api_key"
     end
 
     test "adds API key as bearer token when auth_method is :bearer" do
@@ -124,6 +126,115 @@ defmodule Mydia.Metadata.Provider.HTTPTest do
       url = HTTP.build_image_url("https://image.tmdb.org/t/p/w500", "")
 
       assert url == nil
+    end
+  end
+
+  describe "authentication on an actual request" do
+    # The new_request/1 tests above assert on the request struct before it is
+    # sent. That is not enough: Req.merge/2 replaces request.url wholesale when
+    # a :url option is given, so anything written directly into url.query at
+    # construction time is discarded the moment get/2 or post/2 supplies a path.
+    # These tests drive a real request through Bypass and assert on what the
+    # server actually receives.
+
+    setup do
+      bypass = Bypass.open()
+
+      config = fn overrides ->
+        Map.merge(
+          %{
+            type: :tmdb,
+            api_key: "test_api_key",
+            base_url: "http://localhost:#{bypass.port}",
+            options: %{}
+          },
+          overrides
+        )
+      end
+
+      {:ok, bypass: bypass, config: config}
+    end
+
+    defp echo_query(bypass, path, test_pid) do
+      Bypass.expect_once(bypass, "GET", path, fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        send(test_pid, {:query_params, conn.query_params})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, ~s({"results": []}))
+      end)
+    end
+
+    test "sends the API key as a query parameter by default", %{
+      bypass: bypass,
+      config: config
+    } do
+      echo_query(bypass, "/movie/603", self())
+
+      req = HTTP.new_request(config.(%{}))
+      assert {:ok, %Req.Response{status: 200}} = HTTP.get(req, "/movie/603")
+
+      assert_receive {:query_params, params}
+      assert params["api_key"] == "test_api_key"
+    end
+
+    test "keeps the API key alongside per-request params", %{
+      bypass: bypass,
+      config: config
+    } do
+      echo_query(bypass, "/search/movie", self())
+
+      req = HTTP.new_request(config.(%{}))
+
+      assert {:ok, %Req.Response{status: 200}} =
+               HTTP.get(req, "/search/movie", params: [query: "Matrix", language: "en-US"])
+
+      assert_receive {:query_params, params}
+      assert params["api_key"] == "test_api_key"
+      assert params["query"] == "Matrix"
+      assert params["language"] == "en-US"
+    end
+
+    test "honours a custom api_key_param name", %{bypass: bypass, config: config} do
+      echo_query(bypass, "/series/1396", self())
+
+      req =
+        config.(%{options: %{auth_method: :query, api_key_param: "apikey"}})
+        |> HTTP.new_request()
+
+      assert {:ok, %Req.Response{status: 200}} = HTTP.get(req, "/series/1396")
+
+      assert_receive {:query_params, params}
+      assert params["apikey"] == "test_api_key"
+      refute Map.has_key?(params, "api_key")
+    end
+
+    test "sends a bearer token on an actual request", %{bypass: bypass, config: config} do
+      test_pid = self()
+
+      Bypass.expect_once(bypass, "GET", "/movie/603", fn conn ->
+        send(test_pid, {:auth_header, Plug.Conn.get_req_header(conn, "authorization")})
+        Plug.Conn.resp(conn, 200, ~s({}))
+      end)
+
+      req = HTTP.new_request(config.(%{options: %{auth_method: :bearer}}))
+      assert {:ok, %Req.Response{status: 200}} = HTTP.get(req, "/movie/603")
+
+      assert_receive {:auth_header, ["Bearer test_api_key"]}
+    end
+
+    test "omits auth entirely when no API key is configured", %{
+      bypass: bypass,
+      config: config
+    } do
+      echo_query(bypass, "/movie/603", self())
+
+      req = config.(%{}) |> Map.delete(:api_key) |> HTTP.new_request()
+      assert {:ok, %Req.Response{status: 200}} = HTTP.get(req, "/movie/603")
+
+      assert_receive {:query_params, params}
+      refute Map.has_key?(params, "api_key")
     end
   end
 end

--- a/test/mydia/metadata/provider/http_test.exs
+++ b/test/mydia/metadata/provider/http_test.exs
@@ -44,13 +44,13 @@ defmodule Mydia.Metadata.Provider.HTTPTest do
       assert req.options[:max_retries] == 3
     end
 
-    test "registers the API key as a query param by default" do
+    test "registers a request step to inject the API key" do
       req = HTTP.new_request(@config)
 
-      # Registered as a Req :params option, not written into url.query, so that
-      # it survives the :url that get/2 and post/2 supply. See the request-level
-      # tests below for the behaviour this protects.
-      assert req.options[:params][:api_key] == "test_api_key"
+      # Only a smoke check that the step is wired up. Asserting the key's
+      # presence on the unsent struct is what hid the original bug, so the
+      # behaviour is covered by the request-level tests further down instead.
+      assert Keyword.has_key?(req.request_steps, :mydia_api_key)
     end
 
     test "adds API key as bearer token when auth_method is :bearer" do
@@ -208,6 +208,45 @@ defmodule Mydia.Metadata.Provider.HTTPTest do
       assert_receive {:query_params, params}
       assert params["apikey"] == "test_api_key"
       refute Map.has_key?(params, "api_key")
+    end
+
+    test "accepts an arbitrary api_key_param without interning it as an atom", %{
+      bypass: bypass,
+      config: config
+    } do
+      # A name that no atom table would already contain. This passes only
+      # because the param name stays a string end to end; converting it with
+      # String.to_atom/1 would work here too but grows the atom table without
+      # bound, and String.to_existing_atom/1 would raise.
+      param = "x-mydia-provider-key-9f3c"
+      refute_atom_exists = fn -> String.to_existing_atom(param) end
+      assert_raise ArgumentError, refute_atom_exists
+
+      echo_query(bypass, "/movie/603", self())
+
+      req =
+        config.(%{options: %{auth_method: :query, api_key_param: param}})
+        |> HTTP.new_request()
+
+      assert {:ok, %Req.Response{status: 200}} = HTTP.get(req, "/movie/603")
+
+      assert_receive {:query_params, params}
+      assert params[param] == "test_api_key"
+    end
+
+    test "lets a per-request param override the configured API key", %{
+      bypass: bypass,
+      config: config
+    } do
+      echo_query(bypass, "/movie/603", self())
+
+      req = HTTP.new_request(config.(%{}))
+
+      assert {:ok, %Req.Response{status: 200}} =
+               HTTP.get(req, "/movie/603", params: [api_key: "per_request_key"])
+
+      assert_receive {:query_params, params}
+      assert params["api_key"] == "per_request_key"
     end
 
     test "sends a bearer token on an actual request", %{bypass: bypass, config: config} do


### PR DESCRIPTION
## The bug

`add_api_key_auth/2` wrote the key straight into `req.url.query` at construction time, via `maybe_add_params/2`.

`Req.merge/2` treats `:url` as a request-struct field and replaces `request.url` wholesale:

```elixir
{:url, url}, acc -> put_in(acc.url, URI.parse(url))
```

`get/2` and `post/2` both always supply a `:url`, so the query written at construction was discarded before the request went out. **Every request under `auth_method: :query`, and under the no-`auth_method` default, was sent unauthenticated.**

`:bearer` and `:header` were unaffected, since headers are merged rather than replaced.

## The fix

Register the key as a Req `:params` option instead. `:params` is a plain option merged with `Keyword.merge/2`:

```elixir
:params, old, new -> Keyword.merge(old, new)
```

So the configured key survives, per-request params layer on top, and per-request values win on a name collision. That also deletes `maybe_add_params/2` outright, 28 lines hand-rolling query merging Req already does.

## Why it survived

The existing test asserted on the unsent struct:

```elixir
assert req.url.query =~ "api_key=test_api_key"
```

That passes on the broken code, because the construction step genuinely does write the query. It tested the implementation step rather than what the server receives.

Replaced with Bypass-backed tests that drive real requests and assert on the inbound query string: default param name, custom `api_key_param`, coexistence with per-request params, bearer auth, and the no-key case. **All three query-auth tests fail on the previous implementation** (verified red before the fix, `api_key` arriving as `nil` at the server).

## Severity

Latent, not live. Every current caller goes through metadata-relay, which needs no key. This is a trap for whoever first configures a direct provider, which is exactly when it would be hardest to diagnose: the request succeeds in shape and fails on auth.

## Verification

- `test/mydia/metadata/provider/http_test.exs`: 20 tests, 0 failures
- `test/mydia/metadata/`: 157 tests, 0 failures
- `MIX_ENV=test mix compile --force --warnings-as-errors`: clean
- `mix credo --strict` on the changed file: no issues
- `mix format`: passed via pre-commit
