### PR TITLE
fix: surface skipped quality profiles, unmatched LiveView messages, and download failure categories

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -155,6 +155,7 @@ config :logger, :default_formatter,
     :device,
     :device1,
     :device2,
+    :quality_profile,
     # Status and results
     :reason,
     :error,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -215,6 +215,7 @@ config :logger, :default_formatter,
     :device,
     :device1,
     :device2,
+    :quality_profile,
     # Status and results
     :reason,
     :error,

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -594,6 +594,7 @@ defmodule Mydia.Events do
         "download_id" => download.id
       }
       |> maybe_add_media_context(media_item)
+      |> maybe_add_failure_classification(opts)
 
     create_event_async(%{
       category: "downloads",
@@ -1155,6 +1156,26 @@ defmodule Mydia.Events do
       "media_type" => media_item.type
     })
   end
+
+  # The download client's own account of *why* a download failed (#237).
+  #
+  # Written only when the caller supplies it, so the DownloadMonitor paths
+  # that detect a Mydia-side failure (missing from client, stuck import,
+  # escalated stall) keep emitting exactly the metadata they always have.
+  #
+  # The caller passes an already-rendered slug rather than a category atom,
+  # so this module stays independent of `FailureCategory` and the slug is
+  # guaranteed to be the same string written to
+  # `release_blacklist.failure_reason` beside it.
+  defp maybe_add_failure_classification(metadata, opts) do
+    metadata
+    |> maybe_put_metadata("failure_category", opts[:failure_category])
+    |> maybe_put_metadata("failure_detail", opts[:failure_detail])
+  end
+
+  defp maybe_put_metadata(metadata, _key, nil), do: metadata
+  defp maybe_put_metadata(metadata, _key, ""), do: metadata
+  defp maybe_put_metadata(metadata, key, value), do: Map.put(metadata, key, value)
 
   # Helper to build search description with episode info
   defp build_search_description(prefix, metadata) do

--- a/lib/mydia/indexers/quality_profile_resolver.ex
+++ b/lib/mydia/indexers/quality_profile_resolver.ex
@@ -1,0 +1,73 @@
+defmodule Mydia.Indexers.QualityProfileResolver do
+  @moduledoc """
+  Resolves the quality profile a search should rank its results against.
+
+  A media item with no `quality_profile_id` used to arrive at
+  `Mydia.Indexers.RankingOptions.build/1` as a bare `nil`, which silently
+  dropped every size, resolution, and seed-ratio bound. The release was then
+  ranked on seeders alone and nothing anywhere recorded that the bounds had
+  been skipped.
+
+  This module is the one place the three search paths (the TV job, the movie
+  job, and the manual search dialog) resolve that profile, so they cannot
+  drift apart the way their hand-rolled helpers did:
+
+    1. the media item's own `:quality_profile`
+    2. the instance default (`media.default_quality_profile_id`)
+    3. `nil`, logged as a warning
+
+  `RankingOptions.build/1` is deliberately left untouched. Its `nil`
+  fall-through is still the correct behaviour for a search that genuinely has
+  no profile, and keeping it free of database reads is what lets it stay a
+  pure builder with pure unit tests.
+  """
+
+  require Logger
+
+  alias Mydia.Media.MediaItem
+  alias Mydia.Repo
+  alias Mydia.Settings
+  alias Mydia.Settings.QualityProfile
+
+  @doc """
+  Returns the quality profile to rank `media_item`'s search against, or `nil`
+  when the item has none and no instance default is configured.
+
+  `Repo.preload/2` is a no-op when `:quality_profile` is already loaded, so
+  callers that hold a preloaded item (the manual search dialog) pay no query.
+
+  Takes a `%MediaItem{}` and nothing else. Every caller has one in hand, so a
+  `nil` here is a bug worth raising on rather than quietly absorbing.
+  """
+  @spec resolve(MediaItem.t()) :: QualityProfile.t() | nil
+  def resolve(%MediaItem{} = media_item) do
+    # A deleted profile nils the FK (`on_delete: :nilify_all`), so a missing
+    # profile and a never-assigned one both surface here as `nil`.
+    case Repo.preload(media_item, :quality_profile).quality_profile do
+      %QualityProfile{} = profile -> profile
+      nil -> fall_back(media_item)
+    end
+  end
+
+  defp fall_back(%MediaItem{} = media_item) do
+    case Settings.get_default_quality_profile() do
+      %QualityProfile{} = profile ->
+        Logger.info(
+          "Media item has no quality profile, ranking against the instance default",
+          media_item_id: media_item.id,
+          quality_profile: profile.name
+        )
+
+        profile
+
+      nil ->
+        Logger.warning(
+          "Media item has no quality profile and no instance default is configured, " <>
+            "searching with no size or resolution bounds",
+          media_item_id: media_item.id
+        )
+
+        nil
+    end
+  end
+end

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -336,16 +336,25 @@ defmodule Mydia.Jobs.DownloadMonitor do
     # Get the download struct from database (with media_item preloaded)
     download = Downloads.get_download!(download_map.id, preload: [:media_item])
 
