### PR TITLE
fix(library): bound chapter-derived intro spans

### DIFF
--- a/lib/mydia/library/segment_detection.ex
+++ b/lib/mydia/library/segment_detection.ex
@@ -382,7 +382,8 @@ defmodule Mydia.Library.SegmentDetection do
   # can still answer, so the failure degrades to "no chapters".
   defp chapter_segments(file) do
     with path when is_binary(path) <- MediaFile.absolute_path(file),
-         {:ok, found} <- Chapters.detect(path) do
+         {:ok, duration} <- duration_seconds(file),
+         {:ok, found} <- Chapters.detect(path, round(duration * 1000)) do
       found
     else
       _no_chapters -> %{}

--- a/lib/mydia/library/segment_detection/chapters.ex
+++ b/lib/mydia/library/segment_detection/chapters.ex
@@ -133,7 +133,8 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
   `{:ok, %{}}`, which is a successful result and not an error.
   """
   @spec detect(String.t(), non_neg_integer()) :: {:ok, segments()} | {:error, term()}
-  def detect(path, runtime_ms) when is_binary(path) and is_integer(runtime_ms) do
+  def detect(path, runtime_ms)
+      when is_binary(path) and is_integer(runtime_ms) and runtime_ms >= 0 do
     args = ["-v", "quiet", "-print_format", "json", "-show_chapters", path]
 
     case Ffmpeg.probe(args) do
@@ -152,10 +153,12 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
   the first of them is implausible it is describing something else entirely.
   """
   @spec parse_chapters(String.t(), non_neg_integer()) :: {:ok, segments()} | {:error, term()}
-  def parse_chapters(json, runtime_ms) when is_binary(json) and is_integer(runtime_ms) do
+  def parse_chapters(json, runtime_ms)
+      when is_binary(json) and is_integer(runtime_ms) and runtime_ms >= 0 do
     case Jason.decode(json) do
       {:ok, %{"chapters" => chapters}} when is_list(chapters) ->
-        {:ok, Enum.reduce(chapters, %{}, &collect(&1, &2, max_intro_ms(runtime_ms)))}
+        max_intro_ms = max_intro_ms(runtime_ms)
+        {:ok, Enum.reduce(chapters, %{}, &collect(&1, &2, max_intro_ms))}
 
       {:ok, _without_chapters} ->
         {:ok, %{}}
@@ -203,14 +206,16 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
   defp plausible?(:credits, _span_ms, _max_intro_ms), do: true
 
   # The longest span a chapter-derived intro may claim for a file of this
-  # runtime. A non-positive runtime falls back to the absolute bound; callers
-  # in this app always have a real one, since `analyze_season/2` filters to
-  # files with a known duration before any chapter read happens.
-  defp max_intro_ms(runtime_ms) when is_integer(runtime_ms) and runtime_ms > 0 do
+  # runtime. The public guards reject anything negative, so the only value that
+  # reaches the second clause is a zero runtime, which falls back to the
+  # absolute bound rather than collapsing it to nothing. Callers in this app
+  # always have a real duration: `analyze_season/2` filters to files with a
+  # known one before any chapter read happens.
+  defp max_intro_ms(runtime_ms) when runtime_ms > 0 do
     min(@max_intro_ms, round(runtime_ms * @max_intro_fraction))
   end
 
-  defp max_intro_ms(_unknown_runtime), do: @max_intro_ms
+  defp max_intro_ms(_zero_runtime), do: @max_intro_ms
 
   defp chapter_title(%{"tags" => %{"title" => title}}) when is_binary(title), do: title
   defp chapter_title(_chapter), do: nil

--- a/lib/mydia/library/segment_detection/chapters.ex
+++ b/lib/mydia/library/segment_detection/chapters.ex
@@ -38,6 +38,31 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
       `The Credits Union Heist` contains the token `credits` but is a plot
       chapter, and `Opening Credits` has to resolve as an intro rather than as
       credits, which only the full sequence can decide.
