### PR TITLE
feat(admin): show per-season segment detection status

### DIFF
--- a/lib/mydia/library/segment_detection.ex
+++ b/lib/mydia/library/segment_detection.ex
@@ -210,31 +210,86 @@ defmodule Mydia.Library.SegmentDetection do
     :ok
   end
 
+  @typedoc """
+  One segment type reduced across a whole season.
+
+  `:files` is how many of the season's files carry this type, and it is what
+  keeps the offsets honest: an intro that two episodes share is not the same
+  claim as one the whole season shares. `:start_ms` and `:end_ms` are medians
+  over those files, the same summary the consensus step uses.
+  """
+  @type segment_summary :: %{
+          start_ms: integer(),
+          end_ms: integer(),
+          files: non_neg_integer()
+        }
+
+  @typedoc "A season reduced to what the admin row renders."
+  @type season_summary :: %{
+          state: atom(),
+          files: non_neg_integer(),
+          segments: %{optional(String.t()) => segment_summary()},
+          sources: [String.t()]
+        }
+
   @doc """
-  Summarises a season for the admin UI.
+  Summarises every season of a show at once, keyed by season number.
+
+  The admin page renders one row per season, so asking season by season would
+  scale queries with season count. Files and their segments are loaded once
+  and grouped in memory instead.
+  """
+  @spec season_statuses(binary()) :: %{optional(integer()) => season_summary()}
+  def season_statuses(media_item_id) do
+    media_item_id
+    |> show_files_by_season()
+    |> Map.new(fn {season_number, files} -> {season_number, summarise(files)} end)
+  end
+
+  @doc """
+  Summarises one season for the admin UI.
 
   `:state` is derived: `:detected` when every file resolved with at least one
   segment, `:partial` when some did, and otherwise the dominant file state.
   """
-  @spec season_status(binary(), integer()) :: %{
-          state: atom(),
-          segments: %{optional(String.t()) => MediaSegment.t()},
-          source: String.t() | nil
-        }
+  @spec season_status(binary(), integer()) :: season_summary()
   def season_status(media_item_id, season_number) do
-    files =
-      media_item_id
-      |> season_files(season_number)
-      |> Repo.preload(:segments)
+    media_item_id
+    |> season_files(season_number)
+    |> Repo.preload(:segments)
+    |> summarise()
+  end
 
+  # Every file with segments contributes. Sampling one file instead made both
+  # the offsets and the provenance depend on whichever file and segment came
+  # back first, which is neither stable across page loads nor true of a season
+  # whose episodes disagree: an intro found on one episode and credits on
+  # another would have reported the credits as missing.
+  defp summarise(files) do
     with_segments = Enum.filter(files, &(&1.segments != []))
-    sample = List.first(with_segments)
+    segments = Enum.flat_map(with_segments, & &1.segments)
 
     %{
       state: derive_state(files, with_segments),
-      segments: sample_segments(sample),
-      source: sample_source(sample)
+      files: length(files),
+      segments: summarise_segments(segments),
+      sources: segments |> Enum.map(& &1.source) |> Enum.uniq() |> Enum.sort()
     }
+  end
+
+  # One segment per type per file is guaranteed by the unique index, so the
+  # count of segments of a type is the count of files carrying it.
+  defp summarise_segments(segments) do
+    segments
+    |> Enum.group_by(& &1.type)
+    |> Map.new(fn {type, of_type} ->
+      {type,
+       %{
+         start_ms: median(Enum.map(of_type, & &1.start_ms)),
+         end_ms: median(Enum.map(of_type, & &1.end_ms)),
+         files: length(of_type)
+       }}
+    end)
   end
 
   defp derive_state(files, with_segments) do
@@ -247,12 +302,6 @@ defmodule Mydia.Library.SegmentDetection do
       true -> :pending
     end
   end
-
-  defp sample_segments(nil), do: %{}
-  defp sample_segments(file), do: Map.new(file.segments, &{&1.type, &1})
-
-  defp sample_source(nil), do: nil
-  defp sample_source(file), do: file.segments |> List.first() |> Map.fetch!(:source)
 
   # -- season loading -------------------------------------------------------
 
@@ -268,6 +317,27 @@ defmodule Mydia.Library.SegmentDetection do
         preload: :library_path
       )
     )
