### PR TITLE
fix(jobs): consolidate metadata refresh and fix Access-on-struct crash

### DIFF
--- a/lib/mydia/jobs/metadata_refresh.ex
+++ b/lib/mydia/jobs/metadata_refresh.ex
@@ -8,8 +8,10 @@ defmodule Mydia.Jobs.MetadataRefresh do
   - For TV shows, updates episode information
   - Can be triggered manually or scheduled
 
-  For scheduled "refresh all" runs, a random delay (0-30 minutes) is applied
-  to spread load across self-hosted instances hitting the metadata relay.
+  The refresh itself lives in `Mydia.Media.Refresh`; this module is the Oban
+  wrapper around it. A full pass isolates each item so one bad media item
+  cannot abort the run, and reports its failures through `Mydia.Events` rather
+  than reporting success regardless of outcome.
   """
 
   use Oban.Worker,
@@ -17,8 +19,8 @@ defmodule Mydia.Jobs.MetadataRefresh do
     max_attempts: 3
 
   require Logger
-  alias Mydia.{Media, Metadata}
-  alias Mydia.Metadata.NfoWriter
+  alias Mydia.{Events, Media}
+  alias Mydia.Media.Refresh
 
   defmodule Args do
     @moduledoc false
@@ -51,36 +53,73 @@ defmodule Mydia.Jobs.MetadataRefresh do
     end
   end
 
-  # Random delay range for scheduled refresh_all (0-30 minutes in ms)
-  @max_startup_delay_ms 30 * 60 * 1000
+  # Cap on how many individual failures are attached to the reported event.
+  @max_failure_samples 10
 
-  @spec perform(Oban.Job.t()) :: :ok | {:ok, term()} | {:error, term()} | {:snooze, pos_integer()}
+  @spec perform(Oban.Job.t()) :: :ok | {:error, term()} | {:snooze, pos_integer()}
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"media_item_id" => media_item_id} = raw_args}) do
     args = Args.parse(raw_args)
-    start_time = System.monotonic_time(:millisecond)
-    fetch_episodes = args.fetch_episodes
-    config = Metadata.default_relay_config()
+    run_one(media_item_id, args.fetch_episodes)
+  end
 
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"refresh_all" => true}}), do: run_all()
+
+  # Manual trigger from the UI sends empty args.
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: raw_args}) when raw_args == %{}, do: run_all()
+
+  @doc false
+  # The default argument is the seam that makes crash isolation testable
+  # without a mocking library.
+  def run_all(refresh_fun \\ &refresh_one/1) do
+    start_time = System.monotonic_time(:millisecond)
+    media_items = Media.list_media_items(monitored: true)
+    total = length(media_items)
+
+    Logger.info("Refreshing metadata for #{total} media items")
+
+    results = Enum.map(media_items, &safe_refresh(&1, refresh_fun))
+    duration = System.monotonic_time(:millisecond) - start_time
+
+    failures =
+      results
+      |> Enum.filter(&match?({_item, {:error, _reason}}, &1))
+      |> Enum.map(fn {item, {:error, reason}} -> {item, reason} end)
+
+    succeeded = total - length(failures)
+
+    Logger.info("Metadata refresh all completed",
+      duration_ms: duration,
+      total: total,
+      succeeded: succeeded,
+      failed: length(failures)
+    )
+
+    report_failures(failures, total, succeeded)
+
+    :ok
+  end
+
+  ## Private Functions
+
+  defp run_one(media_item_id, fetch_episodes) do
+    start_time = System.monotonic_time(:millisecond)
     Logger.info("Starting metadata refresh", media_item_id: media_item_id)
 
     result =
-      case Media.get_media_item!(media_item_id) do
-        nil ->
-          Logger.error("Media item not found", media_item_id: media_item_id)
-          {:error, :not_found}
-
-        media_item ->
-          refresh_media_item(media_item, config, fetch_episodes)
-      end
+      media_item_id
+      |> Media.get_media_item!()
+      |> Refresh.run(recover_by_title: true, fetch_episodes: fetch_episodes)
 
     duration = System.monotonic_time(:millisecond) - start_time
 
     case result do
-      :ok ->
+      {:ok, updated} ->
         Logger.info("Metadata refresh completed",
           duration_ms: duration,
-          media_item_id: media_item_id
+          media_item_id: updated.id
         )
 
         :ok
@@ -100,253 +139,52 @@ defmodule Mydia.Jobs.MetadataRefresh do
       {:error, :not_found}
   end
 
-  @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"refresh_all" => true} = raw_args}) do
-    args = Args.parse(raw_args)
-
-    # Add random delay for scheduled runs to spread load across instances
-    # Skip delay for manual triggers (skip_delay: true)
-    unless args.skip_delay do
-      delay_ms = :rand.uniform(@max_startup_delay_ms)
-      delay_minutes = Float.round(delay_ms / 60_000, 1)
-
-      Logger.info("Metadata refresh scheduled, waiting #{delay_minutes} minutes before starting")
-      Process.sleep(delay_ms)
-    end
-
-    start_time = System.monotonic_time(:millisecond)
-    Logger.info("Starting metadata refresh for all media items")
-
-    result = refresh_all_media()
-    duration = System.monotonic_time(:millisecond) - start_time
-
-    case result do
-      {:ok, count} ->
-        Logger.info("Metadata refresh all completed",
-          duration_ms: duration,
-          items_processed: count
-        )
-
-        :ok
-    end
+  defp refresh_one(media_item) do
+    Refresh.run(media_item, recover_by_title: true, fetch_episodes: false)
   end
 
-  # Fallback for manual trigger from UI (empty args) - skip delay for immediate execution
-  @impl Oban.Worker
-  def perform(%Oban.Job{args: raw_args}) when raw_args == %{} do
-    perform(%Oban.Job{args: %{"refresh_all" => true, "skip_delay" => true}})
-  end
+  # A single bad item must not abort the pass. The ErrorTracker report is
+  # load-bearing: rescuing without it would hide exactly the class of bug this
+  # isolation exists to survive.
+  defp safe_refresh(media_item, refresh_fun) do
+    {media_item, refresh_fun.(media_item)}
+  rescue
+    error ->
+      ErrorTracker.report(error, __STACKTRACE__, %{media_item_id: media_item.id})
 
-  ## Private Functions
-
-  defp refresh_media_item(media_item, config, fetch_episodes) do
-    media_type = parse_media_type(media_item.type)
-
-    # Get the appropriate provider ID and its source (tvdb_id for TV shows, tmdb_id for movies)
-    {provider_id, provider_source} = get_or_extract_provider_id(media_item, media_type)
-
-    # If no provider ID, try to recover it via the shared Media function
-    {provider_id, provider_source, media_item} =
-      if provider_id do
-        {provider_id, provider_source, media_item}
-      else
-        Logger.info("No provider ID found, attempting to recover by title search",
-          media_item_id: media_item.id,
-          title: media_item.title
-        )
-
-        case Media.recover_provider_id_by_title(media_item, media_type) do
-          {:ok, found_id, updated_item} ->
-            Logger.info("Successfully recovered provider ID via title search",
-              media_item_id: media_item.id,
-              title: media_item.title,
-              provider_id: found_id
-            )
-
-            source = if updated_item.tvdb_id, do: :tvdb, else: :tmdb
-            {found_id, source, updated_item}
-
-          {:error, reason} ->
-            Logger.warning("Failed to recover provider ID via title search",
-              media_item_id: media_item.id,
-              title: media_item.title,
-              reason: reason
-            )
-
-            {nil, nil, media_item}
-        end
-      end
-
-    if provider_id do
-      Logger.info("Refreshing metadata",
+      Logger.warning("Exception refreshing metadata, continuing pass",
         media_item_id: media_item.id,
-        title: media_item.title,
-        provider_id: provider_id,
-        provider_source: provider_source,
-        media_type: media_type
+        error: inspect(error)
       )
 
-      case fetch_updated_metadata(provider_id, media_type, provider_source, config) do
-        {:ok, metadata} ->
-          attrs = build_update_attrs(metadata, media_type, media_item)
-
-          case Media.update_media_item(media_item, attrs, reason: "Metadata refreshed") do
-            {:ok, updated_item} ->
-              Logger.info("Successfully refreshed metadata",
-                media_item_id: updated_item.id,
-                title: updated_item.title
-              )
-
-              # For TV shows, optionally refresh episodes
-              if media_type == :tv_show and fetch_episodes do
-                Media.refresh_episodes_for_tv_show(updated_item)
-              end
-
-              # Regenerate NFO files if enabled for any library path
-              NfoWriter.maybe_write_nfos(updated_item)
-
-              :ok
-
-            {:error, changeset} ->
-              Logger.error("Failed to update media item",
-                media_item_id: media_item.id,
-                errors: inspect(changeset.errors)
-              )
-
-              {:error, :update_failed}
-          end
-
-        {:error, reason} ->
-          Logger.error("Failed to fetch updated metadata",
-            media_item_id: media_item.id,
-            provider_id: provider_id,
-            reason: reason
-          )
-
-          {:error, reason}
-      end
-    else
-      Logger.warning("Media item has no provider ID and could not recover via title search",
-        media_item_id: media_item.id
-      )
-
-      {:error, :no_provider_id}
-    end
+      {media_item, {:error, {:exception, Exception.message(error)}}}
   end
 
-  defp refresh_all_media do
-    media_items = Media.list_media_items(monitored: true)
+  defp report_failures([], _total, _succeeded), do: :ok
 
-    Logger.info("Refreshing metadata for #{length(media_items)} media items")
+  defp report_failures(failures, total, succeeded) do
+    failed = length(failures)
 
-    results =
-      Enum.map(media_items, fn media_item ->
-        config = Metadata.default_relay_config()
-        refresh_media_item(media_item, config, false)
+    samples =
+      failures
+      |> Enum.take(@max_failure_samples)
+      |> Enum.map(fn {item, reason} ->
+        %{
+          "media_item_id" => item.id,
+          "title" => item.title,
+          "reason" => inspect(reason)
+        }
       end)
 
-    successful = Enum.count(results, &(&1 == :ok))
-    failed = Enum.count(results, &match?({:error, _}, &1))
+    message =
+      "#{failed} of #{total} media items failed to refresh " <>
+        "(showing #{length(samples)} of #{failed})"
 
-    Logger.info("Metadata refresh completed",
-      total: length(results),
-      successful: successful,
-      failed: failed
-    )
-
-    {:ok, successful}
-  end
-
-  defp parse_media_type("movie"), do: :movie
-  defp parse_media_type("tv_show"), do: :tv_show
-  defp parse_media_type(_), do: :movie
-
-  defp fetch_updated_metadata(provider_id, media_type, provider_source, config) do
-    fetch_opts = [
-      media_type: media_type,
-      provider: provider_source,
-      append_to_response: ["credits", "images", "videos", "keywords"]
-    ]
-
-    Metadata.fetch_by_id(config, to_string(provider_id), fetch_opts)
-  end
-
-  defp build_update_attrs(metadata, media_type, media_item) do
-    base_attrs = %{
-      title: metadata.title,
-      original_title: metadata.original_title,
-      year: extract_year(metadata),
-      imdb_id: metadata.imdb_id,
-      metadata: metadata
-    }
-
-    # Route the metadata ID to the correct field based on provider source
-    {_provider_id, provider_source} = get_or_extract_provider_id(media_item, media_type)
-
-    case provider_source do
-      :tvdb ->
-        Map.put(base_attrs, :tvdb_id, metadata.id)
-
-      _ ->
-        Map.put(base_attrs, :tmdb_id, metadata.id)
-    end
-  end
-
-  defp get_or_extract_provider_id(media_item, media_type) do
-    cond do
-      # For TV shows, prefer tvdb_id
-      media_type == :tv_show and media_item.tvdb_id ->
-        {media_item.tvdb_id, :tvdb}
-
-      # Fall back to tmdb_id for any media type
-      media_item.tmdb_id ->
-        {media_item.tmdb_id, :tmdb}
-
-      # Try to extract from metadata["id"] (new format - string key)
-      media_item.metadata && media_item.metadata["id"] ->
-        id =
-          case media_item.metadata["id"] do
-            id when is_integer(id) ->
-              id
-
-            id when is_binary(id) ->
-              case Integer.parse(id) do
-                {parsed_id, ""} -> parsed_id
-                _ -> nil
-              end
-
-            _ ->
-              nil
-          end
-
-        {id, :tmdb}
-
-      # Try to extract from metadata["provider_id"] (old format - string key)
-      media_item.metadata && media_item.metadata["provider_id"] ->
-        id =
-          case Integer.parse(media_item.metadata["provider_id"]) do
-            {id, ""} -> id
-            _ -> nil
-          end
-
-        {id, :tmdb}
-
-      # No provider ID available
-      true ->
-        {nil, nil}
-    end
-  end
-
-  defp extract_year(metadata) do
-    cond do
-      metadata.release_date ->
-        metadata.release_date.year
-
-      metadata.first_air_date ->
-        metadata.first_air_date.year
-
-      true ->
-        nil
-    end
+    Events.job_failed("metadata_refresh", message, %{
+      "total" => total,
+      "succeeded" => succeeded,
+      "failed" => failed,
+      "sample_failures" => samples
+    })
   end
 end

--- a/lib/mydia/jobs/metadata_refresh.ex
+++ b/lib/mydia/jobs/metadata_refresh.ex
@@ -56,6 +56,9 @@ defmodule Mydia.Jobs.MetadataRefresh do
   # Cap on how many individual failures are attached to the reported event.
   @max_failure_samples 10
 
+  # Random jitter range for scheduled refresh_all runs (0-30 minutes, in seconds).
+  @max_startup_delay_seconds 30 * 60
+
   @spec perform(Oban.Job.t()) :: :ok | {:error, term()} | {:snooze, pos_integer()}
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"media_item_id" => media_item_id} = raw_args}) do
@@ -64,7 +67,23 @@ defmodule Mydia.Jobs.MetadataRefresh do
   end
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"refresh_all" => true}}), do: run_all()
+  def perform(%Oban.Job{attempt: attempt, args: %{"refresh_all" => true} = raw_args}) do
+    args = Args.parse(raw_args)
+
+    # Spread load across self-hosted instances hitting the shared metadata relay
+    # at 05:00 Sunday. Snoozing releases the queue slot instead of holding it for
+    # up to half an hour, and Oban increments max_attempts so the jitter does not
+    # consume one of the pass's real attempts.
+    if attempt == 1 and not args.skip_delay do
+      delay_seconds = :rand.uniform(@max_startup_delay_seconds)
+
+      Logger.info("Metadata refresh scheduled, snoozing #{delay_seconds}s to spread relay load")
+
+      {:snooze, delay_seconds}
+    else
+      run_all()
+    end
+  end
 
   # Manual trigger from the UI sends empty args.
   @impl Oban.Worker

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -2091,13 +2091,17 @@ defmodule Mydia.Media do
 
   For TV shows, searches TVDB and stores tvdb_id. For movies, searches TMDB and stores tmdb_id.
 
+  Pass `config` to reuse a caller's relay config; it defaults to
+  `Metadata.default_relay_config/0`. A caller running against a specific relay
+  must not have its recovery search silently fall back to the global default.
+
   Returns {:ok, provider_id, updated_media_item} or {:error, reason}
   """
