### PR TITLE
fix(downloads): stop a titleless release crashing DownloadMonitor

### DIFF
--- a/.github/workflows/ci-player-e2e.yml
+++ b/.github/workflows/ci-player-e2e.yml
@@ -14,7 +14,10 @@ jobs:
   test-player-e2e:
     name: Test / Player E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # A run that has to populate a cold layer cache still pays the full build
+    # cost, so this has to clear a cold build, not a warm one. 30 minutes did
+    # not, and the job died mid-`apt-get` without ever running a test.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout
@@ -67,9 +70,27 @@ jobs:
         if: steps.should.outputs.run == 'true'
         uses: docker/setup-buildx-action@v3
 
+      # Built through bake rather than `docker compose build` so the layers can
+      # be cached across runs. The player test image installs the whole GTK /
+      # mpv / Flutter Linux desktop toolchain in one apt layer, which alone has
+      # taken ~20 of the job's 30 minutes and timed the job out before the tests
+      # ever ran. `type=gha` cache needs ACTIONS_CACHE_URL and
+      # ACTIONS_RUNTIME_TOKEN in the environment, which the Docker actions
+      # inject and a plain `run:` step does not, so this cannot be done as a
+      # shell step. Scopes are per-image so the three do not evict each other.
       - name: Build E2E images
         if: steps.should.outputs.run == 'true'
-        run: DOCKER_BUILDKIT=1 docker compose -f compose.player-e2e.yml build
+        uses: docker/bake-action@v6
+        with:
+          files: compose.player-e2e.yml
+          load: true
+          set: |
+            relay.cache-from=type=gha,scope=player-e2e-relay
+            relay.cache-to=type=gha,mode=max,scope=player-e2e-relay
+            mydia.cache-from=type=gha,scope=player-e2e-mydia
+            mydia.cache-to=type=gha,mode=max,scope=player-e2e-mydia
+            test.cache-from=type=gha,scope=player-e2e-test
+            test.cache-to=type=gha,mode=max,scope=player-e2e-test
 
       - name: Run player E2E tests
         if: steps.should.outputs.run == 'true'

--- a/.github/workflows/ci-player-e2e.yml
+++ b/.github/workflows/ci-player-e2e.yml
@@ -14,9 +14,10 @@ jobs:
   test-player-e2e:
     name: Test / Player E2E
     runs-on: ubuntu-latest
-    # A run that has to populate a cold layer cache still pays the full build
-    # cost, so this has to clear a cold build, not a warm one. 30 minutes did
-    # not, and the job died mid-`apt-get` without ever running a test.
+    # The build is uncached and routinely spends ~20 minutes in the player test
+    # image's apt layer alone, which left almost no margin at 30 and timed the
+    # job out mid-install without running a single test. This is headroom for a
+    # slow-mirror day, not a fix; the build genuinely wants layer caching.
     timeout-minutes: 60
 
     steps:
@@ -70,27 +71,17 @@ jobs:
         if: steps.should.outputs.run == 'true'
         uses: docker/setup-buildx-action@v3
 
-      # Built through bake rather than `docker compose build` so the layers can
-      # be cached across runs. The player test image installs the whole GTK /
-      # mpv / Flutter Linux desktop toolchain in one apt layer, which alone has
-      # taken ~20 of the job's 30 minutes and timed the job out before the tests
-      # ever ran. `type=gha` cache needs ACTIONS_CACHE_URL and
-      # ACTIONS_RUNTIME_TOKEN in the environment, which the Docker actions
-      # inject and a plain `run:` step does not, so this cannot be done as a
-      # shell step. Scopes are per-image so the three do not evict each other.
+      # Keep this a sequential `docker compose build`. Switching it to
+      # `docker buildx bake` to gain layer caching was tried and reverted: bake
+      # builds every target in parallel, and three heavy images (Elixir release,
+      # Rust p2p NIF, and the GTK/mpv/Flutter desktop toolchain) competing for a
+      # two-core runner starved the apt layer from ~20 minutes to over 56, which
+      # is worse than the problem it was meant to fix. Layer caching here also
+      # cannot bootstrap: a cold build that cannot finish inside the job budget
+      # never exports a cache, so every run stays cold.
       - name: Build E2E images
         if: steps.should.outputs.run == 'true'
