### PR TITLE
feat(jobs): schedule and run per-season segment detection

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -261,6 +261,7 @@ config :mydia, Oban,
     media: 3,
     search: 2,
     analysis: 2,
+    segments: 1,
     notifications: 1,
     maintenance: 1,
     import_lists: 2,
@@ -294,6 +295,9 @@ config :mydia, Oban,
        {"*/15 * * * *", Mydia.Jobs.ImportListScheduler},
        # Enqueue scans for library paths whose scan_interval has elapsed (opt-in per path)
        {"*/15 * * * *", Mydia.Jobs.LibraryScanScheduler},
+       # Look for seasons needing intro/credits detection. The work itself runs
+       # on the segments queue at concurrency 1, so this only ever queues.
+       {"*/5 * * * *", Mydia.Jobs.SegmentDetectionScheduler},
        # Refresh metadata for all monitored items weekly on Sunday at 5 AM
        {"0 5 * * 0", Mydia.Jobs.MetadataRefresh, args: %{"refresh_all" => true}},
        # Refresh Trakt tokens approaching expiry daily at 6 AM

--- a/lib/mydia/jobs/segment_detection.ex
+++ b/lib/mydia/jobs/segment_detection.ex
@@ -1,0 +1,37 @@
+defmodule Mydia.Jobs.SegmentDetection do
+  @moduledoc """
+  Detects intro and credits segments for one season.
+
+  Runs on the dedicated `:segments` queue at concurrency 1. That concurrency is
+  the throttle for the whole feature: audio decoding is CPU heavy, and on a
+  small home server it must never compete with library scanning or streaming.
+
+  A season is the tuple `(media_item_id, season_number)`; there is no `seasons`
+  table. A season that no longer exists is a success rather than a failure,
+  because `analyze_season/2` finds no files and so has nothing to do.
+  """
+
+  use Oban.Worker,
+    queue: :segments,
+    max_attempts: 3,
+    unique: [
+      period: 300,
+      fields: [:worker, :args],
+      states: [:suspended, :available, :scheduled, :executing, :retryable]
+    ]
+
+  require Logger
+
+  alias Mydia.Library.SegmentDetection
+
+  @impl Oban.Worker
+  @spec perform(Oban.Job.t()) :: :ok
+  def perform(%Oban.Job{args: %{"media_item_id" => media_item_id, "season_number" => season}}) do
+    Logger.debug("Detecting segments for season",
+      media_item_id: media_item_id,
+      season_number: season
+    )
+
+    SegmentDetection.analyze_season(media_item_id, season)
+  end
+end

--- a/lib/mydia/jobs/segment_detection_scheduler.ex
+++ b/lib/mydia/jobs/segment_detection_scheduler.ex
@@ -1,0 +1,125 @@
+defmodule Mydia.Jobs.SegmentDetectionScheduler do
+  @moduledoc """
+  Cron worker that finds seasons needing segment detection and enqueues one
+  job each.
+
+  Detection is season-scoped but its state is tracked per file, so this worker
+  translates "files needing work" into "seasons to process". There is no
+  `seasons` table: a season is the tuple `(media_item_id, season_number)`
+  derived from `episodes`.
+
+  A file is only eligible once `FileAnalysis` has given it a duration, because
+  both fingerprint windows are computed from runtime. Waiting for that is an
+  ordering dependency between the two workers rather than a failure, so a file
+  without one is not selected, stays `pending`, and spends no attempt.
+
+  When `fpcalc` is absent this enqueues nothing at all. Availability is a
+  runtime capability check, never a persisted state, so installing chromaprint
+  later needs no data repair: the backlog of `pending` files is picked up on
+  the next tick.
+  """
+
+  use Oban.Worker,
+    queue: :segments,
+    max_attempts: 1,
+    # Matches FileAnalysis. A tick that overruns the 5-minute schedule would
+    # otherwise have a second tick select the same seasons behind it.
+    unique: [
+      period: 300,
+      fields: [:worker],
+      states: [:suspended, :available, :scheduled, :executing, :retryable]
+    ]
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Mydia.Jobs.SegmentDetection, as: SegmentDetectionJob
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.SegmentDetection
+  alias Mydia.Library.SegmentDetection.Fingerprint
+  alias Mydia.Media.Episode
+  alias Mydia.Repo
+
+  # The segments queue runs at concurrency 1, so a tick that queued the whole
+  # library would just build a backlog the next tick cannot see past. Bounding
+  # it keeps the queue short and the ordering stable.
+  @seasons_per_tick 20
+
+  @impl Oban.Worker
+  @spec perform(Oban.Job.t()) :: :ok
+  def perform(%Oban.Job{}) do
+    if Fingerprint.available?() do
+      enqueue_pending_seasons()
+    else
+      # Debug rather than info: this ticks every 5 minutes, and an operator
+      # without chromaprint installed should not have their logs filled with
+      # it. The admin UI surfaces the same capability check where it is useful.
+      Logger.debug("Skipping segment detection: audio fingerprinting is unavailable")
+      :ok
+    end
+  end
+
+  @doc """
+  Seasons with at least one file waiting on detection, as
+  `{media_item_id, season_number}` tuples.
+  """
+  @spec pending_seasons() :: [{binary(), integer()}]
+  def pending_seasons do
+    max_attempts = SegmentDetection.max_attempts()
+
+    Repo.all(
+      from(mf in MediaFile,
+        join: e in Episode,
+        on: e.id == mf.episode_id,
+        where:
+          mf.segment_analysis_state == "pending" and
+            mf.segment_analysis_attempts < ^max_attempts and
+            not is_nil(mf.analyzed_at) and is_nil(mf.trashed_at),
+        group_by: [e.media_item_id, e.season_number],
+        order_by: [asc: e.media_item_id, asc: e.season_number],
+        limit: @seasons_per_tick,
+        select: {e.media_item_id, e.season_number}
+      )
+    )
+  end
+
+  defp enqueue_pending_seasons do
+    seasons = pending_seasons()
+
+    if seasons != [] do
+      Logger.debug("Enqueueing segment detection", seasons: length(seasons))
+    end
+
+    # IMPORTANT: enqueue one at a time with Oban.insert/1.
+    #
+    # Oban.insert_all/1 silently bypasses the worker's `unique:` option on the
+    # Basic and Lite engines this project runs, so a slow season would collect
+    # a duplicate job on every tick. The app disables Oban's engine entirely
+    # under test (`engine: false`), where uniqueness does not apply either, so
+    # nothing in the default test setup would flag the regression.
+    # Do not "optimize" this into insert_all.
+    Enum.each(seasons, &enqueue_season/1)
+
+    :ok
+  end
+
+  defp enqueue_season({media_item_id, season_number}) do
+    %{media_item_id: media_item_id, season_number: season_number}
+    |> SegmentDetectionJob.new()
+    |> Oban.insert()
+    |> case do
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to enqueue segment detection",
+          media_item_id: media_item_id,
+          season_number: season_number,
+          reason: inspect(reason)
+        )
+
+        :error
+    end
+  end
+end