-  @spec recover_provider_id_by_title(MediaItem.t(), atom()) ::
+  @spec recover_provider_id_by_title(MediaItem.t(), atom(), map() | nil) ::
           {:ok, integer(), MediaItem.t()} | {:error, term()}
-  def recover_provider_id_by_title(%MediaItem{} = media_item, media_type) do
+  def recover_provider_id_by_title(%MediaItem{} = media_item, media_type, config \\ nil) do
     alias Mydia.Metadata
-    config = Metadata.default_relay_config()
+    config = config || Metadata.default_relay_config()
     do_recover_provider_id_by_title(media_item, media_type, config)
   end
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1083,10 +1083,11 @@ defmodule Mydia.Media do
   @doc """
   Re-fetches metadata from the provider and updates the media item.
 
-  Determines the provider (TVDB/TMDB) from the media item's IDs,
-  fetches fresh metadata via `Metadata.fetch_by_id/3` (uncached),
-  and updates the media item's metadata field. For TV shows, also
-  refreshes episodes.
+  Delegates to `Mydia.Media.Refresh.run/2`, which owns provider resolution,
+  the attribute writes, episode refresh and NFO regeneration.
+
+  The second argument is a bare config map rather than a keyword list, for
+  backwards compatibility with existing callers.
 
   ## Returns
     - `{:ok, media_item}` - Updated media item
@@ -1095,65 +1096,8 @@ defmodule Mydia.Media do
   @spec refresh_metadata(MediaItem.t(), map() | nil) ::
           {:ok, MediaItem.t()} | {:error, term()}
   def refresh_metadata(%MediaItem{} = media_item, config \\ nil) do
-    alias Mydia.Metadata
-
-    config = config || Metadata.default_relay_config()
-    media_type = if media_item.type == "tv_show", do: :tv_show, else: :movie
-
-    {provider_id, provider_source} = refresh_provider_preference(media_item)
-
-    if is_nil(provider_id) do
-      {:error, :missing_provider_id}
-    else
-      fetch_opts = [
-        media_type: media_type,
-        provider: provider_source,
-        append_to_response: ["credits", "images", "videos", "keywords"]
-      ]
-
-      case Metadata.fetch_by_id(config, provider_id, fetch_opts) do
-        {:ok, full_metadata} ->
-          attrs = %{metadata: full_metadata}
-
-          case update_media_item(media_item, attrs, reason: "Metadata refreshed from provider") do
-            {:ok, updated_item} = result ->
-              # Regenerate NFO files if enabled for any library path
-              Mydia.Metadata.NfoWriter.maybe_write_nfos(updated_item)
-              result
-
-            error ->
-              error
-          end
-
-        {:error, reason} ->
-          Logger.warning("Failed to refresh metadata for #{media_item.title}: #{inspect(reason)}")
-          {:error, reason}
-      end
-    end
+    Mydia.Media.Refresh.run(media_item, config: config)
   end
-
-  # Resolve the `{provider_id, provider_source}` a refresh should fetch from.
-  #
-  # `metadata_source` is the authoritative provenance recorded when an item was
-  # matched under per-library provider selection, so it wins even when a
-  # back-filled id for the other provider is also present (e.g. a TMDB-sourced
-  # show that carries a discovered `tvdb_id`). Only when it is absent do we fall
-  # back to the legacy TVDB-precedence rule (prefer `tvdb_id`, then `tmdb_id`).
-  defp refresh_provider_preference(%MediaItem{metadata_source: :tmdb, tmdb_id: tmdb_id})
-       when not is_nil(tmdb_id),
-       do: {to_string(tmdb_id), :tmdb}
-
-  defp refresh_provider_preference(%MediaItem{metadata_source: :tvdb, tvdb_id: tvdb_id})
-       when not is_nil(tvdb_id),
-       do: {to_string(tvdb_id), :tvdb}
-
-  defp refresh_provider_preference(%MediaItem{tvdb_id: tvdb_id}) when not is_nil(tvdb_id),
-    do: {to_string(tvdb_id), :tvdb}
-
-  defp refresh_provider_preference(%MediaItem{tmdb_id: tmdb_id}) when not is_nil(tmdb_id),
-    do: {to_string(tmdb_id), :tmdb}
-
-  defp refresh_provider_preference(%MediaItem{}), do: {nil, nil}
 
   @doc """
   Refreshes episodes for a TV show by fetching metadata and creating missing episodes.