-        uses: docker/bake-action@v6
-        with:
-          files: compose.player-e2e.yml
-          load: true
-          set: |
-            relay.cache-from=type=gha,scope=player-e2e-relay
-            relay.cache-to=type=gha,mode=max,scope=player-e2e-relay
-            mydia.cache-from=type=gha,scope=player-e2e-mydia
-            mydia.cache-to=type=gha,mode=max,scope=player-e2e-mydia
-            test.cache-from=type=gha,scope=player-e2e-test
-            test.cache-to=type=gha,mode=max,scope=player-e2e-test
+        run: DOCKER_BUILDKIT=1 docker compose -f compose.player-e2e.yml build
 
       - name: Run player E2E tests
         if: steps.should.outputs.run == 'true'

--- a/compose.player-e2e.yml
+++ b/compose.player-e2e.yml
@@ -24,6 +24,10 @@ services:
   # Metadata Relay Service
   # ============================================
   relay:
+    # Explicit image names: without them the tag is derived from the compose
+    # project (the checkout directory), so a git worktree and CI disagree, and
+    # the CI build step tags something `docker compose up` then does not find.
+    image: mydia-e2e-relay:latest
     build:
       context: .
       dockerfile: metadata-relay/Dockerfile
@@ -53,6 +57,7 @@ services:
   # Mydia Main Application
   # ============================================
   mydia:
+    image: mydia-e2e-app:latest
     build:
       context: .
       dockerfile: Dockerfile.e2e
@@ -111,6 +116,7 @@ services:
   # The test container includes Chrome and runs tests using
   # `flutter test -d chrome`, which manages Chrome directly.
   test:
+    image: mydia-e2e-test:latest
     build:
       context: .
       dockerfile: player/Dockerfile.test

--- a/lib/mydia/downloads/external_torrents/classifier.ex
+++ b/lib/mydia/downloads/external_torrents/classifier.ex
@@ -75,6 +75,12 @@ defmodule Mydia.Downloads.ExternalTorrents.Classifier do
     TorrentMatcher.find_top_candidates_in(pool, parsed, max_results: @max_suggestions)
   rescue
     e ->
+      # Report, do not just log. This rescue silently swallowed the nil-title
+      # scoring crash for as long as it has existed: the same defect that
+      # aborted DownloadMonitor through the untracked-matching path was
+      # invisible here. Degrading to no suggestions is the right behaviour;
+      # doing it without a report is not.
+      ErrorTracker.report(e, __STACKTRACE__, %{parsed_title: parsed.title})
       Logger.warning("Failed to find match candidates: #{inspect(e)}")
       []
   end

--- a/lib/mydia/downloads/release_intake.ex
+++ b/lib/mydia/downloads/release_intake.ex
@@ -16,6 +16,10 @@ defmodule Mydia.Downloads.ReleaseIntake do
   - `:unknown` type with no usable title → `{:error, :unable_to_parse}`
   - `:unknown` type with a usable title → `{:ok, info}` so the matcher's
     title-similarity path can still produce a *suggestion*
+  - any other type with no usable title → `{:error, :missing_title}`.
+    `ReleaseParser.infer_media_type/4` types a release `:movie` on a year or
+    quality token alone without consulting the title, so a titleless `:movie`
+    is reachable and cannot be title-matched against the library.
   - otherwise → `{:ok, %ParsedFileInfo{}}`
 
   Downloads callers must use this function rather than calling

--- a/lib/mydia/downloads/release_intake.ex
+++ b/lib/mydia/downloads/release_intake.ex
@@ -64,6 +64,10 @@ defmodule Mydia.Downloads.ReleaseIntake do
     |> String.trim()
   end
 
+  # A release whose title did not parse cannot be title-matched against the
+  # library whatever type was inferred for it. ReleaseParser.infer_media_type/4
+  # returns :movie on a year or quality token alone, so a titleless :movie is
+  # reachable and previously fell through the catch-all clause into matching.
   defp classify_parse_result(%ParsedFileInfo{type: :unknown} = info) do
     if usable_title?(info.title) do
       {:ok, info}
@@ -72,7 +76,13 @@ defmodule Mydia.Downloads.ReleaseIntake do
     end
   end
 
-  defp classify_parse_result(%ParsedFileInfo{} = info), do: {:ok, info}
+  defp classify_parse_result(%ParsedFileInfo{} = info) do
+    if usable_title?(info.title) do
+      {:ok, info}
+    else
+      {:error, :missing_title}
+    end
+  end
 
   defp usable_title?(title) when is_binary(title), do: String.trim(title) != ""
   defp usable_title?(_), do: false

