### PR TITLE
fix(player): hide the Updates settings section on iOS

### DIFF
--- a/player/lib/core/update/platform_updater.dart
+++ b/player/lib/core/update/platform_updater.dart
@@ -1,8 +1,9 @@
 import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 
 import '../../domain/models/app_update.dart';
+import '../player/platform_features.dart';
 import 'updaters/linux_updater.dart';
 import 'updaters/macos_updater.dart';
 import 'updaters/windows_updater.dart';
@@ -27,4 +28,29 @@ abstract class PlatformUpdater {
     if (Platform.isLinux) return LinuxUpdater();
     return null;
   }
+
+  /// Whether the current platform ships an in-app updater at all.
+  ///
+  /// Update surfaces gate on this instead of listing platforms themselves, so
+  /// a platform without an updater cannot grow a dead update menu item — which
+  /// is exactly what iOS had, since the Settings "Updates" section only
+  /// excluded web and Android.
+  static bool get supportedOnCurrentPlatform => supportedOnPlatform(
+        isWeb: PlatformFeatures.isWeb,
+        isAndroid: PlatformFeatures.isAndroid,
+        isIOS: PlatformFeatures.isIOS,
+      );
+
+  /// The support decision itself, separated from the static platform lookups
+  /// so it can be exercised for every platform on one machine.
+  ///
+  /// iOS and Android update through their app stores and web is served by the
+  /// Mydia server, so none of them can replace the running app.
+  @visibleForTesting
+  static bool supportedOnPlatform({
+    required bool isWeb,
+    required bool isAndroid,
+    required bool isIOS,
+  }) =>
+      !isWeb && !isAndroid && !isIOS;
 }

--- a/player/lib/presentation/screens/settings_screen.dart
+++ b/player/lib/presentation/screens/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../core/connection/connection_provider.dart';
 import '../../core/graphql/graphql_provider.dart';
+import '../../core/update/platform_updater.dart';
 import '../../core/update/update_provider.dart';
 import '../../core/update/updaters/macos_updater.dart';
 import '../widgets/ambient_backdrop_provider.dart';
@@ -141,8 +142,9 @@ class SettingsScreen extends ConsumerWidget {
             const ConnectionStatusTile(),
             const Divider(),
 
-            // Updates section (desktop only, not Android)
-            if (!kIsWeb && !Platform.isAndroid) ...[
+            // Updates section (desktop only — mobile updates through the app
+            // stores and web is served by the Mydia server)
+            if (PlatformUpdater.supportedOnCurrentPlatform) ...[
               const _SectionHeader(title: 'Updates'),
               // On macOS, Sparkle manages update notifications natively
               if (!Platform.isMacOS) const UpdateTile(),

--- a/player/test/core/update/platform_updater_test.dart
+++ b/player/test/core/update/platform_updater_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/update/platform_updater.dart';
+
+void main() {
+  group('PlatformUpdater.supportedOnPlatform', () {
+    test('web has no in-app updater', () {
+      expect(
+        PlatformUpdater.supportedOnPlatform(
+          isWeb: true,
+          isAndroid: false,
+          isIOS: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('iOS has no in-app updater', () {
+      expect(
+        PlatformUpdater.supportedOnPlatform(
+          isWeb: false,
+          isAndroid: false,
+          isIOS: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('Android has no in-app updater', () {
+      expect(
+        PlatformUpdater.supportedOnPlatform(
+          isWeb: false,
+          isAndroid: true,
+          isIOS: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('desktop ships an in-app updater', () {
+      expect(
+        PlatformUpdater.supportedOnPlatform(
+          isWeb: false,
+          isAndroid: false,
+          isIOS: false,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('PlatformUpdater.supportedOnCurrentPlatform', () {
+    // Guards against the two enumerations drifting apart: a platform that
+    // reports support but has no concrete updater would surface a Settings
+    // "Updates" section whose every action is a no-op. Only observable for
+    // whichever platform the suite runs on, which is why the decision itself
+    // is tested purely above.
+    test('agrees with forCurrentPlatform on the platform under test', () {
+      expect(
+        PlatformUpdater.supportedOnCurrentPlatform,
+        PlatformUpdater.forCurrentPlatform() != null,
+      );
+    });
+
+    test('is true on the desktop platforms the suite runs on', () {
+      // `flutter test` is always a non-web VM run, so this pins the desktop
+      // answer against an accidental inversion of the predicate.
+      expect(kIsWeb, isFalse);
+      expect(PlatformUpdater.supportedOnCurrentPlatform, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What

The player's Settings screen showed an **Updates** section on iOS. It should not: iOS has no in-app updater, so the section rendered a "Check for Updates" tile whose every action was a no-op.

## Why it happened

The section was gated on a hand-maintained platform list that only excluded web and Android:

```dart
if (!kIsWeb && !Platform.isAndroid) ...[
```

iOS fell straight through. Meanwhile `PlatformUpdater.forCurrentPlatform()` returns `null` on iOS, so the two notions of "can this platform update itself" had already drifted apart. iOS ships updates through the App Store regardless.

## The fix

Gate the section on the update layer's own notion of support instead of restating the platform list at the call site:

```dart
if (PlatformUpdater.supportedOnCurrentPlatform) ...[
```

A platform without an updater now cannot grow a dead update menu item again.

The decision itself is a pure predicate (`supportedOnPlatform`) separated from the static platform lookups, following the existing `CastCapabilities.forPlatform` pattern, so every platform is covered from a single `flutter test` run rather than only whichever platform the suite happens to run on.

## Behavior

| Platform | Before | After |
|---|---|---|
| iOS | Updates section shown (all actions no-op) | Hidden |
| Android | Hidden | Hidden |
| Web | Hidden | Hidden |
| macOS / Windows / Linux | Shown | Shown |

Only iOS changes. macOS keeps its Sparkle path untouched.

## Testing

- New `player/test/core/update/platform_updater_test.dart`: 6 tests covering web, iOS, Android and desktop, plus a guard that `supportedOnCurrentPlatform` stays consistent with `forCurrentPlatform()`.
- Mutation-checked: restoring the old `!isWeb && !isAndroid` predicate fails the iOS test, confirming the test actually pins the fix.
- Full player suite green at `--concurrency=1`: **1417 tests passed**.
- `flutter analyze`: no errors or warnings; no new issues in the changed files.