### PR TITLE
fix(infra): scrape metadata-relay and iroh-relay metrics

### DIFF
--- a/infra/kubernetes/apps/iroh-relay/deployment.yaml
+++ b/infra/kubernetes/apps/iroh-relay/deployment.yaml
@@ -16,6 +16,13 @@ spec:
       labels:
         app.kubernetes.io/name: iroh-relay
         app.kubernetes.io/part-of: mydia
+      annotations:
+        # Picked up by the monitoring stack's `kubernetes-pods` scrape job.
+        # relayserver_* counters are process-local and reset on restart, so
+        # without scraping there is no history of relay usage at all.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       containers:
         - name: iroh-relay

--- a/infra/kubernetes/apps/metadata-relay/deployment.yaml
+++ b/infra/kubernetes/apps/metadata-relay/deployment.yaml
@@ -25,9 +25,20 @@ spec:
         app.kubernetes.io/name: metadata-relay
         app.kubernetes.io/component: relay-service
         app.kubernetes.io/part-of: mydia
+      annotations:
+        # Picked up by the monitoring stack's `kubernetes-pods` scrape job.
+        # Without these the relay's counters are only visible by curling the
+        # pod directly, and they reset to zero on every restart.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "4000"
+        prometheus.io/path: "/metrics"
     spec:
       containers:
         - name: metadata-relay
+          # NOTE: Keel owns this tag at runtime (see keel.sh/* annotations above)
+          # and the live deployment is normally ahead of what is pinned here.
+          # `kubectl apply -k .` will roll production BACK to this tag, so
+          # prefer `kubectl patch` for targeted changes.
           image: ghcr.io/getmydia/mydia/metadata-relay:0.9.0
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
## Why

Neither relay pod carried `prometheus.io/scrape` annotations, so the monitoring stack's `kubernetes-pods` scrape job (`vmagent-config` in ns `monitoring`) skipped both. Confirmed empirically: querying VictoriaMetrics for `relayserver_unique_client_keys_total`, `relayserver_accepts_total` and `relayserver_qad_connections_total` returns `seriesFetched: 0`.

The practical effect is that both relays' counters are process-local and reset on every restart, so there is no history of relay usage at all. Answering "how many clients are running" currently requires curling pods and hand-parsing rotated Traefik logs off the host.

## What

Annotate both pod templates so vmagent scrapes them:
- `metadata-relay` on `4000` `/metrics` (Plug endpoint backed by the ETS counters in `MetadataRelay.Metrics`)
- `iroh-relay` on `9090` `/metrics` (`metrics_addr` already set in its configmap, and the service already exposes the port)

Also added a comment flagging that Keel owns the `metadata-relay` image tag at runtime. The live deployment is on `0.11` while this file pins `0.9.0`, so a full `kubectl apply -k .` would roll production backwards.

## Deploying

This needs a targeted patch rather than `apply -k` (see above). Both deployments use the `Recreate` strategy, so each will briefly restart:

```bash
kubectl patch deploy -n metadata-relay metadata-relay \
  -p '{"spec":{"template":{"metadata":{"annotations":{"prometheus.io/scrape":"true","prometheus.io/port":"4000","prometheus.io/path":"/metrics"}}}}}'

kubectl patch deploy -n iroh-relay iroh-relay \
  -p '{"spec":{"template":{"metadata":{"annotations":{"prometheus.io/scrape":"true","prometheus.io/port":"9090","prometheus.io/path":"/metrics"}}}}}'
```

Verify with a query against VictoriaMetrics for `relayserver_accepts_total` and `metadata_relay_requests_total`.

## Follow-up worth considering

`relayserver_unique_client_keys_total` is not usable as a distinct-node metric. In iroh-relay 1.0.0, `ClientCounter::default()` is constructed per connection actor (`server/client.rs:139`) and never shared, so its `update()` always inserts into an empty set and the counter increments on every accept. It is an exact duplicate of `accepts` (both read 296 on the live relay). Use `accepts - disconnects` for currently-connected nodes instead. This looks like an upstream bug worth reporting to n0-computer.