@@ -1193,16 +1137,15 @@ defmodule Mydia.Media do
     # Resolve the provider to fetch from. `metadata_source` (when set) is the
     # authoritative provenance; only fall back to the legacy TVDB-precedence
     # rule and the stored metadata provider_id when it is absent.
+    # Refresh.resolve_provider/1 already includes the stored-metadata fallback,
+    # reading struct fields rather than string keys. (The old fallback here
+    # matched %{"provider_id" => id} against an atom-keyed %MediaMetadata{} and
+    # could never fire.) It returns an integer id; this function threads
+    # provider ids as strings.
     {provider_id, provider_source} =
-      case refresh_provider_preference(media_item) do
-        {nil, nil} ->
-          case media_item.metadata do
-            %{"provider_id" => id} when is_binary(id) -> {id, :tmdb}
-            _ -> {nil, nil}
-          end
-
-        pair ->
-          pair
+      case Mydia.Media.Refresh.resolve_provider(media_item) do
+        {nil, nil} -> {nil, nil}
+        {id, source} -> {to_string(id), source}
       end
 
     # If we have a TMDB ID but no TVDB ID, try to discover the TVDB ID so we can

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -10,11 +10,119 @@ defmodule Mydia.Media.Refresh do
   `Access`.
   """
 
+  require Logger
+
+  alias Mydia.Media
   alias Mydia.Media.MediaItem
+  alias Mydia.Metadata
+  alias Mydia.Metadata.NfoWriter
   alias Mydia.Metadata.Structs.MediaMetadata
 
   @typedoc "A resolved provider id and the provider that owns it."
   @type resolution :: {pos_integer() | nil, :tvdb | :tmdb | nil}
+
+  @doc """
+  Refreshes one media item's metadata from its provider.
+
+  ## Options
+
+    * `:config` - relay config. Defaults to `Metadata.default_relay_config/0`.
+    * `:fetch_episodes` - refresh episodes for TV shows. Defaults to `true`.
+    * `:recover_by_title` - when no provider id can be resolved, search the
+      provider by title to re-identify the item. Defaults to `false`, because
+      fuzzy re-identification is surprising when triggered from a UI button.
+  """
+  @spec run(MediaItem.t(), keyword()) :: {:ok, MediaItem.t()} | {:error, term()}
+  def run(%MediaItem{} = media_item, opts \\ []) do
+    config = Keyword.get(opts, :config) || Metadata.default_relay_config()
+    fetch_episodes = Keyword.get(opts, :fetch_episodes, true)
+    media_type = media_type(media_item)
+
+    case resolve_provider(media_item) do
+      {nil, _source} ->
+        {:error, :missing_provider_id}
+
+      {provider_id, source} ->
+        with {:ok, metadata} <- fetch(provider_id, media_type, source, config),
+             {:ok, updated} <- apply_metadata(media_item, metadata, source) do
+          post_update(updated, media_type, fetch_episodes)
+          {:ok, updated}
+        end
+    end
+  end
+
+  defp media_type(%MediaItem{type: "tv_show"}), do: :tv_show
+  defp media_type(%MediaItem{}), do: :movie
+
+  defp fetch(provider_id, media_type, source, config) do
+    fetch_opts = [
+      media_type: media_type,
+      provider: source,
+      append_to_response: ["credits", "images", "videos", "keywords"]
+    ]
+
+    Metadata.fetch_by_id(config, to_string(provider_id), fetch_opts)
+  end
+
+  # `source` is threaded in from the resolution that actually produced
+  # `metadata`, never re-derived from the pre-update struct. Re-deriving is what
+  # let a recovered id get written to the wrong column.
+  defp apply_metadata(media_item, metadata, source) do
+    attrs =
+      %{
+        title: metadata.title,
+        original_title: metadata.original_title,
+        year: extract_year(metadata),
+        imdb_id: metadata.imdb_id,
+        metadata: metadata
+      }
+      |> put_provider_id(source, metadata.id)
+
+    case Media.update_media_item(media_item, attrs, reason: "Metadata refreshed") do
+      {:ok, updated} ->
+        {:ok, updated}
+
+      {:error, changeset} ->
+        Logger.error("Failed to update media item during refresh",
+          media_item_id: media_item.id,
+          errors: inspect(changeset.errors)
+        )
+
+        {:error, :update_failed}
+    end
+  end
+
+  defp put_provider_id(attrs, _source, nil), do: attrs
+  defp put_provider_id(attrs, :tvdb, id), do: Map.put(attrs, :tvdb_id, id)
+  defp put_provider_id(attrs, _source, id), do: Map.put(attrs, :tmdb_id, id)
+
+  # Episode refresh is best-effort: every other caller already ignores its
+  # result, and a failed episode fetch must not fail an otherwise good metadata
+  # refresh. Log it so the failure is still visible.
+  defp post_update(updated, :tv_show, true) do
+    case Media.refresh_episodes_for_tv_show(updated) do
+      {:ok, _count} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Metadata refreshed but episode refresh failed",
+          media_item_id: updated.id,
+          reason: inspect(reason)
+        )
+    end
+
+    NfoWriter.maybe_write_nfos(updated)
+    :ok
+  end
+
+  defp post_update(updated, _media_type, _fetch_episodes) do
+    NfoWriter.maybe_write_nfos(updated)
+    :ok
+  end
+
+  defp extract_year(%MediaMetadata{release_date: %Date{} = date}), do: date.year
+  defp extract_year(%MediaMetadata{first_air_date: %Date{} = date}), do: date.year
+  defp extract_year(%MediaMetadata{}), do: nil
 
   @doc """
   Resolves which provider and id a refresh should fetch from.

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -38,16 +38,57 @@ defmodule Mydia.Media.Refresh do
     fetch_episodes = Keyword.get(opts, :fetch_episodes, true)
     media_type = media_type(media_item)
 