+    # Bound once and used for both the event and the blacklist row below, so
+    # the activity feed and the admin blacklist page can never disagree about
+    # why this release failed (issue #237).
+    failure_slug = FailureCategory.slug(download_map.client_failure_category)
+
     # Track failure event before deletion. This metadata is what the activity
     # feed and the media-item history render, so the composed message is the
-    # operator's only lasting record — the Download row is deleted below.
-    Events.download_failed(download, error_msg, media_item: download.media_item)
+    # operator's only lasting record. The Download row is deleted below.
+    Events.download_failed(download, error_msg,
+      media_item: download.media_item,
+      failure_category: failure_slug,
+      failure_detail: download_map.client_error_detail
+    )
 
     # Blacklist the release so the next search excludes it (issue #123).
     # The reason is the provider's own classification when we have one
     # (issue #237), falling back to the pre-existing generic slug.
-    # This MUST NOT block failure handling — wrap in try/rescue and log.
-    record_blacklist_entry(download, FailureCategory.slug(download_map.client_failure_category))
+    # This MUST NOT block failure handling, so wrap in try/rescue and log.
+    record_blacklist_entry(download, failure_slug)
 
     # Delete the download record - downloads table is ephemeral
     case Downloads.delete_download(download) do

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -36,6 +36,7 @@ defmodule Mydia.Jobs.MovieSearch do
   alias Mydia.{Repo, Media, Indexers, Downloads, Events, Search}
   alias Mydia.Downloads.{Blacklists, Download}
   alias Mydia.Indexers.RankingOptions
+  alias Mydia.Indexers.QualityProfileResolver
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Library.MediaFile
   alias Mydia.Media.MediaItem
@@ -547,7 +548,7 @@ defmodule Mydia.Jobs.MovieSearch do
     # no expected_season/expected_episode are supplied (a TV-pattern release is
     # softly penalized as an identity mismatch inside the ranker).
     RankingOptions.build(%{
-      quality_profile: load_quality_profile(movie),
+      quality_profile: QualityProfileResolver.resolve(movie),
       media_type: :movie,
       min_seeders: args.min_seeders || get_min_seeders(),
       size_range: args.size_range,
@@ -556,14 +557,6 @@ defmodule Mydia.Jobs.MovieSearch do
       blocked_tags: merged_blocked_tags(args.blocked_tags),
       preferred_tags: args.preferred_tags
     })
-  end
-
-  defp load_quality_profile(%MediaItem{quality_profile_id: nil}), do: nil
-
-  defp load_quality_profile(%MediaItem{} = movie) do
-    movie
-    |> Repo.preload(:quality_profile)
-    |> Map.get(:quality_profile)
   end
 
   defp initiate_download(movie, result) do

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -56,6 +56,7 @@ defmodule Mydia.Jobs.TVShowSearch do
   alias Mydia.{Repo, Media, Indexers, Downloads, Events, Search}
   alias Mydia.Downloads.{Blacklists, Download}
   alias Mydia.Indexers.RankingOptions
+  alias Mydia.Indexers.QualityProfileResolver
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Indexers.Structs.SearchResultMetadata
   alias Mydia.Media.{MediaItem, Episode}
