### PR TITLE
fix(player): keep runApp reachable when startup steps fail

### DIFF
--- a/player/lib/core/startup/startup_error_app.dart
+++ b/player/lib/core/startup/startup_error_app.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import '../theme/app_theme.dart';
+
+/// Last-resort UI for when startup cannot proceed to [MyApp].
+///
+/// The one invariant `main()` must uphold is that `runApp` is always called,
+/// on every code path. If a startup step fails badly enough that the app
+/// can't reasonably continue, this is what gets run instead of leaving the
+/// user staring at a black window with no explanation.
+class StartupErrorApp extends StatelessWidget {
+  const StartupErrorApp({
+    super.key,
+    required this.title,
+    required this.message,
+    this.details,
+  });
+
+  /// Shown when another instance of the app is already running and holding
+  /// the lock on the shared data directory. Specifically detected, so the
+  /// message can be user-actionable instead of a generic error dump.
+  factory StartupErrorApp.alreadyRunning(Object error) => StartupErrorApp(
+        title: 'Mydia Player is already running',
+        message: 'Another window of Mydia Player is already open on this '
+            'computer. Quit it, then reopen this one.',
+        details: '$error',
+        key: const Key('startup-error-already-running'),
+      );
+
+  /// Shown for any other fatal startup failure, with whatever underlying
+  /// error text is available so the user (or a bug report) has something to
+  /// go on.
+  factory StartupErrorApp.generic(Object error) => StartupErrorApp(
+        title: "Mydia Player couldn't start",
+        message: 'Something went wrong while starting the app.',
+        details: '$error',
+        key: const Key('startup-error-generic'),
+      );
+
+  final String title;
+  final String message;
+  final String? details;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Mydia Player',
+      debugShowCheckedModeBanner: false,
+      theme: AppTheme.darkTheme,
+      home: Scaffold(
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(32),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.error_outline, color: Colors.red, size: 56),
+                const SizedBox(height: 16),
+                Text(
+                  title,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  message,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: Colors.white70),
+                ),
+                if (details != null) ...[
+                  const SizedBox(height: 24),
+                  SelectableText(
+                    details!,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Colors.white38,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/player/lib/core/startup/startup_lock.dart
+++ b/player/lib/core/startup/startup_lock.dart
@@ -1,4 +1,20 @@
-import 'dart:io';
+/// Detection for the "another instance already holds our on-disk locks"
+/// startup failure.
+///
+/// The check is inherently `dart:io`-shaped — it inspects a
+/// `FileSystemException`, and has to consult `Platform` to know which OS
+/// error code means "already locked" — so it lives in a native-only
+/// implementation, with a stub for web.
+///
+/// Importing `dart:io` on web compiles (dart2js patches the library rather
+/// than omitting it), but `Platform.isLinux` and friends throw
+/// `UnsupportedError` there, so the split is load-bearing rather than
+/// cosmetic. Web has nothing to detect regardless: a browser tab gets its
+/// own IndexedDB-backed store, not a shared lock file.
+library;
+
+import 'startup_lock_stub.dart' if (dart.library.io) 'startup_lock_native.dart'
+    as impl;
 
 /// Whether [error] indicates that another instance of the app already holds
 /// an on-disk lock this process just tried to acquire.
@@ -8,19 +24,12 @@ import 'dart:io';
 /// directory and is guarded by a `.lock` file. A second instance of the app
 /// pointed at that same directory fails to open *all* of them with the same
 /// underlying `FileSystemException`: a failed `lock()` call on a `.lock`
-/// file, surfaced as `errno 35` (`EAGAIN`/`EWOULDBLOCK`) on POSIX platforms.
+/// file, surfaced as `EAGAIN`/`EWOULDBLOCK`.
 ///
 /// That is the one startup failure with a specific, user-actionable
 /// explanation ("quit the other window") instead of being a generic error,
 /// so it is worth detecting on its own rather than folding it into the
 /// catch-all startup-failure path.
-bool isLockContentionError(Object error) {
-  if (error is! FileSystemException) return false;
-
-  final looksLikeLockFile = (error.path ?? '').endsWith('.lock');
-
-  const eagain = 35; // EAGAIN / EWOULDBLOCK
-  final isResourceUnavailable = error.osError?.errorCode == eagain;
-
-  return looksLikeLockFile || isResourceUnavailable;
-}
+///
+/// Always `false` on web, which has no such lock to contend for.
+bool isLockContentionError(Object error) => impl.isLockContentionError(error);

--- a/player/lib/core/startup/startup_lock.dart
+++ b/player/lib/core/startup/startup_lock.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+/// Whether [error] indicates that another instance of the app already holds
+/// an on-disk lock this process just tried to acquire.
+///
+/// Every persistent store the app opens at startup (the GraphQL Hive cache,
+/// the fetch log, the download database) lives under the same per-user data
+/// directory and is guarded by a `.lock` file. A second instance of the app
+/// pointed at that same directory fails to open *all* of them with the same
+/// underlying `FileSystemException`: a failed `lock()` call on a `.lock`
+/// file, surfaced as `errno 35` (`EAGAIN`/`EWOULDBLOCK`) on POSIX platforms.
+///
+/// That is the one startup failure with a specific, user-actionable
+/// explanation ("quit the other window") instead of being a generic error,
+/// so it is worth detecting on its own rather than folding it into the
+/// catch-all startup-failure path.
+bool isLockContentionError(Object error) {
+  if (error is! FileSystemException) return false;
+
+  final looksLikeLockFile = (error.path ?? '').endsWith('.lock');
+
+  const eagain = 35; // EAGAIN / EWOULDBLOCK
+  final isResourceUnavailable = error.osError?.errorCode == eagain;
+
+  return looksLikeLockFile || isResourceUnavailable;
+}

--- a/player/lib/core/startup/startup_lock_native.dart
+++ b/player/lib/core/startup/startup_lock_native.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+/// Native implementation of `isLockContentionError`. See `startup_lock.dart`
+/// for what this detects and why it is worth detecting separately.
+bool isLockContentionError(Object error) {
+  if (error is! FileSystemException) return false;
+
+  final looksLikeLockFile = (error.path ?? '').endsWith('.lock');
+
+  final code = error.osError?.errorCode;
+  final isLockAlreadyHeld = code != null && _lockContentionCodes.contains(code);
+
+  return looksLikeLockFile || isLockAlreadyHeld;
+}
+
+/// The OS error codes *this* platform reports when a lock is already held.
+///
+/// `EAGAIN`/`EWOULDBLOCK` — what a failed non-blocking `flock()` returns, and
+/// what the reproduced macOS bug surfaced as — is not a portable number: it
+/// is 35 on Darwin and the BSDs but 11 on Linux. Windows does not report an
+/// errno here at all; a contended `LockFileEx` comes back as
+/// `ERROR_SHARING_VIOLATION` (32) or `ERROR_LOCK_VIOLATION` (33).
+///
+/// Matching a bare number on every platform would misfire, because each of
+/// these values means something unrelated elsewhere (35 is `EDEADLK` on
+/// Linux, 33 is `EDOM` on both Linux and Darwin), so only the running
+/// platform's own codes count.
+Set<int> get _lockContentionCodes {
+  if (Platform.isLinux || Platform.isAndroid) return const {11};
+  if (Platform.isWindows) return const {32, 33};
+  // Darwin (macOS, iOS) and the BSDs.
+  return const {35};
+}

--- a/player/lib/core/startup/startup_lock_stub.dart
+++ b/player/lib/core/startup/startup_lock_stub.dart
@@ -1,0 +1,6 @@
+/// Web stub for `isLockContentionError`. See `startup_lock.dart`.
+///
+/// The web build cannot import `dart:io`, and has nothing to detect anyway:
+/// each tab gets its own IndexedDB-backed Hive store rather than a shared
+/// on-disk one, so two "instances" never contend for a lock file.
+bool isLockContentionError(Object error) => false;

--- a/player/lib/main.dart
+++ b/player/lib/main.dart
@@ -7,6 +7,8 @@ import 'package:media_kit/media_kit.dart';
 import 'app.dart';
 import 'core/downloads/download_service.dart';
 import 'core/graphql/watch/fetch_log.dart';
+import 'core/startup/startup_error_app.dart';
+import 'core/startup/startup_lock.dart';
 
 // Only import FRB on native platforms (not web)
 // ignore: unused_import
@@ -24,50 +26,118 @@ void main() async {
   runZonedGuarded(
     () async {
       WidgetsFlutterBinding.ensureInitialized();
-
-      // Initialize Rust Bridge (native platforms only - not available on web)
-      // This MUST complete before any P2P/Libp2p code runs
-      if (!kIsWeb) {
-        try {
-          await RustLib.init();
-          debugPrint('[RustLib] Rust bridge initialized successfully');
-        } catch (e) {
-          debugPrint('[RustLib] Failed to initialize Rust bridge: $e');
-          // Re-throw to prevent app from starting with broken P2P
-          rethrow;
-        }
-      } else {
-        debugPrint(
-            '[RustLib] Skipping Rust bridge initialization on web platform');
-      }
-
-      // Initialize media_kit for video playback
-      MediaKit.ensureInitialized();
-
-      // Initialize GraphQL Hive cache for offline support
-      await initHiveForFlutter();
-
-      // Fetch log: when each query last reached the network. A missing entry
-      // is treated as infinitely stale, so an install upgrading from a build
-      // without this box performs a real network fetch on first launch.
-      final fetchLog = await HiveFetchLog.open();
-
-      // Initialize download database (only on native platforms)
-      if (isDownloadSupported) {
-        final downloadDb = getDownloadDatabase();
-        await downloadDb.initialize();
-      }
-
-      runApp(
-        ProviderScope(
-          overrides: [fetchLogProvider.overrideWithValue(fetchLog)],
-          child: const MyApp(),
-        ),
-      );
+      await _startApp();
     },
     (error, stack) {
+      // `_startApp` guarantees `runApp` has already run by the time control
+      // reaches here, falling back to a startup-error screen along the way
+      // if a step failed fatally. This handler only logs whatever slips
+      // through afterwards (e.g. an error from deep inside a running widget
+      // tree) — it must never again be the sole handler of a fatal startup
+      // failure, silently leaving the window black.
       debugPrint('Caught error: $error');
       debugPrint('Stack trace: $stack');
     },
+  );
+}
+
+/// Runs every startup step needed before [runApp], degrading gracefully
+/// where a failure allows it and falling back to [StartupErrorApp] where it
+/// doesn't.
+///
+/// Invariant: this function calls `runApp` exactly once, on every path.
+/// Nothing after `WidgetsFlutterBinding.ensureInitialized()` is allowed to
+/// throw its way out of here uncaught, because a second instance of this
+/// app pointed at the same user-data directory will otherwise leave the
+/// window completely black forever with no indication why (the bug this
+/// function exists to fix).
+Future<void> _startApp() async {
+  // Initialize Rust Bridge (native platforms only - not available on web).
+  // This MUST complete before any P2P/Libp2p code runs. Unlike the steps
+  // below, there's no reasonable degraded mode without it, so a failure here
+  // goes straight to the last-resort error screen rather than continuing.
+  if (!kIsWeb) {
+    try {
+      await RustLib.init();
+      debugPrint('[RustLib] Rust bridge initialized successfully');
+    } catch (e, st) {
+      debugPrint('[RustLib] Failed to initialize Rust bridge: $e');
+      debugPrint('Stack trace: $st');
+      runApp(StartupErrorApp.generic(e));
+      return;
+    }
+  } else {
+    debugPrint('[RustLib] Skipping Rust bridge initialization on web platform');
+  }
+
+  // Initialize media_kit for video playback. Best-effort: the rest of the
+  // app (browsing, library management, etc.) works without it — only
+  // playback would be affected, and that fails on its own terms later.
+  try {
+    MediaKit.ensureInitialized();
+  } catch (e, st) {
+    debugPrint('[MediaKit] Failed to initialize: $e');
+    debugPrint('Stack trace: $st');
+  }
+
+  // Everything below persists to Hive boxes under the same per-user data
+  // directory. A second instance of the app fails to open every one of them
+  // with the same lock error, so the first failure that looks like lock
+  // contention short-circuits straight to a dedicated, actionable screen
+  // instead of limping through the remaining steps degraded.
+  FetchLog fetchLog = InMemoryFetchLog();
+
+  try {
+    // Initialize GraphQL Hive cache for offline support. Best-effort: it's
+    // an optimisation for offline support, not a requirement to run.
+    await initHiveForFlutter();
+  } catch (e, st) {
+    debugPrint('[Hive] Failed to initialize GraphQL cache: $e');
+    debugPrint('Stack trace: $st');
+    if (isLockContentionError(e)) {
+      runApp(StartupErrorApp.alreadyRunning(e));
+      return;
+    }
+    // Any other cause: continue without a persistent GraphQL cache.
+  }
+
+  try {
+    // Fetch log: when each query last reached the network. A missing entry
+    // is treated as infinitely stale, so an install upgrading from a build
+    // without this box performs a real network fetch on first launch.
+    fetchLog = await HiveFetchLog.open();
+  } catch (e, st) {
+    debugPrint('[Hive] Failed to open fetch log: $e');
+    debugPrint('Stack trace: $st');
+    if (isLockContentionError(e)) {
+      runApp(StartupErrorApp.alreadyRunning(e));
+      return;
+    }
+    // Any other cause: `fetchLog` stays the in-memory fallback assigned
+    // above, so every query is simply treated as stale this session.
+  }
+
+  // Initialize download database (only on native platforms).
+  if (isDownloadSupported) {
+    try {
+      final downloadDb = getDownloadDatabase();
+      await downloadDb.initialize();
+    } catch (e, st) {
+      debugPrint('[Downloads] Failed to initialize download database: $e');
+      debugPrint('Stack trace: $st');
+      if (isLockContentionError(e)) {
+        runApp(StartupErrorApp.alreadyRunning(e));
+        return;
+      }
+      // Any other cause: downloads are unavailable this session, the rest
+      // of the app still works.
+    }
+  }
+
+  runApp(
+    ProviderScope(
+      overrides: [fetchLogProvider.overrideWithValue(fetchLog)],
+      child: const MyApp(),
+    ),
   );
 }

--- a/player/test/core/startup/startup_error_app_test.dart
+++ b/player/test/core/startup/startup_error_app_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/startup/startup_error_app.dart';
+
+void main() {
+  group('StartupErrorApp', () {
+    testWidgets('alreadyRunning names the actual problem and the fix',
+        (tester) async {
+      await tester.pumpWidget(
+        StartupErrorApp.alreadyRunning(Exception('lock failed')),
+      );
+
+      expect(find.text('Mydia Player is already running'), findsOneWidget);
+      expect(
+        find.textContaining('Quit it, then reopen this one'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('lock failed'), findsOneWidget);
+    });
+
+    testWidgets('generic surfaces the underlying error text', (tester) async {
+      await tester.pumpWidget(
+        StartupErrorApp.generic(Exception('disk is on fire')),
+      );
+
+      expect(find.text("Mydia Player couldn't start"), findsOneWidget);
+      expect(find.textContaining('disk is on fire'), findsOneWidget);
+    });
+
+    testWidgets('always renders a MaterialApp, never a blank screen',
+        (tester) async {
+      await tester.pumpWidget(
+        StartupErrorApp.generic(Exception('boom')),
+      );
+
+      expect(find.byType(MaterialApp), findsOneWidget);
+      expect(find.byType(Scaffold), findsOneWidget);
+    });
+  });
+}

--- a/player/test/core/startup/startup_lock_test.dart
+++ b/player/test/core/startup/startup_lock_test.dart
@@ -2,14 +2,28 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/startup/startup_lock.dart';
+import 'package:player/core/startup/startup_lock_stub.dart' as web_stub;
+
+/// The code this platform reports for a lock that is already held, mirroring
+/// the table in `startup_lock_native.dart`: `EAGAIN` is 11 on Linux and 35 on
+/// Darwin, and Windows reports `ERROR_LOCK_VIOLATION` instead.
+int get lockHeldCode {
+  if (Platform.isLinux || Platform.isAndroid) return 11;
+  if (Platform.isWindows) return 33;
+  return 35;
+}
+
+/// A code that means "lock already held" on *some other* platform but not
+/// this one, so it must not be matched here.
+int get foreignLockHeldCode => lockHeldCode == 11 ? 35 : 11;
 
 void main() {
   group('isLockContentionError', () {
     test('detects the reproduced two-instance failure', () {
-      const error = FileSystemException(
+      final error = FileSystemException(
         'lock failed',
         '/Users/someone/Documents/graphqlclientstore.lock',
-        OSError('Resource temporarily unavailable', 35),
+        OSError('Resource temporarily unavailable', lockHeldCode),
       );
 
       expect(isLockContentionError(error), isTrue);
@@ -24,14 +38,27 @@ void main() {
       expect(isLockContentionError(error), isTrue);
     });
 
-    test('detects errno 35 even on a path without a .lock suffix', () {
-      const error = FileSystemException(
+    test('detects this platform\'s code on a path without a .lock suffix', () {
+      final error = FileSystemException(
         'lock failed',
         '/Users/someone/Documents/mydia_fetch_log',
-        OSError('Resource temporarily unavailable', 35),
+        OSError('Resource temporarily unavailable', lockHeldCode),
       );
 
       expect(isLockContentionError(error), isTrue);
+    });
+
+    test('ignores another platform\'s code on a path without a .lock suffix',
+        () {
+      // The same number means something unrelated here (e.g. 35 is EDEADLK on
+      // Linux, 11 is EDEADLK on Darwin), so it must not be read as contention.
+      final error = FileSystemException(
+        'something else went wrong',
+        '/Users/someone/Documents/mydia_fetch_log',
+        OSError('Some other failure', foreignLockHeldCode),
+      );
+
+      expect(isLockContentionError(error), isFalse);
     });
 
     test('does not flag an unrelated FileSystemException', () {
@@ -47,6 +74,22 @@ void main() {
     test('does not flag a non-FileSystemException error', () {
       expect(isLockContentionError(Exception('boom')), isFalse);
       expect(isLockContentionError(StateError('boom')), isFalse);
+    });
+  });
+
+  group('web stub', () {
+    // The stub is what the web build compiles against in place of the
+    // `dart:io` implementation; a browser tab has no shared lock to contend
+    // for, so it answers false for everything.
+    test('never reports lock contention', () {
+      const lockError = FileSystemException(
+        'lock failed',
+        '/Users/someone/Documents/graphqlclientstore.lock',
+        OSError('Resource temporarily unavailable', 35),
+      );
+
+      expect(web_stub.isLockContentionError(lockError), isFalse);
+      expect(web_stub.isLockContentionError(Exception('boom')), isFalse);
     });
   });
 }

--- a/player/test/core/startup/startup_lock_test.dart
+++ b/player/test/core/startup/startup_lock_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/startup/startup_lock.dart';
+
+void main() {
+  group('isLockContentionError', () {
+    test('detects the reproduced two-instance failure', () {
+      const error = FileSystemException(
+        'lock failed',
+        '/Users/someone/Documents/graphqlclientstore.lock',
+        OSError('Resource temporarily unavailable', 35),
+      );
+
+      expect(isLockContentionError(error), isTrue);
+    });
+
+    test('detects a .lock path even without an OSError attached', () {
+      const error = FileSystemException(
+        'lock failed',
+        '/Users/someone/Documents/download_tasks.lock',
+      );
+
+      expect(isLockContentionError(error), isTrue);
+    });
+
+    test('detects errno 35 even on a path without a .lock suffix', () {
+      const error = FileSystemException(
+        'lock failed',
+        '/Users/someone/Documents/mydia_fetch_log',
+        OSError('Resource temporarily unavailable', 35),
+      );
+
+      expect(isLockContentionError(error), isTrue);
+    });
+
+    test('does not flag an unrelated FileSystemException', () {
+      const error = FileSystemException(
+        'No such file or directory',
+        '/Users/someone/Documents/missing.txt',
+        OSError('No such file or directory', 2),
+      );
+
+      expect(isLockContentionError(error), isFalse);
+    });
+
+    test('does not flag a non-FileSystemException error', () {
+      expect(isLockContentionError(Exception('boom')), isFalse);
+      expect(isLockContentionError(StateError('boom')), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## The bug

Launching a second instance of the macOS app while one is already running gives you a **completely black window** — no error, no message, no spinner, forever.

Both instances share a user-level Hive store, so the second one can't take the lock:

```
FileSystemException: lock failed, path = '~/Documents/graphqlclientstore.lock'
(OS Error: Resource temporarily unavailable, errno = 35)
```

## Root cause

The entire startup sequence ran inside `runZonedGuarded`. When `initHiveForFlutter()` threw, the zone's error handler logged it and returned — so **`runApp()` was never reached**. No widget tree was ever built.

The same applied to anything else throwing before `runApp`: `HiveFetchLog.open()`, `downloadDb.initialize()`, `MediaKit.ensureInitialized()`.

## The fix

`runApp()` is now reachable on every path.

- **Cache init failure is non-fatal.** The GraphQL/Hive cache is an offline-support optimisation; if it can't initialise, the app starts degraded rather than dead.
- **"Already running" is detected and named.** The second instance now shows *"Mydia Player is already running — quit it, then reopen this one"*, with the underlying error beneath, instead of a black void.
- **Last-resort error screen** for any other fatal startup failure, stating what went wrong in plain language.
- The zone handler still logs, but no longer silently swallows a fatal startup error.

## Verification

Reproduced before and after by launching two instances directly (not via `open`, which hides stdout).

**Before:** black window, indefinitely.
**After:**
```
flutter: [Hive] Failed to initialize GraphQL cache: FileSystemException: lock failed, path = ...
```
followed by a rendered "Mydia Player is already running" screen.

Single-instance boot re-verified unaffected end-to-end: RustLib, MediaKit, Hive cache, P2P mesh connect, and a live GraphQL request/response all succeed through to the authenticated router.

`flutter test` 740/740 pass (8 new tests under `test/core/startup/`); `flutter analyze` clean; `flutter build macos --debug` succeeds.