### PR TITLE
fix(player): keep the macOS traffic lights off the back button

### DIFF
--- a/player/lib/app.dart
+++ b/player/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'core/auth/auth_status.dart';
+import 'core/layout/window_chrome_inset.dart';
 import 'core/theme/app_theme.dart';
 import 'core/providers/providers.dart';
 import 'core/graphql/graphql_provider.dart';
@@ -166,8 +167,13 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
       routerConfig: router,
       // Float the cast mini controller above every route. `CastBarLayer`
       // documents what mounting it out here costs the bar.
-      builder: (context, child) =>
-          CastBarLayer(child: child ?? const SizedBox.shrink()),
+      //
+      // `WindowChromeInset` wraps it rather than the reverse: the cast bar is
+      // itself a route-level overlay, so it has to sit inside the reserved
+      // window chrome like everything else.
+      builder: (context, child) => WindowChromeInset(
+        child: CastBarLayer(child: child ?? const SizedBox.shrink()),
+      ),
     );
   }
 }

--- a/player/lib/core/layout/window_chrome_inset.dart
+++ b/player/lib/core/layout/window_chrome_inset.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import '../window/window_fullscreen.dart';
+
+/// Height of the macOS title bar strip the traffic light window controls
+/// float in.
+///
+/// `MainFlutterWindow.swift` sets `titlebarAppearsTransparent`, hides the
+/// title and inserts `.fullSizeContentView`, so the Flutter view runs under
+/// the title bar and AppKit draws the close/minimize/zoom buttons on top of
+/// it at roughly x 7-75, y 8-28. The embedder reports no safe-area inset for
+/// that strip, so the app has to reserve it.
+///
+/// 28 is the standard regular-height title bar. The buttons span roughly
+/// y14-y26, so this clears them with a few points to spare.
+const double kMacTitleBarOverlap = 28.0;
+
+/// Reserves the macOS title bar strip by republishing [MediaQuery] with a
+/// larger `padding.top`.
+///
+/// Mounted once, outermost in the `MaterialApp.router` builder. Injecting into
+/// `MediaQuery` rather than padding individual screens means `SafeArea`,
+/// `Scaffold`, `AppBar` and `SliverAppBar` all honour the strip for free, so
+/// a screen cannot forget it — which is exactly how the detail screens and the
+/// player ended up under the traffic lights in the first place.
+///
+/// Full-bleed layers stay full-bleed: the video surface and the ambient
+/// backdrop sit outside any `SafeArea`, so they are unaffected by this.
+class WindowChromeInset extends StatelessWidget {
+  const WindowChromeInset({
+    super.key,
+    required this.child,
+    ValueListenable<bool>? fullscreen,
+  }) : _fullscreen = fullscreen;
+
+  final Widget child;
+
+  /// Injected by tests. Defaults to the app-wide [windowFullscreen] signal.
+  final ValueListenable<bool>? _fullscreen;
+
+  @override
+  Widget build(BuildContext context) {
+    // Web is checked first: `defaultTargetPlatform` reports macOS for Safari
+    // and Chrome on a Mac, where there is no frameless window and no traffic
+    // lights to clear.
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.macOS) return child;
+
+    return ValueListenableBuilder<bool>(
+      valueListenable: _fullscreen ?? windowFullscreen,
+      builder: (context, isFullscreen, child) {
+        // macOS auto-hides the traffic lights in fullscreen, so reserving the
+        // strip there would only letterbox the video.
+        if (isFullscreen) return child!;
+
+        final media = MediaQuery.of(context);
+        return MediaQuery(
+          data: media.copyWith(
+            padding: media.padding.copyWith(
+              top: media.padding.top + kMacTitleBarOverlap,
+            ),
+          ),
+          child: child!,
+        );
+      },
+      child: child,
+    );
+  }
+}

--- a/player/lib/core/layout/window_chrome_inset.dart
+++ b/player/lib/core/layout/window_chrome_inset.dart
@@ -41,17 +41,26 @@ class WindowChromeInset extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Web is checked first: `defaultTargetPlatform` reports macOS for Safari
-    // and Chrome on a Mac, where there is no frameless window and no traffic
-    // lights to clear.
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.macOS) return child;
+    final isWeb = kIsWeb;
+    final platform = defaultTargetPlatform;
+
+    // Short-circuits before ever subscribing to the fullscreen signal: off
+    // macOS (and on web, where `defaultTargetPlatform` reports macOS for
+    // Safari/Chrome on a Mac but there is no frameless window to clear)
+    // fullscreen can never flip this decision, so there is no reason to
+    // rebuild on it.
+    if (isWeb || platform != TargetPlatform.macOS) return child;
 
     return ValueListenableBuilder<bool>(
       valueListenable: _fullscreen ?? windowFullscreen,
       builder: (context, isFullscreen, child) {
-        // macOS auto-hides the traffic lights in fullscreen, so reserving the
-        // strip there would only letterbox the video.
-        if (isFullscreen) return child!;
+        if (!shouldReserveTitleBar(
+          isWeb: isWeb,
+          platform: platform,
+          isFullscreen: isFullscreen,
+        )) {
+          return child!;
+        }
 
         final media = MediaQuery.of(context);
         return MediaQuery(
@@ -67,3 +76,27 @@ class WindowChromeInset extends StatelessWidget {
     );
   }
 }
+
+/// Pure predicate behind [WindowChromeInset.build], exposed separately so it
+/// can be unit-tested for every input combination without actually running
+/// on each platform.
+///
+/// `kIsWeb` is a compile-time constant baked in per build target — it is
+/// always `false` under `flutter test`, so a regression that deleted the web
+/// check from [WindowChromeInset.build] would pass every test unless the
+/// underlying boolean logic is tested independently of the real `kIsWeb`
+/// value. Mirrors `PlatformFeatures.computeSupportsKeyboardShortcuts` in
+/// `platform_features.dart`, which exists for exactly the same reason.
+///
+/// Web is checked first: `defaultTargetPlatform` reports macOS for Safari
+/// and Chrome on a Mac, where there is no frameless window and no traffic
+/// lights to clear. Fullscreen is checked last: macOS auto-hides the
+/// traffic lights there, so reserving the strip would only letterbox the
+/// video.
+@visibleForTesting
+bool shouldReserveTitleBar({
+  required bool isWeb,
+  required TargetPlatform platform,
+  required bool isFullscreen,
+}) =>
+    !isWeb && platform == TargetPlatform.macOS && !isFullscreen;

--- a/player/lib/core/window/desktop_window_native.dart
+++ b/player/lib/core/window/desktop_window_native.dart
@@ -33,6 +33,7 @@ import '../player/platform_features.dart';
 import 'player_window_sizer.dart';
 import 'player_window_sizer_native.dart';
 import 'window_controller_native.dart';
+import 'window_fullscreen_controller.dart';
 import 'window_geometry_controller.dart';
 import 'window_geometry_math.dart';
 import 'window_geometry_store.dart';
@@ -69,6 +70,19 @@ Future<void> initDesktopWindow() async {
     _geometry = controller;
   } catch (e) {
     debugPrint('[DesktopWindow] Failed to track window geometry: $e');
+  }
+
+  // Separate try from the geometry listener above: a failure to track
+  // fullscreen costs a 28pt inset in fullscreen, which must not also cost
+  // geometry persistence, and vice versa.
+  try {
+    final fullscreen = WindowFullscreenController(
+      window: const WindowManagerController(),
+    );
+    await fullscreen.seed();
+    windowManager.addListener(fullscreen);
+  } catch (e) {
+    debugPrint('[DesktopWindow] Failed to track fullscreen state: $e');
   }
 }
 