@@ -1249,7 +1250,7 @@ defmodule Mydia.Jobs.TVShowSearch do
     # the requested episode above wrong episodes and season packs (which match
     # the season but lack the episode).
     RankingOptions.build(%{
-      quality_profile: load_quality_profile(episode),
+      quality_profile: QualityProfileResolver.resolve(episode.media_item),
       media_type: :episode,
       min_seeders: args.min_seeders || get_min_seeders(),
       size_range: args.size_range,
@@ -1268,7 +1269,7 @@ defmodule Mydia.Jobs.TVShowSearch do
     # matches on season alone — a season pack for the requested season matches,
     # a wrong-season pack is penalized.
     RankingOptions.build(%{
-      quality_profile: load_season_quality_profile(media_item),
+      quality_profile: QualityProfileResolver.resolve(media_item),
       media_type: :episode,
       min_seeders: args.min_seeders || get_min_seeders(),
       size_range: args.size_range,
@@ -1278,18 +1279,6 @@ defmodule Mydia.Jobs.TVShowSearch do
       blocked_tags: merged_blocked_tags(args.blocked_tags),
       preferred_tags: args.preferred_tags
     })
-  end
-
-  defp load_quality_profile(%Episode{media_item: media_item}) do
-    load_season_quality_profile(media_item)
-  end
-
-  defp load_season_quality_profile(%MediaItem{quality_profile_id: nil}), do: nil
-
-  defp load_season_quality_profile(%MediaItem{} = media_item) do
-    media_item
-    |> Repo.preload(:quality_profile)
-    |> then(& &1.quality_profile)
   end
 
   ## Private Functions - Download Initiation

--- a/lib/mydia_web/live/calendar_live/index.ex
+++ b/lib/mydia_web/live/calendar_live/index.ex
@@ -97,6 +97,13 @@ defmodule MydiaWeb.CalendarLive.Index do
     {:noreply, socket}
   end
 
+  # Grab outcomes are broadcast on the "downloads" topic and handled by
+  # MediaLive.Show, which owns the manual-search UI. Ignore them quietly here
+  # so the catch-all below keeps meaning "genuinely unexpected message".
+  def handle_info({:grab_completed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_failed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_duplicate, _payload}, socket), do: {:noreply, socket}
+
   def handle_info(msg, socket) do
     # Catch-all for unhandled messages to prevent crashes
     Logger.warning("Unhandled message in CalendarLive.Index: #{inspect(msg)}")

--- a/lib/mydia_web/live/calendar_live/index.ex
+++ b/lib/mydia_web/live/calendar_live/index.ex
@@ -2,6 +2,8 @@ defmodule MydiaWeb.CalendarLive.Index do
   use MydiaWeb, :live_view
   alias Mydia.Media
 
+  require Logger
+
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket) do
@@ -92,6 +94,12 @@ defmodule MydiaWeb.CalendarLive.Index do
   def handle_info({:download_updated, _download_id}, socket) do
     # Just trigger a re-render to update the downloads counter in the sidebar
     # The counter will be recalculated when the layout renders
+    {:noreply, socket}
+  end
+
+  def handle_info(msg, socket) do
+    # Catch-all for unhandled messages to prevent crashes
+    Logger.warning("Unhandled message in CalendarLive.Index: #{inspect(msg)}")
     {:noreply, socket}
   end
 

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -3,6 +3,8 @@ defmodule MydiaWeb.DashboardLive.Index do
 
   import MydiaWeb.DiscoverComponents
 
+  require Logger
+
   alias Mydia.Media
   alias Mydia.Library
   alias Mydia.Downloads
@@ -256,6 +258,12 @@ defmodule MydiaWeb.DashboardLive.Index do
          |> assign(:adding_item_id, nil)
          |> put_flash(:error, "Failed to fetch metadata: #{inspect(reason)}")}
     end
+  end
+
+  def handle_info(msg, socket) do
+    # Catch-all for unhandled messages to prevent crashes
+    Logger.warning("Unhandled message in DashboardLive.Index: #{inspect(msg)}")
+    {:noreply, socket}
   end
 
   ## Private Helpers

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -260,6 +260,13 @@ defmodule MydiaWeb.DashboardLive.Index do
     end
   end
 
+  # Grab outcomes are broadcast on the "downloads" topic and handled by
+  # MediaLive.Show, which owns the manual-search UI. Ignore them quietly here
+  # so the catch-all below keeps meaning "genuinely unexpected message".
+  def handle_info({:grab_completed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_failed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_duplicate, _payload}, socket), do: {:noreply, socket}
+
   def handle_info(msg, socket) do
     # Catch-all for unhandled messages to prevent crashes
     Logger.warning("Unhandled message in DashboardLive.Index: #{inspect(msg)}")

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -824,6 +824,13 @@ defmodule MydiaWeb.DownloadsLive.Index do
     {:noreply, socket}
   end
 
