### PR TITLE
fix(downloads): let season packs fill partially-complete seasons

### DIFF
--- a/lib/mydia/downloads/grabber.ex
+++ b/lib/mydia/downloads/grabber.ex
@@ -96,7 +96,7 @@ defmodule Mydia.Downloads.Grabber do
       |> Keyword.put(:download_type, search_result.download_protocol)
 
     case Queue.check_for_duplicate_download(search_result, opts) do
-      {:error, :duplicate_download} ->
+      {:error, reason} when reason in [:duplicate_download, :already_have_files] ->
         History.delete_download(download)
         broadcast({:grab_duplicate, %{download_url: download.download_url}})
         :duplicate

--- a/lib/mydia/downloads/grabber.ex
+++ b/lib/mydia/downloads/grabber.ex
@@ -12,7 +12,10 @@ defmodule Mydia.Downloads.Grabber do
 
     * `{:grab_completed, %{download_id: id, download_url: url}}`
     * `{:grab_failed, %{download_id: id, download_url: url, reason: reason}}`
-    * `{:grab_duplicate, %{download_url: url}}`
+    * `{:grab_duplicate, %{download_url: url, reason: reason}}`
+
+  The duplicate `reason` is `:duplicate_download` when a download is already in
+  flight, or `:already_have_files` when the files are already on disk.
 
   A duplicate is benign: the optimistic record is deleted rather than failed.
   So is a task that never starts: the record is deleted and the caller gets
@@ -98,7 +101,13 @@ defmodule Mydia.Downloads.Grabber do
     case Queue.check_for_duplicate_download(search_result, opts) do
       {:error, reason} when reason in [:duplicate_download, :already_have_files] ->
         History.delete_download(download)
-        broadcast({:grab_duplicate, %{download_url: download.download_url}})
+
+        # Carry the reason the way :grab_failed already does. The two cases mean
+        # different things to an operator (something is in flight vs. we already
+        # have the files), and collapsing them is what made the original
+        # season-pack incident so hard to read.
+        broadcast({:grab_duplicate, %{download_url: download.download_url, reason: reason}})
+
         :duplicate
 
       :ok ->

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -393,12 +393,16 @@ defmodule Mydia.Downloads.Queue do
             episode_id: episode_id
           )
 
-          {:error, :duplicate_download}
+          {:error, :already_have_files}
         else
           :ok
         end
 
-      # For season packs, check if any episodes in the season already have media files
+      # A pack is grabbed to fill a specific set of episodes, so it is only
+      # redundant when every one of them is already on disk. The old rule
+      # rejected the pack if ANY episode in the season had a file, which made a
+      # partially-complete season permanently unfillable: one stray episode
+      # blocked every future pack for that season.
       media_item_id &&
           match?(
             %SearchResultMetadata{season_pack: true, season_number: _},
@@ -406,33 +410,18 @@ defmodule Mydia.Downloads.Queue do
           ) ->
         season_number = search_result.metadata.season_number
 
-        # Get all episodes for this season
-        episodes_query =
-          from(e in Episode,
-            where: e.media_item_id == ^media_item_id and e.season_number == ^season_number,
-            select: e.id
+        targeted_ids = targeted_episode_ids(search_result.metadata, media_item_id, season_number)
+
+        if targeted_ids != [] and all_episodes_have_files?(targeted_ids) do
+          Logger.info(
+            "Skipping download - every episode this season pack targets already has a file",
+            media_item_id: media_item_id,
+            season_number: season_number,
+            targeted_episodes: length(targeted_ids)
           )
 
-        episode_ids = Repo.all(episodes_query)
-
-        if episode_ids != [] do
-          # Check if any of these episodes have media files
-          media_files_query =
-            from(f in MediaFile, where: f.episode_id in ^episode_ids and is_nil(f.trashed_at))
-
-          if Repo.exists?(media_files_query) do
-            Logger.info(
-              "Skipping download - media files already exist for some episodes in season",
-              media_item_id: media_item_id,
-              season_number: season_number
-            )
-
-            {:error, :duplicate_download}
-          else
-            :ok
-          end
+          {:error, :already_have_files}
         else
-          # No episodes found for this season yet - allow download
           :ok
         end
 
@@ -463,7 +452,7 @@ defmodule Mydia.Downloads.Queue do
                 media_item_id: media_item_id
               )
 
-              {:error, :duplicate_download}
+              {:error, :already_have_files}
             else
               :ok
             end