+  end
+
+  # Two queries for the whole show, whatever the season count: one join for the
+  # files, one preload for their segments.
+  defp show_files_by_season(media_item_id) do
+    rows =
+      Repo.all(
+        from(mf in MediaFile,
+          join: e in Episode,
+          on: e.id == mf.episode_id,
+          where: e.media_item_id == ^media_item_id and is_nil(mf.trashed_at),
+          order_by: [asc: e.season_number, asc: e.episode_number],
+          select: {e.season_number, mf}
+        )
+      )
+
+    {season_numbers, files} = Enum.unzip(rows)
+
+    season_numbers
+    |> Enum.zip(Repo.preload(files, :segments))
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
   end
 
   defp pending?(%MediaFile{segment_analysis_state: "pending", segment_analysis_attempts: n}),

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -13,6 +13,7 @@ defmodule MydiaWeb.MediaLive.Show do
   alias MydiaWeb.MediaLive.Show.SubtitleEvents
   alias MydiaWeb.MediaLive.Show.FileEvents
   alias MydiaWeb.MediaLive.Show.SearchEvents
+  alias MydiaWeb.MediaLive.Show.SegmentEvents
   alias MydiaWeb.MediaLive.Show.FranchiseEvents
 
   # Import helper modules
@@ -161,6 +162,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:show_trailer_modal, false)
      # Collection state
      |> CollectionEvents.load_collection_data(media_item)
+     |> SegmentEvents.assign_segment_status(media_item)
      |> FranchiseEvents.maybe_load()
      |> stream_configure(:search_results, dom_id: &generate_positioned_id/1)
      |> stream(:search_results, [])}
@@ -208,6 +210,9 @@ defmodule MydiaWeb.MediaLive.Show do
 
   def handle_event("rescan_movie", params, socket),
     do: FileEvents.rescan_movie(params, socket)
+
+  def handle_event("re_analyze_segments", params, socket),
+    do: SegmentEvents.re_analyze(params, socket)
 
   def handle_event("show_delete_confirm", params, socket),
     do: MediaItemEvents.show_delete_confirm(params, socket)

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -207,6 +207,8 @@
             auto_searching_episode={@auto_searching_episode}
             playback_enabled={@playback_enabled}
             transcode_jobs={@transcode_jobs}
+            segment_statuses={@segment_statuses}
+            segment_detection_available={@segment_detection_available}
           />
           <%!-- Media Files Section --%>
           <Components.media_files_section

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -6,6 +6,8 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   import MydiaWeb.MediaLive.Show.Formatters
   import MydiaWeb.MediaLive.Show.Helpers
 
+  alias MydiaWeb.MediaLive.Show.SegmentComponents
+
   @doc """
   Hero section with backdrop image, poster, and quick action buttons.
   """
@@ -489,6 +491,8 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :auto_searching_episode, :any, default: nil
   attr :playback_enabled, :boolean, required: true
   attr :transcode_jobs, :map, default: %{}
+  attr :segment_statuses, :map, default: %{}
+  attr :segment_detection_available, :boolean, default: true
 
   def episodes_section(assigns) do
     ~H"""
@@ -512,6 +516,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
               <span>{length(@media_item.episodes)} total</span>
             </div>
           </div>
+          <SegmentComponents.segment_unavailable_note :if={!@segment_detection_available} />
         </div>
 
         <%!-- All seasons in one container --%>
@@ -597,6 +602,12 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                   </div>
                 </div>
               </div>
+
+              <SegmentComponents.segment_status_row
+                :if={@segment_detection_available}
+                season_number={season_num}
+                status={Map.get(@segment_statuses, season_num)}
+              />
 
               <%!-- Episodes list --%>
               <div class="bg-base-100 rounded-lg divide-y divide-base-200">

--- a/lib/mydia_web/live/media_live/show/segment_components.ex
+++ b/lib/mydia_web/live/media_live/show/segment_components.ex
@@ -12,7 +12,7 @@ defmodule MydiaWeb.MediaLive.Show.SegmentComponents do
   use MydiaWeb, :html
 
   # What a season shows before detection has reported anything for it.
-  @empty_status %{state: :pending, segments: %{}, source: nil}
+  @empty_status %{state: :pending, files: 0, segments: %{}, sources: []}
 
   @doc """
   Compact status row for one season's detected segments.
@@ -38,14 +38,14 @@ defmodule MydiaWeb.MediaLive.Show.SegmentComponents do
       </span>
 
       <span id={"segment-intro-season-#{@season_number}"} class="text-base-content/60">
-        Intro {format_span(@status.segments["intro"])}
+        Intro {format_span(@status.segments["intro"], @status.files)}
       </span>
 
       <span id={"segment-credits-season-#{@season_number}"} class="text-base-content/60">
-        Credits {format_span(@status.segments["credits"])}
+        Credits {format_span(@status.segments["credits"], @status.files)}
       </span>
 
-      <span :if={@status.source} class="badge badge-ghost badge-sm">{@status.source}</span>
+      <span :for={source <- @status.sources} class="badge badge-ghost badge-sm">{source}</span>
 
       <div class="tooltip tooltip-bottom ml-auto" data-tip="Re-analyze skip segments">
         <button
