### PR TITLE
fix(migrations): stop SQLite table rebuilds from destroying foreign key children

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -155,3 +155,10 @@ config :wallaby,
   capabilities: chrome_capabilities,
   # Increase timeout for CI environments which may be slower
   max_wait_time: 10_000
+
+# Migration tests start this repo themselves, one temp database per test, so it
+# is intentionally absent from :ecto_repos and carries no :database here.
+config :mydia, Mydia.MigrationTestRepo,
+  pool_size: 1,
+  foreign_keys: :on,
+  priv: "priv/repo"

--- a/lib/mydia/repo/migrations/helpers.ex
+++ b/lib/mydia/repo/migrations/helpers.ex
@@ -498,6 +498,72 @@ defmodule Mydia.Repo.Migrations.Helpers do
     end
   end
 
+  @doc false
+  # Every table that references `table`, directly or transitively, ordered
+  # deepest first: a table always appears before the table it references.
+  #
+  # Deleting in this order never fires a cascade, because a table's own
+  # children are already empty by the time it is emptied. Restoring in the
+  # reverse order never violates a foreign key, because a row's target is
+  # always back in place before the row is.
+  #
+  # Takes the repo explicitly rather than calling `Ecto.Migration.repo/0` so it
+  # can be exercised without a migration wrapped around it.
+  @spec sqlite_fk_children(module(), atom() | String.t()) :: [String.t()]
+  def sqlite_fk_children(repo, table) do
+    {ordered, _visited} =
+      collect_fk_children(
+        to_string(table),
+        direct_fk_children(repo),
+        [to_string(table)],
+        [],
+        MapSet.new()
+      )
+
+    ordered
+  end
+
+  defp collect_fk_children(table, graph, stack, acc, visited) do
+    graph
+    |> Map.get(table, [])
+    |> Enum.reduce({acc, visited}, fn child, {acc, visited} ->
+      cond do
+        child in stack ->
+          raise Ecto.MigrationError,
+            message:
+              "foreign key cycle detected while rebuilding #{List.last(stack)}: " <>
+                Enum.join(Enum.reverse([child | stack]), " -> ")
+
+        MapSet.member?(visited, child) ->
+          {acc, visited}
+
+        true ->
+          {acc, visited} =
+            collect_fk_children(child, graph, [child | stack], acc, MapSet.put(visited, child))
+
+          {acc ++ [child], visited}
+      end
+    end)
+  end
+
+  # %{parent_table => [child_table]} for the whole database.
+  defp direct_fk_children(repo) do
+    %{rows: tables} =
+      repo.query!(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+      )
+
+    Enum.reduce(tables, %{}, fn [table], graph ->
+      %{rows: foreign_keys} = repo.query!(~s|PRAGMA foreign_key_list("#{table}")|)
+
+      Enum.reduce(foreign_keys, graph, fn [_id, _seq, parent | _rest], graph ->
+        Map.update(graph, parent, [table], fn children ->
+          if table in children, do: children, else: children ++ [table]
+        end)
+      end)
+    end)
+  end
+
   # Map Ecto types to PostgreSQL types
   defp pg_type(:string), do: "VARCHAR"
   defp pg_type(:text), do: "TEXT"

--- a/lib/mydia/repo/migrations/helpers.ex
+++ b/lib/mydia/repo/migrations/helpers.ex
@@ -374,6 +374,12 @@ defmodule Mydia.Repo.Migrations.Helpers do
   end
 
   defp sqlite_recreate_table(table_name, opts) do
+    preserving_fk_children(table_name, fn ->
+      sqlite_recreate_table_body(table_name, opts)
+    end)
+  end
+
+  defp sqlite_recreate_table_body(table_name, opts) do
     columns = opts[:columns] || raise ArgumentError, ":columns option is required for SQLite"
     indexes = opts[:indexes] || []
     primary_key_opt = Keyword.get(opts, :primary_key, false)

--- a/lib/mydia/repo/migrations/helpers.ex
+++ b/lib/mydia/repo/migrations/helpers.ex
@@ -557,9 +557,13 @@ defmodule Mydia.Repo.Migrations.Helpers do
       %{rows: foreign_keys} = repo.query!(~s|PRAGMA foreign_key_list("#{table}")|)
 
       Enum.reduce(foreign_keys, graph, fn [_id, _seq, parent | _rest], graph ->
-        Map.update(graph, parent, [table], fn children ->
-          if table in children, do: children, else: children ++ [table]
-        end)
+        if parent == table do
+          graph
+        else
+          Map.update(graph, parent, [table], fn children ->
+            if table in children, do: children, else: children ++ [table]
+          end)
+        end
       end)
     end)
   end

--- a/lib/mydia/repo/migrations/helpers.ex
+++ b/lib/mydia/repo/migrations/helpers.ex
@@ -37,6 +37,8 @@ defmodule Mydia.Repo.Migrations.Helpers do
 
   import Ecto.Migration
 
