### PR TITLE
fix(player): surface Apple local-network denial when casting

### DIFF
--- a/player/lib/core/cast/cast_backend.dart
+++ b/player/lib/core/cast/cast_backend.dart
@@ -52,6 +52,14 @@ enum CastFailureKind {
   /// The OS refused discovery (iOS local network denied, multicast lock failed).
   discoveryDenied,
 
+  /// The OS refused this app access to the local network, so the receiver
+  /// cannot be reached even though it is on the network.
+  ///
+  /// Distinct from [unreachable], which means the *receiver* could not reach
+  /// our media. This one is a block on our own side, so no alternate media
+  /// route fixes it.
+  localNetworkDenied,
+
   unknown,
 }
 

--- a/player/lib/core/cast/cast_session_manager.dart
+++ b/player/lib/core/cast/cast_session_manager.dart
@@ -450,6 +450,9 @@ class CastSessionManager {
 
       case CastFailureKind.connectionLost:
       case CastFailureKind.discoveryDenied:
+      // A block on our own side. No alternate media route reaches a receiver
+      // the OS will not let us open a socket to.
+      case CastFailureKind.localNetworkDenied:
       case CastFailureKind.unknown:
         return null;
     }

--- a/player/lib/core/cast/dart_cast_backend.dart
+++ b/player/lib/core/cast/dart_cast_backend.dart
@@ -112,6 +112,70 @@ CastFailureKind failureKindFor(dc.CastException e) {
   return CastFailureKind.unknown;
 }
 
+/// EHOSTUNREACH on Darwin.
+///
+/// The same number is `ENOPKG` on Linux, where EHOSTUNREACH is 113. That
+/// collision is why [looksLikeLocalNetworkDenial] checks the platform before
+/// it looks at the errno.
+const int _ehostunreachDarwin = 65;
+
+/// Whether [address] sits on a network the OS treats as local, and is
+/// therefore subject to Apple's local-network permission gate.
+///
+/// Loopback is deliberately excluded: a receiver on loopback is nonsense, and
+/// loopback traffic is never permission-gated. Carrier-grade NAT
+/// (`100.64.0.0/10`) is excluded for the same kind of reason, being carrier
+/// space rather than a home LAN.
+bool isLocalNetworkAddress(InternetAddress address) {
+  final raw = address.rawAddress;
+
+  if (address.type == InternetAddressType.IPv4) {
+    if (raw.length != 4) return false;
+    if (raw[0] == 10) return true;
+    if (raw[0] == 172 && raw[1] >= 16 && raw[1] <= 31) return true;
+    if (raw[0] == 192 && raw[1] == 168) return true;
+    // RFC 3927 link-local, what a receiver falls back to with no DHCP.
+    if (raw[0] == 169 && raw[1] == 254) return true;
+    return false;
+  }
+
+  if (address.type == InternetAddressType.IPv6) {
+    if (raw.length != 16) return false;
+    if (raw[0] == 0xfe && (raw[1] & 0xc0) == 0x80) return true; // fe80::/10
+    if ((raw[0] & 0xfe) == 0xfc) return true; // fc00::/7
+    return false;
+  }
+
+  return false;
+}
+
+/// Whether a raw `connect()` error looks like Apple's local-network permission
+/// gate rather than a receiver that is genuinely absent.
+///
+/// This is a heuristic and is knowingly imperfect. macOS and iOS expose no
+/// public API for reading local-network authorization state, and ICMP would
+/// need raw sockets Dart cannot open unprivileged, so there is no way to
+/// confirm the receiver is actually alive. A denied permission and an
+/// unplugged Chromecast produce the same errno. The message this drives is
+/// hedged for exactly that reason: it names the permission as a likely cause
+/// without asserting it.
+///
+/// [applePlatform] is injected rather than read from `Platform.isMacOS` so
+/// this stays testable for every platform on one machine, following
+/// `PlatformFeatures.computeSupportsKeyboardShortcuts`.
+bool looksLikeLocalNetworkDenial({
+  required Object error,
+  required InternetAddress? target,
+  required bool applePlatform,
+}) {
+  // Must come first: see the note on [_ehostunreachDarwin].
+  if (!applePlatform) return false;
+  if (error is! SocketException) return false;
+  if (error.osError?.errorCode != _ehostunreachDarwin) return false;
+  if (target == null) return false;
+  return isLocalNetworkAddress(target);
+}
+
 /// Maps a stream of raw discovery exceptions to the app's failure
 /// vocabulary. Extracted from [DartCastBackend]'s constructor so the exact
 /// composition wiring [BonsoirChromecastDiscovery.failures] into