--- a/lib/mydia/downloads/torrent_matcher.ex
+++ b/lib/mydia/downloads/torrent_matcher.ex
@@ -669,6 +669,12 @@ defmodule Mydia.Downloads.TorrentMatcher do
 
   # Detects sequel/suffix markers in titles
   # Returns true if the title contains sequel markers like: II, 2, Part 2, Reloaded, etc.
+  # A release with no parsed title carries no sequel marker. Mirrors the
+  # `normalize_string(nil)` clause below: every other scoring path in this
+  # module already tolerates a nil title, and a raise here aborts the whole
+  # DownloadMonitor pass.
+  defp has_sequel_marker?(nil), do: false
+
   defp has_sequel_marker?(str) do
     normalized = String.downcase(str)
 

--- a/lib/mydia/downloads/untracked_matcher.ex
+++ b/lib/mydia/downloads/untracked_matcher.ex
@@ -152,10 +152,12 @@ defmodule Mydia.Downloads.UntrackedMatcher do
     process_untracked_torrent(torrent)
   rescue
     error ->
-      # Map.get, not dot access: the torrent map is what failed, so it may be
-      # missing the very keys used to describe it.
-      name = Map.get(torrent, :name)
-      client = Map.get(torrent, :client_name)
+      # The torrent is what failed, so it may be missing the very keys used to
+      # describe it, or not be a map at all. Dot access would raise on a missing
+      # key and Map.get/2 would raise BadMapError on a non-map, and a rescue
+      # that can itself raise defeats the isolation this function exists for.
+      name = torrent_field(torrent, :name)
+      client = torrent_field(torrent, :client_name)
 
       ErrorTracker.report(error, __STACKTRACE__, %{torrent_name: name, client: client})
 
@@ -167,6 +169,10 @@ defmodule Mydia.Downloads.UntrackedMatcher do
 
       {:error, :match_exception}
   end
+
+  # Total by construction so the rescue above can never raise a second time.
+  defp torrent_field(torrent, key) when is_map(torrent), do: Map.get(torrent, key)
+  defp torrent_field(_torrent, _key), do: nil
 
   @doc false
   # Public for testing the parse/match/route decision in isolation. Not part of

--- a/lib/mydia/downloads/untracked_matcher.ex
+++ b/lib/mydia/downloads/untracked_matcher.ex
@@ -55,7 +55,7 @@ defmodule Mydia.Downloads.UntrackedMatcher do
 
     # Attempt to match and create downloads for untracked torrents
     not_imported
-    |> Enum.map(&process_untracked_torrent/1)
+    |> Enum.map(&safe_process_untracked_torrent/1)
     |> Enum.filter(&match?({:ok, _}, &1))
     |> Enum.map(fn {:ok, download} -> download end)
   end
@@ -132,6 +132,40 @@ defmodule Mydia.Downloads.UntrackedMatcher do
 
       imported?
     end)
+  end
+
+  @doc false
+  # A single malformed torrent must not abort the pass. A raise here propagates
+  # out of Mydia.Jobs.DownloadMonitor.perform/1 and kills every pass that runs
+  # after it (the external-torrent refresh, stuck-download detection), and
+  # because the torrent stays in the client the job then fails on every
+  # subsequent run.
+  #
+  # The ErrorTracker report is load-bearing: rescuing without it would hide
+  # exactly the class of bug this isolation exists to survive. Mirrors
+  # Mydia.Jobs.MetadataRefresh.safe_refresh/2.
+  #
+  # Public for the same reason process_untracked_torrent/1 is: the repo has no
+  # download client mock, so find_and_match_untracked/0 cannot be driven end to
+  # end in a test.
+  def safe_process_untracked_torrent(torrent) do
+    process_untracked_torrent(torrent)
+  rescue
+    error ->
+      # Map.get, not dot access: the torrent map is what failed, so it may be
+      # missing the very keys used to describe it.
+      name = Map.get(torrent, :name)
+      client = Map.get(torrent, :client_name)
+
+      ErrorTracker.report(error, __STACKTRACE__, %{torrent_name: name, client: client})
+
+      Logger.error("Exception matching untracked torrent, continuing pass",
+        torrent_name: name,
+        client: client,
+        error: inspect(error)
+      )
+
+      {:error, :match_exception}
   end
 
   @doc false

