### PR TITLE
fix(dev): keep devenv shell entry out of the database and off postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
         run: |
           set -euo pipefail
           BLOCK=$(awk '/"mydia:ecto" = \{/,/^    \};/' devenv.nix)
+          [ -n "$BLOCK" ] || { echo "::error::guard could not locate the mydia:ecto block in devenv.nix"; exit 1; }
           if echo "$BLOCK" | grep -n 'before = onEnterShell'; then
             echo "::error::mydia:ecto must not run on shell entry; it belongs to processes.phoenix.after"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,24 @@ jobs:
             exit 1
           fi
 
+      # Shell entry must not boot the app or start a service. mydia:ecto does
+      # both: it runs the backup task and, under Postgres, needs a live server.
+      # Attaching it to enterShell is what made every fresh worktree fail on
+      # entry and what spawned a second postmaster beside `./dev up -d`. It
+      # belongs to processes.phoenix.after and `./dev db.setup`.
+      - name: Guard shell-entry purity
+        run: |
+          set -euo pipefail
+          BLOCK=$(awk '/"mydia:ecto" = \{/,/^    \};/' devenv.nix)
+          if echo "$BLOCK" | grep -n 'before = onEnterShell'; then
+            echo "::error::mydia:ecto must not run on shell entry; it belongs to processes.phoenix.after"
+            exit 1
+          fi
+          if echo "$BLOCK" | grep -n 'devenv:processes:postgres'; then
+            echo "::error::mydia:ecto must not depend on the postgres process; a task dependency starts a second postmaster"
+            exit 1
+          fi
+
       - name: Test (SQLite) under devenv
         run: |
           devenv shell -- bash <<'DEVENV'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,18 @@ jobs:
       # ClientHealth.init/1 queries download_client_configs synchronously, and
       # the failure leaves fresh worktrees unmigrated forever rather than
       # retrying. It needs the repo and nothing else.
+      # Both guards below strip full-line comments before matching. Matching the
+      # raw source has already caused two defects during this branch's
+      # implementation: a guard regex that matched the explanatory comment
+      # sitting next to the code it described, and a guard search string that
+      # appeared verbatim in a comment inside the block it scans. Both would
+      # have made CI permanently red, and the workaround each time — contorting
+      # the prose to dodge the guard — is backwards, and narrowing a guard's
+      # regex to avoid a comment also opens an evasion gap in the code match.
       - name: Guard the pre-migration backup task
         run: |
           set -euo pipefail
-          if grep -nE 'Mix\.Task\.run\(\s*"app\.start"' lib/mix/tasks/mydia.backup_before_migrate.ex; then
+          if grep -vE '^[[:space:]]*#' lib/mix/tasks/mydia.backup_before_migrate.ex | grep -nE 'app\.start'; then
             echo "::error::mydia.backup_before_migrate must not start the application; use Ecto.Migrator.with_repo/2"
             exit 1
           fi
@@ -139,11 +147,14 @@ jobs:
       # both: it runs the backup task and, under Postgres, needs a live server.
       # Attaching it to enterShell is what made every fresh worktree fail on
       # entry and what spawned a second postmaster beside `./dev up -d`. It
-      # belongs to processes.phoenix.after and `./dev db.setup`.
+      # belongs to processes.phoenix.after and `./dev db.setup` — and nothing
+      # else stops someone deleting that `after`, which would silently restore
+      # the original crash (phoenix booting against an unmigrated database)
+      # with CI green, so the positive invariant is guarded too.
       - name: Guard shell-entry purity
         run: |
           set -euo pipefail
-          BLOCK=$(awk '/"mydia:ecto" = \{/,/^    \};/' devenv.nix)
+          BLOCK=$(awk '/"mydia:ecto" = \{/,/^    \};/' devenv.nix | grep -vE '^[[:space:]]*#')
           [ -n "$BLOCK" ] || { echo "::error::guard could not locate the mydia:ecto block in devenv.nix"; exit 1; }
           if echo "$BLOCK" | grep -n 'before = onEnterShell'; then
             echo "::error::mydia:ecto must not run on shell entry; it belongs to processes.phoenix.after"
@@ -153,6 +164,8 @@ jobs:
             echo "::error::mydia:ecto must not depend on the postgres process; a task dependency starts a second postmaster"
             exit 1
           fi
