### PR TITLE
fix(player/cast): mount the cast bar with an Overlay and a Navigator

### DIFF
--- a/player/lib/app.dart
+++ b/player/lib/app.dart
@@ -164,20 +164,10 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
       debugShowCheckedModeBanner: false,
       theme: AppTheme.darkTheme,
       routerConfig: router,
-      builder: (context, child) {
-        // Add cast mini controller overlay to all screens
-        return Stack(
-          children: [
-            if (child != null) child,
-            const Positioned(
-              left: 0,
-              right: 0,
-              bottom: 0,
-              child: CastMiniController(),
-            ),
-          ],
-        );
-      },
+      // Float the cast mini controller above every route. `CastBarLayer`
+      // documents what mounting it out here costs the bar.
+      builder: (context, child) =>
+          CastBarLayer(child: child ?? const SizedBox.shrink()),
     );
   }
 }

--- a/player/lib/core/router/app_router.dart
+++ b/player/lib/core/router/app_router.dart
@@ -25,11 +25,11 @@ import '../../domain/models/search_result.dart';
 import '../../presentation/widgets/app_shell.dart';
 import '../auth/auth_status.dart';
 import '../graphql/graphql_provider.dart';
+import 'navigator_keys.dart';
 
 part 'app_router.g.dart';
 
 /// Global key for the navigator used by the app shell
-final _rootNavigatorKey = GlobalKey<NavigatorState>();
 final _shellNavigatorKey = GlobalKey<NavigatorState>();
 
 /// Simple ChangeNotifier to trigger GoRouter refreshes.
