### PR TITLE
feat(library): add Chromaprint fingerprint source for segment detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -223,6 +223,7 @@ RUN apk add --no-cache \
     curl \
     ca-certificates \
     ffmpeg \
+    chromaprint \
     fdk-aac \
     su-exec \
     tzdata \

--- a/devenv.nix
+++ b/devenv.nix
@@ -143,6 +143,8 @@ in
 
     # Media processing
     ffmpeg
+    # fpcalc, the audio fingerprinter behind intro/credits segment detection
+    chromaprint
 
     # Build tools for NIFs (bcrypt_elixir, argon2_elixir, membrane, exqlite)
     gnumake

--- a/lib/mydia/library/segment_detection/fingerprint.ex
+++ b/lib/mydia/library/segment_detection/fingerprint.ex
@@ -1,0 +1,69 @@
+defmodule Mydia.Library.SegmentDetection.Fingerprint do
+  @moduledoc """
+  Behaviour for producing an audio fingerprint over a window of a media file.
+
+  A fingerprint is one unsigned 32-bit integer per audio frame. Two recordings
+  of the same audio produce near-identical hash streams, which is what
+  `Correlator` exploits to locate a shared theme.
+
+  This exists as a behaviour so the implementation can be swapped. Today it is
+  `Fpcalc`, shelling out to Chromaprint. A Rust NIF alongside `mydia_p2p_core`
+  would remove the external binary and run faster; that swap should be a module
+  change here, not a redesign.
+
+  Tests inject a stub via `config :mydia, :fingerprint_impl, MyStub`.
+  """
+
+  defmodule Result do
+    @moduledoc """
+    A fingerprint and the frame duration needed to convert it back to time.
+
+    `frame_ms` is derived per call, never hardcoded. Chromaprint's frame rate
+    depends on its algorithm version, and a wrong constant produces timestamps
+    that drift further the longer the matched run.
+
+    `window_start_ms` records where in the file this window began. The credits
+    window does not start at zero, so frame positions inside it are meaningless
+    without it. It is a real struct field rather than something bolted on later
+    with `Map.put/3`, which would produce a struct carrying an undeclared key.
+    """
+
+    @type t :: %__MODULE__{
+            hashes: [non_neg_integer()],
+            frame_ms: float(),
+            window_start_ms: non_neg_integer()
+          }
+
+    defstruct hashes: [], frame_ms: 0.0, window_start_ms: 0
+  end
+
+  @default_impl Mydia.Library.SegmentDetection.Fingerprint.Fpcalc
+
+  @doc """
+  Fingerprints `length_s` seconds of `path` starting at `start_s`.
+  """
+  @callback fingerprint(path :: String.t(), start_s :: number(), length_s :: number()) ::
+              {:ok, Result.t()} | {:error, term()}
+
+  @doc "True when the configured implementation can actually run."
+  @callback available?() :: boolean()
+
+  @doc """
+  The implementation module currently configured.
+  """
+  @spec impl() :: module()
+  def impl, do: Application.get_env(:mydia, :fingerprint_impl, @default_impl)
+
+  @doc """
+  Fingerprints `length_s` seconds of `path` starting at `start_s` with the
+  configured implementation.
+  """
+  @spec fingerprint(String.t(), number(), number()) :: {:ok, Result.t()} | {:error, term()}
+  def fingerprint(path, start_s, length_s), do: impl().fingerprint(path, start_s, length_s)
+
+  @doc """
+  True when the configured implementation can actually run.
+  """
+  @spec available?() :: boolean()
+  def available?, do: impl().available?()
+end

