### PR TITLE
Bound the API key Argon2 scan and drop the media token expiry raise

### DIFF
--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -395,12 +395,18 @@ defmodule Mydia.Accounts do
   @doc """
   Verifies an API key and returns the associated user and API key.
   Returns {:error, reason} if the key is invalid, expired, or revoked.
+
+  The candidate set is narrowed by the indexed `key_prefix` column, which is
+  derived from the presented key. A key whose prefix matches no row costs zero
+  Argon2 passes, which keeps this endpoint from amplifying CPU under a brute
+  force attempt. Keys predating the key_prefix column have a NULL prefix, match
+  nothing, and are revoked by the RevokePrefixlessApiKeys migration.
   """
   def verify_api_key(key) when is_binary(key) do
-    # Find all API keys and verify against them
-    # This is not ideal for performance but works for small numbers of keys
-    # For production, consider using a more efficient lookup mechanism
+    prefix = extract_key_prefix(key)
+
     ApiKey
+    |> where([k], k.key_prefix == ^prefix)
     |> preload(:user)
     |> Repo.all()
     |> Enum.find(fn api_key ->

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -199,7 +199,7 @@ defmodule MydiaWeb.Schema.CommonTypes do
   object :api_key do
     field :id, non_null(:id), description: "API key ID"
     field :name, non_null(:string), description: "User-given name"
-    field :key_prefix, non_null(:string), description: "Key prefix for identification"
+    field :key_prefix, :string, description: "Key prefix for identification"
 
     field :permissions, non_null(list_of(non_null(:string))),
       description: "List of granted permissions"

--- a/lib/mydia_web/schema/resolvers/remote_access_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/remote_access_resolver.ex
@@ -67,18 +67,15 @@ defmodule MydiaWeb.Schema.Resolvers.RemoteAccessResolver do
   end
 
   def refresh_media_token(_parent, %{token: token}, _context) do
-    case MediaToken.refresh_token(token) do
-      {:ok, new_token, claims} ->
-        expires_at = DateTime.from_unix!(claims["exp"])
-        permissions = Map.get(claims, "permissions", [])
-
-        {:ok,
-         %{
-           token: new_token,
-           expires_at: expires_at,
-           permissions: permissions
-         }}
-
+    with {:ok, new_token, claims} <- MediaToken.refresh_token(token),
+         {:ok, expires_at} <- expires_at_from_claims(claims) do
+      {:ok,
+       %{
+         token: new_token,
+         expires_at: expires_at,
+         permissions: Map.get(claims, "permissions", [])
+       }}
+    else
       {:error, :token_expired} ->
         {:error, "Token has expired"}
 
@@ -90,6 +87,9 @@ defmodule MydiaWeb.Schema.Resolvers.RemoteAccessResolver do
 
       {:error, :device_revoked} ->
         {:error, "Device has been revoked"}
+
+      {:error, :missing_expiry} ->
+        {:error, "Failed to refresh token: missing expiry"}
 
       {:error, reason} ->
         {:error, "Failed to refresh token: #{inspect(reason)}"}

--- a/priv/repo/migrations/20260804033644_revoke_prefixless_api_keys.exs
+++ b/priv/repo/migrations/20260804033644_revoke_prefixless_api_keys.exs
@@ -4,7 +4,8 @@ defmodule Mydia.Repo.Migrations.RevokePrefixlessApiKeys do
   # API keys created before 20251226020220 added the key_prefix column have no
   # prefix, and it cannot be recovered from an Argon2 hash. Verification now
   # narrows by prefix, so these keys can no longer authenticate. Revoke them so
-  # the admin UI shows why, instead of leaving them to fail silently.
+  # the key's state is inspectable via the API and explicable in release notes,
+  # instead of the key silently failing.
   def up do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 

--- a/priv/repo/migrations/20260804033644_revoke_prefixless_api_keys.exs
+++ b/priv/repo/migrations/20260804033644_revoke_prefixless_api_keys.exs
@@ -1,0 +1,21 @@
+defmodule Mydia.Repo.Migrations.RevokePrefixlessApiKeys do
+  use Ecto.Migration
+
+  # API keys created before 20251226020220 added the key_prefix column have no
+  # prefix, and it cannot be recovered from an Argon2 hash. Verification now
+  # narrows by prefix, so these keys can no longer authenticate. Revoke them so
+  # the admin UI shows why, instead of leaving them to fail silently.
+  def up do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    execute("""
+    UPDATE api_keys SET revoked_at = '#{now}'
+    WHERE key_prefix IS NULL AND revoked_at IS NULL
+    """)
+  end
+
+  # Not reversible. Rolling back cannot distinguish keys this migration revoked
+  # from keys the operator revoked by hand, and un-revoking a key on rollback is
+  # the wrong default for a security action.
+  def down, do: :ok
+end

--- a/test/mydia/accounts/api_key_test.exs
+++ b/test/mydia/accounts/api_key_test.exs
@@ -218,10 +218,10 @@ defmodule Mydia.Accounts.ApiKeyTest do
 
       now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-      Mydia.Repo.query!(
-        "UPDATE api_keys SET revoked_at = ? WHERE key_prefix IS NULL AND revoked_at IS NULL",
-        [now]
-      )
+      Mydia.Repo.query!("""
+      UPDATE api_keys SET revoked_at = '#{now}'
+      WHERE key_prefix IS NULL AND revoked_at IS NULL
+      """)
 
       assert Accounts.get_api_key!(legacy.id).revoked_at != nil
       assert Accounts.get_api_key!(modern.id).revoked_at == nil
@@ -239,10 +239,10 @@ defmodule Mydia.Accounts.ApiKeyTest do
 
       later = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
 
-      Mydia.Repo.query!(
-        "UPDATE api_keys SET revoked_at = ? WHERE key_prefix IS NULL AND revoked_at IS NULL",
-        [later]
-      )
+      Mydia.Repo.query!("""
+      UPDATE api_keys SET revoked_at = '#{later}'
+      WHERE key_prefix IS NULL AND revoked_at IS NULL
+      """)
 
       assert Accounts.get_api_key!(legacy.id).revoked_at == original_revoked_at
     end

--- a/test/mydia/accounts/api_key_test.exs
+++ b/test/mydia/accounts/api_key_test.exs
@@ -153,6 +153,20 @@ defmodule Mydia.Accounts.ApiKeyTest do
 
       assert {:error, :invalid_key} = Accounts.verify_api_key(plain_key)
     end
+
+    test "rejects a key whose stored prefix is NULL", %{plain_key: plain_key, api_key: api_key} do
+      Mydia.Repo.update_all(
+        from(k in Mydia.Accounts.ApiKey, where: k.id == ^api_key.id),
+        set: [key_prefix: nil]
+      )
+
+      assert {:error, :invalid_key} = Accounts.verify_api_key(plain_key)
+    end
+
+    test "rejects a well-formed key whose prefix matches no row" do
+      unknown = "mydia_ak_" <> String.duplicate("Z", 32)
+      assert {:error, :invalid_key} = Accounts.verify_api_key(unknown)
+    end
   end
 
   describe "revoke_api_key/1" do

--- a/test/mydia/accounts/api_key_test.exs
+++ b/test/mydia/accounts/api_key_test.exs
@@ -185,4 +185,52 @@ defmodule Mydia.Accounts.ApiKeyTest do
       assert Accounts.list_api_keys(user.id) == []
     end
   end
+
+  describe "prefix-less key revocation statement" do
+    setup do
+      user = AccountsFixtures.user_fixture()
+      %{user: user}
+    end
+
+    test "revokes a prefix-less key and leaves a prefixed key alone", %{user: user} do
+      {:ok, legacy, _} = Accounts.create_api_key(user.id, %{name: "Legacy Key"})
+      {:ok, modern, _} = Accounts.create_api_key(user.id, %{name: "Modern Key"})
+
+      # Simulate a row created before the key_prefix column existed.
+      Mydia.Repo.update_all(
+        from(k in Mydia.Accounts.ApiKey, where: k.id == ^legacy.id),
+        set: [key_prefix: nil]
+      )
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Mydia.Repo.query!(
+        "UPDATE api_keys SET revoked_at = ? WHERE key_prefix IS NULL AND revoked_at IS NULL",
+        [now]
+      )
+
+      assert Accounts.get_api_key!(legacy.id).revoked_at != nil
+      assert Accounts.get_api_key!(modern.id).revoked_at == nil
+    end
+
+    test "does not overwrite an existing revocation timestamp", %{user: user} do
+      {:ok, legacy, _} = Accounts.create_api_key(user.id, %{name: "Already Revoked"})
+      {:ok, revoked} = Accounts.revoke_api_key(legacy)
+      original_revoked_at = revoked.revoked_at
+
+      Mydia.Repo.update_all(
+        from(k in Mydia.Accounts.ApiKey, where: k.id == ^legacy.id),
+        set: [key_prefix: nil]
+      )
+
+      later = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+
+      Mydia.Repo.query!(
+        "UPDATE api_keys SET revoked_at = ? WHERE key_prefix IS NULL AND revoked_at IS NULL",
+        [later]
+      )
+
+      assert Accounts.get_api_key!(legacy.id).revoked_at == original_revoked_at
+    end
+  end
 end


### PR DESCRIPTION
Two follow-ups deliberately left out of scope in #301, plus the review fixes they turned up.

## ⚠️ Breaking, operator-facing

**API keys created before 2025-12-26 stop working and are marked revoked.** Those keys predate the `key_prefix` column and have it NULL, and the prefix cannot be backfilled because it is not recoverable from an Argon2 hash. Verification now matches on prefix, so they can no longer authenticate. The remedy is to issue a new key.

This needs a release note. Mydia has no admin UI for API keys, so the release note is the only channel that reaches an operator wondering why their key stopped working. It should name the date boundary and the remedy.

## What changed

**`verify_api_key/1` narrowed to an indexed prefix lookup.** It previously loaded every row of `api_keys` with its user preloaded and ran Argon2 against each until one matched. A wrong key therefore cost one full Argon2 pass per active key, which turns API authentication into a CPU amplifier, and the full-table load ran on successful requests too. `key_prefix` is already stored, populated by the only creation path, indexed, and derivable from the presented key, so narrowing by it gives:

- wrong key, unrecognised prefix: one indexed query, **zero** Argon2 passes
- wrong key, recognised prefix: one pass
- correct key: one pass

The everyday win is arguably the success path, which no longer loads the whole table. Rate limiting in `ApiAuth` is unchanged; this removes the amplification factor underneath it.

The hash check is untouched. Prefix matching is an additional filter, never a substitute: a key still has to pass `Argon2.verify_pass`, and revocation and expiry are still enforced.

**`refresh_media_token/3` reports a missing expiry instead of raising.** It called `DateTime.from_unix!/1` on `claims["exp"]`. It is a public unauthenticated mutation, so a raise would crash the request. This is defensive only: `MediaToken.create_token/2` passes an explicit ttl, so Guardian always writes an integer `exp` and it cannot raise today. No client-visible change on any existing path; all five existing error strings are byte-identical.

**`ApiKey.keyPrefix` relaxed from `non_null(:string)` to `:string`.** Found in review. Legacy rows have it NULL, so a client selecting `keyPrefix` hit a non-null violation on precisely the rows the migration revokes, hiding the keys an operator would need to diagnose. This is a latent bug independent of the rest of this PR.

## Migration ordering

The migration lands before the query narrowing, so no commit leaves a key silently failing without having been marked revoked.

At runtime there is no window either: `Ecto.Migrator` is child #3 in the supervision tree and the endpoint starts later, so migrations complete before any request is served. The exception is a dev `mix phx.server` run where migrations are skipped, and there the key is equally dead, just without the recorded reason. It self-heals on the next migrate.

`down/0` is deliberately a no-op. Rollback cannot distinguish keys this migration revoked from keys the operator revoked by hand, and un-revoking on rollback is the wrong default for a security action. Note that `mix ecto.rollback` will therefore report success while doing nothing.

## Known trade-off

A prefix miss returns in microseconds while a prefix hit costs a full Argon2 pass, so the endpoint now discloses whether a given 8-character prefix exists. That is inherent to the zero-pass goal, constant time and zero-pass are incompatible. Across a 62^8 space behind per-IP rate limiting it is uninteresting, but it is a deliberate choice rather than an oversight.

## Verification

- SQLite: `✓ Precommit passed` (compile, unused deps, format, credo --strict, tests); full suite `6217 tests, 0 failures, 34 skipped`.
- **PostgreSQL: `22 tests, 0 failures`** on the API key file against a real PG 17.10 instance. Review round 1 caught tests using the exqlite `?` placeholder, which is a Postgrex syntax error and would have gone red on the `test-postgres` CI job; they now use a placeholder-free literal that also exercises the migration's actual statement rather than a different bound-parameter path.
- Postgres full suite: 3 failures, all triaged as pre-existing and unrelated. One `CardigannTest` timing flake (clean on isolated re-run, 15 tests 0 failures) and two `MediaImportTest` failures from the documented deep-worktree-path `varchar(255)` tmp_dir hazard. Neither touches any file this PR changes.
- Migration rollback and re-migrate verified clean on both adapters. The interpolated timestamp was confirmed to round-trip correctly on SQLite and PostgreSQL.

## Note on commit messages

The body of 514bf82c says revocation makes the key visible "in the admin UI". That is wrong, there is no admin UI for API keys, and the claim came from the design doc. Review caught it. The migration comment is corrected in 09293bab; the commit message is left as-is rather than rewriting history.
