### PR TITLE
fix(player): keep detecting audio tracks after mpv finishes probing

### DIFF
--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -197,6 +197,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   bool _watchedInvalidationSent = false;
 
   StreamSubscription<Duration>? _positionSubscription;
+
+  /// Keeps the audio track list current as media_kit revises it. Detection
+  /// cannot be a one-shot sample after `open()`: mpv publishes tracks only
+  /// once it has probed the file, and a probe that outruns the sample used to
+  /// leave the selector empty for the rest of the session.
+  StreamSubscription<Tracks>? _tracksSubscription;
   bool _isLoading = true;
   String? _error;
   String? _loadingMessage;
@@ -934,6 +940,16 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     // the previous subscription itself.
     _windowSizer?.bindVideoParams(player.stream.videoParams);
 
+    // Subscribe before opening. `player.stream.tracks` is a plain broadcast
+    // stream with no replay, so a revision published between `open()` and the
+    // detection pass below would otherwise be lost — which is the whole
+    // failure this guards against.
+    await _tracksSubscription?.cancel();
+    _tracksSubscription = watchAudioTracks(
+      player.stream.tracks,
+      _onAudioTracksDetected,
+    );
+
     // Open media
     await player.open(
       Media(mediaSource, httpHeaders: httpHeaders),
@@ -943,7 +959,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     // Wait for player to be ready
     await Future.delayed(const Duration(milliseconds: 500));
 
-    // Detect available tracks from media_kit
+    // Detect available tracks from media_kit. Covers whatever mpv already
+    // knew before the subscription above went live; anything discovered
+    // later arrives through that subscription instead.
     _detectTracks();
 
     // A plain seek, not a `seekToReal`: these paths hold the whole file, so
@@ -1233,33 +1251,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     if (player == null) return;
 
     // --- Audio tracks ---
-    final mkAudioTracks = player.state.tracks.audio;
-    final audioTracks = <app_models_audio.AudioTrack>[];
-    final audioMap = <String, AudioTrack>{};
-
-    for (final mkTrack in mkAudioTracks) {
-      // Skip the "auto" and "no" sentinel tracks
-      if (mkTrack == AudioTrack.auto() || mkTrack == AudioTrack.no()) continue;
-
-      final appTrack = app_models_audio.AudioTrack(
-        id: mkTrack.id,
-        language: mkTrack.language ?? 'und',
-        title: mkTrack.title,
-      );
-      audioTracks.add(appTrack);
-      audioMap[appTrack.id] = mkTrack;
-    }
-
-    // Mark first track as default if available
-    if (audioTracks.isNotEmpty) {
-      final firstTrack = audioTracks.first;
-      audioTracks[0] = app_models_audio.AudioTrack(
-        id: firstTrack.id,
-        language: firstTrack.language,
-        title: firstTrack.title,
-        isDefault: true,
-      );
-    }
+    final audioDetection = detectAudioTracks(player.state.tracks.audio);
 
     // --- Subtitle tracks ---
     final mkSubtitleTracks = player.state.tracks.subtitle;
@@ -1315,25 +1307,50 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       }
     }
 
-    _audioTracks = audioTracks;
-    _mediaKitAudioTrackMap = audioMap;
+    _audioTracks = audioDetection.tracks;
+    _mediaKitAudioTrackMap = audioDetection.byId;
     _mediaKitSubtitleTrackMap = subtitleMap;
 
-    // Auto-select the current audio track
-    final currentMkAudio = player.state.track.audio;
-    if (currentMkAudio != AudioTrack.auto() &&
-        currentMkAudio != AudioTrack.no()) {
-      for (final appTrack in _audioTracks) {
-        if (_mediaKitAudioTrackMap[appTrack.id]?.id == currentMkAudio.id) {
-          _selectedAudioTrack = appTrack;
-          break;
-        }
-      }
-    }
+    _syncSelectedAudioTrack();
 
     debugPrint('[PlayerScreen] Detected ${_audioTracks.length} audio tracks, '
         '${_subtitleTracks.length} subtitle tracks '
         '(directPlay=$_isDirectPlay)');