+  alias Ecto.Migration.Runner
+
   @doc """
   Returns true if using PostgreSQL adapter.
 
@@ -307,6 +309,10 @@ defmodule Mydia.Repo.Migrations.Helpers do
   For SQLite: Performs full table recreation (rename -> create -> copy -> drop).
   For PostgreSQL: Executes the provided ALTER statements.
 
+  On SQLite this runs through `preserving_fk_children/2` and inherits its
+  constraints: the migration must run inside a transaction and must define
+  explicit `up/0` and `down/0` rather than `change/0`.
+
   ## Options
 
   - `:table` - Table name (atom, required)
@@ -454,6 +460,10 @@ defmodule Mydia.Repo.Migrations.Helpers do
   For SQLite: Recreates the table with the new column definitions.
   For PostgreSQL: Executes ALTER COLUMN statements.
 
+  On SQLite this runs through `preserving_fk_children/2` and inherits its
+  constraints: the migration must run inside a transaction and must define
+  explicit `up/0` and `down/0` rather than `change/0`.
+
   ## Options
 
   - `:table` - Table name (atom, required)
@@ -528,10 +538,45 @@ defmodule Mydia.Repo.Migrations.Helpers do
   On PostgreSQL this simply calls `rebuild_fun`, which never needs to drop the
   parent table.
 
-  ## Constraint
+  ## Constraints
 
-  This calls `Ecto.Migration.flush/0`, which raises when called from a `change/0`
-  migration running backward. Callers must define explicit `up/0` and `down/0`.
+  The migration must run inside a transaction, so it must not set
+  `@disable_ddl_transaction true`.
+
+  The migration must define explicit `up/0` and `down/0` rather than `change/0`.
+  This helper has to flush the migration's queued commands so its own immediate
+  queries see them, and flushing is impossible while a `change/0` body is being
+  replayed backward for a rollback. A `change/0` migration that reaches this
+  helper works when rolled forward and raises with that instruction when rolled
+  back; with explicit `up/0` and `down/0`, both directions work.
+
+  ## What the restore assumes
+
+  Children are restored with `INSERT INTO child SELECT * FROM snapshot`, which
+  assumes three things about the child set:
+
+  - `rebuild_fun` alters no table in it. The snapshots carry the pre-rebuild
+    column layout, so a rebuild that also reshapes a child leaves the restore
+    inserting the wrong number of columns.
+  - No child has a `GENERATED` column. `SELECT *` supplies a value for every
+    column and SQLite rejects an explicit insert into a generated one.
+  - No child has a self-referencing foreign key. `direct_fk_children/1` drops
+    self-edges for every table rather than only for the root, so such a child is
+    emptied and restored as a single unordered batch and its own rows can
+    violate the self-reference on the way back in.
+
+  All three hold in this schema today, and all three fail loudly inside the
+  migration's transaction rather than corrupting data. Only the first is
+  something a future caller can introduce without noticing.
+
+  ## Disk usage
+
+  The snapshots temporarily double every child table on disk, inside the
+  migration's transaction. An operator upgrading a large library from a
+  pre-`20251128014213` install pulls in `media_files` with its blob columns, so a
+  disk-constrained server can hit `SQLITE_FULL`. The transaction rolls back
+  cleanly, but SQLite's error says nothing about free space, so check free disk
+  before concluding the migration itself is broken.
 
   ## Example
 
@@ -572,7 +617,7 @@ defmodule Mydia.Repo.Migrations.Helpers do
     # `execute/1` and the migration DSL queue their commands; `repo().query!`
     # below runs immediately. Flush so anything queued earlier in this migration
     # is applied before the snapshots are taken.
-    flush()
+    flush_migration_commands!()
 
     children = sqlite_fk_children(repo(), table)
 
@@ -586,7 +631,7 @@ defmodule Mydia.Repo.Migrations.Helpers do
 
     # Flush again so the caller's queued rebuild has actually run before the
     # rows go back.
-    flush()
+    flush_migration_commands!()
 
     children
     |> Enum.reverse()
@@ -607,6 +652,46 @@ defmodule Mydia.Repo.Migrations.Helpers do
     end)
 
     result
+  end
+
+  # `Ecto.Migration.flush/0` is a macro, and the rollback guard it expands to
+  # tests `function_exported?(__MODULE__, :down, 0)` with `__MODULE__` resolved
+  # at the *expansion* site. Expanded in this module that is
+  # `Mydia.Repo.Migrations.Helpers`, which exports no `down/0`, so the guard
+  # collapses to `direction() == :down` and fires for every rollback that
+  # reaches here, including migrations that do define an explicit `down/0`.
+  # Flush through the runner directly and re-apply the guard against the
+  # migration module that is actually running.
+  defp flush_migration_commands! do
+    module = running_migration()
+
+    if rolling_back_a_change?(module) do
+      raise Ecto.MigrationError,
+        message:
+          "#{inspect(module)} rebuilds a table through preserving_fk_children/2, which has to " <>
+            "flush the migration's queued commands. Flushing is not supported while a change/0 " <>
+            "migration is replayed backward for a rollback. Replace change/0 with explicit " <>
+            "up/0 and down/0."
+    end
+
+    Runner.flush()
+  end
+
+  defp rolling_back_a_change?(nil), do: false
+
+  defp rolling_back_a_change?(module) do
+    Runner.migrator_direction() == :down and not function_exported?(module, :down, 0)
+  end
+
+  # The migration module currently running, or `nil` when the runner's state
+  # cannot be read. `nil` is only reachable if ecto_sql changes that state's
+  # shape, and it deliberately skips the guard rather than blocking every
+  # rollback the way the mis-expanded `flush/0` did.
+  defp running_migration do
+    case Process.get(:ecto_migration) do
+      %{runner: runner} -> Agent.get(runner, &Map.get(&1, :migration))
+      _ -> nil
+    end
   end
 
   defp fk_snapshot_table(child), do: "__mydia_fk_snap_#{child}"

--- a/lib/mydia/repo/migrations/helpers.ex
+++ b/lib/mydia/repo/migrations/helpers.ex
@@ -548,6 +548,21 @@ defmodule Mydia.Repo.Migrations.Helpers do
   end
 
   defp sqlite_preserving_fk_children(table, rebuild_fun) do
+    # This empties child tables before the rebuild and relies entirely on the
+    # migration's transaction to undo that if anything below fails. Without
+    # it, a failure between the DELETE loop and the restore leaves every
+    # child table permanently empty - worse than the bug this primitive
+    # exists to fix. Ecto wraps migrations in a transaction by default; this
+    # guards against a future `@disable_ddl_transaction true` silently
+    # turning this into a data-loss primitive.
+    unless repo().in_transaction?() do
+      raise Ecto.MigrationError,
+        message:
+          "preserving_fk_children/2 requires the migration to run inside a transaction " <>
+            "(it empties child tables and relies on transaction rollback to undo that on " <>
+            "failure); this migration must not set @disable_ddl_transaction true"
+    end
+
     # `execute/1` and the migration DSL queue their commands; `repo().query!`
     # below runs immediately. Flush so anything queued earlier in this migration
     # is applied before the snapshots are taken.
@@ -573,7 +588,13 @@ defmodule Mydia.Repo.Migrations.Helpers do
       repo().query!(~s|INSERT INTO "#{child}" SELECT * FROM "#{fk_snapshot_table(child)}"|)
     end)
 
-    assert_no_fk_violations!()
+    # Scoped to the tables this rebuild actually touched, not the whole
+    # database: an unscoped `PRAGMA foreign_key_check` would abort (and
+    # roll back) on a pre-existing orphan row anywhere else in the schema,
+    # naming an unrelated table as if this rebuild caused it. Any violation
+    # the restore itself could introduce already raises at the INSERT above,
+    # since foreign keys here are enforced immediately.
+    assert_no_fk_violations!([table | children])
 
     Enum.each(children, fn child ->
       repo().query!(~s|DROP TABLE "#{fk_snapshot_table(child)}"|)
@@ -584,16 +605,22 @@ defmodule Mydia.Repo.Migrations.Helpers do
 
   defp fk_snapshot_table(child), do: "__mydia_fk_snap_#{child}"
 
-  defp assert_no_fk_violations! do
-    case repo().query!("PRAGMA foreign_key_check") do
-      %{rows: []} ->
+  defp assert_no_fk_violations!(tables) do
+    violations =
+      Enum.flat_map(tables, fn table ->
+        %{rows: rows} = repo().query!(~s|PRAGMA foreign_key_check("#{table}")|)
+        rows
+      end)
+
+    case violations do
+      [] ->
         :ok
 
-      %{rows: rows} ->
-        tables = rows |> Enum.map(&List.first/1) |> Enum.uniq() |> Enum.join(", ")
+      rows ->
+        offending = rows |> Enum.map(&List.first/1) |> Enum.uniq() |> Enum.join(", ")
 
         raise Ecto.MigrationError,
-          message: "foreign key violations remain after rebuild, in: #{tables}"
+          message: "foreign key violations remain after rebuild, in: #{offending}"
     end
   end
 

--- a/lib/mydia/repo/migrations/helpers.ex
+++ b/lib/mydia/repo/migrations/helpers.ex
@@ -498,6 +498,105 @@ defmodule Mydia.Repo.Migrations.Helpers do
     end
   end
 
+  @doc """
+  Run a SQLite table rebuild without destroying the table's foreign key children.
+
+  SQLite cannot alter a column's type, nullability, constraints, or foreign key
+  actions, so changing any of those means rebuilding the table: create a
+  replacement, copy the rows, drop the original, rename. Under
+  `PRAGMA foreign_keys=ON`, which is how this application always runs, that
+  `DROP TABLE` performs an implicit `DELETE FROM` and fires the foreign key
+  actions of every table referencing it. Children declared `ON DELETE CASCADE`
+  lose all their rows, children declared `ON DELETE SET NULL` lose the
+  assignment, and children with no action abort the migration outright.
+
+  This wraps such a rebuild so none of that happens. It snapshots every table
+  that references `table_name`, directly or transitively, empties them, runs
+  `rebuild_fun`, then restores them. Emptying first is what lets one code path
+  cover all three foreign key actions: there is nothing left to cascade to, null
+  out, or abort on.
+
+  Everything runs inside the transaction the migrator already opened, so a
+  failure at any point rolls back the rebuild and the snapshots together.
+
+  On PostgreSQL this simply calls `rebuild_fun`, which never needs to drop the
+  parent table.
+
+  ## Constraint
+
+  This calls `Ecto.Migration.flush/0`, which raises when called from a `change/0`
+  migration running backward. Callers must define explicit `up/0` and `down/0`.
+
+  ## Example
+
+      def up do
+        preserving_fk_children(:library_paths, fn ->
+          execute "CREATE TABLE library_paths_new (...)"
+          execute "INSERT INTO library_paths_new SELECT ... FROM library_paths"
+          execute "DROP TABLE library_paths"
+          execute "ALTER TABLE library_paths_new RENAME TO library_paths"
+        end)
+      end
+  """
+  @spec preserving_fk_children(atom() | String.t(), (-> any())) :: any()
+  def preserving_fk_children(table_name, rebuild_fun) when is_function(rebuild_fun, 0) do
+    if postgres?() do
+      rebuild_fun.()
+    else
+      sqlite_preserving_fk_children(to_string(table_name), rebuild_fun)
+    end
+  end
+
+  defp sqlite_preserving_fk_children(table, rebuild_fun) do
+    # `execute/1` and the migration DSL queue their commands; `repo().query!`
+    # below runs immediately. Flush so anything queued earlier in this migration
+    # is applied before the snapshots are taken.
+    flush()
+
+    children = sqlite_fk_children(repo(), table)
+
+    Enum.each(children, fn child ->
+      repo().query!(~s|CREATE TABLE "#{fk_snapshot_table(child)}" AS SELECT * FROM "#{child}"|)
+    end)
+
+    Enum.each(children, fn child -> repo().query!(~s|DELETE FROM "#{child}"|) end)
+
+    result = rebuild_fun.()
+
+    # Flush again so the caller's queued rebuild has actually run before the
+    # rows go back.
+    flush()
+
+    children
+    |> Enum.reverse()
+    |> Enum.each(fn child ->
+      repo().query!(~s|INSERT INTO "#{child}" SELECT * FROM "#{fk_snapshot_table(child)}"|)
+    end)
+
+    assert_no_fk_violations!()
+
+    Enum.each(children, fn child ->
+      repo().query!(~s|DROP TABLE "#{fk_snapshot_table(child)}"|)
+    end)
+
+    result
+  end
+
+  defp fk_snapshot_table(child), do: "__mydia_fk_snap_#{child}"
+
+  defp assert_no_fk_violations! do
+    case repo().query!("PRAGMA foreign_key_check") do
+      %{rows: []} ->
+        :ok
+
+      %{rows: rows} ->
+        tables = rows |> Enum.map(&List.first/1) |> Enum.uniq() |> Enum.join(", ")
+
+        raise Ecto.MigrationError,
+          message: "foreign key violations remain after rebuild, in: #{tables}"
+    end
+  end
+
   @doc false
   # Every table that references `table`, directly or transitively, ordered
   # deepest first: a table always appears before the table it references.

--- a/lib/mydia/repo/migrations/helpers.ex
+++ b/lib/mydia/repo/migrations/helpers.ex
@@ -13,8 +13,16 @@ defmodule Mydia.Repo.Migrations.Helpers do
   - Cannot change column types directly
   - Cannot modify CHECK constraints
 
-  For these operations, SQLite requires table recreation (rename -> create new -> copy -> drop old).
+  For these operations, SQLite requires table recreation: create new -> copy ->
+  drop old -> rename new. The original table is deliberately not renamed first,
+  because SQLite rewrites other tables' foreign key references to follow a
+  rename, which breaks them once the old table is dropped.
   PostgreSQL supports direct ALTER TABLE statements.
+
+  Use `recreate_table/1` rather than hand-rolling that sequence. Dropping a
+  table fires the foreign key actions of every table referencing it, which
+  deletes or nulls their rows; `recreate_table/1` goes through
+  `preserving_fk_children/2`, which prevents that.
 
   ## Usage in Migrations
 
@@ -85,8 +93,8 @@ defmodule Mydia.Repo.Migrations.Helpers do
   ## Note for SQLite
 
   SQLite doesn't support ALTER COLUMN. For complex schema changes on SQLite,
-  use `recreate_table_with_changes/3` instead, which handles the full
-  table recreation workflow.
+  use `recreate_table/1` instead, which handles the full table recreation
+  workflow and preserves the rebuilt table's foreign key children.
   """
   @spec modify_column_null(atom(), atom(), boolean()) :: :ok
   def modify_column_null(table_name, column_name, nullable) do
@@ -114,14 +122,12 @@ defmodule Mydia.Repo.Migrations.Helpers do
             modify :#{column_name}, :string, null: #{nullable}
           end
 
-      2. For complex cases, manually recreate the table:
-         - Rename original table
-         - Create new table with desired schema
-         - Copy data
-         - Drop old table
-         - Recreate indexes
+      2. For complex cases, use `recreate_table/1` from this module, which
+         rebuilds the table and preserves its foreign key children.
 
-      See existing migrations for examples of table recreation pattern.
+      Do not hand-roll the rebuild. Dropping a table fires the foreign key
+      actions of every table referencing it, silently deleting or nulling
+      their rows.
       """
     end
   end
@@ -163,14 +169,12 @@ defmodule Mydia.Repo.Migrations.Helpers do
       raise """
       SQLite does not support ALTER COLUMN TYPE.
 
-      For SQLite compatibility, you must recreate the table:
-      1. Rename original table to #{table_name}_old
-      2. Create new table with updated column type
-      3. Copy data from old table
-      4. Drop old table
-      5. Recreate indexes
+      For SQLite compatibility, use `recreate_table/1` from this module,
+      passing #{table_name}'s full column list with the updated type.
 
