### PR TITLE
feat(graphql): expose detected intro and credits segments on media files

### DIFF
--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -48,6 +48,28 @@ defmodule MydiaWeb.Schema.CommonTypes do
     field :subtitles, list_of(:subtitle_track) do
       resolve(&MydiaWeb.Schema.Resolvers.SubtitleResolver.list_subtitles/3)
     end
+
+    @desc "Skippable segments (intro, credits). Empty when detection has not run or found nothing."
+    field :segments, non_null(list_of(non_null(:media_segment))) do
+      resolve(&MydiaWeb.Schema.Resolvers.MediaResolver.segments/3)
+    end
+  end
+
+  @desc """
+  A detected skippable segment.
+
+  `source` and `confidence` are deliberately absent from the wire format. They
+  are operator concerns, and keeping the confidence floor server side means it
+  is enforced in one place rather than reimplemented in every client.
+  """
+  object :media_segment do
+    @desc "Which kind of segment this is"
+    field :type, non_null(:segment_type) do
+      resolve(fn segment, _args, _info -> {:ok, String.to_existing_atom(segment.type)} end)
+    end
+
+    field :start_ms, non_null(:integer), description: "Segment start, milliseconds"
+    field :end_ms, non_null(:integer), description: "Segment end, milliseconds"
   end
 
   @desc "User playback progress on a media item or episode"

--- a/lib/mydia_web/schema/enum_types.ex
+++ b/lib/mydia_web/schema/enum_types.ex
@@ -78,4 +78,10 @@ defmodule MydiaWeb.Schema.EnumTypes do
     value(:hls_copy, description: "HLS with stream copy")
     value(:transcode, description: "Full transcoding")
   end
+
+  @desc "A region of a media file a viewer may want to skip"
+  enum :segment_type do
+    value(:intro, description: "Opening theme")
+    value(:credits, description: "Closing credits")
+  end
 end

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -321,6 +321,17 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
   @doc """
   Filters persisted segments down to the ones trustworthy enough to show a viewer.
 
+  The floor is a single condition on `confidence`, with no exception by
+  `source`. Chapter-sourced segments clear it because the detection pipeline
+  writes chapter matches at confidence 1.0, not because this function treats
+  them specially.
+
+  That uniformity is deliberate. Exposure stays one rule in one place, which is
+  the same reason `confidence` and `source` never reach the player. And a
+  chapter segment that somehow lands below the floor vanishing from the wire is
+  the signal you want, because it means something wrote it wrong; a bypass on
+  `source` would mask precisely that.
+
   Public so the confidence floor can be exercised directly in tests.
   """
   @spec visible_segments(map()) :: [Library.MediaSegment.t()]

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -7,6 +7,16 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
 
   alias Mydia.Metadata.Access, as: MetadataAccess
   alias Mydia.Metadata.ImageUrl
+  alias Mydia.Repo
+
+  # Detections below this floor are persisted, so the operator can see and
+  # diagnose them, but are not shown to players. 0.4 is exactly 2 agreeing
+  # partners out of 5 attempted, the lowest value the detection acceptance rule
+  # can produce, so the floor admits every accepted detection while still
+  # leaving room to raise it from field reports without re-analyzing anything.
+  # A 0.5 floor would discard every minimum-consensus detection and make the
+  # acceptance rule unreachable in practice.
+  @segment_confidence_floor 0.4
 
   # Movie and TVShow field resolvers
 
@@ -297,4 +307,32 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
         {:ok, Media.is_favorite?(user.id, media_item_id)}
     end
   end