-    case resolve_provider(media_item) do
-      {nil, _source} ->
+    recover? = Keyword.get(opts, :recover_by_title, false)
+
+    case resolve_or_recover(media_item, media_type, recover?, config) do
+      {nil, _source, _item} ->
         {:error, :missing_provider_id}
 
-      {provider_id, source} ->
+      {provider_id, source, item} ->
         with {:ok, metadata} <- fetch(provider_id, media_type, source, config),
-             {:ok, updated} <- apply_metadata(media_item, metadata, source) do
+             {:ok, updated} <- apply_metadata(item, metadata, source) do
           post_update(updated, media_type, fetch_episodes)
           {:ok, updated}
         end
+    end
+  end
+
+  # Returns the item alongside the resolution because recovery persists the
+  # discovered id; downstream steps must see the updated struct.
+  defp resolve_or_recover(media_item, media_type, recover?, config) do
+    case resolve_provider(media_item) do
+      {nil, _source} when recover? ->
+        recover(media_item, media_type, config)
+
+      {nil, _source} ->
+        {nil, nil, media_item}
+
+      {provider_id, source} ->
+        {provider_id, source, media_item}
+    end
+  end
+
+  defp recover(media_item, media_type, config) do
+    Logger.info("No provider id found, attempting recovery by title search",
+      media_item_id: media_item.id,
+      title: media_item.title
+    )
+
+    case Media.recover_provider_id_by_title(media_item, media_type, config) do
+      {:ok, _found_id, updated_item} ->
+        # Recovery persists the id to the correct column, so re-resolving the
+        # updated item yields the authoritative {id, source} pair.
+        {id, source} = resolve_provider(updated_item)
+        {id, source, updated_item}
+
+      {:error, reason} ->
+        Logger.warning("Failed to recover provider id by title search",
+          media_item_id: media_item.id,
+          title: media_item.title,
+          reason: inspect(reason)
+        )
+
+        {nil, nil, media_item}
     end
   end
 

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -1,0 +1,63 @@
+defmodule Mydia.Media.Refresh do
+  @moduledoc """
+  Owns refreshing a single media item's metadata from its provider.
+
+  This module is the single source of truth for the refresh flow. Before it
+  existed the same sequence was written three times (the Oban job, the `Media`
+  context, and the show LiveView) and the copies had drifted apart, which is
+  how a crash reached production: the job resolved providers using
+  `media_item.metadata["id"]`, and `%MediaMetadata{}` does not implement
+  `Access`.
+  """
+
+  alias Mydia.Media.MediaItem
+  alias Mydia.Metadata.Structs.MediaMetadata
+
+  @typedoc "A resolved provider id and the provider that owns it."
+  @type resolution :: {pos_integer() | nil, :tvdb | :tmdb | nil}
+
+  @doc """
+  Resolves which provider and id a refresh should fetch from.
+
+  `metadata_source` is the authoritative provenance recorded when an item was
+  matched under per-library provider selection, so it wins even when a
+  back-filled id for the other provider is also present. Only when it is absent
+  do we fall back to the legacy TVDB-precedence rule, and only after that to the
+  id stored inside the metadata blob.
+
+  Returns the id as an **integer**. Callers building an HTTP path convert with
+  `to_string/1`.
+  """
+  @spec resolve_provider(MediaItem.t()) :: resolution()
+  def resolve_provider(%MediaItem{metadata_source: :tmdb, tmdb_id: id}) when not is_nil(id),
+    do: {id, :tmdb}
+
+  def resolve_provider(%MediaItem{metadata_source: :tvdb, tvdb_id: id}) when not is_nil(id),
+    do: {id, :tvdb}
+
+  def resolve_provider(%MediaItem{tvdb_id: id}) when not is_nil(id), do: {id, :tvdb}
+  def resolve_provider(%MediaItem{tmdb_id: id}) when not is_nil(id), do: {id, :tmdb}
+
+  def resolve_provider(%MediaItem{metadata: %MediaMetadata{} = metadata}) do
+    case normalize_id(metadata.id) || normalize_id(metadata.provider_id) do
+      nil -> {nil, nil}
+      id -> {id, :tmdb}
+    end
+  end
+
+  def resolve_provider(%MediaItem{}), do: {nil, nil}
+
+  # Struct field access, never Access syntax. `provider_id` is frequently the
+  # empty string because `MetadataType.map_to_struct/1` defaults it to
+  # `to_string(data[:id] || "")`, and "" is truthy in Elixir.
+  defp normalize_id(id) when is_integer(id), do: id
+
+  defp normalize_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {parsed, ""} -> parsed
+      _ -> nil
+    end
+  end
+
+  defp normalize_id(_), do: nil
+end

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -187,14 +187,31 @@ defmodule Mydia.Media.Refresh do
   def resolve_provider(%MediaItem{tvdb_id: id}) when not is_nil(id), do: {id, :tvdb}
   def resolve_provider(%MediaItem{tmdb_id: id}) when not is_nil(id), do: {id, :tmdb}
 
