### PR TITLE
feat(downloads): manually match files when an import fails

### DIFF
--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -404,6 +404,20 @@ defmodule Mydia.Downloads do
   defdelegate resolve_file_mappings(download, mappings), to: Mydia.Downloads.Queue
 
   @doc """
+  Rejects a release the operator has judged unusable: blacklists
+  `(indexer, guid)`, removes it from the download client (best effort),
+  deletes the download row, and queues a fresh search. See
+  `Mydia.Downloads.Queue.reject_release/2` for details.
+
+  ## Options
+    - `:actor_type` - The type of actor (:user, :system, :job) - defaults to :user
+    - `:actor_id` - The ID of the actor (user_id, job name, etc.)
+  """
+  @spec reject_release(Download.t(), keyword()) ::
+          {:ok, :rejected} | {:error, :no_indexer | :no_guid | term()}
+  defdelegate reject_release(download, opts \\ []), to: Mydia.Downloads.Queue
+
+  @doc """
   Re-matches an already-imported download to a corrected movie or episode,
   enqueuing a MediaRematch job to move + relink the file. See
   `Mydia.Downloads.Queue.rematch_imported_download/3` for return values.

--- a/lib/mydia/downloads/blacklists.ex
+++ b/lib/mydia/downloads/blacklists.ex
@@ -39,6 +39,25 @@ defmodule Mydia.Downloads.Blacklists do
         ]
 
   @doc """
+  Pulls the `(indexer, guid)` blacklist key off a download.
+
+  The indexer is read from the column first and falls back to the copy stored
+  in `metadata`, which is where older rows carry it.
+  """
+  @spec extract_key(Mydia.Downloads.Download.t()) ::
+          {:ok, String.t(), String.t()} | {:error, :no_indexer | :no_guid}
+  def extract_key(download) do
+    indexer = download.indexer || get_in(download.metadata || %{}, ["indexer"])
+    guid = get_in(download.metadata || %{}, ["guid"])
+
+    cond do
+      is_nil(indexer) or indexer == "" -> {:error, :no_indexer}
+      is_nil(guid) or guid == "" -> {:error, :no_guid}
+      true -> {:ok, indexer, guid}
+    end
+  end
+
+  @doc """
   Inserts a blacklist row, upserting on `(indexer, guid)` conflicts.
 
   Options:

--- a/lib/mydia/downloads/import_candidates.ex
+++ b/lib/mydia/downloads/import_candidates.ex
@@ -9,8 +9,10 @@ defmodule Mydia.Downloads.ImportCandidates do
   """
 
   alias Mydia.Library.ContentProbe
+  alias Mydia.Library.PathMapping
   alias Mydia.Library.ReleaseParser
   alias Mydia.Library.SampleDetector
+  alias Mydia.Settings
 
   @video_extensions ~w(.mkv .mp4 .avi .mov .wmv .flv .webm .m4v .mpg .mpeg .m2ts)
   @music_extensions ~w(.mp3 .flac .wav .aac .ogg .m4a .wma .opus .ape .alac .aiff)
@@ -119,5 +121,160 @@ defmodule Mydia.Downloads.ImportCandidates do
   defp probe?(candidate) do
     candidate["skip_reason"] == "not_video_extension" and
       candidate["size"] >= @probe_size_floor
+  end
+
+  @doc """
+  Loads the candidate listing to show the operator.
+
+  Prefers a live re-listing of the download folder, since the operator may
+  have fixed a mount or permission since the failure, but only when the
+  recorded `metadata["save_path"]` is specific to this download. A
+  `save_path` that resolves to the download client's own shared download
+  root is never walked recursively (see `shared_download_root?/2`):
+  clients that put a download's files directly inside their shared output
+  folder would otherwise have every *other* download sharing that folder
+  enumerated and offered up for import here.
+
+  Falls back to the snapshot captured at failure time whenever a live
+  listing isn't possible or safe: no `save_path`, a `save_path` that is the
+  shared root, a folder that no longer exists, or one that comes back
+  empty. In the fallback case each recorded path is individually re-stat'd
+  rather than the directory being walked, so files that vanished are still
+  caught without ever enumerating unrelated downloads.
+
+  Every returned candidate carries `"missing"`, true when the path is no
+  longer on disk.
+  """
+  @spec load(Mydia.Downloads.Download.t()) ::
+          {:ok, :live | :snapshot, [map()]} | {:error, :unavailable}
+  def load(download) do
+    metadata = download.metadata || %{}
+    snapshot = Map.get(metadata, "import_candidates") || []
+
+    case live_listing(download, metadata) do
+      {:ok, files} when files != [] ->
+        {:ok, :live, merge(files, snapshot, download)}
+
+      _not_live ->
+        if snapshot == [] do
+          {:error, :unavailable}
+        else
+          {:ok, :snapshot, Enum.map(snapshot, &mark_missing/1)}
+        end
+    end
+  end
+
+  defp live_listing(download, metadata) do
+    case listable_save_path(metadata, download) do
+      nil ->
+        {:error, :no_path}
+
+      path ->
+        if File.dir?(path) do
+          {:ok, list_recursive(path)}
+        else
+          {:error, :not_a_directory}
+        end
+    end
+  end
+
+  # Only a `save_path` explicitly present on the download's own metadata is
+  # eligible for a live re-listing, and only when it isn't the download
+  # client's shared root. There is deliberately no fallback to
+  # `Path.dirname/1` of a snapshot path here: in production, downloads
+  # sometimes sit directly inside the client's shared download root, and
+  # `Path.dirname/1` of a file in that root IS the root, so recursively
+  # listing it would surface every unrelated torrent's files as if they
+  # belonged to this download.
+  defp listable_save_path(metadata, download) do
+    case Map.get(metadata, "save_path") do
+      path when is_binary(path) and path != "" ->
+        if shared_download_root?(path, download), do: nil, else: path
+
+      _other ->
+        nil
+    end
+  end
+
+  # Mirrors `Mydia.Jobs.MediaImport`'s guard of the same name, which exists
+  # for the same reason: refusing to recursively walk a save_path that is
+  # actually the client's shared download root, not a folder specific to
+  # this download. Duplicated here (rather than shared) because that
+  # function is private to the import job and takes the job's full
+  # `client_info` map; this only needs the configured `download_directory`.
+  defp shared_download_root?(save_path, download) do
+    case client_download_directory(download) do
+      root when is_binary(root) and root != "" ->
+        same_dir?(save_path, root) or
+          same_dir?(PathMapping.rewrite(save_path), PathMapping.rewrite(root))
+
+      _no_root ->
+        false
+    end
+  end
+
+  defp client_download_directory(%{download_client: name})
+       when is_binary(name) and name != "" do
+    Settings.list_download_client_configs()
+    |> Enum.find(&(&1.name == name))
+    |> case do
+      nil -> nil
+      config -> Map.get(config, :download_directory)
+    end
+  end
+
+  defp client_download_directory(_download), do: nil
+
+  defp same_dir?(a, b) when is_binary(a) and a != "" and is_binary(b) and b != "",
+    do: Path.expand(a) == Path.expand(b)
+
+  defp same_dir?(_a, _b), do: false
+
+  defp list_recursive(dir) do
+    dir
+    |> Path.join("**/*")
+    |> Path.wildcard(match_dot: false)
+    |> Enum.filter(&File.regular?/1)
+    |> Enum.map(fn path ->
+      %{path: path, name: Path.basename(path), size: File.stat!(path).size}
+    end)
+  end
+
+  # Re-derive skip reasons from the live listing, but keep any probe verdict
+  # already computed for the same path so the modal does not re-probe on
+  # open.
+  defp merge(files, snapshot, download) do
+    probes =
+      snapshot
+      |> Enum.filter(&Map.has_key?(&1, "probe"))
+      |> Map.new(&{&1["path"], &1["probe"]})
+
+    files
+    |> build(library_type_for(download), [])
+    |> Enum.map(fn candidate ->
+      candidate
+      |> maybe_restore_probe(probes)
+      |> Map.put("missing", false)
+    end)
+  end
+
+  defp maybe_restore_probe(candidate, probes) do
+    case Map.fetch(probes, candidate["path"]) do
+      {:ok, probe} -> Map.put(candidate, "probe", probe)
+      :error -> candidate
+    end
+  end
+
+  # This is a display-only guess (the actual library type used at import
+  # time comes from the resolved library path, not the media item), so a
+  # mismatch is cosmetic. `media_item` may be an unloaded association when
+  # the caller didn't preload it: Elixir's map pattern matching falls
+  # through to the next clause rather than raising when a key is absent, so
+  # `%Ecto.Association.NotLoaded{}` safely falls to the :series guess below.
+  defp library_type_for(%{media_item: %{type: "movie"}}), do: :movies
+  defp library_type_for(_download), do: :series
+
+  defp mark_missing(candidate) do
+    Map.put(candidate, "missing", not File.regular?(candidate["path"] || ""))
   end
 end

--- a/lib/mydia/downloads/import_candidates.ex
+++ b/lib/mydia/downloads/import_candidates.ex
@@ -1,0 +1,123 @@
+defmodule Mydia.Downloads.ImportCandidates do
+  @moduledoc """
+  Builds the file listing that a failed import stores on its download, so the
+  operator can see what the download actually contained and match files by hand.
+
+  A candidate records why the automatic importer skipped a file. For files
+  rejected on extension alone, it also carries an ffprobe verdict, which is what
+  separates an obfuscated release from a fake one.
+  """
+
+  alias Mydia.Library.ContentProbe
+  alias Mydia.Library.ReleaseParser
+  alias Mydia.Library.SampleDetector
+
+  @video_extensions ~w(.mkv .mp4 .avi .mov .wmv .flv .webm .m4v .mpg .mpeg .m2ts)
+  @music_extensions ~w(.mp3 .flac .wav .aac .ogg .m4a .wma .opus .ape .alac .aiff)
+  @book_extensions ~w(.epub .pdf .mobi .azw .azw3 .cbr .cbz .djvu .fb2 .lit .txt .rtf)
+  @adult_extensions ~w(.mkv .mp4 .avi .mov .wmv .flv .webm .m4v .jpg .jpeg .png .gif .webp .bmp .tiff)
+
+  @probe_size_floor 10_485_760
+  @probe_cap 20
+
+  @doc "Minimum file size, in bytes, before an extension-rejected file is probed."
+  @spec probe_size_floor() :: pos_integer()
+  def probe_size_floor, do: @probe_size_floor
+
+  @doc "Maximum number of files probed per download."
+  @spec probe_cap() :: pos_integer()
+  def probe_cap, do: @probe_cap
+
+  @doc """
+  Turns the importer's file list into persistable candidates.
+
+  `library_type` is the resolved library's type, matching the branches in
+  `MediaImport.filter_files_for_library_type/2`. `parser_opts` is the same
+  keyword list the importer passes to `ReleaseParser.parse/2`, so the season and
+  episode guesses here match the ones the importer would have made.
+  """
+  @spec build([map()], atom(), keyword()) :: [map()]
+  def build(files, library_type, parser_opts) when is_list(files) do
+    files
+    |> Enum.map(&candidate(&1, library_type, parser_opts))
+    |> add_probes()
+  end
+
+  defp candidate(file, library_type, parser_opts) do
+    parsed = ReleaseParser.parse(file.name, parser_opts)
+
+    %{
+      "path" => file.path,
+      "name" => file.name,
+      "size" => file.size,
+      "skip_reason" => skip_reason(file, library_type),
+      "parsed_season" => parsed && parsed.season,
+      "parsed_episode" => parsed && first_episode(parsed)
+    }
+  end
+
+  defp first_episode(%{episodes: episodes}) when is_list(episodes), do: List.first(episodes)
+  defp first_episode(_parsed), do: nil
+
+  # Mirrors the importer's two filters in the same order, so the reason shown to
+  # the operator is the reason the file was actually dropped.
+  defp skip_reason(file, library_type) do
+    cond do
+      not importable?(file, library_type) ->
+        "not_video_extension"
+
+      SampleDetector.skip_detection?(file.path) ->
+        nil
+
+      true ->
+        detection = SampleDetector.detect(file.path)
+
+        if SampleDetector.excluded?(detection) do
+          SampleDetector.exclusion_reason(detection)
+        end
+    end
+  end
+
+  @doc """
+  True when `file` has an extension the given library type accepts.
+
+  This module owns the extension vocabulary. `MediaImport` delegates its own
+  filtering here so the skip reason shown to the operator can never disagree
+  with the filter that actually dropped the file.
+  """
+  @spec importable?(map(), atom()) :: boolean()
+  def importable?(file, library_type) do
+    ext = file.name |> Path.extname() |> String.downcase()
+
+    case library_type do
+      type when type in [:movies, :series, :mixed] -> ext in @video_extensions
+      :music -> ext in @music_extensions
+      :books -> ext in @book_extensions
+      :adult -> ext in @adult_extensions
+      _unknown -> true
+    end
+  end
+
+  # Only files rejected purely on extension are worth probing: everything else
+  # either imported fine or was correctly identified as a sample.
+  defp add_probes(candidates) do
+    probable =
+      candidates
+      |> Enum.filter(&probe?/1)
+      |> Enum.take(@probe_cap)
+      |> MapSet.new(& &1["path"])
+
+    Enum.map(candidates, fn candidate ->
+      if MapSet.member?(probable, candidate["path"]) do
+        Map.put(candidate, "probe", ContentProbe.probe(candidate["path"]))
+      else
+        candidate
+      end
+    end)
+  end
+
+  defp probe?(candidate) do
+    candidate["skip_reason"] == "not_video_extension" and
+      candidate["size"] >= @probe_size_floor
+  end
+end

--- a/lib/mydia/downloads/import_candidates.ex
+++ b/lib/mydia/downloads/import_candidates.ex
@@ -287,12 +287,20 @@ defmodule Mydia.Downloads.ImportCandidates do
   recursively enumerate.
 
   Returns `false` (not proven shared) whenever either argument is missing
-  or blank — callers that need "unknown" to mean "assume shared" must
-  apply that policy themselves, since what counts as an acceptable
-  assumption differs: the importer already refuses to run at all when it
-  cannot resolve a client, so it only reaches this check with a resolved
-  one; `load/1` has no such upstream gate and fails closed itself before
-  calling this.
+  or blank — callers that need "unknown" to mean "assume shared" must apply
+  that policy themselves, and the two current callers differ:
+
+  `load/1` fails closed itself (see `safe_to_list?/2`) before ever calling
+  this, so a `false` here only reaches it once a live listing has already
+  been ruled unsafe for other reasons.
+
+  `Mydia.Jobs.MediaImport`'s `save_path_fallback/4` does NOT fail closed on
+  a `false` here. It only reaches this check once the download's client has
+  resolved, but a resolved client can still have no `download_directory`
+  configured — there is then nothing to compare `save_path` against, this
+  returns `false`, and the importer proceeds with the fallback listing
+  anyway. Only a `save_path` *provably equal* to the client's configured
+  directory is refused.
   """
   @spec shared_download_root?(String.t() | nil, String.t() | nil) :: boolean()
   def shared_download_root?(save_path, download_root)
@@ -348,7 +356,7 @@ defmodule Mydia.Downloads.ImportCandidates do
       |> Map.new(&{&1["path"], &1["probe"]})
 
     files
