### PR TITLE
fix(player): stop pinning playback to a file the server has deleted

### DIFF
--- a/player/lib/core/player/playback_error.dart
+++ b/player/lib/core/player/playback_error.dart
@@ -1,0 +1,36 @@
+/// Turning a media_kit failure into something a viewer can act on.
+///
+/// Extracted as a free function so it can be unit-tested without a widget
+/// tree, following the same pattern as `shouldOfferResume` in
+/// [resume_plan.dart].
+library;
+
+/// mpv's wording when a source cannot be resolved at all.
+///
+/// This is what a stream that 404s looks like from the player's side: the
+/// local p2p proxy forwards the server's status, and mpv reports only that the
+/// URL would not open. The underlying cause is almost always that the bytes
+/// are no longer where the client was told they would be — a file replaced by
+/// a quality upgrade, deleted by hand, or an HLS session that has since been
+/// reaped.
+const String _openFailure = 'failed to open';
+
+/// A viewer-facing sentence for a raw media_kit error string.
+///
+/// Falls through to the raw text for anything unrecognised. Showing an ugly
+/// mpv string is worse than showing a clean one, but it is far better than the
+/// alternative this function exists to replace, which was showing nothing at
+/// all and leaving a black screen running a timeline.
+String playbackErrorMessage(String raw) {
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) {
+    return 'Playback failed for an unknown reason.';
+  }
+
+  if (trimmed.toLowerCase().contains(_openFailure)) {
+    return 'Could not open this stream. The file may have been moved, '
+        'replaced, or deleted on the server. Try playing it again.';
+  }
+
+  return 'Playback failed: $trimmed';
+}

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -21,6 +21,7 @@ import '../../../core/playback/playback_progress_store.dart';
 import '../../../core/utils/file_utils.dart' as file_utils;
 import '../../../core/utils/web_lifecycle.dart' as web_lifecycle;
 import '../../../core/player/platform_features.dart';
+import '../../../core/player/playback_error.dart';
 import '../../../core/player/stream_timeline.dart';
 import '../../../core/cast/cast_backend.dart';
 import '../../../core/cast/cast_providers.dart';
@@ -203,6 +204,30 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// once it has probed the file, and a probe that outruns the sample used to
   /// leave the selector empty for the rest of the session.
   StreamSubscription<Tracks>? _tracksSubscription;
+
+  /// media_kit reports playback failures asynchronously, long after
+  /// [Player.open] has returned, so the try/catch around initialisation cannot
+  /// see them. Without this the failure has nowhere to go: the screen sits
+  /// there with its loading state cleared and its timeline running off the
+  /// duration the server supplied, and a stream that never delivers a byte
+  /// looks exactly like one that is merely dark.
+  StreamSubscription<String>? _errorSubscription;
+
+  /// The furthest real playback position observed so far, seeded with the
+  /// resume offset so a seek is not mistaken for progress.
+  Duration _furthestPosition = Duration.zero;
+
+  /// Whether playback has ever actually moved forward.
+  ///
+  /// This gates [_onPlaybackError], and the gate is the whole reason that
+  /// handler is safe. media_kit's error stream carries every mpv log line at
+  /// error level, which includes recoverable decoder (`vd`/`ad`) and network
+  /// (`ffmpeg tcp:`) complaints that a healthy stream shrugs off. Replacing a
+  /// playing video with an error page over one of those would be a worse bug
+  /// than the one this exists to fix. A stream that has never advanced is not
+  /// having a hiccup: it never played at all, and a black screen is all the
+  /// viewer would otherwise get.
+  bool _playbackAdvanced = false;
   bool _isLoading = true;
   String? _error;
   String? _loadingMessage;
@@ -931,6 +956,17 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     _player = player;
     _videoController = VideoController(player);
 
+    // Bound before `open` deliberately: a source that fails to resolve at all
+    // (a deleted file id, a dead HLS session) errors during the open itself,
+    // which a subscription attached afterwards would miss entirely.
+    //
+    // This is a brand new `Player`, so nothing it does has been observed yet:
+    // a previous source's progress must not vouch for this one.
+    _playbackAdvanced = false;
+    _furthestPosition = Duration.zero;
+    await _errorSubscription?.cancel();
+    _errorSubscription = player.stream.error.listen(_onPlaybackError);
+
     // Re-bound whenever `_initializePlayer` runs again for this screen: a
     // source switch, a session restart, or a fresh `PlayerScreen` state for
     // a new queue item. It is *not* re-bound by navigating to the next