+          grep -q 'processes\.phoenix\.after = \[ "mydia:ecto@succeeded" \]' devenv.nix || {
+            echo "::error::phoenix must wait for mydia:ecto@succeeded, or it boots against an unmigrated database"; exit 1; }
 
       - name: Test (SQLite) under devenv
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Guard the pre-migration backup task
         run: |
           set -euo pipefail
-          if grep -nE 'Mix\.Task\.run\("app\.start"\)' lib/mix/tasks/mydia.backup_before_migrate.ex; then
+          if grep -nE 'Mix\.Task\.run\(\s*"app\.start"' lib/mix/tasks/mydia.backup_before_migrate.ex; then
             echo "::error::mydia.backup_before_migrate must not start the application; use Ecto.Migrator.with_repo/2"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,19 @@ jobs:
           fi
           exit "$FAIL"
 
+      # This task runs from devenv's mydia:ecto against a database that may have
+      # no tables yet. Booting the supervision tree there is fatal, because
+      # ClientHealth.init/1 queries download_client_configs synchronously, and
+      # the failure leaves fresh worktrees unmigrated forever rather than
+      # retrying. It needs the repo and nothing else.
+      - name: Guard the pre-migration backup task
+        run: |
+          set -euo pipefail
+          if grep -nE 'Mix\.Task\.run\("app\.start"\)' lib/mix/tasks/mydia.backup_before_migrate.ex; then
+            echo "::error::mydia.backup_before_migrate must not start the application; use Ecto.Migrator.with_repo/2"
+            exit 1
+          fi
+
       - name: Test (SQLite) under devenv
         run: |
           devenv shell -- bash <<'DEVENV'

--- a/dev
+++ b/dev
@@ -72,12 +72,20 @@ in_player() {
 # as a task dependency instead is what produced "lock file postmaster.pid
 # already exists" alongside a running `./dev up -d`.
 #
-# `processes start` is tolerated failing: if Postgres genuinely cannot start,
-# the mydia:ecto task's own readiness poll reports it with a better message
-# than devenv does, and it names the host and port.
+# `devenv processes start` talks to the process daemon over its native socket,
+# which does not exist until some daemon is already running — so on a cold
+# worktree (no `./dev up -d` yet) it errors immediately. Fall back to
+# `devenv up -d postgres`, which starts just that one process detached with no
+# daemon required. Both forms are tolerated failing: if Postgres genuinely
+# cannot start, the mydia:ecto task's own readiness poll reports it with a
+# better message than devenv does, and it names the host and port.
 ensure_dev_db() {
     case "${DATABASE_TYPE:-}" in
-        postgres|postgresql) devenv processes start postgres || true ;;
+        postgres|postgresql)
+            devenv processes start postgres 2>/dev/null \
+                || devenv up -d postgres \
+                || true
+            ;;
     esac
     devenv tasks run mydia:ecto
 }
@@ -381,6 +389,11 @@ case "$COMMAND" in
             echo "Usage: ./dev user <list|add|delete|reset-password> [args...]"
             exit 1
         fi
+        # mix mydia.user boots the full supervision tree (Mix.Task.run("app.start")),
+        # which dies in ClientHealth.init/1 against an unmigrated database. This is
+        # the documented dev user-management path, so it needs the same guard as
+        # iex/phx.server rather than assuming `./dev up` already ran.
+        ensure_dev_db
         in_shell mix mydia.user "$@"
         ;;
 

--- a/dev
+++ b/dev
@@ -65,6 +65,23 @@ in_player() {
     devenv shell -- bash -c 'cd player && exec "$@"' _ "$@"
 }
 
+# Create and migrate the development database.
+#
+# Under Postgres this asks the process daemon to start the server FIRST, so the
+# daemon stays the single owner of the postmaster. Letting devenv start Postgres
+# as a task dependency instead is what produced "lock file postmaster.pid
+# already exists" alongside a running `./dev up -d`.
+#
+# `processes start` is tolerated failing: if Postgres genuinely cannot start,
+# the mydia:ecto task's own readiness poll reports it with a better message
+# than devenv does, and it names the host and port.
+ensure_dev_db() {
+    case "${DATABASE_TYPE:-}" in
+        postgres|postgresql) devenv processes start postgres || true ;;
+    esac
+    devenv tasks run mydia:ecto
+}
+
 # Show help if no arguments provided
 if [ $# -eq 0 ]; then
     cat <<EOF
@@ -99,6 +116,7 @@ ${YELLOW}Development Commands:${NC}
   feature-test [args]  Run Wallaby browser tests (uses in-shell chromedriver)
   format               Format code (mix format)
   deps.get             Install dependencies
+  db.setup             Create and migrate the development database
   ecto.migrate         Run database migrations
   ecto.reset           Reset database
   phx.server           Start the Phoenix server (foreground)
@@ -293,6 +311,9 @@ case "$COMMAND" in
         ;;
     iex)
         echo -e "${GREEN}Starting IEx...${NC}"
