### PR TITLE
fix(player): resume from a saved position when casting and when playing downloads

### DIFF
--- a/docs/development/cast-manual-test-checklist.md
+++ b/docs/development/cast-manual-test-checklist.md
@@ -78,3 +78,26 @@ already implemented behind the same gate.
   unreachable case) and only escalates to a transcode if that also fails — a
   failing cast may take up to three attempts (direct → bridge → transcode)
   before reporting an error to the user.
+
+## Resume
+
+Automated coverage for the resume decision itself lives in
+`resume_decision_coverage_test.dart`, one widget test per playback source. It
+cannot reach real receivers, real elapsed time, or a real progress sync round
+trip to the server, so run this section by hand against actual hardware.
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | Watch 20 minutes of an episode locally, stop, choose a Chromecast from the detail screen, play | Resume prompt appears, then the receiver starts at 20 minutes |
+| 2 | Let it run past a progress sync (10 seconds), stop casting | **The server records roughly 20 minutes, not 0.** This is the progress-destruction guard |
+| 3 | Scrub the cast to 50 minutes | A brief reload, then playback at 50 minutes, not a snap back |
+| 4 | Scrub the cast back to 5 minutes, before the resume offset | A reload, then playback at 5 minutes |
+| 5 | Airplane mode, play a downloaded episode, watch 10 minutes, quit, replay | Resume prompt at 10 minutes |
+| 6 | Go back online | The server picks up the offline position within a few seconds |
+| 7 | Repeat case 1 against a DLNA renderer | Resume with no reload, since progressive routes seek directly |
+
+Case 2 is the one to check most carefully. A resume that looks correct on
+screen, receiver playing from the right spot and all, can still report
+position 0 back to the server if the sync fires before the resumed offset
+takes effect. That silently erases the user's real watch history for that
+title, with nothing on screen to suggest anything went wrong.

--- a/player/lib/core/cast/cast_route_resolver.dart
+++ b/player/lib/core/cast/cast_route_resolver.dart
@@ -93,6 +93,21 @@ class CastRouteResolver {
     required this.streamingSessions,
   });
 
+  /// How a receiver speaking [protocol] is fed media.
+  ///
+  /// Chromecast plays HLS natively, which gives seeking and adaptive bitrate.
+  /// DLNA renderers generally cannot, so they get a progressive byte-range
+  /// stream of the whole file.
+  ///
+  /// Deliberately one function rather than a rule repeated per call site:
+  /// [resolve] decides the kind, and anything that later has to reason about
+  /// the resulting stream — notably `shouldRestartCastForSeek`, which must
+  /// never restart a progressive route — has to reach the same answer.
+  static CastMediaKind mediaKindFor(CastProtocolKind protocol) =>
+      protocol == CastProtocolKind.chromecast
+          ? CastMediaKind.hls
+          : CastMediaKind.progressive;
+
   /// Whether [resolve] with these flags would produce a bridge route.
   ///
   /// The manager asks first so it can enable LAN access *before* the bridge