+  # Grab outcomes are broadcast on the "downloads" topic and handled by
+  # MediaLive.Show, which owns the manual-search UI. Ignore them quietly here
+  # so the catch-all below keeps meaning "genuinely unexpected message".
+  def handle_info({:grab_completed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_failed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_duplicate, _payload}, socket), do: {:noreply, socket}
+
   def handle_info(msg, socket) do
     # Catch-all for unhandled messages to prevent crashes
     Logger.warning("Unhandled message in DownloadsLive.Index: #{inspect(msg)}")

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -9,6 +9,8 @@ defmodule MydiaWeb.DownloadsLive.Index do
   alias MydiaWeb.Live.Authorization
   import MydiaWeb.Formatters
 
+  require Logger
+
   @items_per_page 50
 
   @default_sort "added_desc"
@@ -819,6 +821,12 @@ defmodule MydiaWeb.DownloadsLive.Index do
         socket
       end
 
+    {:noreply, socket}
+  end
+
+  def handle_info(msg, socket) do
+    # Catch-all for unhandled messages to prevent crashes
+    Logger.warning("Unhandled message in DownloadsLive.Index: #{inspect(msg)}")
     {:noreply, socket}
   end
 

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -34,6 +34,7 @@ defmodule MydiaWeb.MediaLive.Show do
 
     media_item = load_media_item(id)
     quality_profiles = Settings.list_quality_profiles()
+    default_quality_profile_id = Settings.get_default_quality_profile_id()
 
     # Load downloads with real-time status
     downloads_with_status = load_downloads_with_status(media_item)
@@ -73,6 +74,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:show_delete_confirm, false)
      |> assign(:delete_files, false)
      |> assign(:quality_profiles, quality_profiles)
+     |> assign(:default_quality_profile_id, default_quality_profile_id)
      |> assign(:show_file_delete_confirm, false)
      |> assign(:file_to_delete, nil)
      |> assign(:delete_file_from_disk, true)

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -25,6 +25,7 @@
           auto_searching={@auto_searching}
           downloads_with_status={@downloads_with_status}
           quality_profiles={@quality_profiles}
+          default_quality_profile_id={@default_quality_profile_id}
           applying_monitoring_preset={@applying_monitoring_preset}
           is_favorite={@is_favorite}
           item_collections={@item_collections}
@@ -265,7 +266,6 @@
       quality_filter={@quality_filter}
       min_seeders={@min_seeders}
       sort_by={@sort_by}
-      quality_profile={@media_item.quality_profile}
     />
   <% end %>
   <%= if @show_rename_modal do %>

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -16,6 +16,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :auto_searching, :boolean, required: true
   attr :downloads_with_status, :list, required: true
   attr :quality_profiles, :list, required: true
+  attr :default_quality_profile_id, :string, default: nil
   attr :applying_monitoring_preset, :boolean, default: false
   attr :is_favorite, :boolean, default: false
   attr :item_collections, :list, default: []
@@ -303,7 +304,11 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                     is_nil(@media_item.quality_profile_id) && "active"
                   ]}
                 >
-                  No Profile
+                  <%= if @default_quality_profile_id do %>
+                    Use instance default
+                  <% else %>
+                    No Profile
+                  <% end %>
                   <%= if is_nil(@media_item.quality_profile_id) do %>
                     <.icon name="hero-check" class="w-4 h-4" />
                   <% end %>

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -563,7 +563,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   Uses DaisyUI list components for a cleaner, more scannable UI.
   """
   attr :manual_search_context, :map, default: nil
-  attr :media_item, :map, required: true
+  attr :media_item, Mydia.Media.MediaItem, required: true
   attr :manual_search_query, :string, required: true
   attr :searching, :boolean, required: true
   attr :close_after_grab, :boolean, default: false
@@ -574,7 +574,6 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   attr :quality_filter, :string, default: nil
   attr :min_seeders, :integer, default: 0
   attr :sort_by, :atom, required: true
-  attr :quality_profile, :map, default: nil
 
   def manual_search_modal(assigns) do
     # Calculate media_type for profile scoring
@@ -747,7 +746,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                 class="list-row hover:bg-base-200/50 transition-colors px-4 py-3 border-b border-base-200 last:border-b-0"
               >
                 <%!-- Score display --%>
-                <%= if @quality_profile do %>
+                <%= if Keyword.get(@manual_ranking_opts, :quality_profile) do %>
                   <%!-- Unified ranker score with breakdown dropdown --%>
                   <% score_data = profile_score_breakdown(result, @manual_ranking_opts) %>
                   <% breakdown = score_data.breakdown %>

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   """
 
   alias Mydia.Indexers