-      See existing migrations for examples of this pattern.
+      Do not hand-roll the rebuild. Dropping a table fires the foreign key
+      actions of every table referencing it, silently deleting or nulling
+      their rows; `recreate_table/1` preserves them.
       """
     end
   end
@@ -306,7 +310,10 @@ defmodule Mydia.Repo.Migrations.Helpers do
   @doc """
   Recreate a table with a new schema definition.
 
-  For SQLite: Performs full table recreation (rename -> create -> copy -> drop).
+  For SQLite: Performs full table recreation, in the order create new -> copy ->
+  drop old -> rename new. The original is deliberately not renamed first,
+  because SQLite rewrites other tables' foreign key references to follow a
+  rename, breaking them once the old table is dropped.
   For PostgreSQL: Executes the provided ALTER statements.
 
   On SQLite this runs through `preserving_fk_children/2` and inherits its

--- a/priv/repo/migrations/20251128014213_add_specialized_library_types.exs
+++ b/priv/repo/migrations/20251128014213_add_specialized_library_types.exs
@@ -42,72 +42,80 @@ defmodule Mydia.Repo.Migrations.AddSpecializedLibraryTypes do
 
   # SQLite: Recreate table with new CHECK constraint including music, books, adult
   defp sqlite_recreate_table_up do
-    execute """
-    CREATE TABLE library_paths_new (
-      id TEXT PRIMARY KEY NOT NULL,
-      path TEXT NOT NULL UNIQUE,
-      type TEXT NOT NULL CHECK(type IN ('movies', 'series', 'mixed', 'music', 'books', 'adult')),
-      monitored INTEGER DEFAULT 1 CHECK(monitored IN (0, 1)),
-      scan_interval INTEGER DEFAULT 3600,
-      last_scan_at TEXT,
-      last_scan_status TEXT CHECK(last_scan_status IS NULL OR last_scan_status IN ('success', 'failed', 'in_progress')),
-      last_scan_error TEXT,
-      quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL,
-      updated_by_id TEXT REFERENCES users(id) ON DELETE SET NULL,
-      inserted_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    )
-    """
+    # Dropping library_paths fires media_files.library_path_id ON DELETE CASCADE,
+    # which deletes every media file row. The wrapper snapshots and restores it.
+    preserving_fk_children(:library_paths, fn ->
+      execute """
+      CREATE TABLE library_paths_new (
+        id TEXT PRIMARY KEY NOT NULL,
+        path TEXT NOT NULL UNIQUE,
+        type TEXT NOT NULL CHECK(type IN ('movies', 'series', 'mixed', 'music', 'books', 'adult')),
+        monitored INTEGER DEFAULT 1 CHECK(monitored IN (0, 1)),
+        scan_interval INTEGER DEFAULT 3600,
+        last_scan_at TEXT,
+        last_scan_status TEXT CHECK(last_scan_status IS NULL OR last_scan_status IN ('success', 'failed', 'in_progress')),
+        last_scan_error TEXT,
+        quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL,
+        updated_by_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+        inserted_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+      """
 
-    execute """
-    INSERT INTO library_paths_new
-    SELECT id, path, type, monitored, scan_interval, last_scan_at, last_scan_status,
-           last_scan_error, quality_profile_id, updated_by_id, inserted_at, updated_at
-    FROM library_paths
-    """
+      execute """
+      INSERT INTO library_paths_new
+      SELECT id, path, type, monitored, scan_interval, last_scan_at, last_scan_status,
+             last_scan_error, quality_profile_id, updated_by_id, inserted_at, updated_at
+      FROM library_paths
+      """
 
-    execute "DROP TABLE library_paths"
-    execute "ALTER TABLE library_paths_new RENAME TO library_paths"
+      execute "DROP TABLE library_paths"
+      execute "ALTER TABLE library_paths_new RENAME TO library_paths"
 
-    # Recreate indexes
-    execute "CREATE INDEX library_paths_monitored_index ON library_paths (monitored)"
-    execute "CREATE INDEX library_paths_type_index ON library_paths (type)"
+      # Recreate indexes
+      execute "CREATE INDEX library_paths_monitored_index ON library_paths (monitored)"
+      execute "CREATE INDEX library_paths_type_index ON library_paths (type)"
 
-    execute "CREATE INDEX library_paths_quality_profile_id_index ON library_paths (quality_profile_id)"
+      execute "CREATE INDEX library_paths_quality_profile_id_index ON library_paths (quality_profile_id)"
+    end)
   end
 
   # SQLite: Recreate table with old CHECK constraint (movies, series, mixed only)
   defp sqlite_recreate_table_down do
-    execute """
-    CREATE TABLE library_paths_new (
-      id TEXT PRIMARY KEY NOT NULL,
-      path TEXT NOT NULL UNIQUE,
-      type TEXT NOT NULL CHECK(type IN ('movies', 'series', 'mixed')),
-      monitored INTEGER DEFAULT 1 CHECK(monitored IN (0, 1)),
-      scan_interval INTEGER DEFAULT 3600,
-      last_scan_at TEXT,
-      last_scan_status TEXT CHECK(last_scan_status IS NULL OR last_scan_status IN ('success', 'failed', 'in_progress')),
-      last_scan_error TEXT,
-      quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL,
-      updated_by_id TEXT REFERENCES users(id) ON DELETE SET NULL,
-      inserted_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    )
-    """
+    # Dropping library_paths fires media_files.library_path_id ON DELETE CASCADE,
+    # which deletes every media file row. The wrapper snapshots and restores it.
+    preserving_fk_children(:library_paths, fn ->
+      execute """
+      CREATE TABLE library_paths_new (
+        id TEXT PRIMARY KEY NOT NULL,
+        path TEXT NOT NULL UNIQUE,
+        type TEXT NOT NULL CHECK(type IN ('movies', 'series', 'mixed')),
+        monitored INTEGER DEFAULT 1 CHECK(monitored IN (0, 1)),
+        scan_interval INTEGER DEFAULT 3600,
+        last_scan_at TEXT,
+        last_scan_status TEXT CHECK(last_scan_status IS NULL OR last_scan_status IN ('success', 'failed', 'in_progress')),
+        last_scan_error TEXT,
+        quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL,
+        updated_by_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+        inserted_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+      """
 
-    execute """
-    INSERT INTO library_paths_new
-    SELECT id, path, type, monitored, scan_interval, last_scan_at, last_scan_status,
-           last_scan_error, quality_profile_id, updated_by_id, inserted_at, updated_at
-    FROM library_paths
-    """
+      execute """
+      INSERT INTO library_paths_new
+      SELECT id, path, type, monitored, scan_interval, last_scan_at, last_scan_status,
+             last_scan_error, quality_profile_id, updated_by_id, inserted_at, updated_at
+      FROM library_paths
+      """
 
-    execute "DROP TABLE library_paths"
-    execute "ALTER TABLE library_paths_new RENAME TO library_paths"
+      execute "DROP TABLE library_paths"
+      execute "ALTER TABLE library_paths_new RENAME TO library_paths"
 
-    execute "CREATE INDEX library_paths_monitored_index ON library_paths (monitored)"
-    execute "CREATE INDEX library_paths_type_index ON library_paths (type)"
+      execute "CREATE INDEX library_paths_monitored_index ON library_paths (monitored)"
+      execute "CREATE INDEX library_paths_type_index ON library_paths (type)"
 
-    execute "CREATE INDEX library_paths_quality_profile_id_index ON library_paths (quality_profile_id)"
+      execute "CREATE INDEX library_paths_quality_profile_id_index ON library_paths (quality_profile_id)"
+    end)
   end
 end

--- a/priv/repo/migrations/20260322000000_fix_episode_cascade_deletes.exs
+++ b/priv/repo/migrations/20260322000000_fix_episode_cascade_deletes.exs
@@ -105,6 +105,12 @@ defmodule Mydia.Repo.Migrations.FixEpisodeCascadeDeletes do
     [:last_watched_at]
   ]
 
+  @doc false
+  def __media_files_columns__, do: @media_files_columns
+
+  @doc false
+  def __media_files_indexes__, do: @media_files_indexes
+
   def up do
     fix_table_up(:media_files, @media_files_columns, @media_files_indexes, :nilify_all)
     fix_table_up(:downloads, @downloads_columns, @downloads_indexes, :nilify_all)

--- a/priv/repo/migrations/20260628000000_unify_quality_profiles.exs
+++ b/priv/repo/migrations/20260628000000_unify_quality_profiles.exs
@@ -18,9 +18,11 @@ defmodule Mydia.Repo.Migrations.UnifyQualityProfiles do
   # --- Backfill ---
 
   defp backfill_preferred_resolutions do
-    # A replayed migration (schema_migrations reset, or a database restored from
-    # a point after `qualities` was already dropped) has nothing left to
-    # backfill from, and selecting a missing column would abort the migration.
+    # A migration replayed after a schema_migrations reset finds `qualities`
+    # already dropped, with nothing left to backfill from, and selecting a
+    # missing column would abort it. The guard is SQLite-only: on PostgreSQL it
+    # always falls through, so a Postgres replay still aborts exactly as it did
+    # before, which keeps the Postgres path byte-identical.
     if postgres?() or sqlite_column?("quality_profiles", "qualities") do
       %{rows: rows} =
         repo().query!("SELECT id, qualities, quality_standards FROM quality_profiles")

--- a/priv/repo/migrations/20260628000000_unify_quality_profiles.exs
+++ b/priv/repo/migrations/20260628000000_unify_quality_profiles.exs
@@ -18,20 +18,39 @@ defmodule Mydia.Repo.Migrations.UnifyQualityProfiles do
   # --- Backfill ---
 
   defp backfill_preferred_resolutions do
-    %{rows: rows} =
-      repo().query!("SELECT id, qualities, quality_standards FROM quality_profiles")
+    # A replayed migration (schema_migrations reset, or a database restored from
+    # a point after `qualities` was already dropped) has nothing left to
+    # backfill from, and selecting a missing column would abort the migration.
+    if column_exists?("quality_profiles", "qualities") do
+      %{rows: rows} =
+        repo().query!("SELECT id, qualities, quality_standards FROM quality_profiles")
 
