### PR TITLE
fix(player): play the file the user selected

### DIFF
--- a/lib/mydia/library/file_ranking.ex
+++ b/lib/mydia/library/file_ranking.ex
@@ -39,10 +39,13 @@ defmodule Mydia.Library.FileRanking do
     "360p" => 360
   }
 
-  # Deliberately unanchored at the start, matching the player's
-  # `MediaFileSelector.parseToPixels` (media_file_selector.dart:46) so client
-  # and server agree on odd values. It reads "1920x1080" as 1080.
-  @numeric_resolution ~r/(\d+)p?$/
+  # Deliberately unanchored at the start. Originally matched the player's
+  # `MediaFileSelector.parseToPixels` (media_file_selector.dart:46) for odd
+  # values like "1920x1080" -> 1080. Additionally accepts interlaced suffixes
+  # because ReleaseParser persists them (e.g. "1080i") and the Dart parser
+  # does not yet handle them. Treats interlaced as equal to progressive at
+  # the same height.
+  @numeric_resolution ~r/(\d+)[pi]?$/
 
   @doc """
   Parses a resolution string into a vertical pixel count.

--- a/lib/mydia/library/file_ranking.ex
+++ b/lib/mydia/library/file_ranking.ex
@@ -1,0 +1,101 @@
+defmodule Mydia.Library.FileRanking do
+  @moduledoc """
+  Ranks media files by playback quality.
+
+  Used wherever a caller names a movie or an episode rather than a specific
+  file, so the server has to choose one. Those call sites previously took the
+  head of an unordered `has_many` preload, which meant the file that played was
+  whichever row the database happened to return first.
+
+  Ranking is deliberately device-blind: it always prefers the highest-quality
+  file, because the server cannot know what the requesting client can handle.
+  Clients that care which file plays send an explicit file id instead, which
+  skips this module entirely.
+  """
+
+  alias Mydia.Library.MediaFile
+
+  # Keys are lowercased; values are vertical pixels. Covers everything
+  # `Mydia.Library.FileAnalyzer.extract_resolution/1` (file_analyzer.ex:318)
+  # emits, plus the extra spellings `Mydia.Library.ReleaseParser` can persist
+  # (release_parser.ex:243).
+  @named_resolutions %{
+    "8k" => 4320,
+    "4320p" => 4320,
+    "4k" => 2160,
+    "uhd" => 2160,
+    "2160p" => 2160,
+    "2k" => 1440,
+    "qhd" => 1440,
+    "1440p" => 1440,
+    "fhd" => 1080,
+    "1080p" => 1080,
+    "hd" => 720,
+    "720p" => 720,
+    "576p" => 576,
+    "540p" => 540,
+    "sd" => 480,
+    "480p" => 480,
+    "360p" => 360
+  }
+
+  # Deliberately unanchored at the start, matching the player's
+  # `MediaFileSelector.parseToPixels` (media_file_selector.dart:46) so client
+  # and server agree on odd values. It reads "1920x1080" as 1080.
+  @numeric_resolution ~r/(\d+)p?$/
+
+  @doc """
+  Parses a resolution string into a vertical pixel count.
+
+  Returns `0` for `nil` and for anything unparseable, which sorts those files
+  last. A `nil` resolution means the file has not been analyzed yet, and an
+  unanalyzed file is the least safe thing to pick blindly.
+  """
+  @spec resolution_pixels(String.t() | nil) :: non_neg_integer()
+  def resolution_pixels(nil), do: 0
+
+  def resolution_pixels(resolution) when is_binary(resolution) do
+    key = resolution |> String.trim() |> String.downcase()
+
+    case Map.fetch(@named_resolutions, key) do
+      {:ok, pixels} -> pixels
+      :error -> parse_numeric_resolution(key)
+    end
+  end
+
+  def resolution_pixels(_other), do: 0
+
+  @doc """
+  Returns the highest-quality file in `files`, or `nil` when `files` is empty.
+
+  Callers use the `nil` to detect "this media item has no playable files".
+  """
+  @spec best([MediaFile.t()]) :: MediaFile.t() | nil
+  def best([]), do: nil
+  def best([file]), do: file
+  def best(files) when is_list(files), do: files |> sort() |> hd()
+
+  @doc """
+  Sorts `files` best-first.
+
+  Resolution descending, then bitrate descending, then id descending. The id is
+  an arbitrary but stable final tiebreak: two files equal on every quality
+  signal are interchangeable, but ranking them consistently means the same set
+  produces the same answer on every call, whatever order the database returned.
+  """
+  @spec sort([MediaFile.t()]) :: [MediaFile.t()]
+  def sort(files) when is_list(files) do
+    Enum.sort_by(files, &rank_key/1, :desc)
+  end
+
+  defp rank_key(%MediaFile{} = file) do
+    {resolution_pixels(file.resolution), file.bitrate || 0, file.id}
+  end
+
+  defp parse_numeric_resolution(key) do
+    case Regex.run(@numeric_resolution, key) do
+      [_full, digits] -> String.to_integer(digits)
+      nil -> 0
+    end
+  end
+end

--- a/lib/mydia/streaming/candidates.ex
+++ b/lib/mydia/streaming/candidates.ex
@@ -57,7 +57,12 @@ defmodule Mydia.Streaming.Candidates do
 
       "file" ->
         try do
-          media_file = Mydia.Library.get_media_file!(id, preload: [:library_path])
+          # A trashed file is not a streaming candidate, same as the "movie"
+          # and "episode" clauses above. Without this, a quality upgrade that
+          # trashes the old file (Mydia.Upgrades.apply_upgrade/4) would leave
+          # a dead file id resolvable here, so the player's self-heal (which
+          # relies on this returning :not_found) would never fire.
+          media_file = Repo.get!(active_files_query, id)
           {:ok, media_file}
         rescue
           Ecto.NoResultsError -> {:error, :not_found}

--- a/lib/mydia/streaming/candidates.ex
+++ b/lib/mydia/streaming/candidates.ex
@@ -39,6 +39,7 @@ defmodule Mydia.Streaming.Candidates do
           end
         rescue
           Ecto.NoResultsError -> {:error, :not_found}
+          Ecto.Query.CastError -> {:error, :not_found}
         end
 
       "episode" ->
@@ -51,6 +52,7 @@ defmodule Mydia.Streaming.Candidates do
           end
         rescue
           Ecto.NoResultsError -> {:error, :not_found}
+          Ecto.Query.CastError -> {:error, :not_found}
         end
 
       "file" ->
@@ -59,6 +61,7 @@ defmodule Mydia.Streaming.Candidates do
           {:ok, media_file}
         rescue
           Ecto.NoResultsError -> {:error, :not_found}
+          Ecto.Query.CastError -> {:error, :not_found}
         end
 
       _ ->

--- a/lib/mydia/streaming/candidates.ex
+++ b/lib/mydia/streaming/candidates.ex
@@ -11,7 +11,7 @@ defmodule Mydia.Streaming.Candidates do
   require Logger
 
   alias Mydia.Library
-  alias Mydia.Library.{FileAnalyzer, MediaFile}
+  alias Mydia.Library.{FileAnalyzer, FileRanking, MediaFile}
   alias Mydia.Library.Structs.FileMetadata
   alias Mydia.Repo
   alias Mydia.Streaming.{CodecString, Compatibility}
@@ -33,9 +33,9 @@ defmodule Mydia.Streaming.Candidates do
           media_item =
             Mydia.Media.get_media_item!(id, preload: [media_files: active_files_query])
 
-          case media_item.media_files do
-            [media_file | _] -> {:ok, media_file}
-            [] -> {:error, :no_media_files}
+          case FileRanking.best(media_item.media_files) do
+            nil -> {:error, :no_media_files}
+            media_file -> {:ok, media_file}
           end
         rescue
           Ecto.NoResultsError -> {:error, :not_found}
@@ -45,9 +45,9 @@ defmodule Mydia.Streaming.Candidates do
         try do
           episode = Mydia.Media.get_episode!(id, preload: [media_files: active_files_query])
 
-          case episode.media_files do
-            [media_file | _] -> {:ok, media_file}
-            [] -> {:error, :no_media_files}
+          case FileRanking.best(episode.media_files) do
+            nil -> {:error, :no_media_files}
+            media_file -> {:ok, media_file}
           end
         rescue
           Ecto.NoResultsError -> {:error, :not_found}

--- a/lib/mydia_web/controllers/api/player/v1/subtitle_controller.ex
+++ b/lib/mydia_web/controllers/api/player/v1/subtitle_controller.ex
@@ -11,9 +11,9 @@ defmodule MydiaWeb.Api.Player.V1.SubtitleController do
 
   import Ecto.Query, only: [from: 2]
 
-  alias Mydia.Library
   alias Mydia.Library.FileRanking
   alias Mydia.Library.MediaFile
+  alias Mydia.Repo
   alias Mydia.Subtitles.Extractor
 
   require Logger
@@ -185,7 +185,9 @@ defmodule MydiaWeb.Api.Player.V1.SubtitleController do
 
       "file" ->
         try do
-          media_file = Library.get_media_file!(id, preload: [:library_path])
+          # A trashed file is not a subtitle source, same as the "movie" and
+          # "episode" clauses above (see active_files_query/0 below).
+          media_file = Repo.get!(active_files_query(), id)
           {:ok, media_file}
         rescue
           Ecto.NoResultsError -> {:error, :not_found}

--- a/lib/mydia_web/controllers/api/player/v1/subtitle_controller.ex
+++ b/lib/mydia_web/controllers/api/player/v1/subtitle_controller.ex
@@ -9,7 +9,11 @@ defmodule MydiaWeb.Api.Player.V1.SubtitleController do
 
   use MydiaWeb, :controller
 
+  import Ecto.Query, only: [from: 2]
+
   alias Mydia.Library
+  alias Mydia.Library.FileRanking
+  alias Mydia.Library.MediaFile
   alias Mydia.Subtitles.Extractor
 
   require Logger
@@ -157,11 +161,11 @@ defmodule MydiaWeb.Api.Player.V1.SubtitleController do
       "movie" ->
         try do
           media_item =
-            Mydia.Media.get_media_item!(id, preload: [media_files: :library_path])
+            Mydia.Media.get_media_item!(id, preload: [media_files: active_files_query()])
 
-          case media_item.media_files do
-            [media_file | _] -> {:ok, media_file}
-            [] -> {:error, :no_media_files}
+          case FileRanking.best(media_item.media_files) do
+            nil -> {:error, :no_media_files}
+            media_file -> {:ok, media_file}
           end
         rescue
           Ecto.NoResultsError -> {:error, :not_found}
@@ -169,11 +173,11 @@ defmodule MydiaWeb.Api.Player.V1.SubtitleController do
 
       "episode" ->
         try do
-          episode = Mydia.Media.get_episode!(id, preload: [media_files: :library_path])
+          episode = Mydia.Media.get_episode!(id, preload: [media_files: active_files_query()])
 
-          case episode.media_files do
-            [media_file | _] -> {:ok, media_file}
-            [] -> {:error, :no_media_files}
+          case FileRanking.best(episode.media_files) do
+            nil -> {:error, :no_media_files}
+            media_file -> {:ok, media_file}
           end
         rescue
           Ecto.NoResultsError -> {:error, :not_found}
@@ -190,6 +194,12 @@ defmodule MydiaWeb.Api.Player.V1.SubtitleController do
       _ ->
         {:error, :invalid_type}
     end
+  end
+
+  # Mirrors the filter in Mydia.Streaming.Candidates: a trashed file is not a
+  # subtitle source.
+  defp active_files_query do
+    from(mf in MediaFile, where: is_nil(mf.trashed_at), preload: :library_path)
   end
 
   # Parse track ID from string parameter

--- a/lib/mydia_web/controllers/api/stream_controller.ex
+++ b/lib/mydia_web/controllers/api/stream_controller.ex
@@ -1,7 +1,10 @@
 defmodule MydiaWeb.Api.StreamController do
   use MydiaWeb, :controller
 
+  import Ecto.Query, only: [from: 2]
+
   alias Mydia.Library
+  alias Mydia.Library.FileRanking
   alias Mydia.Library.MediaFile
   alias Mydia.Library.Structs.FileMetadata
 
@@ -26,17 +29,17 @@ defmodule MydiaWeb.Api.StreamController do
   def stream_movie(conn, %{"id" => media_item_id}) do
     try do
       media_item =
-        Mydia.Media.get_media_item!(media_item_id, preload: [media_files: :library_path])
+        Mydia.Media.get_media_item!(media_item_id, preload: [media_files: active_files_query()])
 
-      # Select the first (highest quality) media file
-      case media_item.media_files do
-        [media_file | _] ->
-          stream_media_file(conn, media_file)
-
-        [] ->
+      # Highest resolution, then bitrate. See Mydia.Library.FileRanking.
+      case FileRanking.best(media_item.media_files) do
+        nil ->
           conn
           |> put_status(:not_found)
           |> json(%{error: "No media files available for this movie"})
+
+        media_file ->
+          stream_media_file(conn, media_file)
       end
     rescue
       Ecto.NoResultsError ->
@@ -53,17 +56,18 @@ defmodule MydiaWeb.Api.StreamController do
   """
   def stream_episode(conn, %{"id" => episode_id}) do
     try do
