### PR TITLE
fix(downloads): adopt or honestly orphan downloads when a client is removed

### DIFF
--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -338,6 +338,15 @@ defmodule Mydia.Downloads do
   @spec count_completed() :: non_neg_integer()
   defdelegate count_completed(), to: Mydia.Downloads.History
 
+  @spec count_downloads_for_client(String.t()) :: non_neg_integer()
+  defdelegate count_downloads_for_client(client_name), to: Mydia.Downloads.History
+
+  @spec removed_client_groups() :: [%{download_client: String.t(), count: non_neg_integer()}]
+  defdelegate removed_client_groups(), to: Mydia.Downloads.History
+
+  @spec clear_downloads_for_removed_client(String.t()) :: {non_neg_integer(), nil | [term()]}
+  defdelegate clear_downloads_for_removed_client(client_name), to: Mydia.Downloads.History
+
   @doc """
   Checks for duplicate downloads (active downloads or existing media files).
   """

--- a/lib/mydia/downloads/client_adoption.ex
+++ b/lib/mydia/downloads/client_adoption.ex
@@ -1,0 +1,76 @@
+defmodule Mydia.Downloads.ClientAdoption do
+  @moduledoc """
+  Decides whether a download whose client is gone can be re-adopted by a
+  client that is still configured.
+
+  Clients are identified by name, so renaming one is indistinguishable from
+  deleting it. When that happens the torrent itself is usually still sitting
+  in the same daemon under a new client name, and `DownloadMonitor` already
+  holds every configured client's torrent list from its regular poll. This
+  module turns that list into an adoption decision.
+
+  ## The rule
+
+  Adopt only when *exactly one* reachable client reports the download's
+  `download_client_id`, and only when that client is a torrent type.
+
+  Both halves are load-bearing:
+
+    * **Single claimant.** Two clients can legitimately hold the same info
+      hash (the same release seeded in two places). Since commit 96d75b00
+      scoped every client to its own files, adopting onto the wrong claimant
+      means importing from the wrong `save_path`.
+
+    * **Torrent types only.** Only there is `download_client_id` a
+      content-addressed info hash, stable across clients and identical when
+      the same daemon is re-added under a different name. Usenet clients use
+      `nzo_id` or numeric ids that are client-local and recycled; debrid ids
+      are meaningful only to the provider that issued them. A cross-client
+      match on either is coincidence, not identity. `:blackhole` is a watch
+      directory with no listing API, so it can never appear as a claimant
+      regardless.
+
+  This module is deliberately pure: no database, no network. It is the whole
+  decision surface for adoption, so its tests are the whole edge-case suite.
+  """
+
+  @adoptable_types [:qbittorrent, :transmission, :rqbit, :rtorrent]
+
+  @typedoc "Poll results, exactly as `History.fetch_all_client_statuses/2` returns them."
+  @type client_statuses :: %{String.t() => {:reachable, map()} | :unreachable}
+
+  @typedoc "Client name to its configured adapter type."
+  @type client_types :: %{String.t() => atom()}
+
+  @doc """
+  The client types whose `download_client_id` is a portable, content-addressed
+  identifier.
+  """
+  @spec adoptable_types() :: [atom()]
+  def adoptable_types, do: @adoptable_types
+
+  @doc """
+  Returns `{:ok, client_name}` when exactly one reachable torrent-type client
+  reports `client_id`, and `:none` otherwise.
+
+  `:none` covers every ambiguous or unsafe case: no claimant, several
+  claimants, a claimant of a non-adoptable type, and a claimant whose type is
+  unknown.
+  """
+  @spec find_claimant(String.t() | nil, client_statuses(), client_types()) ::
+          {:ok, String.t()} | :none
+  def find_claimant(nil, _client_statuses, _client_types), do: :none
+
+  def find_claimant(client_id, client_statuses, client_types) do
+    claimants =
+      for {name, {:reachable, torrents}} <- client_statuses,
+          Map.has_key?(torrents, client_id),
+          Map.get(client_types, name) in @adoptable_types,
+          do: name
+
+    case claimants do
+      [only_claimant] -> {:ok, only_claimant}
+      _ambiguous_or_empty -> :none
+    end
+  end
+end

--- a/lib/mydia/downloads/client_adoption.ex
+++ b/lib/mydia/downloads/client_adoption.ex
@@ -21,8 +21,8 @@ defmodule Mydia.Downloads.ClientAdoption do
       scoped every client to its own files, adopting onto the wrong claimant
       means importing from the wrong `save_path`.
 
-    * **Torrent types only.** Only there is `download_client_id` a
-      content-addressed info hash, stable across clients and identical when
+    * **Torrent types only.** `download_client_id` is a content-addressed info
+      hash only for these types, stable across clients and identical when
       the same daemon is re-added under a different name. Usenet clients use
       `nzo_id` or numeric ids that are client-local and recycled; debrid ids
       are meaningful only to the provider that issued them. A cross-client
@@ -35,6 +35,11 @@ defmodule Mydia.Downloads.ClientAdoption do
   """
 
   @adoptable_types [:qbittorrent, :transmission, :rqbit, :rtorrent]
+
+  # The copy the previously released code wrote for every client-gone case,
+  # before this feature existed to tell them apart. Rows carrying it are
+  # orphans with no tag.
+  @legacy_orphan_message_prefix "Removed from download client"
 
   @typedoc "Poll results, exactly as `History.fetch_all_client_statuses/2` returns them."
   @type client_statuses :: %{String.t() => {:reachable, map()} | :unreachable}
@@ -73,4 +78,28 @@ defmodule Mydia.Downloads.ClientAdoption do
       _ambiguous_or_empty -> :none
     end
   end
+
+  @doc """
+  Whether a download's persisted failure state is orphan state this feature
+  owns, and may therefore clear when a client picks the download back up.
+
+  True for the `"no_client"` tag, and for a legacy row carrying the previously
+  released "Removed from download client ..." message with no tag at all (the
+  tag did not exist when it was written). False for every other failure: a
+  genuine import failure always sets `import_failure_reason`, and adoption
+  fixes which client owns a torrent, it does not vindicate a broken import.
+
+  Lives here, next to the adoption rule, because the read path
+  (`Mydia.Downloads.History`) and the writer (`Mydia.Jobs.DownloadMonitor`)
+  must agree on it exactly. If the read path proposed a heal the writer then
+  declined to perform, the monitor would re-propose it on every poll and
+  broadcast a download update each time.
+  """
+  @spec orphan_state?(String.t() | nil, String.t() | nil) :: boolean()
+  def orphan_state?("no_client", _error_message), do: true
+
+  def orphan_state?(nil, error_message) when is_binary(error_message),
+    do: String.starts_with?(error_message, @legacy_orphan_message_prefix)
+
+  def orphan_state?(_import_failure_reason, _error_message), do: false
 end

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -79,16 +79,23 @@ defmodule Mydia.Downloads.History do
   end
 
   @doc """
-  Counts every download assigned to `client_name`.
+  Counts the downloads still waiting on `client_name`: rows assigned to it that
+  have not been imported.
 
   Called before deleting a download client, while that client still exists, to
-  show the operator the blast radius. Deliberately not restricted to orphans:
-  a healthy in-flight download is exactly what the warning is about.
+  show the operator the blast radius. Deliberately not restricted to orphans,
+  since a healthy in-flight download is exactly what the warning is about, but
+  imported rows are excluded. Import does not delete the row (`MediaImport`
+  stamps `imported_at` and leaves it, which is why `count_completed/0` exists),
+  so on a mature instance import history dominates any count that includes it,
+  while deleting the client does nothing at all to that history: it never
+  reaches the `missing` filter, never gets an error, and never gets tagged.
   """
   @spec count_downloads_for_client(String.t()) :: non_neg_integer()
   def count_downloads_for_client(client_name) do
     Download
     |> where([d], d.download_client == ^client_name)
+    |> where([d], is_nil(d.imported_at))
     |> Repo.aggregate(:count)
   end
 
@@ -395,6 +402,7 @@ defmodule Mydia.Downloads.History do
             download
             |> enrich_download_with_torrent_status(torrent_status)
             |> with_client_state(:present)
+            |> heal_own_client()
         end
 
       :unreachable ->
@@ -442,7 +450,7 @@ defmodule Mydia.Downloads.History do
         download
         |> enrich_download_with_torrent_status(torrent_status)
         |> with_client_state(config_state)
-        |> Map.put(:adoptable_client, claimant)
+        |> with_adoptable_client(claimant)
 
       :none ->
         download
@@ -453,6 +461,31 @@ defmodule Mydia.Downloads.History do
 
   defp with_client_state(%EnrichedDownload{} = enriched, config_state) do
     %{enriched | client_config_state: config_state}
+  end
+
+  defp with_adoptable_client(%EnrichedDownload{} = enriched, claimant) do
+    %{enriched | adoptable_client: claimant}
+  end
+
+  # The download's own client answered and still holds the torrent, so whatever
+  # took the client away is over: it was re-enabled, or deleted and re-added
+  # under the same name. Both are what Mydia's own copy tells the operator to
+  # do (the disabled-client message says "re-enable the client", the admin
+  # delete modal says re-adding picks the downloads back up).
+  #
+  # Nothing else clears orphan state on that route, so without this the row
+  # keeps a false error message forever, stays out of `Download.occupying/1`,
+  # and keeps its group in the Issues-tab banner, whose "Clear them" button
+  # would delete the record of a download that is visibly running on the Queue
+  # tab. Naming the row's own client as the adoption candidate routes the heal
+  # through `DownloadMonitor.adopt_download/1`: same writer, same clearing
+  # rule, and its `download_client` write is a no-op.
+  defp heal_own_client(%EnrichedDownload{} = enriched) do
+    if ClientAdoption.orphan_state?(enriched.import_failure_reason, enriched.error_message) do
+      with_adoptable_client(enriched, enriched.download_client)
+    else
+      enriched
+    end
   end
 
   defp enrich_download_with_torrent_status(download, torrent_status) do

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -100,7 +100,11 @@ defmodule Mydia.Downloads.History do
   end
 
   @doc """
-  Groups orphaned downloads by the client they reference.
+  Groups orphaned downloads by the client they reference, ordered by name.
+
+  The ordering is load-bearing rather than cosmetic: the Issues tab derives a
+  DOM id per group, and an unordered result could reassign those ids between
+  renders, which is exactly what LiveView's id-keyed patching must not see.
 
   An orphan is a row tagged `import_failure_reason == "no_client"`, written
   either by `DownloadMonitor.handle_missing/1` for a download still in flight
@@ -112,6 +116,7 @@ defmodule Mydia.Downloads.History do
     Download
     |> where([d], d.import_failure_reason == "no_client" and not is_nil(d.download_client))
     |> group_by([d], d.download_client)
+    |> order_by([d], asc: d.download_client)
     |> select([d], %{download_client: d.download_client, count: count(d.id)})
     |> Repo.all()
   end

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -78,6 +78,51 @@ defmodule Mydia.Downloads.History do
     |> Repo.aggregate(:count)
   end
 