@@ -481,6 +470,37 @@ defmodule Mydia.Downloads.Queue do
       true ->
         :ok
     end
+  end
+
+  # The search records the episodes a pack was grabbed for in `episode_ids`.
+  # Manual grabs and rows predating that field carry none, so fall back to the
+  # season's full episode list, which makes the rule "block only if the whole
+  # season is already on disk".
+  defp targeted_episode_ids(%SearchResultMetadata{episode_ids: ids}, _media_item_id, _season)
+       when is_list(ids) and ids != [],
+       do: ids
+
+  defp targeted_episode_ids(_metadata, media_item_id, season_number) do
+    Repo.all(
+      from(e in Episode,
+        where: e.media_item_id == ^media_item_id and e.season_number == ^season_number,
+        select: e.id
+      )
+    )
+  end
+
+  defp all_episodes_have_files?(episode_ids) do
+    wanted = episode_ids |> Enum.uniq() |> length()
+
+    filed =
+      Repo.one(
+        from(f in MediaFile,
+          where: f.episode_id in ^episode_ids and is_nil(f.trashed_at),
+          select: count(f.episode_id, :distinct)
+        )
+      )
+
+    filed == wanted
   end
 
   # --- Issues Tab Functions ---

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -1562,6 +1562,7 @@ defmodule Mydia.Events do
 
   defp format_download_error(:no_clients_configured), do: "No download clients configured"
   defp format_download_error(:duplicate_download), do: "Download already exists"
+  defp format_download_error(:already_have_files), do: "Already have these episodes"
   defp format_download_error(:no_suitable_client), do: "No suitable download client found"
   defp format_download_error(:client_error), do: "Download client error"
 

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -1562,7 +1562,9 @@ defmodule Mydia.Events do
 
   defp format_download_error(:no_clients_configured), do: "No download clients configured"
   defp format_download_error(:duplicate_download), do: "Download already exists"
-  defp format_download_error(:already_have_files), do: "Already have these episodes"
+  # Covers episodes, season packs and movies alike, so the wording stays
+  # media-type-agnostic.
+  defp format_download_error(:already_have_files), do: "Files already exist"
   defp format_download_error(:no_suitable_client), do: "No suitable download client found"
   defp format_download_error(:client_error), do: "Download client error"
 

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -38,6 +38,7 @@ defmodule Mydia.Jobs.MediaImport do
   alias Mydia.Library.{FileNamer, FileOrganizer, SampleDetector}
   alias Mydia.Library.ReleaseParser
   alias Mydia.Library.ReleaseParser.TargetContext
+  alias Mydia.Media.Episode
   alias Mydia.Indexers.QualityParser
   alias Mydia.MediaServer.Notifier, as: MediaServerNotifier
   alias Mydia.Metadata.NfoWriter
@@ -858,11 +859,14 @@ defmodule Mydia.Jobs.MediaImport do
           end
         end)
 
-      # Separate results into imported, unresolved, and errors
+      # Separate results into imported, unresolved, and errors. Skipped files
+      # (season pack entries for episodes that already have a file) belong to
+      # none of the three: they are a deliberate no-op, not a failure.
       {imported, unresolved, errors} =
         Enum.reduce(results, {[], [], []}, fn
           {:ok, media_file}, {imp, unr, err} -> {[media_file | imp], unr, err}
           {:unresolved, file_info}, {imp, unr, err} -> {imp, [file_info | unr], err}
+          {:skipped, _info}, {imp, unr, err} -> {imp, unr, err}
           {:error, _} = error, {imp, unr, err} -> {imp, unr, [error | err]}
         end)
 
@@ -1388,8 +1392,39 @@ defmodule Mydia.Jobs.MediaImport do
         {:unresolved, file_info}
 
       {episode, dest_dir} ->
-        import_file_to_destination(file, episode, dest_dir, download, library_path, args)
+        if skip_already_filed_episode?(episode, download) do
+          Logger.info("Skipping season pack file - episode already has a media file",
+            download_id: download.id,
+            file: file.name,
+            episode_id: episode.id
+          )
+
+          {:skipped, %{name: file.name, episode_id: episode.id}}
+        else
+          import_file_to_destination(file, episode, dest_dir, download, library_path, args)
+        end
     end