-    |> build_candidates(library_type_for(download), [])
+    |> build_candidates(resolved_library_type(download), [])
     |> Enum.map(fn candidate ->
       candidate
       |> maybe_restore_probe(probes)
@@ -363,12 +371,30 @@ defmodule Mydia.Downloads.ImportCandidates do
     end
   end
 
-  # This is a display-only guess (the actual library type used at import
-  # time comes from the resolved library path, not the media item), so a
-  # mismatch is cosmetic. `media_item` may be an unloaded association when
-  # the caller didn't preload it: Elixir's map pattern matching falls
-  # through to the next clause rather than raising when a key is absent, so
-  # `%Ecto.Association.NotLoaded{}` safely falls to the :series guess below.
+  # Prefers the download's actually-resolved `library_path.type` — the type
+  # `MediaImport.organize_and_import_files/4` really filtered against — over
+  # the movie/series guess below. A failed download was routed through
+  # `determine_library_path/1` at least once, so when the caller preloaded
+  # `:library_path` this is authoritative, not cosmetic: it's what makes the
+  # live-listing's `skip_reason` agree with the reason the file was actually
+  # dropped for non-movies/series types (`:music`, `:books`, `:adult`),
+  # which `library_type_for/1` can never guess since it only ever returns
+  # `:movies` or `:series`.
+  #
+  # Falls back to the guess when `library_path` isn't preloaded, isn't set
+  # (a download whose failure never got as far as resolving one), or is a
+  # different struct entirely: `%LibraryPath{type: type}` simply fails to
+  # match `%Ecto.Association.NotLoaded{}` or `nil`, so this never raises.
+  defp resolved_library_type(%{library_path: %Mydia.Settings.LibraryPath{type: type}}), do: type
+  defp resolved_library_type(download), do: library_type_for(download)
+
+  # Display-only guess for when the resolved library path isn't available: a
+  # mismatch here is cosmetic (the actual library type used at import time
+  # comes from the resolved library path, not the media item). `media_item`
+  # may be an unloaded association when the caller didn't preload it:
+  # Elixir's map pattern matching falls through to the next clause rather
+  # than raising when a key is absent, so `%Ecto.Association.NotLoaded{}`
+  # safely falls to the :series guess below.
   defp library_type_for(%{media_item: %{type: "movie"}}), do: :movies
   defp library_type_for(_download), do: :series
 

--- a/lib/mydia/downloads/import_candidates.ex
+++ b/lib/mydia/downloads/import_candidates.ex
@@ -167,7 +167,7 @@ defmodule Mydia.Downloads.ImportCandidates do
           {:ok, :live | :snapshot, [map()]} | {:error, :unavailable}
   def load(download) do
     metadata = download.metadata || %{}
-    snapshot = Map.get(metadata, "import_candidates") || []
+    snapshot = candidate_snapshot(metadata)
 
     case live_listing(download, metadata) do
       {:ok, files} when files != [] ->
@@ -181,6 +181,49 @@ defmodule Mydia.Downloads.ImportCandidates do
         end
     end
   end
+
+  # Prefers the failure-time `"import_candidates"` snapshot (written by
+  # `MediaImport.snapshot_candidates_on_failure/4` on every import failure).
+  # Downloads flagged `unresolved_files` before that snapshot existed only
+  # carry `metadata["unresolved_files"]` (written by
+  # `MediaImport.flag_unresolved_files/2`), and in a self-hosted deployment
+  # those rows persist indefinitely until an operator resolves them. Falling
+  # back to normalizing that list keeps the modal usable for them instead of
+  # reporting "unavailable" and stranding an operator who relied on the
+  # inline picker this modal replaces.
+  defp candidate_snapshot(metadata) do
+    case Map.get(metadata, "import_candidates") do
+      candidates when is_list(candidates) and candidates != [] ->
+        candidates
+
+      _no_snapshot ->
+        metadata
+        |> Map.get("unresolved_files")
+        |> List.wrap()
+        |> Enum.map(&normalize_unresolved_file/1)
+    end
+  end
+
+  # `flag_unresolved_files/2` writes "path", "name", "size", "parsed_season",
+  # "parsed_episode", and "assigned_episode_id" — no "skip_reason" or
+  # "probe", since those only exist on the newer import-candidates path.
+  # Missing keys degrade gracefully: the modal template only renders a probe
+  # or skip-reason line when the key is present/truthy.
+  defp normalize_unresolved_file(file) do
+    path = file["path"]
+
+    %{
+      "path" => path,
+      "name" => file["name"] || basename(path),
+      "size" => file["size"],
+      "skip_reason" => nil,
+      "parsed_season" => file["parsed_season"],
+      "parsed_episode" => file["parsed_episode"]
+    }
+  end
+
+  defp basename(path) when is_binary(path) and path != "", do: Path.basename(path)
+  defp basename(_path), do: nil
 
   defp live_listing(download, metadata) do
     case listable_save_path(metadata, download) do

--- a/lib/mydia/downloads/import_candidates.ex
+++ b/lib/mydia/downloads/import_candidates.ex
@@ -331,13 +331,26 @@ defmodule Mydia.Downloads.ImportCandidates do
 
   defp same_dir?(_a, _b), do: false
 
+  # Uses `File.stat/1` rather than `File.regular?/1` + `File.stat!/1`: a file
+  # can be deleted or renamed between the wildcard expansion and the stat
+  # call (a real race in a self-hosted deployment where the operator or the
+  # download client can be touching the same folder), and `File.stat!/1`
+  # raises on a path that no longer resolves. That would crash the modal
+  # open instead of just showing the files still there. An entry that can't
+  # be stat'd, or isn't a regular file, is silently skipped rather than
+  # raising.
   defp list_recursive(dir) do
     dir
     |> Path.join("**/*")
     |> Path.wildcard(match_dot: false)
-    |> Enum.filter(&File.regular?/1)
-    |> Enum.map(fn path ->
-      %{path: path, name: Path.basename(path), size: File.stat!(path).size}
+    |> Enum.flat_map(fn path ->
+      case File.stat(path) do
+        {:ok, %File.Stat{type: :regular, size: size}} ->
+          [%{path: path, name: Path.basename(path), size: size}]
+
+        _not_a_stable_regular_file ->
+          []
+      end
     end)
   end
 
@@ -355,11 +368,14 @@ defmodule Mydia.Downloads.ImportCandidates do
       |> Enum.filter(&Map.has_key?(&1, "probe"))
       |> Map.new(&{&1["path"], &1["probe"]})
 
+    parsed = Map.new(snapshot, &{&1["path"], {&1["parsed_season"], &1["parsed_episode"]}})
+
     files
     |> build_candidates(resolved_library_type(download), [])
     |> Enum.map(fn candidate ->
       candidate
       |> maybe_restore_probe(probes)
+      |> maybe_restore_parsed(parsed)
       |> Map.put("missing", false)
     end)
   end
@@ -368,6 +384,32 @@ defmodule Mydia.Downloads.ImportCandidates do
     case Map.fetch(probes, candidate["path"]) do
       {:ok, probe} -> Map.put(candidate, "probe", probe)
       :error -> candidate
+    end
+  end
+
+  # Restores the failure-time snapshot's `parsed_season`/`parsed_episode` for
+  # any path also present in the snapshot, rather than trusting a fresh
+  # re-parse of the live listing. `merge/3` reparses every live candidate
+  # with `parser_opts: []` (no `TargetContext`), while the snapshot was built
+  # by `MediaImport.snapshot_candidates_on_failure/4` with the real parser
+  # opts for the download's bound media item (see `parser_opts_for/1` and
+  # `target_context_for/1` in `Mydia.Jobs.MediaImport`). Without this, the
+  # same file can show a different prefilled episode target depending on
+  # whether the modal happened to get a live listing or fell back to the
+  # snapshot, with nothing telling the operator why.
+  #
+  # A path that only exists in the live listing (genuinely new on disk,
+  # never seen at failure time) has nothing to restore and keeps its
+  # re-parsed guess, since that is the best information available for it.
+  defp maybe_restore_parsed(candidate, parsed) do
+    case Map.fetch(parsed, candidate["path"]) do
+      {:ok, {season, episode}} ->
+        candidate
+        |> Map.put("parsed_season", season)
+        |> Map.put("parsed_episode", episode)
+
+      :error ->
+        candidate
     end
   end
 

--- a/lib/mydia/downloads/import_candidates.ex
+++ b/lib/mydia/downloads/import_candidates.ex
@@ -41,8 +41,17 @@ defmodule Mydia.Downloads.ImportCandidates do
   @spec build([map()], atom(), keyword()) :: [map()]
   def build(files, library_type, parser_opts) when is_list(files) do
     files
-    |> Enum.map(&candidate(&1, library_type, parser_opts))
+    |> build_candidates(library_type, parser_opts)
     |> add_probes()
+  end
+
+  # Candidate construction without probing, factored out so `merge/3` (the
+  # live-listing path of `load/1`) can reuse it without paying for
+  # `add_probes/1`'s ffprobe subprocesses on every modal open. `build/3`
+  # itself is unchanged: it always probes, which is what the failure-time
+  # snapshot (Task 4) wants.
+  defp build_candidates(files, library_type, parser_opts) do
+    Enum.map(files, &candidate(&1, library_type, parser_opts))
   end
 
   defp candidate(file, library_type, parser_opts) do
@@ -135,12 +144,21 @@ defmodule Mydia.Downloads.ImportCandidates do
   folder would otherwise have every *other* download sharing that folder
   enumerated and offered up for import here.
 
+  This fails closed: a live listing only happens when the download's
+  client resolves to a *known* `download_directory` that is provably
+  different from `save_path`. A client that no longer resolves (renamed or
+  deleted — plausible in a self-hosted deployment reconfigured by env
+  vars, and a failed download can sit for weeks before anyone opens this
+  modal) means there is no way to prove `save_path` is not that client's
+  shared root, so it is treated the same as if it were.
+
   Falls back to the snapshot captured at failure time whenever a live
-  listing isn't possible or safe: no `save_path`, a `save_path` that is the
-  shared root, a folder that no longer exists, or one that comes back
-  empty. In the fallback case each recorded path is individually re-stat'd
-  rather than the directory being walked, so files that vanished are still
-  caught without ever enumerating unrelated downloads.
+  listing isn't possible or safe: no `save_path`, an unresolvable client,
+  a `save_path` that is the shared root, a folder that no longer exists,
+  or one that comes back empty. In the fallback case each recorded path is
+  individually re-stat'd rather than the directory being walked, so files
+  that vanished are still caught without ever enumerating unrelated
+  downloads.
 
   Every returned candidate carries `"missing"`, true when the path is no
   longer on disk.
@@ -179,39 +197,71 @@ defmodule Mydia.Downloads.ImportCandidates do
   end
 
   # Only a `save_path` explicitly present on the download's own metadata is
-  # eligible for a live re-listing, and only when it isn't the download
-  # client's shared root. There is deliberately no fallback to
-  # `Path.dirname/1` of a snapshot path here: in production, downloads
-  # sometimes sit directly inside the client's shared download root, and
-  # `Path.dirname/1` of a file in that root IS the root, so recursively
-  # listing it would surface every unrelated torrent's files as if they
-  # belonged to this download.
+  # eligible for a live re-listing, and only when it can be *proven* not to
+  # be the download client's shared root. There is deliberately no
+  # fallback to `Path.dirname/1` of a snapshot path here: in production,
+  # downloads sometimes sit directly inside the client's shared download
+  # root, and `Path.dirname/1` of a file in that root IS the root, so
+  # recursively listing it would surface every unrelated torrent's files as
+  # if they belonged to this download.
   defp listable_save_path(metadata, download) do
     case Map.get(metadata, "save_path") do
       path when is_binary(path) and path != "" ->
-        if shared_download_root?(path, download), do: nil, else: path
+        safe_to_list?(path, download)
 
       _other ->
         nil
     end
   end
 
-  # Mirrors `Mydia.Jobs.MediaImport`'s guard of the same name, which exists
-  # for the same reason: refusing to recursively walk a save_path that is
-  # actually the client's shared download root, not a folder specific to
-  # this download. Duplicated here (rather than shared) because that
-  # function is private to the import job and takes the job's full
-  # `client_info` map; this only needs the configured `download_directory`.
-  defp shared_download_root?(save_path, download) do
+  # Fails closed. This only returns `save_path` (making it eligible for a
+  # live listing) when the download's client resolves to a known,
+  # non-blank `download_directory` that `shared_download_root?/2` can
+  # positively rule out as the same directory. An unresolvable client, or
+  # one with no `download_directory` configured, means there is nothing to
+  # compare `save_path` against — "unknown" must mean "don't enumerate",
+  # not "assume it's safe".
+  defp safe_to_list?(save_path, download) do
     case client_download_directory(download) do
       root when is_binary(root) and root != "" ->
-        same_dir?(save_path, root) or
-          same_dir?(PathMapping.rewrite(save_path), PathMapping.rewrite(root))
+        if shared_download_root?(save_path, root), do: nil, else: save_path
 
-      _no_root ->
-        false
+      _unresolved ->
+        nil
     end
   end
+
+  @doc """
+  True when `save_path` and `download_root` name the same directory on
+  disk, tolerant of any configured path-mapping rewrite applying to either
+  side.
+
+  This is the single source of truth for "is this path actually a download
+  client's shared download root, not a folder specific to one download."
+  `Mydia.Jobs.MediaImport` delegates to this before its own save_path
+  fallback, and `load/1` delegates to it before offering a live
+  re-listing, so the two can never silently disagree about what is safe to
+  recursively enumerate.
+
+  Returns `false` (not proven shared) whenever either argument is missing
+  or blank — callers that need "unknown" to mean "assume shared" must
+  apply that policy themselves, since what counts as an acceptable
+  assumption differs: the importer already refuses to run at all when it
+  cannot resolve a client, so it only reaches this check with a resolved
+  one; `load/1` has no such upstream gate and fails closed itself before
+  calling this.
+  """
+  @spec shared_download_root?(String.t() | nil, String.t() | nil) :: boolean()
+  def shared_download_root?(save_path, download_root)
+
+  def shared_download_root?(save_path, download_root)
+      when is_binary(save_path) and save_path != "" and
+             is_binary(download_root) and download_root != "" do
+    same_dir?(save_path, download_root) or
+      same_dir?(PathMapping.rewrite(save_path), PathMapping.rewrite(download_root))
+  end
+
+  def shared_download_root?(_save_path, _download_root), do: false
 
   defp client_download_directory(%{download_client: name})
        when is_binary(name) and name != "" do
@@ -241,8 +291,13 @@ defmodule Mydia.Downloads.ImportCandidates do
   end
 
   # Re-derive skip reasons from the live listing, but keep any probe verdict
-  # already computed for the same path so the modal does not re-probe on
-  # open.
+  # already computed for the same path so the modal does not spawn a fresh
+  # ffprobe subprocess (up to `probe_cap/0` of them, each with its own
+  # timeout) on every open. Calls `build_candidates/3` rather than
+  # `build/3` deliberately: the latter always probes, which is correct for
+  # the failure-time snapshot but far too slow for a synchronous
+  # modal-open re-listing whose accurate verdicts are already sitting in
+  # the snapshot to restore.
   defp merge(files, snapshot, download) do
     probes =
       snapshot
@@ -250,7 +305,7 @@ defmodule Mydia.Downloads.ImportCandidates do
       |> Map.new(&{&1["path"], &1["probe"]})
 
     files
-    |> build(library_type_for(download), [])
+    |> build_candidates(library_type_for(download), [])
     |> Enum.map(fn candidate ->
       candidate
       |> maybe_restore_probe(probes)

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -6,6 +6,7 @@ defmodule Mydia.Downloads.Queue do
   alias Mydia.Repo
   alias Mydia.Downloads.ContentType
   alias Mydia.Downloads.Download
+  alias Mydia.Downloads.Blacklists
   alias Mydia.Downloads.Client
   alias Mydia.Downloads.Client.Registry
   alias Mydia.Downloads.History
@@ -127,6 +128,46 @@ defmodule Mydia.Downloads.Queue do
       {:error, reason} ->
         Logger.warning("Failed to cancel download: #{inspect(reason)}")
         {:error, reason}
+    end
+  end
+
+  @doc """
+  Rejects a release the operator has judged unusable.
+
+  Blacklists `(indexer, guid)` so future searches filter it out, removes the
+  torrent and its data from the client, deletes the download row, and queues a
+  fresh search for the bound episode or movie.
+
+  The blacklist write happens first: if a later step fails, the release must
+  still not be re-grabbed. Client removal is best effort, since the torrent may
+  already be gone.
+  """
+  @spec reject_release(Download.t(), keyword()) ::
+          {:ok, :rejected} | {:error, :no_indexer | :no_guid | term()}
+  def reject_release(%Download{} = download, opts \\ []) do
+    with {:ok, indexer, guid} <- Blacklists.extract_key(download),
+         {:ok, _row} <-
+           Blacklists.add(indexer, guid, download.title || "Unknown release", "rejected_by_user") do
+      # Computed before deletion: it reads through the media_item association.
+      search = replacement_search(download)
+
+      remove_from_client(download)
+
+      case History.delete_download(download) do
+        {:ok, _deleted} ->
+          enqueue_search(search)
+
+          Events.download_cancelled(
+            download,
+            Keyword.get(opts, :actor_type, :user),
+            Keyword.get(opts, :actor_id, "unknown")
+          )
+
+          {:ok, :rejected}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 
@@ -722,6 +763,59 @@ defmodule Mydia.Downloads.Queue do
     )
     |> Repo.delete_all()
   end
+
+  # Best effort: a torrent the client no longer holds must not block the reject.
+  defp remove_from_client(%Download{download_client: nil}), do: :ok
+  defp remove_from_client(%Download{download_client_id: nil}), do: :ok
+
+  defp remove_from_client(download) do
+    with {:ok, client_config} <- find_client_config(download.download_client),
+         {:ok, adapter} <- get_adapter_for_client(client_config) do
+      Client.remove_download(
+        adapter,
+        config_to_map(client_config),
+        download.download_client_id,
+        delete_files: true
+      )
+    end
+
+    :ok
+  rescue
+    exception ->
+      Logger.warning("Could not remove rejected release from client",
+        download_id: download.id,
+        error: Exception.message(exception)
+      )
+
+      :ok
+  end
+
+  # Returns an Oban changeset, or nil when there is nothing sensible to search
+  # for. `Media` exposes only the raising `get_media_item!/1`, so this reads the
+  # association instead: a deleted media item yields nil rather than raising in
+  # the middle of a cleanup path.
+  defp replacement_search(%Download{episode_id: episode_id}) when is_binary(episode_id) do
+    Mydia.Jobs.TVShowSearch.new(%{"mode" => "specific", "episode_id" => episode_id})
+  end
+
+  defp replacement_search(%Download{media_item_id: media_item_id} = download)
+       when is_binary(media_item_id) do
+    case Repo.preload(download, :media_item).media_item do
+      %{type: "movie", id: id} ->
+        Mydia.Jobs.MovieSearch.new(%{"mode" => "specific", "media_item_id" => id})
+
+      %{type: "tv_show", id: id} ->
+        Mydia.Jobs.TVShowSearch.new(%{"mode" => "show", "media_item_id" => id})
+
+      _other ->
+        nil
+    end
+  end
+
+  defp replacement_search(_download), do: nil
+
+  defp enqueue_search(nil), do: :ok
+  defp enqueue_search(changeset), do: insert_job(changeset)
 
   ## Private Functions - Download Initiation
 

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -788,6 +788,21 @@ defmodule Mydia.Downloads.Queue do
       )
 
       :ok
+  catch
+    # The debrid adapter's remove_torrent/3 terminates any running Fetcher
+    # first via DynamicSupervisor.terminate_child/2 — a GenServer.call that
+    # emits an :exit signal (not an Elixir exception) if the supervisor isn't
+    # alive, same hazard documented on
+    # Mydia.Downloads.Client.Debrid.RateLimiter.acquire/3. `rescue` alone
+    # would not catch it, and a client that will not answer must not block
+    # rejecting a bad release.
+    :exit, reason ->
+      Logger.warning("Could not remove rejected release from client (process exit)",
+        download_id: download.id,
+        reason: inspect(reason)
+      )
+
+      :ok
   end
 
   # Returns an Oban changeset, or nil when there is nothing sensible to search

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -355,7 +355,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # filter the result out. Best-effort: rescue all errors so a failing
   # blacklist write never blocks the rest of failure handling.
   defp record_blacklist_entry(download, failure_reason) do
-    case extract_blacklist_key(download) do
+    case Blacklists.extract_key(download) do
       {:ok, indexer, guid} ->
         try do
           case Blacklists.add(indexer, guid, download.title || "", failure_reason) do
@@ -396,20 +396,6 @@ defmodule Mydia.Jobs.DownloadMonitor do
         )
 
         :ok
-    end
-  end
-
-  # Returns `{:ok, indexer, guid}` when both are present on the download.
-  # The `indexer` and `guid` should have been plumbed in at download
-  # creation time (see `Mydia.Downloads.Queue.create_download_record/4`).
-  defp extract_blacklist_key(download) do
-    indexer = download.indexer || get_in(download.metadata || %{}, ["indexer"])
-    guid = get_in(download.metadata || %{}, ["guid"])
-
-    cond do
-      is_nil(indexer) or indexer == "" -> {:error, :no_indexer}
-      is_nil(guid) or guid == "" -> {:error, :no_guid}
-      true -> {:ok, indexer, guid}
     end
   end
 

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -620,9 +620,18 @@ defmodule Mydia.Jobs.MediaImport do
       errors = Enum.filter(results, &match?({:error, _}, &1))
 
       if errors == [] do
-        # All targeted files imported — clear match_status and unresolved_files metadata
+        # All targeted files imported — clear match_status and the stale
+        # candidate/unresolved-file listings. Without dropping
+        # "import_candidates" and "import_candidates_at" too, a hand-matched
+        # download would keep carrying the listing (and probe verdicts) from
+        # the failure this import just resolved, forever.
         current_metadata = download.metadata || %{}
