### PR TITLE
feat(library): add media_segments table and segment analysis state

### DIFF
--- a/lib/mydia/library/media_file.ex
+++ b/lib/mydia/library/media_file.ex
@@ -27,6 +27,11 @@ defmodule Mydia.Library.MediaFile do
           vtt_blob: String.t() | nil,
           preview_blob: String.t() | nil,
           phash: String.t() | nil,
+          segment_analysis_state: String.t(),
+          segments_analyzed_at: DateTime.t() | nil,
+          segment_analysis_attempts: integer(),
+          last_segment_analysis_error: String.t() | nil,
+          fingerprint_blob: String.t() | nil,
           generated_at: DateTime.t() | nil,
           trashed_at: DateTime.t() | nil,
           relative_path: String.t() | nil,
@@ -62,6 +67,14 @@ defmodule Mydia.Library.MediaFile do
     field :phash, :string
     field :generated_at, :utc_datetime
 
+    # Intro/credits segment detection state, mirroring the analyzed_at /
+    # analysis_attempts / last_analysis_error triple used by FileAnalysis.
+    field :segment_analysis_state, :string, default: "pending"
+    field :segments_analyzed_at, :utc_datetime
+    field :segment_analysis_attempts, :integer, default: 0
+    field :last_segment_analysis_error, :string
+    field :fingerprint_blob, :string
+
     # Soft-delete: files missing from disk are trashed for 30 days before permanent deletion
     field :trashed_at, :utc_datetime
 
@@ -72,6 +85,7 @@ defmodule Mydia.Library.MediaFile do
     belongs_to :media_item, Mydia.Media.MediaItem
     belongs_to :episode, Mydia.Media.Episode
     belongs_to :quality_profile, Mydia.Settings.QualityProfile
+    has_many :segments, Mydia.Library.MediaSegment, on_replace: :delete
     belongs_to :supersedes_media_file, __MODULE__, foreign_key: :supersedes_media_file_id
 
     timestamps(type: :utc_datetime)
@@ -142,6 +156,11 @@ defmodule Mydia.Library.MediaFile do
       :vtt_blob,
       :preview_blob,
       :phash,
+      :segment_analysis_state,
+      :segments_analyzed_at,
+      :segment_analysis_attempts,
+      :last_segment_analysis_error,
+      :fingerprint_blob,
       :generated_at,
       :trashed_at,
       :supersedes_media_file_id
@@ -191,6 +210,11 @@ defmodule Mydia.Library.MediaFile do
       :vtt_blob,
       :preview_blob,
       :phash,
+      :segment_analysis_state,
+      :segments_analyzed_at,
+      :segment_analysis_attempts,
+      :last_segment_analysis_error,
+      :fingerprint_blob,
       :generated_at,
       :trashed_at
     ])

--- a/lib/mydia/library/media_file.ex
+++ b/lib/mydia/library/media_file.ex
@@ -85,7 +85,7 @@ defmodule Mydia.Library.MediaFile do
     belongs_to :media_item, Mydia.Media.MediaItem
     belongs_to :episode, Mydia.Media.Episode
     belongs_to :quality_profile, Mydia.Settings.QualityProfile
-    has_many :segments, Mydia.Library.MediaSegment, on_replace: :delete
+    has_many :segments, Mydia.Library.MediaSegment
     belongs_to :supersedes_media_file, __MODULE__, foreign_key: :supersedes_media_file_id
 
     timestamps(type: :utc_datetime)

