### PR TITLE
fix(metadata): show trailers for TV shows on discover, dashboard, and library detail

### DIFF
--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -336,8 +336,18 @@ defmodule Mydia.Metadata.Provider.Relay do
   # never fail the fetch, so every failure path degrades to an empty list.
   defp resolve_tvdb_videos(config, data, preferred_codes, language) do
     case Video.from_tvdb_trailers(data["trailers"], preferred_codes) do
-      [] -> fetch_tmdb_videos_for_tvdb(config, data, language)
-      videos -> videos
+      [] ->
+        # Degrade here, outside the cache boundary, rather than inside the
+        # memoized fetch. A relay failure has to stay an error until it is past
+        # `Cache.fetch/3`, otherwise one transient 500 is stored as a
+        # confirmed-empty result and suppresses the trailer for 24 hours.
+        case fetch_tmdb_videos_for_tvdb(config, data, language) do
+          {:ok, videos} when is_list(videos) -> videos
+          _ -> []
+        end
+
+      videos ->
+        videos
     end
   end
 
@@ -348,7 +358,7 @@ defmodule Mydia.Metadata.Provider.Relay do
           tvdb_id: data["id"]
         )
 
-        []
+        {:ok, []}
 
       tmdb_id ->
         fetch_tmdb_videos(config, tmdb_id, language)
@@ -358,25 +368,28 @@ defmodule Mydia.Metadata.Provider.Relay do
   # The spec's coverage sample found zero TVDB trailers on 4 of 4 popular shows,
   # so this fallback is the typical path rather than the exception. Memoize it so
   # a weekly `MetadataRefresh.refresh_all_media/0` doesn't cost one extra relay
-  # round-trip per TV show. The result is wrapped in `{:ok, _}` because
-  # `Cache.fetch/3` only stores `{:ok, _}` — an empty list has to be cached too,
-  # since "neither provider has a trailer" is exactly the case that would
-  # otherwise re-request forever.
+  # round-trip per TV show. `Cache.fetch/3` stores only `{:ok, _}`, which is
+  # exactly the split we want: a successful empty list is cached (since "neither
+  # provider has a trailer" is the case that would otherwise re-request
+  # forever), while an error is returned uncached and retried next time.
   defp fetch_tmdb_videos(config, tmdb_id, language) do
     cache_key = "tvdb_tmdb_videos:#{tmdb_id}:#{language}"
 
-    cache_key
-    |> Cache.fetch(fn -> {:ok, request_tmdb_videos(config, tmdb_id)} end, ttl: :timer.hours(24))
-    |> case do
-      {:ok, videos} when is_list(videos) -> videos
-      _ -> []
-    end
+    Cache.fetch(cache_key, fn -> request_tmdb_videos(config, tmdb_id) end, ttl: :timer.hours(24))
   end
 
   defp request_tmdb_videos(config, tmdb_id) do
     case perform_tmdb_fetch(config, tmdb_id, :tv_show, append_to_response: ["videos"]) do
       {:ok, %MediaMetadata{videos: videos}} when is_list(videos) ->
-        videos
+        {:ok, videos}
+
+      {:error, _reason} = error ->
+        Logger.debug("TMDB trailer fallback failed; leaving it uncached",
+          tmdb_id: tmdb_id,
+          result: inspect(error)
+        )
+
+        error
 
       other ->
         Logger.debug("TMDB trailer fallback returned no videos",
@@ -384,7 +397,7 @@ defmodule Mydia.Metadata.Provider.Relay do
           result: inspect(other)
         )
 
-        []
+        {:ok, []}
     end
   end
 

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -65,6 +65,7 @@ defmodule Mydia.Metadata.Provider.Relay do
   @behaviour Mydia.Metadata.Provider
 
   require Logger
+  alias Mydia.Metadata.Cache
   alias Mydia.Metadata.Provider.{Error, HTTP}
   alias Mydia.Metadata.LanguageCode
   alias Mydia.Metadata.ProviderIDRegistry
@@ -313,7 +314,7 @@ defmodule Mydia.Metadata.Provider.Relay do
         metadata = %{
           metadata
           | provider: :tvdb,
-            videos: resolve_tvdb_videos(config, data, preferred)
+            videos: resolve_tvdb_videos(config, data, preferred, language)
         }
 
         {:ok, metadata}
@@ -333,24 +334,46 @@ defmodule Mydia.Metadata.Provider.Relay do
   # Thrones and Stranger Things carry none — so fall back to TMDB's videos via
   # the cross-reference TVDB publishes in `remoteIds`. A missing trailer must
   # never fail the fetch, so every failure path degrades to an empty list.
-  defp resolve_tvdb_videos(config, data, preferred_codes) do
+  defp resolve_tvdb_videos(config, data, preferred_codes, language) do
     case Video.from_tvdb_trailers(data["trailers"], preferred_codes) do
-      [] -> fetch_tmdb_videos_for_tvdb(config, data)
+      [] -> fetch_tmdb_videos_for_tvdb(config, data, language)
       videos -> videos
     end
   end
 
-  defp fetch_tmdb_videos_for_tvdb(config, data) do
+  defp fetch_tmdb_videos_for_tvdb(config, data, language) do
     case tmdb_id_from_remote_ids(data["remoteIds"]) do
       nil ->
+        Logger.debug("No TMDB cross-reference in TVDB remoteIds; leaving videos empty",
+          tvdb_id: data["id"]
+        )
+
         []
 
       tmdb_id ->
-        fetch_tmdb_videos(config, tmdb_id)
+        fetch_tmdb_videos(config, tmdb_id, language)
     end
   end
 
