### PR TITLE
feat(player): hold anywhere to drag the desktop window, hide chrome on mouse exit

### DIFF
--- a/player/lib/core/player/platform_features.dart
+++ b/player/lib/core/player/platform_features.dart
@@ -78,10 +78,12 @@ class PlatformFeatures {
   /// `PanelMetrics.touchTargets`/`TransportSurface.compact`), no
   /// `UpNextOverlay` (autoplay-only, next-episode-only), and — before this
   /// fix — no keyboard fallback either, since [supportsKeyboardShortcuts]
-  /// was false on web. `isDesktop` itself is left alone: it has two other,
-  /// unrelated call sites in `player_screen.dart` (double-click-to-fullscreen
-  /// gating) that were never asked to change and that this fix doesn't
-  /// touch.
+  /// was false on web. `isDesktop` itself is left alone: its live consumers
+  /// are now `window_drag_service_native.dart` (gating OS window dragging)
+  /// and `playback_chrome.dart` (gating the window-drag and double-click
+  /// fullscreen callbacks) — the double-click-to-fullscreen gating that used
+  /// to live in `player_screen.dart` was removed from there by a later
+  /// commit on this branch.
   static bool get supportsKeyboardShortcuts =>
       computeSupportsKeyboardShortcuts(isDesktop: isDesktop, isWeb: isWeb);
 

--- a/player/lib/core/player/window_drag_service.dart
+++ b/player/lib/core/player/window_drag_service.dart
@@ -1,0 +1,7 @@
+// Cross-platform OS window dragging.
+//
+// Uses conditional imports so the web build never links `window_manager`,
+// which has no web implementation. Mirrors `network_info_service.dart` in
+// this same directory.
+export 'window_drag_service_stub.dart'
+    if (dart.library.io) 'window_drag_service_native.dart';

--- a/player/lib/core/player/window_drag_service_native.dart
+++ b/player/lib/core/player/window_drag_service_native.dart
@@ -6,7 +6,24 @@
 /// is that nothing after `WidgetsFlutterBinding.ensureInitialized()` escapes
 /// uncaught, and [startWindowDrag] runs from a pointer handler where an
 /// exception would surface as a red screen mid-playback.
+///
+/// `windowManager.startDragging()` itself is declared `async`, so the drag
+/// call proper can never throw synchronously: every failure from the actual
+/// platform call lands in the returned `Future`, caught below via
+/// `.catchError`. A separate, genuinely synchronous throw is still possible
+/// one step earlier, evaluating the `windowManager` getter: it lazily
+/// constructs a `WindowManager._()` singleton exactly once per isolate, and
+/// that constructor calls `setMethodCallHandler` before any Flutter binding
+/// may exist yet, which is an assertion failure, not `MissingPluginException`.
+/// In the running app this never fires — `runApp` initializes the binding,
+/// and [initWindowDrag] forces (and catches) that first construction earlier
+/// in startup — but `window_drag_service_test.dart` calls both entry points
+/// from bare `test()`s with no binding ever initialized, so every access to
+/// `windowManager` in that file hits it. The outer `try` in [startWindowDrag]
+/// exists for that construction step, not for the drag call.
 library;
+
+import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:window_manager/window_manager.dart';
@@ -25,7 +42,12 @@ Future<void> initWindowDrag() async {
 void startWindowDrag() {
   if (!PlatformFeatures.isDesktop) return;
   try {
-    windowManager.startDragging();
+    unawaited(
+      windowManager.startDragging().catchError(
+            (Object e) =>
+                debugPrint('[WindowDrag] Failed to start window drag: $e'),
+          ),
+    );
   } catch (e) {
     debugPrint('[WindowDrag] Failed to start window drag: $e');
   }

--- a/player/lib/core/player/window_drag_service_native.dart
+++ b/player/lib/core/player/window_drag_service_native.dart
@@ -1,0 +1,32 @@
+/// Native implementation of OS window dragging, backed by `window_manager`.
+///
+/// `dart.library.io` is also true on iOS and Android, so both entry points
+/// gate on [PlatformFeatures.isDesktop] as well. Neither is allowed to
+/// throw: [initWindowDrag] runs inside `_startApp`, whose stated invariant
+/// is that nothing after `WidgetsFlutterBinding.ensureInitialized()` escapes
+/// uncaught, and [startWindowDrag] runs from a pointer handler where an
+/// exception would surface as a red screen mid-playback.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:window_manager/window_manager.dart';
+
+import 'platform_features.dart';
+
+Future<void> initWindowDrag() async {
+  if (!PlatformFeatures.isDesktop) return;
+  try {
+    await windowManager.ensureInitialized();
+  } catch (e) {
+    debugPrint('[WindowDrag] Failed to initialize window manager: $e');
+  }
+}
+
+void startWindowDrag() {
+  if (!PlatformFeatures.isDesktop) return;
+  try {
+    windowManager.startDragging();
+  } catch (e) {
+    debugPrint('[WindowDrag] Failed to start window drag: $e');
+  }
+}

--- a/player/lib/core/player/window_drag_service_stub.dart
+++ b/player/lib/core/player/window_drag_service_stub.dart
@@ -1,0 +1,8 @@
+/// Stub implementation for platforms with no movable OS window (web).
+library;
+
+/// No-op: there is no window to prepare.
+Future<void> initWindowDrag() async {}
+
+/// No-op: there is no window to drag.
+void startWindowDrag() {}

--- a/player/lib/main.dart
+++ b/player/lib/main.dart
@@ -9,6 +9,7 @@ import 'core/downloads/download_service.dart';
 import 'package:flutter/services.dart';
 
 import 'core/graphql/watch/fetch_log.dart';
+import 'core/player/window_drag_service.dart';
 import 'core/startup/startup_error_app.dart';
 import 'core/startup/startup_lock.dart';
 
@@ -93,6 +94,12 @@ Future<void> _startApp() async {
     debugPrint('[MediaKit] Failed to initialize: $e');
     debugPrint('Stack trace: $st');
   }
+
+  // Prepare the OS window for hold-anywhere dragging on native desktop.
+  // Best-effort and self-guarding: `initWindowDrag` never throws and is a
+  // no-op off desktop, so this cannot violate this function's invariant that
+  // `runApp` is called exactly once on every path.
+  await initWindowDrag();
 
   // Everything below persists to Hive boxes under the same per-user data
   // directory. A second instance of the app fails to open every one of them

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -123,7 +123,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
   // Desktop feature state
   final FocusNode _focusNode = FocusNode();
-  DateTime? _lastClickTime;
 
   // Fullscreen state
   bool _isFullscreen = false;
@@ -1472,20 +1471,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     }
   }
 
-  /// Handle double-click for fullscreen toggle (desktop only)
-  void _handleTap() {
-    if (!PlatformFeatures.isDesktop) return;
-
-    final now = DateTime.now();
-    if (_lastClickTime != null &&
-        now.difference(_lastClickTime!) < const Duration(milliseconds: 300)) {
-      _lastClickTime = null;
-      _toggleFullscreen();
-    } else {
-      _lastClickTime = now;
-    }
-  }
-
   @override
   void dispose() {
     // Exit fullscreen if active
@@ -1697,14 +1682,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     if (PlatformFeatures.supportsGestureControls && player != null) {
       videoPlayer = GestureControls(
         player: player,
-        child: videoPlayer,
-      );
-    }
-
-    // Add double-click handler for desktop
-    if (PlatformFeatures.isDesktop) {
-      videoPlayer = GestureDetector(
-        onTap: _handleTap,
         child: videoPlayer,
       );
     }

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -24,6 +24,15 @@ import 'video_progress_bar.dart';
 /// not scrubbing, and the pointer is not resting over the chrome. That last
 /// condition fixes a real defect — previously the chrome would fade out from
 /// under a stationary cursor that was aiming at a button.
+///
+/// The pointer-left-the-window hide (below, in [build]) is gated on
+/// `!PlatformFeatures.isMobile`, i.e. it is live on Flutter web as well as
+/// native desktop, not desktop-only. That is deliberate: on web, moving the
+/// cursor to the browser's tab strip or URL bar also collapses the auto-hide
+/// timer to zero and hides the chrome mid-playback. A pointer that has left
+/// the content area is nobody aiming at a control regardless of which chrome
+/// (OS window or browser tab) it left into, and the same `MouseRegion`
+/// already hides the mouse cursor itself on web for the same reason.
 class ChromeVisibility extends StatefulWidget {
   /// Whether playback is running. Chrome never auto-hides while paused.
   final bool isPlaying;

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -10,6 +10,7 @@ import 'center_play_button.dart';
 import 'chrome_panel.dart';
 import 'chrome_top_bar.dart';
 import 'panel_controls.dart';
+import 'playback_surface.dart';
 import 'transport_cluster.dart';
 import 'video_progress_bar.dart';
 
@@ -33,12 +34,26 @@ class ChromeVisibility extends StatefulWidget {
 
   final Duration autoHide;
 
+  /// Toggles fullscreen on a background double-click. Null by default.
+  ///
+  /// The platform gate lives in [PlaybackChrome], not here. Registering a
+  /// double-tap handler makes Flutter defer the single tap by
+  /// `kDoubleTapTimeout`, and `flutter test` runs on Linux where
+  /// `PlatformFeatures.isDesktop` is true, so gating here would silently add
+  /// that deferral to every widget test that constructs this class directly.
+  final VoidCallback? onDoubleTap;
+
+  /// Starts an OS window drag from the background. Null by default.
+  final VoidCallback? onWindowDrag;
+
   const ChromeVisibility({
     super.key,
     required this.isPlaying,
     required this.child,
     this.isSeeking = false,
     this.autoHide = const Duration(seconds: 3),
+    this.onDoubleTap,
+    this.onWindowDrag,
   });
 
   static const Key contentKey = Key('chrome-content');
@@ -94,6 +109,16 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
   /// this itself, only [_mayHide] does. Route through `setState` if that
   /// changes.
   bool _pointerOverChrome = false;
+
+  /// Whether the player's own route is still the top one, sampled in [build].
+  ///
+  /// Read in [build] rather than in the exit handler on purpose:
+  /// `ModalRoute.of` registers an inherited-widget dependency, and
+  /// `_ModalScopeStatus.updateShouldNotify` compares `isCurrent`, so sampling
+  /// it here means this widget rebuilds when a selector opens or closes and
+  /// the flag stays accurate without calling into the element tree from a
+  /// pointer callback.
+  bool _routeIsCurrent = true;
 
   /// Authoritative shown/hidden intent. Deliberately **not** derived from
   /// `_controller.value > 0` (the brief's original approach): that value is
@@ -175,6 +200,8 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
 
   @override
   Widget build(BuildContext context) {
+    _routeIsCurrent = ModalRoute.of(context)?.isCurrent ?? true;
+
     final content = ChromeAnimation(
       animation: _curved,
       child: FadeTransition(
@@ -206,10 +233,10 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
     Widget stack = Stack(
       fit: StackFit.expand,
       children: [
-        GestureDetector(
-          behavior: HitTestBehavior.opaque,
+        PlaybackSurface(
           onTap: _toggle,
-          child: const SizedBox.expand(),
+          onDoubleTap: widget.onDoubleTap,
+          onWindowDrag: widget.onWindowDrag,
         ),
         content,
       ],
@@ -225,6 +252,22 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
           // every hover event, up to ~120/sec.
           if (_visible && _hideTimer != null) return;
           _show();
+        },
+        onExit: (_) {
+          // A pointer outside the window is nobody aiming at a control, so
+          // collapse the auto-hide timer to zero. `_mayHide` still governs,
+          // which is what preserves the paused, seeking and
+          // pointer-over-chrome invariants. The 250ms reverse fade still
+          // runs; "immediately" refers to the timer, not the animation.
+          //
+          // `_routeIsCurrent` keeps an open selector from hiding the chrome
+          // underneath itself, which would leave it gone after dismissal
+          // until the mouse moved again.
+          //
+          // `mounted` is checked because a test's `gesture.removePointer`
+          // teardown, and a real window close, both synthesise an exit that
+          // can arrive while this State is being torn down.
+          if (mounted && _routeIsCurrent && _mayHide) _hide();
         },
         child: stack,
       );

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -5,6 +5,7 @@ import 'package:media_kit/media_kit.dart';
 
 import '../../../core/player/duration_override.dart';
 import '../../../core/player/platform_features.dart';
+import '../../../core/player/window_drag_service.dart';
 import '../../../core/theme/depth_tokens.dart';
 import 'center_play_button.dart';
 import 'chrome_panel.dart';
@@ -341,10 +342,11 @@ class ChromeSlide extends StatelessWidget {
 ///
 /// **Why double-tap ±10s (`gesture_controls.dart`) still works through
 /// [ChromeVisibility]'s background tap-to-toggle catcher:** that catcher is
-/// a full-screen, opaque `GestureDetector` and is the *first* child of this
-/// widget's `Stack` (see `ChromeVisibility.build`), i.e. the bottom-most
-/// layer, not the topmost — it only claims a tap that nothing painted above
-/// it wants. In production, [PlaybackChrome] is never a `Stack` sibling of
+/// [PlaybackSurface] (a `Listener` wrapping an opaque `GestureDetector`) and
+/// is the *first* child of this widget's `Stack` (see
+/// `ChromeVisibility.build`), i.e. the bottom-most layer, not the topmost —
+/// it only claims a tap that nothing painted above it wants. In production,
+/// [PlaybackChrome] is never a `Stack` sibling of
 /// `GestureControls`; it is the `controls` builder media_kit's `Video`
 /// renders via `Positioned.fill` inside `Video`'s own internal `Stack`, and
 /// `GestureControls` wraps that entire `Video` as its child, using
@@ -422,6 +424,18 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
         return ChromeVisibility(
           isPlaying: snapshot.data ?? false,
           isSeeking: _seeking,
+          // Both gates live here, not inside ChromeVisibility, so widget
+          // tests can construct that class with plain callbacks and get
+          // deterministic behaviour regardless of the host platform.
+          //
+          // Double-click stays available in fullscreen, since that is how
+          // you get back out. The window drag does not: there is no window
+          // to move.
+          onDoubleTap:
+              PlatformFeatures.isDesktop ? widget.onFullscreenTap : null,
+          onWindowDrag: PlatformFeatures.isDesktop && !widget.isFullscreen
+              ? startWindowDrag
+              : null,
           child: SafeArea(
             child: Stack(
               children: [

--- a/player/lib/presentation/widgets/video_controls/playback_surface.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_surface.dart
@@ -65,7 +65,8 @@ class _PlaybackSurfaceState extends State<PlaybackSurface> {
   /// runs after `onPointerUp`, and clearing there would defeat the whole
   /// mechanism. It is cleared on the next pointer down instead, which also
   /// covers the case where the OS takes the pointer for a window drag and
-  /// Flutter never sees a matching up event at all.
+  /// Flutter never sees a matching up event at all. [_handleTap] also clears
+  /// it whenever the arena does resolve a tap after a drag was flagged.
   bool _draggedThisGesture = false;
 
   void _onPointerDown(PointerDownEvent event) {

--- a/player/lib/presentation/widgets/video_controls/playback_surface.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_surface.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+/// The bare video background beneath the playback chrome.
+///
+/// Owns every pointer semantic for the region that is *not* a control: tap to
+/// toggle chrome, double-click to toggle fullscreen, and press-and-move to
+/// drag the OS window. Consolidating them here is the point. Before this
+/// widget, three separate gesture layers competed over the same region and
+/// the outermost one (desktop double-click-to-fullscreen in
+/// `player_screen.dart`) lost every arena to the innermost one and never
+/// fired.
+///
+/// **Why the drag lives in a `Listener` and not `GestureDetector.onPanStart`.**
+/// For a mouse, Flutter's drag recognizers accept after
+/// `kPrecisePointerHitSlop`, which is 1 logical pixel and is not configurable
+/// for precise pointers through `DeviceGestureSettings`. A pan recognizer here
+/// would win the arena and cancel the click after a single pixel of hand
+/// tremor. A `Listener` does not enter the gesture arena at all, so it can
+/// watch the pointer without ever stealing a tap.
+class PlaybackSurface extends StatefulWidget {
+  /// Toggles chrome visibility. Suppressed when the gesture became a drag.
+  final VoidCallback onTap;
+
+  /// Toggles fullscreen. Null off native desktop.
+  ///
+  /// Passing null is load-bearing, not merely tidy: registering a double-tap
+  /// handler makes Flutter defer [onTap] by `kDoubleTapTimeout`, so platforms
+  /// with no double-click must not register one.
+  final VoidCallback? onDoubleTap;
+
+  /// Hands the gesture to the OS as a window drag. Null when there is no
+  /// window to move (web, mobile) or it cannot be moved (fullscreen). When
+  /// null, no drag distance is tracked at all and taps behave exactly as they
+  /// would without this widget.
+  final VoidCallback? onWindowDrag;
+
+  const PlaybackSurface({
+    super.key,
+    required this.onTap,
+    this.onDoubleTap,
+    this.onWindowDrag,
+  });
+
+  /// Movement past this many logical pixels, while the pointer is held,
+  /// promotes the gesture from a click to a window drag.
+  ///
+  /// Deliberately well above `kPrecisePointerHitSlop` (1.0) so a click is
+  /// clearly distinct from a drag. Note this leaves 1px to 8px accepted as
+  /// neither: Flutter has already rejected the tap by then. That dead zone is
+  /// pre-existing behaviour, not something this threshold introduces.
+  static const double dragSlop = 8.0;
+
+  @override
+  State<PlaybackSurface> createState() => _PlaybackSurfaceState();
+}
+
+class _PlaybackSurfaceState extends State<PlaybackSurface> {
+  Offset? _downPosition;
+
+  /// Set once the held pointer travels past [PlaybackSurface.dragSlop]. Read
+  /// by [_handleTap] to suppress the toggle.
+  ///
+  /// Never cleared on pointer up. `GestureBinding` routes the up event to
+  /// this `Listener` *before* it sweeps the gesture arena, so `onTap` always
+  /// runs after `onPointerUp`, and clearing there would defeat the whole
+  /// mechanism. It is cleared on the next pointer down instead, which also
+  /// covers the case where the OS takes the pointer for a window drag and
+  /// Flutter never sees a matching up event at all.
+  bool _draggedThisGesture = false;
+
+  void _onPointerDown(PointerDownEvent event) {
+    _downPosition = event.position;
+    _draggedThisGesture = false;
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    final startDrag = widget.onWindowDrag;
+    final down = _downPosition;
+    if (startDrag == null || down == null || _draggedThisGesture) return;
+    if ((event.position - down).distance < PlaybackSurface.dragSlop) return;
+
+    _draggedThisGesture = true;
+    startDrag();
+  }
+
+  void _onPointerFinished(PointerEvent event) => _downPosition = null;
+
+  void _handleTap() {
+    if (_draggedThisGesture) {
+      _draggedThisGesture = false;
+      return;
+    }
+    widget.onTap();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerUp: _onPointerFinished,
+      onPointerCancel: _onPointerFinished,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _handleTap,
+        onDoubleTap: widget.onDoubleTap,
+        child: const SizedBox.expand(),
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/video_controls/playback_surface.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_surface.dart
@@ -5,10 +5,10 @@ import 'package:flutter/material.dart';
 /// Owns every pointer semantic for the region that is *not* a control: tap to
 /// toggle chrome, double-click to toggle fullscreen, and press-and-move to
 /// drag the OS window. Consolidating them here is the point. Before this
-/// widget, three separate gesture layers competed over the same region and
+/// widget, three separate gesture layers competed over the same region, with
 /// the outermost one (desktop double-click-to-fullscreen in
-/// `player_screen.dart`) lost every arena to the innermost one and never
-/// fired.
+/// `player_screen.dart`) expected to lose every arena to the innermost one
+/// and so never fire in practice.
 ///
 /// **Why the drag lives in a `Listener` and not `GestureDetector.onPanStart`.**
 /// For a mouse, Flutter's drag recognizers accept after

--- a/player/pubspec.lock
+++ b/player/pubspec.lock
@@ -1230,6 +1230,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.6"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: ace919117a7520c13a50a6259e60c4a0d4cbe98809468792a91b5c5adada2aa6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: "7b52006a5ceae1f3d5af7f77188c3290d6e7d8ded16d99809bea84967c65c257"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: a1489b99cce597c45a54b9aae1cd94c8d4705353b7e0bb2457a6e4de44e0ad8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: "94a5535277510a63184ca178ce12a1449bc0b38618879aa1c18bf57369c5064a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: dafc6922b0bfbf1d48cf3ccbf519b4fff47bdcb820da1728ea6db675fecc9324
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   shared_preferences:
     dependency: transitive
     description:
@@ -1691,6 +1731,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: "05c231fd7b23d2380f14c5cc10b7b93d60d4fa4a2fb4e0f032de27e44b5560e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
   xdg_directories:
     dependency: transitive
     description:

--- a/player/pubspec.yaml
+++ b/player/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   hive_ce: ^2.16.0
   hive_ce_flutter: ^2.3.4
   freezed_annotation: ^3.1.0
+  window_manager: ^0.5.2
 
 dev_dependencies:
   flutter_test:

--- a/player/test/core/player/window_drag_service_test.dart
+++ b/player/test/core/player/window_drag_service_test.dart
@@ -2,10 +2,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/player/window_drag_service.dart';
 
 void main() {
-  // Under `flutter test` there is no plugin registrant, so every
-  // `window_manager` call throws MissingPluginException. Both entry points
-  // must swallow that. `initWindowDrag` is called from `_startApp`, which
-  // documents an invariant that nothing after
+  // Under `flutter test` there is no `runApp`, so no Flutter binding ever
+  // exists in this file's isolate. `window_manager`'s lazily-constructed
+  // `WindowManager._()` singleton calls `setMethodCallHandler` before a
+  // binding exists, which throws synchronously — and since a failed lazy
+  // top-level initializer retries on every subsequent access, both tests
+  // below hit it independently, not just the first one to touch
+  // `windowManager`. Both entry points must swallow that. `initWindowDrag` is
+  // called from `_startApp`, which documents an invariant that nothing after
   // `WidgetsFlutterBinding.ensureInitialized()` may throw its way out, on
   // pain of a permanently black window.
   group('window drag service', () {

--- a/player/test/core/player/window_drag_service_test.dart
+++ b/player/test/core/player/window_drag_service_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/window_drag_service.dart';
+
+void main() {
+  // Under `flutter test` there is no plugin registrant, so every
+  // `window_manager` call throws MissingPluginException. Both entry points
+  // must swallow that. `initWindowDrag` is called from `_startApp`, which
+  // documents an invariant that nothing after
+  // `WidgetsFlutterBinding.ensureInitialized()` may throw its way out, on
+  // pain of a permanently black window.
+  group('window drag service', () {
+    test('initWindowDrag completes without throwing', () async {
+      await expectLater(initWindowDrag(), completes);
+    });
+
+    test('startWindowDrag does not throw', () {
+      expect(startWindowDrag, returnsNormally);
+    });
+  });
+}

--- a/player/test/presentation/widgets/video_controls/playback_chrome_test.dart
+++ b/player/test/presentation/widgets/video_controls/playback_chrome_test.dart
@@ -3,9 +3,34 @@ import 'dart:async';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:media_kit/media_kit.dart';
 import 'package:player/presentation/widgets/video_controls/playback_chrome.dart';
 
 Widget _host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+/// A [PlatformPlayer] that never touches native mpv/web bindings — safe to
+/// construct inside `flutter test`. Same shape as
+/// `playback_chrome_episode_nav_test.dart`'s fake (kept separate, not shared,
+/// since neither file exports it and duplicating ~15 lines is cheaper than
+/// introducing a new shared test-only import).
+class _FakePlatformPlayer extends PlatformPlayer {
+  _FakePlatformPlayer() : super(configuration: const PlayerConfiguration());
+
+  @override
+  Future<void> play() async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> playOrPause() async {}
+
+  @override
+  Future<void> setVolume(double volume) async {}
+
+  @override
+  Future<void> seek(Duration duration) async {}
+}
 
 double _opacity(WidgetTester tester) => tester
     .widget<FadeTransition>(
@@ -496,6 +521,67 @@ void main() {
       );
 
       expect(find.byKey(markerKey), findsOneWidget);
+    });
+  });
+
+  group('PlaybackChrome gating', () {
+    late Player player;
+
+    setUp(() {
+      player = Player(platformPlayer: _FakePlatformPlayer());
+    });
+
+    tearDown(() => player.dispose());
+
+    Widget host({required bool isFullscreen}) => _host(
+          PlaybackChrome(
+            player: player,
+            onFullscreenTap: () {},
+            isFullscreen: isFullscreen,
+          ),
+        );
+
+    testWidgets(
+        'not fullscreen: both the window drag and the double-tap '
+        'fullscreen-exit callbacks reach ChromeVisibility', (tester) async {
+      await tester.pumpWidget(host(isFullscreen: false));
+      await tester.pumpAndSettle();
+
+      final chromeVisibility =
+          tester.widget<ChromeVisibility>(find.byType(ChromeVisibility));
+
+      expect(
+        chromeVisibility.onWindowDrag,
+        isNotNull,
+        reason: 'a normal window should be draggable from the background',
+      );
+      expect(
+        chromeVisibility.onDoubleTap,
+        isNotNull,
+        reason: 'double-tap should still toggle fullscreen',
+      );
+    });
+
+    testWidgets(
+        'fullscreen: the window drag callback is gone (no window to move) '
+        'but double-tap survives (it is how fullscreen is exited)',
+        (tester) async {
+      await tester.pumpWidget(host(isFullscreen: true));
+      await tester.pumpAndSettle();
+
+      final chromeVisibility =
+          tester.widget<ChromeVisibility>(find.byType(ChromeVisibility));
+
+      expect(
+        chromeVisibility.onWindowDrag,
+        isNull,
+        reason: 'there is no window to drag while fullscreen',
+      );
+      expect(
+        chromeVisibility.onDoubleTap,
+        isNotNull,
+        reason: 'double-tap is the only way to exit fullscreen',
+      );
     });
   });
 }

--- a/player/test/presentation/widgets/video_controls/playback_chrome_test.dart
+++ b/player/test/presentation/widgets/video_controls/playback_chrome_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -263,6 +265,127 @@ void main() {
       expect(_opacity(tester), 1.0,
           reason: 'a tap mid-fade should bring chrome back, not finish '
               'hiding it');
+    });
+
+    testWidgets('hides immediately when the mouse leaves the window',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          const ChromeVisibility(
+            isPlaying: true,
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: SizedBox(width: 200, height: 60, child: Text('chrome')),
+            ),
+          ),
+        ),
+      );
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      // Enter over the content itself, not bare background. Leaving the
+      // window from over a control fires the inner content MouseRegion's
+      // onExit (clearing _pointerOverChrome) and the outer one's. Flutter
+      // dispatches exits innermost first, so _pointerOverChrome is already
+      // false when the outer handler evaluates _mayHide. If that ever
+      // inverted, exiting over a control would silently stop hiding, and
+      // this test is what would catch it.
+      await gesture.addPointer(location: tester.getCenter(find.text('chrome')));
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      expect(_opacity(tester), 1.0);
+
+      // Move the pointer outside the 800x600 test window.
+      await gesture.moveTo(const Offset(-50, -50));
+      await tester.pumpAndSettle();
+
+      expect(
+        _opacity(tester),
+        0.0,
+        reason: 'chrome should not wait out the 3s timer once the pointer '
+            'has left the window',
+      );
+    });
+
+    testWidgets('does not hide on mouse exit while paused', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          const ChromeVisibility(
+            isPlaying: false,
+            child: SizedBox(width: 200, height: 100, child: Text('chrome')),
+          ),
+        ),
+      );
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: const Offset(400, 300));
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+
+      await gesture.moveTo(const Offset(-50, -50));
+      await tester.pumpAndSettle();
+
+      expect(_opacity(tester), 1.0,
+          reason: 'the paused invariant must survive mouse exit');
+    });
+
+    testWidgets('does not hide on mouse exit while seeking', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          const ChromeVisibility(
+            isPlaying: true,
+            isSeeking: true,
+            child: SizedBox(width: 200, height: 100, child: Text('chrome')),
+          ),
+        ),
+      );
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: const Offset(400, 300));
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+
+      await gesture.moveTo(const Offset(-50, -50));
+      await tester.pumpAndSettle();
+
+      expect(_opacity(tester), 1.0,
+          reason: 'dragging the scrubber past the window edge must not '
+              'yank the chrome away mid-seek');
+    });
+
+    testWidgets('does not hide on mouse exit while a modal route is on top',
+        (tester) async {
+      // Opening the quality, audio, subtitle or cast picker pushes a route
+      // over the player and moves the pointer off it. Hiding underneath would
+      // leave the chrome gone after dismissal until the mouse moved again,
+      // because only onHover calls _show().
+      await tester.pumpWidget(
+        _host(
+          const ChromeVisibility(
+            isPlaying: true,
+            child: SizedBox(width: 200, height: 100, child: Text('chrome')),
+          ),
+        ),
+      );
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: const Offset(400, 300));
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+
+      final context = tester.element(find.byType(ChromeVisibility));
+      unawaited(
+        showDialog<void>(
+          context: context,
+          builder: (_) => const AlertDialog(content: Text('picker')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await gesture.moveTo(const Offset(-50, -50));
+      await tester.pumpAndSettle();
+
+      expect(_opacity(tester), 1.0,
+          reason: 'chrome hid underneath an open selector');
     });
   });
 

--- a/player/test/presentation/widgets/video_controls/playback_surface_test.dart
+++ b/player/test/presentation/widgets/video_controls/playback_surface_test.dart
@@ -44,7 +44,13 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(drags, 1, reason: 'the OS drag must be handed off exactly once');
-      expect(taps, 0, reason: 'a drag is not a click');
+      // `taps == 0` here is NOT evidence that the suppression flag works.
+      // Flutter's own TapGestureRecognizer uses kPrecisePointerHitSlop (1.0)
+      // for a mouse, so a 60px move has already rejected the tap before
+      // _handleTap could run, and this assertion would still pass with the
+      // suppression check deleted. The flag is falsifiable only on a touch
+      // pointer, which the next test covers.
+      expect(taps, 0, reason: 'a 60px mouse move is not a click');
     });
 
     testWidgets('a mouse move under the slop starts no window drag',

--- a/player/test/presentation/widgets/video_controls/playback_surface_test.dart
+++ b/player/test/presentation/widgets/video_controls/playback_surface_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/video_controls/playback_surface.dart';
+
+Widget _host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('PlaybackSurface', () {
+    testWidgets('a click with no movement toggles', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_host(PlaybackSurface(onTap: () => taps++)));
+
+      await tester.tapAt(const Offset(400, 300));
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+    });
+
+    testWidgets(
+        'a mouse drag past the slop starts exactly one window drag and does '
+        'not toggle', (tester) async {
+      var taps = 0;
+      var drags = 0;
+      await tester.pumpWidget(
+        _host(
+          PlaybackSurface(
+            onTap: () => taps++,
+            onWindowDrag: () => drags++,
+          ),
+        ),
+      );
+
+      final gesture = await tester.startGesture(
+        const Offset(400, 300),
+        kind: PointerDeviceKind.mouse,
+      );
+      // Several moves well past dragSlop: the drag must fire once, not once
+      // per move event.
+      await gesture.moveBy(const Offset(20, 0));
+      await gesture.moveBy(const Offset(20, 0));
+      await gesture.moveBy(const Offset(20, 0));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(drags, 1, reason: 'the OS drag must be handed off exactly once');
+      expect(taps, 0, reason: 'a drag is not a click');
+    });
+
+    testWidgets('a mouse move under the slop starts no window drag',
+        (tester) async {
+      var drags = 0;
+      await tester.pumpWidget(
+        _host(
+          PlaybackSurface(onTap: () {}, onWindowDrag: () => drags++),
+        ),
+      );
+
+      final gesture = await tester.startGesture(
+        const Offset(400, 300),
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.moveBy(const Offset(3, 0));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(drags, 0);
+      // Deliberately no assertion about `taps` here. Flutter's own
+      // TapGestureRecognizer uses kPrecisePointerHitSlop (1.0) for a mouse,
+      // so it has already rejected this gesture as a tap regardless of
+      // anything PlaybackSurface does. That 1px-to-8px dead zone predates
+      // this widget.
+    });
+
+    testWidgets(
+        'a touch drag between dragSlop and kTouchSlop drags the window and '
+        'suppresses the toggle', (tester) async {
+      // The case that actually exercises the suppression flag. A desktop
+      // touchscreen gets kTouchSlop (18), so a 10px drag is still a tap as
+      // far as Flutter is concerned, but is past this widget's 8px dragSlop.
+      // Without the flag the window would move AND the chrome would toggle.
+      var taps = 0;
+      var drags = 0;
+      await tester.pumpWidget(
+        _host(
+          PlaybackSurface(
+            onTap: () => taps++,
+            onWindowDrag: () => drags++,
+          ),
+        ),
+      );
+
+      final gesture = await tester.startGesture(
+        const Offset(400, 300),
+        kind: PointerDeviceKind.touch,
+      );
+      await gesture.moveBy(const Offset(10, 0));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(drags, 1);
+      expect(taps, 0, reason: 'the suppression flag did not hold');
+    });
+
+    testWidgets('a double-click fires onDoubleTap', (tester) async {
+      var doubles = 0;
+      await tester.pumpWidget(
+        _host(
+          PlaybackSurface(onTap: () {}, onDoubleTap: () => doubles++),
+        ),
+      );
+
+      await tester.tapAt(const Offset(400, 300));
+      await tester.pump(kDoubleTapMinTime);
+      await tester.tapAt(const Offset(400, 300));
+      await tester.pumpAndSettle();
+
+      expect(doubles, 1);
+    });
+
+    testWidgets('with onWindowDrag null a long drag does nothing',
+        (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_host(PlaybackSurface(onTap: () => taps++)));
+
+      final gesture = await tester.startGesture(
+        const Offset(400, 300),
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.moveBy(const Offset(60, 0));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(taps, 0, reason: 'the mouse moved well past the 1px tap slop');
+    });
+
+    testWidgets(
+        'with onDoubleTap null a tap resolves without waiting out the '
+        'double-tap timeout', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_host(PlaybackSurface(onTap: () => taps++)));
+
+      await tester.tapAt(const Offset(400, 300));
+      await tester.pump();
+
+      expect(taps, 1,
+          reason: 'registering no double-tap handler must keep taps instant, '
+              'which is what keeps mobile and the existing ChromeVisibility '
+              'tests behaving as they do today');
+    });
+
+    testWidgets(
+        'with onDoubleTap set a tap is deferred until the double-tap timeout',
+        (tester) async {
+      // Documents the accepted trade-off rather than guarding against it:
+      // offering double-click-to-fullscreen costs an instant single click.
+      var taps = 0;
+      await tester.pumpWidget(
+        _host(PlaybackSurface(onTap: () => taps++, onDoubleTap: () {})),
+      );
+
+      await tester.tapAt(const Offset(400, 300));
+      await tester.pump();
+      expect(taps, 0, reason: 'the tap should still be waiting for a second');
+
+      await tester.pump(kDoubleTapTimeout + const Duration(milliseconds: 50));
+      expect(taps, 1);
+    });
+  });
+}


