### PR TITLE
ci(release): pin releases to a commit and refuse to publish partial builds

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,62 +1,99 @@
 ---
 allowed-tools: Bash(git*,gh*), Read, Edit
 argument-hint: [major|minor|patch|beta|rc (optional - auto-detected)]
-description: Create and publish a new release with version bump and release notes
+description: Cut a draft release pinned to a commit and dispatch the release workflow
 ---
 
 # Release Process
 
-Create a new release by:
+Releases are draft-first. You create a draft pinned to a commit, then dispatch
+`release.yml`, which builds every platform, uploads the assets, and publishes
+the draft. **Never create a git tag yourself.** GitHub creates it when the
+workflow publishes the draft.
 
-1. **Analyze changes since last release**
+Full reference: `docs/development/releasing.md`.
 
-   - Get the latest tag using `git describe --tags --abbrev=0` or `git tag --sort=-version:refname | head -n1`
-   - Use `git log <last-tag>..HEAD --oneline` to see all commits since last release
-   - Look at the git diff and commit messages to understand the nature of changes
+## 1. Analyze changes since the last release
 
-2. **Determine version increment** (unless specified as $1)
+- Latest tag: `git tag --sort=-version:refname | grep -v metadata-relay | head -n1`
+- Commits since: `git log <last-tag>..origin/master --oneline`
+- Read the commit messages and diffs to understand what actually changed
 
-   - **PREFER patch (0.0.X)** for bugfixes, small improvements, or unclear changes
-   - Use **minor (0.X.0)** ONLY for significant new features or major functionality additions
-   - Use **major (X.0.0)** ONLY if explicitly instructed with `$ARGUMENTS` containing "major"
-   - Use **beta** to create a pre-release version with `-beta.N` suffix (e.g., v1.2.3-beta.1)
-   - Use **rc** to create a release candidate with `-rc.N` suffix (e.g., v1.2.3-rc.1)
-   - Current version is derived from the latest git tag (mix.exs reads BUILD_VERSION at compile time)
-   - Parse the latest tag version, increment appropriately
+## 2. Determine the version increment (unless given as `$1`)
 
-3. **Categorize changes** for release notes:
+- **Prefer patch (0.0.X)** for bugfixes, small improvements, or unclear changes
+- **minor (0.X.0)** only for significant new features
+- **major (X.0.0)** only when explicitly asked
+- **beta** for a prerelease with a `-beta.N` suffix
+- **rc** for a release candidate with an `-rc.N` suffix
 
-   - 🎉 **New Features** - Significant new functionality
-   - 🐛 **Bug Fixes** - Fixes for bugs or issues
-   - 🔧 **Technical Changes** - Refactoring, dependencies, configuration
-   - 🚀 **Deployment Notes** - Important deployment-related changes (migrations, config changes)
-   - Skip empty sections
+Be conservative: when in doubt, patch. To create `beta.N`, find the existing
+beta tags for that version and increment N.
 
-4. **Create release tag**
+The version comes from the tag. `mix.exs` reads `BUILD_VERSION` at compile
+time, so there is nothing to edit and no commit to make.
 
-   - Version is set automatically from the git tag via `BUILD_VERSION` in CI — no need to update mix.exs
-   - **For stable releases**:
-     - Tag: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
-     - Push: `git push && git push --tags`
-   - **For beta/rc releases**:
-     - Tag: `git tag -a vX.Y.Z-beta.N -m "Release vX.Y.Z-beta.N"`
-     - Push: `git push --tags`
+## 3. Write the release notes
 
-5. **Create GitHub release with gh CLI**
-   - Generate release notes with sections identified above
-   - Keep it concise - short bullet points (one line each)
-   - Add link to full changelog: `**Full Changelog**: https://github.com/OWNER/REPO/compare/vOLD...vNEW`
-   - **For stable releases**: `gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."`
-   - **For beta/rc releases**: `gh release create vX.Y.Z-beta.N --title "vX.Y.Z-beta.N" --notes "..." --prerelease`
+Categorize into these sections, skipping any that are empty:
 
-## Important Notes
+- 🎉 **New Features**
+- 🐛 **Bug Fixes**
+- 🔧 **Technical Changes**
+- 🚀 **Deployment Notes** (migrations, config changes, anything an operator must act on)
 
-- Always verify you're on the correct branch (usually main/master)
-- Ensure working directory is clean before starting
-- If $1 is provided (major/minor/patch/beta/rc), use that instead of auto-detection
-- Be conservative: when in doubt, use patch version
-- **Beta/RC releases**: These are for testing unreleased versions without affecting stable production
-  - Docker images are tagged with 'beta' (not 'latest')
-  - No commit is made, only a Git tag
-  - GitHub release is marked as pre-release
-  - To create beta.N, find existing beta tags and increment N (e.g., if v1.2.3-beta.1 exists, create v1.2.3-beta.2)
+Keep bullets to one line each. End with:
+`**Full Changelog**: https://github.com/getmydia/mydia/compare/vOLD...vNEW`
+
+**A patch release carries the preceding minor's notes as well as its own.**
+Someone upgrading from v0.11.x to v0.12.1 reads the v0.12.1 page and needs to
+see what v0.12.0 changed.
+
+## 4. Create the draft, pinned to a commit
+
+```bash
+git fetch origin
+SHA=$(git rev-parse origin/master)
+
+gh release create vX.Y.Z \
+  --repo getmydia/mydia \
+  --target "$SHA" \
+  --draft \
+  --notes-file notes.md
+```
+
+Add `--prerelease` for beta and rc.
+
+`--target` must be a full commit SHA. The workflow rejects a draft targeting a
+branch, because a branch is resolved once at build time and again when the tag
+is created, which lets the tag land on code that was never built.
+
+## 5. Dispatch the workflow
+
+```bash
+gh workflow run release.yml --repo getmydia/mydia -f version=vX.Y.Z
+```
+
+Then watch it:
+
+```bash
+gh run watch "$(gh run list --repo getmydia/mydia --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+```
+
+## Important notes
+
+- **Never create or push a git tag.** The workflow's publish step creates it.
+- If `$1` is provided (major/minor/patch/beta/rc), use it instead of auto-detection
+- Verify the working directory is clean before starting
+- If commits land on master after the draft is cut, the workflow fails and lists
+  them. Either re-point the draft (`gh release edit vX.Y.Z --target <new-sha>`)
+  and update the notes, or re-dispatch with `-f accept_drift=true` to ship the
+  pinned commit as-is.
+- If a platform build fails, the release stays a draft. Re-run the failed jobs
+  from the Actions UI. To ship without that platform, re-dispatch with
+  `-f allow_missing=<platform>`.
+- Before a release you care about, rehearse first:
+  `gh workflow run release.yml -f dry_run=true`. It builds, signs, and notarizes
+  everything without publishing or pushing.
+- Prereleases tag Docker images `beta` rather than `latest`, and skip the docs
+  deploy.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Release procedure (Immutable Releases enabled on this repo).
-# Full docs: docs/contributing/releasing.md
+# Full docs: docs/development/releasing.md
 #
 #   1. SHA=$(git rev-parse origin/master)
 #      gh release create vX.Y.Z --target "$SHA" --draft --prerelease \