+  alias Mydia.Indexers.QualityProfileResolver
   alias Mydia.Indexers.RankingOptions
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Indexers.SearchResult
@@ -222,7 +223,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
     {expected_season, expected_episode} = expected_identity(context)
 
     RankingOptions.build(%{
-      quality_profile: media_item.quality_profile,
+      quality_profile: QualityProfileResolver.resolve(media_item),
       media_type: get_media_type(media_item),
       min_seeders: Map.get(assigns, :min_seeders),
       search_query: Map.get(assigns, :manual_search_query),

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -588,6 +588,12 @@ defmodule MydiaWeb.SearchLive.Index do
     end
   end
 
+  def handle_info(msg, socket) do
+    # Catch-all for unhandled messages to prevent crashes
+    Logger.warning("Unhandled message in SearchLive.Index: #{inspect(msg)}")
+    {:noreply, socket}
+  end
+
   @impl true
   def handle_async(:search, {:ok, {:ok, results, indexer_errors}}, socket) do
     start_time = System.monotonic_time(:millisecond)

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -588,6 +588,13 @@ defmodule MydiaWeb.SearchLive.Index do
     end
   end
 
+  # Grab outcomes are broadcast on the "downloads" topic and handled by
+  # MediaLive.Show, which owns the manual-search UI. Ignore them quietly here
+  # so the catch-all below keeps meaning "genuinely unexpected message".
+  def handle_info({:grab_completed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_failed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_duplicate, _payload}, socket), do: {:noreply, socket}
+
   def handle_info(msg, socket) do
     # Catch-all for unhandled messages to prevent crashes
     Logger.warning("Unhandled message in SearchLive.Index: #{inspect(msg)}")

--- a/test/mydia/events_test.exs
+++ b/test/mydia/events_test.exs
@@ -927,4 +927,52 @@ defmodule Mydia.EventsTest do
       assert event.metadata["mode"] == "specific"
     end
   end
+
+  describe "download_failed/3 failure classification" do
+    setup do
+      media_item = Mydia.MediaFixtures.media_item_fixture()
+
+      download =
+        Mydia.DownloadsFixtures.download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "my-debrid"
+        })
+
+      %{download: download, media_item: media_item}
+    end
+
+    test "stores both keys when the caller supplies them", %{download: download} do
+      Events.download_failed(download, "boom",
+        failure_category: "missing_files",
+        failure_detail: "missingFiles"
+      )
+
+      Process.sleep(100)
+
+      assert [event] = Events.list_events(type: "download.failed")
+      assert event.metadata["failure_category"] == "missing_files"
+      assert event.metadata["failure_detail"] == "missingFiles"
+    end
+
+    test "omits the detail key when there is no detail", %{download: download} do
+      Events.download_failed(download, "boom", failure_category: "no_peers")
+
+      Process.sleep(100)
+
+      assert [event] = Events.list_events(type: "download.failed")
+      assert event.metadata["failure_category"] == "no_peers"
+      refute Map.has_key?(event.metadata, "failure_detail")
+    end
+
+    test "omits both keys entirely when the caller supplies neither", %{download: download} do
+      Events.download_failed(download, "boom")
+
+      Process.sleep(100)
+
+      assert [event] = Events.list_events(type: "download.failed")
+      refute Map.has_key?(event.metadata, "failure_category")
+      refute Map.has_key?(event.metadata, "failure_detail")
+      assert event.metadata["error_message"] == "boom"
+    end
+  end
 end