+  }
+
+  /// Point [_selectedAudioTrack] at whichever detected track media_kit is
+  /// actually playing, so the selector opens on the real current choice.
+  void _syncSelectedAudioTrack() {
+    final player = _player;
+    if (player == null) return;
+
+    final currentMkAudio = player.state.track.audio;
+    if (currentMkAudio == AudioTrack.auto() ||
+        currentMkAudio == AudioTrack.no()) {
+      return;
+    }
+
+    for (final appTrack in _audioTracks) {
+      if (_mediaKitAudioTrackMap[appTrack.id]?.id == currentMkAudio.id) {
+        _selectedAudioTrack = appTrack;
+        return;
+      }
+    }
+  }
+
+  /// Adopt a track list media_kit published after playback opened.
+  ///
+  /// The audio button is gated on `audioTrackCount > 0`, so until this lands
+  /// a late-probing file leaves it disabled with no way to reach a second
+  /// language.
+  void _onAudioTracksDetected(AudioTrackDetection detection) {
+    if (!mounted) return;
+
+    setState(() {
+      _audioTracks = detection.tracks;
+      _mediaKitAudioTrackMap = detection.byId;
+      _syncSelectedAudioTrack();
+    });
   }
 
   /// Build a full subtitle URL from a relative URL path.
@@ -1813,6 +1830,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
         await _positionSubscription?.cancel();
         _positionSubscription = null;
+        await _tracksSubscription?.cancel();
+        _tracksSubscription = null;
         _progressService?.stopSync();
         await _player?.dispose();
         _player = null;
@@ -2166,8 +2185,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       web_lifecycle.unregisterBeforeUnload();
     }
 
-    // Cancel stream subscription to prevent memory leak
+    // Cancel stream subscriptions to prevent memory leaks
     _positionSubscription?.cancel();
+    _tracksSubscription?.cancel();
 
     // Cancel auto-play timer
     _upNextTimer?.cancel();
@@ -2221,6 +2241,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   Future<void> _restartLocalPlayback() async {
     await _positionSubscription?.cancel();
     _positionSubscription = null;
+    await _tracksSubscription?.cancel();
+    _tracksSubscription = null;
     _progressService?.stopSync();
 
     final player = _player;
@@ -2717,4 +2739,84 @@ Future<void> trackRestartInFlight(
   } finally {
     setInFlight(false);
   }
+}
+
+/// media_kit's current audio track list mapped onto the app's own model,
+/// together with the reverse lookup needed to hand a chosen track back to
+/// media_kit.
+@visibleForTesting
+class AudioTrackDetection {
+  const AudioTrackDetection({required this.tracks, required this.byId});
+
+  /// Selectable tracks, in the order media_kit reports them. Never contains
+  /// the `auto`/`no` sentinels.
+  final List<app_models_audio.AudioTrack> tracks;
+
+  /// [app_models_audio.AudioTrack.id] to the media_kit track it came from.
+  /// `_showAudioSelector` passes the resolved value to `setAudioTrack`, so a
+  /// missing entry silently no-ops the user's choice.
+  final Map<String, AudioTrack> byId;
+}
+
+/// Maps media_kit's audio tracks onto the app's model.
+///
+/// Extracted as a free function so the mapping can be unit-tested without a
+/// live `Player` — see [shouldRestartForSeek]'s dartdoc for why one cannot be
+/// constructed under `flutter test`.
+///
+/// Which track counts as the default comes from media_kit's own `isDefault`
+/// flag, which carries the container's disposition. Position is only the
+/// fallback, for files that flag nothing: a dual-language release can order
+/// its tracks one way and flag another, and picking by position alone
+/// mislabels those.
+@visibleForTesting
+AudioTrackDetection detectAudioTracks(List<AudioTrack> mkTracks) {
+  final tracks = <app_models_audio.AudioTrack>[];
+  final byId = <String, AudioTrack>{};
+
+  for (final mkTrack in mkTracks) {
+    // Skip the "auto" and "no" sentinel tracks
+    if (mkTrack == AudioTrack.auto() || mkTrack == AudioTrack.no()) continue;
+
+    tracks.add(
+      app_models_audio.AudioTrack(
+        id: mkTrack.id,
+        language: mkTrack.language ?? 'und',
+        title: mkTrack.title,
+        isDefault: mkTrack.isDefault ?? false,
+      ),
+    );
+    byId[mkTrack.id] = mkTrack;
+  }
+
+  if (tracks.isNotEmpty && !tracks.any((t) => t.isDefault)) {
+    final first = tracks.first;
+    tracks[0] = app_models_audio.AudioTrack(
+      id: first.id,
+      language: first.language,
+      title: first.title,
+      isDefault: true,
+    );
+  }
+
+  return AudioTrackDetection(tracks: tracks, byId: byId);
+}
+
+/// Reports an [AudioTrackDetection] every time media_kit revises [tracks].
+///
+/// mpv discovers tracks asynchronously while it probes the file, and revises
+/// the list afterwards, so sampling it once at a fixed moment after `open()`
+/// races the probe. On a slow enough source the sample lands before any audio
+/// track exists and the selector is left permanently empty. Driving detection
+/// off the stream instead means a late arrival still reaches the UI.
+///
+/// `player.stream.tracks` is a plain broadcast stream with no replay, so
+/// callers must subscribe before opening the media and still run a detection
+/// pass afterwards to cover anything emitted in between.
+@visibleForTesting
+StreamSubscription<Tracks> watchAudioTracks(
+  Stream<Tracks> tracks,
+  void Function(AudioTrackDetection detection) onDetected,
+) {
+  return tracks.listen((t) => onDetected(detectAudioTracks(t.audio)));
 }