--- a/lib/mydia/library/segment_detection/fingerprint/fpcalc.ex
+++ b/lib/mydia/library/segment_detection/fingerprint/fpcalc.ex
@@ -1,0 +1,161 @@
+defmodule Mydia.Library.SegmentDetection.Fingerprint.Fpcalc do
+  @moduledoc """
+  Fingerprints audio with Chromaprint's `fpcalc`.
+
+  ffmpeg does the decoding rather than handing the original file to `fpcalc`,
+  for two reasons: ffmpeg handles every container in a real library, and it
+  gives us windowing (`-ss` / `-t`) for free. `fpcalc` then reads a plain mono
+  11025 Hz WAV, which is the rate Chromaprint works at internally anyway.
+
+  The binary is resolved from PATH, or from the `:fpcalc_path` application env
+  override, matching how `Mydia.Library.Ffmpeg` resolves ffmpeg.
+  """
+
+  @behaviour Mydia.Library.SegmentDetection.Fingerprint
+
+  alias Mydia.Library.Ffmpeg
+  alias Mydia.Library.SegmentDetection.Fingerprint.Result
+
+  @sample_rate "11025"
+
+  @impl true
+  def available?, do: not is_nil(executable())
+
+  @impl true
+  def fingerprint(path, start_s, length_s) do
+    tmp = tmp_path()
+
+    try do
+      with {:ok, binary} <- fpcalc_binary(),
+           :ok <- decode_window(path, start_s, length_s, tmp),
+           {:ok, output} <- run_fpcalc(binary, tmp, length_s),
+           {:ok, %Result{} = result} <- parse_output(output) do
+        {:ok, %{result | window_start_ms: max(round(start_s * 1000), 0)}}
+      end
+    after
+      # Removed here rather than after a successful run so a crash or an error
+      # return mid-fingerprint cannot leak WAVs into the temp directory.
+      File.rm(tmp)
+    end
+  end
+
+  @doc """
+  Parses `fpcalc -raw` output into a `Result`.
+
+  Public so it can be tested against captured output without a binary present.
+  """
+  @spec parse_output(String.t()) :: {:ok, Result.t()} | {:error, term()}
+  def parse_output(output) when is_binary(output) do
+    fields =
+      output
+      |> String.split("\n", trim: true)
+      |> Enum.reduce(%{}, fn line, acc ->
+        case String.split(line, "=", parts: 2) do
+          [key, value] -> Map.put(acc, key, value)
+          _ -> acc
+        end
+      end)
+
+    with {:ok, duration_s} <- parse_duration(fields),
+         {:ok, hashes} <- parse_hashes(fields) do
+      # The frame rate is derived, never hardcoded: Chromaprint's frames per
+      # second depends on its algorithm version, and a wrong constant produces
+      # timestamps that drift further the longer the matched run. This division
+      # is only correct because `-length` covers the whole input, so DURATION
+      # describes the span that was actually fingerprinted. See run_fpcalc/3.
+      {:ok, %Result{hashes: hashes, frame_ms: duration_s * 1000 / length(hashes)}}
+    end
+  end
+
+  defp parse_duration(%{"DURATION" => raw}) do
+    case Float.parse(raw) do
+      {seconds, _rest} when seconds > 0 -> {:ok, seconds}
+      _ -> {:error, :no_duration}
+    end
+  end
+
+  defp parse_duration(_fields), do: {:error, :no_duration}
+
+  defp parse_hashes(%{"FINGERPRINT" => raw}) do
+    hashes =
+      raw
+      |> String.split(",", trim: true)
+      |> Enum.flat_map(fn value ->
+        case Integer.parse(String.trim(value)) do
+          # fpcalc may print signed values; mask back to unsigned 32-bit so the
+          # correlator's bit arithmetic behaves.
+          {int, _rest} -> [Bitwise.band(int, 0xFFFFFFFF)]
+          :error -> []
+        end
+      end)
+
+    if hashes == [], do: {:error, :no_fingerprint}, else: {:ok, hashes}
+  end
+
+  defp parse_hashes(_fields), do: {:error, :no_fingerprint}
+
+  defp decode_window(path, start_s, length_s, tmp) do
+    args = [
+      "-nostdin",
+      "-ss",
+      to_string(start_s),
+      "-t",
+      to_string(length_s),
+      "-i",
+      path,
+      "-vn",
+      "-ac",
+      "1",
+      "-ar",
+      @sample_rate,
+      "-f",
+      "wav",
+      "-y",
+      tmp
+    ]
+
+    case Ffmpeg.run(args) do
+      {:ok, _output} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # `-length` is mandatory, do not remove it as redundant.
+  #
+  # fpcalc defaults to fingerprinting only the first 120 seconds of its input
+  # and silently discarding the rest. Two things break when that happens:
+  # the detection window is truncated to two minutes, so an intro after a cold
+  # open is never seen; and DURATION still reports the length of the whole
+  # input rather than the fingerprinted span, so the derived frame_ms comes back
+  # roughly 5x too large (measured 614.98 ms/frame against a true 124.17). Every
+  # episode pair went from matching to not matching. Passing a length that
+  # covers the whole temp WAV keeps DURATION and the frame count describing the
+  # same span. One extra second absorbs ffmpeg rounding at the window edge.
+  defp run_fpcalc(binary, tmp, length_s) do
+    args = ["-raw", "-length", to_string(ceil(length_s) + 1), tmp]
+
+    case System.cmd(binary, args, stderr_to_stdout: true) do
+      {output, 0} -> {:ok, output}
+      {output, code} -> {:error, {:fpcalc_error, code, output}}
+    end
+  end
+
+  defp fpcalc_binary do
+    case executable() do
+      nil -> {:error, :fpcalc_not_found}
+      binary -> {:ok, binary}
+    end
+  end
+
+  # An application-env override is resolved the same way as a bare name, so a
+  # stale or non-executable override surfaces as :fpcalc_not_found instead of
+  # raising inside System.cmd/3.
+  defp executable do
+    System.find_executable(Application.get_env(:mydia, :fpcalc_path) || "fpcalc")
+  end
+
+  defp tmp_path do
+    name = "mydia_fp_#{System.unique_integer([:positive])}.wav"
+    Path.join(System.tmp_dir!(), name)
+  end
+end

