### PR TITLE
feat(library): add chapter marker fast path for segment detection

### DIFF
--- a/lib/mydia/library/segment_detection/chapters.ex
+++ b/lib/mydia/library/segment_detection/chapters.ex
@@ -42,7 +42,17 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
 
   alias Mydia.Library.Ffmpeg
 
-  @typedoc "Segment type key (intro or credits) mapped to a {start_ms, end_ms} tuple."
+  @typedoc """
+  Detected segments, keyed by type, each mapped to a `{start_ms, end_ms}` tuple.
+
+  The only keys ever produced are `"intro"` and `"credits"`, and either may be
+  absent since each type resolves independently. The spec cannot say so:
+  Elixir has no singleton string literal type, so every key is `String.t()` to
+  the type system. The narrow contract is pinned on `classify/1`, which returns
+  `:intro | :credits | :unknown`; these keys are `Atom.to_string/1` of that.
+  Strings rather than atoms because the key crosses into the
+  `media_segments.type` column and out through GraphQL.
+  """
   @type segments :: %{optional(String.t()) => {non_neg_integer(), non_neg_integer()}}
 
   # Normalised (lowercase, unaccented, punctuation-free) whole titles.

--- a/lib/mydia/library/segment_detection/chapters.ex
+++ b/lib/mydia/library/segment_detection/chapters.ex
@@ -154,9 +154,16 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
   defp chapter_title(_chapter), do: nil
 
   defp to_ms(value) when is_binary(value) do
+    # Float.parse/1 accepts a partial parse, so "12.3oops" comes back as
+    # {12.3, "oops"}. Treat leftover text as malformed rather than silently
+    # trusting the prefix: a wrong timestamp is worse than no timestamp,
+    # because it ships a skip button that jumps to the wrong place.
     case Float.parse(value) do
-      {seconds, _rest} -> {:ok, round(seconds * 1000)}
-      :error -> :error
+      {seconds, rest} ->
+        if String.trim(rest) == "", do: {:ok, round(seconds * 1000)}, else: :error
+
+      :error ->
+        :error
     end
   end
 