--- a/test/mydia/indexers/quality_profile_resolver_test.exs
+++ b/test/mydia/indexers/quality_profile_resolver_test.exs
@@ -1,0 +1,46 @@
+defmodule Mydia.Indexers.QualityProfileResolverTest do
+  use Mydia.DataCase, async: true
+
+  import ExUnit.CaptureLog
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Indexers.QualityProfileResolver
+  alias Mydia.Settings
+  alias Mydia.Settings.QualityProfile
+
+  describe "resolve/1" do
+    test "returns the item's own profile and ignores the instance default" do
+      own = quality_profile_fixture(%{name: "own-profile"})
+      other = quality_profile_fixture(%{name: "instance-default"})
+      {:ok, _} = Settings.set_default_quality_profile(other.id)
+
+      media_item = media_item_fixture(%{quality_profile_id: own.id})
+
+      assert %QualityProfile{} = resolved = QualityProfileResolver.resolve(media_item)
+      assert resolved.id == own.id
+    end
+
+    test "falls back to the instance default when the item has no profile" do
+      default = quality_profile_fixture(%{name: "instance-default"})
+      {:ok, _} = Settings.set_default_quality_profile(default.id)
+
+      media_item = media_item_fixture()
+      assert is_nil(media_item.quality_profile_id)
+
+      assert %QualityProfile{} = resolved = QualityProfileResolver.resolve(media_item)
+      assert resolved.id == default.id
+    end
+
+    test "returns nil and warns when there is no profile and no instance default" do
+      media_item = media_item_fixture()
+
+      log =
+        capture_log(fn ->
+          assert is_nil(QualityProfileResolver.resolve(media_item))
+        end)
+
+      assert log =~ "no size or resolution bounds"
+    end
+  end
+end

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1247,6 +1247,14 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       message = event.metadata["error_message"]
 
       assert message == "my-debrid reported missing files: missingFiles"
+
+      # The event and the blacklist row must carry the identical slug, so the
+      # activity feed and the admin blacklist page can be filtered on one
+      # vocabulary (#237). `handle_failure/1` binds the slug once and passes
+      # the same value to both.
+      assert event.metadata["failure_category"] == "missing_files"
+      assert event.metadata["failure_category"] == row.failure_reason
+      assert event.metadata["failure_detail"] == "missingFiles"
     end
 
     test "an unclassified failure still uses the pre-existing fallback slug" do

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -117,7 +117,6 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
         quality_filter: nil,
         min_seeders: 0,
         sort_by: :seeders,
