### PR TITLE
fix(web): stop metadata structs being read with Access syntax

### DIFF
--- a/lib/mydia_web/live/components/library_search_form.ex
+++ b/lib/mydia_web/live/components/library_search_form.ex
@@ -43,7 +43,9 @@ defmodule MydiaWeb.Live.Components.LibrarySearchForm do
               phx-value-title={item.title}
               phx-value-type={item.type}
             >
-              <% poster_path = get_in(item.metadata || %{}, [:poster_path]) %>
+              <%!-- MediaItem.metadata loads as a %MediaMetadata{}, which has no
+              Access implementation — get_in/bracket syntax raises here. --%>
+              <% poster_path = item.metadata && item.metadata.poster_path %>
               <%= if poster_path do %>
                 <img
                   src={ImageUrl.image_url(poster_path, "w92")}

--- a/lib/mydia_web/live/request_media_live/index.html.heex
+++ b/lib/mydia_web/live/request_media_live/index.html.heex
@@ -69,20 +69,20 @@
         </h2>
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4">
           <%= for {result, index} <- Enum.with_index(@search_results) do %>
-            <% is_requested = MapSet.member?(@requested_items, result[:id]) %>
+            <% is_requested = MapSet.member?(@requested_items, result.id) %>
             <% is_requesting = @requesting_index == index %>
             <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow overflow-hidden">
               <figure class="relative aspect-[2/3] overflow-hidden bg-base-300">
                 <img
                   src={get_poster_url(result)}
-                  alt={result[:title] || result[:name]}
+                  alt={result.title || result.name}
                   class="w-full h-full object-cover"
                   loading="lazy"
                 />
-                <%= if result[:vote_average] do %>
+                <%= if result.vote_average do %>
                   <div class="badge badge-primary badge-sm absolute top-2 right-2">
                     <.icon name="hero-star-solid" class="w-3 h-3 mr-1" />
-                    {format_rating(result[:vote_average])}
+                    {format_rating(result.vote_average)}
                   </div>
                 <% end %>
                 <%= if is_requested do %>
@@ -95,12 +95,12 @@
               </figure>
               <div class="card-body p-3">
                 <h3 class="card-title text-sm line-clamp-2 h-10">
-                  {result[:title] || result[:name]}
+                  {result.title || result.name}
                 </h3>
                 <p class="text-xs text-base-content/70">{format_year(result)}</p>
-                <%= if result[:overview] do %>
+                <%= if result.overview do %>
                   <p class="text-xs text-base-content/60 line-clamp-2 mt-1">
-                    {result[:overview]}
+                    {result.overview}
                   </p>
                 <% end %>
                 <div class="card-actions mt-2">
@@ -141,18 +141,18 @@
             <div class="w-20 flex-shrink-0">
               <img
                 src={get_poster_url(@request_modal_result)}
-                alt={@request_modal_result[:title] || @request_modal_result[:name]}
+                alt={@request_modal_result.title || @request_modal_result.name}
                 class="w-full rounded"
               />
             </div>
             <div class="flex-1 min-w-0">
               <h4 class="font-bold text-base">
-                {@request_modal_result[:title] || @request_modal_result[:name]}
+                {@request_modal_result.title || @request_modal_result.name}
               </h4>
               <p class="text-sm text-base-content/70">{format_year(@request_modal_result)}</p>
-              <%= if @request_modal_result[:overview] do %>
+              <%= if @request_modal_result.overview do %>
                 <p class="text-xs text-base-content/60 mt-2 line-clamp-3">
-                  {@request_modal_result[:overview]}
+                  {@request_modal_result.overview}
                 </p>
               <% end %>
             </div>

--- a/test/mydia_web/live/components/library_search_form_test.exs
+++ b/test/mydia_web/live/components/library_search_form_test.exs
@@ -1,0 +1,70 @@
+defmodule MydiaWeb.Live.Components.LibrarySearchFormTest do
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Media.MediaItem
+  alias Mydia.Metadata.Structs.MediaMetadata
+  alias MydiaWeb.Live.Components.LibrarySearchForm
+
+  defp media_item(metadata) do
+    %MediaItem{
+      id: "a3f1c9e2-0000-4000-8000-000000000001",
+      title: "The Matrix",
+      type: "movie",
+      year: 1999,
+      metadata: metadata
+    }
+  end
+
+  defp render_form(results) do
+    render_component(&LibrarySearchForm.library_search_form/1,
+      search_results: results,
+      on_search: "search_library",
+      on_select: "select_library_item",
+      download_id: "dl-1"
+    )
+  end
+
+  describe "library_search_form/1" do
+    test "renders the poster of an item whose metadata is a MediaMetadata struct" do
+      # MediaItem.metadata is a Mydia.Media.MetadataType, so a persisted item
+      # always loads as a %MediaMetadata{} — a struct that does not implement
+      # Access. Reading it with get_in/bracket syntax raised
+      # UndefinedFunctionError (MediaMetadata.fetch/2) and took the whole
+      # Issues tab down with it.
+      metadata = %MediaMetadata{
+        provider_id: "603",
+        provider: :metadata_relay,
+        media_type: :movie,
+        poster_path: "/matrix-poster.jpg"
+      }
+
+      html = render_form([media_item(metadata)])
+
+      assert html =~ "The Matrix"
+      assert html =~ "matrix-poster.jpg"
+    end
+
+    test "falls back to the placeholder when the struct carries no poster" do
+      metadata = %MediaMetadata{
+        provider_id: "603",
+        provider: :metadata_relay,
+        media_type: :movie,
+        poster_path: nil
+      }
+
+      html = render_form([media_item(metadata)])
+
+      assert html =~ "The Matrix"
+      assert html =~ "hero-film"
+    end
+
+    test "renders an item with no metadata at all" do
+      html = render_form([media_item(nil)])
+
+      assert html =~ "The Matrix"
+      assert html =~ "hero-film"
+    end
+  end
+end