+        # An IEx session against an unmigrated dev database is useless, and this
+        # is the common command that needs one without going through `./dev up`.
+        ensure_dev_db
         if [ $# -gt 0 ]; then
             in_shell iex "$@"
         else
@@ -341,8 +362,15 @@ case "$COMMAND" in
         echo -e "${GREEN}Resetting database...${NC}"
         in_shell mix ecto.reset
         ;;
+    db.setup)
+        echo -e "${GREEN}Setting up the development database...${NC}"
+        ensure_dev_db
+        ;;
     phx.server)
         echo -e "${GREEN}Starting Phoenix server...${NC}"
+        # `./dev up` gets this ordering from processes.phoenix.after; the
+        # foreground shortcut bypasses the process graph, so do it by hand.
+        ensure_dev_db
         in_shell mix phx.server
         ;;
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -303,10 +303,23 @@ in
         ''}
         mix ecto.create --quiet && mix mydia.backup_before_migrate && mix ecto.migrate
       '';
-      # Re-run when a migration is added or changed (idempotent otherwise). A
-      # failed run does not update the recorded hashes, so a worktree that broke
-      # here heals itself on the next run.
-      execIfModified = [ "priv/repo/migrations" ];
+      # Deliberately NO execIfModified, overriding this file's original R6
+      # design (Task 3 shipped `execIfModified = [ "priv/repo/migrations" ]`
+      # here). Caching this task made devenv report a cached run as
+      # "succeeded" without checking whether the database still existed:
+      # `./dev db.setup` silently no-op'd against a missing/corrupt database,
+      # and `./dev iex`, `./dev phx.server`, and processes.phoenix.after all
+      # sailed past a Skipped-but-"succeeded" task into exactly the crash it
+      # exists to prevent. The original rationale for caching — keeping shell
+      # entry cheap — no longer applies: this task is off shell entry
+      # entirely, so every remaining caller (db.setup, iex, phx.server, the
+      # process graph) wants it to actually verify state, not skip. Running
+      # it unconditionally is safe and cheap: `mix ecto.create --quiet`
+      # no-ops on an existing database, `mix mydia.backup_before_migrate`
+      # returns `:no_migrations` immediately when nothing is pending, and
+      # `mix ecto.migrate` no-ops when the schema is current. The added cost
+      # is one BEAM boot (~2-3s) on commands that are already starting a BEAM
+      # or a whole stack.
       after = [ "mydia:deps" ];
     };
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -214,6 +214,14 @@ in
   // lib.optionalAttrs pkgs.stdenv.isLinux {
     CHROME_PATH = "${pkgs.chromium}/bin/chromium";
     CHROMEDRIVER_PATH = "${pkgs.chromedriver}/bin/chromedriver";
+  }
+  # :database_adapter is a compile-time env entry, so a _build compiled for
+  # SQLite and reused under DATABASE_TYPE=postgres fails Mix's compile-env
+  # validation on every boot, restart-looping phoenix with nothing in its log
+  # but that error. Give Postgres its own build root. SQLite keeps the default
+  # `_build`, so no existing worktree pays a recompile.
+  // lib.optionalAttrs usePostgres {
+    MIX_BUILD_ROOT = "_build/postgres";
   };
 
   # ── Postgres service (R4) ───────────────────────────────────────────────────
@@ -229,6 +237,13 @@ in
 
   # ── Long-running processes (R5) ─────────────────────────────────────────────
   processes.phoenix.exec = "mix phx.server";
+
+  # The dev database is created and migrated by mydia:ecto, which is deliberately
+  # NOT a shell-entry task (see below). Nothing else migrates it: skip_migrations?/0
+  # in Mydia.Application returns true whenever RELEASE_NAME is unset, so the
+  # supervision tree's Ecto.Migrator never runs under mix. Booting against an
+  # unmigrated database dies in ClientHealth.init/1, so wait for the task.
+  processes.phoenix.after = [ "mydia:ecto@succeeded" ];
 
   # build_runner watch performs GraphQL/Riverpod codegen for the player. This is
   # distinct from MydiaWeb.FlutterWatcher (config/dev.exs), which runs