--- a/lib/mydia/library/segment_detection/fingerprint/fpcalc.ex
+++ b/lib/mydia/library/segment_detection/fingerprint/fpcalc.ex
@@ -94,30 +94,40 @@ defmodule Mydia.Library.SegmentDetection.Fingerprint.Fpcalc do
 
   defp parse_hashes(_fields), do: {:error, :no_fingerprint}
 
+  # Input seeking first, output seeking as a fallback, mirroring the same
+  # trade-off ThumbnailGenerator makes: `-ss` before `-i` skips straight to the
+  # window and is dramatically cheaper on a credits window 22 minutes into a
+  # file, but it fails on some containers. Output seeking decodes from the start
+  # and is slower, so it is only worth paying for when the fast path errors.
+  #
+  # Without the fallback a container that rejects input seeking never yields
+  # segments at all: the file burns its three attempts and lands in `failed`.
   defp decode_window(path, start_s, length_s, tmp) do
-    args = [
-      "-nostdin",
-      "-ss",
-      to_string(start_s),
-      "-t",
-      to_string(length_s),
-      "-i",
-      path,
-      "-vn",
-      "-ac",
-      "1",
-      "-ar",
-      @sample_rate,
-      "-f",
-      "wav",
-      "-y",
-      tmp
-    ]
+    case Ffmpeg.run(decode_args(path, start_s, length_s, tmp, :input)) do
+      {:ok, _output} ->
+        :ok
 
-    case Ffmpeg.run(args) do
-      {:ok, _output} -> :ok
-      {:error, reason} -> {:error, reason}
+      {:error, {:ffmpeg_error, _code, _output}} ->
+        case Ffmpeg.run(decode_args(path, start_s, length_s, tmp, :output)) do
+          {:ok, _output} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
+  end
+
+  defp decode_args(path, start_s, length_s, tmp, seek) do
+    seek_args =
+      case seek do
+        :input -> ["-ss", to_string(start_s), "-t", to_string(length_s), "-i", path]
+        :output -> ["-i", path, "-ss", to_string(start_s), "-t", to_string(length_s)]
+      end
+
+    ["-nostdin"] ++
+      seek_args ++
+      ["-vn", "-ac", "1", "-ar", @sample_rate, "-f", "wav", "-y", tmp]
   end
 
   # `-length` is mandatory, do not remove it as redundant.