@@ -33,7 +33,7 @@ on:
         type: boolean
         default: false
       accept_drift:
-        description: 'Proceed even though master has moved past the commit the draft targets'
+        description: 'Proceed even though the default branch has moved past the commit the draft targets'
         type: boolean
         default: false
       allow_missing:
@@ -120,7 +120,7 @@ jobs:
             # at publish, so the tag can land on code these jobs never built.
             SHA=$(echo "$RELEASE_JSON" | jq -r '.targetCommitish')
             if ! [[ "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "::error::Draft $TAG targets '$SHA', which is a branch, not a commit. Pin it first: gh release edit $TAG --repo $REPO --target \$(git rev-parse origin/master)" >&2
+              echo "::error::Draft $TAG targets '$SHA', which is a branch, not a commit. Pin it first: gh release edit $TAG --repo $REPO --target \$(git rev-parse origin/${DEFAULT_BRANCH})" >&2
               exit 1
             fi
 
@@ -134,19 +134,19 @@ jobs:
             # rather than absorbing it silently.
             DRIFT=$(git rev-list --count "${SHA}..origin/${DEFAULT_BRANCH}" 2>/dev/null || echo 0)
             if [ "$DRIFT" -gt 0 ]; then
-              echo "::group::${DRIFT} commit(s) on master are NOT in this release"
+              echo "::group::${DRIFT} commit(s) on ${DEFAULT_BRANCH} are NOT in this release"
               git log --oneline "${SHA}..origin/${DEFAULT_BRANCH}"
               echo "::endgroup::"
               {
                 echo "### Release drift"
                 echo
-                echo "\`$TAG\` targets \`${SHA:0:12}\`, which is **${DRIFT} commit(s) behind master**."
+                echo "\`$TAG\` targets \`${SHA:0:12}\`, which is **${DRIFT} commit(s) behind ${DEFAULT_BRANCH}**."
                 echo
                 git log --oneline "${SHA}..origin/${DEFAULT_BRANCH}" | sed 's/^/- /'
               } >> "$GITHUB_STEP_SUMMARY"
 
               if [ "$ACCEPT_DRIFT" != "true" ]; then
-                echo "::error::${DRIFT} commit(s) landed on master after this draft was cut. Either re-point the draft and update its notes (gh release edit $TAG --repo $REPO --target \$(git rev-parse origin/master)), or re-dispatch with -f accept_drift=true to ship $TAG as-is." >&2
+                echo "::error::${DRIFT} commit(s) landed on ${DEFAULT_BRANCH} after this draft was cut. Either re-point the draft and update its notes (gh release edit $TAG --repo $REPO --target \$(git rev-parse origin/${DEFAULT_BRANCH})), or re-dispatch with -f accept_drift=true to ship $TAG as-is." >&2
                 exit 1
               fi
               echo "accept_drift was set: shipping ${SHA:0:12} and leaving the ${DRIFT} newer commit(s) for a later release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,48 @@
 name: Release
 
-# Release procedure (Immutable Releases enabled on this repo):
+# Release procedure (Immutable Releases enabled on this repo).
+# Full docs: docs/contributing/releasing.md
 #
-#   1. gh release create vX.Y.Z --target master --draft --prerelease \
+#   1. SHA=$(git rev-parse origin/master)
+#      gh release create vX.Y.Z --target "$SHA" --draft --prerelease \
 #        --notes-file notes.md
 #   2. gh workflow run release.yml -f version=vX.Y.Z
+#
+# The draft must target a full commit SHA, not a branch. A branch target is
+# resolved separately at build time and again at publish time, so the tag can
+# end up on code that was never built. Pinning the draft to a commit makes the
+# notes, the images and the tag all describe the same thing.
 #
 # The workflow uploads assets to the draft and publishes it. The `release`
 # event is not used because GitHub Actions silently drops `release: created`
 # for drafts (https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
 # and asset uploads to a published immutable release are blocked.
+#
+# To rehearse without shipping anything:
+#
+#   gh workflow run release.yml -f dry_run=true
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag of an existing draft release (e.g., v1.0.0)'
-        required: true
+        description: 'Version tag of an existing draft release (e.g., v1.0.0). Ignored when dry_run is set.'
+        required: false
+      dry_run:
+        description: 'Build, sign and notarize every platform without publishing, pushing images or uploading to stores'
+        type: boolean
+        default: false
+      accept_drift:
+        description: 'Proceed even though master has moved past the commit the draft targets'
+        type: boolean
+        default: false
+      allow_missing:
+        description: "Comma-separated platforms whose failure must not block publish (android,ios,macos,windows,linux,docker)"
+        required: false
+        default: ''
 
 concurrency:
-  group: release-${{ github.event.inputs.version }}
+  group: release-${{ inputs.dry_run && format('dryrun-{0}', github.run_id) || inputs.version }}
   cancel-in-progress: false
 
 env:
@@ -38,46 +61,116 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
       version_code: ${{ steps.get_version.outputs.version_code }}
       is_prerelease: ${{ steps.get_version.outputs.is_prerelease }}
+      sha: ${{ steps.get_version.outputs.sha }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Extract version info
         id: get_version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          ACCEPT_DRIFT: ${{ inputs.accept_drift }}
+          INPUT_VERSION: ${{ inputs.version }}
+          RUN_NUMBER: ${{ github.run_number }}
+          DISPATCH_SHA: ${{ github.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          TAG="${{ github.event.inputs.version }}"
-
-          # Enforce draft-first authoring. This repo has Immutable Releases
-          # enabled, so assets can only be uploaded while the release is a
-          # draft. The workflow publishes the draft at the end.
-          IS_DRAFT=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft --jq '.isDraft')
-          if [ "$IS_DRAFT" != "true" ]; then
-            echo "::error::Release $TAG is not a draft. Create the release with --draft so the workflow can upload assets before publishing." >&2
-            exit 1
-          fi
-
-          # Remove 'v' prefix for marketing version (CFBundleShortVersionString / versionName)
-          VERSION_NUM="${TAG#v}"
+          set -euo pipefail
 
           # Build number (CFBundleVersion / Android versionCode) — globally
           # monotonic via github.run_number, with an offset to clear the
           # historical high-water mark of 1000 from earlier failed uploads.
           # Re-runs of the same workflow run preserve run_number; new dispatches
           # increment it, which is exactly what TestFlight/Play Store require.
-          VERSION_CODE=$(( ${{ github.run_number }} + 10000 ))
+          VERSION_CODE=$(( RUN_NUMBER + 10000 ))
 
-          # Check if this is a prerelease
-          if [[ "$TAG" =~ -beta|-rc|-alpha ]]; then
+          if [ "$DRY_RUN" = "true" ]; then
+            # Rehearsal: no draft, no tag, no publish. Everything that has
+            # historically broken (signing, notarization, appcast, installer)
+            # still runs, against a synthetic version.
+            TAG="(dry run)"
+            VERSION_NUM="0.0.0-dryrun.${RUN_NUMBER}"
             IS_PRERELEASE=true
+            SHA="$DISPATCH_SHA"
+            echo "Dry run: building ${VERSION_NUM} from ${SHA}. Nothing will be pushed or published."
           else
-            IS_PRERELEASE=false
+            TAG="$INPUT_VERSION"
+            if [ -z "$TAG" ]; then
+              echo "::error::version is required unless dry_run is set." >&2
+              exit 1
+            fi
+
+            # Enforce draft-first authoring. This repo has Immutable Releases
+            # enabled, so assets can only be uploaded while the release is a
+            # draft. The workflow publishes the draft at the end.
+            RELEASE_JSON=$(gh release view "$TAG" --repo "$REPO" --json isDraft,targetCommitish)
+            IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
+            if [ "$IS_DRAFT" != "true" ]; then
+              echo "::error::Release $TAG is not a draft. Create the release with --draft so the workflow can upload assets before publishing." >&2
+              exit 1
+            fi
+
+            # The draft must name a commit, not a branch. A branch target is
+            # resolved independently here and again when GitHub creates the tag
+            # at publish, so the tag can land on code these jobs never built.
+            SHA=$(echo "$RELEASE_JSON" | jq -r '.targetCommitish')
+            if ! [[ "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::Draft $TAG targets '$SHA', which is a branch, not a commit. Pin it first: gh release edit $TAG --repo $REPO --target \$(git rev-parse origin/master)" >&2
+              exit 1
+            fi
+
+            if ! git cat-file -e "${SHA}^{commit}" 2>/dev/null; then
+              echo "::error::Draft $TAG targets commit $SHA, which does not exist in this repository." >&2
+              exit 1
+            fi
+
+            # Drift check. Anything merged since the draft was cut is not in
+            # this release, and the notes were written without it. Surface it
+            # rather than absorbing it silently.
+            DRIFT=$(git rev-list --count "${SHA}..origin/${DEFAULT_BRANCH}" 2>/dev/null || echo 0)
+            if [ "$DRIFT" -gt 0 ]; then
+              echo "::group::${DRIFT} commit(s) on master are NOT in this release"
+              git log --oneline "${SHA}..origin/${DEFAULT_BRANCH}"
+              echo "::endgroup::"
+              {
+                echo "### Release drift"
+                echo
+                echo "\`$TAG\` targets \`${SHA:0:12}\`, which is **${DRIFT} commit(s) behind master**."
+                echo
+                git log --oneline "${SHA}..origin/${DEFAULT_BRANCH}" | sed 's/^/- /'
+              } >> "$GITHUB_STEP_SUMMARY"
+
+              if [ "$ACCEPT_DRIFT" != "true" ]; then
+                echo "::error::${DRIFT} commit(s) landed on master after this draft was cut. Either re-point the draft and update its notes (gh release edit $TAG --repo $REPO --target \$(git rev-parse origin/master)), or re-dispatch with -f accept_drift=true to ship $TAG as-is." >&2
+                exit 1
+              fi
+              echo "accept_drift was set: shipping ${SHA:0:12} and leaving the ${DRIFT} newer commit(s) for a later release."
+            fi
+
+            # Remove 'v' prefix for marketing version (CFBundleShortVersionString / versionName)
+            VERSION_NUM="${TAG#v}"
+
+            if [[ "$TAG" =~ -beta|-rc|-alpha ]]; then
+              IS_PRERELEASE=true
+            else
+              IS_PRERELEASE=false
+            fi
           fi
 
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT
-          echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
-          echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION_NUM"
+            echo "version_code=$VERSION_CODE"
+            echo "is_prerelease=$IS_PRERELEASE"
+            echo "sha=$SHA"
+          } >> "$GITHUB_OUTPUT"
 
-          echo "Building version: $VERSION_NUM (code: $VERSION_CODE, prerelease: $IS_PRERELEASE)"
+          echo "Building version: $VERSION_NUM (code: $VERSION_CODE, prerelease: $IS_PRERELEASE, commit: $SHA)"
 
   docker-build:
     name: Docker / ${{ matrix.db }} / ${{ matrix.arch }}
@@ -116,6 +209,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
 
       # Route Docker Hub pulls through Google's pull-through cache to avoid
       # anonymous rate-limit timeouts. The daemon mirror covers the BuildKit
@@ -147,16 +242,17 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
-          push: true
+          # A rehearsal proves the image builds without writing to ghcr.
+          push: ${{ !inputs.dry_run }}
           build-args: |
             DATABASE_TYPE=${{ matrix.db }}
             BUILD_VERSION=${{ needs.prepare.outputs.version }}
-            BUILD_COMMIT=${{ github.sha }}
+            BUILD_COMMIT=${{ needs.prepare.outputs.sha }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}${{ matrix.tag_suffix }}-${{ matrix.arch }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ needs.prepare.outputs.sha }}
           cache-from: type=gha,scope=docker-${{ matrix.db }}
           # Only amd64 writes cache to avoid arm64 overwriting with different layers
           cache-to: ${{ matrix.arch == 'amd64' && format('type=gha,mode=max,scope=docker-{0}', matrix.db) || '' }}
@@ -164,6 +260,8 @@ jobs:
   docker-merge:
     name: Docker / ${{ matrix.db }} / Merge
     needs: [prepare, docker-build]
+    # Nothing was pushed during a rehearsal, so there is nothing to merge.
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -202,15 +300,52 @@ jobs:
       - name: Create multi-arch manifest
         id: merge
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           VERSION: ${{ needs.prepare.outputs.version }}
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
           SUFFIX: ${{ matrix.tag_suffix }}
         run: |
+          set -euo pipefail
+
           SOURCES="${IMAGE}:${VERSION}${SUFFIX}-amd64 ${IMAGE}:${VERSION}${SUFFIX}-arm64"
 
-          TAGS="-t ${IMAGE}:${VERSION}${SUFFIX}"
+          # The exact version tag is always applied. Floating tags are only
+          # applied when this release is the newest of its class, so that
+          # patching an older line (v0.11.2 after v0.12.0) cannot drag
+          # :latest, :0 and :0.11 backwards onto the older build. The same
+          # applies to :beta against other prereleases.
           if [ "$IS_PRERELEASE" = "true" ]; then
+            CLASS="prerelease"
+            NEWEST=$(gh release list --repo "$REPO" --limit 100 \
+              --json tagName,isDraft,isPrerelease \
+              --jq '[.[] | select(.isDraft == false and .isPrerelease == true) | .tagName | ltrimstr("v")] | .[]' \
+              | sort -V | tail -n1)
+          else
+            CLASS="stable"
+            NEWEST=$(gh release list --repo "$REPO" --limit 100 \
+              --json tagName,isDraft,isPrerelease \
+              --jq '[.[] | select(.isDraft == false and .isPrerelease == false) | .tagName | ltrimstr("v")] | .[]' \
+              | sort -V | tail -n1)
+          fi
+
+          # This release is not published yet, so it is absent from the list
+          # above. It is the newest when it sorts strictly after everything
+          # already published in its class.
+          IS_NEWEST=true
+          if [ -n "$NEWEST" ]; then
+            HIGHEST=$(printf '%s\n%s\n' "$VERSION" "$NEWEST" | sort -V | tail -n1)
+            if [ "$HIGHEST" != "$VERSION" ]; then
+              IS_NEWEST=false
+            fi
+          fi
+
+          TAGS="-t ${IMAGE}:${VERSION}${SUFFIX}"
+          if [ "$IS_NEWEST" != "true" ]; then
+            echo "::warning::${VERSION} is older than the newest published ${CLASS} release (${NEWEST}). Applying only :${VERSION}${SUFFIX} and skipping the floating tags so they keep pointing at ${NEWEST}."
+            echo "- \`${SUFFIX:-sqlite}\`: applied \`${VERSION}${SUFFIX}\` only; floating tags left on \`${NEWEST}\`" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$IS_PRERELEASE" = "true" ]; then
             TAGS="${TAGS} -t ${IMAGE}:beta${SUFFIX}"
           else
             MAJOR_MINOR=$(echo "$VERSION" | grep -oE '^[0-9]+\.[0-9]+')
@@ -231,53 +366,6 @@ jobs:
           subject-digest: ${{ steps.merge.outputs.digest }}
           push-to-registry: true
 
-  player-web:
-    name: Player / Web
-    needs: prepare
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version-file: player/.fvmrc
-          channel: 'stable'
-          cache: true
-
-      - name: Update version
-        working-directory: ${{ env.PLAYER_PATH }}
-        run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
-          VERSION_CODE="${{ needs.prepare.outputs.version_code }}"
-          sed -i "s/^version: .*/version: ${VERSION}+${VERSION_CODE}/" pubspec.yaml
-          echo "Updated pubspec.yaml version to ${VERSION}+${VERSION_CODE}"
-          cat pubspec.yaml | grep "^version:"
-
-      - name: Install dependencies
-        working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub get
-
-      - name: Run code generation
-        working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub run build_runner build
-
-      - name: Build web
-        working-directory: ${{ env.PLAYER_PATH }}
-        run: |
-          flutter build web \
-            --release \
-            --base-href /player/ \
-            --tree-shake-icons
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mydia-player-web
-          path: ${{ env.PLAYER_PATH }}/build/web
-          retention-days: 7
-
   player-android:
     name: Player / Android
     needs: prepare
@@ -285,19 +373,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Check platform support
-        id: check_android
-        run: |
-          if [ -d "${{ env.PLAYER_PATH }}/android" ]; then
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-            echo "Android platform not configured yet. Skipping build."
-          fi
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
 
       - name: Setup Flutter
-        if: steps.check_android.outputs.enabled == 'true'
         uses: subosito/flutter-action@v2
         with:
           flutter-version-file: player/.fvmrc
@@ -305,14 +384,12 @@ jobs:
           cache: true
 
       - name: Setup Java
-        if: steps.check_android.outputs.enabled == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Update version
-        if: steps.check_android.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
@@ -320,24 +397,22 @@ jobs:
           sed -i "s/^version: .*/version: ${VERSION}+${VERSION_CODE}/" pubspec.yaml
 
       - name: Install dependencies
-        if: steps.check_android.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub get
 
       - name: Run code generation
-        if: steps.check_android.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub run build_runner build
 
       - name: Decode keystore
-        if: steps.check_android.outputs.enabled == 'true' && env.ANDROID_KEYSTORE_BASE64 != ''
+        if: env.ANDROID_KEYSTORE_BASE64 != ''
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         working-directory: ${{ env.PLAYER_PATH }}
         run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
 
       - name: Create key.properties
-        if: steps.check_android.outputs.enabled == 'true' && env.ANDROID_KEYSTORE_BASE64 != ''
+        if: env.ANDROID_KEYSTORE_BASE64 != ''
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         working-directory: ${{ env.PLAYER_PATH }}
@@ -350,17 +425,15 @@ jobs:
           EOF
 
       - name: Build APK
-        if: steps.check_android.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build apk --release
 
       - name: Build AAB
-        if: steps.check_android.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build appbundle --release
 
       - name: Setup Ruby for Fastlane
-        if: steps.check_android.outputs.enabled == 'true' && env.PLAY_STORE_CREDENTIALS != ''
+        if: ${{ !inputs.dry_run && env.PLAY_STORE_CREDENTIALS != '' }}
         env:
           PLAY_STORE_CREDENTIALS: ${{ secrets.PLAY_STORE_CREDENTIALS }}
         uses: ruby/setup-ruby@v1
@@ -370,7 +443,7 @@ jobs:
           working-directory: ${{ env.PLAYER_PATH }}/android
 
       - name: Upload to Play Store
-        if: steps.check_android.outputs.enabled == 'true' && env.PLAY_STORE_CREDENTIALS != ''
+        if: ${{ !inputs.dry_run && env.PLAY_STORE_CREDENTIALS != '' }}
         env:
           PLAY_STORE_CREDENTIALS: ${{ secrets.PLAY_STORE_CREDENTIALS }}
         working-directory: ${{ env.PLAYER_PATH }}/android
@@ -381,7 +454,6 @@ jobs:
           rm play-store-credentials.json
 
       - name: "Upload artifact: APK"
-        if: steps.check_android.outputs.enabled == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: mydia-player-android-apk
@@ -395,19 +467,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Check platform support
-        id: check_ios
-        run: |
-          if [ -d "${{ env.PLAYER_PATH }}/ios" ]; then
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-            echo "iOS platform not configured yet. Skipping build."
-          fi
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
 
       - name: Setup Flutter
-        if: steps.check_ios.outputs.enabled == 'true'
         uses: subosito/flutter-action@v2
         with:
           flutter-version-file: player/.fvmrc
@@ -415,7 +478,6 @@ jobs:
           cache: true
 
       - name: Update version
-        if: steps.check_ios.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
@@ -428,17 +490,15 @@ jobs:
           sed -i '' "s/^version: .*/version: ${MARKETING_VERSION}+${VERSION_CODE}/" pubspec.yaml
 
       - name: Install dependencies
-        if: steps.check_ios.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub get
 
       - name: Run code generation
-        if: steps.check_ios.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub run build_runner build
 
       - name: Install certificate and provisioning profile
-        if: steps.check_ios.outputs.enabled == 'true' && env.IOS_CERTIFICATE_BASE64 != ''
+        if: env.IOS_CERTIFICATE_BASE64 != ''
         env:
           IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
@@ -464,7 +524,7 @@ jobs:
           cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
       - name: Configure manual signing for CI
-        if: steps.check_ios.outputs.enabled == 'true' && env.IOS_CERTIFICATE_BASE64 != ''
+        if: env.IOS_CERTIFICATE_BASE64 != ''
         env:
           IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
         working-directory: ${{ env.PLAYER_PATH }}/ios
@@ -487,21 +547,21 @@ jobs:
           EOF
 
       - name: Build iOS (unsigned)
-        if: steps.check_ios.outputs.enabled == 'true' && env.IOS_CERTIFICATE_BASE64 == ''
+        if: env.IOS_CERTIFICATE_BASE64 == ''
         env:
           IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build ios --release --no-codesign
 
       - name: Build iOS (signed)
-        if: steps.check_ios.outputs.enabled == 'true' && env.IOS_CERTIFICATE_BASE64 != ''
+        if: env.IOS_CERTIFICATE_BASE64 != ''
         env:
           IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build ios --release
 
       - name: Setup Ruby for Fastlane
-        if: steps.check_ios.outputs.enabled == 'true' && env.APP_STORE_CONNECT_API_KEY_ID != ''
+        if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
         uses: ruby/setup-ruby@v1
@@ -511,7 +571,7 @@ jobs:
           working-directory: ${{ env.PLAYER_PATH }}/ios
 
       - name: Upload to TestFlight
-        if: steps.check_ios.outputs.enabled == 'true' && env.APP_STORE_CONNECT_API_KEY_ID != ''
+        if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -520,7 +580,7 @@ jobs:
         run: bundle exec fastlane beta
 
       - name: Cleanup keychain
-        if: always() && steps.check_ios.outputs.enabled == 'true'
+        if: always()
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
 
@@ -531,19 +591,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Check platform support
-        id: check_macos
-        run: |
-          if [ -d "${{ env.PLAYER_PATH }}/macos" ]; then
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-            echo "macOS platform not configured yet. Skipping build."
-          fi
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
 
       - name: Setup Flutter
-        if: steps.check_macos.outputs.enabled == 'true'
         uses: subosito/flutter-action@v2
         with:
           flutter-version-file: player/.fvmrc
@@ -551,7 +602,6 @@ jobs:
           cache: true
 
       - name: Update version
-        if: steps.check_macos.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
@@ -559,22 +609,19 @@ jobs:
           sed -i '' "s/^version: .*/version: ${VERSION}+${VERSION_CODE}/" pubspec.yaml
 
       - name: Install dependencies
-        if: steps.check_macos.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub get
 
       - name: Run code generation
-        if: steps.check_macos.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub run build_runner build
 
       - name: Build macOS
-        if: steps.check_macos.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build macos --release
 
       - name: Install signing certificate
-        if: steps.check_macos.outputs.enabled == 'true' && env.MACOS_CERTIFICATE != ''
+        if: env.MACOS_CERTIFICATE != ''
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
         run: |
@@ -594,7 +641,7 @@ jobs:
           security list-keychain -d user -s $KEYCHAIN_PATH
 
       - name: Sign app bundle
-        if: steps.check_macos.outputs.enabled == 'true' && env.MACOS_CERTIFICATE != ''
+        if: env.MACOS_CERTIFICATE != ''
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
         run: |
@@ -618,7 +665,7 @@ jobs:
           fi
 
       - name: Notarize app bundle
-        if: steps.check_macos.outputs.enabled == 'true' && env.MACOS_CERTIFICATE != ''
+        if: env.MACOS_CERTIFICATE != ''
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
         working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
@@ -632,14 +679,13 @@ jobs:
           rm "Mydia Player.zip"
 
       - name: Staple notarization ticket
-        if: steps.check_macos.outputs.enabled == 'true' && env.MACOS_CERTIFICATE != ''
+        if: env.MACOS_CERTIFICATE != ''
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
         run: |
           xcrun stapler staple "${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release/Mydia Player.app"
 
       - name: Create DMG
-        if: steps.check_macos.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
         run: |
           # Create a temporary directory for DMG contents
@@ -655,14 +701,13 @@ jobs:
           rm -rf dmg_contents
 
       - name: Download Sparkle tools
-        if: steps.check_macos.outputs.enabled == 'true'
         run: |
           curl -L https://github.com/sparkle-project/Sparkle/releases/download/2.8.1/Sparkle-2.8.1.tar.xz -o sparkle.tar.xz
           mkdir -p sparkle-tools
           tar xf sparkle.tar.xz -C sparkle-tools
 
       - name: Generate appcast
-        if: steps.check_macos.outputs.enabled == 'true' && env.SPARKLE_EDDSA_KEY != ''
+        if: env.SPARKLE_EDDSA_KEY != ''
         env:
           SPARKLE_EDDSA_KEY: ${{ secrets.SPARKLE_EDDSA_KEY }}
         working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
@@ -710,7 +755,7 @@ jobs:
           EOF
 
       - name: Validate appcast
-        if: steps.check_macos.outputs.enabled == 'true' && env.SPARKLE_EDDSA_KEY != ''
+        if: env.SPARKLE_EDDSA_KEY != ''
         env:
           SPARKLE_EDDSA_KEY: ${{ secrets.SPARKLE_EDDSA_KEY }}
         working-directory: ${{ env.PLAYER_PATH }}/build/macos/Build/Products/Release
@@ -753,7 +798,6 @@ jobs:
           echo "appcast.xml validated (well-formed, single signature/length, sparkle:version=$sparkle_version)"
 
       - name: Upload DMG artifact
-        if: steps.check_macos.outputs.enabled == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: mydia-player-macos-dmg
@@ -761,7 +805,7 @@ jobs:
           retention-days: 30
 
       - name: Upload appcast artifact
-        if: steps.check_macos.outputs.enabled == 'true' && env.SPARKLE_EDDSA_KEY != ''
+        if: env.SPARKLE_EDDSA_KEY != ''
         env:
           SPARKLE_EDDSA_KEY: ${{ secrets.SPARKLE_EDDSA_KEY }}
         uses: actions/upload-artifact@v4
@@ -781,20 +825,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Check platform support
-        id: check_windows
-        shell: bash
-        run: |
-          if [ -d "${{ env.PLAYER_PATH }}/windows" ]; then
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-            echo "Windows platform not configured yet. Skipping build."
-          fi
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
 
       - name: Setup Flutter
-        if: steps.check_windows.outputs.enabled == 'true'
         uses: subosito/flutter-action@v2
         with:
           flutter-version-file: player/.fvmrc
@@ -802,7 +836,6 @@ jobs:
           cache: true
 
       - name: Update version
-        if: steps.check_windows.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         shell: bash
         run: |
@@ -811,29 +844,24 @@ jobs:
           sed -i "s/^version: .*/version: ${VERSION}+${VERSION_CODE}/" pubspec.yaml
 
       - name: Install dependencies
-        if: steps.check_windows.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub get
 
       - name: Run code generation
-        if: steps.check_windows.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub run build_runner build
 
       - name: Build Windows
-        if: steps.check_windows.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build windows --release
 
       - name: Build installer
-        if: steps.check_windows.outputs.enabled == 'true'
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.4
         with:
           path: player/windows/installer.iss
           options: /DMyAppVersion=${{ needs.prepare.outputs.version }}
 
       - name: Upload artifact
-        if: steps.check_windows.outputs.enabled == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: mydia-player-windows-installer
@@ -847,19 +875,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Check platform support
-        id: check_linux
-        run: |
-          if [ -d "${{ env.PLAYER_PATH }}/linux" ]; then
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-            echo "Linux platform not configured yet. Skipping build."
-          fi
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
 
       - name: Install system dependencies
-        if: steps.check_linux.outputs.enabled == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -873,7 +892,6 @@ jobs:
             libmpv-dev
 
       - name: Setup Flutter
-        if: steps.check_linux.outputs.enabled == 'true'
         uses: subosito/flutter-action@v2
         with:
           flutter-version-file: player/.fvmrc
@@ -881,7 +899,6 @@ jobs:
           cache: true
 
       - name: Update version
-        if: steps.check_linux.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
@@ -889,22 +906,18 @@ jobs:
           sed -i "s/^version: .*/version: ${VERSION}+${VERSION_CODE}/" pubspec.yaml
 
       - name: Install dependencies
-        if: steps.check_linux.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub get
 
       - name: Run code generation
-        if: steps.check_linux.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter pub run build_runner build
 
       - name: Build Linux
-        if: steps.check_linux.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build linux --release
 
       - name: Upload artifact
-        if: steps.check_linux.outputs.enabled == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: mydia-player-linux-bundle
@@ -913,11 +926,12 @@ jobs:
 
   publish:
     name: Publish Release
-    if: always() && needs.prepare.result == 'success'
+    # always() so this job runs even when a platform failed, and can report
+    # which one. The gate below decides whether it proceeds.
+    if: always() && needs.prepare.result == 'success' && !inputs.dry_run
     needs:
       - prepare
       - docker-merge
-      - player-web
       - player-android
       - player-ios
       - player-macos
@@ -927,6 +941,72 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Require every platform to have built
+        id: gate
+        env:
+          ALLOW_MISSING: ${{ inputs.allow_missing }}
+          RESULT_DOCKER: ${{ needs.docker-merge.result }}
+          RESULT_ANDROID: ${{ needs.player-android.result }}
+          RESULT_IOS: ${{ needs.player-ios.result }}
+          RESULT_MACOS: ${{ needs.player-macos.result }}
+          RESULT_WINDOWS: ${{ needs.player-windows.result }}
+          RESULT_LINUX: ${{ needs.player-linux.result }}
+        run: |
+          set -euo pipefail
+
+          # Publishing used to happen regardless of platform outcome, so a
+          # failed Windows build shipped a release quietly missing its
+          # installer. Every platform must now succeed, or be waived by name.
+          WAIVED=",$(echo "$ALLOW_MISSING" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]'),"
+
+          # Join array elements with ", ". ${arr[*]} only ever uses the first
+          # character of IFS, so a two-character separator cannot be done that
+          # way.
+          join() { printf '%s, ' "$@" | sed 's/, $//'; }
+
+          FAILED=()
+          FAILED_NAMES=()
+          WAIVED_LIST=()
+          WAIVED_NAMES=()
+          for entry in \
+            "docker:$RESULT_DOCKER" \
+            "android:$RESULT_ANDROID" \
+            "ios:$RESULT_IOS" \
+            "macos:$RESULT_MACOS" \
+            "windows:$RESULT_WINDOWS" \
+            "linux:$RESULT_LINUX"; do
+            name="${entry%%:*}"
+            result="${entry#*:}"
+            [ "$result" = "success" ] && continue
+            if [[ "$WAIVED" == *",${name},"* ]]; then
+              WAIVED_LIST+=("${name} (${result})")
+              WAIVED_NAMES+=("${name}")
+            else
+              FAILED+=("${name} (${result})")
+              FAILED_NAMES+=("${name}")
+            fi
+          done
+
+          if [ ${#FAILED[@]} -gt 0 ]; then
+            # The suggestion carries the already-waived platforms too, so that
+            # pasting it does not silently drop an existing waiver.
+            SUGGEST=$(IFS=','; echo "${FAILED_NAMES[*]}${WAIVED_NAMES[*]:+,${WAIVED_NAMES[*]}}")
+            printf '::error::Refusing to publish: %s did not succeed. Re-run the failed jobs, or re-dispatch with -f allow_missing=%s to ship without them.\n' \
+              "$(join "${FAILED[@]}")" "$SUGGEST" >&2
+            exit 1
+          fi
+
+          if [ ${#WAIVED_LIST[@]} -gt 0 ]; then
+            NOTE="Published without: $(join "${WAIVED_LIST[@]}")"
+            echo "::warning::${NOTE}"
+            {
+              echo "### Waived platforms"
+              echo
+              echo "$NOTE"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "note=${NOTE}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -1040,17 +1120,31 @@ jobs:
       - name: Publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           TAG: ${{ needs.prepare.outputs.tag }}
+          SHA: ${{ needs.prepare.outputs.sha }}
+          WAIVER: ${{ steps.gate.outputs.note }}
         run: |
+          set -euo pipefail
+
+          # A waived platform means the release ships without one of its
+          # assets. Record that on the release itself, so the gap is visible
+          # to anyone who lands on the page rather than only in the run log.
+          if [ -n "$WAIVER" ]; then
+            BODY=$(gh release view "$TAG" --repo "$REPO" --json body --jq '.body')
+            printf '%s\n\n---\n\n> **Incomplete release.** %s\n' "$BODY" "$WAIVER" \
+              | gh release edit "$TAG" --repo "$REPO" --notes-file -
+          fi
+
           gh release edit "${TAG}" \
             --draft=false \
-            --repo "${{ github.repository }}"
+            --repo "$REPO"
 
-          echo "Released: https://github.com/${{ github.repository }}/releases/tag/${TAG}"
+          echo "Released: https://github.com/${REPO}/releases/tag/${TAG} (${SHA})"
 
   docs:
     name: Deploy Docs
-    if: needs.prepare.outputs.is_prerelease == 'false'
+    if: needs.prepare.outputs.is_prerelease == 'false' && !inputs.dry_run
     needs:
       - prepare
       - publish
@@ -1062,6 +1156,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -1,0 +1,178 @@
+# Releasing
+
+Mydia and the metadata-relay service release through two different mechanisms.
+This page covers both.
+
+## Mydia
+
+Releases are draft-first. The draft is created by hand, the workflow builds
+against it, and the workflow publishes it at the end. GitHub creates the git tag
+at publish time, so no tag exists while the release is being built.
+
+This shape is forced by two constraints. The repository has Immutable Releases
+enabled, so assets can only be uploaded while a release is still a draft. And
+GitHub Actions silently drops the `release: created` event for drafts, so the
+workflow cannot trigger on the release itself and is dispatched manually
+instead.
+
+### Cutting a release
+
+**1. Pin a commit and create the draft.**
+
+```bash
+git fetch origin
+SHA=$(git rev-parse origin/master)
+
+gh release create v0.13.0 \
+  --repo getmydia/mydia \
+  --target "$SHA" \
+  --draft \
+  --notes-file notes.md
+```
+
+Add `--prerelease` for a beta or rc.
+
+`--target` must be a full commit SHA. A branch name is resolved once when the
+workflow builds and again when GitHub creates the tag, which lets the tag land
+on code that was never built. The workflow rejects a draft that targets a
+branch.
+
+Pinning also fixes what the release contains. Anything merged to master after
+this point is simply not in the release, which is what you want, and the
+workflow tells you about it rather than absorbing it silently.
+
+**2. Dispatch the workflow.**
+
+```bash
+gh workflow run release.yml --repo getmydia/mydia -f version=v0.13.0
+```
+
+The workflow builds Docker images for both database variants on both
+architectures, builds and signs the player for Android, iOS, macOS, Windows and
+Linux, uploads the assets to the draft, and publishes it.
+
+For a stable release it then deploys versioned documentation. Prereleases skip
+the docs deploy.
+
+### Dispatch inputs
+
+| Input | Default | Effect |
+| --- | --- | --- |
+| `version` | required | Tag of an existing draft release. Ignored when `dry_run` is set. |
+| `dry_run` | `false` | Build, sign and notarize everything without publishing, pushing images, or uploading to stores. |
+| `accept_drift` | `false` | Proceed even though master has moved past the commit the draft targets. |
+| `allow_missing` | `""` | Comma-separated platforms whose failure must not block publish: `android`, `ios`, `macos`, `windows`, `linux`, `docker`. |
+
+### Rehearsing
+
+Signing, notarization, the Sparkle appcast, and the Windows installer only
+execute during a release, which historically meant discovering breakage while
+shipping. A rehearsal runs all of it against master without side effects:
+
+```bash
+gh workflow run release.yml --repo getmydia/mydia -f dry_run=true
+```
+
+A rehearsal builds every image without pushing to ghcr, builds and signs and
+notarizes every player artifact, and generates and validates the appcast. It
+skips the store uploads, the asset upload, the publish step, and the docs
+deploy. It needs no draft.
+
+Run one before any release you care about, and after any change to
+`release.yml`, the Dockerfile, or the player's platform directories.
+
+The rehearsal does not exercise TestFlight or Play Store credentials, since it
+stops before those calls. Credential expiry still surfaces for the first time
+during a real release.
+
+### When the workflow refuses
+
+**"Draft targets 'master', which is a branch, not a commit."**
+
+The draft was created without `--target <sha>`. Pin it:
+
+```bash
+gh release edit v0.13.0 --repo getmydia/mydia --target "$(git rev-parse origin/master)"
+```
+
+**"N commit(s) landed on master after this draft was cut."**
+
+Someone merged while the release was being prepared, so the notes no longer
+describe what would ship. The run summary lists the commits. Either fold them in:
+
+```bash
+gh release edit v0.13.0 --repo getmydia/mydia --target "$(git rev-parse origin/master)"
+# then update the notes to cover the new commits
+```
+
+Or ship the pinned commit as-is and leave the rest for the next release:
+
+```bash
+gh workflow run release.yml --repo getmydia/mydia -f version=v0.13.0 -f accept_drift=true
+```
+
+**"Refusing to publish: windows (failure) did not succeed."**
+
+A platform build failed. The release stays a draft and nothing was published.
+Re-run the failed jobs from the Actions UI, which reuses the same run and
+therefore the same build number.
+
+If the failure is external and you need to ship without that platform, name it
+explicitly:
+
+```bash
+gh workflow run release.yml --repo getmydia/mydia -f version=v0.13.0 -f allow_missing=windows
+```
+
+The published release then carries a note saying which assets are absent.
+
+### Recovering from a failed release
+
+Nothing is published until every gate passes, so a failed run leaves the draft
+intact. Fix the cause and dispatch again with the same version.
+
+Two things do survive a failed run. Per-arch Docker images tagged
+`<version>-amd64` and `<version>-arm64` may already be in ghcr, and they are
+overwritten by the next attempt. And the build number, derived from the
+workflow run number, increases on every new dispatch. That is deliberate:
+TestFlight and the Play Store both reject a reused build number.
+
+## Docker tags
+
+Every tag has a `-pg` counterpart built against PostgreSQL. The unsuffixed tag
+is the SQLite build.
+
+| Tag | Points at |
+| --- | --- |
+| `master`, `master-pg` | Every commit on master. Built by `ci-docker.yml`, not the release workflow. |
+| `latest`, `latest-pg` | The newest published stable release. |
+| `beta`, `beta-pg` | The newest published prerelease. |
+| `0.13.0`, `0.13.0-pg` | That exact release. Never moves. |
+| `0.13`, `0.13-pg` | The newest stable release on that minor line. |
+| `0`, `0-pg` | The newest stable release on that major line. |
+
+The floating tags only ever move forward. Publishing a v0.11.2 patch after
+v0.12.0 applies `0.11.2` and `0.11`, and leaves `latest` and `0` pointing at
+v0.12.0.
+
+## Release notes
+
+Notes are written by hand into the draft. There is no CHANGELOG and nothing is
+generated from the commit range.
+
+A patch release carries the preceding minor's notes as well as its own. Someone
+upgrading from v0.11.x to v0.12.1 reads the v0.12.1 page and needs to see what
+v0.12.0 changed.
+
+## Metadata relay
+
+The relay releases on a pushed tag rather than a dispatched draft.
+`deploy-relay.yml` triggers on tags matching `metadata-relay-v*`:
+
+```bash
+git tag -a metadata-relay-v0.12.0 -m "Metadata Relay v0.12.0"
+git push origin metadata-relay-v0.12.0
+```
+
+The relay lives in this repository at `metadata-relay/` but deploys entirely
+separately, so its version is independent of mydia's.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - E2E Testing: development/e2e-testing.md
       - Architecture: development/architecture.md
       - CI Builds: development/ci-artifacts.md
+      - Releasing: development/releasing.md
 
 extra:
   version:


### PR DESCRIPTION
Audit of the release process, plus fixes for what it turned up.

## What was wrong

**A release could publish while broken.** `publish` ran under `if: always()` and only aborted when *zero* assets existed. A failed Windows build published a release silently missing its installer. Each platform job also had a `check_<platform>` step that skipped the entire build when the directory was absent and reported success either way. All six directories exist under `player/`, so those gates were vestigial from when platforms were being added one at a time, and their only remaining effect was letting a job report success while building nothing.

**The git tag could point at code nobody built.** The draft targeted `master`, a floating branch name. That got resolved once when the jobs checked out `github.sha`, and again when GitHub created the tag at publish. Docker builds take up to two hours, so any merge in that window left the tag on a different commit than the images. Confirmed on the live `v0.13.0-beta.1` draft, whose `target_commitish` was the literal string `"master"`.

**`:latest` could move backwards.** `docker-merge` applied `latest`, `<major>` and `<major>.<minor>` to any stable release, so a v0.11.2 patch after v0.12.0 would repoint all three at the older build. Same for `:beta` across prereleases.

**Nothing rehearsed the release path.** Six of the last fourteen completed release runs failed, and `release.yml` has taken 25 commits in six months, mostly `fix(ci)` / `fix(release)`. Signing, notarization, appcast generation, Inno Setup, TestFlight and Play Store upload only ever executed during a real release, so every break was found while shipping.

**The documented process did not exist.** `.claude/commands/release.md` still described the pre-June tag-first flow. Following it creates a premature tag and a non-draft release that `prepare` rejects with exit 1. There was no release documentation anywhere in `docs/`.

## What changed

- **A release names a commit.** The draft must target a full SHA. Every job checks it out; Docker records it as `BUILD_COMMIT` and the `revision` label. `prepare` also lists commits that landed after the draft was cut and stops, since the notes were written without them. `accept_drift` ships anyway.
- **Publish blocks on any failed platform.** `allow_missing` waives one by name for a genuine outage, and the waiver is appended to the release body so the gap is visible on the release page. The `check_<platform>` gates are gone.
- **Floating tags only move forward**, compared with `sort -V` against published releases of the same class.
- **`dry_run` rehearses everything** that has historically broken, without pushing to ghcr, uploading to the stores, publishing, or deploying docs.
- **`Player / Web` removed.** It duplicated the Dockerfile's `flutter-builder` stage, which already bakes the web player into `priv/static/player/`. Its artifact was downloaded by nothing while gating `publish`.
- **Docs**: `/release` rewritten, and `docs/development/releasing.md` added, covering both this flow and metadata-relay's separate tag-push flow.

## New dispatch inputs

| Input | Default | Effect |
| --- | --- | --- |
| `version` | required | Tag of an existing draft release. Ignored when `dry_run` is set. |
| `dry_run` | `false` | Build, sign and notarize without publishing, pushing, or uploading to stores |
| `accept_drift` | `false` | Proceed although master moved past the draft's commit |
| `allow_missing` | `""` | Comma-separated platforms whose failure must not block publish |

## Verification

Workflow changes cannot be fully proven without a run, so this is what was actually checked:

- `actionlint` reports no expression or syntax errors. Findings dropped 43 → 28, all remaining ones pre-existing shellcheck style notes in untouched scripts.
- The publish gate's shell was **extracted from the committed workflow** and run against 7 scenarios: all-green, single failure, waived failure, two failures with one waived, `skipped` treated as failure, waivers with mixed case and whitespace, and a waiver naming a job that passed. All behave correctly. Two bugs were found and fixed this way: `IFS=', '` only joins on the comma, and the suggested `allow_missing` dropped platforms already waived, so pasting it would have silently un-waived them.
- A step-name diff against `master` confirms the only removals are `Check platform support` from each platform job and the `player-web` job. Every build, sign, notarize and upload step survives.
- `mkdocs build --strict` passes with the new page in the nav.

**Not verified:** no release or rehearsal has been dispatched with this workflow yet. The intended next step is `gh workflow run release.yml -f dry_run=true` on this branch before the next real release uses it.

## Follow-ups, not in this PR

- `v0.13.0-beta.1` published successfully under the old workflow while this PR was being written, so it needs no action. Its `target_commitish` is still the literal `"master"`, which is the bug this PR closes for future releases.
- The rehearsal stops before the store uploads by choice, so App Store Connect and Play Store credential expiry still surfaces first during a real release.
- `docs/development/releasing.md` matches master's layout. The unmerged `docs/diataxis-restructure` branch moves these pages to `docs/contributing/`, so one of the two will need to relocate it on merge.