@@ -970,6 +1006,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     if (plan.resumes) {
       await player.seek(plan.position);
     }
+
+    // The bar a position has to clear to count as playback. Zero on the HLS
+    // branch, which always arrives here with `ResumePlan.fromStart` because
+    // its offset went into FFmpeg's `-ss` instead, so its player-local
+    // coordinates genuinely do start at zero.
+    _furthestPosition = plan.position;
 
     // Start playback
     await player.play();
@@ -1054,6 +1096,24 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   }
 
   /// Fetch streaming candidates from the server via GraphQL.
+  ///
+  /// `networkOnly` is load-bearing. This query is keyed by *content* id, not by
+  /// file id, so its cache entry outlives the file it describes: replacing an
+  /// episode's file (a manual delete and re-download, or an automatic quality
+  /// upgrade, which supersedes the row and deletes the old one) leaves the
+  /// entry pointing at a `fileId` that no longer exists. The direct-play branch
+  /// below takes its id from this response rather than from the route, so a
+  /// cached hit sends playback to a deleted file: the server answers "media
+  /// file not found in database", no bytes arrive, and the screen stays black
+  /// while the timeline runs off the equally stale cached duration. The default
+  /// policy for a one-shot `query()` is `cacheFirst` and the store is Hive on
+  /// disk, so that state survives restarts and never self-heals.
+  ///
+  /// `cacheAndNetwork` is not the fix: on a one-shot `client.query()` it
+  /// returns the cached result and discards the network one, which is the same
+  /// defect `core/graphql/watch/query_watcher.dart` documents. Nothing is lost
+  /// by going to the network here — the offline branch returns long before this
+  /// runs, and every remaining path needs the server to serve a single byte.
   Future<Query$StreamingCandidates$streamingCandidates?>
       _fetchStreamingCandidates(
     GraphQLClient graphqlClient,
@@ -1068,6 +1128,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
             contentType: contentType,
             id: id,
           ).toJson(),
+          fetchPolicy: FetchPolicy.networkOnly,
         ),
       );
 
@@ -1414,6 +1475,15 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     final player = _player;
     if (player == null || !mounted) return;
 
+    // Strictly greater, against a mark seeded with the resume offset, so that
+    // neither a resume seek nor a position that simply stands still counts as
+    // playback. See [_playbackAdvanced].
+    final position = player.state.position;
+    if (position > _furthestPosition) {
+      _furthestPosition = position;
+      _playbackAdvanced = true;
+    }
+
     _maybeAutoSkipSegment(player);
 
     // Check if video is near completion (90%)
@@ -1434,6 +1504,31 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         _saveProgress().whenComplete(_invalidateAfterPlayback);
       }
     }
+  }
+
+  /// Surface a playback failure media_kit reported after the media opened.
+  ///
+  /// Only fatal-looking failures reach the UI: see [_playbackAdvanced] for why
+  /// an error arriving mid-playback is logged and otherwise ignored.
+  ///
+  /// Clearing [_isLoading] matters as much as setting [_error]: a failure
+  /// during `open` leaves the screen still loading, and `_buildBody` checks
+  /// the loading state first, so an error set on its own would never be
+  /// reached.
+  void _onPlaybackError(String message) {
+    debugPrint('[PlayerScreen] Playback error: $message');
+    if (!mounted) return;
+
+    if (_playbackAdvanced) {
+      // Already playing, so this is something the stream can survive. Killing
+      // the video over it would be the regression, not the fix.
+      return;
+    }
+
+    setState(() {
+      _error = playbackErrorMessage(message);
+      _isLoading = false;
+    });
   }
 
   /// Seek past a detected segment the viewer opted into skipping.
@@ -1832,6 +1927,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         _positionSubscription = null;
         await _tracksSubscription?.cancel();
         _tracksSubscription = null;
+        await _errorSubscription?.cancel();
+        _errorSubscription = null;
         _progressService?.stopSync();
         await _player?.dispose();
         _player = null;
@@ -2188,6 +2285,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     // Cancel stream subscriptions to prevent memory leaks
     _positionSubscription?.cancel();
     _tracksSubscription?.cancel();
+    _errorSubscription?.cancel();
 
     // Cancel auto-play timer
     _upNextTimer?.cancel();
@@ -2243,6 +2341,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     _positionSubscription = null;
     await _tracksSubscription?.cancel();
     _tracksSubscription = null;
+    await _errorSubscription?.cancel();
+    _errorSubscription = null;
     _progressService?.stopSync();
 
     final player = _player;