--- a/test/mydia/downloads/release_intake_test.exs
+++ b/test/mydia/downloads/release_intake_test.exs
@@ -68,4 +68,36 @@ defmodule Mydia.Downloads.ReleaseIntakeTest do
       assert is_binary(info.title) and info.title != ""
     end
   end
+
+  # ReleaseParser.infer_media_type/4 returns :movie on a year or quality token
+  # without consulting the title, so a titleless :movie is reachable. It cannot
+  # be title-matched against a library, so it is rejected at the boundary.
+  describe "parse_release/1 — titleless releases" do
+    test "a tracker-tagged name whose only title token was the tag is rejected" do
+      # The validator runs on the original name, where "[Tracker]" is meaningful
+      # content. clean_torrent_name/1 then strips bracket tags before parsing,
+      # leaving nothing to use as a title.
+      assert {:error, :missing_title} =
+               ReleaseIntake.parse_release("[Tracker] (2019) 2160p UHD BluRay x265-GROUP")
+    end
+
+    test "a quality-and-group-only name is rejected" do
+      assert {:error, :missing_title} =
+               ReleaseIntake.parse_release("1080p.BluRay.x264-GROUP")
+    end
+
+    test "a normal movie release is still accepted" do
+      assert {:ok, %ParsedFileInfo{type: :movie, title: title}} =
+               ReleaseIntake.parse_release("The.Matrix.1999.1080p.BluRay.x264-GROUP")
+
+      assert is_binary(title)
+    end
+
+    test "a normal TV release is still accepted" do
+      assert {:ok, %ParsedFileInfo{type: :tv_show, title: title}} =
+               ReleaseIntake.parse_release("From.S04E07.1080p.WEB.h264-GROUP")
+
+      assert is_binary(title)
+    end
+  end
 end

--- a/test/mydia/downloads/torrent_matcher_nil_title_test.exs
+++ b/test/mydia/downloads/torrent_matcher_nil_title_test.exs
@@ -1,0 +1,35 @@
+defmodule Mydia.Downloads.TorrentMatcherNilTitleTest do
+  @moduledoc """
+  A release can parse to a movie with no title (see
+  `ReleaseParser.infer_media_type/4`, which returns `:movie` on a year or
+  quality token without consulting the title). Matching must score such a
+  release as a non-match rather than raising, because a raise here aborts the
+  entire `Mydia.Jobs.DownloadMonitor` pass.
+  """
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Downloads.TorrentMatcher
+
+  import Mydia.Factory
+
+  describe "find_match/2 with a nil title" do
+    setup do
+      movie = insert(:media_item, %{type: "movie", title: "The Matrix", year: 1999})
+      %{movie: movie}
+    end
+
+    test "a titleless movie release returns no match instead of raising" do
+      torrent_info = %{type: :movie, title: nil, year: 2019}
+
+      assert {:error, :no_match_found} =
+               TorrentMatcher.find_match(torrent_info, monitored_only: false)
+    end
+
+    test "a titleless movie release with no year also returns no match" do
+      torrent_info = %{type: :movie, title: nil, year: nil}
+
+      assert {:error, :no_match_found} =
+               TorrentMatcher.find_match(torrent_info, monitored_only: false)
+    end
+  end
+end

--- a/test/mydia/downloads/untracked_matcher_test.exs
+++ b/test/mydia/downloads/untracked_matcher_test.exs
@@ -66,4 +66,37 @@ defmodule Mydia.Downloads.UntrackedMatcherTest do
       assert Repo.aggregate(Mydia.Downloads.Download, :count) == 0
     end
   end
+
+  # One malformed torrent must not abort the whole DownloadMonitor pass. Before
+  # this isolation, a raise here killed ExternalTorrents.refresh/0 and
+  # stuck-download detection on every run, and the torrent stayed in the client
+  # so the job failed permanently.
+  describe "per-torrent exception isolation" do
+    test "an exception during processing is contained instead of propagating" do
+      insert(:media_item, %{type: "movie", title: "The Matrix", year: 1999, monitored: true})
+
+      # Matches the library, so processing reaches create_download_record/3,
+      # which reads torrent.client_name. Dropping that key raises a KeyError
+      # deep in the call, which is what the rescue must contain.
+      malformed =
+        "The.Matrix.1999.1080p.BluRay.x264-GROUP"
+        |> torrent()
+        |> Map.delete(:client_name)
+
+      assert {:error, :match_exception} =
+               UntrackedMatcher.safe_process_untracked_torrent(malformed)
+    end
+
+    test "a well-formed torrent still succeeds through the same entry point" do
+      movie =
+        insert(:media_item, %{type: "movie", title: "The Matrix", year: 1999, monitored: true})
+
+      assert {:ok, download} =
+               UntrackedMatcher.safe_process_untracked_torrent(
+                 torrent("The.Matrix.1999.1080p.BluRay.x264-GROUP")
+               )
+
+      assert download.media_item_id == movie.id
+    end
+  end
 end