-  def resolve_provider(%MediaItem{metadata: %MediaMetadata{} = metadata}) do
+  def resolve_provider(%MediaItem{metadata: %MediaMetadata{} = metadata} = media_item) do
     case normalize_id(metadata.id) || normalize_id(metadata.provider_id) do
       nil -> {nil, nil}
-      id -> {id, :tmdb}
+      id -> {id, stored_blob_provider(media_item, metadata)}
     end
   end
 
   def resolve_provider(%MediaItem{}), do: {nil, nil}
+
+  # Which provider issued the id stored inside the metadata blob.
+  #
+  # The blob records its own provenance: `Relay.fetch_tvdb_by_id/3` stamps
+  # `provider: :tvdb`, while the TMDB path leaves the
+  # `MediaMetadata.from_api_response/3` default of `:metadata_relay`. Assuming
+  # `:tmdb` unconditionally (as the old duplicated resolvers did) routes a TVDB
+  # id to `/tmdb/tv/shows/<tvdb-id>` and fetches an unrelated title.
+  #
+  # `metadata_source` still outranks the blob when set, since it is the
+  # authoritative provenance recorded at match time.
+  defp stored_blob_provider(%MediaItem{metadata_source: source}, _metadata)
+       when source in [:tvdb, :tmdb],
+       do: source
+
+  defp stored_blob_provider(_media_item, %MediaMetadata{provider: :tvdb}), do: :tvdb
+  defp stored_blob_provider(_media_item, %MediaMetadata{}), do: :tmdb
 
   # Struct field access, never Access syntax. `provider_id` is frequently the
   # empty string because `MetadataType.map_to_struct/1` defaults it to

--- a/lib/mydia_web/live/media_live/show/file_events.ex
+++ b/lib/mydia_web/live/media_live/show/file_events.ex
@@ -145,41 +145,22 @@ defmodule MydiaWeb.MediaLive.Show.FileEvents do
      |> put_flash(:error, "Provider switch failed unexpectedly")}
   end
 
+  # Refresh.run/2 already refreshes episodes for TV shows and writes NFOs, so
+  # this no longer hand-rolls the two-call sequence. Episode-refresh failures
+  # are logged there rather than surfaced as a flash: they are best-effort and
+  # must not read as a failed metadata refresh.
   defp do_standard_refresh(media_item, socket) do
-    metadata_result = Media.refresh_metadata(media_item)
-
-    case {media_item.type, metadata_result} do
-      {"tv_show", {:ok, updated_item}} ->
-        case Media.refresh_episodes_for_tv_show(updated_item) do
-          {:ok, count} ->
-            {:noreply,
-             socket
-             |> assign(:media_item, load_media_item(media_item.id))
-             |> put_flash(
-               :info,
-               "Refreshed metadata: #{count} episodes updated#{ambiguous_note(media_item)}"
-             )}
-
-          {:error, reason} ->
-            {:noreply,
-             socket
-             |> assign(:media_item, load_media_item(media_item.id))
-             |> put_flash(
-               :warning,
-               "Metadata refreshed but episode refresh failed: #{inspect(reason)}"
-             )}
-        end
-
-      {"movie", {:ok, _updated_item}} ->
+    case Media.Refresh.run(media_item) do
+      {:ok, _updated_item} ->
         {:noreply,
          socket
          |> assign(:media_item, load_media_item(media_item.id))
-         |> put_flash(:info, "Metadata refreshed")}
+         |> put_flash(:info, "Metadata refreshed#{ambiguous_note(media_item)}")}
 
-      {_, {:error, :missing_provider_id}} ->
+      {:error, :missing_provider_id} ->
         {:noreply, put_flash(socket, :error, "Cannot refresh: Missing provider ID (TMDB/TVDB)")}
 
-      {_, {:error, reason}} ->
+      {:error, reason} ->
         {:noreply, put_flash(socket, :error, "Failed to refresh metadata: #{inspect(reason)}")}
     end
   end

--- a/test/mydia/jobs/metadata_refresh_test.exs
+++ b/test/mydia/jobs/metadata_refresh_test.exs
@@ -2,6 +2,7 @@ defmodule Mydia.Jobs.MetadataRefreshTest do
   use Mydia.DataCase, async: false
   use Oban.Testing, repo: Mydia.Repo
 
+  alias Mydia.Events
   alias Mydia.Jobs.MetadataRefresh
 
   import Mydia.MediaFixtures
@@ -14,8 +15,7 @@ defmodule Mydia.Jobs.MetadataRefreshTest do
                perform_job(MetadataRefresh, %{"media_item_id" => fake_id})
     end
 
-    test "returns error when media item has no provider ID and title search fails" do
-      # Create media item without TMDB ID
+    test "returns missing_provider_id when nothing resolves and recovery fails" do
       media_item =
         media_item_fixture(%{
           type: "movie",
@@ -24,103 +24,55 @@ defmodule Mydia.Jobs.MetadataRefreshTest do
           tmdb_id: nil
         })
 