-  defp fetch_tmdb_videos(config, tmdb_id) do
+  # The spec's coverage sample found zero TVDB trailers on 4 of 4 popular shows,
+  # so this fallback is the typical path rather than the exception. Memoize it so
+  # a weekly `MetadataRefresh.refresh_all_media/0` doesn't cost one extra relay
+  # round-trip per TV show. The result is wrapped in `{:ok, _}` because
+  # `Cache.fetch/3` only stores `{:ok, _}` — an empty list has to be cached too,
+  # since "neither provider has a trailer" is exactly the case that would
+  # otherwise re-request forever.
+  defp fetch_tmdb_videos(config, tmdb_id, language) do
+    cache_key = "tvdb_tmdb_videos:#{tmdb_id}:#{language}"
+
+    cache_key
+    |> Cache.fetch(fn -> {:ok, request_tmdb_videos(config, tmdb_id)} end, ttl: :timer.hours(24))
+    |> case do
+      {:ok, videos} when is_list(videos) -> videos
+      _ -> []
+    end
+  end
+
+  defp request_tmdb_videos(config, tmdb_id) do
     case perform_tmdb_fetch(config, tmdb_id, :tv_show, append_to_response: ["videos"]) do
       {:ok, %MediaMetadata{videos: videos}} when is_list(videos) ->
         videos
@@ -365,6 +388,11 @@ defmodule Mydia.Metadata.Provider.Relay do
     end
   end
 
+  # The `is_binary(id)` guard is load-bearing, not defensive noise. `remoteIds`
+  # is untyped relay-forwarded JSON, and a non-string id would flow into
+  # `ProviderIDRegistry.record_id_type/3`, whose `is_binary(provider_id)` guard
+  # would raise FunctionClauseError from inside the TVDB fetch — turning a
+  # missing trailer into a failed TV show fetch.
   defp tmdb_id_from_remote_ids(remote_ids) when is_list(remote_ids) do
     Enum.find_value(remote_ids, fn
       %{"sourceName" => "TheMovieDB.com", "id" => id} when is_binary(id) and id != "" -> id

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -75,7 +75,8 @@ defmodule Mydia.Metadata.Provider.Relay do
     MediaMetadata,
     SeasonData,
     ImagesResponse,
-    Collection
+    Collection,
+    Video
   }
 
   @default_language "en-US"
@@ -305,8 +306,16 @@ defmodule Mydia.Metadata.Provider.Relay do
         # Transform TVDB response to TMDB-like format for parsing
         transformed = transform_tvdb_to_tmdb_format(data, media_type, language)
         metadata = parse_metadata(transformed, media_type, provider_id)
-        # Override provider to :tvdb
-        metadata = %{metadata | provider: :tvdb}
+        # Override provider to :tvdb. Trailers live outside the transformed
+        # payload, so videos are resolved separately.
+        preferred = tvdb_preferred_codes(language, data["originalLanguage"])
+
+        metadata = %{
+          metadata
+          | provider: :tvdb,
+            videos: resolve_tvdb_videos(config, data, preferred)
+        }
+
         {:ok, metadata}
 
       {:ok, %{status: 404}} ->
@@ -319,6 +328,51 @@ defmodule Mydia.Metadata.Provider.Relay do
         {:error, error}
     end
   end
+
+  # TVDB's own `trailers` array is sparse — popular shows such as Game of
+  # Thrones and Stranger Things carry none — so fall back to TMDB's videos via
+  # the cross-reference TVDB publishes in `remoteIds`. A missing trailer must
+  # never fail the fetch, so every failure path degrades to an empty list.
+  defp resolve_tvdb_videos(config, data, preferred_codes) do
+    case Video.from_tvdb_trailers(data["trailers"], preferred_codes) do
+      [] -> fetch_tmdb_videos_for_tvdb(config, data)
+      videos -> videos
+    end
+  end
+
+  defp fetch_tmdb_videos_for_tvdb(config, data) do
+    case tmdb_id_from_remote_ids(data["remoteIds"]) do
+      nil ->
+        []
+
+      tmdb_id ->
+        fetch_tmdb_videos(config, tmdb_id)
+    end
+  end
+
+  defp fetch_tmdb_videos(config, tmdb_id) do
+    case perform_tmdb_fetch(config, tmdb_id, :tv_show, append_to_response: ["videos"]) do
+      {:ok, %MediaMetadata{videos: videos}} when is_list(videos) ->
+        videos
+
+      other ->
+        Logger.debug("TMDB trailer fallback returned no videos",
+          tmdb_id: tmdb_id,
+          result: inspect(other)
+        )
+
+        []
+    end
+  end
+
+  defp tmdb_id_from_remote_ids(remote_ids) when is_list(remote_ids) do
+    Enum.find_value(remote_ids, fn
+      %{"sourceName" => "TheMovieDB.com", "id" => id} when is_binary(id) and id != "" -> id
+      _ -> nil
+    end)
+  end
+
+  defp tmdb_id_from_remote_ids(_), do: nil
 
   # Transform TVDB API response to match TMDB format for consistent parsing
   defp transform_tvdb_to_tmdb_format(data, _media_type, language) when is_map(data) do

--- a/lib/mydia/metadata/structs/video.ex
+++ b/lib/mydia/metadata/structs/video.ex
@@ -44,6 +44,10 @@ defmodule Mydia.Metadata.Structs.Video do
   # Hosts whose entire path is the key.
   @youtube_short_hosts ~w(youtu.be www.youtu.be)
 
+  # Mirrors the cap in `MediaMetadata.parse_videos/1` so TVDB-sourced and
+  # TMDB-sourced items persist lists of the same maximum length.
+  @max_videos 5
+
   @doc """
   Creates a new Video struct from a map or keyword list.
 
@@ -170,6 +174,9 @@ defmodule Mydia.Metadata.Structs.Video do
   language codes such as `["eng", "en"]` — sort ahead of the rest; order within
   a group is preserved. Unmatched languages are kept, not dropped, because a
   trailer in the wrong language still beats no trailer.
+
+  The result is capped at 5 entries to match `MediaMetadata.parse_videos/1`, so
+  TVDB-sourced items don't persist a longer list than TMDB-sourced ones.
   """
   @spec from_tvdb_trailers(list() | nil, [String.t()]) :: [t()]
   def from_tvdb_trailers(trailers, preferred_codes \\ [])
@@ -183,13 +190,17 @@ defmodule Mydia.Metadata.Structs.Video do
       end
     end)
     |> Enum.sort_by(fn {language, _video} -> language_rank(language, preferred_codes) end)