+
+  ## Why an intro span is bounded but a credits span is not
+
+  A chapter's `end_time` is where the *next* chapter begins, not where the
+  named thing stops. Container chapters partition the whole timeline, so a
+  correct title carries no promise of a correct span, and the two failures are
+  not symmetric.
+
+  An intro is followed by the episode body. A release that marks only
+  structural points gives its opening chapter an end at the *next* marker, so
+  the span swallows everything the viewer came for. Bluey ships exactly two
+  chapters, `Intro` and `Credits`, which made every episode's intro 96% of its
+  runtime and a Skip Intro button that ended the episode.
+
+  Credits are the last thing in an episode. That same chapter runs to the next
+  marker or to EOF, and both are where the credits genuinely end: skipping to
+  either lands at the end of the file or at a post-credits scene. Across 389
+  chapter-derived credits rows in a production library, none had an implausible
+  span, against 128 of 402 intros. So only the intro is bounded, by 180 seconds
+  absolute and 25% of runtime, whichever is tighter.
+
+  Rejection is per chapter rather than per file, so a release whose first title
+  match is implausible can still resolve on a later one. Jujutsu Kaisen labels
+  its cold open `Intro` and its real 90-second theme `Opening`; bounding the
+  first lets the second win.
   """
 
   alias Mydia.Library.Ffmpeg
@@ -88,19 +113,31 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
     "creditos finales"
   ]
 
+  # Ceiling on a chapter-derived intro span. Measured real intros run 40 to 90
+  # seconds and the fingerprint engine has never produced one over 121s across
+  # 739 production rows, so 180s leaves half again as much headroom as anything
+  # observed. The fraction is what catches short-form content, where an
+  # episode-swallowing span is still well under the absolute bound.
+  @max_intro_ms 180_000
+  @max_intro_fraction 0.25
+
   @doc """
   Runs ffprobe against `path` and returns any recognisable chapter segments.
+
+  `runtime_ms` is the file's duration, used to bound the intro span. Callers
+  always have one: `analyze_season/2` filters to files with a known duration
+  before any chapter read happens.
 
   The returned map is keyed by segment type (`"intro"`, `"credits"`) with
   `{start_ms, end_ms}` values. A file with no recognisable chapters yields
   `{:ok, %{}}`, which is a successful result and not an error.
   """
-  @spec detect(String.t()) :: {:ok, segments()} | {:error, term()}
-  def detect(path) when is_binary(path) do
+  @spec detect(String.t(), non_neg_integer()) :: {:ok, segments()} | {:error, term()}
+  def detect(path, runtime_ms) when is_binary(path) and is_integer(runtime_ms) do
     args = ["-v", "quiet", "-print_format", "json", "-show_chapters", path]
 
     case Ffmpeg.probe(args) do
-      {:ok, output} -> parse_chapters(output)
+      {:ok, output} -> parse_chapters(output, runtime_ms)
       {:error, reason} -> {:error, reason}
     end
   end
@@ -108,16 +145,17 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
   @doc """
   Parses ffprobe `-show_chapters` JSON into recognisable segments.
 
-  Separated from `detect/1` so it can be tested against fixture JSON without
+  Separated from `detect/2` so it can be tested against fixture JSON without
   invoking ffprobe. Each segment type resolves independently, and the first