@@ -92,10 +92,21 @@ defmodule MydiaWeb.MediaLive.Show.SegmentComponents do
   defp state_class(:failed), do: "badge-error"
   defp state_class(_other), do: "badge-ghost"
 
-  defp format_span(nil), do: "-"
+  defp format_span(nil, _total), do: "-"
 
-  defp format_span(segment) do
-    "#{format_ms(segment.start_ms)} to #{format_ms(segment.end_ms)}"
+  defp format_span(%{files: files} = summary, total) when files >= total do
+    span(summary)
+  end
+
+  # The offsets are medians over the files that carry this type, so a season
+  # where only some episodes have one says so rather than implying the whole
+  # season shares it.
+  defp format_span(summary, total) do
+    "#{span(summary)} (#{summary.files} of #{total})"
+  end
+
+  defp span(summary) do
+    "#{format_ms(summary.start_ms)} to #{format_ms(summary.end_ms)}"
   end
 
   defp format_ms(ms) do

--- a/lib/mydia_web/live/media_live/show/segment_components.ex
+++ b/lib/mydia_web/live/media_live/show/segment_components.ex
@@ -1,0 +1,108 @@
+defmodule MydiaWeb.MediaLive.Show.SegmentComponents do
+  @moduledoc """
+  Per-season intro and credits detection status for the show page.
+
+  A compact summary row plus a single action, matching the pattern used by
+  download clients and indexers. There is no inline editing: detection either
+  worked or it did not, and the remedy is to run it again.
+
+  Lives in its own module because `show/components.ex` is already well past the
+  file size guideline.
+  """
+  use MydiaWeb, :html
+
+  # What a season shows before detection has reported anything for it.
+  @empty_status %{state: :pending, segments: %{}, source: nil}
+
+  @doc """
+  Compact status row for one season's detected segments.
+  """
+  attr :season_number, :any, required: true
+  attr :status, :map, default: nil
+
+  def segment_status_row(assigns) do
+    assigns = assign(assigns, :status, assigns.status || @empty_status)
+
+    ~H"""
+    <div
+      id={"segment-status-season-#{@season_number}"}
+      class="flex flex-wrap items-center gap-2 mb-3 text-xs"
+    >
+      <span class="text-base-content/60">Skip segments</span>
+
+      <span
+        id={"segment-state-season-#{@season_number}"}
+        class={["badge badge-sm", state_class(@status.state)]}
+      >
+        {state_label(@status.state)}
+      </span>
+
+      <span id={"segment-intro-season-#{@season_number}"} class="text-base-content/60">
+        Intro {format_span(@status.segments["intro"])}
+      </span>
+
+      <span id={"segment-credits-season-#{@season_number}"} class="text-base-content/60">
+        Credits {format_span(@status.segments["credits"])}
+      </span>
+
+      <span :if={@status.source} class="badge badge-ghost badge-sm">{@status.source}</span>
+
+      <div class="tooltip tooltip-bottom ml-auto" data-tip="Re-analyze skip segments">
+        <button
+          id={"segment-reanalyze-season-#{@season_number}"}
+          type="button"
+          class="btn btn-xs btn-ghost"
+          phx-click="re_analyze_segments"
+          phx-value-season-number={@season_number}
+        >
+          <.icon name="hero-arrow-path" class="w-3 h-3" /> Re-analyze
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Shown once, in place of the per-season rows, when `fpcalc` is missing.
+
+  Availability is a runtime capability check rather than a stored state, so
+  installing chromaprint later needs no data repair: the pending backlog is
+  picked up on the next scheduler tick.
+  """
+  def segment_unavailable_note(assigns) do
+    ~H"""
+    <div
+      id="segment-detection-unavailable"
+      class="text-xs text-base-content/60 flex items-center gap-1"
+    >
+      <.icon name="hero-information-circle" class="w-4 h-4" />
+      Detection unavailable: chromaprint not installed
+    </div>
+    """
+  end
+
+  defp state_label(:detected), do: "Detected"
+  defp state_label(:partial), do: "Partial"
+  defp state_label(:not_found), do: "Not found"
+  defp state_label(:failed), do: "Failed"
+  defp state_label(_pending), do: "Pending"
+
+  defp state_class(:detected), do: "badge-success"
+  defp state_class(:partial), do: "badge-warning"
+  defp state_class(:failed), do: "badge-error"
+  defp state_class(_other), do: "badge-ghost"
+
+  defp format_span(nil), do: "-"
+
+  defp format_span(segment) do
+    "#{format_ms(segment.start_ms)} to #{format_ms(segment.end_ms)}"
+  end
+
+  defp format_ms(ms) do
+    total_seconds = div(ms, 1000)
+    minutes = div(total_seconds, 60)
+    seconds = rem(total_seconds, 60)
+
+    "#{minutes}:#{String.pad_leading(to_string(seconds), 2, "0")}"
+  end
+end