+    |> Enum.take(@max_videos)
     |> Enum.map(fn {_language, video} -> video end)
   end
 
   def from_tvdb_trailers(_trailers, _preferred_codes), do: []
 
-  defp trailer_id(nil), do: nil
-  defp trailer_id(id), do: to_string(id)
+  # `to_string/1` raises Protocol.UndefinedError for a map, and nothing between
+  # here and the TVDB fetch rescues it, so a malformed `id` would fail the whole
+  # TV show fetch. Only convert types we know are safe.
+  defp trailer_id(id) when is_integer(id) or is_binary(id), do: to_string(id)
+  defp trailer_id(_), do: nil
 
   # Enum.sort_by/2 is stable, so equal ranks keep their input order.
   defp language_rank(language, preferred_codes) do
@@ -199,8 +210,13 @@ defmodule Mydia.Metadata.Structs.Video do
     end
   end
 
+  # `URI.parse/1` does not normalize the host, so "HTTPS://WWW.YouTube.com/..."
+  # parses to host "WWW.YouTube.com". TVDB trailer URLs are user-contributed and
+  # mixed case is common, so downcase before matching.
   defp youtube_key(url) do
-    case URI.parse(url) do
+    uri = URI.parse(url)
+
+    case %{uri | host: downcase_host(uri.host)} do
       %URI{host: host, path: path, query: query} when host in @youtube_hosts ->
         key_from_embed_path(path) || key_from_query(query)
 
@@ -211,6 +227,9 @@ defmodule Mydia.Metadata.Structs.Video do
         nil
     end
   end
+
+  defp downcase_host(host) when is_binary(host), do: String.downcase(host)
+  defp downcase_host(host), do: host
 
   defp key_from_embed_path(nil), do: nil
 

--- a/lib/mydia/metadata/structs/video.ex
+++ b/lib/mydia/metadata/structs/video.ex
@@ -39,6 +39,11 @@ defmodule Mydia.Metadata.Structs.Video do
           published_at: DateTime.t() | nil
         }
 
