### PR TITLE
refactor(admin): route the remaining config pages through admin_page

### DIFF
--- a/lib/mydia_web.ex
+++ b/lib/mydia_web.ex
@@ -91,7 +91,7 @@ defmodule MydiaWeb do
       import MydiaWeb.LibraryComponents
       # Collection components for collection views
       import MydiaWeb.CollectionComponents
-      # Admin configuration components (tab_nav, admin_page)
+      # Admin configuration page chrome (admin_page)
       import MydiaWeb.AdminComponents
 
       # Common modules used in templates

--- a/lib/mydia_web/components/admin_components.ex
+++ b/lib/mydia_web/components/admin_components.ex
@@ -13,7 +13,7 @@ defmodule MydiaWeb.AdminComponents do
 
   attr :active_tab, :atom, required: true
 
-  def tab_nav(assigns) do
+  defp tab_nav(assigns) do
     remote_access_enabled =
       Application.get_env(:mydia, :features, [])
       |> Keyword.get(:remote_access_enabled, false)

--- a/lib/mydia_web/live/admin_download_clients_live/index.html.heex
+++ b/lib/mydia_web/live/admin_download_clients_live/index.html.heex
@@ -1,22 +1,9 @@
 <Layouts.app {assigns}>
-  <div>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-3xl font-bold">Configuration</h1>
-        <p class="text-base-content/70 mt-1">
-          System status, application settings, and configuration management
-        </p>
-      </div>
-    </div>
-
-    <MydiaWeb.AdminComponents.tab_nav active_tab={@active_tab} />
-
-    <div class="bg-base-100">
-      <MydiaWeb.AdminDownloadClientsLive.Components.download_clients_tab
-        download_clients={@download_clients}
-        client_health={@client_health}
-      />
-    </div>
+  <.admin_page active_tab={@active_tab}>
+    <MydiaWeb.AdminDownloadClientsLive.Components.download_clients_tab
+      download_clients={@download_clients}
+      client_health={@client_health}
+    />
 
     <%!-- Download Client Modal --%>
     <%= if assigns[:show_download_client_modal] do %>
@@ -32,5 +19,5 @@
       client={assigns[:pending_delete_client]}
       count={assigns[:pending_delete_count] || 0}
     />
-  </div>
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_indexers_live/index.html.heex
+++ b/lib/mydia_web/live/admin_indexers_live/index.html.heex
@@ -1,28 +1,15 @@
 <Layouts.app {assigns}>
-  <div>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-3xl font-bold">Configuration</h1>
-        <p class="text-base-content/70 mt-1">
-          System status, application settings, and configuration management
-        </p>
-      </div>
-    </div>
-
-    <MydiaWeb.AdminComponents.tab_nav active_tab={@active_tab} />
-
-    <div class="bg-base-100">
-      <MydiaWeb.AdminIndexersLive.Components.indexers_tab
-        indexers={@indexers}
-        indexer_health={@indexer_health}
-        library_indexers={@library_indexers}
-        library_indexer_stats={@library_indexer_stats}
-        cardigann_enabled={@cardigann_enabled}
-        recently_disabled_indexer={@recently_disabled_indexer}
-        flaresolverr={@flaresolverr}
-        flaresolverr_status={@flaresolverr_status}
-      />
-    </div>
+  <.admin_page active_tab={@active_tab}>
+    <MydiaWeb.AdminIndexersLive.Components.indexers_tab
+      indexers={@indexers}
+      indexer_health={@indexer_health}
+      library_indexers={@library_indexers}
+      library_indexer_stats={@library_indexer_stats}
+      cardigann_enabled={@cardigann_enabled}
+      recently_disabled_indexer={@recently_disabled_indexer}
+      flaresolverr={@flaresolverr}
+      flaresolverr_status={@flaresolverr_status}
+    />
 
     <%!-- FlareSolverr Edit Modal --%>
     <%= if @flaresolverr_modal_open do %>
@@ -70,5 +57,5 @@
         test_result={assigns[:library_config_test_result]}
       />
     <% end %>
-  </div>
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_library_paths_live/index.html.heex
+++ b/lib/mydia_web/live/admin_library_paths_live/index.html.heex
@@ -1,23 +1,10 @@
 <Layouts.app {assigns}>
