### PR TITLE
fix(player): remove the dead space above the library poster grid

### DIFF
--- a/player/lib/presentation/screens/library/library_screen.dart
+++ b/player/lib/presentation/screens/library/library_screen.dart
@@ -142,52 +142,63 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
       extendBodyBehindAppBar: true,
       appBar:
           _buildAppBar(title, icon, isDesktop, effectiveShowSearch, barHeight),
-      body: Column(
+      // A `Stack`, not a `Column`: `FreshnessHeader` carries a top inset that
+      // exists purely to clear an app bar this body already extends behind. As
+      // a `Column` sibling that inset was charged as layout height too, so
+      // every background refetch shoved the whole grid down by ~161px on top
+      // of its own padding. Overlaying keeps the header in the same pixels
+      // without it owning any of the scroll view's space.
+      body: Stack(
         children: [
-          FreshnessHeader(
-            queryKeys: [
-              widget.libraryType == LibraryType.movies
-                  ? QueryKeys.moviesList
-                  : QueryKeys.tvShowsList,
-            ],
-            topInset: chromeTop,
-          ),
-          Expanded(
-            child: RefreshIndicator(
-              onRefresh: () async {
-                await ref
-                    .read(
-                        libraryControllerProvider(widget.libraryType).notifier)
-                    .refresh();
+          RefreshIndicator(
+            // Without this the spinner drops from y=0, behind the glass bar.
+            edgeOffset: chromeTop,
+            onRefresh: () async {
+              await ref
+                  .read(libraryControllerProvider(widget.libraryType).notifier)
+                  .refresh();
+            },
+            child: libraryData.when(
+              loading: () => _buildLoadingView(),
+              error: (error, stackTrace) => _buildErrorView(error),
+              data: (data) {
+                if (data.isEmpty) {
+                  return _buildEmptyState();
+                }
+
+                // Filter items based on search query
+                final searchQuery = _searchController.text.toLowerCase().trim();
+                final filteredItems = searchQuery.isEmpty
+                    ? data.items
+                    : data.items
+                        .where((item) =>
+                            item.title.toLowerCase().contains(searchQuery))
+                        .toList();
+
+                if (filteredItems.isEmpty && searchQuery.isNotEmpty) {
+                  return _buildNoSearchResultsState(searchQuery);
+                }
+
+                return _viewMode == ViewMode.grid
+                    ? _buildGridView(context, filteredItems, scrollTopPadding)
+                    : _buildListView(context, filteredItems, scrollTopPadding);
               },
-              child: libraryData.when(
-                loading: () => _buildLoadingView(),
-                error: (error, stackTrace) => _buildErrorView(error),
-                data: (data) {
-                  if (data.isEmpty) {
-                    return _buildEmptyState();
-                  }
-
-                  // Filter items based on search query
-                  final searchQuery =
-                      _searchController.text.toLowerCase().trim();
-                  final filteredItems = searchQuery.isEmpty
-                      ? data.items
-                      : data.items
-                          .where((item) =>
-                              item.title.toLowerCase().contains(searchQuery))
-                          .toList();
-
-                  if (filteredItems.isEmpty && searchQuery.isNotEmpty) {
-                    return _buildNoSearchResultsState(searchQuery);
-                  }
-
-                  return _viewMode == ViewMode.grid
-                      ? _buildGridView(context, filteredItems, scrollTopPadding)
-                      : _buildListView(
-                          context, filteredItems, scrollTopPadding);
-                },
-              ),
+            ),
+          ),
+          // `Positioned` rather than a bare `Stack` child so the header spans
+          // the full width explicitly instead of relying on loose constraints
+          // plus the banner's own `width: double.infinity`.
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: FreshnessHeader(
+              queryKeys: [
+                widget.libraryType == LibraryType.movies
+                    ? QueryKeys.moviesList
+                    : QueryKeys.tvShowsList,
+              ],
+              topInset: chromeTop,
             ),
           ),
         ],

--- a/player/lib/presentation/screens/library/library_screen.dart
+++ b/player/lib/presentation/screens/library/library_screen.dart
@@ -34,6 +34,18 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   SortOption _currentSort = SortOption.recentlyAdded;
   bool _showSearch = false;
 
+  /// Height of the search row when it is expanded. Matches the
+  /// `AnimatedContainer` in `_buildAppBar` below.
+  static const double _searchRowHeight = 56;
+
+  /// The app bar's settled height, excluding the status bar inset.
+  ///
+  /// The single source of truth for three call sites that used to carry their
+  /// own copy: `preferredSize`, the freshness inset, and the scroll padding.
+  /// The old copies all said 120 while the bar actually builds 112.
+  double _barHeight(bool showSearch) =>
+      kToolbarHeight + (showSearch ? _searchRowHeight : 0);
+
   @override
   void initState() {
     super.initState();
@@ -111,13 +123,25 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     // On desktop, always show search bar expanded
     final effectiveShowSearch = isDesktop || _showSearch;
 
+    final barHeight = _barHeight(effectiveShowSearch);
+    // Read MediaQuery *here*, above the `Scaffold`. Inside the body of a
+    // `Scaffold(extendBodyBehindAppBar: true)` Flutter rewrites `padding.top`
+    // to the app bar's own bottom edge (see `_BodyBuilder` in
+    // material/scaffold.dart), so any descendant that reads it and adds
+    // `barHeight` again counts the bar twice. That was this screen's bug: the
+    // grid read it from a `LayoutBuilder` inside the body and sat 128px too
+    // low, while the list read it from this context and was nearly right.
+    final chromeTop = freshnessTopInset(context, appBarHeight: barHeight);
+    final scrollTopPadding = chromeTop + 8;
+
     // Library grids use the calm static backdrop (no per-title artwork).
     publishBackdropSource(ref, BackdropSource.none);
 
     return Scaffold(
       backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: true,
-      appBar: _buildAppBar(title, icon, isDesktop, effectiveShowSearch),
+      appBar:
+          _buildAppBar(title, icon, isDesktop, effectiveShowSearch, barHeight),
       body: Column(
         children: [
           FreshnessHeader(
@@ -126,10 +150,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                   ? QueryKeys.moviesList
                   : QueryKeys.tvShowsList,
             ],
-            topInset: freshnessTopInset(
-              context,
-              appBarHeight: effectiveShowSearch ? 120 : kToolbarHeight,
-            ),
+            topInset: chromeTop,
           ),
           Expanded(
             child: RefreshIndicator(
@@ -162,8 +183,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                   }
 
                   return _viewMode == ViewMode.grid
-                      ? _buildGridView(context, filteredItems)
-                      : _buildListView(context, filteredItems);
+                      ? _buildGridView(context, filteredItems, scrollTopPadding)
+                      : _buildListView(
+                          context, filteredItems, scrollTopPadding);
                 },
               ),
             ),
@@ -173,12 +195,12 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     );
   }
 
-  PreferredSizeWidget _buildAppBar(
-      String title, IconData icon, bool isDesktop, bool showSearch) {
+  PreferredSizeWidget _buildAppBar(String title, IconData icon, bool isDesktop,
+      bool showSearch, double barHeight) {
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
 
     return PreferredSize(
-      preferredSize: Size.fromHeight(showSearch ? 120 : kToolbarHeight),
+      preferredSize: Size.fromHeight(barHeight),
       child: GlassSurface.appBar(
         opacity: 0.85,
         child: SafeArea(
@@ -266,7 +288,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
               AnimatedContainer(
                 duration: const Duration(milliseconds: 200),
                 curve: Curves.easeInOut,
-                height: showSearch ? 56 : 0,
+                height: showSearch ? _searchRowHeight : 0,
                 child: AnimatedOpacity(
                   duration: const Duration(milliseconds: 200),
                   opacity: showSearch ? 1.0 : 0.0,
@@ -473,22 +495,14 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     );
   }
 
-  double _getTopPadding(BuildContext context, bool showSearch) {
-    final safeAreaTop = MediaQuery.of(context).padding.top;
-    final appBarHeight = showSearch ? 120.0 : kToolbarHeight;
-    return safeAreaTop + appBarHeight + 8;
-  }
-
-  Widget _buildGridView(BuildContext context, List items) {
+  Widget _buildGridView(BuildContext context, List items, double topPadding) {
     final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
-    final effectiveShowSearch = isDesktop || _showSearch;
 
     return LayoutBuilder(
       builder: (context, constraints) {
         final crossAxisCount = _calculateCrossAxisCount(constraints.maxWidth);
-        final topPadding = _getTopPadding(context, effectiveShowSearch);
         // Less bottom padding on desktop (no bottom nav)
         final bottomPadding = isDesktop ? 32.0 : 100.0;
 
@@ -519,11 +533,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     );
   }
 
-  Widget _buildListView(BuildContext context, List items) {
+  Widget _buildListView(BuildContext context, List items, double topPadding) {
     final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
-    final effectiveShowSearch = isDesktop || _showSearch;
-    final topPadding = _getTopPadding(context, effectiveShowSearch);
     final bottomPadding = isDesktop ? 32.0 : 100.0;
 
     return ListView.builder(

--- a/player/test/presentation/screens/library/library_screen_layout_test.dart
+++ b/player/test/presentation/screens/library/library_screen_layout_test.dart
@@ -4,9 +4,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 // Riverpod 3.x; it lives in the `misc.dart` sub-library.
 import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/cast/cast_capabilities.dart';
 import 'package:player/core/cast/cast_providers.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/core/graphql/watch/freshness.dart';
+import 'package:player/core/graphql/watch/query_key.dart';
 import 'package:player/presentation/screens/library/library_controller.dart';
 import 'package:player/presentation/screens/library/library_screen.dart';
 import 'package:player/presentation/widgets/media_poster.dart';
@@ -133,6 +136,51 @@ double appBarBottom(WidgetTester tester) {
 double firstPosterTop(WidgetTester tester) =>
     tester.getTopLeft(find.byType(MediaPoster).first).dy;
 
+/// Pins the freshness state for the whole test.
+///
+/// `build()` alone is not enough: the screen's real `LibraryController`
+/// creates a watcher that calls `publish` as soon as its fetch resolves, which
+/// would immediately overwrite the state under test with
+/// `isRefreshing: false`. Both mutators are no-ops so the pinned map wins.
+class _PinnedFreshnessRegistry extends FreshnessRegistry {
+  _PinnedFreshnessRegistry(this._pinned);
+
+  final Map<QueryKey, Freshness> _pinned;
+
+  @override
+  Map<QueryKey, Freshness> build() => _pinned;
+
+  @override
+  void publish(QueryKey key, Freshness freshness) {}
+
+  @override
+  void clear(QueryKey key) {}
+}
+
+/// `FreshnessHeader` renders nothing at all in offline mode, so the auth state
+/// has to be pinned to authenticated for the in-flight line to show.
+class _StubAuthState extends AuthStateNotifier {
+  _StubAuthState(this._status);
+
+  final AuthStatus _status;
+
+  @override
+  AsyncValue<AuthStatus> build() => AsyncValue.data(_status);
+}
+
+List<Override> refreshingOverrides() => [
+      authStateProvider
+          .overrideWith(() => _StubAuthState(AuthStatus.authenticated)),
+      freshnessRegistryProvider.overrideWith(
+        () => _PinnedFreshnessRegistry({
+          QueryKeys.moviesList: Freshness(
+            fetchedAt: DateTime(2026, 8, 4),
+            isRefreshing: true,
+          ),
+        }),
+      ),
+    ];
+
 void main() {
   testWidgets('grid starts just below the app bar on desktop', (tester) async {
     await pumpLibrary(tester, size: kDesktopSize);
@@ -159,5 +207,33 @@ void main() {
     final listTop = tester.widget<ListView>(find.byType(ListView)).padding;
 
     expect(listTop, gridTop);
+  });
+
+  testWidgets('a refresh in flight does not move the grid', (tester) async {
+    await pumpLibrary(
+      tester,
+      size: kDesktopSize,
+      extraOverrides: refreshingOverrides(),
+      settle: false,
+    );
+
+    expect(find.byKey(const Key('freshness-inflight')), findsOneWidget);
+    expect(firstPosterTop(tester), appBarBottom(tester) + kContentGap);
+  });
+
+  testWidgets('the grid still scrolls while the refresh line shows',
+      (tester) async {
+    await pumpLibrary(
+      tester,
+      size: kDesktopSize,
+      extraOverrides: refreshingOverrides(),
+      settle: false,
+    );
+
+    final before = firstPosterTop(tester);
+    await tester.drag(find.byType(GridView), const Offset(0, -120));
+    await tester.pump();
+
+    expect(before - firstPosterTop(tester), 120);
   });
 }

--- a/player/test/presentation/screens/library/library_screen_layout_test.dart
+++ b/player/test/presentation/screens/library/library_screen_layout_test.dart
@@ -77,6 +77,51 @@ Map<String, dynamic> moviesPage(List<String> ids) => {
       },
     };
 
+/// The TV shows connection, whose node shape differs from a movie's: no
+/// `progress`, plus `status`, `seasonCount`, `episodeCount` and `nextEpisode`.
+Map<String, dynamic> tvShowsPage(List<String> ids) => {
+      '__typename': 'Query',
+      'tvShows': {
+        '__typename': 'TvShowConnection',
+        'edges': [
+          for (final id in ids)
+            {
+              '__typename': 'TvShowEdge',
+              'cursor': 'c-$id',
+              'node': {
+                '__typename': 'TvShow',
+                'id': id,
+                'title': 'Show $id',
+                'year': 2026,
+                'overview': null,
+                'status': null,
+                'genres': <String>[],
+                'contentRating': null,
+                'rating': null,
+                'seasonCount': 1,
+                'episodeCount': 8,
+                'artwork': {
+                  '__typename': 'Artwork',
+                  'posterUrl': null,
+                  'backdropUrl': null,
+                  'thumbnailUrl': null,
+                },
+                'isFavorite': false,
+                'nextEpisode': null,
+              },
+            }
+        ],
+        'pageInfo': {
+          '__typename': 'PageInfo',
+          'hasNextPage': false,
+          'hasPreviousPage': false,
+          'startCursor': 'c-${ids.first}',
+          'endCursor': 'c-${ids.last}',
+        },
+        'totalCount': ids.length,
+      },
+    };
+
 /// Mounts the real [LibraryScreen] over a scripted GraphQL link.
 ///
 /// [settle] must be false whenever the freshness in-flight line will be
@@ -87,6 +132,7 @@ Map<String, dynamic> moviesPage(List<String> ids) => {
 Future<void> pumpLibrary(
   WidgetTester tester, {
   required Size size,
+  LibraryType libraryType = LibraryType.movies,
   int itemCount = 40,
   List<Override> extraOverrides = const [],
   bool settle = true,
@@ -96,23 +142,23 @@ Future<void> pumpLibrary(
   tester.view.padding = const FakeViewPadding(top: kStatusBarTop);
   addTearDown(tester.view.reset);
 
+  final ids = List.generate(itemCount, (i) => '$i');
+  final page =
+      libraryType == LibraryType.movies ? moviesPage(ids) : tvShowsPage(ids);
+
   await mockNetworkImages(() async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
           asyncGraphqlClientProvider.overrideWith(
-            (ref) async => stubClient(
-              StubLink.responses([
-                moviesPage(List.generate(itemCount, (i) => '$i')),
-              ]),
-            ),
+            (ref) async => stubClient(StubLink.responses([page])),
           ),
           castCapabilitiesProvider
               .overrideWithValue(const CastCapabilities.full()),
           ...extraOverrides,
         ],
-        child: const MaterialApp(
-          home: LibraryScreen(libraryType: LibraryType.movies),
+        child: MaterialApp(
+          home: LibraryScreen(libraryType: libraryType),
         ),
       ),
     );
@@ -184,6 +230,17 @@ List<Override> refreshingOverrides() => [
 void main() {
   testWidgets('grid starts just below the app bar on desktop', (tester) async {
     await pumpLibrary(tester, size: kDesktopSize);
+
+    expect(firstPosterTop(tester), appBarBottom(tester) + kContentGap);
+  });
+
+  testWidgets('tv shows grid starts just below the app bar too',
+      (tester) async {
+    await pumpLibrary(
+      tester,
+      size: kDesktopSize,
+      libraryType: LibraryType.tvShows,
+    );
 
     expect(firstPosterTop(tester), appBarBottom(tester) + kContentGap);
   });

--- a/player/test/presentation/screens/library/library_screen_layout_test.dart
+++ b/player/test/presentation/screens/library/library_screen_layout_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+// `Override` is not re-exported by the main `flutter_riverpod.dart` barrel in
+// Riverpod 3.x; it lives in the `misc.dart` sub-library.
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/presentation/screens/library/library_controller.dart';
+import 'package:player/presentation/screens/library/library_screen.dart';
+import 'package:player/presentation/widgets/media_poster.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+import '../../../test_utils/stub_graphql_client.dart';
+
+/// The status bar inset every test in this file runs with.
+const double kStatusBarTop = 47;
+
+/// What the screen intends between the app bar's bottom edge and the first
+/// row of content.
+const double kContentGap = 8;
+
+/// A desktop width (>= Breakpoints.tablet, so the search row is always shown).
+const Size kDesktopSize = Size(1200, 900);
+
+/// A mobile width. Deliberately not narrower: at 400px the app bar's `Row`
+/// overflows by 20px on a pre-existing responsive bug unrelated to layout
+/// padding, and the test would fail for the wrong reason.
+const Size kMobileSize = Size(600, 900);
+
+/// Every object needs `__typename`, the root included: `gql()` injects a
+/// `__typename` selection into every selection set, and the normalized cache
+/// refuses to write data that lacks a matching one. A miss surfaces as a
+/// spurious `hasException`, not as an obvious error.
+Map<String, dynamic> moviesPage(List<String> ids) => {
+      '__typename': 'Query',
+      'movies': {
+        '__typename': 'MovieConnection',
+        'edges': [
+          for (final id in ids)
+            {
+              '__typename': 'MovieEdge',
+              'cursor': 'c-$id',
+              'node': {
+                '__typename': 'Movie',
+                'id': id,
+                'title': 'Movie $id',
+                'year': 2026,
+                'overview': null,
+                'runtime': null,
+                'genres': <String>[],
+                'contentRating': null,
+                'rating': null,
+                'artwork': {
+                  '__typename': 'Artwork',
+                  'posterUrl': null,
+                  'backdropUrl': null,
+                  'thumbnailUrl': null,
+                },
+                'progress': null,
+                'isFavorite': false,
+              },
+            }
+        ],
+        'pageInfo': {
+          '__typename': 'PageInfo',
+          'hasNextPage': false,
+          'hasPreviousPage': false,
+          'startCursor': 'c-${ids.first}',
+          'endCursor': 'c-${ids.last}',
+        },
+        'totalCount': ids.length,
+      },
+    };
+
+/// Mounts the real [LibraryScreen] over a scripted GraphQL link.
+///
+/// [settle] must be false whenever the freshness in-flight line will be
+/// showing: it renders a `LinearProgressIndicator`, whose animation never
+/// ends, so `pumpAndSettle` would time out. The bounded loop advances enough
+/// frames for the async client override to resolve and for the 200ms search
+/// row animation to finish.
+Future<void> pumpLibrary(
+  WidgetTester tester, {
+  required Size size,
+  int itemCount = 40,
+  List<Override> extraOverrides = const [],
+  bool settle = true,
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.padding = const FakeViewPadding(top: kStatusBarTop);
+  addTearDown(tester.view.reset);
+
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          asyncGraphqlClientProvider.overrideWith(
+            (ref) async => stubClient(
+              StubLink.responses([
+                moviesPage(List.generate(itemCount, (i) => '$i')),
+              ]),
+            ),
+          ),
+          castCapabilitiesProvider
+              .overrideWithValue(const CastCapabilities.full()),
+          ...extraOverrides,
+        ],
+        child: const MaterialApp(
+          home: LibraryScreen(libraryType: LibraryType.movies),
+        ),
+      ),
+    );
+
+    if (settle) {
+      await tester.pumpAndSettle();
+    } else {
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+    }
+  });
+}
+
+/// The y coordinate where the app bar stops covering the body.
+double appBarBottom(WidgetTester tester) {
+  final box = tester.renderObject<RenderBox>(find.byType(PreferredSize).first);
+  return box.localToGlobal(Offset.zero).dy + box.size.height;
+}
+
+double firstPosterTop(WidgetTester tester) =>
+    tester.getTopLeft(find.byType(MediaPoster).first).dy;
+
+void main() {
+  testWidgets('grid starts just below the app bar on desktop', (tester) async {
+    await pumpLibrary(tester, size: kDesktopSize);
+
+    expect(firstPosterTop(tester), appBarBottom(tester) + kContentGap);
+  });
+
+  testWidgets('grid starts just below the app bar on mobile', (tester) async {
+    await pumpLibrary(tester, size: kMobileSize);
+
+    expect(firstPosterTop(tester), appBarBottom(tester) + kContentGap);
+  });
+
+  testWidgets('list view starts at the same offset as the grid',
+      (tester) async {
+    await pumpLibrary(tester, size: kDesktopSize);
+
+    final gridTop = tester.widget<GridView>(find.byType(GridView)).padding;
+
+    // In grid mode the toggle button shows the *list* icon.
+    await tester.tap(find.byIcon(Icons.view_list_rounded));
+    await tester.pumpAndSettle();
+
+    final listTop = tester.widget<ListView>(find.byType(ListView)).padding;
+
+    expect(listTop, gridTop);
+  });
+}


### PR DESCRIPTION
The Movies and TV Shows library screens rendered the poster grid 128px below
the app bar, leaving a large empty band under the search field.

`LibraryScreen` uses `Scaffold(extendBodyBehindAppBar: true)`. Flutter rewrites
`MediaQuery.padding.top` inside such a body to mean the app bar's bottom edge
rather than the status bar inset, and `_getTopPadding` added the bar height to
that value a second time. The list view escaped because it read the same
expression from a context above the `Scaffold`, where it still meant the status
bar, which is why toggling to list looked fine.

Two related defects went with it. The bar's height was declared in three places
and all three said 120 for a bar that builds 112. And `FreshnessHeader` sat in a
`Column` beside the scroll view while carrying a top inset meant to clear the
app bar, so its inset was charged as layout height as well and every background
refetch shoved the grid down another 161px.

Measured, at `devicePixelRatio` 1.0 with a 47px status bar:

| Case | Gap before | Gap after |
| --- | --- | --- |
| Desktop 1200x900, search expanded | 128px | 8px |
| Mobile 600x900, search collapsed | 64px | 8px |
| Desktop, refresh in flight | 297px | 8px |

Six widget tests mount the real screen and pin these, covering both the movies
and tv shows libraries, grid and list, idle and refreshing. The refresh spinner
also gets an `edgeOffset` so it stops dropping from behind the glass app bar.

Scope is the library screen only. `favorites`, `recently_added`, `unwatched`,
`collections` and `home` share the `Column`-sibling header arrangement and
hardcode their own top padding; they are untouched here.

Verification: `flutter test --concurrency=1` green at 1431 tests.