### PR TITLE
fix(admin): stop /admin/config 500 when a streaming user has no username

### DIFF
--- a/lib/mydia_web/live/admin_system_live/components.ex
+++ b/lib/mydia_web/live/admin_system_live/components.ex
@@ -254,7 +254,7 @@ defmodule MydiaWeb.AdminSystemLive.Components do
         <div class="avatar placeholder">
           <div class="bg-neutral text-neutral-content rounded-full w-10">
             <span class="text-sm uppercase">
-              {String.slice(@session.user.username, 0, 2)}
+              {String.slice(user_label(@session.user), 0, 2)}
             </span>
           </div>
         </div>
@@ -291,7 +291,7 @@ defmodule MydiaWeb.AdminSystemLive.Components do
             <%= if @job.user_id && @job.user do %>
               <div class="text-xs opacity-60 flex items-center gap-1">
                 <.icon name="hero-user" class="w-3 h-3" />
-                {@job.user.username}
+                {user_label(@job.user)}
               </div>
             <% end %>
           </div>
@@ -435,7 +435,7 @@ defmodule MydiaWeb.AdminSystemLive.Components do
       assigns
       |> assign(:poster_path, poster_path)
       |> assign(:title, title)
-      |> assign(:username, (user && user.username) || "Unknown")
+      |> assign(:username, user_label(user))
       |> assign(:avatar_url, user && user.avatar_url)
 
     ~H"""
@@ -495,6 +495,13 @@ defmodule MydiaWeb.AdminSystemLive.Components do
   # ============================================================================
   # Helper Functions
   # ============================================================================
+
+  # Users created through OIDC have no username (see `Mydia.Accounts.User.role_changeset/2`),
+  # so fall back to the email before giving up entirely.
+  defp user_label(nil), do: "Unknown"
+  defp user_label(%{username: username}) when is_binary(username) and username != "", do: username
+  defp user_label(%{email: email}) when is_binary(email) and email != "", do: email
+  defp user_label(_), do: "Unknown"
 
   # Helper for image URLs
   defp build_image_url(nil), do: nil

--- a/test/mydia_web/live/admin_system_live_test.exs
+++ b/test/mydia_web/live/admin_system_live_test.exs
@@ -167,4 +167,103 @@ defmodule MydiaWeb.AdminSystemLiveTest do
       assert html =~ ~s{href="/admin/config/media-servers"}
     end
   end
+
+  describe "Activity panel with usernameless users" do
+    # OIDC-created users have a nil username (see User.role_changeset/2), so every
+    # activity card must fall back rather than assume a binary is present.
+    defp status_tab_assigns(overrides) do
+      Map.merge(
+        %{
+          system_info: %{
+            app_version: "1.2.3",
+            dev_mode: false,
+            elixir_version: "1.19.5",
+            memory_used: "128.0 MB",
+            uptime: "1h 2m"
+          },
+          database_info: %{
+            adapter: :sqlite,
+            path: "/config/mydia.db",
+            size: "4.0 MB",
+            exists: true,
+            health: :healthy
+          },
+          library_paths_count: 0,
+          download_clients_count: 0,
+          indexers_count: 0,
+          active_sessions: [],
+          active_jobs: [],
+          recent_activity: []
+        },
+        overrides
+      )
+    end
+
+    test "renders an active streaming session for an OIDC user with no username" do
+      oidc_user = %Mydia.Accounts.User{
+        id: Ecto.UUID.generate(),
+        username: nil,
+        email: "oidc@example.com",
+        role: "admin"
+      }
+
+      session = %Mydia.Streaming.ActiveSession{
+        session_id: "sess-1",
+        user: oidc_user,
+        media_title: "Some Movie",
+        media_type: :movie,
+        episode_info: nil,
+        mode: :direct,
+        started_at: DateTime.utc_now(),
+        ready: true
+      }
+
+      html =
+        render_component(
+          &MydiaWeb.AdminSystemLive.Components.status_tab/1,
+          status_tab_assigns(%{active_sessions: [session]})
+        )
+
+      assert html =~ "Some Movie"
+
+      # Avatar initials fall back to the email rather than crashing on nil.
+      assert html =~ ~r{class="avatar placeholder".*?<span[^>]*>\s*oi\s*</span>}s
+    end
+
+    test "renders an active transcode job for an OIDC user with no username" do
+      oidc_user = %Mydia.Accounts.User{
+        id: Ecto.UUID.generate(),
+        username: nil,
+        email: "oidc@example.com",
+        role: "admin"
+      }
+
+      job = %{
+        id: Ecto.UUID.generate(),
+        type: "stream",
+        status: "transcoding",
+        progress: 0.42,
+        error: nil,
+        resolution: "1080p",
+        file_size: nil,
+        started_at: DateTime.utc_now(),
+        user_id: oidc_user.id,
+        user: oidc_user,
+        media_file: %{
+          episode: nil,
+          media_item: %{title: "Some Movie"},
+          relative_path: "Movies/some-movie.mkv",
+          path: nil
+        }
+      }
+
+      html =
+        render_component(
+          &MydiaWeb.AdminSystemLive.Components.status_tab/1,
+          status_tab_assigns(%{active_jobs: [job]})
+        )
+
+      assert html =~ "oidc@example.com"
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`/admin/config` returns a 500 on the production instance. The crash:

```
** (FunctionClauseError) no function clause matching in String.slice/3
    (elixir 1.19.5) lib/string.ex:2392: String.slice(nil, 0, 2)
    lib/mydia_web/live/admin_system_live/components.ex:257: anonymous fn/2 in ...active_session_card...
    lib/mydia_web/live/admin_system_live/components.ex:192: ...status_tab/1
```

`active_session_card` built the avatar initials with `String.slice(@session.user.username, 0, 2)`, assuming `username` is always a binary. It is not: users created through OIDC have a `nil` username. `Mydia.Accounts.User.role_changeset/2` exists precisely because those users "have a `nil` username and would otherwise fail the local `changeset/2` validations", and the typespec already declares `username: String.t() | nil`.

So the Status tab crashes for as long as any OIDC user has an active streaming session, taking the whole page down with it. On the affected instance, two of three users have a NULL username and four live sessions belong to one of them.

The rest of the app already guards this. `layouts.ex:375` uses `username || email || "U"` and `admin_users_live/index.html.heex:111` uses `username || "?"`. This one component was the outlier.

## Fix

Route every activity card through a single `user_label/1` helper that falls back `username -> email -> "Unknown"`, and use it in the three places that render a user in this module:

- `active_session_card` (the crash)
- `active_job_card`, which rendered a blank name instead of crashing
- `recent_watch_card`, which already had an ad-hoc `|| "Unknown"` guard and now shows the email rather than "Unknown" for OIDC users

## Tests

Added two regression tests that render `status_tab/1` with a session and a job owned by a usernameless user. The session test reproduces the production stack trace exactly before the fix.

## Verification

- `./dev mix test test/mydia_web/live/admin_system_live_test.exs` — 14 tests, 0 failures
- `./dev mix format --check-formatted` — exit 0
- `MIX_ENV=test ./dev mix compile --warnings-as-errors` — exit 0
- `./dev mix credo --strict` — no issues