### PR TITLE
fix: renew expired player access tokens and close GraphQL auth by default

### DIFF
--- a/lib/mydia/remote_access/pairing.ex
+++ b/lib/mydia/remote_access/pairing.ex
@@ -61,16 +61,26 @@ defmodule Mydia.RemoteAccess.Pairing do
   Generates a JWT access token for the device's user.
   """
   def generate_access_token(device) do
-    # Preload user if not already loaded
-    device = Mydia.Repo.preload(device, :user)
-
-    case Guardian.encode_and_sign(device.user, %{
-           "device_id" => device.id,
-           "typ" => "access"
-         }) do
+    case generate_access_token_with_claims(device) do
       {:ok, token, _claims} -> token
       {:error, reason} -> raise "Failed to generate access token: #{inspect(reason)}"
     end
+  end
+
+  @doc """
+  Generates a JWT access token for the device's user, returning the claims too.
+
+  Used by the token refresh flow, which needs the expiry to hand back to the
+  client and must report failures rather than raising.
+  """
+  def generate_access_token_with_claims(device) do
+    # Preload user if not already loaded
+    device = Mydia.Repo.preload(device, :user)
+
+    Guardian.encode_and_sign(device.user, %{
+      "device_id" => device.id,
+      "typ" => "access"
+    })
   end
 
   # Generates a unique device token

--- a/lib/mydia_web/plugs/absinthe_context.ex
+++ b/lib/mydia_web/plugs/absinthe_context.ex
@@ -17,11 +17,17 @@ defmodule MydiaWeb.Plugs.AbsintheContext do
   end
 
   defp build_context(conn) do
-    base = %{source: :http}
+    # remote_ip lets unauthenticated resolvers rate limit per caller, the same way
+    # MydiaWeb.Plugs.ApiAuth does for API key validation.
+    base = %{source: :http, remote_ip: format_ip(conn.remote_ip)}
 
     case Guardian.Plug.current_resource(conn) do
       nil -> base
       user -> Map.put(base, :current_user, user)
     end
   end
+
+  defp format_ip({a, b, c, d}), do: "#{a}.#{b}.#{c}.#{d}"
+  defp format_ip({a, b, c, d, e, f, g, h}), do: "#{a}:#{b}:#{c}:#{d}:#{e}:#{f}:#{g}:#{h}"
+  defp format_ip(_), do: "unknown"
 end

--- a/lib/mydia_web/schema.ex
+++ b/lib/mydia_web/schema.ex
@@ -50,4 +50,30 @@ defmodule MydiaWeb.Schema do
     import_fields(:playback_subscriptions)
     import_fields(:device_subscriptions)
   end
+
+  # Root fields that must stay reachable without an authenticated user: logging
+  # in, and trading an existing credential for a fresh one. Everything else is
+  # denied by default. Introspection is left open so GraphiQL keeps working; it
+  # exposes the schema shape only, never data.
+  @public_fields [:login, :refresh_media_token, :refresh_access_token]
+  @introspection_fields [:__schema, :__type, :__typename]
+
+  @doc """
+  Applies fail-closed authentication to every root field.
+
+  Authorization used to be opt-in inside each resolver, so any resolver that
+  omitted its own `current_user` check was readable by anyone who could reach the
+  endpoint. This inverts the default: a root field requires an authenticated user
+  unless it is explicitly listed in `@public_fields`.
+  """
+  def middleware(middleware, field, %{identifier: object})
+      when object in [:query, :mutation, :subscription] do
+    if field.identifier in @public_fields or field.identifier in @introspection_fields do
+      middleware
+    else
+      [MydiaWeb.Schema.Middleware.RequireAuth | middleware]
+    end
+  end
+
+  def middleware(middleware, _field, _object), do: middleware
 end

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -167,6 +167,12 @@ defmodule MydiaWeb.Schema.CommonTypes do
       description: "List of granted permissions"
   end
 
+  @desc "Access token for authenticating GraphQL and API requests"
+  object :access_token do
+    field :token, non_null(:string), description: "JWT access token"
+    field :expires_at, non_null(:datetime), description: "Token expiration timestamp"
+  end
+
   @desc "API key for programmatic access"
   object :api_key do
     field :id, non_null(:id), description: "API key ID"

--- a/lib/mydia_web/schema/middleware/require_auth.ex
+++ b/lib/mydia_web/schema/middleware/require_auth.ex
@@ -1,0 +1,24 @@
+defmodule MydiaWeb.Schema.Middleware.RequireAuth do
+  @moduledoc """
+  Absinthe middleware that rejects a resolution when no user is authenticated.
+
+  `MydiaWeb.Schema.middleware/3` applies this to every root query, mutation and
+  subscription field outside a small public allowlist, so authorization fails
+  closed. Resolvers may still perform their own `current_user` checks; those now
+  act as defence in depth rather than as the only barrier.
+
+  The error message matches the one resolvers already return so clients have a
+  single string to detect an expired or missing token.
+  """
+
+  @behaviour Absinthe.Middleware
+
+  @impl Absinthe.Middleware
+  def call(%{context: %{current_user: user}} = resolution, _config) when not is_nil(user) do
+    resolution
+  end
+
+  def call(resolution, _config) do
+    Absinthe.Resolution.put_result(resolution, {:error, "Authentication required"})
+  end
+end

--- a/lib/mydia_web/schema/mutation_types.ex
+++ b/lib/mydia_web/schema/mutation_types.ex
@@ -86,6 +86,12 @@ defmodule MydiaWeb.Schema.MutationTypes do
       resolve(&RemoteAccessResolver.refresh_media_token/3)
     end
 
+    @desc "Exchange a pairing device token for a fresh access token"
+    field :refresh_access_token, :access_token do
+      arg(:device_token, non_null(:string))
+      resolve(&RemoteAccessResolver.refresh_access_token/3)
+    end
+
     @desc "Generate a pairing claim code for device pairing (requires authentication)"
     field :generate_claim_code, :claim_code do
       resolve(&RemoteAccessResolver.generate_claim_code/3)

--- a/lib/mydia_web/schema/resolvers/remote_access_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/remote_access_resolver.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.Schema.Resolvers.RemoteAccessResolver do
 
   require Logger
 
+  alias Mydia.Accounts.ApiKeyRateLimiter
   alias Mydia.RemoteAccess
   alias Mydia.RemoteAccess.MediaToken
   alias Mydia.RemoteAccess.Pairing
@@ -104,19 +105,51 @@ defmodule MydiaWeb.Schema.Resolvers.RemoteAccessResolver do
   authentication: the device token is the proof of identity, the same way
   `refresh_media_token/3` trusts the media token.
   """