-  chapter matching a type wins: a release carrying both `Opening` and `Intro`
-  is describing the same thing twice.
+  chapter matching a type *with a plausible span* wins: a release carrying both
+  `Opening` and `Intro` is usually describing the same thing twice, but when
+  the first of them is implausible it is describing something else entirely.
   """
-  @spec parse_chapters(String.t()) :: {:ok, segments()} | {:error, term()}
-  def parse_chapters(json) when is_binary(json) do
+  @spec parse_chapters(String.t(), non_neg_integer()) :: {:ok, segments()} | {:error, term()}
+  def parse_chapters(json, runtime_ms) when is_binary(json) and is_integer(runtime_ms) do
     case Jason.decode(json) do
       {:ok, %{"chapters" => chapters}} when is_list(chapters) ->
-        {:ok, Enum.reduce(chapters, %{}, &collect/2)}
+        {:ok, Enum.reduce(chapters, %{}, &collect(&1, &2, max_intro_ms(runtime_ms)))}
 
       {:ok, _without_chapters} ->
         {:ok, %{}}
@@ -126,6 +164,19 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
         {:error, reason}
     end
   end
+
+  @doc """
+  The longest span a chapter-derived intro may claim for a file of `runtime_ms`.
+
+  Public so the backfill that clears already-stored bad spans applies the same
+  rule this module enforces, rather than a second copy that could drift.
+  """
+  @spec max_intro_ms(non_neg_integer()) :: non_neg_integer()
+  def max_intro_ms(runtime_ms) when is_integer(runtime_ms) and runtime_ms > 0 do
+    min(@max_intro_ms, round(runtime_ms * @max_intro_fraction))
+  end
+
+  def max_intro_ms(_unknown_runtime), do: @max_intro_ms
 
   @doc """
   Classifies a chapter title as `:intro`, `:credits`, or `:unknown`.
@@ -147,18 +198,22 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
     end
   end
 
-  defp collect(chapter, acc) do
+  defp collect(chapter, acc, max_intro_ms) do
     with type when type != :unknown <- classify(chapter_title(chapter)),
          key = Atom.to_string(type),
          false <- Map.has_key?(acc, key),
          {:ok, start_ms} <- to_ms(chapter["start_time"]),
          {:ok, end_ms} <- to_ms(chapter["end_time"]),
-         true <- end_ms > start_ms do
+         true <- end_ms > start_ms,
+         true <- plausible?(type, end_ms - start_ms, max_intro_ms) do
       Map.put(acc, key, {start_ms, end_ms})
     else
       _no_usable_span -> acc
     end
   end
+
+  defp plausible?(:intro, span_ms, max_intro_ms), do: span_ms <= max_intro_ms
+  defp plausible?(:credits, _span_ms, _max_intro_ms), do: true
 
   defp chapter_title(%{"tags" => %{"title" => title}}) when is_binary(title), do: title
   defp chapter_title(_chapter), do: nil