-        cleaned_metadata = Map.delete(current_metadata, "unresolved_files")
+
+        cleaned_metadata =
+          current_metadata
+          |> Map.delete("unresolved_files")
+          |> Map.delete("import_candidates")
+          |> Map.delete("import_candidates_at")
 
         Downloads.update_download(download, %{
           imported_at: DateTime.utc_now(),

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -382,21 +382,15 @@ defmodule Mydia.Jobs.MediaImport do
     end
   end
 
-  # True when the reported save_path is the client's configured download
-  # directory rather than a per-download subfolder. Compared after path
-  # mapping so a remote root and its local mount both match.
-  defp shared_download_root?(save_path, %{download_directory: root})
-       when is_binary(save_path) and save_path != "" and is_binary(root) and root != "" do
-    same_dir?(save_path, root) or
-      same_dir?(mapped_path_quiet(save_path), mapped_path_quiet(root))
+  # Delegates to `ImportCandidates.shared_download_root?/2`, the single
+  # source of truth for "is the reported save_path the client's configured
+  # download directory rather than a per-download subfolder." The manual
+  # file matching modal's read path (`ImportCandidates.load/1`) relies on
+  # the exact same check before offering a live re-listing, so the two can
+  # never silently disagree about what is safe to enumerate.
+  defp shared_download_root?(save_path, client_info) do
+    ImportCandidates.shared_download_root?(save_path, Map.get(client_info, :download_directory))
   end
-
-  defp shared_download_root?(_save_path, _client_info), do: false
-
-  defp same_dir?(a, b) when is_binary(a) and a != "" and is_binary(b) and b != "",
-    do: Path.expand(a) == Path.expand(b)
-
-  defp same_dir?(_a, _b), do: false
 
   defp process_import(download, files, args) do
     library_path = determine_library_path(download)
@@ -759,13 +753,6 @@ defmodule Mydia.Jobs.MediaImport do
         mapped
     end
   end
-
-  # Same rewrite without the log line, for comparisons that are not about to
-  # touch the filesystem.
-  defp mapped_path_quiet(path) when is_binary(path),
-    do: Mydia.Library.PathMapping.rewrite(path)
-
-  defp mapped_path_quiet(path), do: path
 
   defp list_files_in_path(path) do
     path_stat = File.stat(path)

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -431,21 +431,35 @@ defmodule Mydia.Jobs.MediaImport do
     # paths) already wrote its own metadata to the row by the time this runs.
     # Merging onto the stale in-memory struct would blindly overwrite that
     # write instead of layering on top of it.
-    current = Downloads.get_download!(download.id)
+    #
+    # The row can also be gone by now — an operator dismissing the download
+    # while a large import is still copying files, for example — so this
+    # mirrors `fetch_download/1`'s rescue rather than letting a raised
+    # `Ecto.NoResultsError` crash the job. There is nothing left to attach a
+    # candidate listing to, so skip the snapshot and hand back the original
+    # result untouched; the job still fails/succeeds exactly as it would have
+    # without this snapshot step.
+    case fetch_current_download(download.id) do
+      {:ok, current} ->
+        metadata =
+          (current.metadata || %{})
+          |> Map.put("import_candidates", candidates)
+          |> Map.put("import_candidates_at", DateTime.utc_now() |> DateTime.to_iso8601())
 
-    metadata =
-      (current.metadata || %{})
-      |> Map.put("import_candidates", candidates)
-      |> Map.put("import_candidates_at", DateTime.utc_now() |> DateTime.to_iso8601())
+        case Downloads.update_download(current, %{metadata: metadata}) do
+          {:ok, _updated} ->
+            :ok
 
-    case Downloads.update_download(current, %{metadata: metadata}) do
-      {:ok, _updated} ->
-        :ok
+          {:error, changeset} ->
+            Logger.warning("Failed to store import candidates",
+              download_id: download.id,
+              errors: inspect(changeset.errors)
+            )
+        end
 
-      {:error, changeset} ->
-        Logger.warning("Failed to store import candidates",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
+      :not_found ->
+        Logger.info("Skipping import candidate snapshot: download row no longer exists",
+          download_id: download.id
         )
     end
 
@@ -453,6 +467,12 @@ defmodule Mydia.Jobs.MediaImport do
   end
 
   defp snapshot_candidates_on_failure(result, _download, _files, _library_path), do: result
+
+  defp fetch_current_download(download_id) do
+    {:ok, Downloads.get_download!(download_id)}
+  rescue
+    Ecto.NoResultsError -> :not_found
+  end
 
   defp do_process_import(download, files, library_path, args) do
     case organize_and_import_files(download, files, library_path, args) do
@@ -1895,7 +1915,7 @@ defmodule Mydia.Jobs.MediaImport do
       import_failed_at: import_failed_at
     }
 
-    case Downloads.update_download(download, attrs) do
+    case update_retry_metadata(download, attrs) do
       {:ok, _updated} ->
         if terminal? do
           Logger.warning("Import failed terminally — no further retries",
@@ -1921,7 +1941,26 @@ defmodule Mydia.Jobs.MediaImport do
         )
 
         :ok
+
+      :not_found ->
+        # The row this whole job is about was deleted while the job was
+        # running (e.g. an operator dismissed it mid-import). `Repo.update/1`
+        # raises `Ecto.StaleEntryError` when the struct's primary key no
+        # longer matches any row — there is no retry metadata left to
+        # attach it to, and the job already self-heals next attempt via
+        # `fetch_download/1`'s `:not_found` guard, so skip rather than crash.
+        Logger.info("Skipping retry-metadata update: download row no longer exists",
+          download_id: download.id
+        )
+
+        :ok
     end
+  end
+
+  defp update_retry_metadata(download, attrs) do
+    Downloads.update_download(download, attrs)
+  rescue
+    Ecto.StaleEntryError -> :not_found
   end
 
   # Structured failure classification persisted alongside the human message, so

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -399,125 +399,167 @@ defmodule Mydia.Jobs.MediaImport do
   defp same_dir?(_a, _b), do: false
 
   defp process_import(download, files, args) do
-    # Get library path for this media type
     library_path = determine_library_path(download)
 
-    if library_path do
-      # The resolved library path's auto_rename policy is authoritative at
-      # execution time: it drives renaming in both directions, overriding
-      # whatever rename_files the job was enqueued with.
-      args = %{args | rename_files: library_path.auto_rename}
+    result =
+      if library_path do
+        # The resolved library path's auto_rename policy is authoritative at
+        # execution time: it drives renaming in both directions, overriding
+        # whatever rename_files the job was enqueued with.
+        args = %{args | rename_files: library_path.auto_rename}
 
-      # Organize files into library structure
-      case organize_and_import_files(download, files, library_path, args) do
-        {:ok, imported_files} ->
-          Logger.info("Successfully imported files",
-            download_id: download.id,
-            file_count: length(imported_files)
-          )
-
-          # Detect partial season packs: a download that claimed to deliver N
-          # episodes but actually matched fewer. Sets match_status accordingly
-          # so future re-imports and reporting can recognize it.
-          partial_pack_status = detect_partial_pack(download, imported_files)
-
-          # Reload download to check if it was flagged as having unresolved files
-          updated_download =
-            Downloads.get_download!(download.id,
-              preload: [{:media_item, :episodes}, :episode, :library_path]
-            )
-
-          has_unresolved = updated_download.match_status == "unresolved_files"
-
-          # Cleanup is only safe when every file resolved — keep the
-          # download in the client when some files remain unmatched so
-          # the user can manually retry after fixing the matches.
-          unless has_unresolved do
-            client_info = get_client_info(download)
-            should_cleanup = client_info && client_info.remove_completed
-
-            if should_cleanup do
-              Logger.info("Removing download from client (remove_completed enabled)",
-                download_id: download.id,
-                client: download.download_client
-              )
-
-              cleanup_download_client(download)
-            else
-              Logger.info("Keeping download in client for seeding (remove_completed disabled)",
-                download_id: download.id,
-                client: download.download_client
-              )
-            end
-          end
-
-          # Always stamp `imported_at` once we've made an honest attempt,
-          # even when some files are still unresolved. `match_status` keeps
-          # surfacing the partial result in the Issues tab. The previous
-          # behaviour left `imported_at` nil on partial imports, which
-          # caused DownloadMonitor.list_stuck_downloads/1 to re-flag the
-          # download every poll and enqueue a fresh MediaImport job every
-          # 2 minutes — a retry loop that did no useful work but kept
-          # showing "Import stalled - never ran" in the UI.
-          import_update =
-            %{imported_at: DateTime.utc_now()}
-            |> then(fn attrs ->
-              # Preserve `match_status: "unresolved_files"` when present so
-              # the Issues tab can still surface partial imports. Only
-              # touch match_status when we're transitioning to a clean
-              # state (partial_pack or nil), never overwrite the
-              # in-progress "unresolved_files" flag.
-              if has_unresolved do
-                attrs
-              else
-                Map.put(attrs, :match_status, partial_pack_status)
-              end
-            end)
-
-          case Downloads.update_download(updated_download, import_update) do
-            {:ok, _updated} ->
-              Logger.info("Download marked as imported",
-                download_id: download.id,
-                has_unresolved: has_unresolved
-              )
-
-            {:error, changeset} ->
-              Logger.warning("Failed to mark download as imported",
-                download_id: download.id,
-                errors: inspect(changeset.errors)
-              )
-          end
-
-          # Write NFO metadata files if enabled for this library path
-          if download.media_item_id do
-            NfoWriter.maybe_write_nfos(download.media_item_id)
-          end
-
-          # Notify media servers (Plex, Jellyfin) to scan for new content
-          # This is fire-and-forget (async) - errors won't affect import success
-          MediaServerNotifier.notify_all()
-
-          if has_unresolved do
-            Logger.info("Partial import complete, unresolved files flagged",
-              download_id: download.id
-            )
-
-            {:ok, :partial_import}
-          else
-            {:ok, :imported}
-          end
-
-        {:error, reason} ->
-          Logger.error("Failed to import files",
-            download_id: download.id,
-            reason: inspect(reason)
-          )
-
-          {:error, reason}
+        do_process_import(download, files, library_path, args)
+      else
+        Logger.error("Could not determine library path for download", download_id: download.id)
+        {:error, :no_library_path}
       end
-    else
-      Logger.error("Could not determine library path for download", download_id: download.id)
-      {:error, :no_library_path}
+
+    snapshot_candidates_on_failure(result, download, files, library_path)
+  end
+
+  # Persist what the download actually contained whenever the import fails after
+  # the file listing succeeded. Without this the operator sees only an error
+  # string and has no way to inspect or hand-match the files.
+  defp snapshot_candidates_on_failure({:error, _reason} = result, download, files, library_path) do
+    library_type = if library_path, do: library_path.type, else: :unknown
+
+    candidates = ImportCandidates.build(files, library_type, parser_opts_for(download))
+
+    # Reload rather than starting from the `download` struct captured before
+    # `do_process_import/4` ran: `flag_unresolved_files/2` (called from
+    # `organize_and_import_files/4` on the all-unresolved and partial-import
+    # paths) already wrote its own metadata to the row by the time this runs.
+    # Merging onto the stale in-memory struct would blindly overwrite that
+    # write instead of layering on top of it.
+    current = Downloads.get_download!(download.id)
+
+    metadata =
+      (current.metadata || %{})
+      |> Map.put("import_candidates", candidates)
+      |> Map.put("import_candidates_at", DateTime.utc_now() |> DateTime.to_iso8601())
+
+    case Downloads.update_download(current, %{metadata: metadata}) do
+      {:ok, _updated} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.warning("Failed to store import candidates",
+          download_id: download.id,
+          errors: inspect(changeset.errors)
+        )
+    end
+
+    result
+  end
+
+  defp snapshot_candidates_on_failure(result, _download, _files, _library_path), do: result
+
+  defp do_process_import(download, files, library_path, args) do
+    case organize_and_import_files(download, files, library_path, args) do
+      {:ok, imported_files} ->
+        Logger.info("Successfully imported files",
+          download_id: download.id,
+          file_count: length(imported_files)
+        )
+
+        # Detect partial season packs: a download that claimed to deliver N
+        # episodes but actually matched fewer. Sets match_status accordingly
+        # so future re-imports and reporting can recognize it.
+        partial_pack_status = detect_partial_pack(download, imported_files)
+
+        # Reload download to check if it was flagged as having unresolved files
+        updated_download =
+          Downloads.get_download!(download.id,
+            preload: [{:media_item, :episodes}, :episode, :library_path]
+          )
+
+        has_unresolved = updated_download.match_status == "unresolved_files"
+
+        # Cleanup is only safe when every file resolved — keep the
+        # download in the client when some files remain unmatched so
+        # the user can manually retry after fixing the matches.
+        unless has_unresolved do
+          client_info = get_client_info(download)
+          should_cleanup = client_info && client_info.remove_completed
+
+          if should_cleanup do
+            Logger.info("Removing download from client (remove_completed enabled)",
+              download_id: download.id,
+              client: download.download_client
+            )
+
+            cleanup_download_client(download)
+          else
+            Logger.info("Keeping download in client for seeding (remove_completed disabled)",
+              download_id: download.id,
+              client: download.download_client
+            )
+          end
+        end
+
+        # Always stamp `imported_at` once we've made an honest attempt,
+        # even when some files are still unresolved. `match_status` keeps
+        # surfacing the partial result in the Issues tab. The previous
+        # behaviour left `imported_at` nil on partial imports, which
+        # caused DownloadMonitor.list_stuck_downloads/1 to re-flag the
+        # download every poll and enqueue a fresh MediaImport job every
+        # 2 minutes — a retry loop that did no useful work but kept
+        # showing "Import stalled - never ran" in the UI.
+        import_update =
+          %{imported_at: DateTime.utc_now()}
+          |> then(fn attrs ->
+            # Preserve `match_status: "unresolved_files"` when present so
+            # the Issues tab can still surface partial imports. Only
+            # touch match_status when we're transitioning to a clean
+            # state (partial_pack or nil), never overwrite the
+            # in-progress "unresolved_files" flag.
+            if has_unresolved do
+              attrs
+            else
+              Map.put(attrs, :match_status, partial_pack_status)
+            end
+          end)
+
+        case Downloads.update_download(updated_download, import_update) do
+          {:ok, _updated} ->
+            Logger.info("Download marked as imported",
+              download_id: download.id,
+              has_unresolved: has_unresolved
+            )
+
+          {:error, changeset} ->
+            Logger.warning("Failed to mark download as imported",
+              download_id: download.id,
+              errors: inspect(changeset.errors)
+            )
+        end
+
+        # Write NFO metadata files if enabled for this library path
+        if download.media_item_id do
+          NfoWriter.maybe_write_nfos(download.media_item_id)
+        end
+
+        # Notify media servers (Plex, Jellyfin) to scan for new content
+        # This is fire-and-forget (async) - errors won't affect import success
+        MediaServerNotifier.notify_all()
+
+        if has_unresolved do
+          Logger.info("Partial import complete, unresolved files flagged",
+            download_id: download.id
+          )
+
+          {:ok, :partial_import}
+        else
+          {:ok, :imported}
+        end
+
+      {:error, reason} ->
+        Logger.error("Failed to import files",
+          download_id: download.id,
+          reason: inspect(reason)
+        )
+
+        {:error, reason}
     end
   end
 

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -35,6 +35,7 @@ defmodule Mydia.Jobs.MediaImport do
   require Logger
   alias Mydia.{Downloads, Library, Media, Settings}
   alias Mydia.Downloads.Client
+  alias Mydia.Downloads.ImportCandidates
   alias Mydia.Library.{FileNamer, FileOrganizer, SampleDetector}
   alias Mydia.Library.ReleaseParser
   alias Mydia.Library.ReleaseParser.TargetContext
@@ -1079,56 +1080,11 @@ defmodule Mydia.Jobs.MediaImport do
     |> String.trim()
   end
 
-  defp filter_video_files(files) do
-    video_extensions = ~w(.mkv .mp4 .avi .mov .wmv .flv .webm .m4v .mpg .mpeg .m2ts)
-
-    Enum.filter(files, fn file ->
-      ext = Path.extname(file.name) |> String.downcase()
-      ext in video_extensions
-    end)
-  end
-
-  # Filter files based on library type
-  defp filter_files_for_library_type(files, library_type)
-       when library_type in [:movies, :series, :mixed] do
-    # For video libraries, only import video files
-    filter_video_files(files)
-  end
-
-  defp filter_files_for_library_type(files, :music) do
-    # Music file extensions
-    music_extensions = ~w(.mp3 .flac .wav .aac .ogg .m4a .wma .opus .ape .alac .aiff)
-
-    Enum.filter(files, fn file ->
-      ext = Path.extname(file.name) |> String.downcase()
-      ext in music_extensions
-    end)
-  end
-
-  defp filter_files_for_library_type(files, :books) do
-    # Ebook file extensions
-    book_extensions = ~w(.epub .pdf .mobi .azw .azw3 .cbr .cbz .djvu .fb2 .lit .txt .rtf)
-
-    Enum.filter(files, fn file ->
-      ext = Path.extname(file.name) |> String.downcase()
-      ext in book_extensions
-    end)
-  end
-
-  defp filter_files_for_library_type(files, :adult) do
-    # Adult libraries can contain video and image files
-    media_extensions =
-      ~w(.mkv .mp4 .avi .mov .wmv .flv .webm .m4v .jpg .jpeg .png .gif .webp .bmp .tiff)
-
-    Enum.filter(files, fn file ->
-      ext = Path.extname(file.name) |> String.downcase()
-      ext in media_extensions
-    end)
-  end
-
-  defp filter_files_for_library_type(files, _unknown) do
-    # For unknown library types, import all files (fallback)
-    files
+  # The extension vocabulary lives in `ImportCandidates`, which also derives the
+  # skip reasons shown to the operator on a failed import. Keeping one copy means
+  # the two can never disagree.
+  defp filter_files_for_library_type(files, library_type) do
+    Enum.filter(files, &ImportCandidates.importable?(&1, library_type))
   end
 
   defp filter_extras_and_samples(files) do

--- a/lib/mydia/library/content_probe.ex
+++ b/lib/mydia/library/content_probe.ex
@@ -25,12 +25,11 @@ defmodule Mydia.Library.ContentProbe do
   @spec probe(String.t()) :: verdict()
   def probe(path) when is_binary(path) do
     with {:ok, ffprobe} <- executable(),
-         true <- File.regular?(path) || {:error, :not_a_file} do
+         {:file, true} <- {:file, File.regular?(path)} do
       run(ffprobe, path)
     else
       {:error, :ffprobe_not_found} -> verdict("unknown", "ffprobe not installed")
-      {:error, :not_a_file} -> verdict("unknown", "file not found")
-      false -> verdict("unknown", "file not found")
+      {:file, false} -> verdict("unknown", "file not found")
     end
   end
 
@@ -41,6 +40,18 @@ defmodule Mydia.Library.ContentProbe do
     end
   end
 
+  # Runs ffprobe through a Port we own directly (no Task), for two reasons:
+  #
+  #   * A `Task.async` result is linked to this process, so a raise inside the
+  #     spawned function (e.g. ffprobe vanishing between `executable/0`'s check
+  #     and invocation) would exit this process via a linked EXIT before the
+  #     `rescue` below ever ran. A directly-opened port raises in this process,
+  #     where `rescue` can actually catch it.
+  #   * `Task.shutdown(:brutal_kill)` only kills the BEAM process that called
+  #     `System.cmd/3` — it does not touch the ffprobe OS process `System.cmd`
+  #     spawned, which survives, reparents to init, and keeps running. Opening
+  #     our own port lets us capture the OS pid via `Port.info/2` and send it
+  #     a real SIGKILL on timeout.
   defp run(ffprobe, path) do
     args = [
       "-v",
@@ -54,17 +65,75 @@ defmodule Mydia.Library.ContentProbe do
       path
     ]
 
-    task = Task.async(fn -> System.cmd(ffprobe, args, stderr_to_stdout: true) end)
+    port =
+      Port.open({:spawn_executable, ffprobe}, [
+        :binary,
+        :exit_status,
+        :hide,
+        :stderr_to_stdout,
+        args: args
+      ])
 
-    case Task.yield(task, @timeout_ms) || Task.shutdown(task, :brutal_kill) do
-      {:ok, {output, 0}} -> classify(output)
-      {:ok, {output, _code}} -> verdict("not_media", first_line(output))
-      nil -> verdict("unknown", "probe timed out")
-    end
+    collect(port, port_os_pid(port), "")
   rescue
     exception ->
-      Logger.debug("Content probe raised: #{Exception.message(exception)}")
+      Logger.warning("Content probe raised: #{Exception.message(exception)}")
       verdict("unknown", "probe failed")
+  end
+
+  defp port_os_pid(port) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, pid} -> pid
+      nil -> nil
+    end
+  end
+
+  defp collect(port, os_pid, acc) do
+    receive do
+      {^port, {:data, chunk}} -> collect(port, os_pid, acc <> chunk)
+      {^port, {:exit_status, 0}} -> classify(acc)
+      {^port, {:exit_status, _code}} -> verdict("not_media", first_line(acc))
+    after
+      @timeout_ms ->
+        kill_and_close(port, os_pid)
+        verdict("unknown", "probe timed out")
+    end
+  end
+
+  # `Port.close/1` alone does not guarantee the OS process dies: it only
+  # detaches Erlang's end of the stdio pipes. A process like ffprobe, which
+  # reads its input from a file path (not stdin) and only writes to stdout
+  # once done, never notices the pipe closing and keeps running as an orphan.
+  # Verified empirically: closing the port left the ffprobe process alive and
+  # still reading; sending SIGKILL to the OS pid from `Port.info/2` reliably
+  # killed it. So we signal the pid directly instead of relying on close.
+  defp kill_and_close(port, os_pid) do
+    send_kill(os_pid)
+    close_port(port)
+    flush_port_messages(port)
+  end
+
+  defp send_kill(nil), do: :ok
+
+  defp send_kill(os_pid) do
+    System.cmd("kill", ["-KILL", to_string(os_pid)], stderr_to_stdout: true)
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp close_port(port) do
+    Port.close(port)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp flush_port_messages(port) do
+    receive do
+      {^port, _} -> flush_port_messages(port)
+    after
+      0 -> :ok
+    end
   end
 
   defp classify(output) do

--- a/lib/mydia/library/content_probe.ex
+++ b/lib/mydia/library/content_probe.ex
@@ -119,7 +119,12 @@ defmodule Mydia.Library.ContentProbe do
     System.cmd("kill", ["-KILL", to_string(os_pid)], stderr_to_stdout: true)
     :ok
   rescue
-    _ -> :ok
+    exception ->
+      Logger.warning(
+        "Content probe could not kill timed-out ffprobe process #{os_pid}: #{Exception.message(exception)}"
+      )
+
+      :ok
   end
 
   defp close_port(port) do

--- a/lib/mydia/library/content_probe.ex
+++ b/lib/mydia/library/content_probe.ex
@@ -1,0 +1,139 @@
+defmodule Mydia.Library.ContentProbe do
+  @moduledoc """
+  Classifies a file as media or not by reading its container headers.
+
+  Used when a download's file was rejected on extension alone, so the operator
+  can tell an obfuscated release (a Matroska file named `.bin`) from a fake one
+  (a Windows executable named `.exe`). Reads headers only, so it is cheap even
+  on multi-gigabyte files.
+  """
+
+  require Logger
+
+  @timeout_ms 10_000
+
+  @type verdict :: %{required(String.t()) => String.t()}
+
+  @doc """
+  Probes `path` and returns a verdict map with string keys, ready to store in
+  the download's JSON metadata.
+
+    * `%{"status" => "media", "detail" => "matroska,webm, 24:31, h264"}`
+    * `%{"status" => "not_media", "detail" => "invalid data"}`
+    * `%{"status" => "unknown", "detail" => "ffprobe not installed"}`
+  """
+  @spec probe(String.t()) :: verdict()
+  def probe(path) when is_binary(path) do
+    with {:ok, ffprobe} <- executable(),
+         true <- File.regular?(path) || {:error, :not_a_file} do
+      run(ffprobe, path)
+    else
+      {:error, :ffprobe_not_found} -> verdict("unknown", "ffprobe not installed")
+      {:error, :not_a_file} -> verdict("unknown", "file not found")
+      false -> verdict("unknown", "file not found")
+    end
+  end
+
+  defp executable do
+    case System.find_executable("ffprobe") do
+      nil -> {:error, :ffprobe_not_found}
+      path -> {:ok, path}
+    end
+  end
+
+  defp run(ffprobe, path) do
+    args = [
+      "-v",
+      "error",
+      "-show_entries",
+      "format=format_name,duration",
+      "-show_entries",
+      "stream=codec_type,codec_name",
+      "-of",
+      "default=noprint_wrappers=1",
+      path
+    ]
+
+    task = Task.async(fn -> System.cmd(ffprobe, args, stderr_to_stdout: true) end)
+
+    case Task.yield(task, @timeout_ms) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {output, 0}} -> classify(output)
+      {:ok, {output, _code}} -> verdict("not_media", first_line(output))
+      nil -> verdict("unknown", "probe timed out")
+    end
+  rescue
+    exception ->
+      Logger.debug("Content probe raised: #{Exception.message(exception)}")
+      verdict("unknown", "probe failed")
+  end
+
+  defp classify(output) do
+    fields = parse_fields(output)
+
+    if Map.has_key?(fields, "format_name") and has_av_stream?(fields) do
+      verdict("media", summarize(fields))
+    else
+      verdict("not_media", "no audio or video stream")
+    end
+  end
+
+  defp parse_fields(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.reduce(%{}, fn line, acc ->
+      case String.split(line, "=", parts: 2) do
+        [key, value] ->
+          Map.update(acc, String.trim(key), [String.trim(value)], &[String.trim(value) | &1])
+
+        _ ->
+          acc
+      end
+    end)
+    |> Map.new(fn {k, v} -> {k, Enum.reverse(v)} end)
+    |> then(fn map ->
+      Map.new(map, fn
+        {"format_name", [first | _]} -> {"format_name", first}
+        {"duration", [first | _]} -> {"duration", first}
+        {k, v} -> {k, v}
+      end)
+    end)
+  end
+
+  defp has_av_stream?(fields) do
+    types = Map.get(fields, "codec_type", [])
+    "video" in types or "audio" in types
+  end
+
+  defp summarize(fields) do
+    [
+      Map.get(fields, "format_name"),
+      format_duration(Map.get(fields, "duration")),
+      fields |> Map.get("codec_name", []) |> List.first()
+    ]
+    |> Enum.reject(&(is_nil(&1) or &1 == ""))
+    |> Enum.join(", ")
+  end
+
+  defp format_duration(nil), do: nil
+
+  defp format_duration(raw) do
+    case Float.parse(raw) do
+      {seconds, _} when seconds > 0 ->
+        total = trunc(seconds)
+        "#{div(total, 60)}:#{String.pad_leading("#{rem(total, 60)}", 2, "0")}"
+
+      _ ->
+        nil
+    end
+  end
+
+  defp first_line(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> List.first()
+    |> Kernel.||("unreadable")
+    |> String.slice(0, 200)
+  end
+
+  defp verdict(status, detail), do: %{"status" => status, "detail" => detail}
+end

--- a/lib/mydia_web/live/downloads_live/components.ex
+++ b/lib/mydia_web/live/downloads_live/components.ex
@@ -1,0 +1,166 @@
+defmodule MydiaWeb.DownloadsLive.Components do
+  @moduledoc """
+  Components used only by `MydiaWeb.DownloadsLive.Index`.
+
+  Not globally imported. See the component organization rules in CLAUDE.md.
+  """
+  use MydiaWeb, :html
+
+  alias Mydia.Downloads.Blacklists
+
+  @doc """
+  The match-files modal.
+
+  Lets the operator see every file a failed import's download folder actually
+  contained (not just "no importable files found") and match any of them to an
+  episode, the movie destination, or leave them ignored.
+  """
+  attr :modal, :map, required: true
+  attr :error, :string, default: nil
+
+  def match_files_modal(assigns) do
+    ~H"""
+    <.modal id="match-files-modal" show={true} on_cancel="close_match_files">
+      <:title>Match files</:title>
+      <p class="text-sm text-base-content/60 truncate">{@modal.download.title}</p>
+
+      <p :if={@modal.source == :snapshot} class="alert alert-warning mt-3 text-sm">
+        <.icon name="hero-exclamation-triangle" class="size-4" />
+        Mydia cannot read this download's folder right now, so this is the listing
+        recorded when the import failed.
+      </p>
+
+      <p :if={@error} id="match-files-error" class="alert alert-error mt-3 text-sm">
+        {@error}
+      </p>
+
+      <form id="match-files-form" phx-submit="match_files_import" class="mt-4 space-y-2">
+        <div
+          :for={candidate <- @modal.candidates}
+          class="flex items-start gap-3 bg-base-200 rounded-lg px-3 py-2"
+        >
+          <div class="flex-1 min-w-0">
+            <div
+              class={[
+                "text-sm font-mono truncate",
+                candidate["missing"] && "line-through opacity-50"
+              ]}
+              title={candidate["path"]}
+            >
+              {candidate["name"]}
+            </div>
+            <div class="text-xs text-base-content/50">
+              {format_size(candidate["size"])}
+              <span :if={candidate["probe"]}>
+                • {probe_label(candidate["probe"])}
+              </span>
+              <span :if={candidate["skip_reason"]}>
+                • skipped: {skip_label(candidate["skip_reason"])}
+              </span>
+            </div>
+          </div>
+          <select
+            name={"target[#{candidate["path"]}]"}
+            disabled={candidate["missing"]}
+            class="select select-bordered select-sm w-56"
+          >
+            <option value="">Ignore</option>
+            <option
+              :for={episode <- @modal.episodes}
+              value={episode.id}
+              selected={prefilled?(candidate, episode)}
+            >
+              {episode_label(episode)}
+            </option>
+            <option :if={@modal.episodes == []} value="movie">
+              Import as this movie
+            </option>
+          </select>
+        </div>
+      </form>
+
+      <:actions>
+        <button type="button" class="btn btn-ghost btn-sm" phx-click="close_match_files">
+          Cancel
+        </button>
+        <button
+          type="button"
+          id="match-files-reject"
+          class="btn btn-warning btn-sm"
+          phx-click="reject_release"
+          phx-value-id={@modal.download.id}
+          disabled={not rejectable?(@modal.download)}
+          title={reject_hint(@modal.download)}
+          data-confirm="Blacklist this release, delete it and its files, and search again?"
+        >
+          Reject release
+        </button>
+        <button
+          type="submit"
+          form="match-files-form"
+          id="match-files-import"
+          class="btn btn-primary btn-sm"
+        >
+          <.icon name="hero-arrow-down-tray" class="size-4" /> Import selected
+        </button>
+      </:actions>
+    </.modal>
+    """
+  end
+
+  defp prefilled?(candidate, episode) do
+    candidate["parsed_season"] == episode.season_number and
+      candidate["parsed_episode"] == episode.episode_number
+  end
+
+  defp episode_label(episode) do
+    season = String.pad_leading("#{episode.season_number}", 2, "0")
+    number = String.pad_leading("#{episode.episode_number}", 2, "0")
+
+    if episode.title do
+      "S#{season}E#{number} - #{episode.title}"
+    else
+      "S#{season}E#{number}"
+    end
+  end
+
+  defp skip_label("not_video_extension"), do: "not a video extension"
+  defp skip_label(reason) when is_binary(reason), do: reason
+  defp skip_label(_reason), do: nil
+
+  defp probe_label(%{"status" => "media", "detail" => detail}), do: "Media (#{detail})"
+  defp probe_label(%{"status" => "not_media", "detail" => detail}), do: "Not media (#{detail})"
+  defp probe_label(%{"detail" => detail}), do: "Unknown (#{detail})"
+  defp probe_label(_probe), do: nil
+
+  defp rejectable?(download) do
+    match?({:ok, _indexer, _guid}, Blacklists.extract_key(download))
+  end
+
+  defp reject_hint(download) do
+    case Blacklists.extract_key(download) do
+      {:ok, _indexer, _guid} -> "Blacklist this release and search again"
+      {:error, :no_indexer} -> "No indexer recorded, so this release cannot be blacklisted"
+      {:error, :no_guid} -> "No release id recorded, so this release cannot be blacklisted"
+    end
+  end
+
+  @doc """
+  Formats a byte count for display. Returns "—" for `nil`.
+
+  The single formatter for this feature (downloads list + this modal). Public
+  so `DownloadsLive.Index`'s template can call `Components.format_size/1`.
+  """
+  @spec format_size(integer() | nil) :: String.t()
+  def format_size(nil), do: "—"
+
+  def format_size(bytes) when is_integer(bytes) do
+    cond do
+      bytes >= 1_099_511_627_776 -> "#{Float.round(bytes / 1_099_511_627_776, 2)} TB"
+      bytes >= 1_073_741_824 -> "#{Float.round(bytes / 1_073_741_824, 2)} GB"
+      bytes >= 1_048_576 -> "#{Float.round(bytes / 1_048_576, 2)} MB"
+      bytes >= 1024 -> "#{Float.round(bytes / 1024, 2)} KB"
+      true -> "#{bytes} B"
+    end
+  end
+end

--- a/lib/mydia_web/live/downloads_live/components.ex
+++ b/lib/mydia_web/live/downloads_live/components.ex
@@ -19,6 +19,8 @@ defmodule MydiaWeb.DownloadsLive.Components do
   attr :error, :string, default: nil
 
   def match_files_modal(assigns) do
+    assigns = assign(assigns, :target_kind, target_kind(assigns.modal))
+
     ~H"""
     <.modal id="match-files-modal" show={true} on_cancel="close_match_files">
       <:title>Match files</:title>
@@ -28,6 +30,15 @@ defmodule MydiaWeb.DownloadsLive.Components do
         <.icon name="hero-exclamation-triangle" class="size-4" />
         Mydia cannot read this download's folder right now, so this is the listing
         recorded when the import failed.
+      </p>
+
+      <p
+        :if={@target_kind in [:tv_show_no_episodes, :unmatched]}
+        id="match-files-blocked"
+        class="alert alert-warning mt-3 text-sm"
+      >
+        <.icon name="hero-exclamation-triangle" class="size-4" />
+        {blocked_reason(@target_kind)}
       </p>
 
       <p :if={@error} id="match-files-error" class="alert alert-error mt-3 text-sm">
@@ -59,23 +70,36 @@ defmodule MydiaWeb.DownloadsLive.Components do
               </span>
             </div>
           </div>
-          <select
-            name={"target[#{candidate["path"]}]"}
-            disabled={candidate["missing"]}
-            class="select select-bordered select-sm w-56"
-          >
-            <option value="">Ignore</option>
-            <option
-              :for={episode <- @modal.episodes}
-              value={episode.id}
-              selected={prefilled?(candidate, episode)}
-            >
-              {episode_label(episode)}
-            </option>
-            <option :if={@modal.episodes == []} value="movie">
-              Import as this movie
-            </option>
-          </select>
+          <%= case @target_kind do %>
+            <% :movie -> %>
+              <select
+                name={"target[#{candidate["path"]}]"}
+                disabled={candidate["missing"]}
+                class="select select-bordered select-sm w-56"
+              >
+                <option value="">Ignore</option>
+                <option value="movie">Import as this movie</option>
+              </select>
+            <% :tv_show -> %>
+              <select
+                name={"target[#{candidate["path"]}]"}
+                disabled={candidate["missing"]}
+                class="select select-bordered select-sm w-56"
+              >
+                <option value="">Ignore</option>
+                <option
+                  :for={episode <- @modal.episodes}
+                  value={episode.id}
+                  selected={prefilled?(candidate, episode)}
+                >
+                  {episode_label(episode)}
+                </option>
+              </select>
+            <% _blocked -> %>
+              <span class="select select-sm select-bordered w-56 flex items-center text-base-content/40 italic">
+                Can't match yet
+              </span>
+          <% end %>
         </div>
       </form>
 
@@ -100,6 +124,7 @@ defmodule MydiaWeb.DownloadsLive.Components do
           form="match-files-form"
           id="match-files-import"
           class="btn btn-primary btn-sm"
+          disabled={@target_kind in [:tv_show_no_episodes, :unmatched]}
         >
           <.icon name="hero-arrow-down-tray" class="size-4" /> Import selected
         </button>
@@ -107,6 +132,30 @@ defmodule MydiaWeb.DownloadsLive.Components do
     </.modal>
     """
   end
+
+  # Whether the modal's candidates can target a movie destination, an episode,
+  # or neither. Deliberately keyed off `download.media_item.type` (authoritative)
+  # rather than `episodes == []` — an ordinary TV show whose episodes haven't
+  # been fetched yet also has an empty episode list, and treating that the same
+  # as "this is a movie" let a file get routed with `episode_id: nil`, which
+  # `MediaImport.process_targeted_import/3` places at the *show's* root folder
+  # instead of a season folder — an orphaned show-level file reported back to
+  # the operator as a successful import.
+  defp target_kind(%{download: %{media_item: %{type: "movie"}}}), do: :movie
+
+  defp target_kind(%{download: %{media_item: %{type: "tv_show"}}, episodes: []}),
+    do: :tv_show_no_episodes
+
+  defp target_kind(%{download: %{media_item: %{type: "tv_show"}}}), do: :tv_show
+
+  defp target_kind(_modal), do: :unmatched
+
+  defp blocked_reason(:tv_show_no_episodes),
+    do:
+      "This show's episodes have not been loaded yet, so these files cannot be matched to one. Refresh the show's episode list, then try again."
+
+  defp blocked_reason(:unmatched),
+    do: "This download has no matched title, so its files cannot be matched to a destination yet."
 
   defp prefilled?(candidate, episode) do
     candidate["parsed_season"] == episode.season_number and

--- a/lib/mydia_web/live/downloads_live/components.ex
+++ b/lib/mydia_web/live/downloads_live/components.ex
@@ -185,7 +185,7 @@ defmodule MydiaWeb.DownloadsLive.Components do
     end
   end
 
-  defp skip_label("not_video_extension"), do: "not a video extension"
+  defp skip_label("not_video_extension"), do: "unsupported file type for this library"
   defp skip_label(reason) when is_binary(reason), do: reason
   defp skip_label(_reason), do: nil
 

--- a/lib/mydia_web/live/downloads_live/components.ex
+++ b/lib/mydia_web/live/downloads_live/components.ex
@@ -47,9 +47,21 @@ defmodule MydiaWeb.DownloadsLive.Components do
 
       <form id="match-files-form" phx-submit="match_files_import" class="mt-4 space-y-2">
         <div
-          :for={candidate <- @modal.candidates}
+          :for={{candidate, index} <- Enum.with_index(@modal.candidates)}
           class="flex items-start gap-3 bg-base-200 rounded-lg px-3 py-2"
         >
+          <%!--
+            The path travels as a hidden input's VALUE, never as part of a
+            form field NAME. Plug's query decoder splits a bracketed field
+            name on "][", so a name built from a path like
+            ".../[Bluray-1080p][Opus 2.0]/ep01.mkv" (the normal shape of an
+            anime release) would decode into nested garbage instead of a
+            flat map, and the operator's selection would silently vanish.
+            Keying everything on the candidate's index sidesteps that
+            entirely — see MydiaWeb.DownloadsLive.Index.match_files_import
+            for the server-side reassembly.
+          --%>
+          <input type="hidden" name={"target_path[#{index}]"} value={candidate["path"]} />
           <div class="flex-1 min-w-0">
             <div
               class={[
@@ -73,7 +85,7 @@ defmodule MydiaWeb.DownloadsLive.Components do
           <%= case @target_kind do %>
             <% :movie -> %>
               <select
-                name={"target[#{candidate["path"]}]"}
+                name={"target[#{index}]"}
                 disabled={candidate["missing"]}
                 class="select select-bordered select-sm w-56"
               >
@@ -82,7 +94,7 @@ defmodule MydiaWeb.DownloadsLive.Components do
               </select>
             <% :tv_show -> %>
               <select
-                name={"target[#{candidate["path"]}]"}
+                name={"target[#{index}]"}
                 disabled={candidate["missing"]}
                 class="select select-bordered select-sm w-56"
               >
@@ -115,7 +127,7 @@ defmodule MydiaWeb.DownloadsLive.Components do
           phx-value-id={@modal.download.id}
           disabled={not rejectable?(@modal.download)}
           title={reject_hint(@modal.download)}
-          data-confirm="Blacklist this release, delete it and its files, and search again?"
+          data-confirm="Blacklist this release, remove the download and its data from the download client, and search again. Files already imported to the library are kept."
         >
           Reject release
         </button>

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -106,7 +106,6 @@ defmodule MydiaWeb.DownloadsLive.Index do
      |> assign(:search_open_for, nil)
      |> assign(:library_search_value, "")
      |> assign(:library_search_results, [])
-     |> assign(:episodes_by_media_item, %{})
      # Match / re-match modal state (in-flight correction + post-import re-match)
      |> assign(:match_modal, nil)
      # Initialize all streams
@@ -820,36 +819,29 @@ defmodule MydiaWeb.DownloadsLive.Index do
     end
   end
 
-  def handle_event("resolve_files", %{"download_id" => download_id} = params, socket) do
+  def handle_event("reject_release", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(download_id, preload: [:media_item])
+      download = Downloads.get_download!(id)
 
-      # Collect episode assignments from form params
-      # Params come as "episode_<index>" => episode_id
-      unresolved_files = get_in(download.metadata || %{}, ["unresolved_files"]) || []
+      case Downloads.reject_release(download) do
+        {:ok, :rejected} ->
+          {:noreply,
+           socket
+           |> assign(:match_files_modal, nil)
+           |> assign(:match_files_error, nil)
+           |> put_flash(:info, "Release blacklisted and a new search was queued")
+           |> load_downloads()}
 
-      mappings =
-        unresolved_files
-        |> Enum.with_index()
-        |> Enum.map(fn {file, idx} ->
-          episode_id = Map.get(params, "episode_#{idx}")
-          %{"path" => file["path"], "episode_id" => episode_id}
-        end)
-        |> Enum.reject(fn m -> is_nil(m["episode_id"]) or m["episode_id"] == "" end)
+        {:error, reason} when reason in [:no_indexer, :no_guid] ->
+          {:noreply,
+           assign(
+             socket,
+             :match_files_error,
+             "This download has no indexer or release id recorded, so it cannot be blacklisted."
+           )}
 
-      if length(mappings) == length(unresolved_files) do
-        case Downloads.resolve_file_mappings(download, mappings) do
-          {:ok, _updated} ->
-            {:noreply,
-             socket
-             |> put_flash(:info, "Files resolved and import queued")
-             |> load_downloads()}
-
-          {:error, _} ->
-            {:noreply, put_flash(socket, :error, "Failed to resolve files")}
-        end
-      else
-        {:noreply, put_flash(socket, :error, "Please assign an episode to every file")}
+        {:error, _reason} ->
+          {:noreply, assign(socket, :match_files_error, "Failed to reject the release.")}
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
@@ -1092,16 +1084,6 @@ defmodule MydiaWeb.DownloadsLive.Index do
       other: length(other)
     }
 
-    # Pre-fetch episodes for all unresolved downloads to avoid N+1 queries in template
-    episodes_by_media_item =
-      unresolved
-      |> Enum.filter(& &1.media_item)
-      |> Enum.map(& &1.media_item.id)
-      |> Enum.uniq()
-      |> Enum.into(%{}, fn media_item_id ->
-        {media_item_id, Media.list_episodes(media_item_id)}
-      end)
-
     all_empty = counts.unmatched == 0 and counts.unresolved == 0 and counts.other == 0
 
     socket
@@ -1110,7 +1092,6 @@ defmodule MydiaWeb.DownloadsLive.Index do
     |> assign(:issues_counts, counts)
     |> assign(:scan, scan)
     |> assign(:removed_client_groups, removed_client_groups())
-    |> assign(:episodes_by_media_item, episodes_by_media_item)
     |> stream(:needs_matching, needs_matching, reset: true)
     |> stream(:unresolved_downloads, unresolved, reset: true)
     |> stream(:other_issues, other, reset: true)
@@ -1725,9 +1706,5 @@ defmodule MydiaWeb.DownloadsLive.Index do
       diff < 86400 -> "in #{div(diff, 3600)}h"
       true -> "in #{div(diff, 86400)}d"
     end
-  end
-
-  defp get_episodes_for_media_item(episodes_by_media_item, media_item) do
-    Map.get(episodes_by_media_item, media_item.id, [])
   end
 end

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -719,7 +719,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("open_match_files", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id, preload: [:media_item])
+      download = Downloads.get_download!(id, preload: [:media_item, :library_path])
 
       case ImportCandidates.load(download) do
         {:ok, source, candidates} ->
@@ -762,25 +762,41 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("match_files_import", params, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      %{download: download, candidates: candidates} = socket.assigns.match_files_modal
+      %{download: modal_download, candidates: candidates} = socket.assigns.match_files_modal
+
+      # Re-read the download at submit time rather than trusting the assign
+      # captured when the modal opened. The modal has no way to notice a
+      # re-bind: the separate match/re-match modal can rebind this download to
+      # a different show while this one stays open, and process_targeted_import/3
+      # must build destinations from the CURRENT media_item — trusting the
+      # stale struct would link an episode from the OLD show onto files
+      # imported under the NEW one.
+      download = Downloads.get_download!(modal_download.id, preload: [:media_item])
 
       # Defense in depth: a disabled <select> only stops a normal browser. Never
       # trust a submitted path or target purely from client state — re-derive
       # what's actually allowed from the socket's own candidate list and the
-      # download's authoritative media type before building mappings.
+      # download's authoritative (freshly reloaded) media type before building
+      # mappings.
       #
+      # - Submitted targets arrive keyed by candidate INDEX, with the path
+      #   carried separately as a same-indexed hidden input value. Plug's form
+      #   decoder splits a bracketed field NAME on "][", so a path like
+      #   ".../[Bluray-1080p][Opus 2.0]/ep01.mkv" used as a form key would
+      #   decode into nested garbage. Values are never split that way, so the
+      #   path travels safely as one.
       # - `valid_paths` drops any path that was never a candidate for this
       #   download, or that is flagged "missing" (gone from disk since the
       #   modal opened): resolve_file_mappings/2 does no path validation of
       #   its own, and existence is only checked much later inside the Oban
       #   job.
       # - `movie?` rejects a "movie" target (episode_id: nil) unless the bound
-      #   media item really is a movie. Without this, a crafted or stale
-      #   submission against a TV show would reach
-      #   MediaImport.process_targeted_import/3 with episode_id: nil, which
-      #   places the file at the show's root folder instead of a season
-      #   folder — an orphaned show-level file reported back as a successful
-      #   import.
+      #   media item really is a movie, and every episode target is checked
+      #   against the download's ACTUAL episode list. Without this, a crafted
+      #   or stale submission could link an episode belonging to a different
+      #   show onto this download's files — MediaImport.process_targeted_import/3
+      #   trusts the submitted episode_id outright and never checks it belongs
+      #   to the media item it builds the destination path from.
       valid_paths =
         candidates
         |> Enum.reject(& &1["missing"])
@@ -788,31 +804,65 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
       movie? = download.media_item && download.media_item.type == "movie"
 
-      mappings =
+      valid_episode_ids =
+        case download.media_item do
+          %{type: "tv_show", id: media_item_id} ->
+            media_item_id |> Media.list_episodes() |> MapSet.new(& &1.id)
+
+          _other ->
+            MapSet.new()
+        end
+
+      path_by_index = Map.get(params, "target_path", %{})
+
+      targets =
         params
         |> Map.get("target", %{})
+        |> Enum.map(fn {index, target} -> {Map.get(path_by_index, index), target} end)
         |> Enum.reject(fn {_path, target} -> target in [nil, ""] end)
-        |> Enum.filter(fn {path, _target} -> MapSet.member?(valid_paths, path) end)
-        |> Enum.map(fn {path, target} ->
-          %{"path" => path, "episode_id" => if(target == "movie", do: nil, else: target)}
+        |> Enum.filter(fn {path, _target} ->
+          is_binary(path) and MapSet.member?(valid_paths, path)
         end)
-        |> Enum.reject(fn mapping -> is_nil(mapping["episode_id"]) and not movie? end)
 
-      if mappings == [] do
-        {:noreply, assign(socket, :match_files_error, "Select at least one file to import.")}
-      else
-        case Downloads.resolve_file_mappings(download, mappings) do
-          {:ok, _updated} ->
-            {:noreply,
-             socket
-             |> assign(:match_files_modal, nil)
-             |> assign(:match_files_error, nil)
-             |> put_flash(:info, "Import queued for #{length(mappings)} file(s)")
-             |> load_downloads()}
+      invalid_target? =
+        Enum.any?(targets, fn {_path, target} ->
+          if target == "movie" do
+            not movie?
+          else
+            not MapSet.member?(valid_episode_ids, target)
+          end
+        end)
 
-          {:error, _reason} ->
-            {:noreply, assign(socket, :match_files_error, "Failed to queue the import.")}
-        end
+      cond do
+        invalid_target? ->
+          {:noreply,
+           assign(
+             socket,
+             :match_files_error,
+             "One or more selected targets are no longer valid for this download. Close and reopen Match files, then try again."
+           )}
+
+        targets == [] ->
+          {:noreply, assign(socket, :match_files_error, "Select at least one file to import.")}
+
+        true ->
+          mappings =
+            Enum.map(targets, fn {path, target} ->
+              %{"path" => path, "episode_id" => if(target == "movie", do: nil, else: target)}
+            end)
+
+          case Downloads.resolve_file_mappings(download, mappings) do
+            {:ok, _updated} ->
+              {:noreply,
+               socket
+               |> assign(:match_files_modal, nil)
+               |> assign(:match_files_error, nil)
+               |> put_flash(:info, "Import queued for #{length(mappings)} file(s)")
+               |> load_downloads()}
+
+            {:error, _reason} ->
+              {:noreply, assign(socket, :match_files_error, "Failed to queue the import.")}
+          end
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -2,12 +2,14 @@ defmodule MydiaWeb.DownloadsLive.Index do
   use MydiaWeb, :live_view
   alias Mydia.Downloads
   alias Mydia.Downloads.ExternalTorrents
+  alias Mydia.Downloads.ImportCandidates
   alias Mydia.Downloads.Structs.DownloadMetadata
   alias Mydia.Library.Structs.Quality
   alias Mydia.Library
   alias Mydia.Media
   alias Phoenix.PubSub
   alias MydiaWeb.Live.Authorization
+  alias MydiaWeb.DownloadsLive.Components
   import MydiaWeb.Formatters
 
   require Logger
@@ -94,6 +96,9 @@ defmodule MydiaWeb.DownloadsLive.Index do
      |> assign(:clearable_count, 0)
      # Issues tab state
      |> assign(:issues_counts, %{unmatched: 0, unresolved: 0, other: 0})
+     # Match files modal state (manual matching of a failed import's file listing)
+     |> assign(:match_files_modal, nil)
+     |> assign(:match_files_error, nil)
      # Derived view of client torrents Mydia does not manage. Read from the
      # ExternalTorrents cache, never from the database.
      |> assign(:scan, ExternalTorrents.get())
@@ -709,6 +714,84 @@ defmodule MydiaWeb.DownloadsLive.Index do
   def handle_event("match_modal_pick_episode", %{"episode_id" => episode_id}, socket) do
     %{selected: %{id: media_item_id}} = socket.assigns.match_modal
     submit_match(socket, media_item_id, episode_id)
+  end
+
+  # --- Match files modal (manual file matching on import failure) ---
+
+  def handle_event("open_match_files", %{"id" => id}, socket) do
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      download = Downloads.get_download!(id, preload: [:media_item])
+
+      case ImportCandidates.load(download) do
+        {:ok, source, candidates} ->
+          episodes =
+            if download.media_item && download.media_item.type == "tv_show" do
+              Media.list_episodes(download.media_item.id)
+            else
+              []
+            end
+
+          {:noreply,
+           socket
+           |> assign(:match_files_error, nil)
+           |> assign(:match_files_modal, %{
+             download: download,
+             source: source,
+             candidates: candidates,
+             episodes: episodes
+           })}
+
+        {:error, :unavailable} ->
+          {:noreply,
+           put_flash(
+             socket,
+             :error,
+             "Mydia could not read this download's folder and has no recorded listing for it."
+           )}
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("close_match_files", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:match_files_modal, nil)
+     |> assign(:match_files_error, nil)}
+  end
+
+  def handle_event("match_files_import", params, socket) do
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      %{download: download} = socket.assigns.match_files_modal
+
+      mappings =
+        params
+        |> Map.get("target", %{})
+        |> Enum.reject(fn {_path, target} -> target in [nil, ""] end)
+        |> Enum.map(fn {path, target} ->
+          %{"path" => path, "episode_id" => if(target == "movie", do: nil, else: target)}
+        end)
+
+      if mappings == [] do
+        {:noreply, assign(socket, :match_files_error, "Select at least one file to import.")}
+      else
+        case Downloads.resolve_file_mappings(download, mappings) do
+          {:ok, _updated} ->
+            {:noreply,
+             socket
+             |> assign(:match_files_modal, nil)
+             |> assign(:match_files_error, nil)
+             |> put_flash(:info, "Import queued for #{length(mappings)} file(s)")
+             |> load_downloads()}
+
+          {:error, _reason} ->
+            {:noreply, assign(socket, :match_files_error, "Failed to queue the import.")}
+        end
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
   end
 
   def handle_event("resolve_files", %{"download_id" => download_id} = params, socket) do
@@ -1328,18 +1411,6 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
       true ->
         "#{bytes_per_second} B/s"
-    end
-  end
-
-  defp format_size(nil), do: "—"
-
-  defp format_size(bytes) when is_integer(bytes) do
-    cond do
-      bytes >= 1_099_511_627_776 -> "#{Float.round(bytes / 1_099_511_627_776, 2)} TB"
-      bytes >= 1_073_741_824 -> "#{Float.round(bytes / 1_073_741_824, 2)} GB"
-      bytes >= 1_048_576 -> "#{Float.round(bytes / 1_048_576, 2)} MB"
-      bytes >= 1024 -> "#{Float.round(bytes / 1024, 2)} KB"
-      true -> "#{bytes} B"
     end
   end
 

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -763,15 +763,41 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("match_files_import", params, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      %{download: download} = socket.assigns.match_files_modal
+      %{download: download, candidates: candidates} = socket.assigns.match_files_modal
+
+      # Defense in depth: a disabled <select> only stops a normal browser. Never
+      # trust a submitted path or target purely from client state — re-derive
+      # what's actually allowed from the socket's own candidate list and the
+      # download's authoritative media type before building mappings.
+      #
+      # - `valid_paths` drops any path that was never a candidate for this
+      #   download, or that is flagged "missing" (gone from disk since the
+      #   modal opened): resolve_file_mappings/2 does no path validation of
+      #   its own, and existence is only checked much later inside the Oban
+      #   job.
+      # - `movie?` rejects a "movie" target (episode_id: nil) unless the bound
+      #   media item really is a movie. Without this, a crafted or stale
+      #   submission against a TV show would reach
+      #   MediaImport.process_targeted_import/3 with episode_id: nil, which
+      #   places the file at the show's root folder instead of a season
+      #   folder — an orphaned show-level file reported back as a successful
+      #   import.
+      valid_paths =
+        candidates
+        |> Enum.reject(& &1["missing"])
+        |> MapSet.new(& &1["path"])
+
+      movie? = download.media_item && download.media_item.type == "movie"
 
       mappings =
         params
         |> Map.get("target", %{})
         |> Enum.reject(fn {_path, target} -> target in [nil, ""] end)
+        |> Enum.filter(fn {path, _target} -> MapSet.member?(valid_paths, path) end)
         |> Enum.map(fn {path, target} ->
           %{"path" => path, "episode_id" => if(target == "movie", do: nil, else: target)}
         end)
+        |> Enum.reject(fn mapping -> is_nil(mapping["episode_id"]) and not movie? end)
 
       if mappings == [] do
         {:noreply, assign(socket, :match_files_error, "Select at least one file to import.")}

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -538,70 +538,19 @@
                   {get_display_title(download)}
                 </div>
                 <div class="text-xs text-base-content/50">{download.title}</div>
-                <%!-- Unresolved files list with episode pickers --%>
-                <% unresolved_files = get_metadata_value(download, "unresolved_files") || [] %>
-                <%= if unresolved_files != [] do %>
-                  <form
-                    id={"resolve-files-form-#{download.id}"}
-                    phx-submit="resolve_files"
-                    class="mt-3 space-y-2"
-                  >
-                    <input type="hidden" name="download_id" value={download.id} />
-                    <%= for {file, idx} <- Enum.with_index(unresolved_files) do %>
-                      <div class="flex items-center gap-3 bg-base-200 rounded-lg px-3 py-2">
-                        <div class="flex-1 min-w-0">
-                          <div class="text-sm font-mono truncate">
-                            {file["name"] || Path.basename(file["path"])}
-                          </div>
-                          <div class="text-xs text-base-content/50">
-                            {Components.format_size(file["size"] || 0)}
-                            <%= if file["parsed_season"] do %>
-                              <span>
-                                • S{String.pad_leading("#{file["parsed_season"]}", 2, "0")}
-                                <%= if file["parsed_episode"] do %>
-                                  E{String.pad_leading("#{file["parsed_episode"]}", 2, "0")}
-                                <% end %>
-                              </span>
-                            <% end %>
-                          </div>
-                        </div>
-                        <select
-                          name={"episode_#{idx}"}
-                          class="select select-bordered select-sm w-48"
-                        >
-                          <option value="">Select episode...</option>
-                          <%!-- Episodes will be populated based on the media item --%>
-                          <%= if download.media_item do %>
-                            <% episodes =
-                              get_episodes_for_media_item(
-                                @episodes_by_media_item,
-                                download.media_item
-                              ) %>
-                            <%= for episode <- episodes do %>
-                              <option value={episode.id}>
-                                S{String.pad_leading("#{episode.season_number}", 2, "0")}E{String.pad_leading(
-                                  "#{episode.episode_number}",
-                                  2,
-                                  "0"
-                                )}
-                                <%= if episode.title do %>
-                                  - {episode.title}
-                                <% end %>
-                              </option>
-                            <% end %>
-                          <% end %>
-                        </select>
-                      </div>
-                    <% end %>
-                    <div class="flex justify-end gap-2 mt-2">
-                      <button type="submit" class="btn btn-sm btn-primary">
-                        <.icon name="hero-arrow-down-tray" class="size-4" /> Import Files
-                      </button>
-                    </div>
-                  </form>
-                <% end %>
               </div>
               <div class="flex gap-1">
+                <button
+                  type="button"
+                  id={"match-files-#{download.id}"}
+                  class="btn btn-sm btn-outline"
+                  phx-click="open_match_files"
+                  phx-value-id={download.id}
+                  title="See what this download contains and match files by hand"
+                >
+                  <.icon name="hero-document-magnifying-glass" class="size-4" />
+                  <span class="hidden sm:inline">Match files…</span>
+                </button>
                 <button
                   type="button"
                   class="btn btn-square btn-ghost btn-sm"

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -256,7 +256,7 @@
                   )}
                 </span>
                 <span class="inline-flex items-center gap-1 tabular-nums" title="Size">
-                  <.icon name="hero-circle-stack" class="size-3 opacity-70" />{format_size(
+                  <.icon name="hero-circle-stack" class="size-3 opacity-70" />{Components.format_size(
                     download.size
                   )}
                 </span>
@@ -286,7 +286,7 @@
                   )}
                 </span>
                 <span class="inline-flex items-center gap-1 tabular-nums" title="Size">
-                  <.icon name="hero-circle-stack" class="size-3 opacity-70" />{format_size(
+                  <.icon name="hero-circle-stack" class="size-3 opacity-70" />{Components.format_size(
                     download.size
                   )}
                 </span>
@@ -554,7 +554,7 @@
                             {file["name"] || Path.basename(file["path"])}
                           </div>
                           <div class="text-xs text-base-content/50">
-                            {format_size(file["size"] || 0)}
+                            {Components.format_size(file["size"] || 0)}
                             <%= if file["parsed_season"] do %>
                               <span>
                                 • S{String.pad_leading("#{file["parsed_season"]}", 2, "0")}
@@ -774,6 +774,17 @@
                 <% end %>
                 <button
                   type="button"
+                  id={"match-files-#{download.id}"}
+                  class="btn btn-sm btn-outline"
+                  phx-click="open_match_files"
+                  phx-value-id={download.id}
+                  title="See what this download contains and match files by hand"
+                >
+                  <.icon name="hero-document-magnifying-glass" class="size-4" />
+                  <span class="hidden sm:inline">Match files…</span>
+                </button>
+                <button
+                  type="button"
                   class="btn btn-square btn-ghost btn-sm"
                   phx-click="dismiss_download"
                   phx-value-id={download.id}
@@ -979,5 +990,12 @@
         </button>
       </:actions>
     </.modal>
+
+    <%!-- Match files modal (manual file matching on import failure) --%>
+    <Components.match_files_modal
+      :if={@match_files_modal}
+      modal={@match_files_modal}
+      error={@match_files_error}
+    />
   </div>
 </Layouts.app>

--- a/test/mydia/downloads/blacklists_test.exs
+++ b/test/mydia/downloads/blacklists_test.exs
@@ -5,6 +5,8 @@ defmodule Mydia.Downloads.BlacklistsTest do
   alias Mydia.Downloads.ReleaseBlacklist
   alias Mydia.Repo
 
+  import Mydia.DownloadsFixtures
+
   describe "add/5" do
     test "inserts a row with the given fields" do
       assert {:ok, row} =
@@ -210,6 +212,40 @@ defmodule Mydia.Downloads.BlacklistsTest do
       future = DateTime.add(DateTime.utc_now(), 3600, :second)
       {:ok, _} = Blacklists.add("a", "1", "T", "x", expires_at: future)
       assert 0 == Blacklists.cleanup_expired()
+    end
+  end
+
+  describe "extract_key/1" do
+    test "returns indexer and guid from metadata" do
+      download =
+        download_fixture(%{
+          indexer: "1337x",
+          metadata: %{"guid" => "https://1337x.to/torrent/123/"}
+        })
+
+      assert {:ok, "1337x", "https://1337x.to/torrent/123/"} = Blacklists.extract_key(download)
+    end
+
+    test "falls back to the indexer stored in metadata" do
+      download =
+        download_fixture(%{
+          indexer: nil,
+          metadata: %{"indexer" => "nyaa", "guid" => "abc"}
+        })
+
+      assert {:ok, "nyaa", "abc"} = Blacklists.extract_key(download)
+    end
+
+    test "errors when the guid is missing" do
+      download = download_fixture(%{indexer: "1337x", metadata: %{}})
+
+      assert {:error, :no_guid} = Blacklists.extract_key(download)
+    end
+
+    test "errors when the indexer is missing" do
+      download = download_fixture(%{indexer: nil, metadata: %{"guid" => "abc"}})
+
+      assert {:error, :no_indexer} = Blacklists.extract_key(download)
     end
   end
 end

--- a/test/mydia/downloads/import_candidates_test.exs
+++ b/test/mydia/downloads/import_candidates_test.exs
@@ -1,0 +1,65 @@
+defmodule Mydia.Downloads.ImportCandidatesTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.ImportCandidates
+
+  @moduletag :tmp_dir
+
+  defp file(tmp_dir, name, size) do
+    path = Path.join(tmp_dir, name)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, :binary.copy(<<0>>, size))
+    %{path: path, name: name, size: size}
+  end
+
+  test "flags a non-video extension and probes it", %{tmp_dir: tmp_dir} do
+    big = ImportCandidates.probe_size_floor() + 1
+    files = [file(tmp_dir, "payload.exe", big)]
+
+    assert [candidate] = ImportCandidates.build(files, :series, [])
+    assert candidate["name"] == "payload.exe"
+    assert candidate["size"] == big
+    assert candidate["skip_reason"] == "not_video_extension"
+    assert candidate["probe"]["status"] in ["not_media", "unknown"]
+  end
+
+  test "does not probe extension-rejected files below the size floor", %{tmp_dir: tmp_dir} do
+    files = [file(tmp_dir, "release.nfo", 2048)]
+
+    assert [candidate] = ImportCandidates.build(files, :series, [])
+    assert candidate["skip_reason"] == "not_video_extension"
+    refute Map.has_key?(candidate, "probe")
+  end
+
+  test "flags a sample with the detector's reason and does not probe it", %{tmp_dir: tmp_dir} do
+    files = [file(tmp_dir, "show.s01e01-sample.mkv", 1024)]
+
+    assert [candidate] = ImportCandidates.build(files, :series, [])
+    assert candidate["skip_reason"] =~ "Sample"
+    refute Map.has_key?(candidate, "probe")
+  end
+
+  test "leaves an importable file unflagged and records the parser guess", %{tmp_dir: tmp_dir} do
+    files = [file(tmp_dir, "Some.Show.S03E06.1080p.WEB-DL.mkv", 1024)]
+
+    assert [candidate] = ImportCandidates.build(files, :series, [])
+    assert candidate["skip_reason"] == nil
+    assert candidate["parsed_season"] == 3
+    assert candidate["parsed_episode"] == 6
+    refute Map.has_key?(candidate, "probe")
+  end
+
+  test "probes at most probe_cap files", %{tmp_dir: tmp_dir} do
+    big = ImportCandidates.probe_size_floor() + 1
+
+    files =
+      for i <- 1..(ImportCandidates.probe_cap() + 3) do
+        file(tmp_dir, "payload#{i}.exe", big)
+      end
+
+    candidates = ImportCandidates.build(files, :series, [])
+
+    probed = Enum.count(candidates, &Map.has_key?(&1, "probe"))
+    assert probed == ImportCandidates.probe_cap()
+  end
+end

--- a/test/mydia/downloads/import_candidates_test.exs
+++ b/test/mydia/downloads/import_candidates_test.exs
@@ -96,18 +96,31 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
     end
 
     test "skips a listed entry that cannot be stat'd instead of crashing", %{tmp_dir: tmp_dir} do
-      # The real bug is a TOCTOU race: `Path.wildcard/2` returns a path, and
-      # by the time the code gets around to stat-ing it, the file has been
-      # deleted or renamed out from under it — plausible in a self-hosted
+      # The bug this fixes is a TOCTOU race: the old implementation checked
+      # `File.regular?/1` in one pass, then called `File.stat!/1` on the
+      # survivors in a second pass — two separate filesystem checks on the
+      # same path, with a window between them where the file could be
+      # deleted or renamed out from under it (plausible in a self-hosted
       # deployment where the operator or the download client can be
-      # touching the same folder while the modal is open. That exact
-      # interleaving needs real concurrency to reproduce deterministically,
-      # which would make this test flaky, so a broken symlink is used
-      # instead: `Path.wildcard/2` lists it (a directory listing does not
-      # resolve symlink targets), but `File.stat/1` (which follows
-      # symlinks) cannot resolve it, exactly the "entry the listing found
-      # but stat can't confirm" shape the fix has to handle. Before the fix
-      # this crashed the modal open via `File.stat!/1`.
+      # touching the same folder while the modal is open). `File.stat!/1`
+      # raises if that happens, crashing the modal open. The fix collapses
+      # both checks into a single `File.stat/1` call, which structurally
+      # eliminates the window rather than narrowing it.
+      #
+      # That two-syscall race needs real concurrency to reproduce
+      # deterministically (something deleting the file at the exact moment
+      # `list_recursive/1` is between its two filesystem calls), so it is
+      # not what this test proves and no attempt is made to simulate it
+      # here. Instead, this pins the narrower property the fix also
+      # guarantees on the same code path: an entry the directory listing
+      # surfaces that `File.stat/1` cannot confirm is skipped rather than
+      # raising. A broken symlink stands in for that: `Path.wildcard/2`
+      # lists it (a directory listing does not resolve symlink targets),
+      # but `File.stat/1` (which follows symlinks) cannot resolve it. Note
+      # this particular case was already handled by the old code too —
+      # `File.regular?/1` also follows symlinks, so it already returned
+      # `false` and filtered the broken symlink out before `File.stat!/1`
+      # ever ran on it. This is not a regression test for the TOCTOU race.
       dir = Path.join(tmp_dir, "live")
       File.mkdir_p!(dir)
       File.write!(Path.join(dir, "keep.mkv"), "x")

--- a/test/mydia/downloads/import_candidates_test.exs
+++ b/test/mydia/downloads/import_candidates_test.exs
@@ -72,8 +72,15 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
       File.mkdir_p!(dir)
       File.write!(Path.join(dir, "extra.mkv"), "x")
 
+      # A resolvable client whose download_directory is provably NOT `dir`
+      # is required here: `shared_download_root?/2` now fails closed, so
+      # without a client that positively rules out `dir` as the shared
+      # root, this would fall back to the snapshot instead of listing live.
+      client = client_with_unrelated_root(tmp_dir)
+
       download =
         download_fixture(%{
+          download_client: client.name,
           metadata: %{
             "save_path" => dir,
             "import_candidates" => [
@@ -88,8 +95,11 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
     end
 
     test "falls back to the snapshot when the folder is gone", %{tmp_dir: tmp_dir} do
+      client = client_with_unrelated_root(tmp_dir)
+
       download =
         download_fixture(%{
+          download_client: client.name,
           metadata: %{
             "save_path" => Path.join(tmp_dir, "gone"),
             "import_candidates" => [
@@ -197,5 +207,105 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
       assert {:ok, :live, [candidate]} = ImportCandidates.load(download)
       assert candidate["name"] == "Silo.S01E01.mkv"
     end
+
+    test "fails closed when the download's client cannot be resolved", %{tmp_dir: tmp_dir} do
+      # No DownloadClientConfig exists under this name (a renamed or deleted
+      # client, entirely plausible in a self-hosted deployment reconfigured
+      # by env vars, and these failed downloads can sit for weeks before
+      # anyone opens the modal). We cannot prove save_path differs from
+      # that client's shared root, so this must not enumerate it even
+      # though save_path genuinely IS a shared directory with an unrelated
+      # file in it.
+      root = Path.join(tmp_dir, "shared")
+      File.mkdir_p!(root)
+      File.write!(Path.join(root, "Some.Other.Show.S01E01.mkv"), "unrelated")
+      File.write!(Path.join(root, "Silo.S01E01.mkv"), "silo")
+
+      download =
+        download_fixture(%{
+          download_client: "renamed-or-deleted-client-#{System.unique_integer([:positive])}",
+          metadata: %{
+            "save_path" => root,
+            "import_candidates" => [
+              %{
+                "path" => Path.join(root, "Silo.S01E01.mkv"),
+                "name" => "Silo.S01E01.mkv",
+                "size" => 4
+              }
+            ]
+          }
+        })
+
+      assert {:ok, :snapshot, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "Silo.S01E01.mkv"
+    end
+
+    test "does not probe on the live listing, even for a large non-video file",
+         %{tmp_dir: tmp_dir} do
+      dir = Path.join(tmp_dir, "live")
+      File.mkdir_p!(dir)
+      big = ImportCandidates.probe_size_floor() + 1
+      File.write!(Path.join(dir, "payload.exe"), :binary.copy(<<0>>, big))
+
+      client = client_with_unrelated_root(tmp_dir)
+
+      download =
+        download_fixture(%{
+          download_client: client.name,
+          metadata: %{
+            "save_path" => dir,
+            "import_candidates" => [
+              %{"path" => Path.join(dir, "old.exe"), "name" => "old.exe", "size" => 1}
+            ]
+          }
+        })
+
+      assert {:ok, :live, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "payload.exe"
+      assert candidate["skip_reason"] == "not_video_extension"
+      # If the live path probed (as `build/3` normally does), this would be
+      # a freshly computed verdict. There is no snapshot probe for this
+      # path to restore, so its absence proves probing did not run.
+      refute Map.has_key?(candidate, "probe")
+    end
+
+    test "restores a snapshot's stashed probe verdict on the live listing instead of recomputing",
+         %{tmp_dir: tmp_dir} do
+      dir = Path.join(tmp_dir, "live")
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "payload.exe"), "x")
+
+      stashed_probe = %{"status" => "video", "note" => "stashed"}
+      client = client_with_unrelated_root(tmp_dir)
+
+      download =
+        download_fixture(%{
+          download_client: client.name,
+          metadata: %{
+            "save_path" => dir,
+            "import_candidates" => [
+              %{
+                "path" => Path.join(dir, "payload.exe"),
+                "name" => "payload.exe",
+                "size" => 1,
+                "probe" => stashed_probe
+              }
+            ]
+          }
+        })
+
+      assert {:ok, :live, [candidate]} = ImportCandidates.load(download)
+      assert candidate["probe"] == stashed_probe
+    end
+  end
+
+  ## Helpers
+
+  # A resolvable download client config whose download_directory is
+  # deliberately NOT under the caller's test directory, so
+  # `shared_download_root?/2` can positively rule it out and a live listing
+  # proceeds instead of failing closed.
+  defp client_with_unrelated_root(tmp_dir) do
+    download_client_config_fixture(%{download_directory: Path.join(tmp_dir, "elsewhere")})
   end
 end

--- a/test/mydia/downloads/import_candidates_test.exs
+++ b/test/mydia/downloads/import_candidates_test.exs
@@ -95,6 +95,41 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
       assert candidate["missing"] == false
     end
 
+    test "skips a listed entry that cannot be stat'd instead of crashing", %{tmp_dir: tmp_dir} do
+      # The real bug is a TOCTOU race: `Path.wildcard/2` returns a path, and
+      # by the time the code gets around to stat-ing it, the file has been
+      # deleted or renamed out from under it — plausible in a self-hosted
+      # deployment where the operator or the download client can be
+      # touching the same folder while the modal is open. That exact
+      # interleaving needs real concurrency to reproduce deterministically,
+      # which would make this test flaky, so a broken symlink is used
+      # instead: `Path.wildcard/2` lists it (a directory listing does not
+      # resolve symlink targets), but `File.stat/1` (which follows
+      # symlinks) cannot resolve it, exactly the "entry the listing found
+      # but stat can't confirm" shape the fix has to handle. Before the fix
+      # this crashed the modal open via `File.stat!/1`.
+      dir = Path.join(tmp_dir, "live")
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "keep.mkv"), "x")
+      File.ln_s!(Path.join(dir, "does-not-exist.mkv"), Path.join(dir, "ghost.mkv"))
+
+      client = client_with_unrelated_root(tmp_dir)
+
+      download =
+        download_fixture(%{
+          download_client: client.name,
+          metadata: %{
+            "save_path" => dir,
+            "import_candidates" => [
+              %{"path" => Path.join(dir, "old.mkv"), "name" => "old.mkv", "size" => 1}
+            ]
+          }
+        })
+
+      assert {:ok, :live, candidates} = ImportCandidates.load(download)
+      assert Enum.map(candidates, & &1["name"]) == ["keep.mkv"]
+    end
+
     test "falls back to the snapshot when the folder is gone", %{tmp_dir: tmp_dir} do
       client = client_with_unrelated_root(tmp_dir)
 
@@ -361,6 +396,59 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
 
       assert {:ok, :live, [candidate]} = ImportCandidates.load(download)
       assert candidate["probe"] == stashed_probe
+    end
+
+    test "restores the snapshot's parsed season/episode on the live listing instead of a bare re-parse",
+         %{tmp_dir: tmp_dir} do
+      # A bare re-parse (the `parser_opts: []` `merge/3` always uses for a
+      # live listing) of this name yields season 3, episode 6 — see "leaves
+      # an importable file unflagged and records the parser guess" above.
+      # The failure-time snapshot was parsed by `MediaImport` with the
+      # download's real parser opts (a `TargetContext` built from its bound
+      # media item) and landed on season 1, episode 1 instead — a
+      # legitimate difference, e.g. for an absolute-numbered release the
+      # TargetContext maps against the show's actual episode list. Without
+      # restoring the snapshot's values, the operator would see a different
+      # prefilled episode for the same file depending on whether the modal
+      # happened to get a live listing or fell back to the snapshot.
+      dir = Path.join(tmp_dir, "live")
+      File.mkdir_p!(dir)
+      known_name = "Some.Show.S03E06.1080p.WEB-DL.mkv"
+      File.write!(Path.join(dir, known_name), "x")
+
+      # Genuinely new on disk since the failure, so absent from the
+      # snapshot — there is nothing to restore, and it must keep its fresh
+      # re-parse rather than being blanked out.
+      new_name = "Some.Show.S02E04.1080p.WEB-DL.mkv"
+      File.write!(Path.join(dir, new_name), "y")
+
+      client = client_with_unrelated_root(tmp_dir)
+
+      download =
+        download_fixture(%{
+          download_client: client.name,
+          metadata: %{
+            "save_path" => dir,
+            "import_candidates" => [
+              %{
+                "path" => Path.join(dir, known_name),
+                "name" => known_name,
+                "size" => 1,
+                "parsed_season" => 1,
+                "parsed_episode" => 1
+              }
+            ]
+          }
+        })
+
+      assert {:ok, :live, candidates} = ImportCandidates.load(download)
+      by_name = Map.new(candidates, &{&1["name"], &1})
+
+      assert by_name[known_name]["parsed_season"] == 1
+      assert by_name[known_name]["parsed_episode"] == 1
+
+      assert by_name[new_name]["parsed_season"] == 2
+      assert by_name[new_name]["parsed_episode"] == 4
     end
 
     test "falls back to metadata[\"unresolved_files\"] when there is no import_candidates snapshot",

--- a/test/mydia/downloads/import_candidates_test.exs
+++ b/test/mydia/downloads/import_candidates_test.exs
@@ -297,6 +297,77 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
       assert {:ok, :live, [candidate]} = ImportCandidates.load(download)
       assert candidate["probe"] == stashed_probe
     end
+
+    test "falls back to metadata[\"unresolved_files\"] when there is no import_candidates snapshot",
+         %{tmp_dir: tmp_dir} do
+      # Every unresolved-files download that existed before the
+      # import_candidates snapshot shipped only has this key. There is
+      # deliberately no "save_path" here (and no resolvable client), so this
+      # exercises the pure snapshot fallback, not a live re-listing.
+      missing_path = Path.join(tmp_dir, "gone/Show.S01E02.mkv")
+
+      download =
+        download_fixture(%{
+          metadata: %{
+            "unresolved_files" => [
+              %{
+                "path" => missing_path,
+                "name" => "Show.S01E02.mkv",
+                "size" => 123,
+                "parsed_season" => 1,
+                "parsed_episode" => 2,
+                "assigned_episode_id" => nil
+              }
+            ]
+          }
+        })
+
+      assert {:ok, :snapshot, [candidate]} = ImportCandidates.load(download)
+      assert candidate["path"] == missing_path
+      assert candidate["name"] == "Show.S01E02.mkv"
+      assert candidate["size"] == 123
+      assert candidate["parsed_season"] == 1
+      assert candidate["parsed_episode"] == 2
+      assert candidate["skip_reason"] == nil
+      assert candidate["missing"] == true
+    end
+
+    test "derives a name from the path when unresolved_files omits it", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "Show.S01E02.mkv")
+      File.write!(path, "x")
+
+      download =
+        download_fixture(%{
+          metadata: %{"unresolved_files" => [%{"path" => path}]}
+        })
+
+      assert {:ok, :snapshot, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "Show.S01E02.mkv"
+      assert candidate["missing"] == false
+    end
+
+    test "prefers import_candidates over unresolved_files when both are present" do
+      download =
+        download_fixture(%{
+          metadata: %{
+            "import_candidates" => [
+              %{"path" => "/tmp/a.mkv", "name" => "a.mkv", "size" => 1}
+            ],
+            "unresolved_files" => [
+              %{"path" => "/tmp/b.mkv", "name" => "b.mkv", "size" => 2}
+            ]
+          }
+        })
+
+      assert {:ok, :snapshot, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "a.mkv"
+    end
+
+    test "still reports unavailable when neither key is present" do
+      download = download_fixture(%{metadata: %{"unresolved_files" => nil}})
+
+      assert {:error, :unavailable} = ImportCandidates.load(download)
+    end
   end
 
   ## Helpers

--- a/test/mydia/downloads/import_candidates_test.exs
+++ b/test/mydia/downloads/import_candidates_test.exs
@@ -16,9 +16,29 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
     %{path: path, name: name, size: size}
   end
 
+  # Same contract as `file/3`, but produces a sparse file: `File.stat!/1`
+  # reports `size` bytes, while the actual disk blocks consumed are close to
+  # zero. Used by tests that only need to clear `probe_size_floor/0` — the
+  # bytes themselves are never read for content, only counted, so writing
+  # `size` real bytes to disk buys nothing but I/O pressure. Seeking to the
+  # last byte and writing it is what makes the file sparse: the filesystem
+  # only allocates blocks for ranges that were actually written, and the gap
+  # before that final byte is reported as zeros without being stored.
+  defp sparse_file(tmp_dir, name, size) do
+    path = Path.join(tmp_dir, name)
+    File.mkdir_p!(Path.dirname(path))
+
+    {:ok, fd} = :file.open(path, [:write, :binary])
+    {:ok, _} = :file.position(fd, size - 1)
+    :ok = :file.write(fd, <<0>>)
+    :ok = :file.close(fd)
+
+    %{path: path, name: name, size: size}
+  end
+
   test "flags a non-video extension and probes it", %{tmp_dir: tmp_dir} do
     big = ImportCandidates.probe_size_floor() + 1
-    files = [file(tmp_dir, "payload.exe", big)]
+    files = [sparse_file(tmp_dir, "payload.exe", big)]
 
     assert [candidate] = ImportCandidates.build(files, :series, [])
     assert candidate["name"] == "payload.exe"
@@ -58,7 +78,7 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
 
     files =
       for i <- 1..(ImportCandidates.probe_cap() + 3) do
-        file(tmp_dir, "payload#{i}.exe", big)
+        sparse_file(tmp_dir, "payload#{i}.exe", big)
       end
 
     candidates = ImportCandidates.build(files, :series, [])
@@ -358,7 +378,7 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
       dir = Path.join(tmp_dir, "live")
       File.mkdir_p!(dir)
       big = ImportCandidates.probe_size_floor() + 1
-      File.write!(Path.join(dir, "payload.exe"), :binary.copy(<<0>>, big))
+      sparse_file(dir, "payload.exe", big)
 
       client = client_with_unrelated_root(tmp_dir)
 

--- a/test/mydia/downloads/import_candidates_test.exs
+++ b/test/mydia/downloads/import_candidates_test.exs
@@ -1,5 +1,8 @@
 defmodule Mydia.Downloads.ImportCandidatesTest do
-  use ExUnit.Case, async: true
+  use Mydia.DataCase, async: true
+
+  import Mydia.DownloadsFixtures
+  import Mydia.SettingsFixtures
 
   alias Mydia.Downloads.ImportCandidates
 
@@ -61,5 +64,138 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
 
     probed = Enum.count(candidates, &Map.has_key?(&1, "probe"))
     assert probed == ImportCandidates.probe_cap()
+  end
+
+  describe "load/1" do
+    test "returns the live listing when the folder is readable", %{tmp_dir: tmp_dir} do
+      dir = Path.join(tmp_dir, "live")
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "extra.mkv"), "x")
+
+      download =
+        download_fixture(%{
+          metadata: %{
+            "save_path" => dir,
+            "import_candidates" => [
+              %{"path" => Path.join(dir, "old.exe"), "name" => "old.exe", "size" => 1}
+            ]
+          }
+        })
+
+      assert {:ok, :live, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "extra.mkv"
+      assert candidate["missing"] == false
+    end
+
+    test "falls back to the snapshot when the folder is gone", %{tmp_dir: tmp_dir} do
+      download =
+        download_fixture(%{
+          metadata: %{
+            "save_path" => Path.join(tmp_dir, "gone"),
+            "import_candidates" => [
+              %{
+                "path" => Path.join(tmp_dir, "gone/payload.exe"),
+                "name" => "payload.exe",
+                "size" => 1,
+                "skip_reason" => "not_video_extension"
+              }
+            ]
+          }
+        })
+
+      assert {:ok, :snapshot, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "payload.exe"
+      assert candidate["missing"] == true
+    end
+
+    test "errors when there is neither a listing nor a snapshot" do
+      download = download_fixture(%{metadata: %{}})
+
+      assert {:error, :unavailable} = ImportCandidates.load(download)
+    end
+
+    test "falls back to the snapshot when there is no explicit save_path", %{tmp_dir: tmp_dir} do
+      # No "save_path" key at all: the old behaviour derived a directory to
+      # list from `Path.dirname/1` of the first snapshot path. That is the
+      # hazard this task fixes, so with no explicit save_path there must be
+      # no re-listing at all, live or otherwise.
+      dir = Path.join(tmp_dir, "implicit")
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "payload.exe"), "x")
+      File.write!(Path.join(dir, "unrelated.mkv"), "y")
+
+      download =
+        download_fixture(%{
+          metadata: %{
+            "import_candidates" => [
+              %{"path" => Path.join(dir, "payload.exe"), "name" => "payload.exe", "size" => 1}
+            ]
+          }
+        })
+
+      assert {:ok, :snapshot, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "payload.exe"
+      assert candidate["missing"] == false
+    end
+
+    test "does not enumerate the client's shared download root", %{tmp_dir: tmp_dir} do
+      root = Path.join(tmp_dir, "shared")
+      File.mkdir_p!(root)
+      File.write!(Path.join(root, "Some.Other.Show.S01E01.mkv"), "unrelated")
+      File.write!(Path.join(root, "Silo.S01E01.mkv"), "silo")
+
+      client = download_client_config_fixture(%{download_directory: root})
+
+      download =
+        download_fixture(%{
+          download_client: client.name,
+          metadata: %{
+            "save_path" => root,
+            "import_candidates" => [
+              %{
+                "path" => Path.join(root, "Silo.S01E01.mkv"),
+                "name" => "Silo.S01E01.mkv",
+                "size" => 4
+              }
+            ]
+          }
+        })
+
+      # A live listing here would have surfaced both files. Getting the
+      # snapshot back with only the recorded candidate proves the shared
+      # root was never walked.
+      assert {:ok, :snapshot, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "Silo.S01E01.mkv"
+      assert candidate["missing"] == false
+    end
+
+    test "still re-lists a save_path that is a per-download subfolder of the shared root",
+         %{tmp_dir: tmp_dir} do
+      root = Path.join(tmp_dir, "shared")
+      own_dir = Path.join(root, "Silo.S01E01.1080p-GROUP")
+      File.mkdir_p!(own_dir)
+      File.write!(Path.join(own_dir, "Silo.S01E01.mkv"), "silo")
+      File.write!(Path.join(root, "Some.Other.Show.S01E01.mkv"), "unrelated")
+
+      client = download_client_config_fixture(%{download_directory: root})
+
+      download =
+        download_fixture(%{
+          download_client: client.name,
+          metadata: %{
+            "save_path" => own_dir,
+            "import_candidates" => [
+              %{
+                "path" => Path.join(own_dir, "Silo.S01E01.mkv"),
+                "name" => "Silo.S01E01.mkv",
+                "size" => 4
+              }
+            ]
+          }
+        })
+
+      assert {:ok, :live, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "Silo.S01E01.mkv"
+    end
   end
 end

--- a/test/mydia/downloads/import_candidates_test.exs
+++ b/test/mydia/downloads/import_candidates_test.exs
@@ -2,6 +2,7 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
   use Mydia.DataCase, async: true
 
   import Mydia.DownloadsFixtures
+  import Mydia.MediaFixtures
   import Mydia.SettingsFixtures
 
   alias Mydia.Downloads.ImportCandidates
@@ -238,6 +239,70 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
 
       assert {:ok, :snapshot, [candidate]} = ImportCandidates.load(download)
       assert candidate["name"] == "Silo.S01E01.mkv"
+    end
+
+    test "uses the download's resolved library_path type over the media_item guess",
+         %{tmp_dir: tmp_dir} do
+      dir = Path.join(tmp_dir, "live")
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "track.mkv"), "x")
+
+      client = client_with_unrelated_root(tmp_dir)
+      # `library_type_for/1`'s guess only ever returns :movies or :series from
+      # `media_item.type`, and a "tv_show" media_item guesses :series — under
+      # which a `.mkv` file passes the extension filter (skip_reason nil).
+      # Resolving the real, non-guessable `:music` library type instead makes
+      # the SAME file fail it, proving the resolved type won.
+      library_path = library_path_fixture(%{type: "music"})
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client.name,
+          library_path_id: library_path.id,
+          metadata: %{
+            "save_path" => dir,
+            "import_candidates" => [
+              %{"path" => Path.join(dir, "old.mkv"), "name" => "old.mkv", "size" => 1}
+            ]
+          }
+        })
+        |> Repo.preload(:library_path)
+
+      assert {:ok, :live, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "track.mkv"
+      assert candidate["skip_reason"] == "not_video_extension"
+    end
+
+    test "falls back to the media_item guess when library_path isn't preloaded",
+         %{tmp_dir: tmp_dir} do
+      dir = Path.join(tmp_dir, "live")
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "track.mkv"), "x")
+
+      client = client_with_unrelated_root(tmp_dir)
+      library_path = library_path_fixture(%{type: "music"})
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client.name,
+          library_path_id: library_path.id,
+          metadata: %{
+            "save_path" => dir,
+            "import_candidates" => [
+              %{"path" => Path.join(dir, "old.mkv"), "name" => "old.mkv", "size" => 1}
+            ]
+          }
+        })
+
+      # No `Repo.preload(:library_path)`: an unloaded association must fall
+      # back to the guess rather than raise `FunctionClauseError`.
+      assert {:ok, :live, [candidate]} = ImportCandidates.load(download)
+      assert candidate["name"] == "track.mkv"
+      assert candidate["skip_reason"] == nil
     end
 
     test "does not probe on the live listing, even for a large non-video file",

--- a/test/mydia/downloads/reject_release_test.exs
+++ b/test/mydia/downloads/reject_release_test.exs
@@ -1,0 +1,79 @@
+defmodule Mydia.Downloads.RejectReleaseTest do
+  use Mydia.DataCase, async: true
+  use Oban.Testing, repo: Mydia.Repo
+
+  alias Mydia.Downloads
+  alias Mydia.Downloads.Blacklists
+  alias Mydia.Repo
+
+  import Mydia.DownloadsFixtures
+  import Mydia.MediaFixtures
+
+  describe "reject_release/2" do
+    test "blacklists the release, deletes the row, and queues a fresh search" do
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          indexer: "1337x",
+          metadata: %{"guid" => "https://1337x.to/torrent/6314993/"}
+        })
+
+      assert {:ok, :rejected} = Downloads.reject_release(download)
+
+      assert Blacklists.blacklisted?("1337x", "https://1337x.to/torrent/6314993/")
+      refute Repo.get(Mydia.Downloads.Download, download.id)
+
+      assert_enqueued(
+        worker: Mydia.Jobs.TVShowSearch,
+        args: %{"mode" => "show", "media_item_id" => media_item.id}
+      )
+    end
+
+    test "queues a specific episode search when the download is bound to an episode" do
+      media_item = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: media_item.id})
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          episode_id: episode.id,
+          indexer: "1337x",
+          metadata: %{"guid" => "abc"}
+        })
+
+      assert {:ok, :rejected} = Downloads.reject_release(download)
+
+      assert_enqueued(
+        worker: Mydia.Jobs.TVShowSearch,
+        args: %{"mode" => "specific", "episode_id" => episode.id}
+      )
+    end
+
+    test "queues a movie search for a movie download" do
+      media_item = media_item_fixture(%{type: "movie"})
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          indexer: "1337x",
+          metadata: %{"guid" => "abc"}
+        })
+
+      assert {:ok, :rejected} = Downloads.reject_release(download)
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MovieSearch,
+        args: %{"mode" => "specific", "media_item_id" => media_item.id}
+      )
+    end
+
+    test "refuses and changes nothing when the guid is missing" do
+      download = download_fixture(%{indexer: "1337x", metadata: %{}})
+
+      assert {:error, :no_guid} = Downloads.reject_release(download)
+      assert Repo.get(Mydia.Downloads.Download, download.id)
+    end
+  end
+end