--- a/lib/mydia/library/media_segment.ex
+++ b/lib/mydia/library/media_segment.ex
@@ -1,0 +1,79 @@
+defmodule Mydia.Library.MediaSegment do
+  @moduledoc """
+  A detected region of a media file that a viewer may want to skip.
+
+  Exactly one segment per `type` per file. `source` records how the segment was
+  found so the operator can tell a chapter-marker hit (always trustworthy) from
+  a fingerprint consensus (scored by `confidence`).
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @types ~w(intro credits)
+  @sources ~w(chapters fingerprint)
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          media_file_id: binary(),
+          type: String.t(),
+          start_ms: integer(),
+          end_ms: integer(),
+          source: String.t(),
+          confidence: float(),
+          media_file: Mydia.Library.MediaFile.t() | Ecto.Association.NotLoaded.t(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "media_segments" do
+    field :type, :string
+    field :start_ms, :integer
+    field :end_ms, :integer
+    field :source, :string
+    field :confidence, :float
+
+    belongs_to :media_file, Mydia.Library.MediaFile
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc "Returns the valid segment types."
+  @spec types() :: [String.t()]
+  def types, do: @types
+
+  @doc "Returns the valid segment sources."
+  @spec sources() :: [String.t()]
+  def sources, do: @sources
+
+  @doc """
+  Changeset for creating or updating a segment.
+  """
+  def changeset(segment, attrs) do
+    segment
+    |> cast(attrs, [:media_file_id, :type, :start_ms, :end_ms, :source, :confidence])
+    |> validate_required([:media_file_id, :type, :start_ms, :end_ms, :source, :confidence])
+    |> validate_inclusion(:type, @types)
+    |> validate_inclusion(:source, @sources)
+    |> validate_number(:start_ms, greater_than_or_equal_to: 0)
+    |> validate_number(:confidence, greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0)
+    |> validate_end_after_start()
+    |> foreign_key_constraint(:media_file_id)
+    |> unique_constraint([:media_file_id, :type],
+      name: :media_segments_media_file_id_type_index
+    )
+  end
+
+  defp validate_end_after_start(changeset) do
+    start_ms = get_field(changeset, :start_ms)
+    end_ms = get_field(changeset, :end_ms)
+
+    if is_integer(start_ms) and is_integer(end_ms) and end_ms <= start_ms do
+      add_error(changeset, :end_ms, "must be greater than start_ms")
+    else
+      changeset
+    end
+  end
+end

--- a/priv/repo/migrations/20260731130000_create_media_segments.exs
+++ b/priv/repo/migrations/20260731130000_create_media_segments.exs
@@ -1,0 +1,26 @@
+defmodule Mydia.Repo.Migrations.CreateMediaSegments do
+  use Ecto.Migration
+
+  # Purely additive: a brand new table. No ALTER COLUMN, so this needs no
+  # SQLite/Postgres branching.
+  def change do
+    create table(:media_segments, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :media_file_id,
+          references(:media_files, type: :binary_id, on_delete: :delete_all),
+          null: false
+
+      add :type, :string, null: false
+      add :start_ms, :integer, null: false
+      add :end_ms, :integer, null: false
+      add :source, :string, null: false
+      add :confidence, :float, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:media_segments, [:media_file_id])
+    create unique_index(:media_segments, [:media_file_id, :type])
+  end
+end

--- a/priv/repo/migrations/20260731130100_add_segment_analysis_to_media_files.exs
+++ b/priv/repo/migrations/20260731130100_add_segment_analysis_to_media_files.exs
@@ -1,0 +1,21 @@
+defmodule Mydia.Repo.Migrations.AddSegmentAnalysisToMediaFiles do
+  use Ecto.Migration
+
+  # Purely additive: new columns only. No ALTER COLUMN, so this needs no
+  # SQLite/Postgres branching.
+  #
+  # last_segment_analysis_error is :text rather than :string to match the
+  # existing last_analysis_error column: ffmpeg and fpcalc failures routinely
+  # run past the varchar(255) that :string means on Postgres.
+  def change do
+    alter table(:media_files) do
+      add :segment_analysis_state, :string, default: "pending", null: false
+      add :segments_analyzed_at, :utc_datetime
+      add :segment_analysis_attempts, :integer, default: 0, null: false
+      add :last_segment_analysis_error, :text
+      add :fingerprint_blob, :string
+    end
+
+    create index(:media_files, [:segment_analysis_state])
+  end
+end

--- a/test/mydia/library/media_segment_test.exs
+++ b/test/mydia/library/media_segment_test.exs
@@ -1,0 +1,90 @@
+defmodule Mydia.Library.MediaSegmentTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Library.MediaSegment
+  alias Mydia.Repo
+
+  defp valid_attrs(media_file) do
+    %{
+      media_file_id: media_file.id,
+      type: "intro",
+      start_ms: 30_000,
+      end_ms: 90_000,
+      source: "fingerprint",
+      confidence: 0.8
+    }
+  end
+
+  test "inserts a valid segment" do
+    media_file = media_file_fixture()
+
+    assert {:ok, segment} =
+             %MediaSegment{} |> MediaSegment.changeset(valid_attrs(media_file)) |> Repo.insert()
+
+    assert segment.type == "intro"
+    assert segment.start_ms == 30_000
+  end
+
+  test "rejects an unknown type" do
+    media_file = media_file_fixture()
+    attrs = %{valid_attrs(media_file) | type: "recap"}
+
+    assert {:error, changeset} = %MediaSegment{} |> MediaSegment.changeset(attrs) |> Repo.insert()
+    assert %{type: _} = errors_on(changeset)
+  end
+
+  test "rejects an unknown source" do
+    media_file = media_file_fixture()
+    attrs = %{valid_attrs(media_file) | source: "guesswork"}
+
+    assert {:error, changeset} = %MediaSegment{} |> MediaSegment.changeset(attrs) |> Repo.insert()
+    assert %{source: _} = errors_on(changeset)
+  end
+
+  test "rejects end_ms not after start_ms" do
+    media_file = media_file_fixture()
+    attrs = %{valid_attrs(media_file) | start_ms: 90_000, end_ms: 90_000}
+
+    assert {:error, changeset} = %MediaSegment{} |> MediaSegment.changeset(attrs) |> Repo.insert()
+    assert %{end_ms: _} = errors_on(changeset)
+  end
+
+  test "rejects confidence outside 0.0..1.0" do
+    media_file = media_file_fixture()
+    attrs = %{valid_attrs(media_file) | confidence: 1.5}
+
+    assert {:error, changeset} = %MediaSegment{} |> MediaSegment.changeset(attrs) |> Repo.insert()
+    assert %{confidence: _} = errors_on(changeset)
+  end
+
+  test "enforces one segment per type per file" do
+    media_file = media_file_fixture()
+    attrs = valid_attrs(media_file)
+
+    assert {:ok, _} = %MediaSegment{} |> MediaSegment.changeset(attrs) |> Repo.insert()
+    assert {:error, changeset} = %MediaSegment{} |> MediaSegment.changeset(attrs) |> Repo.insert()
+    assert %{media_file_id: _} = errors_on(changeset)
+  end
+
+  test "deletes segments when the media file is deleted" do
+    media_file = media_file_fixture()
+
+    {:ok, segment} =
+      %MediaSegment{} |> MediaSegment.changeset(valid_attrs(media_file)) |> Repo.insert()
+
+    Repo.delete!(media_file)
+
+    refute Repo.get(MediaSegment, segment.id)
+  end
+
+  test "media files default to pending segment analysis state" do
+    media_file = media_file_fixture()
+
+    assert media_file.segment_analysis_state == "pending"
+    assert media_file.segment_analysis_attempts == 0
+    assert is_nil(media_file.segments_analyzed_at)
+    assert is_nil(media_file.fingerprint_blob)
+  end
+end


### PR DESCRIPTION
## What

Adds the persistence layer for intro and credits detection: a new `media_segments`
table, an `Mydia.Library.MediaSegment` schema, and the per-file analysis state that
the background detector will drive.

This is schema only. Nothing writes to these tables yet.

### `media_segments`

One row per skippable region of a file. Unique on `(media_file_id, type)`, plain
index on `media_file_id`, and `ON DELETE CASCADE` off `media_files` so deleting a
file takes its segments with it.

| Column | Type | Notes |
|---|---|---|
| `id` | `binary_id` | autogenerated |
| `media_file_id` | `binary_id` | FK to `media_files` |
| `type` | `string` | `"intro"` or `"credits"` |
| `start_ms` / `end_ms` | `integer` | milliseconds |
| `source` | `string` | `"chapters"` or `"fingerprint"` |
| `confidence` | `float` | 0.0 to 1.0 |

`source` and `confidence` exist for operator visibility and for a server-side
confidence floor later. Neither is meant to reach the player.

### New `media_files` columns

These mirror the existing `analyzed_at` / `analysis_attempts` / `last_analysis_error`
triple that `Mydia.Jobs.FileAnalysis` already uses, so the state-driven worker
pattern transfers directly.

- `segment_analysis_state` (defaults to `"pending"`)
- `segments_analyzed_at`
- `segment_analysis_attempts` (defaults to 0)
- `last_segment_analysis_error`
- `fingerprint_blob`, a checksum key into `GeneratedMedia`, following the existing
  `sprite_blob` / `vtt_blob` / `preview_blob` convention

## Database portability

Both migrations are purely additive: a new table plus new columns. No `ALTER COLUMN`,
so no adapter branching and no `Mydia.Repo.Migrations.Helpers`. They run unchanged on
SQLite and PostgreSQL.

`last_segment_analysis_error` is `:text` rather than `:string`, matching the existing
`last_analysis_error` column. ffmpeg and fingerprint failures routinely run past the
`varchar(255)` that `:string` means on PostgreSQL.

## Testing

`test/mydia/library/media_segment_test.exs`, 8 tests: valid insert, unknown type,
unknown source, `end_ms` not after `start_ms`, confidence outside 0.0 to 1.0, the
one-segment-per-type-per-file constraint, cascade delete through the foreign key, and
the `media_files` defaults.

Full `mix precommit` on SQLite: 6046 tests, 0 failures.
