### PR TITLE
fix(ci): package the macOS player artifact with ditto

### DIFF
--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -127,6 +127,26 @@ jobs:
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build ${{ matrix.platform_dir }} --release
 
+      # upload-artifact archives a directory path as a plain zip, and its zip
+      # implementation replaces every symlink with a copy of the symlink's
+      # target. That is what broke the macOS artifact (see the packaging step
+      # below). The Linux bundle has no symlinks today: CMake's
+      # install(FILES ...) at player/linux/CMakeLists.txt:111 dereferences them,
+      # and media_kit links the system libmpv rather than bundling a versioned
+      # .so chain. Assert that rather than assume it, so the day a dependency
+      # starts shipping lib/foo.so.1 -> foo.so.1.2 this fails here instead of
+      # producing a silently broken bundle.
+      - name: Assert Linux bundle has no symlinks
+        if: matrix.platform == 'Linux' && steps.check_platform.outputs.enabled == 'true'
+        run: |
+          LINKS=$(find ${{ env.PLAYER_PATH }}/build/linux/x64/release/bundle -type l)
+          if [ -n "$LINKS" ]; then
+            echo "::error::Linux bundle contains symlinks; upload-artifact flattens them into copies. Archive the bundle before uploading."
+            echo "$LINKS"
+            exit 1
+          fi
+          echo "Linux bundle has no symlinks; direct directory upload is safe."
+
       - name: Upload artifact
         if: steps.check_platform.outputs.enabled == 'true'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -201,10 +201,16 @@ jobs:
       - name: Assert Linux bundle has no symlinks
         if: matrix.platform == 'Linux' && steps.check_platform.outputs.enabled == 'true'
         run: |
-          LINKS=$(find ${{ env.PLAYER_PATH }}/build/linux/x64/release/bundle -type l)
-          if [ -n "$LINKS" ]; then
+          BUNDLE="${{ env.PLAYER_PATH }}/build/linux/x64/release/bundle"
+          # Assign first, rather than testing `if [ -n "$(find ...)" ]` directly:
+          # set -e is suppressed inside an if condition, so a find failure on a
+          # missing bundle would read as "no symlinks" and pass. A standalone
+          # assignment keeps the step fail-closed. -print -quit stops at the
+          # first hit; the full list is only worth computing when we fail.
+          FIRST_LINK=$(find "$BUNDLE" -type l -print -quit)
+          if [ -n "$FIRST_LINK" ]; then
             echo "::error::Linux bundle contains symlinks; upload-artifact flattens them into copies. Archive the bundle before uploading."
-            echo "$LINKS"
+            find "$BUNDLE" -type l
             exit 1
           fi
           echo "Linux bundle has no symlinks; direct directory upload is safe."

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -144,6 +144,39 @@ jobs:
         working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
         run: ditto -c -k --keepParent "Mydia Player.app" "mydia-player-macos.zip"
 
+      # Verify the archive we are about to upload, not the build output. The
+      # build was never broken; the packaging was, so a guard on the pre-upload
+      # bundle would pass while still shipping a dead artifact. This defect went
+      # unnoticed for every run that ever produced this artifact, which is why
+      # it fails the job rather than warning.
+      - name: Verify packaged macOS app
+        if: matrix.platform == 'macOS' && steps.check_platform.outputs.enabled == 'true'
+        working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
+        run: |
+          rm -rf verify && mkdir verify
+          ditto -x -k "mydia-player-macos.zip" verify
+
+          APP="verify/Mydia Player.app"
+          if [ ! -d "$APP" ]; then
+            echo "::error::Archive has no 'Mydia Player.app' root; --keepParent was lost."
+            ls -la verify
+            exit 1
+          fi
+
+          LINKS=$(find "$APP" -type l | wc -l | tr -d ' ')
+          if [ "$LINKS" -eq 0 ]; then
+            echo "::error::Packaged bundle has 0 symlinks; framework symlinks were flattened."
+            exit 1
+          fi
+
+          # Authoritative check. A flattened bundle fails here with
+          # "bundle format is ambiguous (could be app or framework)", which is
+          # exactly what issue #275 reported.
+          codesign --verify --verbose=2 "$APP"
+
+          echo "Packaged bundle OK ($LINKS symlinks, signature valid)"
+          rm -rf verify
+
       # upload-artifact archives a directory path as a plain zip, and its zip
       # implementation replaces every symlink with a copy of the symlink's
       # target. That is what broke the macOS artifact (see the packaging step

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -44,7 +44,7 @@ jobs:
             os: macos-latest
             platform_dir: macos
             artifact_name: mydia-player-macos-app
