### PR TITLE
refactor(library): extract shared Ffmpeg runner from four generators

### DIFF
--- a/lib/mydia/library/ffmpeg.ex
+++ b/lib/mydia/library/ffmpeg.ex
@@ -7,7 +7,8 @@ defmodule Mydia.Library.Ffmpeg do
   `ThumbnailGenerator`. All four now delegate here.
 
   Both binaries can be overridden for tests via application env
-  (`:ffmpeg_path`, `:ffprobe_path`); otherwise they are resolved from PATH.
+  (`:ffmpeg_path`, `:ffprobe_path`), which must be absolute paths; otherwise
+  they are resolved from PATH.
   """
 
   @doc """
@@ -21,16 +22,23 @@ defmodule Mydia.Library.Ffmpeg do
   to stdout (for example piping raw frame data via `-f rawvideo ... -`), so
   ffmpeg's banner and log lines on stderr don't corrupt the payload. This
   matches `PhashGenerator`'s original behavior for its pixel-extraction call.
+
+  The output is typed `binary()` rather than `String.t()` because it is not
+  always text: `PhashGenerator` reads raw grayscale pixel bytes back through
+  this function.
   """
   @spec run([String.t()], keyword()) ::
-          {:ok, String.t()} | {:error, :ffmpeg_not_found | {:ffmpeg_error, integer(), String.t()}}
+          {:ok, binary()} | {:error, :ffmpeg_not_found | {:ffmpeg_error, integer(), binary()}}
   def run(args, opts \\ []) when is_list(args) do
     invoke(executable(:ffmpeg_path, "ffmpeg"), args, opts, :ffmpeg_not_found, :ffmpeg_error)
   end
 
+  @doc """
+  Runs `ffprobe` with `args` and returns the combined stdout/stderr output.
+  """
   @spec probe([String.t()]) ::
-          {:ok, String.t()}
-          | {:error, :ffprobe_not_found | {:ffprobe_error, integer(), String.t()}}
+          {:ok, binary()}
+          | {:error, :ffprobe_not_found | {:ffprobe_error, integer(), binary()}}
   def probe(args) when is_list(args) do
     invoke(executable(:ffprobe_path, "ffprobe"), args, [], :ffprobe_not_found, :ffprobe_error)
   end
@@ -46,11 +54,12 @@ defmodule Mydia.Library.Ffmpeg do
   @spec available?() :: boolean()
   def available?, do: not is_nil(executable(:ffmpeg_path, "ffmpeg"))
 
+  # An application-env override is resolved the same way as a bare name.
+  # System.find_executable/1 accepts an absolute path and returns nil unless it
+  # names something that is actually executable, so a stale or non-executable
+  # override surfaces as :ffmpeg_not_found instead of raising inside System.cmd/3.
   defp executable(env_key, default_name) do
-    case Application.get_env(:mydia, env_key) do
-      nil -> System.find_executable(default_name)
-      path -> if File.exists?(path), do: path, else: nil
-    end
+    System.find_executable(Application.get_env(:mydia, env_key) || default_name)
   end
 
   defp invoke(nil, _args, _opts, not_found_reason, _error_tag), do: {:error, not_found_reason}

--- a/lib/mydia/library/ffmpeg.ex
+++ b/lib/mydia/library/ffmpeg.ex
@@ -1,0 +1,66 @@
+defmodule Mydia.Library.Ffmpeg do
+  @moduledoc """
+  Shared invocation of the `ffmpeg` and `ffprobe` binaries.
+
+  Before this module existed, `run_ffmpeg/1` was copy-pasted as a private
+  function into `PreviewGenerator`, `SpriteGenerator`, `PhashGenerator`, and
+  `ThumbnailGenerator`. All four now delegate here.
+
+  Both binaries can be overridden for tests via application env
+  (`:ffmpeg_path`, `:ffprobe_path`); otherwise they are resolved from PATH.
+  """
+
+  @doc """
+  Runs `ffmpeg` with `args` and returns the combined stdout/stderr output.
+
+  By default stderr is merged into the returned output (matching the
+  original behavior of three of the four generators, which write their
+  result to a file and only use the returned text for error diagnostics).
+
+  Pass `stderr_to_stdout: false` when the command writes its actual result
+  to stdout (for example piping raw frame data via `-f rawvideo ... -`), so
+  ffmpeg's banner and log lines on stderr don't corrupt the payload. This
+  matches `PhashGenerator`'s original behavior for its pixel-extraction call.
+  """
+  @spec run([String.t()], keyword()) ::
+          {:ok, String.t()} | {:error, :ffmpeg_not_found | {:ffmpeg_error, integer(), String.t()}}
+  def run(args, opts \\ []) when is_list(args) do
+    invoke(executable(:ffmpeg_path, "ffmpeg"), args, opts, :ffmpeg_not_found, :ffmpeg_error)
+  end
+
+  @spec probe([String.t()]) ::
+          {:ok, String.t()}
+          | {:error, :ffprobe_not_found | {:ffprobe_error, integer(), String.t()}}
+  def probe(args) when is_list(args) do
+    invoke(executable(:ffprobe_path, "ffprobe"), args, [], :ffprobe_not_found, :ffprobe_error)
+  end
+
+  @doc """
+  Returns true when the `ffmpeg` binary is resolvable. Used by callers that want
+  to degrade gracefully rather than fail per-file.
+
+  Only `ffmpeg` is checked; the two binaries ship together in every environment
+  this runs in (the nix devenv shell and the Alpine runtime image both install
+  them from a single package).
+  """
+  @spec available?() :: boolean()
+  def available?, do: not is_nil(executable(:ffmpeg_path, "ffmpeg"))
+
+  defp executable(env_key, default_name) do
+    case Application.get_env(:mydia, env_key) do
+      nil -> System.find_executable(default_name)
+      path -> if File.exists?(path), do: path, else: nil
+    end
+  end
+
+  defp invoke(nil, _args, _opts, not_found_reason, _error_tag), do: {:error, not_found_reason}
+
+  defp invoke(executable, args, opts, _not_found_reason, error_tag) do
+    stderr_to_stdout = Keyword.get(opts, :stderr_to_stdout, true)
+
+    case System.cmd(executable, args, stderr_to_stdout: stderr_to_stdout) do
+      {output, 0} -> {:ok, output}
+      {output, exit_code} -> {:error, {error_tag, exit_code, output}}
+    end
+  end
+end

--- a/lib/mydia/library/phash_generator.ex
+++ b/lib/mydia/library/phash_generator.ex
@@ -34,6 +34,7 @@ defmodule Mydia.Library.PhashGenerator do
 
   require Logger
 
+  alias Mydia.Library.Ffmpeg
   alias Mydia.Library.MediaFile
   alias Mydia.Library.ThumbnailGenerator
 
@@ -203,7 +204,10 @@ defmodule Mydia.Library.PhashGenerator do
       "-"
     ]
 
-    case run_ffmpeg(args) do
+    # stderr is kept out of the captured output here: ffmpeg writes the raw
+    # pixel bytes to stdout ("-"), so merging its banner/log text from
+    # stderr would corrupt the fixed-size payload checked below.
+    case Ffmpeg.run(args, stderr_to_stdout: false) do
       {:ok, output} when byte_size(output) == @hash_width * @hash_height ->
         {:ok, output}
 
@@ -300,21 +304,4 @@ defmodule Mydia.Library.PhashGenerator do
   end
 
   defp pad_number(n), do: String.pad_leading(to_string(n), 2, "0")
-
-  defp run_ffmpeg(args) do
-    ffmpeg = System.find_executable("ffmpeg")
-
-    if is_nil(ffmpeg) do
-      {:error, :ffmpeg_not_found}
-    else
-      case System.cmd(ffmpeg, args, stderr_to_stdout: false) do
-        {output, 0} ->
-          {:ok, output}
-
-        {output, exit_code} ->
-          Logger.debug("FFmpeg failed with exit code #{exit_code}")
-          {:error, {:ffmpeg_error, exit_code, output}}
-      end
-    end
-  end
 end

--- a/lib/mydia/library/preview_generator.ex
+++ b/lib/mydia/library/preview_generator.ex
@@ -36,6 +36,7 @@ defmodule Mydia.Library.PreviewGenerator do
 
   require Logger
 
+  alias Mydia.Library.Ffmpeg
   alias Mydia.Library.GeneratedMedia
   alias Mydia.Library.MediaFile
   alias Mydia.Library.ThumbnailGenerator
@@ -265,7 +266,7 @@ defmodule Mydia.Library.PreviewGenerator do
       output_path
     ]
 
-    case run_ffmpeg(args) do
+    case Ffmpeg.run(args) do
       {:ok, _output} ->
         if File.exists?(output_path) do
           :ok
@@ -304,7 +305,7 @@ defmodule Mydia.Library.PreviewGenerator do
       output_path
     ]
 
-    case run_ffmpeg(args) do
+    case Ffmpeg.run(args) do
       {:ok, _} ->
         if File.exists?(output_path) do
           {:ok, output_path}
@@ -342,22 +343,5 @@ defmodule Mydia.Library.PreviewGenerator do
 
   defp cleanup_temp_directory(temp_dir) do
     File.rm_rf(temp_dir)
-  end
-
-  defp run_ffmpeg(args) do
-    ffmpeg = System.find_executable("ffmpeg")
-
-    if is_nil(ffmpeg) do
-      {:error, :ffmpeg_not_found}
-    else
-      case System.cmd(ffmpeg, args, stderr_to_stdout: true) do
-        {output, 0} ->
-          {:ok, output}
-
-        {output, exit_code} ->
-          Logger.debug("FFmpeg failed with exit code #{exit_code}: #{output}")
-          {:error, {:ffmpeg_error, exit_code, output}}
-      end
-    end
   end
 end

--- a/lib/mydia/library/sprite_generator.ex
+++ b/lib/mydia/library/sprite_generator.ex
@@ -46,6 +46,7 @@ defmodule Mydia.Library.SpriteGenerator do
 
   require Logger
 
+  alias Mydia.Library.Ffmpeg
   alias Mydia.Library.GeneratedMedia
   alias Mydia.Library.MediaFile
   alias Mydia.Library.ThumbnailGenerator
@@ -251,7 +252,7 @@ defmodule Mydia.Library.SpriteGenerator do
       output_path
     ]
 
-    case run_ffmpeg(args) do
+    case Ffmpeg.run(args) do
       {:ok, _output} ->
         if File.exists?(output_path) do
           :ok
@@ -301,7 +302,7 @@ defmodule Mydia.Library.SpriteGenerator do
           concat_path
         ]
 
-    case run_ffmpeg(concat_args) do
+    case Ffmpeg.run(concat_args) do
       {:ok, _} ->
         # Now apply tile filter to create sprite sheet
         tile_args = [
@@ -315,7 +316,7 @@ defmodule Mydia.Library.SpriteGenerator do
           output_path
         ]
 
-        case run_ffmpeg(tile_args) do
+        case Ffmpeg.run(tile_args) do
           {:ok, _} ->
             if File.exists?(output_path) do
               {:ok, output_path}
@@ -386,7 +387,7 @@ defmodule Mydia.Library.SpriteGenerator do
           output_path
         ]
 
-    case run_ffmpeg(args) do
+    case Ffmpeg.run(args) do
       {:ok, _} ->
         if File.exists?(output_path) do
           {:ok, output_path}
@@ -461,22 +462,5 @@ defmodule Mydia.Library.SpriteGenerator do
 
   defp cleanup_temp_directory(temp_dir) do
     File.rm_rf(temp_dir)
-  end
-
-  defp run_ffmpeg(args) do
-    ffmpeg = System.find_executable("ffmpeg")
-
-    if is_nil(ffmpeg) do
-      {:error, :ffmpeg_not_found}
-    else
-      case System.cmd(ffmpeg, args, stderr_to_stdout: true) do
-        {output, 0} ->
-          {:ok, output}
-
-        {output, exit_code} ->
-          Logger.debug("FFmpeg failed with exit code #{exit_code}: #{output}")
-          {:error, {:ffmpeg_error, exit_code, output}}
-      end
-    end
   end
 end

--- a/lib/mydia/library/thumbnail_generator.ex
+++ b/lib/mydia/library/thumbnail_generator.ex
@@ -24,6 +24,7 @@ defmodule Mydia.Library.ThumbnailGenerator do
 
   require Logger
 
+  alias Mydia.Library.Ffmpeg
   alias Mydia.Library.GeneratedMedia
   alias Mydia.Library.MediaFile
 
@@ -436,7 +437,7 @@ defmodule Mydia.Library.ThumbnailGenerator do
   end
 
   defp run_and_verify(args, output_path) do
-    case run_ffmpeg(args) do
+    case Ffmpeg.run(args) do
       {:ok, _output} ->
         if File.exists?(output_path) do
           :ok
@@ -446,23 +447,6 @@ defmodule Mydia.Library.ThumbnailGenerator do
 
       {:error, reason} ->
         {:error, reason}
-    end
-  end
-
-  defp run_ffmpeg(args) do
-    ffmpeg = System.find_executable("ffmpeg")
-
-    if is_nil(ffmpeg) do
-      {:error, :ffmpeg_not_found}
-    else
-      case System.cmd(ffmpeg, args, stderr_to_stdout: true) do
-        {output, 0} ->
-          {:ok, output}
-
-        {output, exit_code} ->
-          Logger.debug("FFmpeg failed with exit code #{exit_code}: #{output}")
-          {:error, {:ffmpeg_error, exit_code, output}}
-      end
     end
   end
 

--- a/test/mydia/library/ffmpeg_test.exs
+++ b/test/mydia/library/ffmpeg_test.exs
@@ -1,0 +1,50 @@
+defmodule Mydia.Library.FfmpegTest do
+  # Mutates Application env for the binary path, so serial.
+  use ExUnit.Case, async: false
+
+  alias Mydia.Library.Ffmpeg
+
+  setup do
+    on_exit(fn ->
+      Application.delete_env(:mydia, :ffmpeg_path)
+      Application.delete_env(:mydia, :ffprobe_path)
+    end)
+
+    :ok
+  end
+
+  describe "run/1" do
+    test "returns the combined output on success" do
+      assert {:ok, output} = Ffmpeg.run(["-version"])
+      assert output =~ "ffmpeg version"
+    end
+
+    test "returns a structured error with exit code and output on failure" do
+      assert {:error, {:ffmpeg_error, code, output}} =
+               Ffmpeg.run(["-i", "/nonexistent/definitely-not-here.mkv", "-f", "null", "-"])
+
+      assert is_integer(code)
+      assert code != 0
+      assert is_binary(output)
+    end
+
+    test "returns :ffmpeg_not_found when the binary is missing" do
+      Application.put_env(:mydia, :ffmpeg_path, "/nonexistent/ffmpeg-binary")
+
+      assert {:error, :ffmpeg_not_found} = Ffmpeg.run(["-version"])
+    end
+  end
+
+  describe "probe/1" do
+    test "returns the combined output on success" do
+      assert {:ok, output} = Ffmpeg.probe(["-version"])
+      assert output =~ "ffprobe version"
+    end
+
+    test "returns :ffprobe_not_found when the binary is missing" do
+      Application.put_env(:mydia, :ffprobe_path, "/nonexistent/ffprobe-binary")
+
+      assert {:error, :ffprobe_not_found} = Ffmpeg.probe(["-version"])
+    end
+  end
+end

--- a/test/mydia/library/ffmpeg_test.exs
+++ b/test/mydia/library/ffmpeg_test.exs
@@ -13,7 +13,7 @@ defmodule Mydia.Library.FfmpegTest do
     :ok
   end
 
-  describe "run/1" do
+  describe "run/2" do
     test "returns the combined output on success" do
       assert {:ok, output} = Ffmpeg.run(["-version"])
       assert output =~ "ffmpeg version"
@@ -30,6 +30,16 @@ defmodule Mydia.Library.FfmpegTest do
 
     test "returns :ffmpeg_not_found when the binary is missing" do
       Application.put_env(:mydia, :ffmpeg_path, "/nonexistent/ffmpeg-binary")
+
+      assert {:error, :ffmpeg_not_found} = Ffmpeg.run(["-version"])
+    end
+
+    @tag :tmp_dir
+    test "returns :ffmpeg_not_found when the override is not executable", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "ffmpeg")
+      File.write!(path, "not a binary")
+      File.chmod!(path, 0o644)
+      Application.put_env(:mydia, :ffmpeg_path, path)
 
       assert {:error, :ffmpeg_not_found} = Ffmpeg.run(["-version"])
     end


### PR DESCRIPTION
Extracts the `run_ffmpeg/1` helper that was copy-pasted, near-identically, into four modules: `PreviewGenerator`, `SpriteGenerator`, `PhashGenerator`, and `ThumbnailGenerator`.

`Mydia.Library.Ffmpeg` now owns `run/2`, `probe/1`, and `available?/0`, along with the shared not-found handling. All four callers delegate to it. The return shapes are unchanged (`{:ok, output}`, `{:error, :ffmpeg_not_found}`, `{:error, {:ffmpeg_error, code, output}}`), so no surrounding `case` clause needed editing.

### One behavioural detail worth a look

Three of the four generators wrote their result to a file and used the returned text only for error diagnostics, so they merged stderr into stdout. `PhashGenerator` does not: it pipes raw pixel bytes to stdout via `-f rawvideo ... -` and then checks the payload against a fixed expected size. Merging ffmpeg's banner and log lines into that stream would corrupt it.

`run/2` therefore takes a `stderr_to_stdout:` option, defaulting to `true`, and `PhashGenerator` passes `false` to preserve its original behaviour.

`thumbnail_generator.ex` also has a separate `run_ffmpeg_thumbnail/5`, which is not a duplicate and is left alone. `run_ffprobe/1` there is likewise untouched in this PR.

### Why now

This is preparatory work for intro/credits detection, which would otherwise have added a fifth copy. It stands on its own and carries no behaviour change, so it is split out rather than bundled into that feature.

### Verification

`./dev test test/mydia/library/ test/mydia/jobs/` — 1392 tests, 0 failures, 5 skipped.

New `test/mydia/library/ffmpeg_test.exs` covers success output, structured failure with exit code, and the not-found path for both binaries.


### Review follow-ups

- `run/2` and `probe/1` now type their output as `binary()` rather than `String.t()`. `PhashGenerator` reads back raw grayscale pixel bytes, which are not valid UTF-8, so the looser type is the honest one.
- An application-env override (`:ffmpeg_path`, `:ffprobe_path`) is resolved through `System.find_executable/1` instead of `File.exists?/1`. It accepts an absolute path and returns nil unless the target is genuinely executable, so a stale or non-executable override surfaces as `:ffmpeg_not_found` rather than raising inside `System.cmd/3`. Covered by a new test using a mode-0644 file.