--- a/lib/mydia_web/live/media_live/show/segment_events.ex
+++ b/lib/mydia_web/live/media_live/show/segment_events.ex
@@ -49,14 +49,8 @@ defmodule MydiaWeb.MediaLive.Show.SegmentEvents do
 
   defp season_statuses(_media_item, false), do: %{}
 
-  defp season_statuses(%{type: "tv_show"} = media_item, true) do
-    media_item.episodes
-    |> Enum.map(& &1.season_number)
-    |> Enum.uniq()
-    |> Map.new(fn season_number ->
-      {season_number, SegmentDetection.season_status(media_item.id, season_number)}
-    end)
-  end
+  defp season_statuses(%{type: "tv_show"} = media_item, true),
+    do: SegmentDetection.season_statuses(media_item.id)
 
   defp season_statuses(_media_item, true), do: %{}
 end

--- a/lib/mydia_web/live/media_live/show/segment_events.ex
+++ b/lib/mydia_web/live/media_live/show/segment_events.ex
@@ -4,9 +4,12 @@ defmodule MydiaWeb.MediaLive.Show.SegmentEvents do
   import Phoenix.Component, only: [assign: 3]
   import Phoenix.LiveView, only: [put_flash: 3]
 
+  alias Mydia.Jobs.SegmentDetection, as: SegmentDetectionJob
   alias Mydia.Library.SegmentDetection
   alias Mydia.Library.SegmentDetection.Fingerprint
   alias MydiaWeb.Live.Authorization
+
+  require Logger
 
   @doc """
   Assigns the per-season detection summary the show page renders.
@@ -28,8 +31,9 @@ defmodule MydiaWeb.MediaLive.Show.SegmentEvents do
   Clears a season's detections and returns its files to the pending backlog.
 
   Cached fingerprints are kept, so the second pass does not re-decode any
-  audio. The files land back in the same `pending` state the detection
-  scheduler drains, which is what picks the season up again.
+  audio. The season is enqueued straight away rather than left for the
+  scheduler's next tick, because an operator who just clicked the button
+  should not wait five minutes to see anything happen.
   """
   def re_analyze(%{"season-number" => season_number_str}, socket) do
     with :ok <- Authorization.authorize_update_media(socket) do
@@ -37,6 +41,7 @@ defmodule MydiaWeb.MediaLive.Show.SegmentEvents do
       media_item = socket.assigns.media_item
 
       :ok = SegmentDetection.reset_season(media_item.id, season_number)