-      # Since title search will fail (no mock results), should return error
-      result = perform_job(MetadataRefresh, %{"media_item_id" => media_item.id})
-
-      assert result == {:error, :no_provider_id}
-    end
-
-    test "refreshes media item when TMDB ID exists" do
-      # Create media item with TMDB ID
-      media_item =
-        media_item_fixture(%{
-          type: "movie",
-          title: "Test Movie",
-          year: 2024,
-          tmdb_id: 12345
-        })
-
-      # This will fail because no mock server, but should get past the TMDB ID check
-      result = perform_job(MetadataRefresh, %{"media_item_id" => media_item.id})
-
-      # Will fail due to no metadata relay, but should not be :no_provider_id
-      assert result != {:error, :no_provider_id}
+      assert {:error, :missing_provider_id} =
+               perform_job(MetadataRefresh, %{"media_item_id" => media_item.id})
     end
   end
 
-  describe "title similarity scoring" do
-    test "exact title match scores highest" do
-      score = calculate_similarity_score("The Matrix", "The Matrix")
-      assert score == 1.0
+  describe "run_all/1 - pass isolation" do
+    test "one raising item does not abort the pass" do
+      for n <- 1..3 do
+        media_item_fixture(%{type: "movie", title: "Item #{n}", year: 2024})
+      end
+
+      attempted = :counters.new(1, [])
+
+      raise_on_second = fn _media_item ->
+        :counters.add(attempted, 1, 1)
+
+        if :counters.get(attempted, 1) == 2 do
+          raise "boom"
+        end
+
+        {:error, :relay_unavailable}
+      end
+
+      assert :ok = MetadataRefresh.run_all(raise_on_second)
+
+      # All three were attempted: the raise was contained, not propagated.
+      assert :counters.get(attempted, 1) == 3
     end
 
-    test "case insensitive match scores high" do
-      score = calculate_similarity_score("the matrix", "The Matrix")
-      assert score == 1.0
+    test "emits a job_failed event carrying accurate counts" do
+      for n <- 1..3 do
+        media_item_fixture(%{type: "movie", title: "Item #{n}", year: 2024})
+      end
+
+      assert :ok = MetadataRefresh.run_all(fn _item -> {:error, :relay_unavailable} end)
+
+      assert [event] = Events.list_events(category: "system", type: "job.failed")
+      assert event.metadata["job_name"] == "metadata_refresh"
+      assert event.metadata["total"] == 3
+      assert event.metadata["succeeded"] == 0
+      assert event.metadata["failed"] == 3
     end
 
-    test "substring match scores well" do
-      score = calculate_similarity_score("The Matrix", "The Matrix Reloaded")
-      assert score >= 0.7
-    end
+    test "emits no event when every item succeeds" do
+      item = media_item_fixture(%{type: "movie", title: "Fine", year: 2024})
 
-    test "completely different titles score low" do
-      score = calculate_similarity_score("The Matrix", "Inception")
-      assert score < 0.6
-    end
-  end
+      assert :ok = MetadataRefresh.run_all(fn _item -> {:ok, item} end)
 
-  describe "year matching" do
-    test "exact year match returns true" do
-      assert year_matches?(2020, 2020)
-    end
-
-    test "year difference of 1 returns true" do
-      assert year_matches?(2020, 2021)
-      assert year_matches?(2021, 2020)
-    end
-
-    test "year difference of 2 or more returns false" do
-      refute year_matches?(2020, 2022)
-    end
-
-    test "nil media year returns true when result has year" do
-      assert year_matches?(2020, nil)
-    end
-
-    test "nil result year returns false" do
-      refute year_matches?(nil, 2020)
-    end
-  end
-
-  # Helper functions to test the scoring logic
-  # These mirror the private functions in MetadataRefresh
-
-  defp calculate_similarity_score(title1, title2) do
-    norm1 = normalize_title(title1)
-    norm2 = normalize_title(title2)
-
-    cond do
-      norm1 == norm2 -> 1.0
-      String.contains?(norm1, norm2) or String.contains?(norm2, norm1) -> 0.8
-      true -> String.jaro_distance(norm1, norm2)
+      assert [] = Events.list_events(category: "system", type: "job.failed")
     end
   end
-
-  defp normalize_title(title) do
-    title
-    |> String.downcase()
-    |> String.replace(~r/[^\w\s]/, "")
-    |> String.replace(~r/\s+/, " ")
-    |> String.trim()
-  end
-
-  defp year_matches?(result_year, nil), do: result_year != nil
-  defp year_matches?(nil, _media_year), do: false
-
-  defp year_matches?(result_year, media_year) when is_integer(result_year) do
-    abs(result_year - media_year) <= 1
-  end
-
-  defp year_matches?(_result_year, _media_year), do: false
 end

--- a/test/mydia/jobs/metadata_refresh_test.exs
+++ b/test/mydia/jobs/metadata_refresh_test.exs
@@ -75,4 +75,25 @@ defmodule Mydia.Jobs.MetadataRefreshTest do
       assert [] = Events.list_events(category: "system", type: "job.failed")
     end
   end
+
+  describe "scheduled jitter" do
+    test "first attempt snoozes instead of sleeping" do
+      assert {:snooze, seconds} = perform_job(MetadataRefresh, %{"refresh_all" => true})
+      assert seconds >= 1
+      assert seconds <= 1800
+    end
+
+    test "runs the pass on a later attempt" do
+      assert :ok = perform_job(MetadataRefresh, %{"refresh_all" => true}, attempt: 2)
+    end
+
+    test "runs immediately when skip_delay is set" do
+      assert :ok =
+               perform_job(MetadataRefresh, %{"refresh_all" => true, "skip_delay" => true})
+    end
+
+    test "runs immediately for a manual empty-args trigger" do
+      assert :ok = perform_job(MetadataRefresh, %{})
+    end
+  end
 end