--- a/player/lib/core/window/window_fullscreen.dart
+++ b/player/lib/core/window/window_fullscreen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+
+/// Whether the OS window is in native fullscreen.
+///
+/// Deliberately platform-free: this file imports nothing that `window_manager`
+/// touches, so widgets on every target — including web, where `window_manager`
+/// has no implementation — can read it without a conditional import. The half
+/// that actually talks to the window lives in
+/// `window_fullscreen_controller.dart`, reachable only from
+/// `desktop_window_native.dart`.
+///
+/// Off desktop nothing ever writes to it and it stays `false`, which is the
+/// correct answer there: a platform with no window cannot be fullscreen in
+/// the sense the chrome inset cares about.
+///
+/// `WindowFullscreenController` is the only intended writer. Deliberately NOT
+/// marked `@visibleForTesting`: that annotation fires
+/// `invalid_use_of_visible_for_testing_member` as soon as the controller —
+/// which lives in a different library file — touches it, and tests do not need
+/// it anyway, since both the controller and `WindowChromeInset` accept an
+/// injected notifier.
+final ValueNotifier<bool> windowFullscreenSignal = ValueNotifier<bool>(false);
+
+/// Read-only view of [windowFullscreenSignal] for consumers.
+ValueListenable<bool> get windowFullscreen => windowFullscreenSignal;

--- a/player/lib/core/window/window_fullscreen_controller.dart
+++ b/player/lib/core/window/window_fullscreen_controller.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/foundation.dart';
+import 'package:window_manager/window_manager.dart';
+
+import 'window_controller.dart';
+import 'window_fullscreen.dart';
+
+/// Keeps [windowFullscreen] in step with the OS window.
+///
+/// Takes a [WindowController] rather than reading the `windowManager`
+/// singleton, matching `WindowGeometryController`: reading that getter
+/// constructs a `WindowManager._()` which calls `setMethodCallHandler` before
+/// a Flutter binding may exist, so tests that touch it assert-fail.
+///
+/// This exists rather than reusing `PlayerScreen`'s own `_isFullscreen` field
+/// because the green button, the View menu and Cmd+Ctrl+F also fullscreen the
+/// window, and that field never learns about any of them.
+class WindowFullscreenController with WindowListener {
+  WindowFullscreenController({
+    required WindowController window,
+    ValueNotifier<bool>? signal,
+  })  : _window = window,
+        _signal = signal ?? windowFullscreenSignal;
+
+  final WindowController _window;
+  final ValueNotifier<bool> _signal;
+
+  /// Reads the window's current state once, for the case where the app is
+  /// launched into an already-fullscreen window and no event ever fires.
+  ///
+  /// Never throws: startup must not fail over window chrome, and a failed read
+  /// leaves the signal at `false`, which only costs a 28pt inset that the next
+  /// real event corrects.
+  Future<void> seed() async {
+    try {
+      _signal.value = await _window.isFullScreen();
+    } catch (e) {
+      debugPrint('[WindowFullscreen] Failed to read fullscreen state: $e');
+    }
+  }
+
+  @override
+  void onWindowEnterFullScreen() => _signal.value = true;
+
+  @override
+  void onWindowLeaveFullScreen() => _signal.value = false;
+}

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -100,6 +100,34 @@ class PlayerScreen extends ConsumerStatefulWidget {
 
   @override
   ConsumerState<PlayerScreen> createState() => _PlayerScreenState();
+
+  /// The player's outer frame: a black [Scaffold] with a [SafeArea] that
+  /// only insets the sides and bottom, never the top.
+  ///
+  /// `top: false` is deliberate on every platform, not just macOS. On macOS
+  /// windowed, `WindowChromeInset` folds `kMacTitleBarOverlap` into
+  /// `MediaQuery.padding.top` app-wide so `SafeArea`/`AppBar` clear the
+  /// traffic lights for free; a bare `SafeArea` here would consume that same
+  /// strip a second time, pushing the media_kit `Video` down by 28pt and
+  /// putting a black band above every video — `NativePlayerWindowSizer` then
+  /// snaps the window to the video's aspect ratio *without* that 28pt, so
+  /// media_kit adds side pillars too. `playback_chrome.dart`'s own
+  /// `SafeArea` is what insets the on-screen chrome (back pill, transport)
+  /// instead; it is unaffected by this.
+  ///
+  /// On iOS this also puts the video full-bleed under the notch, which is
+  /// intentional, not a side effect: this is an immersive video player, the
+  /// controls keep their own `SafeArea`, and edge-to-edge video is what
+  /// video players do.
+  ///
+  /// Public and `@visibleForTesting` so a test can assert the seam directly
+  /// (see `player_screen_frame_inset_test.dart`) without mounting the full
+  /// screen, which needs a live player controller and platform channels.
+  @visibleForTesting
+  static Widget playerFrame({required Widget child}) => Scaffold(
+        backgroundColor: Colors.black,
+        body: SafeArea(top: false, child: child),
+      );
 }
 
 class _PlayerScreenState extends ConsumerState<PlayerScreen> {
@@ -2168,12 +2196,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       );
     }
 
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: body,
-      ),
-    );
+    return PlayerScreen.playerFrame(child: body);
   }
 
   /// Tear the local player down and rebuild it from scratch.

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -2557,17 +2557,19 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         Positioned(
           top: 8,
           left: 8,
-          child: IconButton(
-            icon: const Icon(Icons.arrow_back, color: Colors.white),
-            onPressed: () {
-              if (context.canPop()) {
-                context.pop();
-              } else {
-                context.go('/');
-              }
-            },
-            style: IconButton.styleFrom(
-              backgroundColor: Colors.black.withValues(alpha: 0.5),
+          child: SafeArea(
+            child: IconButton(
+              icon: const Icon(Icons.arrow_back, color: Colors.white),
+              onPressed: () {
+                if (context.canPop()) {
+                  context.pop();
+                } else {
+                  context.go('/');
+                }
+              },
+              style: IconButton.styleFrom(
+                backgroundColor: Colors.black.withValues(alpha: 0.5),
+              ),
             ),
           ),
         ),

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -1,5 +1,4 @@
-import 'package:flutter/foundation.dart'
-    show TargetPlatform, debugPrint, defaultTargetPlatform, kIsWeb;
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -147,11 +146,6 @@ class _PulsingDotState extends State<_PulsingDot>
     );
   }
 }
-
-/// Extra top padding on macOS to clear the traffic light window controls
-/// when using fullSizeContentView.
-final double _macOSTitleBarPadding =
-    !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS ? 28.0 : 0.0;
 
 /// Modern app shell with adaptive navigation.
 /// Shows sidebar on desktop (≥900px) and bottom nav on mobile.
@@ -440,18 +434,25 @@ class _AppShellState extends ConsumerState<AppShell> {
                   isOffline: isOffline,
                 ),
                 Expanded(
-                  child: Column(
-                    children: [
-                      SizedBox(height: _macOSTitleBarPadding),
-                      if (isOffline) const OfflineBanner(),
-                      Expanded(child: widget.child),
-                    ],
+                  child: SafeArea(
+                    top: true,
+                    bottom: false,
+                    left: false,
+                    right: false,
+                    child: Column(
+                      children: [
+                        if (isOffline) const OfflineBanner(),
+                        Expanded(child: widget.child),
+                      ],
+                    ),
                   ),
                 ),
               ],
             ),
             if (showCastOverlay)