-      episode = Mydia.Media.get_episode!(episode_id, preload: [media_files: :library_path])
+      episode =
+        Mydia.Media.get_episode!(episode_id, preload: [media_files: active_files_query()])
 
-      # Select the first (highest quality) media file
-      case episode.media_files do
-        [media_file | _] ->
-          stream_media_file(conn, media_file)
-
-        [] ->
+      # Highest resolution, then bitrate. See Mydia.Library.FileRanking.
+      case FileRanking.best(episode.media_files) do
+        nil ->
           conn
           |> put_status(:not_found)
           |> json(%{error: "No media files available for this episode"})
+
+        media_file ->
+          stream_media_file(conn, media_file)
       end
     rescue
       Ecto.NoResultsError ->
@@ -163,6 +167,13 @@ defmodule MydiaWeb.Api.StreamController do
         |> put_status(:bad_request)
         |> json(%{error: "Invalid content type. Use 'movie', 'episode', or 'file'"})
     end
+  end
+
+  # Mirrors the filter in Mydia.Streaming.Candidates: a trashed file is not a
+  # streaming candidate. Without this, ranking would reliably surface a trashed
+  # high-resolution file where the unordered head only did so sometimes.
+  defp active_files_query do
+    from(mf in MediaFile, where: is_nil(mf.trashed_at), preload: :library_path)
   end
 
   # Main streaming function that handles a media file

--- a/lib/mydia_web/controllers/api/stream_controller.ex
+++ b/lib/mydia_web/controllers/api/stream_controller.ex
@@ -3,10 +3,10 @@ defmodule MydiaWeb.Api.StreamController do
 
   import Ecto.Query, only: [from: 2]
 
-  alias Mydia.Library
   alias Mydia.Library.FileRanking
   alias Mydia.Library.MediaFile
   alias Mydia.Library.Structs.FileMetadata
