### PR TITLE
feat(player): add skip intro and skip credits button

### DIFF
--- a/player/lib/core/settings/settings_service.dart
+++ b/player/lib/core/settings/settings_service.dart
@@ -14,6 +14,7 @@ class SettingsService {
 
   static const _defaultQualityKey = 'default_quality';
   static const _autoPlayNextKey = 'auto_play_next_episode';
+  static const _autoSkipSegmentsKey = 'auto_skip_segments';
 
   /// Get the default quality setting.
   Future<String> getDefaultQuality() async {
@@ -38,11 +39,26 @@ class SettingsService {
     await _storage.write(key: _autoPlayNextKey, value: enabled.toString());
   }
 
+  /// Get the automatic intro and credits skipping setting.
+  ///
+  /// Defaults to disabled: a wrong detection that silently jumps the viewer out
+  /// of content is far more annoying than a button they can ignore.
+  Future<bool> getAutoSkipSegments() async {
+    final value = await _storage.read(key: _autoSkipSegmentsKey);
+    return value == 'true';
+  }
+
+  /// Set the automatic intro and credits skipping setting.
+  Future<void> setAutoSkipSegments(bool enabled) async {
+    await _storage.write(key: _autoSkipSegmentsKey, value: enabled.toString());
+  }
+
   /// Clear all settings.
   Future<void> clearSettings() async {
     await Future.wait([
       _storage.delete(key: _defaultQualityKey),
       _storage.delete(key: _autoPlayNextKey),
+      _storage.delete(key: _autoSkipSegmentsKey),
     ]);
   }
 }

--- a/player/lib/domain/models/media_segment.dart
+++ b/player/lib/domain/models/media_segment.dart
@@ -29,9 +29,11 @@ class MediaSegment {
 
   /// Parses a `segments` collection out of a decoded GraphQL payload.
   ///
-  /// Anything that is not a well-formed list of maps yields an empty list, so
-  /// an older server that answered the whole query with a field error lands on
-  /// the same result as a season nothing was detected in.
+  /// A value that is not a list yields an empty list. Within a list, entries
+  /// that are not maps are skipped and the well-formed ones are still
+  /// returned. Partial salvage is deliberate: the cost of keeping a good
+  /// segment out of a half-malformed payload is one skip button that works,
+  /// and the cost of discarding it is a feature that silently does nothing.
   static List<MediaSegment> listFromJson(dynamic raw) {
     final segments = <MediaSegment>[];
     if (raw is List) {

--- a/player/lib/domain/models/media_segment.dart
+++ b/player/lib/domain/models/media_segment.dart
@@ -1,0 +1,110 @@
+/// A region of a media file the viewer may want to skip.
+enum SegmentType { intro, credits, unknown }
+
+/// A detected skippable segment, as delivered by the server.
+///
+/// The server applies its own confidence threshold before sending these, so
+/// anything that arrives here is considered trustworthy enough to act on. The
+/// player deliberately holds no threshold logic of its own.
+class MediaSegment {
+  const MediaSegment({
+    required this.type,
+    required this.startMs,
+    required this.endMs,
+  });
+
+  /// Builds a segment from a decoded GraphQL map.
+  ///
+  /// Every field is read defensively. Mydia is self-hosted with no coordinated
+  /// deploy order, so a newer player regularly meets an older server whose
+  /// schema carries no segment fields at all. A missing or malformed value has
+  /// to mean "no skip affordance", never a playback error.
+  factory MediaSegment.fromJson(Map<String, dynamic> json) {
+    return MediaSegment(
+      type: _parseType(json['type']),
+      startMs: (json['startMs'] as num?)?.toInt() ?? 0,
+      endMs: (json['endMs'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  /// Parses a `segments` collection out of a decoded GraphQL payload.
+  ///
+  /// Anything that is not a well-formed list of maps yields an empty list, so
+  /// an older server that answered the whole query with a field error lands on
+  /// the same result as a season nothing was detected in.
+  static List<MediaSegment> listFromJson(dynamic raw) {
+    final segments = <MediaSegment>[];
+    if (raw is List) {
+      for (final entry in raw) {
+        if (entry is Map<String, dynamic>) {
+          segments.add(MediaSegment.fromJson(entry));
+        }
+      }
+    }
+    return segments;
+  }
+
+  final SegmentType type;
+  final int startMs;
+  final int endMs;
+
+  static SegmentType _parseType(dynamic raw) {
+    switch (raw) {
+      case 'INTRO':
+      case 'intro':
+        return SegmentType.intro;
+      case 'CREDITS':
+      case 'credits':
+        return SegmentType.credits;
+      default:
+        return SegmentType.unknown;
+    }
+  }
+
+  /// Whether [position] falls inside this segment.
+  ///
+  /// Inclusive of the start, exclusive of the end, so the button disappears at
+  /// the instant a skip would have landed.
+  bool containsPosition(Duration position) {
+    final ms = position.inMilliseconds;
+    return ms >= startMs && ms < endMs;
+  }
+
+  Duration get end => Duration(milliseconds: endMs);
+
+  /// Stable identity for once-per-session skip tracking.
+  ///
+  /// Derived from the segment's own values rather than a server id, so it stays
+  /// stable across a refetch and costs nothing extra on the wire.
+  String get key => '${type.name}:$startMs:$endMs';
+
+  /// Whether this segment is worth offering at all.
+  ///
+  /// An unrecognised type means the server knows a segment kind this build does
+  /// not, and a zero-or-negative span is not skippable.
+  bool get actionable => type != SegmentType.unknown && endMs > startMs;
+
+  String get label {
+    switch (type) {
+      case SegmentType.intro:
+        return 'Skip Intro';
+      case SegmentType.credits:
+        return 'Skip Credits';
+      case SegmentType.unknown:
+        return 'Skip';
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is MediaSegment &&
+      other.type == type &&
+      other.startMs == startMs &&
+      other.endMs == endMs;
+
+  @override
+  int get hashCode => Object.hash(type, startMs, endMs);
+
+  @override
+  String toString() => 'MediaSegment($key)';
+}

--- a/player/lib/domain/models/media_segment.dart
+++ b/player/lib/domain/models/media_segment.dart
@@ -44,6 +44,39 @@ class MediaSegment {
     return segments;
   }
 
+  /// Picks the segments for [fileId] out of a decoded segments-query payload.
+  ///
+  /// [root] is the query's root field, `movie` or `episode`.
+  ///
+  /// Reads the raw response map rather than a generated result class for two
+  /// reasons: the movie and episode queries generate distinct types for an
+  /// identical selection, so one code path here serves both; and a shape
+  /// surprise from an unfamiliar server yields an empty list rather than a
+  /// cast error, which is the whole point of this path being additive.
+  static List<MediaSegment> forFile(
+    Map<String, dynamic>? data, {
+    required String root,
+    required String fileId,
+  }) {
+    if (data == null) return const [];
+
+    final media = data[root];
+    if (media is! Map) return const [];
+
+    final files = media['files'];
+    if (files is! List) return const [];
+
+    for (final file in files) {
+      if (file is! Map) continue;
+      if (file['id'] != fileId) continue;
+      return listFromJson(file['segments'])
+          .where((segment) => segment.actionable)
+          .toList(growable: false);
+    }
+
+    return const [];
+  }
+
   final SegmentType type;
   final int startMs;
   final int endMs;

--- a/player/lib/domain/models/user_settings.dart
+++ b/player/lib/domain/models/user_settings.dart
@@ -5,11 +5,18 @@ class UserSettings {
   final String defaultQuality;
   final bool autoPlayNextEpisode;
 
+  /// Whether detected intros and credits are skipped without asking.
+  ///
+  /// Off by default. Each segment is still skipped at most once per playback,
+  /// so seeking back into an intro on purpose keeps working.
+  final bool autoSkipSegments;
+
   const UserSettings({
     required this.serverUrl,
     required this.username,
     this.defaultQuality = 'auto',
     this.autoPlayNextEpisode = true,
+    this.autoSkipSegments = false,
   });
 
   UserSettings copyWith({
@@ -17,12 +24,14 @@ class UserSettings {
     String? username,
     String? defaultQuality,
     bool? autoPlayNextEpisode,
+    bool? autoSkipSegments,
   }) {
     return UserSettings(
       serverUrl: serverUrl ?? this.serverUrl,
       username: username ?? this.username,
       defaultQuality: defaultQuality ?? this.defaultQuality,
       autoPlayNextEpisode: autoPlayNextEpisode ?? this.autoPlayNextEpisode,
+      autoSkipSegments: autoSkipSegments ?? this.autoSkipSegments,
     );
   }
 
@@ -32,6 +41,7 @@ class UserSettings {
       'username': username,
       'defaultQuality': defaultQuality,
       'autoPlayNextEpisode': autoPlayNextEpisode,
+      'autoSkipSegments': autoSkipSegments,
     };
   }
 
@@ -41,6 +51,7 @@ class UserSettings {
       username: json['username'] as String? ?? '',
       defaultQuality: json['defaultQuality'] as String? ?? 'auto',
       autoPlayNextEpisode: json['autoPlayNextEpisode'] as bool? ?? true,
+      autoSkipSegments: json['autoSkipSegments'] as bool? ?? false,
     );
   }
 }

--- a/player/lib/graphql/fragments/media_file_fragment.graphql
+++ b/player/lib/graphql/fragments/media_file_fragment.graphql
@@ -17,9 +17,4 @@ fragment MediaFileFragment on MediaFile {
     embedded
     url(format: VTT)
   }
-  segments {
-    type
-    startMs
-    endMs
-  }
 }

--- a/player/lib/graphql/fragments/media_file_fragment.graphql
+++ b/player/lib/graphql/fragments/media_file_fragment.graphql
@@ -17,4 +17,9 @@ fragment MediaFileFragment on MediaFile {
     embedded
     url(format: VTT)
   }
+  segments {
+    type
+    startMs
+    endMs
+  }
 }

--- a/player/lib/graphql/queries/media_segments.graphql
+++ b/player/lib/graphql/queries/media_segments.graphql
@@ -1,0 +1,40 @@
+# Skippable intro/credits segments, deliberately fetched on their own.
+#
+# DO NOT fold these selections back into MediaFileFragment as a tidy-up. An
+# unknown field is a *document* validation error in GraphQL, not a field-level
+# one, so a server that predates the segments schema rejects the entire query
+# it appears in and returns no data at all. Inside MediaFileFragment that would
+# cost the resume position and the external subtitle list on every episode and
+# movie detail view.
+#
+# That is the common path, not an edge case: the player auto-updates from an
+# app store while the server is upgraded by hand by the operator, sometimes
+# months later. Keeping segments in their own document means an older server
+# costs exactly one thing, the skip button.
+query MovieSegments($id: ID!) {
+  movie(id: $id) {
+    id
+    files {
+      id
+      segments {
+        type
+        startMs
+        endMs
+      }
+    }
+  }
+}
+
+query EpisodeSegments($id: ID!) {
+  episode(id: $id) {
+    id
+    files {
+      id
+      segments {
+        type
+        startMs
+        endMs
+      }
+    }
+  }
+}

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -45,6 +45,7 @@ import '../../../domain/models/cast_device.dart';
 import '../../../graphql/fragments/media_file_fragment.graphql.dart';
 import '../../../graphql/queries/movie_detail.graphql.dart';
 import '../../../graphql/queries/episode_detail.graphql.dart';
+import '../../../graphql/queries/media_segments.graphql.dart';
 import '../../../graphql/queries/season_episodes.graphql.dart';
 import '../../../graphql/mutations/start_streaming_session.graphql.dart';
 import '../../../graphql/mutations/end_streaming_session.graphql.dart';
@@ -1021,8 +1022,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
               DateTime.tryParse(movie?.progress?.lastWatchedAt ?? '');
           _runtimeMinutes = movie?.runtime;
 
-          // Extract subtitle tracks and skippable segments from files
-          _extractFileDetails(movie?.files);
+          // Extract subtitle tracks from files
+          _extractSubtitlesFromFiles(movie?.files);
         }
       } else if (widget.mediaType == 'episode') {
         // Fetch episode progress
@@ -1042,8 +1043,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
               DateTime.tryParse(episode?.progress?.lastWatchedAt ?? '');
           _runtimeMinutes = episode?.runtime;
 
-          // Extract subtitle tracks and skippable segments from files
-          _extractFileDetails(episode?.files);
+          // Extract subtitle tracks from files
+          _extractSubtitlesFromFiles(episode?.files);
 
           // If we have show and season info, fetch episode list for navigation
           if (widget.showId != null && widget.seasonNumber != null) {
@@ -1054,11 +1055,14 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     } catch (e) {
       debugPrint('Error fetching progress: $e');
     }
+
+    // Deliberately outside the block above: segments are their own query, and
+    // neither failure may take the other down with it.
+    await _fetchSegments(client);
   }
 
-  /// Extract subtitle tracks and skippable segments from media files returned
-  /// by GraphQL.
-  void _extractFileDetails(List<Fragment$MediaFileFragment?>? files) {
+  /// Extract subtitle tracks from media files returned by GraphQL
+  void _extractSubtitlesFromFiles(List<Fragment$MediaFileFragment?>? files) {
     if (files == null || files.isEmpty) return;
 
     // Find the file matching the current fileId
@@ -1074,7 +1078,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           debugPrint(
               'Extracted ${_subtitleTracks.length} subtitle tracks from GraphQL');
         }
-        _adoptSegments(file.segments);
         break;
       }
     }
@@ -1102,13 +1105,56 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     _skipTracker.reset();
   }
 
-  /// Adopt the segments reported for the file now playing.
-  void _adoptSegments(List<Fragment$MediaFileFragment$segments> segments) {
-    _segments = MediaSegment.listFromJson(
-      segments.map((segment) => segment.toJson()).toList(),
-    ).where((segment) => segment.actionable).toList(growable: false);
+  /// Fetch the skippable segments for the file now playing.
+  ///
+  /// This is a **separate query on purpose, and has to stay that way.** An
+  /// unknown field is a document-level validation error in GraphQL, not a
+  /// field-level one, so a server predating the segments schema rejects the
+  /// whole query the selection appears in and returns no data at all. Folded
+  /// back into `MediaFileFragment` as a tidy-up, that would cost the resume
+  /// position and the external subtitle list on every episode and movie detail
+  /// view. Here it costs exactly one thing, the skip button.
+  ///
+  /// That is the common path rather than an edge case: the player auto-updates
+  /// from an app store while the operator upgrades the server by hand,
+  /// sometimes months later, so "newer player, older server" is the norm.
+  ///
+  /// Every failure lands on the same answer, no segments. Detection is
+  /// additive background work and must never surface as a playback error.
+  Future<void> _fetchSegments(GraphQLClient client) async {
+    final root = switch (widget.mediaType) {
+      'movie' => 'movie',
+      'episode' => 'episode',
+      _ => null,
+    };
+    if (root == null) return;
 
-    debugPrint('[PlayerScreen] ${_segments.length} skippable segment(s)');
+    try {
+      final result = await client.query(
+        QueryOptions(
+          document: root == 'movie'
+              ? documentNodeQueryMovieSegments
+              : documentNodeQueryEpisodeSegments,
+          variables: root == 'movie'
+              ? Variables$Query$MovieSegments(id: widget.mediaId).toJson()
+              : Variables$Query$EpisodeSegments(id: widget.mediaId).toJson(),
+        ),
+      );
+
+      if (result.hasException) {
+        debugPrint('[PlayerScreen] No segments available: ${result.exception}');
+        return;
+      }
+
+      _segments = MediaSegment.forFile(
+        result.data,
+        root: root,
+        fileId: widget.fileId,
+      );
+      debugPrint('[PlayerScreen] ${_segments.length} skippable segment(s)');
+    } catch (e) {
+      debugPrint('[PlayerScreen] Error fetching segments: $e');
+    }
   }
 
   /// Detect available audio and subtitle tracks from the media_kit player

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -36,8 +36,10 @@ import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
 import '../../widgets/cast_device_picker.dart';
 import '../../widgets/video_controls/custom_video_controls.dart';
+import '../../widgets/video_controls/skip_segment_button.dart';
 import '../../widgets/up_next_overlay.dart';
 import '../../../domain/models/audio_track.dart' as app_models_audio;
+import '../../../domain/models/media_segment.dart';
 import '../../../domain/models/subtitle_track.dart' as app_models;
 import '../../../domain/models/cast_device.dart';
 import '../../../graphql/fragments/media_file_fragment.graphql.dart';
@@ -50,6 +52,7 @@ import '../../../graphql/queries/streaming_candidates.graphql.dart';
 import '../../../graphql/schema.graphql.dart';
 import '../../../core/p2p/local_proxy_service.dart';
 import '../../../core/player/resume_plan.dart';
+import '../settings/settings_controller.dart';
 
 export '../../../core/player/resume_plan.dart'
     show
@@ -229,6 +232,26 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   // Fullscreen state
   bool _isFullscreen = false;
 
+  /// Skippable intro/credits segments for the file being played, as reported
+  /// by the server. Empty whenever detection has not run, found nothing, or
+  /// the query failed: an older server has no `segments` field at all, and
+  /// that must degrade to "no skip button", never to a playback error.
+  List<MediaSegment> _segments = const [];
+
+  /// Once-per-playback record of automatic skips. Reset when the media
+  /// changes, not when a seek restarts the HLS session, so a restart mid-intro
+  /// cannot re-arm a skip the viewer already overrode.
+  final SegmentSkipTracker _skipTracker = SegmentSkipTracker();
+
+  /// Identifies the media [_skipTracker] is currently armed for. See
+  /// [_resetSegmentsIfMediaChanged].
+  String? _skipTrackerMediaKey;
+
+  /// Whether detected segments are skipped without asking. Off unless the
+  /// viewer opted in; loaded once in [initState] and deliberately not watched,
+  /// since flipping it mid-episode is not a case worth a rebuild.
+  bool _autoSkipSegments = false;
+
   // Auto-play next episode state
   bool _showUpNext = false;
   int _autoPlayCountdown = 10;
@@ -257,6 +280,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       fireImmediately: true,
     );
 
+    _loadAutoSkipPreference();
     _initializePlayer();
 
     // Force landscape orientation on mobile devices
@@ -270,6 +294,22 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     // Register beforeunload handler for web to terminate HLS session on tab close
     if (kIsWeb) {
       web_lifecycle.registerBeforeUnload(_terminateHlsSession);
+    }
+  }
+
+  /// Read the auto-skip preference once at mount.
+  ///
+  /// Failure is not propagated: secure storage being unreadable is no reason
+  /// to fail playback, and the safe answer is the default (skip nothing
+  /// automatically, leave the button).
+  Future<void> _loadAutoSkipPreference() async {
+    try {
+      final enabled =
+          await ref.read(settingsServiceProvider).getAutoSkipSegments();
+      if (!mounted) return;
+      _autoSkipSegments = enabled;
+    } catch (e) {
+      debugPrint('[PlayerScreen] Could not read auto-skip preference: $e');
     }
   }
 
@@ -356,6 +396,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   }
 
   Future<void> _initializePlayer() async {
+    _resetSegmentsIfMediaChanged();
+
     try {
       setState(() {
         _isLoading = true;
@@ -979,8 +1021,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
               DateTime.tryParse(movie?.progress?.lastWatchedAt ?? '');
           _runtimeMinutes = movie?.runtime;
 
-          // Extract subtitle tracks from files
-          _extractSubtitlesFromFiles(movie?.files);
+          // Extract subtitle tracks and skippable segments from files
+          _extractFileDetails(movie?.files);
         }
       } else if (widget.mediaType == 'episode') {
         // Fetch episode progress
@@ -1000,8 +1042,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
               DateTime.tryParse(episode?.progress?.lastWatchedAt ?? '');
           _runtimeMinutes = episode?.runtime;
 
-          // Extract subtitle tracks from files
-          _extractSubtitlesFromFiles(episode?.files);
+          // Extract subtitle tracks and skippable segments from files
+          _extractFileDetails(episode?.files);
 
           // If we have show and season info, fetch episode list for navigation
           if (widget.showId != null && widget.seasonNumber != null) {
@@ -1014,8 +1056,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     }
   }
 
-  /// Extract subtitle tracks from media files returned by GraphQL
-  void _extractSubtitlesFromFiles(List<Fragment$MediaFileFragment?>? files) {
+  /// Extract subtitle tracks and skippable segments from media files returned
+  /// by GraphQL.
+  void _extractFileDetails(List<Fragment$MediaFileFragment?>? files) {
     if (files == null || files.isEmpty) return;
 
     // Find the file matching the current fileId
@@ -1031,9 +1074,41 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           debugPrint(
               'Extracted ${_subtitleTracks.length} subtitle tracks from GraphQL');
         }
+        _adoptSegments(file.segments);
         break;
       }
     }
+  }
+
+  /// Drop the previous media's segments and re-arm the once-per-session skip
+  /// guard, but only when the media actually changed.
+  ///
+  /// Keyed on the media rather than reset on every [_initializePlayer] run,
+  /// because a seek past the transcoded end restarts the whole session for the
+  /// *same* file. Resetting there would let auto-skip fire a second time on a
+  /// segment the viewer had deliberately seeked back into, which is the exact
+  /// behaviour the guard exists to prevent.
+  ///
+  /// Clearing [_segments] here rather than only on a successful fetch matters
+  /// because go_router reuses this State across episodes: a next-episode
+  /// navigation whose detail query then fails would otherwise keep offering the
+  /// previous episode's skip button at the previous episode's timestamps.
+  void _resetSegmentsIfMediaChanged() {
+    final mediaKey = '${widget.mediaType}:${widget.mediaId}:${widget.fileId}';
+    if (_skipTrackerMediaKey == mediaKey) return;
+
+    _skipTrackerMediaKey = mediaKey;
+    _segments = const [];
+    _skipTracker.reset();
+  }
+
+  /// Adopt the segments reported for the file now playing.
+  void _adoptSegments(List<Fragment$MediaFileFragment$segments> segments) {
+    _segments = MediaSegment.listFromJson(
+      segments.map((segment) => segment.toJson()).toList(),
+    ).where((segment) => segment.actionable).toList(growable: false);
+
+    debugPrint('[PlayerScreen] ${_segments.length} skippable segment(s)');
   }
 
   /// Detect available audio and subtitle tracks from the media_kit player
@@ -1207,6 +1282,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     final player = _player;
     if (player == null || !mounted) return;
 
+    _maybeAutoSkipSegment(player);
+
     // Check if video is near completion (90%)
     final isWatched = _progressService?.isWatched(player) == true;
     if (isWatched) {
@@ -1225,6 +1302,31 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         _saveProgress().whenComplete(_invalidateAfterPlayback);
       }
     }