+  # Hosts whose /embed/KEY, /v/KEY, /shorts/KEY paths or ?v=KEY query carry the key.
+  @youtube_hosts ~w(youtube.com www.youtube.com m.youtube.com music.youtube.com)
+  # Hosts whose entire path is the key.
+  @youtube_short_hosts ~w(youtu.be www.youtu.be)
+
   @doc """
   Creates a new Video struct from a map or keyword list.
 
@@ -114,6 +119,127 @@ defmodule Mydia.Metadata.Structs.Video do
   end
 
   def youtube_embed_url(_), do: nil
+
+  @doc """
+  Builds a Video struct from a raw TVDB trailer map.
+
+  TVDB trailer entries from `/series/{id}/extended` look like:
+
+      %{"id" => 204863, "language" => "eng", "name" => "Trailer",
+        "runtime" => 0, "url" => "https://www.youtube.com/watch?v=M1bhOaLV4FU"}
+
+  They carry no `type`, `official`, or `published_at`, so `type` is set to
+  "Trailer" to keep these structs consistent with TMDB-derived ones.
+
+  Returns `:error` for anything that is not a recognisable YouTube URL, since
+  `youtube_embed_url/1` is the only embed helper the UI has.
+
+  ## Examples
+
+      iex> from_tvdb_trailer(%{"id" => 1, "name" => "Trailer", "url" => "https://youtu.be/abc123"})
+      {:ok, %Video{id: "1", key: "abc123", name: "Trailer", site: "YouTube", type: "Trailer"}}
+
+      iex> from_tvdb_trailer(%{"url" => "https://vimeo.com/123"})
+      :error
+  """
+  @spec from_tvdb_trailer(map()) :: {:ok, t()} | :error
+  def from_tvdb_trailer(%{"url" => url} = trailer) when is_binary(url) do
+    case youtube_key(url) do
+      nil ->
+        :error
+
+      key ->
+        {:ok,
+         %__MODULE__{
+           id: trailer_id(trailer["id"]),
+           key: key,
+           name: trailer["name"],
+           site: "YouTube",
+           type: "Trailer"
+         }}
+    end
+  end
+
+  def from_tvdb_trailer(_), do: :error
+
+  @doc """
+  Builds Video structs from a raw TVDB `trailers` list.
+
+  Entries whose URL cannot be parsed as a YouTube link are dropped. Entries
+  whose `language` matches one of `preferred_codes` — an ordered list of TVDB
+  language codes such as `["eng", "en"]` — sort ahead of the rest; order within
+  a group is preserved. Unmatched languages are kept, not dropped, because a
+  trailer in the wrong language still beats no trailer.
+  """
+  @spec from_tvdb_trailers(list() | nil, [String.t()]) :: [t()]
+  def from_tvdb_trailers(trailers, preferred_codes \\ [])
+
+  def from_tvdb_trailers(trailers, preferred_codes) when is_list(trailers) do
+    trailers
+    |> Enum.flat_map(fn trailer ->
+      case from_tvdb_trailer(trailer) do
+        {:ok, video} -> [{trailer["language"], video}]
+        :error -> []
+      end
+    end)
+    |> Enum.sort_by(fn {language, _video} -> language_rank(language, preferred_codes) end)
+    |> Enum.map(fn {_language, video} -> video end)
+  end
+
+  def from_tvdb_trailers(_trailers, _preferred_codes), do: []
+
+  defp trailer_id(nil), do: nil
+  defp trailer_id(id), do: to_string(id)
+
+  # Enum.sort_by/2 is stable, so equal ranks keep their input order.
+  defp language_rank(language, preferred_codes) do
+    case Enum.find_index(preferred_codes, &(&1 == language)) do
+      nil -> length(preferred_codes)
+      index -> index
+    end
+  end
+
+  defp youtube_key(url) do
+    case URI.parse(url) do
+      %URI{host: host, path: path, query: query} when host in @youtube_hosts ->
+        key_from_embed_path(path) || key_from_query(query)
+
+      %URI{host: host, path: path} when host in @youtube_short_hosts ->
+        key_from_short_path(path)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp key_from_embed_path(nil), do: nil
+
+  defp key_from_embed_path(path) do
+    case String.split(path, "/", trim: true) do
+      ["embed", key | _] -> presence(key)
+      ["v", key | _] -> presence(key)
+      ["shorts", key | _] -> presence(key)
+      _ -> nil
+    end
+  end
+
+  defp key_from_short_path(nil), do: nil
+
+  defp key_from_short_path(path) do
+    case String.split(path, "/", trim: true) do
+      [key] -> presence(key)
+      _ -> nil
+    end
+  end
+
+  defp key_from_query(nil), do: nil
+
+  defp key_from_query(query) do
+    query |> URI.decode_query() |> Map.get("v") |> presence()
+  end
+
+  defp presence(value) when is_binary(value) and value != "", do: value
+  defp presence(_), do: nil
 
   defp parse_datetime(nil), do: nil
   defp parse_datetime(""), do: nil

--- a/test/mydia/metadata/provider/relay_test.exs
+++ b/test/mydia/metadata/provider/relay_test.exs
@@ -3,6 +3,7 @@ defmodule Mydia.Metadata.Provider.RelayTest do
 
   alias Mydia.Metadata.Provider.Relay
   alias Mydia.Metadata.Provider.Error
+  alias Mydia.Metadata.Structs.Video
 
   @moduletag :external
 
@@ -391,6 +392,29 @@ defmodule Mydia.Metadata.Provider.RelayTest do
       assert String.contains?(String.downcase(metadata.title), "breaking bad")
       assert is_integer(metadata.year)
       assert is_list(metadata.genres)
+    end
+
+    test "populates videos from TVDB's own trailers when it has them" do
+      # House of the Dragon - TVDB ID: 371572. TVDB carries 8 trailers for this
+      # show, so no TMDB fallback should be needed.
+      assert {:ok, metadata} =
+               Relay.fetch_by_id(@config, "371572", media_type: :tv_show, provider: :tvdb)
+
+      assert metadata.provider == :tvdb
+      assert [%Video{} | _] = metadata.videos
+      assert Enum.all?(metadata.videos, &(&1.site == "YouTube"))
+      assert Enum.all?(metadata.videos, &(is_binary(&1.key) and &1.key != ""))
+    end
+
+    test "falls back to TMDB videos when TVDB has no trailers" do
+      # Game of Thrones - TVDB ID: 121361. TVDB carries no trailers, but its
+      # remoteIds cross-references TheMovieDB.com 1399, which does.
+      assert {:ok, metadata} =
+               Relay.fetch_by_id(@config, "121361", media_type: :tv_show, provider: :tvdb)
+
+      assert metadata.provider == :tvdb
+      assert [%Video{} | _] = metadata.videos
+      assert Enum.all?(metadata.videos, &(&1.site == "YouTube"))
     end
   end
 

--- a/test/mydia/metadata/provider/relay_tvdb_videos_test.exs
+++ b/test/mydia/metadata/provider/relay_tvdb_videos_test.exs
@@ -1,0 +1,288 @@
+defmodule Mydia.Metadata.Provider.RelayTvdbVideosTest do
+  @moduledoc """
+  Offline coverage for the three-tier trailer resolution on the TVDB fetch path.
+
+  Deliberately NOT tagged `:external` — `test/test_helper.exs` excludes that tag,
+  and the tier logic (provider data shapes, the TMDB cross-reference fallback,
+  and the "a missing trailer must never fail the fetch" degrade path) has to run
+  in CI. Both relay endpoints are stubbed with Bypass.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.Provider.Relay
+  alias Mydia.Metadata.Structs.Video
+
+  setup do
+    bypass = Bypass.open()
+
+    config = %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{
+        language: "en-US",
+        include_adult: false,
+        # Keep the fast-degrade paths fast: the fixture server is local.
+        timeout: 2_000,
+        connect_timeout: 1_000
+      }
+    }
+
+    # Offset well past any real provider id so the process-global
+    # Mydia.Metadata.Cache and Mydia.Metadata.ProviderIDRegistry entries these
+    # tests create can never collide with another test file's ids.
+    tvdb_id = to_string(900_000_000 + System.unique_integer([:positive]))
+    tmdb_id = to_string(900_000_000 + System.unique_integer([:positive]))
+
+    {:ok, bypass: bypass, config: config, tvdb_id: tvdb_id, tmdb_id: tmdb_id}
+  end
+
+  describe "tier 1: TVDB's own trailers" do
+    test "uses TVDB trailers and never requests TMDB", ctx do
+      stub_tvdb(ctx, %{
+        "trailers" => [tvdb_trailer("https://www.youtube.com/watch?v=TVDBKEY1")],
+        "remoteIds" => [tmdb_remote_id(ctx.tmdb_id)]
+      })
+
+      stub_tmdb(ctx, [tmdb_video("TMDBKEY1")])
+
+      assert {:ok, metadata} =
+               Relay.fetch_by_id(ctx.config, ctx.tvdb_id, media_type: :tv_show, provider: :tvdb)
+
+      assert metadata.provider == :tvdb
+      assert [%Video{} = video] = metadata.videos
+      assert video.key == "TVDBKEY1"
+      assert video.site == "YouTube"
+      assert video.type == "Trailer"
+
+      # Tier 1 short-circuits: the cross-reference exists but must not be used.
+      refute_receive {:relay_request, :tmdb}, 100
+    end
+  end
+
+  describe "tier 2: TMDB cross-reference fallback" do
+    test "uses TMDB videos when TVDB carries no trailers", ctx do
+      stub_tvdb(ctx, %{
+        "trailers" => [],
+        "remoteIds" => [tmdb_remote_id(ctx.tmdb_id)]
+      })
+
+      stub_tmdb(ctx, [tmdb_video("TMDBKEY1")])
+
+      assert {:ok, metadata} =
+               Relay.fetch_by_id(ctx.config, ctx.tvdb_id, media_type: :tv_show, provider: :tvdb)
+
+      assert metadata.provider == :tvdb
+      assert [%Video{} = video] = metadata.videos
+      assert video.key == "TMDBKEY1"
+      assert video.site == "YouTube"
+
+      assert_receive {:relay_request, :tmdb}, 100
+    end
+
+    test "memoizes the fallback so repeat fetches cost one TMDB request", ctx do
+      stub_tvdb(ctx, %{
+        "trailers" => [],
+        "remoteIds" => [tmdb_remote_id(ctx.tmdb_id)]
+      })
+
+      stub_tmdb(ctx, [tmdb_video("TMDBKEY1")])
+
+      for _ <- 1..3 do
+        assert {:ok, metadata} =
+                 Relay.fetch_by_id(ctx.config, ctx.tvdb_id, media_type: :tv_show, provider: :tvdb)
+
+        assert [%Video{key: "TMDBKEY1"}] = metadata.videos
+      end
+
+      assert_receive {:relay_request, :tmdb}, 100
+      refute_receive {:relay_request, :tmdb}, 100
+    end
+
+    test "caches an empty result so a show with no trailers anywhere stops re-requesting", ctx do
+      stub_tvdb(ctx, %{
+        "trailers" => [],
+        "remoteIds" => [tmdb_remote_id(ctx.tmdb_id)]
+      })
+
+      stub_tmdb(ctx, [])
+
+      for _ <- 1..3 do
+        assert {:ok, metadata} =
+                 Relay.fetch_by_id(ctx.config, ctx.tvdb_id, media_type: :tv_show, provider: :tvdb)
+
+        assert metadata.videos == []
+      end
+
+      assert_receive {:relay_request, :tmdb}, 100
+      refute_receive {:relay_request, :tmdb}, 100
+    end
+  end
+
+  describe "tier 3: degrade to no videos" do
+    test "returns an empty list when there is no TMDB cross-reference", ctx do
+      stub_tvdb(ctx, %{"trailers" => [], "remoteIds" => []})
+      stub_tmdb(ctx, [tmdb_video("TMDBKEY1")])
+
+      assert {:ok, metadata} =
+               Relay.fetch_by_id(ctx.config, ctx.tvdb_id, media_type: :tv_show, provider: :tvdb)
+
+      assert metadata.provider == :tvdb
+      assert metadata.videos == []
+      assert metadata.title == "Fixture Show"
+
+      refute_receive {:relay_request, :tmdb}, 100
+    end
+
+    test "ignores a non-string TMDB id in remoteIds rather than raising", ctx do
+      # An integer id would reach ProviderIDRegistry.record_id_type/3, whose
+      # is_binary/1 guard would raise FunctionClauseError inside the fetch.
+      stub_tvdb(ctx, %{
+        "trailers" => [],
+        "remoteIds" => [%{"sourceName" => "TheMovieDB.com", "id" => 1399, "type" => 12}]
+      })
+
+      stub_tmdb(ctx, [tmdb_video("TMDBKEY1")])
+
+      assert {:ok, metadata} =
+               Relay.fetch_by_id(ctx.config, ctx.tvdb_id, media_type: :tv_show, provider: :tvdb)
+
+      assert metadata.videos == []
+      refute_receive {:relay_request, :tmdb}, 100
+    end
+
+    test "still returns {:ok, metadata} when the TMDB fallback request fails", ctx do
+      stub_tvdb(ctx, %{
+        "trailers" => [],
+        "remoteIds" => [tmdb_remote_id(ctx.tmdb_id)]
+      })
+
+      test_pid = self()
+
+      Bypass.expect(ctx.bypass, "GET", tmdb_path(ctx), fn conn ->
+        send(test_pid, {:relay_request, :tmdb})
+        Plug.Conn.resp(conn, 500, "boom")
+      end)
+
+      # Req treats 5xx as transient and retries, which logs warnings; swallow
+      # them so the suite output stays readable.
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:ok, metadata} =
+                 Relay.fetch_by_id(ctx.config, ctx.tvdb_id,
+                   media_type: :tv_show,
+                   provider: :tvdb
+                 )
+
+        # The binding constraint: a missing trailer never fails the fetch.
+        assert metadata.provider == :tvdb
+        assert metadata.videos == []
+        assert metadata.title == "Fixture Show"
+      end)
+
+      assert_receive {:relay_request, :tmdb}, 100
+    end
+  end
+
+  ## Fixtures
+
+  defp tmdb_path(ctx), do: "/tmdb/tv/shows/#{ctx.tmdb_id}"
+
+  defp stub_tvdb(ctx, overrides) do
+    test_pid = self()
+    body = tvdb_extended(ctx.tvdb_id, overrides)
+
+    Bypass.expect(ctx.bypass, "GET", "/tvdb/series/#{ctx.tvdb_id}/extended", fn conn ->
+      send(test_pid, {:relay_request, :tvdb})
+      json(conn, 200, body)
+    end)
+  end
+
+  defp stub_tmdb(ctx, videos) do
+    test_pid = self()
+    body = tmdb_tv_show(ctx.tmdb_id, videos)
+
+    Bypass.stub(ctx.bypass, "GET", tmdb_path(ctx), fn conn ->
+      send(test_pid, {:relay_request, :tmdb})
+      json(conn, 200, body)
+    end)
+  end
+
+  defp json(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(status, Jason.encode!(body))
+  end
+
+  # Mirrors the real /tvdb/series/{id}/extended shape: everything nests under
+  # "data", and the fields below are the ones transform_tvdb_to_tmdb_format/3
+  # and parse_metadata/3 read.
+  defp tvdb_extended(tvdb_id, overrides) do
+    data =
+      Map.merge(
+        %{
+          "id" => String.to_integer(tvdb_id),
+          "name" => "Fixture Show",
+          "overview" => "A show used to exercise trailer resolution.",
+          "firstAired" => "2016-07-15",
+          "lastAired" => "2019-07-04",
+          "status" => %{"name" => "Continuing"},
+          "originalLanguage" => "eng",
+          "originalCountry" => "usa",
+          "image" => "https://artworks.thetvdb.com/banners/posters/fixture.jpg",
+          "artworks" => [
+            %{
+              "type" => 3,
+              "image" => "https://artworks.thetvdb.com/banners/backgrounds/fixture.jpg"
+            }
+          ],
+          "genres" => [%{"id" => 18, "name" => "Drama"}],
+          "seasons" => [
+            %{
+              "id" => 1_001,
+              "number" => 1,
+              "name" => "Season 1",
+              "type" => %{"type" => "official"},
+              "episodeCount" => 8
+            }
+          ],
+          "translations" => %{"nameTranslations" => [], "overviewTranslations" => []},
+          "remoteIds" => [],
+          "trailers" => []
+        },
+        overrides
+      )
+
+    %{"data" => data}
+  end
+
+  defp tvdb_trailer(url) do
+    %{"id" => 204_863, "language" => "eng", "name" => "Trailer", "runtime" => 0, "url" => url}
+  end
+
+  defp tmdb_remote_id(tmdb_id) do
+    %{"id" => tmdb_id, "type" => 12, "sourceName" => "TheMovieDB.com"}
+  end
+
+  defp tmdb_tv_show(tmdb_id, videos) do
+    %{
+      "id" => String.to_integer(tmdb_id),
+      "name" => "Fixture Show",
+      "overview" => "A show used to exercise trailer resolution.",
+      "first_air_date" => "2016-07-15",
+      "genres" => [%{"id" => 18, "name" => "Drama"}],
+      "videos" => %{"results" => videos}
+    }
+  end
+
+  defp tmdb_video(key) do
+    %{
+      "id" => "5f0#{key}",
+      "key" => key,
+      "name" => "Official Trailer",
+      "site" => "YouTube",
+      "type" => "Trailer",
+      "official" => true,
+      "published_at" => "2019-07-01T14:00:00.000Z"
+    }
+  end
+end

--- a/test/mydia/metadata/provider/relay_tvdb_videos_test.exs
+++ b/test/mydia/metadata/provider/relay_tvdb_videos_test.exs
@@ -181,6 +181,51 @@ defmodule Mydia.Metadata.Provider.RelayTvdbVideosTest do
 
       assert_receive {:relay_request, :tmdb}, 100
     end
+
+    test "does not cache a failed fallback, so the next fetch recovers the trailer", ctx do
+      stub_tvdb(ctx, %{
+        "trailers" => [],
+        "remoteIds" => [tmdb_remote_id(ctx.tmdb_id)]
+      })
+
+      test_pid = self()
+      body = tmdb_tv_show(ctx.tmdb_id, [tmdb_video("TMDBKEY1")])
+      # Flipped by the test rather than counted, because `HTTP.new_request/1`
+      # sets `retry: :transient, max_retries: 3` — one logical failed fetch
+      # arrives as several HTTP requests.
+      {:ok, relay_state} = Agent.start_link(fn -> :down end)
+
+      Bypass.stub(ctx.bypass, "GET", tmdb_path(ctx), fn conn ->
+        send(test_pid, {:relay_request, :tmdb})
+
+        case Agent.get(relay_state, & &1) do
+          :down -> Plug.Conn.resp(conn, 500, "boom")
+          :up -> json(conn, 200, body)
+        end
+      end)
+
+      # Req logs a warning per retry; swallow them so the suite stays readable.
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:ok, metadata} =
+                 Relay.fetch_by_id(ctx.config, ctx.tvdb_id,
+                   media_type: :tv_show,
+                   provider: :tvdb
+                 )
+
+        assert metadata.videos == []
+      end)
+
+      assert_receive {:relay_request, :tmdb}, 100
+
+      Agent.update(relay_state, fn _ -> :up end)
+
+      assert {:ok, metadata} =
+               Relay.fetch_by_id(ctx.config, ctx.tvdb_id, media_type: :tv_show, provider: :tvdb)
+
+      # Had the failure been memoized as a confirmed-empty result, this second
+      # fetch would never reach TMDB and `videos` would still be [].
+      assert [%Video{key: "TMDBKEY1"}] = metadata.videos
+    end
   end
 
   ## Fixtures