--- a/player/test/core/player/playback_error_test.dart
+++ b/player/test/core/player/playback_error_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/playback_error.dart';
+
+void main() {
+  group('playbackErrorMessage', () {
+    test('explains a source that would not open', () {
+      final message = playbackErrorMessage(
+        'Failed to open http://127.0.0.1:12345/direct/file-old/stream.',
+      );
+
+      expect(message, contains('Could not open this stream'));
+      expect(
+        message,
+        contains('replaced'),
+        reason: 'a replaced or deleted file is the common cause, and naming it '
+            'is what turns a dead end into something the viewer can act on',
+      );
+    });
+
+    test('matches regardless of how mpv cases the phrase', () {
+      expect(
+        playbackErrorMessage('FAILED TO OPEN whatever'),
+        contains('Could not open this stream'),
+      );
+    });
+
+    test('passes an unrecognised error through rather than swallowing it', () {
+      final message = playbackErrorMessage('Audio device init failed');
+
+      expect(message, contains('Audio device init failed'));
+      expect(
+        message,
+        startsWith('Playback failed'),
+        reason: 'an ugly message beats the black screen this replaces',
+      );
+    });
+
+    test('still says something when the error is empty', () {
+      expect(playbackErrorMessage('   '), isNotEmpty);
+      expect(playbackErrorMessage(''), contains('unknown reason'));
+    });
+  });
+}