-  <div>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-3xl font-bold">Configuration</h1>
-        <p class="text-base-content/70 mt-1">
-          System status, application settings, and configuration management
-        </p>
-      </div>
-    </div>
-
-    <MydiaWeb.AdminComponents.tab_nav active_tab={@active_tab} />
-
-    <div class="bg-base-100">
-      <MydiaWeb.AdminLibraryPathsLive.Components.library_paths_tab
-        library_paths={@library_paths}
-        reorganizing_library_ids={@reorganizing_library_ids}
-        reclassifying_library_ids={@reclassifying_library_ids}
-      />
-    </div>
+  <.admin_page active_tab={@active_tab}>
+    <MydiaWeb.AdminLibraryPathsLive.Components.library_paths_tab
+      library_paths={@library_paths}
+      reorganizing_library_ids={@reorganizing_library_ids}
+      reclassifying_library_ids={@reclassifying_library_ids}
+    />
 
     <%!-- Library Path Modal --%>
     <%= if assigns[:show_library_path_modal] do %>
@@ -26,5 +13,5 @@
         library_path_mode={@library_path_mode}
       />
     <% end %>
-  </div>
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_media_servers_live/index.html.heex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.html.heex
@@ -1,22 +1,9 @@
 <Layouts.app {assigns}>
-  <div>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-3xl font-bold">Configuration</h1>
-        <p class="text-base-content/70 mt-1">
-          System status, application settings, and configuration management
-        </p>
-      </div>
-    </div>
-
-    <MydiaWeb.AdminComponents.tab_nav active_tab={@active_tab} />
-
-    <div class="bg-base-100">
-      <MydiaWeb.AdminMediaServersLive.Components.media_servers_tab
-        media_servers={@media_servers}
-        media_server_health={@media_server_health}
-      />
-    </div>
+  <.admin_page active_tab={@active_tab}>
+    <MydiaWeb.AdminMediaServersLive.Components.media_servers_tab
+      media_servers={@media_servers}
+      media_server_health={@media_server_health}
+    />
 
     <%!-- Media Server Modal --%>
     <%= if assigns[:show_media_server_modal] do %>
@@ -31,5 +18,5 @@
         plex_connection_statuses={assigns[:plex_connection_statuses] || %{}}
       />
     <% end %>
-  </div>
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_path_mappings_live/index.html.heex
+++ b/lib/mydia_web/live/admin_path_mappings_live/index.html.heex
@@ -1,19 +1,6 @@
 <Layouts.app {assigns}>
-  <div>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-3xl font-bold">Configuration</h1>
-        <p class="text-base-content/70 mt-1">
-          System status, application settings, and configuration management
-        </p>
-      </div>
-    </div>
-
-    <MydiaWeb.AdminComponents.tab_nav active_tab={@active_tab} />
-
-    <div class="bg-base-100">
-      <MydiaWeb.AdminPathMappingsLive.Components.path_mappings_tab path_mappings={@path_mappings} />
-    </div>
+  <.admin_page active_tab={@active_tab}>
+    <MydiaWeb.AdminPathMappingsLive.Components.path_mappings_tab path_mappings={@path_mappings} />
 
     <%= if @show_modal do %>
       <MydiaWeb.AdminPathMappingsLive.Components.path_mapping_modal
@@ -23,5 +10,5 @@
         local_suggestions={@local_suggestions}
       />
     <% end %>
-  </div>
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_quality_profiles_live/index.html.heex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/index.html.heex
@@ -1,22 +1,9 @@
 <Layouts.app {assigns}>
-  <div>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-3xl font-bold">Configuration</h1>
-        <p class="text-base-content/70 mt-1">
-          System status, application settings, and configuration management
-        </p>
-      </div>
-    </div>
-
-    <MydiaWeb.AdminComponents.tab_nav active_tab={@active_tab} />
-
-    <div class="bg-base-100">
-      <MydiaWeb.AdminQualityProfilesLive.Components.quality_profiles_tab
-        quality_profiles={@quality_profiles}
-        default_quality_profile_id={@default_quality_profile_id}
-      />
-    </div>
+  <.admin_page active_tab={@active_tab}>
+    <MydiaWeb.AdminQualityProfilesLive.Components.quality_profiles_tab
+      quality_profiles={@quality_profiles}
+      default_quality_profile_id={@default_quality_profile_id}
+    />
 
     <%!-- Quality Profile Modal --%>
     <%= if assigns[:show_quality_profile_modal] do %>
