### PR TITLE
feat(quality): per-profile source exclusion to stop CAM/TELESYNC grabs

### DIFF
--- a/lib/mydia/indexers/quality_parser.ex
+++ b/lib/mydia/indexers/quality_parser.ex
@@ -31,6 +31,7 @@ defmodule Mydia.Indexers.QualityParser do
   """
 
   alias Mydia.Library.Structs.Quality
+  alias Mydia.Quality.Sources
 
   # Resolution patterns (ordered by priority for matching)
   defp resolutions do
@@ -41,25 +42,6 @@ defmodule Mydia.Indexers.QualityParser do
       {"576p", ~r/576p/i},
       {"480p", ~r/480p/i},
       {"360p", ~r/360p/i}
-    ]
-  end
-
-  # Source patterns
-  defp sources do
-    [
-      {"REMUX", ~r/remux/i},
-      {"BluRay", ~r/blu[\-\s]?ray|bluray|bdrip|brrip|bd(?:$|[\.\s])/i},
-      {"WEB-DL", ~r/web[\-\s]?dl|webdl/i},
-      {"WEBRip", ~r/web[\-\s]?rip|webrip/i},
-      {"HDTV", ~r/hdtv/i},
-      {"SDTV", ~r/sdtv/i},
-      {"DVDRip", ~r/dvd[\-\s]?rip|dvdrip/i},
-      {"DVD", ~r/dvd/i},
-      {"Telecine", ~r/telecine|tc/i},
-      {"Telesync", ~r/telesync|ts/i},
-      {"CAM", ~r/cam(?:rip)?/i},
-      {"Screener", ~r/screener|scr/i},
-      {"PDTV", ~r/pdtv/i}
     ]
   end
 
@@ -203,10 +185,7 @@ defmodule Mydia.Indexers.QualityParser do
   """
   @spec extract_source(String.t()) :: String.t() | nil
   def extract_source(title) do
-    sources()
-    |> Enum.find_value(fn {label, pattern} ->
-      if Regex.match?(pattern, title), do: label
-    end)
+    Sources.detect(title)
   end
 
   @doc """

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -52,6 +52,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
   alias Mydia.Indexers.Structs.{RankedResult, ScoreBreakdown}
   alias Mydia.Library.ReleaseParser
   alias Mydia.Library.Structs.ParsedFileInfo
+  alias Mydia.Quality.Sources
   alias Mydia.Settings.QualityProfile
 
   @type ranked_result :: RankedResult.t()
@@ -141,6 +142,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
       results
       |> reject_invalid_releases()
       |> filter_acceptable(opts)
+      |> reject_excluded_sources(opts)
       |> reject_title_mismatches(expected_title)
       |> Enum.map(fn result ->
         breakdown = calculate_score_breakdown(result, opts)
@@ -211,6 +213,54 @@ defmodule Mydia.Indexers.ReleaseRanker do
       end
     end)
   end
+
+  # Drops releases whose parsed source appears in the profile's
+  # :excluded_sources list. This is a hard removal, not a penalty: there is no
+  # minimum-score threshold before grabbing, so a down-scored release is still
+  # downloaded whenever it is the only survivor, which is precisely the
+  # theatrical-window case this exists to prevent.
+  #
+  # A nil profile, an absent key, an empty list, or an unparseable source all
+  # mean "no exclusion". Exclusion is opt-in per profile and never global.
+  defp reject_excluded_sources(results, opts) do
+    case excluded_sources(opts) do
+      [] ->
+        results
+
+      excluded ->
+        Enum.filter(results, fn result ->
+          case result_source(result) do
+            nil ->
+              true
+
+            source ->
+              if source in excluded do
+                Logger.info(
+                  "[ReleaseRanker] Filtered out (excluded source #{source}): #{result.title}"
+                )
+
+                false
+              else
+                true
+              end
+          end
+        end)
+    end
+  end
+
+  defp excluded_sources(opts) do
+    case Keyword.get(opts, :quality_profile) do
+      %{quality_standards: standards} when is_map(standards) ->
+        Map.get(standards, :excluded_sources) || []
+
+      _ ->
+        []
+    end
+  end
+
+  defp result_source(%SearchResult{quality: %{source: source}}) when is_binary(source), do: source
+  defp result_source(%SearchResult{title: title}) when is_binary(title), do: Sources.detect(title)
+  defp result_source(_), do: nil
 
   ## Private Functions - Filtering
 
@@ -584,7 +634,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
       # Only hard removals are reported as rejections now; size/seeders/ratio
       # shortcomings are penalties on accepted results (mirrors filter_acceptable
       # and the identity penalty, which must stay in lockstep — see Risks).
-      case get_rejection_reason(result, blocked_tags, expected_title) do
+      case get_rejection_reason(result, blocked_tags, expected_title, excluded_sources(opts)) do
         nil ->
           # Accepted — record the full breakdown (including penalties) so the
           # Activity view can render the penalized-but-kept state.
@@ -698,13 +748,16 @@ defmodule Mydia.Indexers.ReleaseRanker do
   # removals are invalid releases (validator), blocked tags, and wrong-show
   # title mismatches. Size/seeders/ratio are no longer rejection reasons — they
   # are soft penalties on accepted results.
-  defp get_rejection_reason(result, blocked_tags, expected_title) do
+  defp get_rejection_reason(result, blocked_tags, expected_title, excluded) do
     cond do
       invalid_reason = invalid_release_reason(result) ->
         "invalid: #{invalid_reason}"
 
       blocked_tag = find_blocked_tag(result, blocked_tags) ->
         "blocked_tag: #{blocked_tag}"
+
+      (source = result_source(result)) && source in excluded ->
+        "excluded_source: #{source}"
 
       expected_title_mismatch?(result, expected_title) ->
         "title_mismatch"

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -43,6 +43,10 @@ defmodule Mydia.Indexers.ReleaseRanker do
     each result is parsed with `ReleaseParser` and rejected if the parsed title has a Jaro distance
     below 0.7 from the expected title. Unparseable releases pass through (fail-open).
     Ignored when `nil` or empty/whitespace-only. (default: `nil`)
+  - `:apply_source_exclusion` - Whether `:quality_profile`'s `:excluded_sources` list is enforced
+    as a hard removal (default: `true`). The automatic search jobs leave this at the default.
+    Manual search deliberately passes `false`: per spec R8, manual search and manual grab are the
+    operator's explicit escape hatch and must not silently drop a release the profile excludes.
   """
 
   require Logger
@@ -72,7 +76,8 @@ defmodule Mydia.Indexers.ReleaseRanker do
           expected_season: non_neg_integer() | nil,
           expected_episode: non_neg_integer() | nil,
           min_post_age_minutes: non_neg_integer() | nil,
-          now: DateTime.t() | nil
+          now: DateTime.t() | nil,
+          apply_source_exclusion: boolean() | nil
         ]
 
   @default_min_seeders 0
@@ -248,13 +253,24 @@ defmodule Mydia.Indexers.ReleaseRanker do
     end
   end
 
+  # Resolves the effective excluded-sources list for this ranking pass. Reads
+  # :apply_source_exclusion (default true) *before* looking at the profile at
+  # all, so the opt-out is a positive flag the caller sets, never inferred
+  # from whether a profile happens to be present. Manual search passes a
+  # resolved profile (for scoring) and still must not filter — see the
+  # moduledoc and R8: manual search/grab is the operator's deliberate escape
+  # hatch from any exclusion the automatic path applies.
   defp excluded_sources(opts) do
-    case Keyword.get(opts, :quality_profile) do
-      %{quality_standards: standards} when is_map(standards) ->
-        Map.get(standards, :excluded_sources) || []
+    if Keyword.get(opts, :apply_source_exclusion, true) do
+      case Keyword.get(opts, :quality_profile) do
+        %{quality_standards: standards} when is_map(standards) ->
+          Map.get(standards, :excluded_sources) || []
 
-      _ ->
-        []
+        _ ->
+          []
+      end
+    else
+      []
     end
   end
 

