### PR TITLE
feat(library): add pure fingerprint correlator for segment detection

### DIFF
--- a/lib/mydia/library/segment_detection/correlator.ex
+++ b/lib/mydia/library/segment_detection/correlator.ex
@@ -1,0 +1,190 @@
+defmodule Mydia.Library.SegmentDetection.Correlator do
+  @moduledoc """
+  Finds the longest run of near-identical audio between two fingerprint streams.
+
+  A fingerprint stream is a list of unsigned 32-bit integers, one per audio
+  frame. Two episodes of the same show share a run of near-identical frames
+  wherever they share audio, which is exactly what the opening theme and the
+  closing credits music are.
+
+  ## Why not brute force
+
+  Comparing every alignment offset is O(n^2). A 15-minute window is roughly
+  7,200 frames, so a single pair of episodes would be about 50 million
+  comparisons, multiplied again by the number of pairings and episodes. That is
+  not viable here.
+
+  Instead this module seeds and extends:
+
+  1. Index stream B as `%{key => [positions]}`, keyed on the **top 16 bits** of
+     each hash. Those are the most stable bits, so the key survives minor
+     encoding differences while keeping the map small.
+  2. Walk stream A. Each position looks up its key and votes for the alignment
+     offset `i - j`.
+  3. Verify only the highest-voted offsets with a single linear pass each,
+     using a Hamming-distance tolerance per frame.
+
+  That is O(n) lookups plus a small constant number of linear passes.
+
+  All functions here are pure. No I/O, no database, no ffmpeg.
+  """
+
+  import Bitwise
+
+  defmodule Match do
+    @moduledoc "A verified run of matching frames, positioned in the first stream."
+
+    @type t :: %__MODULE__{
+            start_frame: non_neg_integer(),
+            end_frame: non_neg_integer(),
+            offset: integer(),
+            length: pos_integer()
+          }
+
+    defstruct [:start_frame, :end_frame, :offset, :length]
+  end
+
+  # Maximum differing bits (of 32) for two frames to count as the same audio.
+  @hamming_tolerance 6
+
+  # Consecutive non-matching frames a run can absorb before it is considered
+  # finished. Survives a brief dropout without merging two distinct runs.
+  @gap_tolerance 3
+
+  # How many of the highest-voted alignment offsets get a verification pass.
+  @candidate_offsets 5
+
+  # Popcount via four byte-sized lookups, built at compile time.
+  @popcount_table (for i <- 0..255, into: %{} do
+                     {i, Enum.count(Integer.digits(i, 2), &(&1 == 1))}
+                   end)
+
+  @doc """
+  Returns the longest verified run of matching frames between `a` and `b`.
+
+  Positions in the returned `Match` are indices into `a`. `offset` is the value
+  such that `a[i]` aligns with `b[i - offset]`.
+
+  ## Options
+
+    * `:min_frames` - required. Runs shorter than this are rejected.
+  """
+  @spec best_match([non_neg_integer()], [non_neg_integer()], keyword()) ::
+          {:ok, Match.t()} | :no_match
+  def best_match(a, b, opts) do
+    min_frames = Keyword.fetch!(opts, :min_frames)
+
+    if a == [] or b == [] do
+      :no_match
+    else
+      a_tuple = List.to_tuple(a)
+      b_tuple = List.to_tuple(b)
+
+      b
+      |> build_index()
+      |> vote_offsets(a)
+      |> top_offsets()
+      |> Enum.map(&verify_offset(a_tuple, b_tuple, &1))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.filter(&(&1.length >= min_frames))
+      |> case do
+        [] -> :no_match
+        matches -> {:ok, Enum.max_by(matches, & &1.length)}
+      end
+    end
+  end
+
+  # Index by the top 16 bits: stable enough to survive re-encoding, selective
+  # enough to keep candidate lists short.
+  defp build_index(stream) do
+    stream
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {hash, position}, acc ->
+      Map.update(acc, key(hash), [position], &[position | &1])
+    end)
+  end
+
+  defp key(hash), do: hash >>> 16
+
+  defp vote_offsets(index, a) do
+    a
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {hash, i}, votes ->
+      case Map.get(index, key(hash)) do
+        nil ->
+          votes
+
+        positions ->
+          Enum.reduce(positions, votes, fn j, acc ->
+            Map.update(acc, i - j, 1, &(&1 + 1))
+          end)
+      end
+    end)
+  end
+
+  defp top_offsets(votes) do
+    votes
+    |> Enum.sort_by(fn {_offset, count} -> count end, :desc)
+    |> Enum.take(@candidate_offsets)
+    |> Enum.map(fn {offset, _count} -> offset end)
+  end
+
+  # One linear pass over `a` at a fixed alignment, tracking the longest run of
+  # frames whose Hamming distance is within tolerance.
+  defp verify_offset(a_tuple, b_tuple, offset) do
+    a_size = tuple_size(a_tuple)
+    b_size = tuple_size(b_tuple)
+
+    state = %{best: nil, run_start: nil, last_match: nil, gap: 0}
+
+    0..(a_size - 1)
+    |> Enum.reduce(state, fn i, acc ->
+      j = i - offset
+
+      if j >= 0 and j < b_size and
+           similar?(elem(a_tuple, i), elem(b_tuple, j)) do
+        %{acc | run_start: acc.run_start || i, last_match: i, gap: 0}
+      else
+        advance_gap(acc, offset)
+      end
+    end)
+    |> close_run(offset)
+    |> Map.fetch!(:best)
+  end
+
+  defp advance_gap(%{run_start: nil} = acc, _offset), do: acc
+
+  defp advance_gap(acc, offset) do
+    if acc.gap + 1 > @gap_tolerance do
+      acc |> close_run(offset) |> Map.merge(%{run_start: nil, last_match: nil, gap: 0})
+    else
+      %{acc | gap: acc.gap + 1}
+    end
+  end
+
+  defp close_run(%{run_start: nil} = acc, _offset), do: acc
+
+  defp close_run(acc, offset) do
+    match = %Match{
+      start_frame: acc.run_start,
+      end_frame: acc.last_match,
+      offset: offset,
+      length: acc.last_match - acc.run_start + 1
+    }
+
+    if is_nil(acc.best) or match.length > acc.best.length do
+      %{acc | best: match}
+    else
+      acc
+    end
+  end
+
+  defp similar?(x, y), do: popcount(bxor(x, y)) <= @hamming_tolerance
+
+  defp popcount(n) do
+    @popcount_table[n &&& 0xFF] +
+      @popcount_table[n >>> 8 &&& 0xFF] +
+      @popcount_table[n >>> 16 &&& 0xFF] +
+      @popcount_table[n >>> 24 &&& 0xFF]
+  end
+end