+  end
+
+  # A season pack legitimately contains episodes the library already has, now
+  # that the grab guard only blocks a pack whose every targeted episode is on
+  # disk. Importing those files would create a second non-trashed media_files
+  # row for the episode: the importer's only existence check is on the
+  # destination path, and there is no unique index on media_files.episode_id.
+  #
+  # Upgrades are exempt. An upgrade pack targets episodes that already have
+  # files by definition, and its per-episode supersede pointer (see
+  # supersede_target/3) is what trashes the loser after the margin gate.
+  defp skip_already_filed_episode?(%Episode{id: episode_id}, download) do
+    get_in(download.metadata, ["season_pack"]) == true and
+      not upgrade_download?(download) and
+      Library.episode_has_media_file?(episode_id)
+  end
+
+  defp skip_already_filed_episode?(_episode, _download), do: false
+
+  defp upgrade_download?(download) do
+    match?(%{"upgrade_target_media_file_id" => id} when is_binary(id), download.metadata)
   end
 
   defp import_file_to_destination(file, episode, dest_dir, download, library_path, args) do

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -189,6 +189,20 @@ defmodule Mydia.Library do
   end
 
   @doc """
+  Returns true when the episode already has a media file that has not been trashed.
+
+  Used by the importer to skip season-pack files for episodes the library
+  already has, since nothing downstream reconciles two live files for one
+  episode outside the upgrade path.
+  """
+  @spec episode_has_media_file?(String.t()) :: boolean()
+  def episode_has_media_file?(episode_id) when is_binary(episode_id) do
+    Repo.exists?(
+      from(f in MediaFile, where: f.episode_id == ^episode_id and is_nil(f.trashed_at))
+    )
+  end
+
+  @doc """
   Creates a media file.
   """
   @spec create_media_file(map()) :: {:ok, MediaFile.t()} | {:error, Ecto.Changeset.t()}

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -546,6 +546,13 @@ defmodule MydiaWeb.SearchLive.Index do
          socket
          |> put_flash(:info, "#{title} added to library. Download already in progress.")}
 
+      {:error, :already_have_files} ->
+        Logger.info("Skipping download - media files already exist")
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "#{title} added to library. You already have these files.")}
+
       {:error, :no_clients_configured} ->
         Logger.warning("Cannot initiate download - no download clients configured")
 

--- a/test/mydia/downloads/grabber_test.exs
+++ b/test/mydia/downloads/grabber_test.exs
@@ -94,8 +94,32 @@ defmodule Mydia.Downloads.GrabberTest do
                Grabber.run_grab(optimistic, sr, media_item_id: movie.id, manual: true)
 
       assert Repo.get(Download, optimistic.id) == nil
-      assert_receive {:grab_duplicate, %{download_url: url}}
+      assert_receive {:grab_duplicate, %{download_url: url, reason: :duplicate_download}}
       assert url == sr.download_url
+    end
+
+    test "carries :already_have_files when files on disk are the blocker" do
+      # No in-flight download here. The movie already has a media file and the
+      # grab is not manual, so the existing-files check is what rejects it.
+      # Subscribers need the two cases apart: one means wait, the other means
+      # there is nothing to wait for.
+      movie = media_item_fixture(%{type: "movie"})
+      media_file_fixture(%{media_item_id: movie.id})
+
+      sr = search_result()
+
+      {:ok, optimistic} =
+        Downloads.create_download(%{
+          title: sr.title,
+          indexer: sr.indexer,
+          download_url: sr.download_url,
+          media_item_id: movie.id
+        })
+
+      assert :duplicate = Grabber.run_grab(optimistic, sr, media_item_id: movie.id)
+
+      assert Repo.get(Download, optimistic.id) == nil
+      assert_receive {:grab_duplicate, %{reason: :already_have_files}}
     end
   end
 

--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -715,7 +715,7 @@ defmodule Mydia.DownloadsTest do
       # Try to initiate download for episode that already has files
       result = Downloads.initiate_download(search_result, episode_id: episode.id)
 