--- a/player/test/presentation/screens/player/audio_track_detection_test.dart
+++ b/player/test/presentation/screens/player/audio_track_detection_test.dart
@@ -1,0 +1,136 @@
+// Unit coverage for `detectAudioTracks` and `watchAudioTracks`, the pure
+// pieces extracted from `_PlayerScreenState._detectTracks`.
+//
+// Extracted (rather than tested through a fully mounted `PlayerScreen`) for
+// the same reason as `seek_restart_decision_test.dart`: reaching a non-null
+// `_player` under `flutter test` needs a real, native-backed media_kit
+// `Player`, and `PlayerScreen` always builds a bare `Player()` with no seam
+// to substitute a fake. media_kit's `Tracks`/`AudioTrack` are plain const
+// data classes with no native dependency, so the mapping and the
+// late-arrival behaviour can both be driven directly.
+//
+// The late-arrival group is the one that matters. Track detection used to run
+// exactly once, after a fixed 500ms sleep following `player.open(play:
+// false)`, and nothing ever re-ran it. mpv discovers tracks asynchronously
+// while it probes, so a file whose probe outran that sleep — a 4K HEVC remote
+// stream, say — left the audio list permanently empty and the audio button
+// disabled, with no way to reach a second language.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:player/presentation/screens/player/player_screen.dart';
+
+/// The dual-language shape that exposed this: Italian first and flagged
+/// default, English second. Mirrors the real streams in
+/// `Silo.S03E03.A.Dark.Web.2160p...ENG.ITA...mkv`.
+const _italian = AudioTrack('1', null, 'ita', isDefault: true);
+const _english = AudioTrack('2', null, 'eng');
+
+/// What media_kit reports before it has probed the file: sentinels only.
+const _sentinelsOnly = Tracks();
+
+void main() {
+  group('detectAudioTracks', () {
+    test('skips the auto and no sentinels', () {
+      final detection = detectAudioTracks(const [
+        AudioTrack('auto', null, null),
+        AudioTrack('no', null, null),
+      ]);
+
+      expect(detection.tracks, isEmpty);
+      expect(detection.byId, isEmpty);
+    });
+
+    test('reports both languages of a dual-language file', () {
+      final detection = detectAudioTracks(const [
+        AudioTrack('auto', null, null),
+        AudioTrack('no', null, null),
+        _italian,
+        _english,
+      ]);
+
+      expect(detection.tracks.map((t) => t.language), ['ita', 'eng']);
+      expect(
+        detection.tracks.map((t) => t.displayName),
+        ['Italian', 'English'],
+      );
+    });
+
+    test('resolves each app track back to its media_kit track', () {
+      final detection = detectAudioTracks(const [_italian, _english]);
+
+      // The reverse lookup is what `_showAudioSelector` hands to
+      // `player.setAudioTrack`, so a broken mapping silently no-ops the
+      // user's choice.
+      for (final track in detection.tracks) {
+        expect(detection.byId[track.id], isNotNull);
+        expect(detection.byId[track.id]!.id, track.id);
+      }
+    });
+
+    test('marks the track media_kit flagged default, not merely the first', () {
+      final detection = detectAudioTracks(const [_english, _italian]);
+
+      final byLanguage = {for (final t in detection.tracks) t.language: t};
+      expect(byLanguage['ita']!.isDefault, isTrue);
+      expect(byLanguage['eng']!.isDefault, isFalse);
+    });
+
+    test('falls back to the first track when nothing is flagged default', () {
+      final detection = detectAudioTracks(const [
+        AudioTrack('1', null, 'eng'),
+        AudioTrack('2', null, 'fre'),
+      ]);
+
+      expect(detection.tracks.first.isDefault, isTrue);
+      expect(detection.tracks.last.isDefault, isFalse);
+    });
+
+    test('keeps an untagged track selectable rather than dropping it', () {
+      final detection = detectAudioTracks(const [AudioTrack('1', null, null)]);
+
+      expect(detection.tracks, hasLength(1));
+      expect(detection.tracks.single.language, 'und');
+    });
+  });
+
+  group('watchAudioTracks', () {
+    test('reports tracks that media_kit only discovers after playback opens',
+        () async {
+      final controller = StreamController<Tracks>();
+      addTearDown(controller.close);
+
+      final seen = <AudioTrackDetection>[];
+      final subscription = watchAudioTracks(controller.stream, seen.add);
+      addTearDown(subscription.cancel);
+
+      // The probe has not finished: this is exactly the state the old fixed
+      // 500ms sample could land in.
+      controller.add(_sentinelsOnly);
+      await pumpEventQueue();
+      expect(seen.last.tracks, isEmpty);
+
+      // mpv finishes probing and revises the list.
+      controller.add(const Tracks(audio: [_italian, _english]));
+      await pumpEventQueue();
+
+      expect(seen.last.tracks.map((t) => t.language), ['ita', 'eng']);
+    });
+
+    test('stops reporting once cancelled', () async {
+      final controller = StreamController<Tracks>();
+      addTearDown(controller.close);
+
+      final seen = <AudioTrackDetection>[];
+      final subscription = watchAudioTracks(controller.stream, seen.add);
+      await subscription.cancel();
+
+      controller.add(const Tracks(audio: [_italian, _english]));
+      await pumpEventQueue();
+
+      expect(seen, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## What broke

Silo S03E03 direct-plays on the desktop player and offers no way to reach its English audio track.

The file carries two audio streams. Italian is first and flagged `default`, English is second:

```
#0:1  eac3  6ch  ita  (default)
#0:2  eac3  6ch  eng
```

mpv sees both. The player did not.

## Root cause

`_openPlayerAndStart` sampled the track list exactly once, 500ms after `player.open(play: false)`, and nothing ever re-ran it:

```dart
await player.open(Media(mediaSource, ...), play: false);
await Future.delayed(const Duration(milliseconds: 500));
_detectTracks();
```

mpv only publishes tracks once it has probed the file. Nothing subscribed to `player.stream.tracks`, so whatever mpv had at that 500ms mark was frozen for the session. A 4K HEVC stream pulled over HTTP or the p2p proxy routinely outruns the sleep, leaving `_audioTracks` empty. The audio button is gated on `audioTrackCount > 0` (`panel_controls.dart`), so it stayed disabled outright.

## Fix

- Drive detection off `player.stream.tracks` so a late arrival still reaches the UI. That stream is a plain broadcast controller with no replay, so the subscription is opened before `open()` and the post-open pass is kept for whatever mpv already knew.
- Cancel the subscription everywhere `_positionSubscription` is already cancelled: re-open, seek restart, cast restart, and dispose.
- Take the default track from media_kit's own `isDefault` flag instead of assuming index 0. A dual-language release can order its tracks one way and flag another; position alone mislabels those. Position stays as the fallback for files that flag nothing.
- Extract `detectAudioTracks` / `watchAudioTracks` as `@visibleForTesting` free functions, matching the existing `shouldRestartForSeek` pattern, since `PlayerScreen` builds a bare `Player()` that cannot be constructed under `flutter test`.

## Tests

New `audio_track_detection_test.dart`, 8 cases. The one that pins the bug feeds a `StreamController<Tracks>` sentinels first, then the real pair, and asserts both languages are reported after the late revision. media_kit's `Tracks`/`AudioTrack` are plain const data classes, so this needs no native init.

Full player suite green at 1419 tests (`--concurrency=1`). `flutter analyze` reports no errors and nothing new in the touched files.

## Not covered here

Streaming the same file through the HLS path drops English before it leaves the server: the transcoder passes no `-map`, so ffmpeg's default selection keeps only the `default`-flagged Italian stream, and `-ac 2` downmixes it. That is a separate, larger change spanning the analyzer, the transcoder, GraphQL, and the web player, and is not addressed here.