-            artifact_path: player/build/macos/Build/Products/Release/Mydia Player.app
+            artifact_path: player/build/macos/Build/Products/Release/mydia-player-macos.zip
             shell: bash
           - platform: Linux
             os: ubuntu-latest
@@ -126,6 +126,23 @@ jobs:
         if: steps.check_platform.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build ${{ matrix.platform_dir }} --release
+
+      # Do NOT point artifact_path at the .app directory and let upload-artifact
+      # zip it. Its zip implementation replaces every symlink with a full copy of
+      # the target, which flattens all 25 frameworks in the bundle:
+      # Versions/Current stops being a link to Versions/A, and the top-level
+      # Foo.framework/Foo and Foo.framework/Resources aliases become duplicates.
+      # That invalidates the code signature, so codesign reports "bundle format
+      # is ambiguous (could be app or framework)" and Gatekeeper refuses to
+      # launch the app. ditto preserves symlinks, and --keepParent keeps
+      # "Mydia Player.app" as the archive root so the download does not unpack as
+      # a bare Contents/. Same invocation release.yml:626 uses for notarization.
+      # Uploading a single file also means GitHub's own re-zip of the artifact
+      # has no symlinks left to flatten. See issue #275.
+      - name: Package macOS app
+        if: matrix.platform == 'macOS' && steps.check_platform.outputs.enabled == 'true'
+        working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
+        run: ditto -c -k --keepParent "Mydia Player.app" "mydia-player-macos.zip"
 
       # upload-artifact archives a directory path as a plain zip, and its zip
       # implementation replaces every symlink with a copy of the symlink's

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -44,6 +44,8 @@ jobs:
             os: macos-latest
             platform_dir: macos
             artifact_name: mydia-player-macos-app
+            # Must stay the ditto archive, not the .app directory. "Package
+            # macOS app" and "Verify packaged macOS app" below both enforce this.
             artifact_path: player/build/macos/Build/Products/Release/mydia-player-macos.zip
             shell: bash
           - platform: Linux
@@ -153,6 +155,16 @@ jobs:
         if: matrix.platform == 'macOS' && steps.check_platform.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
         run: |
+          # The guards below validate the archive. This asserts the archive is
+          # what actually gets uploaded: without it, repointing artifact_path
+          # back at the .app directory would still leave both guards green while
+          # shipping the flattened bundle that issue #275 is about.
+          EXPECTED="${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release/mydia-player-macos.zip"
+          if [ "${{ matrix.artifact_path }}" != "$EXPECTED" ]; then
+            echo "::error::artifact_path is '${{ matrix.artifact_path }}' but must be '$EXPECTED'. The uploaded artifact is not the verified archive."
+            exit 1
+          fi
+
           rm -rf verify && mkdir verify
           ditto -x -k "mydia-player-macos.zip" verify
 
@@ -180,7 +192,7 @@ jobs:
       # upload-artifact archives a directory path as a plain zip, and its zip
       # implementation replaces every symlink with a copy of the symlink's
       # target. That is what broke the macOS artifact (see the packaging step
-      # below). The Linux bundle has no symlinks today: CMake's
+      # above). The Linux bundle has no symlinks today: CMake's
       # install(FILES ...) at player/linux/CMakeLists.txt:111 dereferences them,
       # and media_kit links the system libmpv rather than bundling a versioned
       # .so chain. Assert that rather than assume it, so the day a dependency

