### PR TITLE
feat(player): ship the Linux player as a Flatpak on beta and stable channels

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -60,7 +60,7 @@ jobs:
           hits="$(
             git ls-files -z \
                 '*.nix' '.github/workflows/*' '*Dockerfile*' '*compose*.yml' \
-                'scripts/*' 'dev' \
+                'scripts/*' 'dev' 'player/flatpak/*' \
               | xargs -0 grep -HnIiE 'flutter' \
               | grep -vE ':[[:space:]]*uses:[[:space:]]*[^[:space:]]+@' \
               | grep -E '[0-9]+\.[0-9]+|[Ff]lutter[0-9]' \
@@ -74,6 +74,7 @@ jobs:
             echo "  workflows   -> subosito/flutter-action with flutter-version-file"
             echo "  Dockerfiles -> jq -r .flutter player/.fvmrc"
             echo "  nix         -> import player/flutter-version.nix"
+            echo "  flatpak     -> read it in build.sh from player/.fvmrc"
             exit 1
           fi
           echo "OK: player/.fvmrc is the only file naming a Flutter version."

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -334,7 +334,10 @@ jobs:
       - name: Install flatpak-builder
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder xvfb
+          # appstream provides appstreamcli, which flatpak-builder shells out to
+          # on the host during export. Without it the build fails at the very
+          # last step, after everything has already compiled.
+          sudo apt-get install -y flatpak flatpak-builder xvfb appstream
 
       - name: Allow unprivileged user namespaces
         # Ubuntu 24.04 restricts these through AppArmor, which breaks the

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -298,3 +298,24 @@ jobs:
       - name: Check web icons are current
         working-directory: player
         run: tool/gen-web-icons.sh --check
+
+  flatpak-validate:
+    name: Flatpak / Validate metadata
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Seconds, not minutes. Catches most manifest metadata mistakes long
+      # before the full flatpak-build job below finishes compiling mpv.
+      - name: Install validators
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y desktop-file-utils appstream
+
+      - name: Validate desktop entry
+        run: desktop-file-validate player/flatpak/dev.mydia.player.desktop
+
+      - name: Validate AppStream metainfo
+        run: appstreamcli validate --explain player/flatpak/dev.mydia.player.metainfo.xml

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -345,7 +345,9 @@ jobs:
         run: |
           flatpak remote-add --user --if-not-exists flathub \
             https://dl.flathub.org/repo/flathub.flatpakrepo
-          flatpak install --user -y flathub org.gnome.Platform//50 org.gnome.Sdk//50
+          flatpak install --user -y flathub \
+            org.gnome.Platform//50 org.gnome.Sdk//50 \
+            org.freedesktop.Sdk.Extension.llvm21//25.08
 
       - name: Build
         run: |

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -319,3 +319,43 @@ jobs:
 
       - name: Validate AppStream metainfo
         run: appstreamcli validate --explain player/flatpak/dev.mydia.player.metainfo.xml
+
+  flatpak-build:
+    name: Flatpak / Build
+    runs-on: ubuntu-latest
+    # mpv, libplacebo and libass account for roughly a third of this; the
+    # Flutter build and its Rust cdylib account for the rest.
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install flatpak-builder
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder xvfb
+
+      - name: Allow unprivileged user namespaces
+        # Ubuntu 24.04 restricts these through AppArmor, which breaks the
+        # bubblewrap sandbox flatpak-builder needs.
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Add Flathub and install the runtime
+        run: |
+          flatpak remote-add --user --if-not-exists flathub \
+            https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub org.gnome.Platform//50 org.gnome.Sdk//50
+
+      - name: Build
+        run: |
+          flatpak-builder --user --force-clean --disable-rofiles-fuse \
+            --repo=staged-repo --default-branch=stable \
+            build-dir player/flatpak/dev.mydia.player.yml
+
+      - name: Install and smoke test
+        run: |
+          flatpak remote-add --user --no-gpg-verify --if-not-exists \
+            staged "$PWD/staged-repo"
+          flatpak install --user -y --reinstall staged dev.mydia.player
+          ./player/flatpak/smoke-test.sh stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,13 @@ jobs:
             echo "::error::devenv.nix names a version literal; read it from rust-toolchain.toml"
             FAIL=1
           fi
+          # The Flatpak build installs rustup with --default-toolchain none and
+          # lets it resolve rust-toolchain.toml, so nothing under player/flatpak
+          # may name a channel.
+          if grep -rnE -- '--default-toolchain[[:space:]]+[0-9]|^[[:space:]]*channel[[:space:]]*=' player/flatpak/; then
+            echo "::error::player/flatpak pins a Rust version; rustup resolves rust-toolchain.toml on its own"
+            FAIL=1
+          fi
           exit "$FAIL"
 
       # This task runs from devenv's mydia:ecto against a database that may have

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1400,7 +1400,7 @@ jobs:
             REMOTE="mydia"
           fi
 
-          flatpak remote-add --user --if-not-exists --from "$REPOFILE"
+          flatpak remote-add --user --if-not-exists --from "$REMOTE" "$REPOFILE"
           flatpak install --user -y "$REMOTE" dev.mydia.player
           flatpak info --user dev.mydia.player
           echo "Verified: dev.mydia.player installs from $REPOFILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ on:
         type: boolean
         default: false
       allow_missing:
-        description: "Comma-separated platforms whose failure must not block publish (android,ios,macos,windows,linux,docker)"
+        description: "Comma-separated platforms whose failure must not block publish (android,ios,macos,windows,linux,flatpak,docker)"
         required: false
         default: ''
 
@@ -938,6 +938,115 @@ jobs:
           path: ${{ env.PLAYER_PATH }}/build/linux/x64/release/bundle
           retention-days: 30
 
