### PR TITLE
feat(library): add fingerprint content type to GeneratedMedia

### DIFF
--- a/lib/mydia/library/generated_media.ex
+++ b/lib/mydia/library/generated_media.ex
@@ -22,6 +22,7 @@ defmodule Mydia.Library.GeneratedMedia do
   - `:sprite` - Sprite sheets for scrubber timeline (JPG)
   - `:vtt` - WebVTT files mapping timestamps to sprite coordinates
   - `:preview` - Preview video clips (MP4)
+  - `:fingerprint` - Cached Chromaprint audio fingerprints (FPR)
 
   ## Configuration
 
@@ -29,15 +30,21 @@ defmodule Mydia.Library.GeneratedMedia do
   Defaults to `/data/generated` in production (Docker) or `priv/generated` in dev.
   """
 
-  @type content_type :: :cover | :sprite | :vtt | :preview
+  @type content_type :: :cover | :sprite | :vtt | :preview | :fingerprint
   @type checksum :: String.t()
 
   @extensions %{
     cover: ".jpg",
     sprite: ".jpg",
     vtt: ".vtt",
-    preview: ".mp4"
+    preview: ".mp4",
+    fingerprint: ".fpr"
   }
+
+  # Single source of truth for the guards below. Previously each function
+  # repeated this list inline, which made adding a type a six-site change and
+  # any omission a runtime FunctionClauseError rather than a compile error.
+  @content_types [:cover, :sprite, :vtt, :preview, :fingerprint]
 
   @doc """
   Stores binary content and returns the checksum.
@@ -46,7 +53,7 @@ defmodule Mydia.Library.GeneratedMedia do
   structure, and writes the file. Returns the checksum on success.
 
   ## Parameters
-    - `type` - The content type (`:cover`, `:sprite`, `:vtt`, `:preview`)
+    - `type` - The content type (`:cover`, `:sprite`, `:vtt`, `:preview`, `:fingerprint`)
     - `content` - Binary content to store
 
   ## Returns
@@ -60,7 +67,7 @@ defmodule Mydia.Library.GeneratedMedia do
   """
   @spec store(content_type(), binary()) :: {:ok, checksum()} | {:error, term()}
   def store(type, content)
-      when type in [:cover, :sprite, :vtt, :preview] and is_binary(content) do
+      when type in @content_types and is_binary(content) do
     checksum = compute_checksum(content)
     path = build_path(type, checksum)
 
@@ -91,7 +98,7 @@ defmodule Mydia.Library.GeneratedMedia do
   """
   @spec store_file(content_type(), Path.t()) :: {:ok, checksum()} | {:error, term()}
   def store_file(type, source_path)
-      when type in [:cover, :sprite, :vtt, :preview] and is_binary(source_path) do
+      when type in @content_types and is_binary(source_path) do
     case File.read(source_path) do
       {:ok, content} ->
         store(type, content)
@@ -117,7 +124,7 @@ defmodule Mydia.Library.GeneratedMedia do
       "/data/generated/covers/ab/c1/abc123def456.jpg"
   """
   @spec get_path(content_type(), checksum()) :: Path.t()
-  def get_path(type, checksum) when type in [:cover, :sprite, :vtt, :preview] do
+  def get_path(type, checksum) when type in @content_types do
     build_path(type, checksum)
   end
 
@@ -132,7 +139,7 @@ defmodule Mydia.Library.GeneratedMedia do
     - `true` if the file exists, `false` otherwise
   """
   @spec exists?(content_type(), checksum()) :: boolean()
-  def exists?(type, checksum) when type in [:cover, :sprite, :vtt, :preview] do
+  def exists?(type, checksum) when type in @content_types do
     type
     |> get_path(checksum)
     |> File.exists?()
@@ -150,7 +157,7 @@ defmodule Mydia.Library.GeneratedMedia do
     - `{:error, reason}` on failure
   """
   @spec delete(content_type(), checksum()) :: :ok | {:error, term()}
-  def delete(type, checksum) when type in [:cover, :sprite, :vtt, :preview] do
+  def delete(type, checksum) when type in @content_types do
     path = get_path(type, checksum)
 
     case File.rm(path) do
@@ -186,7 +193,7 @@ defmodule Mydia.Library.GeneratedMedia do
     - The URL path (e.g., "/generated/covers/ab/c1/abc123.jpg")
   """
   @spec url_path(content_type(), checksum()) :: String.t()
-  def url_path(type, checksum) when type in [:cover, :sprite, :vtt, :preview] do
+  def url_path(type, checksum) when type in @content_types do
     ext = Map.fetch!(@extensions, type)
     {tier1, tier2} = split_checksum_tiers(checksum)
     type_dir = type_directory(type)
@@ -214,6 +221,7 @@ defmodule Mydia.Library.GeneratedMedia do
   defp type_directory(:sprite), do: "sprites"
   defp type_directory(:vtt), do: "vtt"
   defp type_directory(:preview), do: "previews"
+  defp type_directory(:fingerprint), do: "fingerprints"
 
   defp compute_checksum(content) do
     :crypto.hash(:md5, content)

--- a/lib/mydia/library/generated_media.ex
+++ b/lib/mydia/library/generated_media.ex
@@ -44,7 +44,10 @@ defmodule Mydia.Library.GeneratedMedia do
   # Single source of truth for the guards below. Previously each function
   # repeated this list inline, which made adding a type a six-site change and
   # any omission a runtime FunctionClauseError rather than a compile error.