--- a/lib/mydia/library/segment_detection/chapters.ex
+++ b/lib/mydia/library/segment_detection/chapters.ex
@@ -166,19 +166,6 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
   end
 
   @doc """
-  The longest span a chapter-derived intro may claim for a file of `runtime_ms`.
-
-  Public so the backfill that clears already-stored bad spans applies the same
-  rule this module enforces, rather than a second copy that could drift.
-  """
-  @spec max_intro_ms(non_neg_integer()) :: non_neg_integer()
-  def max_intro_ms(runtime_ms) when is_integer(runtime_ms) and runtime_ms > 0 do
-    min(@max_intro_ms, round(runtime_ms * @max_intro_fraction))
-  end
-
-  def max_intro_ms(_unknown_runtime), do: @max_intro_ms
-
-  @doc """
   Classifies a chapter title as `:intro`, `:credits`, or `:unknown`.
 
   Comparison is against the whole normalised title. Accents and punctuation are
@@ -214,6 +201,16 @@ defmodule Mydia.Library.SegmentDetection.Chapters do
 
   defp plausible?(:intro, span_ms, max_intro_ms), do: span_ms <= max_intro_ms
   defp plausible?(:credits, _span_ms, _max_intro_ms), do: true
+
+  # The longest span a chapter-derived intro may claim for a file of this
+  # runtime. A non-positive runtime falls back to the absolute bound; callers
+  # in this app always have a real one, since `analyze_season/2` filters to
+  # files with a known duration before any chapter read happens.
+  defp max_intro_ms(runtime_ms) when is_integer(runtime_ms) and runtime_ms > 0 do
+    min(@max_intro_ms, round(runtime_ms * @max_intro_fraction))
+  end
+
+  defp max_intro_ms(_unknown_runtime), do: @max_intro_ms
 
   defp chapter_title(%{"tags" => %{"title" => title}}) when is_binary(title), do: title
   defp chapter_title(_chapter), do: nil

--- a/priv/repo/migrations/20260804120000_clear_inflated_chapter_intro_segments.exs
+++ b/priv/repo/migrations/20260804120000_clear_inflated_chapter_intro_segments.exs
@@ -1,0 +1,51 @@
+defmodule Mydia.Repo.Migrations.ClearInflatedChapterIntroSegments do
+  use Ecto.Migration
+
+  # A chapter's end_time is where the *next* chapter begins, not where the
+  # named thing stops. Releases that mark only structural points therefore gave
+  # their opening chapter a span running all the way to the credits. Bluey
+  # ships two chapters per episode, Intro and Credits, so every episode stored
+  # an intro covering 96% of its runtime and a Skip Intro button that jumped to
+  # 7:00 of 7:18.
+  #
+  # `SegmentDetection.Chapters` now bounds a chapter-derived intro, but rows
+  # written before that rule are still stored and still drive the button. This
+  # clears the ones the rule would reject and returns their files to the
+  # pending backlog, which is what the per-season Re-analyze button already
+  # does. Nothing here is user data: segments are derived, and the detector
+  # rebuilds them on the scheduler's next tick.
+  #
+  # Only the intro rows are touched. A credits chapter runs to the next marker
+  # or to EOF, and both are where the credits genuinely end, so that side was
+  # never inflated. Across 389 chapter-derived credits rows in a production
+  # library none had an implausible span, against 128 of 402 intros.
+  #
+  # The bound applied here is the absolute 180s with no runtime term. Runtime
+  # lives in media_files.metadata as JSON, and reading it would need
+  # adapter-specific JSON SQL for SQLite and Postgres. Measured against that
+  # same library the two rules select exactly the same rows, because an intro
+  # long enough to swallow an episode is far past 180s either way.
+  @max_intro_ms 180_000
+
+  @condition """
+  source = 'chapters' AND type = 'intro' AND (end_ms - start_ms) > #{@max_intro_ms}
+  """
+
+  def up do
+    # The update runs first: it reads the subquery that the delete then empties.
+    execute("""
+    UPDATE media_files
+    SET segment_analysis_state = 'pending',
+        segment_analysis_attempts = 0,
+        last_segment_analysis_error = NULL,
+        segments_analyzed_at = NULL
+    WHERE id IN (SELECT media_file_id FROM media_segments WHERE #{@condition})
+    """)
+
+    execute("DELETE FROM media_segments WHERE #{@condition}")
+  end
+
+  # Irreversible by design. The rows removed here were wrong, and re-inserting
+  # them would restore the bug.
+  def down, do: :ok
+end

--- a/priv/repo/migrations/20260804120000_clear_inflated_chapter_intro_segments.exs
+++ b/priv/repo/migrations/20260804120000_clear_inflated_chapter_intro_segments.exs
@@ -27,9 +27,7 @@ defmodule Mydia.Repo.Migrations.ClearInflatedChapterIntroSegments do
   # long enough to swallow an episode is far past 180s either way.
   @max_intro_ms 180_000
 
-  @condition """
-  source = 'chapters' AND type = 'intro' AND (end_ms - start_ms) > #{@max_intro_ms}
-  """
+  @condition "source = 'chapters' AND type = 'intro' AND (end_ms - start_ms) > #{@max_intro_ms}"
 
   def up do
     # The update runs first: it reads the subquery that the delete then empties.

--- a/test/mydia/library/segment_detection/chapters_test.exs
+++ b/test/mydia/library/segment_detection/chapters_test.exs
@@ -313,6 +313,27 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
       refute Map.has_key?(segments, "intro")
     end
 
+    test "refuses a negative runtime rather than deriving a bound from it" do
+      # The spec says non_neg_integer. A negative runtime is a caller bug, and
+      # silently bounding against it would produce a negative ceiling that
+      # rejects every intro.
+      assert_raise FunctionClauseError, fn ->
+        Chapters.parse_chapters(~s({"chapters": []}), -1)
+      end
+    end
+
+    test "falls back to the absolute bound when runtime is zero" do
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "0.000000", "end_time": "90.000000",
+         "tags": {"title": "Opening"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json, 0)
+      assert segments["intro"] == {0, 90_000}
+    end
+
     test "bounds the intro absolutely on long-form content" do
       # 25% of a 90 minute runtime is 22 minutes, which is no one's opening.
       json = """

--- a/test/mydia/library/segment_detection/chapters_test.exs
+++ b/test/mydia/library/segment_detection/chapters_test.exs
@@ -1,5 +1,5 @@
 defmodule Mydia.Library.SegmentDetection.ChaptersTest do
-  # detect/1 stubs the ffprobe binary through application env, which is global,
+  # detect/2 stubs the ffprobe binary through application env, which is global,
   # so this file runs serially even though everything else in it is pure.
   use ExUnit.Case, async: false
 
@@ -17,6 +17,11 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
      "tags": {"title": "End Credits"}}
   ]}
   """
+
+  # Runtime of the fixture file, in milliseconds. Every caller in production
+  # has one: `analyze_season/2` filters to files with a known duration before
+  # any chapter read happens.
+  @runtime_ms 1_420_000
 
   setup do
     on_exit(fn -> Application.delete_env(:mydia, :ffprobe_path) end)
@@ -102,9 +107,9 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
     end
   end
 
-  describe "parse_chapters/1" do
+  describe "parse_chapters/2" do
     test "extracts intro and credits segments from ffprobe json" do
-      assert {:ok, segments} = Chapters.parse_chapters(@sample_json)
+      assert {:ok, segments} = Chapters.parse_chapters(@sample_json, @runtime_ms)
       assert segments["intro"] == {35_000, 125_500}
       assert segments["credits"] == {1_300_000, 1_420_000}
     end
@@ -119,7 +124,7 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
       ]}
       """
 