--- a/lib/mydia/library/segment_detection/chapters.ex
+++ b/lib/mydia/library/segment_detection/chapters.ex
@@ -1,0 +1,182 @@
+defmodule Mydia.Library.SegmentDetection.Chapters do
+  @moduledoc """
+  Reads container chapter markers and classifies them as intro or credits.
+
+  Many well-mastered releases label their opening and ending. Reading those
+  labels costs milliseconds and is strictly more accurate than any heuristic,
+  so this runs before the fingerprinting path. Recall is limited (a sizeable
+  share of files carry no chapter markers at all), which is why it is a fast
+  path rather than the engine.
+
+  Resolution is per segment type. A file whose chapters name an opening but not
+  an ending resolves only `"intro"`, and its credits window still needs
+  fingerprinting.
+
+  ## Why matching is on whole titles
+
+  A survey of 60 episode files from a real library found 129 titled chapters.
+  The near misses are more common than the true positives:
+
+    * `Prologue` (16 occurrences) is the cold open that runs *before* the
+      opening theme. Calling it an intro would skip real story content.
+    * `Preview` (15) is the next-episode teaser that runs *after* the ending.
+    * `Epilogue` (12) is a post-credits scene.
+
+  Compare those against `Intro` (2) and `Credits` (2): a sloppy matcher is
+  wrong far more often than it is right on this data.
+
+  So the title is lowercased, stripped of accents and punctuation, split into
+  tokens, and the whole token sequence is compared for equality against the
+  known titles. Nothing is ever matched as a substring, and no single token in
+  a longer title is enough on its own:
+
+    * Substring matching would be catastrophic for the two-letter titles.
+      `OP` and `ED` occur inside a large fraction of English words, so `ed`
+      alone would match `Wedding` and `Predator`, and `op` would match `Stop`
+      and `Cooper`.
+    * Matching any single token would still be wrong for the longer words.
+      `The Credits Union Heist` contains the token `credits` but is a plot
+      chapter, and `Opening Credits` has to resolve as an intro rather than as
+      credits, which only the full sequence can decide.
+  """
+
+  alias Mydia.Library.Ffmpeg
+
+  @typedoc "Segment type key (intro or credits) mapped to a {start_ms, end_ms} tuple."
+  @type segments :: %{optional(String.t()) => {non_neg_integer(), non_neg_integer()}}
+
+  # Normalised (lowercase, unaccented, punctuation-free) whole titles.
+  @intro_titles [
+    "intro",
+    "opening",
+    "op",
+    "opening credits",
+    "opening titles",
+    "main titles",
+    "title sequence",
+    "theme",
+    "opening theme",
+    "vorspann",
+    "generique de debut",
+    "sigla iniziale",
+    "apertura"
+  ]
+
+  @credits_titles [
+    "credits",
+    "end credits",
+    "ending",
+    "ed",
+    "closing credits",
+    "closing",
+    "end titles",
+    "outro",
+    "ending theme",
+    "abspann",
+    "generique de fin",
+    "sigla finale",
+    "creditos finales"
+  ]
+
+  @doc """
+  Runs ffprobe against `path` and returns any recognisable chapter segments.
+
+  The returned map is keyed by segment type (`"intro"`, `"credits"`) with
+  `{start_ms, end_ms}` values. A file with no recognisable chapters yields
+  `{:ok, %{}}`, which is a successful result and not an error.
+  """
+  @spec detect(String.t()) :: {:ok, segments()} | {:error, term()}
+  def detect(path) when is_binary(path) do
+    args = ["-v", "quiet", "-print_format", "json", "-show_chapters", path]
+
+    case Ffmpeg.probe(args) do
+      {:ok, output} -> parse_chapters(output)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Parses ffprobe `-show_chapters` JSON into recognisable segments.
+
+  Separated from `detect/1` so it can be tested against fixture JSON without
+  invoking ffprobe. Each segment type resolves independently, and the first
+  chapter matching a type wins: a release carrying both `Opening` and `Intro`
+  is describing the same thing twice.
+  """
+  @spec parse_chapters(String.t()) :: {:ok, segments()} | {:error, term()}
+  def parse_chapters(json) when is_binary(json) do
+    case Jason.decode(json) do
+      {:ok, %{"chapters" => chapters}} when is_list(chapters) ->
+        {:ok, Enum.reduce(chapters, %{}, &collect/2)}
+
+      {:ok, _without_chapters} ->
+        {:ok, %{}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Classifies a chapter title as `:intro`, `:credits`, or `:unknown`.
+
+  Comparison is against the whole normalised title. Accents and punctuation are
+  stripped so "Générique de début" matches, and standalone numbers are dropped
+  so the numbered variants common in anime ("OP1", "Ending 2") match their
+  unnumbered form. No substring matching is done, and a matching token inside a
+  longer title is not a match.
+  """
+  @spec classify(String.t() | nil) :: :intro | :credits | :unknown
+  def classify(nil), do: :unknown
+
+  def classify(title) when is_binary(title) do
+    case normalise(title) do
+      normalised when normalised in @intro_titles -> :intro
+      normalised when normalised in @credits_titles -> :credits
+      _unrecognised -> :unknown
+    end
+  end
+
+  defp collect(chapter, acc) do
+    with type when type != :unknown <- classify(chapter_title(chapter)),
+         key = Atom.to_string(type),
+         false <- Map.has_key?(acc, key),
+         {:ok, start_ms} <- to_ms(chapter["start_time"]),
+         {:ok, end_ms} <- to_ms(chapter["end_time"]),
+         true <- end_ms > start_ms do
+      Map.put(acc, key, {start_ms, end_ms})
+    else
+      _no_usable_span -> acc
+    end
+  end
+
+  defp chapter_title(%{"tags" => %{"title" => title}}) when is_binary(title), do: title
+  defp chapter_title(_chapter), do: nil
+
+  defp to_ms(value) when is_binary(value) do
+    case Float.parse(value) do
+      {seconds, _rest} -> {:ok, round(seconds * 1000)}
+      :error -> :error
+    end
+  end
+
+  defp to_ms(value) when is_number(value), do: {:ok, round(value * 1000)}
+  defp to_ms(_value), do: :error
+
+  # Lowercase, strip accents, split letter/digit runs apart ("ED1" -> "ed 1"),
+  # replace punctuation with whitespace, then drop standalone numbers so
+  # variant numbering does not defeat the match.
+  defp normalise(title) do
+    title
+    |> String.downcase()
+    |> :unicode.characters_to_nfd_binary()
+    |> String.replace(~r/[\x{0300}-\x{036f}]/u, "")
+    |> String.replace(~r/(\p{L})(\p{N})/u, "\\1 \\2")
+    |> String.replace(~r/[^\p{L}\p{N}\s]/u, " ")
+    |> String.split()
+    |> Enum.reject(&number?/1)
+    |> Enum.join(" ")
+  end
+
+  defp number?(token), do: String.match?(token, ~r/\A\p{N}+\z/u)
+end