+  @doc """
+  Counts every download assigned to `client_name`.
+
+  Called before deleting a download client, while that client still exists, to
+  show the operator the blast radius. Deliberately not restricted to orphans:
+  a healthy in-flight download is exactly what the warning is about.
+  """
+  @spec count_downloads_for_client(String.t()) :: non_neg_integer()
+  def count_downloads_for_client(client_name) do
+    Download
+    |> where([d], d.download_client == ^client_name)
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
+  Groups orphaned downloads by the client they reference.
+
+  An orphan is a row tagged `import_failure_reason == "no_client"`, written
+  either by `DownloadMonitor.handle_missing/1` for a download still in flight
+  or by `MediaImport` for one that died at import. The Issues tab renders one
+  bulk-clear banner per group.
+  """
+  @spec removed_client_groups() :: [%{download_client: String.t(), count: non_neg_integer()}]
+  def removed_client_groups do
+    Download
+    |> where([d], d.import_failure_reason == "no_client" and not is_nil(d.download_client))
+    |> group_by([d], d.download_client)
+    |> select([d], %{download_client: d.download_client, count: count(d.id)})
+    |> Repo.all()
+  end
+
+  @doc """
+  Deletes the orphaned downloads referencing `client_name`.
+
+  Scoped on purpose, unlike `dismiss_all_cancelled/0`, which deletes every
+  errored row in the Issues tab. No attempt is made to remove anything from
+  the download client: that client is precisely what no longer exists.
+  """
+  @spec clear_downloads_for_removed_client(String.t()) :: {non_neg_integer(), nil | [term()]}
+  def clear_downloads_for_removed_client(client_name) do
+    Download
+    |> where([d], d.download_client == ^client_name and d.import_failure_reason == "no_client")
+    |> Repo.delete_all()
+  end
+
   def list_downloads_with_status(opts \\ []) do
     # Get all download records from database
     # Preload episode.media_item to get parent show info for episode downloads

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -12,6 +12,7 @@ defmodule Mydia.Downloads.History do
     ]
 
   alias Mydia.Repo
+  alias Mydia.Downloads.ClientAdoption
   alias Mydia.Downloads.Download
   alias Mydia.Downloads.Client
   alias Mydia.Downloads.Structs.DownloadMetadata
@@ -82,12 +83,20 @@ defmodule Mydia.Downloads.History do
     # Preload episode.media_item to get parent show info for episode downloads
     downloads = list_downloads(preload: [:media_item, episode: :media_item])
 
-    # Get all configured download clients
-    clients = get_configured_clients()
+    # Every configured client, including disabled ones. Disabled clients are
+    # never polled, but we still need their names to tell "disabled" apart
+    # from "deleted" when classifying a download's client.
+    all_configured = Settings.list_download_client_configs()
+    clients = Enum.filter(all_configured, & &1.enabled)
 
-    if clients == [] do
+    configured_names = MapSet.new(all_configured, & &1.name)
+    client_types = Map.new(all_configured, &{&1.name, &1.type})
+
+    if all_configured == [] do
       Logger.warning("No download clients configured")
-      # Return downloads with empty status
+      # Return downloads with empty status. `client_config_state` stays nil,
+      # per EnrichedDownload's contract, because there is nothing configured
+      # to classify against — not even a disabled entry to point to.
       Enum.map(downloads, &enrich_download_with_empty_status/1)
     else
       # Get status from all clients
@@ -95,7 +104,9 @@ defmodule Mydia.Downloads.History do
 
       # Enrich downloads with client status
       downloads
-      |> Enum.map(&enrich_download_with_status(&1, client_statuses))
+      |> Enum.map(
+        &enrich_download_with_status(&1, client_statuses, client_types, configured_names)
+      )
       |> apply_status_filters(opts[:filter] || :all)
     end
   end
@@ -228,11 +239,6 @@ defmodule Mydia.Downloads.History do
 
   ## Private Functions - Client Status Fetching
 
-  defp get_configured_clients do
-    Settings.list_download_client_configs()
-    |> Enum.filter(& &1.enabled)
-  end
-
   defp fetch_all_client_statuses(clients, downloads) do
     # Fetch torrents from all clients concurrently. We deliberately distinguish
     # between two outcomes that previously collapsed into "empty list":
@@ -316,29 +322,78 @@ defmodule Mydia.Downloads.History do
     end)
   end
 
-  defp enrich_download_with_status(download, client_statuses) do
-    case Map.get(client_statuses, download.download_client) do
+  defp enrich_download_with_status(download, client_statuses, client_types, configured_names) do
+    case classify_client(download.download_client, client_statuses, configured_names) do
       {:reachable, torrents_map} ->
         case Map.get(torrents_map, download.download_client_id) do
           nil ->
             # Client confirmed it doesn't have this torrent — genuinely missing.
-            enrich_download_with_empty_status(download, false)
+            download
+            |> enrich_download_with_empty_status(false)
+            |> with_client_state(:present)
 
           torrent_status ->
-            enrich_download_with_torrent_status(download, torrent_status)
+            download
+            |> enrich_download_with_torrent_status(torrent_status)
+            |> with_client_state(:present)
         end
 
       :unreachable ->
         # Client is misbehaving (down, restarting, network blip). We can't tell
         # whether the torrent is there — DO NOT mark missing. Surface status as
         # "unknown" so DownloadMonitor's missing-handler skips it this cycle.
-        enrich_download_with_unknown_status(download)
+        download
+        |> enrich_download_with_unknown_status()
+        |> with_client_state(:present)
 
-      nil ->
-        # The client referenced by the download isn't configured at all (deleted,
-        # renamed, or never existed) — treat as genuinely missing.
+      :no_client_assigned ->
+        # A grab record that never reached a client. `list_stale_grabs/1`
+        # owns these; classification has nothing to say about them.
         enrich_download_with_empty_status(download)
+
+      config_state when config_state in [:disabled, :removed] ->
+        adopt_or_orphan(download, client_statuses, client_types, config_state)
     end
+  end
+
+  # Distinguishes the three ways a download's client can fail to appear in the
+  # poll results. `:removed` and `:disabled` used to collapse into one branch,
+  # which is why a disabled client produced "removed from download client".
+  defp classify_client(nil, _client_statuses, _configured_names), do: :no_client_assigned
+
+  defp classify_client(client_name, client_statuses, configured_names) do
+    case Map.get(client_statuses, client_name) do
+      {:reachable, _torrents} = reachable -> reachable
+      :unreachable -> :unreachable
+      nil -> if MapSet.member?(configured_names, client_name), do: :disabled, else: :removed
+    end
+  end
+
+  # A download whose client is gone or switched off. If exactly one reachable
+  # torrent client holds this torrent, the download is alive under a new client
+  # name: report the real torrent status so the UI shows genuine progress, and
+  # flag the candidate for `DownloadMonitor` to persist. Otherwise it is a true
+  # orphan.
+  defp adopt_or_orphan(download, client_statuses, client_types, config_state) do
+    case ClientAdoption.find_claimant(download.download_client_id, client_statuses, client_types) do
+      {:ok, claimant} ->
+        {:reachable, torrents} = Map.fetch!(client_statuses, claimant)
+        torrent_status = Map.fetch!(torrents, download.download_client_id)
+
+        download
+        |> enrich_download_with_torrent_status(torrent_status)
+        |> with_client_state(config_state)
+        |> Map.put(:adoptable_client, claimant)
+
+      :none ->
+        download
+        |> enrich_download_with_empty_status()
+        |> with_client_state(config_state)
+    end
+  end
+
+  defp with_client_state(%EnrichedDownload{} = enriched, config_state) do
+    %{enriched | client_config_state: config_state}
   end
 
   defp enrich_download_with_torrent_status(download, torrent_status) do

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -94,10 +94,24 @@ defmodule Mydia.Downloads.History do
 
     if all_configured == [] do
       Logger.warning("No download clients configured")
-      # Return downloads with empty status. `client_config_state` stays nil,
-      # per EnrichedDownload's contract, because there is nothing configured
-      # to classify against — not even a disabled entry to point to.
-      Enum.map(downloads, &enrich_download_with_empty_status/1)
+
+      # No clients at all means every download that names one references a
+      # client that is gone: for a self-hosted operator with a single client,
+      # deleting it IS this scenario, not an edge case of it. Classify those
+      # rows :removed so the honest copy and the `no_client` tag still apply.
+      # A download with no `download_client` at all has nothing to classify
+      # against, so `client_config_state` stays nil for it, per
+      # EnrichedDownload's contract. Polling and `apply_status_filters` stay
+      # skipped either way — there is nothing to poll.
+      Enum.map(downloads, fn download ->
+        enriched = enrich_download_with_empty_status(download)
+
+        if is_nil(download.download_client) do
+          enriched
+        else
+          with_client_state(enriched, :removed)
+        end
+      end)
     else
       # Get status from all clients
       client_statuses = fetch_all_client_statuses(clients, downloads)

--- a/lib/mydia/downloads/structs/enriched_download.ex
+++ b/lib/mydia/downloads/structs/enriched_download.ex
@@ -72,6 +72,23 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
     # false = client confirmed the torrent is gone
     # nil   = client unreachable; presence unknown
     :in_client?,
+    # How the download's client appears in configuration at poll time.
+    # :present  = the client is configured and enabled
+    # :disabled = the client is configured but disabled, so it is not polled
+    # :removed  = no client by that name exists at all (deleted, renamed, or
+    #             dropped from env vars)
+    # nil       = not evaluated (no clients configured at all)
+    #
+    # `:disabled` and `:removed` are kept apart because they need different
+    # error copy: telling an operator their client is "no longer configured"
+    # when it is sitting in the settings list, disabled, is its own kind of
+    # wrong.
+    :client_config_state,
+    # When the client is :disabled or :removed and exactly one reachable
+    # torrent-type client reports this download's `download_client_id`, the
+    # name of that client. `DownloadMonitor` persists it; see
+    # `Mydia.Downloads.ClientAdoption`.
+    :adoptable_client,
     # Whether a completed download is eligible for post-import re-match: exactly
     # one non-trashed imported file (packs resolve to several and can't be
     # re-matched as a unit). Computed per-tab in the LiveView; nil when not
@@ -126,6 +143,8 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
           last_observed_at: DateTime.t() | nil,
           stalled_since: DateTime.t() | nil,
           in_client?: boolean() | nil,
+          client_config_state: :present | :disabled | :removed | nil,
+          adoptable_client: String.t() | nil,
           rematch_eligible?: boolean() | nil
         }
 

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -101,6 +101,14 @@ defmodule Mydia.Jobs.DownloadMonitor do
     # Get all downloads with their real-time status from clients
     downloads = Downloads.list_downloads_with_status(filter: :all)
 
+    # Re-adopt downloads whose client was renamed, deleted, or disabled but
+    # whose torrent is still sitting in exactly one other configured client.
+    # This is the only writer for adoptions: `list_downloads_with_status/1`
+    # is a read path called from LiveViews and must stay pure.
+    downloads
+    |> Enum.filter(&(&1.adoptable_client != nil))
+    |> Enum.each(&adopt_download/1)
+
     # Find downloads that have completed or failed
     # Note: "seeding" means download is complete and now seeding (100% progress)
     # A torrent can also be paused at 100% progress (manually paused after completion)
@@ -457,26 +465,86 @@ defmodule Mydia.Jobs.DownloadMonitor do
     end
   end
 
+  # Persist an adoption discovered by `Mydia.Downloads.ClientAdoption`.
+  #
+  # Clearing the orphan error state is what makes re-adding a client a real
+  # fix: delete a client, its downloads park in the Issues tab, re-add it (or
+  # a client holding the same torrents) and they come back to life on the next
+  # poll with no operator action. Renames heal by the same path.
+  defp adopt_download(download_map) do
+    Logger.info("Adopting download onto reconfigured client",
+      download_id: download_map.id,
+      previous_client: download_map.download_client,
+      adopted_client: download_map.adoptable_client
+    )
+
+    download = Downloads.get_download!(download_map.id)
+
+    attrs =
+      %{download_client: download_map.adoptable_client}
+      |> maybe_clear_orphan_state(download)
+
+    case Downloads.update_download(download, attrs) do
+      {:ok, _updated} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.warning("Failed to adopt download onto new client",
+          download_id: download_map.id,
+          errors: inspect(changeset.errors)
+        )
+
+        :ok
+    end
+  end
+
+  # Only clear failure state this feature created. A download carrying an
+  # unrelated import failure keeps it: adoption fixes which client owns the
+  # torrent, it does not vindicate a broken import.
+  defp maybe_clear_orphan_state(attrs, %{import_failure_reason: "no_client"}) do
+    Map.merge(attrs, %{
+      error_message: nil,
+      import_failure_reason: nil,
+      import_last_error: nil,
+      import_failed_at: nil,
+      import_next_retry_at: nil
+    })
+  end
+
+  defp maybe_clear_orphan_state(attrs, _download), do: attrs
+
   defp handle_missing(download_map) do
     Logger.warning("Download missing from client - preserving for user investigation",
       download_id: download_map.id,
       title: download_map.title,
-      client: download_map.download_client
+      client: download_map.download_client,
+      client_config_state: download_map.client_config_state
     )
 
     # Get the download struct from database (with media_item preloaded)
     download = Downloads.get_download!(download_map.id, preload: [:media_item])
 
-    # Instead of deleting, mark as missing with error message
-    # This preserves the record in the Issues tab for user investigation
-    error_msg =
-      "Removed from download client '#{download_map.download_client}' before import completed. " <>
-        "The download may have been manually deleted, or the client may have encountered an error."
+    error_msg = missing_error_message(download_map)
 
     # `Download` has no `:status` field — status is derived at read time from the
     # client poll (see `Downloads.list_downloads_with_status/1`). Persisting
-    # `error_message` is what moves the row into the Issues tab.
-    case Downloads.update_download(download, %{error_message: error_msg}) do
+    # `error_message` is what moves the row into the Issues tab, and what drops
+    # it out of `Download.occupying/1` so the target is released.
+    #
+    # For an orphan we also persist the grouping tag the Issues tab bulk-clear
+    # keys on. It is deliberately the same tag `MediaImport` emits for
+    # `:no_client`, so a still-downloading orphan and one that died in import
+    # group together.
+    attrs =
+      case download_map.client_config_state do
+        state when state in [:removed, :disabled] ->
+          %{error_message: error_msg, import_failure_reason: "no_client"}
+
+        _present_or_unassigned ->
+          %{error_message: error_msg}
+      end
+
+    case Downloads.update_download(download, attrs) do
       {:ok, _updated} ->
         Logger.info("Download marked as missing (preserved for Issues tab)",
           download_id: download_map.id,
@@ -495,6 +563,37 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
         :ok
     end
+  end
+
+  @doc false
+  # Public, with a function head, only so the copy-selection branches can be
+  # tested without standing up a reachable client behind a Bypass stub. The
+  # function is pure: it maps a config state to a string and touches nothing
+  # else. Not part of the module's intended API.
+  def missing_error_message(download_map)
+
+  # The client is gone: deleted from the UI, dropped from env vars, or renamed
+  # (matching is by name, so a rename is indistinguishable from a delete).
+  # Naming the removal is the point — the operator otherwise goes and inspects
+  # a download client that is perfectly healthy.
+  def missing_error_message(%{client_config_state: :removed} = download_map) do
+    "Download client '#{download_map.download_client}' is no longer configured in Mydia. " <>
+      "The download may still be running in the client itself. " <>
+      "Re-add the client to resume tracking, or clear this download."
+  end
+
+  # The client still exists but is switched off, so Mydia never polls it.
+  def missing_error_message(%{client_config_state: :disabled} = download_map) do
+    "Download client '#{download_map.download_client}' is disabled in Mydia, so its " <>
+      "downloads are no longer tracked. Re-enable the client to resume tracking, " <>
+      "or clear this download."
+  end
+
+  # The original case: a configured, reachable client reported that it does not
+  # have this torrent.
+  def missing_error_message(download_map) do
+    "Removed from download client '#{download_map.download_client}' before import completed. " <>
+      "The download may have been manually deleted, or the client may have encountered an error."
   end
 
   defp handle_stuck(download) do

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -53,6 +53,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   require Logger
   alias Mydia.Downloads
   alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.ClientAdoption
   alias Mydia.Downloads.Client.FailureCategory
   alias Mydia.Downloads.StallDetector
   alias Mydia.Downloads.UntrackedMatcher
@@ -108,6 +109,17 @@ defmodule Mydia.Jobs.DownloadMonitor do
     downloads
     |> Enum.filter(&(&1.adoptable_client != nil))
     |> Enum.each(&adopt_download/1)
+
+    # Backfill the grouping tag onto orphans the previously released code
+    # already marked. Those rows carry an `error_message`, and the `missing`
+    # filter below requires a nil one, so they can never re-enter
+    # `handle_missing/1` to be tagged: without this the operator upgrading with
+    # a backlog of falsely blamed orphans, which is exactly who this feature is
+    # for, would see no banner at all. Runs after the adoption pass and skips
+    # anything it just healed.
+    downloads
+    |> Enum.filter(&legacy_orphan?/1)
+    |> Enum.each(&tag_legacy_orphan/1)
 
     # Find downloads that have completed or failed
     # Note: "seeding" means download is complete and now seeding (100% progress)
@@ -465,25 +477,43 @@ defmodule Mydia.Jobs.DownloadMonitor do
     end
   end
 
-  # Persist an adoption discovered by `Mydia.Downloads.ClientAdoption`.
+  # Persist an adoption proposed by the read path.
   #
   # Clearing the orphan error state is what makes re-adding a client a real
   # fix: delete a client, its downloads park in the Issues tab, re-add it (or
   # a client holding the same torrents) and they come back to life on the next
   # poll with no operator action. Renames heal by the same path.
+  #
+  # The proposed client can also be the row's own, which is how a client that
+  # was merely disabled and then re-enabled heals (see `heal_own_client/1` in
+  # `Mydia.Downloads.History`). The `download_client` write is then a no-op and
+  # only the orphan state clears.
   defp adopt_download(download_map) do
-    Logger.info("Adopting download onto reconfigured client",
-      download_id: download_map.id,
-      previous_client: download_map.download_client,
-      adopted_client: download_map.adoptable_client
-    )
-
     download = Downloads.get_download!(download_map.id)
 
     attrs =
       %{download_client: download_map.adoptable_client}
       |> maybe_clear_orphan_state(download)
 
+    if attrs == %{download_client: download.download_client} do
+      # Nothing to persist: the row already names this client and carries no
+      # orphan state to clear. Writing anyway would broadcast a download update
+      # on every single poll, and every open Downloads view re-polls all its
+      # clients on that broadcast. Only reachable if the row changed between
+      # the poll's snapshot and this write.
+      :ok
+    else
+      Logger.info("Adopting download onto reconfigured client",
+        download_id: download_map.id,
+        previous_client: download.download_client,
+        adopted_client: download_map.adoptable_client
+      )
+
+      persist_adoption(download, download_map, attrs)
+    end
+  end
+
+  defp persist_adoption(download, download_map, attrs) do
     case Downloads.update_download(download, attrs) do
       {:ok, _updated} ->
         :ok
@@ -501,27 +531,17 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # Only clear failure state this feature created. A download carrying an
   # unrelated import failure keeps it: adoption fixes which client owns the
   # torrent, it does not vindicate a broken import.
-  defp maybe_clear_orphan_state(attrs, %{import_failure_reason: "no_client"}) do
-    clear_orphan_attrs(attrs)
-  end
-
-  # A row written by the release that predates the `no_client` tag: it carries
-  # the old "Removed from download client" copy with no `import_failure_reason`
-  # at all. Without this clause such a row is adopted (the client re-points)
-  # but the stale message never clears, so it displays a permanent failure
-  # forever while downloading fine, and stays outside `Download.occupying/1`.
-  # A genuine import failure always sets `import_failure_reason`, so this
-  # can't misfire on one.
-  defp maybe_clear_orphan_state(attrs, %{import_failure_reason: nil, error_message: error_message})
-       when is_binary(error_message) do
-    if String.starts_with?(error_message, "Removed from download client") do
+  #
+  # The predicate is shared with the read path that proposes the adoption in
+  # the first place (see `Mydia.Downloads.ClientAdoption.orphan_state?/2`), so
+  # the two can never disagree about whether a heal is available.
+  defp maybe_clear_orphan_state(attrs, download) do
+    if ClientAdoption.orphan_state?(download.import_failure_reason, download.error_message) do
       clear_orphan_attrs(attrs)
     else
       attrs
     end
   end
-
-  defp maybe_clear_orphan_state(attrs, _download), do: attrs
 
   defp clear_orphan_attrs(attrs) do
     Map.merge(attrs, %{
@@ -531,6 +551,44 @@ defmodule Mydia.Jobs.DownloadMonitor do
       import_failed_at: nil,
       import_next_retry_at: nil
     })
+  end
+
+  # An orphan the previous release marked: the old "Removed from download
+  # client" copy, no `import_failure_reason` (the tag did not exist yet), and a
+  # client that is still gone or switched off today.
+  defp legacy_orphan?(%{import_failure_reason: nil} = download_map) do
+    download_map.client_config_state in [:removed, :disabled] and
+      is_nil(download_map.adoptable_client) and
+      ClientAdoption.orphan_state?(nil, download_map.error_message)
+  end
+
+  defp legacy_orphan?(_download_map), do: false
+
+  # Tag only. The message is left exactly as it was written, and no
+  # `Events.download_failed/3` is emitted: these failures already happened and
+  # were already reported, so replaying them would dump a backlog of stale
+  # failures into the activity feed on the first poll after an upgrade.
+  defp tag_legacy_orphan(download_map) do
+    Logger.info("Tagging pre-existing orphaned download for grouping",
+      download_id: download_map.id,
+      client: download_map.download_client,
+      client_config_state: download_map.client_config_state
+    )
+
+    download = Downloads.get_download!(download_map.id)
+
+    case Downloads.update_download(download, %{import_failure_reason: "no_client"}) do
+      {:ok, _updated} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.warning("Failed to tag pre-existing orphaned download",
+          download_id: download_map.id,
+          errors: inspect(changeset.errors)
+        )
+
+        :ok
+    end
   end
 
   defp handle_missing(download_map) do

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -502,6 +502,28 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # unrelated import failure keeps it: adoption fixes which client owns the
   # torrent, it does not vindicate a broken import.
   defp maybe_clear_orphan_state(attrs, %{import_failure_reason: "no_client"}) do
+    clear_orphan_attrs(attrs)
+  end
+
+  # A row written by the release that predates the `no_client` tag: it carries
+  # the old "Removed from download client" copy with no `import_failure_reason`
+  # at all. Without this clause such a row is adopted (the client re-points)
+  # but the stale message never clears, so it displays a permanent failure
+  # forever while downloading fine, and stays outside `Download.occupying/1`.
+  # A genuine import failure always sets `import_failure_reason`, so this
+  # can't misfire on one.
+  defp maybe_clear_orphan_state(attrs, %{import_failure_reason: nil, error_message: error_message})
+       when is_binary(error_message) do
+    if String.starts_with?(error_message, "Removed from download client") do
+      clear_orphan_attrs(attrs)
+    else
+      attrs
+    end
+  end
+
+  defp maybe_clear_orphan_state(attrs, _download), do: attrs
+
+  defp clear_orphan_attrs(attrs) do
     Map.merge(attrs, %{
       error_message: nil,
       import_failure_reason: nil,
@@ -510,8 +532,6 @@ defmodule Mydia.Jobs.DownloadMonitor do
       import_next_retry_at: nil
     })
   end
-
-  defp maybe_clear_orphan_state(attrs, _download), do: attrs
 
   defp handle_missing(download_map) do
     Logger.warning("Download missing from client - preserving for user investigation",

--- a/lib/mydia_web/live/admin_download_clients_live/components.ex
+++ b/lib/mydia_web/live/admin_download_clients_live/components.ex
@@ -718,10 +718,10 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
         <h3 class="text-lg font-bold">Delete '{@client.name}'?</h3>
 
         <p :if={@count > 0} class="py-2">
-          {@count} download(s) are assigned to this client. Deleting it will not stop them
-          in the client itself. They will move to Downloads then Issues, where you can
-          clear them. If you re-add a client holding these same torrents, Mydia picks them
-          back up automatically.
+          {@count} {if @count == 1, do: "download is", else: "downloads are"} assigned to this
+          client. Deleting it will not stop them in the client itself. They will move to
+          Downloads then Issues, where you can clear them. If you re-add a client holding
+          these same torrents, Mydia picks them back up automatically.
         </p>
 
         <p :if={@count == 0} class="py-2">
@@ -740,6 +740,7 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
             id="confirm-delete-download-client"
             class="btn btn-error"
             phx-click="delete_download_client"
+            phx-disable-with="Deleting..."
           >
             Delete client
           </button>

--- a/lib/mydia_web/live/admin_download_clients_live/components.ex
+++ b/lib/mydia_web/live/admin_download_clients_live/components.ex
@@ -706,7 +706,14 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
 
   @doc """
   Renders the delete-confirmation modal for a download client, warning the
