### PR TITLE
fix(downloads): attach trackers to magnets that arrive without any

### DIFF
--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -12,6 +12,7 @@ defmodule Mydia.Downloads.Queue do
   alias Mydia.Downloads.Priority
   alias Mydia.Downloads.Structs.DownloadMetadata
   alias Mydia.Downloads.Structs.ExternalTorrent
+  alias Mydia.Downloads.TorrentHash
   alias Mydia.Indexers.SearchResult
   alias Mydia.Indexers.Structs.SearchResultMetadata
   alias Mydia.Settings
@@ -1139,19 +1140,30 @@ defmodule Mydia.Downloads.Queue do
   end
 
   defp prepare_torrent_input(url, indexer_name) do
-    cond do
-      # Magnet links can be used directly
-      String.starts_with?(url, "magnet:") ->
-        {:ok, {:magnet, url}}
+    result =
+      cond do
+        # Magnet links can be used directly
+        String.starts_with?(url, "magnet:") ->
+          {:ok, {:magnet, url}}
 
-      # For HTTP(S) URLs, download the torrent file content
-      # This avoids redirect issues that download clients can't handle
-      String.starts_with?(url, "http://") or String.starts_with?(url, "https://") ->
-        download_torrent_file(url, indexer_name)
+        # For HTTP(S) URLs, download the torrent file content
+        # This avoids redirect issues that download clients can't handle
+        String.starts_with?(url, "http://") or String.starts_with?(url, "https://") ->
+          download_torrent_file(url, indexer_name)
 
-      # Unknown format, try as URL
-      true ->
-        {:ok, {:url, url}}
+        # Unknown format, try as URL
+        true ->
+          {:ok, {:url, url}}
+      end
+
+    # Every magnet-producing path funnels back through here: the direct link
+    # above, a redirect to a magnet, a response body that *is* a magnet, and a
+    # magnet scraped out of an HTML page. Enriching once at the exit keeps a
+    # trackerless magnet from reaching the client with DHT as its only peer
+    # source. See `TorrentHash.ensure_trackers/1`.
+    case result do
+      {:ok, {:magnet, magnet}} -> {:ok, {:magnet, TorrentHash.ensure_trackers(magnet)}}
+      other -> other
     end
   end
 

--- a/lib/mydia/downloads/torrent_hash.ex
+++ b/lib/mydia/downloads/torrent_hash.ex
@@ -128,11 +128,7 @@ defmodule Mydia.Downloads.TorrentHash do
     if Regex.match?(~r/^[a-f0-9]{40}$/, hash) or Regex.match?(~r/^[a-f0-9]{64}$/, hash) do
       encoded_title = URI.encode(title || "Unknown")
 
-      tracker_params =
-        @public_trackers
-        |> Enum.map_join(&("&tr=" <> URI.encode(&1)))
-
-      "magnet:?xt=urn:btih:#{hash}&dn=#{encoded_title}#{tracker_params}"
+      "magnet:?xt=urn:btih:#{hash}&dn=#{encoded_title}#{tracker_params()}"
     else
       Logger.warning("Invalid info hash format: #{inspect(info_hash)}")
       nil
@@ -141,7 +137,41 @@ defmodule Mydia.Downloads.TorrentHash do
 
   def build_magnet(_, _), do: nil
 
+  @doc """
+  Appends the public tracker list to a magnet URI that carries none.
+
+  Indexers hand us magnets in whatever shape they like, and several emit a bare
+  `magnet:?xt=urn:btih:HASH&dn=NAME` with no `tr=` parameter at all (Bitmagnet
+  always does; Prowlarr does whenever `/download` redirects to a magnet instead
+  of serving a `.torrent`). Such a magnet gives the download client no way to
+  find peers except DHT, so it sits at zero bytes forever on any client whose
+  DHT cannot reach the swarm, and is eventually escalated by the stall detector.
+
+  Magnets that already advertise a tracker are returned untouched, as is any
+  non-magnet input. The info hash is never altered, so client-side deduplication
+  keeps matching.
+  """
+  @spec ensure_trackers(String.t() | nil) :: String.t() | nil
+  def ensure_trackers("magnet:" <> _ = magnet) do
+    if tracker_param?(magnet), do: magnet, else: magnet <> tracker_params()
+  end
+
+  def ensure_trackers(other), do: other
+
   ## Private Functions
+
+  defp tracker_params do
+    Enum.map_join(@public_trackers, fn tracker ->
+      "&tr=" <> URI.encode(tracker, &URI.char_unreserved?/1)
+    end)
+  end
+
+  defp tracker_param?(magnet) do
+    case String.split(magnet, "?", parts: 2) do
+      [_, query] -> query |> String.split("&") |> Enum.any?(&String.starts_with?(&1, "tr="))
+      _ -> false
+    end
+  end
 
   defp format_hash(hash, opts) do
     case Keyword.get(opts, :case, :upper) do