--- a/test/mydia/downloads/untracked_matcher_test.exs
+++ b/test/mydia/downloads/untracked_matcher_test.exs
@@ -87,6 +87,13 @@ defmodule Mydia.Downloads.UntrackedMatcherTest do
                UntrackedMatcher.safe_process_untracked_torrent(malformed)
     end
 
+    test "a torrent that is not a map is contained rather than raising in the rescue" do
+      # The rescue describes the torrent it failed on. If it reached for those
+      # keys with Map.get/2 it would raise BadMapError here and propagate,
+      # defeating the isolation.
+      assert {:error, :match_exception} = UntrackedMatcher.safe_process_untracked_torrent(nil)
+    end
+
     test "a well-formed torrent still succeeds through the same entry point" do
       movie =
         insert(:media_item, %{type: "movie", title: "The Matrix", year: 1999, monitored: true})


### PR DESCRIPTION
## Problem

`Mydia.Jobs.DownloadMonitor` crashed with:

```
** (FunctionClauseError) no function clause matching in String.downcase/2
    String.downcase(nil, :default)
    lib/mydia/downloads/torrent_matcher.ex:673: has_sequel_marker?/1
    lib/mydia/downloads/torrent_matcher.ex:296: calculate_movie_confidence/2
```

`ReleaseParser.infer_media_type/4` types a release as `:movie` on a year or quality token without consulting the title, and `ReleaseIntake` only validated the title for `:unknown` results. A titleless `:movie` therefore reached matching, where `has_sequel_marker?/1` was the one scoring function missing the `nil` clause its neighbours have (`normalize_string/1` has had one all along, which is why the other four call sites tolerate it).

Two real names reproduce it, both verified against the parser:

- `[Tracker] (2019) 2160p UHD BluRay x265-GROUP` - the validator runs on the original name where the bracket tag counts as meaningful content, then `clean_torrent_name/1` strips it before parsing, leaving no title. Tracker-tagged names are common, which is likely how this reached production.
- `1080p.BluRay.x264-GROUP` - the release group satisfies the validator, the parser then strips it as a release group.

## Blast radius

`find_and_match_untracked/0` had no per-torrent isolation, so one bad torrent aborted `DownloadMonitor.perform/1` at the untracked-matching step, killing the two passes that run after it: `ExternalTorrents.refresh/0` and stuck-download detection. The torrent stays in the client across runs, so the job failed on every invocation until an operator removed it by hand. Oban retries re-ran the earlier passes, which are idempotent, so no data was corrupted.

`ExternalTorrents.refresh/0` reaches the same scoring function through `find_top_candidates_in/3`. That path survived only because `Classifier.suggestions/2` already rescues, and that rescue logged a bare warning and reported nothing, so the same defect has been firing there unobserved.

## Changes

- Guard `has_sequel_marker?/1` against a nil title, matching the `normalize_string(nil)` convention already in the module
- Reject titleless releases at the `ReleaseIntake` boundary with a new `:missing_title` reason, kept distinct from `:unable_to_parse` so the two causes stay separable in logs
- Contain per-torrent exceptions in `UntrackedMatcher`, mirroring `MetadataRefresh.safe_refresh/2` including its load-bearing ErrorTracker report
- Report from the `Classifier.suggestions/2` rescue so it stops masking this class of bug

## Testing

New coverage for the nil-title guard (both with and without a year), both intake rejections plus two positive cases confirming normal movie and TV releases still parse, and the exception isolation (contained, and the happy path still works through the same entry point).

`mix precommit` green: 6225 tests, 0 failures.

## Note

An earlier draft of this change also filtered non-binary entries out of `alternative_titles`. It was dropped after testing showed it is unreachable: a nil alternative title scores 0.0 through `normalize_string/1` and `Enum.max_by` returns the first max, and the primary title is always a non-nil binary, so a nil variant can only win when the torrent title is also nil, which the first fix already covers.