--- a/test/mydia/metadata/structs/video_tvdb_trailer_test.exs
+++ b/test/mydia/metadata/structs/video_tvdb_trailer_test.exs
@@ -1,0 +1,123 @@
+defmodule Mydia.Metadata.Structs.VideoTvdbTrailerTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.Structs.Video
+
+  # A real TVDB trailer entry, as returned by /series/{id}/extended. TVDB
+  # carries no type/official/published_at fields.
+  defp trailer(attrs) do
+    Map.merge(
+      %{"id" => 204_863, "language" => "eng", "name" => "Trailer", "runtime" => 0},
+      attrs
+    )
+  end
+
+  describe "from_tvdb_trailer/1" do
+    test "parses a youtube watch URL" do
+      assert {:ok, video} =
+               Video.from_tvdb_trailer(
+                 trailer(%{"url" => "https://www.youtube.com/watch?v=M1bhOaLV4FU"})
+               )
+
+      assert video.key == "M1bhOaLV4FU"
+      assert video.site == "YouTube"
+      assert video.type == "Trailer"
+      assert video.name == "Trailer"
+      assert video.id == "204863"
+    end
+
+    test "parses a youtu.be short URL" do
+      assert {:ok, video} =
+               Video.from_tvdb_trailer(trailer(%{"url" => "https://youtu.be/M1bhOaLV4FU"}))
+
+      assert video.key == "M1bhOaLV4FU"
+    end
+
+    test "parses a youtube embed URL" do
+      assert {:ok, video} =
+               Video.from_tvdb_trailer(
+                 trailer(%{"url" => "https://www.youtube.com/embed/M1bhOaLV4FU"})
+               )
+
+      assert video.key == "M1bhOaLV4FU"
+    end
+
+    test "rejects a non-YouTube URL" do
+      assert :error = Video.from_tvdb_trailer(trailer(%{"url" => "https://vimeo.com/123456"}))
+    end
+
+    test "rejects a malformed URL" do
+      assert :error = Video.from_tvdb_trailer(trailer(%{"url" => "not a url"}))
+    end
+
+    test "rejects a trailer with no url" do
+      assert :error = Video.from_tvdb_trailer(%{"id" => 1, "name" => "Trailer"})
+    end
+
+    test "tolerates a missing id" do
+      assert {:ok, video} =
+               Video.from_tvdb_trailer(%{
+                 "name" => "Trailer",
+                 "url" => "https://www.youtube.com/watch?v=M1bhOaLV4FU"
+               })
+
+      assert video.id == nil
+    end
+  end
+
+  describe "from_tvdb_trailers/2" do
+    test "returns an empty list for nil and empty input" do
+      assert Video.from_tvdb_trailers(nil, ["eng"]) == []
+      assert Video.from_tvdb_trailers([], ["eng"]) == []
+    end
+
+    test "drops entries that cannot be parsed" do
+      videos =
+        Video.from_tvdb_trailers(
+          [
+            trailer(%{"url" => "https://vimeo.com/123456"}),
+            trailer(%{"url" => "https://www.youtube.com/watch?v=keepme"})
+          ],
+          ["eng"]
+        )
+
+      assert Enum.map(videos, & &1.key) == ["keepme"]
+    end
+
+    test "sorts preferred-language entries ahead of the rest" do
+      videos =
+        Video.from_tvdb_trailers(
+          [
+            trailer(%{"language" => "pt", "url" => "https://www.youtube.com/watch?v=ptkey"}),
+            trailer(%{"language" => "eng", "url" => "https://www.youtube.com/watch?v=engkey"})
+          ],
+          ["eng", "en"]
+        )
+
+      assert Enum.map(videos, & &1.key) == ["engkey", "ptkey"]
+    end
+
+    test "preserves input order within the same language" do
+      videos =
+        Video.from_tvdb_trailers(
+          [
+            trailer(%{"language" => "eng", "url" => "https://www.youtube.com/watch?v=first"}),
+            trailer(%{"language" => "eng", "url" => "https://www.youtube.com/watch?v=second"})
+          ],
+          ["eng"]
+        )
+
+      assert Enum.map(videos, & &1.key) == ["first", "second"]
+    end
+
+    test "keeps unmatched languages rather than dropping them" do
+      videos =
+        Video.from_tvdb_trailers(
+          [trailer(%{"language" => "spa", "url" => "https://www.youtube.com/watch?v=spakey"})],
+          ["eng"]
+        )
+
+      assert Enum.map(videos, & &1.key) == ["spakey"]
+    end
+  end
+end