+
+  # Skippable segments
+
+  @doc """
+  Resolves the skippable segments of a media file.
+  """
+  @spec segments(map(), map(), Absinthe.Resolution.t()) :: {:ok, [Library.MediaSegment.t()]}
+  def segments(media_file, _args, _info) do
+    {:ok, visible_segments(media_file)}
+  end
+
+  @doc """
+  Filters persisted segments down to the ones trustworthy enough to show a viewer.
+
+  Public so the confidence floor can be exercised directly in tests.
+  """
+  @spec visible_segments(map()) :: [Library.MediaSegment.t()]
+  def visible_segments(%{segments: %Ecto.Association.NotLoaded{}} = media_file) do
+    media_file |> Repo.preload(:segments) |> visible_segments()
+  end
+
+  def visible_segments(%{segments: segments}) when is_list(segments) do
+    segments
+    |> Enum.filter(&(&1.confidence >= @segment_confidence_floor))
+    |> Enum.sort_by(& &1.start_ms)
+  end
+
+  def visible_segments(_media_file), do: []
 end

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -103,6 +103,9 @@ type RootMutationType {
   "Refresh a media access token before it expires"
   refreshMediaToken(token: String!): MediaToken
 
+  "Exchange a pairing device token for a fresh access token"
+  refreshAccessToken(deviceToken: String!): AccessToken
+
   "Generate a pairing claim code for device pairing (requires authentication)"
   generateClaimCode: ClaimCode
 
@@ -573,6 +576,27 @@ type MediaFile {
 
   "Available subtitle tracks (embedded and external)"
   subtitles: [SubtitleTrack]
+
+  "Skippable segments (intro, credits). Empty when detection has not run or found nothing."
+  segments: [MediaSegment!]!
+}
+
+"""
+A detected skippable segment.
+
+`source` and `confidence` are deliberately absent from the wire format. They
+are operator concerns, and keeping the confidence floor server side means it
+is enforced in one place rather than reimplemented in every client.
+"""
+type MediaSegment {
+  "Which kind of segment this is"
+  type: SegmentType!
+
+  "Segment start, milliseconds"
+  startMs: Int!
+
+  "Segment end, milliseconds"
+  endMs: Int!
 }
 
 "User playback progress on a media item or episode"
@@ -713,6 +737,15 @@ type MediaToken {
 
   "List of granted permissions"
   permissions: [String!]!
+}
+
+"Access token for authenticating GraphQL and API requests"
+type AccessToken {
+  "JWT access token"
+  token: String!
+
+  "Token expiration timestamp"
+  expiresAt: DateTime!
 }
 
 "API key for programmatic access"
@@ -1139,6 +1172,15 @@ enum StreamingCandidateStrategy {
 
   "Full transcoding"
   TRANSCODE
+}
+
+"A region of a media file a viewer may want to skip"
+enum SegmentType {
+  "Opening theme"
+  INTRO
+
+  "Closing credits"
+  CREDITS
 }
 
 """

--- a/test/mydia_web/schema/media_segment_test.exs
+++ b/test/mydia_web/schema/media_segment_test.exs
@@ -85,11 +85,27 @@ defmodule MydiaWeb.Schema.MediaSegmentTest do
       assert visible_segments_for(media_file) == []
     end
 
-    test "chapter sourced segments are always exposed" do
+    test "exposes chapter sourced segments, which the pipeline writes at full confidence" do
       media_file = media_file_fixture()
       insert_segment(media_file, %{source: "chapters", confidence: 1.0})
 
       assert [_segment] = visible_segments_for(media_file)
+    end
+
+    test "applies the floor uniformly, without a bypass for chapter sourced segments" do
+      # The floor is deliberately a single condition on confidence, with no
+      # exception by source. A chapter hit clears it because the detection
+      # pipeline writes chapter matches at confidence 1.0, not because the
+      # resolver treats `source` specially.
+      #
+      # Keeping it uniform means a chapter segment that somehow lands below the
+      # floor disappears from the wire, which is the signal you want: it says
+      # something wrote it wrong. A source bypass would mask exactly that bug
+      # and split exposure across two rules.
+      media_file = media_file_fixture()
+      insert_segment(media_file, %{source: "chapters", confidence: 0.2})
+
+      assert visible_segments_for(media_file) == []
     end
 
     test "preloads segments when the association has not been loaded" do

--- a/test/mydia_web/schema/media_segment_test.exs
+++ b/test/mydia_web/schema/media_segment_test.exs
@@ -1,0 +1,209 @@
+defmodule MydiaWeb.Schema.MediaSegmentTest do
+  use MydiaWeb.ConnCase, async: false
+
+  alias Mydia.AccountsFixtures
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.MediaSegment
+  alias Mydia.MediaFixtures
+  alias Mydia.Repo
+  alias MydiaWeb.Schema.Resolvers.MediaResolver
+
+  @movie_segments_query """
+  query Movie($id: ID!) {
+    movie(id: $id) {
+      id
+      files {
+        id
+        segments {
+          type
+          startMs
+          endMs
+        }
+      }
+    }
+  }
+  """
+
+  @movie_segment_confidence_query """
+  query Movie($id: ID!) {
+    movie(id: $id) {
+      files {
+        segments {
+          type
+          confidence
+        }
+      }
+    }
+  }
+  """
+
+  @movie_segment_source_query """
+  query Movie($id: ID!) {
+    movie(id: $id) {
+      files {
+        segments {
+          type
+          source
+        }
+      }
+    }
+  }
+  """
+
+  describe "confidence floor" do
+    test "exposes segments above the floor" do
+      media_file = media_file_fixture()
+      insert_segment(media_file, %{confidence: 0.8})
+
+      assert [segment] = visible_segments_for(media_file)
+      assert segment.type == "intro"
+      assert segment.start_ms == 30_000
+    end
+
+    test "hides segments below the floor" do
+      media_file = media_file_fixture()
+      insert_segment(media_file, %{confidence: 0.2})
+
+      assert visible_segments_for(media_file) == []
+    end
+
+    test "exposes a segment at exactly the minimum consensus confidence" do
+      # 2 agreeing partners out of 5 attempted is 0.4, the lowest value the
+      # detection acceptance rule can produce. If the exposure floor rejected
+      # this, every minimum-consensus detection would be invisible and the
+      # acceptance rule would be unreachable in practice.
+      media_file = media_file_fixture()
+      insert_segment(media_file, %{confidence: 0.4})
+
+      assert [_segment] = visible_segments_for(media_file)
+    end
+
+    test "hides a segment just below the minimum consensus confidence" do
+      media_file = media_file_fixture()
+      insert_segment(media_file, %{confidence: 0.39})
+
+      assert visible_segments_for(media_file) == []
+    end
+
+    test "chapter sourced segments are always exposed" do
+      media_file = media_file_fixture()
+      insert_segment(media_file, %{source: "chapters", confidence: 1.0})
+
+      assert [_segment] = visible_segments_for(media_file)
+    end
+
+    test "preloads segments when the association has not been loaded" do
+      media_file = media_file_fixture()
+      insert_segment(media_file, %{confidence: 0.8})
+
+      unloaded = Repo.get!(MediaFile, media_file.id)
+      assert %Ecto.Association.NotLoaded{} = unloaded.segments
+
+      assert [_segment] = MediaResolver.visible_segments(unloaded)
+    end
+
+    test "returns segments ordered by start position" do
+      media_file = media_file_fixture()
+      insert_segment(media_file, %{type: "credits", start_ms: 1_200_000, end_ms: 1_260_000})
+      insert_segment(media_file, %{type: "intro", start_ms: 30_000, end_ms: 90_000})
+
+      assert ["intro", "credits"] = Enum.map(visible_segments_for(media_file), & &1.type)
+    end
+  end
+
+  describe "mediaFile.segments over GraphQL" do
+    setup do
+      %{user: AccountsFixtures.user_fixture()}
+    end
+
+    test "returns detected segments on the file", %{user: user} do
+      media_item = MediaFixtures.media_item_fixture(%{type: "movie"})
+      media_file = MediaFixtures.media_file_fixture(%{media_item_id: media_item.id})
+      insert_segment(media_file, %{type: "credits", start_ms: 1_200_000, end_ms: 1_260_000})
+
+      assert {:ok, %{data: data}} =
+               run_query(@movie_segments_query, %{"id" => media_item.id}, user)
+
+      assert [%{"segments" => [segment]}] = data["movie"]["files"]
+
+      assert segment == %{
+               "type" => "CREDITS",
+               "startMs" => 1_200_000,
+               "endMs" => 1_260_000
+             }
+    end
+
+    test "omits segments below the confidence floor", %{user: user} do
+      media_item = MediaFixtures.media_item_fixture(%{type: "movie"})
+      media_file = MediaFixtures.media_file_fixture(%{media_item_id: media_item.id})
+      insert_segment(media_file, %{confidence: 0.2})
+
+      assert {:ok, %{data: data}} =
+               run_query(@movie_segments_query, %{"id" => media_item.id}, user)
+
+      assert [%{"segments" => []}] = data["movie"]["files"]
+    end
+
+    test "returns an empty list when detection has not run", %{user: user} do
+      media_item = MediaFixtures.media_item_fixture(%{type: "movie"})
+      MediaFixtures.media_file_fixture(%{media_item_id: media_item.id})
+
+      assert {:ok, %{data: data}} =
+               run_query(@movie_segments_query, %{"id" => media_item.id}, user)
+
+      assert [%{"segments" => []}] = data["movie"]["files"]
+    end
+
+    test "keeps confidence off the wire", %{user: user} do
+      media_item = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+      assert {:ok, %{errors: errors}} =
+               run_query(@movie_segment_confidence_query, %{"id" => media_item.id}, user)
+
+      assert Enum.any?(errors, &(&1.message =~ "confidence"))
+    end
+
+    test "keeps source off the wire", %{user: user} do
+      media_item = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+      assert {:ok, %{errors: errors}} =
+               run_query(@movie_segment_source_query, %{"id" => media_item.id}, user)
+
+      assert Enum.any?(errors, &(&1.message =~ "source"))
+    end
+  end
+
+  defp media_file_fixture do
+    media_item = MediaFixtures.media_item_fixture(%{type: "movie"})
+    MediaFixtures.media_file_fixture(%{media_item_id: media_item.id})
+  end
+
+  defp insert_segment(media_file, attrs) do
+    %MediaSegment{}
+    |> MediaSegment.changeset(
+      Map.merge(
+        %{
+          media_file_id: media_file.id,
+          type: "intro",
+          start_ms: 30_000,
+          end_ms: 90_000,
+          source: "fingerprint",
+          confidence: 0.8
+        },
+        attrs
+      )
+    )
+    |> Repo.insert!()
+  end
+
+  defp visible_segments_for(media_file) do
+    MediaFile
+    |> Repo.get!(media_file.id)
+    |> Repo.preload(:segments)
+    |> MediaResolver.visible_segments()
+  end
+
+  defp run_query(query, variables, user) do
+    Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: %{current_user: user})
+  end
+end


### PR DESCRIPTION
Task 10 of the intro/credits detection plan: the GraphQL surface that carries detected segments to the player.

## What lands

- `SegmentType` enum (`INTRO`, `CREDITS`) in `enum_types.ex`
- `MediaSegment` object with `type`, `startMs`, `endMs`
- `segments: [MediaSegment!]!` on `MediaFile`
- `MediaResolver.segments/3` plus a public `visible_segments/1` that applies the confidence floor and preloads the association when it has not been loaded
- Regenerated `priv/graphql/schema.graphql`

## Why `source` and `confidence` are not on the wire

They are operator concerns. Keeping them server side means the confidence floor is enforced in exactly one place instead of the player growing its own threshold logic. The admin UI still sees every accepted detection and its confidence, which is what makes a borderline result diagnosable, and the floor can be retuned from field reports without re-analyzing any library.

## Why the floor is 0.4 and not 0.5

The detection acceptance rule requires at least 2 agreeing matches out of 5 attempted, which is exactly 0.4 confidence. A 0.5 floor would silently discard every detection that met the acceptance rule at its minimum, making that rule unreachable in practice.

Two tests pin the boundary rather than leaving it to a comment: a segment at exactly `confidence == 0.4` is exposed, and one at `0.39` is not.

## Compatibility

Mydia is self-hosted with no coordinated deploy order, so there is no version gating here and none is needed. An older player simply does not request `segments`; a newer player against an older server gets a field error it treats as "no segments".

## Notes

Two deviations from the task sheet, both for repo consistency:

- The task sheet placed the enum and object in `media_types.ex`, but `object :media_file` actually lives in `common_types.ex` and every other enum lives in `enum_types.ex`. The types follow the existing layout.
- The task sheet asked for a refresh of the root `schema.json`. That file is stale and unreferenced (it predates the `subtitles` field, among others). The live artifact is `priv/graphql/schema.graphql`, which the player symlinks and `mix mydia.graphql export` maintains, so that is what was regenerated. Doing so also picks up the previously unexported `refreshAccessToken` mutation and `AccessToken` type.

## Verification

- `mix test test/mydia_web/schema/` — 74 tests, 0 failures (12 of them new)
- `mix format --check-formatted` clean
- `mix credo --strict` — no issues across 984 files
- `MIX_ENV=test mix compile --warnings-as-errors` clean