+      enqueue_detection(media_item.id, season_number)
 
       {:noreply,
        socket
@@ -44,6 +49,35 @@ defmodule MydiaWeb.MediaLive.Show.SegmentEvents do
        |> put_flash(:info, "Season #{season_number} queued for segment re-analysis")}
     else
       {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  # IMPORTANT: singular Oban.insert/1, never insert_all/1, which silently
+  # bypasses the worker's `unique:` option on the Basic and Lite engines this
+  # project runs. The scheduler carries the same warning.
+  #
+  # That uniqueness guard is also why a season the scheduler already queued is
+  # not an error here: Oban returns {:ok, job} with `conflict?` set and the
+  # existing job stands. The season gets analyzed, which is what was asked for.
+  defp enqueue_detection(media_item_id, season_number) do
+    %{media_item_id: media_item_id, season_number: season_number}
+    |> SegmentDetectionJob.new()
+    |> Oban.insert()
+    |> case do
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        # Not worth alarming the operator over: the files are back in the
+        # pending backlog either way, so the scheduler picks the season up on
+        # its next tick.
+        Logger.warning("Failed to enqueue segment re-analysis",
+          media_item_id: media_item_id,
+          season_number: season_number,
+          reason: inspect(reason)
+        )
+
+        :error
     end
   end
 

--- a/lib/mydia_web/live/media_live/show/segment_events.ex
+++ b/lib/mydia_web/live/media_live/show/segment_events.ex
@@ -1,0 +1,62 @@
+defmodule MydiaWeb.MediaLive.Show.SegmentEvents do
+  @moduledoc false
+
+  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.LiveView, only: [put_flash: 3]
+
+  alias Mydia.Library.SegmentDetection
+  alias Mydia.Library.SegmentDetection.Fingerprint
+  alias MydiaWeb.Live.Authorization
+
+  @doc """
+  Assigns the per-season detection summary the show page renders.
+
+  Availability is a runtime capability check rather than a stored state, so
+  installing chromaprint later needs no data repair. While it is missing the
+  page shows one note instead of repeating the same status on every season,
+  and there is nothing worth querying.
+  """
+  def assign_segment_status(socket, media_item) do
+    available? = Fingerprint.available?()
+
+    socket
+    |> assign(:segment_detection_available, available?)
+    |> assign(:segment_statuses, season_statuses(media_item, available?))
+  end
+
+  @doc """
+  Clears a season's detections and returns its files to the pending backlog.
+
+  Cached fingerprints are kept, so the second pass does not re-decode any
+  audio. The files land back in the same `pending` state the detection
+  scheduler drains, which is what picks the season up again.
+  """
+  def re_analyze(%{"season-number" => season_number_str}, socket) do
+    with :ok <- Authorization.authorize_update_media(socket) do
+      season_number = String.to_integer(season_number_str)
+      media_item = socket.assigns.media_item
+
+      :ok = SegmentDetection.reset_season(media_item.id, season_number)
+
+      {:noreply,
+       socket
+       |> assign_segment_status(media_item)
+       |> put_flash(:info, "Season #{season_number} queued for segment re-analysis")}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  defp season_statuses(_media_item, false), do: %{}
+
+  defp season_statuses(%{type: "tv_show"} = media_item, true) do
+    media_item.episodes
+    |> Enum.map(& &1.season_number)
+    |> Enum.uniq()
+    |> Map.new(fn season_number ->
+      {season_number, SegmentDetection.season_status(media_item.id, season_number)}
+    end)
+  end
+
+  defp season_statuses(_media_item, true), do: %{}
+end

--- a/test/mydia/library/segment_detection_test.exs
+++ b/test/mydia/library/segment_detection_test.exs
@@ -434,23 +434,58 @@ defmodule Mydia.Library.SegmentDetectionTest do
       {media_item, files} = season_fixture(2)
 
       for {media_file, _path} <- files do
-        %MediaSegment{}
-        |> MediaSegment.changeset(%{
-          media_file_id: media_file.id,
-          type: "intro",
-          start_ms: 20_000,
-          end_ms: 50_000,
-          source: "chapters",
-          confidence: 1.0
-        })
-        |> Repo.insert!()
+        insert_segment(media_file, start_ms: 20_000, end_ms: 50_000, source: "chapters")
       end
 
       status = SegmentDetection.season_status(media_item.id, 1)
 
       assert status.state == :detected
-      assert status.source == "chapters"
-      assert status.segments["intro"].start_ms == 20_000
+      assert status.sources == ["chapters"]
+      assert status.files == 2
+      assert status.segments["intro"] == %{start_ms: 20_000, end_ms: 50_000, files: 2}
+    end
+
+    test "takes the median offset across every file carrying the type" do
+      {media_item, [{first, _}, {second, _}, {third, _}]} = season_fixture(3)
+
+      insert_segment(first, start_ms: 10_000, end_ms: 40_000)
+      insert_segment(second, start_ms: 20_000, end_ms: 50_000)
+      insert_segment(third, start_ms: 90_000, end_ms: 120_000)
+
+      status = SegmentDetection.season_status(media_item.id, 1)
+
+      assert status.segments["intro"] == %{start_ms: 20_000, end_ms: 50_000, files: 3}
+    end
+
+    test "reports a type found on only some files rather than dropping it" do
+      {media_item, [{first, _}, {second, _}]} = season_fixture(2)
+
+      insert_segment(first, type: "intro", start_ms: 20_000, end_ms: 50_000)
+
+      insert_segment(second,
+        type: "credits",
+        start_ms: 1_400_000,
+        end_ms: 1_490_000,
+        source: "chapters"
+      )
+
+      status = SegmentDetection.season_status(media_item.id, 1)
+
+      # Sampling one file used to report whichever type that file happened to
+      # carry and call the other one missing.
+      assert status.segments["intro"].files == 1
+      assert status.segments["credits"].files == 1
+      assert status.files == 2
+    end
+
+    test "reports every provenance a mixed season used, sorted" do
+      {media_item, [{first, _}, {second, _}]} = season_fixture(2)
+
+      insert_segment(first, source: "fingerprint")
+      insert_segment(second, source: "chapters")
+
+      assert SegmentDetection.season_status(media_item.id, 1).sources ==
+               ["chapters", "fingerprint"]
     end
 
     test "reports partial when only some files resolved" do
@@ -469,5 +504,46 @@ defmodule Mydia.Library.SegmentDetectionTest do
 
       assert SegmentDetection.season_status(media_item.id, 1).state == :partial
     end
+  end
+
+  describe "season_statuses/1" do
+    test "summarises every season of a show in one pass" do
+      {media_item, [{first, _}, _second]} = season_fixture(2)
+
+      insert_segment(first)
+
+      second_season_episode =
+        episode_fixture(%{media_item_id: media_item.id, season_number: 2, episode_number: 1})
+
+      second_season_file = media_file_fixture(%{episode_id: second_season_episode.id})
+      insert_segment(second_season_file, start_ms: 30_000, end_ms: 60_000, source: "chapters")
+
+      statuses = SegmentDetection.season_statuses(media_item.id)
+
+      assert Map.keys(statuses) |> Enum.sort() == [1, 2]
+      assert statuses[1].state == :partial
+      assert statuses[1].files == 2
+      assert statuses[2].state == :detected
+      assert statuses[2].segments["intro"] == %{start_ms: 30_000, end_ms: 60_000, files: 1}
+    end
+
+    test "returns an empty map for a show with no files" do
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      assert SegmentDetection.season_statuses(media_item.id) == %{}
+    end
+  end
+
+  defp insert_segment(media_file, opts \\ []) do
+    %MediaSegment{}
+    |> MediaSegment.changeset(%{
+      media_file_id: media_file.id,
+      type: Keyword.get(opts, :type, "intro"),
+      start_ms: Keyword.get(opts, :start_ms, 20_000),
+      end_ms: Keyword.get(opts, :end_ms, 50_000),
+      source: Keyword.get(opts, :source, "fingerprint"),
+      confidence: Keyword.get(opts, :confidence, 1.0)
+    })
+    |> Repo.insert!()
   end
 end

--- a/test/mydia_web/live/media_live/segment_status_test.exs
+++ b/test/mydia_web/live/media_live/segment_status_test.exs
@@ -93,7 +93,7 @@ defmodule MydiaWeb.MediaLive.SegmentStatusTest do
     assert has_element?(view, "#segment-status-season-1", "fingerprint")
   end
 
-  test "shows a partial badge when only some files resolved", %{conn: conn} do
+  test "shows a partial badge and says how many files carry the segment", %{conn: conn} do
     {media_item, [first | _rest]} = show_with_season()
 
     detect(first)
@@ -101,6 +101,22 @@ defmodule MydiaWeb.MediaLive.SegmentStatusTest do
     {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
 
     assert has_element?(view, "#segment-state-season-1", "Partial")
+    # The offset belongs to one episode of two, and the row has to say so
+    # rather than implying the whole season shares it.
+    assert has_element?(view, "#segment-intro-season-1", "1 of 2")
+    assert has_element?(view, "#segment-credits-season-1", "-")
+  end
+
+  test "shows every provenance a mixed season used", %{conn: conn} do
+    {media_item, [first, second]} = show_with_season()
+
+    detect(first, source: "fingerprint")
+    detect(second, source: "chapters")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    assert has_element?(view, "#segment-status-season-1", "chapters")
+    assert has_element?(view, "#segment-status-season-1", "fingerprint")
   end
 
   test "shows a pending badge before detection has run", %{conn: conn} do

--- a/test/mydia_web/live/media_live/segment_status_test.exs
+++ b/test/mydia_web/live/media_live/segment_status_test.exs
@@ -3,12 +3,14 @@ defmodule MydiaWeb.MediaLive.SegmentStatusTest do
   # otherwise hides test rows from the mount process. The fingerprint
   # implementation is also swapped through Application env, which is global.
   use MydiaWeb.ConnCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
 
   import Phoenix.LiveViewTest
   import Mydia.AccountsFixtures
   import Mydia.MediaFixtures
   import MydiaWeb.AuthHelpers
 
+  alias Mydia.Jobs.SegmentDetection, as: SegmentDetectionJob
   alias Mydia.Library.MediaFile
   alias Mydia.Library.MediaSegment
   alias Mydia.Repo
@@ -38,6 +40,12 @@ defmodule MydiaWeb.MediaLive.SegmentStatusTest do
   end
 
   setup %{conn: conn} do
+    # The app skips Oban in test (engine: false), so Oban.insert cannot be
+    # resolved from the LiveView process. Start an isolated, manual-mode
+    # instance so the re-analyze enqueue lands where assert_enqueued sees it.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Repo, engine: engine, testing: :manual})
+
     # The row is a capability-gated view of real detection, so the host's
     # chromaprint install must not decide what the test sees.
     Application.put_env(:mydia, :fingerprint_impl, AvailableStub)
@@ -157,6 +165,42 @@ defmodule MydiaWeb.MediaLive.SegmentStatusTest do
     end
 
     assert has_element?(view, "#segment-state-season-1", "Pending")
+  end
+
+  test "re-analyze enqueues detection for that season straight away", %{conn: conn} do
+    {media_item, [first | _rest]} = show_with_season()
+
+    detect(first)
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    view |> element("#segment-reanalyze-season-1") |> render_click()
+
+    # Waiting for the scheduler's next tick would read as a broken button.
+    assert_enqueued(
+      worker: SegmentDetectionJob,
+      args: %{media_item_id: media_item.id, season_number: 1}
+    )
+
+    assert length(all_enqueued(worker: SegmentDetectionJob)) == 1
+  end
+
+  test "re-analyzing a season the scheduler already queued does not duplicate it", %{conn: conn} do
+    {media_item, _files} = show_with_season()
+
+    {:ok, _job} =
+      %{media_item_id: media_item.id, season_number: 1}
+      |> SegmentDetectionJob.new()
+      |> Oban.insert()
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    view |> element("#segment-reanalyze-season-1") |> render_click()
+
+    # The worker's unique guard makes this a no-op rather than an error, and
+    # the operator is told the season is queued either way, which it is.
+    assert length(all_enqueued(worker: SegmentDetectionJob)) == 1
+    assert render(view) =~ "queued for segment re-analysis"
   end
 
   test "shows one note and no rows when chromaprint is missing", %{conn: conn} do

--- a/test/mydia_web/live/media_live/segment_status_test.exs
+++ b/test/mydia_web/live/media_live/segment_status_test.exs
@@ -1,0 +1,159 @@
+defmodule MydiaWeb.MediaLive.SegmentStatusTest do
+  # Connected LiveView tests must not be async: the Postgres non-shared sandbox
+  # otherwise hides test rows from the mount process. The fingerprint
+  # implementation is also swapped through Application env, which is global.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.MediaSegment
+  alias Mydia.Repo
+
+  defmodule AvailableStub do
+    @moduledoc false
+
+    @behaviour Mydia.Library.SegmentDetection.Fingerprint
+
+    @impl true
+    def available?, do: true
+
+    @impl true
+    def fingerprint(_path, _start_s, _length_s), do: {:error, :not_used}
+  end
+
+  defmodule UnavailableStub do
+    @moduledoc false
+
+    @behaviour Mydia.Library.SegmentDetection.Fingerprint
+
+    @impl true
+    def available?, do: false
+
+    @impl true
+    def fingerprint(_path, _start_s, _length_s), do: {:error, :fpcalc_not_found}
+  end
+
+  setup %{conn: conn} do
+    # The row is a capability-gated view of real detection, so the host's
+    # chromaprint install must not decide what the test sees.
+    Application.put_env(:mydia, :fingerprint_impl, AvailableStub)
+    on_exit(fn -> Application.delete_env(:mydia, :fingerprint_impl) end)
+
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  defp show_with_season do
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    files =
+      for n <- 1..2 do
+        episode =
+          episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: n})
+
+        media_file_fixture(%{episode_id: episode.id})
+      end
+
+    {media_item, files}
+  end
+
+  defp detect(file, opts \\ []) do
+    Repo.insert!(
+      MediaSegment.changeset(%MediaSegment{}, %{
+        media_file_id: file.id,
+        type: Keyword.get(opts, :type, "intro"),
+        start_ms: Keyword.get(opts, :start_ms, 35_000),
+        end_ms: Keyword.get(opts, :end_ms, 125_000),
+        source: Keyword.get(opts, :source, "fingerprint"),
+        confidence: 0.8
+      })
+    )
+
+    file |> Ecto.Changeset.change(%{segment_analysis_state: "detected"}) |> Repo.update!()
+  end
+
+  test "shows a detected badge, both offsets and the provenance chip", %{conn: conn} do
+    {media_item, files} = show_with_season()
+
+    for file <- files do
+      detect(file)
+      detect(file, type: "credits", start_ms: 1_320_000, end_ms: 1_400_000)
+    end
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    assert has_element?(view, "#segment-status-season-1")
+    assert has_element?(view, "#segment-state-season-1", "Detected")
+    assert has_element?(view, "#segment-intro-season-1", "0:35")
+    assert has_element?(view, "#segment-intro-season-1", "2:05")
+    assert has_element?(view, "#segment-credits-season-1", "22:00")
+    assert has_element?(view, "#segment-status-season-1", "fingerprint")
+  end
+
+  test "shows a partial badge when only some files resolved", %{conn: conn} do
+    {media_item, [first | _rest]} = show_with_season()
+
+    detect(first)
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    assert has_element?(view, "#segment-state-season-1", "Partial")
+  end
+
+  test "shows a pending badge before detection has run", %{conn: conn} do
+    {media_item, _files} = show_with_season()
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    assert has_element?(view, "#segment-state-season-1", "Pending")
+    assert has_element?(view, "#segment-intro-season-1", "-")
+    assert has_element?(view, "#segment-credits-season-1", "-")
+  end
+
+  test "re-analyze clears segments and returns files to pending", %{conn: conn} do
+    {media_item, files} = show_with_season()
+
+    for file <- files do
+      detect(file)
+
+      file
+      |> Ecto.Changeset.change(%{
+        segment_analysis_attempts: 2,
+        last_segment_analysis_error: "boom"
+      })
+      |> Repo.update!()
+    end
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    view |> element("#segment-reanalyze-season-1") |> render_click()
+
+    for file <- files do
+      reloaded = Repo.preload(Repo.get!(MediaFile, file.id), :segments)
+
+      assert reloaded.segment_analysis_state == "pending"
+      assert reloaded.segment_analysis_attempts == 0
+      assert reloaded.last_segment_analysis_error == nil
+      assert reloaded.segments == []
+    end
+
+    assert has_element?(view, "#segment-state-season-1", "Pending")
+  end
+
+  test "shows one note and no rows when chromaprint is missing", %{conn: conn} do
+    Application.put_env(:mydia, :fingerprint_impl, UnavailableStub)
+
+    {media_item, [first | _rest]} = show_with_season()
+
+    detect(first)
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    assert has_element?(view, "#segment-detection-unavailable")
+    refute has_element?(view, "#segment-status-season-1")
+    refute has_element?(view, "#segment-reanalyze-season-1")
+  end
+end