+  player-flatpak:
+    name: Player / Flatpak
+    needs: prepare
+    runs-on: ubuntu-latest
+    # mpv, libplacebo and libass are roughly a third of this; the Flutter
+    # build and its Rust cdylib are the rest.
+    timeout-minutes: 90
+    outputs:
+      channel: ${{ steps.channel.outputs.channel }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - name: Pick the channel
+        id: channel
+        env:
+          IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
+        run: |
+          set -euo pipefail
+          # The same flag that decides :beta against :latest for Docker.
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            echo "channel=beta" >> "$GITHUB_OUTPUT"
+          else
+            echo "channel=stable" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install flatpak-builder
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder xvfb
+
+      - name: Allow unprivileged user namespaces
+        # Ubuntu 24.04 restricts these through AppArmor, which breaks the
+        # bubblewrap sandbox flatpak-builder needs.
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Add Flathub and install the runtime
+        run: |
+          flatpak remote-add --user --if-not-exists flathub \
+            https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub \
+            org.gnome.Platform//50 org.gnome.Sdk//50 \
+            org.freedesktop.Sdk.Extension.llvm21//25.08
+
+      - name: Stamp the version
+        run: |
+          ./player/flatpak/stamp-version.sh \
+            "${{ needs.prepare.outputs.version }}" \
+            "${{ needs.prepare.outputs.version_code }}" \
+            "$(date -u +%Y-%m-%d)"
+
+      - name: Build
+        run: |
+          flatpak-builder --user --force-clean --disable-rofiles-fuse \
+            --repo=staged-repo \
+            --default-branch=${{ steps.channel.outputs.channel }} \
+            build-dir player/flatpak/dev.mydia.player.yml
+
+      - name: Install and smoke test
+        run: |
+          flatpak remote-add --user --no-gpg-verify --if-not-exists \
+            staged "$PWD/staged-repo"
+          flatpak install --user -y --reinstall staged dev.mydia.player
+          ./player/flatpak/smoke-test.sh ${{ steps.channel.outputs.channel }}
+
+      - name: Rehearse signing and install (dry run only)
+        if: inputs.dry_run
+        run: |
+          set -euo pipefail
+          # flatpak-publish is skipped on a dry run because it needs `publish`,
+          # which carries !inputs.dry_run. So the rehearsal of signing and of
+          # installing from a signed repo has to happen here, with a throwaway
+          # key. The real key never enters this job in either mode.
+          sudo apt-get install -y ostree rclone
+          GNUPGHOME="$(mktemp -d)"
+          export GNUPGHOME
+          # --pinentry-mode loopback is required even for an unprotected key,
+          # or gpg-agent fails with "No pinentry" on a headless runner.
+          gpg --batch --pinentry-mode loopback --passphrase '' \
+            --quick-generate-key "Dry Run <dryrun@mydia.dev>" rsa2048 sign never
+          KEYID=$(gpg --list-keys --with-colons dryrun@mydia.dev | awk -F: '/^fpr:/ {print $10; exit}')
+
+          # The destination is a local directory, which rclone treats like any
+          # other backend. Nothing leaves the runner.
+          GPG_KEY_ID="$KEYID" LIVE_REPO_DIR="$PWD/dryrun-live" \
+            ./player/flatpak/publish.sh \
+              "${{ steps.channel.outputs.channel }}" \
+              "$PWD/staged-repo" "$PWD/dryrun-dest"
+
+          # Replace the unsigned staged install with one that came through the
+          # real signing and publishing path.
+          flatpak uninstall --user -y dev.mydia.player
+          flatpak remote-add --user --no-gpg-verify --if-not-exists \
+            dryrun "$PWD/dryrun-dest"
+          flatpak install --user -y dryrun dev.mydia.player
+          ./player/flatpak/smoke-test.sh ${{ steps.channel.outputs.channel }}
+          echo "Dry run rehearsal complete. Nothing was uploaded."
+
+      - name: Upload staged repo
+        uses: actions/upload-artifact@v4
+        with:
+          # Deliberately not named mydia-player-*: the publish job downloads
+          # that pattern and has no use for a multi-hundred-megabyte repo.
+          name: flatpak-repo-staged
+          path: staged-repo
+          retention-days: 30
+
   publish:
     name: Publish Release
     # always() so this job runs even when a platform failed, and can report
@@ -951,6 +1060,7 @@ jobs:
       - player-macos
       - player-windows
       - player-linux
+      - player-flatpak
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -965,6 +1075,7 @@ jobs:
           RESULT_MACOS: ${{ needs.player-macos.result }}
           RESULT_WINDOWS: ${{ needs.player-windows.result }}
           RESULT_LINUX: ${{ needs.player-linux.result }}
+          RESULT_FLATPAK: ${{ needs.player-flatpak.result }}
         run: |
           set -euo pipefail
 
@@ -988,7 +1099,8 @@ jobs:
             "ios:$RESULT_IOS" \
             "macos:$RESULT_MACOS" \
             "windows:$RESULT_WINDOWS" \
-            "linux:$RESULT_LINUX"; do
+            "linux:$RESULT_LINUX" \
+            "flatpak:$RESULT_FLATPAK"; do
             name="${entry%%:*}"
             result="${entry#*:}"
             [ "$result" = "success" ] && continue
@@ -1193,3 +1305,99 @@ jobs:
           uv run --project docs mike delete --push latest || true
           uv run --project docs mike deploy --push --update-aliases "$VERSION" latest
           uv run --project docs mike set-default --push latest
+
+  flatpak-publish:
+    name: Publish Flatpak
+    # Needs `publish`, which carries !inputs.dry_run, so this is skipped
+    # entirely on a rehearsal. No R2 traffic can happen during a dry run.
+    needs:
+      - prepare
+      - player-flatpak
+      - publish
+    runs-on: ubuntu-latest
+    concurrency:
+      # Syncing down, committing and syncing back up is a read-modify-write
+      # against one shared repo. The workflow's release-${version} group does
+      # not serialise two different versions against each other.
+      group: flatpak-publish-${{ needs.player-flatpak.outputs.channel }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak ostree rclone
+
+      - name: Download staged repo
+        uses: actions/download-artifact@v4
+        with:
+          name: flatpak-repo-staged
+          path: staged-repo
+
+      - name: Import the signing key
+        env:
+          FLATPAK_GPG_PRIVATE_KEY: ${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$FLATPAK_GPG_PRIVATE_KEY" ]; then
+            echo "::error::FLATPAK_GPG_PRIVATE_KEY is not set. See docs/contributing/releasing.md, 'Flatpak channels'." >&2
+            exit 1
+          fi
+          echo "$FLATPAK_GPG_PRIVATE_KEY" | base64 -d \
+            | gpg --batch --pinentry-mode loopback --import
+
+      - name: Configure rclone for R2
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.config/rclone
+          cat > ~/.config/rclone/rclone.conf <<EOF
+          [r2]
+          type = s3
+          provider = Cloudflare
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
+          acl = private
+          EOF
+
+      - name: Publish
+        env:
+          GPG_KEY_ID: ${{ secrets.FLATPAK_GPG_KEY_ID }}
+          CHANNEL: ${{ needs.player-flatpak.outputs.channel }}
+        run: |
+          ./player/flatpak/publish.sh "$CHANNEL" staged-repo "r2:mydia-flatpak/$CHANNEL"
+
+      - name: Publish the .flatpakrepo files
+        run: |
+          set -euo pipefail
+          ./player/flatpak/make-flatpakrepo.sh repofiles
+          rclone copy repofiles r2:mydia-flatpak --include '*.flatpakrepo'
+
+      - name: Verify the published repo end to end
+        env:
+          CHANNEL: ${{ needs.player-flatpak.outputs.channel }}
+        run: |
+          set -euo pipefail
+          # Detection, not prevention: the GitHub release is already published
+          # by now. A failure here means running the rollback procedure in
+          # docs/contributing/releasing.md.
+          if [ "$CHANNEL" = "beta" ]; then
+            REPOFILE="https://flatpak.mydia.dev/mydia-beta.flatpakrepo"
+            REMOTE="mydia-beta"
+          else
+            REPOFILE="https://flatpak.mydia.dev/mydia.flatpakrepo"
+            REMOTE="mydia"
+          fi
+
+          flatpak remote-add --user --if-not-exists --from "$REPOFILE"
+          flatpak install --user -y "$REMOTE" dev.mydia.player
+          flatpak info --user dev.mydia.player
+          echo "Verified: dev.mydia.player installs from $REPOFILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -969,7 +969,10 @@ jobs:
       - name: Install flatpak-builder
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder xvfb
+          # appstream provides appstreamcli, which flatpak-builder shells out to
+          # on the host during export. Without it the build fails at the very
+          # last step, after everything has already compiled.
+          sudo apt-get install -y flatpak flatpak-builder xvfb appstream
 
       - name: Allow unprivileged user namespaces
         # Ubuntu 24.04 restricts these through AppArmor, which breaks the

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,13 @@ docs/research/
 # Subagent-driven-development scratch (ledger, briefs, review packages)
 .superpowers/
 player/ios/scripts/test-ci-signing.sh
+
+# Flatpak build artifacts. Produced in the repository root by the
+# flatpak-builder and publish commands in docs/contributing/releasing.md.
+.flatpak-builder/
+build-dir/
+staged-repo/
+live-repo/
+dryrun-live/
+dryrun-dest/
+repofiles/

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -196,6 +196,83 @@ The floating tags only ever move forward. Publishing a v0.11.2 patch after
 v0.12.0 applies `0.11.2` and `0.11`, and leaves `latest` and `0` pointing at
 v0.12.0.
 
+## Flatpak channels
+
+The player publishes to two self-hosted OSTree repositories on Cloudflare R2.
+The channel comes from the draft's prerelease flag, the same flag that decides
+between the `beta` and `latest` Docker tags.
+
+| Remote | Repo file | Fed by | History kept |
+| --- | --- | --- | --- |
+| `mydia` | `https://flatpak.mydia.dev/mydia.flatpakrepo` | Published stable release | 5 commits |
+| `mydia-beta` | `https://flatpak.mydia.dev/mydia-beta.flatpakrepo` | Published prerelease | 2 commits |
+
+Both ship `dev.mydia.player`, distinguished by OSTree branch. `flatpak-publish`
+runs after `publish`, so a rehearsal never touches R2.
+
+The manifest pins `org.gnome.Platform` 50 and the `llvm21` SDK extension built
+for freedesktop 25.08. Those two move together: a newer GNOME runtime sits on a
+newer freedesktop base and needs the matching LLVM extension. The pinned
+runtime eventually goes end of life and nothing detects that automatically, so
+check it when cutting a release.
+
+Codecs come from `org.freedesktop.Platform.codecs-extra`, which the GNOME
+runtime declares itself and flatpak installs automatically. The older
+`org.freedesktop.Platform.ffmpeg-full` extension does not exist for freedesktop
+25.08 and cannot be used with this runtime.
+
+### First-time setup
+
+One-time operator actions. The release job fails without them.
+
+1. Create an R2 bucket named `mydia-flatpak`, attach `flatpak.mydia.dev` to it
+   and enable public access.
+2. Create an R2 API token with object read and write on that bucket.
+3. Generate the signing key on a trusted machine, not in CI. The
+   `--pinentry-mode loopback` flag is required even for an unprotected key, or
+   gpg fails with "No pinentry" on a headless machine:
+
+   ```bash
+   gpg --batch --pinentry-mode loopback --passphrase '' \
+     --quick-generate-key "Mydia Flatpak Signing <releases@mydia.dev>" rsa4096 sign never
+   KEYID=$(gpg --list-keys --with-colons releases@mydia.dev | awk -F: '/^fpr:/ {print $10; exit}')
+   gpg --export-secret-keys --armor "$KEYID" | base64 -w0 > flatpak-signing-key.b64
+   gpg --export --armor "$KEYID" > player/flatpak/flatpak-signing-key.pub.asc
+   echo "$KEYID"
+   ```
+
+4. Back up `flatpak-signing-key.b64` somewhere other than GitHub. See below.
+5. Add the secrets `FLATPAK_GPG_PRIVATE_KEY` (contents of the `.b64` file),
+   `FLATPAK_GPG_KEY_ID` (the fingerprint), `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`
+   and `R2_SECRET_ACCESS_KEY`.
+6. Commit `player/flatpak/flatpak-signing-key.pub.asc`. The public half is not
+   a secret, and `make-flatpakrepo.sh` embeds it in both repo files.
+
+The existing `CLOUDFLARE_API_TOKEN` is a Pages deploy token and cannot do S3
+auth against R2.
+
+### Rolling back a bad Flatpak publish
+
+Pruning keeps previous commits, so a bad publish is recoverable. From a machine
+with the signing key and R2 credentials:
+
+```bash
+rclone sync r2:mydia-flatpak/stable ./live-repo --create-empty-src-dirs
+ostree log --repo=live-repo app/dev.mydia.player/x86_64/stable
+ostree reset --repo=live-repo app/dev.mydia.player/x86_64/stable <previous-commit>
+flatpak build-update-repo --gpg-sign=$GPG_KEY_ID live-repo
+./player/flatpak/sync-repo.sh ./live-repo r2:mydia-flatpak/stable
+```
+
+Anyone who already updated moves back on their next `flatpak update`.
+
+### If the signing key is lost
+
+The public key is pinned inside every `.flatpakrepo` users added, so a lost
+private key breaks updates for every existing install. Recovery means shipping
+new repo files and asking users to re-add the remote. Keep a backup outside
+GitHub Actions.
+
 ## Release notes
 
 Notes are authored into `priv/changelog/<version>.md` and tracked in the

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -74,7 +74,7 @@ the docs deploy.
 | `version` | required | Tag of an existing draft release. Ignored when `dry_run` is set. |
 | `dry_run` | `false` | Build, sign and notarize everything without publishing, pushing images, or uploading to stores. |
 | `accept_drift` | `false` | Proceed even though master has moved past the commit the draft targets. |
-| `allow_missing` | `""` | Comma-separated platforms whose failure must not block publish: `android`, `ios`, `macos`, `windows`, `linux`, `docker`. |
+| `allow_missing` | `""` | Comma-separated platforms whose failure must not block publish: `android`, `ios`, `macos`, `windows`, `linux`, `flatpak`, `docker`. |
 
 ### Patch releases
 
@@ -236,7 +236,7 @@ One-time operator actions. The release job fails without them.
    gpg --batch --pinentry-mode loopback --passphrase '' \
      --quick-generate-key "Mydia Flatpak Signing <releases@mydia.dev>" rsa4096 sign never
    KEYID=$(gpg --list-keys --with-colons releases@mydia.dev | awk -F: '/^fpr:/ {print $10; exit}')
-   gpg --export-secret-keys --armor "$KEYID" | base64 -w0 > flatpak-signing-key.b64
+   gpg --export-secret-keys --armor "$KEYID" | base64 | tr -d '\n' > flatpak-signing-key.b64
    gpg --export --armor "$KEYID" > player/flatpak/flatpak-signing-key.pub.asc
    echo "$KEYID"
    ```

--- a/docs/using/how-to/install-player-linux.md
+++ b/docs/using/how-to/install-player-linux.md
@@ -1,0 +1,66 @@
+# Install the player on Linux
+
+Mydia Player is distributed as a Flatpak. The Flatpak bundles its own media
+stack, so nothing else needs installing.
+
+## Stable
+
+```bash
+flatpak remote-add --if-not-exists --from https://flatpak.mydia.dev/mydia.flatpakrepo
+flatpak install mydia dev.mydia.player
+flatpak run dev.mydia.player
+```
+
+Updates arrive with `flatpak update`, alongside everything else on your system.
+
+## Beta
+
+Beta tracks prereleases. It is the same application under a different remote,
+so pick one channel or the other rather than adding both.
+
+```bash
+flatpak remote-add --if-not-exists --from https://flatpak.mydia.dev/mydia-beta.flatpakrepo
+flatpak install mydia-beta dev.mydia.player
+```
+
+To move back to stable:
+
+```bash
+flatpak uninstall dev.mydia.player
+flatpak remote-delete mydia-beta
+flatpak remote-add --if-not-exists --from https://flatpak.mydia.dev/mydia.flatpakrepo
+flatpak install mydia dev.mydia.player
+```
+
+## Tarball
+
+Every release also carries `mydia-player-linux-vX.Y.Z.tar.gz` for systems
+without Flatpak. Unlike the Flatpak, it links your system libmpv, so install
+that first or the binary will not start.
+
+```bash
+# Debian and Ubuntu
+sudo apt install libmpv2
+
+# Fedora
+sudo dnf install mpv-libs
+
+# Arch
+sudo pacman -S mpv
+```
+
+Then unpack the archive and run `./mydia-player`.
+
+## Troubleshooting
+
+If the application starts and immediately exits, run it from a terminal. A
+message naming a missing shared library means you are on the tarball without
+libmpv installed, and the Flatpak is the fix.
+
+If video plays but a particular file shows a black screen, the codec extension
+may not have installed. Check for it and add it if missing:
+
+```bash
+flatpak list | grep codecs-extra
+flatpak install org.freedesktop.Platform.codecs-extra//25.08-extra
+```

--- a/docs/using/how-to/install-player-linux.md
+++ b/docs/using/how-to/install-player-linux.md
@@ -6,7 +6,7 @@ stack, so nothing else needs installing.
 ## Stable
 
 ```bash
-flatpak remote-add --if-not-exists --from https://flatpak.mydia.dev/mydia.flatpakrepo
+flatpak remote-add --if-not-exists --from mydia https://flatpak.mydia.dev/mydia.flatpakrepo
 flatpak install mydia dev.mydia.player
 flatpak run dev.mydia.player
 ```
@@ -19,7 +19,7 @@ Beta tracks prereleases. It is the same application under a different remote,
 so pick one channel or the other rather than adding both.
 
 ```bash
-flatpak remote-add --if-not-exists --from https://flatpak.mydia.dev/mydia-beta.flatpakrepo
+flatpak remote-add --if-not-exists --from mydia-beta https://flatpak.mydia.dev/mydia-beta.flatpakrepo
 flatpak install mydia-beta dev.mydia.player
 ```
 
@@ -28,7 +28,7 @@ To move back to stable:
 ```bash
 flatpak uninstall dev.mydia.player
 flatpak remote-delete mydia-beta
-flatpak remote-add --if-not-exists --from https://flatpak.mydia.dev/mydia.flatpakrepo
+flatpak remote-add --if-not-exists --from mydia https://flatpak.mydia.dev/mydia.flatpakrepo
 flatpak install mydia dev.mydia.player
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
           - using/how-to/update-mydia.md
           - using/how-to/monitor-and-logs.md
           - using/how-to/nixos.md
+          - using/how-to/install-player-linux.md
           - using/how-to/remote-access.md
       - Reference:
           - using/reference/index.md

--- a/player/flatpak/build.sh
+++ b/player/flatpak/build.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Runs inside the flatpak-builder sandbox as the mydia-player module's only
+# build command, with the repository root as the working directory.
+#
+# Reads the Flutter version from player/.fvmrc and lets rustup resolve
+# rust-toolchain.toml. Neither version is named here; see the Flutter and Rust
+# pin guards in ci-nix.yml and ci.yml, which scan this directory.
+set -euo pipefail
+
+BUILD_HOME="${PWD}/.flatpak-build-home"
+mkdir -p "$BUILD_HOME"
+export HOME="$BUILD_HOME"
+export PUB_CACHE="$BUILD_HOME/.pub-cache"
+
+# --- Flutter -----------------------------------------------------------------
+FLUTTER_VERSION="$(python3 -c 'import json;print(json.load(open("player/.fvmrc"))["flutter"])')"
+FLUTTER_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+
+echo "Fetching Flutter ${FLUTTER_VERSION}"
+curl -fsSL "$FLUTTER_URL" -o "$BUILD_HOME/flutter.tar.xz"
+tar -xf "$BUILD_HOME/flutter.tar.xz" -C "$BUILD_HOME"
+export PATH="$BUILD_HOME/flutter/bin:$PATH"
+
+# The tarball ships a git repo whose ownership will not match the build user;
+# without this every flutter invocation aborts on "dubious ownership".
+git config --global --add safe.directory "$BUILD_HOME/flutter"
+
+flutter config --no-analytics --no-cli-animations
+flutter --version
+
+# --- Rust --------------------------------------------------------------------
+# rustup reads rust-toolchain.toml at the repository root on first use, so the
+# pinned channel installs itself with no version named here.
+echo "Installing Rust from rust-toolchain.toml"
+curl -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none
+export PATH="$BUILD_HOME/.cargo/bin:$PATH"
+rustup show
+
+# --- Build -------------------------------------------------------------------
+cd player
+flutter pub get
+flutter pub run build_runner build --delete-conflicting-outputs
+flutter build linux --release
+cd ..
+
+# --- Install -----------------------------------------------------------------
+BUNDLE="player/build/linux/x64/release/bundle"
+install -d /app/lib/mydia-player
+cp -r "$BUNDLE"/. /app/lib/mydia-player/
+chmod +x /app/lib/mydia-player/mydia-player
+
+# $ORIGIN in the runner's RPATH resolves through the symlink to the real
+# directory, so the bundled libflutter_linux_gtk.so is still found.
+install -d /app/bin
+ln -sf ../lib/mydia-player/mydia-player /app/bin/mydia-player
+
+install -Dm644 player/flatpak/dev.mydia.player.desktop \
+  /app/share/applications/dev.mydia.player.desktop
+install -Dm644 player/flatpak/dev.mydia.player.metainfo.xml \
+  /app/share/metainfo/dev.mydia.player.metainfo.xml
+
+# Icons come from the existing player assets rather than a second copy checked
+# into player/flatpak/, which would only drift.
+install -Dm644 player/assets/icon.svg \
+  /app/share/icons/hicolor/scalable/apps/dev.mydia.player.svg
+for size in 64 128 256; do
+  install -d "/app/share/icons/hicolor/${size}x${size}/apps"
+  rsvg-convert -w "$size" -h "$size" player/assets/icon.svg \
+    -o "/app/share/icons/hicolor/${size}x${size}/apps/dev.mydia.player.png"
+done
+
+echo "Installed mydia-player into /app"

--- a/player/flatpak/build.sh
+++ b/player/flatpak/build.sh
@@ -59,10 +59,16 @@ install -Dm644 player/flatpak/dev.mydia.player.desktop \
 install -Dm644 player/flatpak/dev.mydia.player.metainfo.xml \
   /app/share/metainfo/dev.mydia.player.metainfo.xml
 
-# Icons come from the existing player assets rather than a second copy checked
-# into player/flatpak/, which would only drift.
-install -Dm644 player/assets/icon.svg \
-  /app/share/icons/hicolor/scalable/apps/dev.mydia.player.svg
+# Icons are rasterised from the existing player asset rather than a second copy
+# checked into player/flatpak/, which would only drift.
+#
+# Deliberately PNG only. Installing the SVG as a scalable hicolor icon makes
+# flatpak-builder's `appstreamcli compose` step fail the whole build with
+# "Unrecognized image file format", because appstreamcli reads icons through
+# gdk-pixbuf and its SVG loader is not present on every host. The AppStream
+# catalog stores rasterised PNGs regardless, and desktop environments are happy
+# with the hicolor sizes below, so the SVG buys nothing and costs a
+# host-dependent build failure.
 for size in 64 128 256; do
   install -d "/app/share/icons/hicolor/${size}x${size}/apps"
   rsvg-convert -w "$size" -h "$size" player/assets/icon.svg \

--- a/player/flatpak/dev.mydia.player.desktop
+++ b/player/flatpak/dev.mydia.player.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=Mydia Player
+GenericName=Media Player
+Comment=Watch the TV shows and movies on your Mydia server
+Exec=mydia-player
+Icon=dev.mydia.player
+Terminal=false
+Categories=AudioVideo;Video;Player;
+Keywords=media;video;streaming;movies;tv;mydia;
+StartupNotify=true
+StartupWMClass=mydia-player

--- a/player/flatpak/dev.mydia.player.metainfo.xml
+++ b/player/flatpak/dev.mydia.player.metainfo.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>dev.mydia.player</id>
+
+  <name>Mydia Player</name>
+  <summary>Watch the TV shows and movies on your Mydia server</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0-or-later</project_license>
+
+  <developer id="dev.mydia">
+    <name>Mydia</name>
+  </developer>
+
+  <description>
+    <p>
+      Mydia Player is the desktop client for Mydia, a self-hosted media manager
+      for TV shows and movies. Point it at your own Mydia server and stream your
+      library, either over the local network or remotely through an encrypted
+      peer-to-peer connection.
+    </p>
+    <p>What it does:</p>
+    <ul>
+      <li>Streams the TV shows and movies from a Mydia server you run yourself</li>
+      <li>Reaches that server remotely over an encrypted peer-to-peer connection, with no port forwarding</li>
+      <li>Keeps watch progress in sync with every other device signed in to the same server</li>
+      <li>Bundles its own media stack, so no codec packages need installing</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">dev.mydia.player.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://mydia.dev/img/player-1.png</image>
+      <caption>Browsing a library</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://mydia.dev/img/player-2.png</image>
+      <caption>Playing an episode</caption>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://mydia.dev</url>
+  <url type="bugtracker">https://github.com/getmydia/mydia/issues</url>
+  <url type="help">https://docs.mydia.dev</url>
+  <url type="vcs-browser">https://github.com/getmydia/mydia</url>
+
+  <content_rating type="oars-1.1"/>
+
+  <releases>
+    <release version="0.0.0" date="2026-08-04"/>
+  </releases>
+</component>

--- a/player/flatpak/dev.mydia.player.yml
+++ b/player/flatpak/dev.mydia.player.yml
@@ -60,6 +60,12 @@ modules:
   - name: libplacebo
     buildsystem: meson
     config-opts:
+      # --libdir=lib is not cosmetic. Meson's default libdir is environment
+      # dependent: it resolved to lib locally but to lib64 on the CI runner,
+      # which put libplacebo.pc outside PKG_CONFIG_PATH and made the mpv
+      # module fail with 'Dependency "libplacebo" not found'. Pin it so both
+      # agree.
+      - --libdir=lib
       - -Dvulkan=enabled
       - -Dopengl=enabled
       - -Ddemos=false
@@ -72,6 +78,10 @@ modules:
   - name: mpv
     buildsystem: meson
     config-opts:
+      # Same reason as libplacebo: media_kit dlopens libmpv.so.2 through
+      # LD_LIBRARY_PATH=/app/lib, so an environment-dependent lib64 would
+      # leave it unfindable at runtime rather than at build time.
+      - --libdir=lib
       # libmpv only. media_kit dlopens libmpv.so.2 and never runs the player
       # binary, so building cplayer would be dead weight in the image.
       - -Dlibmpv=true

--- a/player/flatpak/dev.mydia.player.yml
+++ b/player/flatpak/dev.mydia.player.yml
@@ -23,6 +23,14 @@ runtime-version: '50'
 sdk: org.gnome.Sdk
 command: mydia-player
 
+# Flutter's Linux desktop build hardcodes CC=clang and CXX=clang++, and the
+# GNOME SDK ships gcc only. Without this the build dies in CMake with
+# "Could not find the compiler specified in the environment variable CXX".
+# llvm21 is the LLVM extension built for freedesktop 25.08, which is the base
+# GNOME 50 sits on; it is a build-time dependency and ships nothing in the app.
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.llvm21
+
 finish-args:
   # Talks to the Mydia server over HTTP and to p2p peers over QUIC/UDP.
   - --share=network
@@ -79,6 +87,9 @@ modules:
   - name: mydia-player
     buildsystem: simple
     build-options:
+      # Puts the llvm21 extension's clang on PATH ahead of the SDK's gcc.
+      append-path: /usr/lib/sdk/llvm21/bin
+      prepend-ld-library-path: /usr/lib/sdk/llvm21/lib
       # Not hermetic, and deliberately so. flutter pub get, cargokit's crate
       # fetches and Flutter's own SDK download all need the network. Making
       # this build offline would mean vendoring all three, which is only

--- a/player/flatpak/dev.mydia.player.yml
+++ b/player/flatpak/dev.mydia.player.yml
@@ -1,0 +1,103 @@
+# Mydia Player Flatpak.
+#
+# Built on the GNOME runtime because player/linux/CMakeLists.txt requires
+# gtk+-3.0, which the freedesktop runtime does not carry.
+#
+# libass, libplacebo and mpv are built here because media_kit links a system
+# libmpv rather than bundling one. That is also the bug this package fixes: the
+# tarball release fails at load time for anyone without libmpv installed.
+#
+# Codecs come from org.freedesktop.Platform.codecs-extra, which the GNOME
+# runtime declares as its own extension (directory lib/x86_64-linux-gnu/
+# codecs-extra, version 25.08-extra, add-ld-path lib) and flatpak installs
+# automatically. Nothing is declared here for it. Note the older
+# org.freedesktop.Platform.ffmpeg-full extension does NOT exist for freedesktop
+# 25.08 and cannot be used with this runtime.
+#
+# This manifest deliberately names no Flutter or Rust version. build.sh reads
+# both from player/.fvmrc and rust-toolchain.toml, which the CI pin guards
+# require.
+app-id: dev.mydia.player
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: mydia-player
+
+finish-args:
+  # Talks to the Mydia server over HTTP and to p2p peers over QUIC/UDP.
+  - --share=network
+  # Required alongside fallback X11.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  # Hardware video decode.
+  - --device=dri
+  # Stop the screen blanking during playback.
+  - --talk-name=org.freedesktop.ScreenSaver
+  # The Flutter bundle and mpv both live under /app/lib.
+  - --env=LD_LIBRARY_PATH=/app/lib
+  # No --filesystem: the player streams from a server and reads no local media.
+
+modules:
+  - name: libass
+    config-opts:
+      - --disable-static
+    sources:
+      - type: git
+        url: https://github.com/libass/libass.git
+        tag: '0.17.5'
+        commit: 64ebcac709d949e6059bdacf5356c3af7848e8e5
+
+  - name: libplacebo
+    buildsystem: meson
+    config-opts:
+      - -Dvulkan=enabled
+      - -Dopengl=enabled
+      - -Ddemos=false
+    sources:
+      - type: git
+        url: https://code.videolan.org/videolan/libplacebo.git
+        tag: v7.360.1
+        commit: 719cc95244a1f1d648dd72459822e026e6530f22
+
+  - name: mpv
+    buildsystem: meson
+    config-opts:
+      # libmpv only. media_kit dlopens libmpv.so.2 and never runs the player
+      # binary, so building cplayer would be dead weight in the image.
+      - -Dlibmpv=true
+      - -Dcplayer=false
+      - -Dmanpage-build=disabled
+      - -Dlua=disabled
+    sources:
+      - type: git
+        url: https://github.com/mpv-player/mpv.git
+        tag: v0.41.0
+        commit: 2c219aa822df18a1b7fd9abe3e151cd93ad67307
+
+  - name: mydia-player
+    buildsystem: simple
+    build-options:
+      # Not hermetic, and deliberately so. flutter pub get, cargokit's crate
+      # fetches and Flutter's own SDK download all need the network. Making
+      # this build offline would mean vendoring all three, which is only
+      # required for Flathub, and Flathub is out of scope.
+      build-args:
+        - --share=network
+    build-commands:
+      - bash player/flatpak/build.sh
+    sources:
+      - type: dir
+        path: ../..
+        skip:
+          - .git
+          - .claude
+          - _build
+          - deps
+          - node_modules
+          - docs/.venv
+          - player/build
+          - site/dist
+          - site/node_modules
+          - target

--- a/player/flatpak/make-flatpakrepo.sh
+++ b/player/flatpak/make-flatpakrepo.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Generates the two .flatpakrepo files users add as remotes. The embedded
+# GPGKey is the base64 of the DER public key, which is what flatpak expects.
+#
+# The public key is an operator artifact, generated alongside the private key
+# and committed to this directory. It is deliberately not in the repository
+# until that has happened, so this script fails loudly rather than signing
+# nothing. FLATPAK_PUBKEY overrides the path, which is how the test drives it
+# with a throwaway key.
+#
+# Usage: player/flatpak/make-flatpakrepo.sh <output-dir>
+set -euo pipefail
+
+OUT="${1:?output directory required}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUBKEY="${FLATPAK_PUBKEY:-$HERE/flatpak-signing-key.pub.asc}"
+
+if [ ! -f "$PUBKEY" ]; then
+  echo "::error::missing $PUBKEY" >&2
+  echo "Generate the signing key and commit its public half, as described in" >&2
+  echo "docs/contributing/releasing.md under 'Flatpak channels'." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT"
+KEY_B64="$(gpg --dearmor < "$PUBKEY" | base64 -w0)"
+
+write_repo() {
+  local file="$1" title="$2" url="$3" comment="$4"
+  cat > "$OUT/$file" <<EOF
+[Flatpak Repo]
+Title=$title
+Url=$url
+Homepage=https://mydia.dev
+Comment=$comment
+Description=$comment
+Icon=https://mydia.dev/img/logo.svg
+GPGKey=$KEY_B64
+EOF
+  echo "wrote $OUT/$file"
+}
+
+write_repo mydia.flatpakrepo \
+  "Mydia" \
+  "https://flatpak.mydia.dev/stable/" \
+  "Mydia Player, stable releases"
+
+write_repo mydia-beta.flatpakrepo \
+  "Mydia Beta" \
+  "https://flatpak.mydia.dev/beta/" \
+  "Mydia Player, prerelease builds"

--- a/player/flatpak/make-flatpakrepo.sh
+++ b/player/flatpak/make-flatpakrepo.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Generates the two .flatpakrepo files users add as remotes. The embedded
-# GPGKey is the base64 of the DER public key, which is what flatpak expects.
+# GPGKey is the base64 of the binary OpenPGP keyring that `gpg --dearmor`
+# produces, which is the form flatpak expects.
 #
 # The public key is an operator artifact, generated alongside the private key
 # and committed to this directory. It is deliberately not in the repository
@@ -23,7 +24,9 @@ if [ ! -f "$PUBKEY" ]; then
 fi
 
 mkdir -p "$OUT"
-KEY_B64="$(gpg --dearmor < "$PUBKEY" | base64 -w0)"
+# base64 -w0 is GNU-only and fails on macOS/BSD, where operators may run
+# this. `tr -d` strips the wrapping portably.
+KEY_B64="$(gpg --dearmor < "$PUBKEY" | base64 | tr -d '\n')"
 
 write_repo() {
   local file="$1" title="$2" url="$3" comment="$4"

--- a/player/flatpak/publish.sh
+++ b/player/flatpak/publish.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Publishes a staged Flatpak build into a live channel repo.
+#
+# Reads the live repo down, commits the staged build into it, signs, prunes,
+# regenerates the summary, then uploads with sync-repo.sh.
+#
+# Usage: player/flatpak/publish.sh <channel> <staged-repo> <rclone-dest>
+# Requires: GPG_KEY_ID in the environment.
+set -euo pipefail
+
+CHANNEL="${1:?channel required (stable or beta)}"
+STAGED="${2:?staged repo path required}"
+DEST="${3:?rclone destination required}"
+: "${GPG_KEY_ID:?GPG_KEY_ID must be set}"
+
+case "$CHANNEL" in
+  stable) PRUNE_DEPTH=5 ;;
+  beta)   PRUNE_DEPTH=2 ;;
+  *) echo "::error::unknown channel '$CHANNEL', expected stable or beta" >&2; exit 1 ;;
+esac
+
+LIVE="${LIVE_REPO_DIR:-./live-repo}"
+
+echo "publish: syncing $DEST down to $LIVE"
+mkdir -p "$LIVE"
+rclone sync "$DEST" "$LIVE" --create-empty-src-dirs \
+  --transfers 32 --checkers 32 --retries 5
+
+# Idempotent, and it recreates the refs/ skeleton if object storage ever lost
+# an empty directory. Safe on an existing repo: ostree init leaves the config
+# and objects alone.
+ostree init --repo="$LIVE" --mode=archive
+
+echo "publish: committing the staged build into $LIVE"
+flatpak build-commit-from \
+  --src-repo="$STAGED" \
+  --gpg-sign="$GPG_KEY_ID" \
+  "$LIVE"
+
+echo "publish: updating summary, generating deltas, pruning to depth $PRUNE_DEPTH"
+flatpak build-update-repo \
+  --generate-static-deltas \
+  --prune --prune-depth="$PRUNE_DEPTH" \
+  --gpg-sign="$GPG_KEY_ID" \
+  "$LIVE"
+
+echo "publish: refs now in $LIVE"
+ostree refs --repo="$LIVE"
+
+"$(dirname "${BASH_SOURCE[0]}")/sync-repo.sh" "$LIVE" "$DEST"
+
+echo "publish: $CHANNEL published to $DEST"

--- a/player/flatpak/smoke-test.sh
+++ b/player/flatpak/smoke-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Launches the installed Flatpak under Xvfb and asserts it survives ten
+# seconds, then exits cleanly on SIGTERM. Catches a missing or unresolvable
+# shared library, libmpv above all, which is the failure this package exists
+# to remove.
+#
+# Usage: player/flatpak/smoke-test.sh <branch>
+set -euo pipefail
+
+BRANCH="${1:?branch required (stable or beta)}"
+LOG="$(mktemp)"
+
+echo "Launching dev.mydia.player//${BRANCH} under Xvfb"
+xvfb-run -a --server-args="-screen 0 1280x800x24" \
+  flatpak run --branch="$BRANCH" dev.mydia.player >"$LOG" 2>&1 &
+WRAPPER_PID=$!
+
+sleep 10
+
+# If the app dies, xvfb-run exits too, so the wrapper's liveness is a valid
+# proxy for the app's.
+if ! kill -0 "$WRAPPER_PID" 2>/dev/null; then
+  echo "::error::Player exited within 10 seconds. Output follows:"
+  cat "$LOG"
+  exit 1
+fi
+
+echo "Still running after 10s. Last output:"
+tail -n 20 "$LOG"
+
+kill -TERM "$WRAPPER_PID" 2>/dev/null || true
+wait "$WRAPPER_PID" 2>/dev/null || true
+
+# A dynamic-linker failure prints to stderr before dying, so a clean run must
+# not mention one even if the process happened to survive the ten seconds.
+if grep -qiE 'error while loading shared libraries|cannot open shared object' "$LOG"; then
+  echo "::error::Dynamic linker error in output:"
+  cat "$LOG"
+  exit 1
+fi
+
+echo "PASS: smoke test clean"

--- a/player/flatpak/stamp-version.sh
+++ b/player/flatpak/stamp-version.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Stamps a release version into the two files the Flatpak build reads it from.
+# Run from the repository root, on the host, before flatpak-builder copies the
+# tree into the sandbox.
+#
+# Usage: player/flatpak/stamp-version.sh <version> <version_code> <iso_date>
+set -euo pipefail
+
+VERSION="${1:?version required (e.g. 1.2.3)}"
+VERSION_CODE="${2:?version_code required (e.g. 10042)}"
+DATE="${3:?ISO date required (e.g. 2026-08-04)}"
+
+METAINFO="player/flatpak/dev.mydia.player.metainfo.xml"
+
+# Same rewrite the player-linux job in release.yml already performs.
+sed -i "s/^version: .*/version: ${VERSION}+${VERSION_CODE}/" player/pubspec.yaml
+
+# Replace the whole <releases> block rather than appending, so repeated runs
+# are idempotent and the committed 0.0.0 placeholder never ships.
+python3 - "$METAINFO" "$VERSION" "$DATE" <<'PY'
+import re
+import sys
+
+path, version, date = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, encoding="utf-8") as fh:
+    xml = fh.read()
+
+block = f'  <releases>\n    <release version="{version}" date="{date}"/>\n  </releases>'
+xml, count = re.subn(r"  <releases>.*?</releases>", block, xml, flags=re.DOTALL)
+if count != 1:
+    sys.exit(f"expected exactly one <releases> block in {path}, replaced {count}")
+
+with open(path, "w", encoding="utf-8") as fh:
+    fh.write(xml)
+PY
+
+echo "Stamped ${VERSION}+${VERSION_CODE} (${DATE})"