-      assert {:error, :duplicate_download} = result
+      assert {:error, :already_have_files} = result
     end
 
     test "prevents movie download when media files already exist", %{
@@ -728,31 +728,90 @@ defmodule Mydia.DownloadsTest do
       # Try to initiate download for movie that already has files
       result = Downloads.initiate_download(search_result, media_item_id: movie.id)
 
-      assert {:error, :duplicate_download} = result
+      assert {:error, :already_have_files} = result
     end
 
-    test "prevents season pack download when some episodes already have media files", %{
+    test "allows a season pack when only SOME episodes already have media files", %{
       search_result: search_result,
       tv_show: tv_show
     } do
-      # Create episodes for season 2 (to avoid conflict with setup which creates season 1 episode 1)
+      # The prod regression: S03 had 2 of 7 episodes on disk, and the pack that
+      # would have filled the other 5 was rejected every hour, forever.
+      # Season 2 here to avoid the setup block's season 1 episode.
       episode1 = episode_fixture(media_item_id: tv_show.id, season_number: 2, episode_number: 1)
       episode2 = episode_fixture(media_item_id: tv_show.id, season_number: 2, episode_number: 2)
       _episode3 = episode_fixture(media_item_id: tv_show.id, season_number: 2, episode_number: 3)
 
-      # Create media files for some episodes (but not all)
       media_file_fixture(%{episode_id: episode1.id})
       media_file_fixture(%{episode_id: episode2.id})
 
-      # Try to initiate season pack download - should be prevented since some episodes have files
+      # No episode_ids, so this exercises the season-wide fallback rule.
       season_pack_result = %{
         search_result
         | metadata: SearchResultMetadata.season_pack(2, 3)
       }
 
-      result = Downloads.initiate_download(season_pack_result, media_item_id: tv_show.id)
+      assert {:ok, _download} =
+               Downloads.initiate_download(season_pack_result, media_item_id: tv_show.id)
+    end
 
-      assert {:error, :duplicate_download} = result
+    test "blocks a season pack when EVERY episode in the season has a media file", %{
+      search_result: search_result,
+      tv_show: tv_show
+    } do
+      episode1 = episode_fixture(media_item_id: tv_show.id, season_number: 6, episode_number: 1)
+      episode2 = episode_fixture(media_item_id: tv_show.id, season_number: 6, episode_number: 2)
+
+      media_file_fixture(%{episode_id: episode1.id})
+      media_file_fixture(%{episode_id: episode2.id})
+
+      season_pack_result = %{
+        search_result
+        | metadata: SearchResultMetadata.season_pack(6, 2)
+      }
+
+      assert {:error, :already_have_files} =
+               Downloads.initiate_download(season_pack_result, media_item_id: tv_show.id)
+    end
+
+    test "blocks a season pack when every TARGETED episode already has a file", %{
+      search_result: search_result,
+      tv_show: tv_show
+    } do
+      # episode_ids names the two episodes the search wanted. Both are now on
+      # disk, so the grab is genuinely redundant even though ep3 has no file.
+      episode1 = episode_fixture(media_item_id: tv_show.id, season_number: 7, episode_number: 1)
+      episode2 = episode_fixture(media_item_id: tv_show.id, season_number: 7, episode_number: 2)
+      _episode3 = episode_fixture(media_item_id: tv_show.id, season_number: 7, episode_number: 3)
+
+      media_file_fixture(%{episode_id: episode1.id})
+      media_file_fixture(%{episode_id: episode2.id})
+
+      season_pack_result = %{
+        search_result
+        | metadata: SearchResultMetadata.season_pack(7, 2, [episode1.id, episode2.id])
+      }
+
+      assert {:error, :already_have_files} =
+               Downloads.initiate_download(season_pack_result, media_item_id: tv_show.id)
+    end
+
+    test "allows a season pack when a TARGETED episode is still missing", %{
+      search_result: search_result,
+      tv_show: tv_show
+    } do
+      episode1 = episode_fixture(media_item_id: tv_show.id, season_number: 8, episode_number: 1)
+      episode2 = episode_fixture(media_item_id: tv_show.id, season_number: 8, episode_number: 2)
+
+      media_file_fixture(%{episode_id: episode1.id})
+
+      season_pack_result = %{
+        search_result
+        | metadata: SearchResultMetadata.season_pack(8, 2, [episode1.id, episode2.id])
+      }
+
+      assert {:ok, _download} =
+               Downloads.initiate_download(season_pack_result, media_item_id: tv_show.id)
     end
 
     test "allows season pack download when no episodes have media files", %{

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -1213,6 +1213,140 @@ defmodule Mydia.Jobs.MediaImportTest do
     end
   end
 
+  describe "season pack containing episodes that already have files" do
+    @tag :tmp_dir
+    test "skips the overlapping file, imports the missing one, no partial_pack",
+         %{tmp_dir: tmp_dir} do
+      # A pack legitimately contains episodes we already have, now that the grab
+      # guard only blocks a pack whose every targeted episode is on disk.
+      # Importing the overlap would leave two live media_files rows for one
+      # episode, with no quality gate to reconcile them: the importer's only
+      # existence check is on the destination path.
+      _library_path = create_test_library_path(tmp_dir, :series)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+
+      for name <- ["Overlap.Show.S03E01.mkv", "Overlap.Show.S03E02.mkv"] do
+        File.write!(Path.join(download_dir, name), "fake video")
+      end
+
+      media_item = media_item_fixture(%{type: "tv_show", title: "Overlap Show"})
+
+      ep1 = episode_fixture(%{media_item_id: media_item.id, season_number: 3, episode_number: 1})
+      ep2 = episode_fixture(%{media_item_id: media_item.id, season_number: 3, episode_number: 2})
+
+      # E01 is already on disk. E02 is the one the pack was grabbed for.
+      media_file_fixture(%{episode_id: ep1.id})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "OverlapClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "OverlapClient",
+          download_client_id: "overlap-1",
+          metadata: %{
+            "season_pack" => true,
+            "season_number" => 3,
+            # episode_count is the count of MISSING episodes the search wanted,
+            # not the season total. Only E02 was missing.
+            "episode_count" => 1,
+            "episode_ids" => [ep2.id]
+          }
+        })
+
+      assert {:ok, :imported} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      files_by_episode =
+        Library.list_media_files()
+        |> Enum.filter(&(&1.episode_id in [ep1.id, ep2.id]))
+        |> Enum.group_by(& &1.episode_id)
+
+      assert length(Map.get(files_by_episode, ep1.id, [])) == 1,
+             "E01 already had a file; the pack's copy must be skipped, not added"
+
+      assert length(Map.get(files_by_episode, ep2.id, [])) == 1,
+             "E02 was missing and must be imported"
+
+      updated = Mydia.Downloads.get_download!(download.id)
+
+      refute updated.match_status == "partial_pack",
+             "1 imported vs episode_count 1 must not read as a short pack"
+    end
+
+    @tag :tmp_dir
+    test "an upgrade pack still imports over an episode that already has a file",
+         %{tmp_dir: tmp_dir} do
+      # Upgrades target episodes that already have files by definition, so the
+      # skip must not apply or UpgradeSweep breaks entirely.
+      _library_path = create_test_library_path(tmp_dir, :series)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+      File.write!(Path.join(download_dir, "Upgrade.Show.S03E01.mkv"), "fake video")
+
+      media_item = media_item_fixture(%{type: "tv_show", title: "Upgrade Show"})
+      ep1 = episode_fixture(%{media_item_id: media_item.id, season_number: 3, episode_number: 1})
+      existing = media_file_fixture(%{episode_id: ep1.id})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "UpgradeClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "UpgradeClient",
+          download_client_id: "upgrade-1",
+          metadata: %{
+            "season_pack" => true,
+            "season_number" => 3,
+            "episode_count" => 1,
+            # The discriminator supersede_target/3 keys on.
+            "upgrade_target_media_file_id" => existing.id
+          }
+        })
+
+      assert {:ok, :imported} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      count = Library.list_media_files() |> Enum.count(&(&1.episode_id == ep1.id))
+
+      assert count == 2,
+             "an upgrade must import alongside the file it supersedes, not be skipped"
+    end
+  end
+
   # Regression for the partial-import retry loop (Bug C).
   #
   # When a season-pack import resolves some files but flags others as