-              CastOverlayButton(topInset: _macOSTitleBarPadding + 12),
+              CastOverlayButton(
+                topInset: MediaQuery.paddingOf(context).top + 12,
+              ),
           ],
         ),
       );
@@ -478,14 +479,22 @@ class _AppShellState extends ConsumerState<AppShell> {
       body: Stack(
         children: [
           Positioned.fill(child: backdrop),
-          Column(
-            children: [
-              if (isOffline) const OfflineBanner(),
-              Expanded(child: widget.child),
-            ],
+          SafeArea(
+            top: true,
+            bottom: false,
+            left: false,
+            right: false,
+            child: Column(
+              children: [
+                if (isOffline) const OfflineBanner(),
+                Expanded(child: widget.child),
+              ],
+            ),
           ),
           if (showCastOverlay)
-            const CastOverlayButton(topInset: kToolbarHeight + 8),
+            CastOverlayButton(
+              topInset: MediaQuery.paddingOf(context).top + kToolbarHeight + 8,
+            ),
         ],
       ),
       bottomNavigationBar: _ModernBottomNav(
@@ -796,7 +805,7 @@ class _DesktopSidebar extends StatelessWidget {
   Widget build(BuildContext context) {
     return GlassSidebarPanel(
       child: SafeArea(
-        top: false,
+        top: true,
         child: SidebarContent(
           location: location,
           onNavigate: onNavigate,
@@ -805,7 +814,7 @@ class _DesktopSidebar extends StatelessWidget {
           onToggleHome: onToggleHome,
           onToggleLibrary: onToggleLibrary,
           isOffline: isOffline,
-          topPadding: _macOSTitleBarPadding,
+          topPadding: 0,
           backToMydiaWidget:
               showBackToMydia ? const _BackToMydiaButton() : null,
         ),

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -449,10 +449,7 @@ class _AppShellState extends ConsumerState<AppShell> {
                 ),
               ],
             ),
-            if (showCastOverlay)
-              CastOverlayButton(
-                topInset: MediaQuery.paddingOf(context).top + 12,
-              ),
+            if (showCastOverlay) const CastOverlayButton(topInset: 12),
           ],
         ),
       );
@@ -492,9 +489,7 @@ class _AppShellState extends ConsumerState<AppShell> {
             ),
           ),
           if (showCastOverlay)
-            CastOverlayButton(
-              topInset: MediaQuery.paddingOf(context).top + kToolbarHeight + 8,
-            ),
+            const CastOverlayButton(topInset: kToolbarHeight + 8),
         ],
       ),
       bottomNavigationBar: _ModernBottomNav(

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -205,6 +205,26 @@ class AppShell extends ConsumerStatefulWidget {
         topInset: isDesktop ? 12 : kToolbarHeight + 8,
       );
 
+  /// The gutter both the desktop and mobile branches wrap their main content
+  /// column in: a `SafeArea` that consumes the ambient `MediaQuery.padding`
+  /// on top only, leaving the sidebar/drawer chrome and bottom nav to handle
+  /// their own edges.
+  ///
+  /// Public (rather than inlined at each call site) and annotated
+  /// `@visibleForTesting`, mirroring [castOverlay], so a test can exercise
+  /// the exact widget both branches build directly, instead of hand-rolling
+  /// a `SafeArea` that can silently drift out of sync with the real call
+  /// sites — the shell's actual gutter could lose its `SafeArea` entirely
+  /// and a mirror-based test would stay green.
+  @visibleForTesting
+  static Widget contentGutter({required Widget child}) => SafeArea(
+        top: true,
+        bottom: false,
+        left: false,
+        right: false,
+        child: child,
+      );
+
   @override
   ConsumerState<AppShell> createState() => _AppShellState();
 }