-  operator how many downloads currently reference it.
+  operator how many downloads are still waiting on it.
+
+  The count comes from `Mydia.Downloads.count_downloads_for_client/1` and
+  excludes imported downloads, which keep their row as history and are
+  untouched by the delete. The copy is hedged about where the rest end up
+  because not all of them land in Issues: a row that is downloaded but not yet
+  imported, or one that was never matched, never enters the missing handler
+  that writes the Issues-tab error.
   """
   attr :client, :map, default: nil
   attr :count, :integer, default: 0
@@ -718,14 +725,14 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
         <h3 class="text-lg font-bold">Delete '{@client.name}'?</h3>
 
         <p :if={@count > 0} class="py-2">
-          {@count} {if @count == 1, do: "download is", else: "downloads are"} assigned to this
-          client. Deleting it will not stop them in the client itself. They will move to
-          Downloads then Issues, where you can clear them. If you re-add a client holding
-          these same torrents, Mydia picks them back up automatically.
+          {@count} {if @count == 1, do: "download is", else: "downloads are"} still waiting on
+          this client. Deleting it will not stop them in the client itself, and the ones still
+          in flight move to the Issues tab where you can clear them. If you re-add a client
+          holding these same torrents, Mydia picks them back up automatically.
         </p>
 
         <p :if={@count == 0} class="py-2">
-          No downloads reference this client.
+          No downloads are waiting on this client.
         </p>
 
         <div class="modal-action">

--- a/lib/mydia_web/live/admin_download_clients_live/components.ex
+++ b/lib/mydia_web/live/admin_download_clients_live/components.ex
@@ -195,10 +195,10 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
                         <.icon name="hero-pencil" class="w-4 h-4" />
                       </button>
                       <button
+                        id={"delete-download-client-#{client.id}"}
                         class="btn btn-sm btn-ghost join-item text-error"
-                        phx-click="delete_download_client"
+                        phx-click="confirm_delete_download_client"
                         phx-value-id={client.id}
-                        data-confirm="Are you sure you want to delete this download client?"
                         title="Delete"
                       >
                         <.icon name="hero-trash" class="w-4 h-4" />
@@ -700,6 +700,52 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
         </.form>
       </div>
       <div class="modal-backdrop bg-black/50" phx-click="close_download_client_modal"></div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders the delete-confirmation modal for a download client, warning the
+  operator how many downloads currently reference it.
+  """
+  attr :client, :map, default: nil
+  attr :count, :integer, default: 0
+
+  def delete_download_client_modal(assigns) do
+    ~H"""
+    <div :if={@client} id="delete-download-client-modal" class="modal modal-open">
+      <div class="modal-box">
+        <h3 class="text-lg font-bold">Delete '{@client.name}'?</h3>
+
+        <p :if={@count > 0} class="py-2">
+          {@count} download(s) are assigned to this client. Deleting it will not stop them
+          in the client itself. They will move to Downloads then Issues, where you can
+          clear them. If you re-add a client holding these same torrents, Mydia picks them
+          back up automatically.
+        </p>
+
+        <p :if={@count == 0} class="py-2">
+          No downloads reference this client.
+        </p>
+
+        <div class="modal-action">
+          <button
+            id="cancel-delete-download-client"
+            class="btn btn-ghost"
+            phx-click="cancel_delete_download_client"
+          >
+            Cancel
+          </button>
+          <button
+            id="confirm-delete-download-client"
+            class="btn btn-error"
+            phx-click="delete_download_client"
+          >
+            Delete client
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop" phx-click="cancel_delete_download_client"></div>
     </div>
     """
   end

--- a/lib/mydia_web/live/admin_download_clients_live/index.ex
+++ b/lib/mydia_web/live/admin_download_clients_live/index.ex
@@ -1,6 +1,7 @@
 defmodule MydiaWeb.AdminDownloadClientsLive.Index do
   use MydiaWeb, :live_view
 
+  alias Mydia.Downloads
   alias Mydia.Settings
   alias Mydia.Settings.DownloadClientConfig
   alias Mydia.Downloads.ClientHealth
@@ -14,6 +15,8 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Index do
      socket
      |> assign(:page_title, "Configuration - Download Clients")
      |> assign(:active_tab, :clients)
+     |> assign(:pending_delete_client, nil)
+     |> assign(:pending_delete_count, 0)
      |> load_data()}
   end
 
@@ -107,7 +110,7 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Index do
   end
 
   @impl true
-  def handle_event("delete_download_client", %{"id" => id}, socket) do
+  def handle_event("confirm_delete_download_client", %{"id" => id}, socket) do
     client = Settings.get_download_client_config!(id)
 
     if Settings.runtime_config?(client) do
@@ -118,28 +121,54 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Index do
          "Cannot delete runtime-configured download client. This client is configured via environment variables and is read-only in the UI."
        )}
     else
-      case Settings.delete_download_client_config(client) do
-        {:ok, _client} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Download client deleted successfully")
-           |> load_data()}
+      # Counted before deletion, while the client still exists, so the operator
+      # sees the real blast radius rather than a bare "are you sure".
+      count = Downloads.count_downloads_for_client(client.name)
 