--- a/player/flatpak/sync-repo.sh
+++ b/player/flatpak/sync-repo.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Uploads an OSTree repo to an rclone destination in three ordered passes.
+#
+# The ordering is the whole point. A client reads the summary first and then
+# fetches what it names, so the summary must never arrive before the objects it
+# references, and pruned objects must not vanish before the summary that
+# stopped referencing them.
+#
+#   pass 1  objects and deltas, additive only
+#   pass 2  refs, summary, summary signature
+#   pass 3  delete whatever pruning removed
+#
+# --create-empty-src-dirs is not optional. `ostree init` creates an empty
+# refs/heads, refs/mirrors and refs/remotes skeleton, and rclone skips empty
+# directories by default. Without the flag the destination fails `ostree fsck`
+# with opendir(refs/remotes), and pass 3 would delete any skeleton that pass 1
+# did manage to create. That matters because publish.sh syncs this destination
+# back down and runs ostree against it.
+#
+# Usage: player/flatpak/sync-repo.sh <local-repo> <rclone-dest>
+set -euo pipefail
+
+SRC="${1:?local repo path required}"
+DEST="${2:?rclone destination required}"
+
+[ -f "$SRC/config" ] || { echo "::error::$SRC is not an ostree repo" >&2; exit 1; }
+
+echo "sync-repo: pass 1, objects and deltas -> $DEST"
+rclone copy "$SRC" "$DEST" \
+  --exclude '/summary' --exclude '/summary.sig' --exclude '/refs/**' \
+  --create-empty-src-dirs \
+  --transfers 32 --checkers 32 --retries 5
+
+echo "sync-repo: pass 2, refs and summary -> $DEST"
+rclone copy "$SRC" "$DEST" \
+  --include '/summary' --include '/summary.sig' --include '/refs/**' \
+  --create-empty-src-dirs \
+  --transfers 8 --checkers 8 --retries 5
+
+echo "sync-repo: pass 3, delete pruned objects at $DEST"
+rclone sync "$SRC" "$DEST" \
+  --create-empty-src-dirs \
+  --transfers 32 --checkers 32 --retries 5
+
+echo "sync-repo: done"