--- a/test/mydia_web/live/request_media_live_test.exs
+++ b/test/mydia_web/live/request_media_live_test.exs
@@ -1,0 +1,89 @@
+defmodule MydiaWeb.RequestMediaLive.IndexTest do
+  # Not async: the provider registry is global process state, and a connected
+  # LiveView mount runs in a separate process from the test (see the note in
+  # DownloadsLive.IndexTest about the non-shared Postgres sandbox).
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Metadata.Provider
+  alias Mydia.Metadata.Structs.SearchResult
+
+  # `Metadata.search/3` returns %SearchResult{} structs, not maps. Reading them
+  # with bracket syntax raised UndefinedFunctionError (SearchResult.fetch/2),
+  # so every guest request search blew up as soon as it had a result to render.
+  defmodule ResultProvider do
+    @behaviour Mydia.Metadata.Provider
+
+    alias Mydia.Metadata.Structs.ImagesResponse
+
+    @impl true
+    def test_connection(_config), do: {:ok, %{status: "ok"}}
+
+    @impl true
+    def search(_config, _query, _opts) do
+      {:ok,
+       [
+         %SearchResult{
+           provider_id: "603",
+           provider: :metadata_relay,
+           media_type: :movie,
+           id: 603,
+           title: "The Matrix",
+           release_date: "1999-03-30",
+           overview: "A computer hacker learns about the true nature of reality.",
+           poster_path: "/matrix-poster.jpg",
+           vote_average: 8.2
+         }
+       ]}
+    end
+
+    @impl true
+    def fetch_by_id(_config, _id, _opts), do: {:ok, %{}}
+
+    @impl true
+    def fetch_images(_config, _id, _opts),
+      do: {:ok, ImagesResponse.new(%{posters: [], backdrops: [], logos: []})}
+
+    @impl true
+    def fetch_season(_config, _id, _season, _opts), do: {:ok, %{}}
+
+    @impl true
+    def fetch_trending(_config, _opts), do: {:ok, []}
+  end
+
+  setup %{conn: conn} do
+    Provider.Registry.register(:metadata_relay, ResultProvider)
+    on_exit(fn -> Mydia.Metadata.register_providers() end)
+
+    user = create_test_user()
+    %{conn: log_in_user(conn, user)}
+  end
+
+  describe "search results" do
+    test "renders SearchResult structs returned by the provider", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/request/movie?q=matrix")
+
+      html = render(view)
+
+      assert html =~ "Search Results"
+      assert html =~ "The Matrix"
+      assert html =~ "true nature of reality"
+      assert html =~ "matrix-poster.jpg"
+      assert html =~ "1999"
+    end
+
+    test "renders the request modal for a selected SearchResult", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/request/movie?q=matrix")
+
+      html =
+        view
+        |> element(~s(button[phx-click="open_request_modal"][phx-value-index="0"]))
+        |> render_click()
+
+      assert html =~ "Request Media"
+      assert html =~ "The Matrix"
+      assert html =~ "true nature of reality"
+    end
+  end
+end


### PR DESCRIPTION
Fixes #282.

## The bug

`Mydia.Metadata.Structs.MediaMetadata` and `Mydia.Metadata.Structs.SearchResult` are plain structs. They implement no `Access` behaviour, so bracket syntax and `get_in/2` on them raise `UndefinedFunctionError` (`.fetch/2`) instead of quietly returning `nil`. Two templates were reading them that way.

**Issues tab library picker** — `library_search_form.ex:46` did `get_in(item.metadata || %{}, [:poster_path])`. `MediaItem.metadata` is a `Mydia.Media.MetadataType`, so a persisted item always loads as a `%MediaMetadata{}`. Opening the picker for any item that has metadata killed the tab. This is the crash in the telemetry attached to the issue (18 occurrences, 2 instances, 0.12.0 and dev builds), and the `(nofile)` frame matches a HEEx template.

**Guest request page** — `request_media_live/index.html.heex` read `result[:title]`, `result[:id]`, `result[:overview]` and the same fields on `@request_modal_result`. `Metadata.search/3` returns `[%SearchResult{}]`, so every search on `/request/movie` and `/request/series` crashed the moment it had a result to render. That path was unreported because it has no test coverage, but it is the same defect and the LiveView module beside it was already using `result.id`.

## The fix

Direct field access in both templates. Both structs have fixed field sets, so this is safe and a typo becomes a compile-visible error rather than a silent `nil`. It is also what `CLAUDE.md` already requires.

The issue suggested grepping the class rather than patching the one reported path, so I swept every `get_in`/bracket read in `lib/`. The other hits are on genuine maps (`event.metadata["..."]`, download-client API response bodies, `@grouped_files`) and are fine. These two templates were the only struct reads.

## Tests

- `test/mydia_web/live/components/library_search_form_test.exs` — renders the component with a `%MediaMetadata{}` carrying a poster, without one, and with no metadata at all.
- `test/mydia_web/live/request_media_live_test.exs` — mounts the request page against a stub provider returning a `%SearchResult{}` and asserts both the results grid and the request modal render.

Both fail on master with the exact `UndefinedFunctionError` from the issue and pass with the fix. `mix precommit` is green: 6052 tests, 0 failures, plus format and `credo --strict`.