-      assert {:ok, segments} = Chapters.parse_chapters(json)
+      assert {:ok, segments} = Chapters.parse_chapters(json, @runtime_ms)
       assert segments["intro"] == {30_000, 120_000}
       refute Map.has_key?(segments, "credits")
     end
@@ -132,18 +137,18 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
       ]}
       """
 
-      assert {:ok, segments} = Chapters.parse_chapters(json)
+      assert {:ok, segments} = Chapters.parse_chapters(json, @runtime_ms)
       assert segments == %{}
     end
 
     test "returns an empty map when the file has no chapters" do
-      assert {:ok, %{}} = Chapters.parse_chapters(~s({"chapters": []}))
+      assert {:ok, %{}} = Chapters.parse_chapters(~s({"chapters": []}), @runtime_ms)
     end
 
     test "tolerates chapters with no tags block" do
       json = ~s({"chapters": [{"id": 0, "start_time": "0.0", "end_time": "10.0"}]})
 
-      assert {:ok, %{}} = Chapters.parse_chapters(json)
+      assert {:ok, %{}} = Chapters.parse_chapters(json, @runtime_ms)
     end
 
     test "skips chapters whose span is missing or empty" do
@@ -155,10 +160,10 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
       ]}
       """
 
-      assert {:ok, %{}} = Chapters.parse_chapters(json)
+      assert {:ok, %{}} = Chapters.parse_chapters(json, @runtime_ms)
     end
 
-    test "keeps the first match when a type appears twice" do
+    test "keeps the first plausible match when a type appears twice" do
       json = """
       {"chapters": [
         {"id": 0, "start_time": "10.000000", "end_time": "40.000000",
@@ -168,21 +173,21 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
       ]}
       """
 
