### PR TITLE
feat(library): refine detected credits end with blackdetect

### DIFF
--- a/lib/mydia/library/segment_detection/boundary.ex
+++ b/lib/mydia/library/segment_detection/boundary.ex
@@ -1,0 +1,123 @@
+defmodule Mydia.Library.SegmentDetection.Boundary do
+  @moduledoc """
+  Snaps a detected credits end to the picture's actual end.
+
+  Fingerprinting locates the credits *music*. The music and the picture rarely
+  stop at the same instant, so the raw fingerprint end can leave a few seconds
+  of black on screen or cut the last card off. Running `blackdetect` over a
+  narrow window around the detected end and taking the last black transition
+  fixes that cheaply.
+
+  Every failure path returns the original value. This is a refinement, so a
+  missing binary, an unreadable file, or partial ffmpeg output must degrade to
+  "good enough", never to an error the caller has to handle.
+  """
+
+  require Logger
+
+  alias Mydia.Library.Ffmpeg
+
+  # How far either side of the detected end to look.
+  @window_ms 20_000
+
+  # blackdetect tuning: minimum black duration in seconds, and the picture
+  # threshold. These are ffmpeg's own defaults apart from a shorter minimum
+  # duration, since credits-to-black transitions are brief.
+  #
+  # MEASURED CONFIRMATION 2026-08-03, do not "clean this up" back to the default.
+  # ffmpeg's default d is 2.0 seconds. Real credits-to-black transitions are far
+  # shorter: on a sampled episode the transition at the detected credits end was
+  # 0.125s long. With the default d=2.0 blackdetect reported NOTHING over that
+  # window; with d=0.05 it found the transition. Reverting this constant does not
+  # break loudly, it just makes refine_end/2 silently never refine anything.
+  @min_black_duration "0.05"
+  @picture_threshold "0.98"
+
+  @doc """
+  Returns a refined end timestamp in milliseconds, or `end_ms` unchanged.
+  """
+  @spec refine_end(String.t(), integer()) :: integer()
+  def refine_end(path, end_ms) when is_binary(path) and is_integer(end_ms) do
+    {window_start_ms, window_length_ms} = search_window(end_ms)
+
+    args = [
+      "-nostdin",
+      "-ss",
+      to_string(window_start_ms / 1000),
+      "-t",
+      to_string(window_length_ms / 1000),
+      "-i",
+      path,
+      "-vf",
+      "blackdetect=d=#{@min_black_duration}:pic_th=#{@picture_threshold}",
+      "-an",
+      "-f",
+      "null",
+      "-"
+    ]
+
+    case Ffmpeg.run(args) do
+      {:ok, output} ->
+        output
+        |> parse_black_intervals(window_start_ms)
+        |> pick_end(end_ms)
+
+      {:error, reason} ->
+        Logger.debug("Skipping credits boundary refinement",
+          path: path,
+          reason: inspect(reason)
+        )
+
+        end_ms
+    end
+  end
+
+  @doc """
+  Returns `{window_start_ms, window_length_ms}` for the blackdetect pass.
+
+  The window is `end_ms` plus or minus #{@window_ms} ms, clamped at the start of
+  the file. Clamping shortens the window instead of sliding it forward, so an
+  end near the start of the file never searches beyond `end_ms + #{@window_ms}`.
+
+  Public for testing.
+  """
+  @spec search_window(integer()) :: {non_neg_integer(), non_neg_integer()}
+  def search_window(end_ms) when is_integer(end_ms) do
+    window_start_ms = max(end_ms - @window_ms, 0)
+    window_end_ms = max(end_ms + @window_ms, 0)
+
+    {window_start_ms, window_end_ms - window_start_ms}
+  end
+
+  @doc """
+  Extracts absolute `black_start` times in milliseconds from blackdetect output.
+
+  blackdetect reports times relative to the trimmed input, because the window is
+  cut with `-ss`, so `window_start_ms` is added back to make them absolute.
+
+  Unparseable text is skipped rather than raised on. blackdetect output is
+  interleaved with the rest of ffmpeg's logging and can be truncated partway
+  through a line.
+  """
+  @spec parse_black_intervals(String.t(), integer()) :: [integer()]
+  def parse_black_intervals(output, window_start_ms) when is_binary(output) do
+    ~r/black_start:([0-9]+(?:\.[0-9]+)?)/
+    |> Regex.scan(output, capture: :all_but_first)
+    |> Enum.flat_map(fn [value] ->
+      case Float.parse(value) do
+        {seconds, _rest} -> [window_start_ms + round(seconds * 1000)]
+        :error -> []
+      end
+    end)
+  end
+
+  @doc """
+  Chooses the refined end from the detected black starts.
+
+  The latest transition wins: credits fade to black at their end, and any
+  earlier black is a transition *within* the credits.
+  """
+  @spec pick_end([integer()], integer()) :: integer()
+  def pick_end([], end_ms), do: end_ms
+  def pick_end(candidates, _end_ms), do: Enum.max(candidates)
+end