--- a/test/mydia/downloads/torrent_hash_test.exs
+++ b/test/mydia/downloads/torrent_hash_test.exs
@@ -1,0 +1,83 @@
+defmodule Mydia.Downloads.TorrentHashTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.TorrentHash
+
+  @hash "58949ffdddcacb400c1aa22fe8253294783bd948"
+
+  describe "ensure_trackers/1" do
+    test "appends public trackers to a trackerless magnet" do
+      # Shape emitted by Bitmagnet, and by Prowlarr when /download redirects to
+      # a magnet instead of serving a .torrent.
+      magnet = "magnet:?xt=urn:btih:#{@hash}&dn=Some.Release.1080p"
+
+      enriched = TorrentHash.ensure_trackers(magnet)
+
+      assert String.starts_with?(enriched, magnet)
+      assert enriched =~ "&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce"
+    end
+
+    test "leaves a magnet that already carries trackers untouched" do
+      magnet =
+        "magnet:?xt=urn:btih:#{@hash}&dn=Some.Release&tr=" <>
+          URI.encode("udp://tracker.example.org:1337/announce")
+
+      assert TorrentHash.ensure_trackers(magnet) == magnet
+    end
+
+    test "preserves the info hash so client-side dedupe still matches" do
+      magnet = "magnet:?xt=urn:btih:#{@hash}&dn=Some.Release"
+
+      enriched = TorrentHash.ensure_trackers(magnet)
+
+      assert TorrentHash.extract({:magnet, enriched}) ==
+               TorrentHash.extract({:magnet, magnet})
+    end
+
+    test "keeps trailing parameters such as xl intact" do
+      magnet = "magnet:?xt=urn:btih:#{@hash}&dn=The.Croods+%282013%29&xl=793286521"
+
+      enriched = TorrentHash.ensure_trackers(magnet)
+
+      assert enriched =~ "&xl=793286521"
+      assert enriched =~ "&tr="
+    end
+
+    test "does not mistake a dn containing 'tr=' for a tracker parameter" do
+      magnet = "magnet:?xt=urn:btih:#{@hash}&dn=attr%3Dvalue"
+
+      assert TorrentHash.ensure_trackers(magnet) =~ "&tr=udp%3A%2F%2F"
+    end
+
+    test "leaves non-magnet input unchanged" do
+      url = "https://example.com/file.torrent"
+
+      assert TorrentHash.ensure_trackers(url) == url
+    end
+
+    test "leaves nil unchanged" do
+      assert TorrentHash.ensure_trackers(nil) == nil
+    end
+
+    test "is idempotent" do
+      magnet = "magnet:?xt=urn:btih:#{@hash}&dn=Some.Release"
+
+      once = TorrentHash.ensure_trackers(magnet)
+
+      assert TorrentHash.ensure_trackers(once) == once
+    end
+  end
+
+  describe "build_magnet/2" do
+    test "still emits trackers so hash-built magnets keep working" do
+      magnet = TorrentHash.build_magnet(@hash, "Some.Release")
+
+      assert magnet =~ "magnet:?xt=urn:btih:#{@hash}"
+      assert magnet =~ "&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce"
+    end
+
+    test "returns nil for an invalid hash" do
+      assert TorrentHash.build_magnet("not-a-hash", "Some.Release") == nil
+    end
+  end
+end

--- a/test/mydia/downloads/torrent_hash_test.exs
+++ b/test/mydia/downloads/torrent_hash_test.exs
@@ -44,8 +44,13 @@ defmodule Mydia.Downloads.TorrentHashTest do
     end
 
     test "does not mistake a dn containing 'tr=' for a tracker parameter" do
-      magnet = "magnet:?xt=urn:btih:#{@hash}&dn=attr%3Dvalue"
+      # "attr=value" ends in the literal substring "tr=", so a naive
+      # String.contains?(magnet, "tr=") check would decide this magnet already
+      # has a tracker and skip enrichment. The parameter is matched per
+      # &-separated segment instead, and this segment starts with "dn=".
+      magnet = "magnet:?xt=urn:btih:#{@hash}&dn=Release.attr=value"
 
+      assert String.contains?(magnet, "tr=")
       assert TorrentHash.ensure_trackers(magnet) =~ "&tr=udp%3A%2F%2F"
     end
 

--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -30,13 +30,22 @@ defmodule Mydia.DownloadsTest do
       {:ok, %{version: "1.0.0", api_version: "1.0"}}
     end
 
+    # Prefix matches: a trackerless magnet is enriched with the public tracker
+    # list on its way to the client, so the string the client sees is longer
+    # than the one the search result carried.
     @impl true
-    def add_torrent(_config, {:magnet, "magnet:?xt=valid"}, _opts) do
+    def add_torrent(_config, {:magnet, "magnet:?xt=valid" <> _}, _opts) do
       {:ok, "mock-client-id-123"}
     end
 