--- a/player/lib/core/cast/dart_cast_backend.dart
+++ b/player/lib/core/cast/dart_cast_backend.dart
@@ -324,18 +324,14 @@ class DartCastBackend implements CastBackend {
     // `CastSessionManager.restoreSession` takes right after a fresh app
     // launch, before any discovery sweep has run.
     //
-    // reconstructDartCastDevice is called *inside* the try below, not out
-    // here: `InternetAddress(host)` throws a synchronous ArgumentError on a
+    // The declaration is hoisted out of the try so the catch below can
+    // inspect the address we tried to reach. The *assignment* stays inside:
+    // `InternetAddress(host)` throws a synchronous ArgumentError on a
     // malformed persisted host, and that needs the same translation to
     // CastBackendException everything else in this method gets — otherwise
     // a corrupt stored session surfaces as a raw ArgumentError from
     // startCast (restoreSession happens to swallow arbitrary exceptions,
     // but startCast does not).
-    // Hoisted out of the try purely so the catch below can inspect the
-    // address we tried to reach. The *assignment* stays inside, because
-    // `InternetAddress(host)` throws a synchronous ArgumentError on a
-    // malformed persisted host and needs the same translation to
-    // CastBackendException everything else here gets.
     dc.CastDevice? target;
 
     try {

--- a/player/lib/core/cast/dart_cast_backend.dart
+++ b/player/lib/core/cast/dart_cast_backend.dart
@@ -5,6 +5,7 @@ import 'package:dart_cast/dart_cast.dart' as dc;
 import 'package:flutter/foundation.dart';
 
 import '../../domain/models/cast_device.dart';
+import '../player/platform_features.dart';
 import 'bonsoir_chromecast_discovery.dart';
 import 'cast_backend.dart';
 import 'cast_capabilities.dart';
@@ -330,9 +331,15 @@ class DartCastBackend implements CastBackend {
     // a corrupt stored session surfaces as a raw ArgumentError from
     // startCast (restoreSession happens to swallow arbitrary exceptions,
     // but startCast does not).
+    // Hoisted out of the try purely so the catch below can inspect the
+    // address we tried to reach. The *assignment* stays inside, because
+    // `InternetAddress(host)` throws a synchronous ArgumentError on a
+    // malformed persisted host and needs the same translation to
+    // CastBackendException everything else here gets.
+    dc.CastDevice? target;
+
     try {
-      final target =
-          _discovered[device.id] ?? reconstructDartCastDevice(device);
+      target = _discovered[device.id] ?? reconstructDartCastDevice(device);
       if (target == null) {
         throw const CastBackendException(
           'That device is no longer on the network.',
@@ -357,11 +364,27 @@ class DartCastBackend implements CastBackend {
       throw CastBackendException(e.toString(), failureKindFor(e));
     } catch (e) {
       // dart_cast also throws raw TimeoutException (ChromecastSession.connect
-      // after 15s with no RECEIVER_STATUS) and ArgumentError
+      // after 15s with no RECEIVER_STATUS), ArgumentError
       // (DlnaSession.fromDevice when the persisted metadata is missing a
-      // control URL, or InternetAddress() on a malformed persisted host) on
-      // this path — none of those are a CastException, so nothing here
-      // would otherwise be translated before reaching the UI.
+      // control URL, or InternetAddress() on a malformed persisted host) and
+      // SocketException on this path — none of those are a CastException, so
+      // nothing here would otherwise be translated before reaching the UI.
+      //
+      // The SocketException case is worth separating out: on macOS 15+ a
+      // denied local-network permission is indistinguishable from an
+      // ordinary unreachable host except by errno, and reporting it as
+      // `unknown` sent users to their router instead of to Settings.
+      if (looksLikeLocalNetworkDenial(
+        error: e,
+        target: target?.address,
+        applePlatform: PlatformFeatures.isMacOS || PlatformFeatures.isIOS,
+      )) {
+        throw CastBackendException(
+          e.toString(),
+          CastFailureKind.localNetworkDenied,
+        );
+      }
+
       throw CastBackendException(e.toString(), CastFailureKind.unknown);
     }
   }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -342,12 +342,14 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       debugPrint('[PlayerScreen] Cast target failed, playing locally: $e');
       castNotifier.clear();
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text(e is CastBackendException
-              ? castErrorMessage(e, ref: ref)
-              : 'Failed to start casting: $e'),
-          backgroundColor: Colors.red,
-        ));
+        if (e is CastBackendException) {
+          showCastErrorSnackBar(context, e, ref: ref);
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text('Failed to start casting: $e'),
+            backgroundColor: Colors.red,
+          ));
+        }
       }
       return false;
     }
@@ -2245,10 +2247,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       }
     } on CastBackendException catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(castErrorMessage(e, ref: ref)),