--- a/lib/mydia/library/segment_detection.ex
+++ b/lib/mydia/library/segment_detection.ex
@@ -68,6 +68,16 @@ defmodule Mydia.Library.SegmentDetection do
   @segment_types ~w(intro credits)
 
   @doc """
+  How many times a file may fail detection before it is marked `failed`.
+
+  Exposed so the scheduler selects exactly the files this module will act on.
+  A second copy of the ceiling would drift into either jobs that find nothing
+  to do or files that are never retried.
+  """
+  @spec max_attempts() :: pos_integer()
+  def max_attempts, do: @max_attempts
+
+  @doc """
   Analyses one season and writes its segments.
 
   Always returns `:ok`. Per-file failures are recorded on the row rather than

--- a/lib/mydia/library/segment_detection.ex
+++ b/lib/mydia/library/segment_detection.ex
@@ -1,0 +1,527 @@
+defmodule Mydia.Library.SegmentDetection do
+  @moduledoc """
+  Locates intro and credits segments across a season of TV episodes.
+
+  ## Why a season is the unit
+
+  An opening theme is only recognisable as one because it *recurs*. A single
+  episode in isolation gives nothing to compare against, so detection is
+  inherently season-scoped even though results are stored per file.
+
+  There is no `seasons` table: a season is the tuple
+  `(media_item_id, season_number)` derived from `episodes`.
+
+  ## Order of operations
+
+  1. Chapter markers, when the container has them. Near-free and exact.
+  2. Audio fingerprint correlation for whatever chapters did not resolve.
+  3. Black-frame refinement of the credits end.
+
+  Results below the acceptance bar are recorded as `not_found`, which is an
+  answer rather than a failure and therefore consumes no retry attempts.
+
+  ## Strictly additive
+
+  This is background work. Nothing here blocks scanning, import, or playback,
+  and every per-file failure is recorded on the row instead of raised, so one
+  unreadable file cannot abort the rest of the season.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.MediaSegment
+  alias Mydia.Library.SegmentDetection.Boundary
+  alias Mydia.Library.SegmentDetection.Chapters
+  alias Mydia.Library.SegmentDetection.Correlator
+  alias Mydia.Library.SegmentDetection.Fingerprint
+  alias Mydia.Library.SegmentDetection.FingerprintCache
+  alias Mydia.Media.Episode
+  alias Mydia.Repo
+
+  # Search windows, in seconds and as a fraction of runtime. An intro is almost
+  # always in the first stretch, but a long cold open can push it later.
+  @intro_window_max_s 15 * 60
+  @intro_window_fraction 0.4
+  @credits_window_max_s 10 * 60
+  @credits_window_fraction 0.3
+
+  # Minimum length for a run to count as a theme. Measured intros run 40 to 90
+  # seconds, so these floors are deliberately conservative.
+  @min_intro_s 15
+  @min_credits_s 20
+
+  # Correlation partners per target, and the minimum that must agree.
+  @partner_count 5
+  @min_agreeing 2
+
+  # Two matches agree when their starts land within this of each other. Real
+  # detections cluster within a frame or two (~124ms); this is deliberately
+  # loose enough to absorb that while still rejecting a spurious match
+  # elsewhere in the episode.
+  @agree_tolerance_ms 2_000
+
+  @max_attempts 3
+
+  @segment_types ~w(intro credits)
+
+  @doc """
+  Analyses one season and writes its segments.
+
+  Always returns `:ok`. Per-file failures are recorded on the row rather than
+  raised, so one unreadable file cannot abort the rest of the season.
+  """
+  @spec analyze_season(binary(), integer()) :: :ok
+  def analyze_season(media_item_id, season_number) do
+    files = season_files(media_item_id, season_number)
+
+    # Both search windows are computed from the runtime, which `FileAnalysis`
+    # supplies. A file without one is not a failure, it is not ready: it stays
+    # `pending`, spends no attempt, and is picked up on a later tick.
+    ready = Enum.filter(files, &duration_known?/1)
+    targets = Enum.filter(ready, &pending?/1)
+
+    cond do
+      targets == [] ->
+        :ok
+
+      length(files) < 2 ->
+        # Nothing to correlate against, ever. Chapters may still resolve it.
+        Enum.each(targets, &analyze_chapters_only/1)
+        :ok
+
+      length(ready) < 2 ->
+        # The season is big enough, but its other files have no runtime yet.
+        # Waiting is the right answer here; `not_found` would be terminal.
+        :ok
+
+      true ->
+        Enum.each(targets, &analyze_file(&1, ready))
+        :ok
+    end
+  end
+
+  @doc """
+  Combines per-partner matches into a single result.
+
+  Requires `#{@min_agreeing}` matches **that agree with each other**. Matches
+  are first reduced to the largest cluster whose starts fall within
+  `#{@agree_tolerance_ms}` ms; medians of start and end are then taken
+  independently over that cluster. Confidence is the share of attempted
+  pairings that agreed.
+
+  Clustering before counting is what makes the minimum case safe. Counting
+  every match instead would measure "partners that found any run" rather than
+  "partners that agreed on the same run", and the median of two values is
+  their midpoint, so a correct match at 2:00 paired with a spurious one at
+  15:00 would ship a segment at 8:30 at exactly the confidence the exposure
+  floor admits. Agreement is all or nothing on real media, so clustering costs
+  nothing in the common case and only bites when a spurious run appears.
+  """
+  @spec consensus([%{start_ms: integer(), end_ms: integer()}], pos_integer()) ::
+          {:ok, %{start_ms: integer(), end_ms: integer(), confidence: float()}} | :no_consensus
+  def consensus(matches, attempted) when is_list(matches) and is_integer(attempted) do
+    agreeing = largest_cluster(matches)
+
+    if attempted > 0 and length(agreeing) >= @min_agreeing do
+      {:ok,
+       %{
+         start_ms: median(Enum.map(agreeing, & &1.start_ms)),
+         end_ms: median(Enum.map(agreeing, & &1.end_ms)),
+         confidence: length(agreeing) / attempted
+       }}
+    else
+      :no_consensus
+    end
+  end
+
+  def consensus(_matches, _attempted), do: :no_consensus
+
+  @doc """
+  Picks correlation partners spread across the season.
+
+  Deliberately not the nearest neighbours: a two-part opener or a recap-heavy
+  premiere sits next to exactly the episodes that would otherwise be chosen.
+  """
+  @spec partners([term()], term(), pos_integer()) :: [term()]
+  def partners(files, target, count) do
+    case Enum.reject(files, &(&1 == target)) do
+      [] ->
+        []
+
+      others ->
+        total = length(others)
+
+        if total <= count do
+          others
+        else
+          step = total / count
+
+          0..(count - 1)
+          |> Enum.map(fn i -> Enum.at(others, trunc(i * step)) end)
+          |> Enum.uniq()
+        end
+    end
+  end
+
+  @doc """
+  Clears a season's segments and returns its files to `pending`.
+
+  Cached fingerprints are kept, so a re-analysis does not re-decode audio.
+  """
+  @spec reset_season(binary(), integer()) :: :ok
+  def reset_season(media_item_id, season_number) do
+    file_ids = media_item_id |> season_files(season_number) |> Enum.map(& &1.id)
+
+    Repo.delete_all(from(s in MediaSegment, where: s.media_file_id in ^file_ids))
+
+    Repo.update_all(
+      from(mf in MediaFile, where: mf.id in ^file_ids),
+      set: [
+        segment_analysis_state: "pending",
+        segment_analysis_attempts: 0,
+        last_segment_analysis_error: nil,
+        segments_analyzed_at: nil
+      ]
+    )
+
+    :ok
+  end
+
+  @doc """
+  Summarises a season for the admin UI.
+
+  `:state` is derived: `:detected` when every file resolved with at least one
+  segment, `:partial` when some did, and otherwise the dominant file state.
+  """
+  @spec season_status(binary(), integer()) :: %{
+          state: atom(),
+          segments: %{optional(String.t()) => MediaSegment.t()},
+          source: String.t() | nil
+        }
+  def season_status(media_item_id, season_number) do
+    files =
+      media_item_id
+      |> season_files(season_number)
+      |> Repo.preload(:segments)
+
+    with_segments = Enum.filter(files, &(&1.segments != []))
+    sample = List.first(with_segments)
+
+    %{
+      state: derive_state(files, with_segments),
+      segments: sample_segments(sample),
+      source: sample_source(sample)
+    }
+  end
+
+  defp derive_state(files, with_segments) do
+    cond do
+      files == [] -> :pending
+      Enum.any?(files, &(&1.segment_analysis_state == "failed")) -> :failed
+      length(with_segments) == length(files) -> :detected
+      with_segments != [] -> :partial
+      Enum.all?(files, &(&1.segment_analysis_state == "not_found")) -> :not_found
+      true -> :pending
+    end
+  end
+
+  defp sample_segments(nil), do: %{}
+  defp sample_segments(file), do: Map.new(file.segments, &{&1.type, &1})
+
+  defp sample_source(nil), do: nil
+  defp sample_source(file), do: file.segments |> List.first() |> Map.fetch!(:source)
+
+  # -- season loading -------------------------------------------------------
+
+  defp season_files(media_item_id, season_number) do
+    Repo.all(
+      from(mf in MediaFile,
+        join: e in Episode,
+        on: e.id == mf.episode_id,
+        where:
+          e.media_item_id == ^media_item_id and e.season_number == ^season_number and
+            is_nil(mf.trashed_at),
+        order_by: [asc: e.episode_number],
+        preload: :library_path
+      )
+    )
+  end
+
+  defp pending?(%MediaFile{segment_analysis_state: "pending", segment_analysis_attempts: n}),
+    do: n < @max_attempts
+
+  defp pending?(_file), do: false
+
+  defp duration_known?(file), do: match?({:ok, _duration}, duration_seconds(file))
+
+  # -- per-file analysis ----------------------------------------------------
+
+  defp analyze_chapters_only(file) do
+    case chapter_segments(file) do
+      found when found != %{} ->
+        write_chapter_segments(file, found)
+        mark(file, "detected")
+
+      _none ->
+        mark(file, "not_found")
+    end
+  end
+
+  defp analyze_file(file, files) do
+    chapters = chapter_segments(file)
+    write_chapter_segments(file, chapters)
+
+    # Resolution is per segment type: a file whose chapters name an opening but
+    # not an ending still needs its credits window fingerprinted.
+    remaining = Enum.reject(@segment_types, &Map.has_key?(chapters, &1))
+
+    case detect_by_fingerprint(file, files, remaining) do
+      {:ok, detected_any?} ->
+        mark(file, if(detected_any? or chapters != %{}, do: "detected", else: "not_found"))
+
+      {:error, reason} ->
+        mark_failure(file, reason)
+    end
+  end
+
+  # A chapter read that fails is not a detection failure. ffprobe may be
+  # missing, or the container may carry no chapters at all, and fingerprinting
+  # can still answer, so the failure degrades to "no chapters".
+  defp chapter_segments(file) do
+    with path when is_binary(path) <- MediaFile.absolute_path(file),
+         {:ok, found} <- Chapters.detect(path) do
+      found
+    else
+      _no_chapters -> %{}
+    end
+  end
+
+  defp write_chapter_segments(file, chapters) do
+    Enum.each(chapters, fn {type, {start_ms, end_ms}} ->
+      upsert_segment(file, type, start_ms, end_ms, "chapters", 1.0)
+    end)
+  end
+
+  defp detect_by_fingerprint(_file, _files, []), do: {:ok, false}
+
+  defp detect_by_fingerprint(file, files, types) do
+    Enum.reduce_while(types, {:ok, false}, fn type, {:ok, acc} ->
+      case detect_type(file, files, type) do
+        {:ok, true} -> {:cont, {:ok, true}}
+        {:ok, false} -> {:cont, {:ok, acc}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp detect_type(file, files, type) do
+    case fingerprint_for(file, type) do
+      {:ok, target_fp} -> correlate(file, files, type, target_fp)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp correlate(file, files, type, target_fp) do
+    candidates = partners(files, file, @partner_count)
+
+    matches =
+      Enum.flat_map(candidates, fn partner ->
+        case fingerprint_for(partner, type) do
+          {:ok, partner_fp} -> match_pair(target_fp, partner_fp, type)
+          {:error, _reason} -> []
+        end
+      end)
+
+    case consensus(matches, max(length(candidates), 1)) do
+      {:ok, result} ->
+        end_ms = maybe_refine(file, type, result.end_ms)
+        upsert_segment(file, type, result.start_ms, end_ms, "fingerprint", result.confidence)
+        {:ok, true}
+
+      :no_consensus ->
+        {:ok, false}
+    end
+  end
+
+  defp match_pair(target_fp, partner_fp, type) do
+    min_frames = round(min_seconds(type) * 1000 / target_fp.frame_ms)
+
+    case Correlator.best_match(target_fp.hashes, partner_fp.hashes, min_frames: min_frames) do
+      {:ok, match} ->
+        # Frame positions are relative to the window, so the window's own start
+        # is added back. For the intro window that is zero; for credits it is
+        # not. `end_frame` is inclusive, hence the + 1.
+        offset_ms = target_fp.window_start_ms
+
+        [
+          %{
+            start_ms: offset_ms + round(match.start_frame * target_fp.frame_ms),
+            end_ms: offset_ms + round((match.end_frame + 1) * target_fp.frame_ms)
+          }
+        ]
+
+      :no_match ->
+        []
+    end
+  end
+
+  defp min_seconds("intro"), do: @min_intro_s
+  defp min_seconds("credits"), do: @min_credits_s
+
+  defp maybe_refine(file, "credits", end_ms) do
+    case MediaFile.absolute_path(file) do
+      nil -> end_ms
+      path -> Boundary.refine_end(path, end_ms)
+    end
+  end
+
+  defp maybe_refine(_file, _type, end_ms), do: end_ms
+
+  # -- fingerprints ---------------------------------------------------------
+
+  defp fingerprint_for(file, type) do
+    with {:ok, duration} <- duration_seconds(file),
+         path when is_binary(path) <- MediaFile.absolute_path(file) do
+      {start_s, length_s} = window(type, duration)
+      load_or_compute(file, type, path, start_s, length_s)
+    else
+      nil -> {:error, :path_not_resolved}
+      :error -> {:error, :duration_unknown}
+    end
+  end
+
+  defp load_or_compute(file, type, path, start_s, length_s) do
+    case FingerprintCache.fetch(file, type) do
+      {:ok, result} ->
+        {:ok, put_window(result, start_s)}
+
+      :miss ->
+        case Fingerprint.fingerprint(path, start_s, length_s) do
+          {:ok, result} ->
+            FingerprintCache.put(file, type, result)
+            {:ok, put_window(result, start_s)}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp put_window(result, start_s), do: %{result | window_start_ms: max(round(start_s * 1000), 0)}
+
+  defp window("intro", duration) do
+    {0, min(@intro_window_max_s, duration * @intro_window_fraction)}
+  end
+
+  defp window("credits", duration) do
+    length_s = min(@credits_window_max_s, duration * @credits_window_fraction)
+    {max(duration - length_s, 0), length_s}
+  end
+
+  defp duration_seconds(%MediaFile{metadata: %{duration: duration}})
+       when is_number(duration) and duration > 0,
+       do: {:ok, duration}
+
+  defp duration_seconds(_file), do: :error
+
+  # -- persistence ----------------------------------------------------------
+
+  defp upsert_segment(file, type, start_ms, end_ms, source, confidence) do
+    attrs = %{
+      media_file_id: file.id,
+      type: type,
+      start_ms: start_ms,
+      end_ms: end_ms,
+      source: source,
+      confidence: confidence
+    }
+
+    result =
+      case Repo.get_by(MediaSegment, media_file_id: file.id, type: type) do
+        nil -> %MediaSegment{} |> MediaSegment.changeset(attrs) |> Repo.insert()
+        segment -> segment |> MediaSegment.changeset(attrs) |> Repo.update()
+      end
+
+    case result do
+      {:ok, segment} ->
+        segment
+
+      {:error, changeset} ->
+        Logger.warning("Rejected detected segment",
+          file_id: file.id,
+          type: type,
+          errors: inspect(changeset.errors)
+        )
+
+        nil
+    end
+  end
+
+  # State writes are guarded on the row still being `pending`, so a concurrent
+  # operator re-analysis or a second worker cannot clobber a fresher result.
+  defp mark(file, state) do
+    Repo.update_all(
+      from(mf in MediaFile, where: mf.id == ^file.id and mf.segment_analysis_state == "pending"),
+      set: [
+        segment_analysis_state: state,
+        segments_analyzed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        last_segment_analysis_error: nil
+      ]
+    )
+
+    :ok
+  end
+
+  defp mark_failure(file, reason) do
+    attempts = file.segment_analysis_attempts + 1
+    state = if attempts >= @max_attempts, do: "failed", else: "pending"
+
+    Repo.update_all(
+      from(mf in MediaFile, where: mf.id == ^file.id and mf.segment_analysis_state == "pending"),
+      set: [
+        segment_analysis_state: state,
+        segment_analysis_attempts: attempts,
+        last_segment_analysis_error: inspect(reason)
+      ]
+    )
+
+    Logger.warning("Segment detection failed",
+      file_id: file.id,
+      attempts: attempts,
+      reason: inspect(reason)
+    )
+
+    :ok
+  end
+
+  # -- consensus helpers ----------------------------------------------------
+
+  # Largest group whose starts agree within tolerance. O(n^2) over at most
+  # @partner_count matches, so the naive form is fine.
+  defp largest_cluster([]), do: []
+
+  defp largest_cluster(matches) do
+    matches
+    |> Enum.map(fn anchor ->
+      Enum.filter(matches, &(abs(&1.start_ms - anchor.start_ms) <= @agree_tolerance_ms))
+    end)
+    |> Enum.max_by(&length/1)
+  end
+
+  defp median([]), do: 0
+
+  defp median(values) do
+    sorted = Enum.sort(values)
+    count = length(sorted)
+    mid = div(count, 2)
+
+    if rem(count, 2) == 1 do
+      Enum.at(sorted, mid)
+    else
+      div(Enum.at(sorted, mid - 1) + Enum.at(sorted, mid), 2)
+    end
+  end
+end

--- a/lib/mydia/library/segment_detection/fingerprint_cache.ex
+++ b/lib/mydia/library/segment_detection/fingerprint_cache.ex
@@ -1,0 +1,88 @@
+defmodule Mydia.Library.SegmentDetection.FingerprintCache do
+  @moduledoc """
+  Persists computed fingerprints so a season is decoded once, not per pairing.
+
+  Storage follows the existing `sprite_blob` / `vtt_blob` / `preview_blob`
+  convention: the payload lives in `GeneratedMedia` under the `:fingerprint`
+  content type, and `media_files.fingerprint_blob` holds its checksum. One blob
+  carries both windows, keyed by segment type.
+
+  ## Why the checksum is read from the row, not the struct
+
+  A season is loaded once and then every file is fingerprinted several times
+  over: once as a correlation target, and again each time it is picked as
+  someone else's partner. The struct loaded at the start of the run predates
+  all of those writes, so trusting its `fingerprint_blob` would miss every
+  cache entry the same run just created and cost roughly six decodes per file
+  instead of one. Reading through the row also keeps the two windows in one
+  blob, since the intro is stored before the credits window is computed.
+
+  Every failure path degrades to a miss. A cache that cannot be read or written
+  costs time, never correctness.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Mydia.Library.GeneratedMedia
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.SegmentDetection.Fingerprint
+  alias Mydia.Repo
+
+  @doc """
+  Returns the cached fingerprint for `type`, or `:miss`.
+
+  `window_start_ms` is not stored, because it is derived from the file's
+  runtime rather than from the fingerprint. The caller sets it.
+  """
+  @spec fetch(MediaFile.t(), String.t()) :: {:ok, Fingerprint.Result.t()} | :miss
+  def fetch(%MediaFile{} = file, type) do
+    case file |> current_checksum() |> read() do
+      %{^type => %{"hashes" => hashes, "frame_ms" => frame_ms}} ->
+        {:ok, %Fingerprint.Result{hashes: hashes, frame_ms: frame_ms}}
+
+      _miss ->
+        :miss
+    end
+  end
+
+  @doc """
+  Stores the fingerprint for `type`, merging it into whatever is already cached.
+  """
+  @spec put(MediaFile.t(), String.t(), Fingerprint.Result.t()) :: :ok
+  def put(%MediaFile{} = file, type, %Fingerprint.Result{} = result) do
+    payload =
+      file
+      |> current_checksum()
+      |> read()
+      |> Map.put(type, %{"hashes" => result.hashes, "frame_ms" => result.frame_ms})
+
+    with {:ok, encoded} <- Jason.encode(payload),
+         {:ok, stored} <- GeneratedMedia.store(:fingerprint, encoded) do
+      Repo.update_all(from(mf in MediaFile, where: mf.id == ^file.id),
+        set: [fingerprint_blob: stored]
+      )
+    else
+      {:error, reason} ->
+        Logger.debug("Could not cache fingerprint", file_id: file.id, reason: inspect(reason))
+    end
+
+    :ok
+  end
+
+  defp current_checksum(file) do
+    Repo.one(from(mf in MediaFile, where: mf.id == ^file.id, select: mf.fingerprint_blob))
+  end
+
+  defp read(nil), do: %{}
+
+  defp read(checksum) do
+    with {:ok, binary} <- File.read(GeneratedMedia.get_path(:fingerprint, checksum)),
+         {:ok, decoded} when is_map(decoded) <- Jason.decode(binary) do
+      decoded
+    else
+      _unreadable -> %{}
+    end
+  end
+end

--- a/test/mydia/jobs/segment_detection_test.exs
+++ b/test/mydia/jobs/segment_detection_test.exs
@@ -1,0 +1,235 @@
+defmodule Mydia.Jobs.SegmentDetectionTest do
+  # Swaps the fingerprint implementation via Application env, so serial.
+  use Mydia.DataCase, async: false
+
+  use Oban.Testing, repo: Mydia.Repo
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.FingerprintStub
+  alias Mydia.Jobs.SegmentDetection
+  alias Mydia.Jobs.SegmentDetectionScheduler
+  alias Mydia.Library.MediaFile
+
+  setup do
+    # The app skips Oban in test (engine: false), so Oban.insert cannot be
+    # resolved from inside the scheduler. Start an isolated, manual-mode
+    # instance so enqueues land somewhere assert_enqueued can see them.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+    start_supervised!(%{id: FingerprintStub, start: {FingerprintStub, :start_link, []}})
+    Application.put_env(:mydia, :fingerprint_impl, FingerprintStub)
+
+    # Fingerprints are cached through GeneratedMedia, so give the run its own
+    # directory rather than writing into priv/generated.
+    cache_dir =
+      Path.join([
+        System.tmp_dir!(),
+        "segment_detection_jobs_test_#{System.unique_integer([:positive])}"
+      ])
+
+    File.mkdir_p!(cache_dir)
+    Application.put_env(:mydia, :generated_media_path, cache_dir)
+
+    on_exit(fn ->
+      File.rm_rf!(cache_dir)
+      Application.delete_env(:mydia, :generated_media_path)
+      Application.delete_env(:mydia, :fingerprint_impl)
+    end)
+
+    :ok
+  end
+
+  defp noise(count, seed) do
+    Enum.map(1..count, fn i -> :erlang.phash2({seed, i}, 4_294_967_296) end)
+  end
+
+  # Builds a season of TV episodes, each with one media file, and returns
+  # {media_item, [{media_file, absolute_path}]}. Files default to analyzed with
+  # a known duration, which is what makes them eligible for detection.
+  defp season_fixture(episode_count, opts \\ []) do
+    media_item =
+      Keyword.get_lazy(opts, :media_item, fn -> media_item_fixture(%{type: "tv_show"}) end)
+
+    season_number = Keyword.get(opts, :season_number, 1)
+    duration = Keyword.get(opts, :duration, 1500.0)
+
+    analyzed_at =
+      Keyword.get(opts, :analyzed_at, DateTime.utc_now() |> DateTime.truncate(:second))
+
+    files =
+      for n <- 1..episode_count do
+        episode =
+          episode_fixture(%{
+            media_item_id: media_item.id,
+            season_number: season_number,
+            episode_number: n
+          })
+
+        # The fixture replaces :metadata wholesale, so the duration segment
+        # detection needs has to be carried here explicitly.
+        media_file =
+          media_file_fixture(%{
+            episode_id: episode.id,
+            analyzed_at: analyzed_at,
+            relative_path: "s#{season_number}e#{n}.mkv",
+            metadata: %{"container" => "mkv", "duration" => duration}
+          })
+
+        {media_file, MediaFile.absolute_path(Repo.preload(media_file, :library_path))}
+      end
+
+    {media_item, files}
+  end
+
+  defp update_files(files, changes) do
+    Enum.map(files, fn {media_file, path} ->
+      {media_file |> Ecto.Changeset.change(changes) |> Repo.update!(), path}
+    end)
+  end
+
+  describe "SegmentDetectionScheduler" do
+    test "enqueues exactly one job per season, however many files are pending" do
+      {show, _files} = season_fixture(3)
+      {_show, _more} = season_fixture(2, media_item: show, season_number: 2)
+      {other_show, _files} = season_fixture(1)
+
+      assert :ok = perform_job(SegmentDetectionScheduler, %{})
+
+      assert_enqueued(worker: SegmentDetection, args: %{media_item_id: show.id, season_number: 1})
+      assert_enqueued(worker: SegmentDetection, args: %{media_item_id: show.id, season_number: 2})
+
+      assert_enqueued(
+        worker: SegmentDetection,
+        args: %{media_item_id: other_show.id, season_number: 1}
+      )
+
+      assert length(all_enqueued(worker: SegmentDetection)) == 3
+    end
+
+    test "does not select files whose duration is unknown" do
+      season_fixture(2, analyzed_at: nil)
+
+      assert :ok = perform_job(SegmentDetectionScheduler, %{})
+
+      assert all_enqueued(worker: SegmentDetection) == []
+    end
+
+    test "enqueues nothing when fingerprinting is unavailable" do
+      # fpcalc missing is a runtime capability check, not a stored state: the
+      # files stay pending and get picked up once chromaprint is installed.
+      FingerprintStub.put_available(false)
+
+      {_media_item, files} = season_fixture(2)
+
+      assert :ok = perform_job(SegmentDetectionScheduler, %{})
+
+      assert all_enqueued(worker: SegmentDetection) == []
+
+      for {media_file, _path} <- files do
+        assert Repo.get!(MediaFile, media_file.id).segment_analysis_state == "pending"
+      end
+    end
+
+    test "does not enqueue seasons whose files exhausted their attempts" do
+      {_media_item, files} = season_fixture(2)
+      update_files(files, %{segment_analysis_attempts: 3})
+
+      assert :ok = perform_job(SegmentDetectionScheduler, %{})
+
+      assert all_enqueued(worker: SegmentDetection) == []
+    end
+
+    test "does not enqueue seasons that already reached a terminal state" do
+      {_media_item, files} = season_fixture(2)
+      update_files(files, %{segment_analysis_state: "detected"})
+
+      assert :ok = perform_job(SegmentDetectionScheduler, %{})
+
+      assert all_enqueued(worker: SegmentDetection) == []
+    end
+  end
+
+  describe "configuration" do
+    setup do
+      source =
+        Config.Reader.read!(Path.expand("../../../config/config.exs", __DIR__), env: :prod)
+
+      %{oban: get_in(source, [:mydia, Oban]) || []}
+    end
+
+    test "the segments queue runs at concurrency 1", %{oban: oban} do
+      # Concurrency 1 is the throttle for the whole feature: one season at a
+      # time, never competing with analysis or media.
+      assert Keyword.get(oban[:queues], :segments) == 1
+    end
+
+    test "cron ticks the scheduler", %{oban: oban} do
+      assert {Oban.Plugins.Cron, opts} =
+               Enum.find(oban[:plugins], &match?({Oban.Plugins.Cron, _opts}, &1))
+
+      crontab = Keyword.fetch!(opts, :crontab)
+
+      assert Enum.any?(crontab, &match?({_schedule, SegmentDetectionScheduler}, &1)),
+             "expected Mydia.Jobs.SegmentDetectionScheduler in the crontab"
+    end
+  end
+
+  describe "SegmentDetection worker" do
+    test "analyzes the requested season" do
+      {media_item, files} = season_fixture(3)
+
+      theme = noise(300, :theme)
+
+      for {{_media_file, path}, index} <- Enum.with_index(files, 1) do
+        FingerprintStub.put(
+          path,
+          noise(200, {:open, index}) ++ theme ++ noise(400, {:body, index})
+        )
+      end
+
+      assert :ok =
+               perform_job(SegmentDetection, %{
+                 "media_item_id" => media_item.id,
+                 "season_number" => 1
+               })
+
+      for {media_file, _path} <- files do
+        reloaded = Repo.preload(Repo.get!(MediaFile, media_file.id), :segments)
+        assert reloaded.segment_analysis_state == "detected"
+        assert Enum.any?(reloaded.segments, &(&1.type == "intro"))
+      end
+    end
+
+    test "marks a file failed once it reaches the attempt ceiling" do
+      {media_item, files} = season_fixture(2)
+      update_files(files, %{segment_analysis_attempts: 2})
+
+      for {_media_file, path} <- files do
+        FingerprintStub.put_error(path, :fpcalc_exploded)
+      end
+
+      assert :ok =
+               perform_job(SegmentDetection, %{
+                 "media_item_id" => media_item.id,
+                 "season_number" => 1
+               })
+
+      for {media_file, _path} <- files do
+        reloaded = Repo.get!(MediaFile, media_file.id)
+        assert reloaded.segment_analysis_state == "failed"
+        assert reloaded.segment_analysis_attempts == 3
+        assert reloaded.last_segment_analysis_error =~ "fpcalc_exploded"
+      end
+    end
+
+    test "succeeds when the season no longer exists" do
+      assert :ok =
+               perform_job(SegmentDetection, %{
+                 "media_item_id" => Ecto.UUID.generate(),
+                 "season_number" => 1
+               })
+    end
+  end
+end

--- a/test/mydia/library/segment_detection_test.exs
+++ b/test/mydia/library/segment_detection_test.exs
@@ -1,0 +1,358 @@
+defmodule Mydia.Library.SegmentDetectionTest do
+  # Swaps the fingerprint implementation via Application env, so serial.
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.FingerprintStub
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.MediaSegment
+  alias Mydia.Library.SegmentDetection
+
+  setup do
+    start_supervised!(%{id: FingerprintStub, start: {FingerprintStub, :start_link, []}})
+    Application.put_env(:mydia, :fingerprint_impl, FingerprintStub)
+
+    # Fingerprints are cached through GeneratedMedia, so give the run its own
+    # directory rather than writing into priv/generated.
+    cache_dir =
+      Path.join([
+        System.tmp_dir!(),
+        "segment_detection_test_#{System.unique_integer([:positive])}"
+      ])
+
+    File.mkdir_p!(cache_dir)
+    Application.put_env(:mydia, :generated_media_path, cache_dir)
+
+    on_exit(fn ->
+      File.rm_rf!(cache_dir)
+      Application.delete_env(:mydia, :generated_media_path)
+      Application.delete_env(:mydia, :fingerprint_impl)
+    end)
+
+    :ok
+  end
+
+  defp noise(count, seed) do
+    Enum.map(1..count, fn i -> :erlang.phash2({seed, i}, 4_294_967_296) end)
+  end
+
+  # Builds a TV season whose episodes each have one media file with a known
+  # duration, and returns {media_item, [{media_file, absolute_path}]}.
+  defp season_fixture(episode_count, opts \\ []) do
+    duration = Keyword.get(opts, :duration, 1500.0)
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    files =
+      for n <- 1..episode_count do
+        episode =
+          episode_fixture(%{
+            media_item_id: media_item.id,
+            season_number: 1,
+            episode_number: n
+          })
+
+        # Segment detection requires a known duration, which FileAnalysis
+        # normally supplies. The fixture replaces :metadata wholesale, so the
+        # duration has to be carried here explicitly.
+        media_file =
+          media_file_fixture(%{
+            episode_id: episode.id,
+            relative_path: "s01e#{String.pad_leading(to_string(n), 2, "0")}.mkv",
+            metadata: %{"container" => "mkv", "duration" => duration}
+          })
+
+        {media_file, MediaFile.absolute_path(Repo.preload(media_file, :library_path))}
+      end
+
+    {media_item, files}
+  end
+
+  describe "consensus/2" do
+    test "accepts two agreeing matches and reports the agreement ratio" do
+      matches = [
+        %{start_ms: 30_000, end_ms: 90_000},
+        %{start_ms: 30_100, end_ms: 90_200}
+      ]
+
+      assert {:ok, result} = SegmentDetection.consensus(matches, 5)
+      assert result.start_ms == 30_050
+      assert result.end_ms == 90_100
+      assert_in_delta result.confidence, 0.4, 0.0001
+    end
+
+    test "takes the median of an odd number of matches" do
+      # All three agree within tolerance, so the cluster is the whole list and
+      # the middle value wins.
+      matches = [
+        %{start_ms: 30_000, end_ms: 90_000},
+        %{start_ms: 31_000, end_ms: 91_000},
+        %{start_ms: 31_800, end_ms: 91_800}
+      ]
+
+      assert {:ok, result} = SegmentDetection.consensus(matches, 3)
+      assert result.start_ms == 31_000
+      assert result.end_ms == 91_000
+      assert_in_delta result.confidence, 1.0, 0.0001
+    end
+
+    test "rejects a single match" do
+      assert :no_consensus = SegmentDetection.consensus([%{start_ms: 1, end_ms: 2}], 5)
+    end
+
+    test "rejects an empty match list" do
+      assert :no_consensus = SegmentDetection.consensus([], 5)
+    end
+
+    test "rejects two matches that disagree rather than averaging them" do
+      # A real intro at 2:00 and a spurious hit at 15:00. Taking the median of
+      # the pair would ship a segment at 8:30 at exactly the confidence the
+      # exposure floor admits, so the disagreement has to be caught here.
+      matches = [
+        %{start_ms: 120_000, end_ms: 180_000},
+        %{start_ms: 900_000, end_ms: 960_000}
+      ]
+
+      assert :no_consensus = SegmentDetection.consensus(matches, 5)
+    end
+
+    test "drops an outlier and scores confidence on the cluster, not the raw count" do
+      matches = [
+        %{start_ms: 120_000, end_ms: 180_000},
+        %{start_ms: 120_200, end_ms: 180_100},
+        %{start_ms: 900_000, end_ms: 960_000}
+      ]
+
+      assert {:ok, result} = SegmentDetection.consensus(matches, 5)
+      assert result.start_ms == 120_100
+      assert result.end_ms == 180_050
+      # 2 of 5 agreed, not 3 of 5.
+      assert_in_delta result.confidence, 0.4, 0.0001
+    end
+
+    test "treats matches a frame or two apart as one cluster" do
+      matches = [
+        %{start_ms: 30_000, end_ms: 90_000},
+        %{start_ms: 30_124, end_ms: 90_124},
+        %{start_ms: 30_248, end_ms: 90_248}
+      ]
+
+      assert {:ok, result} = SegmentDetection.consensus(matches, 3)
+      assert result.start_ms == 30_124
+      assert result.end_ms == 90_124
+      assert_in_delta result.confidence, 1.0, 0.0001
+    end
+  end
+
+  describe "partners/3" do
+    test "spreads partners across the season rather than taking neighbours" do
+      files = for n <- 1..20, do: %{id: n}
+      target = %{id: 1}
+
+      partners = SegmentDetection.partners(files, target, 5)
+
+      assert length(partners) == 5
+      refute target in partners
+      # Should reach beyond the immediate neighbours.
+      assert Enum.any?(partners, &(&1.id > 10))
+    end
+
+    test "returns everything available when the season is smaller than the count" do
+      files = for n <- 1..3, do: %{id: n}
+      target = %{id: 2}
+
+      partners = SegmentDetection.partners(files, target, 5)
+
+      assert length(partners) == 2
+      refute target in partners
+    end
+  end
+
+  describe "analyze_season/2" do
+    test "detects a shared intro and persists it for every episode" do
+      {media_item, files} = season_fixture(4)
+
+      theme = noise(300, :theme)
+
+      for {{_media_file, path}, index} <- Enum.with_index(files, 1) do
+        # Every episode carries the same 300-frame theme after 200 frames of
+        # cold open, then unique content.
+        FingerprintStub.put(
+          path,
+          noise(200, {:open, index}) ++ theme ++ noise(500, {:body, index})
+        )
+      end
+
+      assert :ok = SegmentDetection.analyze_season(media_item.id, 1)
+
+      for {media_file, _path} <- files do
+        reloaded = Repo.preload(Repo.get!(MediaFile, media_file.id), :segments)
+        assert reloaded.segment_analysis_state == "detected"
+        assert %DateTime{} = reloaded.segments_analyzed_at
+
+        intro = Enum.find(reloaded.segments, &(&1.type == "intro"))
+        assert intro.source == "fingerprint"
+        # 200 frames at 100ms per frame.
+        assert intro.start_ms == 20_000
+        assert intro.end_ms == 50_000
+        assert intro.confidence > 0.5
+      end
+    end
+
+    test "marks the season not_found when episodes share nothing" do
+      {media_item, files} = season_fixture(3)
+
+      for {{_media_file, path}, index} <- Enum.with_index(files, 1) do
+        FingerprintStub.put(path, noise(800, {:unique, index}))
+      end
+
+      assert :ok = SegmentDetection.analyze_season(media_item.id, 1)
+
+      for {media_file, _path} <- files do
+        reloaded = Repo.get!(MediaFile, media_file.id)
+        assert reloaded.segment_analysis_state == "not_found"
+        assert reloaded.segment_analysis_attempts == 0
+      end
+    end
+
+    test "short-circuits a season with fewer than two files without spending attempts" do
+      {media_item, [{media_file, _path}]} = season_fixture(1)
+
+      assert :ok = SegmentDetection.analyze_season(media_item.id, 1)
+
+      reloaded = Repo.get!(MediaFile, media_file.id)
+      assert reloaded.segment_analysis_state == "not_found"
+      assert reloaded.segment_analysis_attempts == 0
+    end
+
+    test "leaves files pending when the rest of the season has no duration yet" do
+      {media_item, files} = season_fixture(3)
+      [{first, _}, {second, _}, {third, _}] = files
+
+      # FileAnalysis has not reached these two, so there is nothing ready to
+      # correlate the first file against. That is an ordering dependency, not a
+      # failure, so nothing may be marked and no attempt may be spent.
+      for file <- [second, third] do
+        file
+        |> Ecto.Changeset.change(%{analyzed_at: nil, metadata: %{"container" => "mkv"}})
+        |> Repo.update!()
+      end
+
+      assert :ok = SegmentDetection.analyze_season(media_item.id, 1)
+
+      for file <- [first, second, third] do
+        reloaded = Repo.get!(MediaFile, file.id)
+        assert reloaded.segment_analysis_state == "pending"
+        assert reloaded.segment_analysis_attempts == 0
+      end
+    end
+
+    test "counts an attempt and records the error when fingerprinting fails" do
+      {media_item, files} = season_fixture(2)
+
+      for {_media_file, path} <- files do
+        FingerprintStub.put_error(path, :fpcalc_exploded)
+      end
+
+      assert :ok = SegmentDetection.analyze_season(media_item.id, 1)
+
+      for {media_file, _path} <- files do
+        reloaded = Repo.get!(MediaFile, media_file.id)
+        assert reloaded.segment_analysis_state == "pending"
+        assert reloaded.segment_analysis_attempts == 1
+        assert reloaded.last_segment_analysis_error =~ "fpcalc_exploded"
+      end
+    end
+
+    test "skips files that already have a terminal state" do
+      {media_item, files} = season_fixture(2)
+      [{first, _}, _] = files
+
+      first
+      |> Ecto.Changeset.change(%{segment_analysis_state: "detected"})
+      |> Repo.update!()
+
+      for {_media_file, path} <- files do
+        FingerprintStub.put(path, noise(400, :whatever))
+      end
+
+      assert :ok = SegmentDetection.analyze_season(media_item.id, 1)
+
+      assert Repo.get!(MediaFile, first.id).segment_analysis_state == "detected"
+    end
+  end
+
+  describe "reset_season/2" do
+    test "clears segments and returns files to pending" do
+      {media_item, files} = season_fixture(2)
+      [{first, _}, _] = files
+
+      %MediaSegment{}
+      |> MediaSegment.changeset(%{
+        media_file_id: first.id,
+        type: "intro",
+        start_ms: 1000,
+        end_ms: 2000,
+        source: "fingerprint",
+        confidence: 0.9
+      })
+      |> Repo.insert!()
+
+      first
+      |> Ecto.Changeset.change(%{
+        segment_analysis_state: "detected",
+        segment_analysis_attempts: 2
+      })
+      |> Repo.update!()
+
+      assert :ok = SegmentDetection.reset_season(media_item.id, 1)
+
+      reloaded = Repo.preload(Repo.get!(MediaFile, first.id), :segments)
+      assert reloaded.segment_analysis_state == "pending"
+      assert reloaded.segment_analysis_attempts == 0
+      assert reloaded.segments == []
+    end
+  end
+
+  describe "season_status/2" do
+    test "reports detected with the segments and their provenance" do
+      {media_item, files} = season_fixture(2)
+
+      for {media_file, _path} <- files do
+        %MediaSegment{}
+        |> MediaSegment.changeset(%{
+          media_file_id: media_file.id,
+          type: "intro",
+          start_ms: 20_000,
+          end_ms: 50_000,
+          source: "chapters",
+          confidence: 1.0
+        })
+        |> Repo.insert!()
+      end
+
+      status = SegmentDetection.season_status(media_item.id, 1)
+
+      assert status.state == :detected
+      assert status.source == "chapters"
+      assert status.segments["intro"].start_ms == 20_000
+    end
+
+    test "reports partial when only some files resolved" do
+      {media_item, [{first, _}, _second]} = season_fixture(2)
+
+      %MediaSegment{}
+      |> MediaSegment.changeset(%{
+        media_file_id: first.id,
+        type: "intro",
+        start_ms: 1000,
+        end_ms: 2000,
+        source: "fingerprint",
+        confidence: 0.6
+      })
+      |> Repo.insert!()
+
+      assert SegmentDetection.season_status(media_item.id, 1).state == :partial
+    end
+  end
+end

--- a/test/support/fixtures/fingerprint_stub.ex
+++ b/test/support/fixtures/fingerprint_stub.ex
@@ -1,0 +1,44 @@
+defmodule Mydia.FingerprintStub do
+  @moduledoc """
+  Test double for `Mydia.Library.SegmentDetection.Fingerprint`.
+
+  Streams are registered per file path in an Agent before the code under test
+  runs, so a test can construct a season whose episodes share an exact,
+  known-length run of audio and then assert on the timestamps that come out.
+
+  The window arguments are deliberately ignored. A test registers one stream
+  per path and gets it back for both the intro and the credits window, so a
+  test that cares about only one segment type asserts on that type alone.
+  """
+
+  @behaviour Mydia.Library.SegmentDetection.Fingerprint
+
+  alias Mydia.Library.SegmentDetection.Fingerprint.Result
+
+  @doc "Starts the registry backing the stub."
+  def start_link do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  @doc "Registers the hash stream returned for `path`, with a frame duration in ms."
+  def put(path, hashes, frame_ms \\ 100.0) do
+    Agent.update(__MODULE__, &Map.put(&1, path, %Result{hashes: hashes, frame_ms: frame_ms}))
+  end
+
+  @doc "Registers an error to be returned for `path`."
+  def put_error(path, reason) do
+    Agent.update(__MODULE__, &Map.put(&1, path, {:error, reason}))
+  end
+
+  @impl true
+  def available?, do: true
+
+  @impl true
+  def fingerprint(path, _start_s, _length_s) do
+    case Agent.get(__MODULE__, &Map.get(&1, path)) do
+      nil -> {:error, :not_registered}
+      {:error, reason} -> {:error, reason}
+      %Result{} = result -> {:ok, result}
+    end
+  end
+end

--- a/test/support/fixtures/fingerprint_stub.ex
+++ b/test/support/fixtures/fingerprint_stub.ex
@@ -30,8 +30,18 @@ defmodule Mydia.FingerprintStub do
     Agent.update(__MODULE__, &Map.put(&1, path, {:error, reason}))
   end
 
+  @doc """
+  Sets whether the stub reports fingerprinting as available.
+
+  Defaults to `true`, so only a test that cares about the missing-`fpcalc`
+  path has to say anything about it.
+  """
+  def put_available(available?) do
+    Agent.update(__MODULE__, &Map.put(&1, :available?, available?))
+  end
+
   @impl true
-  def available?, do: true
+  def available?, do: Agent.get(__MODULE__, &Map.get(&1, :available?, true))
 
   @impl true
   def fingerprint(path, _start_s, _length_s) do


### PR DESCRIPTION
Task 9 of the intro/credits detection plan: the background job layer.

Stacked on #315 (`feat/segment-detection-context`), which is where
`SegmentDetection.analyze_season/2` lives. Until that merges, its commit shows
up in this diff too; it drops out once #315 lands.

## What this adds

- **`Mydia.Jobs.SegmentDetectionScheduler`** — cron worker, every 5 minutes. It
  checks that `fpcalc` is present, then selects seasons holding at least one
  file that is `pending`, has `analyzed_at IS NOT NULL`, and is below the
  attempt ceiling, and enqueues one job per season. Carries a `unique:` guard on
  `[:worker]` across the incomplete states, matching `FileAnalysis`, so a slow
  tick cannot pile up.
- **`Mydia.Jobs.SegmentDetection`** — per-season worker taking
  `%{media_item_id, season_number}`, `max_attempts: 3`, unique on those args.
- **`segments: 1`** Oban queue plus the crontab entry in `config/config.exs`.

## Notes

**The scheduler enqueues with singular `Oban.insert/1` in a loop, never
`Oban.insert_all/1`.** `insert_all` bypasses the worker's `unique:` option on
the Basic and Lite engines this project runs, so a slow season would collect a
duplicate job on every tick. The reason is spelled out in a comment at the call
site so it does not get "optimized" away later.

Concurrency of 1 on the queue is the throttle for the whole feature: one season
at a time, never competing with `analysis: 2` or `media: 3`.

A file with no duration yet is skipped rather than failed. That is an ordering
dependency on `FileAnalysis`, so it stays `pending` and spends no attempt.

`fpcalc` availability is a runtime capability check, not a persisted state.
When it is missing the scheduler enqueues nothing, files stay `pending`, and
installing chromaprint later needs no data repair because the backlog is picked
up on the next tick.

Two small changes outside the two new modules:

- `SegmentDetection.max_attempts/0` is now public, so the scheduler selects
  exactly the files the context will act on rather than keeping a second copy
  of the ceiling that could drift.
- `FingerprintStub` gained `put_available/1`, so the missing-`fpcalc` path can
  be tested without a second stub module.

## Tests

`test/mydia/jobs/segment_detection_test.exs`, 10 tests: one job per season
regardless of file count, files with `analyzed_at IS NULL` never selected,
nothing enqueued when fingerprinting reports unavailable, seasons past the
attempt ceiling and seasons in a terminal state skipped, the queue concurrency
and crontab entry pinned against `config.exs`, plus the worker's state
transition to `detected`, the attempt ceiling landing on `failed`, and a season
that no longer exists succeeding.

28 tests green across the jobs and context suites; `mix format --check-formatted`
and `mix credo --strict` clean.