--- a/test/mydia/metadata/structs/video_tvdb_trailer_test.exs
+++ b/test/mydia/metadata/structs/video_tvdb_trailer_test.exs
@@ -42,6 +42,40 @@ defmodule Mydia.Metadata.Structs.VideoTvdbTrailerTest do
       assert video.key == "M1bhOaLV4FU"
     end
 
+    test "parses a youtube /v/ URL" do
+      assert {:ok, video} =
+               Video.from_tvdb_trailer(
+                 trailer(%{"url" => "https://www.youtube.com/v/M1bhOaLV4FU"})
+               )
+
+      assert video.key == "M1bhOaLV4FU"
+    end
+
+    test "parses a youtube /shorts/ URL" do
+      assert {:ok, video} =
+               Video.from_tvdb_trailer(
+                 trailer(%{"url" => "https://www.youtube.com/shorts/M1bhOaLV4FU"})
+               )
+
+      assert video.key == "M1bhOaLV4FU"
+    end
+
+    test "parses a mixed-case scheme and host" do
+      # URI.parse/1 does not normalize the host, and TVDB trailer URLs are
+      # user-contributed, so mixed case must still match.
+      assert {:ok, video} =
+               Video.from_tvdb_trailer(
+                 trailer(%{"url" => "HTTPS://WWW.YouTube.com/watch?v=M1bhOaLV4FU"})
+               )
+
+      assert video.key == "M1bhOaLV4FU"
+
+      assert {:ok, short} =
+               Video.from_tvdb_trailer(trailer(%{"url" => "HTTPS://YOUTU.BE/M1bhOaLV4FU"}))
+
+      assert short.key == "M1bhOaLV4FU"
+    end
+
     test "rejects a non-YouTube URL" do
       assert :error = Video.from_tvdb_trailer(trailer(%{"url" => "https://vimeo.com/123456"}))
     end