@@ -257,15 +272,42 @@ in
       after = [ "mydia:hex" ];
     };
 
+    # Deliberately NOT a shell-entry task. Entering a devenv shell must never
+    # boot the OTP application and must never start a service; this task does
+    # both by necessity, so it belongs to the process graph
+    # (processes.phoenix.after) and to `./dev db.setup`.
     "mydia:ecto" = {
-      # backup_before_migrate self-skips when no migrations are pending, so it
-      # is a cheap no-op except right before a migration actually runs — keeping
-      # the dev-DB safety net the retired docker-entrypoint.sh provided.
-      exec = "mix ecto.create --quiet && mix mydia.backup_before_migrate && mix ecto.migrate";
-      # Re-run when a migration is added/changed (idempotent otherwise).
+      # backup_before_migrate self-skips when nothing is pending AND when the
+      # database has no applied migrations at all, so it is a cheap no-op except
+      # right before a migration actually runs, keeping the dev-DB safety net
+      # the retired docker-entrypoint.sh provided.
+      exec = ''
+        ${lib.optionalString usePostgres ''
+          # Poll for Postgres instead of adding the postgres process as an
+          # `after` dependency (e.g. its "@ready" suffix). A task dependency
+          # like that makes devenv START Postgres whenever this task runs,
+          # which collided with the postmaster already owned by `./dev up -d`
+          # ("lock file postmaster.pid already exists", six attempts in 87ms).
+          # Polling only ever observes, so the process daemon stays the single
+          # owner.
+          for _ in $(seq 1 60); do
+            pg_isready -q -h "$DATABASE_HOST" -p "$DATABASE_PORT" && break
+            sleep 0.5
+          done
+
+          if ! pg_isready -q -h "$DATABASE_HOST" -p "$DATABASE_PORT"; then
+            echo "Postgres is not accepting connections on $DATABASE_HOST:$DATABASE_PORT." >&2
+            echo "Start it with './dev up -d', or run './dev db.setup'." >&2
+            exit 1
+          fi
+        ''}
+        mix ecto.create --quiet && mix mydia.backup_before_migrate && mix ecto.migrate
+      '';
+      # Re-run when a migration is added or changed (idempotent otherwise). A
+      # failed run does not update the recorded hashes, so a worktree that broke
+      # here heals itself on the next run.
       execIfModified = [ "priv/repo/migrations" ];
-      before = onEnterShell;
-      after = [ "mydia:deps" ] ++ lib.optional usePostgres "devenv:processes:postgres@ready";
+      after = [ "mydia:deps" ];
     };
 
     "mydia:assets" = {

--- a/devenv.nix
+++ b/devenv.nix
@@ -284,12 +284,13 @@ in
       exec = ''
         ${lib.optionalString usePostgres ''
           # Poll for Postgres instead of adding the postgres process as an
-          # `after` dependency (e.g. its "@ready" suffix). A task dependency
-          # like that makes devenv START Postgres whenever this task runs,
-          # which collided with the postmaster already owned by `./dev up -d`
-          # ("lock file postmaster.pid already exists", six attempts in 87ms).
-          # Polling only ever observes, so the process daemon stays the single
-          # owner.
+          # `after` dependency (its "devenv:processes:postgres@ready" suffix).
+          # A task dependency like that makes devenv START Postgres whenever
+          # this task runs, which collided with the postmaster already owned
+          # by `./dev up -d` ("lock file postmaster.pid already exists", six
+          # attempts in 87ms). Polling only ever observes, so the process
+          # daemon stays the single owner.
+          echo "Waiting for Postgres on $DATABASE_HOST:$DATABASE_PORT…" >&2
           for _ in $(seq 1 60); do
             pg_isready -q -h "$DATABASE_HOST" -p "$DATABASE_PORT" && break
             sleep 0.5
@@ -297,14 +298,14 @@ in
 
           if ! pg_isready -q -h "$DATABASE_HOST" -p "$DATABASE_PORT"; then
             echo "Postgres is not accepting connections on $DATABASE_HOST:$DATABASE_PORT." >&2
-            echo "Start it with './dev up -d', or run './dev db.setup'." >&2
+            echo "Start it with './dev up -d'." >&2
             exit 1
           fi
         ''}
-        mix ecto.create --quiet && mix mydia.backup_before_migrate && mix ecto.migrate
+        mix do ecto.create --quiet + mydia.backup_before_migrate + ecto.migrate
       '';
       # Deliberately NO execIfModified, overriding this file's original R6
-      # design (Task 3 shipped `execIfModified = [ "priv/repo/migrations" ]`
+      # caching design (it shipped `execIfModified = [ "priv/repo/migrations" ]`
       # here). Caching this task made devenv report a cached run as
       # "succeeded" without checking whether the database still existed:
       # `./dev db.setup` silently no-op'd against a missing/corrupt database,
@@ -317,9 +318,16 @@ in
       # it unconditionally is safe and cheap: `mix ecto.create --quiet`
       # no-ops on an existing database, `mix mydia.backup_before_migrate`
       # returns `:no_migrations` immediately when nothing is pending, and
-      # `mix ecto.migrate` no-ops when the schema is current. The added cost
-      # is one BEAM boot (~2-3s) on commands that are already starting a BEAM
-      # or a whole stack.
+      # `mix ecto.migrate` no-ops when the schema is current. The three
+      # commands run as one `mix do a + b + c` invocation rather than three
+      # separate `mix` processes chained with `&&`, so the added cost is one
+      # BEAM boot (~2-3s) on commands that are already starting a BEAM or a
+      # whole stack, not three. `mix do` aborts the chain the same way `&&`
+      # does: `mydia.backup_before_migrate` calls `exit({:shutdown, 1})` on a
+      # failed backup, which terminates the `mix do` process outright (Mix's
+      # `do` task has no rescue/catch around each step) before `ecto.migrate`
+      # ever runs — verified empirically against this pinned Elixir 1.19.5
+      # with a throwaway two-task `mix do`, not just read off the docs.
       after = [ "mydia:deps" ];
     };
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -36,8 +36,12 @@ git clone https://github.com/getmydia/mydia.git
 cd mydia
 
 # Authorize direnv for this worktree (one time). This builds the toolchain and
