### PR TITLE
Remove the unauthenticated read_media p2p request

### DIFF
--- a/lib/mydia/p2p.ex
+++ b/lib/mydia/p2p.ex
@@ -46,13 +46,6 @@ defmodule Mydia.P2p do
   def send_response(_resource, _request_id, _response), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """
-  Read a file chunk and send it as a response.
-  This is optimized to read and send directly from Rust.
-  """
-  def respond_with_file_chunk(_resource, _request_id, _file_path, _offset, _length),
-    do: :erlang.nif_error(:nif_not_loaded)
-
-  @doc """
   Get network statistics including connected peers and relay status.
   """
   def get_network_stats(_resource), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/mydia/p2p.ex
+++ b/lib/mydia/p2p.ex
@@ -114,19 +114,6 @@ defmodule Mydia.P2p.PairingResponse do
         }
 end
 
-defmodule Mydia.P2p.ReadMediaRequest do
-  @moduledoc """
-  A request to read a media file chunk.
-  """
-  defstruct [:file_path, :offset, :length]
-
-  @type t :: %__MODULE__{
-          file_path: String.t(),
-          offset: non_neg_integer(),
-          length: non_neg_integer()
-        }
-end
-
 defmodule Mydia.P2p.NetworkStats do
   @moduledoc """
   Network statistics from the p2p host.

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -285,26 +285,6 @@ defmodule Mydia.P2p.Server do
     {:noreply, state}
   end
 
-  def handle_info({:ok, "request_received", "read_media", request_id, req}, state) do
-    # Validate file path exists
-    # SECURITY: In production, verify path is within allowed directories!
-    if File.exists?(req.file_path) do
-      # Use the optimized NIF to read chunk and respond
-      P2p.respond_with_file_chunk(
-        state.resource,
-        request_id,
-        req.file_path,
-        req.offset,
-        req.length
-      )
-    else
-      Logger.warning("Requested file not found: #{req.file_path}")
-      P2p.send_response(state.resource, request_id, {:error, "File not found"})
-    end
-
-    {:noreply, state}
-  end
-
   def handle_info({:ok, "request_received", "graphql", request_id, req}, state) do
     Logger.debug("P2P Request: GraphQL query")
 

--- a/native/mydia_p2p/src/lib.rs
+++ b/native/mydia_p2p/src/lib.rs
@@ -110,14 +110,6 @@ struct ElixirPairingResponse {
 }
 
 #[derive(NifStruct)]
-#[module = "Mydia.P2p.ReadMediaRequest"]
-struct ElixirReadMediaRequest {
-    pub file_path: String,
-    pub offset: u64,
-    pub length: u32,
-}
-
-#[derive(NifStruct)]
 #[module = "Mydia.P2p.GraphQLRequest"]
 struct ElixirGraphQLRequest {
     pub query: String,
@@ -361,21 +353,6 @@ fn start_listening(
                                 atoms::ok(),
                                 "request_received",
                                 "pairing",
-                                request_id,
-                                elixir_req,
-                            )
-                                .encode(env)
-                        }
-                        MydiaRequest::ReadMedia(req) => {
-                            let elixir_req = ElixirReadMediaRequest {
-                                file_path: req.file_path,
-                                offset: req.offset,
-                                length: req.length,
-                            };
-                            (
-                                atoms::ok(),
-                                "request_received",
-                                "read_media",
                                 request_id,
                                 elixir_req,
                             )

--- a/native/mydia_p2p/src/lib.rs
+++ b/native/mydia_p2p/src/lib.rs
@@ -9,8 +9,6 @@ use mydia_p2p_core::{
 use rustler::{
     Binary, Encoder, Env, LocalPid, NifStruct, NifTaggedEnum, OwnedEnv, ResourceArc, Term,
 };
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
 use std::thread;
 
 mod atoms {
@@ -181,43 +179,6 @@ fn send_response(
         Ok(_) => Ok("ok".to_string()),
         Err(e) => Err(rustler::Error::Term(Box::new(e))),
     }
-}
-
-/// Read a file chunk and send it as a response.
-/// This is done in a separate thread to avoid blocking the NIF.
-#[rustler::nif]
-fn respond_with_file_chunk(
-    resource: ResourceArc<HostResource>,
-    request_id: String,
-    file_path: String,
-    offset: u64,
-    length: u32,
-) -> Result<String, rustler::Error> {
-    let resource_clone = resource.clone();
-
-    thread::spawn(move || {
-        let response = match File::open(&file_path) {
-            Ok(mut file) => {
-                if file.seek(SeekFrom::Start(offset)).is_ok() {
-                    let mut buffer = vec![0; length as usize];
-                    match file.read(&mut buffer) {
-                        Ok(n) => {
-                            buffer.truncate(n);
-                            MydiaResponse::MediaChunk(buffer)
-                        }
-                        Err(e) => MydiaResponse::Error(format!("Read error: {}", e)),
-                    }
-                } else {
-                    MydiaResponse::Error("Seek error".to_string())
-                }
-            }
-            Err(e) => MydiaResponse::Error(format!("File open error: {}", e)),
-        };
-
-        let _ = resource_clone.host.send_response(request_id, response);
-    });
-
-    Ok("ok".to_string())
 }
 
 /// Send an HLS response header for a streaming request.

--- a/native/mydia_p2p_core/src/lib.rs
+++ b/native/mydia_p2p_core/src/lib.rs
@@ -26,7 +26,6 @@ const ALPN: &[u8] = b"/mydia/1.0.0";
 pub enum MydiaRequest {
     Ping,
     Pairing(PairingRequest),
-    ReadMedia(ReadMediaRequest),
     GraphQL(GraphQLRequest),
     HlsStream(HlsRequest),
     Custom(Vec<u8>),
@@ -38,13 +37,6 @@ pub struct PairingRequest {
     pub device_name: String,
     pub device_type: String,
     pub device_os: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct ReadMediaRequest {
-    pub file_path: String,
-    pub offset: u64,
-    pub length: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
Closes an unauthenticated arbitrary file read on the p2p transport.

## The problem

`read_media` accepted a peer-supplied `file_path`, checked `File.exists?`, and streamed the bytes back. `ReadMediaRequest` carried no `auth_token` field at all, unlike `GraphQLRequest` and `HlsRequest` which both do, so nothing in the path checked a credential. The accept loop validates ALPN and nothing else, and iroh publishes the node ID over DNS discovery, so reachability was not obscure. Any peer able to dial the node could read any file the server process could read.

The existing code comment said as much:

```elixir
# SECURITY: In production, verify path is within allowed directories!
```

**Blast radius is bounded to installs that opted into remote access.** `remote_access_enabled` defaults to `false` (`config/config.exs`), and `Mydia.P2p.Server` only starts when that flag is on. Operators running with remote access enabled should upgrade.

## Why delete rather than secure it

Nothing calls it. Verified across `.rs`, `.dart`, `.ex` and `.exs`: the only references were the type definitions, the NIF dispatch arm, and the handler. Git history confirms it was never live in a shipped client, `a0799ba8` removed the last client-side caller and replaced it with `notImplemented`.

Offline download, the one feature that would plausibly want raw file transfer over p2p, already runs on a safer path: the player requests a job id over authenticated GraphQL, then fetches via an HLS request carrying an auth token with `session_id: "download:{jobId}"`, and the server resolves the path from the job rather than accepting one from the client. That is the capability-lookup pattern, strictly better than confining a client-supplied path. Securing `read_media` would have meant maintaining a second, weaker way to do what already works.

## Changes

Two commits, split so the tree stays both compilable and loadable in between:

1. Remove the request path: CBOR enum variant, `ReadMediaRequest`, `ElixirReadMediaRequest`, the NIF dispatch arm, `Mydia.P2p.ReadMediaRequest`, and the GenServer handler.
2. Remove the orphaned `respond_with_file_chunk` NIF and its Elixir stub, plus the two `std` imports it was the last user of. These two must land together: the BEAM refuses to load a native library registering a NIF with no matching Elixir function, which fails at load rather than at compile.

## Compatibility

No window to manage, which matters because this is self-hosted with no coordinated deploy order between server and player.

`serde_cbor` 0.11 with a plain derive uses externally tagged enums keyed by variant **name** (`{"ReadMedia": {...}}`), not by ordinal. Confirmed against the vendored crate source: `Serializer::new` defaults to `packed: false`, and `serialize_newtype_variant` writes a one-entry map keyed by the variant name. Removing this variant therefore leaves `Ping`, `Pairing`, `GraphQL`, `HlsStream` and `Custom` byte-identical on the wire. The fix is server-side only; no client change is needed and none helps.

## Verification

- `./dev mix precommit` passed (compile, unused deps, format, credo --strict, tests).
- Full suite: `6213 tests, 0 failures, 34 skipped (142 excluded)`.
- NIF registration confirmed at runtime with the app booted: module loads, `function_exported?(Mydia.P2p, :respond_with_file_chunk, 5)` is `false`.
- All 10 remaining `#[rustler::nif]` functions audited 1:1 against their Elixir stubs; no orphan in either direction.

## Deliberately out of scope

Three p2p authorization gaps remain, all pre-existing and none a regression from this PR:

- The accept loop still admits any dialer after the ALPN check (no pairing gate).
- `handle_download_stream/4` streams `job.output_path` with no check that the job belongs to the authenticated user. Requires a valid token, and installs are typically single-household.
- `MydiaRequest::Custom` is reachable without a credential. It reaches no handler and discloses nothing, but each request holds a pending-response entry, a task, and an open QUIC stream for the 30 second timeout.

All three are tracked for a follow-up focused on connection-layer authorization.