### PR DESCRIPTION
Task 11 of the intro and credits detection plan: the operator-facing half of segment detection.

## What this adds

Every season on a show page gets a compact summary row for intro and credits detection, in the same shape as the download client and indexer rows:

- a state badge: `Detected`, `Partial`, `Not found`, `Failed`, or `Pending`, where `Partial` means some files in the season resolved and others did not
- the intro and credits offsets in `mm:ss`, or a dash when nothing was found. Offsets are medians across the files carrying that type, and a type only some episodes have is suffixed with its coverage (`0:35 to 2:05 (1 of 2)`) so the offsets never contradict the state badge
- a provenance chip per distinct source the season used, `chapters` or `fingerprint` or both
- a **Re-analyze** action

**Re-analyze** clears that season's `media_segments` rows, returns its files to `segment_analysis_state = "pending"`, zeroes `segment_analysis_attempts`, and clears `last_segment_analysis_error`, all through `SegmentDetection.reset_season/2`, then enqueues `Mydia.Jobs.SegmentDetection` for the season immediately rather than leaving it for the scheduler's next tick. Cached `fingerprint_blob` values survive, so the second pass does not re-decode any audio.

The enqueue uses singular `Oban.insert/1`, never `insert_all/1`, which silently bypasses the worker's `unique:` option on the Basic and Lite engines this project runs. That guard is also why a season the scheduler already queued is not an error here: Oban returns the existing job, the season gets analyzed, and the operator is told what they asked for happened.