-# runs first-run setup (deps.get, ecto.create/migrate, asset npm install,
-# flutter pub get). The first build downloads the toolchain and can take a while.
+# runs first-run setup (deps.get, asset npm install, flutter pub get). The first
+# build downloads the toolchain and can take a while.
+#
+# Shell entry deliberately does NOT touch the development database: it must not
+# boot the app or start a service. `./dev up` sets the database up before
+# starting Phoenix, and `./dev db.setup` does it on demand.
 direnv allow
 
 # Start the stack (Phoenix + Flutter codegen watcher)
@@ -83,6 +87,12 @@ port and creates `mydia_dev` / `mydia_test`.
 > `initialDatabases` only runs on first init. To change it later, delete
 > `.devenv/state/postgres` and re-enter the shell.
 
+`DATABASE_TYPE` is read when devenv evaluates, so export it *before* entering
+the shell. Postgres builds into `_build/postgres` rather than `_build`, because
+the Ecto adapter is a compile-time setting and sharing one build root between
+adapters makes Phoenix restart-loop on a compile-env mismatch. Switching back
+and forth costs no recompile.
+
 ## The `./dev` Script
 
 `./dev` is a thin wrapper over devenv that preserves the historical command
@@ -114,8 +124,13 @@ vocabulary. Run `./dev` with no arguments to see everything.
 ./dev test         # Run tests
 ./dev format       # Format code
 ./dev deps.get     # Fetch dependencies