--- a/test/mydia/downloads/reject_release_test.exs
+++ b/test/mydia/downloads/reject_release_test.exs
@@ -75,5 +75,36 @@ defmodule Mydia.Downloads.RejectReleaseTest do
       assert {:error, :no_guid} = Downloads.reject_release(download)
       assert Repo.get(Mydia.Downloads.Download, download.id)
     end
+
+    test "refuses and changes nothing when the indexer is missing" do
+      download = download_fixture(%{indexer: nil, metadata: %{"guid" => "abc"}})
+
+      assert {:error, :no_indexer} = Downloads.reject_release(download)
+      assert Repo.get(Mydia.Downloads.Download, download.id)
+    end
+
+    # Ordering-adjacent coverage: extract_key/1 and Blacklists.add/4 are the
+    # gate a real order-inversion bug would still have to pass through
+    # (neither has any way to fail given the inputs reject_release/2 always
+    # supplies — see the fix report for why a genuine Blacklists.add/4
+    # failure can't be forced here without mocking). This proves the
+    # blacklist-then-delete sequence completes correctly even when the
+    # optional search step is a no-op, so nothing downstream of the gate is
+    # silently skipped or reordered around a missing media item.
+    test "still blacklists and deletes the row when there is no media item to search for" do
+      download =
+        download_fixture(%{
+          media_item_id: nil,
+          indexer: "1337x",
+          metadata: %{"guid" => "no-media-item-guid"}
+        })
+
+      assert {:ok, :rejected} = Downloads.reject_release(download)
+
+      assert Blacklists.blacklisted?("1337x", "no-media-item-guid")
+      refute Repo.get(Mydia.Downloads.Download, download.id)
+      refute_enqueued(worker: Mydia.Jobs.TVShowSearch)
+      refute_enqueued(worker: Mydia.Jobs.MovieSearch)
+    end
   end
 end