--- a/lib/mydia/library/segment_detection/boundary.ex
+++ b/lib/mydia/library/segment_detection/boundary.ex
@@ -99,8 +99,11 @@ defmodule Mydia.Library.SegmentDetection.Boundary do
   interleaved with the rest of ffmpeg's logging and can be truncated partway
   through a line.
   """
-  @spec parse_black_intervals(String.t(), integer()) :: [integer()]
-  def parse_black_intervals(output, window_start_ms) when is_binary(output) do
+  # binary() rather than String.t(): this parses whatever `Ffmpeg.run/2` hands
+  # back, and that output is not guaranteed to be valid UTF-8.
+  @spec parse_black_intervals(binary(), integer()) :: [integer()]
+  def parse_black_intervals(output, window_start_ms)
+      when is_binary(output) and is_integer(window_start_ms) do
     ~r/black_start:([0-9]+(?:\.[0-9]+)?)/
     |> Regex.scan(output, capture: :all_but_first)
     |> Enum.flat_map(fn [value] ->

--- a/test/mydia/library/segment_detection/boundary_test.exs
+++ b/test/mydia/library/segment_detection/boundary_test.exs
@@ -1,5 +1,6 @@
 defmodule Mydia.Library.SegmentDetection.BoundaryTest do
-  # refine_end/2 mutates Application env for the ffmpeg path, so serial.
+  # These tests set :ffmpeg_path in Application env to point refine_end/2 at a
+  # stub binary. That is global state, so the file runs serially.
   use ExUnit.Case, async: false
 
   alias Mydia.Library.Ffmpeg

--- a/test/mydia/library/segment_detection/boundary_test.exs
+++ b/test/mydia/library/segment_detection/boundary_test.exs
@@ -1,0 +1,125 @@
+defmodule Mydia.Library.SegmentDetection.BoundaryTest do
+  # refine_end/2 mutates Application env for the ffmpeg path, so serial.
+  use ExUnit.Case, async: false
+
+  alias Mydia.Library.Ffmpeg
+  alias Mydia.Library.SegmentDetection.Boundary
+
+  setup do
+    on_exit(fn -> Application.delete_env(:mydia, :ffmpeg_path) end)
+
+    :ok
+  end
+
+  describe "parse_black_intervals/2" do
+    test "extracts black start times and offsets them by the window start" do
+      output = """
+      [blackdetect @ 0x55] black_start:2.5 black_end:3.1 black_duration:0.6
+      [blackdetect @ 0x55] black_start:18.25 black_end:20 black_duration:1.75
+      """
+
+      # Window began at 1_300_000ms, so times are relative to that.
+      assert Boundary.parse_black_intervals(output, 1_300_000) == [1_302_500, 1_318_250]
+    end
+
+    test "parses ffmpeg's real output, including whole-second timestamps" do
+      output =
+        "[Parsed_blackdetect_0 @ 0x703384003700] " <>
+          "black_start:19 black_end:19.5 black_duration:0.5\n"
+
+      assert Boundary.parse_black_intervals(output, 6_000) == [25_000]
+    end
+
+    test "returns an empty list when no black interval was reported" do
+      assert Boundary.parse_black_intervals("no detections here", 0) == []
+    end
+
+    test "ignores malformed black_start values" do
+      output = "[blackdetect] black_start:abc black_end:1.0\n"
+
+      assert Boundary.parse_black_intervals(output, 0) == []
+    end
+
+    test "keeps the detections that precede a truncated final line" do
+      output = "[blackdetect] black_start:4.0 black_end:4.5\n[blackdetect] black_st"
+
+      assert Boundary.parse_black_intervals(output, 0) == [4_000]
+    end
+  end
+
+  describe "pick_end/2" do
+    test "snaps to the latest black start inside the window" do
+      assert Boundary.pick_end([1_290_000, 1_310_000], 1_300_000) == 1_310_000
+    end
+
+    test "keeps the original end when there are no candidates" do
+      assert Boundary.pick_end([], 1_300_000) == 1_300_000
+    end
+  end
+
+  describe "search_window/1" do
+    test "spans the detected end plus and minus the window" do
+      assert {1_280_000, 40_000} = Boundary.search_window(1_300_000)
+    end
+
+    test "clamps at the start of the file without searching past the end" do
+      assert {0, 25_000} = Boundary.search_window(5_000)
+    end
+  end
+
+  describe "refine_end/2" do
+    test "returns the original end when ffmpeg cannot run" do
+      Application.put_env(:mydia, :ffmpeg_path, "/nonexistent/ffmpeg-binary")
+
+      assert Boundary.refine_end("/some/file.mkv", 1_300_000) == 1_300_000
+    end
+
+    test "returns the original end when ffmpeg cannot read the file" do
+      assert Boundary.refine_end("/nonexistent/definitely-not-here.mkv", 1_300_000) == 1_300_000
+    end
+
+    @tag :tmp_dir
+    test "snaps the end back to the black cut in a generated clip", %{tmp_dir: tmp_dir} do
+      # 25s white, then a 0.5s black cut, then 4.5s more white. The true picture
+      # end is at 25_000ms; a fingerprint-derived end lands a second past it.
+      #
+      # The black cut is deliberately shorter than blackdetect's default minimum
+      # duration of 2.0s, so this fails if @min_black_duration is reverted.
+      path = Path.join(tmp_dir, "credits.mp4")
+
+      assert {:ok, _} =
+               Ffmpeg.run([
+                 "-nostdin",
+                 "-y",
+                 "-f",
+                 "lavfi",
+                 "-i",
+                 "color=c=white:s=64x48:r=10:d=25",
+                 "-f",
+                 "lavfi",
+                 "-i",
+                 "color=c=black:s=64x48:r=10:d=0.5",
+                 "-f",
+                 "lavfi",
+                 "-i",
+                 "color=c=white:s=64x48:r=10:d=4.5",
+                 "-filter_complex",
+                 "[0:v][1:v][2:v]concat=n=3:v=1:a=0[out]",
+                 "-map",
+                 "[out]",
+                 "-c:v",
+                 "libx264",
+                 "-preset",
+                 "ultrafast",
+                 "-pix_fmt",
+                 "yuv420p",
+                 path
+               ])
+
+      refined = Boundary.refine_end(path, 26_000)
+
+      assert refined != 26_000
+      assert_in_delta refined, 25_000, 200
+    end
+  end
+end


### PR DESCRIPTION
Task 7 of the intro/credits detection plan.

Fingerprinting locates the credits *music*, and the music rarely stops at the same instant the picture does. `Mydia.Library.SegmentDetection.Boundary.refine_end/2` runs ffmpeg's `blackdetect` over a narrow window around the fingerprint-derived end and snaps to the last black transition found. When no transition turns up, the original end stands unchanged.

Nothing calls this yet. It lands ahead of the per-season worker that will consume it.

### What is in here

- `refine_end(path, end_ms) :: integer()` always returns an integer. A missing binary, an unreadable file, or partial ffmpeg output degrades to the input value.
- `parse_black_intervals/2` adds the window start back to blackdetect's timestamps. The window is cut with `-ss`, so blackdetect reports positions relative to the trim, not to the file.
- `search_window/1` returns the plus-or-minus-20s window, clamped at the start of the file.
- `pick_end/2` takes the latest transition. Earlier black is a transition *within* the credits.

### The one constant worth knowing about

`@min_black_duration` is `"0.05"`. ffmpeg's own default for blackdetect's `d` is 2.0 seconds, which is far longer than a real credits-to-black transition. On a sampled episode the transition at the detected credits end lasted 0.125s: with `d=2.0` blackdetect reported nothing over that window, with `d=0.05` it found the cut. Reverting the constant does not break loudly, it just makes `refine_end/2` silently stop refining anything.

The last test in the file pins it. A generated 30s clip carries a 0.5s black cut at 25s, `refine_end(path, 26_000)` has to snap back to 25s, and the cut is deliberately shorter than 2.0s so the default value fails the assertion. The same test covers the `-ss` offset arithmetic end to end, since a window starting at 6s means blackdetect reports 19s for a cut at 25s.

The same measurement puts the true black cut about 1.1s ahead of the fingerprint-derived end, so the design's plus-or-minus-20s window has plenty of room.

### Tests

12 tests, 0 failures. Parsing covers the offset arithmetic, ffmpeg's real whole-second output format, absent detections, malformed values, and a truncated final line. `refine_end/2` covers a missing binary, an unreadable file, and the generated-clip snap.

Builds on the shared `Ffmpeg` runner from #305, already merged, so this diff is just the two new files.