--- a/lib/mydia/quality/sources.ex
+++ b/lib/mydia/quality/sources.ex
@@ -1,0 +1,125 @@
+defmodule Mydia.Quality.Sources do
+  @moduledoc """
+  The single source-detection vocabulary for release names.
+
+  Every consumer that needs to know whether a release is a BluRay, a WEB-DL, or
+  a camcorder recording goes through this module. Before it existed the project
+  had three independent implementations that disagreed with each other.
+
+  ## Why the short tokens are delimiter-anchored
+
+  Scene names abbreviate Telesync to `TS`, Telecine to `TC`, Workprint to `WP`,
+  and Screener to `SCR`. Matching those as bare substrings misclassifies
+  ordinary words: `Ghosts` contains `ts`, `Watchmen` contains `tc`, `Scream`
+  contains `scr`.
+
+  Word boundaries alone are still not enough, because `\\bts\\b` matches the
+  release-group suffix in `Some.Movie.2020.1080p.x264-TS` and the leading word
+  in `Ts.Madison.Show.2021.1080p.x264`.
+
+  So the ambiguous short tokens require a dot, space, or bracket on both sides,
+  which excludes the hyphenated group position and the start of the string.
+  Unambiguous long forms (`telesync`, `workprint`, `hdcam`) keep plain `\\b`.
+
+  The tradeoff is deliberate: a genuine telesync marked only as `-TS` in the
+  group position is not detected. A false negative means one bad release slips
+  through, which is the pre-existing behavior anyway. A false positive means a
+  legitimate release is silently refused with no way for the operator to find
+  out why. Precision wins.
+  """
+
+  @cam_tier ["CAM", "Telesync", "Telecine", "Screener", "Workprint"]
+
+  @doc """
+  The release types that are camcorder or pre-release captures rather than
+  clean digital sources.
+
+      iex> Mydia.Quality.Sources.cam_tier()
+      ["CAM", "Telesync", "Telecine", "Screener", "Workprint"]
+  """
+  @spec cam_tier() :: [String.t()]
+  def cam_tier, do: @cam_tier
+
+  @doc """
+  Whether a detected source label is cam-tier. `nil` is not cam-tier.
+
+      iex> Mydia.Quality.Sources.cam_tier?("Telesync")
+      true
+
+      iex> Mydia.Quality.Sources.cam_tier?("BluRay")
+      false
+
+      iex> Mydia.Quality.Sources.cam_tier?(nil)
+      false
+  """
+  @spec cam_tier?(String.t() | nil) :: boolean()
+  def cam_tier?(nil), do: false
+  def cam_tier?(source) when is_binary(source), do: source in @cam_tier
+
+  @doc """
+  Every source label this module can detect, in match order.
+  """
+  @spec all() :: [String.t()]
+  def all, do: Enum.map(patterns(), fn {label, _pattern} -> label end)
+
+  @doc """
+  Detects the source of a release name, or `nil` when no source token is found.
+
+  Matching is first-wins in table order, so a name carrying an explicit good
+  source token resolves to that source even if a cam-tier abbreviation also
+  appears later in the string.
+
+      iex> Mydia.Quality.Sources.detect("Movie.2026.1080p.BluRay.x264")
+      "BluRay"
+
+      iex> Mydia.Quality.Sources.detect("Movie.2026.1080p.TELESYNC.x264")
+      "Telesync"
+
+      iex> Mydia.Quality.Sources.detect("Movie.2026.1080p.x264")
+      nil
+  """
+  @spec detect(String.t()) :: String.t() | nil
+  def detect(title) when is_binary(title) do
+    Enum.find_value(patterns(), fn {label, pattern} ->
+      if Regex.match?(pattern, title), do: label
+    end)
+  end
+
+  def detect(_), do: nil
+
+  @doc """
+  The label/pattern table, in match order.
+
+  Order is load-bearing in two places:
+
+  1. `Screener` sits above `DVD`, otherwise `DVDScr` matches the bare `dvd`
+     pattern first and resolves to `DVD`.
+  2. Every good source is checked before every cam-tier source, so an explicit
+     `BluRay` token beats a `-TS` release-group suffix.
+  """
+  @spec patterns() :: [{String.t(), Regex.t()}]
+  def patterns do
+    [
+      {"REMUX", ~r/remux/i},
+      {"BluRay", ~r/blu[\-\s]?ray|bluray|bdrip|brrip|bd(?:$|[\.\s])/i},
+      {"WEB-DL", ~r/web[\-\s]?dl|webdl/i},
+      {"WEBRip", ~r/web[\-\s]?rip|webrip/i},
+      {"HDTV", ~r/hdtv/i},
+      {"SDTV", ~r/sdtv/i},
+      {"DVDRip", ~r/dvd[\-\s]?rip|dvdrip/i},
+      # Screener must precede DVD so DVDScr does not match the bare dvd pattern.
+      {"Screener", ~r/\b(?:dvd|bd|web)scr(?:eener)?\b|\bscreener\b|#{delimited("scr")}/i},
+      {"DVD", ~r/dvd/i},
+      {"Telecine", ~r/\btelecine\b|\bhd\-?tc\b|#{delimited("tc")}/i},
+      {"Telesync", ~r/\btelesync\b|\bhd\-?ts\b|\bpdvd\b|\bpredvd\b|#{delimited("ts")}/i},
+      {"CAM", ~r/\bhd\-?cam\b|\bcam\-?rip\b|\bhqcam\b|#{delimited("cam")}/i},
+      {"Workprint", ~r/\bworkprint\b|#{delimited("wp")}/i},
+      {"PDTV", ~r/pdtv/i}
+    ]
+  end
+
+  # Requires a dot, space, or bracket on both sides of the token. This excludes
+  # the hyphenated release-group position (`x264-TS`) and the start of the
+  # string (`Ts.Madison`), both of which plain \b would match.
+  defp delimited(token), do: "(?<=[.\\s\\[])#{token}(?=[.\\s\\]]|$)"
+end

--- a/lib/mydia/quality/sources.ex
+++ b/lib/mydia/quality/sources.ex
@@ -1,10 +1,16 @@
 defmodule Mydia.Quality.Sources do
   @moduledoc """
-  The single source-detection vocabulary for release names.
+  The source-detection vocabulary for the indexer search/grab path.
 
-  Every consumer that needs to know whether a release is a BluRay, a WEB-DL, or
-  a camcorder recording goes through this module. Before it existed the project
-  had three independent implementations that disagreed with each other.
+  `QualityParser` uses this module to classify release names during search and
+  grab, and `QualityProfileEngine.infer_source_from_filename/1` uses it to
+  infer a source for on-disk files that lack stored metadata. It is not the
+  only source parser in the codebase: `Mydia.Library.FileParser`'s
+  `@source_pattern`, the V3 parser (`priv/release_parser/sources.exs`), and
+  `Mydia.Upgrades.Attrs`'s `@canonical_sources` each carry their own,
+  independently-maintained vocabularies for their respective pipelines.
+  Unifying those is separate follow-up work, not something this module
+  attempts.
 
   ## Why the short tokens are delimiter-anchored
 

--- a/lib/mydia/settings/default_quality_profiles.ex
+++ b/lib/mydia/settings/default_quality_profiles.ex
@@ -36,6 +36,7 @@ defmodule Mydia.Settings.DefaultQualityProfiles do
         upgrade_until_score: 95,
         description: "Any quality, no size limits. Maximizes availability.",
         quality_standards: %{
+          excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
           preferred_resolutions: ["360p", "480p", "576p", "720p", "1080p", "2160p"]
         }
       },
@@ -45,6 +46,7 @@ defmodule Mydia.Settings.DefaultQualityProfiles do
         upgrade_until_score: 45,
         description: "Standard Definition up to 480p/DVD quality. Limited to 2GB.",
         quality_standards: %{
+          excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
           max_resolution: "576p",
           preferred_resolutions: ["480p", "576p"],
           preferred_sources: ["DVD", "DVDRip", "SDTV"],
@@ -57,6 +59,7 @@ defmodule Mydia.Settings.DefaultQualityProfiles do
         upgrades_allowed: false,
         description: "720p HD content. Balanced quality and file size (1-5GB).",
         quality_standards: %{
+          excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
           min_resolution: "720p",
           max_resolution: "720p",
           preferred_resolutions: ["720p"],
@@ -73,6 +76,7 @@ defmodule Mydia.Settings.DefaultQualityProfiles do
         upgrades_allowed: false,
         description: "1080p Full HD content. Standard high quality (2-15GB).",
         quality_standards: %{
+          excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
           min_resolution: "1080p",
           max_resolution: "1080p",
           preferred_resolutions: ["1080p"],
@@ -89,6 +93,7 @@ defmodule Mydia.Settings.DefaultQualityProfiles do
         upgrades_allowed: false,
         description: "Strict 1080p with high-quality sources only (4-20GB).",
         quality_standards: %{
+          excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
           min_resolution: "1080p",
           max_resolution: "1080p",
           preferred_resolutions: ["1080p"],
@@ -105,6 +110,7 @@ defmodule Mydia.Settings.DefaultQualityProfiles do
         upgrades_allowed: false,
         description: "Lossless 1080p REMUX releases. Premium quality (20-40GB).",
         quality_standards: %{
+          excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
           min_resolution: "1080p",
           max_resolution: "1080p",
           preferred_resolutions: ["1080p"],
@@ -122,6 +128,7 @@ defmodule Mydia.Settings.DefaultQualityProfiles do
         upgrades_allowed: false,
         description: "Ultra HD 2160p/4K content. Maximum quality (15-80GB).",
         quality_standards: %{
+          excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
           min_resolution: "2160p",
           max_resolution: "2160p",
           preferred_resolutions: ["2160p"],
@@ -140,6 +147,7 @@ defmodule Mydia.Settings.DefaultQualityProfiles do
         upgrades_allowed: false,
         description: "Lossless 4K REMUX releases. Ultimate quality (40-100GB).",
         quality_standards: %{
+          excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
           min_resolution: "2160p",
           max_resolution: "2160p",
           preferred_resolutions: ["2160p"],

--- a/lib/mydia/settings/quality_profile.ex
+++ b/lib/mydia/settings/quality_profile.ex
@@ -786,6 +786,22 @@ defmodule Mydia.Settings.QualityProfile do
           violations
       end
 
+    # Excluded sources are a hard violation, not a scoring penalty. A file whose
+    # source the profile refuses to grab should read as maximally upgradable so
+    # the upgrade path replaces it once a real release appears.
+    violations =
+      case {Map.get(standards, :excluded_sources), Map.get(media_attrs, :source)} do
+        {excluded, source} when is_list(excluded) and is_binary(source) ->
+          if source in excluded do
+            ["Source #{source} is excluded by this profile" | violations]
+          else
+            violations
+          end
+
+        _ ->
+          violations
+      end
+
     violations
   end
 

--- a/lib/mydia/settings/quality_profile.ex
+++ b/lib/mydia/settings/quality_profile.ex
@@ -55,12 +55,14 @@ defmodule Mydia.Settings.QualityProfile do
   ]
   @valid_audio_channels ["1.0", "2.0", "2.1", "5.1", "6.1", "7.1", "7.1.2", "7.1.4"]
   @valid_resolutions ["360p", "480p", "576p", "720p", "1080p", "2160p", "4320p"]
-  # "BDRip" is deliberately absent: Mydia.Quality.Sources.detect/1 folds it
-  # into "BluRay" (the BluRay pattern matches `bdrip`), so no release can
-  # ever be detected as the literal "BDRip" any more. Listing it here would
-  # let an operator select a preference no release will ever match.
+  # Mydia.Quality.Sources.detect/1 folds "bdrip" into "BluRay" for the
+  # indexer search/grab path, but the V3 release parser
+  # (priv/release_parser/sources.exs) still emits canonical "BDRip" for
+  # on-disk files, and that value flows through Mydia.Upgrades.Attrs into
+  # scoring. So "BDRip" remains a meaningful, selectable preference here.
   @valid_sources [
     "BluRay",
+    "BDRip",
     "REMUX",
     "WEB-DL",
     "WEBRip",

--- a/lib/mydia/settings/quality_profile.ex
+++ b/lib/mydia/settings/quality_profile.ex
@@ -5,6 +5,7 @@ defmodule Mydia.Settings.QualityProfile do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Mydia.Quality.Sources
   alias Mydia.Settings.JsonAtomMapType
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -65,6 +66,10 @@ defmodule Mydia.Settings.QualityProfile do
     "DVDRip",
     "BDRip"
   ]
+  # Sources that may appear in an exclusion list. Superset of @valid_sources,
+  # since the whole point of the exclusion list is naming the cam-tier types
+  # that are never valid *preferences*.
+  @valid_excludable_sources @valid_sources ++ Sources.cam_tier()
   @valid_hdr_formats ["hdr10", "hdr10+", "dolby_vision", "hlg"]
 
   schema "quality_profiles" do
@@ -166,6 +171,7 @@ defmodule Mydia.Settings.QualityProfile do
         |> validate_resolution_ranges(standards)
         |> validate_resolutions(standards)
         |> validate_sources(standards)
+        |> validate_excluded_sources(standards)
         |> validate_media_type_sizes(standards)
         |> validate_hdr_formats(standards)
         |> validate_min_ratio(standards)
@@ -489,6 +495,30 @@ defmodule Mydia.Settings.QualityProfile do
 
       _ ->
         add_error(changeset, :quality_standards, "preferred_sources must be a list")
+    end
+  end
+
+  defp validate_excluded_sources(changeset, standards) do
+    case Map.get(standards, :excluded_sources) do
+      nil ->
+        changeset
+
+      sources when is_list(sources) ->
+        invalid = sources -- @valid_excludable_sources
+
+        if Enum.empty?(invalid) do
+          changeset
+        else
+          add_error(
+            changeset,
+            :quality_standards,
+            "contains invalid excluded sources: #{Enum.join(invalid, ", ")}. " <>
+              "Valid sources: #{Enum.join(@valid_excludable_sources, ", ")}"
+          )
+        end
+
+      _ ->
+        add_error(changeset, :quality_standards, "excluded_sources must be a list")
     end
   end
 

--- a/lib/mydia/settings/quality_profile.ex
+++ b/lib/mydia/settings/quality_profile.ex
@@ -55,6 +55,10 @@ defmodule Mydia.Settings.QualityProfile do
   ]
   @valid_audio_channels ["1.0", "2.0", "2.1", "5.1", "6.1", "7.1", "7.1.2", "7.1.4"]
   @valid_resolutions ["360p", "480p", "576p", "720p", "1080p", "2160p", "4320p"]
+  # "BDRip" is deliberately absent: Mydia.Quality.Sources.detect/1 folds it
+  # into "BluRay" (the BluRay pattern matches `bdrip`), so no release can
+  # ever be detected as the literal "BDRip" any more. Listing it here would
+  # let an operator select a preference no release will ever match.
   @valid_sources [
     "BluRay",
     "REMUX",
@@ -63,8 +67,7 @@ defmodule Mydia.Settings.QualityProfile do
     "HDTV",
     "SDTV",
     "DVD",
-    "DVDRip",
-    "BDRip"
+    "DVDRip"
   ]
   # Sources that may appear in an exclusion list. Superset of @valid_sources,
   # since the whole point of the exclusion list is naming the cam-tier types

--- a/lib/mydia/settings/quality_profile_engine.ex
+++ b/lib/mydia/settings/quality_profile_engine.ex
@@ -40,6 +40,7 @@ defmodule Mydia.Settings.QualityProfileEngine do
 
   require Logger
   import Ecto.Query
+  alias Mydia.Quality.Sources
   alias Mydia.Repo
   alias Mydia.Settings.QualityProfile
   alias Mydia.Library.MediaFile
@@ -472,36 +473,19 @@ defmodule Mydia.Settings.QualityProfileEngine do
     end
   end
 
-  # Infers source type from filename patterns
-  defp infer_source_from_filename(filename) do
-    filename_lower = String.downcase(filename)
+  @doc """
+  Infers the source type from a media file's relative path.
 
-    cond do
-      String.contains?(filename_lower, "bluray") or String.contains?(filename_lower, "blu-ray") ->
-        "BluRay"
-
-      String.contains?(filename_lower, "remux") ->
-        "REMUX"
-
-      String.contains?(filename_lower, "web-dl") or String.contains?(filename_lower, "webdl") ->
-        "WEB-DL"
-
-      String.contains?(filename_lower, "webrip") ->
-        "WEBRip"
-
-      String.contains?(filename_lower, "hdtv") ->
-        "HDTV"
-
-      String.contains?(filename_lower, "dvdrip") ->
-        "DVDRip"
-
-      String.contains?(filename_lower, "bdrip") ->
-        "BDRip"
-
-      true ->
-        nil
-    end
+  Public so the source vocabulary can be tested directly against real on-disk
+  paths. Delegates to `Mydia.Quality.Sources` so the on-disk path and the
+  indexer search path agree on what a release is.
+  """
+  @spec infer_source_from_filename(String.t()) :: String.t() | nil
+  def infer_source_from_filename(filename) when is_binary(filename) do
+    Sources.detect(filename)
   end
+
+  def infer_source_from_filename(_), do: nil
 
   # Generates upgrade recommendations based on scoring results
   defp generate_recommendations(profile, media_attrs, scoring_result) do

--- a/lib/mydia/settings/quality_profile_presets.ex
+++ b/lib/mydia/settings/quality_profile_presets.ex
@@ -132,6 +132,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "TRaSH Guides: High-quality HD encodes for Blu-ray and streaming sources (6-15 GB)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "720p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -163,6 +164,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           upgrade_until_score: 95,
           description: "TRaSH Guides: Ultra HD 4K encodes with HDR support (20-60 GB)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "2160p",
             max_resolution: "2160p",
             preferred_resolutions: ["2160p"],
@@ -195,6 +197,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           upgrade_until_score: 85,
           description: "TRaSH Guides: 1080p with lossless audio (20-40 GB)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "1080p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -226,6 +229,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           upgrade_until_score: 95,
           description: "TRaSH Guides: 4K with lossless audio and HDR (40-100 GB)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "2160p",
             max_resolution: "2160p",
             preferred_resolutions: ["2160p"],
@@ -258,6 +262,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           upgrade_until_score: 85,
           description: "TRaSH Guides: Web releases optimized for TV shows (1-3 GB per episode)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "720p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -290,6 +295,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "TRaSH Guides: 4K web releases with HDR for TV shows (5-15 GB per episode)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "2160p",
             max_resolution: "2160p",
             preferred_resolutions: ["2160p"],
@@ -331,6 +337,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Transparent x264 720p encodes using GPPI scoring (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "720p",
             preferred_resolutions: ["720p"],
@@ -364,6 +371,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Transparent x264 1080p encodes using GPPI scoring (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -397,6 +405,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Transparent x265 HDR 1080p encodes using GPPI scoring (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -431,6 +440,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Consistent 1080p WEB-DLs with streaming source prioritization (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -465,6 +475,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Efficient 1080p x265 WEB-DLs for smaller file sizes (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -498,6 +509,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Compact 1080p x265 encodes for maximum storage efficiency (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -532,6 +544,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Lossless 1080p Remux with premium audio (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -567,6 +580,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Transparent x265 4K encodes using EEI scoring (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "2160p",
             preferred_resolutions: ["2160p", "1080p"],
@@ -601,6 +615,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Consistent 2160p WEB-DLs with streaming source prioritization (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "2160p",
             preferred_resolutions: ["2160p", "1080p"],
@@ -637,6 +652,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Efficient 2160p HEVC WEB-DLs for smaller 4K file sizes (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "2160p",
             preferred_resolutions: ["2160p", "1080p"],
@@ -672,6 +688,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Profilarr: Lossless 4K UHD Remux with premium audio and HDR (original language only)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "480p",
             max_resolution: "2160p",
             preferred_resolutions: ["2160p", "1080p"],
@@ -712,6 +729,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           description:
             "Compact file sizes for limited storage (1-4 GB movies, 300-800 MB episodes)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             max_resolution: "1080p",
             preferred_resolutions: ["720p", "1080p"],
             preferred_sources: ["WEB-DL", "WEBRip"],
@@ -742,6 +760,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           upgrade_until_score: 85,
           description: "Balanced quality and size (4-10 GB movies, 800-2 GB episodes)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "720p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p"],
@@ -773,6 +792,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           upgrade_until_score: 95,
           description: "Maximum quality for archival (30-80 GB movies)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "1080p",
             preferred_resolutions: ["2160p", "1080p"],
             preferred_sources: ["REMUX", "BluRay"],
@@ -810,6 +830,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           upgrade_until_score: 85,
           description: "Optimized for streaming (2-8 GB movies)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "720p",
             max_resolution: "1080p",
             preferred_resolutions: ["1080p", "720p"],
@@ -841,6 +862,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           upgrade_until_score: 95,
           description: "High quality for local playback (10-40 GB movies)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             min_resolution: "1080p",
             preferred_resolutions: ["1080p", "2160p"],
             preferred_sources: ["BluRay", "REMUX"],
@@ -868,6 +890,7 @@ defmodule Mydia.Settings.QualityProfilePresets do
           upgrades_allowed: false,
           description: "Mobile-friendly sizes and codecs (500 MB-2 GB movies)",
           quality_standards: %{
+            excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
             max_resolution: "720p",
             preferred_resolutions: ["720p", "480p"],
             preferred_sources: ["WEB-DL", "WEBRip"],

--- a/lib/mydia/upgrades/attrs.ex
+++ b/lib/mydia/upgrades/attrs.ex
@@ -41,6 +41,7 @@ defmodule Mydia.Upgrades.Attrs do
 
   alias Mydia.Library.MediaFile
   alias Mydia.Library.Structs.Quality
+  alias Mydia.Quality.Sources
 
   @bytes_per_mb 1024 * 1024
 
@@ -189,7 +190,29 @@ defmodule Mydia.Upgrades.Attrs do
     }
   end
 
-  defp metadata_source(%MediaFile{metadata: %{source: source}}), do: source
+  defp metadata_source(%MediaFile{metadata: %{source: source}}) when is_binary(source),
+    do: source
+
+  # V3's ReleaseParser (priv/release_parser/sources.exs) carries zero
+  # cam-tier entries, so a download-imported telesync or cam release lands
+  # here with metadata.source nil. Without this fallback such a file scores
+  # a neutral 50.0 forever, and R7 (a cam-tier file already in the library
+  # scores 0 so the upgrade path replaces it) never fires.
+  #
+  # The fallback is deliberately restricted to cam-tier detections. Every
+  # on-disk file with no metadata.source today reaches score_source/2 with a
+  # nil source and takes the 50.0 catch-all. Returning any filename-detected
+  # source here - not just cam-tier - would give every clean file a real
+  # source and swing scores by up to +/-9 points (source weight 0.12)
+  # against a default upgrade_until_score of 85, churning upgrade decisions
+  # library-wide. Restricting to cam-tier means only the files this feature
+  # exists to catch move; everything else keeps its current nil-and-50.0
+  # behavior.
+  defp metadata_source(%MediaFile{relative_path: relative_path}) when is_binary(relative_path) do
+    detected = Sources.detect(relative_path)
+    if Sources.cam_tier?(detected), do: detected, else: nil
+  end
+
   defp metadata_source(_file), do: nil
 
   # Prefer the analyzer's untouched audio string over the streaming-normalized

--- a/lib/mydia/upgrades/attrs.ex
+++ b/lib/mydia/upgrades/attrs.ex
@@ -138,7 +138,8 @@ defmodule Mydia.Upgrades.Attrs do
     "hlg" => "hlg"
   }
 
-  @canonical_sources ~w(BluRay REMUX WEB-DL WEBRip HDTV SDTV DVD DVDRip BDRip)
+  @canonical_sources ~w(BluRay REMUX WEB-DL WEBRip HDTV SDTV DVD DVDRip BDRip) ++
+                       ["CAM", "Telesync", "Telecine", "Screener", "Workprint"]
 
   # Precedence for fused audio strings that carry two codec tokens, e.g.
   # FileAnalyzer's "TrueHD Atmos" or "DTS-HD MA". Atmos is a higher-tier

--- a/lib/mydia_web/live/admin_quality_profiles_live/components.ex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/components.ex
@@ -555,7 +555,7 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Components do
           <span class="label-text-alt text-xs">In priority order</span>
         </label>
         <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
-          <%= for source <- ["BluRay", "REMUX", "WEB-DL", "WEBRip", "HDTV", "SDTV", "DVD", "DVDRip"] do %>
+          <%= for source <- ["BluRay", "BDRip", "REMUX", "WEB-DL", "WEBRip", "HDTV", "SDTV", "DVD", "DVDRip"] do %>
             <label class="label cursor-pointer justify-start gap-2">
               <input
                 type="checkbox"

--- a/lib/mydia_web/live/admin_quality_profiles_live/components.ex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/components.ex
@@ -555,7 +555,7 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Components do
           <span class="label-text-alt text-xs">In priority order</span>
         </label>
         <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
-          <%= for source <- ["BluRay", "REMUX", "WEB-DL", "WEBRip", "HDTV", "SDTV", "DVD", "DVDRip", "BDRip"] do %>
+          <%= for source <- ["BluRay", "REMUX", "WEB-DL", "WEBRip", "HDTV", "SDTV", "DVD", "DVDRip"] do %>
             <label class="label cursor-pointer justify-start gap-2">
               <input
                 type="checkbox"

--- a/lib/mydia_web/live/admin_quality_profiles_live/components.ex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/components.ex
@@ -264,6 +264,15 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Components do
           >
             Quality Standards
           </button>
+          <button
+            type="button"
+            role="tab"
+            class={["tab", @quality_profile_active_tab == "exclude" && "tab-active"]}
+            phx-click="change_quality_profile_tab"
+            phx-value-tab="exclude"
+          >
+            Exclude
+          </button>
         </div>
 
         <.form
@@ -280,6 +289,11 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Components do
           <%!-- Quality Standards Tab - Always rendered, hidden when not active --%>
           <div class={if @quality_profile_active_tab != "standards", do: "hidden"}>
             <.quality_profile_standards_tab form={@quality_profile_form} />
+          </div>
+
+          <%!-- Exclude Tab - Always rendered, hidden when not active --%>
+          <div class={if @quality_profile_active_tab != "exclude", do: "hidden"}>
+            <.quality_profile_exclude_tab form={@quality_profile_form} />
           </div>
 
           <div class="modal-action">
@@ -945,6 +959,63 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Components do
           <button type="button" class="btn" phx-click="close_browse_presets_modal">
             Close
           </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders the Exclude tab: release types this profile will never grab.
+
+  The hidden input before the checkbox group matters. Browsers omit unchecked
+  checkboxes entirely, so without it, clearing every box would submit no key at
+  all, `cast` would see no change, and the previous list would silently persist
+  with no way for the operator to turn the exclusion off.
+  """
+  attr :form, :any, required: true
+
+  def quality_profile_exclude_tab(assigns) do
+    assigns = assign(assigns, :cam_tier, Mydia.Quality.Sources.cam_tier())
+
+    ~H"""
+    <div class="space-y-4">
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-semibold">Never Grab These Release Types</span>
+          <span class="label-text-alt text-xs">Dropped before ranking, even if nothing else is available</span>
+        </label>
+
+        <p class="text-sm opacity-70 mb-3">
+          Camcorder and pre-release captures. When a film is still in cinemas these are
+          often the only releases that exist, so without this list Mydia will download one
+          rather than wait for a proper release.
+        </p>
+
+        <input
+          type="hidden"
+          name="quality_profile[quality_standards][excluded_sources][]"
+          value=""
+        />
+
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
+          <%= for source <- @cam_tier do %>
+            <label class="label cursor-pointer justify-start gap-2">
+              <input
+                type="checkbox"
+                name="quality_profile[quality_standards][excluded_sources][]"
+                value={source}
+                checked={
+                  source in (get_in(
+                               Ecto.Changeset.get_field(@form.source, :quality_standards, %{}),
+                               [:excluded_sources]
+                             ) || [])
+                }
+                class="checkbox checkbox-sm checkbox-primary"
+              />
+              <span class="label-text text-sm">{source}</span>
+            </label>
+          <% end %>
         </div>
       </div>
     </div>

--- a/lib/mydia_web/live/admin_quality_profiles_live/index.ex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/index.ex
@@ -444,10 +444,11 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
               "preferred_audio_channels",
               "preferred_resolutions",
               "preferred_sources",
+              "excluded_sources",
               "hdr_formats"
             ] do
     case value do
-      list when is_list(list) -> list
+      list when is_list(list) -> Enum.reject(list, &(&1 == ""))
       str when is_binary(str) -> String.split(str, ",") |> Enum.map(&String.trim/1)
       _ -> nil
     end

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -180,9 +180,16 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   Sort manual-search results using a pre-built RankingOptions keyword list.
 
   For the `:quality` sort mode this routes through `ReleaseRanker.rank_all/2`,
-  so the manual top result equals what automatic search would select (R2).
-  Penalized releases (size/seeder/identity) remain visible, sorted to the bottom
-  (R3); only hard removals (blocked tags, invalid, too-recent NZB) drop out.
+  so the manual top result equals what automatic search would select (R2),
+  with one deliberate exception: `quality_sort_via_ranker/2` passes
+  `apply_source_exclusion: false`, so a profile's `:excluded_sources` list is
+  NOT enforced here. Per spec R8, manual search and manual grab are the
+  operator's explicit escape hatch and must stay unaffected by exclusion the
+  automatic path applies — silently dropping a release from the manual
+  dialog, recoverable only by switching sort mode, would remove that escape
+  hatch. Penalized releases (size/seeder/identity) remain visible, sorted to
+  the bottom (R3); the hard removals that still apply to manual search are
+  blocked tags, invalid releases, and too-recent NZBs.
   Non-quality sort modes (`:seeders`, `:size`, `:date`) stay as direct sorts.
   """
   def sort_search_results_with_opts(results, :quality, ranking_opts) do
@@ -199,6 +206,13 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   # Run the unified ranker and return the surviving SearchResults in ranked
   # order. When no quality profile is set, fall back to a seeders sort (matching
   # the legacy no-profile behavior).
+  #
+  # apply_source_exclusion: false is load-bearing (R8): this is the manual
+  # search dialog, and manual search/grab must never silently drop a release
+  # because of a profile's :excluded_sources list, even though a resolved
+  # profile IS passed through for scoring/sorting. The opt-out is an explicit
+  # flag rather than "no profile present" so it can't be defeated by the
+  # profile the manual dialog legitimately does pass.
   defp quality_sort_via_ranker(results, ranking_opts) do
     case Keyword.get(ranking_opts, :quality_profile) do
       nil ->
@@ -206,7 +220,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
 
       _profile ->
         results
-        |> ReleaseRanker.rank_all(ranking_opts)
+        |> ReleaseRanker.rank_all(Keyword.put(ranking_opts, :apply_source_exclusion, false))
         |> Enum.map(& &1.result)
     end
   end

--- a/priv/repo/migrations/20260804182323_backfill_excluded_sources.exs
+++ b/priv/repo/migrations/20260804182323_backfill_excluded_sources.exs
@@ -1,0 +1,55 @@
+defmodule Mydia.Repo.Migrations.BackfillExcludedSources do
+  @moduledoc """
+  Backfills `quality_standards.excluded_sources` onto every existing quality
+  profile so upgrading instances stop grabbing camcorder captures.
+
+  Downloading a telesync is not a preference anyone tuned a profile to express,
+  so this corrects a default rather than overriding a choice. The field stays
+  per-profile and editable, and profiles that already carry the key (including
+  an operator who deliberately cleared it) are left untouched.
+
+  `quality_standards` is a JSON text column, so this is a read-modify-write in
+  Elixir and runs identically on SQLite and PostgreSQL.
+  """
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  # Inlined rather than calling Mydia.Quality.Sources.cam_tier/0 so a later
+  # change to that list cannot retroactively alter what this migration did.
+  @cam_tier ["CAM", "Telesync", "Telecine", "Screener", "Workprint"]
+
+  def up do
+    repo().all(from(p in "quality_profiles", select: {p.id, p.quality_standards}))
+    |> Enum.each(fn {id, raw} ->
+      standards = decode(raw)
+
+      unless Map.has_key?(standards, "excluded_sources") do
+        updated = Map.put(standards, "excluded_sources", @cam_tier)
+
+        repo().update_all(
+          from(p in "quality_profiles", where: p.id == ^id),
+          set: [quality_standards: Jason.encode!(updated)]
+        )
+      end
+    end)
+  end
+
+  # Irreversible by design: we cannot distinguish a profile we backfilled from
+  # one an operator configured identically afterwards, and removing the key
+  # would silently re-enable cam grabs.
+  def down, do: :ok
+
+  defp decode(nil), do: %{}
+  defp decode(""), do: %{}
+
+  defp decode(raw) when is_binary(raw) do
+    case Jason.decode(raw) do
+      {:ok, map} when is_map(map) -> map
+      _ -> %{}
+    end
+  end
+
+  defp decode(map) when is_map(map), do: map
+  defp decode(_), do: %{}
+end

--- a/test/mydia/indexers/quality_parser_test.exs
+++ b/test/mydia/indexers/quality_parser_test.exs
@@ -459,4 +459,29 @@ defmodule Mydia.Indexers.QualityParserTest do
       assert quality.audio == "DTS-HD MA"
     end
   end
+
+  describe "extract_source/1 regression: unanchored short tokens" do
+    test "ordinary words containing cam-tier letter pairs are not cam-tier" do
+      alias Mydia.Quality.Sources
+
+      for title <- [
+            "Ghosts.of.Mars.2001.1080p.x264-GRP",
+            "The.Watchmen.2009.2160p.HDR.x265",
+            "Scream.VI.2023.1080p.x265-RARBG",
+            "Cameron.Diaz.Doc.2020.1080p.x264",
+            "Lights.Out.2016.1080p.x264"
+          ] do
+        refute Sources.cam_tier?(QualityParser.extract_source(title)),
+               "#{title} must not be classified cam-tier"
+      end
+    end
+
+    test "real telesync releases are still detected" do
+      assert QualityParser.extract_source("The.Odyssey.2026.1080p.TELESYNC.HEVC.AAC2.0") ==
+               "Telesync"
+
+      assert QualityParser.extract_source("Movie.2026.HDTS.x264") == "Telesync"
+      assert QualityParser.extract_source("Movie.2026.HDCAM.x264") == "CAM"
+    end
+  end
 end

--- a/test/mydia/indexers/release_ranker_excluded_sources_test.exs
+++ b/test/mydia/indexers/release_ranker_excluded_sources_test.exs
@@ -1,0 +1,143 @@
+defmodule Mydia.Indexers.ReleaseRankerExcludedSourcesTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Indexers.{QualityParser, ReleaseRanker, SearchResult}
+  alias Mydia.Settings.QualityProfile
+
+  defp telesync do
+    SearchResult.new(
+      title: "The.Odyssey.2026.1080p.TELESYNC.HEVC.AAC2.0-SLH",
+      size: 3_293_700_000,
+      seeders: 500,
+      leechers: 40,
+      download_url: "magnet:?xt=urn:btih:aaa",
+      indexer: "Prowlarr",
+      guid: "telesync-1"
+    )
+  end
+
+  # Same release as `telesync/0`, but with :quality populated the way a real
+  # indexer adapter would (via QualityParser.parse/1) rather than left nil.
+  # This exercises the first result_source/1 clause (result.quality.source);
+  # the plain telesync/0 helper above exercises the title-fallback clause.
+  defp telesync_with_quality do
+    title = "The.Odyssey.2026.1080p.TELESYNC.HEVC.AAC2.0-SLH"
+
+    SearchResult.new(
+      title: title,
+      size: 3_293_700_000,
+      seeders: 500,
+      leechers: 40,
+      download_url: "magnet:?xt=urn:btih:aaa2",
+      indexer: "Prowlarr",
+      guid: "telesync-quality-1",
+      quality: QualityParser.parse(title)
+    )
+  end
+
+  defp bluray do
+    SearchResult.new(
+      title: "The.Odyssey.2026.1080p.BluRay.x264-GRP",
+      size: 8_000_000_000,
+      seeders: 20,
+      leechers: 2,
+      download_url: "magnet:?xt=urn:btih:bbb",
+      indexer: "Prowlarr",
+      guid: "bluray-1"
+    )
+  end
+
+  defp profile_excluding(sources) do
+    %QualityProfile{
+      name: "Test",
+      quality_standards: %{excluded_sources: sources}
+    }
+  end
+
+  describe "excluded sources are dropped before ranking" do
+    test "an excluded release is dropped even when it is the ONLY candidate" do
+      # The theatrical-window case: nothing but a telesync exists. The item must
+      # stay wanted rather than take the cam.
+      assert ReleaseRanker.select_best_result([telesync()],
+               quality_profile: profile_excluding(["Telesync"]),
+               expected_title: "The Odyssey"
+             ) == nil
+    end
+
+    test "an excluded release with :quality populated is dropped even when it is the ONLY candidate" do
+      # Same as above, but exercises the result.quality.source clause of
+      # result_source/1 rather than the title-fallback clause.
+      assert telesync_with_quality().quality.source == "Telesync"
+
+      assert ReleaseRanker.select_best_result([telesync_with_quality()],
+               quality_profile: profile_excluding(["Telesync"]),
+               expected_title: "The Odyssey"
+             ) == nil
+    end
+
+    test "a non-excluded release still wins when both are present" do
+      result =
+        ReleaseRanker.select_best_result([telesync(), bluray()],
+          quality_profile: profile_excluding(["Telesync"]),
+          expected_title: "The Odyssey"
+        )
+
+      refute is_nil(result)
+      assert result.result.guid == "bluray-1"
+    end
+
+    test "an empty exclusion list changes nothing (the opt-out must work)" do
+      result =
+        ReleaseRanker.select_best_result([telesync()],
+          quality_profile: profile_excluding([]),
+          expected_title: "The Odyssey"
+        )
+
+      refute is_nil(result), "an empty exclusion list must not filter anything"
+      assert result.result.guid == "telesync-1"
+    end
+
+    test "a profile without the key changes nothing" do
+      profile = %QualityProfile{name: "NoKey", quality_standards: %{}}
+
+      result =
+        ReleaseRanker.select_best_result([telesync()],
+          quality_profile: profile,
+          expected_title: "The Odyssey"
+        )
+
+      refute is_nil(result)
+    end
+
+    test "a nil profile changes nothing" do
+      result =
+        ReleaseRanker.select_best_result([telesync()],
+          quality_profile: nil,
+          expected_title: "The Odyssey"
+        )
+
+      refute is_nil(result)
+    end
+
+    test "a release whose source could not be parsed is never dropped" do
+      unknown =
+        SearchResult.new(
+          title: "The.Odyssey.2026.1080p.x264",
+          size: 4_000_000_000,
+          seeders: 10,
+          leechers: 1,
+          download_url: "magnet:?xt=urn:btih:ccc",
+          indexer: "Prowlarr",
+          guid: "unknown-1"
+        )
+
+      result =
+        ReleaseRanker.select_best_result([unknown],
+          quality_profile: profile_excluding(["Telesync", "CAM"]),
+          expected_title: "The Odyssey"
+        )
+
+      refute is_nil(result)
+    end
+  end
+end

--- a/test/mydia/indexers/release_ranker_excluded_sources_test.exs
+++ b/test/mydia/indexers/release_ranker_excluded_sources_test.exs
@@ -140,4 +140,48 @@ defmodule Mydia.Indexers.ReleaseRankerExcludedSourcesTest do
       refute is_nil(result)
     end
   end
+
+  describe "apply_source_exclusion opt-out (R8: manual search is unaffected)" do
+    test "apply_source_exclusion: false skips the filter even with a profile and matching source" do
+      # This is the raw ReleaseRanker-level opt-out that the manual search
+      # dialog relies on (see MydiaWeb.MediaLive.Show.SearchHelpers
+      # .quality_sort_via_ranker/2). Passing a profile that excludes the
+      # source is not enough on its own to filter -- the caller must also
+      # leave apply_source_exclusion at its true default.
+      result =
+        ReleaseRanker.select_best_result([telesync()],
+          quality_profile: profile_excluding(["Telesync"]),
+          apply_source_exclusion: false,
+          expected_title: "The Odyssey"
+        )
+
+      refute is_nil(result), "apply_source_exclusion: false must disable the hard filter"
+      assert result.result.guid == "telesync-1"
+    end
+
+    test "apply_source_exclusion defaults to true, so the automatic path keeps filtering" do
+      # Guards against the opt-out silently inverting: omitting the option
+      # entirely (the shape every automatic search call site uses) must
+      # still drop the excluded release, exactly like the bare-options tests
+      # above.
+      result =
+        ReleaseRanker.select_best_result([telesync()],
+          quality_profile: profile_excluding(["Telesync"]),
+          expected_title: "The Odyssey"
+        )
+
+      assert result == nil
+    end
+
+    test "apply_source_exclusion: true is equivalent to the default (explicit opt-in is harmless)" do
+      result =
+        ReleaseRanker.select_best_result([telesync()],
+          quality_profile: profile_excluding(["Telesync"]),
+          apply_source_exclusion: true,
+          expected_title: "The Odyssey"
+        )
+
+      assert result == nil
+    end
+  end
 end

--- a/test/mydia/quality/sources_test.exs
+++ b/test/mydia/quality/sources_test.exs
@@ -1,0 +1,130 @@
+defmodule Mydia.Quality.SourcesTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Quality.Sources
+
+  # Titles that must NEVER be classified cam-tier. Covers three distinct
+  # failure modes of the old unanchored patterns plus legitimate controls.
+  @never_cam_tier [
+    # substring matches inside ordinary words
+    "Ghosts.of.Mars.2001.1080p.x264-GRP",
+    "The.Watchmen.2009.2160p.HDR.x265",
+    "Dutch.1991.1080p.x264",
+    "Scream.VI.2023.1080p.x265-RARBG",
+    "Cameron.Diaz.Doc.2020.1080p.x264",
+    "Kitchen.Nightmares.S01E01.1080p.x264",
+    "Lights.Out.2016.1080p.x264",
+    # release-group suffixes in the hyphenated position
+    "Some.Movie.2020.1080p.x264-WP",
+    "Some.Movie.2020.1080p.x264-TS",
+    "Some.Movie.2020.1080p.x264-TC",
+    "Some.Movie.2020.2160p.HDR.DV.x265-SCR",
+    # title-initial token
+    "Ts.Madison.Show.2021.1080p.x264",
+    # legitimate releases with explicit good sources
+    "The.Matrix.1999.1080p.BluRay.x264",
+    "Interstellar.2014.2160p.WEB-DL.x265",
+    "Hitchcock.2012.1080p.WEBRip.x264",
+    "Descriptions.2020.720p.HDTV.x264",
+    # legitimate releases with no source token at all
+    "WALL-E.2008.1080p.x264",
+    "Wonka.2023.1080p.x264",
+    "The.Big.Short.2015.1080p.x264",
+    "Doctor.Who.2005.S01E01.1080p.x264"
+  ]
+
+  # Titles that must ALWAYS be classified cam-tier. The first three are real
+  # releases grabbed by the production instance on 2026-08-04.
+  @always_cam_tier [
+    "The.Odyssey.2026.1080p.TELESYNC.HEVC.10bit.AAC2.0-SLH.mkv",
+    "The Odyssey (2026) 1080p HQ HDTS - x264 - [Tel + Tam + Hin + Eng] - HQ Clean - 3.3GB.mkv",
+    "Spider Man.Brand.New.Day.2026.1080p.TELESYNC.x264-DKS",
+    "Movie.2026.TS.x264-GRP",
+    "Movie.2026.HDCAM.x264",
+    "Movie.2026.CAMRip.XviD",
+    "Movie.2026.HDTS.x264",
+    "Movie.2026.DVDScr.x264",
+    "Movie.2026.WORKPRINT.x264",
+    "Movie 2026 CAM x264",
+    "Movie.2026.TC.x264-GRP",
+    "Odyseja - The Odyssey 2026 [HGL HDR SDR] [1080p.TELESYNC.H264-AS76-FT] [ENG-Lektor PL AI] [Alusia]"
+  ]
+
+  describe "cam_tier/0" do
+    test "returns exactly the five cam-tier labels" do
+      assert Sources.cam_tier() == ["CAM", "Telesync", "Telecine", "Screener", "Workprint"]
+    end
+  end
+
+  describe "cam_tier?/1" do
+    test "true for every cam-tier label" do
+      for label <- Sources.cam_tier() do
+        assert Sources.cam_tier?(label)
+      end
+    end
+
+    test "false for good sources and nil" do
+      refute Sources.cam_tier?("BluRay")
+      refute Sources.cam_tier?("WEB-DL")
+      refute Sources.cam_tier?(nil)
+    end
+  end
+
+  describe "detect/1 - must never be cam-tier" do
+    for title <- @never_cam_tier do
+      test "#{title}" do
+        detected = Sources.detect(unquote(title))
+
+        refute Sources.cam_tier?(detected),
+               "expected #{unquote(title)} not to be cam-tier, got #{inspect(detected)}"
+      end
+    end
+  end
+
+  describe "detect/1 - must always be cam-tier" do
+    for title <- @always_cam_tier do
+      test "#{title}" do
+        detected = Sources.detect(unquote(title))
+
+        assert Sources.cam_tier?(detected),
+               "expected #{unquote(title)} to be cam-tier, got #{inspect(detected)}"
+      end
+    end
+  end
+
+  describe "detect/1 - load-bearing table properties" do
+    test "Screener is checked before DVD so DVDScr does not resolve DVD" do
+      assert Sources.detect("Movie.2026.DVDScr.x264") == "Screener"
+    end
+
+    test "first-wins keeps an explicit good source ahead of a group suffix" do
+      assert Sources.detect("Movie.2026.1080p.BluRay.x264-TS") == "BluRay"
+    end
+
+    test "good sources still resolve correctly" do
+      assert Sources.detect("Movie.2026.1080p.BluRay.x264") == "BluRay"
+      assert Sources.detect("Movie.2026.2160p.WEB-DL.x265") == "WEB-DL"
+      assert Sources.detect("Movie.2026.1080p.WEBRip.x264") == "WEBRip"
+      assert Sources.detect("Movie.2026.1080p.REMUX.x264") == "REMUX"
+      assert Sources.detect("Show.S01E01.720p.HDTV.x264") == "HDTV"
+      assert Sources.detect("Movie.2026.DVDRip.XviD") == "DVDRip"
+    end
+
+    test "returns nil when no source token is present" do
+      assert Sources.detect("Movie.2026.1080p.x264") == nil
+    end
+  end
+
+  describe "all/0" do
+    test "includes every cam-tier label" do
+      for label <- Sources.cam_tier() do
+        assert label in Sources.all()
+      end
+    end
+
+    test "includes the good sources" do
+      assert "BluRay" in Sources.all()
+      assert "WEB-DL" in Sources.all()
+    end
+  end
+end

--- a/test/mydia/repo/migrations/backfill_excluded_sources_test.exs
+++ b/test/mydia/repo/migrations/backfill_excluded_sources_test.exs
@@ -1,0 +1,124 @@
+defmodule Mydia.Repo.Migrations.BackfillExcludedSourcesTest do
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Settings
+  alias Mydia.Settings.QualityProfile
+
+  @cam_tier ["CAM", "Telesync", "Telecine", "Screener", "Workprint"]
+
+  # Deliberately NOT the numeric timestamp from the migration filename
+  # (20260804182323). The `test` mix alias runs `ecto.migrate --quiet` before
+  # ExUnit starts, which already applies that real version to the persistent
+  # test database. Calling Ecto.Migrator.up/4 again with that same version
+  # would see it in `schema_migrations` and short-circuit to `:already_up`
+  # without invoking `up/0` at all. A version far outside the range any real
+  # migration will ever use keeps this test's bookkeeping row confined to the
+  # sandboxed transaction for the current test, which rolls back on exit.
+  @migration_version 20_991_231_235_959
+
+  # Migration modules are not compiled into the app (priv/repo/migrations is
+  # not in elixirc_paths), so load the file explicitly before referencing it.
+  Code.require_file("priv/repo/migrations/20260804182323_backfill_excluded_sources.exs")
+
+  describe "shipped profile definitions" do
+    test "every default profile excludes cam-tier out of the box" do
+      for profile <- Mydia.Settings.DefaultQualityProfiles.defaults() do
+        excluded = get_in(profile, [:quality_standards, :excluded_sources]) || []
+
+        assert Enum.sort(excluded) == Enum.sort(@cam_tier),
+               "#{profile.name} must ship with the cam-tier exclusion"
+      end
+    end
+  end
+
+  describe "backfill behavior" do
+    # Driving Ecto.Migrator.up/4 against the DataCase-sandboxed Mydia.Repo
+    # deadlocks under PostgreSQL: Migrator takes the migration lock on the
+    # connection the test process already holds via the sandbox, then spawns
+    # a Task to run the migration body inside its own repo.transaction/2,
+    # which needs a *second* concurrent connection. The sandbox virtualizes
+    # every checkout to the single connection the test process is already
+    # blocked holding, so the Task's checkout times out
+    # (DBConnection.ConnectionError). This is a property of
+    # Ecto.Migrator + Ecto.Adapters.SQL.Sandbox on Postgres, independent of
+    # what the migration does - it reproduces with a no-op migration too, and
+    # matches the reasoning documented on Mydia.MigrationTestRepo for why that
+    # helper never touches Mydia.Repo. SQLite does not hit this because its
+    # migrator path does not take the same lock+Task detour.
+    #
+    # The migration's actual behavior is still verified on both engines: this
+    # describe block covers it on SQLite (the default `mix test` adapter),
+    # and `mix ecto.migrate` was run directly against a real PostgreSQL
+    # database as part of this change (see the task report) to confirm the
+    # backfill applies cleanly there too.
+    @describetag skip:
+                   Mydia.DB.postgres?() and
+                     "Ecto.Migrator.up/4 deadlocks the SQL sandbox on Postgres (see comment); verified separately via mix ecto.migrate"
+
+    test "adds the exclusion without losing other standards" do
+      {:ok, profile} =
+        Settings.create_quality_profile(%{
+          name: "Legacy Profile",
+          quality_standards: %{
+            preferred_resolutions: ["1080p"],
+            min_resolution: "1080p",
+            preferred_sources: ["BluRay", "WEB-DL"]
+          }
+        })
+
+      run_migration_up()
+
+      reloaded = Repo.get!(QualityProfile, profile.id)
+      assert Enum.sort(reloaded.quality_standards.excluded_sources) == Enum.sort(@cam_tier)
+      # pre-existing keys survive
+      assert reloaded.quality_standards.min_resolution == "1080p"
+      assert reloaded.quality_standards.preferred_sources == ["BluRay", "WEB-DL"]
+    end
+
+    test "never overwrites a deliberate choice" do
+      {:ok, profile} =
+        Settings.create_quality_profile(%{
+          name: "Deliberately Permissive",
+          quality_standards: %{preferred_resolutions: ["1080p"], excluded_sources: []}
+        })
+
+      run_migration_up()
+
+      reloaded = Repo.get!(QualityProfile, profile.id)
+
+      assert reloaded.quality_standards.excluded_sources == [],
+             "an operator who cleared the list must keep it cleared"
+    end
+
+    test "is idempotent across repeated runs" do
+      {:ok, profile} =
+        Settings.create_quality_profile(%{
+          name: "Idempotent",
+          quality_standards: %{preferred_resolutions: ["720p"], min_resolution: "720p"}
+        })
+
+      run_migration_up()
+      first = Repo.get!(QualityProfile, profile.id).quality_standards
+
+      run_migration_up()
+      second = Repo.get!(QualityProfile, profile.id).quality_standards
+
+      assert first == second
+    end
+  end
+
+  # Invokes the migration's own up/0 through the real Ecto migrator, rather
+  # than a test helper that copies the migration's per-row logic: a test that
+  # duplicates the code under test cannot catch a mistake in that code.
+  #
+  # Ecto.Migration.Runner.run/7 (as documented in older Ecto releases) does not
+  # match the installed Ecto 3.14.1, which takes an extra `config` argument
+  # (run/8) and is private API not meant to be driven directly from a test.
+  # Ecto.Migrator.up/4 is the public entry point and works against the
+  # DataCase-managed sandbox connection for Mydia.Repo.
+  defp run_migration_up do
+    Ecto.Migrator.up(Repo, @migration_version, Mydia.Repo.Migrations.BackfillExcludedSources,
+      log: false
+    )
+  end
+end

--- a/test/mydia/settings/quality_profile_engine_test.exs
+++ b/test/mydia/settings/quality_profile_engine_test.exs
@@ -1,6 +1,7 @@
 defmodule Mydia.Settings.QualityProfileEngineTest do
   use Mydia.DataCase, async: true
 
+  alias Mydia.Quality.Sources
   alias Mydia.Settings
   alias Mydia.Settings.QualityProfileEngine
   alias Mydia.Library.MediaFile
@@ -210,6 +211,31 @@ defmodule Mydia.Settings.QualityProfileEngineTest do
       assert summary.processed == 0
       assert summary.updated == 0
       assert summary.errors == []
+    end
+  end
+
+  describe "source inference from an on-disk path" do
+    test "detects cam-tier releases already sitting in the library" do
+      # The real file the production instance imported on 2026-08-04.
+      path =
+        "The Odyssey (2026)/The Odyssey (2026) 1080p HQ HDTS - x264 - [Tel + Tam + Hin + Eng] - HQ Clean - 3.3GB.mkv"
+
+      assert Sources.cam_tier?(QualityProfileEngine.infer_source_from_filename(path))
+    end
+
+    test "still detects good sources" do
+      assert QualityProfileEngine.infer_source_from_filename(
+               "The Matrix (1999)/The.Matrix.1999.1080p.BluRay.x264.mkv"
+             ) == "BluRay"
+
+      assert QualityProfileEngine.infer_source_from_filename(
+               "Interstellar (2014)/Interstellar.2014.2160p.WEB-DL.x265.mkv"
+             ) == "WEB-DL"
+    end
+
+    test "returns nil when the path carries no source token" do
+      assert QualityProfileEngine.infer_source_from_filename("Wonka (2023)/Wonka.2023.1080p.mkv") ==
+               nil
     end
   end
 end

--- a/test/mydia/settings/quality_profile_test.exs
+++ b/test/mydia/settings/quality_profile_test.exs
@@ -91,6 +91,45 @@ defmodule Mydia.Settings.QualityProfileTest do
     end
   end
 
+  # Mydia.Quality.Sources.detect/1 folds "bdrip" into "BluRay" - the BluRay
+  # pattern matches it - so no release can ever be detected as the literal
+  # "BDRip" any more. It must not be selectable as a preference.
+  describe "quality_standards preferred_sources validation" do
+    test "rejects BDRip: no release can ever be detected as that literal value" do
+      changeset =
+        QualityProfile.changeset(%QualityProfile{}, %{
+          name: "Preferred BDRip",
+          quality_standards: %{preferred_resolutions: ["1080p"], preferred_sources: ["BDRip"]}
+        })
+
+      refute changeset.valid?
+      assert %{quality_standards: [msg]} = errors_on(changeset)
+      assert msg =~ "BDRip"
+    end
+
+    test "accepts the remaining source vocabulary" do
+      changeset =
+        QualityProfile.changeset(%QualityProfile{}, %{
+          name: "Preferred Sources",
+          quality_standards: %{
+            preferred_resolutions: ["1080p"],
+            preferred_sources: [
+              "BluRay",
+              "REMUX",
+              "WEB-DL",
+              "WEBRip",
+              "HDTV",
+              "SDTV",
+              "DVD",
+              "DVDRip"
+            ]
+          }
+        })
+
+      assert changeset.valid?
+    end
+  end
+
   describe "excluded sources as a hard violation" do
     test "a file whose source is excluded scores zero and reports the violation" do
       profile = %QualityProfile{

--- a/test/mydia/settings/quality_profile_test.exs
+++ b/test/mydia/settings/quality_profile_test.exs
@@ -40,4 +40,54 @@ defmodule Mydia.Settings.QualityProfileTest do
       assert %{min_upgrade_margin: _} = errors_on(changeset)
     end
   end
+
+  describe "quality_standards excluded_sources validation" do
+    test "accepts the cam-tier vocabulary" do
+      changeset =
+        QualityProfile.changeset(%QualityProfile{}, %{
+          name: "Excl Accepts",
+          quality_standards: %{
+            preferred_resolutions: ["1080p"],
+            excluded_sources: Mydia.Quality.Sources.cam_tier()
+          }
+        })
+
+      assert changeset.valid?
+    end
+
+    test "accepts an empty list" do
+      changeset =
+        QualityProfile.changeset(%QualityProfile{}, %{
+          name: "Excl Empty",
+          quality_standards: %{preferred_resolutions: ["1080p"], excluded_sources: []}
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects an unknown source" do
+      changeset =
+        QualityProfile.changeset(%QualityProfile{}, %{
+          name: "Excl Unknown",
+          quality_standards: %{
+            preferred_resolutions: ["1080p"],
+            excluded_sources: ["NotARealSource"]
+          }
+        })
+
+      refute changeset.valid?
+      assert %{quality_standards: [msg]} = errors_on(changeset)
+      assert msg =~ "NotARealSource"
+    end
+
+    test "rejects a non-list value" do
+      changeset =
+        QualityProfile.changeset(%QualityProfile{}, %{
+          name: "Excl NonList",
+          quality_standards: %{preferred_resolutions: ["1080p"], excluded_sources: "Telesync"}
+        })
+
+      refute changeset.valid?
+    end
+  end
 end

--- a/test/mydia/settings/quality_profile_test.exs
+++ b/test/mydia/settings/quality_profile_test.exs
@@ -90,4 +90,43 @@ defmodule Mydia.Settings.QualityProfileTest do
       refute changeset.valid?
     end
   end
+
+  describe "excluded sources as a hard violation" do
+    test "a file whose source is excluded scores zero and reports the violation" do
+      profile = %QualityProfile{
+        name: "Excl Violation",
+        quality_standards: %{excluded_sources: ["Telesync", "CAM"]}
+      }
+
+      result =
+        QualityProfile.score_media_file(profile, %{resolution: "1080p", source: "Telesync"})
+
+      assert result.score == 0.0
+      assert [violation] = result.violations
+      assert violation =~ "Telesync"
+    end
+
+    test "a file with an allowed source is unaffected" do
+      profile = %QualityProfile{
+        name: "Excl Allowed",
+        quality_standards: %{excluded_sources: ["Telesync", "CAM"]}
+      }
+
+      result = QualityProfile.score_media_file(profile, %{resolution: "1080p", source: "BluRay"})
+
+      assert result.violations == []
+      assert result.score > 0.0
+    end
+
+    test "a file with an unknown source is unaffected" do
+      profile = %QualityProfile{
+        name: "Excl Unknown Source",
+        quality_standards: %{excluded_sources: ["Telesync"]}
+      }
+
+      result = QualityProfile.score_media_file(profile, %{resolution: "1080p"})
+
+      assert result.violations == []
+    end
+  end
 end

--- a/test/mydia/settings/quality_profile_test.exs
+++ b/test/mydia/settings/quality_profile_test.exs
@@ -91,20 +91,19 @@ defmodule Mydia.Settings.QualityProfileTest do
     end
   end
 
-  # Mydia.Quality.Sources.detect/1 folds "bdrip" into "BluRay" - the BluRay
-  # pattern matches it - so no release can ever be detected as the literal
-  # "BDRip" any more. It must not be selectable as a preference.
+  # Mydia.Quality.Sources.detect/1 folds "bdrip" into "BluRay" for the indexer
+  # search/grab path, but the V3 release parser still emits canonical "BDRip"
+  # for on-disk files, and that value flows through Mydia.Upgrades.Attrs into
+  # scoring. So "BDRip" must remain selectable as a preference.
   describe "quality_standards preferred_sources validation" do
-    test "rejects BDRip: no release can ever be detected as that literal value" do
+    test "accepts BDRip: the V3 parser still emits it for on-disk files" do
       changeset =
         QualityProfile.changeset(%QualityProfile{}, %{
           name: "Preferred BDRip",
           quality_standards: %{preferred_resolutions: ["1080p"], preferred_sources: ["BDRip"]}
         })
 
-      refute changeset.valid?
-      assert %{quality_standards: [msg]} = errors_on(changeset)
-      assert msg =~ "BDRip"
+      assert changeset.valid?
     end
 
     test "accepts the remaining source vocabulary" do

--- a/test/mydia/upgrades/attrs_test.exs
+++ b/test/mydia/upgrades/attrs_test.exs
@@ -259,4 +259,102 @@ defmodule Mydia.Upgrades.AttrsTest do
       assert Attrs.from_media_file(file, :movie).source == "BluRay"
     end
   end
+
+  # R7: a cam-tier file already in the library must score 0 so the upgrade
+  # path replaces it once a real release appears. The real shape of a
+  # download-imported telesync is metadata.source == nil - V3's
+  # ReleaseParser (priv/release_parser/sources.exs) has zero cam-tier
+  # entries, so media_import.ex:1642 writes source: nil for exactly the
+  # files this feature exists to catch. The tests above pre-populate
+  # metadata.source and so never exercise that gap. These do not.
+  describe "from_media_file/2 falls back to filename detection when metadata.source is absent" do
+    test "a nil metadata.source still detects a cam-tier source from the filename" do
+      relative_path =
+        "The Odyssey (2026)/The Odyssey (2026) 1080p HQ HDTS - x264 - HQ Clean.mkv"
+
+      file = %MediaFile{
+        relative_path: relative_path,
+        resolution: "1080p",
+        codec: "x264",
+        metadata: %FileMetadata{source: nil}
+      }
+
+      attrs = Attrs.from_media_file(file, :movie)
+
+      assert attrs.source == "Telesync"
+    end
+
+    test "an absent metadata still detects a cam-tier source from the filename" do
+      relative_path =
+        "The Odyssey (2026)/The Odyssey (2026) 1080p HQ HDTS - x264 - HQ Clean.mkv"
+
+      file = %MediaFile{
+        relative_path: relative_path,
+        resolution: "1080p",
+        codec: "x264"
+      }
+
+      attrs = Attrs.from_media_file(file, :movie)
+
+      assert attrs.source == "Telesync"
+    end
+
+    # The fallback must stay scoped to cam-tier detections. Every on-disk
+    # file that has no metadata.source today reaches score_source/2 with a
+    # nil source and takes the neutral 50.0 catch-all. An unrestricted
+    # filename fallback would give every clean file a real source and swing
+    # scores by up to +/-9 points (source weight 0.12) against a default
+    # upgrade_until_score of 85, churning upgrade decisions library-wide.
+    test "a clean file with no metadata.source still yields nil, not BluRay" do
+      relative_path = "The Matrix (1999)/The.Matrix.1999.1080p.BluRay.x264.mkv"
+
+      file = %MediaFile{
+        relative_path: relative_path,
+        resolution: "1080p",
+        codec: "x264",
+        metadata: %FileMetadata{source: nil}
+      }
+
+      assert Attrs.from_media_file(file, :movie).source == nil
+    end
+
+    test "a file with no source token anywhere in the filename still yields nil" do
+      file = %MediaFile{
+        relative_path: "Some Show/Some.Show.S01E01.1080p.x264.mkv",
+        resolution: "1080p",
+        codec: "x264"
+      }
+
+      assert Attrs.from_media_file(file, :movie).source == nil
+    end
+
+    # End of the chain: a real download-imported telesync (metadata.source
+    # nil, exactly what media_import.ex writes today) run through the full
+    # pipeline against a profile that excludes Telesync must score 0 and
+    # carry the violation, not silently no-op.
+    test "a profile excluding Telesync scores a nil-metadata telesync file zero with a violation" do
+      relative_path =
+        "The Odyssey (2026)/The Odyssey (2026) 1080p HQ HDTS - x264 - HQ Clean.mkv"
+
+      file = %MediaFile{
+        relative_path: relative_path,
+        resolution: "1080p",
+        codec: "x264",
+        metadata: %FileMetadata{source: nil}
+      }
+
+      attrs = Attrs.from_media_file(file, :movie)
+
+      profile = %Mydia.Settings.QualityProfile{
+        name: "Excludes Telesync",
+        quality_standards: %{excluded_sources: ["Telesync"]}
+      }
+
+      result = Mydia.Settings.QualityProfile.score_media_file(profile, attrs)
+
+      assert result.score == 0.0
+      assert [violation] = result.violations
+      assert violation =~ "Telesync"
+    end
+  end
 end

--- a/test/mydia/upgrades/attrs_test.exs
+++ b/test/mydia/upgrades/attrs_test.exs
@@ -210,4 +210,53 @@ defmodule Mydia.Upgrades.AttrsTest do
       assert attrs.source == nil
     end
   end
+
+  # from_media_file/2's metadata_source/1 (attrs.ex:191) reads metadata.source
+  # directly - it does not parse relative_path itself, as the "lifts source
+  # out of nested metadata" test above already establishes. So these fixtures
+  # pre-populate metadata.source with what Mydia.Quality.Sources.detect/1 (the
+  # same detector Task 3 wired into QualityProfileEngine.extract_source/1)
+  # would derive from the filename, rather than relying on from_media_file/2
+  # to parse relative_path itself - it doesn't. That keeps the assertion
+  # honest about what is actually under test: canonical_source/1's mapping,
+  # not filename inference (which from_media_file/2 does not perform).
+  describe "cam-tier sources survive normalization" do
+    test "a telesync file normalizes to a cam-tier source, not nil" do
+      # Without cam-tier in @canonical_sources this returns nil, the violation
+      # in collect_violations/2 requires is_binary(source), and the whole
+      # excluded-source mechanism silently no-ops on the upgrade path.
+      relative_path =
+        "The Odyssey (2026)/The Odyssey (2026) 1080p HQ HDTS - x264 - HQ Clean.mkv"
+
+      detected_source = Mydia.Quality.Sources.detect(relative_path)
+      assert detected_source == "Telesync"
+
+      file = %MediaFile{
+        relative_path: relative_path,
+        resolution: "1080p",
+        codec: "x264",
+        metadata: %FileMetadata{source: detected_source}
+      }
+
+      attrs = Attrs.from_media_file(file, :movie)
+
+      assert Mydia.Quality.Sources.cam_tier?(attrs.source),
+             "expected a cam-tier source, got #{inspect(attrs.source)}"
+    end
+
+    test "clean sources still normalize correctly" do
+      relative_path = "The Matrix (1999)/The.Matrix.1999.1080p.BluRay.x264.mkv"
+      detected_source = Mydia.Quality.Sources.detect(relative_path)
+      assert detected_source == "BluRay"
+
+      file = %MediaFile{
+        relative_path: relative_path,
+        resolution: "1080p",
+        codec: "x264",
+        metadata: %FileMetadata{source: detected_source}
+      }
+
+      assert Attrs.from_media_file(file, :movie).source == "BluRay"
+    end
+  end
 end

--- a/test/mydia_web/live/admin_quality_profiles_live_test.exs
+++ b/test/mydia_web/live/admin_quality_profiles_live_test.exs
@@ -174,4 +174,92 @@ defmodule MydiaWeb.AdminQualityProfilesLiveTest do
              )
     end
   end
+
+  describe "Exclude tab" do
+    setup %{conn: conn, token: token} do
+      start_supervised!(Mydia.Indexers.Health)
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/quality")
+
+      # The tabs only exist inside the profile modal.
+      view |> element("button[phx-click='new_quality_profile']") |> render_click()
+
+      %{conn: conn, view: view}
+    end
+
+    test "renders a checkbox for every cam-tier source", %{view: view} do
+      view |> element("button[phx-value-tab='exclude']") |> render_click()
+
+      for source <- Mydia.Quality.Sources.cam_tier() do
+        assert has_element?(
+                 view,
+                 "input[name='quality_profile[quality_standards][excluded_sources][]'][value='#{source}']"
+               )
+      end
+    end
+
+    test "carries a hidden empty input so unchecking every box clears the list", %{view: view} do
+      assert has_element?(
+               view,
+               "input[type='hidden'][name='quality_profile[quality_standards][excluded_sources][]']"
+             )
+    end
+  end
+
+  describe "Exclude tab - clearing a saved exclusion list" do
+    setup %{conn: conn, token: token} do
+      start_supervised!(Mydia.Indexers.Health)
+
+      {:ok, profile} =
+        Settings.create_quality_profile(%{
+          name: "Excludes-#{System.unique_integer([:positive])}",
+          quality_standards: %{
+            preferred_resolutions: ["1080p"],
+            excluded_sources: ["CAM", "Telesync"]
+          }
+        })
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/quality")
+
+      %{conn: conn, view: view, profile: profile}
+    end
+
+    test "unchecking every box clears a previously saved exclusion list", %{
+      view: view,
+      profile: profile
+    } do
+      view
+      |> element(~s{button[phx-click="edit_quality_profile"][phx-value-id="#{profile.id}"]})
+      |> render_click()
+
+      view |> element("button[phx-value-tab='exclude']") |> render_click()
+
+      view
+      |> form("#quality-profile-form",
+        quality_profile: %{
+          "name" => profile.name,
+          "quality_standards" => %{
+            "preferred_resolutions" => ["1080p"],
+            "excluded_sources" => [""]
+          }
+        }
+      )
+      |> render_submit()
+
+      updated = Settings.get_quality_profile!(profile.id)
+      assert updated.quality_standards[:excluded_sources] == []
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/show/search_helpers_test.exs
+++ b/test/mydia_web/live/media_live/show/search_helpers_test.exs
@@ -266,6 +266,68 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpersTest do
     end
   end
 
+  describe "sort_search_results_with_opts/3 does not apply source exclusion (R8)" do
+    test "an excluded release survives manual quality-sort routing, unlike the automatic path" do
+      profile = %QualityProfile{
+        name: "Excludes telesync",
+        quality_standards: %{excluded_sources: ["Telesync"]}
+      }
+
+      telesync_title = "The.Odyssey.2026.1080p.TELESYNC.HEVC.AAC2.0-SLH"
+
+      results = [
+        build_result(%{
+          title: telesync_title,
+          download_url: "magnet:?xt=urn:btih:manual-telesync",
+          seeders: 500,
+          quality: QualityParser.parse(telesync_title)
+        })
+      ]
+
+      opts = RankingOptions.build(%{quality_profile: profile, media_type: :movie})
+
+      # Sanity check: the same profile/opts DO drop this release on the
+      # automatic path (ReleaseRanker.rank_all/2 called directly, where
+      # apply_source_exclusion defaults to true). This proves the manual-path
+      # assertion below is a genuine divergence and not a fixture that was
+      # never going to be filtered in the first place.
+      assert ReleaseRanker.rank_all(results, opts) == []
+
+      # The manual search dialog routes quality-sorted results through
+      # sort_search_results_with_opts/3, which internally passes
+      # apply_source_exclusion: false (see quality_sort_via_ranker/2). Per
+      # spec R8, manual search/grab is the operator's explicit escape hatch
+      # and must not silently drop this release the way the automatic path
+      # does above.
+      sorted = SearchHelpers.sort_search_results_with_opts(results, :quality, opts)
+
+      assert length(sorted) == 1
+      assert List.first(sorted).download_url == "magnet:?xt=urn:btih:manual-telesync"
+    end
+
+    test "sort_search_results/5 (the back-compat manual entry point) also does not exclude" do
+      profile = %QualityProfile{
+        name: "Excludes telesync",
+        quality_standards: %{excluded_sources: ["Telesync"]}
+      }
+
+      telesync_title = "The.Odyssey.2026.1080p.TELESYNC.HEVC.AAC2.0-SLH"
+
+      results = [
+        build_result(%{
+          title: telesync_title,
+          download_url: "magnet:?xt=urn:btih:manual-telesync-5arity",
+          seeders: 500,
+          quality: QualityParser.parse(telesync_title)
+        })
+      ]
+
+      sorted = SearchHelpers.sort_search_results(results, :quality, profile, :movie, nil)
+
+      assert length(sorted) == 1
+    end
+  end
+
   describe "profile_score_breakdown/2 unified breakdown (U6)" do
     test "returns a ScoreBreakdown struct with a real 0-10 title_match" do
       profile = build_quality_profile()


### PR DESCRIPTION
Closes #80.

## The bug

Mydia had no source-quality floor. A TELESYNC or CAM release passed every gate in the automatic search path and got downloaded whenever it was the best or only candidate, which is the normal state of affairs for a film still in cinemas.

Observed on a production instance on 2026-08-04, where two of the four automatic grabs in the log window were telesyncs, and one had already been imported into the library:

```
Spider Man.Brand.New.Day.2026.1080p.TELESYNC.x264-DKS   score 83.4  grabbed
The Odyssey (2026) 1080p HQ HDTS - x264 ... 3.3GB.mkv   score 75.4  grabbed + imported
Jane.Eyre.1996.1080p.BluRay.x264-VETO[rarbg]            score 62.3
All.Creatures...S03.1080p.WEBRip.x265-KONTRAST          score 63.77
```

Both telesyncs outscored the legitimate releases. The instance default profile already declared `preferred_sources: ["BluRay", "WEB-DL"]`, and that declaration had no effect.

Four things were wrong:

1. `ReleaseRanker.filter_acceptable/2` had only two hard removals, blocked tags and NZB post-age. Source was never among them, and `blocked_release_tokens` defaults to `[]` with no UI to set it.
2. `collect_violations/2`, the only thing that can zero a score, covered `require_hdr` and resolution bounds. Source reached scoring alone, worth 25.0 at weight 0.12, so declaring `preferred_sources` docked a telesync about 9 points out of 100.
3. There is no minimum-score threshold before grabbing, so a release scoring 0 is still downloaded when it is the only survivor.
4. The source regexes were unanchored two-letter alternations. `Ghosts.of.Mars` classified as Telesync, `Watchmen` as Telecine, `Scream` as Screener, `Cameron` as CAM.

Point 4 is why the parser fix ships in the same PR. Adding the filter alone would have converted a grabbing-garbage bug into a silently-refusing-legitimate-releases bug.

## The change

A per-profile `excluded_sources` list, stored in the existing `quality_standards` map, applied as a hard drop before ranking. Exclusion is per-profile and defeatable, never global.

- **`Mydia.Quality.Sources`** — one delimiter-anchored source vocabulary, replacing the table in `QualityParser` and the hand-rolled `cond` chain in `QualityProfileEngine`. Short tokens (`ts`, `tc`, `wp`, `scr`, `cam`) require dot, space, or bracket delimiters on both sides, which excludes both the hyphenated release-group position (`x264-TS`) and title-initial words (`Ts.Madison`) that plain word boundaries still matched.
- **`excluded_sources` on the profile**, validated, in `quality_standards` rather than a new column so clone, export, import, and version-compare carry it without touching any of their six field lists.
- **One filter step** in `ReleaseRanker.rank_all/2`, covering movie and TV search since both reach it through `select_best_result/2`. A hard drop, not a penalty, because of point 3 above.
- **Backfill migration** onto every existing profile, plus all 8 shipped defaults and 23 presets. Idempotent, and leaves alone any profile that already carries the key, including one an operator deliberately cleared.
- **An Exclude tab** in the profile editor.
- **A hard violation** for cam-tier files already in the library, so they score 0 and the upgrade path replaces them.

Manual search is deliberately exempt via `apply_source_exclusion: false`. Clicking download on a specific release is explicit intent that outranks the profile.

## Verification

SQLite full suite 6311 tests, 0 failures. PostgreSQL full suite 6311, 2 failures, both `media_import_test` varchar(255) tmp_dir truncation reproduced identically on the base commit and environmental. `mix precommit` clean, Credo `--strict` no issues.

Source detection is pinned by a 20-title false-positive corpus (substring matches, release-group suffixes, title-initial tokens, legitimate controls) and a 12-title cam-tier corpus including the three real production titles.

## Known follow-ups

- Three migration tests skip under PostgreSQL; `Ecto.Migrator.up/4` deadlocks the SQL sandbox. The migration has no adapter branch and was confirmed against real Postgres via `mix ecto.migrate`.
- `Sources`' short tokens treat spaces as delimiters, so a film titled e.g. `Spy Cam` with no source token anywhere in its path can misclassify. Needs a film with a cam-tier word in the title and no source token at all.
- The V3 parser (`priv/release_parser/sources.exs`) still has no cam-tier vocabulary and remains a separate list.
- The `preferred_sources` checkbox group still has the uncheck-all bug that is fixed here only for `excluded_sources`.
- `QualityParser.source_score/1` has no `Workprint` clause; reachable only from manual-search sorting.