-        quality_profile: nil,
         close_after_grab: false
       )
     end

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -108,7 +108,7 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
 
       render_component(&Modals.manual_search_modal/1,
         manual_search_context: %{type: :media_item},
-        media_item: %{title: "Some Movie", type: "movie", quality_profile: nil},
+        media_item: %Mydia.Media.MediaItem{title: "Some Movie", type: "movie"},
         manual_search_query: "Some Movie 2020",
         searching: false,
         results_empty?: false,

--- a/test/mydia_web/live/media_live/show/search_helpers_profile_fallback_test.exs
+++ b/test/mydia_web/live/media_live/show/search_helpers_profile_fallback_test.exs
@@ -1,0 +1,80 @@
+defmodule MydiaWeb.MediaLive.Show.SearchHelpersProfileFallbackTest do
+  # Separate from search_helpers_test.exs, which is deliberately DB-free.
+  # This one needs the repo because the fallback reads the instance default.
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Repo
+  alias Mydia.Settings
+  alias Mydia.Settings.QualityProfile
+  alias MydiaWeb.MediaLive.Show.SearchHelpers
+
+  defp assigns_for(media_item) do
+    %{
+      media_item: media_item,
+      manual_search_context: %{type: :media_item},
+      min_seeders: nil,
+      manual_search_query: "Some Movie"
+    }
+  end
+
+  test "a profile-less item ranks against the instance default's size bounds" do
+    default =
+      quality_profile_fixture(%{
+        name: "instance-default",
+        quality_standards: %{
+          preferred_resolutions: ["1080p"],
+          movie_min_size_mb: 500,
+          movie_max_size_mb: 8000
+        }
+      })
+
+    {:ok, _} = Settings.set_default_quality_profile(default.id)
+
+    media_item =
+      media_item_fixture(%{type: "movie"})
+      |> Repo.preload(:quality_profile)
+
+    assert is_nil(media_item.quality_profile)
+
+    opts = SearchHelpers.build_manual_ranking_opts(assigns_for(media_item))
+
+    assert %QualityProfile{} = Keyword.get(opts, :quality_profile)
+    assert Keyword.get(opts, :size_range) == {500, 8000}
+    assert Keyword.get(opts, :preferred_qualities) == ["1080p"]
+  end
+
+  test "an item with its own profile is unaffected by the instance default" do
+    own =
+      quality_profile_fixture(%{
+        name: "own-profile",
+        quality_standards: %{
+          preferred_resolutions: ["1080p"],
+          movie_min_size_mb: 100,
+          movie_max_size_mb: 2000
+        }
+      })
+
+    other =
+      quality_profile_fixture(%{
+        name: "instance-default",
+        quality_standards: %{
+          preferred_resolutions: ["1080p"],
+          movie_min_size_mb: 500,
+          movie_max_size_mb: 8000
+        }
+      })
+
+    {:ok, _} = Settings.set_default_quality_profile(other.id)
+
+    media_item =
+      media_item_fixture(%{type: "movie", quality_profile_id: own.id})
+      |> Repo.preload(:quality_profile)
+
+    opts = SearchHelpers.build_manual_ranking_opts(assigns_for(media_item))
+
+    assert Keyword.get(opts, :size_range) == {100, 2000}
+  end
+end

--- a/test/mydia_web/live/unhandled_message_test.exs
+++ b/test/mydia_web/live/unhandled_message_test.exs
@@ -36,4 +36,36 @@ defmodule MydiaWeb.UnhandledMessageTest do
       assert log =~ "Unhandled message in #{short_name(module)}"
     end
   end
+
+  # `Mydia.Downloads.Grabber` broadcasts these three shapes on the "downloads"
+  # topic alongside `{:download_updated, id}`. Only MediaLive.Show owns the
+  # manual-search UI and needs to act on them; the other subscribers should
+  # ignore them quietly rather than logging them as unhandled.
+  @grab_silent_live_views [
+    MydiaWeb.DashboardLive.Index,
+    MydiaWeb.CalendarLive.Index,
+    MydiaWeb.SearchLive.Index,
+    MydiaWeb.DownloadsLive.Index
+  ]
+
+  @grab_messages [
+    {:grab_completed, %{}},
+    {:grab_failed, %{}},
+    {:grab_duplicate, %{}}
+  ]
+
+  for module <- @grab_silent_live_views, grab_message <- @grab_messages do
+    test "#{inspect(module)} ignores #{inspect(elem(grab_message, 0))} silently" do
+      socket = %Socket{}
+      module = unquote(module)
+      grab_message = unquote(Macro.escape(grab_message))
+
+      log =
+        capture_log(fn ->
+          assert {:noreply, ^socket} = module.handle_info(grab_message, socket)
+        end)
+
+      assert log == ""
+    end
+  end
 end

--- a/test/mydia_web/live/unhandled_message_test.exs
+++ b/test/mydia_web/live/unhandled_message_test.exs
@@ -1,0 +1,39 @@
+defmodule MydiaWeb.UnhandledMessageTest do
+  # Calls handle_info/2 directly rather than mounting. The catch-all never
+  # touches the socket, so a bare struct is sufficient, and this avoids
+  # DashboardLive's metadata-relay fetches at mount entirely.
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Phoenix.LiveView.Socket
+
+  @live_views [
+    MydiaWeb.DashboardLive.Index,
+    MydiaWeb.CalendarLive.Index,
+    MydiaWeb.SearchLive.Index,
+    MydiaWeb.DownloadsLive.Index,
+    MydiaWeb.MediaLive.Index
+  ]
+
+  # The existing MediaLive.Index precedent logs the module name *without* the
+  # MydiaWeb prefix. Match it rather than inventing a second format.
+  defp short_name(module) do
+    module |> Module.split() |> Enum.drop(1) |> Enum.join(".")
+  end
+
+  for module <- @live_views do
+    test "#{inspect(module)} absorbs an unmatched message instead of crashing" do
+      socket = %Socket{}
+      module = unquote(module)
+
+      log =
+        capture_log(fn ->
+          assert {:noreply, ^socket} =
+                   module.handle_info({:totally_unexpected, :message}, socket)
+        end)
+
+      assert log =~ "Unhandled message in #{short_name(module)}"
+    end
+  end
+end

--- a/test/mydia_web/live/unhandled_message_test.exs
+++ b/test/mydia_web/live/unhandled_message_test.exs
@@ -65,7 +65,14 @@ defmodule MydiaWeb.UnhandledMessageTest do
           assert {:noreply, ^socket} = module.handle_info(grab_message, socket)
         end)
 