--- a/test/mydia/jobs/media_import_force_test.exs
+++ b/test/mydia/jobs/media_import_force_test.exs
@@ -1,0 +1,94 @@
+defmodule Mydia.Jobs.MediaImportForceTest do
+  use Mydia.DataCase, async: true
+  use Oban.Testing, repo: Mydia.Repo
+
+  alias Mydia.Downloads
+  alias Mydia.Jobs.MediaImport
+  alias Mydia.Library
+  alias Mydia.Repo
+  alias Mydia.Settings
+
+  import Mydia.DownloadsFixtures
+  import Mydia.MediaFixtures
+
+  @moduletag :tmp_dir
+
+  test "a hand-matched file with a non-video extension is imported", %{tmp_dir: tmp_dir} do
+    _library_path = create_test_library_path(tmp_dir, :series)
+
+    download_dir = Path.join(tmp_dir, "download")
+    File.mkdir_p!(download_dir)
+    obfuscated = Path.join(download_dir, "A1B2C3.bin")
+    File.write!(obfuscated, :binary.copy(<<0>>, 4096))
+
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    episode =
+      episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 1})
+
+    # A resolvable download-client config is required to reach
+    # `process_import/3` at all: without one, `import_download/2` short-circuits
+    # on `{:error, :no_client}` before ever scanning the directory. The host is
+    # unreachable on purpose — the fallback to `save_path` is what actually
+    # lists the file, exactly as it does in production when the client query
+    # fails but a completed torrent's directory is still readable.
+    {:ok, _} =
+      Settings.create_download_client_config(%{
+        name: "ForceImportClient",
+        type: :qbittorrent,
+        host: "nonexistent.invalid",
+        port: 9999,
+        username: "test",
+        password: "test",
+        enabled: true,
+        priority: 1
+      })
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        status: "completed",
+        completed_at: DateTime.utc_now(),
+        download_client: "ForceImportClient",
+        download_client_id: "force-import-1"
+      })
+
+    # The automatic path refuses the file and records what it saw.
+    assert {:cancel, :no_importable_files} =
+             perform_job(MediaImport, %{
+               "download_id" => download.id,
+               "save_path" => download_dir
+             })
+
+    assert [candidate] = Repo.reload!(download).metadata["import_candidates"]
+    assert candidate["skip_reason"] == "not_video_extension"
+
+    # The operator hand-matches the file to the episode.
+    assert {:ok, _download} =
+             Downloads.resolve_file_mappings(Repo.reload!(download), [
+               %{"path" => obfuscated, "episode_id" => episode.id}
+             ])
+
+    # The targeted import bypasses the extension filter entirely.
+    assert {:ok, :imported} =
+             perform_job(MediaImport, %{
+               "download_id" => download.id,
+               "target_files" => [%{"path" => obfuscated, "episode_id" => episode.id}],
+               "use_hardlinks" => true,
+               "move_files" => false
+             })
+
+    assert Repo.reload!(download).imported_at
+    assert [_media_file] = Library.list_media_files(episode_id: episode.id)
+  end
+
+  defp create_test_library_path(base_path, type) do
+    library_path = Path.join(base_path, "library")
+    File.mkdir_p!(library_path)
+
+    {:ok, path_record} =
+      Settings.create_library_path(%{path: library_path, type: type, monitored: true})
+
+    path_record
+  end
+end