--- a/player/flatpak/test/make-flatpakrepo-test.sh
+++ b/player/flatpak/test/make-flatpakrepo-test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Verifies make-flatpakrepo.sh emits files flatpak actually accepts, not merely
+# files with the right-looking keys in them. Uses a throwaway GPG key and a
+# throwaway flatpak installation, so it touches neither the repository nor the
+# developer's real remotes.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+export GNUPGHOME="$WORK/gnupg"
+mkdir -p "$GNUPGHOME"
+chmod 700 "$GNUPGHOME"
+
+# --pinentry-mode loopback is required even for an unprotected key: without it
+# gpg-agent still reaches for pinentry and fails with "No pinentry" on any
+# headless machine, CI included.
+gpg --batch --pinentry-mode loopback --passphrase '' \
+    --quick-generate-key "Throwaway <throwaway@mydia.dev>" rsa2048 sign never >/dev/null 2>&1
+gpg --export --armor throwaway@mydia.dev > "$WORK/pub.asc"
+[ -s "$WORK/pub.asc" ] || { echo "FAIL: throwaway key generation produced no public key"; exit 1; }
+
+FLATPAK_PUBKEY="$WORK/pub.asc" "$REPO_ROOT/player/flatpak/make-flatpakrepo.sh" "$WORK/out"
+
+for f in mydia.flatpakrepo mydia-beta.flatpakrepo; do
+  [ -f "$WORK/out/$f" ] || { echo "FAIL: $f not generated"; exit 1; }
+  grep -q '^\[Flatpak Repo\]$' "$WORK/out/$f" || { echo "FAIL: $f missing section header"; exit 1; }
+  grep -q '^GPGKey=' "$WORK/out/$f" || { echo "FAIL: $f missing GPGKey"; exit 1; }
+done
+
+grep -q '^Url=https://flatpak.mydia.dev/stable/$' "$WORK/out/mydia.flatpakrepo" \
+  || { echo "FAIL: stable Url wrong"; exit 1; }
+grep -q '^Url=https://flatpak.mydia.dev/beta/$' "$WORK/out/mydia-beta.flatpakrepo" \
+  || { echo "FAIL: beta Url wrong"; exit 1; }
+
+# The GPGKey must be base64 of a binary keyring that gpg can read back. A
+# mangled key would still look fine to grep but break every client update.
+grep '^GPGKey=' "$WORK/out/mydia.flatpakrepo" | cut -d= -f2- | base64 -d > "$WORK/roundtrip.gpg"
+gpg --show-keys "$WORK/roundtrip.gpg" 2>/dev/null | grep -q 'throwaway@mydia.dev' \
+  || { echo "FAIL: embedded GPGKey does not decode back to the signing key"; exit 1; }
+
+# flatpak itself must accept the file. --no-gpg-verify is NOT passed, so this
+# exercises the key parsing path specifically.
+export FLATPAK_USER_DIR="$WORK/flatpak"
+mkdir -p "$FLATPAK_USER_DIR"
+if ! flatpak remote-add --user --from mydia-test "$WORK/out/mydia.flatpakrepo" 2>"$WORK/err"; then
+  echo "FAIL: flatpak rejected the generated .flatpakrepo"
+  cat "$WORK/err"
+  exit 1
+fi
+
+flatpak remotes --user --columns=name | grep -qx mydia-test \
+  || { echo "FAIL: remote was not registered"; exit 1; }
+
+echo "PASS"