When `fpcalc` is missing the page shows one "Detection unavailable: chromaprint not installed" note in place of the per-season rows, rather than repeating the same state on every season. That is a runtime capability check rather than a stored state, so installing chromaprint later needs no data repair: the pending backlog is picked up on the next scheduler tick.

## Shape

`MydiaWeb.MediaLive.Show.SegmentComponents` is a new module because `show/components.ex` is already 1313 LOC, well past the file size guideline. The event handler and the mount assign live in `SegmentEvents`, matching how every other `handle_event` clause on this LiveView delegates. `episodes_section` gains two attrs and two component calls, which is the only change inside the oversized file.

Re-analyze is gated on `authorize_update_media/1`, like the other season-level mutations on this page.

## Tests

`test/mydia_web/live/media_live/segment_status_test.exs`, 8 connected LiveView tests, `async: false` because the Postgres non-shared sandbox otherwise hides test rows from the mount process. The fingerprint implementation is swapped for a stub so the host's chromaprint install does not decide what the test sees.

- detected badge with both offsets and the provenance chip
- partial badge, with the coverage suffix naming how many files carry the segment
- every provenance a mixed season used
- pending badge with dashes before detection has run
- re-analyze clears segments, zeroes attempts, clears the last error, and returns files to pending
- re-analyze enqueues the worker with the season's args
- re-analyzing a season the scheduler already queued leaves one job, not two
- one note and no rows when chromaprint is missing

Review findings from the first round are fixed in `3ff05b13`, with six more tests in `test/mydia/library/segment_detection_test.exs`: the season summary now reduces across every file that has segments rather than sampling one, and `SegmentDetection.season_statuses/1` loads the whole show in two queries instead of two per season.

The Oban engine is disabled app-wide in test, so these start an isolated manual-mode instance, the same pattern #316 and `path_mapping_issue_test.exs` use.

`mix precommit` is green: 6176 tests, 0 failures, 34 skipped.