--- a/player/test/presentation/screens/player/player_screen_stale_candidates_test.dart
+++ b/player/test/presentation/screens/player/player_screen_stale_candidates_test.dart
@@ -1,0 +1,171 @@
+// Regression coverage for playback pinned to a file that no longer exists.
+//
+// `StreamingCandidates` is keyed by *content* id, never by file id, so its
+// cache entry outlives the file it describes. Replace an episode's file — by
+// hand, or through an automatic quality upgrade, which writes a new
+// `media_files` row and deletes the old one — and the entry is left naming a
+// `fileId` the server has since dropped.
+//
+// That mattered because the direct-play branch takes its id from this response
+// rather than from the route, and because a one-shot `client.query()` defaults
+// to `FetchPolicy.cacheFirst` over a Hive store on disk. The result was a
+// permanent, restart-surviving black screen: the p2p direct stream answered
+// "media file not found in database", no bytes ever arrived, and the timeline
+// ran happily off the equally stale cached duration so nothing looked wrong.
+//
+// The fix is `fetchPolicy: FetchPolicy.networkOnly` on that query. This test
+// pins it by warming the cache with a stale answer and proving playback still
+// goes where the *server* says, not where the cache does.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+import 'package:player/graphql/queries/streaming_candidates.graphql.dart';
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+/// The request `_fetchStreamingCandidates` issues for the harness's movie.
+Request _candidatesRequest() => Request(
+      operation: const Operation(
+        document: documentNodeQueryStreamingCandidates,
+      ),
+      variables: Variables$Query$StreamingCandidates(
+        contentType: 'movie',
+        id: 'movie-1',
+      ).toJson(),
+    );
+
+void main() {
+  testWidgets('a warm candidates cache cannot pin playback to a deleted file',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    // The install has played this title before, back when it was a different
+    // file. `file-old` is gone from the server now.
+    final cache = GraphQLCache(store: InMemoryStore());
+    cache.writeQuery(
+      _candidatesRequest(),
+      data: streamingCandidatesResponse(
+        duration: 5400,
+        directPlay: true,
+        fileId: 'file-old',
+      ),
+      broadcast: false,
+    );
+
+    // Guard against a false pass. If the seed above did not land under the key
+    // the screen actually reads, the query would miss the cache, go to the
+    // network for unrelated reasons, and this test would go green while the
+    // bug it exists to catch was fully intact.
+    expect(
+      cache.readQuery(_candidatesRequest()),
+      isNotNull,
+      reason: 'the cache must genuinely hold a stale entry for this query, '
+          'otherwise the assertion below proves nothing',
+    );
+
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      // What the server says today, after the file was replaced.
+      streamingCandidatesResponse(
+        duration: 5400,
+        directPlay: true,
+        fileId: 'file-new',
+      ),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: castManager,
+      proxyService: proxyService,
+      cache: cache,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(
+      tester,
+      () => proxyService.directStreamFileIds.isNotEmpty,
+    );
+
+    expect(
+      proxyService.directStreamFileIds,
+      contains('file-new'),
+      reason: 'the file to play is a fact about current server state, so it '
+          'has to come from the server and not from a cache entry that '
+          'outlived the file it names',
+    );
+    expect(
+      proxyService.directStreamFileIds,
+      isNot(contains('file-old')),
+      reason: 'file-old no longer exists; streaming it is the black screen',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the candidates query reaches the network on every playback',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    final cache = GraphQLCache(store: InMemoryStore());
+    cache.writeQuery(
+      _candidatesRequest(),
+      data: streamingCandidatesResponse(
+        duration: 5400,
+        directPlay: true,
+        fileId: 'file-old',
+      ),
+      broadcast: false,
+    );
+
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      streamingCandidatesResponse(
+        duration: 5400,
+        directPlay: true,
+        fileId: 'file-new',
+      ),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: castManager,
+      proxyService: proxyService,
+      cache: cache,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(
+      tester,
+      () => proxyService.directStreamFileIds.isNotEmpty,
+    );
+
+    // Asserting on the transport rather than only on the outcome: it is the
+    // difference between "happened to produce the right id" and "actually
+    // asked". A cacheFirst policy never reaches the link at all.
+    //
+    // Identified by its variables rather than by `operation.operationName`,
+    // which is null here: that field is optional and only carries a value when
+    // the call site passes one, which `_fetchStreamingCandidates` does not.
+    // `contentType` is unique to this query among the three the screen issues.
+    expect(
+      link.requests.where((r) => r.variables.containsKey('contentType')).length,
+      1,
+      reason: 'a warm cache entry must not stand in for asking the server',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+}

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -17,6 +17,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/cast/cast_providers.dart';
 import 'package:player/core/cast/cast_session_manager.dart';
@@ -94,6 +95,13 @@ class TrackingLocalProxyService extends Fake implements LocalProxyService {
   bool stopped = false;
   bool startCalled = false;
 
+  /// Every file id direct playback has been pointed at, in order.
+  ///
+  /// This is the id that actually reaches the wire, which is the only thing
+  /// that distinguishes "asked the server which file to play" from "reused a
+  /// cached answer about a file that has since been deleted".
+  final List<String> directStreamFileIds = [];
+
   @override
   int get port => 12345;
 
@@ -107,8 +115,10 @@ class TrackingLocalProxyService extends Fake implements LocalProxyService {
       'http://127.0.0.1:$port/hls/$sessionId/index.m3u8';
 
   @override
-  String buildDirectStreamUrl(String fileId) =>
-      'http://127.0.0.1:$port/direct/$fileId/stream';
+  String buildDirectStreamUrl(String fileId) {
+    directStreamFileIds.add(fileId);
+    return 'http://127.0.0.1:$port/direct/$fileId/stream';
+  }
 
   @override
   Future<void> stop() async {
@@ -254,15 +264,21 @@ Map<String, dynamic> movieSegmentsResponse({
 /// `_canDirectPlay` declines an empty list. Pass [directPlay] to put a
 /// `DIRECT_PLAY` candidate first instead, which is what makes
 /// `_initializePlayer` take its native direct-play branch.
+///
+/// [fileId] is parameterised because this response is what the direct-play
+/// branch takes its file id from, in preference to the one on the route. A
+/// test that needs to tell a fresh answer apart from a stale cached one has to
+/// be able to make the two differ.
 Map<String, dynamic> streamingCandidatesResponse({
   double? duration,
   bool directPlay = false,
+  String fileId = 'file-1',
 }) {
   return {
     '__typename': 'Query',
     'streamingCandidates': {
       '__typename': 'StreamingCandidatesResult',
-      'fileId': 'file-1',
+      'fileId': fileId,
       'candidates': <dynamic>[
         if (directPlay)
           {
@@ -321,6 +337,10 @@ Map<String, dynamic> endStreamingSessionResponse({bool ok = true}) {
 /// `Override` (the element type `ProviderContainer.overrides` expects) is not
 /// part of `flutter_riverpod`'s public export surface, so a helper can only
 /// spell its return type by constructing the container itself.
+///
+/// Pass [cache] to hand the client a cache that already holds entries, which
+/// is what lets a test stand in for an install that has played this content
+/// before. Omitted, each container gets its own empty non-persistent cache.
 ProviderContainer buildPlayerScreenContainer({
   required StubLink link,
   required conn.ConnectionState connectionState,
@@ -329,6 +349,7 @@ ProviderContainer buildPlayerScreenContainer({
   DownloadedMedia? downloaded,
   AuthStatus authStatus = AuthStatus.authenticated,
   PlaybackProgressStore? progressStore,
+  GraphQLCache? cache,
 }) {
   return ProviderContainer(overrides: [
     authStateProvider.overrideWith(
@@ -336,7 +357,8 @@ ProviderContainer buildPlayerScreenContainer({
     ),
     downloadManagerProvider.overrideWith(
         (ref) async => FakeDownloadService(downloaded: downloaded)),
-    asyncGraphqlClientProvider.overrideWith((ref) async => stubClient(link)),
+    asyncGraphqlClientProvider
+        .overrideWith((ref) async => stubClient(link, cache: cache)),
     serverUrlProvider.overrideWith((ref) async => 'https://mydia.test'),
     authTokenProvider.overrideWith((ref) async => 'tok'),
     conn.connectionProvider


### PR DESCRIPTION
## The bug

Replace an episode's file and the player can never play that episode again. It shows a black screen with a correct, advancing timeline, and no error. Restarting the app does not help.

Diagnosed against the live instance on Silo S03E03, where the server was logging this on every play attempt:

```
[warning] Direct stream: media file 9fc0358e-...-a78b78d6759b not found in database
```

That id belonged to the file that had been deleted 11 minutes earlier. The server was correct throughout: asked directly, it returned the new file. The client was the one holding the dead id, and it kept holding it even after freshly refetching `TvShowDetail` and `SeasonEpisodes` three seconds prior.

## Why

`StreamingCandidates` is keyed by *content* id, never by file id (`player_screen.dart` passes `widget.mediaId`), so its cache entry outlives the file it names. `_fetchStreamingCandidates` issued a bare one-shot `client.query()`, which in graphql 5.2.3 defaults to `FetchPolicy.cacheFirst`, over a `HiveStore()` that `initHiveForFlutter()` puts on disk.

The direct-play branch then does `final fileId = candidatesResult.fileId`, which overrides the route's `fileId` parameter. So a cached hit sent playback to a deleted file no matter how fresh the surrounding episode data was.

The timeline looked right for the same reason it was wrong: `_totalDuration` comes from that same cached blob, and `StreamTimeline` advances client-side whether or not bytes arrive. Progress kept posting because `ProgressService` syncs on a `Timer.periodic`, not on real position.

Nothing evicted the entry. The invalidator in `core/graphql/watch/` only clears the fetch log and refetches registered watchers; this one-shot query has no watcher, and there is no clear-cache affordance in settings. The state survived restarts permanently.

## Scope

This is not limited to deleting a file by hand. `Mydia.Upgrades` writes a new `media_files` row with `supersedes_media_file_id` and deletes the old one, which produces exactly the same dead id. Every automatic quality upgrade permanently broke playback of that title on any device that had played it before.

## The fix

**`fetchPolicy: FetchPolicy.networkOnly` on the candidates query.** Which file to play is a fact about current server state, not display data, and it must not come off disk. `cacheAndNetwork` would not work here: on a one-shot `client.query()` it returns the cached result and discards the network one, which is the defect `query_watcher.dart` already documents in its header. Nothing is lost by going to the network, because the offline branch returns before this runs and every remaining path needs the server to serve a single byte. graphql still writes the fresh result back, so poisoned entries correct themselves on the first play after the update. No one has to clear app data.

**Subscribe to `Player.stream.error`.** Nothing did, so any failure after `open` had nowhere to go and rendered as a black screen. Errors now reach the existing `_error` UI.

That subscription is gated on playback never having advanced, and the gate is what makes it safe: media_kit emits on that stream for every mpv log line at error level, including recoverable `vd`/`ad` decoder and `ffmpeg tcp:` network complaints a healthy stream shrugs off. Replacing playing video with an error page over one of those would be worse than the bug being fixed. A stream that never advanced is not having a hiccup. The advancement mark is seeded with the resume offset so a seek is not mistaken for progress.

Server side is unchanged: `lib/mydia/p2p/server.ex:519` already returns a correct 404.

## Verification

- Both new regression tests fail with the fetch policy reverted (`+0 -2`) and pass with it. The cache-seeding test also asserts `cache.readQuery` is non-null first, so it cannot pass by accidentally missing the cache.
- Full player suite green: **1417 passed**, run at `--concurrency=1`.
- `flutter analyze` reports no errors or warnings introduced.

## Not covered

The error-subscription wiring itself has no widget test. `media_kit`'s `Player` cannot be constructed under `flutter test` (`MediaKit.ensureInitialized must be called`), which is the same constraint the existing player tests document. `playbackErrorMessage` is unit-tested; the subscription and its gate are not.