### PR DESCRIPTION
Two Infuse-inspired changes to the player's playback page, both desktop-facing.

**Hold anywhere to drag the window.** Press and hold anywhere on the bare video surface, then move, to reposition the OS window. On macOS this closes a real gap: `MainFlutterWindow.swift` sets `titlebarAppearsTransparent` + `titleVisibility: .hidden` + `.fullSizeContentView`, so the only draggable region today is the ~28px transparent strip at the top. Windows and Linux keep their native title bars and gain this as a convenience.

**Hide the controls when the mouse leaves the window**, instead of waiting out the 3s auto-hide timer.

## How it works

A new `PlaybackSurface` replaces `ChromeVisibility`'s bare background tap-catcher and becomes the single owner of every pointer semantic on the non-control region: tap toggles chrome, double-click toggles fullscreen, press-and-move past 8px starts an OS window drag.

Three decisions worth knowing before touching this code, each documented at its site:

1. **Drag detection lives in a non-arena `Listener`, not `GestureDetector.onPanStart`.** For a mouse, `computeHitSlop` returns `kPrecisePointerHitSlop` (1.0px) and is not configurable for precise pointers. A pan recognizer would win the arena and cancel the click after one pixel of hand tremor.
2. **`_draggedThisGesture` is deliberately not cleared on pointer up.** `GestureBinding` routes the up event to the `Listener` before it sweeps the arena, so `onTap` runs after `onPointerUp`. It clears on the next pointer down, which also covers the OS stealing the pointer mid-drag so no up event ever arrives.
3. **`ChromeVisibility`'s callbacks default to null with no internal platform gate**; the gate lives in `PlaybackChrome`. `flutter test` runs on Linux where `PlatformFeatures.isDesktop` is true, so an internal gate would register `onDoubleTap` during tests, defer every tap by `kDoubleTapTimeout`, and break nine pre-existing tests.