@@ -113,11 +128,8 @@ class CastRouteResolver {
     bool forceTranscode = false,
     Duration startPosition = Duration.zero,
   }) async {
-    // Chromecast plays HLS natively, which gives seeking and adaptive
-    // bitrate. DLNA renderers generally cannot, so they get progressive.
     final isChromecast = protocol == CastProtocolKind.chromecast;
-    final mediaKind =
-        isChromecast ? CastMediaKind.hls : CastMediaKind.progressive;
+    final mediaKind = mediaKindFor(protocol);
 
     if (usesBridge(forceBridge: forceBridge)) {
       final base = lanBaseUrl();

--- a/player/lib/core/cast/cast_route_resolver.dart
+++ b/player/lib/core/cast/cast_route_resolver.dart
@@ -27,15 +27,25 @@ class CastRoute {
 
   /// Server-side HLS session backing this route, when it needed one.
   ///
-  /// Only the bridged Chromecast route does: the local proxy addresses HLS by
-  /// session id, so one has to exist before the URL means anything. The
-  /// session manager ends it when the route is abandoned or casting stops.
+  /// Every Chromecast route does, bridged or direct: both address HLS by
+  /// session id, so one has to exist before the URL means anything, and only
+  /// a session can carry a resume offset. Null on a progressive route, which
+  /// is served straight from the file endpoint. The session manager ends it
+  /// when the route is abandoned or casting stops.
   final String? hlsSessionId;
 
   /// Media token captured when the route was resolved, so every URL built
   /// from this route — media *and* sidecar subtitles — carries the same
   /// credential the receiver needs.
   final String? mediaToken;
+
+  /// The real media position the stream itself begins at.
+  ///
+  /// Non-zero only on an HLS route resumed mid-item, where the offset is baked
+  /// into FFmpeg's `-ss` because a live-style playlist cannot be seeked into.
+  /// The receiver's position zero means this much into the media, which is
+  /// what `CastSessionManager`'s `StreamTimeline` translates back.
+  final Duration startOffset;
 
   const CastRoute({
     required this.mediaUrl,
@@ -44,6 +54,7 @@ class CastRoute {
     required this.subtitlesSupported,
     this.hlsSessionId,
     this.mediaToken,
+    this.startOffset = Duration.zero,
   });
 }
 
@@ -90,25 +101,23 @@ class CastRouteResolver {
   bool usesBridge({bool forceBridge = false}) => forceBridge || isP2pMode;
 
   /// Returns null when neither route is usable.
+  ///
+  /// [startPosition] is where the user wants playback to resume. On an HLS
+  /// route it is baked into the server-side session, because a live-style
+  /// playlist cannot be seeked into; on a progressive one it is left to a
+  /// plain receiver seek, which byte ranges support.
   Future<CastRoute?> resolve({
     required String fileId,
     required CastProtocolKind protocol,
     bool forceBridge = false,
     bool forceTranscode = false,
+    Duration startPosition = Duration.zero,
   }) async {
     // Chromecast plays HLS natively, which gives seeking and adaptive
     // bitrate. DLNA renderers generally cannot, so they get progressive.
     final isChromecast = protocol == CastProtocolKind.chromecast;
     final mediaKind =
         isChromecast ? CastMediaKind.hls : CastMediaKind.progressive;
-
-    // [forceTranscode] is the escalation after a receiver rejects the media
-    // outright, which is nearly always an unsupported codec.
-    final strategy = forceTranscode
-        ? StreamingStrategy.transcode
-        : isChromecast
-            ? StreamingStrategy.hlsCopy
-            : StreamingStrategy.directPlay;
 
     if (usesBridge(forceBridge: forceBridge)) {
       final base = lanBaseUrl();
@@ -127,17 +136,19 @@ class CastRouteResolver {
         );
       }
 
-      final sessionId = await streamingSessions.start(
+      final session = await streamingSessions.start(
         fileId: fileId,
         transcode: forceTranscode,
+        startPosition: startPosition,
       );
 
       return CastRoute(
-        mediaUrl: '$base/hls/$sessionId/index.m3u8',
+        mediaUrl: '$base/hls/${session.sessionId}/index.m3u8',
         kind: CastRouteKind.localBridge,
         mediaKind: mediaKind,
         subtitlesSupported: false,
-        hlsSessionId: sessionId,
+        hlsSessionId: session.sessionId,
+        startOffset: session.startOffset,
       );
     }
 
@@ -146,11 +157,43 @@ class CastRouteResolver {
 
     final token = await mediaToken();
 
+    if (isChromecast) {
+      // Deliberately not `/api/v1/stream/file/...?strategy=HLS_COPY`. That
+      // redirect starts a session with no offset argument and returns no
+      // session id, so a resume position could never be honored and
+      // `_adoptHlsSession` could never end what it started. The mutation
+      // gives both. `/api/v1/hls/...` sits behind `media_api_auth`, whose
+      // `MediaAuth` plug accepts `?token=`, which a receiver needs because it
+      // cannot send an Authorization header.
+      final session = await streamingSessions.start(
+        fileId: fileId,
+        transcode: forceTranscode,
+        startPosition: startPosition,
+      );
+
+      return CastRoute(
+        mediaUrl:
+            '$server/api/v1/hls/${session.sessionId}/index.m3u8?token=$token',
+        kind: CastRouteKind.directServer,
+        mediaKind: mediaKind,
+        subtitlesSupported: true,
+        mediaToken: token,
+        hlsSessionId: session.sessionId,
+        startOffset: session.startOffset,
+      );
+    }
+
+    // Only a progressive receiver reaches here, so the file endpoint is only
+    // ever asked for whole-file bytes. [forceTranscode] is the escalation
+    // after a receiver rejects the media outright, which is nearly always an
+    // unsupported codec.
     return CastRoute(
       mediaUrl: StreamingStrategyService.buildStreamUrl(
         serverUrl: server,
         fileId: fileId,
-        strategy: strategy,
+        strategy: forceTranscode
+            ? StreamingStrategy.transcode
+            : StreamingStrategy.directPlay,
         mediaToken: token,
       ),
       kind: CastRouteKind.directServer,

--- a/player/lib/core/cast/cast_seek_restart.dart
+++ b/player/lib/core/cast/cast_seek_restart.dart
@@ -1,0 +1,29 @@
+/// How far ahead of the current position a cast seek may target before the
+/// session is restarted instead.
+///
+/// Matches local playback's `kSeekRestartTolerance` deliberately: a restart is
+/// far more disruptive than the small snap-back it avoids, and a 10-second
+/// skip or a double-tap-forward must never tear a session down.
+const Duration kCastSeekRestartTolerance = Duration(seconds: 30);
+
+/// Whether a cast seek must restart the server-side session rather than seek
+/// the receiver in place.
+///
+/// Two independent reasons, mirroring the local predicate's two clauses:
+///
+/// 1. [target] is before [startOffset], so it is not present in this stream
+///    at all. No amount of seeking can reach it.
+/// 2. [target] is far enough ahead of [currentPosition] that FFmpeg has
+///    probably not written it yet. Unlike local playback there is no way to
+///    know for sure: a Chromecast reports `duration: -1` for a live-style
+///    playlist forever, so the transcoded extent is unobservable and distance
+///    from the current position is the only available proxy.
+bool shouldRestartCastForSeek({
+  required Duration target,
+  required Duration currentPosition,
+  required Duration startOffset,
+  Duration tolerance = kCastSeekRestartTolerance,
+}) {
+  if (target < startOffset) return true;
+  return target > currentPosition + tolerance;
+}

--- a/player/lib/core/cast/cast_seek_restart.dart
+++ b/player/lib/core/cast/cast_seek_restart.dart
@@ -1,3 +1,5 @@
+import 'cast_backend.dart';
+
 /// How far ahead of the current position a cast seek may target before the
 /// session is restarted instead.
 ///
@@ -9,7 +11,14 @@ const Duration kCastSeekRestartTolerance = Duration(seconds: 30);
 /// Whether a cast seek must restart the server-side session rather than seek
 /// the receiver in place.
 ///
-/// Two independent reasons, mirroring the local predicate's two clauses:
+/// Only ever true for [CastMediaKind.hls]. A progressive route hands the
+/// receiver a byte-range stream of the whole file: [startOffset] is always
+/// zero, the whole runtime is addressable, and a receiver seek anywhere in it
+/// is valid. Restarting there would tear down and reload a session for a
+/// target it could already reach.
+///
+/// For HLS there are two independent reasons, mirroring the local predicate's
+/// two clauses:
 ///
 /// 1. [target] is before [startOffset], so it is not present in this stream
 ///    at all. No amount of seeking can reach it.
@@ -19,11 +28,13 @@ const Duration kCastSeekRestartTolerance = Duration(seconds: 30);
 ///    playlist forever, so the transcoded extent is unobservable and distance
 ///    from the current position is the only available proxy.
 bool shouldRestartCastForSeek({
+  required CastMediaKind mediaKind,
   required Duration target,
   required Duration currentPosition,
   required Duration startOffset,
   Duration tolerance = kCastSeekRestartTolerance,
 }) {
+  if (mediaKind != CastMediaKind.hls) return false;
   if (target < startOffset) return true;
   return target > currentPosition + tolerance;
 }

--- a/player/lib/core/cast/cast_session_manager.dart
+++ b/player/lib/core/cast/cast_session_manager.dart
@@ -7,6 +7,7 @@ import '../player/progress_service.dart';
 import '../player/stream_timeline.dart';
 import 'cast_backend.dart';
 import 'cast_route_resolver.dart';
+import 'cast_seek_restart.dart';
 import 'cast_session_store.dart';
 import 'cast_streaming_session_service.dart';
 
@@ -68,6 +69,21 @@ class CastSessionManager {
 
   /// Server-side HLS session backing the media currently on the receiver.
   String? _activeHlsSessionId;
+
+  /// True while a cast-seek restart (`startCast`) is running.
+  ///
+  /// `startCast` re-runs the whole route-resolution/load path and mutates
+  /// shared state — `_persisted`, `_activeHlsSessionId`, the backend
+  /// listeners re-armed by `_listenToBackend` — across several `await`
+  /// points. A user dragging a scrub bar fires `seek` faster than one
+  /// restart completes; without this guard a second call reads the same
+  /// stale `_persisted`/`_current` the first call already decided to act on,
+  /// so both restart concurrently, and whichever call's `_adoptHlsSession`
+  /// runs last tears down the session the other one just adopted — killing
+  /// whatever actually ended up loaded on the receiver. Mirrors
+  /// `_PlayerScreenState._isRestartingSession` in player_screen.dart, which
+  /// guards the equivalent local-playback restart the same way.
+  bool _isRestartingForSeek = false;
 
   /// Maps receiver-reported positions onto real media positions.
   ///
@@ -623,7 +639,50 @@ class CastSessionManager {
 
   Future<void> play() => _backend.play();
   Future<void> pause() => _backend.pause();
-  Future<void> seek(Duration position) => _backend.seek(position);
+
+  /// Seeks to a real media position, restarting the session when the target
+  /// is outside what the receiver can reach.
+  ///
+  /// [position] is a real media position, matching what `mediaInfo` publishes
+  /// and what the scrub bar computes against `request.duration`.
+  Future<void> seek(Duration position) async {
+    // A restart already in flight is dropped outright, not queued: this
+    // call's target is superseded either way, and the machinery it would
+    // otherwise re-enter is not safe to run twice at once (see
+    // `_isRestartingForSeek`'s dartdoc).
+    if (_isRestartingForSeek) return;
+
+    final session = _persisted;
+
+    if (session == null ||
+        !shouldRestartCastForSeek(
+          target: position,
+          currentPosition: _current?.mediaInfo?.position ?? Duration.zero,
+          startOffset: _timeline.startOffset,
+        )) {
+      return _backend.seek(_timeline.toPlayer(position));
+    }
+
+    // Out of reach in the current stream: start a new session at the target
+    // and reload the receiver on it. A visible blip, and strictly better than
+    // the silent snap-back the receiver would otherwise do.
+    _isRestartingForSeek = true;
+    try {
+      await startCast(
+        device: session.device,
+        request: CastLaunchRequest(
+          fileId: session.fileId,
+          mediaId: session.mediaId,
+          mediaType: session.mediaType,
+          title: session.title,
+          startPosition: position,
+          duration: session.duration,
+        ),
+      );
+    } finally {
+      _isRestartingForSeek = false;
+    }
+  }
 
   /// Re-cast whatever the stored session was playing.
   ///

--- a/player/lib/core/cast/cast_session_manager.dart
+++ b/player/lib/core/cast/cast_session_manager.dart
@@ -42,6 +42,24 @@ class CastLaunchRequest {
     this.subtitles = const [],
     this.duration,
   });
+
+  /// The same request, resumed from somewhere else.
+  ///
+  /// Only [startPosition] can be replaced, and passing null keeps the current
+  /// one. Everything else is carried across verbatim, which is the whole
+  /// point: a seek restart rebuilds the cast from this, and anything dropped
+  /// here disappears from the receiver for the rest of the session.
+  CastLaunchRequest copyWith({Duration? startPosition}) => CastLaunchRequest(
+        fileId: fileId,
+        mediaId: mediaId,
+        mediaType: mediaType,
+        title: title,
+        subtitleLabel: subtitleLabel,
+        imageUrl: imageUrl,
+        startPosition: startPosition ?? this.startPosition,
+        subtitles: subtitles,
+        duration: duration,
+      );
 }
 
 /// Owns the active cast session: routing, playback, progress and persistence.
@@ -63,6 +81,23 @@ class CastSessionManager {
 
   CastSession? _current;
   PersistedCastSession? _persisted;
+
+  /// The full request behind whatever is on the receiver right now.
+  ///
+  /// Kept alongside [_persisted] because the two answer different questions.
+  /// [PersistedCastSession] is what has to survive the app being killed, so
+  /// it carries only what a cold restore can act on; this carries everything
+  /// the *live* session was launched with — subtitle tracks, artwork, the
+  /// subtitle label. A seek restart rebuilds the cast from this rather than
+  /// from the persisted record, which would silently drop all three for the
+  /// rest of the session.
+  ///
+  /// Set wherever a cast actually loads ([_loadOnRoute], so every retry and
+  /// escalation included) and by [restoreSession] for the branch that adopts
+  /// a receiver already playing, so it is never out of step with
+  /// [_persisted].
+  CastLaunchRequest? _lastRequest;
+
   Duration _lastDuration = Duration.zero;
   DateTime? _lastProgressSync;
   bool _lanEnabled = false;
@@ -456,6 +491,8 @@ class CastSessionManager {
       subtitles: subtitles,
     ));
 
+    _lastRequest = request;
+
     _persisted = PersistedCastSession(
       device: device,
       mediaId: request.mediaId,
@@ -653,9 +690,12 @@ class CastSessionManager {
     if (_isRestartingForSeek) return;
 
     final session = _persisted;
+    final request = _lastRequest;
 
     if (session == null ||
+        request == null ||
         !shouldRestartCastForSeek(
+          mediaKind: CastRouteResolver.mediaKindFor(session.device.protocol),
           target: position,
           currentPosition: _current?.mediaInfo?.position ?? Duration.zero,
           startOffset: _timeline.startOffset,
@@ -666,18 +706,16 @@ class CastSessionManager {
     // Out of reach in the current stream: start a new session at the target
     // and reload the receiver on it. A visible blip, and strictly better than
     // the silent snap-back the receiver would otherwise do.
+    //
+    // Rebuilt from the live request, not from `session`: the persisted record
+    // carries no subtitle tracks, subtitle label or artwork, so restarting
+    // from it would strip all three off the receiver for the rest of the
+    // session.
     _isRestartingForSeek = true;
     try {
       await startCast(
         device: session.device,
-        request: CastLaunchRequest(
-          fileId: session.fileId,
-          mediaId: session.mediaId,
-          mediaType: session.mediaType,
-          title: session.title,
-          startPosition: position,
-          duration: session.duration,
-        ),
+        request: request.copyWith(startPosition: position),
       );
     } finally {
       _isRestartingForSeek = false;
@@ -729,6 +767,7 @@ class CastSessionManager {
     await _disableLanQuietly();
 
     _persisted = null;
+    _lastRequest = null;
     _lastDuration = Duration.zero;
     _lastProgressSync = null;
     _publish(null);
@@ -783,6 +822,14 @@ class CastSessionManager {
       startPosition: stored.position,
       duration: stored.duration,
     );
+
+    // The bridge branch below reloads through `_loadOnRoute`, which sets this
+    // itself; the direct branch adopts a receiver that is already playing and
+    // never loads, so it has to be recorded here. Either way a later seek
+    // restart carries exactly what the restore had — no subtitles or artwork,
+    // because a record that survived an app restart never had them.
+    _lastRequest = request;
+
     _listenToBackend(request);
 
     if (stored.routeKind == CastRouteKind.localBridge) {

--- a/player/lib/core/cast/cast_session_manager.dart
+++ b/player/lib/core/cast/cast_session_manager.dart
@@ -69,6 +69,15 @@ class CastSessionManager {
   /// Server-side HLS session backing the media currently on the receiver.
   String? _activeHlsSessionId;
 
+  /// Maps receiver-reported positions onto real media positions.
+  ///
+  /// Non-zero offset whenever a cast was resumed mid-item on an HLS route:
+  /// the offset is baked into FFmpeg's `-ss`, so the receiver's zero is that
+  /// far into the media. Everything that reads a receiver position goes
+  /// through this, because a raw position reaching `_syncProgress` would
+  /// overwrite the user's real watch position with zero.
+  StreamTimeline _timeline = StreamTimeline.zero;
+
   /// How often receiver position is pushed to the server, matching the
   /// cadence local playback uses.
   static const _progressInterval = Duration(seconds: 10);
@@ -200,6 +209,7 @@ class CastSessionManager {
       protocol: device.protocol,
       forceBridge: forceBridge,
       forceTranscode: forceTranscode,
+      startPosition: request.startPosition ?? Duration.zero,
     );
 
     if (route == null) {
@@ -411,13 +421,22 @@ class CastSessionManager {
             .toList()
         : const <CastSubtitleTrack>[];
 
+    _useTimeline(StreamTimeline(
+      startOffset: route.startOffset,
+      totalDuration: request.duration,
+    ));
+
     await _backend.loadMedia(CastMediaRequest(
       url: route.mediaUrl,
       kind: route.mediaKind,
       title: request.title,
       subtitle: request.subtitleLabel,
       imageUrl: request.imageUrl,
-      startPosition: request.startPosition,
+      // Already baked into the stream on an HLS route, so asking the receiver
+      // to seek there as well would land at twice the offset. On a
+      // progressive route `startOffset` is zero and this is the whole
+      // position, which is a valid byte-range seek.
+      startPosition: _timeline.toPlayer(request.startPosition ?? Duration.zero),
       subtitles: subtitles,
     ));
 
@@ -448,6 +467,17 @@ class CastSessionManager {
         position: request.startPosition ?? Duration.zero,
       ),
     ));
+  }
+
+  /// Points this manager *and* the shared [ProgressService] at [timeline].
+  ///
+  /// One setter because the two must never disagree: the manager translates
+  /// receiver positions for the UI and for persistence, `resolveSync`
+  /// translates them for the server, and a stale value on either side writes
+  /// a wrong position into the user's watch history.
+  void _useTimeline(StreamTimeline timeline) {
+    _timeline = timeline;
+    _progressService.timeline = timeline;
   }
 
   Future<void> _enableLan() async {
@@ -487,9 +517,14 @@ class CastSessionManager {
     // the app), so its `timeline` must be re-pointed at whatever item is
     // cast now — the same duration authority `request.duration` already
     // gives the receiver's own scrub bar (see `CastLaunchRequest.duration`'s
-    // dartdoc). `startOffset` stays zero: casting a resume offset is Task 8's
-    // job, not this one.
-    _progressService.timeline = StreamTimeline(totalDuration: request.duration);
+    // dartdoc).
+    //
+    // No offset yet: which route will actually load, and therefore what
+    // offset the server baked in, is not known until `_loadOnRoute` runs.
+    // Starting from zero rather than leaving the previous item's offset in
+    // place is the safe default — an item cast after a resumed one must not
+    // inherit its offset.
+    _useTimeline(StreamTimeline(totalDuration: request.duration));
 
     _durationSub = _backend.durationStream.listen((duration) {
       // Non-positive is the receiver saying "I don't know" (Chromecast sends
@@ -504,7 +539,11 @@ class CastSessionManager {
     });
 
     _positionSub = _backend.positionStream.listen((position) {
-      _updateMediaInfo(position: position);
+      // Raw to `_syncProgress`: `ProgressService.resolveSync` applies
+      // `timeline.toReal` itself, and `_progressService.timeline` is the same
+      // offset timeline `_useTimeline` set. Translating here as well would
+      // add the offset twice.
+      _updateMediaInfo(position: _timeline.toReal(position));
       unawaited(_syncProgress(request, position));
     });
 
@@ -546,7 +585,14 @@ class CastSessionManager {
 
     final persisted = _persisted;
     if (persisted != null) {
-      _persisted = persisted.copyWith(position: position, savedAt: now);
+      // Translated, unlike the value handed to `_progressService` below:
+      // `reconnectStoredSession` feeds this straight back as `startPosition`,
+      // so a receiver-relative value would compound the offset on every
+      // reconnect.
+      _persisted = persisted.copyWith(
+        position: _timeline.toReal(position),
+        savedAt: now,
+      );
       await _store.save(_persisted!);
     }
 

--- a/player/lib/core/cast/cast_streaming_session_service.dart
+++ b/player/lib/core/cast/cast_streaming_session_service.dart
@@ -19,24 +19,39 @@ import 'cast_backend.dart';
 /// without a GraphQL server, and so the manager can end the session it
 /// started when casting stops.
 abstract class CastStreamingSessionService {
-  /// Starts a session and returns its id.
+  /// Starts a session at [startPosition] and returns its id together with the
+  /// offset the server actually used.
+  ///
+  /// The echoed value, not the requested one, is authoritative: the server
+  /// clamps the request against the runtime and FFmpeg's `-ss` lands on the
+  /// nearest keyframe, so the stream can legitimately begin earlier than
+  /// asked. An older server omits the field, which correctly yields zero.
   ///
   /// Throws [CastBackendException] when the server refuses, so the manager's
   /// existing escalation ladder can treat it like any other route failure.
-  Future<String> start({required String fileId, required bool transcode});
+  Future<({String sessionId, Duration startOffset})> start({
+    required String fileId,
+    required bool transcode,
+    Duration startPosition = Duration.zero,
+  });
 
   /// Best-effort teardown. Never throws: a leaked server-side session is a
   /// far smaller problem than an exception on the stop-casting path.
   Future<void> end(String sessionId);
 }
 
-class GraphqlCastStreamingSessionService implements CastStreamingSessionService {
+class GraphqlCastStreamingSessionService
+    implements CastStreamingSessionService {
   final GraphQLClient _client;
 
   const GraphqlCastStreamingSessionService(this._client);
 
   @override
-  Future<String> start({required String fileId, required bool transcode}) async {
+  Future<({String sessionId, Duration startOffset})> start({
+    required String fileId,
+    required bool transcode,
+    Duration startPosition = Duration.zero,
+  }) async {
     final result = await _client.mutate(MutationOptions(
       document: documentNodeMutationStartStreamingSession,
       variables: Variables$Mutation$StartStreamingSession(
@@ -44,6 +59,8 @@ class GraphqlCastStreamingSessionService implements CastStreamingSessionService 
         strategy: transcode
             ? Enum$StreamingStrategy.TRANSCODE
             : Enum$StreamingStrategy.HLS_COPY,
+        startPosition:
+            startPosition > Duration.zero ? startPosition.inSeconds : null,
       ).toJson(),
     ));
 
@@ -66,7 +83,10 @@ class GraphqlCastStreamingSessionService implements CastStreamingSessionService 
       );
     }
 
-    return session.sessionId;
+    return (
+      sessionId: session.sessionId,
+      startOffset: Duration(seconds: session.startPosition ?? 0),
+    );
   }
 
   @override
@@ -74,12 +94,12 @@ class GraphqlCastStreamingSessionService implements CastStreamingSessionService 
     try {
       await _client.mutate(MutationOptions(
         document: documentNodeMutationEndStreamingSession,
-        variables:
-            Variables$Mutation$EndStreamingSession(sessionId: sessionId)
-                .toJson(),
+        variables: Variables$Mutation$EndStreamingSession(sessionId: sessionId)
+            .toJson(),
       ));
     } catch (e) {
-      debugPrint('[CastStreamingSession] Ignoring end error for $sessionId: $e');
+      debugPrint(
+          '[CastStreamingSession] Ignoring end error for $sessionId: $e');
     }
   }
 }

--- a/player/lib/core/playback/local_playback_progress.dart
+++ b/player/lib/core/playback/local_playback_progress.dart
@@ -1,0 +1,65 @@
+/// One item's playback position as this device knows it.
+///
+/// Written for downloaded media only. Streaming playback still writes
+/// straight to the server, which is reachable by definition.
+///
+/// Serialized as a plain map rather than a generated Hive adapter, matching
+/// `HiveCastSessionStore`: no build_runner step, and no type id to claim.
+class LocalPlaybackProgress {
+  final String mediaId;
+
+  /// 'movie' or 'episode'. Decides which sync mutation the flush uses.
+  final String mediaType;
+
+  final int positionSeconds;
+  final int durationSeconds;
+
+  /// When this device last wrote the position. Compared against the server's
+  /// `lastWatchedAt` to decide which side is newer.
+  final DateTime updatedAt;
+
+  /// When the server was last told. Null means it still does not know, which
+  /// is what the reconnect flush looks for.
+  final DateTime? syncedAt;
+
+  const LocalPlaybackProgress({
+    required this.mediaId,
+    required this.mediaType,
+    required this.positionSeconds,
+    required this.durationSeconds,
+    required this.updatedAt,
+    this.syncedAt,
+  });
+
+  bool get isSynced => syncedAt != null;
+
+  LocalPlaybackProgress copyWith({DateTime? syncedAt}) => LocalPlaybackProgress(
+        mediaId: mediaId,
+        mediaType: mediaType,
+        positionSeconds: positionSeconds,
+        durationSeconds: durationSeconds,
+        updatedAt: updatedAt,
+        syncedAt: syncedAt ?? this.syncedAt,
+      );
+
+  Map<String, dynamic> toMap() => {
+        'mediaId': mediaId,
+        'mediaType': mediaType,
+        'positionSeconds': positionSeconds,
+        'durationSeconds': durationSeconds,
+        'updatedAt': updatedAt.toIso8601String(),
+        'syncedAt': syncedAt?.toIso8601String(),
+      };
+
+  factory LocalPlaybackProgress.fromMap(Map<dynamic, dynamic> map) {
+    final synced = map['syncedAt'] as String?;
+    return LocalPlaybackProgress(
+      mediaId: map['mediaId'] as String,
+      mediaType: map['mediaType'] as String,
+      positionSeconds: map['positionSeconds'] as int,
+      durationSeconds: map['durationSeconds'] as int,
+      updatedAt: DateTime.parse(map['updatedAt'] as String),
+      syncedAt: synced == null ? null : DateTime.parse(synced),
+    );
+  }
+}

--- a/player/lib/core/playback/playback_progress_providers.dart
+++ b/player/lib/core/playback/playback_progress_providers.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_ce/hive.dart';
+
+import 'playback_progress_store.dart';
+
+/// Keep-alive: the store is opened once and read from the player screen on
+/// every playback start, including offline, where nothing else is available
+/// to rebuild it.
+final playbackProgressStoreProvider =
+    FutureProvider<PlaybackProgressStore>((ref) async {
+  final box = await Hive.openBox<Map>(HivePlaybackProgressStore.boxName);
+  return HivePlaybackProgressStore(box);
+});

--- a/player/lib/core/playback/playback_progress_providers.dart
+++ b/player/lib/core/playback/playback_progress_providers.dart
@@ -1,6 +1,12 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_ce/hive.dart';
 
+import '../auth/auth_status.dart';
+import '../graphql/graphql_provider.dart';
+import '../player/progress_service.dart';
 import 'playback_progress_store.dart';
 
 /// Keep-alive: the store is opened once and read from the player screen on
@@ -11,3 +17,35 @@ final playbackProgressStoreProvider =
   final box = await Hive.openBox<Map>(HivePlaybackProgressStore.boxName);
   return HivePlaybackProgressStore(box);
 });
+
+/// Pushes offline-recorded positions once the app is back online.
+///
+/// Watches the same auth state the player screen reads. Only the transition
+/// into `authenticated` triggers a flush; a flush that fails leaves its
+/// records queued for the next transition.
+final progressFlushProvider = Provider<void>((ref) {
+  ref.listen<AsyncValue<AuthStatus>>(authStateProvider, (previous, next) {
+    final wasOffline = previous?.value == AuthStatus.offlineMode;
+    final isOnline = next.value == AuthStatus.authenticated;
+    if (!wasOffline || !isOnline) return;
+
+    unawaited(_flush(ref));
+  });
+});
+
+Future<void> _flush(Ref ref) async {
+  try {
+    final store = await ref.read(playbackProgressStoreProvider.future);
+    final client = await ref.read(asyncGraphqlClientProvider.future);
+    final synced = await flushUnsyncedProgress(
+      store: store,
+      progressService: ProgressService(client),
+      now: DateTime.now(),
+    );
+    if (synced > 0) {
+      debugPrint('[PlaybackProgress] Synced $synced offline position(s)');
+    }
+  } catch (e) {
+    debugPrint('[PlaybackProgress] Deferring flush: $e');
+  }
+}

--- a/player/lib/core/playback/playback_progress_store.dart
+++ b/player/lib/core/playback/playback_progress_store.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_ce/hive.dart';
+
+import 'local_playback_progress.dart';
+
+abstract class PlaybackProgressStore {
+  Future<void> save(LocalPlaybackProgress progress);
+
+  /// Synchronous so the resume decision can read it without an extra await on
+  /// a path that is already several awaits deep. Hive keeps an open box in
+  /// memory, so there is nothing to wait for.
+  LocalPlaybackProgress? get(String mediaId);
+
+  List<LocalPlaybackProgress> unsynced();
+
+  Future<void> markSynced(String mediaId, DateTime syncedAt);
+}
+
+/// Hive-backed store over a plain `Box<Map>` with no type adapter, matching
+/// `HiveCastSessionStore` and `collection_sync_providers.dart`.
+class HivePlaybackProgressStore implements PlaybackProgressStore {
+  static const boxName = 'playback_progress';
+
+  final Box<Map> _box;
+
+  const HivePlaybackProgressStore(this._box);
+
+  @override
+  Future<void> save(LocalPlaybackProgress progress) async {
+    await _box.put(progress.mediaId, progress.toMap());
+  }
+
+  @override
+  LocalPlaybackProgress? get(String mediaId) {
+    final raw = _box.get(mediaId);
+    if (raw == null) return null;
+
+    try {
+      return LocalPlaybackProgress.fromMap(raw);
+    } catch (e) {
+      // A malformed record must never cost the user their playback.
+      debugPrint('[PlaybackProgressStore] Discarding unreadable record: $e');
+      unawaited(_box.delete(mediaId));
+      return null;
+    }
+  }
+
+  @override
+  List<LocalPlaybackProgress> unsynced() {
+    final out = <LocalPlaybackProgress>[];
+    for (final key in _box.keys) {
+      final record = get(key as String);
+      if (record != null && !record.isSynced) out.add(record);
+    }
+    return out;
+  }
+
+  @override
+  Future<void> markSynced(String mediaId, DateTime syncedAt) async {
+    final existing = get(mediaId);
+    if (existing == null) return;
+    await save(existing.copyWith(syncedAt: syncedAt));
+  }
+}
+
+class InMemoryPlaybackProgressStore implements PlaybackProgressStore {
+  final _records = <String, LocalPlaybackProgress>{};
+
+  @override
+  Future<void> save(LocalPlaybackProgress progress) async {
+    _records[progress.mediaId] = progress;
+  }
+
+  @override
+  LocalPlaybackProgress? get(String mediaId) => _records[mediaId];
+
+  @override
+  List<LocalPlaybackProgress> unsynced() =>
+      _records.values.where((p) => !p.isSynced).toList();
+
+  @override
+  Future<void> markSynced(String mediaId, DateTime syncedAt) async {
+    final existing = _records[mediaId];
+    if (existing == null) return;
+    _records[mediaId] = existing.copyWith(syncedAt: syncedAt);
+  }
+}
+
+/// Which side holds the position worth resuming from.
+///
+/// Compared on timestamp rather than fixed precedence, so finishing an episode
+/// on the TV beats a stale offline position on the phone, and an offline
+/// session beats a server record from last week.
+///
+/// A server record with no `lastWatchedAt` cannot be compared, so a local
+/// record wins over it rather than being silently overridden by something
+/// that may be much older.
+({int? positionSeconds, int? durationSeconds}) pickNewerProgress({
+  required LocalPlaybackProgress? local,
+  required int? serverPositionSeconds,
+  required int? serverDurationSeconds,
+  required DateTime? serverLastWatchedAt,
+}) {
+  if (local == null) {
+    return (
+      positionSeconds: serverPositionSeconds,
+      durationSeconds: serverDurationSeconds,
+    );
+  }
+
+  final localWins = serverPositionSeconds == null ||
+      serverLastWatchedAt == null ||
+      !serverLastWatchedAt.isAfter(local.updatedAt);
+
+  if (localWins) {
+    return (
+      positionSeconds: local.positionSeconds,
+      durationSeconds: local.durationSeconds,
+    );
+  }
+
+  return (
+    positionSeconds: serverPositionSeconds,
+    durationSeconds: serverDurationSeconds ?? local.durationSeconds,
+  );
+}

--- a/player/lib/core/playback/playback_progress_store.dart
+++ b/player/lib/core/playback/playback_progress_store.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:hive_ce/hive.dart';
 
+import '../player/progress_service.dart';
 import 'local_playback_progress.dart';
 
 abstract class PlaybackProgressStore {
@@ -155,4 +156,39 @@ Future<void> recordLocalProgress({
   } catch (e) {
     debugPrint('[PlaybackProgressStore] Ignoring failed local write: $e');
   }
+}
+
+/// Pushes every locally-recorded position the server does not have yet.
+///
+/// Records are attempted independently: one unreachable item must not strand
+/// the rest of the queue. A failure leaves `syncedAt` null so the next
+/// reconnect tries again.
+Future<int> flushUnsyncedProgress({
+  required PlaybackProgressStore store,
+  required ProgressService progressService,
+  required DateTime now,
+}) async {
+  var synced = 0;
+
+  for (final record in store.unsynced()) {
+    final position = Duration(seconds: record.positionSeconds);
+    final duration = Duration(seconds: record.durationSeconds);
+
+    try {
+      if (record.mediaType == 'episode') {
+        await progressService.syncEpisodePosition(
+            record.mediaId, position, duration);
+      } else {
+        await progressService.syncMoviePosition(
+            record.mediaId, position, duration);
+      }
+      await store.markSynced(record.mediaId, now);
+      synced++;
+    } catch (e) {
+      debugPrint(
+          '[PlaybackProgressStore] Deferring sync for ${record.mediaId}: $e');
+    }
+  }
+
+  return synced;
 }

--- a/player/lib/core/playback/playback_progress_store.dart
+++ b/player/lib/core/playback/playback_progress_store.dart
@@ -158,6 +158,71 @@ Future<void> recordLocalProgress({
   }
 }
 
+/// Records a downloaded item's position locally *and* pushes it to the
+/// server, marking the local record synced only if the server took it.
+///
+/// This is the online half of the downloaded-media path. [recordLocalProgress]
+/// always writes `syncedAt: null`, meaning "the server does not have this
+/// yet" — true while offline, but wrong the moment the very same save also
+/// reaches the server. Left unmarked, those records pile up as permanently
+/// unsynced, and the first [flushUnsyncedProgress] after offline detection is
+/// reinstated would replay a queue of stale positions over newer server
+/// progress.
+///
+/// The same [position] and [duration] go to both sides, so "synced" means the
+/// two genuinely agree. `sync*Position` is used rather than
+/// `save*Progress` for two reasons: it reports whether the server actually
+/// accepted the write, and it is not subject to the periodic sync's 10 second
+/// throttle, which would otherwise make a save-on-exit report failure simply
+/// because the timer had fired recently.
+///
+/// Marking is never optimistic: a `false` return (nothing sent, or sent and
+/// rejected) and a throw both leave `syncedAt` null for a later flush to
+/// retry.
+Future<void> saveDownloadedProgress({
+  required PlaybackProgressStore store,
+  required ProgressService progressService,
+  required String mediaId,
+  required String mediaType,
+  required Duration position,
+  required Duration duration,
+  required DateTime now,
+}) async {
+  await recordLocalProgress(
+    store: store,
+    mediaId: mediaId,
+    mediaType: mediaType,
+    position: position,
+    duration: duration,
+    now: now,
+  );
+
+  final bool accepted;
+  try {
+    accepted = mediaType == 'episode'
+        ? await progressService.syncEpisodePosition(mediaId, position, duration)
+        : await progressService.syncMoviePosition(mediaId, position, duration);
+  } catch (e) {
+    debugPrint(
+        '[PlaybackProgressStore] Server save for $mediaId failed, leaving it unsynced: $e');
+    return;
+  }
+
+  if (!accepted) {
+    debugPrint(
+        '[PlaybackProgressStore] Server did not accept $mediaId, leaving it unsynced');
+    return;
+  }
+
+  try {
+    await store.markSynced(mediaId, now);
+  } catch (e) {
+    // Same policy as `recordLocalProgress`: a store write must never cost the
+    // user their playback. The record simply stays queued for a later flush.
+    debugPrint('[PlaybackProgressStore] Ignoring failed synced-marking: $e');
+  }
+}
+
 /// Pushes every locally-recorded position the server does not have yet.
 ///
 /// Records are attempted independently: one unreachable item must not strand

--- a/player/lib/core/playback/playback_progress_store.dart
+++ b/player/lib/core/playback/playback_progress_store.dart
@@ -126,3 +126,33 @@ class InMemoryPlaybackProgressStore implements PlaybackProgressStore {
     durationSeconds: serverDurationSeconds ?? local.durationSeconds,
   );
 }
+
+/// Records a position locally, swallowing every failure.
+///
+/// A store write must never cost the user their playback, so this mirrors the
+/// error policy `_fetchProgressAndEpisodes` already uses. A non-positive
+/// duration is dropped rather than stored: a percentage against it is
+/// meaningless, and the server's own progress mutation rejects it.
+Future<void> recordLocalProgress({
+  required PlaybackProgressStore store,
+  required String mediaId,
+  required String mediaType,
+  required Duration position,
+  required Duration duration,
+  required DateTime now,
+}) async {
+  if (duration <= Duration.zero) return;
+  if (position < Duration.zero) return;
+
+  try {
+    await store.save(LocalPlaybackProgress(
+      mediaId: mediaId,
+      mediaType: mediaType,
+      positionSeconds: position.inSeconds,
+      durationSeconds: duration.inSeconds,
+      updatedAt: now,
+    ));
+  } catch (e) {
+    debugPrint('[PlaybackProgressStore] Ignoring failed local write: $e');
+  }
+}

--- a/player/lib/core/playback/playback_progress_store.dart
+++ b/player/lib/core/playback/playback_progress_store.dart
@@ -161,8 +161,15 @@ Future<void> recordLocalProgress({
 /// Pushes every locally-recorded position the server does not have yet.
 ///
 /// Records are attempted independently: one unreachable item must not strand
-/// the rest of the queue. A failure leaves `syncedAt` null so the next
-/// reconnect tries again.
+/// the rest of the queue. A record is only marked synced when
+/// `ProgressService` reports the server actually received it — its `false`
+/// return covers both "nothing was sent" (an invalid position/duration) and
+/// "sent but rejected/failed" — so a flaky reconnect can no longer discard
+/// progress the local store exists to protect. The try/catch is a
+/// belt-and-braces guard for a future throwing implementation; `false` is the
+/// primary failure signal today. Either way, a failure leaves `syncedAt` null
+/// so the next reconnect retries — indefinitely, for a record the server
+/// keeps rejecting; there is no dead-letter handling.
 Future<int> flushUnsyncedProgress({
   required PlaybackProgressStore store,
   required ProgressService progressService,
@@ -175,13 +182,18 @@ Future<int> flushUnsyncedProgress({
     final duration = Duration(seconds: record.durationSeconds);
 
     try {
-      if (record.mediaType == 'episode') {
-        await progressService.syncEpisodePosition(
-            record.mediaId, position, duration);
-      } else {
-        await progressService.syncMoviePosition(
-            record.mediaId, position, duration);
+      final ok = record.mediaType == 'episode'
+          ? await progressService.syncEpisodePosition(
+              record.mediaId, position, duration)
+          : await progressService.syncMoviePosition(
+              record.mediaId, position, duration);
+
+      if (!ok) {
+        debugPrint(
+            '[PlaybackProgressStore] Server did not accept sync for ${record.mediaId}, leaving unsynced');
+        continue;
       }
+
       await store.markSynced(record.mediaId, now);
       synced++;
     } catch (e) {

--- a/player/lib/core/player/progress_service.dart
+++ b/player/lib/core/player/progress_service.dart
@@ -129,6 +129,11 @@ class ProgressService {
 
     _lastSyncTime = DateTime.now();
 
+    // Discarded deliberately: the periodic/manual player-driven sync has
+    // never surfaced success/failure to its callers (`startMovieSync`,
+    // `saveMovieProgress`) and does not start now — only the raw-position
+    // entry points below (`syncMoviePosition`/`syncEpisodePosition`, used by
+    // the cast receiver and the offline-progress flush) need to know.
     await _mutateMovieProgress(movieId, progress);
   }
 
@@ -159,12 +164,19 @@ class ProgressService {
 
     _lastSyncTime = DateTime.now();
 
+    // Discarded — see the matching comment in `_syncMovieProgress`.
     await _mutateEpisodeProgress(episodeId, progress);
   }
 
   /// Sync movie progress from a raw position, for playback we do not own —
   /// notably a cast receiver, where there is no local `Player` to read.
-  Future<void> syncMoviePosition(
+  ///
+  /// Returns whether the server actually received it: false when nothing was
+  /// sent at all (an invalid position/duration), or when the mutation was
+  /// sent but failed. Callers that need to know the server has the position —
+  /// e.g. before marking an offline-recorded record synced — must check this
+  /// rather than assume `await` completing means success.
+  Future<bool> syncMoviePosition(
     String movieId,
     Duration position,
     Duration duration,
@@ -175,14 +187,14 @@ class ProgressService {
         '[ProgressService] Skipping movie sync: invalid position/duration '
         '(position=${position.inSeconds}s, duration=${duration.inSeconds}s)',
       );
-      return;
+      return false;
     }
 
-    await _mutateMovieProgress(movieId, progress);
+    return _mutateMovieProgress(movieId, progress);
   }
 
   /// Sync episode progress from a raw position. See [syncMoviePosition].
-  Future<void> syncEpisodePosition(
+  Future<bool> syncEpisodePosition(
     String episodeId,
     Duration position,
     Duration duration,
@@ -193,13 +205,15 @@ class ProgressService {
         '[ProgressService] Skipping episode sync: invalid position/duration '
         '(position=${position.inSeconds}s, duration=${duration.inSeconds}s)',
       );
-      return;
+      return false;
     }
 
-    await _mutateEpisodeProgress(episodeId, progress);
+    return _mutateEpisodeProgress(episodeId, progress);
   }
 
-  Future<void> _mutateMovieProgress(
+  /// Returns true only when the mutation reached the server with no
+  /// exception thrown and no GraphQL exception in the result.
+  Future<bool> _mutateMovieProgress(
     String movieId,
     ({int positionSeconds, int durationSeconds}) progress,
   ) async {
@@ -221,13 +235,19 @@ class ProgressService {
       if (result.hasException) {
         debugPrint(
             '[ProgressService] Error syncing movie progress: ${result.exception}');
+        return false;
       }
+
+      return true;
     } catch (e) {
       debugPrint('[ProgressService] Exception syncing movie progress: $e');
+      return false;
     }
   }
 
-  Future<void> _mutateEpisodeProgress(
+  /// Returns true only when the mutation reached the server with no
+  /// exception thrown and no GraphQL exception in the result.
+  Future<bool> _mutateEpisodeProgress(
     String episodeId,
     ({int positionSeconds, int durationSeconds}) progress,
   ) async {
@@ -249,9 +269,13 @@ class ProgressService {
       if (result.hasException) {
         debugPrint(
             '[ProgressService] Error syncing episode progress: ${result.exception}');
+        return false;
       }
+
+      return true;
     } catch (e) {
       debugPrint('[ProgressService] Exception syncing episode progress: $e');
+      return false;
     }
   }
 

--- a/player/lib/core/player/resume_plan.dart
+++ b/player/lib/core/player/resume_plan.dart
@@ -1,0 +1,137 @@
+/// Below this, resuming is not worth offering; start from the beginning.
+const int kMinResumeThresholdSeconds = 30;
+
+/// Within this distance of the end, the user has effectively finished.
+const int kEndOfMediaThresholdSeconds = 60;
+
+/// Matches ProgressService's server-side watched threshold.
+const double kWatchedThreshold = 0.90;
+
+/// Whether to offer resuming, given a saved position and the real runtime.
+///
+/// Extracted as a free function so it can be unit-tested without a widget tree,
+/// following the same pattern as [handleEpisodeNavKey].
+///
+/// A null [realDuration] declines deliberately. The alternative is computing a
+/// percentage against media_kit's partial HLS playlist length, which is exactly
+/// the bug that made every resume read as 100%.
+bool shouldOfferResume({
+  required int? savedPositionSeconds,
+  required Duration? realDuration,
+}) {
+  if (savedPositionSeconds == null) return false;
+  if (realDuration == null || realDuration <= Duration.zero) return false;
+  if (savedPositionSeconds <= kMinResumeThresholdSeconds) return false;
+
+  final total = realDuration.inSeconds;
+  if (savedPositionSeconds >= total - kEndOfMediaThresholdSeconds) return false;
+  if (savedPositionSeconds / total >= kWatchedThreshold) return false;
+
+  return true;
+}
+
+/// Whether `_initializePlayer` may even consider showing the resume dialog,
+/// given a possible seek-driven-restart override.
+///
+/// Deliberately gates on [resumeOverride]'s **presence** (`!= null`), not its
+/// value (`!= 0`): a restart targeting real position 0 — dragging the
+/// scrubber back to the start, holding arrow-left to the beginning, or any
+/// sub-second target, since `Duration.inSeconds` truncates — sets
+/// `_resumeOverrideSeconds` to exactly `0`, which a value-based check
+/// (`resumeOverride != 0`) cannot tell apart from "no override was set at
+/// all". Getting this wrong lets a restart to position 0 fall through to the
+/// dialog, which then prompts about the unrelated, never-refreshed
+/// `_savedPositionSeconds` from mount time and, if accepted, silently
+/// overwrites the user's explicit seek-to-start with that stale saved
+/// position.
+///
+/// Extracted as a free function, following the same pattern as
+/// [shouldOfferResume] and [shouldRestartForSeek], so this exact presence-
+/// vs-value distinction has its own name and test, independent of
+/// `_initializePlayer`'s own network/session machinery.
+bool shouldShowResumeDialog({
+  required int? resumeOverride,
+  required bool mounted,
+}) =>
+    resumeOverride == null && mounted;
+
+/// The decided answer to "where should this playback begin?".
+///
+/// One value produced at one call site, upstream of every fork in
+/// `_initializePlayer`. Before this existed the decision was made inside
+/// individual branches, so the three cast exits and the offline branch
+/// silently started at zero without ever asking.
+class ResumePlan {
+  /// The real media position to begin at. Zero means start from the beginning.
+  final Duration position;
+
+  const ResumePlan(this.position);
+
+  static const ResumePlan fromStart = ResumePlan(Duration.zero);
+
+  bool get resumes => position > Duration.zero;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ResumePlan && other.position == position;
+
+  @override
+  int get hashCode => position.hashCode;
+
+  @override
+  String toString() => 'ResumePlan(${position.inSeconds}s)';
+}
+
+/// Decides where playback begins, asking the user only when that is the only
+/// way to know.
+///
+/// Returns null when the caller must abandon startup entirely: either it was
+/// already unmounted, or the route was replaced while the dialog sat open on
+/// its unbounded wait. Carrying on in that state starts an HLS session and
+/// builds a `Player` for a dead screen, leaving FFmpeg running until the
+/// server's inactivity timeout.
+///
+/// [ask] is injected rather than calling `showResumeDialog` directly so this
+/// decision can be tested without a widget tree.
+Future<ResumePlan?> resolveResumePlan({
+  required int? savedPositionSeconds,
+  required Duration? realDuration,
+  required int? resumeOverride,
+  required bool mounted,
+  required Future<bool?> Function(int savedSeconds, int totalSeconds) ask,
+}) async {
+  if (!mounted) {
+    return null;
+  }
+
+  // A seek-driven restart already knows its target. Gating on presence rather
+  // than value is load-bearing: a restart to real position 0 sets this to
+  // exactly 0, which a value check cannot tell apart from "unset".
+  if (resumeOverride != null) {
+    return ResumePlan(Duration(seconds: resumeOverride));
+  }
+
+  if (!shouldShowResumeDialog(
+      resumeOverride: resumeOverride, mounted: mounted)) {
+    return ResumePlan.fromStart;
+  }
+
+  if (savedPositionSeconds == null || realDuration == null) {
+    return ResumePlan.fromStart;
+  }
+
+  if (!shouldOfferResume(
+    savedPositionSeconds: savedPositionSeconds,
+    realDuration: realDuration,
+  )) {
+    return ResumePlan.fromStart;
+  }
+
+  final answer = await ask(savedPositionSeconds, realDuration.inSeconds);
+  if (answer == null) return null;
+
+  return answer
+      ? ResumePlan(Duration(seconds: savedPositionSeconds))
+      : ResumePlan.fromStart;
+}

--- a/player/lib/core/player/resume_plan.dart
+++ b/player/lib/core/player/resume_plan.dart
@@ -112,11 +112,6 @@ Future<ResumePlan?> resolveResumePlan({
     return ResumePlan(Duration(seconds: resumeOverride));
   }
 
-  if (!shouldShowResumeDialog(
-      resumeOverride: resumeOverride, mounted: mounted)) {
-    return ResumePlan.fromStart;
-  }
-
   if (savedPositionSeconds == null || realDuration == null) {
     return ResumePlan.fromStart;
   }

--- a/player/lib/core/player/resume_plan.dart
+++ b/player/lib/core/player/resume_plan.dart
@@ -30,31 +30,6 @@ bool shouldOfferResume({
   return true;
 }
 
-/// Whether `_initializePlayer` may even consider showing the resume dialog,
-/// given a possible seek-driven-restart override.
-///
-/// Deliberately gates on [resumeOverride]'s **presence** (`!= null`), not its
-/// value (`!= 0`): a restart targeting real position 0 — dragging the
-/// scrubber back to the start, holding arrow-left to the beginning, or any
-/// sub-second target, since `Duration.inSeconds` truncates — sets
-/// `_resumeOverrideSeconds` to exactly `0`, which a value-based check
-/// (`resumeOverride != 0`) cannot tell apart from "no override was set at
-/// all". Getting this wrong lets a restart to position 0 fall through to the
-/// dialog, which then prompts about the unrelated, never-refreshed
-/// `_savedPositionSeconds` from mount time and, if accepted, silently
-/// overwrites the user's explicit seek-to-start with that stale saved
-/// position.
-///
-/// Extracted as a free function, following the same pattern as
-/// [shouldOfferResume] and [shouldRestartForSeek], so this exact presence-
-/// vs-value distinction has its own name and test, independent of
-/// `_initializePlayer`'s own network/session machinery.
-bool shouldShowResumeDialog({
-  required int? resumeOverride,
-  required bool mounted,
-}) =>
-    resumeOverride == null && mounted;
-
 /// The decided answer to "where should this playback begin?".
 ///
 /// One value produced at one call site, upstream of every fork in

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1470,23 +1470,46 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     // one that can be played with no server in reach. Streaming playback
     // writes straight to the server, which is reachable by definition.
     final store = _progressStore;
+    final progressService = _progressService;
     if (_isDownloadedSource && store != null) {
+      final position = player.state.position;
+      final duration = _totalDuration ?? player.state.duration;
+
+      // With a server in reach, both writes happen together so the local
+      // record can be marked synced only if the server actually took it.
+      // Writing locally and saving to the server as two independent steps is
+      // what left every downloaded-while-online record permanently unsynced,
+      // queued behind a flush that would one day replay them over newer
+      // server progress.
+      if (progressService != null) {
+        await saveDownloadedProgress(
+          store: store,
+          progressService: progressService,
+          mediaId: widget.mediaId,
+          mediaType: widget.mediaType,
+          position: position,
+          duration: duration,
+          now: DateTime.now(),
+        );
+        return;
+      }
+
       await recordLocalProgress(
         store: store,
         mediaId: widget.mediaId,
         mediaType: widget.mediaType,
-        position: player.state.position,
-        duration: _totalDuration ?? player.state.duration,
+        position: position,
+        duration: duration,
         now: DateTime.now(),
       );
     }
 
-    if (_progressService == null) return;
+    if (progressService == null) return;
 
     if (widget.mediaType == 'movie') {
-      await _progressService!.saveMovieProgress(player, widget.mediaId);
+      await progressService.saveMovieProgress(player, widget.mediaId);
     } else if (widget.mediaType == 'episode') {
-      await _progressService!.saveEpisodeProgress(player, widget.mediaId);
+      await progressService.saveEpisodeProgress(player, widget.mediaId);
     }
   }
 

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -16,6 +16,8 @@ import '../../../core/graphql/graphql_provider.dart';
 import '../../../core/graphql/watch/invalidation_rules.dart';
 import '../../../core/graphql/watch/watcher_registry.dart';
 import '../../../core/player/progress_service.dart';
+import '../../../core/playback/playback_progress_providers.dart';
+import '../../../core/playback/playback_progress_store.dart';
 import '../../../core/utils/file_utils.dart' as file_utils;
 import '../../../core/utils/web_lifecycle.dart' as web_lifecycle;
 import '../../../core/player/platform_features.dart';
@@ -98,6 +100,20 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   Player? _player;
   VideoController? _videoController;
   ProgressService? _progressService;
+
+  /// Set once the offline or already-downloaded branch of
+  /// [_initializePlayer] resolves [playbackProgressStoreProvider]. Null
+  /// whenever that resolution failed, so a broken box open cannot block
+  /// playback; `_saveProgress` treats a null store the same as one that was
+  /// never needed.
+  PlaybackProgressStore? _progressStore;
+
+  /// True once the offline or already-downloaded branch of
+  /// [_initializePlayer] runs. Downloaded media is the only source that can
+  /// be played with no server in reach, so it is the only one `_saveProgress`
+  /// writes locally for; streaming playback writes straight to the server,
+  /// which is reachable by definition.
+  bool _isDownloadedSource = false;
 
   /// Captured in [initState] rather than read from `dispose()`: by the time
   /// `dispose()` runs the widget's element may already be defunct, and
@@ -385,6 +401,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
             ? Duration(minutes: downloadedMedia.runtime!)
             : null;
 
+        _isDownloadedSource = true;
+        try {
+          _progressStore = await ref.read(playbackProgressStoreProvider.future);
+        } catch (e) {
+          debugPrint('Could not open local progress store: $e');
+        }
+
         final plan = await resolveResumePlan(
           savedPositionSeconds: _savedPositionSeconds,
           realDuration: _totalDuration,
@@ -435,6 +458,14 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           // `_timeline`: the file is entirely local, so media_kit's own
           // duration is the authoritative one for everything else.
           _totalDuration = _resolveRealDuration(null);
+
+          _isDownloadedSource = true;
+          try {
+            _progressStore =
+                await ref.read(playbackProgressStoreProvider.future);
+          } catch (e) {
+            debugPrint('Could not open local progress store: $e');
+          }
 
           final plan = await resolveResumePlan(
             savedPositionSeconds: _savedPositionSeconds,
@@ -1399,12 +1430,30 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   }
 
   Future<void> _saveProgress() async {
-    if (_player == null || _progressService == null) return;
+    final player = _player;
+    if (player == null) return;
+
+    // Downloaded media is the only source that writes locally: it is the only
+    // one that can be played with no server in reach. Streaming playback
+    // writes straight to the server, which is reachable by definition.
+    final store = _progressStore;
+    if (_isDownloadedSource && store != null) {
+      await recordLocalProgress(
+        store: store,
+        mediaId: widget.mediaId,
+        mediaType: widget.mediaType,
+        position: player.state.position,
+        duration: _totalDuration ?? player.state.duration,
+        now: DateTime.now(),
+      );
+    }
+
+    if (_progressService == null) return;
 
     if (widget.mediaType == 'movie') {
-      await _progressService!.saveMovieProgress(_player!, widget.mediaId);
+      await _progressService!.saveMovieProgress(player, widget.mediaId);
     } else if (widget.mediaType == 'episode') {
-      await _progressService!.saveEpisodeProgress(_player!, widget.mediaId);
+      await _progressService!.saveEpisodeProgress(player, widget.mediaId);
     }
   }
 

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -54,8 +54,7 @@ export '../../../core/player/resume_plan.dart'
         kMinResumeThresholdSeconds,
         kEndOfMediaThresholdSeconds,
         kWatchedThreshold,
-        shouldOfferResume,
-        shouldShowResumeDialog;
+        shouldOfferResume;
 
 /// How far past the transcoded window a seek may land before the HLS session
 /// is torn down and restarted at the new position.
@@ -274,7 +273,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// widget is disposed while `startCast` is awaited. `ref.read` itself is
   /// not safe to call again at that point, which is why the notifier is
   /// captured before any `await` rather than re-read after one.
-  Future<bool> _castToTargetIfSet() async {
+  ///
+  /// [plan] is resolved by the caller before this runs, on every branch that
+  /// calls it — so the receiver starts where the user asked, instead of
+  /// always at zero the way it did when each of the three call sites reached
+  /// this before the resume decision existed.
+  Future<bool> _castToTargetIfSet(ResumePlan plan) async {
     final target = ref.read(castTargetProvider);
     if (target == null) return false;
 
@@ -302,6 +306,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           mediaType: widget.mediaType,
           title: widget.title ?? 'Untitled',
           duration: _knownCastDuration(),
+          startPosition: plan.position,
         ),
       );
       // The session now owns the device; currentCastDeviceProvider reports
@@ -367,7 +372,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           return;
         }
 
-        if (await _castToTargetIfSet()) return;
+        // Placeholder plan: the offline branch does not yet resolve a real
+        // one, so this always starts at the beginning. A follow-up task
+        // gives it an actual resolved plan.
+        if (await _castToTargetIfSet(ResumePlan.fromStart)) return;
 
         // Play downloaded content in offline mode. The whole file is already
         // on disk, so this is direct play in every sense `seekToReal` and
@@ -385,8 +393,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
             await _resolveDownloadedFilePath(downloadedMedia.filePath);
         if (localPath != null) {
           debugPrint('Playing from local file: $localPath');
-
-          if (await _castToTargetIfSet()) return;
 
           // Try to initialize progress sync (optional - local playback
           // works even if server is unreachable)
@@ -413,7 +419,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           // duration is the authoritative one for everything else.
           _totalDuration = _resolveRealDuration(null);
 
-          await _openPlayerAndStart(localPath, {}, promptResume: true);
+          final plan = await resolveResumePlan(
+            savedPositionSeconds: _savedPositionSeconds,
+            realDuration: _totalDuration,
+            resumeOverride: null,
+            mounted: mounted,
+            ask: (saved, total) async {
+              if (!mounted) return null;
+              return showResumeDialog(context, saved, total);
+            },
+          );
+          if (plan == null) return;
+
+          if (await _castToTargetIfSet(plan)) return;
+
+          await _openPlayerAndStart(localPath, {}, plan: plan);
           return;
         }
         debugPrint('Downloaded file not found, falling back to streaming');
@@ -515,7 +535,25 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       // still zero here; the session result rebuilds this with the real one.
       _timeline = StreamTimeline(totalDuration: _totalDuration);
 
-      if (await _castToTargetIfSet()) return;
+      // Resolved here, upstream of both the cast fork below and the
+      // HLS/direct fork further down. Every branch consumes this one value.
+      // Keeping the decision inside the branches is what let three cast
+      // exits and the offline path start at zero without ever asking.
+      final resumeOverride = _resumeOverrideSeconds;
+      _resumeOverrideSeconds = null;
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: _savedPositionSeconds,
+        realDuration: _totalDuration,
+        resumeOverride: resumeOverride,
+        mounted: mounted,
+        ask: (saved, total) async {
+          if (!mounted) return null;
+          return showResumeDialog(context, saved, total);
+        },
+      );
+      if (plan == null) return;
+
+      if (await _castToTargetIfSet(plan)) return;
 
       String mediaSource;
       Map<String, String> httpHeaders = {};
@@ -554,67 +592,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         // Determine HLS strategy from candidates
         final hlsStrategy = _pickHlsStrategy(candidatesResult?.candidates);
 
-        // The resume decision must be made before the session starts: the
-        // offset is an input to FFmpeg, not something that can be seeked to
-        // once a live-style playlist is already running.
-        //
-        // Captured into locals rather than using `_savedPositionSeconds!`/
-        // `_totalDuration!` below: Dart's flow analysis cannot promote a
-        // field's nullability across the `shouldOfferResume(...)` call
-        // boundary, only across a direct `!= null` check in the same
-        // condition, so these null checks are what let the rest of this
-        // block use non-nullable locals instead of the bang operator.
-        //
-        // `resumeOverride` (not `startPositionSeconds == 0`) is what gates
-        // the dialog below: a seek-driven restart targeting real position 0
-        // (dragging the scrubber back to the start, holding arrow-left to
-        // the beginning, or any sub-second target — `Duration.inSeconds`
-        // truncates) sets `_resumeOverrideSeconds` to exactly 0, which is
-        // indistinguishable from "no override was set" if the check were on
-        // the value instead of on presence. Gating on the nullable local
-        // instead means a restart to position 0 never falls into the
-        // dialog branch, never overwrites 0 with the stale
-        // `_savedPositionSeconds`, and never sends the wrong `startPosition`
-        // to the new session.
-        final resumeOverride = _resumeOverrideSeconds;
-        _resumeOverrideSeconds = null;
-        var startPositionSeconds = resumeOverride ?? 0;
-        final savedPosition = _savedPositionSeconds;
-        final totalDuration = _totalDuration;
-        // The literal `mounted &&` here (not just the one passed into
-        // `shouldShowResumeDialog` below) is load-bearing for the analyzer:
-        // `use_build_context_synchronously` only recognizes a `mounted`
-        // check spelled directly in the guarding condition, not one hidden
-        // behind a function call, before `context` is used past the earlier
-        // `await`s in this method.
-        if (mounted &&
-            shouldShowResumeDialog(
-              resumeOverride: resumeOverride,
-              mounted: mounted,
-            ) &&
-            savedPosition != null &&
-            totalDuration != null &&
-            shouldOfferResume(
-              savedPositionSeconds: savedPosition,
-              realDuration: totalDuration,
-            )) {
-          final shouldResume = await showResumeDialog(
-            context,
-            savedPosition,
-            totalDuration.inSeconds,
-          );
-          // The dialog is an unbounded wait on the user, and it now happens
-          // before the session exists. If the route was replaced while it was
-          // open (`context.go`, a deep link, app teardown) it completes with
-          // null, `dispose()` has already run with `_hlsSessionId == null`,
-          // and carrying on would start an HLS session, build a `Player` and
-          // subscribe streams for a dead screen — with the FFmpeg process
-          // surviving until the server's inactivity timeout.
-          if (!mounted) return;
-          if (shouldResume == true) {
-            startPositionSeconds = savedPosition;
-          }
-        }
+        // The resume decision was already made above, before the cast fork —
+        // it has to be: the offset is an input to FFmpeg, not something that
+        // can be seeked to once a live-style playlist is already running.
+        final startPositionSeconds = plan.position.inSeconds;
 
         // Start HLS session via GraphQL mutation (works for both modes)
         final result = await graphqlClient.mutate(
@@ -680,14 +661,15 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       }
 
       // `canDirect` is exactly the HLS/non-HLS split of this method: the HLS
-      // branch above has already asked about resuming and baked the answer
-      // into the session's start offset, so asking again here would prompt
-      // twice. The direct-play branch has no server-side offset to bake it
-      // into and must resume with a plain seek.
+      // branch above has already baked the resume decision into the
+      // session's start offset, so acting on `plan` again here would
+      // double-apply it via a seek on top of that offset. The direct-play
+      // branch has no server-side offset to bake it into and must resume
+      // with a plain seek, which is what passing `plan` through does.
       await _openPlayerAndStart(
         mediaSource,
         httpHeaders,
-        promptResume: canDirect,
+        plan: canDirect ? plan : ResumePlan.fromStart,
       );
     } catch (e) {
       debugPrint('Error initializing player: $e');
@@ -743,58 +725,22 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   ///
   /// Reached by three paths, not just the HLS one: the HLS branch, the
   /// direct-play branch, and the "already downloaded, still online" branch.
-  /// [promptResume] separates them. The HLS branch passes false because it
-  /// has already asked about resuming and baked the answer into the
-  /// session's FFmpeg start offset — the only way to resume a live-style
-  /// playlist. The other two pass true: they hold the entire file locally,
-  /// have no server-side session to give an offset to, and seek correctly,
-  /// so for them resuming is a plain [Player.seek] after the media opens.
-  ///
-  /// Both are needed. Prompting here for every path would double-prompt the
-  /// HLS one; prompting only in the HLS branch (as this briefly did) silently
-  /// removed the resume prompt from the preferred desktop and mobile path,
-  /// where playback then always started at zero.
+  /// It no longer prompts — the resume decision is made once, upstream of
+  /// every fork, by [resolveResumePlan] — it only executes [plan]. The HLS
+  /// branch bakes that same decision into the session's FFmpeg start offset,
+  /// the only way to resume a live-style playlist; the other two hold the
+  /// entire file locally, have no server-side session to give an offset to,
+  /// and seek correctly, so for them resuming is a plain [Player.seek] after
+  /// the media opens.
   Future<void> _openPlayerAndStart(
     String mediaSource,
     Map<String, String> httpHeaders, {
-    required bool promptResume,
+    required ResumePlan plan,
   }) async {
     if (mounted) {
       setState(() {
         _loadingMessage = null;
       });
-    }
-
-    // Asked before the player is built rather than after, matching the HLS
-    // branch's ordering: `_totalDuration` is already resolved by now, so
-    // there is nothing left to learn by opening the media first.
-    //
-    // Captured into locals for the same reason as the HLS branch: Dart's
-    // flow analysis cannot promote a field's nullability across the
-    // `shouldOfferResume(...)` call boundary.
-    var resumeFrom = Duration.zero;
-    final savedPosition = _savedPositionSeconds;
-    final totalDuration = _totalDuration;
-    if (promptResume &&
-        mounted &&
-        savedPosition != null &&
-        totalDuration != null &&
-        shouldOfferResume(
-          savedPositionSeconds: savedPosition,
-          realDuration: totalDuration,
-        )) {
-      final shouldResume = await showResumeDialog(
-        context,
-        savedPosition,
-        totalDuration.inSeconds,
-      );
-      // Same unbounded-wait hazard as the HLS branch: the route can be
-      // replaced while the dialog is open, in which case `dispose()` has
-      // already run and building a `Player` here would leak it.
-      if (!mounted) return;
-      if (shouldResume == true) {
-        resumeFrom = Duration(seconds: savedPosition);
-      }
     }
 
     // Create media_kit player
@@ -817,8 +763,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     // A plain seek, not a `seekToReal`: these paths hold the whole file, so
     // the player's own coordinates already are the real ones and there is no
     // session that could need restarting.
-    if (resumeFrom > Duration.zero) {
-      await player.seek(resumeFrom);
+    if (plan.resumes) {
+      await player.seek(plan.position);
     }
 
     // Start playback

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -167,6 +167,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   int? _savedPositionSeconds;
   int? _savedDurationSeconds;
 
+  /// When the server last recorded progress for this media, populated by
+  /// [_fetchProgressAndEpisodes]. Feeds [pickNewerProgress] on the
+  /// downloaded-online branch, which needs a timestamp to decide whether the
+  /// server's record or a local one written offline is more recent.
+  DateTime? _serverLastWatchedAt;
+
   /// Set when a seek forced a session restart, so re-initialization starts at
   /// this position instead of re-asking about the saved progress position.
   int? _resumeOverrideSeconds;
@@ -394,19 +400,29 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         // runtime.
         _isDirectPlay = true;
 
-        // No server is reachable, so the runtime comes from what was stored
-        // alongside the download. Without one, `shouldOfferResume` declines
-        // and this path silently loses its prompt.
-        _totalDuration = downloadedMedia.runtime != null
-            ? Duration(minutes: downloadedMedia.runtime!)
-            : null;
-
         _isDownloadedSource = true;
         try {
           _progressStore = await ref.read(playbackProgressStoreProvider.future);
         } catch (e) {
           debugPrint('Could not open local progress store: $e');
         }
+
+        // No server is reachable, so the saved position comes from whatever a
+        // previous offline session recorded locally. The stored duration is
+        // preferred over the download's own runtime metadata: it reflects the
+        // media's real duration as measured during actual playback, while
+        // `runtime` is catalog metadata that can be missing or approximate.
+        // Without either, `shouldOfferResume` declines and this path silently
+        // loses its prompt.
+        final localProgress = _progressStore?.get(widget.mediaId);
+        _savedPositionSeconds = localProgress?.positionSeconds;
+        _savedDurationSeconds = localProgress?.durationSeconds;
+        _totalDuration =
+            _savedDurationSeconds != null && _savedDurationSeconds! > 0
+                ? Duration(seconds: _savedDurationSeconds!)
+                : (downloadedMedia.runtime != null
+                    ? Duration(minutes: downloadedMedia.runtime!)
+                    : null);
 
         final plan = await resolveResumePlan(
           savedPositionSeconds: _savedPositionSeconds,
@@ -450,15 +466,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           // play and must never be treated as a restartable HLS session.
           _isDirectPlay = true;
 
-          // No candidates query runs on this branch — there is no server-side
-          // stream to negotiate — so the runtime has to come from whatever
-          // `_fetchProgressAndEpisodes` just loaded. `shouldOfferResume`
-          // declines outright without one, which would silently cost this
-          // path its resume prompt. Only `_totalDuration` is set, not
-          // `_timeline`: the file is entirely local, so media_kit's own
-          // duration is the authoritative one for everything else.
-          _totalDuration = _resolveRealDuration(null);
-
           _isDownloadedSource = true;
           try {
             _progressStore =
@@ -466,6 +473,28 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           } catch (e) {
             debugPrint('Could not open local progress store: $e');
           }
+
+          // Reconcile the server's progress (just loaded above) against
+          // whatever this device recorded locally, e.g. during an earlier
+          // offline session the server never heard about. The more
+          // recently-updated side wins.
+          final reconciled = pickNewerProgress(
+            local: _progressStore?.get(widget.mediaId),
+            serverPositionSeconds: _savedPositionSeconds,
+            serverDurationSeconds: _savedDurationSeconds,
+            serverLastWatchedAt: _serverLastWatchedAt,
+          );
+          _savedPositionSeconds = reconciled.positionSeconds;
+          _savedDurationSeconds = reconciled.durationSeconds;
+
+          // No candidates query runs on this branch — there is no server-side
+          // stream to negotiate — so the runtime has to come from whatever
+          // was just reconciled above. `shouldOfferResume` declines outright
+          // without one, which would silently cost this path its resume
+          // prompt. Only `_totalDuration` is set, not `_timeline`: the file
+          // is entirely local, so media_kit's own duration is the
+          // authoritative one for everything else.
+          _totalDuration = _resolveRealDuration(null);
 
           final plan = await resolveResumePlan(
             savedPositionSeconds: _savedPositionSeconds,
@@ -944,6 +973,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           final movie = Query$MovieDetail.fromJson(result.data!).movie;
           _savedPositionSeconds = movie?.progress?.positionSeconds;
           _savedDurationSeconds = movie?.progress?.durationSeconds;
+          _serverLastWatchedAt =
+              DateTime.tryParse(movie?.progress?.lastWatchedAt ?? '');
           _runtimeMinutes = movie?.runtime;
 
           // Extract subtitle tracks from files
@@ -963,6 +994,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           final episode = Query$EpisodeDetail.fromJson(result.data!).episode;
           _savedPositionSeconds = episode?.progress?.positionSeconds;
           _savedDurationSeconds = episode?.progress?.durationSeconds;
+          _serverLastWatchedAt =
+              DateTime.tryParse(episode?.progress?.lastWatchedAt ?? '');
           _runtimeMinutes = episode?.runtime;
 
           // Extract subtitle tracks from files

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -372,17 +372,34 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           return;
         }
 
-        // Placeholder plan: the offline branch does not yet resolve a real
-        // one, so this always starts at the beginning. A follow-up task
-        // gives it an actual resolved plan.
-        if (await _castToTargetIfSet(ResumePlan.fromStart)) return;
-
-        // Play downloaded content in offline mode. The whole file is already
-        // on disk, so this is direct play in every sense `seekToReal` and
-        // `_detectTracks` care about — no HLS session exists to restart, and
-        // media_kit's own duration is already the true runtime.
+        // The whole file is on disk, so this is direct play in every sense
+        // `seekToReal` and `_detectTracks` care about: no HLS session exists
+        // to restart, and media_kit's own duration is already the true
+        // runtime.
         _isDirectPlay = true;
-        await _initializeOfflinePlayback(offlinePath);
+
+        // No server is reachable, so the runtime comes from what was stored
+        // alongside the download. Without one, `shouldOfferResume` declines
+        // and this path silently loses its prompt.
+        _totalDuration = downloadedMedia.runtime != null
+            ? Duration(minutes: downloadedMedia.runtime!)
+            : null;
+
+        final plan = await resolveResumePlan(
+          savedPositionSeconds: _savedPositionSeconds,
+          realDuration: _totalDuration,
+          resumeOverride: null,
+          mounted: mounted,
+          ask: (saved, total) async {
+            if (!mounted) return null;
+            return showResumeDialog(context, saved, total);
+          },
+        );
+        if (plan == null) return;
+
+        if (await _castToTargetIfSet(plan)) return;
+
+        await _openPlayerAndStart(offlinePath, {}, plan: plan);
         return;
       }
 
@@ -878,52 +895,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     } catch (e) {
       debugPrint('[PlayerScreen] Error fetching streaming candidates: $e');
       return null;
-    }
-  }
-
-  /// Initialize player for offline playback (no network services required).
-  Future<void> _initializeOfflinePlayback(String filePath) async {
-    try {
-      debugPrint('Initializing offline playback from: $filePath');
-
-      // Create media_kit player
-      _player = Player();
-      _videoController = VideoController(_player!);
-
-      // Open local file
-      await _player!.open(
-        Media(filePath),
-        play: false,
-      );
-
-      // Wait for player to be ready
-      await Future.delayed(const Duration(milliseconds: 500));
-
-      // Start playback
-      await _player!.play();
-
-      // Listen for playback progress (but don't sync - we're offline)
-      // Cancel any existing subscription before creating a new one
-      await _positionSubscription?.cancel();
-      _positionSubscription = _player!.stream.position.listen((_) {
-        _onPlaybackProgress();
-      });
-
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
-      }
-
-      debugPrint('Offline playback initialized successfully');
-    } catch (e) {
-      debugPrint('Error initializing offline playback: $e');
-      if (mounted) {
-        setState(() {
-          _error = 'Failed to play downloaded content: $e';
-          _isLoading = false;
-        });
-      }
     }
   }
 

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -47,15 +47,15 @@ import '../../../graphql/mutations/end_streaming_session.graphql.dart';
 import '../../../graphql/queries/streaming_candidates.graphql.dart';
 import '../../../graphql/schema.graphql.dart';
 import '../../../core/p2p/local_proxy_service.dart';
+import '../../../core/player/resume_plan.dart';
 
-/// Below this, resuming is not worth offering; start from the beginning.
-const int kMinResumeThresholdSeconds = 30;
-
-/// Within this distance of the end, the user has effectively finished.
-const int kEndOfMediaThresholdSeconds = 60;
-
-/// Matches ProgressService's server-side watched threshold.
-const double kWatchedThreshold = 0.90;
+export '../../../core/player/resume_plan.dart'
+    show
+        kMinResumeThresholdSeconds,
+        kEndOfMediaThresholdSeconds,
+        kWatchedThreshold,
+        shouldOfferResume,
+        shouldShowResumeDialog;
 
 /// How far past the transcoded window a seek may land before the HLS session
 /// is torn down and restarted at the new position.
@@ -2369,55 +2369,6 @@ KeyEventResult handleEpisodeNavKey(
       return KeyEventResult.ignored;
   }
 }
-
-/// Whether to offer resuming, given a saved position and the real runtime.
-///
-/// Extracted as a free function so it can be unit-tested without a widget tree,
-/// following the same pattern as [handleEpisodeNavKey].
-///
-/// A null [realDuration] declines deliberately. The alternative is computing a
-/// percentage against media_kit's partial HLS playlist length, which is exactly
-/// the bug that made every resume read as 100%.
-bool shouldOfferResume({
-  required int? savedPositionSeconds,
-  required Duration? realDuration,
-}) {
-  if (savedPositionSeconds == null) return false;
-  if (realDuration == null || realDuration <= Duration.zero) return false;
-  if (savedPositionSeconds <= kMinResumeThresholdSeconds) return false;
-
-  final total = realDuration.inSeconds;
-  if (savedPositionSeconds >= total - kEndOfMediaThresholdSeconds) return false;
-  if (savedPositionSeconds / total >= kWatchedThreshold) return false;
-
-  return true;
-}
-
-/// Whether `_initializePlayer` may even consider showing the resume dialog,
-/// given a possible seek-driven-restart override.
-///
-/// Deliberately gates on [resumeOverride]'s **presence** (`!= null`), not its
-/// value (`!= 0`): a restart targeting real position 0 — dragging the
-/// scrubber back to the start, holding arrow-left to the beginning, or any
-/// sub-second target, since `Duration.inSeconds` truncates — sets
-/// `_resumeOverrideSeconds` to exactly `0`, which a value-based check
-/// (`resumeOverride != 0`) cannot tell apart from "no override was set at
-/// all". Getting this wrong lets a restart to position 0 fall through to the
-/// dialog, which then prompts about the unrelated, never-refreshed
-/// `_savedPositionSeconds` from mount time and, if accepted, silently
-/// overwrites the user's explicit seek-to-start with that stale saved
-/// position.
-///
-/// Extracted as a free function, following the same pattern as
-/// [shouldOfferResume] and [shouldRestartForSeek], so this exact presence-
-/// vs-value distinction has its own name and test, independent of
-/// `_initializePlayer`'s own network/session machinery.
-@visibleForTesting
-bool shouldShowResumeDialog({
-  required int? resumeOverride,
-  required bool mounted,
-}) =>
-    resumeOverride == null && mounted;
 
 /// Whether [_PlayerScreenState.seekToReal] must restart the HLS session
 /// rather than seek the live player in place.

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -10,6 +10,7 @@ import '../../core/downloads/collection_sync_providers.dart';
 import '../../core/downloads/collection_sync_service.dart';
 import '../../core/downloads/download_service.dart' show isDownloadSupported;
 import '../../core/graphql/graphql_provider.dart';
+import '../../core/playback/playback_progress_providers.dart';
 import '../screens/collections/collection_detail_controller.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/p2p/p2p_service.dart';
@@ -396,6 +397,13 @@ class _AppShellState extends ConsumerState<AppShell> {
     final location = widget.location;
     final showBackToMydia = isEmbedMode;
     final isOffline = _isOfflineMode();
+
+    // Keeps the offline-to-online progress flush alive for the whole app
+    // session: AppShell mounts for every reachable route before the
+    // immersive player (which renders outside this shell) can be reached,
+    // so watching it once here is enough for the underlying provider —
+    // not autoDispose — to keep listening for the rest of the session.
+    ref.watch(progressFlushProvider);
     // Use MediaQuery instead of LayoutBuilder to determine layout.
     // LayoutBuilder defers building to the layout phase, which can prevent
     // proper repaint propagation on mobile when combined with GlobalKey

--- a/player/test/core/cast/cast_progress_offset_test.dart
+++ b/player/test/core/cast/cast_progress_offset_test.dart
@@ -1,0 +1,281 @@
+// THE regression guard for this feature. `_syncProgress` pushes receiver
+// position to the server as watch progress every 10 seconds. Once a session
+// carries a start offset, the receiver reports 0 at the start, so an
+// untranslated sync would overwrite the user's real position with 0 within
+// ten seconds of resuming. That is strictly worse than the bug being fixed.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_route_resolver.dart';
+import 'package:player/core/cast/cast_session_manager.dart';
+import 'package:player/core/cast/cast_session_store.dart';
+import 'package:player/core/player/progress_service.dart';
+import 'package:player/core/player/stream_timeline.dart';
+import 'package:player/domain/models/cast_device.dart';
+
+import '../../test_utils/fake_cast_backend.dart';
+import '../../test_utils/fake_streaming_session_service.dart';
+
+/// Captures what the manager syncs, replacing the mocked GraphQL client used
+/// elsewhere: these tests care about the numbers, not the mutation.
+///
+/// It calls [ProgressService.resolveSync] exactly as the real service does,
+/// which is the point: the manager hands over a *raw* receiver position and
+/// the timeline that translates it, so a manager that translated first would
+/// show up here as a doubled offset.
+class RecordingProgressService extends Fake implements ProgressService {
+  final movies = <({String id, int position, int duration})>[];
+
+  @override
+  StreamTimeline timeline = StreamTimeline.zero;
+
+  @override
+  Future<bool> syncMoviePosition(
+    String movieId,
+    Duration position,
+    Duration duration,
+  ) async {
+    final resolved = ProgressService.resolveSync(position, duration, timeline);
+    if (resolved == null) return false;
+    movies.add((
+      id: movieId,
+      position: resolved.positionSeconds,
+      duration: resolved.durationSeconds,
+    ));
+    return true;
+  }
+}
+
+void main() {
+  const device = CastDevice(
+    id: 'd1',
+    name: 'Living Room',
+    protocol: CastProtocolKind.chromecast,
+  );
+
+  late FakeCastBackend backend;
+  late InMemoryCastSessionStore store;
+  late FakeStreamingSessionService sessions;
+  late RecordingProgressService progress;
+
+  /// Pumps the event loop until [condition] holds.
+  ///
+  /// `_syncProgress` is fired with `unawaited` and awaits the session store
+  /// before it ever reaches the progress service, so how many event-loop
+  /// turns separate emitting a position from observing the sync is an
+  /// implementation detail. A fixed delay would be a guess at it.
+  Future<void> until(bool Function() condition,
+      {required String describe}) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (!condition()) {
+      if (DateTime.now().isAfter(deadline)) fail('never observed: $describe');
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  CastSessionManager build() {
+    final manager = CastSessionManager(
+      backend: backend,
+      store: store,
+      progressService: progress,
+      streamingSessions: sessions,
+      resolverFactory: () => CastRouteResolver(
+        isP2pMode: false,
+        serverUrl: 'https://mydia.test',
+        mediaToken: () async => 'tok',
+        lanBaseUrl: () => null,
+        streamingSessions: sessions,
+      ),
+      setLanAccess: (_) async {},
+      clock: () => DateTime.utc(2026, 8, 2, 12),
+    );
+    addTearDown(manager.dispose);
+    return manager;
+  }
+
+  setUp(() {
+    backend = FakeCastBackend();
+    store = InMemoryCastSessionStore();
+    sessions = FakeStreamingSessionService();
+    progress = RecordingProgressService();
+  });
+
+  /// A cast resumed 40 minutes in. The server clamps to the nearest keyframe,
+  /// so it echoes 2394s for a requested 2400s.
+  Future<CastSessionManager> resumedCast() async {
+    sessions.echoedStartOffset = const Duration(seconds: 2394);
+    final manager = build();
+    await manager.startCast(
+      device: device,
+      request: const CastLaunchRequest(
+        fileId: 'file-1',
+        mediaId: 'movie-1',
+        mediaType: 'movie',
+        title: 'Arrival',
+        startPosition: Duration(seconds: 2400),
+        duration: Duration(seconds: 5400),
+      ),
+    );
+    return manager;
+  }
+
+  test('a receiver at position zero syncs the real position, not zero',
+      () async {
+    await resumedCast();
+
+    backend.emitPosition(Duration.zero);
+    await until(() => progress.movies.isNotEmpty,
+        describe: 'the first position event reaching the server');
+
+    expect(
+      progress.movies.single.position,
+      2394,
+      reason: 'syncing the raw receiver position would overwrite the user\'s '
+          'real watch position with zero',
+    );
+    expect(progress.movies.single.duration, 5400);
+  });
+
+  test('a receiver part-way in syncs offset plus receiver position', () async {
+    await resumedCast();
+
+    backend.emitPosition(const Duration(seconds: 60));
+    await until(() => progress.movies.isNotEmpty,
+        describe: 'a synced position');
+
+    expect(
+      progress.movies.single.position,
+      2454,
+      reason: 'a doubled translation would sync 4848 here',
+    );
+  });
+
+  test('mediaInfo publishes real positions', () async {
+    final manager = await resumedCast();
+
+    backend.emitPosition(const Duration(seconds: 60));
+    await until(
+      () =>
+          manager.currentSession?.mediaInfo?.position ==
+          const Duration(seconds: 2454),
+      describe: 'the published position reaching 40:54',
+    );
+
+    expect(
+      manager.currentSession!.mediaInfo!.position,
+      const Duration(seconds: 2454),
+      reason: 'the mini controller must not read 1:00 for a cast resumed 40 '
+          'minutes in',
+    );
+  });
+
+  test('the persisted session stores a real position', () async {
+    await resumedCast();
+
+    backend.emitPosition(const Duration(seconds: 60));
+    // `_syncProgress` saves before it syncs, so a recorded sync proves the
+    // save already landed.
+    await until(() => progress.movies.isNotEmpty,
+        describe: 'a synced position');
+
+    final stored = await store.load();
+    expect(
+      stored!.position,
+      const Duration(seconds: 2454),
+      reason: 'reconnectStoredSession feeds this back as startPosition, so a '
+          'receiver-relative value would compound the offset every reconnect',
+    );
+  });
+
+  test('the receiver is asked only for the residual above the baked-in offset',
+      () async {
+    await resumedCast();
+
+    expect(
+      backend.loadedRequests.single.startPosition,
+      const Duration(seconds: 6),
+      reason: '2394s of the requested 2400s is already in the stream, so only '
+          'the 6s the keyframe snap gave away is left for the receiver',
+    );
+    expect(
+      backend.loadedRequests.single.startPosition,
+      isNot(const Duration(seconds: 2400)),
+      reason: 'seeking to the absolute position on top of the offset would '
+          'land at very nearly twice it',
+    );
+  });
+
+  test('an exactly honored offset leaves the receiver nothing to seek',
+      () async {
+    sessions.echoedStartOffset = const Duration(seconds: 2400);
+    final manager = build();
+
+    await manager.startCast(
+      device: device,
+      request: const CastLaunchRequest(
+        fileId: 'file-1',
+        mediaId: 'movie-1',
+        mediaType: 'movie',
+        title: 'Arrival',
+        startPosition: Duration(seconds: 2400),
+        duration: Duration(seconds: 5400),
+      ),
+    );
+
+    expect(backend.loadedRequests.single.startPosition, Duration.zero);
+  });
+
+  test('a zero-offset session translates nothing', () async {
+    sessions.echoedStartOffset = Duration.zero;
+    final manager = build();
+    await manager.startCast(
+      device: device,
+      request: const CastLaunchRequest(
+        fileId: 'file-1',
+        mediaId: 'movie-1',
+        mediaType: 'movie',
+        title: 'Arrival',
+        duration: Duration(seconds: 5400),
+      ),
+    );
+
+    backend.emitPosition(const Duration(seconds: 60));
+    await until(() => progress.movies.isNotEmpty,
+        describe: 'a synced position');
+
+    expect(progress.movies.single.position, 60);
+  });
+
+  test('a progressive receiver still gets a plain seek', () async {
+    // DLNA keeps `startOffset` at zero, so the resume position has to reach
+    // the receiver as a seek or it is lost entirely.
+    const dlna = CastDevice(
+      id: 'd2',
+      name: 'Bedroom TV',
+      protocol: CastProtocolKind.dlna,
+    );
+    final manager = build();
+
+    await manager.startCast(
+      device: dlna,
+      request: const CastLaunchRequest(
+        fileId: 'file-1',
+        mediaId: 'movie-1',
+        mediaType: 'movie',
+        title: 'Arrival',
+        startPosition: Duration(seconds: 2400),
+        duration: Duration(seconds: 5400),
+      ),
+    );
+
+    expect(
+      backend.loadedRequests.single.startPosition,
+      const Duration(seconds: 2400),
+    );
+
+    backend.emitPosition(const Duration(seconds: 2460));
+    await until(() => progress.movies.isNotEmpty,
+        describe: 'a synced position');
+
+    expect(progress.movies.single.position, 2460);
+  });
+}

--- a/player/test/core/cast/cast_providers_test.dart
+++ b/player/test/core/cast/cast_providers_test.dart
@@ -175,10 +175,24 @@ void main() {
     /// URL with no credential on it.
     ProviderContainer buildFullContainer() {
       client = MockGraphQLClient();
+      // A well-formed `StartStreamingSession` payload, because a direct
+      // Chromecast route now opens a real server-side session (that is what
+      // gives it a session id to end and an offset to resume at). The media
+      // token refresh mutation shares this stub and tolerates the extra key:
+      // it reads only `refreshMediaToken`, and a null there is a benign
+      // "refresh failed" that leaves the stored token in place.
       when(client.mutate(any)).thenAnswer(
         (_) async => QueryResult(
           source: QueryResultSource.network,
-          data: const {},
+          data: const {
+            '__typename': 'RootMutationType',
+            'startStreamingSession': {
+              '__typename': 'StreamingSessionResult',
+              'sessionId': 'sess-1',
+              'duration': null,
+              'startPosition': null,
+            },
+          },
           options: QueryOptions(document: gql('{ __typename }')),
         ),
       );

--- a/player/test/core/cast/cast_resume_offset_test.dart
+++ b/player/test/core/cast/cast_resume_offset_test.dart
@@ -1,0 +1,131 @@
+// Casting from a resumed position always started the receiver at zero:
+// `CastRouteResolver` opened a fresh server-side session at offset zero, and
+// `startPosition` only ever became a seek on the receiver, which cannot work
+// on a live-style HLS playlist with no EXT-X-ENDLIST.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_route_resolver.dart';
+import 'package:player/core/cast/cast_streaming_session_service.dart';
+import 'package:player/domain/models/cast_device.dart';
+
+class RecordingSessionService implements CastStreamingSessionService {
+  Duration? requestedStart;
+  Duration echoed = Duration.zero;
+  final ended = <String>[];
+
+  @override
+  Future<({String sessionId, Duration startOffset})> start({
+    required String fileId,
+    required bool transcode,
+    Duration startPosition = Duration.zero,
+  }) async {
+    requestedStart = startPosition;
+    return (sessionId: 'sess-1', startOffset: echoed);
+  }
+
+  @override
+  Future<void> end(String sessionId) async => ended.add(sessionId);
+}
+
+void main() {
+  CastRouteResolver resolver(
+    RecordingSessionService sessions, {
+    bool p2p = false,
+  }) =>
+      CastRouteResolver(
+        isP2pMode: p2p,
+        serverUrl: 'https://mydia.test',
+        mediaToken: () async => 'tok',
+        lanBaseUrl: () => 'http://192.168.1.5:9999',
+        streamingSessions: sessions,
+      );
+
+  test('a Chromecast route asks the server to start at the resume position',
+      () async {
+    final sessions = RecordingSessionService()
+      ..echoed = const Duration(seconds: 2394);
+
+    final route = await resolver(sessions).resolve(
+      fileId: 'file-1',
+      protocol: CastProtocolKind.chromecast,
+      startPosition: const Duration(seconds: 2400),
+    );
+
+    expect(sessions.requestedStart, const Duration(seconds: 2400));
+    expect(
+      route!.startOffset,
+      const Duration(seconds: 2394),
+      reason: 'the echoed offset is authoritative: the server clamps the '
+          'request and -ss snaps to the nearest keyframe',
+    );
+    expect(route.hlsSessionId, 'sess-1');
+  });
+
+  test('the bridged Chromecast route also carries the resume position',
+      () async {
+    // The bridge serves the same server-side HLS session over the p2p proxy,
+    // so the offset has to be baked in there too.
+    final sessions = RecordingSessionService()
+      ..echoed = const Duration(seconds: 2394);
+
+    final route = await resolver(sessions, p2p: true).resolve(
+      fileId: 'file-1',
+      protocol: CastProtocolKind.chromecast,
+      startPosition: const Duration(seconds: 2400),
+    );
+
+    expect(sessions.requestedStart, const Duration(seconds: 2400));
+    expect(route!.kind, CastRouteKind.localBridge);
+    expect(route.startOffset, const Duration(seconds: 2394));
+  });
+
+  test('the direct-server Chromecast route carries a session id', () async {
+    // It used to redirect through /api/v1/stream/file/:id?strategy=HLS_COPY,
+    // which returns no session id, so `_adoptHlsSession` could never end the
+    // session that route started.
+    final sessions = RecordingSessionService();
+
+    final route = await resolver(sessions).resolve(
+      fileId: 'file-1',
+      protocol: CastProtocolKind.chromecast,
+    );
+
+    expect(route!.kind, CastRouteKind.directServer);
+    expect(route.hlsSessionId, 'sess-1');
+    expect(route.mediaUrl, contains('/api/v1/hls/sess-1/index.m3u8'));
+    expect(route.mediaUrl, contains('token=tok'));
+  });
+
+  test('a progressive route keeps offset zero and resumes with a seek',
+      () async {
+    // DLNA gets a byte-range stream, where a receiver seek is valid, so no
+    // server-side offset is needed or wanted.
+    final sessions = RecordingSessionService();
+
+    final route = await resolver(sessions).resolve(
+      fileId: 'file-1',
+      protocol: CastProtocolKind.dlna,
+      startPosition: const Duration(seconds: 2400),
+    );
+
+    expect(route!.startOffset, Duration.zero);
+    expect(sessions.requestedStart, isNull,
+        reason: 'a progressive route starts no HLS session at all');
+  });
+
+  test('a progressive bridge route keeps offset zero as well', () async {
+    // The proxy's /direct/{fileId}/stream honors Range, so a receiver seek is
+    // valid there too.
+    final sessions = RecordingSessionService();
+
+    final route = await resolver(sessions, p2p: true).resolve(
+      fileId: 'file-1',
+      protocol: CastProtocolKind.dlna,
+      startPosition: const Duration(seconds: 2400),
+    );
+
+    expect(route!.kind, CastRouteKind.localBridge);
+    expect(route.startOffset, Duration.zero);
+    expect(sessions.requestedStart, isNull);
+  });
+}

--- a/player/test/core/cast/cast_route_resolver_test.dart
+++ b/player/test/core/cast/cast_route_resolver_test.dart
@@ -42,9 +42,29 @@ void main() {
 
       expect(route, isNotNull);
       expect(route!.kind, CastRouteKind.directServer);
+      // Session-addressed rather than file-addressed: a Chromecast goes
+      // through the same `StartStreamingSession` mutation the bridge does, so
+      // the route has a session id to end and an offset to resume at.
+      expect(
+        route.mediaUrl,
+        startsWith(
+            'https://mydia.test/api/v1/hls/${sessions.started.single}/index.m3u8'),
+      );
+      expect(route.mediaUrl, contains('token=tok123'));
+    });
+
+    test('a direct DLNA connection still yields a file URL', () async {
+      // A progressive receiver needs whole-file bytes with Range support, not
+      // an HLS playlist, so this route keeps the /stream/file endpoint.
+      final route = await directResolver().resolve(
+        fileId: 'file-1',
+        protocol: CastProtocolKind.dlna,
+      );
+
+      expect(route!.kind, CastRouteKind.directServer);
       expect(route.mediaUrl,
           startsWith('https://mydia.test/api/v1/stream/file/file-1'));
-      expect(route.mediaUrl, contains('token=tok123'));
+      expect(sessions.started, isEmpty);
     });
 
     test('p2p connection yields a LAN bridge URL', () async {
@@ -186,7 +206,10 @@ void main() {
           .resolve(fileId: 'f', protocol: CastProtocolKind.chromecast);
 
       expect(route!.mediaKind, CastMediaKind.hls);
-      expect(route.mediaUrl, contains('strategy=HLS_COPY'));
+      expect(route.mediaUrl, contains('/api/v1/hls/'));
+      expect(sessions.started.single, isNot(contains('transcode')),
+          reason: 'an unforced Chromecast session is an HLS copy, not a '
+              'full transcode');
     });
 
     test('DLNA gets progressive, because DLNA renderers cannot play HLS',
@@ -205,7 +228,11 @@ void main() {
         forceTranscode: true,
       );
 
-      expect(route!.mediaUrl, contains('strategy=TRANSCODE'));
+      // The escalation now rides on the session the mutation opened rather
+      // than a `strategy=` query param, so the fake's transcode marker in the
+      // session id is where it shows.
+      expect(sessions.started.single, contains('transcode'));
+      expect(route!.mediaUrl, contains(sessions.started.single));
       expect(route.mediaKind, CastMediaKind.hls);
     });
 
@@ -245,7 +272,8 @@ void main() {
           fileId: 'f', protocol: CastProtocolKind.chromecast))!;
 
       expect(
-        resolver.resolveSubtitleUrl(route, '/api/player/v1/subtitles/movie/1/2'),
+        resolver.resolveSubtitleUrl(
+            route, '/api/player/v1/subtitles/movie/1/2'),
         'https://mydia.test/api/player/v1/subtitles/movie/1/2?token=tok123',
       );
     });

--- a/player/test/core/cast/cast_seek_restart_test.dart
+++ b/player/test/core/cast/cast_seek_restart_test.dart
@@ -1,0 +1,82 @@
+// Seeking a cast is broken by the same root cause as resuming one: the
+// receiver holds a live-style HLS playlist covering only what FFmpeg has
+// written, so a target beyond it cannot be reached and the receiver clamps,
+// which reads to the user as a snap back.
+//
+// The local predicate `shouldRestartForSeek` cannot be reused: it needs
+// `seekableEnd` from the player's own raw duration, and a Chromecast reports
+// -1 for these playlists forever, so the transcoded extent is not observable
+// from the receiver at all.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_seek_restart.dart';
+
+void main() {
+  test('a small forward skip seeks in place', () {
+    expect(
+      shouldRestartCastForSeek(
+        target: const Duration(seconds: 2410),
+        currentPosition: const Duration(seconds: 2400),
+        startOffset: const Duration(seconds: 2394),
+      ),
+      isFalse,
+    );
+  });
+
+  test('a skip exactly at the tolerance seeks in place', () {
+    expect(
+      shouldRestartCastForSeek(
+        target: const Duration(seconds: 2430),
+        currentPosition: const Duration(seconds: 2400),
+        startOffset: Duration.zero,
+      ),
+      isFalse,
+    );
+  });
+
+  test('a large forward scrub restarts', () {
+    expect(
+      shouldRestartCastForSeek(
+        target: const Duration(seconds: 3000),
+        currentPosition: const Duration(seconds: 2400),
+        startOffset: const Duration(seconds: 2394),
+      ),
+      isTrue,
+    );
+  });
+
+  test('a target before the start offset restarts', () {
+    // Not present in this stream at all: the session begins at 2394s, so
+    // minute five simply is not in the playlist.
+    expect(
+      shouldRestartCastForSeek(
+        target: const Duration(seconds: 300),
+        currentPosition: const Duration(seconds: 2400),
+        startOffset: const Duration(seconds: 2394),
+      ),
+      isTrue,
+    );
+  });
+
+  test('a backward seek inside the window seeks in place', () {
+    expect(
+      shouldRestartCastForSeek(
+        target: const Duration(seconds: 2500),
+        currentPosition: const Duration(seconds: 2600),
+        startOffset: const Duration(seconds: 2394),
+      ),
+      isFalse,
+    );
+  });
+
+  test('a zero-offset session still restarts on a long forward scrub', () {
+    expect(
+      shouldRestartCastForSeek(
+        target: const Duration(seconds: 3600),
+        currentPosition: Duration.zero,
+        startOffset: Duration.zero,
+      ),
+      isTrue,
+    );
+  });
+}

--- a/player/test/core/cast/cast_seek_restart_test.dart
+++ b/player/test/core/cast/cast_seek_restart_test.dart
@@ -9,12 +9,14 @@
 // from the receiver at all.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_backend.dart';
 import 'package:player/core/cast/cast_seek_restart.dart';
 
 void main() {
   test('a small forward skip seeks in place', () {
     expect(
       shouldRestartCastForSeek(
+        mediaKind: CastMediaKind.hls,
         target: const Duration(seconds: 2410),
         currentPosition: const Duration(seconds: 2400),
         startOffset: const Duration(seconds: 2394),
@@ -26,6 +28,7 @@ void main() {
   test('a skip exactly at the tolerance seeks in place', () {
     expect(
       shouldRestartCastForSeek(
+        mediaKind: CastMediaKind.hls,
         target: const Duration(seconds: 2430),
         currentPosition: const Duration(seconds: 2400),
         startOffset: Duration.zero,
@@ -37,6 +40,7 @@ void main() {
   test('a large forward scrub restarts', () {
     expect(
       shouldRestartCastForSeek(
+        mediaKind: CastMediaKind.hls,
         target: const Duration(seconds: 3000),
         currentPosition: const Duration(seconds: 2400),
         startOffset: const Duration(seconds: 2394),
@@ -50,6 +54,7 @@ void main() {
     // minute five simply is not in the playlist.
     expect(
       shouldRestartCastForSeek(
+        mediaKind: CastMediaKind.hls,
         target: const Duration(seconds: 300),
         currentPosition: const Duration(seconds: 2400),
         startOffset: const Duration(seconds: 2394),
@@ -61,6 +66,7 @@ void main() {
   test('a backward seek inside the window seeks in place', () {
     expect(
       shouldRestartCastForSeek(
+        mediaKind: CastMediaKind.hls,
         target: const Duration(seconds: 2500),
         currentPosition: const Duration(seconds: 2600),
         startOffset: const Duration(seconds: 2394),
@@ -72,11 +78,75 @@ void main() {
   test('a zero-offset session still restarts on a long forward scrub', () {
     expect(
       shouldRestartCastForSeek(
+        mediaKind: CastMediaKind.hls,
         target: const Duration(seconds: 3600),
         currentPosition: Duration.zero,
         startOffset: Duration.zero,
       ),
       isTrue,
     );
+  });
+
+  test('a target exactly at the start offset seeks in place', () {
+    // The offset is the first position the stream actually contains, so it is
+    // reachable. The predicate's first clause is deliberately strict
+    // (`target < startOffset`) for this reason.
+    expect(
+      shouldRestartCastForSeek(
+        mediaKind: CastMediaKind.hls,
+        target: const Duration(seconds: 2394),
+        currentPosition: const Duration(seconds: 2400),
+        startOffset: const Duration(seconds: 2394),
+      ),
+      isFalse,
+    );
+  });
+
+  group('progressive routes', () {
+    // A DLNA renderer gets a byte-range stream of the whole file: the offset
+    // is always zero, every position is addressable, and a receiver seek is
+    // valid anywhere. Restarting there tears down a session for a target it
+    // could already reach.
+    test('never restart, however far forward the target is', () {
+      expect(
+        shouldRestartCastForSeek(
+          mediaKind: CastMediaKind.progressive,
+          target: const Duration(seconds: 5400),
+          currentPosition: Duration.zero,
+          startOffset: Duration.zero,
+        ),
+        isFalse,
+        reason: 'a progressive receiver can seek anywhere in the file',
+      );
+    });
+
+    test('never restart even for a target before the offset', () {
+      // Defensive: a progressive route should never carry a non-zero offset in
+      // the first place, but the media kind alone must settle the decision.
+      expect(
+        shouldRestartCastForSeek(
+          mediaKind: CastMediaKind.progressive,
+          target: const Duration(seconds: 60),
+          currentPosition: const Duration(seconds: 2400),
+          startOffset: const Duration(seconds: 2394),
+        ),
+        isFalse,
+      );
+    });
+
+    test('the identical HLS case does restart', () {
+      // The control for the two above: same numbers, different media kind.
+      // Without it, those tests would pass even if the predicate had simply
+      // stopped restarting altogether.
+      expect(
+        shouldRestartCastForSeek(
+          mediaKind: CastMediaKind.hls,
+          target: const Duration(seconds: 5400),
+          currentPosition: Duration.zero,
+          startOffset: Duration.zero,
+        ),
+        isTrue,
+      );
+    });
   });
 }

--- a/player/test/core/cast/cast_session_manager_test.dart
+++ b/player/test/core/cast/cast_session_manager_test.dart
@@ -93,8 +93,12 @@ void main() {
       await manager.startCast(device: device, request: launch);
 
       expect(backend.connectedDevice, device);
-      expect(backend.loadedRequests.single.url,
-          startsWith('https://mydia.test/api/v1/stream/file/file-1'));
+      expect(
+        backend.loadedRequests.single.url,
+        startsWith(
+            'https://mydia.test/api/v1/hls/${sessions.started.single}/index.m3u8'),
+      );
+      expect(sessions.requestedFileIds.single, 'file-1');
       expect(backend.loadedRequests.single.kind, CastMediaKind.hls);
     });
 
@@ -298,7 +302,12 @@ void main() {
       // turns it on, discovers there is no LAN interface, and turns it
       // straight back off before escalating to TRANSCODE.
       expect(lanCalls, [true, false]);
-      expect(backend.loadedRequests.single.url, contains('strategy=TRANSCODE'));
+      // The Chromecast escalation now rides on the server-side session rather
+      // than a `strategy=` query param, so the fake's transcode marker in the
+      // session id is where it shows.
+      expect(sessions.started.last, contains('transcode'));
+      expect(
+          backend.loadedRequests.single.url, contains(sessions.started.last));
     });
 
     test(
@@ -313,8 +322,10 @@ void main() {
       await manager.startCast(device: device, request: launch);
 
       expect(backend.loadedRequests.single.url,
-          startsWith('https://mydia.test/api/v1/stream/file/file-1'));
-      expect(backend.loadedRequests.single.url, contains('strategy=TRANSCODE'));
+          startsWith('https://mydia.test/api/v1/hls/'));
+      expect(sessions.started.last, contains('transcode'));
+      expect(
+          backend.loadedRequests.single.url, contains(sessions.started.last));
     });
 
     test('stops escalating after the TRANSCODE attempt and rethrows', () async {
@@ -714,6 +725,11 @@ void main() {
       expect(backend.loadedRequests, hasLength(1));
       expect(backend.loadedRequests.single.url,
           startsWith('http://192.168.1.20:5000/g/abcd/hls/'));
+      // The stored position is now asked of the server, so the rebuilt HLS
+      // session starts there rather than at the beginning.
+      expect(sessions.requestedStart, const Duration(minutes: 5));
+      // This fake echoes an offset of zero, i.e. an older server that ignored
+      // the request, so the whole position is still left to a receiver seek.
       expect(backend.loadedRequests.single.startPosition,
           const Duration(minutes: 5));
 
@@ -755,7 +771,9 @@ void main() {
 
       await manager.reconnectStoredSession();
 
-      expect(backend.loadedRequests.single.url, contains('file-1'));
+      // The URL is session-addressed now, so the file id only shows in what
+      // the route asked the server for.
+      expect(sessions.requestedFileIds.last, 'file-1');
       expect(backend.loadedRequests.single.title, 'Arrival');
     });
 
@@ -783,18 +801,73 @@ void main() {
       expect(sessions.live, isEmpty);
     });
 
-    test('ends the session started for an abandoned bridge attempt', () async {
+    test('ends the direct route\'s session too, rather than leaking it',
+        () async {
+      // The direct Chromecast route used to redirect through
+      // /api/v1/stream/file/:id, which returns no session id — so
+      // `_adoptHlsSession` had nothing to end and the session it had started
+      // leaked until the server's inactivity timeout.
       final manager = build();
       addTearDown(manager.dispose);
-      // Direct fails, bridge is tried (starting a session) and fails too, then
-      // TRANSCODE back on the direct route succeeds — the bridge session is
-      // now orphaned on the server.
+      await manager.startCast(device: device, request: launch);
+
+      expect(sessions.live, hasLength(1));
+
+      await manager.stopCast();
+
+      expect(sessions.live, isEmpty);
+    });
+
+    test('ends the direct route\'s previous session when switching items',
+        () async {
+      final manager = build();
+      addTearDown(manager.dispose);
+      await manager.startCast(device: device, request: launch);
+      final first = sessions.started.single;
+
+      await manager.startCast(
+        device: device,
+        request: const CastLaunchRequest(
+          fileId: 'file-2',
+          mediaId: 'movie-2',
+          mediaType: 'movie',
+          title: 'Contact',
+        ),
+      );
+
+      expect(sessions.ended, contains(first));
+      expect(sessions.live, hasLength(1));
+    });
+
+    test('a DLNA cast still opens no session at all', () async {
+      // Progressive routes are served straight from the file endpoint, so
+      // there is nothing to start and nothing to leak.
+      const dlna = CastDevice(
+        id: 'd2',
+        name: 'Bedroom TV',
+        protocol: CastProtocolKind.dlna,
+      );
+      final manager = build();
+      addTearDown(manager.dispose);
+
+      await manager.startCast(device: dlna, request: launch);
+
+      expect(sessions.started, isEmpty);
+    });
+
+    test('ends the sessions started for abandoned attempts', () async {
+      final manager = build();
+      addTearDown(manager.dispose);
+      // Direct fails, bridge is tried and fails too, then TRANSCODE back on
+      // the direct route succeeds. Every Chromecast route opens a session, so
+      // the two losing attempts are now orphaned on the server.
       backend.failNextLoad(CastFailureKind.mediaLoadFailed, times: 2);
 
       await manager.startCast(device: device, request: launch);
 
-      expect(sessions.started, isNotEmpty);
-      expect(sessions.live, isEmpty);
+      expect(sessions.started, hasLength(3));
+      expect(sessions.live, [sessions.started.last],
+          reason: 'only the attempt that actually loaded survives');
     });
 
     test('ends every session started by a wholly failed cast', () async {
@@ -843,7 +916,9 @@ void main() {
 
       await manager.startCast(device: device, request: launch);
 
-      expect(backend.loadedRequests.single.url, contains('strategy=TRANSCODE'));
+      expect(sessions.started.last, contains('transcode'));
+      expect(
+          backend.loadedRequests.single.url, contains(sessions.started.last));
       expect(lanCalls, [true, false]);
     });
 

--- a/player/test/core/cast/cast_session_manager_test.dart
+++ b/player/test/core/cast/cast_session_manager_test.dart
@@ -853,6 +853,52 @@ void main() {
       expect(sessions.requestedStart, const Duration(seconds: 300));
     });
 
+    test('a restart keeps the subtitles and artwork the cast was launched with',
+        () async {
+      // `PersistedCastSession` carries neither, because it exists to survive
+      // the app being killed and a cold restore cannot act on them. Rebuilding
+      // the restart request from it stripped subtitle tracks off the receiver
+      // for the rest of the session, on every forward scrub past the
+      // tolerance. The live request is what gets reused instead.
+      sessions.echoedStartOffset = const Duration(seconds: 2394);
+      final manager = build();
+      addTearDown(manager.dispose);
+
+      await manager.startCast(
+        device: device,
+        request: const CastLaunchRequest(
+          fileId: 'file-1',
+          mediaId: 'movie-1',
+          mediaType: 'movie',
+          title: 'Arrival',
+          subtitleLabel: 'English',
+          imageUrl: 'https://mydia.test/poster.jpg',
+          startPosition: Duration(seconds: 2400),
+          duration: Duration(hours: 1),
+          subtitles: [
+            CastSubtitleTrack(
+              url: 'https://mydia.test/subs/en.vtt',
+              label: 'English',
+              language: 'en',
+            ),
+          ],
+        ),
+      );
+
+      expect(backend.loadedRequests.first.subtitles, hasLength(1),
+          reason: 'guard: the initial cast really did carry a subtitle track');
+
+      await manager.seek(const Duration(seconds: 3000));
+
+      expect(backend.loadedRequests, hasLength(2),
+          reason: 'guard: the seek really did restart rather than seek');
+      final reloaded = backend.loadedRequests.last;
+      expect(reloaded.subtitles, hasLength(1));
+      expect(reloaded.subtitles.single.language, 'en');
+      expect(reloaded.subtitle, 'English');
+      expect(reloaded.imageUrl, 'https://mydia.test/poster.jpg');
+    });
+
     test(
         'a seek that arrives while a restart is running is dropped, '
         'not queued', () async {

--- a/player/test/core/cast/cast_session_manager_test.dart
+++ b/player/test/core/cast/cast_session_manager_test.dart
@@ -788,6 +788,97 @@ void main() {
     });
   });
 
+  group('seek', () {
+    // A resume offset baked into the numbers, matching the resume scenario
+    // in cast_resume_offset_test.dart: the server echoes back 2394s for a
+    // request at 2400s (it snapped to the nearest keyframe).
+    const launchWithPosition = CastLaunchRequest(
+      fileId: 'file-1',
+      mediaId: 'movie-1',
+      mediaType: 'movie',
+      title: 'Arrival',
+      startPosition: Duration(seconds: 2400),
+      duration: Duration(hours: 1),
+    );
+
+    test(
+        'seeks the receiver in place, translated to player coordinates, '
+        'when the target is within reach', () async {
+      sessions.echoedStartOffset = const Duration(seconds: 2394);
+      final manager = build();
+      addTearDown(manager.dispose);
+      await manager.startCast(device: device, request: launchWithPosition);
+
+      await manager.seek(const Duration(seconds: 2410));
+
+      expect(backend.seeks, [const Duration(seconds: 16)],
+          reason: 'real target minus the offset the server actually used');
+      expect(backend.loadedRequests, hasLength(1),
+          reason: 'a reachable target seeks in place, no restart');
+      expect(sessions.started, hasLength(1));
+    });
+
+    test(
+        'restarts the session on the same item when the target is far '
+        'ahead of the current position', () async {
+      sessions.echoedStartOffset = const Duration(seconds: 2394);
+      final manager = build();
+      addTearDown(manager.dispose);
+      await manager.startCast(device: device, request: launchWithPosition);
+
+      await manager.seek(const Duration(seconds: 3000));
+
+      expect(backend.seeks, isEmpty,
+          reason: 'the receiver was reloaded, not seeked in place');
+      expect(backend.loadedRequests, hasLength(2));
+      expect(sessions.requestedStart, const Duration(seconds: 3000));
+      expect(manager.persistedSession?.position, const Duration(seconds: 3000));
+      // The persisted session's own fields drive the restart, not some other
+      // item the caller might have on screen.
+      expect(sessions.requestedFileIds.last, 'file-1');
+      expect(backend.loadedRequests.last.title, 'Arrival');
+    });
+
+    test('restarts the session when the target is before the start offset',
+        () async {
+      sessions.echoedStartOffset = const Duration(seconds: 2394);
+      final manager = build();
+      addTearDown(manager.dispose);
+      await manager.startCast(device: device, request: launchWithPosition);
+
+      await manager.seek(const Duration(seconds: 300));
+
+      expect(backend.seeks, isEmpty);
+      expect(backend.loadedRequests, hasLength(2));
+      expect(sessions.requestedStart, const Duration(seconds: 300));
+    });
+
+    test(
+        'a seek that arrives while a restart is running is dropped, '
+        'not queued', () async {
+      // A user dragging the scrub bar (or double-tapping skip-forward) can
+      // fire a second `seek` before the first one's restart (`startCast`)
+      // has finished. `startCast` mutates shared state — `_persisted`,
+      // `_activeHlsSessionId` — across several `await` points, so two
+      // concurrent runs race: each call's `_adoptHlsSession` can decide the
+      // *other* call's just-loaded session is the stale one to tear down,
+      // killing whichever one actually ended up on the receiver.
+      sessions.echoedStartOffset = const Duration(seconds: 2394);
+      final manager = build();
+      addTearDown(manager.dispose);
+      await manager.startCast(device: device, request: launchWithPosition);
+
+      final first = manager.seek(const Duration(seconds: 3000));
+      final second = manager.seek(const Duration(seconds: 3100));
+      await first;
+      await second;
+
+      // One restart, not two: the initial cast plus exactly one reload.
+      expect(sessions.started, hasLength(2));
+      expect(backend.loadedRequests, hasLength(2));
+    });
+  });
+
   group('server-side HLS sessions', () {
     test('ends the session it started when casting stops', () async {
       final manager = build(isP2pMode: true);

--- a/player/test/core/playback/playback_progress_store_test.dart
+++ b/player/test/core/playback/playback_progress_store_test.dart
@@ -1,0 +1,177 @@
+// Offline playback previously recorded progress nowhere: `_saveProgress`
+// returns early without a `ProgressService`, which is always the case
+// offline, and `DownloadedMedia` has no position field. Without this store
+// there is nothing for an offline resume prompt to offer.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/playback/local_playback_progress.dart';
+import 'package:player/core/playback/playback_progress_store.dart';
+
+void main() {
+  LocalPlaybackProgress progress({
+    String mediaId = 'movie-1',
+    int positionSeconds = 600,
+    int durationSeconds = 5400,
+    DateTime? updatedAt,
+    DateTime? syncedAt,
+  }) =>
+      LocalPlaybackProgress(
+        mediaId: mediaId,
+        mediaType: 'movie',
+        positionSeconds: positionSeconds,
+        durationSeconds: durationSeconds,
+        updatedAt: updatedAt ?? DateTime.utc(2026, 8, 2, 12),
+        syncedAt: syncedAt,
+      );
+
+  group('LocalPlaybackProgress', () {
+    test('round-trips through a map', () {
+      final original = progress(syncedAt: DateTime.utc(2026, 8, 2, 13));
+      final restored = LocalPlaybackProgress.fromMap(original.toMap());
+
+      expect(restored.mediaId, original.mediaId);
+      expect(restored.mediaType, original.mediaType);
+      expect(restored.positionSeconds, original.positionSeconds);
+      expect(restored.durationSeconds, original.durationSeconds);
+      expect(restored.updatedAt, original.updatedAt);
+      expect(restored.syncedAt, original.syncedAt);
+    });
+
+    test('round-trips an unsynced record', () {
+      final restored = LocalPlaybackProgress.fromMap(progress().toMap());
+      expect(restored.syncedAt, isNull);
+    });
+  });
+
+  group('InMemoryPlaybackProgressStore', () {
+    test('saves and reads back by media id', () async {
+      final store = InMemoryPlaybackProgressStore();
+      await store.save(progress(positionSeconds: 900));
+
+      expect(store.get('movie-1')!.positionSeconds, 900);
+      expect(store.get('movie-2'), isNull);
+    });
+
+    test('a later save replaces an earlier one', () async {
+      final store = InMemoryPlaybackProgressStore();
+      await store.save(progress(positionSeconds: 600));
+      await store.save(progress(positionSeconds: 900));
+
+      expect(store.get('movie-1')!.positionSeconds, 900);
+    });
+
+    test('unsynced lists only records the server does not have', () async {
+      final store = InMemoryPlaybackProgressStore();
+      await store.save(progress(mediaId: 'a'));
+      await store.save(
+        progress(mediaId: 'b', syncedAt: DateTime.utc(2026, 8, 2, 13)),
+      );
+
+      expect(store.unsynced().map((p) => p.mediaId), ['a']);
+    });
+
+    test('markSynced removes a record from the unsynced list', () async {
+      final store = InMemoryPlaybackProgressStore();
+      await store.save(progress(mediaId: 'a'));
+
+      await store.markSynced('a', DateTime.utc(2026, 8, 2, 14));
+
+      expect(store.unsynced(), isEmpty);
+      expect(store.get('a')!.syncedAt, DateTime.utc(2026, 8, 2, 14));
+      expect(
+        store.get('a')!.positionSeconds,
+        600,
+        reason: 'marking synced must not disturb the position',
+      );
+    });
+
+    test('markSynced on an unknown id is a no-op', () async {
+      final store = InMemoryPlaybackProgressStore();
+      await store.markSynced('ghost', DateTime.utc(2026, 8, 2, 14));
+      expect(store.get('ghost'), isNull);
+    });
+  });
+
+  group('pickNewerProgress', () {
+    test('takes the local record when it is newer', () {
+      final result = pickNewerProgress(
+        local: progress(
+          positionSeconds: 900,
+          updatedAt: DateTime.utc(2026, 8, 2, 12),
+        ),
+        serverPositionSeconds: 300,
+        serverDurationSeconds: 5400,
+        serverLastWatchedAt: DateTime.utc(2026, 8, 1),
+      );
+
+      expect(result.positionSeconds, 900);
+      expect(result.durationSeconds, 5400);
+    });
+
+    test('takes the server record when it is newer', () {
+      // Finished the episode on the TV while the phone held a stale offline
+      // position. The TV must win.
+      final result = pickNewerProgress(
+        local: progress(
+          positionSeconds: 900,
+          updatedAt: DateTime.utc(2026, 8, 1),
+        ),
+        serverPositionSeconds: 3000,
+        serverDurationSeconds: 5400,
+        serverLastWatchedAt: DateTime.utc(2026, 8, 2, 12),
+      );
+
+      expect(result.positionSeconds, 3000);
+    });
+
+    test('falls back to the server when there is no local record', () {
+      final result = pickNewerProgress(
+        local: null,
+        serverPositionSeconds: 300,
+        serverDurationSeconds: 5400,
+        serverLastWatchedAt: DateTime.utc(2026, 8, 2),
+      );
+
+      expect(result.positionSeconds, 300);
+      expect(result.durationSeconds, 5400);
+    });
+
+    test('falls back to local when the server has nothing', () {
+      final result = pickNewerProgress(
+        local: progress(positionSeconds: 900),
+        serverPositionSeconds: null,
+        serverDurationSeconds: null,
+        serverLastWatchedAt: null,
+      );
+
+      expect(result.positionSeconds, 900);
+      expect(result.durationSeconds, 5400);
+    });
+
+    test('prefers local when the server sent no timestamp to compare', () {
+      // An older server, or a progress record written before lastWatchedAt
+      // existed. An uncomparable server record must not silently beat a
+      // local one that is known to be recent.
+      final result = pickNewerProgress(
+        local: progress(positionSeconds: 900),
+        serverPositionSeconds: 300,
+        serverDurationSeconds: 5400,
+        serverLastWatchedAt: null,
+      );
+
+      expect(result.positionSeconds, 900);
+    });
+
+    test('returns nulls when neither side knows anything', () {
+      final result = pickNewerProgress(
+        local: null,
+        serverPositionSeconds: null,
+        serverDurationSeconds: null,
+        serverLastWatchedAt: null,
+      );
+
+      expect(result.positionSeconds, isNull);
+      expect(result.durationSeconds, isNull);
+    });
+  });
+}

--- a/player/test/core/playback/playback_progress_store_test.dart
+++ b/player/test/core/playback/playback_progress_store_test.dart
@@ -170,12 +170,11 @@ void main() {
       final store = HivePlaybackProgressStore(box);
       expect(store.get('bad'), isNull);
 
-      // get() is deliberately synchronous; the malformed-record cleanup
-      // fires an unawaited delete underneath it. Give that a moment to land
-      // before checking the box was actually cleaned up rather than just
-      // reporting null this one time.
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-
+      // No wait needed: Box.delete's keystore mutation happens synchronously
+      // (inside beginTransaction, before the method's first await), and
+      // get()/unsynced() both read that same in-memory keystore. The
+      // unawaited delete's own Future only covers flushing to disk, which
+      // neither assertion below depends on.
       expect(store.get('bad'), isNull);
       expect(store.unsynced(), isEmpty);
     });

--- a/player/test/core/playback/playback_progress_store_test.dart
+++ b/player/test/core/playback/playback_progress_store_test.dart
@@ -3,7 +3,10 @@
 // offline, and `DownloadedMedia` has no position field. Without this store
 // there is nothing for an offline resume prompt to offer.
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
 import 'package:player/core/playback/local_playback_progress.dart';
 import 'package:player/core/playback/playback_progress_store.dart';
 
@@ -89,6 +92,92 @@ void main() {
       final store = InMemoryPlaybackProgressStore();
       await store.markSynced('ghost', DateTime.utc(2026, 8, 2, 14));
       expect(store.get('ghost'), isNull);
+    });
+  });
+
+  group('HivePlaybackProgressStore', () {
+    late Directory tempDir;
+    late Box<Map> box;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('playback_store_test');
+      Hive.init(tempDir.path);
+      box = await Hive.openBox<Map>('playback_progress_test');
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+      await Hive.close();
+      await tempDir.delete(recursive: true);
+    });
+
+    test('save then get round-trips through a real box', () async {
+      final store = HivePlaybackProgressStore(box);
+      await store.save(
+        progress(positionSeconds: 900, updatedAt: DateTime.utc(2026, 8, 2, 12)),
+      );
+
+      final loaded = store.get('movie-1');
+
+      expect(loaded, isNotNull);
+      expect(loaded!.mediaId, 'movie-1');
+      expect(loaded.mediaType, 'movie');
+      expect(loaded.positionSeconds, 900);
+      expect(loaded.durationSeconds, 5400);
+      expect(loaded.updatedAt, DateTime.utc(2026, 8, 2, 12));
+      expect(loaded.syncedAt, isNull);
+    });
+
+    test('a record with syncedAt set also round-trips', () async {
+      final store = HivePlaybackProgressStore(box);
+      await store.save(progress(syncedAt: DateTime.utc(2026, 8, 2, 13)));
+
+      expect(store.get('movie-1')?.syncedAt, DateTime.utc(2026, 8, 2, 13));
+    });
+
+    test('unsynced reads only unsynced records from a real box', () async {
+      final store = HivePlaybackProgressStore(box);
+      await store.save(progress(mediaId: 'a'));
+      await store.save(
+        progress(mediaId: 'b', syncedAt: DateTime.utc(2026, 8, 2, 13)),
+      );
+
+      expect(store.unsynced().map((p) => p.mediaId), ['a']);
+    });
+
+    test('markSynced persists to the real box', () async {
+      final store = HivePlaybackProgressStore(box);
+      await store.save(progress(mediaId: 'a', positionSeconds: 600));
+
+      await store.markSynced('a', DateTime.utc(2026, 8, 2, 14));
+
+      // Read back through a fresh store instance wrapping the same box, to
+      // prove the write landed in the box itself rather than in some
+      // instance-level cache the store does not actually have.
+      final reloaded = HivePlaybackProgressStore(box).get('a');
+      expect(reloaded?.syncedAt, DateTime.utc(2026, 8, 2, 14));
+      expect(
+        reloaded?.positionSeconds,
+        600,
+        reason: 'marking synced must not disturb the position',
+      );
+    });
+
+    test('a malformed record is discarded rather than crashing the store',
+        () async {
+      await box.put('bad', {'nonsense': true});
+
+      final store = HivePlaybackProgressStore(box);
+      expect(store.get('bad'), isNull);
+
+      // get() is deliberately synchronous; the malformed-record cleanup
+      // fires an unawaited delete underneath it. Give that a moment to land
+      // before checking the box was actually cleaned up rather than just
+      // reporting null this one time.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(store.get('bad'), isNull);
+      expect(store.unsynced(), isEmpty);
     });
   });
 

--- a/player/test/core/playback/progress_flush_test.dart
+++ b/player/test/core/playback/progress_flush_test.dart
@@ -108,7 +108,6 @@ void main() {
     final store = InMemoryPlaybackProgressStore();
     await store.save(record(mediaId: 'movie-1'));
     await store.save(record(mediaId: 'movie-2'));
-    final service = RecordingProgressService();
 
     // Fail only the first call, by returning false rather than throwing —
     // the ordinary "server declined the sync" path.
@@ -121,9 +120,13 @@ void main() {
       now: DateTime.utc(2026, 8, 2, 15),
     );
 
+    expect(calls, 2, reason: 'both records were attempted');
     expect(synced, 1);
-    expect(store.unsynced().length, 1);
-    expect(service.movies, isEmpty);
+    // The point of the test: the record AFTER the failure still went through.
+    // Asserting only on counts would pass just as well if the flush had
+    // aborted on the first failure and never reached movie-2.
+    expect(store.get('movie-2')!.syncedAt, DateTime.utc(2026, 8, 2, 15));
+    expect(store.unsynced().map((p) => p.mediaId), ['movie-1']);
   });
 
   test('a sync that throws also leaves the record unsynced', () async {

--- a/player/test/core/playback/progress_flush_test.dart
+++ b/player/test/core/playback/progress_flush_test.dart
@@ -180,6 +180,101 @@ void main() {
     expect(store.unsynced().map((p) => p.mediaId), ['movie-1']);
     expect(rejecting.movieCalls, 2);
   });
+
+  group('saveDownloadedProgress', () {
+    // The downloaded-while-online path writes locally AND to the server in one
+    // step. Doing those as two independent writes left every such record
+    // permanently `syncedAt: null`, so the first flush after offline detection
+    // is reinstated would replay a queue of stale positions over newer server
+    // progress.
+    test('marks the record synced when the server takes it', () async {
+      final store = InMemoryPlaybackProgressStore();
+      final service = RecordingProgressService();
+
+      await saveDownloadedProgress(
+        store: store,
+        progressService: service,
+        mediaId: 'movie-1',
+        mediaType: 'movie',
+        position: const Duration(seconds: 900),
+        duration: const Duration(seconds: 5400),
+        now: DateTime.utc(2026, 8, 2, 12),
+      );
+
+      final saved = store.get('movie-1')!;
+      expect(saved.positionSeconds, 900);
+      expect(saved.syncedAt, DateTime.utc(2026, 8, 2, 12));
+      expect(store.unsynced(), isEmpty);
+      expect(
+          service.movies,
+          [
+            (
+              'movie-1',
+              const Duration(seconds: 900),
+              const Duration(seconds: 5400)
+            )
+          ],
+          reason: 'the server gets the same position that was stored locally');
+    });
+
+    test('leaves the record unsynced when the server declines', () async {
+      final store = InMemoryPlaybackProgressStore();
+      final service = RecordingProgressService()..failNext = true;
+
+      await saveDownloadedProgress(
+        store: store,
+        progressService: service,
+        mediaId: 'movie-1',
+        mediaType: 'movie',
+        position: const Duration(seconds: 900),
+        duration: const Duration(seconds: 5400),
+        now: DateTime.utc(2026, 8, 2, 12),
+      );
+
+      expect(store.get('movie-1')!.positionSeconds, 900,
+          reason: 'the local write still happened; only the marking did not');
+      expect(store.get('movie-1')!.syncedAt, isNull);
+      expect(store.unsynced().map((p) => p.mediaId), ['movie-1']);
+    });
+
+    test('leaves the record unsynced when the server throws', () async {
+      final store = InMemoryPlaybackProgressStore();
+
+      await saveDownloadedProgress(
+        store: store,
+        progressService: _ThrowingProgressService(),
+        mediaId: 'ep-1',
+        mediaType: 'episode',
+        position: const Duration(seconds: 900),
+        duration: const Duration(seconds: 5400),
+        now: DateTime.utc(2026, 8, 2, 12),
+      );
+
+      expect(store.get('ep-1')!.syncedAt, isNull);
+      expect(store.unsynced().map((p) => p.mediaId), ['ep-1'],
+          reason:
+              'a throwing server must never cost the user the local record');
+    });
+
+    test('routes an episode to the episode mutation', () async {
+      final store = InMemoryPlaybackProgressStore();
+      final service = RecordingProgressService();
+
+      await saveDownloadedProgress(
+        store: store,
+        progressService: service,
+        mediaId: 'ep-1',
+        mediaType: 'episode',
+        position: const Duration(seconds: 900),
+        duration: const Duration(seconds: 5400),
+        now: DateTime.utc(2026, 8, 2, 12),
+      );
+
+      expect(service.episodes, hasLength(1));
+      expect(service.movies, isEmpty);
+      expect(store.get('ep-1')!.syncedAt, isNotNull);
+    });
+  });
 }
 
 class _FlakyProgressService extends Fake implements ProgressService {

--- a/player/test/core/playback/progress_flush_test.dart
+++ b/player/test/core/playback/progress_flush_test.dart
@@ -1,0 +1,139 @@
+// Progress written while offline is worthless if it never reaches the server:
+// the web UI and every other device would keep disagreeing with the player
+// after each offline session.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/playback/local_playback_progress.dart';
+import 'package:player/core/playback/playback_progress_store.dart';
+import 'package:player/core/player/progress_service.dart';
+
+class RecordingProgressService extends Fake implements ProgressService {
+  final movies = <(String, Duration, Duration)>[];
+  final episodes = <(String, Duration, Duration)>[];
+  bool failNext = false;
+
+  @override
+  Future<void> syncMoviePosition(
+      String movieId, Duration position, Duration duration) async {
+    if (failNext) throw StateError('server unreachable');
+    movies.add((movieId, position, duration));
+  }
+
+  @override
+  Future<void> syncEpisodePosition(
+      String episodeId, Duration position, Duration duration) async {
+    if (failNext) throw StateError('server unreachable');
+    episodes.add((episodeId, position, duration));
+  }
+}
+
+void main() {
+  LocalPlaybackProgress record({
+    required String mediaId,
+    String mediaType = 'movie',
+    DateTime? syncedAt,
+  }) =>
+      LocalPlaybackProgress(
+        mediaId: mediaId,
+        mediaType: mediaType,
+        positionSeconds: 900,
+        durationSeconds: 5400,
+        updatedAt: DateTime.utc(2026, 8, 2, 12),
+        syncedAt: syncedAt,
+      );
+
+  test('flushes unsynced records and marks them synced', () async {
+    final store = InMemoryPlaybackProgressStore();
+    await store.save(record(mediaId: 'movie-1'));
+    await store.save(record(mediaId: 'ep-1', mediaType: 'episode'));
+    final service = RecordingProgressService();
+
+    final synced = await flushUnsyncedProgress(
+      store: store,
+      progressService: service,
+      now: DateTime.utc(2026, 8, 2, 15),
+    );
+
+    expect(synced, 2);
+    expect(service.movies, [
+      ('movie-1', const Duration(seconds: 900), const Duration(seconds: 5400))
+    ]);
+    expect(service.episodes, [
+      ('ep-1', const Duration(seconds: 900), const Duration(seconds: 5400))
+    ]);
+    expect(store.unsynced(), isEmpty);
+    expect(store.get('movie-1')!.syncedAt, DateTime.utc(2026, 8, 2, 15));
+  });
+
+  test('skips records the server already has', () async {
+    final store = InMemoryPlaybackProgressStore();
+    await store.save(
+      record(mediaId: 'movie-1', syncedAt: DateTime.utc(2026, 8, 2, 13)),
+    );
+    final service = RecordingProgressService();
+
+    final synced = await flushUnsyncedProgress(
+      store: store,
+      progressService: service,
+      now: DateTime.utc(2026, 8, 2, 15),
+    );
+
+    expect(synced, 0);
+    expect(service.movies, isEmpty);
+  });
+
+  test('a failed sync leaves the record for the next attempt', () async {
+    final store = InMemoryPlaybackProgressStore();
+    await store.save(record(mediaId: 'movie-1'));
+    final service = RecordingProgressService()..failNext = true;
+
+    final synced = await flushUnsyncedProgress(
+      store: store,
+      progressService: service,
+      now: DateTime.utc(2026, 8, 2, 15),
+    );
+
+    expect(synced, 0);
+    expect(store.unsynced().map((p) => p.mediaId), ['movie-1']);
+    expect(store.get('movie-1')!.syncedAt, isNull);
+  });
+
+  test('one failure does not abandon the rest of the queue', () async {
+    final store = InMemoryPlaybackProgressStore();
+    await store.save(record(mediaId: 'movie-1'));
+    await store.save(record(mediaId: 'movie-2'));
+    final service = RecordingProgressService();
+
+    // Fail only the first call.
+    var calls = 0;
+    final flaky = _FlakyProgressService(() => calls++ == 0);
+
+    final synced = await flushUnsyncedProgress(
+      store: store,
+      progressService: flaky,
+      now: DateTime.utc(2026, 8, 2, 15),
+    );
+
+    expect(synced, 1);
+    expect(store.unsynced().length, 1);
+    expect(service.movies, isEmpty);
+  });
+}
+
+class _FlakyProgressService extends Fake implements ProgressService {
+  _FlakyProgressService(this.shouldFail);
+
+  final bool Function() shouldFail;
+
+  @override
+  Future<void> syncMoviePosition(
+      String movieId, Duration position, Duration duration) async {
+    if (shouldFail()) throw StateError('flaky');
+  }
+
+  @override
+  Future<void> syncEpisodePosition(
+      String episodeId, Duration position, Duration duration) async {
+    if (shouldFail()) throw StateError('flaky');
+  }
+}

--- a/player/test/core/playback/progress_flush_test.dart
+++ b/player/test/core/playback/progress_flush_test.dart
@@ -10,20 +10,26 @@ import 'package:player/core/player/progress_service.dart';
 class RecordingProgressService extends Fake implements ProgressService {
   final movies = <(String, Duration, Duration)>[];
   final episodes = <(String, Duration, Duration)>[];
+
+  /// When true, the server declines the sync (mirrors `ProgressService`
+  /// returning `false` for a mutation that was sent but failed, or for one
+  /// `resolveSync` rejected outright) rather than throwing.
   bool failNext = false;
 
   @override
-  Future<void> syncMoviePosition(
+  Future<bool> syncMoviePosition(
       String movieId, Duration position, Duration duration) async {
-    if (failNext) throw StateError('server unreachable');
+    if (failNext) return false;
     movies.add((movieId, position, duration));
+    return true;
   }
 
   @override
-  Future<void> syncEpisodePosition(
+  Future<bool> syncEpisodePosition(
       String episodeId, Duration position, Duration duration) async {
-    if (failNext) throw StateError('server unreachable');
+    if (failNext) return false;
     episodes.add((episodeId, position, duration));
+    return true;
   }
 }
 
@@ -104,7 +110,8 @@ void main() {
     await store.save(record(mediaId: 'movie-2'));
     final service = RecordingProgressService();
 
-    // Fail only the first call.
+    // Fail only the first call, by returning false rather than throwing —
+    // the ordinary "server declined the sync" path.
     var calls = 0;
     final flaky = _FlakyProgressService(() => calls++ == 0);
 
@@ -118,6 +125,61 @@ void main() {
     expect(store.unsynced().length, 1);
     expect(service.movies, isEmpty);
   });
+
+  test('a sync that throws also leaves the record unsynced', () async {
+    // Belt-and-braces coverage for the try/catch in `flushUnsyncedProgress`:
+    // `ProgressService`'s own methods no longer throw in practice (they
+    // report failure via a `false` return instead), but a future or
+    // alternate implementation might, and that path must not crash the rest
+    // of the queue or mark this record synced.
+    final store = InMemoryPlaybackProgressStore();
+    await store.save(record(mediaId: 'movie-1'));
+    final throwing = _ThrowingProgressService();
+
+    final synced = await flushUnsyncedProgress(
+      store: store,
+      progressService: throwing,
+      now: DateTime.utc(2026, 8, 2, 15),
+    );
+
+    expect(synced, 0);
+    expect(store.unsynced().map((p) => p.mediaId), ['movie-1']);
+    expect(store.get('movie-1')!.syncedAt, isNull);
+  });
+
+  test(
+      'a record the server rejects stays unsynced and is retried on a '
+      'later flush', () async {
+    // Stands in for a record `ProgressService.resolveSync` would reject
+    // (e.g. a position outside a duration that has since changed) — such a
+    // record is not moved to any dead-letter state, it simply stays queued
+    // and is retried, unmodified, on every future offline-to-online
+    // transition. That is deliberate: making it explicit here rather than
+    // building retry-limiting/dead-letter handling for it.
+    final store = InMemoryPlaybackProgressStore();
+    await store.save(record(mediaId: 'movie-1'));
+    final rejecting = _RejectingProgressService();
+
+    final firstFlush = await flushUnsyncedProgress(
+      store: store,
+      progressService: rejecting,
+      now: DateTime.utc(2026, 8, 2, 15),
+    );
+
+    expect(firstFlush, 0);
+    expect(store.unsynced().map((p) => p.mediaId), ['movie-1']);
+    expect(rejecting.movieCalls, 1);
+
+    final secondFlush = await flushUnsyncedProgress(
+      store: store,
+      progressService: rejecting,
+      now: DateTime.utc(2026, 8, 2, 20),
+    );
+
+    expect(secondFlush, 0);
+    expect(store.unsynced().map((p) => p.mediaId), ['movie-1']);
+    expect(rejecting.movieCalls, 2);
+  });
 }
 
 class _FlakyProgressService extends Fake implements ProgressService {
@@ -126,14 +188,47 @@ class _FlakyProgressService extends Fake implements ProgressService {
   final bool Function() shouldFail;
 
   @override
-  Future<void> syncMoviePosition(
+  Future<bool> syncMoviePosition(
       String movieId, Duration position, Duration duration) async {
-    if (shouldFail()) throw StateError('flaky');
+    return !shouldFail();
   }
 
   @override
-  Future<void> syncEpisodePosition(
+  Future<bool> syncEpisodePosition(
       String episodeId, Duration position, Duration duration) async {
-    if (shouldFail()) throw StateError('flaky');
+    return !shouldFail();
+  }
+}
+
+class _ThrowingProgressService extends Fake implements ProgressService {
+  @override
+  Future<bool> syncMoviePosition(
+      String movieId, Duration position, Duration duration) async {
+    throw StateError('server unreachable');
+  }
+
+  @override
+  Future<bool> syncEpisodePosition(
+      String episodeId, Duration position, Duration duration) async {
+    throw StateError('server unreachable');
+  }
+}
+
+class _RejectingProgressService extends Fake implements ProgressService {
+  int movieCalls = 0;
+  int episodeCalls = 0;
+
+  @override
+  Future<bool> syncMoviePosition(
+      String movieId, Duration position, Duration duration) async {
+    movieCalls++;
+    return false;
+  }
+
+  @override
+  Future<bool> syncEpisodePosition(
+      String episodeId, Duration position, Duration duration) async {
+    episodeCalls++;
+    return false;
   }
 }

--- a/player/test/core/playback/record_local_progress_test.dart
+++ b/player/test/core/playback/record_local_progress_test.dart
@@ -1,0 +1,72 @@
+// `_saveProgress` returned early whenever `_progressService` was null, which
+// is always true offline. Downloaded playback therefore recorded progress
+// nowhere and had nothing to resume from on the next launch.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/playback/local_playback_progress.dart';
+import 'package:player/core/playback/playback_progress_store.dart';
+
+void main() {
+  test('recordLocalProgress writes a well-formed record', () async {
+    final store = InMemoryPlaybackProgressStore();
+
+    await recordLocalProgress(
+      store: store,
+      mediaId: 'movie-1',
+      mediaType: 'movie',
+      position: const Duration(seconds: 900),
+      duration: const Duration(seconds: 5400),
+      now: DateTime.utc(2026, 8, 2, 12),
+    );
+
+    final saved = store.get('movie-1')!;
+    expect(saved.positionSeconds, 900);
+    expect(saved.durationSeconds, 5400);
+    expect(saved.updatedAt, DateTime.utc(2026, 8, 2, 12));
+    expect(saved.syncedAt, isNull,
+        reason: 'a local write is unsynced until the server confirms it');
+  });
+
+  test('recordLocalProgress ignores a zero or unknown duration', () async {
+    final store = InMemoryPlaybackProgressStore();
+
+    await recordLocalProgress(
+      store: store,
+      mediaId: 'movie-1',
+      mediaType: 'movie',
+      position: const Duration(seconds: 900),
+      duration: Duration.zero,
+      now: DateTime.utc(2026, 8, 2, 12),
+    );
+
+    expect(store.get('movie-1'), isNull,
+        reason: 'a percentage against a zero duration is meaningless, and the '
+            'server rejects it too');
+  });
+
+  test('recordLocalProgress swallows a failing store', () async {
+    // A store write must never fail playback.
+    await recordLocalProgress(
+      store: ThrowingStore(),
+      mediaId: 'movie-1',
+      mediaType: 'movie',
+      position: const Duration(seconds: 900),
+      duration: const Duration(seconds: 5400),
+      now: DateTime.utc(2026, 8, 2, 12),
+    );
+  });
+}
+
+class ThrowingStore implements PlaybackProgressStore {
+  @override
+  Future<void> save(_) async => throw StateError('disk full');
+
+  @override
+  LocalPlaybackProgress? get(String mediaId) => null;
+
+  @override
+  List<LocalPlaybackProgress> unsynced() => const [];
+
+  @override
+  Future<void> markSynced(String mediaId, DateTime syncedAt) async {}
+}

--- a/player/test/core/player/resume_plan_test.dart
+++ b/player/test/core/player/resume_plan_test.dart
@@ -1,0 +1,132 @@
+// `resolveResumePlan` is the single place every playback path asks about
+// resuming. Before it existed, the decision lived inside individual branches
+// of `_initializePlayer`, and three cast exits plus the offline branch
+// skipped it entirely (see the 2026-08-02 cast-and-offline-resume spec).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/resume_plan.dart';
+
+void main() {
+  Future<bool?> never(int saved, int total) async {
+    fail('ask() must not be called when the plan is decided without the user');
+  }
+
+  group('resolveResumePlan', () {
+    test('offers, and honors an accepted resume', () async {
+      var askedSaved = 0;
+      var askedTotal = 0;
+
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: null,
+        mounted: true,
+        ask: (saved, total) async {
+          askedSaved = saved;
+          askedTotal = total;
+          return true;
+        },
+      );
+
+      expect(plan, isNotNull);
+      expect(plan!.position, const Duration(seconds: 2700));
+      expect(plan.resumes, isTrue);
+      expect(askedSaved, 2700);
+      expect(askedTotal, 5400);
+    });
+
+    test('starts over when the user declines', () async {
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: null,
+        mounted: true,
+        ask: (_, __) async => false,
+      );
+
+      expect(plan, isNotNull);
+      expect(plan!.position, Duration.zero);
+      expect(plan.resumes, isFalse);
+    });
+
+    test('does not ask below the minimum threshold', () async {
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: kMinResumeThresholdSeconds,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: null,
+        mounted: true,
+        ask: never,
+      );
+
+      expect(plan!.position, Duration.zero);
+    });
+
+    test('does not ask without a real duration', () async {
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: null,
+        resumeOverride: null,
+        mounted: true,
+        ask: never,
+      );
+
+      expect(plan!.position, Duration.zero);
+    });
+
+    test('an override of zero suppresses the dialog and starts at zero',
+        () async {
+      // A seek-driven restart targeting real position 0 sets the override to
+      // exactly 0, which must not be confused with "no override was set".
+      // Confusing them lets the dialog prompt about a stale saved position
+      // and silently overwrite the user's explicit seek to the start.
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: 0,
+        mounted: true,
+        ask: never,
+      );
+
+      expect(plan!.position, Duration.zero);
+    });
+
+    test('a non-zero override is used verbatim, without asking', () async {
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: 1800,
+        mounted: true,
+        ask: never,
+      );
+
+      expect(plan!.position, const Duration(seconds: 1800));
+    });
+
+    test('returns null when the caller is already unmounted', () async {
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: null,
+        mounted: false,
+        ask: never,
+      );
+
+      expect(plan, isNull);
+    });
+
+    test('returns null when the dialog is dismissed by teardown', () async {
+      // `showDialog` completes with null when the route is popped without an
+      // answer. Callers must abandon: `dispose()` has already run, and going
+      // on would start a session and build a Player for a dead screen.
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: null,
+        mounted: true,
+        ask: (_, __) async => null,
+      );
+
+      expect(plan, isNull);
+    });
+  });
+}

--- a/player/test/core/player/resume_plan_test.dart
+++ b/player/test/core/player/resume_plan_test.dart
@@ -129,4 +129,74 @@ void main() {
       expect(plan, isNull);
     });
   });
+
+  // Moved from `seek_restart_decision_test.dart`'s `shouldShowResumeDialog`
+  // group when that function was retired: `resolveResumePlan`'s
+  // `resumeOverride != null` early return is now the only place this
+  // presence-not-value gate lives, so its coverage moves here with it.
+  group('resolveResumePlan (override presence, not value, gates the ask)', () {
+    test(
+        'an override of exactly 0 is honored as a real target, not treated '
+        'as unset — the exact collision a value-based check would miss',
+        () async {
+      // `resumeOverride: 0` is what `_restartSessionAt` sets when the user
+      // sought back to the very start. A regression that checked
+      // `resumeOverride != 0` instead of `resumeOverride != null` would call
+      // `ask` here instead, and prompt about the unrelated, stale
+      // `savedPositionSeconds` below.
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: 0,
+        mounted: true,
+        ask: never,
+      );
+
+      expect(plan!.position, Duration.zero);
+      expect(plan.resumes, isFalse);
+    });
+
+    test(
+        'a non-zero override is honored verbatim without asking, distinct '
+        'from unset', () async {
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: 45,
+        mounted: true,
+        ask: never,
+      );
+
+      expect(plan!.position, const Duration(seconds: 45));
+    });
+
+    test('asks on a fresh mount with no override', () async {
+      var asked = false;
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: null,
+        mounted: true,
+        ask: (saved, total) async {
+          asked = true;
+          return true;
+        },
+      );
+
+      expect(asked, isTrue);
+      expect(plan!.resumes, isTrue);
+    });
+
+    test('returns null when not mounted, even with no override', () async {
+      final plan = await resolveResumePlan(
+        savedPositionSeconds: 2700,
+        realDuration: const Duration(seconds: 5400),
+        resumeOverride: null,
+        mounted: false,
+        ask: never,
+      );
+
+      expect(plan, isNull);
+    });
+  });
 }

--- a/player/test/presentation/screens/player/cast_resume_prompt_test.dart
+++ b/player/test/presentation/screens/player/cast_resume_prompt_test.dart
@@ -1,0 +1,109 @@
+// A cast target chosen before playback (CastButton on a detail screen) used
+// to short-circuit straight into `startCast` from three call sites inside
+// `_initializePlayer`, every one of them upstream of the resume prompt. The
+// receiver therefore always started at zero, and `CastLaunchRequest` was
+// built with no `startPosition` at all.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_target.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+void main() {
+  testWidgets('asks before casting, and carries the answer to the receiver',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    // 45 minutes into a 90 minute movie.
+    final link = StubLink.responses([
+      movieDetailResponse(positionSeconds: 2700),
+      streamingCandidatesResponse(duration: 5400),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: castManager,
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    container.read(castTargetProvider.notifier).set(testDevice);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(tester, () => find.text('Resume').evaluate().isNotEmpty);
+
+    expect(
+      find.text('Resume'),
+      findsOneWidget,
+      reason: 'choosing a cast device must not skip the resume question',
+    );
+
+    await tester.tap(find.text('Resume'));
+    await pumpUntil(tester, () => castManager.capturedRequest != null);
+
+    expect(
+      castManager.capturedRequest!.startPosition,
+      const Duration(seconds: 2700),
+      reason: 'the answer must reach the receiver, not be discarded',
+    );
+  });
+
+  testWidgets('start over sends the receiver to the beginning', (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    final link = StubLink.responses([
+      movieDetailResponse(positionSeconds: 2700),
+      streamingCandidatesResponse(duration: 5400),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: castManager,
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    container.read(castTargetProvider.notifier).set(testDevice);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(
+        tester, () => find.text('Start Over').evaluate().isNotEmpty);
+    await tester.tap(find.text('Start Over'));
+    await pumpUntil(tester, () => castManager.capturedRequest != null);
+
+    expect(castManager.capturedRequest!.startPosition, Duration.zero);
+  });
+
+  testWidgets('does not ask when there is nothing to resume', (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    // 12 seconds in, below kMinResumeThresholdSeconds.
+    final link = StubLink.responses([
+      movieDetailResponse(positionSeconds: 12),
+      streamingCandidatesResponse(duration: 5400),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: castManager,
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    container.read(castTargetProvider.notifier).set(testDevice);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(tester, () => castManager.capturedRequest != null);
+
+    expect(find.text('Resume'), findsNothing);
+    expect(castManager.capturedRequest!.startPosition, Duration.zero);
+  });
+}

--- a/player/test/presentation/screens/player/offline_resume_test.dart
+++ b/player/test/presentation/screens/player/offline_resume_test.dart
@@ -1,0 +1,84 @@
+// `_initializeOfflinePlayback` used to be a separate 40-line player init that
+// never reached `_openPlayerAndStart`, so the offline path never prompted,
+// never seeked, and never tracked progress. It is now a source resolver that
+// feeds the shared tail like every other path.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+void main() {
+  setUp(mockPathProviderDocumentsDirectory);
+
+  testWidgets('offline playback resolves a download and starts',
+      (tester) async {
+    final container = buildPlayerScreenContainer(
+      // Offline mode issues no GraphQL at all; the stub link must never be
+      // hit, so unlike most tests in this directory it has no scripted
+      // responses to play back and throws if a request ever reaches it.
+      link: StubLink((request, callIndex) =>
+          throw StateError('offline mode must not issue GraphQL requests')),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      downloaded: downloadedItem(runtimeMinutes: 90),
+      authStatus: AuthStatus.offlineMode,
+    );
+    addTearDown(container.dispose);
+
+    // Unlike every other test in this directory, this path exercises real
+    // `dart:io` (`File.exists`) and a real platform channel round trip
+    // (`path_provider`) via `_resolveDownloadedFilePath`. Both are genuine
+    // asynchronous I/O, not Dart timers/microtasks, so they never complete
+    // under plain `tester.pump()`: `AutomatedTestWidgetsFlutterBinding` runs
+    // the test body in a synchronous fake-async zone that `pump()` advances
+    // by a virtual `Duration` without ever yielding to the real event loop.
+    // `runAsync` breaks out of that zone, and the mount itself has to happen
+    // inside it too — a pending real Future started before entering `runAsync`
+    // is orphaned in the fake zone that scheduled it and never gets flushed
+    // afterward. The real `Future.delayed` between pumps is what actually
+    // yields control, letting the pending I/O deliver its result.
+    await tester.runAsync(() async {
+      await pumpPlayerScreen(tester, container);
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        await Future.delayed(const Duration(milliseconds: 5));
+      }
+    });
+
+    // `downloadedItem`'s path does not exist, so `_resolveDownloadedFilePath`
+    // returns null and the branch reports the re-download error. Reaching
+    // this exact message proves the offline branch ran and resolved a
+    // download, rather than failing earlier with "not available offline".
+    expect(find.textContaining('Downloaded file not found'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('offline playback without a download says so', (tester) async {
+    final container = buildPlayerScreenContainer(
+      link: StubLink((request, callIndex) =>
+          throw StateError('offline mode must not issue GraphQL requests')),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      authStatus: AuthStatus.offlineMode,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    for (var i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 20));
+    }
+
+    expect(find.textContaining('not available offline'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+}

--- a/player/test/presentation/screens/player/offline_resume_test.dart
+++ b/player/test/presentation/screens/player/offline_resume_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/connection/connection_provider.dart' as conn;
+import 'package:player/core/playback/playback_progress_store.dart';
 
 import '../../../test_utils/stub_graphql_client.dart';
 import 'player_screen_test_harness.dart';
@@ -115,6 +116,154 @@ void main() {
     }
 
     expect(find.textContaining('not available offline'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('offline playback offers to resume from local progress',
+      (tester) async {
+    // A real file for the same reason as the routing test above: a
+    // nonexistent path bails out of the offline branch before the resume
+    // decision ever runs, at the pre-existing "downloaded file not found"
+    // `setState`.
+    final tempDir =
+        Directory.systemTemp.createTempSync('mydia_offline_resume_offer_test_');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+    final tempFile = File('${tempDir.path}/arrival.mkv')
+      ..writeAsBytesSync(const [0]);
+
+    final store = InMemoryPlaybackProgressStore();
+
+    final container = buildPlayerScreenContainer(
+      link: StubLink((request, callIndex) =>
+          throw StateError('offline mode must not issue GraphQL requests')),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      downloaded: downloadedItem(filePath: tempFile.path, runtimeMinutes: 90),
+      authStatus: AuthStatus.offlineMode,
+      progressStore: store,
+    );
+    addTearDown(container.dispose);
+
+    // 45 minutes into a 90 minute movie, written by a previous offline
+    // session. Before the local store existed there was no such record and
+    // this path could never prompt.
+    await seedLocalProgress(container, positionSeconds: 2700);
+
+    // The offline branch resolves the file path through real `dart:io` I/O
+    // (see the routing test's doc comment above for why plain `pump()`
+    // cannot observe that), so this has to run inside `runAsync` and poll
+    // for the real outcome.
+    await tester.runAsync(() async {
+      await pumpPlayerScreen(tester, container);
+      await pumpUntilReal(
+        tester,
+        () => find.text('Resume').evaluate().isNotEmpty,
+      );
+    });
+
+    expect(
+      find.text('Resume'),
+      findsOneWidget,
+      reason: 'a downloaded file held entirely on disk resumes with a plain '
+          'seek, but it still has to ask',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('offline playback does not ask below the resume threshold',
+      (tester) async {
+    final tempDir = Directory.systemTemp
+        .createTempSync('mydia_offline_resume_threshold_test_');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+    final tempFile = File('${tempDir.path}/arrival.mkv')
+      ..writeAsBytesSync(const [0]);
+
+    final store = InMemoryPlaybackProgressStore();
+
+    final container = buildPlayerScreenContainer(
+      link: StubLink((request, callIndex) =>
+          throw StateError('offline mode must not issue GraphQL requests')),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      downloaded: downloadedItem(filePath: tempFile.path, runtimeMinutes: 90),
+      authStatus: AuthStatus.offlineMode,
+      progressStore: store,
+    );
+    addTearDown(container.dispose);
+
+    // 12 seconds in, below kMinResumeThresholdSeconds.
+    await seedLocalProgress(container, positionSeconds: 12);
+
+    await tester.runAsync(() async {
+      await pumpPlayerScreen(tester, container);
+      // Below the threshold, `resolveResumePlan` never asks, so
+      // `_initializePlayer` runs straight through to `_openPlayerAndStart`,
+      // which throws building a real media_kit `Player` under `flutter
+      // test` (same as the routing test above) and lands in `_error`. That
+      // is what clears the spinner and proves the resume decision settled
+      // without ever showing the dialog.
+      await pumpUntilReal(
+        tester,
+        () => find.byType(CircularProgressIndicator).evaluate().isEmpty,
+      );
+    });
+
+    expect(find.text('Resume'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+      'downloaded playback while online reconciles local progress the '
+      'server never heard about', (tester) async {
+    // Still downloaded, but back online this time: the "already downloaded"
+    // branch, not the offline one. The server has no progress at all for
+    // this movie, standing in for a session recorded entirely offline that
+    // has not been flushed yet — reconciliation has nothing to prefer over
+    // the local record.
+    final tempDir = Directory.systemTemp
+        .createTempSync('mydia_downloaded_online_resume_test_');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+    final tempFile = File('${tempDir.path}/arrival.mkv')
+      ..writeAsBytesSync(const [0]);
+
+    final store = InMemoryPlaybackProgressStore();
+
+    final container = buildPlayerScreenContainer(
+      link: StubLink.responses([movieDetailResponse()]),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      downloaded: downloadedItem(filePath: tempFile.path, runtimeMinutes: 90),
+      progressStore: store,
+    );
+    addTearDown(container.dispose);
+
+    // 45 minutes into a 90 minute movie, recorded by an earlier offline
+    // session the server never heard about.
+    await seedLocalProgress(container, positionSeconds: 2700);
+
+    await tester.runAsync(() async {
+      await pumpPlayerScreen(tester, container);
+      await pumpUntilReal(
+        tester,
+        () => find.text('Resume').evaluate().isNotEmpty,
+      );
+    });
+
+    expect(
+      find.text('Resume'),
+      findsOneWidget,
+      reason: 'the server has no progress for this movie, so the resume '
+          'prompt can only come from the reconciled local record',
+    );
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pumpAndSettle();

--- a/player/test/presentation/screens/player/offline_resume_test.dart
+++ b/player/test/presentation/screens/player/offline_resume_test.dart
@@ -3,6 +3,8 @@
 // never seeked, and never tracked progress. It is now a source resolver that
 // feeds the shared tail like every other path.
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/auth/auth_status.dart';
@@ -16,6 +18,22 @@ void main() {
 
   testWidgets('offline playback resolves a download and starts',
       (tester) async {
+    // A real file, not a path that merely looks plausible: `downloadedItem`
+    // feeds this straight to `_resolveDownloadedFilePath`, whose *first*
+    // check is `file_utils.fileExists`. A nonexistent path answers that
+    // check `false` and the offline branch bails out at the pre-existing
+    // "downloaded file not found" `setState` — before any code this task
+    // added ever runs. That bail-out sits upstream of the resume decision,
+    // the cast check, and `_openPlayerAndStart`, so a nonexistent path here
+    // would make this test pass identically against the deleted
+    // `_initializeOfflinePlayback` and against today's routing, proving
+    // nothing about which one actually ran.
+    final tempDir =
+        Directory.systemTemp.createTempSync('mydia_offline_resume_test_');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+    final tempFile = File('${tempDir.path}/arrival.mkv')
+      ..writeAsBytesSync(const [0]);
+
     final container = buildPlayerScreenContainer(
       // Offline mode issues no GraphQL at all; the stub link must never be
       // hit, so unlike most tests in this directory it has no scripted
@@ -25,36 +43,56 @@ void main() {
       connectionState: conn.ConnectionState.direct(),
       castManager: CapturingCastSessionManager(),
       proxyService: TrackingLocalProxyService(),
-      downloaded: downloadedItem(runtimeMinutes: 90),
+      downloaded: downloadedItem(filePath: tempFile.path, runtimeMinutes: 90),
       authStatus: AuthStatus.offlineMode,
     );
     addTearDown(container.dispose);
 
     // Unlike every other test in this directory, this path exercises real
-    // `dart:io` (`File.exists`) and a real platform channel round trip
-    // (`path_provider`) via `_resolveDownloadedFilePath`. Both are genuine
-    // asynchronous I/O, not Dart timers/microtasks, so they never complete
-    // under plain `tester.pump()`: `AutomatedTestWidgetsFlutterBinding` runs
-    // the test body in a synchronous fake-async zone that `pump()` advances
-    // by a virtual `Duration` without ever yielding to the real event loop.
-    // `runAsync` breaks out of that zone, and the mount itself has to happen
-    // inside it too — a pending real Future started before entering `runAsync`
-    // is orphaned in the fake zone that scheduled it and never gets flushed
-    // afterward. The real `Future.delayed` between pumps is what actually
-    // yields control, letting the pending I/O deliver its result.
+    // `dart:io` (`File.exists`) via `_resolveDownloadedFilePath`, genuine
+    // asynchronous I/O rather than a Dart timer/microtask, so it never
+    // completes under plain `tester.pump()`: `AutomatedTestWidgetsFlutterBinding`
+    // runs the test body in a synchronous fake-async zone that `pump()`
+    // advances by a virtual `Duration` without ever yielding to the real
+    // event loop. `runAsync` breaks out of that zone, and the mount itself
+    // has to happen inside it too — a pending real Future started before
+    // entering `runAsync` is orphaned in the fake zone that scheduled it and
+    // never gets flushed afterward. `pumpUntilReal`'s real `Future.delayed`
+    // between pumps is what actually yields control, letting the pending I/O
+    // deliver its result — and it polls for the outcome rather than pumping
+    // a fixed number of times, so this doesn't race a loaded machine.
     await tester.runAsync(() async {
       await pumpPlayerScreen(tester, container);
-      for (var i = 0; i < 20; i++) {
-        await tester.pump(const Duration(milliseconds: 20));
-        await Future.delayed(const Duration(milliseconds: 5));
-      }
+      await pumpUntilReal(
+        tester,
+        () => find.byType(CircularProgressIndicator).evaluate().isEmpty,
+      );
     });
 
-    // `downloadedItem`'s path does not exist, so `_resolveDownloadedFilePath`
-    // returns null and the branch reports the re-download error. Reaching
-    // this exact message proves the offline branch ran and resolved a
-    // download, rather than failing earlier with "not available offline".
-    expect(find.textContaining('Downloaded file not found'), findsOneWidget);
+    // The real file makes `_resolveDownloadedFilePath` return it on the
+    // *first* check, past the "downloaded file not found" bail-out, so
+    // execution reaches `resolveResumePlan`, `_castToTargetIfSet`, and
+    // `_openPlayerAndStart` — which constructs a real media_kit `Player()`.
+    // `flutter test` has no native mpv/FFI available, so that construction
+    // throws, and `_initializePlayer`'s outer `catch` sets `_error` to the
+    // raw `e.toString()`, with no prefix.
+    //
+    // That absence of a prefix is the discriminator: the deleted
+    // `_initializeOfflinePlayback` had its own inner `try`/`catch` that
+    // wrapped the same failure as `'Failed to play downloaded content: $e'`.
+    // Seeing the raw text instead of that prefix proves this run went
+    // through `_openPlayerAndStart`, not the old parallel init — verified by
+    // running this test against the pre-fix `player_screen.dart` (see the
+    // task report's "Fix round 1" section), where it fails on this exact
+    // assertion.
+    expect(
+      find.textContaining('Failed to play downloaded content'),
+      findsNothing,
+    );
+    expect(
+      find.textContaining('MediaKit.ensureInitialized'),
+      findsOneWidget,
+    );
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pumpAndSettle();

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -11,7 +11,10 @@
 // core Flutter design. That is why `player_screen_key_handling_test.dart`
 // only ever tested an extracted free function instead of the widget itself.
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/auth/auth_status.dart';
@@ -52,8 +55,12 @@ class FixedConnectionNotifier extends conn.ConnectionNotifier {
 }
 
 class FakeDownloadService extends Fake implements DownloadService {
+  FakeDownloadService({this.downloaded});
+
+  final DownloadedMedia? downloaded;
+
   @override
-  DownloadedMedia? getDownloadedMediaById(String mediaId) => null;
+  DownloadedMedia? getDownloadedMediaById(String mediaId) => downloaded;
 }
 
 /// Captures the [CastLaunchRequest] handed to `startCast` instead of routing
@@ -102,6 +109,46 @@ const testDevice = CastDevice(
   name: 'Living Room',
   protocol: CastProtocolKind.chromecast,
 );
+
+/// Mocks the path_provider platform channel so `getApplicationDocumentsDirectory`
+/// resolves instead of hanging.
+///
+/// `_resolveDownloadedFilePath` calls it as a fallback once the stored path
+/// misses. Under `testWidgets`, unlike plain `test()`, an unmocked platform
+/// channel does not fail fast with `MissingPluginException` — the awaiting
+/// Future simply never completes, even across repeated `tester.pump()`
+/// calls, so any test that exercises a non-null `downloaded` item hangs until
+/// the runner's watchdog kills it.
+///
+/// Register from `setUp`, not `setUpAll`: a handler registered before the
+/// per-test binding reset that precedes each `testWidgets` body does not
+/// survive into it.
+void mockPathProviderDocumentsDirectory() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    const MethodChannel('plugins.flutter.io/path_provider'),
+    (call) async => Directory.systemTemp.path,
+  );
+}
+
+/// A downloaded item whose `filePath` deliberately does not exist on disk.
+///
+/// `_resolveDownloadedFilePath` returns null for it, which is the branch these
+/// tests want: everything up to and including the resume decision runs, and
+/// playback then stops short of constructing a real media_kit `Player`, which
+/// cannot be built under `flutter test`.
+DownloadedMedia downloadedItem({int? runtimeMinutes}) => DownloadedMedia(
+      id: 'dl-1',
+      mediaId: 'movie-1',
+      title: 'Arrival',
+      quality: '1080p',
+      filePath: '/nonexistent/mydia-test/arrival.mkv',
+      fileSize: 1,
+      mediaType: 'movie',
+      downloadedAt: DateTime(2026, 1, 1),
+      runtime: runtimeMinutes,
+    );
 
 /// A well-formed `MovieDetail` response. All fields beyond the required ones
 /// (`id`, `title`, `monitored`, `addedAt`, `isFavorite`) are omitted deliberately
@@ -212,14 +259,15 @@ ProviderContainer buildPlayerScreenContainer({
   required conn.ConnectionState connectionState,
   required CapturingCastSessionManager castManager,
   required TrackingLocalProxyService proxyService,
+  DownloadedMedia? downloaded,
+  AuthStatus authStatus = AuthStatus.authenticated,
 }) {
   return ProviderContainer(overrides: [
     authStateProvider.overrideWith(
-      () => FakeAuthNotifier(
-        const AsyncValue.data(AuthStatus.authenticated),
-      ),
+      () => FakeAuthNotifier(AsyncValue.data(authStatus)),
     ),
-    downloadManagerProvider.overrideWith((ref) async => FakeDownloadService()),
+    downloadManagerProvider.overrideWith(
+        (ref) async => FakeDownloadService(downloaded: downloaded)),
     asyncGraphqlClientProvider.overrideWith((ref) async => stubClient(link)),
     serverUrlProvider.overrideWith((ref) async => 'https://mydia.test'),
     authTokenProvider.overrideWith((ref) async => 'tok'),

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -25,6 +25,9 @@ import 'package:player/core/downloads/download_providers.dart';
 import 'package:player/core/downloads/download_service.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/core/p2p/local_proxy_service.dart';
+import 'package:player/core/playback/local_playback_progress.dart';
+import 'package:player/core/playback/playback_progress_providers.dart';
+import 'package:player/core/playback/playback_progress_store.dart';
 import 'package:player/domain/models/cast_device.dart';
 import 'package:player/domain/models/download.dart';
 import 'package:player/presentation/screens/player/player_screen.dart';
@@ -157,6 +160,26 @@ DownloadedMedia downloadedItem({
       runtime: runtimeMinutes,
     );
 
+/// Writes a local progress record into a container's store before the screen
+/// mounts, standing in for a previous playback session.
+Future<void> seedLocalProgress(
+  ProviderContainer container, {
+  String mediaId = 'movie-1',
+  String mediaType = 'movie',
+  int positionSeconds = 600,
+  int durationSeconds = 5400,
+  DateTime? updatedAt,
+}) async {
+  final store = await container.read(playbackProgressStoreProvider.future);
+  await store.save(LocalPlaybackProgress(
+    mediaId: mediaId,
+    mediaType: mediaType,
+    positionSeconds: positionSeconds,
+    durationSeconds: durationSeconds,
+    updatedAt: updatedAt ?? DateTime.utc(2026, 8, 2, 12),
+  ));
+}
+
 /// A well-formed `MovieDetail` response. All fields beyond the required ones
 /// (`id`, `title`, `monitored`, `addedAt`, `isFavorite`) are omitted deliberately
 /// so the fallback chain in `_resolveRealDuration` sees nothing from progress
@@ -268,6 +291,7 @@ ProviderContainer buildPlayerScreenContainer({
   required TrackingLocalProxyService proxyService,
   DownloadedMedia? downloaded,
   AuthStatus authStatus = AuthStatus.authenticated,
+  PlaybackProgressStore? progressStore,
 }) {
   return ProviderContainer(overrides: [
     authStateProvider.overrideWith(
@@ -283,6 +307,8 @@ ProviderContainer buildPlayerScreenContainer({
     localProxyServiceProvider.overrideWithValue(proxyService),
     castSessionManagerProvider.overrideWith((ref) async => castManager),
     castSessionProvider.overrideWith((ref) => Stream.value(null)),
+    playbackProgressStoreProvider.overrideWith(
+        (ref) async => progressStore ?? InMemoryPlaybackProgressStore()),
   ]);
 }
 

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -132,18 +132,25 @@ void mockPathProviderDocumentsDirectory() {
   );
 }
 
-/// A downloaded item whose `filePath` deliberately does not exist on disk.
+/// A downloaded item pointing at [filePath].
 ///
-/// `_resolveDownloadedFilePath` returns null for it, which is the branch these
-/// tests want: everything up to and including the resume decision runs, and
-/// playback then stops short of constructing a real media_kit `Player`, which
-/// cannot be built under `flutter test`.
-DownloadedMedia downloadedItem({int? runtimeMinutes}) => DownloadedMedia(
+/// `_resolveDownloadedFilePath` checks `file_utils.fileExists(filePath)`
+/// first, before it ever falls back to `path_provider`: pass a path to a
+/// file that actually exists on disk (e.g. a real temp file the caller
+/// creates and tears down) to drive the offline branch past its "downloaded
+/// file not found" bail-out and into the shared resume/start path this test
+/// suite cares about. Pass a path that does not exist — the default used to
+/// hardcode one — to exercise that bail-out instead.
+DownloadedMedia downloadedItem({
+  required String filePath,
+  int? runtimeMinutes,
+}) =>
+    DownloadedMedia(
       id: 'dl-1',
       mediaId: 'movie-1',
       title: 'Arrival',
       quality: '1080p',
-      filePath: '/nonexistent/mydia-test/arrival.mkv',
+      filePath: filePath,
       fileSize: 1,
       mediaType: 'movie',
       downloadedAt: DateTime(2026, 1, 1),
@@ -312,5 +319,32 @@ Future<void> pumpUntil(
 }) async {
   for (var i = 0; i < maxTries && !condition(); i++) {
     await tester.pump(const Duration(milliseconds: 20));
+  }
+}
+
+/// Polls [condition] until it is satisfied or [ceiling] elapses, yielding to
+/// the real event loop between checks.
+///
+/// For tests whose `_initializePlayer` path depends on real asynchronous I/O
+/// — `dart:io` file checks, a `path_provider` platform-channel round trip
+/// (see [mockPathProviderDocumentsDirectory]'s doc comment for why those
+/// never resolve under plain `tester.pump()`) — a fixed pump-count budget is
+/// either wastefully long or, on a slower/loaded machine, flaky-short. This
+/// polls the actual outcome instead of guessing a duration, with a ceiling
+/// generous enough that hitting it means something is genuinely stuck, not
+/// just slow.
+///
+/// Must be called from inside `tester.runAsync(() async { ... })`: the real
+/// `Future.delayed` between pumps is what yields to the real event loop for
+/// pending I/O to complete, and that only takes effect inside `runAsync`.
+Future<void> pumpUntilReal(
+  WidgetTester tester,
+  bool Function() condition, {
+  Duration ceiling = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(ceiling);
+  while (!condition() && DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 20));
+    await Future.delayed(const Duration(milliseconds: 5));
   }
 }

--- a/player/test/presentation/screens/player/resume_decision_coverage_test.dart
+++ b/player/test/presentation/screens/player/resume_decision_coverage_test.dart
@@ -1,0 +1,129 @@
+// This bug has now been introduced three times: the resume decision lives
+// inside one branch, another branch is added or changed, and that branch
+// silently starts at zero. This test asserts every source reaches the
+// decision, so a seventh path cannot repeat it.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/cast/cast_target.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+import 'package:player/core/playback/playback_progress_store.dart';
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+void main() {
+  setUp(mockPathProviderDocumentsDirectory);
+
+  // Each case sets up one source and asserts the resume dialog appears with a
+  // position that comfortably clears every bound in `shouldOfferResume`. Each
+  // case is responsible for pumping the screen and waiting for its own
+  // outcome — the offline case has to poll real `dart:io` inside
+  // `tester.runAsync`, so a single generic wait after the fact would not
+  // work for every case uniformly.
+  //
+  // The "downloaded, online" source is deliberately absent here: reaching it
+  // genuinely needs the same real-temp-file/runAsync machinery
+  // `offline_resume_test.dart` already exercises for it end to end, and
+  // duplicating that setup here would not add coverage.
+  final cases = <String, Future<void> Function(WidgetTester)>{
+    'streaming, HLS': (tester) async {
+      final container = buildPlayerScreenContainer(
+        link: StubLink.responses([
+          movieDetailResponse(positionSeconds: 2700),
+          streamingCandidatesResponse(duration: 5400),
+        ]),
+        connectionState: conn.ConnectionState.direct(),
+        castManager: CapturingCastSessionManager(),
+        proxyService: TrackingLocalProxyService(),
+      );
+      addTearDown(container.dispose);
+      await pumpPlayerScreen(tester, container);
+      await pumpUntil(tester, () => find.text('Resume').evaluate().isNotEmpty);
+    },
+    'streaming, direct play': (tester) async {
+      final container = buildPlayerScreenContainer(
+        link: StubLink.responses([
+          movieDetailResponse(positionSeconds: 2700),
+          streamingCandidatesResponse(duration: 5400, directPlay: true),
+        ]),
+        connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+        castManager: CapturingCastSessionManager(),
+        proxyService: TrackingLocalProxyService(),
+      );
+      addTearDown(container.dispose);
+      await pumpPlayerScreen(tester, container);
+      await pumpUntil(tester, () => find.text('Resume').evaluate().isNotEmpty);
+    },
+    'cast target chosen before playback': (tester) async {
+      final container = buildPlayerScreenContainer(
+        link: StubLink.responses([
+          movieDetailResponse(positionSeconds: 2700),
+          streamingCandidatesResponse(duration: 5400),
+        ]),
+        connectionState: conn.ConnectionState.direct(),
+        castManager: CapturingCastSessionManager(),
+        proxyService: TrackingLocalProxyService(),
+      );
+      addTearDown(container.dispose);
+      container.read(castTargetProvider.notifier).set(testDevice);
+      await pumpPlayerScreen(tester, container);
+      await pumpUntil(tester, () => find.text('Resume').evaluate().isNotEmpty);
+    },
+    'downloaded, offline': (tester) async {
+      // AuthStatus.offlineMode is reachable here only because the harness
+      // overrides authStateProvider directly. As of this writing nothing in
+      // player/lib actually writes that status in production — the three
+      // writers were dropped by the libp2p migration and never reinstated,
+      // a known, separately tracked gap. This case still guards the offline
+      // branch itself against a future regression; it is not proof the
+      // status is reachable end to end today.
+      final tempDir =
+          Directory.systemTemp.createTempSync('mydia_resume_coverage_test_');
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      final tempFile = File('${tempDir.path}/arrival.mkv')
+        ..writeAsBytesSync(const [0]);
+
+      final store = InMemoryPlaybackProgressStore();
+      final container = buildPlayerScreenContainer(
+        // Offline mode issues no GraphQL at all.
+        link: StubLink((request, callIndex) =>
+            throw StateError('offline mode must not issue GraphQL requests')),
+        connectionState: conn.ConnectionState.direct(),
+        castManager: CapturingCastSessionManager(),
+        proxyService: TrackingLocalProxyService(),
+        downloaded: downloadedItem(filePath: tempFile.path, runtimeMinutes: 90),
+        authStatus: AuthStatus.offlineMode,
+        progressStore: store,
+      );
+      addTearDown(container.dispose);
+      await seedLocalProgress(container, positionSeconds: 2700);
+
+      // Real file, real `dart:io` I/O via `_resolveDownloadedFilePath`: has
+      // to run inside `runAsync` and poll for the real outcome, same as
+      // `offline_resume_test.dart`.
+      await tester.runAsync(() async {
+        await pumpPlayerScreen(tester, container);
+        await pumpUntilReal(
+          tester,
+          () => find.text('Resume').evaluate().isNotEmpty,
+        );
+      });
+    },
+  };
+
+  cases.forEach((name, setUpCase) {
+    testWidgets('$name asks about resuming', (tester) async {
+      await setUpCase(tester);
+
+      expect(find.text('Resume'), findsOneWidget,
+          reason: '$name must reach the single resume decision');
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+    });
+  });
+}

--- a/player/test/presentation/screens/player/seek_restart_decision_test.dart
+++ b/player/test/presentation/screens/player/seek_restart_decision_test.dart
@@ -213,7 +213,8 @@ void main() {
       // back to the start of a resumed session. The target itself (real 0)
       // must still correctly decide to restart — the bug was in how
       // `_initializePlayer` reacted afterward, covered by
-      // `shouldShowResumeDialog` below, not in this decision.
+      // `resolveResumePlan`'s override-presence handling in
+      // `resume_plan_test.dart`, not in this decision.
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
@@ -223,43 +224,6 @@ void main() {
           startOffset: const Duration(seconds: 600),
         ),
         isTrue,
-      );
-    });
-  });
-
-  group('shouldShowResumeDialog', () {
-    test(
-        'suppresses the dialog for a seek-driven restart targeting real '
-        'position 0 — the exact collision a value-based check would miss', () {
-      // `resumeOverride: 0` is what `_restartSessionAt` sets when the user
-      // sought back to the very start. A regression that checked
-      // `resumeOverride != 0` instead of `resumeOverride != null` would
-      // return true here, and this test would fail against it.
-      expect(
-        shouldShowResumeDialog(resumeOverride: 0, mounted: true),
-        isFalse,
-      );
-    });
-
-    test('suppresses the dialog for a restart targeting any other position',
-        () {
-      expect(
-        shouldShowResumeDialog(resumeOverride: 45, mounted: true),
-        isFalse,
-      );
-    });
-
-    test('allows the dialog on a fresh mount with no override', () {
-      expect(
-        shouldShowResumeDialog(resumeOverride: null, mounted: true),
-        isTrue,
-      );
-    });
-
-    test('suppresses the dialog when not mounted, even with no override', () {
-      expect(
-        shouldShowResumeDialog(resumeOverride: null, mounted: false),
-        isFalse,
       );
     });
   });

--- a/player/test/test_utils/fake_streaming_session_service.dart
+++ b/player/test/test_utils/fake_streaming_session_service.dart
@@ -7,6 +7,11 @@ class FakeStreamingSessionService implements CastStreamingSessionService {
   final List<String> started = [];
   final List<String> ended = [];
 
+  /// The file ids sessions were asked for, in order, so a test can prove a
+  /// route targeted the media it meant to. The URL no longer carries the file
+  /// id on a session-addressed HLS route, so this is the only place it shows.
+  final List<String> requestedFileIds = [];
+
   /// Ids handed out, in order. Sequential so a test can tell one attempt's
   /// session from another's.
   int _next = 0;
@@ -14,16 +19,28 @@ class FakeStreamingSessionService implements CastStreamingSessionService {
   /// When set, `start` throws with this kind instead of returning an id.
   CastFailureKind? failure;
 
+  /// The offset the fake server reports back. Tests that care about the
+  /// echoed-not-requested distinction set this to something other than
+  /// [requestedStart].
+  Duration echoedStartOffset = Duration.zero;
+  Duration? requestedStart;
+
   @override
-  Future<String> start({required String fileId, required bool transcode}) async {
+  Future<({String sessionId, Duration startOffset})> start({
+    required String fileId,
+    required bool transcode,
+    Duration startPosition = Duration.zero,
+  }) async {
     final failure = this.failure;
     if (failure != null) {
       throw CastBackendException('fake session failure', failure);
     }
 
+    requestedStart = startPosition;
+    requestedFileIds.add(fileId);
     final id = 'session-${++_next}${transcode ? '-transcode' : ''}';
     started.add(id);
-    return id;
+    return (sessionId: id, startOffset: echoedStartOffset);
   }
 
   @override


### PR DESCRIPTION
Two reported bugs, one root cause: the resume decision lived *inside* individual playback branches, so any branch that exited early never asked.

1. Casting from a resumed position always started the receiver at zero.
2. Downloaded playback never offered to resume.

There are six ways playback can start. Four of them got the decision wrong. All three `_castToTargetIfSet` call sites ran before the prompt and built a `CastLaunchRequest` with no `startPosition` at all; the offline branch bypassed the shared start path entirely; and the downloaded-while-online branch prompted only when a duration happened to resolve, which needed the server.

## What changed

**One decision point.** `ResumePlan` and `resolveResumePlan` move the question into a pure, separately testable unit, resolved once downstream of source selection and upstream of the cast/local fork. Every source now flows through it. A `null` return means the screen was disposed while the dialog was open, and every caller abandons startup rather than building a `Player` for a dead screen and leaking an FFmpeg process until the server's inactivity timeout.

**Casting honours the offset.** The resume position is baked into the server-side HLS session via FFmpeg `-ss`, and `CastSessionManager` gained a real `StreamTimeline` so receiver coordinates translate back to real media time. The **echoed** offset is authoritative, never the requested one, because the server clamps and `-ss` snaps to the nearest keyframe. Progressive routes keep offset zero and resume with a plain receiver seek, which is valid on a byte-range stream.

**Local progress for downloads.** A Hive-backed store (plain `Box<Map>`, no generated adapter, matching `HiveCastSessionStore`) records position for downloaded media, reconciled against the server newest-wins on `lastWatchedAt`, and flushed back when a connection returns.

**Cast seek.** Scrubbing a cast past what FFmpeg has written was broken the same way and now restarts the session at the target. A Chromecast reports `duration: -1` forever on these playlists, so the transcoded extent is unobservable and distance from the current position is the only available proxy — which is why this is a separate predicate from local playback's.

## No server changes

`HlsSessionSupervisor` already accepted `start_position`, the `startStreamingSession` mutation already exposed and echoed it, and `/api/v1/hls/:session_id/index.m3u8` already accepts `?token=`, which is what lets a receiver fetch a session playlist without header support. Every gap was on the player side.

This matters for version drift: an older server omits the echoed `startPosition` and correctly yields offset zero, so a newer player against an older server degrades to today's behaviour rather than mis-seeking.

## Please read before merging

**The offline half is not reachable in this release.** `AuthStatus.offlineMode` has had **zero writers** anywhere in `player/lib` since the libp2p migration (a0799ba8, January 2026) deleted the three that existed. Five readers remain, including the offline playback branch and the reconnect flush, so neither can fire today.

What ships and works is **cast resume** and **downloaded-while-online resume** — the latter has no auth gate and was genuinely broken by a null duration, which is almost certainly the path behind the original report. The offline branch and the sync-back flush are built, tested, and waiting for detection to return. That is deliberate: the store needs to exist before detection is reinstated, or there is nothing to sync.

Reinstating offline detection means writing new connectivity detection on top of libp2p. That is a feature with its own design, not a fix, and belongs in its own change.

## Two latent bugs fixed along the way

- **Cast progress corruption.** `_syncProgress` pushes the receiver position to the server every 10 seconds. Without the coordinate translation, resuming at minute 40 would have reported position 0 and overwritten the user's real progress within ten seconds. The offset and the translation land in a single commit for exactly this reason, and the guard test fails in both directions: too little translation syncs 0, too much syncs double.
- **Cast session leak.** The direct-server Chromecast route returned `hlsSessionId: null`, so `_adoptHlsSession` could never end the session it started and it survived to the inactivity timeout. That route now goes through the mutation and returns a real id.

## Behaviour users will notice

Scrubbing a cast far forward now causes a brief reload instead of silently snapping back.

## Verification

- 16 commits. Full player suite **1082 passing**, up from 1010 on master. `flutter analyze lib test`: **0 errors**.
- Every new regression test was proven to fail without its fix by swapping in the pre-change file and confirming the failure. Two tests that passed both with and without their fix were caught in review and rewritten.
- `docs/development/cast-manual-test-checklist.md` gains a resume section. Case 2 is the one worth running first: after a cast resume, confirm the server records roughly 20 minutes rather than 0.

## Known follow-ups

- Offline-mode reachability (above).
- The cast duration listener publishes the raw receiver duration without `resolveDuration`; latent only, since Chromecast reports `-1` and it is filtered.
- A restored direct-server session cannot recover its offset. Verified unreachable: `probeReceiverContentUrl` returns null unconditionally.