-        backgroundColor: Colors.red,
-      ));
+      showCastErrorSnackBar(context, e, ref: ref);
     } catch (e) {
       // Anything that isn't a CastBackendException: the session manager
       // itself resolving (Hive, GraphQL client), or a non-typed failure from

--- a/player/lib/presentation/widgets/cast_actions.dart
+++ b/player/lib/presentation/widgets/cast_actions.dart
@@ -6,6 +6,7 @@ import '../../core/cast/cast_providers.dart';
 import '../../core/cast/cast_session_manager.dart';
 import '../../core/cast/cast_target.dart';
 import '../../core/p2p/local_proxy_service.dart';
+import '../../core/player/platform_features.dart';
 import 'cast_button.dart';
 import 'cast_device_picker.dart';
 
@@ -22,7 +23,14 @@ import 'cast_device_picker.dart';
 /// should pass it; callers that don't (like this file's own tests) get the
 /// same message minus the port hint, matching what the original method did
 /// whenever the proxy wasn't LAN-accessible.
-String castErrorMessage(CastBackendException e, {WidgetRef? ref}) {
+///
+/// [isIOS] exists only so tests can pin both platform wordings; it defaults
+/// to the real platform when omitted.
+String castErrorMessage(
+  CastBackendException e, {
+  WidgetRef? ref,
+  bool? isIOS,
+}) {
   final proxy = ref?.read(localProxyServiceProvider);
 
   switch (e.kind) {
@@ -40,6 +48,12 @@ String castErrorMessage(CastBackendException e, {WidgetRef? ref}) {
       return 'Lost the connection to the device.';
     case CastFailureKind.discoveryDenied:
       return 'Mydia needs local network permission to find cast devices.';
+    case CastFailureKind.localNetworkDenied:
+      // Hedged on purpose. errno 65 to a local address is also what an
+      // unplugged receiver looks like, and there is no API to check which.
+      final os = (isIOS ?? PlatformFeatures.isIOS) ? 'iOS' : 'macOS';
+      return 'Mydia could not reach the device. If it is powered on, $os may '
+          'be blocking local network access for Mydia.';
     case CastFailureKind.unknown:
       return 'Casting failed: ${e.message}';
   }

--- a/player/lib/presentation/widgets/cast_actions.dart
+++ b/player/lib/presentation/widgets/cast_actions.dart
@@ -65,20 +65,29 @@ String castErrorMessage(
 /// Four call sites built a byte-identical red SnackBar before this existed.
 /// Collapsing them is what gives the permission failures a single place to
 /// hang their Settings action.
+///
+/// [canOpenSettings] overrides the platform check. Tests only.
 void showCastErrorSnackBar(
   BuildContext context,
   CastBackendException e, {
   WidgetRef? ref,
+  bool? canOpenSettings,
 }) {
   // Both kinds are the same OS permission with the same fix.
   final permissionDenied = e.kind == CastFailureKind.localNetworkDenied ||
       e.kind == CastFailureKind.discoveryDenied;
 
+  // `discoveryDenied` is not Apple-only — it also covers Android's multicast
+  // lock failing — and no Android settings pane fixes that, so the remedy is
+  // gated on the platform rather than on the failure kind alone.
+  final offerSettings =
+      permissionDenied && (canOpenSettings ?? localNetworkSettingsAvailable());
+
   ScaffoldMessenger.of(context).showSnackBar(SnackBar(
     content: Text(castErrorMessage(e, ref: ref)),
     backgroundColor: Colors.red,
     duration: Duration(seconds: permissionDenied ? 8 : 4),
-    action: permissionDenied
+    action: offerSettings
         ? SnackBarAction(
             label: 'Settings',
             textColor: Colors.white,

--- a/player/lib/presentation/widgets/cast_actions.dart
+++ b/player/lib/presentation/widgets/cast_actions.dart
@@ -9,6 +9,7 @@ import '../../core/p2p/local_proxy_service.dart';
 import '../../core/player/platform_features.dart';
 import 'cast_button.dart';
 import 'cast_device_picker.dart';
+import 'local_network_settings_button.dart';
 
 /// Turn a cast failure into something the user can act on.
 ///
@@ -59,6 +60,34 @@ String castErrorMessage(
   }
 }
 
+/// Show a cast failure, with a remedy attached when one exists.
+///
+/// Four call sites built a byte-identical red SnackBar before this existed.
+/// Collapsing them is what gives the permission failures a single place to
+/// hang their Settings action.
+void showCastErrorSnackBar(
+  BuildContext context,
+  CastBackendException e, {
+  WidgetRef? ref,
+}) {
+  // Both kinds are the same OS permission with the same fix.
+  final permissionDenied = e.kind == CastFailureKind.localNetworkDenied ||
+      e.kind == CastFailureKind.discoveryDenied;
+
+  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+    content: Text(castErrorMessage(e, ref: ref)),
+    backgroundColor: Colors.red,
+    duration: Duration(seconds: permissionDenied ? 8 : 4),
+    action: permissionDenied
+        ? SnackBarAction(
+            label: 'Settings',
+            textColor: Colors.white,
+            onPressed: () => openLocalNetworkSettings(context),
+          )
+        : null,
+  ));
+}
+
 /// The shared "user tapped a cast affordance" entry point, for every screen
 /// except the player.
 ///
@@ -107,10 +136,7 @@ Future<void> pickCastDevice(BuildContext context, WidgetRef ref) async {
     );
   } on CastBackendException catch (e) {
     if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      content: Text(castErrorMessage(e, ref: ref)),
-      backgroundColor: Colors.red,
-    ));
+    showCastErrorSnackBar(context, e, ref: ref);
   } catch (e) {
     // Anything that isn't a CastBackendException: the session manager
     // itself resolving (Hive, GraphQL client), or a non-typed failure from

--- a/player/lib/presentation/widgets/cast_device_picker.dart
+++ b/player/lib/presentation/widgets/cast_device_picker.dart
@@ -8,6 +8,7 @@ import '../../core/cast/cast_capabilities.dart';
 import '../../core/cast/cast_providers.dart';
 import '../../core/theme/colors.dart';
 import '../../domain/models/cast_device.dart';
+import 'local_network_settings_button.dart';
 
 /// Shows a dialog to pick a cast receiver.
 ///
@@ -269,11 +270,13 @@ class _DiscoveryError extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           const Text(
-            'Enable local network access for Mydia in your system settings, '
-            'then try again.',
+            'Mydia cannot see cast devices until local network access is '
+            'enabled.',
             textAlign: TextAlign.center,
             style: TextStyle(color: AppColors.textSecondary),
           ),
+          const SizedBox(height: 8),
+          const LocalNetworkSettingsButton(),
         ],
       );
     }

--- a/player/lib/presentation/widgets/cast_device_picker.dart
+++ b/player/lib/presentation/widgets/cast_device_picker.dart
@@ -24,7 +24,16 @@ class CastDevicePickerDialog extends ConsumerWidget {
   /// Test seam: lets widget tests drive every async state directly.
   final AsyncValue<List<CastDevice>>? debugDevicesOverride;
 
-  const CastDevicePickerDialog({super.key, this.debugDevicesOverride});
+  /// Test seam: forces the local-network settings affordance on or off. A
+  /// `flutter test` host is never macOS or iOS as far as [PlatformFeatures]
+  /// is concerned, so the Apple branch is unreachable without this.
+  final bool? debugSettingsAvailableOverride;
+
+  const CastDevicePickerDialog({
+    super.key,
+    this.debugDevicesOverride,
+    this.debugSettingsAvailableOverride,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -58,7 +67,10 @@ class CastDevicePickerDialog extends ConsumerWidget {
             capabilities: capabilities,
             currentDeviceId: currentDevice?.id,
           ),
-          error: (error, _) => _DiscoveryError(error: error),
+          error: (error, _) => _DiscoveryError(
+            error: error,
+            settingsAvailable: debugSettingsAvailableOverride,
+          ),
         ),
       ),
       actions: [
@@ -249,7 +261,9 @@ class _ProtocolGroup extends StatelessWidget {
 class _DiscoveryError extends StatelessWidget {
   final Object error;
 
-  const _DiscoveryError({required this.error});
+  final bool? settingsAvailable;
+
+  const _DiscoveryError({required this.error, this.settingsAvailable});
 
   @override
   Widget build(BuildContext context) {
@@ -276,7 +290,7 @@ class _DiscoveryError extends StatelessWidget {
             style: TextStyle(color: AppColors.textSecondary),
           ),
           const SizedBox(height: 8),
-          const LocalNetworkSettingsButton(),
+          LocalNetworkSettingsButton(available: settingsAvailable),
         ],
       );
     }

--- a/player/lib/presentation/widgets/cast_mini_controller.dart
+++ b/player/lib/presentation/widgets/cast_mini_controller.dart
@@ -332,10 +332,7 @@ class _CastMiniControllerState extends ConsumerState<CastMiniController> {
       await manager.reconnectStoredSession();
     } on CastBackendException catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(castErrorMessage(e, ref: ref)),
-        backgroundColor: Colors.red,
-      ));
+      showCastErrorSnackBar(context, e, ref: ref);
     } catch (e) {
       debugPrint('[CastMiniController] Unexpected error reconnecting cast: $e');
       if (!mounted) return;

--- a/player/lib/presentation/widgets/local_network_settings_button.dart
+++ b/player/lib/presentation/widgets/local_network_settings_button.dart
@@ -3,6 +3,17 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/player/platform_features.dart';
 
+/// Whether this platform has a local-network permission pane worth linking to.
+///
+/// Only macOS and iOS gate local network access behind a user-visible switch.
+/// `CastFailureKind.discoveryDenied` also fires on Android when the multicast
+/// lock cannot be acquired — which no settings pane fixes — so the affordance
+/// must not follow that failure onto other platforms. Without this, an
+/// Android discovery failure offered a button that deep-linked to an Apple
+/// URL and then printed macOS instructions on a phone.
+bool localNetworkSettingsAvailable() =>
+    PlatformFeatures.isMacOS || PlatformFeatures.isIOS;
+
 /// Deep link to the OS pane that grants local-network access.
 ///
 /// The macOS anchor is version-sensitive. Apple has renamed panes before, and
@@ -30,6 +41,15 @@ String localNetworkSettingsFallback({required bool isIOS}) => isIOS
 /// Shared by [LocalNetworkSettingsButton] and by the cast error snackbar's
 /// action, so the deep link and its fallback have exactly one implementation.
 Future<void> openLocalNetworkSettings(BuildContext context) async {
+  // Defence in depth. Nothing should offer this on a platform with no such
+  // pane — both call sites check [localNetworkSettingsAvailable] first — but
+  // firing an Apple-only URL scheme on Android would fail and then print
+  // macOS instructions, which is worse than doing nothing.
+  if (!localNetworkSettingsAvailable()) {
+    debugPrint('[LocalNetworkSettings] No settings pane on this platform.');
+    return;
+  }
+
   final isIOS = PlatformFeatures.isIOS;
   var launched = false;
 
@@ -51,11 +71,23 @@ Future<void> openLocalNetworkSettings(BuildContext context) async {
 }
 
 /// Button form of [openLocalNetworkSettings], for surfaces with room for one.
+///
+/// Renders nothing on platforms with no local-network pane, so the surfaces
+/// that show it for `discoveryDenied` — which is not Apple-only — do not have
+/// to branch themselves.
 class LocalNetworkSettingsButton extends StatelessWidget {
-  const LocalNetworkSettingsButton({super.key});
+  /// Overrides the platform check. Tests only; production reads the real
+  /// platform, which a `flutter test` host can never report as Apple.
+  final bool? available;
+
+  const LocalNetworkSettingsButton({super.key, this.available});
 
   @override
   Widget build(BuildContext context) {
+    if (!(available ?? localNetworkSettingsAvailable())) {
+      return const SizedBox.shrink();
+    }
+
     return TextButton.icon(
       key: const Key('local-network-settings-button'),
       onPressed: () => openLocalNetworkSettings(context),

--- a/player/lib/presentation/widgets/local_network_settings_button.dart
+++ b/player/lib/presentation/widgets/local_network_settings_button.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../core/player/platform_features.dart';
+
+/// Deep link to the OS pane that grants local-network access.
+///
+/// The macOS anchor is version-sensitive. Apple has renamed panes before, and
+/// there is no way to ask whether a scheme will resolve before trying it,
+/// which is why [openLocalNetworkSettings] always checks the result.
+Uri localNetworkSettingsUri({required bool isIOS}) => Uri.parse(
+      isIOS
+          ? 'app-settings:'
+          : 'x-apple.systempreferences:com.apple.preference.security'
+              '?Privacy_LocalNetwork',
+    );
+
+/// What to tell the user when the deep link will not open.
+///
+/// A button that silently does nothing is worse than no button, so this text
+/// is the guaranteed floor: it always leaves the user with something they can
+/// act on by hand.
+String localNetworkSettingsFallback({required bool isIOS}) => isIOS
+    ? 'Open Settings > Mydia > Local Network and enable it.'
+    : 'Open System Settings > Privacy & Security > Local Network and '
+        'enable Mydia.';
+
+/// Opens the local-network permission pane, or explains how to reach it.
+///
+/// Shared by [LocalNetworkSettingsButton] and by the cast error snackbar's
+/// action, so the deep link and its fallback have exactly one implementation.
+Future<void> openLocalNetworkSettings(BuildContext context) async {
+  final isIOS = PlatformFeatures.isIOS;
+  var launched = false;
+
+  try {
+    launched = await launchUrl(
+      localNetworkSettingsUri(isIOS: isIOS),
+      mode: LaunchMode.externalApplication,
+    );
+  } catch (e) {
+    debugPrint('[LocalNetworkSettings] Could not open settings: $e');
+  }
+
+  if (launched || !context.mounted) return;
+
+  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+    content: Text(localNetworkSettingsFallback(isIOS: isIOS)),
+    duration: const Duration(seconds: 6),
+  ));
+}
+
+/// Button form of [openLocalNetworkSettings], for surfaces with room for one.
+class LocalNetworkSettingsButton extends StatelessWidget {
+  const LocalNetworkSettingsButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      key: const Key('local-network-settings-button'),
+      onPressed: () => openLocalNetworkSettings(context),
+      icon: const Icon(Icons.settings, size: 18),
+      label: const Text('Open Settings'),
+    );
+  }
+}

--- a/player/macos/Runner/Info.plist
+++ b/player/macos/Runner/Info.plist
@@ -36,5 +36,9 @@
 	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Mydia needs local network access to find Chromecast and DLNA devices to cast to.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_googlecast._tcp</string>
+	</array>
 </dict>
 </plist>

--- a/player/test/core/cast/dart_cast_mapping_test.dart
+++ b/player/test/core/cast/dart_cast_mapping_test.dart
@@ -556,4 +556,141 @@ void main() {
       expect(durations, [const Duration(minutes: 107)]);
     });
   });