-    Enum.each(rows, fn [id, qualities_raw, standards_raw] ->
-      qualities = decode_list(qualities_raw)
-      standards = decode_map(standards_raw)
-      new_standards = QualityProfileBackfill.backfilled_standards(qualities, standards)
+      Enum.each(rows, fn [id, qualities_raw, standards_raw] ->
+        qualities = decode_list(qualities_raw)
+        standards = decode_map(standards_raw)
+        new_standards = QualityProfileBackfill.backfilled_standards(qualities, standards)
 
-      if new_standards != standards do
-        encoded = Jason.encode!(new_standards)
-        {sql, params} = update_sql(encoded, id)
-        repo().query!(sql, params)
-      end
-    end)
+        if new_standards != standards do
+          encoded = Jason.encode!(new_standards)
+          {sql, params} = update_sql(encoded, id)
+          repo().query!(sql, params)
+        end
+      end)
+    end
+  end
+
+  defp column_exists?(table, column) do
+    if postgres?() do
+      %{rows: rows} =
+        repo().query!(
+          "SELECT 1 FROM information_schema.columns WHERE table_name = $1 AND column_name = $2",
+          [table, column]
+        )
+
+      rows != []
+    else
+      sqlite_column?(table, column)
+    end
   end
 
   defp update_sql(encoded, id) do
@@ -70,34 +89,32 @@ defmodule Mydia.Repo.Migrations.UnifyQualityProfiles do
 
   # --- Drop columns (adapter-aware) ---
 
+  @dead_columns ~w(qualities metadata_preferences customizations)
+
   defp drop_dead_columns do
     if postgres?() do
-      execute("ALTER TABLE quality_profiles DROP COLUMN IF EXISTS qualities")
-      execute("ALTER TABLE quality_profiles DROP COLUMN IF EXISTS metadata_preferences")
-      execute("ALTER TABLE quality_profiles DROP COLUMN IF EXISTS customizations")
+      for column <- @dead_columns do
+        execute("ALTER TABLE quality_profiles DROP COLUMN IF EXISTS #{column}")
+      end
     else
-      # SQLite: rebuild the table without the three dropped columns.
-      recreate_table(
-        table: :quality_profiles,
-        primary_key: false,
-        columns: [
-          {:id, :binary_id, [primary_key: true]},
-          {:name, :string, [null: false]},
-          {:upgrades_allowed, :boolean, [default: true]},
-          {:upgrade_until_quality, :string, []},
-          {:description, :text, []},
-          {:is_system, :boolean, [default: false]},
-          {:version, :integer, [default: 1]},
-          {:source_url, :string, []},
-          {:last_synced_at, :utc_datetime, []},
-          {:quality_standards, :text, []}
-        ],
-        indexes: [
-          {[:name], [unique: true]},
-          [:is_system],
-          [:version]
-        ]
-      )
+      # Rebuilding the table here would drop it, and under PRAGMA foreign_keys=ON
+      # that fires the foreign key actions of media_files, media_items,
+      # library_paths, and import_lists: an abort from the first and silently
+      # erased assignments from the other three. Dropping the columns in place
+      # touches no foreign key at all.
+      #
+      # SQLite has had ALTER TABLE ... DROP COLUMN since 3.35 and exqlite bundles
+      # 3.53. None of these columns is indexed or constrained, which is what
+      # SQLite requires for a direct drop. There is no IF EXISTS form, so the
+      # presence check makes a replay safe.
+      for column <- @dead_columns, sqlite_column?("quality_profiles", column) do
+        execute(~s|ALTER TABLE quality_profiles DROP COLUMN "#{column}"|)
+      end
     end
+  end
+
+  defp sqlite_column?(table, column) do
+    %{rows: rows} = repo().query!(~s|PRAGMA table_info("#{table}")|)
+    Enum.any?(rows, fn [_cid, name | _] -> name == column end)
   end
 end

--- a/priv/repo/migrations/20260628000000_unify_quality_profiles.exs
+++ b/priv/repo/migrations/20260628000000_unify_quality_profiles.exs
@@ -21,7 +21,7 @@ defmodule Mydia.Repo.Migrations.UnifyQualityProfiles do
     # A replayed migration (schema_migrations reset, or a database restored from
     # a point after `qualities` was already dropped) has nothing left to
     # backfill from, and selecting a missing column would abort the migration.
-    if column_exists?("quality_profiles", "qualities") do
+    if postgres?() or sqlite_column?("quality_profiles", "qualities") do
       %{rows: rows} =
         repo().query!("SELECT id, qualities, quality_standards FROM quality_profiles")
 
@@ -36,20 +36,6 @@ defmodule Mydia.Repo.Migrations.UnifyQualityProfiles do
           repo().query!(sql, params)
         end
       end)
-    end
-  end
-
-  defp column_exists?(table, column) do
-    if postgres?() do
-      %{rows: rows} =
-        repo().query!(
-          "SELECT 1 FROM information_schema.columns WHERE table_name = $1 AND column_name = $2",
-          [table, column]
-        )
-
-      rows != []
-    else
-      sqlite_column?(table, column)
     end
   end
 

--- a/test/mydia/repo/migrations/add_specialized_library_types_test.exs
+++ b/test/mydia/repo/migrations/add_specialized_library_types_test.exs
@@ -1,0 +1,70 @@
+defmodule Mydia.Repo.Migrations.AddSpecializedLibraryTypesTest do
+  use Mydia.MigrationCase
+
+  Code.require_file("priv/repo/migrations/20251128014213_add_specialized_library_types.exs")
+
+  alias Mydia.Repo.Migrations.AddSpecializedLibraryTypes
+
+  defp build_schema do
+    sql!("CREATE TABLE quality_profiles (id TEXT PRIMARY KEY)")
+    sql!("CREATE TABLE users (id TEXT PRIMARY KEY)")
+
+    sql!("""
+    CREATE TABLE library_paths (
+      id TEXT PRIMARY KEY NOT NULL,
+      path TEXT NOT NULL UNIQUE,
+      type TEXT NOT NULL CHECK(type IN ('movies', 'series', 'mixed')),
+      monitored INTEGER DEFAULT 1 CHECK(monitored IN (0, 1)),
+      scan_interval INTEGER DEFAULT 3600,
+      last_scan_at TEXT,
+      last_scan_status TEXT,
+      last_scan_error TEXT,
+      quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL,
+      updated_by_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+      inserted_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+    """)
+
+    sql!("""
+    CREATE TABLE media_files (id TEXT PRIMARY KEY,
+      library_path_id TEXT REFERENCES library_paths(id) ON DELETE CASCADE)
+    """)
+
+    sql!("""
+    INSERT INTO library_paths (id, path, type, inserted_at, updated_at)
+    VALUES ('lp1', '/movies', 'movies', '2026-01-01 00:00:00', '2026-01-01 00:00:00')
+    """)
+
+    sql!("INSERT INTO media_files (id, library_path_id) VALUES ('mf1', 'lp1')")
+  end
+
+  @tag :tmp_dir
+  test "rebuilding library_paths keeps media_files rows" do
+    build_schema()
+    run_migration!(AddSpecializedLibraryTypes, 20_260_101_000_040)
+
+    assert %{rows: [["mf1", "lp1"]]} = sql!("SELECT id, library_path_id FROM media_files")
+  end
+
+  @tag :tmp_dir
+  test "the widened check constraint survives the wrapper" do
+    build_schema()
+    run_migration!(AddSpecializedLibraryTypes, 20_260_101_000_041)
+
+    sql!("""
+    INSERT INTO library_paths (id, path, type, inserted_at, updated_at)
+    VALUES ('lp2', '/music', 'music', '2026-01-01 00:00:00', '2026-01-01 00:00:00')
+    """)
+
+    assert %{rows: [["lp2", "music"]]} =
+             sql!("SELECT id, type FROM library_paths WHERE id = 'lp2'")
+
+    assert_raise Exqlite.Error, fn ->
+      sql!("""
+      INSERT INTO library_paths (id, path, type, inserted_at, updated_at)
+      VALUES ('lp3', '/nope', 'bogus', '2026-01-01 00:00:00', '2026-01-01 00:00:00')
+      """)
+    end
+  end
+end

--- a/test/mydia/repo/migrations/fix_episode_cascade_deletes_test.exs
+++ b/test/mydia/repo/migrations/fix_episode_cascade_deletes_test.exs
@@ -3,7 +3,35 @@ defmodule Mydia.Repo.Migrations.FixEpisodeCascadeDeletesTest do
 
   Code.require_file("priv/repo/migrations/20260322000000_fix_episode_cascade_deletes.exs")
 
-  alias Mydia.Repo.Migrations.FixEpisodeCascadeDeletes
+  # The migration also rebuilds downloads and playback_progress, which this
+  # test does not create. Drive only the media_files half through the helper,
+  # using the migration's own column and index definitions. Referenced fully
+  # qualified rather than via `alias` because usage tracking does not credit
+  # a reference from inside this nested module's body against an alias
+  # established in the enclosing test module, which would otherwise report a
+  # false-positive "unused alias" warning.
+  defmodule MediaFilesOnlyMigration do
+    use Ecto.Migration
+    import Mydia.Repo.Migrations.Helpers
+
+    def up do
+      columns =
+        Enum.map(Mydia.Repo.Migrations.FixEpisodeCascadeDeletes.__media_files_columns__(), fn
+          {:episode_id, type, _opts} ->
+            {:episode_id, type,
+             [references: {:episodes, [type: :binary_id, on_delete: :nilify_all]}]}
+
+          other ->
+            other
+        end)
+
+      recreate_table(
+        table: :media_files,
+        columns: columns,
+        indexes: Mydia.Repo.Migrations.FixEpisodeCascadeDeletes.__media_files_indexes__()
+      )
+    end
+  end
 
   defp build_schema do
     sql!("CREATE TABLE media_items (id TEXT PRIMARY KEY)")
@@ -57,32 +85,6 @@ defmodule Mydia.Repo.Migrations.FixEpisodeCascadeDeletesTest do
   end
 
   defp run_media_files_rebuild do
-    # The migration also rebuilds downloads and playback_progress, which this
-    # test does not create. Drive only the media_files half through the helper,
-    # using the migration's own column and index definitions.
-    defmodule MediaFilesOnlyMigration do
-      use Ecto.Migration
-      import Mydia.Repo.Migrations.Helpers
-
-      def up do
-        columns =
-          Enum.map(FixEpisodeCascadeDeletes.__media_files_columns__(), fn
-            {:episode_id, type, _opts} ->
-              {:episode_id, type,
-               [references: {:episodes, [type: :binary_id, on_delete: :nilify_all]}]}
-
-            other ->
-              other
-          end)
-
-        recreate_table(
-          table: :media_files,
-          columns: columns,
-          indexes: FixEpisodeCascadeDeletes.__media_files_indexes__()
-        )
-      end
-    end
-
     run_migration!(MediaFilesOnlyMigration, 20_260_101_000_020)
   end
 