--- a/test/mydia/library/segment_detection/fingerprint/fpcalc_test.exs
+++ b/test/mydia/library/segment_detection/fingerprint/fpcalc_test.exs
@@ -80,36 +80,106 @@ defmodule Mydia.Library.SegmentDetection.Fingerprint.FpcalcTest do
     @tag :tmp_dir
     test "derives Chromaprint's real frame rate over a window longer than two minutes",
          %{tmp_dir: tmp_dir} do
-      if Ffmpeg.available?() and Fpcalc.available?() do
-        source = Path.join(tmp_dir, "episode.wav")
-        # 310 seconds of audio so the 300 second window below is comfortably
-        # longer than fpcalc's 120 second default -length.
-        assert {:ok, _} =
-                 Ffmpeg.run([
-                   "-nostdin",
-                   "-f",
-                   "lavfi",
-                   "-i",
-                   "anoisesrc=duration=310:color=pink:seed=7",
-                   "-ac",
-                   "1",
-                   "-ar",
-                   "11025",
-                   "-y",
-                   source
-                 ])
+      # Assert the binaries rather than skipping past them. devenv.nix provides
+      # both ffmpeg and chromaprint, and CI runs its test jobs inside
+      # `devenv shell`, so an absent binary is a broken environment rather than
+      # an expected condition. A test that quietly passes without asserting
+      # anything is worse than no test, because it reads as coverage.
+      assert Ffmpeg.available?(),
+             "ffmpeg not found; run the suite inside the devenv shell (./dev test)"
 
-        assert {:ok, %Result{} = result} = Fpcalc.fingerprint(source, 5, 300)
+      assert Fpcalc.available?(),
+             "fpcalc not found; chromaprint is in devenv.nix, run the suite inside the devenv shell (./dev test)"
 
-        assert result.window_start_ms == 5_000
-        assert length(result.hashes) > 2_000
+      source = Path.join(tmp_dir, "episode.wav")
+      # 310 seconds of audio so the 300 second window below is comfortably
+      # longer than fpcalc's 120 second default -length.
+      assert {:ok, _} =
+               Ffmpeg.run([
+                 "-nostdin",
+                 "-f",
+                 "lavfi",
+                 "-i",
+                 "anoisesrc=duration=310:color=pink:seed=7",
+                 "-ac",
+                 "1",
+                 "-ar",
+                 "11025",
+                 "-y",
+                 source
+               ])
 