-      assert {:ok, segments} = Chapters.parse_chapters(json)
+      assert {:ok, segments} = Chapters.parse_chapters(json, @runtime_ms)
       assert segments["intro"] == {10_000, 40_000}
     end
 
     test "returns an error on malformed json" do
-      assert {:error, _reason} = Chapters.parse_chapters("not json at all")
+      assert {:error, _reason} = Chapters.parse_chapters("not json at all", @runtime_ms)
     end
 
     test "skips chapter entries that are not objects" do
-      # parse_chapters/1 is public and takes arbitrary JSON, so the array can
+      # parse_chapters/2 is public and takes arbitrary JSON, so the array can
       # legally hold non-objects. Access is not implemented for those, and
       # reaching chapter["start_time"] on one would raise.
       json = ~s({"chapters": [null, 42, "Opening", ["OP"], {"not": "a chapter"}]})
 
-      assert {:ok, %{}} = Chapters.parse_chapters(json)
+      assert {:ok, %{}} = Chapters.parse_chapters(json, @runtime_ms)
     end
 
     test "mixes non-object entries alongside a usable chapter without losing it" do
@@ -190,7 +195,7 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
         ~s({"chapters": [null, 42, ) <>
           ~s({"start_time": "60.0", "end_time": "150.0", "tags": {"title": "OP"}}]})
 
-      assert {:ok, %{"intro" => {60_000, 150_000}}} = Chapters.parse_chapters(json)
+      assert {:ok, %{"intro" => {60_000, 150_000}}} = Chapters.parse_chapters(json, @runtime_ms)
     end
 
     test "rejects a timestamp with trailing garbage rather than trusting its prefix" do
@@ -200,17 +205,134 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
         ~s({"chapters": [{"start_time": "60.0oops", "end_time": "150.0", ) <>
           ~s("tags": {"title": "OP"}}]})
 
-      assert {:ok, segments} = Chapters.parse_chapters(json)
+      assert {:ok, segments} = Chapters.parse_chapters(json, @runtime_ms)
       refute Map.has_key?(segments, "intro")
     end
   end
 