-        {:error, error} ->
-          MydiaLogger.log_error(:liveview, "Failed to delete download client",
-            error: error,
-            operation: :delete_download_client,
-            client_id: id,
-            client_name: client.name,
-            user_id: socket.assigns.current_user.id
-          )
+      {:noreply,
+       socket
+       |> assign(:pending_delete_client, client)
+       |> assign(:pending_delete_count, count)}
+    end
+  end
 
-          error_msg = MydiaLogger.user_error_message(:delete_download_client, error)
+  @impl true
+  def handle_event("cancel_delete_download_client", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:pending_delete_client, nil)
+     |> assign(:pending_delete_count, 0)}
+  end
 
-          {:noreply,
-           socket
-           |> put_flash(:error, error_msg)}
-      end
+  @impl true
+  def handle_event("delete_download_client", _params, socket) do
+    client = socket.assigns.pending_delete_client
+
+    case Settings.delete_download_client_config(client) do
+      {:ok, _client} ->
+        {:noreply,
+         socket
+         |> assign(:pending_delete_client, nil)
+         |> assign(:pending_delete_count, 0)
+         |> put_flash(:info, "Download client deleted successfully")
+         |> load_data()}
+
+      {:error, error} ->
+        MydiaLogger.log_error(:liveview, "Failed to delete download client",
+          error: error,
+          operation: :delete_download_client,
+          client_id: client.id,
+          client_name: client.name,
+          user_id: socket.assigns.current_user.id
+        )
+
+        error_msg = MydiaLogger.user_error_message(:delete_download_client, error)
+
+        {:noreply,
+         socket
+         |> assign(:pending_delete_client, nil)
+         |> assign(:pending_delete_count, 0)
+         |> put_flash(:error, error_msg)}
     end
   end
 

--- a/lib/mydia_web/live/admin_download_clients_live/index.ex
+++ b/lib/mydia_web/live/admin_download_clients_live/index.ex
@@ -140,6 +140,19 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Index do
      |> assign(:pending_delete_count, 0)}
   end
 
+  # Nothing pending means the modal already fired once (a double-click sends
+  # two events before the DOM re-renders) or the event arrived out of band.
+  # The native data-confirm dialog used to debounce this implicitly; the modal
+  # does not, so guard explicitly.
+  @impl true
+  def handle_event(
+        "delete_download_client",
+        _params,
+        %{assigns: %{pending_delete_client: nil}} = socket
+      ) do
+    {:noreply, socket}
+  end
+
   @impl true
   def handle_event("delete_download_client", _params, socket) do
     client = socket.assigns.pending_delete_client

--- a/lib/mydia_web/live/admin_download_clients_live/index.html.heex
+++ b/lib/mydia_web/live/admin_download_clients_live/index.html.heex
@@ -27,5 +27,10 @@
         editing_download_client={assigns[:editing_download_client]}
       />
     <% end %>
+
+    <MydiaWeb.AdminDownloadClientsLive.Components.delete_download_client_modal
+      client={assigns[:pending_delete_client]}
+      count={assigns[:pending_delete_count] || 0}
+    />
   </div>
 </Layouts.app>

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -800,7 +800,9 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
       {:noreply,
        socket
-       |> put_flash(:info, "Cleared #{count} download(s) from removed client '#{client_name}'")
+       # Neutral wording: the group covers a deleted client and a disabled one
+       # alike, and the banner it came from says so too.
+       |> put_flash(:info, "Cleared #{count} download(s) referencing '#{client_name}'")
        |> load_downloads()}
     else
       {:unauthorized, socket} -> {:noreply, socket}

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -91,6 +91,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
      |> assign(:clearable_count, 0)
      # Issues tab state
      |> assign(:issues_counts, %{unmatched: 0, unresolved: 0, other: 0})
+     |> assign(:removed_client_groups, [])
      |> assign(:search_open_for, nil)
      |> assign(:library_search_value, "")
      |> assign(:library_search_results, [])
@@ -793,6 +794,19 @@ defmodule MydiaWeb.DownloadsLive.Index do
     end
   end
 
+  def handle_event("clear_removed_client", %{"client" => client_name}, socket) do
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      {count, _} = Downloads.clear_downloads_for_removed_client(client_name)
+
+      {:noreply,
+       socket
+       |> put_flash(:info, "Cleared #{count} download(s) from removed client '#{client_name}'")
+       |> load_downloads()}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
   @impl true
   def handle_info({:download_updated, _download_id}, socket) do
     # Reload downloads when we receive an update
@@ -929,10 +943,33 @@ defmodule MydiaWeb.DownloadsLive.Index do
     |> assign(:has_more, false)
     |> assign(:downloads_empty?, all_empty)
     |> assign(:issues_counts, counts)
+    |> assign(:removed_client_groups, removed_client_groups())
     |> assign(:episodes_by_media_item, episodes_by_media_item)
     |> stream(:unmatched_downloads, unmatched, reset: true)
     |> stream(:unresolved_downloads, unresolved, reset: true)
     |> stream(:other_issues, other, reset: true)
+  end
+
+  # Orphan groups annotated with a DOM-safe slug. Client names come from
+  # operator-supplied config (env vars), so unlike most other ids in this
+  # LiveView they aren't guaranteed to already be DOM-id-safe — a name with
+  # spaces or punctuation would otherwise produce an invalid id/CSS selector.
+  # The raw name is preserved in `download_client` for display and for the
+  # `phx-value-client` sent back to `clear_removed_client/2`.
+  defp removed_client_groups do
+    Downloads.removed_client_groups()
+    |> Enum.map(fn group -> Map.put(group, :slug, slugify(group.download_client)) end)
+  end
+
+  defp slugify(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "-")
+    |> String.trim("-")
+    |> case do
+      "" -> "client"
+      slug -> slug
+    end
   end
 
   # Re-enqueue every failed mismatch download whose reported path is under the

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -960,7 +960,37 @@ defmodule MydiaWeb.DownloadsLive.Index do
   # `phx-value-client` sent back to `clear_removed_client/2`.
   defp removed_client_groups do
     Downloads.removed_client_groups()
-    |> Enum.map(fn group -> Map.put(group, :slug, slugify(group.download_client)) end)
+    |> Enum.map_reduce(MapSet.new(), fn group, taken ->
+      {slug, taken} = unique_slug(slugify(group.download_client), taken)
+      {Map.put(group, :slug, slug), taken}
+    end)
+    |> elem(0)
+  end
+
+  # Distinct client names can slugify to the same string ("Qbit Old" and
+  # "qbit-old"), and anything with no alphanumerics collapses to "client".
+  # Duplicate DOM ids are invalid HTML and make LiveView's id-keyed patching
+  # apply an update to the wrong banner, so the first claimant keeps the bare
+  # slug and later ones get a numeric suffix. `removed_client_groups/0` orders
+  # by client name, so which one is "first" is stable across renders.
+  defp unique_slug(base, taken) do
+    if MapSet.member?(taken, base) do
+      next_free_slug(base, 2, taken)
+    else
+      {base, MapSet.put(taken, base)}
+    end
+  end
+
+  # Skips past a suffix a real client name already claimed, so a group named
+  # "qbit-old-2" cannot be stolen from underneath by a disambiguated sibling.
+  defp next_free_slug(base, n, taken) do
+    candidate = "#{base}-#{n}"
+
+    if MapSet.member?(taken, candidate) do
+      next_free_slug(base, n + 1, taken)
+    else
+      {candidate, MapSet.put(taken, candidate)}
+    end
   end
 
   defp slugify(name) do

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -654,6 +654,30 @@
               </button>
             <% end %>
           </div>
+          <div
+            :for={group <- @removed_client_groups}
+            id={"removed-client-#{group.slug}"}
+            class="alert alert-warning mb-4"
+          >
+            <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
+            <div class="flex-1">
+              <div class="font-semibold">
+                {group.count} download(s) reference the removed client '{group.download_client}'
+              </div>
+              <div class="text-sm opacity-80">
+                Re-adding a client that holds these same torrents will restore them automatically.
+              </div>
+            </div>
+            <button
+              id={"clear-removed-client-#{group.slug}"}
+              class="btn btn-sm btn-warning"
+              phx-click="clear_removed_client"
+              phx-value-client={group.download_client}
+              data-confirm={"Clear #{group.count} download(s) from '#{group.download_client}'? This removes the records from Mydia only."}
+            >
+              Clear them
+            </button>
+          </div>
           <ul id="other-issues" phx-update="stream" class="list bg-base-100 rounded-box shadow-lg">
             <li
               id="no-other-issues"

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -661,11 +661,18 @@
           >
             <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
             <div class="flex-1">
+              <%!--
+                Deliberately neutral about *why* the client is gone. The group
+                covers both a deleted client and one that is merely disabled,
+                and calling a disabled client "removed" steers the operator
+                toward clearing records whose actual fix is to switch the
+                client back on.
+              --%>
               <div class="font-semibold">
-                {group.count} download(s) reference the removed client '{group.download_client}'
+                {group.count} download(s) reference '{group.download_client}', which Mydia is no longer tracking
               </div>
               <div class="text-sm opacity-80">
-                Re-adding a client that holds these same torrents will restore them automatically.
+                Re-enabling or re-adding a client that holds these same torrents will restore them automatically.
               </div>
             </div>
             <button

--- a/test/mydia/downloads/client_adoption_test.exs
+++ b/test/mydia/downloads/client_adoption_test.exs
@@ -1,0 +1,107 @@
+defmodule Mydia.Downloads.ClientAdoptionTest do
+  @moduledoc """
+  The adoption rule is deliberately conservative: exactly one claimant, and
+  only among torrent-type clients.
+
+  Two clients can legitimately hold the same info hash (the same release
+  seeded in two places). Since commit 96d75b00 scoped every client to its own
+  files, adopting onto the wrong claimant means importing from the wrong
+  save_path. Usenet and debrid IDs are client-local or provider-scoped, so a
+  cross-client match on either is coincidence rather than identity.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.ClientAdoption
+
+  defp torrent(id), do: %{id: id, state: "downloading", progress: 42.0}
+
+  describe "find_claimant/3" do
+    test "adopts when exactly one torrent client holds the id" do
+      statuses = %{"new-qbit" => {:reachable, %{"hash-a" => torrent("hash-a")}}}
+      types = %{"new-qbit" => :qbittorrent}
+
+      assert {:ok, "new-qbit"} = ClientAdoption.find_claimant("hash-a", statuses, types)
+    end
+
+    test "refuses when two clients hold the same id" do
+      statuses = %{
+        "qbit-one" => {:reachable, %{"hash-a" => torrent("hash-a")}},
+        "qbit-two" => {:reachable, %{"hash-a" => torrent("hash-a")}}
+      }
+
+      types = %{"qbit-one" => :qbittorrent, "qbit-two" => :transmission}
+
+      assert :none = ClientAdoption.find_claimant("hash-a", statuses, types)
+    end
+
+    test "refuses a usenet claimant because nzo ids are client-local" do
+      statuses = %{"sab" => {:reachable, %{"SABnzbd_nzo_1" => torrent("SABnzbd_nzo_1")}}}
+      types = %{"sab" => :sabnzbd}
+
+      assert :none = ClientAdoption.find_claimant("SABnzbd_nzo_1", statuses, types)
+    end
+
+    test "refuses a debrid claimant because ids are provider-scoped" do
+      statuses = %{"torbox" => {:reachable, %{"job-7" => torrent("job-7")}}}
+      types = %{"torbox" => :debrid}
+
+      assert :none = ClientAdoption.find_claimant("job-7", statuses, types)
+    end
+
+    test "adopts the single torrent claimant while ignoring a usenet collision" do
+      statuses = %{
+        "qbit" => {:reachable, %{"shared-id" => torrent("shared-id")}},
+        "sab" => {:reachable, %{"shared-id" => torrent("shared-id")}}
+      }
+
+      types = %{"qbit" => :qbittorrent, "sab" => :sabnzbd}
+
+      assert {:ok, "qbit"} = ClientAdoption.find_claimant("shared-id", statuses, types)
+    end
+
+    test "ignores unreachable clients entirely" do
+      statuses = %{
+        "qbit" => {:reachable, %{"hash-a" => torrent("hash-a")}},
+        "down" => :unreachable
+      }
+
+      types = %{"qbit" => :qbittorrent, "down" => :qbittorrent}
+
+      assert {:ok, "qbit"} = ClientAdoption.find_claimant("hash-a", statuses, types)
+    end
+
+    test "returns :none when no client holds the id" do
+      statuses = %{"qbit" => {:reachable, %{"hash-b" => torrent("hash-b")}}}
+      types = %{"qbit" => :qbittorrent}
+
+      assert :none = ClientAdoption.find_claimant("hash-a", statuses, types)
+    end
+
+    test "returns :none for a nil client id" do
+      statuses = %{"qbit" => {:reachable, %{"hash-a" => torrent("hash-a")}}}
+      types = %{"qbit" => :qbittorrent}
+
+      assert :none = ClientAdoption.find_claimant(nil, statuses, types)
+    end
+
+    test "returns :none when the claimant has no known type" do
+      statuses = %{"mystery" => {:reachable, %{"hash-a" => torrent("hash-a")}}}
+
+      assert :none = ClientAdoption.find_claimant("hash-a", statuses, %{})
+    end
+
+    test "adoptable_types excludes every non-torrent client type" do
+      types = ClientAdoption.adoptable_types()
+
+      assert :qbittorrent in types
+      assert :transmission in types
+      assert :rqbit in types
+      assert :rtorrent in types
+
+      refute :sabnzbd in types
+      refute :nzbget in types
+      refute :debrid in types
+      refute :blackhole in types
+    end
+  end
+end

--- a/test/mydia/downloads/enriched_download_client_state_test.exs
+++ b/test/mydia/downloads/enriched_download_client_state_test.exs
@@ -1,0 +1,67 @@
+defmodule Mydia.Downloads.EnrichedDownloadClientStateTest do
+  @moduledoc """
+  `client_config_state` distinguishes three situations that used to collapse
+  into one wrong error message: the client is present, the client is merely
+  disabled, and the client is gone entirely.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.Structs.EnrichedDownload
+
+  describe "client config fields" do
+    test "defaults both fields to nil" do
+      enriched =
+        EnrichedDownload.new(%{
+          id: "d-1",
+          title: "Some.Release",
+          download_client: "qbit",
+          status: "downloading"
+        })
+
+      assert enriched.client_config_state == nil
+      assert enriched.adoptable_client == nil
+    end
+
+    test "carries a removed state with no adoption candidate" do
+      enriched =
+        EnrichedDownload.new(%{
+          id: "d-2",
+          title: "Some.Release",
+          download_client: "qbit-old",
+          status: "missing",
+          client_config_state: :removed
+        })
+
+      assert enriched.client_config_state == :removed
+      assert enriched.adoptable_client == nil
+    end
+
+    test "carries a disabled state distinctly from a removed one" do
+      enriched =
+        EnrichedDownload.new(%{
+          id: "d-3",
+          title: "Some.Release",
+          download_client: "qbit-paused",
+          status: "missing",
+          client_config_state: :disabled
+        })
+
+      assert enriched.client_config_state == :disabled
+    end
+
+    test "carries an adoption candidate alongside a removed state" do
+      enriched =
+        EnrichedDownload.new(%{
+          id: "d-4",
+          title: "Some.Release",
+          download_client: "qbit-old",
+          status: "downloading",
+          client_config_state: :removed,
+          adoptable_client: "qbit-new"
+        })
+
+      assert enriched.adoptable_client == "qbit-new"
+      assert enriched.status == "downloading"
+    end
+  end
+end