--- a/test/mydia/repo/migrations/fix_episode_cascade_deletes_test.exs
+++ b/test/mydia/repo/migrations/fix_episode_cascade_deletes_test.exs
@@ -1,0 +1,114 @@
+defmodule Mydia.Repo.Migrations.FixEpisodeCascadeDeletesTest do
+  use Mydia.MigrationCase
+
+  Code.require_file("priv/repo/migrations/20260322000000_fix_episode_cascade_deletes.exs")
+
+  alias Mydia.Repo.Migrations.FixEpisodeCascadeDeletes
+
+  defp build_schema do
+    sql!("CREATE TABLE media_items (id TEXT PRIMARY KEY)")
+    sql!("CREATE TABLE episodes (id TEXT PRIMARY KEY)")
+    sql!("CREATE TABLE quality_profiles (id TEXT PRIMARY KEY)")
+    sql!("CREATE TABLE library_paths (id TEXT PRIMARY KEY)")
+    sql!("CREATE TABLE users (id TEXT PRIMARY KEY)")
+
+    sql!("""
+    CREATE TABLE media_files (
+      id TEXT PRIMARY KEY,
+      media_item_id TEXT REFERENCES media_items(id) ON DELETE CASCADE,
+      episode_id TEXT REFERENCES episodes(id) ON DELETE CASCADE,
+      path TEXT,
+      size BIGINT,
+      quality_profile_id TEXT REFERENCES quality_profiles(id),
+      resolution TEXT, codec TEXT, hdr_format TEXT, audio_codec TEXT,
+      bitrate INTEGER, verified_at TEXT, metadata TEXT, relative_path TEXT,
+      library_path_id TEXT REFERENCES library_paths(id) ON DELETE CASCADE,
+      cover_blob TEXT, sprite_blob TEXT, vtt_blob TEXT, preview_blob TEXT,
+      phash TEXT, generated_at TEXT, trashed_at TEXT,
+      inserted_at TEXT NOT NULL, updated_at TEXT NOT NULL
+    )
+    """)
+
+    sql!("""
+    CREATE TABLE subtitles (id TEXT PRIMARY KEY,
+      media_file_id TEXT REFERENCES media_files(id) ON DELETE CASCADE)
+    """)
+
+    sql!("""
+    CREATE TABLE media_hashes (id TEXT PRIMARY KEY,
+      media_file_id TEXT REFERENCES media_files(id) ON DELETE CASCADE)
+    """)
+
+    sql!("""
+    CREATE TABLE transcode_jobs (id TEXT PRIMARY KEY,
+      media_file_id TEXT REFERENCES media_files(id) ON DELETE CASCADE)
+    """)
+
+    sql!("INSERT INTO episodes (id) VALUES ('e1')")
+
+    sql!("""
+    INSERT INTO media_files (id, episode_id, path, inserted_at, updated_at)
+    VALUES ('mf1', 'e1', '/a.mkv', '2026-01-01 00:00:00', '2026-01-01 00:00:00')
+    """)
+
+    sql!("INSERT INTO subtitles (id, media_file_id) VALUES ('s1', 'mf1')")
+    sql!("INSERT INTO media_hashes (id, media_file_id) VALUES ('h1', 'mf1')")
+    sql!("INSERT INTO transcode_jobs (id, media_file_id) VALUES ('t1', 'mf1')")
+  end
+
+  defp run_media_files_rebuild do
+    # The migration also rebuilds downloads and playback_progress, which this
+    # test does not create. Drive only the media_files half through the helper,
+    # using the migration's own column and index definitions.
+    defmodule MediaFilesOnlyMigration do
+      use Ecto.Migration
+      import Mydia.Repo.Migrations.Helpers
+
+      def up do
+        columns =
+          Enum.map(FixEpisodeCascadeDeletes.__media_files_columns__(), fn
+            {:episode_id, type, _opts} ->
+              {:episode_id, type,
+               [references: {:episodes, [type: :binary_id, on_delete: :nilify_all]}]}
+
+            other ->
+              other
+          end)
+
+        recreate_table(
+          table: :media_files,
+          columns: columns,
+          indexes: FixEpisodeCascadeDeletes.__media_files_indexes__()
+        )
+      end
+    end
+
+    run_migration!(MediaFilesOnlyMigration, 20_260_101_000_020)
+  end
+
+  @tag :tmp_dir
+  test "rebuilding media_files keeps its subtitles" do
+    build_schema()
+    run_media_files_rebuild()
+
+    assert %{rows: [["s1", "mf1"]]} = sql!("SELECT id, media_file_id FROM subtitles")
+  end
+
+  @tag :tmp_dir
+  test "rebuilding media_files keeps its hashes and transcode jobs" do
+    build_schema()
+    run_media_files_rebuild()
+
+    assert %{rows: [["h1", "mf1"]]} = sql!("SELECT id, media_file_id FROM media_hashes")
+    assert %{rows: [["t1", "mf1"]]} = sql!("SELECT id, media_file_id FROM transcode_jobs")
+  end
+
+  @tag :tmp_dir
+  test "the rebuild still changes episode_id to set null" do
+    build_schema()
+    run_media_files_rebuild()
+
+    %{rows: [[sql]]} = sql!("SELECT sql FROM sqlite_master WHERE name = 'media_files'")
+    assert sql =~ ~r/episode_id.*ON DELETE SET NULL/is
+  end
+end

--- a/test/mydia/repo/migrations/fk_children_test.exs
+++ b/test/mydia/repo/migrations/fk_children_test.exs
@@ -1,0 +1,88 @@
+defmodule Mydia.Repo.Migrations.FkChildrenTest do
+  use Mydia.MigrationCase
+
+  alias Mydia.Repo.Migrations.Helpers
+
+  @tag :tmp_dir
+  test "returns an empty list when nothing references the table" do
+    sql!("CREATE TABLE lonely (id TEXT PRIMARY KEY)")
+
+    assert Helpers.sqlite_fk_children(Mydia.MigrationTestRepo, "lonely") == []
+  end
+
+  @tag :tmp_dir
+  test "finds direct children regardless of their on delete action" do
+    sql!("CREATE TABLE parent (id TEXT PRIMARY KEY)")
+
+    sql!(
+      "CREATE TABLE kid_cascade (id TEXT PRIMARY KEY, p TEXT REFERENCES parent(id) ON DELETE CASCADE)"
+    )
+
+    sql!(
+      "CREATE TABLE kid_null (id TEXT PRIMARY KEY, p TEXT REFERENCES parent(id) ON DELETE SET NULL)"
+    )
+
+    sql!("CREATE TABLE kid_noaction (id TEXT PRIMARY KEY, p TEXT REFERENCES parent(id))")
+
+    children = Helpers.sqlite_fk_children(Mydia.MigrationTestRepo, "parent")
+
+    assert Enum.sort(children) == ["kid_cascade", "kid_noaction", "kid_null"]
+  end
+
+  @tag :tmp_dir
+  test "orders grandchildren before children" do
+    sql!("CREATE TABLE parent (id TEXT PRIMARY KEY)")
+
+    sql!(
+      "CREATE TABLE child (id TEXT PRIMARY KEY, p TEXT REFERENCES parent(id) ON DELETE CASCADE)"
+    )
+
+    sql!(
+      "CREATE TABLE grandchild (id TEXT PRIMARY KEY, c TEXT REFERENCES child(id) ON DELETE CASCADE)"
+    )
+
+    assert Helpers.sqlite_fk_children(Mydia.MigrationTestRepo, "parent") ==
+             ["grandchild", "child"]
+  end
+
+  @tag :tmp_dir
+  test "lists a table reachable by two paths exactly once, after both" do
+    sql!("CREATE TABLE parent (id TEXT PRIMARY KEY)")
+
+    sql!(
+      "CREATE TABLE left_kid (id TEXT PRIMARY KEY, p TEXT REFERENCES parent(id) ON DELETE CASCADE)"
+    )
+
+    sql!(
+      "CREATE TABLE right_kid (id TEXT PRIMARY KEY, p TEXT REFERENCES parent(id) ON DELETE CASCADE)"
+    )
+
+    sql!("""
+    CREATE TABLE shared (
+      id TEXT PRIMARY KEY,
+      l TEXT REFERENCES left_kid(id) ON DELETE CASCADE,
+      r TEXT REFERENCES right_kid(id) ON DELETE CASCADE
+    )
+    """)
+
+    children = Helpers.sqlite_fk_children(Mydia.MigrationTestRepo, "parent")
+
+    assert Enum.count(children, &(&1 == "shared")) == 1
+
+    assert Enum.find_index(children, &(&1 == "shared")) <
+             Enum.find_index(children, &(&1 == "left_kid"))
+
+    assert Enum.find_index(children, &(&1 == "shared")) <
+             Enum.find_index(children, &(&1 == "right_kid"))
+  end
+
+  @tag :tmp_dir
+  test "raises on a foreign key cycle" do
+    sql!("CREATE TABLE a (id TEXT PRIMARY KEY, b_id TEXT REFERENCES b(id))")
+    sql!("CREATE TABLE b (id TEXT PRIMARY KEY, a_id TEXT REFERENCES a(id))")
+
+    assert_raise Ecto.MigrationError, ~r/cycle/i, fn ->
+      Helpers.sqlite_fk_children(Mydia.MigrationTestRepo, "a")
+    end
+  end
+end

--- a/test/mydia/repo/migrations/migration_case_test.exs
+++ b/test/mydia/repo/migrations/migration_case_test.exs
@@ -1,0 +1,33 @@
+defmodule Mydia.MigrationCaseTest do
+  use Mydia.MigrationCase
+
+  defmodule AddColumnMigration do
+    use Ecto.Migration
+
+    def up do
+      alter table(:widgets) do
+        add :label, :string
+      end
+    end
+  end
+
+  @tag :tmp_dir
+  test "runs a migration against a populated temp database" do
+    sql!("CREATE TABLE widgets (id TEXT PRIMARY KEY)")
+    sql!("INSERT INTO widgets (id) VALUES ('w1')")
+
+    run_migration!(AddColumnMigration, 20_260_101_000_001)
+
+    assert %{rows: [["w1", nil]]} = sql!("SELECT id, label FROM widgets")
+  end
+
+  @tag :tmp_dir
+  test "foreign keys are enforced in the harness" do
+    sql!("CREATE TABLE parents (id TEXT PRIMARY KEY)")
+    sql!("CREATE TABLE kids (id TEXT PRIMARY KEY, parent_id TEXT REFERENCES parents(id))")
+
+    assert_raise Exqlite.Error, fn ->
+      sql!("INSERT INTO kids (id, parent_id) VALUES ('k1', 'nope')")
+    end
+  end
+end