--- a/player/flatpak/test/make-flatpakrepo-test.sh
+++ b/player/flatpak/test/make-flatpakrepo-test.sh
@@ -53,4 +53,29 @@ fi
 flatpak remotes --user --columns=name | grep -qx mydia-test \
   || { echo "FAIL: remote was not registered"; exit 1; }
 
+# `flatpak remote-add --from URL` without a remote name fails with
+# "LOCATION must be specified". The form is `--from NAME LOCATION`. This test
+# used the correct form above and so did not catch the docs and workflow using
+# the broken one, which would have failed for every user and on every publish.
+# Guard the call sites directly.
+bad=$(grep -rn -- '--from https\?://' \
+        "$REPO_ROOT/docs/using" \
+        "$REPO_ROOT/docs/contributing" \
+        "$REPO_ROOT/site/src" \
+        "$REPO_ROOT/.github/workflows" 2>/dev/null || true)
+if [ -n "$bad" ]; then
+  echo "FAIL: 'flatpak remote-add --from' is missing its remote name:"
+  echo "$bad"
+  exit 1
+fi
+
+# shellcheck disable=SC2016  # matching the literal text "$REPOFILE" in the
+# workflow source, so expansion is exactly what must not happen.
+bad=$(grep -rnF -- '--from "$REPOFILE"' "$REPO_ROOT/.github/workflows" 2>/dev/null || true)
+if [ -n "$bad" ]; then
+  echo "FAIL: workflow passes a repo file to --from with no remote name:"
+  echo "$bad"
+  exit 1
+fi
+
 echo "PASS"