--- a/docs/development/ci-artifacts.md
+++ b/docs/development/ci-artifacts.md
@@ -1,0 +1,80 @@
+# Using CI builds
+
+Every push to `master`, and every pull request touching `player/`, `native/`, or
+`.github/workflows/ci-player.yml`, produces downloadable player builds. They are
+the fastest way to try a change before it reaches a release.
+
+CI builds are not release builds. They are ad-hoc signed and never notarized, so
+Sparkle auto-update does not work on them. If you are testing the updater, use a
+release DMG instead.
+
+Artifacts are kept for 7 days.
+
+## Finding a run
+
+```bash
+gh run list --workflow=ci-player.yml -R getmydia/mydia --limit 10
+```
+
+Take the run ID from the leftmost column of the row you want.
+
+## macOS
+
+```bash
+gh run download <run-id> -R getmydia/mydia -n mydia-player-macos-app
+ditto -x -k mydia-player-macos.zip .
+xattr -cr "Mydia Player.app"
+open "Mydia Player.app"
+```
+
+There are two archives here, which is expected. `gh run download` unwraps
+GitHub's own artifact zip and leaves `mydia-player-macos.zip` on disk. That inner
+archive is the app bundle, packaged with `ditto` so its framework symlinks
+survive the trip. Extract it with `ditto -x -k` or by double clicking it in
+Finder. Both preserve symlinks; some third party unzip tools do not, and a
+bundle whose symlinks have been replaced by copies will not launch.
+
+`xattr -cr` clears the quarantine attribute macOS applies to anything
+downloaded. Without it Gatekeeper refuses to launch the app, because a CI build
+carries an ad-hoc signature rather than a notarized Developer ID one. You only
+need to do this once per download.
+
+## Linux
+
+```bash
+gh run download <run-id> -R getmydia/mydia -n mydia-player-linux-bundle -D mydia-player
+chmod +x mydia-player/mydia-player
+./mydia-player/mydia-player
+```
+
+The artifact contains the contents of the build bundle, so pass `-D` to give it
+a directory of its own. The bundle links against libmpv and GTK 3 rather than
+shipping them, so both must already be installed. On Debian and Ubuntu the GTK
+package is `libgtk-3-0`; the libmpv runtime package is `libmpv2` on Ubuntu 24.04
+and later and `libmpv1` on older releases, so install whichever your release
+provides:
+
+```bash
+sudo apt-get install libgtk-3-0
+sudo apt-get install libmpv2 || sudo apt-get install libmpv1
+```
+
+## Windows
+
+```bash
+gh run download <run-id> -R getmydia/mydia -n mydia-player-windows-release -D mydia-player
+```
+
+Run `mydia-player\mydia-player.exe` from the extracted directory. The build is
+unsigned, so SmartScreen shows a warning; choose "More info" then "Run anyway".
+
+## Android
+
+```bash
+gh run download <run-id> -R getmydia/mydia -n mydia-player-android-apk
+adb install -r app-release.apk
+```
+
+The APK is signed with a debug key, so it will not upgrade over a Play Store or
+release install. Uninstall the release build first if `adb install` reports a
+signature mismatch.

--- a/docs/development/ci-artifacts.md
+++ b/docs/development/ci-artifacts.md
@@ -1,6 +1,6 @@
 # Using CI builds
 
-Every push to `master`, and every pull request, that touches `player/`,
+Every push to `master` or `main`, and every pull request, that touches `player/`,
 `native/`, or `.github/workflows/ci-player.yml` produces downloadable player
 builds. Pushes and pull requests that do not touch those paths do not trigger a
 build, so there is nothing to download for them. These builds are the fastest

--- a/docs/development/ci-artifacts.md
+++ b/docs/development/ci-artifacts.md
@@ -1,8 +1,10 @@
 # Using CI builds
 
-Every push to `master`, and every pull request touching `player/`, `native/`, or
-`.github/workflows/ci-player.yml`, produces downloadable player builds. They are
-the fastest way to try a change before it reaches a release.
+Every push to `master`, and every pull request, that touches `player/`,
+`native/`, or `.github/workflows/ci-player.yml` produces downloadable player
+builds. Pushes and pull requests that do not touch those paths do not trigger a
+build, so there is nothing to download for them. These builds are the fastest
+way to try a change before it reaches a release.
 
 CI builds are not release builds. They are ad-hoc signed and never notarized, so
 Sparkle auto-update does not work on them. If you are testing the updater, use a
@@ -34,10 +36,14 @@ survive the trip. Extract it with `ditto -x -k` or by double clicking it in
 Finder. Both preserve symlinks; some third party unzip tools do not, and a
 bundle whose symlinks have been replaced by copies will not launch.
 