@@ -1468,13 +1602,14 @@ defmodule Mydia.Jobs.MediaImportTest do
       File.write!(dest_file, "existing video")
       relative_path = Path.relative_to(dest_file, library_path.path)
 
-      for _ <- 1..2 do
-        media_file_fixture(%{
-          library_path_id: library_path.id,
-          episode_id: ep_s1e1.id,
-          relative_path: relative_path
-        })
-      end
+      existing_files =
+        for _ <- 1..2 do
+          media_file_fixture(%{
+            library_path_id: library_path.id,
+            episode_id: ep_s1e1.id,
+            relative_path: relative_path
+          })
+        end
 
       {:ok, _} =
         Settings.create_download_client_config(%{
@@ -1495,7 +1630,16 @@ defmodule Mydia.Jobs.MediaImportTest do
           completed_at: DateTime.utc_now(),
           download_client: "PartialErrorClient",
           download_client_id: "partial-error-1",
-          metadata: %{"season_pack" => true, "season_number" => 1}
+          metadata: %{
+            "season_pack" => true,
+            "season_number" => 1,
+            # Marked as an upgrade so the already-filed-episode skip does not
+            # intercept this file. Upgrades are exempt from that skip by design,
+            # since they target episodes that already have files, which makes
+            # this the path where a duplicate-row Repo.one crash is still
+            # reachable and therefore still worth surfacing properly.
+            "upgrade_target_media_file_id" => hd(existing_files).id
+          }
         })
 
       {download, download_dir}