--- a/player/flatpak/test/stamp-version-test.sh
+++ b/player/flatpak/test/stamp-version-test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Verifies stamp-version.sh rewrites both the pubspec version and the
+# metainfo release entry, operating on a throwaway copy of the tree.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/player/flatpak"
+cp "$REPO_ROOT/player/pubspec.yaml" "$WORK/player/pubspec.yaml"
+cp "$REPO_ROOT/player/flatpak/dev.mydia.player.metainfo.xml" \
+   "$WORK/player/flatpak/dev.mydia.player.metainfo.xml"
+
+(cd "$WORK" && "$REPO_ROOT/player/flatpak/stamp-version.sh" 1.2.3 10042 2026-08-04)
+
+grep -q '^version: 1\.2\.3+10042$' "$WORK/player/pubspec.yaml" \
+  || { echo "FAIL: pubspec version not stamped"; exit 1; }
+
+grep -q '<release version="1.2.3" date="2026-08-04"/>' \
+     "$WORK/player/flatpak/dev.mydia.player.metainfo.xml" \
+  || { echo "FAIL: metainfo release not stamped"; exit 1; }
+
+# The committed placeholder must be gone, not merely joined by a second entry.
+# Note this is `! grep -q`, not `grep -qv`: the latter passes whenever any
+# single line fails to match, which is true of almost every file.
+if grep -q '0\.0\.0' "$WORK/player/flatpak/dev.mydia.player.metainfo.xml"; then
+  echo "FAIL: placeholder 0.0.0 release still present"
+  exit 1
+fi
+
+# Running twice must be idempotent, so a re-run of a release job cannot stack
+# release entries.
+(cd "$WORK" && "$REPO_ROOT/player/flatpak/stamp-version.sh" 1.2.3 10042 2026-08-04)
+count=$(grep -c '<release ' "$WORK/player/flatpak/dev.mydia.player.metainfo.xml")
+[ "$count" -eq 1 ] || { echo "FAIL: expected 1 release entry, got $count"; exit 1; }
+
+echo "PASS"