--- a/test/mydia/library/segment_detection/chapters_test.exs
+++ b/test/mydia/library/segment_detection/chapters_test.exs
@@ -175,6 +175,34 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
     test "returns an error on malformed json" do
       assert {:error, _reason} = Chapters.parse_chapters("not json at all")
     end
+
+    test "skips chapter entries that are not objects" do
+      # parse_chapters/1 is public and takes arbitrary JSON, so the array can
+      # legally hold non-objects. Access is not implemented for those, and
+      # reaching chapter["start_time"] on one would raise.
+      json = ~s({"chapters": [null, 42, "Opening", ["OP"], {"not": "a chapter"}]})
+
+      assert {:ok, %{}} = Chapters.parse_chapters(json)
+    end
+
+    test "mixes non-object entries alongside a usable chapter without losing it" do
+      json =
+        ~s({"chapters": [null, 42, ) <>
+          ~s({"start_time": "60.0", "end_time": "150.0", "tags": {"title": "OP"}}]})
+
+      assert {:ok, %{"intro" => {60_000, 150_000}}} = Chapters.parse_chapters(json)
+    end
+
+    test "rejects a timestamp with trailing garbage rather than trusting its prefix" do
+      # Float.parse/1 would happily return {12.3, "oops"}. Accepting that ships
+      # a skip button that jumps to the wrong place.
+      json =
+        ~s({"chapters": [{"start_time": "60.0oops", "end_time": "150.0", ) <>
+          ~s("tags": {"title": "OP"}}]})
+
+      assert {:ok, segments} = Chapters.parse_chapters(json)
+      refute Map.has_key?(segments, "intro")
+    end
   end
 
   describe "detect/1" do
@@ -212,9 +240,12 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
     args_path = Path.join(tmp_dir, "args")
     script_path = Path.join(tmp_dir, "ffprobe")
 