`onDoubleTap` stays enabled in fullscreen (that is how you exit); `onWindowDrag` is suppressed there (no window to move). The asymmetry is intentional.

`window_manager` sits behind a `window_drag_service.dart` conditional-import shim mirroring `network_info_service.dart`, so the web build never links it. Verified at the package manifest level: window_manager 0.5.2 declares only linux/macos/windows plugin classes.

This also deletes the old desktop double-click layer from `player_screen.dart` (`_handleTap`, `_lastClickTime`, and the wrapping `GestureDetector`), whose tap recognizer was expected to lose every arena to `ChromeVisibility`'s inner one. That expectation was never observed on a running build, and the code comments say so rather than asserting it.

## Behaviour note: this ships on web too

The exit-hide is gated on `!isMobile`, not `isDesktop`, matching the `MouseRegion` that already hides the cursor on web. So on the web player, moving the cursor to the browser tab strip or URL bar now hides the chrome mid-playback. This is deliberate and documented in `ChromeVisibility`'s dartdoc. Say the word if you want it desktop-only instead.

## Verified

- `./dev flutter test --concurrency=1`: exit 0, 949 tests, "All tests passed!". 96 of 97 files load; the exclusion is the pre-existing `@TestOn('mac-os')` golden.
- `./dev flutter analyze`: 0 errors. 53 pre-existing info lints, none in any touched file.
- `gesture_chrome_composition_test.dart`, the mobile double-tap-seek regression net, is byte-identical across the whole branch.