-  def refresh_access_token(_parent, %{device_token: device_token}, _context) do
+  def refresh_access_token(_parent, %{device_token: device_token}, %{context: context}) do
+    bucket = rate_limit_bucket(context)
+
+    case ApiKeyRateLimiter.check_rate_limit(bucket) do
+      :ok -> do_refresh_access_token(device_token, bucket)
+      {:error, :rate_limited} -> {:error, "Too many refresh attempts, try again later"}
+    end
+  end
+
+  # Device tokens are Argon2 hashed with a per-row salt, so verification has to
+  # try every non-revoked device: a wrong token costs one full Argon2 pass per
+  # paired device (~70ms each). Left unbounded on an unauthenticated mutation
+  # that is a CPU amplification vector, so failures are rate limited per caller
+  # exactly as ApiAuth does for API key validation. Successful refreshes never
+  # count against the limit.
+  defp do_refresh_access_token(device_token, bucket) do
     with {:ok, device} <- RemoteAccess.verify_device_token(device_token),
-         {:ok, token, claims} <- Pairing.generate_access_token_with_claims(device) do
+         {:ok, token, claims} <- Pairing.generate_access_token_with_claims(device),
+         {:ok, expires_at} <- expires_at_from_claims(claims) do
       RemoteAccess.touch_device(device)
 
-      {:ok, %{token: token, expires_at: DateTime.from_unix!(claims["exp"])}}
+      {:ok, %{token: token, expires_at: expires_at}}
     else
       {:error, :not_found} ->
+        ApiKeyRateLimiter.record_failed_attempt(bucket)
         {:error, "Invalid or revoked device token"}
 
       {:error, reason} ->
         Logger.warning("Failed to refresh access token: #{inspect(reason)}")
+        ApiKeyRateLimiter.record_failed_attempt(bucket)
         {:error, "Failed to refresh access token"}
+    end
+  end
+
+  # Reported rather than raised: this mutation is public, so a surprising claim
+  # set must not crash the request.
+  defp expires_at_from_claims(%{"exp" => exp}) when is_integer(exp), do: DateTime.from_unix(exp)
+  defp expires_at_from_claims(_), do: {:error, :missing_expiry}
+
+  # P2P callers have no IP, but reaching that transport already requires a Noise
+  # session with the node, so they share one bucket.
+  defp rate_limit_bucket(context) do
+    case context[:remote_ip] do
+      ip when is_binary(ip) -> "refresh_access_token:#{ip}"
+      _ -> "refresh_access_token:#{context[:source] || :unknown}"
     end
   end
 end

--- a/lib/mydia_web/schema/resolvers/remote_access_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/remote_access_resolver.ex
@@ -3,8 +3,11 @@ defmodule MydiaWeb.Schema.Resolvers.RemoteAccessResolver do
   Resolvers for remote access GraphQL mutations (media token management).
   """
 
+  require Logger
+
   alias Mydia.RemoteAccess
   alias Mydia.RemoteAccess.MediaToken
+  alias Mydia.RemoteAccess.Pairing
 
   @doc """
   Generates a pairing claim code for the current user.
@@ -89,6 +92,31 @@ defmodule MydiaWeb.Schema.Resolvers.RemoteAccessResolver do
 
       {:error, reason} ->
         {:error, "Failed to refresh token: #{inspect(reason)}"}
+    end
+  end
+
+  @doc """
+  Exchanges a long-lived pairing device token for a fresh access token.
+
+  Access tokens expire after the configured Guardian TTL while the device pairing
+  itself does not, so without this a paired player silently drops to unauthenticated
+  once its token ages out and has to be re-paired by hand. Deliberately requires no
+  authentication: the device token is the proof of identity, the same way
+  `refresh_media_token/3` trusts the media token.
+  """
+  def refresh_access_token(_parent, %{device_token: device_token}, _context) do
+    with {:ok, device} <- RemoteAccess.verify_device_token(device_token),
+         {:ok, token, claims} <- Pairing.generate_access_token_with_claims(device) do
+      RemoteAccess.touch_device(device)
+
+      {:ok, %{token: token, expires_at: DateTime.from_unix!(claims["exp"])}}
+    else
+      {:error, :not_found} ->
+        {:error, "Invalid or revoked device token"}
+
+      {:error, reason} ->
+        Logger.warning("Failed to refresh access token: #{inspect(reason)}")
+        {:error, "Failed to refresh access token"}
     end
   end
 end

--- a/player/lib/core/auth/auth_service.dart
+++ b/player/lib/core/auth/auth_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:http/http.dart' as http;
 import 'package:graphql/client.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -46,9 +47,8 @@ class AuthService {
   /// Store the server URL.
   Future<void> setServerUrl(String url) async {
     // Ensure URL doesn't have trailing slash
-    final normalizedUrl = url.endsWith('/')
-        ? url.substring(0, url.length - 1)
-        : url;
+    final normalizedUrl =
+        url.endsWith('/') ? url.substring(0, url.length - 1) : url;
     await _storage.write(_serverUrlKey, normalizedUrl);
   }
 