+    # args_path is quoted and written with printf: ExUnit derives :tmp_dir from
+    # the test name, and this project's test names routinely contain spaces and
+    # parentheses, so an unquoted redirection target would split or fail.
     File.write!(script_path, """
     #!/bin/sh
-    echo "$@" > #{args_path}
+    printf '%s\\n' "$*" > "#{args_path}"
     cat <<'FIXTURE'
     #{@sample_json}
     FIXTURE

--- a/test/mydia/library/segment_detection/chapters_test.exs
+++ b/test/mydia/library/segment_detection/chapters_test.exs
@@ -1,0 +1,228 @@
+defmodule Mydia.Library.SegmentDetection.ChaptersTest do
+  # detect/1 stubs the ffprobe binary through application env, which is global,
+  # so this file runs serially even though everything else in it is pure.
+  use ExUnit.Case, async: false
+
+  alias Mydia.Library.SegmentDetection.Chapters
+
+  @sample_json """
+  {"chapters": [
+    {"id": 0, "start_time": "0.000000", "end_time": "35.000000",
+     "tags": {"title": "Cold Open"}},
+    {"id": 1, "start_time": "35.000000", "end_time": "125.500000",
+     "tags": {"title": "Opening Credits"}},
+    {"id": 2, "start_time": "125.500000", "end_time": "1300.000000",
+     "tags": {"title": "Chapter 3"}},
+    {"id": 3, "start_time": "1300.000000", "end_time": "1420.000000",
+     "tags": {"title": "End Credits"}}
+  ]}
+  """
+
+  setup do
+    on_exit(fn -> Application.delete_env(:mydia, :ffprobe_path) end)
+
+    :ok
+  end
+
+  describe "classify/1" do
+    test "recognises intro titles" do
+      for title <- [
+            "Intro",
+            "intro",
+            "Opening",
+            "OP",
+            "Opening Credits",
+            "Main Titles",
+            "Vorspann",
+            "Générique de début"
+          ] do
+        assert Chapters.classify(title) == :intro, "expected #{title} to classify as intro"
+      end
+    end
+
+    test "recognises credits titles" do
+      for title <- [
+            "Credits",
+            "End Credits",
+            "Ending",
+            "ED",
+            "Closing Credits",
+            "Abspann",
+            "Générique de fin"
+          ] do
+        assert Chapters.classify(title) == :credits, "expected #{title} to classify as credits"
+      end
+    end
+
+    test "recognises numbered opening and ending variants" do
+      for {title, type} <- [
+            {"OP1", :intro},
+            {"OP 2", :intro},
+            {"Opening 2", :intro},
+            {"ED1", :credits},
+            {"ED 2", :credits},
+            {"Ending 2", :credits}
+          ] do
+        assert Chapters.classify(title) == type, "expected #{title} to classify as #{type}"
+      end
+    end
+
+    test "does not match titles that merely contain a token as a substring" do
+      for title <- [
+            "Introduction of the Suspect",
+            "Introducing Karen",
+            "The Credits Union Heist",
+            "Chapter 1",
+            "Cold Open"
+          ] do
+        assert Chapters.classify(title) == :unknown, "expected #{title} to classify as unknown"
+      end
+    end
+
+    test "does not match the near-miss chapter names real libraries actually use" do
+      # Measured on a real library: Prologue is the cold open before the theme,
+      # Preview is the next-episode teaser after the ending, and Epilogue is a
+      # post-credits scene. Each is more common than the true positive it
+      # resembles.
+      for title <- ["Prologue", "Preview", "Epilogue", "Part A", "Part B", "Episode", "Scene 1"] do
+        assert Chapters.classify(title) == :unknown, "expected #{title} to classify as unknown"
+      end
+    end
+
+    test "does not match ordinary words containing op or ed" do
+      for title <- ["Wedding", "Predator", "Stop", "Cooper", "Opera", "Developed"] do
+        assert Chapters.classify(title) == :unknown, "expected #{title} to classify as unknown"
+      end
+    end
+
+    test "handles nil and blank titles" do
+      assert Chapters.classify(nil) == :unknown
+      assert Chapters.classify("") == :unknown
+      assert Chapters.classify("   ") == :unknown
+    end
+  end
+
+  describe "parse_chapters/1" do
+    test "extracts intro and credits segments from ffprobe json" do
+      assert {:ok, segments} = Chapters.parse_chapters(@sample_json)
+      assert segments["intro"] == {35_000, 125_500}
+      assert segments["credits"] == {1_300_000, 1_420_000}
+    end
+
+    test "resolves each segment type independently" do
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "30.000000", "end_time": "120.000000",
+         "tags": {"title": "OP"}},
+        {"id": 1, "start_time": "120.000000", "end_time": "1400.000000",
+         "tags": {"title": "Part A"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json)
+      assert segments["intro"] == {30_000, 120_000}
+      refute Map.has_key?(segments, "credits")
+    end
+
+    test "returns an empty map when no chapter is recognisable" do
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "0.000000", "end_time": "600.000000",
+         "tags": {"title": "Chapter 1"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json)
+      assert segments == %{}
+    end
+
+    test "returns an empty map when the file has no chapters" do
+      assert {:ok, %{}} = Chapters.parse_chapters(~s({"chapters": []}))
+    end
+
+    test "tolerates chapters with no tags block" do
+      json = ~s({"chapters": [{"id": 0, "start_time": "0.0", "end_time": "10.0"}]})
+
+      assert {:ok, %{}} = Chapters.parse_chapters(json)
+    end
+
+    test "skips chapters whose span is missing or empty" do
+      json = """
+      {"chapters": [
+        {"id": 0, "tags": {"title": "Opening"}},
+        {"id": 1, "start_time": "90.000000", "end_time": "90.000000",
+         "tags": {"title": "Ending"}}
+      ]}
+      """
+
+      assert {:ok, %{}} = Chapters.parse_chapters(json)
+    end
+
+    test "keeps the first match when a type appears twice" do
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "10.000000", "end_time": "40.000000",
+         "tags": {"title": "Opening"}},
+        {"id": 1, "start_time": "60.000000", "end_time": "90.000000",
+         "tags": {"title": "Intro"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json)
+      assert segments["intro"] == {10_000, 40_000}
+    end
+
+    test "returns an error on malformed json" do
+      assert {:error, _reason} = Chapters.parse_chapters("not json at all")
+    end
+  end
+
+  describe "detect/1" do
+    @tag :tmp_dir
+    test "returns the segments parsed out of the probe output", %{tmp_dir: tmp_dir} do
+      stub_ffprobe(tmp_dir)
+
+      assert {:ok, segments} = Chapters.detect("/media/show/s01e01.mkv")
+      assert segments["intro"] == {35_000, 125_500}
+      assert segments["credits"] == {1_300_000, 1_420_000}
+    end
+
+    @tag :tmp_dir
+    test "asks ffprobe for chapters as json", %{tmp_dir: tmp_dir} do
+      args_path = stub_ffprobe(tmp_dir)
+
+      assert {:ok, _segments} = Chapters.detect("/media/show/s01e01.mkv")
+
+      recorded = File.read!(args_path)
+      assert recorded =~ "-show_chapters"
+      assert recorded =~ "-print_format json"
+      assert recorded =~ "/media/show/s01e01.mkv"
+    end
+
+    test "propagates a probe failure" do
+      Application.put_env(:mydia, :ffprobe_path, "/nonexistent/ffprobe-binary")
+
+      assert {:error, :ffprobe_not_found} = Chapters.detect("/media/show/s01e01.mkv")
+    end
+  end
+
+  # Installs a fake ffprobe that records its arguments and prints fixture JSON.
+  # Returns the path the arguments are recorded to.
+  defp stub_ffprobe(tmp_dir) do
+    args_path = Path.join(tmp_dir, "args")
+    script_path = Path.join(tmp_dir, "ffprobe")
+
+    File.write!(script_path, """
+    #!/bin/sh
+    echo "$@" > #{args_path}
+    cat <<'FIXTURE'
+    #{@sample_json}
+    FIXTURE
+    """)
+
+    File.chmod!(script_path, 0o755)
+    Application.put_env(:mydia, :ffprobe_path, script_path)
+
+    args_path
+  end
+end


### PR DESCRIPTION
First piece of the intro/credits detection work: the near-free path that runs before audio fingerprinting.

`Mydia.Library.SegmentDetection.Chapters` probes a file with `ffprobe -show_chapters` through the shared `Mydia.Library.Ffmpeg` runner, classifies the chapter titles, and returns a map keyed by `"intro"` / `"credits"` to `{start_ms, end_ms}`. Each segment type resolves independently, so a file whose chapters name an opening but not an ending still leaves its credits window for the fingerprinting pass to handle. A file with no recognisable chapters returns `{:ok, %{}}`, which is a result and not an error.

## Why the matching is strict

I surveyed 60 randomly sampled episode files from a real library. 26 of them (43%) carry chapters, giving 129 titled chapters. The hit rate is better than the design assumed, so this path is worth more than expected. The awkward part is that the near misses are more common than the true positives:

| Title | Count | Meaning |
|---|---|---|
| `Prologue` | 16 | cold open, runs **before** the theme |
| `Preview` | 15 | next-episode teaser, runs **after** the ending |
| `Epilogue` | 12 | post-credits scene |
| `ED` | 12 | credits |
| `Ending` | 11 | credits |
| `OP` | 8 | intro |
| `Opening` | 6 | intro |
| `Intro` | 2 | intro |
| `Credits` | 2 | credits |

Marking `Prologue` as an intro would skip real story content and leave the theme playing, and `Preview` / `Epilogue` are not credits. Against `Intro` at 2 and `Credits` at 2, a loose matcher is wrong more often than it is right on this data. (The sample skews anime, where OP/ED marking is conventional, so the 43% is not a general figure.)

So titles are lowercased, stripped of accents and punctuation, split into tokens, and compared as a complete token sequence against a curated list:

- **Never substrings.** `OP` and `ED` sit inside a large fraction of English words. A substring match on `ed` would hit `Wedding` and `Predator`, and on `op` would hit `Stop` and `Cooper`.
- **Never a single token out of a longer title either.** `The Credits Union Heist` contains the token `credits` but is a plot chapter, and `Opening Credits` has to resolve as an intro rather than as credits, which only the full sequence can decide.
- Standalone numbers are dropped before comparison, so the numbered variants common in anime (`OP1`, `ED2`, `Ending 2`) match their unnumbered form. `Part 1` and `Scene 1` still fall through to `:unknown`.

Non-English titles are covered: `Vorspann`, `Abspann`, `Générique de début`, `Générique de fin`, `Sigla iniziale`, `Sigla finale`, `Créditos finales`.

## Tests

18 tests, 0 failures. `classify/1` is public specifically so the vocabulary is directly testable, and there are explicit must-not-match cases for `Prologue`, `Preview`, `Epilogue`, `Part A`, `Part B`, `Episode`, `Scene 1`, `Introduction of the Suspect`, `Introducing Karen`, `The Credits Union Heist`, and the ordinary `op`/`ed` words above. `detect/1` is covered against a stub `ffprobe` installed through the existing `:ffprobe_path` application env override, which also pins the argument list.

The file is `async: false` because that stub is global state. Everything else in it is pure.

`mix format --check-formatted`, `mix compile --warnings-as-errors`, and `mix credo --strict` (976 files) are all clean.

Nothing calls this module yet. The season orchestration that consumes it lands in a later change.