-      assert log == ""
+      # Deliberately not `assert log == ""`. `capture_log/1` intercepts the
+      # Logger globally rather than per-process, so under `async: true` any
+      # unrelated test that happens to log during this window bleeds into the
+      # capture and an emptiness assertion fails at random. Asserting the
+      # absence of the catch-all's own line tests the property we actually
+      # care about: the grab message was matched by a silent clause and never
+      # reached the fall-through.
+      refute log =~ "Unhandled message in #{short_name(module)}"
     end
   end
 end


### PR DESCRIPTION
Three independent observability fixes, all the same shape: the system silently dropped information an operator needs. Each is its own commit.

## Profile-less searches ran unbounded

TV search, movie search, and the manual search dialog each hand-rolled a quality-profile lookup that returned `nil` for an item with no profile assigned. `RankingOptions.build/1` then skipped every size, resolution, and seed-ratio bound and ranked on seeders alone, with nothing recording that it had.

All three now resolve through the new `Mydia.Indexers.QualityProfileResolver`, which falls back to the instance default (`media.default_quality_profile_id`) and logs a warning when there is not one. `RankingOptions.build/1` is unchanged and stays database-free, so its pure unit tests still apply.

Two consequences worth flagging for review:

- The manual-search score breakdown is now gated on the *resolved* profile rather than the item's own, so the panel explaining the ordering appears whenever the ordering is actually profile-driven.
- The profile dropdown's null entry now reads **"Use instance default"** when a default is configured, and keeps reading "No Profile" when none is. It previously claimed "No Profile" while the default was silently applied, which was no longer true once this fallback exists.

## Four LiveViews crashed on unmatched messages

`DashboardLive`, `CalendarLive`, `SearchLive`, and `DownloadsLive` all subscribe to the `"downloads"` PubSub topic with no fallthrough `handle_info/2`.

This was not theoretical. Besides `{:download_updated, id}`, `Downloads.Grabber` broadcasts `{:grab_completed, _}`, `{:grab_failed, _}`, and `{:grab_duplicate, _}` on the same topic (`grabber.ex:11-15`), and only `MediaLive.Show` handles them. **Every manual grab was killing the other four subscribing views.**

Each view now ignores the three grab shapes quietly and logs anything genuinely unexpected, matching the clause `MediaLive.Index` already had.

## download.failed events dropped the failure category

`DownloadMonitor.handle_failure/1` had the client's classification and wrote its slug to the release blacklist, but the event beside it kept only the prose message, so the activity feed could not be filtered or correlated with the admin blacklist page.

The slug is now bound **once** and passed to both the event and the blacklist row, which makes divergence structurally impossible rather than a convention two call sites have to remember. `Mydia.Events` gains no dependency on `FailureCategory`; the caller renders the slug to a string. The other three `download.failed` emitters are Mydia-side failures with no client classification and emit byte-identical metadata to before.

No UI change here. This makes the value structured and queryable; rendering a badge or adding a feed filter is separate work.

## Verification

- `./dev mix precommit`: 5558 tests, 0 failures
- `./dev mix credo --strict`: no issues
- Compiles clean under `--warnings-as-errors`

Additive only: no migrations, no schema changes, nothing adapter-specific, and the two new event-metadata keys are read with bracket access, so an operator upgrading a single instance reads old events fine.

## Known follow-ups, deliberately not in scope

- Eight more LiveViews subscribe to PubSub with no catch-all (`activity_live`, `transcodes_live`, four admin views, `admin_remote_access_live`, `music_player_live`). This PR scoped to the `"downloads"` subscribers; the class of bug is not closed.
- `quality_profile_fixture/1` shallow-merges `:quality_standards`, so a partial map silently drops `preferred_resolutions` and trips a changeset validation. Pre-existing trap, worked around here.
- Several other `media_item` attrs in `modals.ex` and `components.ex` are still typed `:map` though callers pass structs.