@@ -86,9 +86,8 @@ class AuthService {
   /// Store a custom relay URL.
   Future<void> setRelayUrl(String url) async {
     // Ensure URL doesn't have trailing slash
-    final normalizedUrl = url.endsWith('/')
-        ? url.substring(0, url.length - 1)
-        : url;
+    final normalizedUrl =
+        url.endsWith('/') ? url.substring(0, url.length - 1) : url;
     await _storage.write(_relayUrlKey, normalizedUrl);
   }
 
@@ -190,9 +189,8 @@ class AuthService {
         throw Exception('Login failed: $errorMessage');
       }
 
-      final mutation = result.data != null
-          ? Mutation$Login.fromJson(result.data!)
-          : null;
+      final mutation =
+          result.data != null ? Mutation$Login.fromJson(result.data!) : null;
       final loginData = mutation?.login;
       if (loginData == null) {
         throw Exception('No data returned from login mutation');
@@ -290,18 +288,105 @@ class AuthService {
     }
   }
 
-  /// Refresh the authentication token.
+  /// Storage key for the durable device token handed out during pairing.
   ///
-  /// Note: The current Mydia backend uses Guardian JWT tokens which don't have
-  /// a built-in refresh mechanism. This method is a placeholder for future
-  /// implementation if token refresh is added to the backend.
+  /// Written by `PairingService`; survives access token expiry, which is what
+  /// makes unattended refresh possible.
+  static const _deviceTokenKey = 'pairing_device_token';
+
+  /// Mutation that trades the pairing device token for a fresh access token.
   ///
-  /// For now, it returns null to indicate that token refresh is not supported.
-  /// When a 401 occurs, the app should redirect to login.
+  /// Deliberately unauthenticated on the server: the device token is the proof
+  /// of identity. Written as a raw document so it works over both the HTTP
+  /// client and the P2P link without depending on codegen output.
+  static const refreshAccessTokenMutation = r'''
+mutation RefreshAccessToken($deviceToken: String!) {
+  refreshAccessToken(deviceToken: $deviceToken) {
+    token
+    expiresAt
+  }
+}
+''';
+
+  /// Get the durable pairing device token, if this client was paired.
+  Future<String?> getDeviceToken() async {
+    return await _storage.read(_deviceTokenKey);
+  }
+
+  /// Refresh the access token over HTTP (direct connection mode).
+  ///
+  /// Access tokens expire well before a pairing does, so without this a paired
+  /// client silently drops to unauthenticated and every gated request fails.
+  /// Returns the new token, or null when the client cannot re-authenticate on
+  /// its own and the user has to pair again.
   Future<String?> refreshToken() async {
-    // TODO: Implement token refresh when backend supports it
-    // For now, Guardian tokens need re-authentication
-    return null;
+    final deviceToken = await getDeviceToken();
+    final serverUrl = await getServerUrl();
+
+    if (deviceToken == null || serverUrl == null) return null;
+
+    try {
+      // No auth on this client: the mutation is intentionally public.
+      final client = createGraphQLClient(serverUrl, null);
+
+      final result = await client.mutate(
+        MutationOptions(
+          document: gql(refreshAccessTokenMutation),
+          variables: {'deviceToken': deviceToken},
+          fetchPolicy: FetchPolicy.noCache,
+        ),
+      );
+
+      if (result.hasException) {
+        debugPrint(
+            '[AuthService] Access token refresh failed: ${result.exception}');
+        return null;
+      }
+
+      return await _storeRefreshedToken(result.data);
+    } catch (e) {
+      debugPrint('[AuthService] Access token refresh error: $e');
+      return null;
+    }
+  }
+
+  /// Refresh the access token over an arbitrary transport.
+  ///
+  /// The P2P link owns its own transport, so it supplies [send] rather than
+  /// having this service reach into the P2P stack. [send] receives the mutation
+  /// document and variables and returns the decoded `data` map.
+  Future<String?> refreshTokenVia(
+    Future<Map<String, dynamic>> Function(
+      String query,
+      Map<String, dynamic> variables,
+    ) send,
+  ) async {
+    final deviceToken = await getDeviceToken();
+    if (deviceToken == null) return null;
+
+    try {
+      final data = await send(
+        refreshAccessTokenMutation,
+        {'deviceToken': deviceToken},
+      );
+      return await _storeRefreshedToken(data);
+    } catch (e) {
+      debugPrint('[AuthService] Access token refresh error: $e');
+      return null;
+    }
+  }
+
+  /// Persist a refreshed access token so later requests pick it up.
+  Future<String?> _storeRefreshedToken(Map<String, dynamic>? data) async {
+    final payload = data?['refreshAccessToken'];
+    if (payload is! Map) return null;
+
+    final token = payload['token'];
+    if (token is! String || token.isEmpty) return null;
+
+    await setToken(token);
+    debugPrint('[AuthService] Access token refreshed');
+    return token;
   }
 
   /// Verify the current token is still valid by making a test API call.

--- a/player/lib/core/graphql/graphql_provider.dart
+++ b/player/lib/core/graphql/graphql_provider.dart
@@ -56,7 +56,8 @@ final graphqlClientProvider = Provider<GraphQLClient?>((ref) {
   final authTokenAsync = ref.watch(authTokenProvider);
   final authService = ref.watch(authServiceProvider);
 
-  debugPrint('[graphqlClientProvider] Building: isP2PMode=${connectionState.isP2PMode}');
+  debugPrint(
+      '[graphqlClientProvider] Building: isP2PMode=${connectionState.isP2PMode}');
 
   // Check if we're in P2P mode
   if (connectionState.isP2PMode) {
@@ -68,7 +69,8 @@ final graphqlClientProvider = Provider<GraphQLClient?>((ref) {
       return null;
     }
 
-    debugPrint('[graphqlClientProvider] Using P2P mode (service will auto-initialize on first request)');
+    debugPrint(
+        '[graphqlClientProvider] Using P2P mode (service will auto-initialize on first request)');
 
     // Create P2P GraphQL client - use the full EndpointAddr JSON for reconnection
     // The P2P service will auto-initialize when ensureConnected is called
@@ -76,6 +78,16 @@ final graphqlClientProvider = Provider<GraphQLClient?>((ref) {
       p2pService: p2pService,
       serverNodeId: serverNodeAddr,
       getAuthToken: () async => await authService.getToken(),
+      // Sent without an auth token on purpose: the pairing device token is the
+      // credential, and going through p2pService directly keeps the refresh from
+      // recursing back through this link.
+      refreshAuthToken: () => authService.refreshTokenVia(
+        (query, variables) => p2pService.sendGraphQLRequest(
+          peer: serverNodeAddr,
+          query: query,
+          variables: variables,
+        ),
+      ),
     );
   }
 
@@ -106,14 +118,16 @@ final graphqlClientProvider = Provider<GraphQLClient?>((ref) {
         },
         loading: () => null,
         error: (error, stackTrace) {
-          debugPrint('[graphqlClientProvider] Auth token error in direct mode: $error\n$stackTrace');
+          debugPrint(
+              '[graphqlClientProvider] Auth token error in direct mode: $error\n$stackTrace');
           return null;
         },
       );
     },
     loading: () => null,
     error: (error, stackTrace) {
-      debugPrint('[graphqlClientProvider] Server URL error: $error\n$stackTrace');
+      debugPrint(
+          '[graphqlClientProvider] Server URL error: $error\n$stackTrace');
       return null;
     },
   );
@@ -152,14 +166,16 @@ final graphqlClientWithSubscriptionsProvider = Provider<GraphQLClient?>((ref) {
         },
         loading: () => null,
         error: (error, stackTrace) {
-          debugPrint('[graphqlClientWithSubscriptionsProvider] Auth token error: $error\n$stackTrace');
+          debugPrint(
+              '[graphqlClientWithSubscriptionsProvider] Auth token error: $error\n$stackTrace');
           return null;
         },
       );
     },
     loading: () => null,
     error: (error, stackTrace) {
-      debugPrint('[graphqlClientWithSubscriptionsProvider] Server URL error: $error\n$stackTrace');
+      debugPrint(
+          '[graphqlClientWithSubscriptionsProvider] Server URL error: $error\n$stackTrace');
       return null;
     },
   );
@@ -197,7 +213,8 @@ class AuthStateNotifier extends Notifier<AsyncValue<AuthStatus>> {
       // Check if we have stored credentials
       final isAuth = await authService.isAuthenticated();
 
-      state = AsyncValue.data(isAuth ? AuthStatus.authenticated : AuthStatus.unauthenticated);
+      state = AsyncValue.data(
+          isAuth ? AuthStatus.authenticated : AuthStatus.unauthenticated);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
     }
@@ -223,13 +240,15 @@ class AuthStateNotifier extends Notifier<AsyncValue<AuthStatus>> {
   }
 
   Future<void> _checkAuth() async {
-    debugPrint('[AuthStateNotifier] _checkAuth() called, setting state to loading');
+    debugPrint(
+        '[AuthStateNotifier] _checkAuth() called, setting state to loading');
     state = const AsyncValue.loading();
     try {
       debugPrint('[AuthStateNotifier] Calling isAuthenticated()...');
       final isAuth = await authService.isAuthenticated();
       debugPrint('[AuthStateNotifier] isAuthenticated() returned: $isAuth');
-      final status = isAuth ? AuthStatus.authenticated : AuthStatus.unauthenticated;
+      final status =
+          isAuth ? AuthStatus.authenticated : AuthStatus.unauthenticated;
       state = AsyncValue.data(status);
       debugPrint('[AuthStateNotifier] State set to AsyncValue.data($status)');
     } catch (e, st) {
@@ -276,7 +295,8 @@ class AuthStateNotifier extends Notifier<AsyncValue<AuthStatus>> {
 
 /// Provider for the auth state notifier.
 final authStateProvider =
-    NotifierProvider<AuthStateNotifier, AsyncValue<AuthStatus>>(AuthStateNotifier.new);
+    NotifierProvider<AuthStateNotifier, AsyncValue<AuthStatus>>(
+        AuthStateNotifier.new);
 
 /// Async provider for the GraphQL client.
 ///
@@ -284,7 +304,7 @@ final authStateProvider =
 /// to be available. This properly handles the async loading of auth state.
 final asyncGraphqlClientProvider = FutureProvider<GraphQLClient>((ref) async {
   debugPrint('[asyncGraphqlClientProvider] Starting...');
-  
+
   // Wait for auth check to complete (isAuthenticatedProvider is a FutureProvider)
   final isAuthenticated = await ref.watch(isAuthenticatedProvider.future);
   debugPrint('[asyncGraphqlClientProvider] isAuthenticated=$isAuthenticated');
@@ -304,7 +324,8 @@ final asyncGraphqlClientProvider = FutureProvider<GraphQLClient>((ref) async {
   // Watch the sync provider to get updates when connection mode changes
   debugPrint('[asyncGraphqlClientProvider] Getting graphqlClientProvider...');
   final client = ref.watch(graphqlClientProvider);
-  debugPrint('[asyncGraphqlClientProvider] client=${client != null ? "available" : "null"}');
+  debugPrint(
+      '[asyncGraphqlClientProvider] client=${client != null ? "available" : "null"}');
   if (client == null) {
     // This shouldn't happen if auth is ready, but handle it gracefully
     throw Exception('GraphQL client not available');
@@ -326,7 +347,8 @@ final mediaTokenServiceProvider = Provider<MediaTokenService?>((ref) {
 /// Async provider for the media token service.
 ///
 /// Use this in async contexts where you need to wait for the service to be ready.
-final asyncMediaTokenServiceProvider = FutureProvider<MediaTokenService>((ref) async {
+final asyncMediaTokenServiceProvider =
+    FutureProvider<MediaTokenService>((ref) async {
   final client = await ref.watch(asyncGraphqlClientProvider.future);
   return MediaTokenService(client);
 });

--- a/player/lib/core/graphql/p2p_link.dart
+++ b/player/lib/core/graphql/p2p_link.dart
@@ -22,18 +22,28 @@ const _baseBackoff = Duration(seconds: 1);
 ///
 /// Includes automatic retry with exponential backoff for transient connection
 /// errors. Between retries, it calls [ensureConnected] to re-dial the peer.
+/// Server error text returned when a request carries no valid access token.
+///
+/// Access tokens outlive nothing in particular: they expire on the server's
+/// Guardian TTL while the pairing itself stays valid, so this is an expected
+/// condition to recover from rather than a fatal one.
+const _authErrorMarker = 'Authentication required';
+
 class P2pGraphQLLink extends Link {
   final P2pService _p2pService;
   final String _serverNodeId;
   final Future<String?> Function() _getAuthToken;
+  final Future<String?> Function()? _refreshAuthToken;
 
   P2pGraphQLLink({
     required P2pService p2pService,
     required String serverNodeId,
     required Future<String?> Function() getAuthToken,
+    Future<String?> Function()? refreshAuthToken,
   })  : _p2pService = p2pService,
         _serverNodeId = serverNodeId,
-        _getAuthToken = getAuthToken;
+        _getAuthToken = getAuthToken,
+        _refreshAuthToken = refreshAuthToken;
 
   @override
   Stream<Response> request(Request request, [NextLink? forward]) async* {
@@ -49,7 +59,7 @@ class P2pGraphQLLink extends Link {
       debugPrint('[P2pGraphQLLink] Sending request: $operationName');
 
       // Attempt the request with retries on connection errors
-      final responseData = await _sendWithRetry(
+      final responseData = await _sendWithAuthRecovery(
         query: query,
         operationName: operationName,
         variables: variables.isNotEmpty ? variables : null,
@@ -80,6 +90,52 @@ class P2pGraphQLLink extends Link {
       );
     }
   }
+
+  /// Send a request, refreshing the access token once if the server rejects it.
+  ///
+  /// A paired client keeps a durable device token, so an expired access token is
+  /// recoverable without user involvement. Without this the client would stay
+  /// permanently unauthenticated until someone re-paired it by hand.
+  Future<Map<String, dynamic>> _sendWithAuthRecovery({
+    required String query,
+    String? operationName,
+    Map<String, dynamic>? variables,
+    String? authToken,
+  }) async {
+    try {
+      return await _sendWithRetry(
+        query: query,
+        operationName: operationName,
+        variables: variables,
+        authToken: authToken,
+      );
+    } catch (e) {
+      final refresh = _refreshAuthToken;
+      if (refresh == null || !_isAuthError(e)) rethrow;
+
+      debugPrint('[P2pGraphQLLink] Access token rejected, refreshing');
+      final refreshed = await refresh();
+
+      if (refreshed == null) {
+        debugPrint('[P2pGraphQLLink] Refresh failed, device must pair again');
+        rethrow;
+      }
+
+      return await _sendWithRetry(
+        query: query,
+        operationName: operationName,
+        variables: variables,
+        authToken: refreshed,
+      );
+    }
+  }
+
+  /// Whether the server rejected the request for lack of a valid token.
+  ///
+  /// Matches on the message because the P2P transport surfaces GraphQL errors as
+  /// plain [Exception]s with no structured error code to key off.
+  static bool _isAuthError(Object error) =>
+      error.toString().contains(_authErrorMarker);
 
   /// Send a GraphQL request with automatic retry on connection errors.
   ///
@@ -163,15 +219,19 @@ class P2pGraphQLLink extends Link {
 /// [p2pService] - The P2P service instance for sending requests
 /// [serverNodeId] - The node ID of the Mydia server to connect to
 /// [getAuthToken] - A function that returns the current auth token
+/// [refreshAuthToken] - Mints a fresh access token when the server rejects the
+/// current one, returning null if the device has to pair again
 GraphQLClient createP2pGraphQLClient({
   required P2pService p2pService,
   required String serverNodeId,
   required Future<String?> Function() getAuthToken,
+  Future<String?> Function()? refreshAuthToken,
 }) {
   final link = P2pGraphQLLink(
     p2pService: p2pService,
     serverNodeId: serverNodeId,
     getAuthToken: getAuthToken,
+    refreshAuthToken: refreshAuthToken,
   );
 
   return GraphQLClient(

--- a/player/test/core/graphql/p2p_link_test.dart
+++ b/player/test/core/graphql/p2p_link_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart'
+    show Operation, Request, gql;
+import 'package:player/core/graphql/p2p_link.dart';
+import 'package:player/core/p2p/p2p_service.dart';
+
+/// Token value this fake treats as expired.
+const _expiredToken = 'expired';
+
+/// Records every send and rejects any request carrying [_expiredToken].
+///
+/// Mirrors how the server behaves once an access token ages past its Guardian
+/// TTL: the transport surfaces the GraphQL error as a plain Exception.
+class _FakeP2pService extends P2pService {
+  final List<String?> tokensSeen = [];
+
+  @override
+  Future<Map<String, dynamic>> sendGraphQLRequest({
+    required String peer,
+    required String query,
+    Map<String, dynamic>? variables,
+    String? operationName,
+    String? authToken,
+  }) async {
+    tokensSeen.add(authToken);
+
+    if (authToken == _expiredToken) {
+      throw Exception('Authentication required');
+    }
+
+    return {'movies': <String, dynamic>{}};
+  }
+}
+
+Request _request() => Request(
+      operation: Operation(
+        document: gql('query Movies { movies { id } }'),
+        operationName: 'Movies',
+      ),
+    );
+
+void main() {
+  group('P2pGraphQLLink access token recovery', () {
+    test('refreshes and retries when the server rejects the token', () async {
+      final service = _FakeP2pService();
+      var refreshCalls = 0;
+
+      final link = P2pGraphQLLink(
+        p2pService: service,
+        serverNodeId: 'node',
+        getAuthToken: () async => 'expired',
+        refreshAuthToken: () async {
+          refreshCalls++;
+          return 'fresh';
+        },
+      );
+
+      final response = await link.request(_request()).first;
+
+      expect(refreshCalls, 1, reason: 'should refresh exactly once');
+      expect(service.tokensSeen, ['expired', 'fresh'],
+          reason: 'retry must carry the refreshed token');
+      expect(response.errors, isNull);
+      expect(response.data, isNotNull);
+    });
+
+    test('does not refresh when the first attempt succeeds', () async {
+      final service = _FakeP2pService();
+      var refreshCalls = 0;
+
+      final link = P2pGraphQLLink(
+        p2pService: service,
+        serverNodeId: 'node',
+        getAuthToken: () async => 'valid',
+        refreshAuthToken: () async {
+          refreshCalls++;
+          return 'fresh';
+        },
+      );
+
+      final response = await link.request(_request()).first;
+
+      expect(refreshCalls, 0);
+      expect(service.tokensSeen, ['valid']);
+      expect(response.errors, isNull);
+    });
+
+    test('surfaces the auth error when refresh cannot mint a token', () async {
+      final service = _FakeP2pService();
+
+      // Null models an unpaired client, or one whose device token was revoked:
+      // there is nothing left to do but ask the user to pair again.
+      final link = P2pGraphQLLink(
+        p2pService: service,
+        serverNodeId: 'node',
+        getAuthToken: () async => 'expired',
+        refreshAuthToken: () async => null,
+      );
+
+      final response = await link.request(_request()).first;
+
+      expect(service.tokensSeen, ['expired'], reason: 'must not retry blindly');
+      expect(response.errors, isNotNull);
+      expect(
+          response.errors!.first.message, contains('Authentication required'));
+    });
+
+    test('surfaces the auth error when no refresher is wired', () async {
+      final service = _FakeP2pService();
+
+      final link = P2pGraphQLLink(
+        p2pService: service,
+        serverNodeId: 'node',
+        getAuthToken: () async => 'expired',
+      );
+
+      final response = await link.request(_request()).first;
+
+      expect(service.tokensSeen, ['expired']);
+      expect(response.errors, isNotNull);
+    });
+  });
+}

--- a/test/mydia_web/schema/api_key_test.exs
+++ b/test/mydia_web/schema/api_key_test.exs
@@ -78,7 +78,10 @@ defmodule MydiaWeb.Schema.ApiKeyTest do
       result = run_query(@list_api_keys_query, %{})
 
       assert {:ok, %{errors: [%{message: message}]}} = result
-      assert message =~ "unauthorized" or message =~ "not authenticated"
+      # Root-field middleware rejects before the resolver runs, so the unified
+      # "Authentication required" message is the expected one now.
+      assert message =~ "Authentication required" or message =~ "unauthorized" or
+               message =~ "not authenticated"
     end
   end
 
@@ -140,7 +143,10 @@ defmodule MydiaWeb.Schema.ApiKeyTest do
       result = run_query(@create_api_key_mutation, variables)
 
       assert {:ok, %{errors: [%{message: message}]}} = result
-      assert message =~ "unauthorized" or message =~ "not authenticated"
+      # Root-field middleware rejects before the resolver runs, so the unified
+      # "Authentication required" message is the expected one now.
+      assert message =~ "Authentication required" or message =~ "unauthorized" or
+               message =~ "not authenticated"
     end
 
     test "rejects invalid permissions", %{user: user} do
@@ -177,7 +183,10 @@ defmodule MydiaWeb.Schema.ApiKeyTest do
       result = run_query(@revoke_api_key_mutation, variables)
 
       assert {:ok, %{errors: [%{message: message}]}} = result
-      assert message =~ "unauthorized" or message =~ "not authenticated"
+      # Root-field middleware rejects before the resolver runs, so the unified
+      # "Authentication required" message is the expected one now.
+      assert message =~ "Authentication required" or message =~ "unauthorized" or
+               message =~ "not authenticated"
     end
 
     test "prevents revoking another user's key" do
@@ -215,7 +224,10 @@ defmodule MydiaWeb.Schema.ApiKeyTest do
       result = run_query(@delete_api_key_mutation, variables)
 
       assert {:ok, %{errors: [%{message: message}]}} = result
-      assert message =~ "unauthorized" or message =~ "not authenticated"
+      # Root-field middleware rejects before the resolver runs, so the unified
+      # "Authentication required" message is the expected one now.
+      assert message =~ "Authentication required" or message =~ "unauthorized" or
+               message =~ "not authenticated"
     end
 
     test "prevents deleting another user's key" do

--- a/test/mydia_web/schema/auth_gating_test.exs
+++ b/test/mydia_web/schema/auth_gating_test.exs
@@ -1,0 +1,90 @@
+defmodule MydiaWeb.Schema.AuthGatingTest do
+  @moduledoc """
+  Guards the fail-closed authorization posture of the GraphQL root types.
+
+  Authorization used to be opt-in per resolver, which left every browse and
+  download field readable by anyone who could reach the endpoint. The structural
+  test below is the one that matters over time: it fails when a new root field is
+  added without gating, rather than waiting for someone to notice the hole.
+  """
+  use MydiaWeb.ConnCase
+
+  alias Mydia.Accounts
+  alias MydiaWeb.Schema
+  alias MydiaWeb.Schema.Middleware.RequireAuth
+
+  @movies_query "{ movies(first: 1) { edges { node { id } } } }"
+
+  # Kept deliberately in step with the allowlist in MydiaWeb.Schema. Adding a
+  # field here is a security decision and should be visible in review.
+  @public_fields [:login, :refresh_media_token, :refresh_access_token]
+  @introspection_fields [:__schema, :__type, :__typename]
+
+  describe "root field gating" do
+    test "every root field requires authentication unless explicitly public" do
+      ungated =
+        for root <- [:query, :mutation, :subscription],
+            type = Absinthe.Schema.lookup_type(Schema, root),
+            {identifier, field} <- type.fields,
+            identifier not in @public_fields,
+            identifier not in @introspection_fields,
+            not gated?(field),
+            do: "#{root}.#{identifier}"
+
+      assert ungated == [],
+             "these root fields are reachable without authentication: #{inspect(ungated)}"
+    end
+
+    test "the public allowlist really is reachable without a user" do
+      for root <- [:query, :mutation],
+          type = Absinthe.Schema.lookup_type(Schema, root),
+          {identifier, field} <- type.fields,
+          identifier in @public_fields do
+        refute gated?(field), "#{identifier} must stay reachable for unauthenticated clients"
+      end
+    end
+  end
+
+  describe "browse queries" do
+    test "are denied without an authenticated user" do
+      assert {:ok, %{errors: errors}} = Absinthe.run(@movies_query, Schema, context: %{})
+      assert Enum.any?(errors, &(&1.message =~ "Authentication required"))
+    end
+
+    test "are denied when the context carries a nil user" do
+      assert {:ok, %{errors: errors}} =
+               Absinthe.run(@movies_query, Schema, context: %{current_user: nil})
+
+      assert Enum.any?(errors, &(&1.message =~ "Authentication required"))
+    end
+
+    test "succeed for an authenticated user" do
+      user = create_user()
+
+      assert {:ok, %{data: %{"movies" => %{"edges" => edges}}}} =
+               Absinthe.run(@movies_query, Schema, context: %{current_user: user})
+
+      assert is_list(edges)
+    end
+  end
+
+  defp gated?(field) do
+    Enum.any?(field.middleware, fn
+      RequireAuth -> true
+      {RequireAuth, _} -> true
+      _ -> false
+    end)
+  end
+
+  defp create_user do
+    {:ok, user} =
+      Accounts.create_user(%{
+        email: "user-#{System.unique_integer([:positive])}@example.com",
+        username: "user#{System.unique_integer([:positive])}",
+        password: "password123",
+        role: "user"
+      })
+
+    user
+  end
+end

--- a/test/mydia_web/schema/remote_access_test.exs
+++ b/test/mydia_web/schema/remote_access_test.exs
@@ -140,6 +140,56 @@ defmodule MydiaWeb.Schema.RemoteAccessTest do
       assert message =~ "Invalid"
     end
 
+    test "rate limits a caller that keeps guessing device tokens" do
+      caller = unique_caller()
+
+      # Each miss costs one Argon2 pass per paired device, so the ceiling is what
+      # stops this unauthenticated mutation being a CPU amplifier.
+      for _ <- 1..10 do
+        assert {:ok, %{errors: [%{message: message}]}} =
+                 run_query(@refresh_access_token_mutation, %{"deviceToken" => "bad"}, caller)
+
+        assert message =~ "Invalid"
+      end
+
+      assert {:ok, %{errors: [%{message: message}]}} =
+               run_query(@refresh_access_token_mutation, %{"deviceToken" => "bad"}, caller)
+
+      assert message =~ "Too many"
+    end
+
+    test "does not rate limit a different caller", %{device_token: device_token} do
+      noisy = unique_caller()
+
+      for _ <- 1..10 do
+        run_query(@refresh_access_token_mutation, %{"deviceToken" => "bad"}, noisy)
+      end
+
+      assert {:ok, %{data: %{"refreshAccessToken" => response}}} =
+               run_query(
+                 @refresh_access_token_mutation,
+                 %{"deviceToken" => device_token},
+                 unique_caller()
+               )
+
+      assert is_binary(response["token"])
+    end
+
+    test "successful refreshes never consume the rate limit budget", %{
+      device_token: device_token
+    } do
+      caller = unique_caller()
+
+      for _ <- 1..12 do
+        assert {:ok, %{data: %{"refreshAccessToken" => _}}} =
+                 run_query(
+                   @refresh_access_token_mutation,
+                   %{"deviceToken" => device_token},
+                   caller
+                 )
+      end
+    end
+
     test "records that the device was seen", %{device: device, device_token: device_token} do
       assert is_nil(device.last_seen_at)
 
@@ -151,8 +201,14 @@ defmodule MydiaWeb.Schema.RemoteAccessTest do
   end
 
   # Helper function to run GraphQL queries (no auth needed for token refresh)
-  defp run_query(query, variables) do
-    Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: %{})
+  defp run_query(query, variables, context \\ %{}) do
+    Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: context)
+  end
+
+  # The rate limiter is backed by a process-wide ETS table rather than the Ecto
+  # sandbox, so each test needs its own bucket to stay isolated.
+  defp unique_caller do
+    %{remote_ip: "203.0.113.#{System.unique_integer([:positive])}"}
   end
 
   # Test Helpers

--- a/test/mydia_web/schema/remote_access_test.exs
+++ b/test/mydia_web/schema/remote_access_test.exs
@@ -2,6 +2,7 @@ defmodule MydiaWeb.Schema.RemoteAccessTest do
   use MydiaWeb.ConnCase
 
   alias Mydia.Accounts
+  alias Mydia.Auth.Guardian
   alias Mydia.RemoteAccess.MediaToken
   alias Mydia.RemoteAccess.RemoteDevice
   alias Mydia.Repo
@@ -84,6 +85,68 @@ defmodule MydiaWeb.Schema.RemoteAccessTest do
 
       assert {:ok, %{data: %{"refreshMediaToken" => response}}} = result
       assert response["permissions"] == ["stream"]
+    end
+  end
+
+  @refresh_access_token_mutation """
+  mutation RefreshAccessToken($deviceToken: String!) {
+    refreshAccessToken(deviceToken: $deviceToken) {
+      token
+      expiresAt
+    }
+  }
+  """
+
+  describe "refreshAccessToken mutation" do
+    setup do
+      user = create_user()
+      device_token = "device-token-#{System.unique_integer([:positive])}"
+      device = create_device(user, %{token: device_token})
+      %{user: user, device: device, device_token: device_token}
+    end
+
+    test "exchanges a valid device token for a usable access token", %{
+      user: user,
+      device_token: device_token
+    } do
+      result = run_query(@refresh_access_token_mutation, %{"deviceToken" => device_token})
+
+      assert {:ok, %{data: %{"refreshAccessToken" => response}}} = result
+      assert is_binary(response["token"])
+      assert response["expiresAt"] != nil
+
+      # The whole point: the minted token must authenticate as the device's user,
+      # which is what the P2P GraphQL context builder does with it.
+      assert {:ok, verified} = Guardian.verify_token(response["token"])
+      assert verified.id == user.id
+    end
+
+    test "returns error for an unknown device token" do
+      result =
+        run_query(@refresh_access_token_mutation, %{"deviceToken" => "no-such-device-token"})
+
+      assert {:ok, %{errors: [%{message: message}]}} = result
+      assert message =~ "Invalid"
+    end
+
+    test "returns error for a revoked device", %{device: device, device_token: device_token} do
+      device
+      |> RemoteDevice.revoke_changeset()
+      |> Repo.update!()
+
+      result = run_query(@refresh_access_token_mutation, %{"deviceToken" => device_token})
+
+      assert {:ok, %{errors: [%{message: message}]}} = result
+      assert message =~ "Invalid"
+    end
+
+    test "records that the device was seen", %{device: device, device_token: device_token} do
+      assert is_nil(device.last_seen_at)
+
+      assert {:ok, %{data: %{"refreshAccessToken" => _}}} =
+               run_query(@refresh_access_token_mutation, %{"deviceToken" => device_token})
+
+      assert Repo.reload!(device).last_seen_at != nil
     end
   end
 

--- a/test/mydia_web/schema/search_test.exs
+++ b/test/mydia_web/schema/search_test.exs
@@ -190,7 +190,9 @@ defmodule MydiaWeb.Schema.SearchTest do
     assert {:ok, %{errors: [%{message: message}]}} =
              run_query(@search_query, %{"query" => "alien"})
 
-    assert message =~ "unauthenticated"
+    # Root-field middleware rejects before the resolver runs, so the unified
+    # "Authentication required" message is the expected one now.
+    assert message =~ "Authentication required" or message =~ "unauthenticated"
   end
 
   test "another user's private collection is not reachable through the API", %{user: user} do


### PR DESCRIPTION
## What broke

Connecting from the iOS player failed with:

```
Failed to start streaming session: OperationException(graphqlErrors:
[GraphQLError(message: Exception: Authentication required)])
```

Browsing still worked, which made it look like a streaming bug. It was not.

Pairing mints a Guardian access token with a 30-day TTL, and nothing could renew it. `AuthService.refreshToken()` was a `TODO` stub returning `null`, there was no refresh endpoint for the access token (only `refreshMediaToken`, for the separate 24h media token), and `RemoteAccess.verify_device_token/1` (the primitive a refresh would need) had zero callers.

So once the token aged out, every P2P GraphQL request arrived unauthenticated and stayed that way forever. The only recovery was re-pairing by hand.

Browsing kept rendering because those resolvers were not auth-gated, and the fields that are (progress, next episode, favorites) degrade silently to defaults. `streaming_resolver` gates the whole resolver, so playback failed loudly. Confirmed on a live instance: every P2P GraphQL log line lacked `user_id=`, including the "successful" ones.

## What this changes

**Access token renewal.** Adds `refreshAccessToken(deviceToken:)`, which trades the durable pairing device token for a fresh access token. It reuses `verify_device_token/1`, which already rejected revoked devices. Unauthenticated by design, exactly like `refreshMediaToken`: the device token is the proof of identity. The player now refreshes once and retries when the server rejects its token, over both HTTP and P2P. The same access token gates the P2P HLS path (`verify_hls_auth`), so this restores playback end to end rather than just the mutation.

**Fail-closed GraphQL authorization.** Investigating the above surfaced a separate problem. Authorization was opt-in per resolver: `schema.ex` installed no auth middleware, and the HTTP `:api_auth` pipeline only attaches identity (`ApiAuth.call/2` returns `conn` untouched when no key is present, and the GraphQL scope never pipes through `:require_authenticated`). Any resolver that omitted a `current_user` check was therefore reachable by anyone who could reach the endpoint.

Three did: `browse_resolver` (14 functions), `download_resolver` (4), `subtitle_resolver` (1). That left the full catalog readable and transcode jobs startable without credentials, on every deployed instance. Verified against a real deployment with no credentials of any kind.

This adds `RequireAuth` middleware applied to every root query, mutation and subscription field, with an explicit allowlist for `login` and the two token-refresh mutations. Introspection stays open so GraphiQL keeps working; it exposes schema shape, never data. Resolver-level checks remain as defence in depth.

Scope, for the record: media bytes were **not** exposed (`/api/v1/stream/file/...` returns 401), API keys were properly gated, and user data (progress, favorites, watch history, devices, collections, search) was gated. No filesystem paths are exposed by the GraphQL types.

## Testing

- `test/mydia_web/schema/auth_gating_test.exs` walks every root field on all three root types and fails when one is added without gating. This is the part that keeps the invariant from rotting.
- `test/mydia_web/schema/remote_access_test.exs` covers the refresh mutation: valid device token mints a token that authenticates as the device's user, unknown and revoked tokens are rejected, and the device is marked seen.
- `player/test/core/graphql/p2p_link_test.dart` covers refresh-and-retry, no refresh on success, and both give-up paths.
- Full suites green: 5972 Elixir tests, 0 failures; 1022 player tests, 0 failures. `mix precommit` passes (format, Credo strict, tests). `dart analyze` clean.

## Notes for review

- Existing tests that asserted the older per-resolver wording now also accept the unified `"Authentication required"` message. They still assert denial.
- Subscriptions are gated too. They are not consumed by the player today (`graphqlClientWithSubscriptionsProvider` is referenced only in example doc comments), and `device_status_changed(user_id:)` previously let anyone subscribe to any user's device events.
- The P2P transport has no pairing gate at the connection layer, so the same surface is reachable by any peer that can dial the node. That is unchanged here and worth a separate look.
- Already-expired devices still need one manual re-pair. Refresh needs a device token the client already holds; it cannot revive a session that has no valid credential left.
