### PR TITLE
fix(nix): correct every Tailwind binary hash and stop stale ones passing

### DIFF
--- a/nix/packages/flake-module.nix
+++ b/nix/packages/flake-module.nix
@@ -174,24 +174,52 @@
         hash = "sha256-DhOg4p37GgILp0IzzgqyoiyTBx6saHz6j4624/+Smj4=";
       };
 
-      # Tailwind CSS v4 binary (not yet in nixpkgs)
-      # Needs to be patched for NixOS
+      # Tailwind CSS v4 standalone binary. nixpkgs does ship tailwindcss_4, but
+      # at 4.2.0, behind the 4.3.3 pinned in lockstep across config, nix and npm
+      # (344719f8), so the release binary is fetched directly instead.
       tailwindVersion = "4.3.3";
-      tailwindBinaryName = {
-        "x86_64-linux" = "tailwindcss-linux-x64";
-        "aarch64-linux" = "tailwindcss-linux-arm64";
-        "x86_64-darwin" = "tailwindcss-macos-x64";
-        "aarch64-darwin" = "tailwindcss-macos-arm64";
-      }.${system} or "tailwindcss-linux-x64";
-      tailwindBinaryHash = {
-        "x86_64-linux" = "sha256-c3vs+NStERXqmN9p+pQCbUAsqP65EwagNbWwBBZ9qN0=";
-        "aarch64-linux" = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-        "x86_64-darwin" = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-        "aarch64-darwin" = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-      }.${system} or "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+      # Keep in sync with tailwindVersion. These are content hashes, so every
+      # entry can be computed from any machine regardless of its own platform:
+      #   nix store prefetch-file \
+      #     https://github.com/tailwindlabs/tailwindcss/releases/download/v<version>/<binary>
+      tailwindBinaries = {
+        "x86_64-linux" = {
+          name = "tailwindcss-linux-x64";
+          hash = "sha256-3GGzrGuMnKh0wMxMV7JAl5GmTFVAQEyl9TZzYLq8MTo=";
+        };
+        "aarch64-linux" = {
+          name = "tailwindcss-linux-arm64";
+          hash = "sha256-Vf0LJBIU7/PeHo7k8ieWZi8tLnpJvPynR3z9C6w5gZU=";
+        };
+        "x86_64-darwin" = {
+          name = "tailwindcss-macos-x64";
+          hash = "sha256-eSLglT8hEMBZduO/WPFOZD2QQnV152a31DP1+Ay+5+E=";
+        };
+        "aarch64-darwin" = {
+          name = "tailwindcss-macos-arm64";
+          hash = "sha256-zfZGcCmHp0NGTf9NnGD9RIDRwec92Bmppn8QeIFdzp0=";
+        };
+      };
+
+      # Fail loudly on an unrecognised system. The previous fallback handed out
+      # an all-A placeholder hash, which surfaced as an opaque hash mismatch
+      # rather than "this platform was never set up".
+      tailwindBinary = tailwindBinaries.${system} or (throw
+        "mydia: no Tailwind ${tailwindVersion} binary recorded for ${system}; add one to tailwindBinaries in nix/packages/flake-module.nix");
+
       tailwindcss_4_src = pkgs.fetchurl {
-        url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v${tailwindVersion}/${tailwindBinaryName}";
-        hash = tailwindBinaryHash;
+        # Version-qualified on purpose. Fixed-output derivations are keyed by
+        # (hash, name) and ignore the URL entirely, so a stale hash can be
+        # satisfied by whatever is already in the local store under the same
+        # name. That is exactly what happened when 344719f8 bumped the version
+        # without updating the hash: the 4.1.18 artifact already present
+        # matched, the package built 4.1.18 while claiming 4.3.3, and it only
+        # failed on machines with a cold store. Including the version in the
+        # name makes a stale hash force a real fetch, and fail immediately.
+        name = "tailwindcss-${tailwindVersion}-${platformSuffix}";
+        url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v${tailwindVersion}/${tailwindBinary.name}";
+        hash = tailwindBinary.hash;
       };
       # Patch the binary for NixOS (fix interpreter and library paths)
       tailwindcss_4 = pkgs.stdenv.mkDerivation {
@@ -205,8 +233,12 @@
         # runs as bare Bun and silently emits an EMPTY stylesheet — the package
         # builds fine and the app boots with no CSS at all. Never strip it.
         dontStrip = true;
-        nativeBuildInputs = [ pkgs.autoPatchelfHook pkgs.makeWrapper ];
-        buildInputs = [ pkgs.stdenv.cc.cc.lib ];
+        # autoPatchelfHook and the libstdc++ wrapping below are ELF-only. The
+        # macOS builds are self-contained Mach-O binaries and need neither.
+        nativeBuildInputs = [ pkgs.makeWrapper ]
+          ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.autoPatchelfHook;
+        buildInputs =
+          pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.stdenv.cc.cc.lib;
         installPhase = ''
           mkdir -p $out/bin
           cp $src $out/bin/tailwindcss
@@ -216,9 +248,24 @@
         # at RUNTIME, so autoPatchelfHook cannot reach it — it does not exist at
         # build time. Without libstdc++ on the loader path the addon fails with
         # ERR_DLOPEN_FAILED. Wrap rather than patch.
-        postFixup = ''
+        postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
           wrapProgram $out/bin/tailwindcss \
             --prefix LD_LIBRARY_PATH : ${pkgs.stdenv.cc.cc.lib}/lib
+        '';
+        # Assert the packaged binary really is the pinned version. Combined with
+        # the version-qualified src name, this makes a hash/version mismatch a
+        # build failure rather than a silently wrong Tailwind, and it also
+        # re-checks that the payload survived fixup (see dontStrip above): a
+        # stripped binary runs as bare Bun and prints no Tailwind version.
+        doInstallCheck = true;
+        installCheckPhase = ''
+          runHook preInstallCheck
+          if ! $out/bin/tailwindcss --help 2>&1 | grep -q "v${tailwindVersion}"; then
+            echo "ERROR: packaged Tailwind does not report v${tailwindVersion}:" >&2
+            $out/bin/tailwindcss --help 2>&1 | head -2 >&2
+            exit 1
+          fi
+          runHook postInstallCheck
         '';
       };
 