### PR DESCRIPTION
## Problem

Production logged this once per hourly TV search, indefinitely:

```
Found release for: All Creatures Great & Small (2020): All.Creatures...S03...KONTRAST
Download failed for: ... (Download already exists)
```

Nothing was downloading. There were **zero** `downloads` rows for the show. S03 has 7 episodes and 2 of them (E02, E07) had files, so 5 were missing (71.4%, past the 70% season-pack threshold). The search correctly selected a pack, and the grab was then rejected by the existing-files guard, which blocked a season pack if **any** episode in the season had a file.

The general form: **any partially-complete season could never be filled by a season pack.** One stray episode file poisoned the season permanently.

A second defect compounded it. `check_for_active_download` ("something is in flight") and `check_for_existing_media_files` ("files are on disk") both returned `:duplicate_download`, and the search callers read that atom as the former and deliberately skip the individual-episode fallback. So the 5 missing episodes were never searched by any route either. No backoff is recorded on that path, so it retried every hour forever.

## Changes

**1. The guard now blocks only when every episode the pack targets is already on disk**, using the `episode_ids` the search already records in the pack metadata. Grabs without `episode_ids` (manual, or rows predating the field) fall back to a season-wide "every episode has a file" test. This is the fix for the production incident.

**2. Split the overloaded atom.** `check_for_existing_media_files` now returns `:already_have_files`; `check_for_active_download` keeps `:duplicate_download`. The `tv_show_search.ex` call sites needed no change: both already end in an `{:error, _reason} -> search_individual_episodes(...)` catch-all placed after the `:duplicate_download` clause, so the split routes the new reason to the fallback automatically. `grabber.ex` did need updating, as its two-clause `case` would have raised `CaseClauseError`.

This half is defence in depth rather than a second live bug: once change 1 lands, `:already_have_files` is essentially unreachable for a pack on the automatic path, since `episode_ids` *is* the missing-episode set. It ensures a files-based rejection can never again strand a whole season.

**3. Import skips pack files for episodes that already have a live media file.** This was required, not optional. The importer's only existence check is on the destination *path*, there is no unique index on `media_files.episode_id`, and the only quality gate runs when `upgrade_target_media_file_id` is set, which the missing-episode path never sets. Without this, relaxing the guard would trade a stuck-download bug for a duplicate-file bug: a pack containing E02 and E07 would create a second non-trashed row for each with nothing to reconcile them.

Upgrade packs are exempt, since they target episodes that already have files by definition and their per-episode supersede pointer handles the replacement.

## Why this does not trip the partial-pack detector

`detect_partial_pack/2` compares imported episodes against `metadata["episode_count"]`, and `initiate_season_pack_download` sets that to the count of **missing** episodes, not the season total. For the incident: `episode_count` is 5, the pack delivers 7 files, 2 are skipped, 5 rows land, 5 is compared against 5. A pack that genuinely shorts a wanted episode still yields fewer than 5 and is still flagged. Pinned by a test rather than left to inference.

## Tests

- Partial season is now grabbable (the regression, red first)
- Every episode in the season filed, and every *targeted* episode filed, both blocked with `:already_have_files`
- A still-missing targeted episode is allowed
- In-flight downloads still return `:duplicate_download`, and `tv_show_search_test.exs:902` still proves that suppresses the fallback
- Import: overlapping file skipped, no second row, missing episode imported, not flagged `partial_pack`
- Import: an upgrade pack still imports over an already-filed episode, so UpgradeSweep is unaffected

The existing duplicate-row error-surfacing regression now runs through an upgrade pack, the path where that crash remains reachable after this change.

`./dev mix precommit`: 6261 tests, 0 failures, Credo and format clean.

## Not included

No backoff changes: once the pack grabs, the hourly retry loop resolves itself, and backoff would mask the cause rather than fix it. No quality comparison for ordinary packs, which UpgradeSweep owns. No unique index on `media_files.episode_id`, since legitimate multi-file episodes exist in production.