+  alias Mydia.Repo
 
   alias Mydia.Streaming.{
     Candidates,
@@ -90,10 +90,15 @@ defmodule MydiaWeb.Api.StreamController do
   - Seeking via Range requests
   """
   def stream(conn, %{"id" => media_file_id}) do
-    # Load media file with preloads to check access
+    # Load media file with preloads to check access. A trashed file is not a
+    # streaming candidate — see the comment on active_files_query/0 below.
     try do
       media_file =
-        Library.get_media_file!(media_file_id, preload: [:media_item, :episode, :library_path])
+        from(mf in MediaFile,
+          where: is_nil(mf.trashed_at),
+          preload: [:media_item, :episode, :library_path]
+        )
+        |> Repo.get!(media_file_id)
 
       stream_media_file(conn, media_file)
     rescue

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -684,11 +684,14 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         });
       }
 
-      final contentType = widget.mediaType == 'movie' ? 'movie' : 'episode';
+      // Ask about the *file*, not the media item. Keying this on mediaId left
+      // the server to pick one of the item's files with no way to express the
+      // user's choice, and its pick then won on the direct-play path below.
+      // `content_type: "file"` is already supported server-side.
       final candidatesResult = await _fetchStreamingCandidates(
         graphqlClient,
-        contentType,
-        widget.mediaId,
+        'file',
+        widget.fileId,
       );
 
       // Determine if direct play is possible
@@ -737,12 +740,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
       if (canDirect) {
         // Direct play path (native only)
-        final fileId = candidatesResult.fileId;
-        debugPrint('[PlayerScreen] Direct play for file_id=$fileId');
+        debugPrint('[PlayerScreen] Direct play for file_id=${widget.fileId}');
 
         if (isP2PMode) {
-          mediaSource =
-              ref.read(localProxyServiceProvider).buildDirectStreamUrl(fileId);
+          mediaSource = ref
+              .read(localProxyServiceProvider)
+              .buildDirectStreamUrl(widget.fileId);
         } else {
           // Get media token for URL (if available)
           final mediaTokenService =
@@ -751,7 +754,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           final mediaToken = await mediaTokenService.getToken();
 
           mediaSource =
-              '$serverUrl/api/v1/stream/file/$fileId?strategy=DIRECT_PLAY';
+              '$serverUrl/api/v1/stream/file/${widget.fileId}?strategy=DIRECT_PLAY';
           if (mediaToken != null) {
             mediaSource += '&token=$mediaToken';
           } else {

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -701,8 +701,22 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
       // The file actually being played. Normally the user's choice; on the
       // offline fall-through it is whatever the server ranked highest.
-      final playFileId =
-          byFile ? widget.fileId : (candidatesResult?.fileId ?? widget.fileId);
+      //
+      // On that fall-through there is no `widget.fileId` worth falling back
+      // to if the candidates call itself failed (network hiccup, server
+      // unreachable): `widget.fileId` is still the `'offline'` sentinel that
+      // sent us down this branch in the first place, not a real file id.
+      // Sending it on to `StartStreamingSession` would just repeat the
+      // malformed-id failure this branch exists to avoid, so fail here
+      // instead with a message the user can act on — the same
+      // throw-into-the-surrounding-catch convention used above for the
+      // missing P2P server address.
+      final playFileId = byFile
+          ? widget.fileId
+          : candidatesResult?.fileId ??
+              (throw Exception(
+                  'Could not reach the server to find a playable file for '
+                  'this download. Check your connection and try again.'));
 
       // Determine if direct play is possible
       final canDirect = !kIsWeb &&

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -684,15 +684,25 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         });
       }
 
-      // Ask about the *file*, not the media item. Keying this on mediaId left
+      // Ask about the *file* the user picked. Keying this on mediaId left
       // the server to pick one of the item's files with no way to express the
       // user's choice, and its pick then won on the direct-play path below.
-      // `content_type: "file"` is already supported server-side.
+      //
+      // The exception is the `'offline'` sentinel: a downloaded item whose
+      // local file has gone missing falls through to streaming from above,
+      // still carrying that sentinel instead of a real file id. There is no
+      // file to ask about, so ask about the media item and let the server rank.
+      final byFile = widget.fileId != 'offline';
       final candidatesResult = await _fetchStreamingCandidates(
         graphqlClient,
-        'file',
-        widget.fileId,
+        byFile ? 'file' : (widget.mediaType == 'movie' ? 'movie' : 'episode'),
+        byFile ? widget.fileId : widget.mediaId,
       );
+
+      // The file actually being played. Normally the user's choice; on the
+      // offline fall-through it is whatever the server ranked highest.
+      final playFileId =
+          byFile ? widget.fileId : (candidatesResult?.fileId ?? widget.fileId);
 
       // Determine if direct play is possible
       final canDirect = !kIsWeb &&
@@ -740,12 +750,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
       if (canDirect) {
         // Direct play path (native only)
-        debugPrint('[PlayerScreen] Direct play for file_id=${widget.fileId}');
+        debugPrint('[PlayerScreen] Direct play for file_id=$playFileId');
 
         if (isP2PMode) {
           mediaSource = ref
               .read(localProxyServiceProvider)
-              .buildDirectStreamUrl(widget.fileId);
+              .buildDirectStreamUrl(playFileId);
         } else {
           // Get media token for URL (if available)
           final mediaTokenService =
@@ -754,7 +764,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           final mediaToken = await mediaTokenService.getToken();
 
           mediaSource =
-              '$serverUrl/api/v1/stream/file/${widget.fileId}?strategy=DIRECT_PLAY';
+              '$serverUrl/api/v1/stream/file/$playFileId?strategy=DIRECT_PLAY';
           if (mediaToken != null) {
             mediaSource += '&token=$mediaToken';
           } else {
@@ -782,7 +792,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           MutationOptions(
             document: documentNodeMutationStartStreamingSession,
             variables: Variables$Mutation$StartStreamingSession(
-              fileId: widget.fileId,
+              fileId: playFileId,
               strategy: hlsStrategy,
               startPosition:
                   startPositionSeconds > 0 ? startPositionSeconds : null,

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -768,30 +768,59 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       // still carrying that sentinel instead of a real file id. There is no
       // file to ask about, so ask about the media item and let the server rank.
       final byFile = widget.fileId != 'offline';
-      final candidatesResult = await _fetchStreamingCandidates(
+      final mediaContentType =
+          widget.mediaType == 'movie' ? 'movie' : 'episode';
+      var candidatesFetch = await _fetchStreamingCandidates(
         graphqlClient,
-        byFile ? 'file' : (widget.mediaType == 'movie' ? 'movie' : 'episode'),
+        byFile ? 'file' : mediaContentType,
         byFile ? widget.fileId : widget.mediaId,
       );
 
-      // The file actually being played. Normally the user's choice; on the
-      // offline fall-through it is whatever the server ranked highest.
+      // A selected file can go missing out from under a live route: a
+      // quality upgrade replaces an episode's file, writing a new
+      // `media_files` row and deleting the old one, and the route still
+      // carries the old id. The server tells us that explicitly —
+      // `serverRejected`, a GraphQL error, not a transport failure — so
+      // re-ask by media item and let the server rank a file that still
+      // exists, the same fallback the offline sentinel already uses below.
       //
-      // On that fall-through there is no `widget.fileId` worth falling back
-      // to if the candidates call itself failed (network hiccup, server
-      // unreachable): `widget.fileId` is still the `'offline'` sentinel that
-      // sent us down this branch in the first place, not a real file id.
-      // Sending it on to `StartStreamingSession` would just repeat the
-      // malformed-id failure this branch exists to avoid, so fail here
-      // instead with a message the user can act on — the same
+      // A transport failure (unreachable server, timeout, socket error) gets
+      // no such retry: `serverRejected` is false in that case specifically so
+      // this branch is skipped, and `playFileId` below keeps resolving to
+      // `widget.fileId`. Falling back on a network blip would silently swap
+      // the user's chosen file for a different one.
+      var usesServerRankedFile = !byFile;
+      if (byFile && candidatesFetch.serverRejected) {
+        usesServerRankedFile = true;
+        candidatesFetch = await _fetchStreamingCandidates(
+          graphqlClient,
+          mediaContentType,
+          widget.mediaId,
+        );
+      }
+
+      final candidatesResult = candidatesFetch.candidates;
+
+      // The file actually being played. Normally the user's choice; on the
+      // offline fall-through, or when the selected file was rejected by the
+      // server and re-asked above, it is whatever the server ranked highest
+      // instead.
+      //
+      // On both of those fall-throughs there is no `widget.fileId` worth
+      // falling back to if the candidates call itself failed (network
+      // hiccup, server unreachable): `widget.fileId` is either the
+      // `'offline'` sentinel or a file id the server has just said does not
+      // exist. Sending either on to `StartStreamingSession` would just
+      // repeat a failure this branch exists to avoid, so fail here instead
+      // with a message the user can act on — the same
       // throw-into-the-surrounding-catch convention used above for the
       // missing P2P server address.
-      final playFileId = byFile
-          ? widget.fileId
-          : candidatesResult?.fileId ??
+      final playFileId = usesServerRankedFile
+          ? candidatesResult?.fileId ??
               (throw Exception(
                   'Could not reach the server to find a playable file for '
-                  'this download. Check your connection and try again.'));
+                  'this title. Check your connection and try again.'))
+          : widget.fileId;
 
       await _resolveQualityForFile(candidatesResult);
 
@@ -1329,8 +1358,23 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// defect `core/graphql/watch/query_watcher.dart` documents. Nothing is lost
   /// by going to the network here — the offline branch returns long before this
   /// runs, and every remaining path needs the server to serve a single byte.
-  Future<Query$StreamingCandidates$streamingCandidates?>
-      _fetchStreamingCandidates(
+  ///
+  /// `serverRejected` distinguishes *why* a call failed, so the caller can
+  /// decide whether it is safe to retry against a different id.
+  /// `streaming_resolver.ex`'s `streaming_candidates/3` answers an unknown
+  /// id with a GraphQL error (e.g. "file not found") rather than throwing —
+  /// the server understood the request and gave a real answer, so
+  /// `result.exception` carries non-empty `graphqlErrors` and a null
+  /// `linkException`. A transport failure (unreachable server, timeout,
+  /// socket error) looks the opposite: no `graphqlErrors`, a non-null
+  /// `linkException`. Only the former means "this id doesn't exist"; the
+  /// latter means "we don't know", and must not be treated the same way by
+  /// callers that would otherwise retry with a different id.
+  Future<
+      ({
+        Query$StreamingCandidates$streamingCandidates? candidates,
+        bool serverRejected,
+      })> _fetchStreamingCandidates(
     GraphQLClient graphqlClient,
     String contentType,
     String id,
@@ -1350,14 +1394,18 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       if (result.hasException) {
         debugPrint(
             '[PlayerScreen] Failed to fetch candidates: ${result.exception}');
-        return null;
+        final exception = result.exception;
+        final serverRejected = exception != null &&
+            exception.graphqlErrors.isNotEmpty &&
+            exception.linkException == null;
+        return (candidates: null, serverRejected: serverRejected);
       }
 
       final data = Query$StreamingCandidates.fromJson(result.data!);
-      return data.streamingCandidates;
+      return (candidates: data.streamingCandidates, serverRejected: false);
     } catch (e) {
       debugPrint('[PlayerScreen] Error fetching streaming candidates: $e');
-      return null;
+      return (candidates: null, serverRejected: false);
     }
   }
 

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -466,14 +466,22 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// calls it — so the receiver starts where the user asked, instead of
   /// always at zero the way it did when each of the three call sites reached
   /// this before the resume decision existed.
-  Future<bool> _castToTargetIfSet(ResumePlan plan) async {
+  ///
+  /// [fileId] is the file id to hand the receiver. Callers before the
+  /// streaming-candidates fetch pass `widget.fileId` (there is no other id
+  /// yet); the caller after it must pass `playFileId` instead, so a self-heal
+  /// that swaps in the server-ranked file for local playback (see
+  /// [_fetchStreamingCandidates]) reaches the receiver too, rather than
+  /// sending it the id the server just rejected.
+  Future<bool> _castToTargetIfSet(ResumePlan plan,
+      {required String fileId}) async {
     final target = ref.read(castTargetProvider);
     if (target == null) return false;
 
     // Downloaded media lives only on this device; the route resolver has no
     // server-side file to hand the receiver. Playing locally is the useful
     // outcome, but silently ignoring the chosen device is not, so say why.
-    if (widget.fileId == 'offline') {
+    if (fileId == 'offline') {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
           content: Text('Downloads cannot be cast — playing on this device.'),
@@ -487,7 +495,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       await manager.startCast(
         device: target,
         request: CastLaunchRequest(
-          fileId: widget.fileId,
+          fileId: fileId,
           mediaId: widget.mediaId,
           mediaType: widget.mediaType,
           title: widget.title ?? 'Untitled',
@@ -613,7 +621,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         );
         if (plan == null) return;
 
-        if (await _castToTargetIfSet(plan)) return;
+        if (await _castToTargetIfSet(plan, fileId: widget.fileId)) return;
 
         await _openPlayerAndStart(offlinePath, {}, plan: plan);
         return;
@@ -685,7 +693,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           );
           if (plan == null) return;
 
-          if (await _castToTargetIfSet(plan)) return;
+          if (await _castToTargetIfSet(plan, fileId: widget.fileId)) return;
 
           await _openPlayerAndStart(localPath, {}, plan: plan);
           return;
@@ -870,7 +878,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       );
       if (plan == null) return;
 
-      if (await _castToTargetIfSet(plan)) return;
+      if (await _castToTargetIfSet(plan, fileId: playFileId)) return;
 
       String mediaSource;
       Map<String, String> httpHeaders = {};
@@ -1341,17 +1349,25 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
   /// Fetch streaming candidates from the server via GraphQL.
   ///
-  /// `networkOnly` is load-bearing. This query is keyed by *content* id, not by
-  /// file id, so its cache entry outlives the file it describes: replacing an
-  /// episode's file (a manual delete and re-download, or an automatic quality
-  /// upgrade, which supersedes the row and deletes the old one) leaves the
-  /// entry pointing at a `fileId` that no longer exists. The direct-play branch
-  /// below takes its id from this response rather than from the route, so a
-  /// cached hit sends playback to a deleted file: the server answers "media
-  /// file not found in database", no bytes arrive, and the screen stays black
-  /// while the timeline runs off the equally stale cached duration. The default
-  /// policy for a one-shot `query()` is `cacheFirst` and the store is Hive on
-  /// disk, so that state survives restarts and never self-heals.
+  /// `networkOnly` is load-bearing. The primary call here is keyed by the
+  /// specific file the user selected (`('file', widget.fileId)`), not by
+  /// content id. When the server rejects that file id — e.g. because a
+  /// quality upgrade trashed it (`Mydia.Upgrades.apply_upgrade/4`) — the
+  /// caller in [_initializePlayer] re-asks by media item and plays whatever
+  /// the server ranks instead (`playFileId`). That self-heal only works if
+  /// the rejection is actually visible: a warm cache entry for
+  /// `('file', id)` recorded before the file was trashed still holds a
+  /// *successful* response, with no `graphqlErrors`, because the request
+  /// that produced it really did succeed at the time. Serving that cached
+  /// hit would make `result.hasException` false, so `serverRejected` below
+  /// would never be true, and the self-heal would silently never fire — the
+  /// exact bug this whole mechanism exists to avoid. `networkOnly` is what
+  /// forces a live request every time, so a rejection is always observable.
+  /// That is the load-bearing reason, not merely keeping a stale `fileId`
+  /// out of the direct-play URL: on the fallback paths (the offline
+  /// sentinel, and this self-heal) the id used for playback comes from this
+  /// response rather than from the route regardless, so a stale cached
+  /// response there would feed a dead file straight into playback either way.
   ///
   /// `cacheAndNetwork` is not the fix: on a one-shot `client.query()` it
   /// returns the cached result and discards the network one, which is the same
@@ -1471,7 +1487,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   void _extractSubtitlesFromFiles(List<Fragment$MediaFileFragment?>? files) {
     if (files == null || files.isEmpty) return;
 
-    // Find the file matching the current fileId
+    // Find the file matching the current fileId. This always matches on
+    // `widget.fileId`, never `playFileId`, so on the self-heal path in
+    // [_initializePlayer] (server rejected the selected file and re-ranked
+    // one instead) this is comparing against the id the server just
+    // rejected. No file matches, so external subtitles are silently
+    // dropped for that playback. Intentional for now — see
+    // [_fetchStreamingCandidates] for the self-heal itself.
     for (final file in files) {
       if (file == null) continue;
       if (file.id == widget.fileId) {
@@ -1557,6 +1579,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         return;
       }
 
+      // Matched on `widget.fileId`, never `playFileId`, so on the self-heal
+      // path in [_initializePlayer] (server rejected the selected file and
+      // re-ranked one instead) this looks up segments for the id the server
+      // just rejected and finds none. Skip markers are silently dropped for
+      // that playback. Intentional for now — see [_fetchStreamingCandidates]
+      // for the self-heal itself.
       _segments = MediaSegment.forFile(
         result.data,
         root: root,

--- a/player/test/presentation/screens/player/offline_sentinel_streaming_fallback_test.dart
+++ b/player/test/presentation/screens/player/offline_sentinel_streaming_fallback_test.dart
@@ -1,0 +1,106 @@
+// Regression coverage for the `'offline'` file-id sentinel reaching the
+// streaming candidates query.
+//
+// `downloads_screen.dart` and `series_downloads_screen.dart` both navigate to
+// `PlayerScreen` with `fileId: 'offline'` for anything already downloaded —
+// there is no real file id to thread through, because the point of that route
+// is "play what's on disk". When the stored local path has rotted (OS
+// cleanup, a container path change across an app update),
+// `_resolveDownloadedFilePath` returns null and the "already downloaded,
+// still online" branch falls through to network streaming without ever
+// returning — carrying `widget.fileId` still literally `'offline'` into the
+// code that used to fetch streaming candidates keyed on the file.
+//
+// A `binary_id` GraphQL argument can't parse `'offline'`, so before this
+// file's fix a live server would raise `Ecto.Query.CastError` and playback
+// would fail outright. `PlayerScreen` has to recognize the sentinel and fall
+// back to asking about the *media item* instead, the same way it did before
+// the file-keyed candidates query existed.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+void main() {
+  setUp(mockPathProviderDocumentsDirectory);
+
+  testWidgets(
+      'a downloaded file missing from disk still reaches a real stream, '
+      'not the offline sentinel', (tester) async {
+    // A path that was never written: `_resolveDownloadedFilePath` fails its
+    // first check (`file_utils.fileExists`) and, with `path_provider` mocked
+    // to a temp dir that shares no files with this one, every fallback it
+    // tries misses too — reproducing a download whose backing file rotted
+    // out from under a stale record.
+    final tempDir = Directory.systemTemp
+        .createTempSync('mydia_offline_sentinel_fallback_test_');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+    final missingPath = '${tempDir.path}/arrival.mkv';
+
+    final proxyService = TrackingLocalProxyService();
+
+    // `streamingCandidatesResponse` hardcodes fileId 'file-1' — the id the
+    // server ranked highest for the movie. Direct play must end up streaming
+    // that id, never the literal string 'offline'.
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      streamingCandidatesResponse(duration: 5400, directPlay: true),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      // P2P so the direct-play URL is built by the tracked proxy, not the
+      // real media-token service — same choice as
+      // player_honors_selected_file_test.dart, for the same reason.
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: CapturingCastSessionManager(),
+      proxyService: proxyService,
+      // Online mode (default authStatus), but with a download on record: the
+      // "already downloaded, still online" branch, not the offline-mode one.
+      downloaded: downloadedItem(filePath: missingPath, runtimeMinutes: 90),
+    );
+    addTearDown(container.dispose);
+
+    // `_resolveDownloadedFilePath`'s fallbacks do real `dart:io` and
+    // `path_provider` I/O (see offline_resume_test.dart's doc comments for
+    // why plain `pump()` can't observe that), so this has to run inside
+    // `runAsync` and poll for the real outcome rather than pump a fixed
+    // number of times.
+    await tester.runAsync(() async {
+      await pumpPlayerScreen(tester, container, fileId: 'offline');
+      await pumpUntilReal(
+        tester,
+        () => proxyService.capturedDirectStreamFileId != null,
+      );
+    });
+
+    expect(
+      proxyService.capturedDirectStreamFileId,
+      'file-1',
+      reason: 'the offline sentinel must never reach the direct-play URL — '
+          'once streaming takes over it has to play whatever the server '
+          'ranked for the media item',
+    );
+
+    // Third scripted call, matching the response order above: detail,
+    // segments, candidates. `StubLink` is index-based, so this ordering is
+    // the same one every other PlayerScreen test relies on.
+    final candidatesVariables = link.requests[2].variables;
+    expect(
+      candidatesVariables['contentType'],
+      'movie',
+      reason: 'there is no file to ask about once the sentinel is in play, '
+          'so the fallback has to ask by media item instead',
+    );
+    expect(candidatesVariables['id'], 'movie-1');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+}

--- a/player/test/presentation/screens/player/offline_sentinel_streaming_fallback_test.dart
+++ b/player/test/presentation/screens/player/offline_sentinel_streaming_fallback_test.dart
@@ -26,6 +26,19 @@ import 'package:player/core/connection/connection_provider.dart' as conn;
 import '../../../test_utils/stub_graphql_client.dart';
 import 'player_screen_test_harness.dart';
 
+// The scenario above is the *happy* offline fall-through: the candidates
+// call succeeds and ranks a real file. The test below is what happens when
+// that call itself fails — a transient GraphQL error, the server
+// unreachable. `candidatesResult` is then null, so `candidatesResult?.fileId`
+// is also null, and the naive `?? widget.fileId` fallback that used to live
+// here would resolve to the literal string `'offline'` — the exact
+// malformed-id failure this whole fallback exists to prevent, just deferred
+// to the server instead of caught locally. The fix has to fail fast with a
+// user-facing error instead, following `_initializePlayer`'s existing
+// convention (surrounding `catch` sets `_error` from a thrown `Exception`,
+// same as the missing-P2P-server-address case a few lines above this one in
+// `player_screen.dart`).
+
 void main() {
   setUp(mockPathProviderDocumentsDirectory);
 
@@ -99,6 +112,77 @@ void main() {
           'so the fallback has to ask by media item instead',
     );
     expect(candidatesVariables['id'], 'movie-1');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+      'a downloaded file missing from disk, when the candidates query '
+      'itself fails, surfaces an error instead of streaming the offline '
+      'sentinel', (tester) async {
+    final tempDir = Directory.systemTemp
+        .createTempSync('mydia_offline_sentinel_fallback_error_test_');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+    final missingPath = '${tempDir.path}/arrival.mkv';
+
+    final proxyService = TrackingLocalProxyService();
+
+    // Same detail/segments responses as the happy-path test above, but the
+    // third scripted response — the streaming candidates call this branch
+    // depends on to find anything to play — fails outright, standing in for
+    // a transient GraphQL error or an unreachable server.
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      graphqlErrorResponse('internal server error'),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: CapturingCastSessionManager(),
+      proxyService: proxyService,
+      downloaded: downloadedItem(filePath: missingPath, runtimeMinutes: 90),
+    );
+    addTearDown(container.dispose);
+
+    await tester.runAsync(() async {
+      await pumpPlayerScreen(tester, container, fileId: 'offline');
+      // The error UI (`_buildError`'s `Icons.error_outline`) is the only
+      // stable signal available here: on this path
+      // `capturedDirectStreamFileId` never becomes non-null, so polling on
+      // it (as the happy-path test above does) would just spin to the
+      // ceiling.
+      await pumpUntilReal(
+        tester,
+        () => find.byIcon(Icons.error_outline).evaluate().isNotEmpty,
+      );
+    });
+
+    expect(
+      find.byIcon(Icons.error_outline),
+      findsOneWidget,
+      reason: 'a failed candidates call must surface as a real error, not '
+          'a silent hang and not an unhandled exception',
+    );
+
+    expect(
+      proxyService.capturedDirectStreamFileId,
+      isNull,
+      reason: 'direct play must never start when the candidates call '
+          'failed — there is no server-ranked file to play',
+    );
+
+    for (final request in link.requests) {
+      expect(
+        request.variables['fileId'],
+        isNot('offline'),
+        reason: 'the offline sentinel must never reach a '
+            'StartStreamingSession (or any other) mutation sent to the '
+            'server',
+      );
+    }
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pumpAndSettle();

--- a/player/test/presentation/screens/player/player_honors_selected_file_test.dart
+++ b/player/test/presentation/screens/player/player_honors_selected_file_test.dart
@@ -1,0 +1,99 @@
+// Regression coverage for the quality selector being ignored on desktop.
+//
+// `PlayerScreen` receives the file the user picked as `widget.fileId`, but the
+// direct-play branch used to stream `candidatesResult.fileId` instead — the
+// server's answer to a question keyed on the *media item*, not the file. With
+// a 1080p and a 4K file on one movie, picking 1080p still played the 4K.
+//
+// Both tests script the server to name a file that is deliberately NOT the one
+// the screen was mounted with. Reintroducing either half of the bug — keying
+// the candidates query on `widget.mediaId`, or shadowing `widget.fileId` with
+// `candidatesResult.fileId` — fails them.
+//
+// P2P connection state so the direct-play URL comes from the stub proxy rather
+// than the real media-token service.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+void main() {
+  testWidgets('direct play streams the file the user selected', (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    // `streamingCandidatesResponse` hardcodes fileId 'file-1'. Mounting with
+    // 'file-2' makes the two disagree, which is exactly the production case:
+    // the user picked one file, the server named another.
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      streamingCandidatesResponse(duration: 5400, directPlay: true),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: castManager,
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container, fileId: 'file-2');
+    await pumpUntil(
+      tester,
+      () => proxyService.capturedDirectStreamFileId != null,
+    );
+
+    expect(
+      proxyService.capturedDirectStreamFileId,
+      'file-2',
+      reason: 'the direct-play branch must stream widget.fileId, not whatever '
+          'the candidates response named',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the candidates query asks about the file, not the media item',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      streamingCandidatesResponse(duration: 5400, directPlay: true),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: castManager,
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container, fileId: 'file-2');
+    await pumpUntil(tester, () => link.requests.length >= 3);
+
+    // Third scripted call, matching the response order above. `StubLink` is
+    // index-based, so this ordering is the same one every other PlayerScreen
+    // test relies on.
+    final candidatesVariables = link.requests[2].variables;
+
+    expect(
+      candidatesVariables['contentType'],
+      'file',
+      reason: 'asking by movie id forces the server to guess which file',
+    );
+    expect(candidatesVariables['id'], 'file-2');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+}

--- a/player/test/presentation/screens/player/player_honors_selected_file_test.dart
+++ b/player/test/presentation/screens/player/player_honors_selected_file_test.dart
@@ -5,16 +5,25 @@
 // server's answer to a question keyed on the *media item*, not the file. With
 // a 1080p and a 4K file on one movie, picking 1080p still played the 4K.
 //
-// Both tests script the server to name a file that is deliberately NOT the one
-// the screen was mounted with. Reintroducing either half of the bug — keying
-// the candidates query on `widget.mediaId`, or shadowing `widget.fileId` with
-// `candidatesResult.fileId` — fails them.
+// The first two tests script the server to name a file that is deliberately
+// NOT the one the screen was mounted with. Reintroducing either half of the
+// bug — keying the candidates query on `widget.mediaId`, or shadowing
+// `widget.fileId` with `candidatesResult.fileId` — fails them.
+//
+// The third proves the fix's edge: `player_screen_stale_candidates_test.dart`
+// covers the case where the server *rejects* the selected file (deleted by a
+// quality upgrade) and the screen falls back to whatever the server ranks for
+// the media item instead. That fallback must not fire on a transport failure
+// — a socket error or an unreachable server says nothing about whether the
+// selected file still exists, and firing anyway would silently swap the
+// user's choice for the server's pick over a network blip.
 //
 // P2P connection state so the direct-play URL comes from the stub proxy rather
 // than the real media-token service.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:player/core/connection/connection_provider.dart' as conn;
 
 import '../../../test_utils/stub_graphql_client.dart';
@@ -92,6 +101,76 @@ void main() {
       reason: 'asking by movie id forces the server to guess which file',
     );
     expect(candidatesVariables['id'], 'file-2');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+      'a transport failure fetching candidates still honors the selected '
+      'file, with no server-ranked fallback', (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    // The candidates call for the selected file never reaches the server at
+    // all. `http.ClientException` is what `package:graphql`'s
+    // `translateFailure` recognizes and wraps into a genuine
+    // `LinkException` — the shape a real socket error or unreachable server
+    // takes, as opposed to the server answering with a GraphQL error (see
+    // `player_screen_stale_candidates_test.dart`, the case this one exists
+    // to be told apart from).
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      http.ClientException('Connection refused'),
+      startStreamingSessionResponse(duration: 5400),
+      endStreamingSessionResponse(),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: castManager,
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container, fileId: 'file-2');
+    // With no candidates response, `_canDirectPlay` has nothing to say yes
+    // to, so this falls to the HLS path instead of direct play — a real,
+    // if incidental, degradation from the network blip. What must not
+    // degrade is *which file* streams, so wait on the session-start
+    // mutation rather than on `directStreamFileIds`, which this path never
+    // populates.
+    await pumpUntil(
+      tester,
+      () => link.requests.any((r) => r.variables.containsKey('strategy')),
+    );
+
+    final sessionRequest =
+        link.requests.firstWhere((r) => r.variables.containsKey('strategy'));
+    expect(
+      sessionRequest.variables['fileId'],
+      'file-2',
+      reason: 'a transport failure must not trigger the deleted-file '
+          'fallback — that would silently swap the file the user picked for '
+          'whatever the server ranks for the whole media item',
+    );
+
+    expect(
+      link.requests.where((r) => r.variables.containsKey('contentType')).length,
+      1,
+      reason: 'the fallback must only re-ask the server when it has '
+          'actually answered and rejected the id, never on a transport '
+          'failure',
+    );
+
+    // Drains `_waitForPlaylist`'s background retry loop (real HTTP calls,
+    // but `flutter_test`'s `HttpOverrides` makes every one an instant 400,
+    // and `FakeAsync` governs the retry backoff timers) so no pending timer
+    // survives into the framework's own end-of-test check — see
+    // `player_screen_resume_offset_test.dart` for the full explanation.
+    await tester.pumpAndSettle();
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pumpAndSettle();

--- a/player/test/presentation/screens/player/player_honors_selected_file_test.dart
+++ b/player/test/presentation/screens/player/player_honors_selected_file_test.dart
@@ -113,12 +113,14 @@ void main() {
     final proxyService = TrackingLocalProxyService();
 
     // The candidates call for the selected file never reaches the server at
-    // all. `http.ClientException` is what `package:graphql`'s
-    // `translateFailure` recognizes and wraps into a genuine
-    // `LinkException` — the shape a real socket error or unreachable server
-    // takes, as opposed to the server answering with a GraphQL error (see
-    // `player_screen_stale_candidates_test.dart`, the case this one exists
-    // to be told apart from).
+    // all. `http.ClientException` is not special here — `package:graphql`'s
+    // `translateFailure` wraps *any* unrecognized thrown object in an
+    // `UnknownException`, so any exception thrown from the link would give a
+    // non-null `linkException` just the same. It is simply a realistic
+    // stand-in for a real socket error or unreachable server, the shape a
+    // transport failure takes, as opposed to the server answering with a
+    // GraphQL error (see `player_screen_stale_candidates_test.dart`, the
+    // case this one exists to be told apart from).
     final link = StubLink.responses([
       movieDetailResponse(),
       movieSegmentsResponse(),

--- a/player/test/presentation/screens/player/player_screen_stale_candidates_test.dart
+++ b/player/test/presentation/screens/player/player_screen_stale_candidates_test.dart
@@ -1,21 +1,34 @@
 // Regression coverage for playback pinned to a file that no longer exists.
 //
-// `StreamingCandidates` is keyed by *content* id, never by file id, so its
-// cache entry outlives the file it describes. Replace an episode's file — by
-// hand, or through an automatic quality upgrade, which writes a new
-// `media_files` row and deletes the old one — and the entry is left naming a
-// `fileId` the server has since dropped.
+// A quality upgrade — or a manual delete-and-redownload — replaces an
+// episode's (or movie's) file: a new `media_files` row is written and the
+// old one is deleted. `_fetchStreamingCandidates` asks the server about the
+// *file* the route names (`('file', fileId)`), not the media item, so a
+// route built before that swap still carries the deleted file's id into that
+// query. The server answers an id it does not recognize with a GraphQL
+// error rather than throwing, and `_initializePlayer` treats that specific
+// shape of failure — `graphqlErrors` present, no `linkException` — as "this
+// file is gone": it re-asks by media item and lets the server rank a file
+// that still exists, instead of handing the dead id on to
+// `StartStreamingSession`.
 //
-// That mattered because the direct-play branch takes its id from this response
-// rather than from the route, and because a one-shot `client.query()` defaults
-// to `FetchPolicy.cacheFirst` over a Hive store on disk. The result was a
-// permanent, restart-surviving black screen: the p2p direct stream answered
-// "media file not found in database", no bytes ever arrived, and the timeline
-// ran happily off the equally stale cached duration so nothing looked wrong.
+// That mattered because the direct-play branch takes its id from
+// `widget.fileId` (see `player_honors_selected_file_test.dart`), and without
+// this fallback a deleted file would either stay pinned there forever or —
+// pre-dating that fix — come from a *media-item*-keyed candidates cache,
+// stale or not. Either way the failure mode was a permanent,
+// restart-surviving black screen: a p2p direct stream for a deleted file
+// answers "media file not found in database", no bytes ever arrive, and the
+// timeline runs happily off an equally stale cached duration so nothing
+// looks wrong.
 //
-// The fix is `fetchPolicy: FetchPolicy.networkOnly` on that query. This test
-// pins it by warming the cache with a stale answer and proving playback still
-// goes where the *server* says, not where the cache does.
+// The second test below keeps the other half of master's original
+// guarantee: `FetchPolicy.networkOnly` on this query is still load-bearing,
+// now pinned to the `('file', <fileId>)` cache key the screen actually reads
+// instead of the old `('movie', ...)` one. A one-shot `client.query()`
+// defaults to `FetchPolicy.cacheFirst` over a Hive store on disk, so a
+// regression back to that default would go undetected by any test that only
+// checks the *outcome* of a request, cache hit or miss.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -26,51 +39,34 @@ import 'package:player/graphql/queries/streaming_candidates.graphql.dart';
 import '../../../test_utils/stub_graphql_client.dart';
 import 'player_screen_test_harness.dart';
 
-/// The request `_fetchStreamingCandidates` issues for the harness's movie.
-Request _candidatesRequest() => Request(
+/// The request `_fetchStreamingCandidates` issues for [fileId] on the
+/// harness's movie.
+Request _fileCandidatesRequest(String fileId) => Request(
       operation: const Operation(
         document: documentNodeQueryStreamingCandidates,
       ),
       variables: Variables$Query$StreamingCandidates(
-        contentType: 'movie',
-        id: 'movie-1',
+        contentType: 'file',
+        id: fileId,
       ).toJson(),
     );
 
 void main() {
-  testWidgets('a warm candidates cache cannot pin playback to a deleted file',
-      (tester) async {
+  testWidgets(
+      'a file the server has rejected falls back to the server-ranked file '
+      'for the media item', (tester) async {
     final castManager = CapturingCastSessionManager();
     final proxyService = TrackingLocalProxyService();
 
-    // The install has played this title before, back when it was a different
-    // file. `file-old` is gone from the server now.
-    final cache = GraphQLCache(store: InMemoryStore());
-    cache.writeQuery(
-      _candidatesRequest(),
-      data: streamingCandidatesResponse(
-        duration: 5400,
-        directPlay: true,
-        fileId: 'file-old',
-      ),
-      broadcast: false,
-    );
-
-    // Guard against a false pass. If the seed above did not land under the key
-    // the screen actually reads, the query would miss the cache, go to the
-    // network for unrelated reasons, and this test would go green while the
-    // bug it exists to catch was fully intact.
-    expect(
-      cache.readQuery(_candidatesRequest()),
-      isNotNull,
-      reason: 'the cache must genuinely hold a stale entry for this query, '
-          'otherwise the assertion below proves nothing',
-    );
-
+    // `file-old` is what the route still names. The server has since
+    // dropped it — a quality upgrade replaced the row — and says so with a
+    // GraphQL error instead of guessing, which is what the fallback below
+    // keys off. The re-ask by media item is what the server ranks highest
+    // today.
     final link = StubLink.responses([
       movieDetailResponse(),
       movieSegmentsResponse(),
-      // What the server says today, after the file was replaced.
+      graphqlErrorResponse('file not found'),
       streamingCandidatesResponse(
         duration: 5400,
         directPlay: true,
@@ -83,11 +79,10 @@ void main() {
       connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
       castManager: castManager,
       proxyService: proxyService,
-      cache: cache,
     );
     addTearDown(container.dispose);
 
-    await pumpPlayerScreen(tester, container);
+    await pumpPlayerScreen(tester, container, fileId: 'file-old');
     await pumpUntil(
       tester,
       () => proxyService.directStreamFileIds.isNotEmpty,
@@ -96,15 +91,27 @@ void main() {
     expect(
       proxyService.directStreamFileIds,
       contains('file-new'),
-      reason: 'the file to play is a fact about current server state, so it '
-          'has to come from the server and not from a cache entry that '
-          'outlived the file it names',
+      reason: 'once the server rejects the route\'s file id, the file to '
+          'play has to come from the server\'s re-ranked answer for the '
+          'media item, not the id the route still carries',
     );
     expect(
       proxyService.directStreamFileIds,
       isNot(contains('file-old')),
-      reason: 'file-old no longer exists; streaming it is the black screen',
+      reason: 'file-old no longer exists; streaming it is the black screen '
+          'this fallback exists to avoid',
     );
+
+    // Pins the mechanism, not just the outcome: the first call has to ask
+    // about the rejected file specifically, and only the retry may ask by
+    // media item. Third/fourth scripted calls, matching the response order
+    // above (detail, segments, then the two candidates calls) — `StubLink`
+    // is index-based, the same ordering every other PlayerScreen test
+    // relies on.
+    expect(link.requests[2].variables['contentType'], 'file');
+    expect(link.requests[2].variables['id'], 'file-old');
+    expect(link.requests[3].variables['contentType'], 'movie');
+    expect(link.requests[3].variables['id'], 'movie-1');
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pumpAndSettle();
@@ -115,9 +122,13 @@ void main() {
     final castManager = CapturingCastSessionManager();
     final proxyService = TrackingLocalProxyService();
 
+    // The install has played this exact file before. Its cached answer is
+    // deliberately stale (`file-old`) so a regression to `cacheFirst` would
+    // both skip the network call the assertion below checks for, and hand
+    // back an id nothing downstream expects.
     final cache = GraphQLCache(store: InMemoryStore());
     cache.writeQuery(
-      _candidatesRequest(),
+      _fileCandidatesRequest('file-1'),
       data: streamingCandidatesResponse(
         duration: 5400,
         directPlay: true,
@@ -126,13 +137,25 @@ void main() {
       broadcast: false,
     );
 
+    // Guard against a false pass. If the seed above did not land under the
+    // key the screen actually reads, the query would miss the cache, go to
+    // the network for unrelated reasons, and this test would go green while
+    // the bug it exists to catch was fully intact.
+    expect(
+      cache.readQuery(_fileCandidatesRequest('file-1')),
+      isNotNull,
+      reason: 'the cache must genuinely hold a stale entry for this query, '
+          'otherwise the assertion below proves nothing',
+    );
+
     final link = StubLink.responses([
       movieDetailResponse(),
       movieSegmentsResponse(),
+      // What the server says today, for the same file the cache answered.
       streamingCandidatesResponse(
         duration: 5400,
         directPlay: true,
-        fileId: 'file-new',
+        fileId: 'file-1',
       ),
     ]);
 

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -94,6 +94,12 @@ class TrackingLocalProxyService extends Fake implements LocalProxyService {
   bool stopped = false;
   bool startCalled = false;
 
+  /// The file id `PlayerScreen` asked to direct-stream, or null if it never
+  /// took the direct-play branch. This is the user's selected file: a test
+  /// that mounts the screen with one file id and scripts the server to name a
+  /// different one proves the selection is honored.
+  String? capturedDirectStreamFileId;
+
   @override
   int get port => 12345;
 
@@ -107,8 +113,10 @@ class TrackingLocalProxyService extends Fake implements LocalProxyService {
       'http://127.0.0.1:$port/hls/$sessionId/index.m3u8';
 
   @override
-  String buildDirectStreamUrl(String fileId) =>
-      'http://127.0.0.1:$port/direct/$fileId/stream';
+  String buildDirectStreamUrl(String fileId) {
+    capturedDirectStreamFileId = fileId;
+    return 'http://127.0.0.1:$port/direct/$fileId/stream';
+  }
 
   @override
   Future<void> stop() async {

--- a/test/mydia/library/file_ranking_test.exs
+++ b/test/mydia/library/file_ranking_test.exs
@@ -40,6 +40,18 @@ defmodule Mydia.Library.FileRankingTest do
       assert FileRanking.resolution_pixels("") == 0
       assert FileRanking.resolution_pixels("unknown") == 0
     end
+
+    test "treats interlaced resolutions as equal to progressive at the same height" do
+      # ReleaseParser persists interlaced forms (e.g. "1080i"), treating them
+      # as equal to progressive at the same resolution for ranking purposes.
+      assert FileRanking.resolution_pixels("1080i") == 1080
+      assert FileRanking.resolution_pixels("720i") == 720
+      assert FileRanking.resolution_pixels("2160i") == 2160
+    end
+
+    test "ignores case for interlaced suffix" do
+      assert FileRanking.resolution_pixels("1080I") == 1080
+    end
   end
 
   describe "best/1" do
@@ -96,6 +108,13 @@ defmodule Mydia.Library.FileRankingTest do
       y = file(id: "bbb", resolution: "1080p", bitrate: 1)
 
       assert FileRanking.best([x, y]).id == FileRanking.best([y, x]).id
+    end
+
+    test "an interlaced file outranks an unanalyzed file" do
+      unanalyzed = file(id: "a", resolution: nil, bitrate: 99_000_000)
+      interlaced = file(id: "b", resolution: "1080i", bitrate: nil)
+
+      assert FileRanking.best([unanalyzed, interlaced]).id == "b"
     end
   end
 

--- a/test/mydia/library/file_ranking_test.exs
+++ b/test/mydia/library/file_ranking_test.exs
@@ -1,0 +1,113 @@
+defmodule Mydia.Library.FileRankingTest do
+  # Pure functions over structs: no database, no shared state.
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.FileRanking
+  alias Mydia.Library.MediaFile
+
+  describe "resolution_pixels/1" do
+    test "maps every tier FileAnalyzer.extract_resolution/1 emits" do
+      assert FileRanking.resolution_pixels("4K") == 2160
+      assert FileRanking.resolution_pixels("2160p") == 2160
+      assert FileRanking.resolution_pixels("1440p") == 1440
+      assert FileRanking.resolution_pixels("1080p") == 1080
+      assert FileRanking.resolution_pixels("720p") == 720
+      assert FileRanking.resolution_pixels("480p") == 480
+      assert FileRanking.resolution_pixels("360p") == 360
+    end
+
+    test "maps the extra spellings ReleaseParser can persist" do
+      assert FileRanking.resolution_pixels("UHD") == 2160
+      assert FileRanking.resolution_pixels("8K") == 4320
+      assert FileRanking.resolution_pixels("4320p") == 4320
+      assert FileRanking.resolution_pixels("576p") == 576
+      assert FileRanking.resolution_pixels("540p") == 540
+    end
+
+    test "ignores case and surrounding whitespace" do
+      assert FileRanking.resolution_pixels("  4k  ") == 2160
+      assert FileRanking.resolution_pixels("1080P") == 1080
+    end
+
+    test "falls back to the trailing number for non-standard heights" do
+      # FileAnalyzer emits "#{height}p" for anything off-tier.
+      assert FileRanking.resolution_pixels("816p") == 816
+      assert FileRanking.resolution_pixels("1920x1080") == 1080
+    end
+
+    test "returns 0 for nil and unparseable input so those files sort last" do
+      assert FileRanking.resolution_pixels(nil) == 0
+      assert FileRanking.resolution_pixels("") == 0
+      assert FileRanking.resolution_pixels("unknown") == 0
+    end
+  end
+
+  describe "best/1" do
+    test "returns nil for an empty list" do
+      assert FileRanking.best([]) == nil
+    end
+
+    test "returns the only file when there is one" do
+      only = file(id: "a", resolution: nil)
+      assert FileRanking.best([only]).id == "a"
+    end
+
+    test "prefers 4K over 1080p whichever order the list arrives in" do
+      hd = file(id: "a", resolution: "1080p")
+      uhd = file(id: "b", resolution: "4K")
+
+      assert FileRanking.best([hd, uhd]).id == "b"
+      assert FileRanking.best([uhd, hd]).id == "b"
+    end
+
+    test "breaks a resolution tie on bitrate" do
+      low = file(id: "a", resolution: "1080p", bitrate: 5_000_000)
+      high = file(id: "b", resolution: "1080p", bitrate: 12_000_000)
+
+      assert FileRanking.best([low, high]).id == "b"
+      assert FileRanking.best([high, low]).id == "b"
+    end
+
+    test "resolution outranks bitrate" do
+      # A 1080p remux can out-bitrate an efficient 4K HEVC encode. Resolution
+      # still wins: this is why the ranking does not sort on bitrate alone.
+      fat_hd = file(id: "a", resolution: "1080p", bitrate: 40_000_000)
+      lean_uhd = file(id: "b", resolution: "4K", bitrate: 25_000_000)
+
+      assert FileRanking.best([fat_hd, lean_uhd]).id == "b"
+    end
+
+    test "an unanalyzed file never outranks one with a known resolution" do
+      unanalyzed = file(id: "a", resolution: nil, bitrate: 99_000_000)
+      known = file(id: "b", resolution: "360p", bitrate: nil)
+
+      assert FileRanking.best([unanalyzed, known]).id == "b"
+    end
+
+    test "treats a missing bitrate as zero rather than crashing" do
+      no_bitrate = file(id: "a", resolution: "1080p", bitrate: nil)
+      some_bitrate = file(id: "b", resolution: "1080p", bitrate: 1)
+
+      assert FileRanking.best([no_bitrate, some_bitrate]).id == "b"
+    end
+
+    test "gives the same answer both ways when every quality signal ties" do
+      x = file(id: "aaa", resolution: "1080p", bitrate: 1)
+      y = file(id: "bbb", resolution: "1080p", bitrate: 1)
+
+      assert FileRanking.best([x, y]).id == FileRanking.best([y, x]).id
+    end
+  end
+
+  describe "sort/1" do
+    test "orders best first" do
+      sd = file(id: "a", resolution: "480p")
+      uhd = file(id: "b", resolution: "4K")
+      hd = file(id: "c", resolution: "1080p")
+
+      assert Enum.map(FileRanking.sort([sd, uhd, hd]), & &1.id) == ["b", "c", "a"]
+    end
+  end
+
+  defp file(attrs), do: struct!(MediaFile, Map.new(attrs))
+end

--- a/test/mydia/streaming/candidates_test.exs
+++ b/test/mydia/streaming/candidates_test.exs
@@ -4,6 +4,7 @@ defmodule Mydia.Streaming.CandidatesTest do
 
   import Ecto.Query
   import Mydia.SettingsFixtures
+  import Mydia.MediaFixtures
 
   alias Mydia.Library
   alias Mydia.Library.MediaFile
@@ -185,6 +186,96 @@ defmodule Mydia.Streaming.CandidatesTest do
       result = Candidates.ensure_codec_info(media_file)
       assert result.id == media_file.id
       assert is_nil(result.analyzed_at)
+    end
+  end
+
+  describe "resolve_media_file/2 file selection" do
+    test "a movie resolves to its highest-resolution file, whichever was created first" do
+      hd_first = media_item_fixture(%{type: "movie"})
+      _hd = media_file_fixture(%{media_item_id: hd_first.id, resolution: "1080p"})
+      uhd = media_file_fixture(%{media_item_id: hd_first.id, resolution: "4K"})
+
+      uhd_first = media_item_fixture(%{type: "movie"})
+      uhd2 = media_file_fixture(%{media_item_id: uhd_first.id, resolution: "4K"})
+      _hd2 = media_file_fixture(%{media_item_id: uhd_first.id, resolution: "1080p"})
+
+      assert {:ok, chosen} = Candidates.resolve_media_file("movie", hd_first.id)
+      assert chosen.id == uhd.id
+
+      assert {:ok, chosen2} = Candidates.resolve_media_file("movie", uhd_first.id)
+      assert chosen2.id == uhd2.id
+    end
+
+    test "an episode resolves to its highest-resolution file" do
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id})
+
+      _hd = media_file_fixture(%{episode_id: episode.id, resolution: "720p"})
+      uhd = media_file_fixture(%{episode_id: episode.id, resolution: "2160p"})
+
+      assert {:ok, chosen} = Candidates.resolve_media_file("episode", episode.id)
+      assert chosen.id == uhd.id
+    end
+
+    test "a resolution tie falls through to bitrate" do
+      movie = media_item_fixture(%{type: "movie"})
+
+      _low =
+        media_file_fixture(%{media_item_id: movie.id, resolution: "1080p", bitrate: 4_000_000})
+
+      high =
+        media_file_fixture(%{media_item_id: movie.id, resolution: "1080p", bitrate: 15_000_000})
+
+      assert {:ok, chosen} = Candidates.resolve_media_file("movie", movie.id)
+      assert chosen.id == high.id
+    end
+
+    test "an unanalyzed file never wins over one with a known resolution" do
+      movie = media_item_fixture(%{type: "movie"})
+
+      _unknown =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          resolution: nil,
+          bitrate: 99_000_000
+        })
+
+      known = media_file_fixture(%{media_item_id: movie.id, resolution: "480p"})
+
+      assert {:ok, chosen} = Candidates.resolve_media_file("movie", movie.id)
+      assert chosen.id == known.id
+    end
+
+    test "content_type \"file\" returns that exact file even when a better sibling exists" do
+      movie = media_item_fixture(%{type: "movie"})
+
+      hd = media_file_fixture(%{media_item_id: movie.id, resolution: "1080p"})
+      _uhd = media_file_fixture(%{media_item_id: movie.id, resolution: "4K"})
+
+      # This is the path the fixed player takes. It must never re-rank.
+      assert {:ok, chosen} = Candidates.resolve_media_file("file", hd.id)
+      assert chosen.id == hd.id
+    end
+
+    test "trashed files are excluded from ranking" do
+      movie = media_item_fixture(%{type: "movie"})
+
+      hd = media_file_fixture(%{media_item_id: movie.id, resolution: "1080p"})
+
+      _trashed_uhd =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          resolution: "4K",
+          trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      assert {:ok, chosen} = Candidates.resolve_media_file("movie", movie.id)
+      assert chosen.id == hd.id
+    end
+
+    test "a movie with no files reports :no_media_files" do
+      movie = media_item_fixture(%{type: "movie"})
+      assert {:error, :no_media_files} = Candidates.resolve_media_file("movie", movie.id)
     end
   end
 

--- a/test/mydia/streaming/candidates_test.exs
+++ b/test/mydia/streaming/candidates_test.exs
@@ -273,6 +273,19 @@ defmodule Mydia.Streaming.CandidatesTest do
       assert chosen.id == hd.id
     end
 
+    test "content_type \"file\" never resolves to a trashed file" do
+      trashed =
+        media_file_fixture(%{
+          resolution: "4K",
+          trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      # This is the exact hole the self-heal in the player depends on: a
+      # quality upgrade trashes the old file (Mydia.Upgrades.apply_upgrade/4)
+      # but leaves its id resolvable if this clause doesn't filter it out.
+      assert {:error, :not_found} = Candidates.resolve_media_file("file", trashed.id)
+    end
+
     test "a movie with no files reports :no_media_files" do
       movie = media_item_fixture(%{type: "movie"})
       assert {:error, :no_media_files} = Candidates.resolve_media_file("movie", movie.id)

--- a/test/mydia/streaming/candidates_test.exs
+++ b/test/mydia/streaming/candidates_test.exs
@@ -277,6 +277,17 @@ defmodule Mydia.Streaming.CandidatesTest do
       movie = media_item_fixture(%{type: "movie"})
       assert {:error, :no_media_files} = Candidates.resolve_media_file("movie", movie.id)
     end
+
+    test "a malformed id reports :not_found instead of raising" do
+      # binary_id primary keys reject anything that doesn't parse as a UUID
+      # with Ecto.Query.CastError, not Ecto.NoResultsError. The player sends
+      # the literal string "offline" here when a downloaded file's local
+      # copy has gone missing and playback falls through to streaming — that
+      # has to come back as a clean not-found, not a crash report.
+      assert {:error, :not_found} = Candidates.resolve_media_file("file", "not-a-uuid")
+      assert {:error, :not_found} = Candidates.resolve_media_file("movie", "not-a-uuid")
+      assert {:error, :not_found} = Candidates.resolve_media_file("episode", "not-a-uuid")
+    end
   end
 
   # Helpers

--- a/test/mydia_web/controllers/api/player/v1/subtitle_controller_test.exs
+++ b/test/mydia_web/controllers/api/player/v1/subtitle_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule MydiaWeb.Api.Player.V1.SubtitleControllerTest do
   use MydiaWeb.ConnCase, async: true
 
+  import Mydia.MediaFixtures
+
   alias Mydia.{Media, Repo}
 
   setup do
@@ -246,6 +248,78 @@ defmodule MydiaWeb.Api.Player.V1.SubtitleControllerTest do
 
       # Should get 401 Unauthorized or redirect to login
       assert conn.status in [401, 302]
+    end
+  end
+
+  describe "subtitle track listing file selection" do
+    test "lists tracks for the highest-resolution file, not an arbitrary one", %{
+      conn: conn,
+      token: token
+    } do
+      movie = media_item_fixture(%{type: "movie"})
+
+      _low = media_file_fixture(%{media_item_id: movie.id, resolution: "1080p"})
+      high = media_file_fixture(%{media_item_id: movie.id, resolution: "4K"})
+
+      {:ok, subtitle} =
+        Repo.insert(%Mydia.Subtitles.Subtitle{
+          media_file_id: high.id,
+          language: "en",
+          provider: "test",
+          subtitle_hash: "hash-#{System.unique_integer([:positive])}",
+          file_path: "/tmp/high-res-subtitle.srt",
+          format: "srt"
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/player/v1/subtitles/movie/#{movie.id}")
+
+      assert %{"data" => tracks} = json_response(conn, 200)
+
+      # The external subtitle is only attached to the 4K file, so it only
+      # shows up here if the controller resolved to that file.
+      track = Enum.find(tracks, fn t -> t["track_id"] == subtitle.id end)
+      assert track != nil
+    end
+
+    test "never resolves to a trashed file", %{conn: conn, token: token} do
+      movie = media_item_fixture(%{type: "movie"})
+
+      # Created first, so an unfiltered/unordered preload would naturally
+      # return it before the active file below.
+      _trashed_uhd =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          resolution: "4K",
+          trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      active = media_file_fixture(%{media_item_id: movie.id, resolution: "1080p"})
+
+      {:ok, subtitle} =
+        Repo.insert(%Mydia.Subtitles.Subtitle{
+          media_file_id: active.id,
+          language: "en",
+          provider: "test",
+          subtitle_hash: "hash-#{System.unique_integer([:positive])}",
+          file_path: "/tmp/active-file-subtitle.srt",
+          format: "srt"
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/player/v1/subtitles/movie/#{movie.id}")
+
+      assert %{"data" => tracks} = json_response(conn, 200)
+
+      # The external subtitle is only attached to the active (non-trashed)
+      # file, so it only shows up here if the controller skipped the trashed
+      # 4K file.
+      track = Enum.find(tracks, fn t -> t["track_id"] == subtitle.id end)
+      assert track != nil
     end
   end
 end

--- a/test/mydia_web/controllers/api/player/v1/subtitle_controller_test.exs
+++ b/test/mydia_web/controllers/api/player/v1/subtitle_controller_test.exs
@@ -164,6 +164,23 @@ defmodule MydiaWeb.Api.Player.V1.SubtitleControllerTest do
       assert json_response(conn, 404)["error"] == "Media not found"
     end
 
+    test "returns 404 for a trashed media file", %{conn: conn, token: token} do
+      # This is the exact hole the player's self-heal depends on: a quality
+      # upgrade trashes the old file (Mydia.Upgrades.apply_upgrade/4) but
+      # leaves its row and id resolvable if this route doesn't filter it out.
+      trashed =
+        media_file_fixture(%{
+          trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/player/v1/subtitles/file/#{trashed.id}")
+
+      assert json_response(conn, 404)["error"] == "Media not found"
+    end
+
     test "returns 400 for invalid type", %{conn: conn, token: token, movie: movie} do
       conn =
         conn

--- a/test/mydia_web/controllers/api/stream_controller_test.exs
+++ b/test/mydia_web/controllers/api/stream_controller_test.exs
@@ -142,6 +142,24 @@ defmodule MydiaWeb.Api.StreamControllerTest do
       assert json_response(conn, 404)["error"] == "Media file not found on disk"
     end
 
+    test "returns 404 for a trashed media file", %{conn: conn, token: token} do
+      # This is the exact hole the player's self-heal depends on: a quality
+      # upgrade trashes the old file (Mydia.Upgrades.apply_upgrade/4) but
+      # leaves its row and id resolvable if this route doesn't filter it out.
+      trashed =
+        media_file_fixture(%{
+          trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/v1/stream/#{trashed.id}")
+
+      assert conn.status == 404
+      assert json_response(conn, 404)["error"] == "Media file not found"
+    end
+
     test "requires authentication", %{conn: conn, media_file: media_file} do
       conn = get(conn, "/api/v1/stream/#{media_file.id}")
 

--- a/test/mydia_web/controllers/api/stream_controller_test.exs
+++ b/test/mydia_web/controllers/api/stream_controller_test.exs
@@ -408,4 +408,98 @@ defmodule MydiaWeb.Api.StreamControllerTest do
       assert conn.status in [401, 302]
     end
   end
+
+  describe "stream_movie/2 file selection" do
+    test "streams the highest-resolution file, not an arbitrary one", %{
+      conn: conn,
+      token: token
+    } do
+      movie = media_item_fixture(%{type: "movie"})
+      library_path = library_path_fixture()
+      File.mkdir_p!(library_path.path)
+
+      lowres_name = "lowres_#{System.unique_integer([:positive])}.mp4"
+      lowres_path = Path.join(library_path.path, lowres_name)
+      File.write!(lowres_path, String.duplicate("l", 100))
+
+      uhd_name = "uhd_#{System.unique_integer([:positive])}.mp4"
+      uhd_path = Path.join(library_path.path, uhd_name)
+      File.write!(uhd_path, String.duplicate("u", 500))
+
+      _lowres =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: library_path.id,
+          relative_path: lowres_name,
+          resolution: "1080p"
+        })
+
+      _uhd =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: library_path.id,
+          relative_path: uhd_name,
+          resolution: "4K"
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/v1/stream/movie/#{movie.id}")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-length") == ["500"]
+      assert conn.resp_body == String.duplicate("u", 500)
+
+      File.rm!(lowres_path)
+      File.rm!(uhd_path)
+    end
+
+    test "never selects a trashed file", %{conn: conn, token: token} do
+      movie = media_item_fixture(%{type: "movie"})
+      library_path = library_path_fixture()
+      File.mkdir_p!(library_path.path)
+
+      active_name = "active_#{System.unique_integer([:positive])}.mp4"
+      active_path = Path.join(library_path.path, active_name)
+      File.write!(active_path, String.duplicate("a", 100))
+
+      trashed_name = "trashed_#{System.unique_integer([:positive])}.mp4"
+      trashed_path = Path.join(library_path.path, trashed_name)
+      File.write!(trashed_path, String.duplicate("t", 500))
+
+      # Created before the active file: the pre-fix implementation takes the
+      # head of an unordered preload, so creation order determines what an
+      # unfiltered query returns first. Trashed-first is what makes this test
+      # genuinely fail before the trashed_at filter exists (see task report).
+      _trashed =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: library_path.id,
+          relative_path: trashed_name,
+          resolution: "4K",
+          trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      _active =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: library_path.id,
+          relative_path: active_name,
+          resolution: "1080p"
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/v1/stream/movie/#{movie.id}")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-length") == ["100"]
+      assert conn.resp_body == String.duplicate("a", 100)
+
+      File.rm!(active_path)
+      File.rm!(trashed_path)
+    end
+  end
 end


### PR DESCRIPTION
Picking the 1080p version of a movie in the desktop player still played the 4K.

## Root cause

Three defects compounded.

**The player asked the wrong question.** `player_screen.dart` fetched streaming candidates keyed on `widget.mediaId` (the movie), so the file the user picked in the quality selector could not be expressed, even though it had been threaded all the way through the router.

**The server had no basis to answer.** `resolve_media_file/2` resolved a movie or episode to a file by taking the head of an unordered `has_many` preload. No ranking, no `order_by`, no primary-file flag. Whichever row the database returned first won.

**The direct-play branch then discarded the choice**, shadowing `widget.fileId` with the server's pick. The HLS branch already did this correctly, and `kIsWeb` forces web onto HLS, which is why this only reproduced on desktop.

Two quieter corruptions rode along even on the HLS path: the reported duration and the `HLS_COPY` vs `TRANSCODE` decision were both computed from the wrong file's metadata.

## What changed

**Player.** Asks for candidates by `('file', widget.fileId)` and streams that id on every direct-play path. `content_type: "file"` was already supported server-side, so there is no schema change and the `.graphql` document is untouched.

**Server.** New pure `Mydia.Library.FileRanking` ranks by resolution, then bitrate, then id as a stable tiebreak, with unanalyzed files last. Wired into the three streaming call sites: `Mydia.Streaming.Candidates`, `StreamController`, and the subtitle controller.

The server half matters because Mydia is self-hosted with no coordinated deploys. A player build already in the field keeps asking by movie id for as long as its owner does not update, and a client-only fix would leave those installs on a coin flip.

Two things surfaced during review and are included:

- `StreamController` and the subtitle controller never filtered trashed files, unlike `Candidates`. Deterministic ranking without that filter would have turned "sometimes streams a trashed file" into "reliably streams the trashed 4K file". This also closes a pre-existing inconsistency where `video_player.js` hit the filtered candidates endpoint and then streamed from the unfiltered route, so the two could name different files.
- A downloaded item whose local file has gone missing falls through to streaming still carrying the `'offline'` sentinel. Keying the query on the file sent that sentinel where a UUID was expected and broke playback that previously worked. The sentinel is now detected and falls back to asking by media item.

## Release note

Until a native player updates, it still asks by movie id. Previously it got an arbitrary file, so a user who picked 1080p got the right one roughly half the time. It now reliably gets the highest-resolution file, so in that window the symptom looks worse before the app update makes it right. The web player ships with the server and takes the HLS branch, so it is unaffected.

## Testing

- `mix precommit`: 6423 tests, 0 failures
- `flutter test --concurrency=1`: 1413 tests, 0 failures
- The malformed-id path was verified separately under PostgreSQL. SQLite stores `binary_id` as a plain string, so that test passed there without exercising the new rescue at all.

Every new test was checked to fail against the pre-fix code rather than pass incidentally. Two were found passing for the wrong reason during review and had their fixture ordering reversed until they went genuinely red.

## Follow-ups, deliberately not in this PR

- The player has two resolution parsers that disagree with each other (`MediaFileSelector.parseToPixels` and `quality_badge.dart`), and both disagree with the server on `8K` and interlaced values. The client's pick is now authoritative, so this went from cosmetic to load-bearing.
- `media_live/index.ex` and `show/helpers.ex` sort resolution strings lexicographically, so `"720p"` beats `"1080p"`. The badge can now show 720p while playback correctly streams 1080p.
- `MediaFileSelector`'s desktop scoring makes resolution worth roughly 0.2 points against a flat +20 for direct-play support, so resolution barely participates in the auto-pick.