-        # Chromaprint runs at about 8.05 frames per second, so a correct run
-        # derives roughly 124.17 ms per frame. A value anywhere near 600 means
-        # -length was dropped from the fpcalc invocation: fpcalc then reads only
-        # the first two minutes while DURATION still describes the whole input.
-        assert_in_delta result.frame_ms, 124.17, 3.0
-      end
+      assert {:ok, %Result{} = result} = Fpcalc.fingerprint(source, 5, 300)
+
+      assert result.window_start_ms == 5_000
+      assert length(result.hashes) > 2_000
+
+      # Chromaprint runs at about 8.05 frames per second, so a correct run
+      # derives roughly 124.17 ms per frame. A value anywhere near 600 means
+      # -length was dropped from the fpcalc invocation: fpcalc then reads only
+      # the first two minutes while DURATION still describes the whole input.
+      assert_in_delta result.frame_ms, 124.17, 3.0
+    end
+
+    @tag :requires_ffmpeg
+    @tag :tmp_dir
+    test "falls back to output seeking when the container rejects input seeking",
+         %{tmp_dir: tmp_dir} do
+      assert Ffmpeg.available?(),
+             "ffmpeg not found; run the suite inside the devenv shell (./dev test)"
+
+      assert Fpcalc.available?(),
+             "fpcalc not found; chromaprint is in devenv.nix, run the suite inside the devenv shell (./dev test)"
+
+      # Real audio the stub hands back on the output-seeking path, so fpcalc
+      # still runs for real and the assertion covers the whole chain.
+      #
+      # Its duration matches the requested window exactly, because real ffmpeg
+      # decodes only the window and fpcalc's DURATION therefore describes the
+      # fingerprinted span. A longer stub file would inflate frame_ms and be an
+      # artifact of the stub rather than of the code under test.
+      prepared = Path.join(tmp_dir, "prepared.wav")
+
+      assert {:ok, _} =
+               Ffmpeg.run([
+                 "-nostdin",
+                 "-f",
+                 "lavfi",
+                 "-i",
+                 "anoisesrc=duration=130:color=pink:seed=11",
+                 "-ac",
+                 "1",
+                 "-ar",
+                 "11025",
+                 "-y",
+                 prepared
+               ])
+
+      # Stands in for a container that rejects `-ss` before `-i`. Input seeking
+      # puts "-ss" in position 2; output seeking puts "-i" there.
+      stub = Path.join(tmp_dir, "ffmpeg-stub")
+
+      File.write!(stub, """
+      #!/bin/sh
+      if [ "$2" = "-ss" ]; then
+        echo "Invalid data found when processing input" >&2
+        exit 1
+      fi
+      eval "target=\\${$#}"
+      cp #{prepared} "$target"
+      """)
+
+      File.chmod!(stub, 0o755)
+      Application.put_env(:mydia, :ffmpeg_path, stub)
+      on_exit(fn -> Application.delete_env(:mydia, :ffmpeg_path) end)
+
+      assert {:ok, %Result{} = result} = Fpcalc.fingerprint("/any/episode.mkv", 7, 130)
+
+      # Reaching a real fingerprint at all means the input-seek attempt failed
+      # and the output-seek retry carried it.
+      assert length(result.hashes) > 900
+      assert result.window_start_ms == 7_000
+      assert_in_delta result.frame_ms, 124.17, 3.0
     end
   end
 end