+
+  group('isLocalNetworkAddress', () {
+    test('accepts every private and link-local IPv4 range', () {
+      for (final address in const [
+        '10.0.0.1',
+        '10.255.255.254',
+        '172.16.0.1',
+        '172.31.255.254',
+        '192.168.1.42',
+        '169.254.10.20',
+      ]) {
+        expect(isLocalNetworkAddress(InternetAddress(address)), isTrue,
+            reason: '$address should be treated as local');
+      }
+    });
+
+    test('rejects the 172.x addresses just outside the private block', () {
+      // 172.16/12 is the narrowest range and the easiest to get wrong.
+      expect(isLocalNetworkAddress(InternetAddress('172.15.0.1')), isFalse);
+      expect(isLocalNetworkAddress(InternetAddress('172.32.0.1')), isFalse);
+    });
+
+    test('rejects public, loopback and carrier-grade NAT addresses', () {
+      for (final address in const [
+        '8.8.8.8',
+        '1.1.1.1',
+        '127.0.0.1',
+        '100.64.0.1',
+      ]) {
+        expect(isLocalNetworkAddress(InternetAddress(address)), isFalse,
+            reason: '$address should not be treated as local');
+      }
+    });
+
+    test('accepts IPv6 link-local and unique-local addresses', () {
+      expect(isLocalNetworkAddress(InternetAddress('fe80::1')), isTrue);
+      expect(isLocalNetworkAddress(InternetAddress('fd00::1')), isTrue);
+    });
+
+    test('rejects IPv6 loopback and global unicast', () {
+      expect(isLocalNetworkAddress(InternetAddress('::1')), isFalse);
+      expect(isLocalNetworkAddress(InternetAddress('2001:4860:4860::8888')),
+          isFalse);
+    });
+  });
+
+  group('looksLikeLocalNetworkDenial', () {
+    const denial = SocketException(
+      'No route to host',
+      osError: OSError('No route to host', 65),
+    );
+
+    test('matches EHOSTUNREACH to a local address on an Apple platform', () {
+      expect(
+        looksLikeLocalNetworkDenial(
+          error: denial,
+          target: InternetAddress('192.168.1.42'),
+          applePlatform: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects the identical error off an Apple platform', () {
+      // errno 65 is EHOSTUNREACH on Darwin but ENOPKG on Linux, where
+      // EHOSTUNREACH is 113. Without the platform gate this would fire on
+      // an unrelated error on every non-Apple target.
+      expect(
+        looksLikeLocalNetworkDenial(
+          error: denial,
+          target: InternetAddress('192.168.1.42'),
+          applePlatform: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects other errnos', () {
+      for (final code in const [51, 61, 113]) {
+        expect(
+          looksLikeLocalNetworkDenial(
+            error: SocketException('nope', osError: OSError('nope', code)),
+            target: InternetAddress('192.168.1.42'),
+            applePlatform: true,
+          ),
+          isFalse,
+          reason: 'errno $code is not EHOSTUNREACH on Darwin',
+        );
+      }
+    });
+
+    test('rejects a SocketException carrying no OSError', () {
+      expect(
+        looksLikeLocalNetworkDenial(
+          error: const SocketException('bare'),
+          target: InternetAddress('192.168.1.42'),
+          applePlatform: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects errors that are not SocketExceptions', () {
+      expect(
+        looksLikeLocalNetworkDenial(
+          error: ArgumentError('malformed host'),
+          target: InternetAddress('192.168.1.42'),
+          applePlatform: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a public target', () {
+      expect(
+        looksLikeLocalNetworkDenial(
+          error: denial,
+          target: InternetAddress('93.184.216.34'),
+          applePlatform: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a null target', () {
+      // reconstructDartCastDevice threw before any connection was attempted,
+      // so there is nothing to blame the permission for.
+      expect(
+        looksLikeLocalNetworkDenial(
+          error: denial,
+          target: null,
+          applePlatform: true,
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/player/test/core/cast/platform_config_test.dart
+++ b/player/test/core/cast/platform_config_test.dart
@@ -26,17 +26,21 @@ void main() {
       expect(pbxproj, isNot(contains('Runner.entitlements')));
     });
 
-    test('macOS Info.plist declares local network usage', () {
+    test('macOS Info.plist declares local network usage and Bonjour service',
+        () {
       final plist = File('macos/Runner/Info.plist').readAsStringSync();
 
       expect(plist, contains('NSLocalNetworkUsageDescription'));
+      expect(plist, contains('NSBonjourServices'));
+      expect(plist, contains('_googlecast._tcp'));
     });
 
     test('Android manifest requests multicast permission', () {
       final manifest =
           File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
 
-      expect(manifest, contains('android.permission.CHANGE_WIFI_MULTICAST_STATE'));
+      expect(
+          manifest, contains('android.permission.CHANGE_WIFI_MULTICAST_STATE'));
     });
 
     test('flutter_chrome_cast is no longer a dependency', () {

--- a/player/test/presentation/widgets/cast_actions_test.dart
+++ b/player/test/presentation/widgets/cast_actions_test.dart
@@ -28,6 +28,23 @@ void main() {
 
       expect(castErrorMessage(e), contains('local network'));
     });
+
+    test('hedges when a local network denial is suspected', () {
+      const e = CastBackendException(
+        'SocketException: No route to host, errno = 65',
+        CastFailureKind.localNetworkDenied,
+      );
+
+      final macMessage = castErrorMessage(e, isIOS: false);
+      expect(macMessage, contains('macOS'));
+      expect(macMessage, contains('local network'));
+      // Hedged, not asserted: the receiver really might just be off.
+      expect(macMessage, contains('may be'));
+      // The raw socket error is never user-facing.
+      expect(macMessage, isNot(contains('errno')));
+
+      expect(castErrorMessage(e, isIOS: true), contains('iOS'));
+    });
   });
 
   group('castErrorMessage covers every failure kind', () {

--- a/player/test/presentation/widgets/cast_actions_test.dart
+++ b/player/test/presentation/widgets/cast_actions_test.dart
@@ -121,8 +121,9 @@ void main() {
   group('showCastErrorSnackBar', () {
     Future<void> pumpAndShow(
       WidgetTester tester,
-      CastFailureKind kind,
-    ) async {
+      CastFailureKind kind, {
+      bool canOpenSettings = true,
+    }) async {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: Builder(
@@ -130,6 +131,7 @@ void main() {
               onPressed: () => showCastErrorSnackBar(
                 context,
                 CastBackendException('raw', kind),
+                canOpenSettings: canOpenSettings,
               ),
               child: const Text('go'),
             ),
@@ -161,6 +163,34 @@ void main() {
 
       expect(find.byType(SnackBar), findsOneWidget);
       expect(find.byType(SnackBarAction), findsNothing);
+    });
+
+    testWidgets('offers no action for denied discovery off Apple platforms',
+        (tester) async {
+      // discoveryDenied also fires when Android cannot take the multicast
+      // lock. No Android pane fixes that, so the remedy is gated on the
+      // platform rather than on the failure kind alone.
+      await pumpAndShow(
+        tester,
+        CastFailureKind.discoveryDenied,
+        canOpenSettings: false,
+      );
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.byType(SnackBarAction), findsNothing);
+    });
+
+    testWidgets('still explains the failure when no remedy is offered',
+        (tester) async {
+      // The message must survive the button being withheld, otherwise an
+      // Android user gets a bare snackbar with nothing actionable at all.
+      await pumpAndShow(
+        tester,
+        CastFailureKind.discoveryDenied,
+        canOpenSettings: false,
+      );
+
+      expect(find.textContaining('local network'), findsOneWidget);
     });
   });
 }

--- a/player/test/presentation/widgets/cast_actions_test.dart
+++ b/player/test/presentation/widgets/cast_actions_test.dart
@@ -117,4 +117,50 @@ void main() {
       expect(icon.icon, Icons.cast_connected);
     });
   });
+
+  group('showCastErrorSnackBar', () {
+    Future<void> pumpAndShow(
+      WidgetTester tester,
+      CastFailureKind kind,
+    ) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => showCastErrorSnackBar(
+                context,
+                CastBackendException('raw', kind),
+              ),
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('go'));
+      await tester.pump();
+    }
+
+    testWidgets('offers a Settings action for a local network denial',
+        (tester) async {
+      await pumpAndShow(tester, CastFailureKind.localNetworkDenied);
+
+      expect(find.byType(SnackBarAction), findsOneWidget);
+      expect(find.text('Settings'), findsOneWidget);
+    });
+
+    testWidgets('offers a Settings action for denied discovery',
+        (tester) async {
+      await pumpAndShow(tester, CastFailureKind.discoveryDenied);
+
+      expect(find.byType(SnackBarAction), findsOneWidget);
+    });
+
+    testWidgets('offers no action for an unreachable receiver', (tester) async {
+      await pumpAndShow(tester, CastFailureKind.unreachable);
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.byType(SnackBarAction), findsNothing);
+    });
+  });
 }

--- a/player/test/presentation/widgets/cast_device_picker_test.dart
+++ b/player/test/presentation/widgets/cast_device_picker_test.dart
@@ -34,8 +34,7 @@ void main() {
     expect(find.byKey(const Key('cast-picker-searching')), findsOneWidget);
   });
 
-  testWidgets('admits it found nothing once the sweep is over',
-      (tester) async {
+  testWidgets('admits it found nothing once the sweep is over', (tester) async {
     // Otherwise a network with no receivers spins forever with no terminal
     // state and nothing for the user to act on.
     await pumpPicker(tester, devices: const AsyncValue.data([]));
@@ -128,6 +127,20 @@ void main() {
 
     expect(
         find.byKey(const Key('cast-picker-permission-denied')), findsOneWidget);
+  });
+
+  testWidgets('offers a settings button when discovery is denied',
+      (tester) async {
+    await pumpPicker(
+      tester,
+      devices: const AsyncValue.error(
+        CastBackendException('denied', CastFailureKind.discoveryDenied),
+        StackTrace.empty,
+      ),
+    );
+
+    expect(
+        find.byKey(const Key('local-network-settings-button')), findsOneWidget);
   });
 
   testWidgets('shows a generic error for other discovery failures',

--- a/player/test/presentation/widgets/cast_device_picker_test.dart
+++ b/player/test/presentation/widgets/cast_device_picker_test.dart
@@ -12,6 +12,7 @@ void main() {
     WidgetTester tester, {
     required AsyncValue<List<CastDevice>> devices,
     CastCapabilities capabilities = const CastCapabilities.full(),
+    bool? settingsAvailable,
   }) async {
     await tester.pumpWidget(ProviderScope(
       overrides: [
@@ -20,7 +21,10 @@ void main() {
       ],
       child: MaterialApp(
         home: Scaffold(
-          body: CastDevicePickerDialog(debugDevicesOverride: devices),
+          body: CastDevicePickerDialog(
+            debugDevicesOverride: devices,
+            debugSettingsAvailableOverride: settingsAvailable,
+          ),
         ),
       ),
     ));
@@ -129,7 +133,7 @@ void main() {
         find.byKey(const Key('cast-picker-permission-denied')), findsOneWidget);
   });
 
-  testWidgets('offers a settings button when discovery is denied',
+  testWidgets('offers a settings button when discovery is denied on Apple',
       (tester) async {
     await pumpPicker(
       tester,
@@ -137,10 +141,31 @@ void main() {
         CastBackendException('denied', CastFailureKind.discoveryDenied),
         StackTrace.empty,
       ),
+      settingsAvailable: true,
     );
 
     expect(
         find.byKey(const Key('local-network-settings-button')), findsOneWidget);
+  });
+
+  testWidgets('withholds the settings button off Apple platforms',
+      (tester) async {
+    // discoveryDenied also covers Android's multicast lock failing. An
+    // Apple-only deep link there fails and then prints macOS instructions,
+    // so the panel keeps its explanation and drops the button.
+    await pumpPicker(
+      tester,
+      devices: const AsyncValue.error(
+        CastBackendException('denied', CastFailureKind.discoveryDenied),
+        StackTrace.empty,
+      ),
+      settingsAvailable: false,
+    );
+
+    expect(
+        find.byKey(const Key('cast-picker-permission-denied')), findsOneWidget);
+    expect(
+        find.byKey(const Key('local-network-settings-button')), findsNothing);
   });
 
   testWidgets('shows a generic error for other discovery failures',

--- a/player/test/presentation/widgets/local_network_settings_button_test.dart
+++ b/player/test/presentation/widgets/local_network_settings_button_test.dart
@@ -40,11 +40,37 @@ void main() {
   testWidgets('LocalNetworkSettingsButton renders a tappable action',
       (tester) async {
     await tester.pumpWidget(const MaterialApp(
-      home: Scaffold(body: LocalNetworkSettingsButton()),
+      home: Scaffold(body: LocalNetworkSettingsButton(available: true)),
     ));
 
     expect(
         find.byKey(const Key('local-network-settings-button')), findsOneWidget);
     expect(find.text('Open Settings'), findsOneWidget);
+  });
+
+  testWidgets('LocalNetworkSettingsButton renders nothing off Apple platforms',
+      (tester) async {
+    // discoveryDenied also covers Android's multicast lock failing, which no
+    // settings pane fixes. Offering the button there deep-linked to an Apple
+    // URL and then printed macOS instructions on a phone.
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: LocalNetworkSettingsButton(available: false)),
+    ));
+
+    expect(
+        find.byKey(const Key('local-network-settings-button')), findsNothing);
+    expect(find.text('Open Settings'), findsNothing);
+  });
+
+  testWidgets('the default is the real platform, which a test host never is',
+      (tester) async {
+    // Guards the production default: no override means no button here.
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: LocalNetworkSettingsButton()),
+    ));
+
+    expect(localNetworkSettingsAvailable(), isFalse);
+    expect(
+        find.byKey(const Key('local-network-settings-button')), findsNothing);
   });
 }

--- a/player/test/presentation/widgets/local_network_settings_button_test.dart
+++ b/player/test/presentation/widgets/local_network_settings_button_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/local_network_settings_button.dart';
+
+void main() {
+  group('localNetworkSettingsUri', () {
+    test('points at the macOS Local Network privacy pane', () {
+      final uri = localNetworkSettingsUri(isIOS: false);
+
+      expect(uri.scheme, 'x-apple.systempreferences');
+      expect(uri.toString(), contains('Privacy_LocalNetwork'));
+    });
+
+    test('points at the iOS app settings page', () {
+      expect(localNetworkSettingsUri(isIOS: true).toString(), 'app-settings:');
+    });
+  });
+
+  group('localNetworkSettingsFallback', () {
+    test('names the macOS path', () {
+      final text = localNetworkSettingsFallback(isIOS: false);
+
+      expect(text, contains('System Settings'));
+      expect(text, contains('Local Network'));
+    });
+
+    test('names the iOS path', () {
+      final text = localNetworkSettingsFallback(isIOS: true);
+
+      expect(text, contains('Settings'));
+      expect(text, contains('Local Network'));
+    });
+
+    test('uses no em dashes in either wording', () {
+      expect(localNetworkSettingsFallback(isIOS: false), isNot(contains('—')));
+      expect(localNetworkSettingsFallback(isIOS: true), isNot(contains('—')));
+    });
+  });
+
+  testWidgets('LocalNetworkSettingsButton renders a tappable action',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: LocalNetworkSettingsButton()),
+    ));
+
+    expect(
+        find.byKey(const Key('local-network-settings-button')), findsOneWidget);
+    expect(find.text('Open Settings'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Why

Casting from macOS with local network access denied produced this:

```
Casting failed: SocketException: No route to host (OS Error: No route to host, errno = 65), address = 192.168.1.42, port = 8009
```

That sends people to their router. The actual cause is a macOS permission toggle. `DartCastBackend.connect` translated `dc.CastException` properly but flattened everything else, including `SocketException`, into `CastFailureKind.unknown` — so the failure did not even reach the `unreachable` branch whose "check your firewall" wording would have been closer.

`CastFailureKind.discoveryDenied` already existed for the discovery-side version of this exact OS gate. The connect path had no counterpart. It does now.

Separately, `macos/Runner/Info.plist` was missing the `NSBonjourServices` declaration iOS has had since ee4dd30c, and the macOS case in `platform_config_test.dart` only guarded the usage string, so nothing caught it.

## What changed

- **New `CastFailureKind.localNetworkDenied`**, raised from `connect()` when a `SocketException` carries errno 65 to an RFC-1918 / link-local address on macOS or iOS.
- **`showCastErrorSnackBar`** collapses four byte-identical red SnackBars (`cast_actions`, `cast_mini_controller`, `player_screen` x2) into one helper, which is where the Settings action hangs.
- **`LocalNetworkSettingsButton`** deep-links to the permission pane and falls back to spelling out the path when the URL scheme does not resolve. The existing `discoveryDenied` panel gains this button, which it never had.
- **`NSBonjourServices` / `_googlecast._tcp`** added to the macOS plist, with the test tightened to match iOS.

## Judgment calls worth reviewing

**The detection is a heuristic, and the copy is hedged to match.** The original idea was "EHOSTUNREACH to an address that is pingable", but Dart cannot ping — ICMP needs raw sockets. Without a reachability probe, a denied permission and an unplugged Chromecast are indistinguishable. So the message says macOS *may be* blocking rather than asserting it. An alternative that would have earned confident wording (only claim denial when the device came from a live discovery sweep) was rejected because it never fires on the `restoreSession` path.

**The platform check runs before the errno check, deliberately.** 65 is EHOSTUNREACH on Darwin but `ENOPKG` on Linux, where EHOSTUNREACH is 113. Reversing the order would misclassify on every non-Apple target. There is a test pinning exactly this.

**`connect()` only, not `loadMedia()`.** Both have the same bare catch, but reaching `loadMedia` proves the permission gate was already passed, so blaming it there would relocate the same misleading-error bug.

**Errno 65 only**, not 51. Widening trades false negatives for false positives on a message that already names macOS as a suspect.

## Testing

- Full player suite: **1129 pass** at `--concurrency=1` (the default silently drops files while exiting 0)
- `flutter analyze`: **0 errors, 0 warnings**
- 12 new unit tests on the classifier: every accepted range plus the 172.15/172.32 boundaries, public/loopback/CGNAT rejection, IPv6 link-local and ULA, non-Apple rejection, wrong errnos, non-`SocketException`, null target

**Not covered by tests:** the `launchUrl` call itself. There is no url_launcher mocking harness anywhere in this repo and inventing one for a single platform call was not worth it. The pure URI and fallback-copy functions are tested and rendering is asserted; the launch needs the manual check below.

## Manual verification still needed (macOS)

I do not have a Mac, so the end-to-end path is unverified:

1. Revoke Mydia under System Settings > Privacy & Security > Local Network
2. Cast to a powered-on Chromecast
3. Expect the hedged message plus a working `Settings` action

If step 3 shows the raw `SocketException` instead, that macOS version reports a different errno — capture the real value before widening the constant.