--- a/test/mydia/jobs/media_import_force_test.exs
+++ b/test/mydia/jobs/media_import_force_test.exs
@@ -80,6 +80,13 @@ defmodule Mydia.Jobs.MediaImportForceTest do
 
     assert Repo.reload!(download).imported_at
     assert [_media_file] = Library.list_media_files(episode_id: episode.id)
+
+    # The hand-matched success must clear the failure-time candidate listing
+    # too, not just "unresolved_files" — otherwise a resolved download keeps
+    # carrying a stale file listing (and probe verdicts) forever.
+    metadata = Repo.reload!(download).metadata
+    refute Map.has_key?(metadata, "import_candidates")
+    refute Map.has_key?(metadata, "import_candidates_at")
   end
 
   defp create_test_library_path(base_path, type) do

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -2079,4 +2079,77 @@ defmodule Mydia.Jobs.MediaImportTest do
       refute Repo.reload!(download).metadata["import_candidates"]
     end
   end
+
+  describe "import candidate snapshot resilience" do
+    test "returns the original failure without crashing when the download row is deleted mid-job",
+         %{tmp_dir: tmp_dir} do
+      # Regression: the snapshot reloads the download (see the comment on
+      # `fetch_current_download/1` in media_import.ex) so it merges onto the
+      # freshest metadata instead of the stale struct captured before
+      # `do_process_import/4` ran. If an operator dismisses the download
+      # while a large import is still copying files, that reload can find
+      # the row gone. `Downloads.get_download!/1` is `Repo.get!`, which
+      # raises `Ecto.NoResultsError` on a missing row — unguarded, that
+      # would crash the Oban job outright instead of returning the failure
+      # tuple the job would have returned before this task's refactor.
+      #
+      # No library path is configured, so this reaches the cheapest
+      # snapshot-triggering failure (`:no_library_path`) without touching
+      # the filesystem-heavy `organize_and_import_files/4` path. A
+      # telemetry handler on the repo's query event deletes the download
+      # row the moment `determine_library_path/1` issues its
+      # `library_paths` SELECT — the last DB read before the snapshot's own
+      # reload — guaranteeing the row is gone by the time that reload runs.
+      download_dir = Path.join(tmp_dir, "download")
+      File.mkdir_p!(download_dir)
+      File.write!(Path.join(download_dir, "Mystery.Show.S01E01.mkv"), "fake video content")
+
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "VanishingRowClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "VanishingRowClient",
+          download_client_id: "vanish-1"
+        })
+
+      handler_id = {__MODULE__, :delete_download_before_snapshot_reload, download.id}
+
+      :telemetry.attach(
+        handler_id,
+        [:mydia, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          if metadata.source == "library_paths" do
+            :telemetry.detach(handler_id)
+            {:ok, _} = Mydia.Downloads.delete_download(download)
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert {:error, :no_library_path} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      assert_raise Ecto.NoResultsError, fn -> Mydia.Downloads.get_download!(download.id) end
+    end
+  end
 end

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -1992,4 +1992,91 @@ defmodule Mydia.Jobs.MediaImportTest do
       assert is_nil(new_file.supersedes_media_file_id)
     end
   end
+
+  describe "import candidate snapshot" do
+    setup %{tmp_dir: tmp_dir} do
+      library_path = create_test_library_path(tmp_dir, :series)
+      %{library_path: library_path}
+    end
+
+    test "records every file with its skip reason when nothing is importable",
+         %{tmp_dir: tmp_dir} do
+      download_dir = Path.join(tmp_dir, "download")
+      File.mkdir_p!(download_dir)
+      File.write!(Path.join(download_dir, "payload.exe"), :binary.copy(<<0>>, 4096))
+      File.write!(Path.join(download_dir, "release.nfo"), "info")
+
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "SnapshotClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "SnapshotClient",
+          download_client_id: "snapshot-1"
+        })
+
+      assert {:cancel, :no_importable_files} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      candidates = Repo.reload!(download).metadata["import_candidates"]
+
+      assert length(candidates) == 2
+      assert Enum.all?(candidates, &(&1["skip_reason"] == "not_video_extension"))
+      assert Enum.find(candidates, &(&1["name"] == "payload.exe"))
+      assert Repo.reload!(download).metadata["import_candidates_at"]
+    end
+
+    test "writes no snapshot when the download path does not exist", %{tmp_dir: tmp_dir} do
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "MissingPathClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "MissingPathClient",
+          download_client_id: "missing-1"
+        })
+
+      # A save_path that never existed fails before the file listing succeeds
+      # (`:path_not_found`), so this must never reach `process_import/3` and
+      # never write a snapshot.
+      assert {:error, {:path_not_found, _}} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => Path.join(tmp_dir, "missing")
+               })
+
+      refute Repo.reload!(download).metadata["import_candidates"]
+    end
+  end
 end