@@ -49,5 +36,5 @@
         selected_category={assigns[:browse_presets_category] || :all}
       />
     <% end %>
-  </div>
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_remote_access_live/index.html.heex
+++ b/lib/mydia_web/live/admin_remote_access_live/index.html.heex
@@ -1,37 +1,24 @@
 <Layouts.app {assigns}>
-  <div>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-3xl font-bold">Configuration</h1>
-        <p class="text-base-content/70 mt-1">
-          System status, application settings, and configuration management
-        </p>
-      </div>
-    </div>
-
-    <MydiaWeb.AdminComponents.tab_nav active_tab={@active_tab} />
-
-    <div class="bg-base-100">
-      <MydiaWeb.AdminRemoteAccessLive.Components.remote_access_panel
-        ra_config={@ra_config}
-        p2p_status={@p2p_status}
-        devices={@devices}
-        claim_code={@claim_code}
-        claim_code_rendezvous_status={@claim_code_rendezvous_status}
-        claim_expires_at={@claim_expires_at}
-        countdown_seconds={@countdown_seconds}
-        pairing_error={@pairing_error}
-        show_revoke_modal={@show_revoke_modal}
-        selected_device={@selected_device}
-        show_delete_modal={@show_delete_modal}
-        device_to_delete={@device_to_delete}
-        show_pairing_modal={@show_pairing_modal}
-        show_add_url_modal={@show_add_url_modal}
-        new_url={@new_url}
-        show_advanced={@show_advanced}
-        show_all_devices={@show_all_devices}
-        show_clear_inactive_modal={@show_clear_inactive_modal}
-      />
-    </div>
-  </div>
+  <.admin_page active_tab={@active_tab}>
+    <MydiaWeb.AdminRemoteAccessLive.Components.remote_access_panel
+      ra_config={@ra_config}
+      p2p_status={@p2p_status}
+      devices={@devices}
+      claim_code={@claim_code}
+      claim_code_rendezvous_status={@claim_code_rendezvous_status}
+      claim_expires_at={@claim_expires_at}
+      countdown_seconds={@countdown_seconds}
+      pairing_error={@pairing_error}
+      show_revoke_modal={@show_revoke_modal}
+      selected_device={@selected_device}
+      show_delete_modal={@show_delete_modal}
+      device_to_delete={@device_to_delete}
+      show_pairing_modal={@show_pairing_modal}
+      show_add_url_modal={@show_add_url_modal}
+      new_url={@new_url}
+      show_advanced={@show_advanced}
+      show_all_devices={@show_all_devices}
+      show_clear_inactive_modal={@show_clear_inactive_modal}
+    />
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_settings_live/index.html.heex
+++ b/lib/mydia_web/live/admin_settings_live/index.html.heex
@@ -1,21 +1,8 @@
 <Layouts.app {assigns}>
-  <div>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-3xl font-bold">Configuration</h1>
-        <p class="text-base-content/70 mt-1">
-          System status, application settings, and configuration management
-        </p>
-      </div>
-    </div>
-
-    <MydiaWeb.AdminComponents.tab_nav active_tab={@active_tab} />
-
-    <div class="bg-base-100">
-      <Components.general_settings_tab
-        config_settings_with_sources={@config_settings_with_sources}
-        crash_report_stats={@crash_report_stats}
-      />
-    </div>
-  </div>
+  <.admin_page active_tab={@active_tab}>
+    <Components.general_settings_tab
+      config_settings_with_sources={@config_settings_with_sources}
+      crash_report_stats={@crash_report_stats}
+    />
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_system_live/index.html.heex
+++ b/lib/mydia_web/live/admin_system_live/index.html.heex
@@ -1,27 +1,14 @@
 <Layouts.app {assigns}>