-    def add_torrent(_config, {:magnet, "magnet:?xt=error"}, _opts) do
+    def add_torrent(_config, {:magnet, "magnet:?xt=error" <> _}, _opts) do
       {:error, Error.invalid_torrent("Invalid magnet link")}
+    end
+
+    # Reports back whether the magnet arrived with trackers attached.
+    def add_torrent(_config, {:magnet, "magnet:?xt=trackers" <> rest}, _opts) do
+      {:ok,
+       if(String.contains?(rest, "&tr="), do: "mock-with-trackers", else: "mock-no-trackers")}
     end
 
     def add_torrent(_config, {:url, url}, _opts) do
@@ -327,6 +336,29 @@ defmodule Mydia.DownloadsTest do
                Downloads.initiate_download(search_result, client_name: disabled_client.name)
 
       assert client_name == disabled_client.name
+    end
+
+    test "hands the client a trackerless magnet with trackers attached", %{client1: _client1} do
+      # Regression: Bitmagnet (and Prowlarr, when /download redirects to a
+      # magnet) emit a bare magnet with no tr= parameter. Forwarding that
+      # verbatim leaves the client with DHT as its only peer source, which
+      # downloads exactly zero bytes on any client whose DHT can't reach the
+      # swarm.
+      bare_magnet = %SearchResult{
+        title: "Trackerless Release",
+        size: 1000,
+        seeders: 5,
+        leechers: 0,
+        download_url: "magnet:?xt=trackers&dn=Trackerless.Release",
+        indexer: "Test"
+      }
+
+      assert {:ok, download} = Downloads.initiate_download(bare_magnet)
+      assert download.download_client_id == "mock-with-trackers"
+
+      # The stored URL stays exactly as the indexer gave it, so history and
+      # duplicate detection keep working off the original release.
+      assert download.download_url == bare_magnet.download_url
     end
 
     test "returns error when client rejects torrent", %{client1: _client1} do


### PR DESCRIPTION
## What was happening

House of the Dragon S03E07 (and 22 other downloads) sat at exactly zero bytes until the stall detector escalated them at 180 minutes, then got re-grabbed onto another dead magnet and repeated. The releases were fine. The magnets Mydia handed the download client had **no trackers on them at all**.

## Root cause

`Queue.prepare_torrent_input/2` forwarded indexer magnets verbatim ("Magnet links can be used directly"). Several indexers emit a bare `magnet:?xt=urn:btih:HASH&dn=NAME` with no `tr=` parameter: Bitmagnet always does, and Prowlarr does whenever `/download` redirects to a magnet instead of serving a `.torrent`. Such a magnet gives the client no way to find peers except DHT.

`TorrentHash.build_magnet/2` already appended a public tracker list, but only two indexer adapters reach it, and only when the indexer supplies a raw `infoHash`. Ready-made magnets bypassed it entirely.

This was invisible while rqbit was the download client, because its DHT reached the swarm. It surfaced the moment a client took over whose DHT does not.

## Evidence from a production instance

| client | link type | completed |
|---|---|---|
| rqbit | magnet | 26 / 26 |
| transmission | magnet | **0 / 23** |
| transmission | .torrent URL | 32 / 48 |

Bitmagnet used the identical bare-magnet format in both periods: 26/26 completed before the client switch, 0/23 after. Inspecting the client directly, every torrent with zero trackers sat at zero bytes and every torrent with trackers progressed, with no exceptions in either direction. UDP trackers still resolved fine (one returned 1467 seeders), so this is DHT-specific rather than a network outage.

## The fix

Enrich at the one point every magnet-producing path funnels back through, which covers all four: the direct magnet link, a redirect to a magnet, a response body that *is* a magnet, and a magnet scraped out of an HTML page.

Deliberately preserved:

- the stored `download_url` keeps the indexer's original string, so history and duplicate detection are unaffected
- the info hash is never altered, so client-side dedupe still matches
- magnets that already advertise a tracker pass through untouched, and the operation is idempotent

Tracker URLs are now percent-encoded, matching what indexers emit and what the repo's own fixtures already contain. `build_magnet/2` and the new path share one helper so they cannot drift.

This keeps Mydia working regardless of which client's DHT is healthy, rather than asking the operator to go repair their VPN's DHT.

## Testing

- New `test/mydia/downloads/torrent_hash_test.exs` covers `ensure_trackers/1`: trackerless enrichment, already-has-trackers passthrough, hash preservation, trailing `xl=` params, a `dn` containing a literal `tr=`, non-magnet and nil input, and idempotency.
- New end-to-end regression test in `downloads_test.exs` asserts the magnet reaching the client carries trackers while the stored URL stays original.
- The mock adapter now prefix-matches magnets, since the client legitimately receives a longer string than the search result carried.
- Full `mix precommit` green: **6228 tests, 0 failures**, plus compile, `format --check-formatted`, and `credo --strict`.

## Note for the affected instance

This fixes new grabs. The 9 already-stalled torrents sitting in the client need re-grabbing (or trackers added to them) to recover.