@@ -66,7 +66,7 @@ GoRouter appRouter(Ref ref) {
   debugPrint('[AppRouter] Initial location: $initialLocation');
 
   return GoRouter(
-    navigatorKey: _rootNavigatorKey,
+    navigatorKey: rootNavigatorKey,
     initialLocation: initialLocation,
     debugLogDiagnostics: true,
     refreshListenable: refreshNotifier,
@@ -120,7 +120,7 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/login',
         name: 'login',
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (context, state) => const LoginScreen(),
       ),
 
@@ -198,13 +198,13 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/settings/devices',
         name: 'devices',
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (context, state) => const DevicesScreen(),
       ),
       GoRoute(
         path: '/collection/:id',
         name: 'collection_detail',
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return CollectionDetailScreen(id: id);
@@ -213,7 +213,7 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/movie/:id',
         name: 'movie_detail',
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return MovieDetailScreen(id: id);
@@ -222,7 +222,7 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/show/:id',
         name: 'show_detail',
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return ShowDetailScreen(id: id);
@@ -231,7 +231,7 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/episode/:id',
         name: 'episode_detail',
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (context, state) {
           final id = state.pathParameters['id']!;
           return EpisodeDetailScreen(id: id);
@@ -241,7 +241,7 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/player/queue',
         name: 'queue_player',
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (context, state) {
           final itemsParam = state.uri.queryParameters['items'];
 
@@ -279,7 +279,7 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/player/:type/:id',
         name: 'player',
-        parentNavigatorKey: _rootNavigatorKey,
+        parentNavigatorKey: rootNavigatorKey,
         builder: (context, state) {
           final type = state.pathParameters['type']!;
           final id = state.pathParameters['id']!;

--- a/player/lib/core/router/navigator_keys.dart
+++ b/player/lib/core/router/navigator_keys.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/widgets.dart';
+
+/// The router's root navigator.
+///
+/// Lives here rather than in `app_router.dart` so widgets that need to reach
+/// the app's navigation stack do not have to import the whole route table.
+///
+/// The one caller outside the router is the cast bar: `app.dart` mounts it
+/// above the router so it floats over every route, which also puts it outside
+/// this navigator, and a dialog it opens has to land here.
+final rootNavigatorKey = GlobalKey<NavigatorState>();

--- a/player/lib/presentation/widgets/cast_mini_controller.dart
+++ b/player/lib/presentation/widgets/cast_mini_controller.dart
@@ -6,8 +6,47 @@ import '../../core/cast/cast_providers.dart';
 import '../../core/cast/cast_seek.dart';
 import '../../core/cast/cast_target.dart';
 import '../../core/graphql/graphql_provider.dart';
+import '../../core/router/navigator_keys.dart';
 import '../../domain/models/cast_device.dart';
 import 'cast_actions.dart';
+
+/// Mounts [CastMiniController] at the bottom of [child], floating above it.
+///
+/// `app.dart` wraps the router's output in this, which is what puts the bar on
+/// every screen — and also puts it outside the Navigator the router builds,
+/// and therefore outside that Navigator's Overlay. Material widgets in the bar
+/// need one: each IconButton's tooltip asserts "No Overlay widget found" and
+/// is replaced by a 100000px error box, which then overflows the bar's Row. So
+/// the layer carries an Overlay of its own. (Dialogs still need a Navigator,
+/// which no Overlay provides — see [_CastMiniControllerState._confirmStop].)
+///
+/// The layer is full-screen rather than a strip pinned to the bottom so
+/// tooltips have somewhere to lay out; an Overlay only as tall as the bar
+/// clamps them back on top of it.
+class CastBarLayer extends StatelessWidget {
+  const CastBarLayer({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        child,
+        // Neither the Overlay nor the Align hit-tests its own empty space, so
+        // everything outside the bar still reaches `child` below.
+        Positioned.fill(
+          child: Overlay.wrap(
+            child: const Align(
+              alignment: Alignment.bottomCenter,
+              child: CastMiniController(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
 
 /// The sole cast control surface, shown at the bottom of every screen.
 ///
@@ -334,8 +373,15 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
   }
 
   Future<void> _confirmStop() async {
+    // `app.dart` mounts this bar above the router so it floats over every
+    // route, which leaves its own context without a Navigator to push a
+    // dialog onto. Push onto the router's root navigator instead. The
+    // fallback is for widget tests, which pump the bar under a plain
+    // MaterialApp that has a Navigator of its own and no router.
+    final dialogContext = rootNavigatorKey.currentContext ?? context;
+
     final shouldStop = await showDialog<bool>(
-      context: context,
+      context: dialogContext,
       builder: (context) => AlertDialog(
         title: const Text('Stop Casting'),
         content: const Text('Do you want to stop casting and disconnect?'),

--- a/player/test/app_cast_bar_mounting_test.dart
+++ b/player/test/app_cast_bar_mounting_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/app.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/cast/cast_session_manager.dart';
+import 'package:player/core/cast/cast_target.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/domain/models/cast_device.dart';
+
+/// Auth notifier whose state the test drives directly.
+class _FakeAuthNotifier extends AuthStateNotifier {
+  _FakeAuthNotifier(this._initial);
+
+  final AsyncValue<AuthStatus> _initial;
+
+  @override
+  AsyncValue<AuthStatus> build() => _initial;
+}
+
+const _device = CastDevice(
+  id: 'd1',
+  name: 'Cottage Chromecast',
+  protocol: CastProtocolKind.chromecast,
+);
+
+CastSession _playingSession() => const CastSession(
+      device: _device,
+      playbackState: CastPlaybackState.playing,
+      isStale: false,
+      mediaInfo: CastMediaInfo(
+        title: 'Silo - S02E01',
+        duration: Duration(minutes: 44),
+        position: Duration(seconds: 29),
+      ),
+    );
+
+/// `app.dart` mounts the cast bar above the router, so the bar's own subtree
+/// gets whatever `MaterialApp.router`'s `builder` provides — not the
+/// `Navigator`/`Overlay` that lives *inside* the router's child. Widgets in
+/// the bar that need either of those (every `IconButton` has a `tooltip`, and
+/// stopping a cast opens a confirmation dialog) break there while looking
+/// perfectly fine in a test that pumps the bar under a plain `MaterialApp`.
+///
+/// These pump the real `MyApp` so the mounting point itself is under test.
+void main() {
+  Future<ProviderContainer> pumpApp(
+    WidgetTester tester, {
+    CastSession? session,
+  }) async {
+    final container = ProviderContainer(overrides: [
+      castCapabilitiesProvider.overrideWithValue(const CastCapabilities.full()),
+      authStateProvider.overrideWith(() =>
+          _FakeAuthNotifier(const AsyncValue.data(AuthStatus.authenticated))),
+      asyncGraphqlClientProvider
+          .overrideWith((ref) => Completer<GraphQLClient>().future),
+      castSessionProvider.overrideWith((ref) => Stream.value(session)),
+      castSessionManagerProvider
+          .overrideWith((ref) => Completer<CastSessionManager>().future),
+    ]);
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: const MyApp(),
+    ));
+    await tester.pump();
+    return container;
+  }
+
+  testWidgets('the idle bar renders where app.dart mounts it', (tester) async {
+    final container = await pumpApp(tester);
+
+    container.read(castTargetProvider.notifier).set(_device);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull,
+        reason: 'the cast bar must build in its real mounting point, not '
+            'only under a Scaffold in a widget test');
+    expect(find.byKey(const Key('cast-bar-idle-clear')), findsOneWidget);
+  });
+
+  testWidgets('stopping a cast can open its confirmation dialog',
+      (tester) async {
+    await pumpApp(tester, session: _playingSession());
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('cast-bar-stop')));
+    // Not `pumpAndSettle`: the screens behind the bar keep a progress
+    // indicator spinning while their GraphQL client never resolves, so the
+    // frames never stop coming. Pump past the dialog's entrance instead.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Stop Casting'), findsOneWidget,
+        reason: 'the confirm dialog needs a Navigator reachable from the '
+            'cast bar');
+  });
+}

--- a/player/test/presentation/widgets/cast_mini_controller_test.dart
+++ b/player/test/presentation/widgets/cast_mini_controller_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/cast/cast_capabilities.dart';
@@ -144,8 +145,14 @@ Future<ProviderContainer> _pumpWithManager(
   return container;
 }
 
-/// Pumps [CastBarLayer] the way `app.dart` does: over a route, with no
-/// Navigator or Overlay of its own above the bar.
+/// Pumps [CastBarLayer] the way `app.dart` does: through a `MaterialApp.router`
+/// builder, so the bar starts with no Navigator or Overlay above it.
+///
+/// `MaterialApp(home: ...)` would not do — its own Navigator's Overlay sits
+/// above everything under `home`, so `Tooltip` would find one whether or not
+/// the layer supplies its own, and the tooltip test would pass with the fix
+/// reverted. The router's Overlay lives *inside* the builder's child, which is
+/// exactly the position that broke.
 Future<bool Function()> _pumpLayer(
   WidgetTester tester, {
   required CastDevice target,
@@ -162,20 +169,28 @@ Future<bool Function()> _pumpLayer(
   ]);
   addTearDown(container.dispose);
 
-  await tester.pumpWidget(UncontrolledProviderScope(
-    container: container,
-    child: MaterialApp(
-      home: CastBarLayer(
-        child: Scaffold(
-          body: Center(
-            child: ElevatedButton(
-              key: const Key('below-the-bar'),
-              onPressed: () => tappedBelow = true,
-              child: const Text('Underneath'),
-            ),
+  final router = GoRouter(routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => Scaffold(
+        body: Center(
+          child: ElevatedButton(
+            key: const Key('below-the-bar'),
+            onPressed: () => tappedBelow = true,
+            child: const Text('Underneath'),
           ),
         ),
       ),
+    ),
+  ]);
+  addTearDown(router.dispose);
+
+  await tester.pumpWidget(UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (context, child) =>
+          CastBarLayer(child: child ?? const SizedBox.shrink()),
     ),
   ));
   container.read(castTargetProvider.notifier).set(target);

--- a/player/test/presentation/widgets/cast_mini_controller_test.dart
+++ b/player/test/presentation/widgets/cast_mini_controller_test.dart
@@ -144,7 +144,88 @@ Future<ProviderContainer> _pumpWithManager(
   return container;
 }
 
+/// Pumps [CastBarLayer] the way `app.dart` does: over a route, with no
+/// Navigator or Overlay of its own above the bar.
+Future<bool Function()> _pumpLayer(
+  WidgetTester tester, {
+  required CastDevice target,
+}) async {
+  var tappedBelow = false;
+
+  final container = ProviderContainer(overrides: [
+    castCapabilitiesProvider.overrideWithValue(const CastCapabilities.full()),
+    authStateProvider.overrideWith(() =>
+        _FakeAuthNotifier(const AsyncValue.data(AuthStatus.authenticated))),
+    asyncGraphqlClientProvider
+        .overrideWith((ref) => Completer<GraphQLClient>().future),
+    castSessionProvider.overrideWith((ref) => Stream.value(null)),
+  ]);
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      home: CastBarLayer(
+        child: Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              key: const Key('below-the-bar'),
+              onPressed: () => tappedBelow = true,
+              child: const Text('Underneath'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  ));
+  container.read(castTargetProvider.notifier).set(target);
+  await tester.pump();
+
+  return () => tappedBelow;
+}
+
 void main() {
+  group('CastBarLayer', () {
+    testWidgets('gives the bar an Overlay, so its tooltips render',
+        (tester) async {
+      await _pumpLayer(tester, target: _device);
+
+      final clear = find.byKey(const Key('cast-bar-idle-clear'));
+      expect(clear, findsOneWidget);
+
+      await tester.longPress(clear);
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Cancel casting to Cottage Chromecast'), findsOneWidget,
+          reason: 'without an Overlay in the layer the tooltip asserts and '
+              'renders as an error box instead');
+    });
+
+    testWidgets('keeps the bar full-width against the bottom edge',
+        (tester) async {
+      await _pumpLayer(tester, target: _device);
+
+      final bar = tester.getRect(find.byType(CastMiniController));
+      final layer = tester.getRect(find.byType(CastBarLayer));
+
+      expect(bar.width, layer.width);
+      expect(bar.bottom, layer.bottom);
+    });
+
+    testWidgets('does not swallow taps meant for the screen below',
+        (tester) async {
+      final tappedBelow = await _pumpLayer(tester, target: _device);
+
+      await tester.tap(find.byKey(const Key('below-the-bar')));
+      await tester.pump();
+
+      expect(tappedBelow(), isTrue,
+          reason: 'the bar is a full-screen layer; only the bar itself may '
+              'take pointer events');
+    });
+  });
+
   testWidgets('shows title and device while casting', (tester) async {
     await _pump(tester,
         session: _session(duration: const Duration(minutes: 44)));


### PR DESCRIPTION
## Summary

Picking a cast target broke whatever screen you were on: the bar rendered as a red error strip, because every one of its icon buttons carries a tooltip and `RawTooltip` asserted `No Overlay widget found`. The failed tooltip is replaced by an `ErrorWidget`, whose render box sizes itself to 100000px — that is the `RenderFlex overflowed by 99140 pixels` that follows it, not a separate layout bug. Stopping a live cast was broken the same way but quietly: the confirmation dialog threw `Navigator operation requested with a context that does not include a Navigator` and never opened.

Both come from where the bar is mounted. `MaterialApp.router`'s `builder` wraps the router's output, so the bar is a sibling of the router's child and sits outside the `Navigator` — and the `Overlay` — that live *inside* it. The bar now mounts through `CastBarLayer`, which carries an Overlay of its own; that layer is full-screen rather than a strip pinned to the bottom, because an Overlay only as tall as the bar clamps tooltips back on top of it. The stop dialog pushes onto the router's root navigator, which moved to `core/router/navigator_keys.dart` so a widget can reach it without importing the whole route table.

## Validation

`flutter test`: 921 passing. The new `test/app_cast_bar_mounting_test.dart` pumps the real `MyApp` — mounting *is* the bug, and a test that pumps the bar under a plain `MaterialApp` is handed a Navigator and Overlay for free, which is why the existing suite stayed green through this. It reproduced both failures (same assertion, same 99k overflow) before the fix. Layer-level tests cover the tooltip rendering, taps passing through the full-screen layer to the screen below, and the bar staying full-width against the bottom edge. Not yet exercised in a running macOS build.

## New concepts

### `MaterialApp.builder` is outside the router's Navigator

`builder` wraps the Router *widget*, and the Navigator (with the Overlay it owns) is built by the router underneath it. Anything mounted there is therefore a sibling of the whole navigation stack, not an ancestor of it:

```mermaid
flowchart TB
  MA[MaterialApp.router] --> B[builder / CastBarLayer]
  B --> R[Router child]
  B --> Bar[CastMiniController]
  R --> N[Navigator] --> O[Overlay] --> Routes[route pages]
```

That position is exactly what makes it float over every route, including ones pushed on the root navigator — which is why the cast bar is there rather than in the app shell. The cost is that `Overlay.of` and `Navigator.of` fail from it, and the failures surface far from the mounting code: as a tooltip assertion, or a dialog that never opens. `Overlay.wrap` buys back the Overlay locally; a Navigator cannot be faked the same way (a nested one puts a `ModalBarrier` over the app and eats every tap), so dialogs go to the root navigator by key.

Worth remembering for anything else that gets mounted globally this way — snackbars are fine, since `MaterialApp` puts `ScaffoldMessenger` *above* `builder`.