@@ -385,6 +432,11 @@
       packages = {
         default = mydia;
         postgres = mydia-postgres;
+        # Exposed so the pinned Tailwind binary can be built and version-checked
+        # per platform (`nix build .#tailwindcss`) without building the whole
+        # Elixir release. The hash table above was wrong on every platform and
+        # nothing could catch it cheaply.
+        tailwindcss = tailwindcss_4;
       };
     };
 }

--- a/nix/packages/flake-module.nix
+++ b/nix/packages/flake-module.nix
@@ -160,13 +160,23 @@
         hash = "sha256-Oup/lGU8a9Dqfho4Llg39t9Y9n4xfUmGk0772OkpnLQ=";
       };
 
-      # Platform-specific binary names for esbuild/tailwind
+      # Platform-specific binary names for esbuild/tailwind.
+      #
+      # Throws rather than falling back. The previous `or "linux-x64"` was
+      # silently wrong on any unlisted system, in three separate ways: it named
+      # the Tailwind fetchurl (collapsing its version-qualified name back onto
+      # the x86_64 one, defeating the stale-hash guard below), and it named the
+      # _build/esbuild-* and _build/tailwind-* symlinks that the Elixir esbuild
+      # and tailwind wrappers look for. A mismatched symlink makes those
+      # wrappers try to download the binary at build time, which fails in the
+      # sandbox for reasons that point nowhere near this table.
       platformSuffix = {
         "x86_64-linux" = "linux-x64";
         "aarch64-linux" = "linux-arm64";
         "x86_64-darwin" = "darwin-x64";
         "aarch64-darwin" = "darwin-arm64";
-      }.${system} or "linux-x64";
+      }.${system} or (throw
+        "mydia: no esbuild/tailwind platform suffix recorded for ${system}; add one to platformSuffix in nix/packages/flake-module.nix (tailwindBinaries below needs an entry too)");
 
       # Pre-fetch npm dependencies (required for sandbox build)
       npmDeps = pkgs.fetchNpmDeps {
@@ -206,7 +216,7 @@
       # an all-A placeholder hash, which surfaced as an opaque hash mismatch
       # rather than "this platform was never set up".
       tailwindBinary = tailwindBinaries.${system} or (throw
-        "mydia: no Tailwind ${tailwindVersion} binary recorded for ${system}; add one to tailwindBinaries in nix/packages/flake-module.nix");
+        "mydia: no Tailwind ${tailwindVersion} binary recorded for ${system}; add one to tailwindBinaries in nix/packages/flake-module.nix (platformSuffix above needs an entry too)");
 
       tailwindcss_4_src = pkgs.fetchurl {
         # Version-qualified on purpose. Fixed-output derivations are keyed by


### PR DESCRIPTION
## What's wrong

All four entries in `tailwindBinaryHash` were wrong.

Three were `sha256-AAAA…` placeholders, so `aarch64-linux` and both darwin systems could never fetch at all. That much was known.

**The fourth was worse.** `x86_64-linux` carried the hash of Tailwind **4.1.18**, left behind when 344719f8 bumped `tailwindVersion` to 4.3.3.

## Why nobody noticed

Fixed-output derivations are keyed by `(hash, name)` and **ignore the URL**. The 4.1.18 artifact already sitting in the store under the name `tailwindcss-linux-x64` satisfied the stale hash, so the fetch never went to the network.

The package has therefore been building **Tailwind 4.1.18 while claiming 4.3.3**.

CI missed it for exactly the same reason: `magic-nix-cache-action` carries that artifact between runs, so `ci-nix` stayed green on a binary two minor versions behind the pin. It only fails on a genuinely cold store, which nothing in the pipeline ever has.

Evidence:

| | size | sha256 | reports |
| --- | --- | --- | --- |
| Artifact the old hash pins | 121,014,727 | `737becf8…` | **v4.1.18** |
| What the v4.3.3 URL actually serves | 111,749,248 | `dc61b3ac…` | v4.3.3 |

## Changes

- **One `tailwindBinaries` attrset** keyed by system, holding both asset name and hash, replacing two parallel tables that could drift apart. All four hashes recomputed from the real v4.3.3 assets and re-verified against upstream; architectures confirmed with `file(1)`.
- **Version-qualified fetchurl name** (`tailwindcss-${version}-${platformSuffix}`). Since the FOD key includes the name, a stale hash can no longer be satisfied by a differently-versioned artifact. It forces a real fetch and fails immediately. **This is the structural fix**; the hashes alone would just reset the clock.
- **`installCheckPhase` asserting the packaged binary reports the pinned version.** Also re-checks that the bun payload survived fixup, since a stripped binary runs as bare Bun and prints no version, the failure mode 85c849a7 fixed.
- **Throw a named error for unrecognised systems** instead of handing back a placeholder hash that surfaced as an opaque mismatch.
- **Guard the ELF-only steps.** `autoPatchelfHook` and the libstdc++ `LD_LIBRARY_PATH` wrap are skipped on darwin, whose Mach-O builds are self-contained.
- **Expose `packages.tailwindcss`** so the binary can be built and version-checked per platform (`nix build .#tailwindcss`) without building the whole Elixir release.

## Why not `pkgs.tailwindcss_4`

nixpkgs does ship it now, so the "not yet in nixpkgs" comment is stale, and switching would delete this whole block. But nixpkgs is at **4.2.0**, behind the 4.3.3 that 344719f8 pinned in lockstep across config, nix, and npm. Adopting it would be a silent downgrade and would desync nix from `package.json`. Left as a deliberate note in the code instead.

## Verification

- `nix build .#tailwindcss` on x86_64-linux succeeds; store path is now `tailwindcss-4.3.3-linux-x64`, confirming it fetched fresh rather than reusing the stale artifact.
- `installCheckPhase` passes and the resulting binary reports **v4.3.3**.
- All four systems evaluate to distinct derivations.
- All four hashes re-verified against upstream after editing: 4 match, 0 mismatch.
- `packages.x86_64-linux.default` still evaluates.

**Not verified:** the darwin builds are evaluated and hash-verified but not built. No macOS host available, and the ELF/Mach-O branching is reasoned rather than tested. `nix build .#tailwindcss` on a Mac is now a one-command check for anyone who has one.