--- a/test/mydia/repo/migrations/no_raw_table_rebuild_test.exs
+++ b/test/mydia/repo/migrations/no_raw_table_rebuild_test.exs
@@ -59,12 +59,12 @@ defmodule Mydia.Repo.Migrations.NoRawTableRebuildTest do
   defp hand_rolled_rebuild?(path) do
     source = File.read!(path)
 
-    ~r/DROP TABLE\s+"?(\w+)"?|drop table\(:(\w+)\)/i
+    ~r/DROP\s+TABLE\s+"?(\w+)"?|drop table\(:(\w+)\)/i
     |> Regex.scan(source)
     |> Enum.map(fn match -> Enum.find(tl(match), &(&1 != "")) end)
     |> Enum.filter(& &1)
     |> Enum.any?(fn table ->
-      Regex.match?(~r/RENAME TO\s+"?#{table}"?/i, source) or
+      Regex.match?(~r/RENAME\s+TO\s+"?#{table}\b"?/i, source) or
         Regex.match?(~r/to:\s*table\(:#{table}\)/, source)
     end)
   end

--- a/test/mydia/repo/migrations/no_raw_table_rebuild_test.exs
+++ b/test/mydia/repo/migrations/no_raw_table_rebuild_test.exs
@@ -1,0 +1,71 @@
+defmodule Mydia.Repo.Migrations.NoRawTableRebuildTest do
+  @moduledoc """
+  SQLite table rebuilds must go through `Mydia.Repo.Migrations.Helpers`.
+
+  A hand-rolled create/copy/drop/rename in a migration drops the original
+  table. Under PRAGMA foreign_keys=ON that fires every referencing table's
+  foreign key actions, which silently deletes or nulls their rows. The helper
+  wraps rebuilds in `preserving_fk_children/2`; raw ones get no such
+  protection, so new ones are rejected here.
+  """
+  use ExUnit.Case, async: true
+
+  # Each entry records why that migration is allowed to hand-roll a rebuild.
+  @allowed %{
+    "20251115185757_make_media_files_path_nullable.exs" =>
+      "nothing referenced media_files yet; subtitles and media_hashes arrive in 20251116022802",
+    "20251125032719_change_event_actor_id_to_string.exs" =>
+      "nothing references events, then or now",
+    "20251128014213_add_specialized_library_types.exs" =>
+      "rebuild is wrapped in preserving_fk_children/2",
+    "20251129052609_make_download_client_host_port_nullable.exs" =>
+      "nothing references download_client_configs",
+    "20260119194743_make_base_url_nullable_in_indexer_configs.exs" =>
+      "nothing references indexer_configs"
+  }
+
+  test "no new migration hand-rolls a SQLite table rebuild" do
+    offenders =
+      "priv/repo/migrations/*.exs"
+      |> Path.wildcard()
+      |> Enum.filter(&hand_rolled_rebuild?/1)
+      |> Enum.map(&Path.basename/1)
+      |> Enum.reject(&Map.has_key?(@allowed, &1))
+      |> Enum.sort()
+
+    assert offenders == [],
+           """
+           These migrations rebuild a table by dropping and renaming it, without
+           going through Mydia.Repo.Migrations.Helpers:
+
+             #{Enum.join(offenders, "\n  ")}
+
+           Dropping a table fires the foreign key actions of every table that
+           references it, which deletes or nulls their rows.
+
+           Use recreate_table/1, or wrap the rebuild in preserving_fk_children/2.
+           If the column only needs removing, ALTER TABLE ... DROP COLUMN avoids
+           the problem entirely.
+           """
+  end
+
+  test "every allowlist entry still names a real migration" do
+    on_disk = "priv/repo/migrations/*.exs" |> Path.wildcard() |> MapSet.new(&Path.basename/1)
+    stale = @allowed |> Map.keys() |> Enum.reject(&MapSet.member?(on_disk, &1)) |> Enum.sort()
+
+    assert stale == [], "allowlist names migrations that no longer exist: #{inspect(stale)}"
+  end
+
+  defp hand_rolled_rebuild?(path) do
+    source = File.read!(path)
+
+    ~r/DROP TABLE\s+"?(\w+)"?|drop table\(:(\w+)\)/i
+    |> Regex.scan(source)
+    |> Enum.map(fn match -> Enum.find(tl(match), &(&1 != "")) end)
+    |> Enum.filter(& &1)
+    |> Enum.any?(fn table ->
+      Regex.match?(~r/RENAME TO\s+"?#{table}"?/i, source) or
+        Regex.match?(~r/to:\s*table\(:#{table}\)/, source)
+    end)
+  end
+end

--- a/test/mydia/repo/migrations/preserving_fk_children_test.exs
+++ b/test/mydia/repo/migrations/preserving_fk_children_test.exs
@@ -1,0 +1,123 @@
+defmodule Mydia.Repo.Migrations.PreservingFkChildrenTest do
+  use Mydia.MigrationCase
+
+  defmodule RebuildParentMigration do
+    use Ecto.Migration
+    import Mydia.Repo.Migrations.Helpers
+
+    def up do
+      preserving_fk_children(:parent, fn ->
+        execute "CREATE TABLE parent_new (id TEXT PRIMARY KEY, label TEXT)"
+        execute "INSERT INTO parent_new (id, label) SELECT id, label FROM parent"
+        execute "DROP TABLE parent"
+        execute "ALTER TABLE parent_new RENAME TO parent"
+      end)
+    end
+  end
+
+  defp build_schema do
+    sql!("CREATE TABLE parent (id TEXT PRIMARY KEY, label TEXT, dead_column TEXT)")
+
+    sql!("""
+    CREATE TABLE kid_cascade (id TEXT PRIMARY KEY,
+      p TEXT REFERENCES parent(id) ON DELETE CASCADE)
+    """)
+
+    sql!("""
+    CREATE TABLE kid_null (id TEXT PRIMARY KEY,
+      p TEXT REFERENCES parent(id) ON DELETE SET NULL)
+    """)
+
+    sql!("CREATE TABLE kid_noaction (id TEXT PRIMARY KEY, p TEXT REFERENCES parent(id))")
+
+    sql!("INSERT INTO parent (id, label, dead_column) VALUES ('p1', 'kept', 'junk')")
+    sql!("INSERT INTO kid_cascade (id, p) VALUES ('c1', 'p1')")
+    sql!("INSERT INTO kid_null (id, p) VALUES ('n1', 'p1')")
+    sql!("INSERT INTO kid_noaction (id, p) VALUES ('a1', 'p1')")
+  end
+
+  @tag :tmp_dir
+  test "a cascade child keeps its rows" do
+    build_schema()
+    run_migration!(RebuildParentMigration, 20_260_101_000_010)
+
+    assert %{rows: [["c1", "p1"]]} = sql!("SELECT id, p FROM kid_cascade")
+  end
+
+  @tag :tmp_dir
+  test "a set null child keeps its assignment" do
+    build_schema()
+    run_migration!(RebuildParentMigration, 20_260_101_000_011)
+
+    assert %{rows: [["n1", "p1"]]} = sql!("SELECT id, p FROM kid_null")
+  end
+
+  @tag :tmp_dir
+  test "a no action child does not abort the rebuild" do
+    build_schema()
+    run_migration!(RebuildParentMigration, 20_260_101_000_012)
+
+    assert %{rows: [["a1", "p1"]]} = sql!("SELECT id, p FROM kid_noaction")
+  end
+
+  @tag :tmp_dir
+  test "the rebuild itself still happens" do
+    build_schema()
+    run_migration!(RebuildParentMigration, 20_260_101_000_013)
+
+    assert %{rows: [["p1", "kept"]]} = sql!("SELECT id, label FROM parent")
+
+    columns =
+      sql!(~s|PRAGMA table_info("parent")|).rows
+      |> Enum.map(fn [_cid, name | _] -> name end)
+
+    refute "dead_column" in columns
+  end
+
+  @tag :tmp_dir
+  test "leaves no snapshot tables behind and no violations" do
+    build_schema()
+    run_migration!(RebuildParentMigration, 20_260_101_000_014)
+
+    %{rows: leftovers} =
+      sql!(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE '__mydia_fk_snap_%'"
+      )
+
+    assert leftovers == []
+    assert %{rows: []} = sql!("PRAGMA foreign_key_check")
+  end
+
+  @tag :tmp_dir
+  test "preserves a grandchild through a cascading chain" do
+    sql!("CREATE TABLE parent (id TEXT PRIMARY KEY, label TEXT)")
+
+    sql!(
+      "CREATE TABLE child (id TEXT PRIMARY KEY, p TEXT REFERENCES parent(id) ON DELETE CASCADE)"
+    )
+
+    sql!("""
+    CREATE TABLE grandchild (id TEXT PRIMARY KEY,
+      c TEXT REFERENCES child(id) ON DELETE CASCADE)
+    """)
+
+    sql!("INSERT INTO parent (id, label) VALUES ('p1', 'kept')")
+    sql!("INSERT INTO child (id, p) VALUES ('c1', 'p1')")
+    sql!("INSERT INTO grandchild (id, c) VALUES ('g1', 'c1')")
+
+    run_migration!(RebuildParentMigration, 20_260_101_000_015)
+
+    assert %{rows: [["c1", "p1"]]} = sql!("SELECT id, p FROM child")
+    assert %{rows: [["g1", "c1"]]} = sql!("SELECT id, c FROM grandchild")
+  end
+
+  @tag :tmp_dir
+  test "does nothing when the table has no children" do
+    sql!("CREATE TABLE parent (id TEXT PRIMARY KEY, label TEXT)")
+    sql!("INSERT INTO parent (id, label) VALUES ('p1', 'kept')")
+
+    run_migration!(RebuildParentMigration, 20_260_101_000_016)
+
+    assert %{rows: [["p1", "kept"]]} = sql!("SELECT id, label FROM parent")
+  end
+end

--- a/test/mydia/repo/migrations/preserving_fk_children_test.exs
+++ b/test/mydia/repo/migrations/preserving_fk_children_test.exs
@@ -15,6 +15,44 @@ defmodule Mydia.Repo.Migrations.PreservingFkChildrenTest do
     end
   end
 
+  defmodule ReversibleRebuildMigration do
+    use Ecto.Migration
+    import Mydia.Repo.Migrations.Helpers
+
+    def up do
+      rebuild_parent_as("CREATE TABLE parent_new (id TEXT PRIMARY KEY, label TEXT)")
+    end
+
+    def down do
+      rebuild_parent_as(
+        "CREATE TABLE parent_new (id TEXT PRIMARY KEY, label TEXT, dead_column TEXT)"
+      )
+    end
+
+    defp rebuild_parent_as(create_sql) do
+      preserving_fk_children(:parent, fn ->
+        execute create_sql
+        execute "INSERT INTO parent_new (id, label) SELECT id, label FROM parent"
+        execute "DROP TABLE parent"
+        execute "ALTER TABLE parent_new RENAME TO parent"
+      end)
+    end
+  end
+
+  defmodule ChangeRebuildMigration do
+    use Ecto.Migration
+    import Mydia.Repo.Migrations.Helpers
+
+    def change do
+      preserving_fk_children(:parent, fn ->
+        execute "CREATE TABLE parent_new (id TEXT PRIMARY KEY, label TEXT)"
+        execute "INSERT INTO parent_new (id, label) SELECT id, label FROM parent"
+        execute "DROP TABLE parent"
+        execute "ALTER TABLE parent_new RENAME TO parent"
+      end)
+    end
+  end
+
   defp build_schema do
     sql!("CREATE TABLE parent (id TEXT PRIMARY KEY, label TEXT, dead_column TEXT)")
 
@@ -109,6 +147,61 @@ defmodule Mydia.Repo.Migrations.PreservingFkChildrenTest do
 
     assert %{rows: [["c1", "p1"]]} = sql!("SELECT id, p FROM child")
     assert %{rows: [["g1", "c1"]]} = sql!("SELECT id, c FROM grandchild")
+  end
+
+  @tag :tmp_dir
+  test "a migration with an explicit down/0 rolls back through the primitive" do
+    build_schema()
+    run_migration!(ReversibleRebuildMigration, 20_260_101_000_017)
+
+    assert :ok = rollback_migration!(ReversibleRebuildMigration, 20_260_101_000_017)
+
+    columns =
+      sql!(~s|PRAGMA table_info("parent")|).rows
+      |> Enum.map(fn [_cid, name | _] -> name end)
+
+    assert "dead_column" in columns
+  end
+
+  @tag :tmp_dir
+  test "the foreign key children survive the rollback too" do
+    build_schema()
+    run_migration!(ReversibleRebuildMigration, 20_260_101_000_018)
+    rollback_migration!(ReversibleRebuildMigration, 20_260_101_000_018)
+
+    assert %{rows: [["c1", "p1"]]} = sql!("SELECT id, p FROM kid_cascade")
+    assert %{rows: [["n1", "p1"]]} = sql!("SELECT id, p FROM kid_null")
+    assert %{rows: [["a1", "p1"]]} = sql!("SELECT id, p FROM kid_noaction")
+    assert %{rows: []} = sql!("PRAGMA foreign_key_check")
+  end
+
+  @tag :tmp_dir
+  test "rolling back a change/0 migration still raises, naming change/0" do
+    build_schema()
+    run_migration!(ChangeRebuildMigration, 20_260_101_000_019)
+
+    message =
+      assert_raise Ecto.MigrationError, fn ->
+        rollback_migration!(ChangeRebuildMigration, 20_260_101_000_019)
+      end
+
+    assert message.message =~ "ChangeRebuildMigration"
+    assert message.message =~ "change/0"
+    assert message.message =~ "explicit up/0 and down/0"
+  end
+
+  @tag :tmp_dir
+  test "a failed change/0 rollback leaves the children untouched" do
+    build_schema()
+    run_migration!(ChangeRebuildMigration, 20_260_101_000_020)
+
+    assert_raise Ecto.MigrationError, fn ->
+      rollback_migration!(ChangeRebuildMigration, 20_260_101_000_020)
+    end
+
+    assert %{rows: [["c1", "p1"]]} = sql!("SELECT id, p FROM kid_cascade")
+    assert %{rows: [["n1", "p1"]]} = sql!("SELECT id, p FROM kid_null")
+    assert %{rows: [["a1", "p1"]]} = sql!("SELECT id, p FROM kid_noaction")
   end
 
   @tag :tmp_dir

--- a/test/mydia/repo/migrations/quality_profile_backfill_test.exs
+++ b/test/mydia/repo/migrations/quality_profile_backfill_test.exs
@@ -1,0 +1,40 @@
+defmodule Mydia.Repo.Migrations.QualityProfileBackfillTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Repo.Migrations.QualityProfileBackfill, as: M
+
+  describe "backfilled_standards/2" do
+    test "fills preferred_resolutions from qualities when standards lack it" do
+      result = M.backfilled_standards(["720p", "1080p"], %{})
+      assert result["preferred_resolutions"] == ["720p", "1080p"]
+    end
+
+    test "derives min/max resolution from qualities when absent" do
+      result = M.backfilled_standards(["720p", "1080p", "2160p"], %{})
+      assert result["min_resolution"] == "720p"
+      assert result["max_resolution"] == "2160p"
+    end
+
+    test "keeps existing non-empty preferred_resolutions untouched" do
+      standards = %{"preferred_resolutions" => ["1080p"], "min_resolution" => "1080p"}
+      assert M.backfilled_standards(["720p", "2160p"], standards) == standards
+    end
+
+    test "handles nil standards" do
+      result = M.backfilled_standards(["1080p"], nil)
+      assert result["preferred_resolutions"] == ["1080p"]
+    end
+
+    test "ignores unknown resolution tokens when deriving min/max but keeps them in the list" do
+      result = M.backfilled_standards(["weird", "1080p"], %{})
+      assert result["preferred_resolutions"] == ["weird", "1080p"]
+      assert result["min_resolution"] == "1080p"
+      assert result["max_resolution"] == "1080p"
+    end
+
+    test "falls back to a full resolution list when qualities is empty" do
+      result = M.backfilled_standards([], %{})
+      assert result["preferred_resolutions"] == ["360p", "480p", "576p", "720p", "1080p", "2160p"]
+    end
+  end
+end

--- a/test/mydia/repo/migrations/unify_quality_profiles_test.exs
+++ b/test/mydia/repo/migrations/unify_quality_profiles_test.exs
@@ -1,40 +1,118 @@
 defmodule Mydia.Repo.Migrations.UnifyQualityProfilesTest do
-  use ExUnit.Case, async: true
+  use Mydia.MigrationCase
 
-  alias Mydia.Repo.Migrations.QualityProfileBackfill, as: M
+  Code.require_file("priv/repo/migrations/20260628000000_unify_quality_profiles.exs")
 
-  describe "backfilled_standards/2" do
-    test "fills preferred_resolutions from qualities when standards lack it" do
-      result = M.backfilled_standards(["720p", "1080p"], %{})
-      assert result["preferred_resolutions"] == ["720p", "1080p"]
-    end
+  alias Mydia.Repo.Migrations.UnifyQualityProfiles
 
-    test "derives min/max resolution from qualities when absent" do
-      result = M.backfilled_standards(["720p", "1080p", "2160p"], %{})
-      assert result["min_resolution"] == "720p"
-      assert result["max_resolution"] == "2160p"
-    end
+  defp build_schema do
+    sql!("""
+    CREATE TABLE quality_profiles (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      upgrades_allowed INTEGER DEFAULT 1,
+      upgrade_until_quality TEXT,
+      description TEXT,
+      is_system INTEGER DEFAULT 0,
+      version INTEGER DEFAULT 1,
+      source_url TEXT,
+      last_synced_at TEXT,
+      quality_standards TEXT,
+      qualities TEXT,
+      metadata_preferences TEXT,
+      customizations TEXT,
+      inserted_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+    """)
 
-    test "keeps existing non-empty preferred_resolutions untouched" do
-      standards = %{"preferred_resolutions" => ["1080p"], "min_resolution" => "1080p"}
-      assert M.backfilled_standards(["720p", "2160p"], standards) == standards
-    end
+    sql!("CREATE UNIQUE INDEX quality_profiles_name_index ON quality_profiles (name)")
 
-    test "handles nil standards" do
-      result = M.backfilled_standards(["1080p"], nil)
-      assert result["preferred_resolutions"] == ["1080p"]
-    end
+    sql!("""
+    CREATE TABLE media_files (id TEXT PRIMARY KEY,
+      quality_profile_id TEXT REFERENCES quality_profiles(id))
+    """)
 
-    test "ignores unknown resolution tokens when deriving min/max but keeps them in the list" do
-      result = M.backfilled_standards(["weird", "1080p"], %{})
-      assert result["preferred_resolutions"] == ["weird", "1080p"]
-      assert result["min_resolution"] == "1080p"
-      assert result["max_resolution"] == "1080p"
-    end
+    sql!("""
+    CREATE TABLE media_items (id TEXT PRIMARY KEY,
+      quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL)
+    """)
 
-    test "falls back to a full resolution list when qualities is empty" do
-      result = M.backfilled_standards([], %{})
-      assert result["preferred_resolutions"] == ["360p", "480p", "576p", "720p", "1080p", "2160p"]
-    end
+    sql!("""
+    CREATE TABLE library_paths (id TEXT PRIMARY KEY,
+      quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL)
+    """)
+
+    sql!("""
+    CREATE TABLE import_lists (id TEXT PRIMARY KEY,
+      quality_profile_id TEXT REFERENCES quality_profiles(id) ON DELETE SET NULL)
+    """)
+
+    sql!("""
+    INSERT INTO quality_profiles
+      (id, name, quality_standards, qualities, metadata_preferences, customizations,
+       inserted_at, updated_at)
+    VALUES ('qp1', 'HD', '{}', '["hdtv-720p"]', '{}', '{}',
+       '2026-01-01 00:00:00', '2026-01-01 00:00:00')
+    """)
+
+    sql!("INSERT INTO media_files (id, quality_profile_id) VALUES ('mf1', 'qp1')")
+    sql!("INSERT INTO media_items (id, quality_profile_id) VALUES ('mi1', 'qp1')")
+    sql!("INSERT INTO library_paths (id, quality_profile_id) VALUES ('lp1', 'qp1')")
+    sql!("INSERT INTO import_lists (id, quality_profile_id) VALUES ('il1', 'qp1')")
+  end
+
+  defp columns_of(table) do
+    sql!(~s|PRAGMA table_info("#{table}")|).rows
+    |> Enum.map(fn [_cid, name | _] -> name end)
+  end
+
+  @tag :tmp_dir
+  test "drops the three dead columns" do
+    build_schema()
+    run_migration!(UnifyQualityProfiles, 20_260_101_000_030)
+
+    columns = columns_of("quality_profiles")
+
+    refute "qualities" in columns
+    refute "metadata_preferences" in columns
+    refute "customizations" in columns
+    assert "quality_standards" in columns
+  end
+
+  @tag :tmp_dir
+  test "does not abort when a media_files row carries a profile" do
+    build_schema()
+    run_migration!(UnifyQualityProfiles, 20_260_101_000_031)
+
+    assert %{rows: [["mf1", "qp1"]]} = sql!("SELECT id, quality_profile_id FROM media_files")
+  end
+
+  @tag :tmp_dir
+  test "keeps every set null assignment, including import_lists" do
+    build_schema()
+    run_migration!(UnifyQualityProfiles, 20_260_101_000_032)
+
+    assert %{rows: [["mi1", "qp1"]]} = sql!("SELECT id, quality_profile_id FROM media_items")
+    assert %{rows: [["lp1", "qp1"]]} = sql!("SELECT id, quality_profile_id FROM library_paths")
+    assert %{rows: [["il1", "qp1"]]} = sql!("SELECT id, quality_profile_id FROM import_lists")
+  end
+
+  @tag :tmp_dir
+  test "still backfills preferred resolutions into quality_standards" do
+    build_schema()
+    run_migration!(UnifyQualityProfiles, 20_260_101_000_033)
+
+    %{rows: [[standards]]} = sql!("SELECT quality_standards FROM quality_profiles")
+    refute standards == "{}"
+  end
+
+  @tag :tmp_dir
+  test "replays cleanly against an already migrated database" do
+    build_schema()
+    run_migration!(UnifyQualityProfiles, 20_260_101_000_034)
+    run_migration!(UnifyQualityProfiles, 20_260_101_000_035)
+
+    assert %{rows: [["qp1"]]} = sql!("SELECT id FROM quality_profiles")
   end
 end

--- a/test/support/migration_case.ex
+++ b/test/support/migration_case.ex
@@ -42,4 +42,15 @@ defmodule Mydia.MigrationCase do
   def run_migration!(module, version) do
     Ecto.Migrator.up(Mydia.MigrationTestRepo, version, module, log: false)
   end
+
+  @doc """
+  Roll a migration module back against the migration test repo.
+
+  Runs `down/0` for a migration defining one, and replays `change/0` backward
+  otherwise. `version` must already have been applied with `run_migration!/2`,
+  otherwise `Ecto.Migrator` reports `:already_down` without running anything.
+  """
+  def rollback_migration!(module, version) do
+    Ecto.Migrator.down(Mydia.MigrationTestRepo, version, module, log: false)
+  end
 end

--- a/test/support/migration_case.ex
+++ b/test/support/migration_case.ex
@@ -1,0 +1,45 @@
+defmodule Mydia.MigrationCase do
+  @moduledoc """
+  Case template for tests that run a migration against a populated database.
+
+  Every test using this must be tagged `@tag :tmp_dir`; the temp directory is
+  where the throwaway SQLite database lives.
+  """
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import Mydia.MigrationCase
+    end
+  end
+
+  setup tags do
+    tmp_dir =
+      tags[:tmp_dir] ||
+        raise "Mydia.MigrationCase requires @tag :tmp_dir on every test"
+
+    database = Path.join(tmp_dir, "migration_test.db")
+
+    start_supervised!(
+      {Mydia.MigrationTestRepo, database: database, pool_size: 1, foreign_keys: :on}
+    )
+
+    {:ok, repo: Mydia.MigrationTestRepo, database: database}
+  end
+
+  @doc """
+  Run a statement against the migration test repo and return the result struct.
+  """
+  def sql!(query, params \\ []) do
+    Mydia.MigrationTestRepo.query!(query, params)
+  end
+
+  @doc """
+  Run a migration module's `up/0` against the migration test repo.
+
+  `version` only has to be unique within a single test's database.
+  """
+  def run_migration!(module, version) do
+    Ecto.Migrator.up(Mydia.MigrationTestRepo, version, module, log: false)
+  end
+end

--- a/test/support/migration_test_repo.ex
+++ b/test/support/migration_test_repo.ex
@@ -1,0 +1,17 @@
+defmodule Mydia.MigrationTestRepo do
+  @moduledoc """
+  Throwaway repo for migration tests.
+
+  Migration tests need real DDL against a real database file. The SQL sandbox
+  wraps each test in a transaction it later rolls back, which conflicts with
+  `Ecto.Migrator` opening its own transaction and writing `schema_migrations`.
+  This repo is started per test against a temporary SQLite file instead, so a
+  migration test can never touch `Mydia.Repo`.
+
+  It is deliberately always SQLite, even when the suite runs against
+  PostgreSQL, because the behavior under test is SQLite-specific.
+  """
+  use Ecto.Repo,
+    otp_app: :mydia,
+    adapter: Ecto.Adapters.SQLite3
+end


### PR DESCRIPTION
Closes #269.

## The bug

SQLite cannot alter a column's type, nullability, constraints, or foreign key actions, so migrations change those by rebuilding the table: create a replacement, copy rows, `DROP TABLE` the original, rename. Under `PRAGMA foreign_keys=ON`, which is how this app always runs (`config/dev.exs:42`, `config/runtime.exs:97`, and exqlite's default), that `DROP TABLE` performs an implicit `DELETE FROM` and fires the foreign key actions of every referencing table. `ON DELETE CASCADE` children lose all their rows, `ON DELETE SET NULL` children lose the assignment, and children with no action abort the migration.

CI never caught it because SQLite tests migrate a fresh, empty database, where the implicit delete has nothing to act on.

## Three live sites

Auditing every rebuild site found more than #269 reported. A rebuild can only harm children that exist at its own position in the migration order, which is how each was classified.

**`20260322000000_fix_episode_cascade_deletes` — shipped, and the worst of the three.** It rebuilds `media_files`, which by then is referenced by `subtitles`, `media_hashes`, and `transcode_jobs`, all `ON DELETE CASCADE`. Every row in those three tables is deleted. This shipped in **v0.10.0 through v0.12.0** and still fires today for anyone upgrading from a pre-v0.10 install.

**`20260628000000_unify_quality_profiles` — the migration #269 reports.** Never shipped in a tagged release: its commit is dated 2026-06-28 and v0.12.0 is dated 2026-06-24, so only `:master` rolling users ran it. The issue lists three affected child tables; there are four, `import_lists.quality_profile_id` being the fourth.

**`20251128014213_add_specialized_library_types` — narrow window.** Rebuilds `library_paths` while `media_files.library_path_id` references it with `ON DELETE CASCADE`, deleting every media file row. Only installs created between 2025-11-03 and 2025-11-28 are exposed.

The other rebuild sites are safe: `media_files` at `20251115185757`, `download_client_configs`, `indexer_configs`, and `events` had no FK children at their point in the order.

## The fix

`preserving_fk_children/2` in `Mydia.Repo.Migrations.Helpers` snapshots a table's transitive FK children, empties them, runs the caller's rebuild, restores them, and checks integrity, all inside the transaction the migrator already opened.

Emptying the children *before* the parent is dropped is what collapses all three FK actions into one code path: `NO ACTION` has nothing left to abort on, `SET NULL` has nothing to null, `CASCADE` has nothing to cascade to. No branch on the child's `on_delete`, and none on database engine.

`recreate_table/1` routes through it, so `modify_columns_null/1` and every future caller inherit the fix rather than just the known sites. **That generic change is what fixes both #269's symptoms and the shipped `media_files` bug** — neither migration needed editing for that.

On top of it:

- `20260628000000` stops rebuilding entirely and uses `ALTER TABLE ... DROP COLUMN`, so it touches no foreign key at all. This matters more than it sounds: that table's transitive child closure is effectively the whole database, so wrapping it would have snapshotted nearly every row in an install. It also fixes a replay bug where the backfill's unconditional `SELECT` of a dropped column failed before the drop logic was reached.
- `20251128014213` is wrapped rather than converted, keeping its inline `CHECK` constraints byte-identical.

## Rejected approaches

The issue suggests disabling foreign keys around the rebuild. Each candidate was tested, not assumed:

- **`PRAGMA foreign_keys=OFF` outside the transaction** needs `@disable_ddl_transaction`, and ecto_sql runs that path as a bare `fun.()` with no connection checkout (`migrator.ex:349`) while ecto_sqlite3's `lock_for_migrations` is also a bare `fun.()`. Statements can land on different pool connections, and the pragma is per-connection. It also trades away the atomicity of a rebuild that drops a table.
- **`PRAGMA defer_foreign_keys`** defers constraint *checking*, not cascade *actions*, so it nulls the SET NULL children anyway and then fails at `COMMIT`.
- **`PRAGMA foreign_keys=OFF` inside the transaction** is a documented no-op.
- **`PRAGMA legacy_alter_table` with rename-first** rewrote children to reference the `_old` name and still fired the actions.

## Also in here

- A migration test harness (`Mydia.MigrationTestRepo` + `Mydia.MigrationCase`), which did not exist. It runs migrations against populated temp SQLite databases, and is deliberately always SQLite so these regression tests run under both CI jobs.
- A lint rejecting new hand-rolled `DROP`/`RENAME` rebuilds in migrations, with the five existing sites allowlisted and each carrying its reason.
- A rollback fix: `Ecto.Migration.flush` is a macro whose `__MODULE__` resolves at the expansion site, so calling it from inside the helper module collapsed its guard and made every SQLite `down/0` reaching the primitive raise. That broke `Mydia.Release.rollback/2`. Rollback coverage was absent entirely and is now present.

## Release note needed

Installs where the old `20260628000000` already succeeded (`:master` users) have had `media_items`, `library_paths`, and `import_lists` quality-profile assignments silently set to NULL. That data is unrecoverable and no migration can restore it. Those operators should re-check their quality profile assignments.

Installs affected by the shipped `media_files` bug lost `subtitles`, `media_hashes`, and `transcode_jobs` rows; subtitles and hashes re-derive from disk on a rescan.

## Verification

- Full suite: 5760 tests, 0 failures.
- `mix precommit` clean apart from a pre-existing seed-dependent `ProwlarrTest` failure, reproduced on the base commit with the same seed.
- Migration chain replayed from zero against a fresh test database with no SQL or FK errors.
- Each fix is covered by a test that reproduced the bug RED first.