-`xattr -cr` clears the quarantine attribute macOS applies to anything
-downloaded. Without it Gatekeeper refuses to launch the app, because a CI build
-carries an ad-hoc signature rather than a notarized Developer ID one. You only
-need to do this once per download.
+`xattr -cr` clears the quarantine attribute. Quarantine is set by the
+downloading application, not unconditionally by macOS: browsers and other
+LaunchServices-aware clients set it, but `gh run download` does not, so for the
+steps above this command is usually a no-op. Run it anyway; it is harmless when
+there is nothing to clear, and it is what makes the app launch if you instead
+download the artifact through the Actions UI in a browser. Without it,
+Gatekeeper refuses to launch a quarantined app, because a CI build carries an
+ad-hoc signature rather than a notarized Developer ID one.
 
 ## Linux
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - Testing: development/testing.md
       - E2E Testing: development/e2e-testing.md
       - Architecture: development/architecture.md
+      - CI Builds: development/ci-artifacts.md
 
 extra:
   version:


### PR DESCRIPTION
`actions/upload-artifact` zips a directory path by replacing every symlink with a
full copy of its target. That flattens all 25 frameworks inside the macOS player
`.app`, invalidates its code signature, and leaves an artifact Gatekeeper refuses
to launch. It also uploaded 490M instead of the real bundle's 166M.

Package with `ditto -c -k --keepParent` instead, the same invocation
`release.yml:626` already uses for the notarization submission. `--keepParent`
also fixes the secondary defect in the issue: the artifact previously unpacked as
a bare `Contents/` with no `.app` root, so the downloader had to know to recreate
the wrapper directory and name it exactly `Mydia Player.app`.

Because the upload path is now a single file, GitHub's own re-zip of the artifact
has no symlinks left to flatten. The corruption becomes structurally impossible
rather than merely avoided.

## Guards

This defect shipped silently on every run that ever produced the artifact,
because nothing checked. So the fix comes with checks:

- **The macOS archive is round-tripped and verified.** It must have an `.app`
  root, must still contain symlinks, and must pass `codesign --verify`. That last
  one is authoritative: a flattened bundle fails it with the exact
  "bundle format is ambiguous (could be app or framework)" error the issue
  reported. The step verifies the uploaded archive rather than the build output,
  because the build was never broken, the packaging was.
- **The verify step asserts `artifact_path` still points at the archive.**
  Without this, repointing the matrix entry back at the `.app` directory would
  leave both guards green while re-shipping the flattened bundle.
- **The Linux bundle is asserted to contain no symlinks**, which answers the
  issue's "worth checking" item with an observation rather than an inference.
  It has none today because CMake's `install(FILES ...)` dereferences them and
  media_kit links the system libmpv, but that was read from the build rules, not
  measured. Now it is measured on every run.

## Docs

`docs/development/ci-artifacts.md` covers downloading and running a CI build on
all four platforms, including the `xattr -cr` step that remains necessary because
CI builds are ad-hoc signed rather than notarized, and the fact that Sparkle
auto-update does not work on them.

## Scope

Signing and notarizing CI builds was considered and rejected. It would add
minutes to every master build, expose signing secrets to a workflow that also
runs on pull requests, and produce two artifact qualities since fork PRs get no
secrets. This restores a valid, launchable bundle; it does not make CI builds
Gatekeeper-clean.

`release.yml` was never affected. It ships a DMG via `hdiutil`, which preserves
symlinks correctly.

Windows is untouched: NTFS builds produce no symlinks.

## Verification

The macOS runner is the only place `ditto` and `codesign` exist, so this PR's own
`ci-player.yml` run is the first real execution of the new guards. Both ran and
passed:

```
Packaged bundle OK (78 symlinks, signature valid)
verify/Mydia Player.app: valid on disk
Linux bundle has no symlinks; direct directory upload is safe.
```

The artifact from that run was downloaded and inspected: a single 61M
`mydia-player-macos.zip` whose sole root is `Mydia Player.app`, with 78 symlinks
preserved in exactly the shapes the issue reported as flattened. Details in the
comment below.

Not yet done: launching the downloaded app on a Mac. Everything structurally
verifiable has been verified.

Fixes #275