## NOT verified: five manual desktop checks

**Please treat this as a pre-release gate for the desktop artifacts.** The environment this was built in has no display (`DISPLAY` and `WAYLAND_DISPLAY` both empty), so the window-drag feature has never been exercised against a real OS window. Static analysis and the "does not throw" tests are the only evidence it works.

Before a desktop build ships from `release.yml` (DMG / Windows installer / Linux bundle), someone with a display should confirm:

1. Press and hold on the video away from the controls, then move. The window follows.
2. A plain click still toggles the chrome.
3. A double-click toggles fullscreen, and in fullscreen press-and-drag does nothing.
4. Moving the mouse out of the window during playback hides the chrome at once.
5. Pausing, then moving the mouse out, leaves the chrome up.

Highest-risk unknown: whether `startDragging()` moves the window when called from a `PointerMove` handler on macOS. `WindowManager.swift` calls `window.performDrag(with: window.currentEvent!)`, and at that moment `currentEvent` is an `NSLeftMouseDragged` rather than the `NSLeftMouseDown` the API is documented against. window_manager's own `DragToMoveArea` calls it from `onPanStart`, which is also mid-drag, so this very likely works. If it does not, it fails silently: the window just does not move.

Web and mobile are unaffected by the drag work: both callbacks resolve to null, no distance is tracked, and the plugin is never linked.

## Known and parked

- Five em dashes in newly written doc comments, which contradicts my usual no-em-dash preference. Left alone because the surrounding files are already saturated with them in pre-existing comments, so fixing only the new ones would look inconsistent. Happy to sweep them if you want the rule to cover Dart comments.
- `PlaybackSurface`'s pointer state is not keyed by pointer id, so a second simultaneous pointer resets first-pointer state. Narrow exposure: single-pointer video surface, no multi-touch handler, drag is null on mobile.
- `gesture_chrome_composition_test.dart`'s own internal comment now describes the background catcher inaccurately. Deliberately untouched, since that file is the regression net. Worth a follow-up.

Design doc and implementation plan are in `docs/superpowers/` locally, which is gitignored, so they do not travel with this branch.