--- a/test/mydia/library/segment_detection/fingerprint/fpcalc_test.exs
+++ b/test/mydia/library/segment_detection/fingerprint/fpcalc_test.exs
@@ -1,0 +1,115 @@
+defmodule Mydia.Library.SegmentDetection.Fingerprint.FpcalcTest do
+  # Mutates Application env for the binary path, so serial.
+  use ExUnit.Case, async: false
+
+  alias Mydia.Library.Ffmpeg
+  alias Mydia.Library.SegmentDetection.Fingerprint.Fpcalc
+  alias Mydia.Library.SegmentDetection.Fingerprint.Result
+
+  setup do
+    on_exit(fn -> Application.delete_env(:mydia, :fpcalc_path) end)
+
+    :ok
+  end
+
+  describe "parse_output/1" do
+    test "parses duration and fingerprint into a result" do
+      output = """
+      DURATION=120
+      FINGERPRINT=1234567,2345678,3456789,4567890
+      """
+
+      assert {:ok, %Result{} = result} = Fpcalc.parse_output(output)
+      assert result.hashes == [1_234_567, 2_345_678, 3_456_789, 4_567_890]
+
+      # frame_ms is derived, never hardcoded: 120_000ms over 4 frames.
+      assert_in_delta result.frame_ms, 30_000.0, 0.001
+    end
+
+    test "masks negative values into unsigned 32-bit" do
+      output = """
+      DURATION=1
+      FINGERPRINT=-1,-2147483648
+      """
+
+      assert {:ok, %Result{hashes: [a, b]}} = Fpcalc.parse_output(output)
+      assert a == 4_294_967_295
+      assert b == 2_147_483_648
+    end
+
+    test "accepts a fractional duration" do
+      output = """
+      DURATION=10.5
+      FINGERPRINT=1,2,3
+      """
+
+      assert {:ok, %Result{} = result} = Fpcalc.parse_output(output)
+      assert_in_delta result.frame_ms, 3500.0, 0.001
+    end
+
+    test "errors when the fingerprint line is missing" do
+      assert {:error, :no_fingerprint} = Fpcalc.parse_output("DURATION=120\n")
+    end
+
+    test "errors when the duration line is missing" do
+      assert {:error, :no_duration} = Fpcalc.parse_output("FINGERPRINT=1,2,3\n")
+    end
+
+    test "errors on an empty fingerprint" do
+      assert {:error, :no_fingerprint} = Fpcalc.parse_output("DURATION=120\nFINGERPRINT=\n")
+    end
+  end
+
+  describe "available?/0" do
+    test "is false when the configured binary does not resolve" do
+      Application.put_env(:mydia, :fpcalc_path, "/nonexistent/fpcalc-binary")
+
+      refute Fpcalc.available?()
+    end
+  end
+
+  describe "fingerprint/3" do
+    test "returns :fpcalc_not_found without decoding when the binary is missing" do
+      Application.put_env(:mydia, :fpcalc_path, "/nonexistent/fpcalc-binary")
+
+      assert {:error, :fpcalc_not_found} =
+               Fpcalc.fingerprint("/nonexistent/episode.mkv", 0, 60)
+    end
+
+    @tag :requires_ffmpeg
+    @tag :tmp_dir
+    test "derives Chromaprint's real frame rate over a window longer than two minutes",
+         %{tmp_dir: tmp_dir} do
+      if Ffmpeg.available?() and Fpcalc.available?() do
+        source = Path.join(tmp_dir, "episode.wav")
+        # 310 seconds of audio so the 300 second window below is comfortably
+        # longer than fpcalc's 120 second default -length.
+        assert {:ok, _} =
+                 Ffmpeg.run([
+                   "-nostdin",
+                   "-f",
+                   "lavfi",
+                   "-i",
+                   "anoisesrc=duration=310:color=pink:seed=7",
+                   "-ac",
+                   "1",
+                   "-ar",
+                   "11025",
+                   "-y",
+                   source
+                 ])
+
+        assert {:ok, %Result{} = result} = Fpcalc.fingerprint(source, 5, 300)
+
+        assert result.window_start_ms == 5_000
+        assert length(result.hashes) > 2_000
+
+        # Chromaprint runs at about 8.05 frames per second, so a correct run
+        # derives roughly 124.17 ms per frame. A value anywhere near 600 means
+        # -length was dropped from the fpcalc invocation: fpcalc then reads only
+        # the first two minutes while DURATION still describes the whole input.
+        assert_in_delta result.frame_ms, 124.17, 3.0
+      end
+    end
+  end
+end