@@ -452,11 +472,7 @@ class _AppShellState extends ConsumerState<AppShell> {
                   isOffline: isOffline,
                 ),
                 Expanded(
-                  child: SafeArea(
-                    top: true,
-                    bottom: false,
-                    left: false,
-                    right: false,
+                  child: AppShell.contentGutter(
                     child: Column(
                       children: [
                         if (isOffline) const OfflineBanner(),
@@ -494,11 +510,7 @@ class _AppShellState extends ConsumerState<AppShell> {
       body: Stack(
         children: [
           Positioned.fill(child: backdrop),
-          SafeArea(
-            top: true,
-            bottom: false,
-            left: false,
-            right: false,
+          AppShell.contentGutter(
             child: Column(
               children: [
                 if (isOffline) const OfflineBanner(),
@@ -607,7 +619,6 @@ class SidebarContent extends StatelessWidget {
   final VoidCallback onToggleHome;
   final VoidCallback onToggleLibrary;
   final bool isOffline;
-  final double topPadding;
   final Widget? backToMydiaWidget;
 
   const SidebarContent({
@@ -619,7 +630,6 @@ class SidebarContent extends StatelessWidget {
     required this.onToggleHome,
     required this.onToggleLibrary,
     required this.isOffline,
-    this.topPadding = 0,
     this.backToMydiaWidget,
   });
 
@@ -629,7 +639,6 @@ class SidebarContent extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        SizedBox(height: topPadding),
         // Back to Mydia link (shown in embed mode)
         if (hasBackWidget)
           Padding(
@@ -826,7 +835,6 @@ class _DesktopSidebar extends StatelessWidget {
           onToggleHome: onToggleHome,
           onToggleLibrary: onToggleLibrary,
           isOffline: isOffline,
-          topPadding: 0,
           backToMydiaWidget:
               showBackToMydia ? const _BackToMydiaButton() : null,
         ),

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -187,6 +187,24 @@ class AppShell extends ConsumerStatefulWidget {
       location.startsWith('/settings') ||
       location.startsWith('/search');
 
+  /// Builds the shell's cast overlay for the desktop or mobile branch.
+  ///
+  /// [CastOverlayButton] wraps its child in its own `SafeArea`, which already
+  /// consumes whatever the ambient `MediaQuery.padding.top` carries (the
+  /// macOS title bar strip, on macOS windowed). `topInset` must therefore be
+  /// the plain pre-strip offset — 12 below the desktop content, or below the
+  /// mobile app bar — never `MediaQuery.paddingOf(context).top` folded in on
+  /// top of that, or the button sits under the strip twice.
+  ///
+  /// Public (rather than inlined at each call site) and annotated
+  /// `@visibleForTesting` so a test can exercise the exact value this shell
+  /// computes for each branch directly, instead of re-declaring the numbers
+  /// in a mirror that can silently drift from the real call sites.
+  @visibleForTesting
+  static Widget castOverlay({required bool isDesktop}) => CastOverlayButton(
+        topInset: isDesktop ? 12 : kToolbarHeight + 8,
+      );
+
   @override
   ConsumerState<AppShell> createState() => _AppShellState();
 }
@@ -449,7 +467,7 @@ class _AppShellState extends ConsumerState<AppShell> {
                 ),
               ],
             ),
-            if (showCastOverlay) const CastOverlayButton(topInset: 12),
+            if (showCastOverlay) AppShell.castOverlay(isDesktop: true),
           ],
         ),
       );
@@ -488,8 +506,7 @@ class _AppShellState extends ConsumerState<AppShell> {
               ],
             ),
           ),
-          if (showCastOverlay)
-            const CastOverlayButton(topInset: kToolbarHeight + 8),
+          if (showCastOverlay) AppShell.castOverlay(isDesktop: false),
         ],
       ),
       bottomNavigationBar: _ModernBottomNav(

--- a/player/test/core/layout/window_chrome_inset_test.dart
+++ b/player/test/core/layout/window_chrome_inset_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/window_chrome_inset.dart';
+
+/// Captures the top padding its subtree sees, so each test asserts on the
+/// value a real screen would read rather than on the widget's internals.
+class _PaddingProbe extends StatelessWidget {
+  const _PaddingProbe({required this.onBuild});
+
+  final void Function(double top) onBuild;
+
+  @override
+  Widget build(BuildContext context) {
+    onBuild(MediaQuery.of(context).padding.top);
+    return const SizedBox.shrink();
+  }
+}
+
+// `debugDefaultTargetPlatformOverride` is reset with a synchronous
+// try/finally rather than `addTearDown`: `TestWidgetsFlutterBinding`
+// verifies foundation debug vars are unset immediately after the test body
+// returns, which is before package:test unwinds its `addTearDown` queue, so
+// an `addTearDown`-based reset trips
+// `debugAssertAllFoundationVarsUnset` on every run.
+Future<double> _topPaddingUnder(
+  WidgetTester tester, {
+  required TargetPlatform platform,
+  required ValueListenable<bool> fullscreen,
+  double existingTop = 0,
+}) async {
+  debugDefaultTargetPlatformOverride = platform;
+  try {
+    late double captured;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: MediaQueryData(padding: EdgeInsets.only(top: existingTop)),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: WindowChromeInset(
+            fullscreen: fullscreen,
+            child: _PaddingProbe(onBuild: (top) => captured = top),
+          ),
+        ),
+      ),
+    );
+    return captured;
+  } finally {
+    debugDefaultTargetPlatformOverride = null;
+  }
+}
+
+void main() {
+  group('WindowChromeInset', () {
+    testWidgets('reserves the traffic light strip on windowed macOS',
+        (tester) async {
+      final top = await _topPaddingUnder(
+        tester,
+        platform: TargetPlatform.macOS,
+        fullscreen: ValueNotifier(false),
+      );
+
+      expect(top, kMacTitleBarOverlap);
+    });
+
+    testWidgets('adds to any inset already present rather than replacing it',
+        (tester) async {
+      final top = await _topPaddingUnder(
+        tester,
+        platform: TargetPlatform.macOS,
+        fullscreen: ValueNotifier(false),
+        existingTop: 12,
+      );
+
+      expect(top, 12 + kMacTitleBarOverlap);
+    });
+
+    testWidgets('reserves nothing in fullscreen, where macOS hides the lights',
+        (tester) async {
+      final top = await _topPaddingUnder(
+        tester,
+        platform: TargetPlatform.macOS,
+        fullscreen: ValueNotifier(true),
+      );
+
+      expect(top, 0);
+    });
+
+    for (final platform in [
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+      TargetPlatform.iOS,
+      TargetPlatform.android,
+    ]) {
+      testWidgets('reserves nothing on ${platform.name}', (tester) async {
+        final top = await _topPaddingUnder(
+          tester,
+          platform: platform,
+          fullscreen: ValueNotifier(false),
+        );
+
+        expect(top, 0);
+      });
+    }
+
+    testWidgets('drops the inset live when the window enters fullscreen',
+        (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        final fullscreen = ValueNotifier(false);
+        final seen = <double>[];
+
+        await tester.pumpWidget(
+          MediaQuery(
+            data: const MediaQueryData(),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: WindowChromeInset(
+                fullscreen: fullscreen,
+                child: _PaddingProbe(onBuild: seen.add),
+              ),
+            ),
+          ),
+        );
+        expect(seen.last, kMacTitleBarOverlap);
+
+        fullscreen.value = true;
+        await tester.pump();
+        expect(seen.last, 0);
+
+        fullscreen.value = false;
+        await tester.pump();
+        expect(seen.last, kMacTitleBarOverlap);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+  });
+}

--- a/player/test/core/layout/window_chrome_inset_test.dart
+++ b/player/test/core/layout/window_chrome_inset_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/layout/window_chrome_inset.dart';
+import 'package:player/core/window/window_fullscreen.dart';
 
 /// Captures the top padding its subtree sees, so each test asserts on the
 /// value a real screen would read rather than on the widget's internals.
@@ -51,6 +52,70 @@ Future<double> _topPaddingUnder(
 }
 
 void main() {
+  // `kIsWeb` is a compile-time constant baked in per build target — it is
+  // always `false` under `flutter test`, so a regression that deleted the
+  // web check from `WindowChromeInset.build` (see that method's doc comment)
+  // would pass every widget test in this file, since none of them can ever
+  // observe `kIsWeb` being `true`. Testing the extracted boolean logic with
+  // explicit inputs is the only way to verify the web branch without a
+  // browser test target — mirrors
+  // `platform_features_keyboard_test.dart`/`computeSupportsKeyboardShortcuts`.
+  group('shouldReserveTitleBar', () {
+    test(
+        'false on web, even on macOS — the regression this predicate exists '
+        'to catch: a deleted kIsWeb check would still pass every other test '
+        'in this file, since kIsWeb is always false under flutter test', () {
+      expect(
+        shouldReserveTitleBar(
+          isWeb: true,
+          platform: TargetPlatform.macOS,
+          isFullscreen: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('true on windowed macOS, off web', () {
+      expect(
+        shouldReserveTitleBar(
+          isWeb: false,
+          platform: TargetPlatform.macOS,
+          isFullscreen: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('false on fullscreen macOS, off web', () {
+      expect(
+        shouldReserveTitleBar(
+          isWeb: false,
+          platform: TargetPlatform.macOS,
+          isFullscreen: true,
+        ),
+        isFalse,
+      );
+    });
+
+    for (final platform in [
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+      TargetPlatform.iOS,
+      TargetPlatform.android,
+    ]) {
+      test('false on ${platform.name}, off web', () {
+        expect(
+          shouldReserveTitleBar(
+            isWeb: false,
+            platform: platform,
+            isFullscreen: false,
+          ),
+          isFalse,
+        );
+      });
+    }
+  });
+
   group('WindowChromeInset', () {
     testWidgets('reserves the traffic light strip on windowed macOS',
         (tester) async {
@@ -132,6 +197,43 @@ void main() {
         await tester.pump();
         expect(seen.last, kMacTitleBarOverlap);
       } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets(
+        'falls back to the real windowFullscreenSignal when no fullscreen '
+        'listenable is injected', (tester) async {
+      // Every other test in this file injects `fullscreen:`, which never
+      // exercises the `_fullscreen ?? windowFullscreen` fallback in
+      // `WindowChromeInset.build` — this is the one test that drives the
+      // real app-wide signal instead. try/finally so a failed assertion
+      // still restores the global to its default (`false`) rather than
+      // leaking `true` into whichever test runs next in this process.
+      final originalValue = windowFullscreenSignal.value;
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        windowFullscreenSignal.value = false;
+        late double captured;
+
+        await tester.pumpWidget(
+          MediaQuery(
+            data: const MediaQueryData(),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: WindowChromeInset(
+                child: _PaddingProbe(onBuild: (top) => captured = top),
+              ),
+            ),
+          ),
+        );
+        expect(captured, kMacTitleBarOverlap);
+
+        windowFullscreenSignal.value = true;
+        await tester.pump();
+        expect(captured, 0);
+      } finally {
+        windowFullscreenSignal.value = originalValue;
         debugDefaultTargetPlatformOverride = null;
       }
     });

--- a/player/test/core/window/window_fullscreen_controller_test.dart
+++ b/player/test/core/window/window_fullscreen_controller_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/window/window_fullscreen_controller.dart';
+
+import 'fake_window_controller.dart';
+
+void main() {
+  group('WindowFullscreenController', () {
+    test(
+        'seeds from the window, so a window already fullscreen at startup '
+        'does not report windowed until the first event', () async {
+      final signal = ValueNotifier(false);
+      final controller = WindowFullscreenController(
+        window: FakeWindowController(fullScreen: true),
+        signal: signal,
+      );
+
+      await controller.seed();
+
+      expect(signal.value, isTrue);
+    });
+
+    test('seeding a windowed window leaves the signal false', () async {
+      final signal = ValueNotifier(false);
+      final controller = WindowFullscreenController(
+        window: FakeWindowController(fullScreen: false),
+        signal: signal,
+      );
+
+      await controller.seed();
+
+      expect(signal.value, isFalse);
+    });
+
+    test('enter and leave events drive the signal', () {
+      final signal = ValueNotifier(false);
+      final controller = WindowFullscreenController(
+        window: FakeWindowController(),
+        signal: signal,
+      );
+
+      controller.onWindowEnterFullScreen();
+      expect(signal.value, isTrue);
+
+      controller.onWindowLeaveFullScreen();
+      expect(signal.value, isFalse);
+    });
+
+    test('notifies once per transition, not once per event', () {
+      final signal = ValueNotifier(false);
+      final controller = WindowFullscreenController(
+        window: FakeWindowController(),
+        signal: signal,
+      );
+      var notifications = 0;
+      signal.addListener(() => notifications++);
+
+      controller.onWindowEnterFullScreen();
+      controller.onWindowEnterFullScreen();
+      controller.onWindowEnterFullScreen();
+
+      expect(notifications, 1);
+    });
+
+    test(
+        'a seed that throws leaves the signal at its default rather than '
+        'propagating, since startup must not fail over window chrome',
+        () async {
+      final signal = ValueNotifier(false);
+      final controller = WindowFullscreenController(
+        window: _ThrowingFullScreenController(),
+        signal: signal,
+      );
+
+      await expectLater(controller.seed(), completes);
+      expect(signal.value, isFalse);
+    });
+  });
+}
+
+class _ThrowingFullScreenController extends FakeWindowController {
+  @override
+  Future<bool> isFullScreen() async => throw StateError('no window');
+}

--- a/player/test/presentation/screens/detail_screen_inset_test.dart
+++ b/player/test/presentation/screens/detail_screen_inset_test.dart
@@ -1,0 +1,94 @@
+// Pins a LAYOUT CONTRACT: how a pinned `SliverAppBar`'s `leading` widget
+// responds when the ambient `MediaQuery` carries a reserved top strip,
+// including across scroll as the app bar collapses. `_detailScreenLike`
+// below reproduces the `CustomScrollView` + pinned `SliverAppBar` shape
+// shared by `movie_detail_screen.dart`, `show_detail_screen.dart` and
+// `episode_detail_screen.dart`, rather than mounting any of them directly —
+// those screens need a provider graph, a GraphQL client and a router
+// location this suite does not construct. That means this file proves the
+// contract `SliverAppBar` already honours, not that the three real screens
+// still build this exact shape.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/window_chrome_inset.dart';
+
+const Key _backKey = Key('detail-back');
+
+/// The structure every detail screen shares: a `CustomScrollView` whose first
+/// sliver is a pinned `SliverAppBar` carrying the back button as `leading`.
+/// Mirrors `movie_detail_screen.dart`, `show_detail_screen.dart` and
+/// `episode_detail_screen.dart`, none of which can be mounted here without
+/// their provider graphs.
+Widget _detailScreenLike({required EdgeInsets padding}) => MediaQuery(
+      data: MediaQueryData(padding: padding),
+      child: const MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: [
+              SliverAppBar(
+                expandedHeight: 380,
+                pinned: true,
+                leading: Padding(
+                  padding: EdgeInsets.all(8),
+                  child: Icon(Icons.arrow_back_rounded, key: _backKey),
+                ),
+                flexibleSpace: FlexibleSpaceBar(
+                  background: ColoredBox(color: Colors.blue),
+                ),
+              ),
+              SliverToBoxAdapter(child: SizedBox(height: 2000)),
+            ],
+          ),
+        ),
+      ),
+    );
+
+void main() {
+  group('detail screen back button vs the macOS traffic lights', () {
+    testWidgets(
+        'REGRESSION WITNESS: with no reserved strip the back icon lands '
+        'inside the traffic light zone', (tester) async {
+      await tester.pumpWidget(_detailScreenLike(padding: EdgeInsets.zero));
+
+      // Measured: (8, 8) - (48, 48). The lights occupy roughly x 7-75,
+      // y 8-28, so this is the bug this whole change exists to fix. The test
+      // documents it rather than asserting the app ships it.
+      expect(
+        tester.getRect(find.byKey(_backKey)).top,
+        lessThan(kMacTitleBarOverlap),
+      );
+    });
+
+    testWidgets('the reserved strip moves the back icon clear', (tester) async {
+      await tester.pumpWidget(
+        _detailScreenLike(
+          padding: const EdgeInsets.only(top: kMacTitleBarOverlap),
+        ),
+      );
+
+      // Measured: (8, 36) - (48, 76).
+      expect(
+        tester.getRect(find.byKey(_backKey)).top,
+        greaterThanOrEqualTo(kMacTitleBarOverlap),
+      );
+    });
+
+    testWidgets('it still clears once the hero collapses under scroll',
+        (tester) async {
+      await tester.pumpWidget(
+        _detailScreenLike(
+          padding: const EdgeInsets.only(top: kMacTitleBarOverlap),
+        ),
+      );
+
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -600));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getRect(find.byKey(_backKey)).top,
+        greaterThanOrEqualTo(kMacTitleBarOverlap),
+      );
+    });
+  });
+}

--- a/player/test/presentation/screens/player/player_screen_frame_inset_test.dart
+++ b/player/test/presentation/screens/player/player_screen_frame_inset_test.dart
@@ -1,0 +1,50 @@
+// Regression guard for the letterboxing defect: `PlayerScreen.build` used to
+// wrap its whole body — including the media_kit `Video` — in a bare
+// `SafeArea`. That was a no-op while `WindowChromeInset` never touched
+// `MediaQuery.padding.top`, but once it started folding `kMacTitleBarOverlap`
+// in on macOS windowed, the bare `SafeArea` ate that strip a second time,
+// pushing the video down by 28pt and putting a black band above every video.
+// It compounds: `NativePlayerWindowSizer` then snaps the window to the
+// video's aspect ratio *without* that 28pt, so media_kit adds side pillars
+// too.
+//
+// This exercises `PlayerScreen.playerFrame` directly — the same
+// `@visibleForTesting` seam `_PlayerScreenState.build` routes through (see
+// player_screen.dart) — rather than mounting the full screen, which needs a
+// live player controller and platform channels this suite does not
+// construct.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/window_chrome_inset.dart';
+import 'package:player/presentation/screens/player/player_screen.dart';
+
+const Key _childKey = Key('player-frame-child');
+
+void main() {
+  group('PlayerScreen.playerFrame under a reserved window chrome strip', () {
+    testWidgets(
+        'the child (the video surface, in production) stays flush with the '
+        'top of the frame, not pushed down by the macOS title bar strip',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(
+              padding: EdgeInsets.only(top: kMacTitleBarOverlap),
+            ),
+            child: PlayerScreen.playerFrame(
+              child: const SizedBox(
+                key: _childKey,
+                height: 100,
+                width: 100,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.getRect(find.byKey(_childKey)).top, 0);
+    });
+  });
+}

--- a/player/test/presentation/widgets/app_shell_cast_overlay_inset_test.dart
+++ b/player/test/presentation/widgets/app_shell_cast_overlay_inset_test.dart
@@ -4,15 +4,15 @@
 // `MediaQuery.padding.top`. A call site that *also* folds that same ambient
 // padding into `topInset` pushes the button down twice on macOS windowed.
 //
-// Mirrors the shell's exact Stack children (see app_shell_cast_overlay_test
-// .dart for the sibling test covering the routing predicate) rather than
-// mounting the full `AppShell`, which needs a Riverpod graph, router
-// location and GraphQL client — no existing shell test does that.
-//
-// Keep the `topInset` expressions below in sync with
-// `lib/presentation/widgets/app_shell.dart`'s two `CastOverlayButton` call
-// sites: this test does not exercise that source file directly, so a future
-// edit to either site needs its mirror updated here too.
+// This exercises `AppShell.castOverlay` directly — the same
+// `@visibleForTesting` seam both the desktop and mobile branches build their
+// overlay from (see app_shell.dart) — rather than mounting the full
+// `AppShell`, which needs a Riverpod graph, router location and GraphQL
+// client (see app_shell_cast_overlay_test.dart for the sibling test covering
+// the routing predicate, `hasOwnCastButton`, the same way). Because the test
+// calls the real seam instead of re-declaring its `topInset` arithmetic, a
+// regression at either call site is caught here without any mirror to keep
+// in sync by hand.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -20,7 +20,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/cast/cast_capabilities.dart';
 import 'package:player/core/cast/cast_providers.dart';
 import 'package:player/core/layout/window_chrome_inset.dart';
-import 'package:player/presentation/widgets/cast_actions.dart';
+import 'package:player/presentation/widgets/app_shell.dart';
 
 void main() {
   group('the shell cast overlay under the macOS title bar strip', () {
@@ -49,9 +49,7 @@ void main() {
         'existed (12 below the safe area), not 12 below double the strip',
         (tester) async {
       await tester.pumpWidget(
-        shellStackChild(
-          const CastOverlayButton(topInset: 12),
-        ),
+        shellStackChild(AppShell.castOverlay(isDesktop: true)),
       );
       await tester.pump();
 
@@ -66,9 +64,7 @@ void main() {
         '(kToolbarHeight + 8 below the safe area), not double the strip',
         (tester) async {
       await tester.pumpWidget(
-        shellStackChild(
-          const CastOverlayButton(topInset: kToolbarHeight + 8),
-        ),
+        shellStackChild(AppShell.castOverlay(isDesktop: false)),
       );
       await tester.pump();
 

--- a/player/test/presentation/widgets/app_shell_cast_overlay_inset_test.dart
+++ b/player/test/presentation/widgets/app_shell_cast_overlay_inset_test.dart
@@ -1,0 +1,81 @@
+// Regression guard for the double-inset defect: `CastOverlayButton` wraps
+// its child in a `SafeArea` (see cast_actions.dart), which already consumes
+// whatever `WindowChromeInset` injects into the ambient
+// `MediaQuery.padding.top`. A call site that *also* folds that same ambient
+// padding into `topInset` pushes the button down twice on macOS windowed.
+//
+// Mirrors the shell's exact Stack children (see app_shell_cast_overlay_test
+// .dart for the sibling test covering the routing predicate) rather than
+// mounting the full `AppShell`, which needs a Riverpod graph, router
+// location and GraphQL client — no existing shell test does that.
+//
+// Keep the `topInset` expressions below in sync with
+// `lib/presentation/widgets/app_shell.dart`'s two `CastOverlayButton` call
+// sites: this test does not exercise that source file directly, so a future
+// edit to either site needs its mirror updated here too.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/layout/window_chrome_inset.dart';
+import 'package:player/presentation/widgets/cast_actions.dart';
+
+void main() {
+  group('the shell cast overlay under the macOS title bar strip', () {
+    Widget shellStackChild(Widget castOverlayButton) {
+      return MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(top: kMacTitleBarOverlap),
+        ),
+        child: ProviderScope(
+          overrides: [
+            castCapabilitiesProvider.overrideWithValue(
+              const CastCapabilities.full(),
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Stack(children: [castOverlayButton]),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+        'desktop: the button lands at the same y it did before the strip '
+        'existed (12 below the safe area), not 12 below double the strip',
+        (tester) async {
+      await tester.pumpWidget(
+        shellStackChild(
+          const CastOverlayButton(topInset: 12),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        tester.getRect(find.byKey(const Key('cast-button'))).top,
+        kMacTitleBarOverlap + 12,
+      );
+    });
+
+    testWidgets(
+        'mobile: the button lands one strip below its pre-strip position '
+        '(kToolbarHeight + 8 below the safe area), not double the strip',
+        (tester) async {
+      await tester.pumpWidget(
+        shellStackChild(
+          const CastOverlayButton(topInset: kToolbarHeight + 8),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        tester.getRect(find.byKey(const Key('cast-button'))).top,
+        kMacTitleBarOverlap + kToolbarHeight + 8,
+      );
+    });
+  });
+}

--- a/player/test/presentation/widgets/app_shell_inset_test.dart
+++ b/player/test/presentation/widgets/app_shell_inset_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/window_chrome_inset.dart';
+
+/// The shell's child, marked so the test can measure where it starts.
+const Key _childKey = Key('shell-child');
+
+void main() {
+  group('shell content under a reserved window chrome strip', () {
+    testWidgets('a SafeArea gutter pushes the child clear of the strip',
+        (tester) async {
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(
+            padding: EdgeInsets.only(top: kMacTitleBarOverlap),
+          ),
+          child: const Directionality(
+            textDirection: TextDirection.ltr,
+            child: SafeArea(
+              top: true,
+              bottom: false,
+              left: false,
+              right: false,
+              child: SizedBox(key: _childKey, height: 100, width: 100),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getRect(find.byKey(_childKey)).top,
+        greaterThanOrEqualTo(kMacTitleBarOverlap),
+      );
+    });
+
+    testWidgets(
+        'the gutter consumes the inset, so a nested AppBar does not inset '
+        'a second time', (tester) async {
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(
+            padding: EdgeInsets.only(top: kMacTitleBarOverlap),
+          ),
+          child: MaterialApp(
+            home: SafeArea(
+              top: true,
+              bottom: false,
+              left: false,
+              right: false,
+              child: Scaffold(
+                appBar: AppBar(title: const Text('probe')),
+                body: const SizedBox(key: _childKey),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // The app bar starts at the gutter, not at gutter + inset. If SafeArea
+      // did not remove the padding it consumed, this would be 2x the overlap.
+      expect(
+        tester.getRect(find.byType(AppBar)).top,
+        kMacTitleBarOverlap,
+      );
+    });
+
+    testWidgets(
+        'CONTROL: with no gutter above it, an AppBar insets itself by growing',
+        (tester) async {
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(
+            padding: EdgeInsets.only(top: kMacTitleBarOverlap),
+          ),
+          child: MaterialApp(
+            home: Scaffold(
+              appBar: AppBar(title: const Text('probe')),
+              body: const SizedBox(key: _childKey),
+            ),
+          ),
+        ),
+      );
+
+      // This is the path every out-of-shell detail screen takes. Measured:
+      // 56 + 28 = 84.
+      expect(
+        tester.getRect(find.byType(AppBar)).height,
+        kToolbarHeight + kMacTitleBarOverlap,
+      );
+    });
+  });
+}

--- a/player/test/presentation/widgets/app_shell_inset_test.dart
+++ b/player/test/presentation/widgets/app_shell_inset_test.dart
@@ -10,11 +10,11 @@ void main() {
     testWidgets('a SafeArea gutter pushes the child clear of the strip',
         (tester) async {
       await tester.pumpWidget(
-        MediaQuery(
-          data: const MediaQueryData(
+        const MediaQuery(
+          data: MediaQueryData(
             padding: EdgeInsets.only(top: kMacTitleBarOverlap),
           ),
-          child: const Directionality(
+          child: Directionality(
             textDirection: TextDirection.ltr,
             child: SafeArea(
               top: true,

--- a/player/test/presentation/widgets/app_shell_inset_test.dart
+++ b/player/test/presentation/widgets/app_shell_inset_test.dart
@@ -1,14 +1,26 @@
+// Regression guard for the shell's content gutter: `AppShell.contentGutter`
+// is the `SafeArea` both the desktop and mobile branches wrap their main
+// content column in (see app_shell.dart), the same `@visibleForTesting` seam
+// `AppShell.castOverlay` established for the cast button. Because the first
+// two tests below call the real seam instead of hand-rolling a `SafeArea`
+// that mirrors its shape, a regression that drops the gutter entirely (or
+// changes which edges it insets) is caught here without any mirror to keep
+// in sync by hand.
+//
+// The third test is a deliberate CONTROL with no gutter at all, showing what
+// an `AppBar` does when nothing above it has already consumed the strip.
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/layout/window_chrome_inset.dart';
+import 'package:player/presentation/widgets/app_shell.dart';
 
-/// The shell's child, marked so the test can measure where it starts.
+/// The gutter's child, marked so the test can measure where it starts.
 const Key _childKey = Key('shell-child');
 
 void main() {
-  group('shell content under a reserved window chrome strip', () {
-    testWidgets('a SafeArea gutter pushes the child clear of the strip',
-        (tester) async {
+  group('AppShell.contentGutter under a reserved window chrome strip', () {
+    testWidgets('pushes its child clear of the strip', (tester) async {
       await tester.pumpWidget(
         const MediaQuery(
           data: MediaQueryData(
@@ -16,12 +28,11 @@ void main() {
           ),
           child: Directionality(
             textDirection: TextDirection.ltr,
-            child: SafeArea(
-              top: true,
-              bottom: false,
-              left: false,
-              right: false,
-              child: SizedBox(key: _childKey, height: 100, width: 100),
+            child: SizedBox(
+              // AppShell.contentGutter is a static method, not a const
+              // constructor, so it cannot be built inside a `const` widget
+              // tree; wrap it via a builder-shaped subtree instead.
+              child: _ContentGutterProbe(),
             ),
           ),
         ),
@@ -34,19 +45,15 @@ void main() {
     });
 
     testWidgets(
-        'the gutter consumes the inset, so a nested AppBar does not inset '
-        'a second time', (tester) async {
+        'consumes the inset, so a nested AppBar does not inset a second '
+        'time', (tester) async {
       await tester.pumpWidget(
         MediaQuery(
           data: const MediaQueryData(
             padding: EdgeInsets.only(top: kMacTitleBarOverlap),
           ),
           child: MaterialApp(
-            home: SafeArea(
-              top: true,
-              bottom: false,
-              left: false,
-              right: false,
+            home: AppShell.contentGutter(
               child: Scaffold(
                 appBar: AppBar(title: const Text('probe')),
                 body: const SizedBox(key: _childKey),
@@ -56,8 +63,9 @@ void main() {
         ),
       );
 
-      // The app bar starts at the gutter, not at gutter + inset. If SafeArea
-      // did not remove the padding it consumed, this would be 2x the overlap.
+      // The app bar starts at the gutter, not at gutter + inset. If the
+      // gutter's SafeArea did not remove the padding it consumed, this
+      // would be 2x the overlap.
       expect(
         tester.getRect(find.byType(AppBar)).top,
         kMacTitleBarOverlap,
@@ -65,8 +73,8 @@ void main() {
     });
 
     testWidgets(
-        'CONTROL: with no gutter above it, an AppBar insets itself by growing',
-        (tester) async {
+        'CONTROL: with no gutter above it, an AppBar insets itself by '
+        'growing', (tester) async {
       await tester.pumpWidget(
         MediaQuery(
           data: const MediaQueryData(
@@ -89,4 +97,18 @@ void main() {
       );
     });
   });
+}
+
+/// Builds `AppShell.contentGutter` around the keyed probe child.
+///
+/// A plain widget (not a `const` literal in the test body) purely so the
+/// static-method call can sit inside the otherwise-`const` `MediaQuery` /
+/// `Directionality` tree used by the first test.
+class _ContentGutterProbe extends StatelessWidget {
+  const _ContentGutterProbe();
+
+  @override
+  Widget build(BuildContext context) => AppShell.contentGutter(
+        child: const SizedBox(key: _childKey, height: 100, width: 100),
+      );
 }

--- a/player/test/presentation/widgets/video_controls/playback_chrome_inset_test.dart
+++ b/player/test/presentation/widgets/video_controls/playback_chrome_inset_test.dart
@@ -4,10 +4,21 @@
 // `playback_chrome.dart`'s shape — a full-bleed surface behind a
 // `SafeArea`-wrapped chrome stack — rather than mounting the real player
 // screen, which needs a live player controller and platform channels this
-// suite does not construct. That means this file proves the contract
-// `SafeArea` already honours, not that `playback_chrome.dart`'s own tree
-// still matches this shape; a widget test that mounts it directly would be
-// needed to catch that kind of drift.
+// suite does not construct.
+//
+// IMPORTANT: `_host`'s stand-in surface sits directly under the strip, with
+// no outer `SafeArea` above it. Production is not shaped that way:
+// `PlayerScreen.build` wraps its whole body — this chrome included — in
+// `PlayerScreen.playerFrame`'s own `SafeArea(top: false, ...)` first. That
+// means this file proves the contract `SafeArea` already honours in
+// isolation — that a full-bleed layer outside a `SafeArea` is unaffected by
+// a reserved strip, and that the chrome inside one is pushed clear of it —
+// not that `playback_chrome.dart`'s real position inside `PlayerScreen`
+// still matches this shape. It would stay green even if `playerFrame` regressed
+// to a bare `SafeArea` and letterboxed every video, because `_host` never
+// reproduces that outer frame. `player_screen_frame_inset_test.dart` is the
+// test that actually guards production: it exercises `PlayerScreen
+// .playerFrame` itself and would fail on that regression.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -64,9 +75,10 @@ void main() {
     });
 
     testWidgets(
-        'the video surface stays full-bleed, because it sits outside the '
-        'SafeArea; a change that inset it would letterbox every video',
-        (tester) async {
+        'CONTROL: the stand-in surface stays full-bleed within this shape, '
+        'because it sits outside the SafeArea — but see the file header: '
+        'this does not prove playback_chrome.dart is actually positioned '
+        'this way inside the real PlayerScreen frame', (tester) async {
       await tester.pumpWidget(
         _host(
           ChromeTopBar(

--- a/player/test/presentation/widgets/video_controls/playback_chrome_inset_test.dart
+++ b/player/test/presentation/widgets/video_controls/playback_chrome_inset_test.dart
@@ -1,0 +1,82 @@
+// Pins a LAYOUT CONTRACT: how a `SafeArea` responds when the ambient
+// `MediaQuery` carries a reserved top strip, and that a full-bleed layer
+// outside that `SafeArea` is unaffected by it. `_host` below reproduces
+// `playback_chrome.dart`'s shape — a full-bleed surface behind a
+// `SafeArea`-wrapped chrome stack — rather than mounting the real player
+// screen, which needs a live player controller and platform channels this
+// suite does not construct. That means this file proves the contract
+// `SafeArea` already honours, not that `playback_chrome.dart`'s own tree
+// still matches this shape; a widget test that mounts it directly would be
+// needed to catch that kind of drift.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/window_chrome_inset.dart';
+import 'package:player/core/player/platform_features.dart';
+import 'package:player/presentation/widgets/video_controls/chrome_top_bar.dart';
+
+const Key _videoSurfaceKey = Key('stand-in-video-surface');
+
+/// Mirrors the structure of `playback_chrome.dart`: a full-bleed surface at the
+/// back, and the chrome in a `SafeArea` on top of it. The point of the test is
+/// that a reserved chrome strip moves the second and not the first.
+Widget _host(Widget chrome) => MaterialApp(
+      home: MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(top: kMacTitleBarOverlap),
+        ),
+        child: Scaffold(
+          body: Stack(
+            children: [
+              const Positioned.fill(
+                child: ColoredBox(
+                  key: _videoSurfaceKey,
+                  color: Colors.black,
+                ),
+              ),
+              SafeArea(
+                child: Stack(
+                  children: [
+                    Positioned(top: 16, left: 16, right: 16, child: chrome),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+void main() {
+  group('playback chrome under a reserved window chrome strip', () {
+    testWidgets('the back pill clears the traffic light strip', (tester) async {
+      await tester.pumpWidget(
+        _host(
+          ChromeTopBar(
+            tier: PlayerGlassTier.full,
+            onBack: () {},
+          ),
+        ),
+      );
+
+      final back = tester.getRect(find.byKey(ChromeTopBar.backKey));
+      expect(back.top, greaterThanOrEqualTo(kMacTitleBarOverlap));
+    });
+
+    testWidgets(
+        'the video surface stays full-bleed, because it sits outside the '
+        'SafeArea; a change that inset it would letterbox every video',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          ChromeTopBar(
+            tier: PlayerGlassTier.full,
+            onBack: () {},
+          ),
+        ),
+      );
+
+      expect(tester.getRect(find.byKey(_videoSurfaceKey)).top, 0);
+    });
+  });
+}


### PR DESCRIPTION
## The bug

On macOS the player window is frameless: `MainFlutterWindow.swift` sets `titlebarAppearsTransparent`, hides the title, and inserts `.fullSizeContentView`. The Flutter view therefore runs under the title bar, and AppKit floats the traffic light buttons on top of it at roughly x 7-75, y 8-28. Flutter's macOS embedder reports no safe-area inset for that strip, so every `SafeArea` in the app is a no-op there.

The only compensation in the codebase was a private `_macOSTitleBarPadding = 28.0` in `app_shell.dart`, applied in two places, both inside the shell's desktop branch. That left three gaps:

- **Routes outside the shell.** `/movie/:id`, `/show/:id`, `/episode/:id`, `/collection/:id` and both player routes all use `parentNavigatorKey: rootNavigatorKey`, so `AppShell` never wraps them. Each puts a back affordance at top-left. This is what was reported.
- **The shell's mobile branch.** Below the 900pt breakpoint the shell renders a different subtree with no compensation at all.
- **Anything added later**, since the rule lived in a private constant that four sites already forgot.

Measured before/after on a detail-screen-shaped `SliverAppBar`: the back icon sits at `(8, 8)-(48, 48)` today, dead centre in the traffic lights, and at `(8, 36)-(48, 76)` with the fix.

## The approach

Reserve the strip once, at the app root, by injecting it into `MediaQuery.padding.top`. `SafeArea`, `Scaffold`, `AppBar` and `SliverAppBar` all already consume that value, so the fix reaches every screen without those screens changing. It drops to 0 in native fullscreen, where macOS hides the buttons, driven by a `WindowListener` in the existing `core/window` module. Linux and Windows are untouched: they use a real `GtkHeaderBar` and standard `WS_OVERLAPPEDWINDOW`, neither of which overlaps the view.

`kMacTitleBarOverlap` is now the single source of the number.

## What is in here

- `core/window/window_fullscreen.dart` + `window_fullscreen_controller.dart`: the fullscreen signal, registered alongside the existing geometry listener in `initDesktopWindow()`. No new dependency, no Swift, no method channel.
- `core/layout/window_chrome_inset.dart`: the widget, mounted outermost in the `MaterialApp.router` builder.
- `app_shell.dart`: the private constant is gone; both branches consume the injected padding through an `AppShell.contentGutter` seam.
- Three bugs found and fixed during review, all of them cases where a widget was leaning on padding that used to be zero:
  - the cast overlay double-inset, because `CastOverlayButton` has its own internal `SafeArea`
  - the player letterboxing every video, because `player_screen.dart` wrapped its entire body including the `Video` in an all-edges `SafeArea`
  - the cast placeholder's back button, which had no `SafeArea` of its own

## Testing

Full suite 1338/1338 at `--concurrency=1` (mandatory here: at default concurrency the runner silently drops files while still exiting 0). `flutter analyze` at its pre-existing 53-issue baseline.

Three testable seams were extracted so the fixes cannot silently regress: `PlayerScreen.playerFrame`, `AppShell.contentGutter`, and a pure `shouldReserveTitleBar` predicate that makes the `kIsWeb` branch reachable on the VM test runner. Each was falsified during review by breaking it and confirming the test fails.

## Not yet verified

**The macOS manual pass has not been run.** No Mac hardware was available. The layout arithmetic is proven by tests, but the real AppKit geometry is not, and no test in this repo can measure it. Before merge, someone on a Mac should run `./dev player macos run` and check:

- [ ] movie, show, episode and collection detail pages: back button fully visible and clickable
- [ ] player windowed: back pill clear of the lights
- [ ] player fullscreen: video reaches the top edge, no black band
- [ ] leaving fullscreen: the inset returns
- [ ] shell narrowed below 900pt (mobile branch)
- [ ] desktop sidebar nav items clear the lights
- [ ] cast overlay button in both branches
- [ ] the aspect-ratio window snap still fits the video

One deliberate cross-platform decision worth a second opinion: `PlayerScreen.playerFrame` uses `SafeArea(top: false)` unconditionally, so video is also full-bleed under the notch on iOS. That is standard for an immersive player and the controls keep their own `SafeArea`, but it is a behaviour change outside the macOS scope.