@@ -62,6 +96,26 @@ defmodule Mydia.Metadata.Structs.VideoTvdbTrailerTest do
                })
 
       assert video.id == nil
+    end
+
+    test "tolerates a non-scalar id rather than raising" do
+      # to_string/1 raises Protocol.UndefinedError for a map, and nothing between
+      # here and the TVDB fetch rescues it, so a malformed id must not blow up.
+      assert {:ok, video} =
+               Video.from_tvdb_trailer(%{
+                 "id" => %{"unexpected" => "shape"},
+                 "url" => "https://www.youtube.com/watch?v=M1bhOaLV4FU"
+               })
+
+      assert video.id == nil
+
+      assert {:ok, list_id} =
+               Video.from_tvdb_trailer(%{
+                 "id" => [1, 2],
+                 "url" => "https://www.youtube.com/watch?v=M1bhOaLV4FU"
+               })
+
+      assert list_id.id == nil
     end
   end
 
@@ -118,6 +172,33 @@ defmodule Mydia.Metadata.Structs.VideoTvdbTrailerTest do
         )
 
       assert Enum.map(videos, & &1.key) == ["spakey"]
+    end
+
+    test "caps the result at 5 to match MediaMetadata.parse_videos/1" do
+      # The Boys carries 11 trailers on TVDB; TVDB-sourced items must not
+      # persist a longer list than TMDB-sourced ones.
+      trailers =
+        for n <- 1..11 do
+          trailer(%{"language" => "eng", "url" => "https://www.youtube.com/watch?v=key#{n}"})
+        end
+
+      videos = Video.from_tvdb_trailers(trailers, ["eng"])
+
+      assert length(videos) == 5
+      assert Enum.map(videos, & &1.key) == ["key1", "key2", "key3", "key4", "key5"]
+    end
+
+    test "applies the cap after the language sort, not before" do
+      trailers =
+        for n <- 1..6 do
+          language = if n == 6, do: "eng", else: "spa"
+          trailer(%{"language" => language, "url" => "https://www.youtube.com/watch?v=key#{n}"})
+        end
+
+      videos = Video.from_tvdb_trailers(trailers, ["eng"])
+
+      assert length(videos) == 5
+      assert List.first(videos).key == "key6"
     end
   end
 end