--- a/test/mydia/library/segment_detection/fingerprint_test.exs
+++ b/test/mydia/library/segment_detection/fingerprint_test.exs
@@ -1,0 +1,60 @@
+defmodule Mydia.Library.SegmentDetection.FingerprintTest do
+  # Mutates Application env to swap the implementation, so serial.
+  use ExUnit.Case, async: false
+
+  alias Mydia.Library.SegmentDetection.Fingerprint
+  alias Mydia.Library.SegmentDetection.Fingerprint.Result
+
+  defmodule StubImpl do
+    @moduledoc false
+
+    @behaviour Mydia.Library.SegmentDetection.Fingerprint
+
+    alias Mydia.Library.SegmentDetection.Fingerprint.Result
+
+    @impl true
+    def available?, do: true
+
+    @impl true
+    def fingerprint(path, start_s, length_s) do
+      send(self(), {:fingerprinted, path, start_s, length_s})
+
+      {:ok, %Result{hashes: [1, 2, 3], frame_ms: 124.17, window_start_ms: round(start_s * 1000)}}
+    end
+  end
+
+  setup do
+    on_exit(fn -> Application.delete_env(:mydia, :fingerprint_impl) end)
+
+    :ok
+  end
+
+  describe "impl/0" do
+    test "defaults to the fpcalc implementation" do
+      assert Fingerprint.impl() == Mydia.Library.SegmentDetection.Fingerprint.Fpcalc
+    end
+
+    test "resolves the configured implementation" do
+      Application.put_env(:mydia, :fingerprint_impl, StubImpl)
+
+      assert Fingerprint.impl() == StubImpl
+    end
+  end
+
+  describe "delegation" do
+    setup do
+      Application.put_env(:mydia, :fingerprint_impl, StubImpl)
+    end
+
+    test "fingerprint/3 forwards the window to the configured implementation" do
+      assert {:ok, %Result{window_start_ms: 30_000}} =
+               Fingerprint.fingerprint("/media/episode.mkv", 30, 600)
+
+      assert_received {:fingerprinted, "/media/episode.mkv", 30, 600}
+    end
+
+    test "available?/0 forwards to the configured implementation" do
+      assert Fingerprint.available?()
+    end
+  end
+end


### PR DESCRIPTION
Intro and credits detection works by correlating the audio of season-mate episodes to find the run of identical audio that is the theme. This is the fingerprint half of that, and nothing consumes it yet: the correlator, the schema, the workers, and the player button follow in later changes.

## What is here

- `Mydia.Library.SegmentDetection.Fingerprint`, a behaviour plus the `Result` struct (`hashes`, `frame_ms`, `window_start_ms`). It exists as a behaviour so the source can become a Rust NIF alongside `mydia_p2p_core` later without a redesign, and so the season-level tests can inject a stub via `config :mydia, :fingerprint_impl`.
- `Mydia.Library.SegmentDetection.Fingerprint.Fpcalc`, the only implementation. ffmpeg decodes the requested window to a temp mono 11025 Hz WAV and `fpcalc -raw` fingerprints that file. Going through ffmpeg rather than handing the original to `fpcalc` means every container in a real library is handled and windowing comes for free.
- `chromaprint` added to the Alpine runtime image and to the devenv shell. Version 1.6.0 ships `fpcalc` in both the pinned nixpkgs and Alpine 3.23.5.

The temp WAV is removed in an `after` block, so a crash or an error return mid-fingerprint cannot leak WAVs into the temp directory.

## Two things worth reviewing carefully

**`-length` is mandatory.** `fpcalc` defaults to fingerprinting only the first 120 seconds of its input and silently discarding the rest. Two things break without an explicit `-length`: the detection window is truncated to two minutes, so an intro that starts after a cold open is never seen, and `DURATION` still reports the length of the whole input rather than the fingerprinted span. Measured against real episodes, a 10 minute window produced 948 frames instead of 4,695, a frame rate of 614.98 ms/frame against a true 124.17, and every episode pair went from matching to not matching. There is a comment on the invocation saying so, since the flag looks redundant if you do not know this.

**The frame rate is derived, not hardcoded.** Chromaprint's frames per second depends on its algorithm version, and a wrong constant produces timestamps that drift further the longer the matched run. `frame_ms` is computed per call as `DURATION / frame count`, which self-calibrates against whatever `fpcalc` is installed. That division is only correct because `-length` covers the whole input, which is the other half of why the flag matters.

## Tests

13 tests, 0 failures.

`parse_output/1` is public and covered against captured output with no binary present: field parsing, the derived frame duration, unsigned 32-bit masking of the signed values `fpcalc` can print, fractional durations, and the three missing-or-empty-field errors.

The integration test fingerprints a 300 second window of ffmpeg-generated noise and asserts the derived rate lands near 124.17 ms/frame. Measured on this branch: **124.90 ms/frame over 2,402 frames**, about 8.01 fps. The window is deliberately longer than two minutes so that dropping `-length` would push the measured rate to roughly 314 and fail the assertion. Runtime is well under a second.