--- a/test/mydia/downloads/history_client_state_test.exs
+++ b/test/mydia/downloads/history_client_state_test.exs
@@ -77,6 +77,41 @@ defmodule Mydia.Downloads.HistoryClientStateTest do
       assert enriched.client_config_state == :present
     end
 
+    test "marks a download as :removed when no clients are configured at all" do
+      # The single-client operator's shape: deleting your only client leaves
+      # `all_configured == []`, an early-return branch that used to leave
+      # `client_config_state` nil unconditionally. A download that still
+      # names a client must classify :removed here too, not just when a
+      # mismatched client is present in a non-empty list.
+      setup_runtime_config([])
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "gone",
+        download_client_id: "hash-e"
+      })
+
+      [enriched] = Downloads.list_downloads_with_status(filter: :all)
+
+      assert enriched.client_config_state == :removed
+    end
+
+    test "leaves client_config_state nil with no clients configured and no client assigned" do
+      setup_runtime_config([])
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: nil,
+        download_client_id: nil
+      })
+
+      [enriched] = Downloads.list_downloads_with_status(filter: :all)
+
+      assert enriched.client_config_state == nil
+    end
+
     test "does not write the adoption candidate to the database" do
       setup_runtime_config([client_config(%{name: "kept", enabled: true})])
       media_item = media_item_fixture()

--- a/test/mydia/downloads/history_client_state_test.exs
+++ b/test/mydia/downloads/history_client_state_test.exs
@@ -1,12 +1,13 @@
 defmodule Mydia.Downloads.HistoryClientStateTest do
   @moduledoc """
   Covers the classification that `DownloadMonitor` acts on: a client that is
-  present, one that is merely disabled, and one that is gone. Also covers the
-  read path reporting an adoption candidate without writing anything.
+  present, one that is merely disabled, and one that is gone.
 
-  No client here is reachable over the network, so every configured client
-  resolves to `:unreachable`. That is deliberate: it isolates the config-state
-  classification from live torrent data.
+  No client in the first describe block is reachable over the network, so every
+  configured client resolves to `:unreachable`. That is deliberate: it isolates
+  the config-state classification from live torrent data. The second block
+  stands up a real (stubbed) client, because a candidate can only be reported
+  when a reachable claimant genuinely exists.
   """
   use Mydia.DataCase, async: false
 
@@ -14,6 +15,8 @@ defmodule Mydia.Downloads.HistoryClientStateTest do
 
   import Mydia.MediaFixtures
   import Mydia.DownloadsFixtures
+
+  @hash "1234567890abcdef1234567890abcdef12345678"
 
   describe "list_downloads_with_status/1 client config state" do
     test "marks a download whose client was removed" do
@@ -111,24 +114,78 @@ defmodule Mydia.Downloads.HistoryClientStateTest do
 
       assert enriched.client_config_state == nil
     end
+  end
 
-    test "does not write the adoption candidate to the database" do
-      setup_runtime_config([client_config(%{name: "kept", enabled: true})])
+  describe "list_downloads_with_status/1 adoption candidates" do
+    setup do
+      bypass = Bypass.open()
+
+      Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=test-sid; HttpOnly")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!([torrent_payload(@hash)]))
+      end)
+
+      {:ok, bypass: bypass}
+    end
+
+    test "reports the candidate and the claimant's live status, and writes neither", %{
+      bypass: bypass
+    } do
+      # A reachable claimant has to genuinely exist for this to prove anything:
+      # with only unreachable clients configured, `find_claimant/3` returns
+      # `:none` and the assertion below would hold even if the read path
+      # persisted every adoption it found.
+      setup_runtime_config([reachable_client("qbit-new", bypass.port)])
       media_item = media_item_fixture()
 
       download =
         download_fixture(%{
           media_item_id: media_item.id,
-          download_client: "gone",
-          download_client_id: "hash-d"
+          download_client: "qbit-old",
+          download_client_id: @hash
         })
 
-      _ = Downloads.list_downloads_with_status(filter: :all)
+      [enriched] = Downloads.list_downloads_with_status(filter: :all)
+
+      assert enriched.adoptable_client == "qbit-new"
+      # Enriched from the claimant's torrent, so the UI shows real progress.
+      assert enriched.status == "downloading"
 
       # The read path reports; it never persists. DownloadMonitor is the only
       # writer.
-      assert Downloads.get_download!(download.id).download_client == "gone"
+      persisted = Downloads.get_download!(download.id)
+      assert persisted.download_client == "qbit-old"
     end
+  end
+
+  defp torrent_payload(hash) do
+    %{
+      "hash" => hash,
+      "name" => "Test Torrent",
+      "state" => "downloading",
+      "progress" => 0.5,
+      "dlspeed" => 100_000,
+      "upspeed" => 0,
+      "downloaded" => 500,
+      "uploaded" => 0,
+      "size" => 1000,
+      "eta" => 60,
+      "ratio" => 0.0,
+      "save_path" => "/downloads",
+      "added_on" => 1_700_000_000,
+      "completion_on" => -1
+    }
+  end
+
+  defp reachable_client(name, port) do
+    client_config(%{name: name, port: port, password: "adminpass"})
   end
 
   defp client_config(overrides) do

--- a/test/mydia/downloads/history_client_state_test.exs
+++ b/test/mydia/downloads/history_client_state_test.exs
@@ -1,0 +1,135 @@
+defmodule Mydia.Downloads.HistoryClientStateTest do
+  @moduledoc """
+  Covers the classification that `DownloadMonitor` acts on: a client that is
+  present, one that is merely disabled, and one that is gone. Also covers the
+  read path reporting an adoption candidate without writing anything.
+
+  No client here is reachable over the network, so every configured client
+  resolves to `:unreachable`. That is deliberate: it isolates the config-state
+  classification from live torrent data.
+  """
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Downloads
+
+  import Mydia.MediaFixtures
+  import Mydia.DownloadsFixtures
+
+  describe "list_downloads_with_status/1 client config state" do
+    test "marks a download whose client was removed" do
+      setup_runtime_config([client_config(%{name: "kept", enabled: true})])
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "gone",
+        download_client_id: "hash-a"
+      })
+
+      [enriched] = Downloads.list_downloads_with_status(filter: :all)
+
+      assert enriched.client_config_state == :removed
+      assert enriched.adoptable_client == nil
+    end
+
+    test "marks a download whose client is disabled, not removed" do
+      setup_runtime_config([client_config(%{name: "paused", enabled: false})])
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "paused",
+        download_client_id: "hash-b"
+      })
+
+      [enriched] = Downloads.list_downloads_with_status(filter: :all)
+
+      assert enriched.client_config_state == :disabled
+    end
+
+    test "leaves client_config_state nil for a download with no client assigned" do
+      setup_runtime_config([client_config(%{name: "kept", enabled: true})])
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: nil,
+        download_client_id: nil
+      })
+
+      [enriched] = Downloads.list_downloads_with_status(filter: :all)
+
+      assert enriched.client_config_state == nil
+    end
+
+    test "reports :present for a configured, enabled client" do
+      setup_runtime_config([client_config(%{name: "kept", enabled: true})])
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "kept",
+        download_client_id: "hash-c"
+      })
+
+      [enriched] = Downloads.list_downloads_with_status(filter: :all)
+
+      assert enriched.client_config_state == :present
+    end
+
+    test "does not write the adoption candidate to the database" do
+      setup_runtime_config([client_config(%{name: "kept", enabled: true})])
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "gone",
+          download_client_id: "hash-d"
+        })
+
+      _ = Downloads.list_downloads_with_status(filter: :all)
+
+      # The read path reports; it never persists. DownloadMonitor is the only
+      # writer.
+      assert Downloads.get_download!(download.id).download_client == "gone"
+    end
+  end
+
+  defp client_config(overrides) do
+    Enum.into(overrides, %{
+      name: "TestClient",
+      type: :qbittorrent,
+      enabled: true,
+      host: "localhost",
+      port: 8080,
+      use_ssl: false,
+      username: "admin",
+      password: "admin",
+      priority: 1
+    })
+  end
+
+  defp setup_runtime_config(download_clients) do
+    config = %Mydia.Config.Schema{
+      server: %Mydia.Config.Schema.Server{},
+      database: %Mydia.Config.Schema.Database{},
+      auth: %Mydia.Config.Schema.Auth{},
+      media: %Mydia.Config.Schema.Media{},
+      downloads: %Mydia.Config.Schema.Downloads{},
+      logging: %Mydia.Config.Schema.Logging{},
+      oban: %Mydia.Config.Schema.Oban{},
+      download_clients: download_clients
+    }
+
+    previous = Application.get_env(:mydia, :runtime_config)
+    Application.put_env(:mydia, :runtime_config, config)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:mydia, :runtime_config)
+        value -> Application.put_env(:mydia, :runtime_config, value)
+      end
+    end)
+  end
+end

--- a/test/mydia/downloads/history_removed_client_test.exs
+++ b/test/mydia/downloads/history_removed_client_test.exs
@@ -13,7 +13,7 @@ defmodule Mydia.Downloads.HistoryRemovedClientTest do
   import Mydia.DownloadsFixtures
 
   describe "count_downloads_for_client/1" do
-    test "counts every row for that client, not only orphaned ones" do
+    test "counts every unimported row for that client, not only orphaned ones" do
       media_item = media_item_fixture()
 
       download_fixture(%{media_item_id: media_item.id, download_client: "qbit"})
@@ -25,6 +25,27 @@ defmodule Mydia.Downloads.HistoryRemovedClientTest do
       assert Downloads.count_downloads_for_client("qbit") == 2
       assert Downloads.count_downloads_for_client("other") == 1
       assert Downloads.count_downloads_for_client("absent") == 0
+    end
+
+    test "excludes imported downloads" do
+      # Import does not delete the row: `MediaImport` stamps `imported_at` and
+      # leaves it as history, which is why `count_completed/0` exists. On a
+      # mature instance that history dwarfs the in-flight downloads, and
+      # deleting the client does nothing at all to it, so counting it would
+      # make the warning report a blast radius that is mostly fiction.
+      media_item = media_item_fixture()
+
+      download_fixture(%{media_item_id: media_item.id, download_client: "qbit"})
+
+      for _ <- 1..3 do
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit",
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+      end
+
+      assert Downloads.count_downloads_for_client("qbit") == 1
     end
   end
 

--- a/test/mydia/downloads/history_removed_client_test.exs
+++ b/test/mydia/downloads/history_removed_client_test.exs
@@ -1,0 +1,115 @@
+defmodule Mydia.Downloads.HistoryRemovedClientTest do
+  @moduledoc """
+  The Issues-tab bulk clear must be scoped. `dismiss_all_cancelled/0` already
+  exists and deletes every errored row in the tab; these functions delete only
+  one removed client's orphans, leaving other clients and other failure
+  reasons alone.
+  """
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Downloads
+
+  import Mydia.MediaFixtures
+  import Mydia.DownloadsFixtures
+
+  describe "count_downloads_for_client/1" do
+    test "counts every row for that client, not only orphaned ones" do
+      media_item = media_item_fixture()
+
+      download_fixture(%{media_item_id: media_item.id, download_client: "qbit"})
+      download_fixture(%{media_item_id: media_item.id, download_client: "qbit"})
+      download_fixture(%{media_item_id: media_item.id, download_client: "other"})
+
+      # This runs before deletion, while the client still exists, so a healthy
+      # in-flight download counts toward the warning's blast radius.
+      assert Downloads.count_downloads_for_client("qbit") == 2
+      assert Downloads.count_downloads_for_client("other") == 1
+      assert Downloads.count_downloads_for_client("absent") == 0
+    end
+  end
+
+  describe "removed_client_groups/0" do
+    test "groups orphans by client name with counts" do
+      media_item = media_item_fixture()
+
+      for _ <- 1..3 do
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-old",
+          error_message: "gone",
+          import_failure_reason: "no_client"
+        })
+      end
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "sab-old",
+        error_message: "gone",
+        import_failure_reason: "no_client"
+      })
+
+      # Not an orphan: different failure reason.
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "qbit-old",
+        error_message: "something else",
+        import_failure_reason: "path_mapping_mismatch"
+      })
+
+      groups = Enum.sort_by(Downloads.removed_client_groups(), & &1.download_client)
+
+      assert groups == [
+               %{download_client: "qbit-old", count: 3},
+               %{download_client: "sab-old", count: 1}
+             ]
+    end
+
+    test "returns an empty list when there are no orphans" do
+      media_item = media_item_fixture()
+      download_fixture(%{media_item_id: media_item.id, download_client: "qbit"})
+
+      assert Downloads.removed_client_groups() == []
+    end
+  end
+
+  describe "clear_downloads_for_removed_client/1" do
+    test "deletes only that client's orphans" do
+      media_item = media_item_fixture()
+
+      target =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-old",
+          error_message: "gone",
+          import_failure_reason: "no_client"
+        })
+
+      other_client =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "sab-old",
+          error_message: "gone",
+          import_failure_reason: "no_client"
+        })
+
+      other_reason =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-old",
+          error_message: "something else",
+          import_failure_reason: "path_mapping_mismatch"
+        })
+
+      healthy =
+        download_fixture(%{media_item_id: media_item.id, download_client: "qbit-old"})
+
+      assert {1, _} = Downloads.clear_downloads_for_removed_client("qbit-old")
+
+      assert_raise Ecto.NoResultsError, fn -> Downloads.get_download!(target.id) end
+
+      assert Downloads.get_download!(other_client.id)
+      assert Downloads.get_download!(other_reason.id)
+      assert Downloads.get_download!(healthy.id)
+    end
+  end
+end