+./dev db.setup     # Create and migrate the development database
 ./dev ecto.migrate # Run migrations
 ```
+
+`./dev up`, `./dev iex`, and `./dev phx.server` run `db.setup` for you. `./dev
+test` and `./dev mix` do not need it: the `test` alias builds and migrates its
+own database, and formatting, Credo, and compilation never open one.
 
 ## Code Quality
 

--- a/lib/mix/tasks/mydia.backup_before_migrate.ex
+++ b/lib/mix/tasks/mydia.backup_before_migrate.ex
@@ -7,10 +7,12 @@ defmodule Mix.Tasks.Mydia.BackupBeforeMigrate do
   `Mydia.Release.MigrationBackup`, which runs before `Ecto.Migrator`.
 
   It will:
-  1. Check if there are pending migrations
-  2. If yes, create a timestamped backup of the database (SQLite only)
-  3. Clean up old backups (keeping the last 10)
-  4. Exit with status 0 if successful, 1 if failed
+  1. Start only `Mydia.Repo`, never the full supervision tree
+  2. Check if there are pending migrations
+  3. If the database already has applied migrations, create a timestamped
+     backup of it (SQLite only)
+  4. Clean up old backups (keeping the last 10)
+  5. Exit with status 0 if successful, 1 if failed
 
   ## Examples
 
@@ -23,29 +25,45 @@ defmodule Mix.Tasks.Mydia.BackupBeforeMigrate do
 
   @impl Mix.Task
   def run(_args) do
-    # Start the application to load configuration
-    Mix.Task.run("app.start")
+    # Load configuration WITHOUT booting the supervision tree.
+    #
+    # `app.start` here was fatal on a fresh database: ClientHealth.init/1 queries
+    # download_client_configs synchronously, so the boot died with "no such
+    # table", took the surrounding `ecto.create && … && ecto.migrate` chain down
+    # with it, and left the database permanently unmigrated. A backup needs the
+    # repo and nothing else, so start exactly that.
+    Mix.Task.run("app.config")
 
-    case Mydia.Release.backup_before_migrations() do
-      {:ok, backup_path} when is_binary(backup_path) ->
-        Mix.shell().info("✓ Database backup created: #{backup_path}")
-        :ok
-
-      {:ok, :no_migrations} ->
-        Mix.shell().info("✓ No pending migrations, skipping backup")
-        :ok
-
-      {:ok, :skipped} ->
-        Mix.shell().info("✓ SKIP_BACKUPS is set, no backup taken")
-        :ok
-
-      {:ok, :unsupported_adapter} ->
-        Mix.shell().info("✓ PostgreSQL: no automatic backup, see the logged warning")
-        :ok
-
-      {:error, reason} ->
-        Mix.shell().error("✗ Failed to create backup: #{inspect(reason)}")
-        exit({:shutdown, 1})
+    case Ecto.Migrator.with_repo(Mydia.Repo, fn _repo ->
+           Mydia.Release.backup_before_migrations()
+         end) do
+      {:ok, result, _started_apps} -> report(result)
+      {:error, reason} -> report({:error, {:repo_not_started, reason}})
     end
+  end
+
+  defp report({:ok, backup_path}) when is_binary(backup_path) do
+    Mix.shell().info("✓ Database backup created: #{backup_path}")
+  end
+
+  defp report({:ok, :no_migrations}) do
+    Mix.shell().info("✓ No pending migrations, skipping backup")
+  end
+
+  defp report({:ok, :no_schema}) do
+    Mix.shell().info("✓ Database has no applied migrations yet, nothing to back up")
+  end
+
+  defp report({:ok, :skipped}) do
+    Mix.shell().info("✓ SKIP_BACKUPS is set, no backup taken")
+  end
+
+  defp report({:ok, :unsupported_adapter}) do
+    Mix.shell().info("✓ PostgreSQL: no automatic backup, see the logged warning")
+  end
+
+  defp report({:error, reason}) do
+    Mix.shell().error("✗ Failed to create backup: #{inspect(reason)}")
+    exit({:shutdown, 1})
   end
 end

--- a/lib/mydia/release.ex
+++ b/lib/mydia/release.ex
@@ -83,17 +83,23 @@ defmodule Mydia.Release do
     * `:pending_migrations?` - override the pending-migration check. Defaults to
       `pending_migrations?/0`. Exists so the boot path and its tests can decide
       migration status without a live migration being pending.
+    * `:schema?` - override the applied-migrations check. Defaults to
+      `schema?/0`. Exists so the boot path and its tests can decide schema
+      status without a live database.
 
   ## Returns
 
     * `{:ok, backup_path}` - a backup was written
     * `{:ok, :no_migrations}` - nothing is pending, so nothing was backed up
+    * `{:ok, :no_schema}` - the database has no applied migrations, so it holds
+      nothing worth backing up
     * `{:ok, :skipped}` - `SKIP_BACKUPS` is set
     * `{:ok, :unsupported_adapter}` - PostgreSQL, operator warned
     * `{:error, reason}` - the backup was attempted and failed
   """
   @spec backup_before_migrations(keyword()) ::
-          {:ok, String.t() | :no_migrations | :skipped | :unsupported_adapter} | {:error, term()}
+          {:ok, String.t() | :no_migrations | :no_schema | :skipped | :unsupported_adapter}
+          | {:error, term()}
   def backup_before_migrations(opts \\ []) do
     cond do
       skip_backups?() ->
@@ -107,6 +113,10 @@ defmodule Mydia.Release do
       not Keyword.get_lazy(opts, :pending_migrations?, &pending_migrations?/0) ->
         Logger.info("No pending migrations detected, skipping backup")
         {:ok, :no_migrations}
+
+      not Keyword.get_lazy(opts, :schema?, &schema?/0) ->
+        Logger.info("Database has no applied migrations yet, so there is nothing to back up")
+        {:ok, :no_schema}
 
       DB.sqlite?() ->
         create_backup()
@@ -139,6 +149,21 @@ defmodule Mydia.Release do
         status == :down
       end)
     end)
+  end
+
+  @doc """
+  Returns true when at least one migration has been applied to the database.
+
+  A database with zero applied versions was created moments ago and holds no
+  rows, so a pre-migration snapshot of it protects nothing. Distinguishing this
+  from "migrations are pending" matters because a brand-new database reports
+  *every* migration as pending.
+  """
+  @spec schema?() :: boolean()
+  def schema? do
+    @app
+    |> Application.get_env(:ecto_repos, [])
+    |> Enum.any?(fn repo -> Ecto.Migrator.migrated_versions(repo) != [] end)
   end
 
   @doc """

--- a/lib/mydia/release/migration_backup.ex
+++ b/lib/mydia/release/migration_backup.ex
@@ -52,10 +52,16 @@ defmodule Mydia.Release.MigrationBackup do
       nothing to back up. Mirrors `Ecto.Migrator`'s option of the same name.
     * `:pending_migrations?` - forwarded to
       `Mydia.Release.backup_before_migrations/1`.
+    * `:schema?` - forwarded to `Mydia.Release.backup_before_migrations/1`.
   """
   @spec run(keyword()) ::
           {:ok,
-           String.t() | :no_migrations | :skipped | :unsupported_adapter | :migrations_skipped}
+           String.t()
+           | :no_migrations
+           | :no_schema
+           | :skipped
+           | :unsupported_adapter
+           | :migrations_skipped}
           | {:error, term()}
   def run(opts \\ []) do
     if Keyword.get(opts, :skip, false) do

--- a/test/mydia/release/migration_backup_test.exs
+++ b/test/mydia/release/migration_backup_test.exs
@@ -117,6 +117,40 @@ defmodule Mydia.Release.MigrationBackupTest do
     end
   end
 
+  describe "run/1 on a database with no applied migrations" do
+    test "takes no backup, because there is nothing to protect", %{db_path: db_path} do
+      force_adapter(Ecto.Adapters.SQLite3)
+
+      assert {:ok, :no_schema} =
+               MigrationBackup.run(pending_migrations?: true, schema?: false)
+
+      assert backups(db_path) == []
+    end
+
+    test "still backs up once the database has applied migrations", %{db_path: db_path} do
+      force_adapter(Ecto.Adapters.SQLite3)
+
+      assert {:ok, backup_path} =
+               MigrationBackup.run(pending_migrations?: true, schema?: true)
+
+      assert File.exists?(backup_path)
+      assert Path.dirname(backup_path) == Path.dirname(db_path)
+    end
+
+    test "skips ahead of the adapter branch on PostgreSQL", %{db_path: db_path} do
+      force_adapter(Ecto.Adapters.Postgres)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, :no_schema} =
+                   MigrationBackup.run(pending_migrations?: true, schema?: false)
+        end)
+
+      assert backups(db_path) == []
+      refute log =~ "NO BACKUP WAS TAKEN"
+    end
+  end
+
   describe "SKIP_BACKUPS" do
     setup do
       force_adapter(Ecto.Adapters.SQLite3)

--- a/test/mydia/release_test.exs
+++ b/test/mydia/release_test.exs
@@ -191,6 +191,12 @@ defmodule Mydia.ReleaseTest do
     end
   end
 
+  describe "schema?/0" do
+    test "is true against the migrated test repo" do
+      assert Release.schema?() == true
+    end
+  end
+
   defp align_to_second_boundary do
     Process.sleep(1000 - rem(System.os_time(:millisecond), 1000))
   end


### PR DESCRIPTION
Three defects in the local dev environment, all with one root cause: the devenv shell-entry task graph did work that does not belong in shell entry.

## What was broken

**1. Shell entry failed permanently in every fresh worktree.** `mydia:ecto` ran `ecto.create && mydia.backup_before_migrate && ecto.migrate` on every shell entry. The middle command called `Mix.Task.run("app.start")`, booting the whole supervision tree, and `ClientHealth.init/1` synchronously queries `download_client_configs`. On a fresh database that table does not exist, so the boot died, `&&` short-circuited, `ecto.migrate` never ran, and the database stayed empty forever.

```
** (Exqlite.Error) no such table: download_client_configs
    lib/mydia/downloads/client_health.ex:127: Mydia.Downloads.ClientHealth.init/1