-  <div>
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-      <div>
-        <h1 class="text-3xl font-bold">Configuration</h1>
-        <p class="text-base-content/70 mt-1">
-          System status, application settings, and configuration management
-        </p>
-      </div>
-    </div>
-
-    <MydiaWeb.AdminComponents.tab_nav active_tab={@active_tab} />
-
-    <div class="bg-base-100">
-      <MydiaWeb.AdminSystemLive.Components.status_tab
-        system_info={@system_info}
-        database_info={@database_info}
-        library_paths_count={@library_paths_count}
-        download_clients_count={@download_clients_count}
-        indexers_count={@indexers_count}
-        active_sessions={@active_sessions}
-        active_jobs={@active_jobs}
-        recent_activity={@recent_activity}
-      />
-    </div>
-  </div>
+  <.admin_page active_tab={@active_tab}>
+    <MydiaWeb.AdminSystemLive.Components.status_tab
+      system_info={@system_info}
+      database_info={@database_info}
+      library_paths_count={@library_paths_count}
+      download_clients_count={@download_clients_count}
+      indexers_count={@indexers_count}
+      active_sessions={@active_sessions}
+      active_jobs={@active_jobs}
+      recent_activity={@recent_activity}
+    />
+  </.admin_page>
 </Layouts.app>


### PR DESCRIPTION
Finishes the `admin_page/1` adoption that started with the plugins page.

## Why

Nine of the ten admin config pages still called `MydiaWeb.AdminComponents.tab_nav/1` directly and inlined an identical twelve-line block of page chrome above it: the "Configuration" header, the tab bar, and the `bg-base-100` content wrapper. Byte-for-byte identical in all nine files.

That meant every change to the admin chrome had to be made in ten places, and `admin_plugins_live` (which already uses `<.admin_page>`) had drifted into a different shape from its siblings.

## What changed

Each of the nine templates collapses to the shape plugins has shipped since `8598b6e3`:

```heex
<Layouts.app {assigns}>
  <.admin_page active_tab={@active_tab}>
    <%!-- tab body --%>
    <%!-- modals --%>
  </.admin_page>
</Layouts.app>
```

The bare structural `<div>` goes away and the modal blocks move inside the slot. `admin_page/1` is globally imported via `mydia_web.ex`, so the `MydiaWeb.AdminComponents.` prefix is gone from the call sites.

With no callers left outside `admin_page/1`, `tab_nav/1` becomes `defp`, making `admin_page` the single entry point for admin page chrome.

No LiveView module changes. All nine already assign `:active_tab` in `mount/3`, which is the component's only required attr. `admin_page/1` itself is unchanged, with no new attrs or slots, since all ten pages want the identical header.

## Rendered-DOM delta

Two changes per page, both intended:

1. One bare `<div>` (no classes, no attributes) is removed.
2. Modals move from siblings of `div.bg-base-100` to children of it.

These modals are DaisyUI `.modal` / `.modal-open`, which is `position: fixed`. A fixed element resolves against the viewport unless an ancestor establishes a containing block via `transform`, `filter`, `perspective`, `contain`, `backdrop-filter`, or `will-change`. `bg-base-100` sets only a background colour and the removed wrapper had no classes at all, so modal positioning is unaffected. The plugins page has rendered its four modals inside the slot since `8598b6e3`.

## Out of scope

- `admin_release_blacklist_live` renders its own "Release Blacklist" header and no tab bar, so it is not a config tab.
- `admin_devices_live`, `admin_import_lists_live`, `admin_requests_live`, and `admin_users_live` have their own headers and are not in the config tab bar.

## Verification

- `mix precommit` green: compile with warnings-as-errors, `deps.unlock --unused`, `format --check-formatted`, `credo --strict`, and the full suite at **5795 tests, 0 failures**.
- All nine pages already have an `admin_*_live_test.exs`; `test/mydia_web/live/` runs **423 tests, 0 failures**. `admin_system_live_test.exs:63` and `admin_remote_access_live_test.exs:48` assert the `"Configuration"` chrome still renders.
- Guard against a silently dropped modal: the sorted set of `<Module.function` references in each template was snapshotted before and after. Every file differs by exactly one line, the removed `<MydiaWeb.AdminComponents.tab_nav`, and nothing else.

Net: 117 lines removed, one canonical shape across all ten config pages.