--- a/test/mydia/library/segment_detection/correlator_test.exs
+++ b/test/mydia/library/segment_detection/correlator_test.exs
@@ -8,14 +8,14 @@ defmodule Mydia.Library.SegmentDetection.CorrelatorTest do
   # with a different seed yields a different but reproducible stream. We avoid
   # :rand so tests never depend on global RNG state.
   defp noise(count, seed) do
-    Enum.map(1..count, fn i ->
+    Enum.map(1..count//1, fn i ->
       :erlang.phash2({seed, i}, 4_294_967_296)
     end)
   end
 
   # Flip `n` bits in the low 32 of an integer, deterministically.
   defp perturb(value, n) do
-    Enum.reduce(0..(n - 1), value, fn bit, acc ->
+    Enum.reduce(0..(n - 1)//1, value, fn bit, acc ->
       Bitwise.bxor(acc, Bitwise.bsl(1, bit))
     end)
   end

--- a/test/mydia/library/segment_detection/correlator_test.exs
+++ b/test/mydia/library/segment_detection/correlator_test.exs
@@ -1,0 +1,132 @@
+defmodule Mydia.Library.SegmentDetection.CorrelatorTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.SegmentDetection.Correlator
+  alias Mydia.Library.SegmentDetection.Correlator.Match
+
+  # Deterministic pseudo-random uint32 stream. Seeded by `seed` so each call
+  # with a different seed yields a different but reproducible stream. We avoid
+  # :rand so tests never depend on global RNG state.
+  defp noise(count, seed) do
+    Enum.map(1..count, fn i ->
+      :erlang.phash2({seed, i}, 4_294_967_296)
+    end)
+  end
+
+  # Flip `n` bits in the low 32 of an integer, deterministically.
+  defp perturb(value, n) do
+    Enum.reduce(0..(n - 1), value, fn bit, acc ->
+      Bitwise.bxor(acc, Bitwise.bsl(1, bit))
+    end)
+  end
+
+  describe "best_match/3" do
+    test "finds a shared run and reports its position in the first stream" do
+      shared = noise(200, :theme)
+
+      a = noise(50, :a_head) ++ shared ++ noise(100, :a_tail)
+      b = noise(120, :b_head) ++ shared ++ noise(30, :b_tail)
+
+      assert {:ok, %Match{} = match} = Correlator.best_match(a, b, min_frames: 100)
+
+      assert match.start_frame == 50
+      assert match.end_frame == 249
+      assert match.length == 200
+      # a-position 50 aligns with b-position 120, so offset is 50 - 120.
+      assert match.offset == -70
+    end
+
+    test "returns :no_match when the streams share nothing" do
+      a = noise(300, :x)
+      b = noise(300, :y)
+
+      assert :no_match = Correlator.best_match(a, b, min_frames: 100)
+    end
+
+    test "returns :no_match when the shared run is shorter than min_frames" do
+      shared = noise(40, :short_theme)
+
+      a = noise(50, :a2) ++ shared ++ noise(50, :a3)
+      b = noise(20, :b2) ++ shared ++ noise(80, :b3)
+
+      assert :no_match = Correlator.best_match(a, b, min_frames: 100)
+    end
+
+    test "tolerates small per-frame bit errors within the Hamming threshold" do
+      shared = noise(200, :theme)
+      # 4 flipped bits is under the tolerance of 6.
+      degraded = Enum.map(shared, &perturb(&1, 4))
+
+      a = noise(30, :a4) ++ shared ++ noise(30, :a5)
+      b = noise(60, :b4) ++ degraded ++ noise(10, :b5)
+
+      assert {:ok, %Match{} = match} = Correlator.best_match(a, b, min_frames: 100)
+      assert match.start_frame == 30
+      assert match.length == 200
+    end
+
+    test "bridges a short dropout instead of splitting the run" do
+      shared = noise(200, :theme)
+
+      # Corrupt 2 consecutive frames beyond recognition in the middle. Gap
+      # tolerance is 3, so the run should survive as one.
+      corrupted =
+        shared
+        |> Enum.with_index()
+        |> Enum.map(fn
+          {_v, i} when i in [100, 101] -> :erlang.phash2({:garbage, i}, 4_294_967_296)
+          {v, _i} -> v
+        end)
+
+      a = noise(30, :a6) ++ shared ++ noise(30, :a7)
+      b = noise(30, :b6) ++ corrupted ++ noise(30, :b7)
+
+      assert {:ok, %Match{} = match} = Correlator.best_match(a, b, min_frames: 150)
+      assert match.start_frame == 30
+      assert match.length == 200
+    end
+
+    test "finds a run that begins at the very start of both streams" do
+      shared = noise(150, :cold_open_theme)
+
+      a = shared ++ noise(100, :a8)
+      b = shared ++ noise(80, :b8)
+
+      assert {:ok, %Match{} = match} = Correlator.best_match(a, b, min_frames: 100)
+      assert match.start_frame == 0
+      assert match.length == 150
+      assert match.offset == 0
+    end
+
+    test "finds a run that ends at the very end of both streams" do
+      shared = noise(150, :credits_theme)
+
+      a = noise(100, :a9) ++ shared
+      b = noise(40, :b9) ++ shared
+
+      assert {:ok, %Match{} = match} = Correlator.best_match(a, b, min_frames: 100)
+      assert match.start_frame == 100
+      assert match.end_frame == 249
+      assert match.length == 150
+    end
+
+    test "prefers the longer run when two candidate offsets both match" do
+      short_shared = noise(120, :bumper)
+      long_shared = noise(300, :theme)
+
+      a = noise(20, :a10) ++ short_shared ++ noise(20, :a11) ++ long_shared
+      b = noise(50, :b10) ++ long_shared ++ noise(50, :b11) ++ short_shared
+
+      assert {:ok, %Match{} = match} = Correlator.best_match(a, b, min_frames: 100)
+
+      # The 300-frame run starts at a-position 20 + 120 + 20 = 160.
+      assert match.start_frame == 160
+      assert match.length == 300
+    end
+
+    test "returns :no_match for empty streams" do
+      assert :no_match = Correlator.best_match([], [], min_frames: 10)
+      assert :no_match = Correlator.best_match(noise(100, :a12), [], min_frames: 10)
+    end
+  end
+end


### PR DESCRIPTION
Adds `Mydia.Library.SegmentDetection.Correlator`, the matching core of the
intro/credits detection work. Given two Chromaprint fingerprint streams (one
uint32 per audio frame), it finds the longest run of near-identical frames and
the offset that aligns them. That run is the opening theme or the closing
credits music: the audio two episodes of the same show actually share.

## Why seed-and-extend

Comparing every alignment offset is O(n^2). At Chromaprint's roughly 8 frames
per second a 15-minute window is about 7,200 frames, so one episode pair is
about 50 million comparisons, multiplied again by 5 pairings and every episode
in a season. That is not viable in Elixir.

Instead:

1. Index one stream as `%{key => [positions]}` keyed on the top 16 bits of each
   hash. Those are the most stable bits, so the key survives minor encoding
   differences while keeping the map small.
2. Walk the other stream. Each position looks up its key and votes for the
   alignment offset `i - j`.
3. Verify only the 5 highest-voted offsets, one linear pass each, applying
   `popcount(a XOR b) <= 6` per frame and tracking the longest contiguous run.
   Gaps of up to 3 frames are absorbed so a brief dropout does not split one
   run into two.

That is O(n) map lookups plus a small constant number of linear passes.

## Purity

The module has no I/O, no database, no ffmpeg, and no processes. That is
deliberate: it is the piece holding the algorithm, and keeping it pure is what
lets the whole thing be tested against synthetic integer streams with no
fixtures and no media files. The surrounding ffmpeg and Oban plumbing lands in
later changes and calls into this.

## Tuning constants

Hamming tolerance (6 of 32 bits), gap tolerance (3 frames), and candidate
offset count (5) are module attributes in one place. They are first guesses and
will be retuned once this runs against real media.

## Tests

`test/mydia/library/segment_detection/correlator_test.exs`, 9 tests, no
fixtures. Streams are built from `:erlang.phash2/2` rather than `:rand` so
nothing depends on global RNG state. Coverage: a planted run recovered at the
exact position and offset, streams that share nothing rejected, a run below
`min_frames` rejected, a degraded copy matched within the Hamming threshold, a
2-frame dropout bridged instead of splitting the run, runs flush against the
start and the end of both streams, competing candidate offsets where the longer
verified run wins, and empty input.

Full suite result on this branch: 9 tests, 0 failures. `mix credo --strict` and
`mix compile --warnings-as-errors` both clean.