✖ Running mydia:ecto in 2.69s (failed)
```

Measured before the fix: **26 of 58 worktrees** on one machine held a 4096-byte `mydia_dev.db` with zero tables. `mix phx.server` could not boot in any of them.

**2. `./dev up -d` collided with a second Postgres.** `mydia:ecto` declared `after = [… "devenv:processes:postgres@ready"]`, and a devenv task dependency makes devenv *start its own* Postgres, colliding with the postmaster `./dev up -d` already owns:

```
FATAL:  lock file "postmaster.pid" already exists
HINT:   Is another postmaster (PID 1641741) running in data directory "…/.devenv/state/postgres"?
```

Six attempts in 87ms, with two runtime log directories proving two owners.

**3. Switching `DATABASE_TYPE` left phoenix restart-looping.** `_build` was shared across adapters, so a SQLite-compiled build reused under `DATABASE_TYPE=postgres` tripped Mix's compile-env validation on `:database_adapter`, and phoenix restart-looped with nothing in its log but that error.

## The invariant

**Entering a devenv shell must not boot the OTP application, and must not start or require a running service.**

- `mydia:ecto` leaves shell entry and joins the process graph: `processes.phoenix.after = [ "mydia:ecto@succeeded" ]`
- Its Postgres process dependency becomes a bounded readiness poll. Polling observes; a task dependency starts things.
- `mix mydia.backup_before_migrate` starts only the repo via `Ecto.Migrator.with_repo/2` plus `app.config`, which is the same bootstrap `Mix.Ecto.ensure_repo/2` uses.
- Postgres gets `MIX_BUILD_ROOT=_build/postgres`. SQLite keeps the default `_build`, so no existing worktree pays a recompile.
- `./dev db.setup` serves the commands that need a database outside the process graph (`iex`, `phx.server`, `user`).
- `backup_before_migrations/1` gains `{:ok, :no_schema}`: a database with zero applied migrations holds nothing worth snapshotting. This also stops a brand-new production instance from `VACUUM INTO`-ing an empty file on first boot, and stops a fresh Postgres instance emitting a "NO BACKUP WAS TAKEN" warning for an empty database.

## Verified, not assumed

- The stuck state reproduced in a fresh worktree, then **self-healed to 110 applied migrations** once the backup fix landed. That is the "26 worktrees heal themselves" claim demonstrated on real state.
- Postgres from a cold start with no daemon: server came up, `mydia_dev` reached 110 migrations, `./dev db.setup` exit 0. No second postmaster.
- `mix do a + b + c` preserves abort-on-failure, checked against Elixir 1.19.5's own `do.ex`, `mix/cli.ex`, and `kernel/cli.ex`. A failed backup still stops `ecto.migrate`, which is the safety property the backup exists for.
- A failed poll fails the task, and phoenix does not start rather than booting unmigrated.
- Full suite: **6183 tests, 0 failures**. Clean `--warnings-as-errors` compile and format.

## CI guards

Three greps, matching the existing convention used for the Rust pin and `.credo.exs`:

1. `mydia.backup_before_migrate` must not contain `app.start`
2. The `mydia:ecto` block must contain neither `before = onEnterShell` nor a postgres process dependency
3. `processes.phoenix.after = [ "mydia:ecto@succeeded" ]` must exist

They strip comment lines before matching, and the block extraction asserts it actually found something so it cannot pass vacuously.

## Known follow-ups (deliberately not in this PR)

- `docs/contributing/setup.md` line 131 lists the commands that run `db.setup` and omits the newly added `./dev user`.
- The vacuity `::error::` annotation in the shell-entry guard is unreachable under `pipefail` (an empty filter result kills the assignment first). Fail-closed: CI still goes red and the invariant is not evadable, only the message text is lost. Fix is `|| true` on the substitution.
- The third guard does not strip comments, unlike the two beside it. Latent only: no comment quotes that line today.
- `ClientHealth.init/1` and `Indexers.Health.init/1` doing synchronous DB I/O in `init/1` is what turns a missing table into a dead supervision tree. This branch removes the trigger in dev but leaves the underlying fragility, which is worth its own issue.