### PR DESCRIPTION
## Problem

TV shows never displayed a trailer. Movies did. Three surfaces were affected:

1. The discover page detail modal
2. The dashboard detail modal (same component)
3. The library TV show detail page, whose **Trailer** button never rendered

## Root cause

The modals render from `metadata.videos` (`trending_detail_modal.ex:113`), and the library detail page reads the same field off persisted metadata (`media_live/show/helpers.ex:186`). For TV shows that field was always empty:

- `MediaAddHelpers.fetch_detail_metadata/3` fetches TMDB details first (which *do* include `videos`), then discards them and returns TVDB metadata whenever the TV metadata source is TVDB — the default (`library_paths.ex:43-54`).
- `Relay.transform_tvdb_to_tmdb_format/3` built a TMDB-shaped map with no `"videos"` key at all, so `MediaMetadata.parse_videos/1` hit its `nil` clause and returned `[]`.
- `MetadataEnricher.fetch_full_metadata/4` makes a TVDB-only fetch for TVDB-matched shows, so the persisted metadata behind the library page had no TMDB response to borrow from either.

Movies were unaffected because they always resolve through `perform_tmdb_fetch/4`, whose default `append_to_response` already includes `videos`.

## Provider coverage

Neither provider alone is sufficient. Sampled against the live relay:

| Show | TVDB `trailers` | TMDB `videos` (en-US, type=Trailer) |
| --- | --- | --- |
| Game of Thrones | 0 | 2 |
| Stranger Things | 0 | 2 |
| Young Sheldon | 0 | 1 |
| Breaking Bad | 0 | 0 |
| Halo | 3 | not sampled |
| House of the Dragon | 8 | not sampled |
| The Boys | 11 | not sampled |

TVDB's extended response does carry a `remoteIds` entry with `sourceName == "TheMovieDB.com"` on every show sampled, so a TVDB-sourced show can always find its TMDB id without a separate lookup.

## Fix

Three-tier resolution inside `Relay.perform_tvdb_fetch/4` — the single funnel every TVDB consumer passes through, so all three surfaces plus `MetadataEnricher` and `Jobs.MetadataRefresh` are fixed at once:

1. TVDB's own `data["trailers"]` when non-empty, mapped to `%Video{}` structs
2. otherwise follow `remoteIds` to TMDB and reuse the existing private `perform_tmdb_fetch/4`
3. otherwise `[]`

The tier-2 result is memoized through `Mydia.Metadata.Cache` (24h, keyed on TMDB id + language), because the coverage table above shows tier 2 is the *typical* path, not the exception — without it, the weekly `MetadataRefresh.refresh_all_media/0` would cost one extra relay round-trip per TV show. A successful-but-empty result is cached, so shows with no trailer anywhere stop re-requesting forever; a **failed** request is deliberately left uncached so a transient relay 5xx can't suppress a trailer for 24 hours. That split follows the existing precedent in `Mydia.Metadata.fetch_collection_cached/3`.

**No LiveView, HEEx, or component changes.** Both UI surfaces already render whatever `videos` contains; they had simply never received a non-empty list for TV.

Reusing the existing `/tmdb/tv/shows/:id` relay route rather than adding a dedicated `/videos` endpoint is deliberate: no `metadata-relay` change, so operators running an older self-hosted relay keep working.

## Verification

`./dev mix precommit`: **5559 tests, 0 failures**, all stages clean.

End-to-end through the real call paths:

- Provider path, Game of Thrones (tier 2): `["KPLWWIOCOOQ", "BpJYNVhGf1s"]`
- Discover/dashboard entry point, `MediaAddHelpers.fetch_detail_metadata("1399", :tv_show)`: `{:tvdb, ["KPLWWIOCOOQ", "BpJYNVhGf1s"]}`
- House of the Dragon (tier 1, TVDB-native): 8 trailers

New CI-visible tests (no network, no `:external` tag):

- `test/mydia/metadata/structs/video_tvdb_trailer_test.exs` — 18 tests over the URL parsing and language ordering
- `test/mydia/metadata/provider/relay_tvdb_videos_test.exs` — 8 Bypass tests covering all three tiers, the TMDB-500 degrade (proving the fetch still returns `{:ok, metadata}`), that tier 1 never calls TMDB, that an empty result *is* cached, and that a failure is *not*

## Notes for review

- Existing library items pick this up on the weekly `MetadataRefresh` cron (`0 5 * * 0`) or the per-item **Refresh metadata** button. No backfill migration, by design.
- `test/mydia/metadata/provider/relay_test.exs` has 4 pre-existing `:external` failures unrelated to this branch (`handles invalid configuration`, `fetch_images/3 TV images`, `search/3 TV shows`, `fetch_by_id/3 TV by ID`). They predate this work, are excluded from CI, and are left alone — but they make `--include external` runs noisy and deserve their own cleanup.

## Known follow-ups (deliberately not in this PR)

- A TMDB **404** on a cross-referenced id is now uncached along with real errors, so a permanently-dead cross-reference costs one relay round-trip per refresh instead of one per 24h. Caching `:not_found` specifically would be the targeted fix if relay load ever shows it.
- Tier precedence ignores language: a show whose only TVDB trailer is Portuguese wins over TMDB's English one on an English instance. The `preferred_codes` sort only orders *within* TVDB's list. This is a product decision about trailer selection semantics, not a defect.
- `transform_tvdb_to_tmdb_format/3` still never reads `remoteIds` for `imdb_id`, so TVDB-sourced items carry no IMDb id. Noticed while tracing this; separate concern.