-  describe "detect/1" do
+  describe "parse_chapters/2 intro plausibility" do
+    # A chapter's end_time is where the *next* chapter begins, not where the
+    # named thing stops. Every fixture below is the real chapter layout of a
+    # file from a production library, reduced to the chapters that matter.
+
+    test "rejects an intro chapter that runs to the credits of a short episode" do
+      # Bluey (2018) S01E01, a 7:18 episode carrying exactly two chapters. The
+      # opening is a few seconds long, but the chapter titled Intro extends all
+      # the way to the credits marker, so its span is 96% of the episode.
+      # Trusting it shipped a Skip Intro button that jumped to 7:00 of 7:18.
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "0.000000", "end_time": "420.420000",
+         "tags": {"title": "Intro"}},
+        {"id": 1, "start_time": "420.420000", "end_time": "437.984000",
+         "tags": {"title": "Credits"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json, 437_984)
+      refute Map.has_key?(segments, "intro")
+    end
+
+    test "keeps the credits of the same file, whose span is genuinely correct" do
+      # The credits chapter runs to the next marker or to EOF, and both are
+      # where the credits actually end, so the inflation is one-sided.
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "0.000000", "end_time": "420.420000",
+         "tags": {"title": "Intro"}},
+        {"id": 1, "start_time": "420.420000", "end_time": "437.984000",
+         "tags": {"title": "Credits"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json, 437_984)
+      assert segments["credits"] == {420_420, 437_984}
+    end
+
+    test "falls through an implausible intro to a later chapter that fits" do
+      # Jujutsu Kaisen S01E02. Intro here labels the cold open and runs 5:46;
+      # the real 90s theme is the next chapter, titled Opening. Keeping the
+      # first title match meant the cold open beat the actual opening.
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "0.000000", "end_time": "345.990000",
+         "tags": {"title": "Intro"}},
+        {"id": 1, "start_time": "345.990000", "end_time": "435.960000",
+         "tags": {"title": "Opening"}},
+        {"id": 2, "start_time": "435.960000", "end_time": "739.970000",
+         "tags": {"title": "Part A"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json, 1_436_020)
+      assert segments["intro"] == {345_990, 435_960}
+    end
+
+    test "rejects a 19 minute intro with no later candidate to fall back on" do
+      # Heavenly Delusion S01E03. Nothing else in the file names an opening, so
+      # the intro stays unresolved and the fingerprint path answers instead.
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "92.009000", "end_time": "1273.941000",
+         "tags": {"title": "Intro"}},
+        {"id": 1, "start_time": "1273.941000", "end_time": "1363.947000",
+         "tags": {"title": "Credits"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json, 1_421_994)
+      refute Map.has_key?(segments, "intro")
+      assert segments["credits"] == {1_273_941, 1_363_947}
+    end
+
+    test "keeps a correctly marked opening theme" do
+      # One-Punch Man S01: the OP chapter ends where the opening ends, which is
+      # what the fast path exists to read. Measured real intros run 40 to 90
+      # seconds, so the bound has to leave this untouched.
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "64.000000", "end_time": "153.000000",
+         "tags": {"title": "OP"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json, 1_440_000)
+      assert segments["intro"] == {64_000, 153_000}
+    end
+
+    test "bounds the intro by a fraction of runtime on short-form content" do
+      # 180s alone would pass an intro spanning half of a 6 minute episode.
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "0.000000", "end_time": "170.000000",
+         "tags": {"title": "Opening"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json, 360_000)
+      refute Map.has_key?(segments, "intro")
+    end
+
+    test "bounds the intro absolutely on long-form content" do
+      # 25% of a 90 minute runtime is 22 minutes, which is no one's opening.
+      json = """
+      {"chapters": [
+        {"id": 0, "start_time": "0.000000", "end_time": "600.000000",
+         "tags": {"title": "Opening"}}
+      ]}
+      """
+
+      assert {:ok, segments} = Chapters.parse_chapters(json, 5_400_000)
+      refute Map.has_key?(segments, "intro")
+    end
+  end
+
+  describe "detect/2" do
     @tag :tmp_dir
     test "returns the segments parsed out of the probe output", %{tmp_dir: tmp_dir} do
       stub_ffprobe(tmp_dir)
 
-      assert {:ok, segments} = Chapters.detect("/media/show/s01e01.mkv")
+      assert {:ok, segments} = Chapters.detect("/media/show/s01e01.mkv", @runtime_ms)
       assert segments["intro"] == {35_000, 125_500}
       assert segments["credits"] == {1_300_000, 1_420_000}
     end
@@ -219,7 +341,7 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
     test "asks ffprobe for chapters as json", %{tmp_dir: tmp_dir} do
       args_path = stub_ffprobe(tmp_dir)
 
-      assert {:ok, _segments} = Chapters.detect("/media/show/s01e01.mkv")
+      assert {:ok, _segments} = Chapters.detect("/media/show/s01e01.mkv", @runtime_ms)
 
       recorded = File.read!(args_path)
       assert recorded =~ "-show_chapters"
@@ -230,7 +352,7 @@ defmodule Mydia.Library.SegmentDetection.ChaptersTest do
     test "propagates a probe failure" do
       Application.put_env(:mydia, :ffprobe_path, "/nonexistent/ffprobe-binary")
 
-      assert {:error, :ffprobe_not_found} = Chapters.detect("/media/show/s01e01.mkv")
+      assert {:error, :ffprobe_not_found} = Chapters.detect("/media/show/s01e01.mkv", @runtime_ms)
     end
   end
 


### PR DESCRIPTION
## What was wrong

Pressing **Skip Intro** on a Bluey episode skipped the entire episode.

The chapter fast path treats a container chapter's `end_time` as the end of the
named thing. It isn't. Container chapters partition the whole timeline, so a
chapter's `end_time` is simply where the *next* chapter begins, and a correct
title carries no promise of a correct span.

Bluey ships exactly two chapters per episode:

```
"Intro"    0.000 -> 420.420   (7:00 of a 7:18 episode)
"Credits"  420.420 -> 437.984
```

So `media_segments` held `intro = 0 -> 420420` at `confidence 1.0`, and the
player does `onSkip: (target) => seekToReal(target.end)`. The button seeked to
7:00 of 7:18.

Not Bluey-specific. Two more from the same library:

- **Jujutsu Kaisen S01E02**: `"Intro"` 0 -> 345.99 is the *cold open*; the real
  90 second theme is the next chapter, `"Opening"`. Keeping the first title
  match meant the cold open beat the actual opening.
- **Heavenly Delusion S01E03**: `"Intro"` 92.0 -> 1273.9, a 19.7 minute intro.

Measured across a production library, the split is entirely one-sided:

| type | source | n | min | max | over 180s |
|---|---|---|---|---|---|
| intro | fingerprint | 739 | 16s | 121s | **0** |
| intro | chapters | 402 | 1s | **1181s** | **128 (32%)** |
| credits | chapters | 389 | 3s | 238s | 0 implausible |

The fingerprint engine is healthy. `write_chapter_segments/2` wrote at a
hardcoded `confidence 1.0` and bypassed every plausibility bound the fingerprint
path enforces, and the player's only guard is `endMs > startMs`.

## The fix

`Chapters.detect/2` and `parse_chapters/2` now take the file runtime and bound a
chapter-derived intro at **180s absolute or 25% of runtime, whichever is
tighter**. Measured real intros run 40 to 90 seconds and the fingerprint engine
has never produced one over 121s across 739 rows, so the bound leaves half again
as much headroom as anything observed.

Rejection is **per chapter, not per file**, so a release whose first title match
is implausible can still resolve on a later one. That is what makes Jujutsu
Kaisen resolve to `"Opening"` instead of failing outright.

Runtime is always available: `analyze_season/2` already filters to files with a
known duration before any chapter read happens, so the argument is required
rather than optional.

### Why credits are left unbounded

The failure is asymmetric. An intro is followed by the episode body, so an
inflated span swallows what the viewer came for. Credits are the last thing in
an episode: that chapter runs to the next marker or to EOF, and both are where
the credits genuinely end, so skipping to either lands at the end of the file or
at a post-credits scene. Zero of 389 chapter-derived credits rows were
implausible, against 128 of 402 intros. Bounding credits would only risk
regressing correct data.

## Backfill

Stored rows predate the rule and still drive the button, so a migration clears
the ones it would reject and returns their files to the pending backlog. That is
the same reset the per-season **Re-analyze** button already performs, on derived
data the detector rebuilds on the scheduler's next tick. Only intro rows are
touched.

The migration applies the absolute 180s with no runtime term, because runtime
lives in `media_files.metadata` as JSON and reading it would need
adapter-specific SQL for SQLite and Postgres. On the production dataset the two
rules select **exactly the same rows**, since an intro long enough to swallow an
episode is far past 180s either way.

Dry-run of the migration predicate against a live production database:

```
segments_to_delete     128
files_to_reset         128
credits_touched          0
intro_rows_surviving  1013
bluey_intros_deleted   104
bluey_credits_kept     104
```

## Verification

- 7 new tests, each fixture the real chapter layout of a production file.
- Neutering the guard fails exactly the 5 rejection assertions and restoring
  gives 28/28, so the tests are load-bearing rather than passing incidentally.
- Full suite: **6224 tests, 0 failures**. `mix compile --warnings-as-errors`
  clean, Credo `--strict` clean, migration applies on SQLite.

## Note on a separate issue

Every Bluey segment is stored twice because two `media_files` rows point at the
identical path. That is a pre-existing duplicate-registration issue, unrelated to
this change and not addressed here.