--- a/player/flatpak/test/sync-repo-ordering-test.sh
+++ b/player/flatpak/test/sync-repo-ordering-test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Proves sync-repo.sh uploads in an order that never exposes a summary
+# referencing absent objects. Uses a plain ostree repo and rclone's local
+# backend, so it needs no runtimes, no network and no flatpak.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+SRC="$WORK/src"
+DEST="$WORK/dest"
+mkdir -p "$SRC" "$DEST" "$WORK/content"
+
+ostree init --repo="$SRC" --mode=archive
+echo "version one" > "$WORK/content/file.txt"
+ostree commit --repo="$SRC" --branch=test --tree=dir="$WORK/content" >/dev/null
+ostree summary --repo="$SRC" --update
+
+# Pass ordering is observable through the trace the script prints.
+TRACE="$("$REPO_ROOT/player/flatpak/sync-repo.sh" "$SRC" "$DEST" 2>&1)"
+echo "$TRACE"
+
+objects_line=$(echo "$TRACE" | grep -n 'pass 1' | cut -d: -f1)
+summary_line=$(echo "$TRACE" | grep -n 'pass 2' | cut -d: -f1)
+delete_line=$(echo "$TRACE" | grep -n 'pass 3' | cut -d: -f1)
+
+[ -n "$objects_line" ] && [ -n "$summary_line" ] && [ -n "$delete_line" ] \
+  || { echo "FAIL: all three passes must be traced"; exit 1; }
+[ "$objects_line" -lt "$summary_line" ] \
+  || { echo "FAIL: objects must upload before the summary"; exit 1; }
+[ "$summary_line" -lt "$delete_line" ] \
+  || { echo "FAIL: summary must upload before deletions"; exit 1; }
+
+# The destination must be a repo a client can actually resolve.
+ostree summary --repo="$DEST" --view >/dev/null \
+  || { echo "FAIL: destination summary is not readable"; exit 1; }
+ostree fsck --repo="$DEST" >/dev/null \
+  || { echo "FAIL: destination repo failed fsck"; exit 1; }
+ostree refs --repo="$DEST" | grep -qx test \
+  || { echo "FAIL: destination is missing the test ref"; exit 1; }
+
+# A second commit must leave the destination consistent, not orphan the first.
+echo "version two" > "$WORK/content/file.txt"
+ostree commit --repo="$SRC" --branch=test --tree=dir="$WORK/content" >/dev/null
+ostree summary --repo="$SRC" --update
+"$REPO_ROOT/player/flatpak/sync-repo.sh" "$SRC" "$DEST" >/dev/null
+ostree fsck --repo="$DEST" >/dev/null \
+  || { echo "FAIL: destination repo failed fsck after second publish"; exit 1; }
+
+# And the destination must actually carry the new content, not a stale copy.
+dest_commit=$(ostree rev-parse --repo="$DEST" test)
+src_commit=$(ostree rev-parse --repo="$SRC" test)
+[ "$dest_commit" = "$src_commit" ] \
+  || { echo "FAIL: destination ref $dest_commit != source $src_commit"; exit 1; }
+
+# Pass 3 must actually delete: plant a stray file and confirm it is removed.
+echo stale > "$DEST/stray-object-file"
+"$REPO_ROOT/player/flatpak/sync-repo.sh" "$SRC" "$DEST" >/dev/null
+[ ! -f "$DEST/stray-object-file" ] \
+  || { echo "FAIL: pass 3 did not delete a stale file"; exit 1; }
+
+echo "PASS"