--- a/test/mydia/jobs/download_monitor_adoption_bypass_test.exs
+++ b/test/mydia/jobs/download_monitor_adoption_bypass_test.exs
@@ -7,6 +7,12 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionBypassTest do
   must re-point the download at 'qbit-new' and clear the orphan error state
   written by an earlier pass, so a row parked in the Issues tab comes back to
   life when the operator re-adds their client.
+
+  The same file covers the symmetric case: the download's *own* client coming
+  back, by being re-enabled or re-added under the same name. That heals through
+  the same writer, because a row that only ever heals when some *other* client
+  claims it would keep a false error message forever on the commonest recovery
+  path there is.
   """
   use Mydia.DataCase, async: false
   use Oban.Testing, repo: Mydia.Repo
@@ -114,6 +120,45 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionBypassTest do
     assert download.id in occupying_ids()
   end
 
+  test "re-enabling a disabled client clears the orphan state it produced", %{bypass: bypass} do
+    # Two monitor passes with the client's `enabled` flag flipped between them:
+    # exactly the sequence the disabled-client error message tells the operator
+    # to perform. Orphaning must not be a one-way transition, otherwise the row
+    # keeps a false error message and the Issues tab keeps offering to delete a
+    # download that is visibly running on the Queue tab.
+    setup_runtime_config([disabled_client("qbit", bypass.port)])
+    media_item = media_item_fixture()
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "qbit",
+        download_client_id: @hash
+      })
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    parked = Downloads.get_download!(download.id)
+    assert parked.import_failure_reason == "no_client"
+    assert parked.error_message =~ "is disabled in Mydia"
+    refute download.id in occupying_ids()
+
+    # The operator does what the message says.
+    setup_runtime_config([reachable_client("qbit", bypass.port)])
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    healed = Downloads.get_download!(download.id)
+
+    assert healed.download_client == "qbit"
+    assert healed.error_message == nil
+    assert healed.import_failure_reason == nil
+    assert download.id in occupying_ids()
+
+    # And the Issues-tab banner stops claiming this client is untracked.
+    assert Downloads.removed_client_groups() == []
+  end
+
   test "leaves an unrelated import failure intact when adopting" do
     # Adoption fixes which client owns the torrent. It does not vindicate a
     # broken import, so failure state this feature did not write must survive.
@@ -171,6 +216,11 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionBypassTest do
       password: "adminpass",
       priority: 1
     }
+  end
+
+  # Same client, switched off: still in the config list, never polled.
+  defp disabled_client(name, port) do
+    %{reachable_client(name, port) | enabled: false}
   end
 
   defp torrent_payload(hash) do

--- a/test/mydia/jobs/download_monitor_adoption_bypass_test.exs
+++ b/test/mydia/jobs/download_monitor_adoption_bypass_test.exs
@@ -1,0 +1,158 @@
+defmodule Mydia.Jobs.DownloadMonitorAdoptionBypassTest do
+  @moduledoc """
+  The adoption success path, end to end.
+
+  A download references 'qbit-old', which no longer exists. A configured,
+  reachable client named 'qbit-new' holds the same info hash. One monitor pass
+  must re-point the download at 'qbit-new' and clear the orphan error state
+  written by an earlier pass, so a row parked in the Issues tab comes back to
+  life when the operator re-adds their client.
+  """
+  use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  alias Mydia.Downloads
+  alias Mydia.Jobs.DownloadMonitor
+
+  import Mydia.MediaFixtures
+  import Mydia.DownloadsFixtures
+
+  @hash "1234567890abcdef1234567890abcdef12345678"
+
+  setup do
+    bypass = Bypass.open()
+
+    Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("set-cookie", "SID=test-sid; HttpOnly")
+      |> Plug.Conn.resp(200, "Ok.")
+    end)
+
+    Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!([torrent_payload(@hash)]))
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  test "adopts an orphan onto the client that actually holds its torrent", %{bypass: bypass} do
+    setup_runtime_config([reachable_client("qbit-new", bypass.port)])
+    media_item = media_item_fixture()
+
+    # An earlier poll already parked this row: the client it referenced is gone.
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "qbit-old",
+        download_client_id: @hash,
+        error_message: "Download client 'qbit-old' is no longer configured in Mydia.",
+        import_failure_reason: "no_client"
+      })
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    updated = Downloads.get_download!(download.id)
+
+    assert updated.download_client == "qbit-new"
+    assert updated.error_message == nil
+    assert updated.import_failure_reason == nil
+    assert updated.import_failed_at == nil
+    assert updated.import_next_retry_at == nil
+  end
+
+  test "leaves an unrelated import failure intact when adopting" do
+    # Adoption fixes which client owns the torrent. It does not vindicate a
+    # broken import, so failure state this feature did not write must survive.
+    bypass = Bypass.open()
+
+    Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("set-cookie", "SID=test-sid; HttpOnly")
+      |> Plug.Conn.resp(200, "Ok.")
+    end)
+
+    Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!([torrent_payload(@hash)]))
+    end)
+
+    setup_runtime_config([reachable_client("qbit-new", bypass.port)])
+    media_item = media_item_fixture()
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "qbit-old",
+        download_client_id: @hash,
+        import_failure_reason: "path_mapping_mismatch",
+        import_last_error: "Could not see /remote/path"
+      })
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    updated = Downloads.get_download!(download.id)
+
+    assert updated.download_client == "qbit-new"
+    assert updated.import_failure_reason == "path_mapping_mismatch"
+    assert updated.import_last_error == "Could not see /remote/path"
+  end
+
+  defp reachable_client(name, port) do
+    %{
+      name: name,
+      type: :qbittorrent,
+      enabled: true,
+      host: "localhost",
+      port: port,
+      use_ssl: false,
+      username: "admin",
+      password: "adminpass",
+      priority: 1
+    }
+  end
+
+  defp torrent_payload(hash) do
+    %{
+      "hash" => hash,
+      "name" => "Test Torrent",
+      "state" => "downloading",
+      "progress" => 0.5,
+      "dlspeed" => 100_000,
+      "upspeed" => 0,
+      "downloaded" => 500,
+      "uploaded" => 0,
+      "size" => 1000,
+      "eta" => 60,
+      "ratio" => 0.0,
+      "save_path" => "/downloads",
+      "added_on" => 1_700_000_000,
+      "completion_on" => -1
+    }
+  end
+
+  defp setup_runtime_config(download_clients) do
+    config = %Mydia.Config.Schema{
+      server: %Mydia.Config.Schema.Server{},
+      database: %Mydia.Config.Schema.Database{},
+      auth: %Mydia.Config.Schema.Auth{},
+      media: %Mydia.Config.Schema.Media{},
+      downloads: %Mydia.Config.Schema.Downloads{},
+      logging: %Mydia.Config.Schema.Logging{},
+      oban: %Mydia.Config.Schema.Oban{},
+      download_clients: download_clients
+    }
+
+    previous = Application.get_env(:mydia, :runtime_config)
+    Application.put_env(:mydia, :runtime_config, config)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:mydia, :runtime_config)
+        value -> Application.put_env(:mydia, :runtime_config, value)
+      end
+    end)
+  end
+end

--- a/test/mydia/jobs/download_monitor_adoption_bypass_test.exs
+++ b/test/mydia/jobs/download_monitor_adoption_bypass_test.exs
@@ -41,14 +41,67 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionBypassTest do
     setup_runtime_config([reachable_client("qbit-new", bypass.port)])
     media_item = media_item_fixture()
 
-    # An earlier poll already parked this row: the client it referenced is gone.
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    # An earlier poll already parked this row: the client it referenced is
+    # gone. `import_failed_at` and `import_next_retry_at` are seeded non-nil
+    # (as `no_client`'s own terminal-after-3-attempts path in MediaImport
+    # would leave them) so the nil assertions below are actually proving
+    # `maybe_clear_orphan_state/2` clears those fields, not just resting on
+    # a fixture default that was already nil.
     download =
       download_fixture(%{
         media_item_id: media_item.id,
         download_client: "qbit-old",
         download_client_id: @hash,
         error_message: "Download client 'qbit-old' is no longer configured in Mydia.",
-        import_failure_reason: "no_client"
+        import_failure_reason: "no_client",
+        import_last_error: "Download client 'qbit-old' is no longer configured in Mydia.",
+        import_failed_at: now,
+        import_next_retry_at: now
+      })
+
+    # Before adoption the row is parked: error_message alone already excludes
+    # it from occupying/1.
+    refute download.id in occupying_ids()
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    updated = Downloads.get_download!(download.id)
+
+    assert updated.download_client == "qbit-new"
+    assert updated.error_message == nil
+    assert updated.import_failure_reason == nil
+    assert updated.import_last_error == nil
+    assert updated.import_failed_at == nil
+    assert updated.import_next_retry_at == nil
+
+    # The whole point of clearing `import_failed_at` / `import_next_retry_at`
+    # (not just `error_message`) is that the row returns to occupying its
+    # target, exactly the set `MediaImport`'s own `no_client` terminal path
+    # writes to when it gives up after 3 attempts.
+    assert download.id in occupying_ids()
+  end
+
+  test "heals a legacy row written before the no_client tag existed", %{bypass: bypass} do
+    # A row marked missing by the previously released code has the old
+    # "Removed from download client" copy but no import_failure_reason at
+    # all (the tag didn't exist yet). Without the widened gate in
+    # maybe_clear_orphan_state/2, adoption would re-point such a row at its
+    # new client but never clear the now-false message, so it would display
+    # a permanent failure forever while downloading fine.
+    setup_runtime_config([reachable_client("qbit-new", bypass.port)])
+    media_item = media_item_fixture()
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "qbit-old",
+        download_client_id: @hash,
+        error_message:
+          "Removed from download client 'qbit-old' before import completed. " <>
+            "The download may have been manually deleted, or the client may have encountered an error.",
+        import_failure_reason: nil
       })
 
     assert :ok = perform_job(DownloadMonitor, %{})
@@ -58,8 +111,7 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionBypassTest do
     assert updated.download_client == "qbit-new"
     assert updated.error_message == nil
     assert updated.import_failure_reason == nil
-    assert updated.import_failed_at == nil
-    assert updated.import_next_retry_at == nil
+    assert download.id in occupying_ids()
   end
 
   test "leaves an unrelated import failure intact when adopting" do
@@ -98,6 +150,13 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionBypassTest do
     assert updated.download_client == "qbit-new"
     assert updated.import_failure_reason == "path_mapping_mismatch"
     assert updated.import_last_error == "Could not see /remote/path"
+  end
+
+  defp occupying_ids do
+    Mydia.Downloads.Download
+    |> Mydia.Downloads.Download.occupying()
+    |> Mydia.Repo.all()
+    |> Enum.map(& &1.id)
   end
 
   defp reachable_client(name, port) do

--- a/test/mydia/jobs/download_monitor_adoption_test.exs
+++ b/test/mydia/jobs/download_monitor_adoption_test.exs
@@ -144,10 +144,11 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionTest do
     end
 
     test "leaves an unrelated failure message untagged" do
-      # The backfill keys on the old release's exact copy. Any other failure
-      # message means some other subsystem owns this row, and mis-tagging it
-      # would offer the operator a bulk delete for a download whose client is
-      # not the problem.
+      # The backfill keys on the old release's message *prefix* ("Removed from
+      # download client"), via `ClientAdoption.orphan_state?/2`. Any other
+      # failure message means some other subsystem owns this row, and
+      # mis-tagging it would offer the operator a bulk delete for a download
+      # whose client is not the problem.
       setup_runtime_config([client_config(%{name: "kept"})])
       media_item = media_item_fixture()
 

--- a/test/mydia/jobs/download_monitor_adoption_test.exs
+++ b/test/mydia/jobs/download_monitor_adoption_test.exs
@@ -107,6 +107,67 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionTest do
       assert Mydia.Repo.aggregate(Mydia.Downloads.ReleaseBlacklist, :count) == 0
     end
 
+    test "tags a legacy orphan the previous release already marked" do
+      # Rows the released code marked with "Removed from download client ..."
+      # carry an error_message, and the monitor's `missing` filter requires a
+      # nil one, so they can never re-enter `handle_missing/1` to be tagged.
+      # Without a backfill the operator who upgrades with 50 falsely blamed
+      # orphans, which is who this feature is for, sees no banner at all.
+      setup_runtime_config([client_config(%{name: "kept"})])
+      media_item = media_item_fixture()
+
+      legacy_message =
+        "Removed from download client 'qbit-old' before import completed. " <>
+          "The download may have been manually deleted, or the client may have " <>
+          "encountered an error."
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-old",
+          download_client_id: "hash-legacy",
+          error_message: legacy_message,
+          import_failure_reason: nil
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      updated = Downloads.get_download!(download.id)
+
+      assert updated.import_failure_reason == "no_client"
+      # Tag only: the message is left exactly as the old release wrote it.
+      assert updated.error_message == legacy_message
+
+      assert Downloads.removed_client_groups() == [
+               %{download_client: "qbit-old", count: 1}
+             ]
+    end
+
+    test "leaves an unrelated failure message untagged" do
+      # The backfill keys on the old release's exact copy. Any other failure
+      # message means some other subsystem owns this row, and mis-tagging it
+      # would offer the operator a bulk delete for a download whose client is
+      # not the problem.
+      setup_runtime_config([client_config(%{name: "kept"})])
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-old",
+          download_client_id: "hash-unrelated",
+          error_message: "Grab timed out",
+          import_failure_reason: nil
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      updated = Downloads.get_download!(download.id)
+
+      assert updated.import_failure_reason == nil
+      assert Downloads.removed_client_groups() == []
+    end
+
     test "keeps the original copy when a configured client dropped the torrent" do
       # A download whose client IS configured classifies as :present, so it
       # must keep the original message. Without this guard, step 6 of the

--- a/test/mydia/jobs/download_monitor_adoption_test.exs
+++ b/test/mydia/jobs/download_monitor_adoption_test.exs
@@ -1,0 +1,170 @@
+defmodule Mydia.Jobs.DownloadMonitorAdoptionTest do
+  @moduledoc """
+  Covers the two halves of the orphan path: adoption onto a renamed client,
+  and honest messaging for orphans that cannot be adopted.
+
+  These tests do not stub a live client, so no adoption candidate is ever
+  found here; adoption itself is unit-tested in
+  `Mydia.Downloads.ClientAdoptionTest`. What this file guards is the message
+  and the persisted tag, which is what the Issues tab groups on.
+  """
+  use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  alias Mydia.Downloads
+  alias Mydia.Downloads.Structs.EnrichedDownload
+  alias Mydia.Jobs.DownloadMonitor
+
+  import Mydia.MediaFixtures
+  import Mydia.DownloadsFixtures
+
+  describe "orphaned downloads" do
+    test "explains that a removed client is gone, and tags the row" do
+      setup_runtime_config([client_config(%{name: "kept"})])
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-old",
+          download_client_id: "hash-a"
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      updated = Downloads.get_download!(download.id)
+
+      assert updated.error_message =~ "no longer configured in Mydia"
+      assert updated.error_message =~ "qbit-old"
+      refute updated.error_message =~ "Removed from download client"
+      assert updated.import_failure_reason == "no_client"
+    end
+
+    test "explains that a disabled client is disabled, not removed" do
+      setup_runtime_config([
+        client_config(%{name: "kept"}),
+        client_config(%{name: "qbit-paused", enabled: false})
+      ])
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-paused",
+          download_client_id: "hash-b"
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      updated = Downloads.get_download!(download.id)
+
+      assert updated.error_message =~ "is disabled in Mydia"
+      refute updated.error_message =~ "no longer configured"
+      assert updated.import_failure_reason == "no_client"
+    end
+
+    test "releases the target so the media can be searched again" do
+      setup_runtime_config([client_config(%{name: "kept"})])
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-old",
+          download_client_id: "hash-c"
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      # `Download.occupying/1` excludes rows with a non-nil error_message, so
+      # writing the message is what frees the episode for a fresh search.
+      occupying_ids =
+        Mydia.Downloads.Download
+        |> Mydia.Downloads.Download.occupying()
+        |> Mydia.Repo.all()
+        |> Enum.map(& &1.id)
+
+      refute download.id in occupying_ids
+    end
+
+    test "does not blacklist the release" do
+      setup_runtime_config([client_config(%{name: "kept"})])
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "qbit-old",
+        download_client_id: "hash-d",
+        indexer: "test-indexer",
+        metadata: %{"guid" => "guid-1", "indexer" => "test-indexer"}
+      })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      # The release never failed. The client left. Blacklisting here would
+      # poison future searches for a perfectly good release.
+      assert Mydia.Repo.aggregate(Mydia.Downloads.ReleaseBlacklist, :count) == 0
+    end
+
+    test "keeps the original copy when a configured client dropped the torrent" do
+      # A download whose client IS configured classifies as :present, so it
+      # must keep the original message. Without this guard, step 6 of the
+      # migration leaves that branch entirely uncovered: every other test in
+      # the suite now exercises the :removed path.
+      present =
+        EnrichedDownload.new(%{
+          id: "d-present",
+          title: "Some.Release",
+          download_client: "kept",
+          status: "missing",
+          client_config_state: :present
+        })
+
+      removed = %{present | client_config_state: :removed, download_client: "gone"}
+
+      assert DownloadMonitor.missing_error_message(present) =~
+               "Removed from download client 'kept'"
+
+      assert DownloadMonitor.missing_error_message(removed) =~
+               "no longer configured in Mydia"
+    end
+  end
+
+  defp client_config(overrides) do
+    Enum.into(overrides, %{
+      name: "TestClient",
+      type: :qbittorrent,
+      enabled: true,
+      host: "localhost",
+      port: 8080,
+      use_ssl: false,
+      username: "admin",
+      password: "admin",
+      priority: 1
+    })
+  end
+
+  defp setup_runtime_config(download_clients) do
+    config = %Mydia.Config.Schema{
+      server: %Mydia.Config.Schema.Server{},
+      database: %Mydia.Config.Schema.Database{},
+      auth: %Mydia.Config.Schema.Auth{},
+      media: %Mydia.Config.Schema.Media{},
+      downloads: %Mydia.Config.Schema.Downloads{},
+      logging: %Mydia.Config.Schema.Logging{},
+      oban: %Mydia.Config.Schema.Oban{},
+      download_clients: download_clients
+    }
+
+    previous = Application.get_env(:mydia, :runtime_config)
+    Application.put_env(:mydia, :runtime_config, config)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:mydia, :runtime_config)
+        value -> Application.put_env(:mydia, :runtime_config, value)
+      end
+    end)
+  end
+end

--- a/test/mydia/jobs/download_monitor_logging_test.exs
+++ b/test/mydia/jobs/download_monitor_logging_test.exs
@@ -36,7 +36,7 @@ defmodule Mydia.Jobs.DownloadMonitorLoggingTest do
       end)
 
       updated = Downloads.get_download!(download.id)
-      assert updated.error_message =~ "Removed from download client"
+      assert updated.error_message =~ "no longer configured in Mydia"
     end
 
     test "marks every missing download in the batch and emits an event for each" do
@@ -54,7 +54,7 @@ defmodule Mydia.Jobs.DownloadMonitorLoggingTest do
       # the first row, so later downloads went unmarked and no event ever fired.
       for download <- downloads do
         assert Downloads.get_download!(download.id).error_message =~
-                 "Removed from download client"
+                 "no longer configured in Mydia"
       end
 
       assert length(Events.list_events(type: "download.failed")) == 3

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -224,7 +224,10 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
   describe "missing download detection" do
     test "marks downloads that no longer exist in any client as missing" do
-      # Setup with no actual clients (simulates missing downloads)
+      # Setup with no actual clients (simulates missing downloads). This is
+      # also the single-client operator's shape: deleting your only client
+      # leaves `all_configured == []`, and that must still classify as
+      # :removed rather than silently falling back to nil.
       setup_runtime_config([])
 
       media_item = media_item_fixture()
@@ -245,8 +248,12 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       # Download should have error_message set (preserved for Issues tab)
       updated = Downloads.get_download!(download.id)
-      assert updated.error_message =~ "Removed from download client"
+      assert updated.error_message =~ "no longer configured in Mydia"
       assert updated.error_message =~ "test-client"
+      # The `no_client` tag is what Task 5's Issues tab groups and
+      # bulk-clears on — it must still be written when there is no
+      # configured client at all, not just when a mismatched one exists.
+      assert updated.import_failure_reason == "no_client"
     end
 
     test "does not remove downloads that are already completed" do
@@ -318,9 +325,14 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       assert :ok = perform_job(DownloadMonitor, %{})
 
       # All missing downloads should have error_message set (preserved for Issues tab)
-      assert Downloads.get_download!(download1.id).error_message =~ "Removed from download client"
-      assert Downloads.get_download!(download2.id).error_message =~ "Removed from download client"
-      assert Downloads.get_download!(download3.id).error_message =~ "Removed from download client"
+      assert Downloads.get_download!(download1.id).error_message =~
+               "no longer configured in Mydia"
+
+      assert Downloads.get_download!(download2.id).error_message =~
+               "no longer configured in Mydia"
+
+      assert Downloads.get_download!(download3.id).error_message =~
+               "no longer configured in Mydia"
     end
 
     test "handles mix of missing, active, and completed downloads" do
@@ -356,7 +368,7 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       # The missing download should have error_message set (preserved for Issues tab)
       updated_missing = Downloads.get_download!(missing_download.id)
-      assert updated_missing.error_message =~ "Removed from download client"
+      assert updated_missing.error_message =~ "no longer configured in Mydia"
 
       # Completed and failed downloads should still exist unchanged
       assert Downloads.get_download!(completed_download.id)
@@ -485,7 +497,7 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       preserved = Mydia.Repo.get(Mydia.Downloads.Download, tracked.id)
       assert preserved
-      assert preserved.error_message =~ "Removed from download client"
+      assert preserved.error_message =~ "no longer configured in Mydia"
     end
 
     test "does not delete unmatched downloads while their client is unreachable" do

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -61,8 +61,8 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       # Note: "status" is calculated dynamically, but error_message persists
       updated_active1 = Downloads.get_download!(active1.id)
       updated_active2 = Downloads.get_download!(active2.id)
-      assert updated_active1.error_message =~ "Removed from download client"
-      assert updated_active2.error_message =~ "Removed from download client"
+      assert updated_active1.error_message =~ "no longer configured in Mydia"
+      assert updated_active2.error_message =~ "no longer configured in Mydia"
 
       # Completed and failed downloads should still exist
       assert Downloads.get_download!(completed.id)
@@ -129,9 +129,9 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       assert :ok = perform_job(DownloadMonitor, %{})
 
       # All downloads should have error_message set (preserved for Issues tab)
-      assert Downloads.get_download!(d1.id).error_message =~ "Removed from download client"
-      assert Downloads.get_download!(d2.id).error_message =~ "Removed from download client"
-      assert Downloads.get_download!(d3.id).error_message =~ "Removed from download client"
+      assert Downloads.get_download!(d1.id).error_message =~ "no longer configured in Mydia"
+      assert Downloads.get_download!(d2.id).error_message =~ "no longer configured in Mydia"
+      assert Downloads.get_download!(d3.id).error_message =~ "no longer configured in Mydia"
     end
 
     test "marks downloads from disabled clients as missing" do

--- a/test/mydia_web/live/admin_download_clients_live_test.exs
+++ b/test/mydia_web/live/admin_download_clients_live_test.exs
@@ -110,6 +110,33 @@ defmodule MydiaWeb.AdminDownloadClientsLiveTest do
       end
     end
 
+    test "a second delete click is a no-op rather than a crash", %{conn: conn} do
+      {:ok, client} =
+        Mydia.Settings.create_download_client_config(%{
+          name: "qbit-doubleclick",
+          type: :qbittorrent,
+          host: "localhost",
+          port: 8080,
+          enabled: true
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/clients")
+
+      view |> element("#delete-download-client-#{client.id}") |> render_click()
+      view |> element("#confirm-delete-download-client") |> render_click()
+
+      # The modal is gone and pending_delete_client is nil now. A second
+      # "delete_download_client" event, as a fast double-click would send
+      # before the DOM re-renders, must not reach
+      # Settings.delete_download_client_config/1 with nil and crash the
+      # LiveView process.
+      assert render_click(view, "delete_download_client", %{}) =~ "Download Clients"
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Mydia.Settings.get_download_client_config!(client.id)
+      end
+    end
+
     test "shows a plain zero-reference message when no downloads reference the client", %{
       conn: conn
     } do

--- a/test/mydia_web/live/admin_download_clients_live_test.exs
+++ b/test/mydia_web/live/admin_download_clients_live_test.exs
@@ -87,7 +87,49 @@ defmodule MydiaWeb.AdminDownloadClientsLiveTest do
       |> render_click()
 
       assert has_element?(view, "#delete-download-client-modal")
-      assert render(view) =~ "1 download"
+      assert has_element?(view, "#delete-download-client-modal", "1 download is still waiting")
+    end
+
+    test "the delete warning counts only downloads that are still waiting", %{conn: conn} do
+      # More than one reference, because a count of 1 cannot tell a correct
+      # count from an inflated one. Imported rows are not deleted after import
+      # (`MediaImport` stamps `imported_at` and the row stays as history), so
+      # on a mature instance they dominate any count that includes them, while
+      # deleting the client does nothing whatsoever to them.
+      {:ok, client} =
+        Mydia.Settings.create_download_client_config(%{
+          name: "qbit-mature",
+          type: :qbittorrent,
+          host: "localhost",
+          port: 8080,
+          enabled: true
+        })
+
+      media_item = Mydia.MediaFixtures.media_item_fixture()
+
+      for _ <- 1..2 do
+        Mydia.DownloadsFixtures.download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-mature"
+        })
+      end
+
+      for _ <- 1..3 do
+        Mydia.DownloadsFixtures.download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: "qbit-mature",
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/clients")
+
+      view
+      |> element("#delete-download-client-#{client.id}")
+      |> render_click()
+
+      assert has_element?(view, "#delete-download-client-modal", "2 downloads are still waiting")
+      refute has_element?(view, "#delete-download-client-modal", "5 downloads")
     end
 
     test "deletes the client after the warning is confirmed", %{conn: conn} do
@@ -156,7 +198,12 @@ defmodule MydiaWeb.AdminDownloadClientsLiveTest do
       |> render_click()
 
       assert has_element?(view, "#delete-download-client-modal")
-      assert render(view) =~ "No downloads reference this client."
+
+      assert has_element?(
+               view,
+               "#delete-download-client-modal",
+               "No downloads are waiting on this client."
+             )
     end
 
     test "cancelling the delete warning leaves the client intact", %{conn: conn} do

--- a/test/mydia_web/live/admin_download_clients_live_test.exs
+++ b/test/mydia_web/live/admin_download_clients_live_test.exs
@@ -63,6 +63,96 @@ defmodule MydiaWeb.AdminDownloadClientsLiveTest do
       assert html =~ "Download Clients"
     end
 
+    test "warns about referencing downloads before deleting a client", %{conn: conn} do
+      {:ok, client} =
+        Mydia.Settings.create_download_client_config(%{
+          name: "qbit-doomed",
+          type: :qbittorrent,
+          host: "localhost",
+          port: 8080,
+          enabled: true
+        })
+
+      media_item = Mydia.MediaFixtures.media_item_fixture()
+
+      Mydia.DownloadsFixtures.download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "qbit-doomed"
+      })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/clients")
+
+      view
+      |> element("#delete-download-client-#{client.id}")
+      |> render_click()
+
+      assert has_element?(view, "#delete-download-client-modal")
+      assert render(view) =~ "1 download"
+    end
+
+    test "deletes the client after the warning is confirmed", %{conn: conn} do
+      {:ok, client} =
+        Mydia.Settings.create_download_client_config(%{
+          name: "qbit-doomed-2",
+          type: :qbittorrent,
+          host: "localhost",
+          port: 8080,
+          enabled: true
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/clients")
+
+      view |> element("#delete-download-client-#{client.id}") |> render_click()
+      view |> element("#confirm-delete-download-client") |> render_click()
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Mydia.Settings.get_download_client_config!(client.id)
+      end
+    end
+
+    test "shows a plain zero-reference message when no downloads reference the client", %{
+      conn: conn
+    } do
+      {:ok, client} =
+        Mydia.Settings.create_download_client_config(%{
+          name: "qbit-unused",
+          type: :qbittorrent,
+          host: "localhost",
+          port: 8080,
+          enabled: true
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/clients")
+
+      view
+      |> element("#delete-download-client-#{client.id}")
+      |> render_click()
+
+      assert has_element?(view, "#delete-download-client-modal")
+      assert render(view) =~ "No downloads reference this client."
+    end
+
+    test "cancelling the delete warning leaves the client intact", %{conn: conn} do
+      {:ok, client} =
+        Mydia.Settings.create_download_client_config(%{
+          name: "qbit-keep",
+          type: :qbittorrent,
+          host: "localhost",
+          port: 8080,
+          enabled: true
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/clients")
+
+      view |> element("#delete-download-client-#{client.id}") |> render_click()
+      assert has_element?(view, "#delete-download-client-modal")
+
+      view |> element("#cancel-delete-download-client") |> render_click()
+
+      refute has_element?(view, "#delete-download-client-modal")
+      assert Mydia.Settings.get_download_client_config!(client.id)
+    end
+
     test "creates a new download client", %{view: view} do
       view
       |> element(~s{button[phx-click="new_download_client"]})

--- a/test/mydia_web/live/downloads_live/removed_client_banner_test.exs
+++ b/test/mydia_web/live/downloads_live/removed_client_banner_test.exs
@@ -1,0 +1,71 @@
+defmodule MydiaWeb.DownloadsLive.RemovedClientBannerTest do
+  @moduledoc """
+  The Issues tab groups orphaned downloads by the client they reference and
+  offers one bulk clear per group.
+  """
+  # Not async: a connected LiveView mount runs in a separate process from the
+  # test. Under PostgreSQL with async: true the sandbox is non-shared, so that
+  # process can't see the rows this test inserts. See index_test.exs.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.DownloadsFixtures
+  import Mydia.AccountsFixtures
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin), admin: admin}
+  end
+
+  defp orphan(media_item, client) do
+    download_fixture(%{
+      media_item_id: media_item.id,
+      download_client: client,
+      error_message: "Download client '#{client}' is no longer configured in Mydia.",
+      import_failure_reason: "no_client"
+    })
+  end
+
+  test "renders one banner per removed client", %{conn: conn} do
+    media_item = media_item_fixture()
+    orphan(media_item, "qbit-old")
+    orphan(media_item, "qbit-old")
+    orphan(media_item, "sab-old")
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    assert has_element?(view, "#removed-client-qbit-old")
+    assert has_element?(view, "#removed-client-sab-old")
+  end
+
+  test "clears only the selected client's orphans", %{conn: conn} do
+    media_item = media_item_fixture()
+    doomed = orphan(media_item, "qbit-old")
+    survivor = orphan(media_item, "sab-old")
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view
+    |> element("#clear-removed-client-qbit-old")
+    |> render_click()
+
+    assert_raise Ecto.NoResultsError, fn -> Mydia.Downloads.get_download!(doomed.id) end
+    assert Mydia.Downloads.get_download!(survivor.id)
+
+    refute has_element?(view, "#removed-client-qbit-old")
+    assert has_element?(view, "#removed-client-sab-old")
+  end
+
+  test "shows no banner when there are no orphans", %{conn: conn} do
+    media_item = media_item_fixture()
+    download_fixture(%{media_item_id: media_item.id, download_client: "qbit"})
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    refute has_element?(view, "[id^='removed-client-']")
+  end
+end

--- a/test/mydia_web/live/downloads_live/removed_client_banner_test.exs
+++ b/test/mydia_web/live/downloads_live/removed_client_banner_test.exs
@@ -27,6 +27,35 @@ defmodule MydiaWeb.DownloadsLive.RemovedClientBannerTest do
     })
   end
 
+  test "gives colliding client names distinct DOM ids", %{conn: conn} do
+    # Client names come from operator-supplied config, so two distinct names
+    # can slugify to the same string. Duplicate ids are invalid HTML and make
+    # LiveView's id-keyed patching update the wrong banner.
+    #
+    # Which name keeps the bare slug depends on collation ("Qbit Old" vs
+    # "qbit-old" sort differently under SQLite's BINARY collation than under a
+    # locale-aware PostgreSQL one), so this asserts only that the two ids are
+    # distinct, which is the property that matters.
+    media_item = media_item_fixture()
+    orphan(media_item, "Qbit Old")
+    orphan(media_item, "qbit-old")
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    assert has_element?(view, "#removed-client-qbit-old")
+    assert has_element?(view, "#removed-client-qbit-old-2")
+
+    # Clearing via the suffixed id removes exactly one client: the raw name
+    # rides on phx-value-client, so disambiguating the id cannot misroute the
+    # delete to its colliding sibling.
+    view |> element("#clear-removed-client-qbit-old-2") |> render_click()
+
+    assert has_element?(view, "#removed-client-qbit-old")
+    refute has_element?(view, "#removed-client-qbit-old-2")
+    assert [%{count: 1}] = Mydia.Downloads.removed_client_groups()
+  end
+
   test "renders one banner per removed client, counting its own orphans", %{conn: conn} do
     media_item = media_item_fixture()
     orphan(media_item, "qbit-old")

--- a/test/mydia_web/live/downloads_live/removed_client_banner_test.exs
+++ b/test/mydia_web/live/downloads_live/removed_client_banner_test.exs
@@ -27,7 +27,7 @@ defmodule MydiaWeb.DownloadsLive.RemovedClientBannerTest do
     })
   end
 
-  test "renders one banner per removed client", %{conn: conn} do
+  test "renders one banner per removed client, counting its own orphans", %{conn: conn} do
     media_item = media_item_fixture()
     orphan(media_item, "qbit-old")
     orphan(media_item, "qbit-old")
@@ -38,6 +38,32 @@ defmodule MydiaWeb.DownloadsLive.RemovedClientBannerTest do
 
     assert has_element?(view, "#removed-client-qbit-old")
     assert has_element?(view, "#removed-client-sab-old")
+
+    # Each banner reports its own group's size, not the total.
+    assert has_element?(view, "#removed-client-qbit-old", "2 download(s)")
+    assert has_element?(view, "#removed-client-sab-old", "1 download(s)")
+  end
+
+  test "does not call a merely disabled client removed", %{conn: conn} do
+    # A disabled client is still sitting in the settings list, switched off.
+    # The per-row error message says so; the banner must not contradict it by
+    # telling the operator the client was removed, which would steer them
+    # toward deleting records whose fix is to flip the client back on.
+    media_item = media_item_fixture()
+
+    download_fixture(%{
+      media_item_id: media_item.id,
+      download_client: "paused",
+      error_message:
+        "Download client 'paused' is disabled in Mydia, so its downloads are no longer tracked.",
+      import_failure_reason: "no_client"
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    assert has_element?(view, "#removed-client-paused")
+    refute has_element?(view, "#removed-client-paused", "removed client")
   end
 
   test "clears only the selected client's orphans", %{conn: conn} do


### PR DESCRIPTION
## Problem

`downloads.download_client` is a plain string holding a client *name*. There is no foreign key and no constraint, so removing a client leaves every download that references it pointing at a name that no longer resolves.

Three paths get there, and the code could not tell them apart:

- **UI delete** was a bare `Repo.delete` with no reference check, no warning, no cleanup.
- **Env var removal** runs no code at all; the client just stops appearing at next boot.
- **Renaming** is indistinguishable from deleting, because matching is by name.

`enrich_download_with_status/2` collapsed "the client answered and does not have this torrent" together with "the client is not configured at all", so orphans were told:

> Removed from download client 'X' before import completed. The download may have been manually deleted, or the client may have encountered an error.

That is false. The client did not remove anything; the client does not exist. The operator goes and inspects a qBittorrent that is perfectly healthy, while the real torrent keeps running in a client Mydia can no longer see or stop.

## What this does

**Re-adopts what it can.** `DownloadMonitor` already fetches every configured client's full torrent list on each poll, so the data needed to re-adopt is in memory at no extra cost. When exactly one reachable torrent-type client reports an orphan's `download_client_id`, the download is re-pointed at that client. Renames and delete-then-re-add heal automatically, with no operator action.

The rule is deliberately conservative: **exactly one claimant, torrent clients only** (`:qbittorrent`, `:transmission`, `:rqbit`, `:rtorrent`). Two clients can legitimately hold the same info hash, and since 96d75b0 scoped every client to its own files, adopting onto the wrong one means importing from the wrong `save_path`. Usenet `nzo_id`s are client-local and recycled; debrid ids are provider-scoped. A cross-client match on either is coincidence, not identity.

**Tells the truth about the rest.** Removed, disabled, and "your client dropped this torrent" are now three distinct states with three distinct messages. A disabled client says it is disabled and to re-enable it, rather than claiming it is gone.

**Gives the operator cleanup surfaces.** A grouped bulk-clear banner in the Issues tab (one per client, scoped delete), and a reference-count confirm modal replacing the blind `data-confirm` in the admin delete flow.

**No migration, no schema change.** Both new fields live on the in-memory `EnrichedDownload` view model.

## Notable behaviors

- Re-adding a client that holds the same torrents restores parked rows on the next poll. So does re-enabling a disabled one.
- Rows marked by the currently released code are healed and tagged on upgrade, so existing installs get the banner rather than only new orphans.
- Orphans are never blacklisted. The release was fine; the client left.
- The read path (`list_downloads_with_status/1`, called on every LiveView render) stays pure. `DownloadMonitor` is the only writer.

## Review findings caught and fixed

Per-task and whole-branch reviews found five real problems, two of which were user-facing bugs:

1. **Critical.** Orphaning was modelled as one-way, so a client returning under its own name left a stale tag. The Issues banner then offered to bulk-delete *live, actively downloading* rows, labelled as belonging to a "removed" client. Fixed by making "the client came back" heal symmetrically with "another client adopted it".
2. **Important.** Deleting your *only* download client (the common self-hosted case) short-circuited classification, so those operators still got the old blaming copy and an ungroupable row.
3. **Important.** The delete-confirm count included imported history, which persists after import, so a mature instance showed an inflated number attached to copy that was false for most of it.
4. **Important.** A double-click on the new confirm modal crashed the LiveView. The old `data-confirm` dialog had implicitly debounced this; the modal did not.
5. **Important.** Legacy pre-upgrade orphans were never tagged, so upgrade-day operators saw no banner.

## Testing

- Full suite: **5580 tests, 0 failures**, 34 skipped
- PostgreSQL cross-adapter pass: **958 + 112 tests, 0 failures**
- `./dev mix precommit` (7 steps including `credo --strict`): passed
- New coverage includes a Bypass-backed end-to-end adoption test (detection, persistence, selective error-state clearing, and return to `Download.occupying/1`), plus a regression guard for the original "client dropped it" message, which had no test before this branch.

## Known residuals

- If a client returns but no longer holds the torrent, the row keeps its stale orphan message. Clearing it there would re-arm the `missing` filter and replay a `download_failed` event, so it was deliberately left. The row is genuinely dead and clearing it is still the right action.
- Two client names that slugify identically produce duplicate DOM ids on the banner. Display-only: `phx-value-client` carries the raw name, so deletion targeting is unaffected.