--- a/test/mydia/library/content_probe_test.exs
+++ b/test/mydia/library/content_probe_test.exs
@@ -16,4 +16,43 @@ defmodule Mydia.Library.ContentProbeTest do
   test "reports unknown for a file that does not exist", %{tmp_dir: tmp_dir} do
     assert %{"status" => "unknown"} = ContentProbe.probe(Path.join(tmp_dir, "gone.mkv"))
   end
+
+  @tag :requires_ffmpeg
+  test "reports media for a real video file", %{tmp_dir: tmp_dir} do
+    if System.find_executable("ffmpeg") do
+      video_path = create_test_video(tmp_dir)
+
+      assert %{"status" => "media", "detail" => detail} = ContentProbe.probe(video_path)
+      assert is_binary(detail) and detail != ""
+    else
+      IO.puts("Skipping test: ffmpeg not available")
+      assert true
+    end
+  end
+
+  # Generates a real, tiny video so classify/1, parse_fields/1, has_av_stream?/1,
+  # and summarize/1 are exercised against actual ffprobe output instead of only
+  # the not_media/unknown paths. Mirrors
+  # ThumbnailGeneratorTest.create_test_video/0.
+  defp create_test_video(tmp_dir) do
+    video_path = Path.join(tmp_dir, "test_video.mp4")
+
+    args = [
+      "-f",
+      "lavfi",
+      "-i",
+      "color=c=blue:s=320x240:d=1",
+      "-c:v",
+      "libx264",
+      "-t",
+      "1",
+      "-y",
+      video_path
+    ]
+
+    case System.cmd("ffmpeg", args, stderr_to_stdout: true) do
+      {_, 0} -> video_path
+      {output, _} -> raise "Failed to create test video: #{output}"
+    end
+  end
 end

--- a/test/mydia/library/content_probe_test.exs
+++ b/test/mydia/library/content_probe_test.exs
@@ -1,0 +1,19 @@
+defmodule Mydia.Library.ContentProbeTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.ContentProbe
+
+  @moduletag :tmp_dir
+
+  test "reports not_media for a file ffprobe cannot parse", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "fake.exe")
+    File.write!(path, "MZ" <> :binary.copy(<<0>>, 4096))
+
+    assert %{"status" => "not_media", "detail" => detail} = ContentProbe.probe(path)
+    assert is_binary(detail)
+  end
+
+  test "reports unknown for a file that does not exist", %{tmp_dir: tmp_dir} do
+    assert %{"status" => "unknown"} = ContentProbe.probe(Path.join(tmp_dir, "gone.mkv"))
+  end
+end

--- a/test/mydia_web/live/downloads_live/match_files_test.exs
+++ b/test/mydia_web/live/downloads_live/match_files_test.exs
@@ -268,4 +268,144 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
     assert html =~ "Select at least one file"
     refute_enqueued(worker: Mydia.Jobs.MediaImport)
   end
+
+  test "rejecting blacklists the release and removes the download", %{
+    conn: conn,
+    tmp_dir: tmp_dir
+  } do
+    %{download: download} = failed_download(tmp_dir)
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view |> element("#match-files-#{download.id}") |> render_click()
+    view |> element("#match-files-reject") |> render_click()
+
+    assert Mydia.Downloads.Blacklists.blacklisted?("1337x", "abc")
+    refute Mydia.Repo.get(Mydia.Downloads.Download, download.id)
+  end
+
+  test "the reject button is disabled without a guid", %{conn: conn, tmp_dir: tmp_dir} do
+    dir = Path.join(tmp_dir, "noguid")
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "payload.exe"), "x")
+
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        indexer: "1337x",
+        import_failure_reason: "no_importable_files",
+        import_failed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        metadata: %{
+          # Deliberately no "guid" — that's what this test is about. A
+          # candidate snapshot is required too: the fixture's download_client
+          # ("test-client") never resolves to a DownloadClientConfig, so
+          # ImportCandidates.load/1 fails closed on the live listing (by
+          # design — see shared_download_root?/2) and, with no snapshot to
+          # fall back to, would return {:error, :unavailable} and never open
+          # the modal at all, which is a different failure than the one this
+          # test means to cover.
+          "save_path" => dir,
+          "import_candidates" => [
+            %{
+              "path" => Path.join(dir, "payload.exe"),
+              "name" => "payload.exe",
+              "size" => 1,
+              "skip_reason" => "not_video_extension",
+              "parsed_season" => nil,
+              "parsed_episode" => nil
+            }
+          ]
+        }
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view |> element("#match-files-#{download.id}") |> render_click()
+
+    assert has_element?(view, "#match-files-reject[disabled]")
+  end
+
+  test "unresolved-file downloads open the same modal", %{conn: conn, tmp_dir: tmp_dir} do
+    dir = Path.join(tmp_dir, "unresolved")
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "Show.S01E02.mkv"), "x")
+
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        match_status: "unresolved_files",
+        metadata: %{
+          "save_path" => dir,
+          "unresolved_files" => [
+            %{"path" => Path.join(dir, "Show.S01E02.mkv"), "name" => "Show.S01E02.mkv"}
+          ]
+        }
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    html =
+      view
+      |> element("#match-files-#{download.id}")
+      |> render_click()
+
+    assert html =~ "Show.S01E02.mkv"
+    assert has_element?(view, "#match-files-modal")
+  end
+
+  # The regression this task exists to prevent: every unresolved download that
+  # existed before Task 4 shipped the import_candidates snapshot carries only
+  # `metadata["unresolved_files"]`. The now-removed inline picker was the only
+  # way to resolve those; this proves the modal's fallback keeps them
+  # resolvable, not just viewable.
+  test "unresolved-file downloads (no import_candidates) can be imported through the modal", %{
+    conn: conn,
+    tmp_dir: tmp_dir
+  } do
+    dir = Path.join(tmp_dir, "unresolved")
+    File.mkdir_p!(dir)
+    file_path = Path.join(dir, "Show.S01E02.mkv")
+    File.write!(file_path, "x")
+
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    episode =
+      episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 2})
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        match_status: "unresolved_files",
+        metadata: %{
+          "save_path" => dir,
+          "unresolved_files" => [
+            %{"path" => file_path, "name" => "Show.S01E02.mkv"}
+          ]
+        }
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view |> element("#match-files-#{download.id}") |> render_click()
+
+    view
+    |> element("#match-files-form")
+    |> render_submit(%{"target" => %{file_path => episode.id}})
+
+    assert_enqueued(
+      worker: Mydia.Jobs.MediaImport,
+      args: %{
+        "download_id" => download.id,
+        "target_files" => [%{"path" => file_path, "episode_id" => episode.id}]
+      }
+    )
+  end
 end

--- a/test/mydia_web/live/downloads_live/match_files_test.exs
+++ b/test/mydia_web/live/downloads_live/match_files_test.exs
@@ -157,9 +157,12 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
 
     view |> element("#match-files-#{download.id}") |> render_click()
 
+    # Drives the real rendered form (target[0] + hidden target_path[0]) rather
+    # than handing handle_event a pre-built params map, so this exercises the
+    # same encode/decode round trip a browser submission goes through.
     view
-    |> element("#match-files-form")
-    |> render_submit(%{"target" => %{exe => episode.id}})
+    |> form("#match-files-form", %{"target" => %{"0" => episode.id}})
+    |> render_submit()
 
     assert_enqueued(
       worker: Mydia.Jobs.MediaImport,
@@ -178,10 +181,11 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
 
     view |> element("#match-files-#{download.id}") |> render_click()
 
+    # No override: the rendered select defaults to "Ignore".
     html =
       view
-      |> element("#match-files-form")
-      |> render_submit(%{"target" => %{}})
+      |> form("#match-files-form")
+      |> render_submit()
 
     assert html =~ "Select at least one file"
     refute_enqueued(worker: Mydia.Jobs.MediaImport)
@@ -200,18 +204,21 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
 
     # `mkv` sits on disk in the same folder, but was never part of the
     # recorded/live candidate list — nothing server-side may trust it just
-    # because a submission mentions it.
+    # because a submission mentions it. `form/3` refuses to let an override
+    # disagree with the real DOM's hidden-input value, so this simulates a
+    # crafted/stale submission via the plain element, the same way a
+    # WebSocket message forged outside the browser could.
     html =
       view
       |> element("#match-files-form")
-      |> render_submit(%{"target" => %{mkv => episode.id}})
+      |> render_submit(%{"target" => %{"0" => episode.id}, "target_path" => %{"0" => mkv}})
 
     assert html =~ "Select at least one file"
     refute_enqueued(worker: Mydia.Jobs.MediaImport)
   end
 
   test "refuses a submitted path flagged missing", %{conn: conn, tmp_dir: tmp_dir} do
-    %{download: download, episode: episode, ghost: ghost} =
+    %{download: download, episode: episode} =
       failed_download_with_missing_candidate(tmp_dir)
 
     {:ok, view, _html} = live(conn, ~p"/downloads")
@@ -219,10 +226,13 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
 
     view |> element("#match-files-#{download.id}") |> render_click()
 
+    # The candidate's <select> is disabled in the DOM (missing files can't be
+    # targeted normally), so a real form submit could never carry target[0].
+    # Force it via the plain element to prove the server refuses it too.
     html =
       view
       |> element("#match-files-form")
-      |> render_submit(%{"target" => %{ghost => episode.id}})
+      |> render_submit(%{"target" => %{"0" => episode.id}})
 
     assert html =~ "Select at least one file"
     refute_enqueued(worker: Mydia.Jobs.MediaImport)
@@ -251,7 +261,7 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
     conn: conn,
     tmp_dir: tmp_dir
   } do