--- a/site/src/components/Player.astro
+++ b/site/src/components/Player.astro
@@ -57,6 +57,17 @@ const features = [
           Download Player
         </a>
 
+        <p class="text-sm text-base-content/60 mb-8">
+          On Linux, install it with Flatpak:
+          <code class="px-2 py-1 rounded bg-base-300/50 text-base-content/80">flatpak install mydia dev.mydia.player</code>
+          <a
+            href="https://docs.mydia.dev/using/how-to/install-player-linux/"
+            class="link link-hover text-primary"
+          >
+            Setup instructions
+          </a>
+        </p>
+
         <div>
           <p class="text-xs text-base-content/40 uppercase tracking-wider font-medium mb-3">Available on</p>
           <div class="flex flex-wrap gap-2">

--- a/site/src/components/Player.astro
+++ b/site/src/components/Player.astro
@@ -57,16 +57,19 @@ const features = [
           Download Player
         </a>
 
-        <p class="text-sm text-base-content/60 mb-8">
-          On Linux, install it with Flatpak:
-          <code class="px-2 py-1 rounded bg-base-300/50 text-base-content/80">flatpak install mydia dev.mydia.player</code>
+        <div class="text-sm text-base-content/60 mb-8">
+          <p class="mb-2">On Linux, install it with Flatpak:</p>
+          <pre
+            class="px-3 py-2 rounded bg-base-300/50 text-base-content/80 text-xs overflow-x-auto"
+          ><code>flatpak remote-add --if-not-exists --from mydia https://flatpak.mydia.dev/mydia.flatpakrepo
+flatpak install mydia dev.mydia.player</code></pre>
           <a
             href="https://docs.mydia.dev/using/how-to/install-player-linux/"
             class="link link-hover text-primary"
           >
-            Setup instructions
+            Beta channel and tarball instructions
           </a>
-        </p>
+        </div>
 
         <div>
           <p class="text-xs text-base-content/40 uppercase tracking-wider font-medium mb-3">Available on</p>


### PR DESCRIPTION
Ships the Linux player as a Flatpak from two self-hosted OSTree repositories, one tracking stable releases and one tracking prereleases.

## Why

The Linux tarball links the **system** libmpv (`ci-player.yml` installs `libmpv-dev` to build it). Anyone who downloads it without libmpv already installed gets a binary that dies at load time with no useful message. It also has no channel: prereleases and stable releases produce the same asset on the same page, so beta testers download by hand and everyone else has no update path.

Docker already solves both for the server via `:beta` and `:latest`. This gives the player the same shape.

## What

| | stable | beta |
| --- | --- | --- |
| Remote | `mydia` | `mydia-beta` |
| R2 prefix | `flatpak.mydia.dev/stable` | `flatpak.mydia.dev/beta` |
| Fed by | Published release | Published prerelease |
| Prune depth | 5 | 2 |

Both ship `dev.mydia.player`, distinguished by OSTree branch, the same way flathub and flathub-beta relate. The channel comes from the draft's prerelease flag, the same flag that already decides `:beta` against `:latest`.

Built on `org.gnome.Platform` 50 with libass, libplacebo and mpv as manifest modules, so **libmpv ships inside the app** and the prerequisite disappears. The player has never had a desktop entry or AppStream metadata on any platform; both are added here, which is what makes it appear in GNOME Software and KDE Discover.

Signing is split from building so the GPG key is never present in the job that runs arbitrary build code from the dependency tree. `flatpak-publish` needs `publish`, which carries `!inputs.dry_run`, so a rehearsal cannot reach R2.

The existing `mydia-player-linux-*.tar.gz` asset stays, with docs leading on the Flatpak.

## Verified

The manifest was built end to end locally, not just written. Full build, install from the staged repo, and launch:

```
BUILD_EXIT=0  INSTALL_EXIT=0  SMOKE_EXIT=0

[MyApp] Auth ready, showing router
[AppRouter] Redirecting to /login (unauthenticated)
[P2pStatusNotifier] Initial status: peerConnectionType=P2pConnectionType.none
```

The app starts inside the sandbox with the Rust p2p core loaded and no shared-library failure. `libmpv.so.2.5.0` is present in the bundle and the ref is `app/dev.mydia.player/x86_64/stable`.

Also green: shellcheck over every script, three local test scripts, `appstreamcli validate`, `desktop-file-validate`, both toolchain pin guards, `mkdocs build --strict`, and the site build.

## Four defects the build caught

Each of these would have failed CI after 40 minutes of compiling, or shipped broken.

- **Flutter hardcodes `CC=clang`** for Linux desktop and the GNOME SDK ships gcc only. Fixed with the `llvm21` SDK extension.
- **`ffmpeg-full` does not exist for freedesktop 25.08.** GNOME 49 and 50 declare `codecs-extra` instead, which the runtime auto-installs, so the manifest declares no extension at all.
- **flatpak-builder shells out to `appstreamcli` on the host** during export. The runners need the `appstream` package or the build dies at the last step.
- **Installing the icon as a scalable SVG fails that same step** with "Unrecognized image file format", because appstreamcli reads icons through gdk-pixbuf and its SVG loader is not on every host. PNGs only now, still rasterised from the same SVG source.

Two more found by the tests themselves:

- **rclone skips empty directories**, so the `refs/` skeleton `ostree init` creates never reached the destination and the repo failed `ostree fsck` on the next sync down. `--create-empty-src-dirs` is load-bearing in `sync-repo.sh`.
- **`gpg --batch --quick-generate-key` needs `--pinentry-mode loopback`** even for an unprotected key, or it fails with "No pinentry" on any headless machine. Corrected in the operator instructions too.

## Before this can publish

`flatpak-publish` fails until an operator does the one-time setup in `docs/contributing/releasing.md` under "Flatpak channels": create the `mydia-flatpak` R2 bucket, generate the signing key, commit its public half, and add five secrets. Until then the rest of the release is unaffected, and `flatpak` can be waived by name through `allow_missing`.

The GNOME runtime pin and the LLVM extension move together and the runtime eventually goes end of life, so that is now a line in the release checklist.

## Not in scope

aarch64, a single-file `.flatpak` bundle on the release page, and Flathub submission. Flathub would require replacing the network-enabled build with a fully vendored one.