--- a/test/mydia/media/refresh_test.exs
+++ b/test/mydia/media/refresh_test.exs
@@ -1,0 +1,98 @@
+defmodule Mydia.Media.RefreshTest do
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Media.MediaItem
+  alias Mydia.Media.Refresh
+  alias Mydia.Metadata.Structs.MediaMetadata
+
+  # MediaMetadata enforces :provider_id, :provider and :media_type, so every
+  # literal needs them. Default provider_id to "" (which is what
+  # MetadataType.map_to_struct/1 stores when there is no id) so tests that care
+  # about `id` are not silently satisfied by `provider_id`.
+  defp metadata(attrs) do
+    defaults = %{provider_id: "", provider: :metadata_relay, media_type: :movie}
+    struct!(MediaMetadata, Map.merge(defaults, Map.new(attrs)))
+  end
+
+  describe "resolve_provider/1" do
+    test "metadata_source :tmdb wins over a back-filled tvdb_id" do
+      item = %MediaItem{metadata_source: :tmdb, tmdb_id: 111, tvdb_id: 222}
+      assert Refresh.resolve_provider(item) == {111, :tmdb}
+    end
+
+    test "metadata_source :tvdb wins over a present tmdb_id" do
+      item = %MediaItem{metadata_source: :tvdb, tmdb_id: 111, tvdb_id: 222}
+      assert Refresh.resolve_provider(item) == {222, :tvdb}
+    end
+
+    test "without metadata_source, tvdb_id takes legacy precedence" do
+      item = %MediaItem{metadata_source: nil, tmdb_id: 111, tvdb_id: 222}
+      assert Refresh.resolve_provider(item) == {222, :tvdb}
+    end
+
+    test "falls back to tmdb_id when no tvdb_id is present" do
+      item = %MediaItem{metadata_source: nil, tmdb_id: 111, tvdb_id: nil}
+      assert Refresh.resolve_provider(item) == {111, :tmdb}
+    end
+
+    # REGRESSION: this is the exact shape that raised in
+    # metadata_refresh.ex:306 via `media_item.metadata["id"]`.
+    # provider_id is deliberately different so this proves `id` is read and wins.
+    test "falls back to metadata.id when both provider id columns are nil" do
+      item = %MediaItem{
+        tmdb_id: nil,
+        tvdb_id: nil,
+        metadata: metadata(id: 12_345, provider_id: "999")
+      }
+
+      assert Refresh.resolve_provider(item) == {12_345, :tmdb}
+    end
+
+    test "parses a string metadata.id" do
+      item = %MediaItem{tmdb_id: nil, tvdb_id: nil, metadata: metadata(id: "678")}
+      assert Refresh.resolve_provider(item) == {678, :tmdb}
+    end
+
+    test "falls back to metadata.provider_id when metadata.id is nil" do
+      item = %MediaItem{
+        tmdb_id: nil,
+        tvdb_id: nil,
+        metadata: metadata(id: nil, provider_id: "999")
+      }
+
+      assert Refresh.resolve_provider(item) == {999, :tmdb}
+    end
+
+    # MetadataType.map_to_struct/1 sets provider_id to `to_string(data[:id] || "")`,
+    # so an empty string is common — and truthy in Elixir.
+    test "an empty provider_id resolves to no provider, not a bogus id" do
+      item = %MediaItem{
+        tmdb_id: nil,
+        tvdb_id: nil,
+        metadata: metadata(id: nil, provider_id: "")
+      }
+
+      assert Refresh.resolve_provider(item) == {nil, nil}
+    end
+
+    test "an unparseable metadata id resolves to no provider" do
+      item = %MediaItem{
+        tmdb_id: nil,
+        tvdb_id: nil,
+        metadata: metadata(id: "abc", provider_id: "xyz")
+      }
+
+      assert Refresh.resolve_provider(item) == {nil, nil}
+    end
+
+    test "nil metadata resolves to no provider" do
+      item = %MediaItem{tmdb_id: nil, tvdb_id: nil, metadata: nil}
+      assert Refresh.resolve_provider(item) == {nil, nil}
+    end
+
+    test "a legacy plain-map metadata resolves to no provider instead of raising" do
+      item = %MediaItem{tmdb_id: nil, tvdb_id: nil, metadata: %{"id" => 5}}
+      assert Refresh.resolve_provider(item) == {nil, nil}
+    end
+  end
+end

--- a/test/mydia/media/refresh_test.exs
+++ b/test/mydia/media/refresh_test.exs
@@ -195,5 +195,65 @@ defmodule Mydia.Media.RefreshTest do
 
       assert {:error, :missing_provider_id} = Refresh.run(item, config: config)
     end
+
+    test "recovers a TV show by title and routes the id to tvdb_id", %{
+      bypass: bypass,
+      config: config
+    } do
+      item =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Recoverable Show",
+          tmdb_id: nil,
+          tvdb_id: nil
+        })
+
+      Bypass.expect_once(bypass, "GET", "/tvdb/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{
+            "data" => [
+              %{
+                "tvdb_id" => "4242",
+                "name" => "Recoverable Show",
+                "year" => "2015",
+                "type" => "series"
+              }
+            ]
+          })
+        )
+      end)
+
+      Bypass.expect_once(bypass, "GET", "/tvdb/series/4242/extended", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{
+            "data" => %{
+              "id" => 4242,
+              "name" => "Recoverable Show",
+              "firstAired" => "2015-03-01",
+              "overview" => "x",
+              "genres" => [],
+              "seasons" => [],
+              "characters" => []
+            }
+          })
+        )
+      end)
+
+      assert {:ok, updated} =
+               Refresh.run(item,
+                 config: config,
+                 recover_by_title: true,
+                 fetch_episodes: false
+               )
+
+      assert updated.tvdb_id == 4242
+      refute updated.tmdb_id == 4242
+    end
   end
 end

--- a/test/mydia/media/refresh_test.exs
+++ b/test/mydia/media/refresh_test.exs
@@ -1,6 +1,8 @@
 defmodule Mydia.Media.RefreshTest do
   use Mydia.DataCase, async: false
 
+  import Mydia.MediaFixtures
+
   alias Mydia.Media.MediaItem
   alias Mydia.Media.Refresh
   alias Mydia.Metadata.Structs.MediaMetadata
@@ -93,6 +95,105 @@ defmodule Mydia.Media.RefreshTest do
     test "a legacy plain-map metadata resolves to no provider instead of raising" do
       item = %MediaItem{tmdb_id: nil, tvdb_id: nil, metadata: %{"id" => 5}}
       assert Refresh.resolve_provider(item) == {nil, nil}
+    end
+  end
+
+  describe "run/2" do
+    setup do
+      bypass = Bypass.open()
+
+      # Inject the relay config directly so this test never mutates the global
+      # METADATA_RELAY_URL env var (which would race concurrent async tests).
+      config = %{
+        type: :metadata_relay,
+        base_url: "http://localhost:#{bypass.port}",
+        options: %{language: "en-US", include_adult: false}
+      }
+
+      %{bypass: bypass, config: config}
+    end
+
+    test "refreshes a movie and syncs the wide attribute set", %{
+      bypass: bypass,
+      config: config
+    } do
+      item = media_item_fixture(%{type: "movie", title: "Stale Title", year: 1999, tmdb_id: 555})
+
+      Bypass.expect_once(bypass, "GET", "/tmdb/movies/555", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{
+            "id" => 555,
+            "title" => "Fresh Title",
+            "original_title" => "Fresh Original",
+            "release_date" => "2020-05-01",
+            "imdb_id" => "tt7654321",
+            "overview" => "x",
+            "credits" => %{"cast" => [], "crew" => []},
+            "genres" => []
+          })
+        )
+      end)
+
+      assert {:ok, updated} = Refresh.run(item, config: config)
+
+      assert updated.title == "Fresh Title"
+      assert updated.original_title == "Fresh Original"
+      assert updated.year == 2020
+      assert updated.imdb_id == "tt7654321"
+      assert updated.tmdb_id == 555
+    end
+
+    # The job's resolver ignored metadata_source entirely, so it would have
+    # fetched this show from TVDB. Only the TMDB path is stubbed, so a
+    # wrong-provider fetch 404s and fails the test.
+    test "a TMDB-sourced show with a back-filled tvdb_id refreshes from TMDB", %{
+      bypass: bypass,
+      config: config
+    } do
+      item =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "TMDB Sourced",
+          metadata_source: :tmdb,
+          tmdb_id: 12_345,
+          tvdb_id: 67_890
+        })
+
+      Bypass.expect_once(bypass, "GET", "/tmdb/tv/shows/12345", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{
+            "id" => 12_345,
+            "name" => "TMDB Sourced",
+            "first_air_date" => "2010-01-01",
+            "overview" => "x",
+            "credits" => %{"cast" => [], "crew" => []},
+            "genres" => [],
+            "seasons" => []
+          })
+        )
+      end)
+
+      assert {:ok, updated} = Refresh.run(item, config: config, fetch_episodes: false)
+      assert updated.tmdb_id == 12_345
+    end
+
+    test "returns :missing_provider_id and makes no request when nothing resolves", %{
+      bypass: bypass,
+      config: config
+    } do
+      item = media_item_fixture(%{type: "movie", title: "No Ids", year: 2024, tmdb_id: nil})
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/search", fn _conn ->
+        flunk("run/2 must not search when recover_by_title is not set")
+      end)
+
+      assert {:error, :missing_provider_id} = Refresh.run(item, config: config)
     end
   end
 end