-  @content_types [:cover, :sprite, :vtt, :preview, :fingerprint]
+  #
+  # Derived from @extensions rather than restated, so a new type cannot be added
+  # to one and forgotten in the other. Sorted for a stable compile-time value.
+  @content_types @extensions |> Map.keys() |> Enum.sort()
 
   @doc """
   Stores binary content and returns the checksum.

--- a/test/mydia/library/generated_media_fingerprint_test.exs
+++ b/test/mydia/library/generated_media_fingerprint_test.exs
@@ -1,0 +1,74 @@
+defmodule Mydia.Library.GeneratedMediaFingerprintTest do
+  use ExUnit.Case, async: false
+
+  alias Mydia.Library.GeneratedMedia
+
+  @content "1234567,2345678,3456789"
+
+  setup do
+    test_dir =
+      Path.join([System.tmp_dir!(), "generated_media_fingerprint_test_#{:rand.uniform(100_000)}"])
+
+    File.mkdir_p!(test_dir)
+
+    Application.put_env(:mydia, :generated_media_path, test_dir)
+
+    on_exit(fn ->
+      File.rm_rf!(test_dir)
+      Application.delete_env(:mydia, :generated_media_path)
+    end)
+
+    {:ok, test_dir: test_dir}
+  end
+
+  test "stores and reads back a fingerprint" do
+    assert {:ok, checksum} = GeneratedMedia.store(:fingerprint, @content)
+    assert GeneratedMedia.exists?(:fingerprint, checksum)
+
+    path = GeneratedMedia.get_path(:fingerprint, checksum)
+    assert Path.extname(path) == ".fpr"
+    assert File.read!(path) == @content
+
+    assert :ok = GeneratedMedia.delete(:fingerprint, checksum)
+    refute GeneratedMedia.exists?(:fingerprint, checksum)
+  end
+
+  test "identical content deduplicates to one checksum" do
+    assert {:ok, a} = GeneratedMedia.store(:fingerprint, @content)
+    assert {:ok, b} = GeneratedMedia.store(:fingerprint, @content)
+    assert a == b
+
+    GeneratedMedia.delete(:fingerprint, a)
+  end
+
+  test "stores a fingerprint from a file on disk", %{test_dir: test_dir} do
+    source_path = Path.join(test_dir, "source.fpr")
+    File.write!(source_path, @content)
+
+    assert {:ok, checksum} = GeneratedMedia.store_file(:fingerprint, source_path)
+    assert GeneratedMedia.exists?(:fingerprint, checksum)
+    assert File.read!(GeneratedMedia.get_path(:fingerprint, checksum)) == @content
+  end
+
+  test "builds a url path for a fingerprint" do
+    checksum = "abc123def456789012345678901234ab"
+
+    assert GeneratedMedia.url_path(:fingerprint, checksum) ==
+             "/generated/fingerprints/ab/c1/#{checksum}.fpr"
+  end
+
+  test "fingerprints are stored under their own directory", %{test_dir: test_dir} do
+    {:ok, checksum} = GeneratedMedia.store(:fingerprint, @content)
+
+    expected_path =
+      Path.join([
+        test_dir,
+        "fingerprints",
+        String.slice(checksum, 0, 2),
+        String.slice(checksum, 2, 2),
+        "#{checksum}.fpr"
+      ])
+
+    assert File.exists?(expected_path)
+  end
+end

--- a/test/mydia/library/generated_media_fingerprint_test.exs
+++ b/test/mydia/library/generated_media_fingerprint_test.exs
@@ -6,8 +6,14 @@ defmodule Mydia.Library.GeneratedMediaFingerprintTest do
   @content "1234567,2345678,3456789"
 
   setup do
+    # System.unique_integer/1 is collision-free within the VM, unlike
+    # :rand.uniform/1, so a leftover directory from an earlier run or a
+    # concurrent test cannot collide with this one.
     test_dir =
-      Path.join([System.tmp_dir!(), "generated_media_fingerprint_test_#{:rand.uniform(100_000)}"])
+      Path.join([
+        System.tmp_dir!(),
+        "generated_media_fingerprint_test_#{System.unique_integer([:positive])}"
+      ])
 
     File.mkdir_p!(test_dir)
 


### PR DESCRIPTION
## What

Adds a `:fingerprint` content type to `Mydia.Library.GeneratedMedia`, stored with the `.fpr` extension under `generated/fingerprints/`.

This is groundwork for intro/credits detection. Cached Chromaprint fingerprints are what let a newly aired episode be analyzed against its season without re-decoding every season-mate again. Nothing writes fingerprints yet; this only opens the storage slot.

## The five-guard trap

The accepted type list was repeated inline in the guards of `store/2`, `store_file/2`, `get_path/2`, `exists?/2` and `delete/2`. It turned out to be **six** sites, not five: `url_path/2` carries the same guard, and the private `type_directory/1` dispatches on the same atoms by clause. Missing any of them produces a `FunctionClauseError` at runtime rather than a compile error.

The list now lives in a single `@content_types` module attribute that every guard references, so the next type is a one-line change.

## Tests

`test/mydia/library/generated_media_fingerprint_test.exs` exercises the round trip through the public API rather than asserting on `@extensions`, which is what actually catches a missed guard:

- store, `exists?`, `get_path` (extension is `.fpr`), read back, `delete`, `exists?` again
- content-addressable dedup: identical content yields one checksum
- `store_file/2` from a file on disk
- `url_path/2` output
- on-disk layout lands under `fingerprints/xx/xx/`

Local run: **23 tests, 0 failures** across the new file and the pre-existing `generated_media_test.exs` (18 pre-existing, unchanged). `mix format --check-formatted` clean, `mix credo --strict` clean on the changed module.