+  }
+
+  /// Seek past a detected segment the viewer opted into skipping.
+  ///
+  /// Runs on every position tick, so the once-per-session bookkeeping lives
+  /// inside [SegmentSkipTracker.takeAutoSkip] rather than here: a segment is
+  /// consumed by the same call that reports it, and seeking back into one that
+  /// has already been skipped does nothing.
+  void _maybeAutoSkipSegment(Player player) {
+    if (!_autoSkipSegments || _segments.isEmpty) return;
+
+    final position = _timeline.toReal(player.state.position);
+    final target = _skipTracker.takeAutoSkip(_segments, position);
+    if (target == null) return;
+
+    debugPrint('[PlayerScreen] Auto-skipping to ${target.end}');
+    unawaited(seekToReal(target.end));
+  }
+
+  /// The segment covering [position], or null when playback is between them.
+  MediaSegment? _segmentAt(Duration position) {
+    for (final segment in _segments) {
+      if (segment.containsPosition(position)) return segment;
+    }
+    return null;
   }
 
   /// Show the "Up Next" overlay if conditions are met.
@@ -2126,6 +2228,29 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     return Stack(
       children: [
         videoPlayer,
+        // Skip Intro / Skip Credits. Driven by its own position stream rather
+        // than a setState per tick, and stood down while the up-next overlay
+        // is showing so the two do not stack in the same bottom-right corner.
+        if (player != null && _segments.isNotEmpty && !_showUpNext)
+          Positioned.fill(
+            child: StreamBuilder<Duration>(
+              stream: player.stream.position,
+              initialData: player.state.position,
+              builder: (context, snapshot) {
+                final position =
+                    _timeline.toReal(snapshot.data ?? Duration.zero);
+                final segment = _segmentAt(position);
+                if (segment == null) return const SizedBox.shrink();
+
+                return SkipSegmentButton(
+                  key: ValueKey(segment.key),
+                  segment: segment,
+                  position: position,
+                  onSkip: (target) => seekToReal(target.end),
+                );
+              },
+            ),
+          ),
         // Up Next overlay for auto-play (always interactive, not tied to controls)
         if (_showUpNext && _getNextEpisodeTitle() != null)
           UpNextOverlay(

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1086,16 +1086,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// Drop the previous media's segments and re-arm the once-per-session skip
   /// guard, but only when the media actually changed.
   ///
-  /// Keyed on the media rather than reset on every [_initializePlayer] run,
-  /// because a seek past the transcoded end restarts the whole session for the
-  /// *same* file. Resetting there would let auto-skip fire a second time on a
-  /// segment the viewer had deliberately seeked back into, which is the exact
-  /// behaviour the guard exists to prevent.
+  /// The comparison, not the clearing, is the load-bearing half. This runs on
+  /// every [_initializePlayer] call, and a seek past the transcoded end
+  /// restarts the whole session for the *same* file. Resetting unconditionally
+  /// would let auto-skip fire a second time on a segment the viewer had
+  /// deliberately seeked back into, which is precisely what the guard exists
+  /// to prevent.
   ///
-  /// Clearing [_segments] here rather than only on a successful fetch matters
-  /// because go_router reuses this State across episodes: a next-episode
-  /// navigation whose detail query then fails would otherwise keep offering the
-  /// previous episode's skip button at the previous episode's timestamps.
+  /// The clearing half is insurance, not a live path. go_router derives the
+  /// page key for `/player/:type/:id` from the route *pattern* rather than the
+  /// resolved location, so a next-episode navigation updates this State in
+  /// place instead of building a new one, and `PlayerScreen` has no
+  /// `didUpdateWidget` to notice the new parameters. [_initializePlayer] is
+  /// therefore never re-entered on that path and neither is this. It is
+  /// written to be correct if that gap is ever closed, and until then the
+  /// media key only ever transitions from null on first mount.
   void _resetSegmentsIfMediaChanged() {
     final mediaKey = '${widget.mediaType}:${widget.mediaId}:${widget.fileId}';
     if (_skipTrackerMediaKey == mediaKey) return;

--- a/player/lib/presentation/screens/settings/settings_controller.dart
+++ b/player/lib/presentation/screens/settings/settings_controller.dart
@@ -28,12 +28,14 @@ class SettingsController extends _$SettingsController {
     final session = await authService.getSession();
     final defaultQuality = await settingsService.getDefaultQuality();
     final autoPlayNext = await settingsService.getAutoPlayNext();
+    final autoSkipSegments = await settingsService.getAutoSkipSegments();
 
     return UserSettings(
       serverUrl: session['serverUrl'] ?? '',
       username: session['username'] ?? '',
       defaultQuality: defaultQuality,
       autoPlayNextEpisode: autoPlayNext,
+      autoSkipSegments: autoSkipSegments,
     );
   }
 
@@ -58,6 +60,18 @@ class SettingsController extends _$SettingsController {
     state = await AsyncValue.guard(() async {
       final currentSettings = await future;
       return currentSettings.copyWith(autoPlayNextEpisode: enabled);
+    });
+  }
+
+  /// Set the automatic intro and credits skipping preference.
+  Future<void> setAutoSkipSegments(bool enabled) async {
+    final settingsService = ref.read(settingsServiceProvider);
+    await settingsService.setAutoSkipSegments(enabled);
+
+    // Update the state
+    state = await AsyncValue.guard(() async {
+      final currentSettings = await future;
+      return currentSettings.copyWith(autoSkipSegments: enabled);
     });
   }
 

--- a/player/lib/presentation/screens/settings_screen.dart
+++ b/player/lib/presentation/screens/settings_screen.dart
@@ -122,6 +122,20 @@ class SettingsScreen extends ConsumerWidget {
             ),
             const Divider(),
 
+            // Playback section
+            const _SectionHeader(title: 'Playback'),
+            SwitchListTile(
+              key: const Key('auto-skip-segments-switch'),
+              secondary: const Icon(Icons.fast_forward),
+              title: const Text('Automatically skip intros and credits'),
+              subtitle: const Text('When off, a skip button appears instead.'),
+              value: settings.autoSkipSegments,
+              onChanged: (value) => ref
+                  .read(settingsControllerProvider.notifier)
+                  .setAutoSkipSegments(value),
+            ),
+            const Divider(),
+
             // Connection section
             const _SectionHeader(title: 'Connection'),
             const ConnectionStatusTile(),

--- a/player/lib/presentation/widgets/video_controls/skip_segment_button.dart
+++ b/player/lib/presentation/widgets/video_controls/skip_segment_button.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/player/platform_features.dart';
+import '../../../domain/models/media_segment.dart';
+import 'chrome_top_bar.dart';
+
+/// Records which segments have already been auto-skipped this playback session.
+///
+/// Without this, auto-skip makes an intro unwatchable: a viewer who seeks back
+/// into it is thrown straight out again with no way to override. Each segment
+/// therefore gets exactly one automatic skip per media item, and [reset] runs
+/// when the media changes so the next episode starts with a clean record.
+///
+/// Identity comes from [MediaSegment.key] rather than object equality, so a
+/// refetch that rebuilds the segment list does not resurrect a spent skip.
+class SegmentSkipTracker {
+  final Set<String> _skipped = <String>{};
+
+  /// Whether [segment] may still be skipped automatically.
+  bool shouldAutoSkip(MediaSegment segment) => !_skipped.contains(segment.key);
+
+  void markSkipped(MediaSegment segment) => _skipped.add(segment.key);
+
+  /// Forgets every recorded skip. Called on media change.
+  void reset() => _skipped.clear();
+
+  /// The segment to auto-skip at [position], or null when none applies.
+  ///
+  /// Marks the segment as spent before returning it, so this is the whole
+  /// once-per-session guard in one place rather than a rule each caller has to
+  /// reassemble from [shouldAutoSkip] and [markSkipped]. The position listener
+  /// calls it on every tick, which is exactly why the marking has to be
+  /// inseparable from the decision.
+  MediaSegment? takeAutoSkip(
+    Iterable<MediaSegment> segments,
+    Duration position,
+  ) {
+    for (final segment in segments) {
+      if (!segment.actionable) continue;
+      if (!segment.containsPosition(position)) continue;
+      if (!shouldAutoSkip(segment)) continue;
+      markSkipped(segment);
+      return segment;
+    }
+    return null;
+  }
+}
+
+/// A transient "Skip Intro" / "Skip Credits" affordance.
+///
+/// Renders nothing unless playback is currently inside [segment], so the caller
+/// can mount it unconditionally and let position drive visibility. It sits
+/// bottom-right above the transport chrome, in the same glass material as the
+/// rest of the playback controls.
+///
+/// The button stays available even for a segment auto-skip has already spent:
+/// a viewer who seeks back into the intro on purpose is choosing to watch it,
+/// and taking the manual affordance away as well would leave them with nothing.
+class SkipSegmentButton extends StatelessWidget {
+  const SkipSegmentButton({
+    super.key,
+    required this.segment,
+    required this.position,
+    required this.onSkip,
+    this.tier,
+  });
+
+  /// The segment this button offers to skip.
+  final MediaSegment segment;
+
+  /// Current playback position, in real media coordinates.
+  final Duration position;
+
+  /// Called with [segment] when the viewer taps. The caller does the seeking;
+  /// this widget deliberately holds no player reference.
+  final void Function(MediaSegment segment) onSkip;
+
+  /// Glass tier override, passed through to [GlassPill] so golden tests do not
+  /// vary with the host platform.
+  final PlayerGlassTier? tier;
+
+  /// Right inset. Matches `UpNextOverlay`, the other bottom-right overlay.
+  static const double _rightInset = 24;
+
+  /// Bottom inset, clearing the transport chrome. Matches `UpNextOverlay`.
+  static const double _bottomInset = 120;
+
+  static const Key buttonKey = Key('skip-segment-button');
+
+  @override
+  Widget build(BuildContext context) {
+    if (!segment.actionable || !segment.containsPosition(position)) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(
+        right: _rightInset,
+        bottom: _bottomInset,
+      ),
+      child: Align(
+        alignment: Alignment.bottomRight,
+        child: GlassPill(
+          key: buttonKey,
+          tier: tier,
+          onTap: () => onSkip(segment),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.fast_forward_rounded),
+              const SizedBox(width: 6),
+              Text(segment.label),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/player/test/presentation/screens/player/cast_resume_prompt_test.dart
+++ b/player/test/presentation/screens/player/cast_resume_prompt_test.dart
@@ -20,6 +20,7 @@ void main() {
     // 45 minutes into a 90 minute movie.
     final link = StubLink.responses([
       movieDetailResponse(positionSeconds: 2700),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400),
     ]);
 
@@ -58,6 +59,7 @@ void main() {
 
     final link = StubLink.responses([
       movieDetailResponse(positionSeconds: 2700),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400),
     ]);
 
@@ -87,6 +89,7 @@ void main() {
     // 12 seconds in, below kMinResumeThresholdSeconds.
     final link = StubLink.responses([
       movieDetailResponse(positionSeconds: 12),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400),
     ]);
 

--- a/player/test/presentation/screens/player/direct_play_resume_prompt_test.dart
+++ b/player/test/presentation/screens/player/direct_play_resume_prompt_test.dart
@@ -39,6 +39,7 @@ void main() {
     // dialog is the call site being gone.
     final link = StubLink.responses([
       movieDetailResponse(positionSeconds: 2700),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400, directPlay: true),
     ]);
 
@@ -78,6 +79,7 @@ void main() {
     // gated by `shouldOfferResume`, not shown unconditionally.
     final link = StubLink.responses([
       movieDetailResponse(positionSeconds: 12),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400, directPlay: true),
     ]);
 

--- a/player/test/presentation/screens/player/player_screen_cast_duration_test.dart
+++ b/player/test/presentation/screens/player/player_screen_cast_duration_test.dart
@@ -31,6 +31,7 @@ void main() {
 
     final link = StubLink.responses([
       movieDetailResponse(),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400),
     ]);
 

--- a/player/test/presentation/screens/player/player_screen_dispose_cleanup_test.dart
+++ b/player/test/presentation/screens/player/player_screen_dispose_cleanup_test.dart
@@ -33,6 +33,7 @@ void main() {
     // candidates or progress queries this scenario never reaches.
     final link = StubLink.responses([
       movieDetailResponse(),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400),
     ]);
 

--- a/player/test/presentation/screens/player/player_screen_dispose_ends_session_test.dart
+++ b/player/test/presentation/screens/player/player_screen_dispose_ends_session_test.dart
@@ -31,6 +31,7 @@ void main() {
 
     final link = StubLink.responses([
       movieDetailResponse(),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400),
       startStreamingSessionResponse(sessionId: 'sess-42'),
       endStreamingSessionResponse(),

--- a/player/test/presentation/screens/player/player_screen_resume_offset_test.dart
+++ b/player/test/presentation/screens/player/player_screen_resume_offset_test.dart
@@ -64,6 +64,7 @@ void main() {
     // the assertion below (looking for the 2695 offset) would fail.
     final link = StubLink.responses([
       movieDetailResponse(positionSeconds: 2700),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400),
       startStreamingSessionResponse(startPosition: 2695),
       endStreamingSessionResponse(),
@@ -117,6 +118,7 @@ void main() {
 
     final link = StubLink.responses([
       movieDetailResponse(positionSeconds: 2700),
+      movieSegmentsResponse(),
       streamingCandidatesResponse(duration: 5400),
       // No `startPosition` key at all — the older-server case.
       startStreamingSessionResponse(startPosition: null),

--- a/player/test/presentation/screens/player/player_screen_segments_isolation_test.dart
+++ b/player/test/presentation/screens/player/player_screen_segments_isolation_test.dart
@@ -1,0 +1,179 @@
+// Pins that the skippable-segments query is isolated from the detail query.
+//
+// `segments` lives in its own document rather than in `MediaFileFragment`
+// because an unknown field is a *document* validation error in GraphQL, not a
+// field-level one: a server predating the segments schema rejects the entire
+// query the selection appears in and returns no data at all. Inside the shared
+// fragment that would silently cost the resume position and the external
+// subtitle list on every episode and movie detail view.
+//
+// This is the common path for a self-hosted app, not an edge case. The player
+// auto-updates from an app store; the operator upgrades the server by hand,
+// sometimes months later.
+//
+// The test drives that exact scenario: the segments query fails the way an
+// older server fails it, while the detail query succeeds. The resume prompt is
+// the observable proof that the detail response was still consumed, since it
+// only appears when `progress.positionSeconds` made it through. Folding
+// `segments` back into `MediaFileFragment` cannot fail this test directly (the
+// stub answers per operation), so the second test pins the request shape
+// instead: exactly one segments document, separate from the detail one.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+/// Whether [request] carries the named query.
+///
+/// `request.operation.operationName` is null for everything this screen
+/// issues, because `QueryOptions` never sets it, and graphql_flutter does not
+/// re-export the `gql` AST node types a document walk would need. What
+/// `Operation.toString()` does give is the printed query text, which names the
+/// operation on its first line.
+bool _isQuery(Request request, String name) =>
+    request.operation.toString().contains('query $name');
+
+/// Answers per operation, so the response script does not depend on the order
+/// the screen happens to issue its queries in.
+StubLink _linkAnsweringSegmentsWith(Object segmentsOutcome) {
+  return StubLink((request, index) {
+    if (_isQuery(request, 'MovieSegments')) return segmentsOutcome;
+    if (_isQuery(request, 'MovieDetail')) {
+      // 45 minutes into a 90 minute movie, comfortably inside every bound
+      // `shouldOfferResume` checks.
+      return movieDetailResponse(positionSeconds: 2700);
+    }
+    return streamingCandidatesResponse(duration: 5400, directPlay: true);
+  });
+}
+
+void main() {
+  testWidgets('a segments failure leaves the rest of the detail data intact',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    // The exact shape an older server answers with: the field does not exist,
+    // so validation rejects the document.
+    final link = _linkAnsweringSegmentsWith(
+      graphqlErrorResponse(
+        'Cannot query field "segments" on type "MediaFile".',
+      ),
+    );
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: castManager,
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(tester, () => find.text('Resume').evaluate().isNotEmpty);
+
+    expect(
+      find.text('Resume'),
+      findsOneWidget,
+      reason: 'the segments query failed the way an older server fails it, '
+          'and the resume position still came through',
+    );
+    expect(find.text('Start Over'), findsOneWidget);
+
+    expect(
+      link.requests.where((r) => _isQuery(r, 'MovieSegments')),
+      hasLength(1),
+      reason: 'the failing path has to have actually been exercised',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('a thrown transport error on segments is swallowed too',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    // Not every failure arrives as a well-formed GraphQL error response; a
+    // link that throws has to land on the same answer.
+    final link = _linkAnsweringSegmentsWith(Exception('connection reset'));
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: castManager,
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(tester, () => find.text('Resume').evaluate().isNotEmpty);
+
+    expect(find.text('Resume'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('segments travel in their own document, not the detail one',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    final link = _linkAnsweringSegmentsWith(const {
+      '__typename': 'Query',
+      'movie': {
+        '__typename': 'Movie',
+        'id': 'movie-1',
+        'files': [
+          {
+            '__typename': 'MediaFile',
+            'id': 'file-1',
+            'segments': [
+              {
+                '__typename': 'MediaSegment',
+                'type': 'INTRO',
+                'startMs': 30000,
+                'endMs': 90000,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: castManager,
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(
+      tester,
+      () => link.requests.any((r) => _isQuery(r, 'MovieSegments')),
+    );
+
+    expect(
+      link.requests.where((r) => _isQuery(r, 'MovieSegments')),
+      hasLength(1),
+      reason: 'one segments query per playback, not one per detail selection',
+    );
+    expect(
+      link.requests.where((r) => _isQuery(r, 'MovieDetail')),
+      hasLength(1),
+      reason: 'the detail query is still its own separate request, and the '
+          'segments selection did not ride along inside it',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+}

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -211,6 +211,34 @@ Map<String, dynamic> movieDetailResponse({
   };
 }
 
+/// A well-formed `MovieSegments` response.
+///
+/// `_fetchProgressAndEpisodes` issues this immediately after the detail query
+/// and before streaming candidates, so an ordered `StubLink.responses` script
+/// has to carry it in that slot. Segments travel in their own document on
+/// purpose, not inside `MediaFileFragment` — see
+/// `player_screen_segments_isolation_test.dart` for why. The default is
+/// "detection found nothing", which is what every test that is not about
+/// segments wants.
+Map<String, dynamic> movieSegmentsResponse({
+  List<Map<String, dynamic>> segments = const [],
+}) {
+  return {
+    '__typename': 'Query',
+    'movie': {
+      '__typename': 'Movie',
+      'id': 'movie-1',
+      'files': [
+        {
+          '__typename': 'MediaFile',
+          'id': 'file-1',
+          'segments': segments,
+        },
+      ],
+    },
+  };
+}
+
 /// A well-formed `StreamingCandidates` response.
 ///
 /// Empty `candidates` (the default) forces the HLS/TRANSCODE path, because

--- a/player/test/presentation/screens/player/resume_decision_coverage_test.dart
+++ b/player/test/presentation/screens/player/resume_decision_coverage_test.dart
@@ -34,6 +34,7 @@ void main() {
       final container = buildPlayerScreenContainer(
         link: StubLink.responses([
           movieDetailResponse(positionSeconds: 2700),
+          movieSegmentsResponse(),
           streamingCandidatesResponse(duration: 5400),
         ]),
         connectionState: conn.ConnectionState.direct(),
@@ -48,6 +49,7 @@ void main() {
       final container = buildPlayerScreenContainer(
         link: StubLink.responses([
           movieDetailResponse(positionSeconds: 2700),
+          movieSegmentsResponse(),
           streamingCandidatesResponse(duration: 5400, directPlay: true),
         ]),
         connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
@@ -62,6 +64,7 @@ void main() {
       final container = buildPlayerScreenContainer(
         link: StubLink.responses([
           movieDetailResponse(positionSeconds: 2700),
+          movieSegmentsResponse(),
           streamingCandidatesResponse(duration: 5400),
         ]),
         connectionState: conn.ConnectionState.direct(),

--- a/player/test/presentation/widgets/video_controls/skip_segment_button_test.dart
+++ b/player/test/presentation/widgets/video_controls/skip_segment_button_test.dart
@@ -1,0 +1,287 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/platform_features.dart';
+import 'package:player/domain/models/media_segment.dart';
+import 'package:player/presentation/widgets/video_controls/skip_segment_button.dart';
+
+void main() {
+  const intro = MediaSegment(
+    type: SegmentType.intro,
+    startMs: 30000,
+    endMs: 90000,
+  );
+  const credits = MediaSegment(
+    type: SegmentType.credits,
+    startMs: 1200000,
+    endMs: 1260000,
+  );
+
+  group('MediaSegment', () {
+    test('parses graphql json', () {
+      final segment = MediaSegment.fromJson(const {
+        'type': 'INTRO',
+        'startMs': 30000,
+        'endMs': 90000,
+      });
+
+      expect(segment.type, SegmentType.intro);
+      expect(segment.startMs, 30000);
+      expect(segment.endMs, 90000);
+    });
+
+    test('falls back to unknown for an unrecognised type', () {
+      final segment = MediaSegment.fromJson(const {
+        'type': 'RECAP',
+        'startMs': 0,
+        'endMs': 1000,
+      });
+
+      expect(segment.type, SegmentType.unknown);
+      expect(segment.actionable, isFalse);
+    });
+
+    test('containsPosition is inclusive of start and exclusive of end', () {
+      expect(
+          intro.containsPosition(const Duration(milliseconds: 29999)), isFalse);
+      expect(
+          intro.containsPosition(const Duration(milliseconds: 30000)), isTrue);
+      expect(
+          intro.containsPosition(const Duration(milliseconds: 89999)), isTrue);
+      expect(
+          intro.containsPosition(const Duration(milliseconds: 90000)), isFalse);
+    });
+
+    // A newer player regularly meets an older server with no segments field,
+    // which fails the whole query rather than returning null for that one
+    // selection. Every shape below has to mean "no skip buttons".
+    test('listFromJson yields an empty list for anything malformed', () {
+      expect(MediaSegment.listFromJson(null), isEmpty);
+      expect(MediaSegment.listFromJson('nope'), isEmpty);
+      expect(MediaSegment.listFromJson(const [42, 'x']), isEmpty);
+      expect(MediaSegment.listFromJson(const <dynamic>[]), isEmpty);
+    });
+
+    test('listFromJson parses a well-formed list', () {
+      final segments = MediaSegment.listFromJson(const [
+        {'type': 'INTRO', 'startMs': 30000, 'endMs': 90000},
+        {'type': 'CREDITS', 'startMs': 1200000, 'endMs': 1260000},
+      ]);
+
+      expect(segments, [intro, credits]);
+    });
+  });
+
+  group('SegmentSkipTracker', () {
+    test('permits a segment only once per session', () {
+      final tracker = SegmentSkipTracker();
+
+      expect(tracker.shouldAutoSkip(intro), isTrue);
+      tracker.markSkipped(intro);
+      expect(tracker.shouldAutoSkip(intro), isFalse);
+    });
+
+    test('reset clears the record so a new media item skips again', () {
+      final tracker = SegmentSkipTracker();
+
+      tracker.markSkipped(intro);
+      tracker.reset();
+
+      expect(tracker.shouldAutoSkip(intro), isTrue);
+    });
+
+    test('takeAutoSkip returns the segment covering the position', () {
+      final tracker = SegmentSkipTracker();
+
+      expect(
+        tracker
+            .takeAutoSkip(const [intro, credits], const Duration(seconds: 45)),
+        intro,
+      );
+    });
+
+    test('takeAutoSkip returns null outside every segment', () {
+      final tracker = SegmentSkipTracker();
+
+      expect(
+        tracker
+            .takeAutoSkip(const [intro, credits], const Duration(seconds: 10)),
+        isNull,
+      );
+    });
+
+    // The guard that makes auto-skip survivable: seeking back into an intro
+    // that has already been skipped must leave playback alone, or the viewer
+    // can never watch it.
+    test('takeAutoSkip does not re-trigger after seeking back in', () {
+      final tracker = SegmentSkipTracker();
+      const segments = [intro, credits];
+
+      expect(
+        tracker.takeAutoSkip(segments, const Duration(seconds: 31)),
+        intro,
+      );
+      // Viewer seeks back to the top of the intro, then plays through it.
+      expect(
+          tracker.takeAutoSkip(segments, const Duration(seconds: 31)), isNull);
+      expect(
+          tracker.takeAutoSkip(segments, const Duration(seconds: 45)), isNull);
+      expect(
+          tracker.takeAutoSkip(segments, const Duration(seconds: 89)), isNull);
+    });
+
+    test('a spent intro does not disarm the credits', () {
+      final tracker = SegmentSkipTracker();
+      const segments = [intro, credits];
+
+      tracker.takeAutoSkip(segments, const Duration(seconds: 45));
+
+      expect(
+        tracker.takeAutoSkip(segments, const Duration(seconds: 1201)),
+        credits,
+      );
+    });
+
+    test('takeAutoSkip ignores segments of an unrecognised type', () {
+      final tracker = SegmentSkipTracker();
+      const unknown = MediaSegment(
+        type: SegmentType.unknown,
+        startMs: 0,
+        endMs: 60000,
+      );
+
+      expect(
+        tracker.takeAutoSkip(const [unknown], const Duration(seconds: 10)),
+        isNull,
+      );
+    });
+
+    test('reset re-arms takeAutoSkip on media change', () {
+      final tracker = SegmentSkipTracker();
+      const segments = [intro];
+
+      tracker.takeAutoSkip(segments, const Duration(seconds: 45));
+      tracker.reset();
+
+      expect(
+          tracker.takeAutoSkip(segments, const Duration(seconds: 45)), intro);
+    });
+  });
+
+  group('SkipSegmentButton', () {
+    Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+    Widget button({
+      MediaSegment segment = intro,
+      required Duration position,
+      void Function(MediaSegment)? onSkip,
+    }) =>
+        SkipSegmentButton(
+          segment: segment,
+          position: position,
+          onSkip: onSkip ?? (_) {},
+          // Pinned so the surface does not vary with the host platform.
+          tier: PlayerGlassTier.full,
+        );
+
+    testWidgets('shows the intro label while inside the segment',
+        (tester) async {
+      await tester
+          .pumpWidget(wrap(button(position: const Duration(seconds: 45))));
+
+      expect(find.text('Skip Intro'), findsOneWidget);
+      expect(find.byKey(SkipSegmentButton.buttonKey), findsOneWidget);
+    });
+
+    testWidgets('appears exactly at the segment start', (tester) async {
+      await tester.pumpWidget(
+        wrap(button(position: const Duration(milliseconds: 29999))),
+      );
+      expect(find.byKey(SkipSegmentButton.buttonKey), findsNothing);
+
+      await tester.pumpWidget(
+        wrap(button(position: const Duration(milliseconds: 30000))),
+      );
+      expect(find.byKey(SkipSegmentButton.buttonKey), findsOneWidget);
+    });
+
+    testWidgets('disappears exactly at the segment end', (tester) async {
+      await tester.pumpWidget(
+        wrap(button(position: const Duration(milliseconds: 89999))),
+      );
+      expect(find.byKey(SkipSegmentButton.buttonKey), findsOneWidget);
+
+      await tester.pumpWidget(
+        wrap(button(position: const Duration(milliseconds: 90000))),
+      );
+      expect(find.byKey(SkipSegmentButton.buttonKey), findsNothing);
+    });
+
+    testWidgets('renders nothing before the segment starts', (tester) async {
+      await tester
+          .pumpWidget(wrap(button(position: const Duration(seconds: 10))));
+
+      expect(find.text('Skip Intro'), findsNothing);
+    });
+
+    testWidgets('renders nothing after the segment ends', (tester) async {
+      await tester
+          .pumpWidget(wrap(button(position: const Duration(seconds: 120))));
+
+      expect(find.text('Skip Intro'), findsNothing);
+    });
+
+    testWidgets('shows the credits label for a credits segment',
+        (tester) async {
+      await tester.pumpWidget(wrap(button(
+        segment: credits,
+        position: const Duration(seconds: 1210),
+      )));
+
+      expect(find.text('Skip Credits'), findsOneWidget);
+    });
+
+    testWidgets('renders nothing for an unrecognised segment type',
+        (tester) async {
+      await tester.pumpWidget(wrap(button(
+        segment: const MediaSegment(
+          type: SegmentType.unknown,
+          startMs: 0,
+          endMs: 60000,
+        ),
+        position: const Duration(seconds: 10),
+      )));
+
+      expect(find.byKey(SkipSegmentButton.buttonKey), findsNothing);
+    });
+
+    testWidgets('reports the segment end when tapped', (tester) async {
+      MediaSegment? skipped;
+
+      await tester.pumpWidget(wrap(button(
+        position: const Duration(seconds: 45),
+        onSkip: (segment) => skipped = segment,
+      )));
+
+      await tester.tap(find.text('Skip Intro'));
+      await tester.pump();
+
+      expect(skipped, isNotNull);
+      expect(skipped!.endMs, 90000);
+      expect(skipped!.end, const Duration(milliseconds: 90000));
+    });
+
+    // Manual skipping stays available for a segment auto-skip already spent:
+    // the once-per-session guard governs the automatic seek, not the button.
+    testWidgets('still renders for a segment already auto-skipped',
+        (tester) async {
+      final tracker = SegmentSkipTracker();
+      tracker.takeAutoSkip(const [intro], const Duration(seconds: 31));
+
+      await tester
+          .pumpWidget(wrap(button(position: const Duration(seconds: 45))));
+
+      expect(find.byKey(SkipSegmentButton.buttonKey), findsOneWidget);
+      expect(tracker.shouldAutoSkip(intro), isFalse);
+    });
+  });
+}

--- a/player/test/presentation/widgets/video_controls/skip_segment_button_test.dart
+++ b/player/test/presentation/widgets/video_controls/skip_segment_button_test.dart
@@ -51,14 +51,26 @@ void main() {
           intro.containsPosition(const Duration(milliseconds: 90000)), isFalse);
     });
 
-    // A newer player regularly meets an older server with no segments field,
-    // which fails the whole query rather than returning null for that one
-    // selection. Every shape below has to mean "no skip buttons".
+    // Detection is additive background work, so no wire shape may become a
+    // playback error. Every one of these has to mean "no skip buttons".
     test('listFromJson yields an empty list for anything malformed', () {
       expect(MediaSegment.listFromJson(null), isEmpty);
       expect(MediaSegment.listFromJson('nope'), isEmpty);
       expect(MediaSegment.listFromJson(const [42, 'x']), isEmpty);
       expect(MediaSegment.listFromJson(const <dynamic>[]), isEmpty);
+    });
+
+    // Partial salvage is the documented behaviour, not an accident: a good
+    // segment sitting next to a bad entry still produces a working button.
+    test('listFromJson keeps the well-formed entries beside malformed ones',
+        () {
+      final segments = MediaSegment.listFromJson(const [
+        42,
+        {'type': 'INTRO', 'startMs': 30000, 'endMs': 90000},
+        'nonsense',
+      ]);
+
+      expect(segments, [intro]);
     });
 
     test('listFromJson parses a well-formed list', () {

--- a/player/test/presentation/widgets/video_controls/skip_segment_button_test.dart
+++ b/player/test/presentation/widgets/video_controls/skip_segment_button_test.dart
@@ -71,6 +71,127 @@ void main() {
     });
   });
 
+  // `forFile` is what the player screen actually calls on the segments query
+  // response. It reads the raw payload rather than a generated result class,
+  // so every shape a strange or older server can produce has to land on an
+  // empty list instead of a cast error.
+  group('MediaSegment.forFile', () {
+    Map<String, dynamic> payload(Object? files) => {
+          '__typename': 'Query',
+          'movie': {
+            '__typename': 'Movie',
+            'id': 'movie-1',
+            'files': files,
+          },
+        };
+
+    Map<String, dynamic> file(String id, Object? segments) => {
+          '__typename': 'MediaFile',
+          'id': id,
+          'segments': segments,
+        };
+
+    const introJson = {
+      '__typename': 'MediaSegment',
+      'type': 'INTRO',
+      'startMs': 30000,
+      'endMs': 90000,
+    };
+
+    test('picks the segments belonging to the file being played', () {
+      final segments = MediaSegment.forFile(
+        payload([
+          file('other-file', const []),
+          file('file-1', const [introJson]),
+        ]),
+        root: 'movie',
+        fileId: 'file-1',
+      );
+
+      expect(segments, [intro]);
+    });
+
+    test('returns empty when no file matches', () {
+      expect(
+        MediaSegment.forFile(
+          payload([
+            file('other-file', const [introJson])
+          ]),
+          root: 'movie',
+          fileId: 'file-1',
+        ),
+        isEmpty,
+      );
+    });
+
+    test('drops segments of an unrecognised type', () {
+      final segments = MediaSegment.forFile(
+        payload([
+          file('file-1', const [
+            {'type': 'RECAP', 'startMs': 0, 'endMs': 1000},
+            introJson,
+          ]),
+        ]),
+        root: 'movie',
+        fileId: 'file-1',
+      );
+
+      expect(segments, [intro]);
+    });
+
+    test('returns empty for a missing or malformed payload', () {
+      expect(
+        MediaSegment.forFile(null, root: 'movie', fileId: 'file-1'),
+        isEmpty,
+      );
+      expect(
+        MediaSegment.forFile(const {}, root: 'movie', fileId: 'file-1'),
+        isEmpty,
+      );
+      expect(
+        MediaSegment.forFile(
+          const {'movie': null},
+          root: 'movie',
+          fileId: 'file-1',
+        ),
+        isEmpty,
+      );
+      expect(
+        MediaSegment.forFile(payload(null), root: 'movie', fileId: 'file-1'),
+        isEmpty,
+      );
+      expect(
+        MediaSegment.forFile(
+          payload(const ['nonsense']),
+          root: 'movie',
+          fileId: 'file-1',
+        ),
+        isEmpty,
+      );
+      expect(
+        MediaSegment.forFile(
+          payload([file('file-1', 'nonsense')]),
+          root: 'movie',
+          fileId: 'file-1',
+        ),
+        isEmpty,
+      );
+    });
+
+    test('returns empty when the root field is absent', () {
+      expect(
+        MediaSegment.forFile(
+          payload([
+            file('file-1', const [introJson])
+          ]),
+          root: 'episode',
+          fileId: 'file-1',
+        ),
+        isEmpty,
+      );
+    });
+  });
+
   group('SegmentSkipTracker', () {
     test('permits a segment only once per session', () {
       final tracker = SegmentSkipTracker();


### PR DESCRIPTION
Adds the player half of intro and credits detection, on top of the `segments` GraphQL field from #314.

## What lands

- **`MediaSegment`** (`player/lib/domain/models/media_segment.dart`) with `SegmentType.intro` / `credits` / `unknown`, `containsPosition` (inclusive start, exclusive end), and defensive JSON parsing.
- **`SkipSegmentButton`** (`player/lib/presentation/widgets/video_controls/skip_segment_button.dart`), a bottom-right "Skip Intro" / "Skip Credits" affordance in the same glass material as the rest of the playback chrome (built on `GlassPill` over `GlassSurface`), positioned like `UpNextOverlay`. It renders nothing outside the segment, so the call site mounts it and lets position drive visibility.
- **`SegmentSkipTracker`**, the once-per-playback auto-skip record.
- **`autoSkipSegments`** in `SettingsService` and `UserSettings`, default **false**, with a Playback toggle in the settings screen.
- **`segments { type startMs endMs }`** added to `MediaFileFragment`, and the player screen wiring.

## The auto-skip guard

Auto-skip consumes a segment the same call that reports it, so each is skipped at most once per playback. Without that, a viewer who deliberately seeks back into the intro is bounced straight out again and can never watch it. The manual button stays available for a spent segment, which is the point: seeking back in is a choice, and taking the button away too would leave nothing.

The record is keyed on the media rather than reset per `_initializePlayer` run, because a seek past the transcoded end restarts the session for the *same* file. Resetting there would re-arm exactly the skip the viewer just overrode. It is cleared when the media changes, including when go_router reuses the screen state across a next-episode navigation.

## Cross-version behaviour

Mydia is self-hosted with no coordinated deploy order, so a newer player regularly meets an older server. Anything other than a well-formed `segments` list parses to no segments, and the existing detail-query error handling already swallows the failure, so the worst case is no skip button rather than a playback error. There is no version gating.

Worth flagging for review: `segments` was added to the shared `MediaFileFragment` as the design specifies, and Absinthe rejects a whole query containing an unknown field. Against a pre-#314 server the episode and movie detail queries therefore return no data at all, which costs the resume position and external subtitle list as well as segments. Playback itself still starts (streaming candidates are a separate query). If that trade is not wanted, the alternative is a dedicated segments query so the field error stays isolated.

## Not in this PR

Rewiring the up-next overlay to trigger off the credits segment, an explicit v1 non-goal. The skip button does stand down while up-next is showing, so the two do not stack in the same corner.

## Testing

`flutter test --concurrency=1`: **1156 tests, all passing** (1134 before, plus 22 new). `flutter analyze` is clean of errors and warnings; the 53 remaining infos are all pre-existing.

New coverage in `player/test/presentation/widgets/video_controls/skip_segment_button_test.dart`:

- boundary visibility, asserted on both sides of `startMs` and `endMs`
- intro and credits labels, and that an unrecognised type renders nothing
- tapping reports the segment so the caller can seek to its end
- the once-per-session guard: seeking back into a skipped segment does not re-trigger, a spent intro does not disarm the credits, and `reset()` re-arms on media change
- malformed and missing wire payloads parsing to an empty list