--- a/test/mydia/media/refresh_test.exs
+++ b/test/mydia/media/refresh_test.exs
@@ -67,6 +67,44 @@ defmodule Mydia.Media.RefreshTest do
 
     # MetadataType.map_to_struct/1 sets provider_id to `to_string(data[:id] || "")`,
     # so an empty string is common — and truthy in Elixir.
+    # The stored blob records its own provenance: fetch_tvdb_by_id/3 stamps
+    # provider: :tvdb, while the TMDB path leaves from_api_response/3's default
+    # of :metadata_relay. Labelling a TVDB id as :tmdb routes it to
+    # /tmdb/tv/shows/<tvdb-id> and fetches an unrelated show.
+    test "a TVDB-sourced blob resolves to :tvdb, not :tmdb" do
+      item = %MediaItem{
+        type: "tv_show",
+        tmdb_id: nil,
+        tvdb_id: nil,
+        metadata: metadata(id: 4242, provider: :tvdb, media_type: :tv_show)
+      }
+
+      assert Refresh.resolve_provider(item) == {4242, :tvdb}
+    end
+
+    test "a relay-sourced blob still resolves to :tmdb" do
+      item = %MediaItem{
+        type: "tv_show",
+        tmdb_id: nil,
+        tvdb_id: nil,
+        metadata: metadata(id: 555, provider: :metadata_relay, media_type: :tv_show)
+      }
+
+      assert Refresh.resolve_provider(item) == {555, :tmdb}
+    end
+
+    test "metadata_source outranks the blob's own provider" do
+      item = %MediaItem{
+        type: "tv_show",
+        metadata_source: :tmdb,
+        tmdb_id: nil,
+        tvdb_id: nil,
+        metadata: metadata(id: 777, provider: :tvdb, media_type: :tv_show)
+      }
+
+      assert Refresh.resolve_provider(item) == {777, :tmdb}
+    end
+
     test "an empty provider_id resolves to no provider, not a bogus id" do
       item = %MediaItem{
         tmdb_id: nil,


### PR DESCRIPTION
## The bug

The weekly metadata refresh (cron `0 5 * * 0`) has been dead. `metadata_refresh.ex:306`
called `media_item.metadata["id"]`, but `metadata` is a `%MediaMetadata{}` struct with
atom keys and no `Access` implementation, so it raised whenever both `tvdb_id` and
`tmdb_id` were nil. 14,868 occurrences on one fingerprint, plus 75 on a second. The Oban
job discarded after 3 attempts on 2026-07-26 and re-died every Sunday.

## Why it went unnoticed

`refresh_all_media/0` always returned `{:ok, successful}`, and `perform/1` matched only
`{:ok, count}`. **A pass where every single item failed still logged "completed" and
recorded success in Oban.** There was no failure signal at all, despite
`Events.job_failed/3` already existing for exactly this purpose (its own doc example is
`job_failed("metadata_refresh", ...)`).

## The actual root cause

The Access call is a symptom. "Refresh one media item" was written three times and only
one copy stayed correct:

| Concern | Oban job | `Media.refresh_metadata/2` | show LiveView |
| --- | --- | --- | --- |
| Provider resolution | own copy, **crashed**, ignored `metadata_source` | correct | delegated |
| Title-search recovery | yes | no | no |
| Attrs written | title, year, imdb_id, ids, metadata | metadata only | via context |
| Episode refresh | yes | no | hand-rolled second call |

Three further defects fell out of that divergence:

1. **`metadata_source` ignored by the job**, so a TMDB-sourced show could be silently
   flipped to TVDB. There is a comment in `media.ex` explicitly warning against this.
2. **Double resolution** — `get_or_extract_provider_id/2` ran twice per item, and the
   second call re-derived the provider from the *pre-recovery* struct, so a recovered id
   could be written to the wrong column.
3. **Dead fallback** in `media.ex` matching `%{"provider_id" => id}` (string key) against
   an atom-keyed struct. Never fired.

## What this does

Extracts `Mydia.Media.Refresh` as the single owner of the flow. `resolve_provider/1` is
public and reads struct fields, so the crash is structurally impossible. The job, the
context function and the LiveView all collapse onto it.

- Provider resolution now exists in **exactly one place** (both duplicates deleted).
- The pass isolates each item, so one bad item can no longer abort the run. Exceptions are
  still reported to ErrorTracker, so the containment does not hide the next bug like it.
- Failures are summarised via `Events.job_failed` with real counts and a capped sample.
- The 30-minute `Process.sleep` becomes `{:snooze, n}`, releasing the queue slot instead of
  holding it. The `@spec` already declared `{:snooze, pos_integer()}`; it was never returned.
- `recover_provider_id_by_title` now accepts the caller's relay config instead of always
  rebuilding the global default (a real bug found while writing tests).

## Behaviour changes worth reviewing

- The UI "Refresh metadata" button now syncs `title`, `original_title`, `year` and
  `imdb_id`, not just the metadata blob. Title-search recovery stays **opt-in** and the UI
  does not pass it, since fuzzy re-identification from a button is surprising.
- The show page's success flash loses its episode count, and the "episode refresh failed"
  warning becomes a log line. The actionable missing-provider-id message is preserved.

## Tests

The old test file had 14 tests, **11 of which called private helpers defined inside the
test file itself**, mirroring functions that had moved to `media.ex` long ago. They passed
regardless of production behaviour. A twelfth asserted `result != {:error, :no_provider_id}`,
satisfied by any failure — it stayed green through this entire incident.

Those are replaced with real coverage: a regression test for the exact crashing shape, a
7-case resolver precedence table, post-recovery id routing, recovery opt-in (asserting no
search request is made), pass isolation, event reporting, and snooze behaviour.

## Verification

- **SQLite:** `./dev mix precommit` green on all 7 steps (deps, compile `--warnings-as-errors`,
  unused deps, format, Credo `--strict`, database, tests). **5545 tests, 0 failures.**
- **PostgreSQL:** 5545 tests, 3 failures, all in `media_import_test.exs`. **Confirmed
  pre-existing and environmental, not from this branch** — checking out `master` in the same
  worktree reproduces the same 3 failures identically.

  Cause: ExUnit's `tmp_dir` gets used as a `library_paths.path`, and here the absolute path
  is ~265 chars (80-char worktree cwd + a 184-char subdirectory derived from a very long
  test name), exceeding `varchar(255)`. SQLite ignores `varchar` length limits; Postgres
  enforces them. It reproduces only in deeply-nested worktrees, which is why CI is green.
- Grep-verified after the change: no `Access` calls on metadata remain in the touched
  modules, and `resolve_provider/1` is the only provider resolver left in `lib/`.