-    %{download: download, exe: exe} = download_without_episodes(tmp_dir)
+    %{download: download} = download_without_episodes(tmp_dir)
 
     {:ok, view, _html} = live(conn, ~p"/downloads")
     render_click(view, "switch_tab", %{"tab" => "issues"})
@@ -260,13 +270,82 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
 
     # A crafted or stale submission: nothing in the DOM offers this value for
     # a tv_show (previous test), but the server must refuse it independently.
+    # Rejected outright (not silently dropped down to "nothing selected"):
+    # an invalid target now fails the whole submission with a specific
+    # error, per the same re-validation that guards a stale episode_id.
     html =
       view
       |> element("#match-files-form")
-      |> render_submit(%{"target" => %{exe => "movie"}})
+      |> render_submit(%{"target" => %{"0" => "movie"}})
 
-    assert html =~ "Select at least one file"
+    assert html =~ "no longer valid for this download"
     refute_enqueued(worker: Mydia.Jobs.MediaImport)
+  end
+
+  test "refuses a submitted episode that belongs to a different show than the download is now bound to",
+       %{conn: conn, tmp_dir: tmp_dir} do
+    dir = Path.join(tmp_dir, "download")
+    File.mkdir_p!(dir)
+    video = Path.join(dir, "Show.S01E01.mkv")
+    File.write!(video, "y")
+
+    show_a = media_item_fixture(%{type: "tv_show"})
+
+    episode_a =
+      episode_fixture(%{media_item_id: show_a.id, season_number: 1, episode_number: 1})
+
+    show_b = media_item_fixture(%{type: "tv_show"})
+    episode_fixture(%{media_item_id: show_b.id, season_number: 1, episode_number: 1})
+
+    download =
+      download_fixture(%{
+        media_item_id: show_a.id,
+        indexer: "1337x",
+        import_failure_reason: "no_importable_files",
+        import_failed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        metadata: %{
+          "guid" => "abc",
+          "save_path" => dir,
+          "import_candidates" => [
+            %{
+              "path" => video,
+              "name" => "Show.S01E01.mkv",
+              "size" => 100,
+              "skip_reason" => nil,
+              "parsed_season" => 1,
+              "parsed_episode" => 1
+            }
+          ]
+        }
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    # Opened while the download is bound to show A — the (now-stale)
+    # in-memory modal assign offers show A's episode as a target.
+    view |> element("#match-files-#{download.id}") |> render_click()
+
+    # The download gets re-bound to a DIFFERENT show while the modal stays
+    # open, exactly what the separate match/re-match modal does — this modal
+    # has no way to notice.
+    {:ok, _} = Mydia.Downloads.manually_match_download(Mydia.Repo.reload!(download), show_b.id)
+
+    # Submit episode_a's id, the value the stale modal offered. The server
+    # must re-check against the CURRENT media_item (show B), not the assign
+    # captured at open time, and refuse it — otherwise the file lands under
+    # show B's destination path while linked to show A's episode.
+    html =
+      view
+      |> element("#match-files-form")
+      |> render_submit(%{"target" => %{"0" => episode_a.id}})
+
+    assert html =~ "no longer valid for this download"
+
+    refute_enqueued(
+      worker: Mydia.Jobs.MediaImport,
+      args: %{"target_files" => [%{"path" => video, "episode_id" => episode_a.id}]}
+    )
   end
 
   test "rejecting blacklists the release and removes the download", %{
@@ -365,6 +444,79 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
   # `metadata["unresolved_files"]`. The now-removed inline picker was the only
   # way to resolve those; this proves the modal's fallback keeps them
   # resolvable, not just viewable.
+  # A path shaped like the anime release that motivated this feature: bracket
+  # groups back to back, the exact form Plug's decode_pair mis-splits on
+  # "][". A form field literally named `target[<this path>]` (the pre-fix
+  # wiring) decodes into nested garbage and the file is silently dropped —
+  # confirmed by running this fixture through `form/3` with a path-keyed
+  # target map against the pre-fix template: `assert_enqueued` failed with
+  # "Instead found: []", the same "Select at least one file" dead end the
+  # operator hit in production.
+  defp failed_download_with_bracket_path(tmp_dir) do
+    dir = Path.join(tmp_dir, "[BlackRabbit] Show (2021) [Bluray-1080p][Opus 2.0]")
+    File.mkdir_p!(dir)
+    video = Path.join(dir, "ep01.mkv")
+    File.write!(video, "y")
+
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    episode =
+      episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 1})
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        indexer: "1337x",
+        import_failure_reason: "no_importable_files",
+        import_failed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        metadata: %{
+          "guid" => "abc",
+          "save_path" => dir,
+          "import_candidates" => [
+            %{
+              "path" => video,
+              "name" => "ep01.mkv",
+              "size" => 1024,
+              "skip_reason" => nil,
+              "parsed_season" => 1,
+              "parsed_episode" => 1
+            }
+          ]
+        }
+      })
+
+    %{download: download, episode: episode, video: video}
+  end
+
+  test "imports a file whose path contains nested brackets", %{conn: conn, tmp_dir: tmp_dir} do
+    %{download: download, episode: episode, video: video} =
+      failed_download_with_bracket_path(tmp_dir)
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view |> element("#match-files-#{download.id}") |> render_click()
+
+    # Drives the real rendered form rather than handing handle_event a
+    # pre-built params map: `form/3` reads the actual `target[0]` /
+    # `target_path[0]` field names and values out of the DOM, and
+    # `render_submit/1` round-trips them through the same
+    # `Plug.Conn.Query.encode/1` + `Plug.Conn.Query.decode/1` a real browser
+    # submission goes through. That round trip is exactly what mangled the
+    # old path-keyed field name (see the fixture comment above).
+    view
+    |> form("#match-files-form", %{"target" => %{"0" => episode.id}})
+    |> render_submit()
+
+    assert_enqueued(
+      worker: Mydia.Jobs.MediaImport,
+      args: %{
+        "download_id" => download.id,
+        "target_files" => [%{"path" => video, "episode_id" => episode.id}]
+      }
+    )
+  end
+
   test "unresolved-file downloads (no import_candidates) can be imported through the modal", %{
     conn: conn,
     tmp_dir: tmp_dir
@@ -397,8 +549,8 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
     view |> element("#match-files-#{download.id}") |> render_click()
 
     view
-    |> element("#match-files-form")
-    |> render_submit(%{"target" => %{file_path => episode.id}})
+    |> form("#match-files-form", %{"target" => %{"0" => episode.id}})
+    |> render_submit()
 
     assert_enqueued(
       worker: Mydia.Jobs.MediaImport,

--- a/test/mydia_web/live/downloads_live/match_files_test.exs
+++ b/test/mydia_web/live/downloads_live/match_files_test.exs
@@ -1,0 +1,112 @@
+defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
+  # Not async: a connected LiveView mount runs in a separate process from the
+  # test. Under PostgreSQL with async: true the sandbox is non-shared, so that
+  # process cannot see the rows this test inserts.
+  use MydiaWeb.ConnCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.DownloadsFixtures
+  import Mydia.MediaFixtures
+
+  @moduletag :tmp_dir
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin), admin: admin}
+  end
+
+  defp failed_download(tmp_dir) do
+    dir = Path.join(tmp_dir, "download")
+    File.mkdir_p!(dir)
+    exe = Path.join(dir, "payload.exe")
+    mkv = Path.join(dir, "Show.S01E01.mkv")
+    File.write!(exe, "x")
+    File.write!(mkv, "y")
+
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    episode =
+      episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 1})
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        indexer: "1337x",
+        import_failure_reason: "no_importable_files",
+        import_last_error: "No importable files found for TV show.",
+        import_failed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        metadata: %{
+          "guid" => "abc",
+          "save_path" => dir,
+          "import_candidates" => [
+            %{
+              "path" => exe,
+              "name" => "payload.exe",
+              "size" => 891_885_056,
+              "skip_reason" => "not_video_extension",
+              "parsed_season" => nil,
+              "parsed_episode" => nil,
+              "probe" => %{"status" => "not_media", "detail" => "invalid data"}
+            }
+          ]
+        }
+      })
+
+    %{download: download, episode: episode, exe: exe, mkv: mkv}
+  end
+
+  test "opens the modal and lists the download's files", %{conn: conn, tmp_dir: tmp_dir} do
+    %{download: download} = failed_download(tmp_dir)
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    html =
+      view
+      |> element("#match-files-#{download.id}")
+      |> render_click()
+
+    assert html =~ "payload.exe"
+    assert has_element?(view, "#match-files-modal")
+  end
+
+  test "imports only the selected file", %{conn: conn, tmp_dir: tmp_dir} do
+    %{download: download, episode: episode, mkv: mkv} = failed_download(tmp_dir)
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view |> element("#match-files-#{download.id}") |> render_click()
+
+    view
+    |> element("#match-files-form")
+    |> render_submit(%{"target" => %{mkv => episode.id}})
+
+    assert_enqueued(
+      worker: Mydia.Jobs.MediaImport,
+      args: %{
+        "download_id" => download.id,
+        "target_files" => [%{"path" => mkv, "episode_id" => episode.id}]
+      }
+    )
+  end
+
+  test "refuses to submit with nothing selected", %{conn: conn, tmp_dir: tmp_dir} do
+    %{download: download} = failed_download(tmp_dir)
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view |> element("#match-files-#{download.id}") |> render_click()
+
+    html =
+      view
+      |> element("#match-files-form")
+      |> render_submit(%{"target" => %{}})
+
+    assert html =~ "Select at least one file"
+    refute_enqueued(worker: Mydia.Jobs.MediaImport)
+  end
+end

--- a/test/mydia_web/live/downloads_live/match_files_test.exs
+++ b/test/mydia_web/live/downloads_live/match_files_test.exs
@@ -57,6 +57,83 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
     %{download: download, episode: episode, exe: exe, mkv: mkv}
   end
 
+  # A candidate recorded at failure time whose file has since vanished from
+  # disk — `ImportCandidates.load/1` marks it `"missing" => true`.
+  defp failed_download_with_missing_candidate(tmp_dir) do
+    dir = Path.join(tmp_dir, "download")
+    File.mkdir_p!(dir)
+    ghost = Path.join(dir, "ghost.mkv")
+
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    episode =
+      episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 1})
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        indexer: "1337x",
+        import_failure_reason: "no_importable_files",
+        import_last_error: "No importable files found for TV show.",
+        import_failed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        metadata: %{
+          "guid" => "abc",
+          "save_path" => dir,
+          "import_candidates" => [
+            %{
+              "path" => ghost,
+              "name" => "ghost.mkv",
+              "size" => 100,
+              "skip_reason" => nil,
+              "parsed_season" => 1,
+              "parsed_episode" => 1
+            }
+          ]
+        }
+      })
+
+    %{download: download, episode: episode, ghost: ghost}
+  end
+
+  # A tv_show whose episodes have never been fetched (an ordinary, common
+  # state, not an error) — `list_episodes/1` returns `[]` for it, same as it
+  # would for an actual movie's media item. The modal must tell these two
+  # cases apart from `download.media_item.type`, not from the empty list.
+  defp download_without_episodes(tmp_dir) do
+    dir = Path.join(tmp_dir, "download")
+    File.mkdir_p!(dir)
+    exe = Path.join(dir, "payload.exe")
+    File.write!(exe, "x")
+
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    download =
+      download_fixture(%{
+        media_item_id: media_item.id,
+        indexer: "1337x",
+        import_failure_reason: "no_importable_files",
+        import_last_error: "No importable files found for TV show.",
+        import_failed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        metadata: %{
+          "guid" => "abc",
+          "save_path" => dir,
+          "import_candidates" => [
+            %{
+              "path" => exe,
+              "name" => "payload.exe",
+              "size" => 891_885_056,
+              "skip_reason" => "not_video_extension",
+              "parsed_season" => nil,
+              "parsed_episode" => nil,
+              "probe" => %{"status" => "not_media", "detail" => "invalid data"}
+            }
+          ]
+        }
+      })
+
+    %{download: download, exe: exe}
+  end
+
   test "opens the modal and lists the download's files", %{conn: conn, tmp_dir: tmp_dir} do
     %{download: download} = failed_download(tmp_dir)
 
@@ -73,7 +150,7 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
   end
 
   test "imports only the selected file", %{conn: conn, tmp_dir: tmp_dir} do
-    %{download: download, episode: episode, mkv: mkv} = failed_download(tmp_dir)
+    %{download: download, episode: episode, exe: exe} = failed_download(tmp_dir)
 
     {:ok, view, _html} = live(conn, ~p"/downloads")
     render_click(view, "switch_tab", %{"tab" => "issues"})
@@ -82,13 +159,13 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
 
     view
     |> element("#match-files-form")
-    |> render_submit(%{"target" => %{mkv => episode.id}})
+    |> render_submit(%{"target" => %{exe => episode.id}})
 
     assert_enqueued(
       worker: Mydia.Jobs.MediaImport,
       args: %{
         "download_id" => download.id,
-        "target_files" => [%{"path" => mkv, "episode_id" => episode.id}]
+        "target_files" => [%{"path" => exe, "episode_id" => episode.id}]
       }
     )
   end
@@ -105,6 +182,88 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
       view
       |> element("#match-files-form")
       |> render_submit(%{"target" => %{}})
+
+    assert html =~ "Select at least one file"
+    refute_enqueued(worker: Mydia.Jobs.MediaImport)
+  end
+
+  test "refuses a submitted path that is not among the candidates", %{
+    conn: conn,
+    tmp_dir: tmp_dir
+  } do
+    %{download: download, episode: episode, mkv: mkv} = failed_download(tmp_dir)
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view |> element("#match-files-#{download.id}") |> render_click()
+
+    # `mkv` sits on disk in the same folder, but was never part of the
+    # recorded/live candidate list — nothing server-side may trust it just
+    # because a submission mentions it.
+    html =
+      view
+      |> element("#match-files-form")
+      |> render_submit(%{"target" => %{mkv => episode.id}})
+
+    assert html =~ "Select at least one file"
+    refute_enqueued(worker: Mydia.Jobs.MediaImport)
+  end
+
+  test "refuses a submitted path flagged missing", %{conn: conn, tmp_dir: tmp_dir} do
+    %{download: download, episode: episode, ghost: ghost} =
+      failed_download_with_missing_candidate(tmp_dir)
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view |> element("#match-files-#{download.id}") |> render_click()
+
+    html =
+      view
+      |> element("#match-files-form")
+      |> render_submit(%{"target" => %{ghost => episode.id}})
+
+    assert html =~ "Select at least one file"
+    refute_enqueued(worker: Mydia.Jobs.MediaImport)
+  end
+
+  test "does not render the movie option for a tv_show with no episodes loaded", %{
+    conn: conn,
+    tmp_dir: tmp_dir
+  } do
+    %{download: download} = download_without_episodes(tmp_dir)
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    html =
+      view
+      |> element("#match-files-#{download.id}")
+      |> render_click()
+
+    refute html =~ "Import as this movie"
+    assert has_element?(view, "#match-files-blocked")
+    assert has_element?(view, "#match-files-import[disabled]")
+  end
+
+  test "refuses a submission that targets the movie destination against a tv_show", %{
+    conn: conn,
+    tmp_dir: tmp_dir
+  } do
+    %{download: download, exe: exe} = download_without_episodes(tmp_dir)
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+    render_click(view, "switch_tab", %{"tab" => "issues"})
+
+    view |> element("#match-files-#{download.id}") |> render_click()
+
+    # A crafted or stale submission: nothing in the DOM offers this value for
+    # a tv_show (previous test), but the server must refuse it independently.
+    html =
+      view
+      |> element("#match-files-form")
+      |> render_submit(%{"target" => %{exe => "movie"}})
 
     assert html =~ "Select at least one file"
     refute_enqueued(worker: Mydia.Jobs.MediaImport)


### PR DESCRIPTION
## The bug

Importing "Mushoku Tensei: Jobless Reincarnation" on the production instance failed with:

> Import failed: No importable files found for TV show. The download may contain only non-media files (samples, NFO, etc.)

Accurate, and useless. The message reports that nothing was importable while hiding the one fact that resolves it: what the download actually contained.

The torrent (from `1337x`, grabbed via transmission) held exactly one file:

```
C7466DBA33FE8C5F53F0F80ED8BCFC62242EF310.exe    891.9 MB
```

Verified on the host: `file` reports `PE32 executable for MS Windows, Intel i386`, and ffprobe rejects it with `Invalid data found`. It is not a misnamed video. It is a fake release, and the import filter was right to refuse it.

Two aggravating details. The indexer advertised 2.69 GB across 23 episodes while the torrent delivered 891.9 MB in one file, a mismatch nothing surfaced. And `media_import.ex` never called `Blacklists.add/5`, so the `release_blacklist` table was empty in production and that same fake release could be re-grabbed on the next search, indefinitely.

Root cause: `organize_and_import_files/4` computed the full file list, filtered it, found nothing importable, and **discarded the list**. Nothing was persisted, so the UI had nothing to show. The failure was terminal, so there was no retry to hang an affordance on.

## What this adds

**A snapshot on failure.** Any import failure that reached the file-listing stage now persists what it saw into `download.metadata["import_candidates"]`: name, size, why each file was skipped, and the parser's season/episode guess.

**A content probe.** Skip reason alone cannot distinguish junk from a video wearing the wrong extension. Files rejected purely on extension, above 10 MB, capped at 20 per download, get an ffprobe header read. Here it prints "Not media (invalid data)" and settles it. On a genuinely obfuscated release it prints the container and codec and tells you to force the import.

**A match-files modal** on the Downloads Issues tab. Lists what the download contains, why each file was skipped, the probe verdict, and a per-file target prefilled from the parser. Import any subset. This reuses the existing `resolve_file_mappings/2` → `process_targeted_import/3` path, which imports by explicit path with no extension filter, so forcing an import of an unusual extension already worked; nothing surfaced it.

**A reject action.** Blacklists `(indexer, guid)` so future searches filter the release out, removes it from the download client, deletes the row, and queues a fresh search. This closes the re-grab loop that was previously wide open.

**One matching UI instead of two.** The cramped inline per-file picker in the Unresolved Files section is retired in favour of the modal. `ImportCandidates.load/1` falls back to `metadata["unresolved_files"]` so downloads that already exist in a user's database keep working across the upgrade.

## Notable decisions

`ImportCandidates` is the single owner of the library-type extension vocabulary, with `media_import.ex` delegating to `importable?/2`. Same for the `shared_download_root?/2` safety predicate. Two copies of either could drift, and the failure mode is silent: the modal would report a skip reason the importer no longer applies, or keep offering neighbouring downloads' files after the importer was hardened.

The modal decides movie versus TV from `media_item.type`, never from an empty episode list. A show whose episodes are not yet fetched produces the same empty list, and treating that as "this is a movie" silently orphans files at the show root while reporting success.

`load/1` re-lists the download folder only when `metadata["save_path"]` is explicitly set and is not the client's download root, and fails closed when the client cannot be resolved. In the case that motivated this feature the file sat directly in `/mnt/storage/media/Downloads`, so a naive `Path.dirname` would have enumerated every unrelated torrent and offered another download's files for import.

Select fields are keyed by candidate index with the path in a hidden input, not by the path itself. Plug's query decoder splits bracket bodies on `][`, so a path like `[BlackRabbit] Show (2021) [Bluray-1080p][Opus 2.0]` mangled the form key and the submission silently became a no-op with a misleading "select at least one file" message. Bracket-heavy names are the norm for anime releases, which is exactly the content this was built for.

## Not included

The advertised-versus-delivered size warning from the design doc. The probe verdict answers the operator's real question more decisively than a size delta, and it added branching to the modal for one informational line. Easy to add later if wanted.

## Testing

`mix precommit` green on SQLite: **6267 tests, 0 failures** (compile with warnings-as-errors, unused deps, format, credo --strict, tests).

PostgreSQL: 6267 tests with 7 failures, all reproduced on the merge-base commit in a scratch worktree and confined to files this branch never modified. They are the known deep-worktree-path issue where ExUnit's `:tmp_dir` overflows `library_paths.path`'s `varchar(255)`, which only PostgreSQL enforces. The new end-to-end test passes on both adapters.

New coverage includes an end-to-end regression proving a file the automatic importer refuses can be hand-matched and land in the library, which is the capability the reported failure lacked.

## Review notes

Fifteen commits, each individually reviewed, plus a whole-branch review. The review loop caught several defects worth flagging for reviewers' attention, since they shaped the final design:

- The candidate snapshot originally merged onto a stale `download` struct and clobbered `metadata["unresolved_files"]` written earlier in the same request, which would have broken the existing unresolved-files flow while adding the new one.
- The ffprobe timeout killed the BEAM task but not the `ffprobe` OS process, leaking one per timeout.
- `remove_from_client/1` used `rescue`, which does not catch exits; `debrid.ex`'s `remove_torrent` can exit `:noproc` via `DynamicSupervisor.terminate_child`.
- The modal re-ran up to 20 sequential ffprobe subprocesses on every open and discarded the results.

Deferred, non-blocking, recorded rather than dropped: a sub-millisecond PID-reuse race in the ffprobe kill path, `reject_release/2`'s `with` ordering not being pinned by a test (both failure branches are unreachable without mocking), and pre-existing `update_download/2` call sites elsewhere carrying the same deleted-row race this branch guarded on its own writers.
