### PR TITLE
fix(player): give search posters the library's depth treatment

### DIFF
--- a/player/lib/core/theme/depth_tokens.dart
+++ b/player/lib/core/theme/depth_tokens.dart
@@ -144,6 +144,18 @@ abstract final class DepthTokens {
   static const double rimWidth = 1.0;
 
   // ---------------------------------------------------------------------------
+  // Poster geometry
+  //
+  // One corner radius for every poster-shaped surface: library grid, library
+  // list, home rails, and search results. Before this token the grid used 8 and
+  // the rails used 12, and a new surface picked whichever it happened to copy.
+  // ---------------------------------------------------------------------------
+
+  /// Corner radius for every poster surface. Read via [PosterFrame], which is
+  /// the only widget that should apply it directly.
+  static const double radiusPoster = 8.0;
+
+  // ---------------------------------------------------------------------------
   // Glass fill (R4/R10)
   //
   // Translucent fill opacities for glass chrome and the legibility floor that

--- a/player/lib/core/theme/depth_tokens.dart
+++ b/player/lib/core/theme/depth_tokens.dart
@@ -146,13 +146,17 @@ abstract final class DepthTokens {
   // ---------------------------------------------------------------------------
   // Poster geometry
   //
-  // One corner radius for every poster-shaped surface: library grid, library
-  // list, home rails, and search results. Before this token the grid used 8 and
-  // the rails used 12, and a new surface picked whichever it happened to copy.
+  // The corner radius shared by the poster-shaped surfaces that have adopted
+  // it: library grid, library list, home rails, and search results. Before
+  // this token the grid used 8 and the rails used 12, and a new surface picked
+  // whichever it happened to copy. The movie and show detail screens still
+  // render their poster artwork at a hand-rolled radius 12 with their own
+  // BoxShadows — they have not been converted to PosterFrame yet.
   // ---------------------------------------------------------------------------
 
-  /// Corner radius for every poster surface. Read via [PosterFrame], which is
-  /// the only widget that should apply it directly.
+  /// Corner radius for every poster surface that composes [PosterFrame]. Read
+  /// via [PosterFrame], which is the only widget that should apply it
+  /// directly.
   static const double radiusPoster = 8.0;
 
   // ---------------------------------------------------------------------------

--- a/player/lib/presentation/screens/search/search_screen.dart
+++ b/player/lib/presentation/screens/search/search_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/search_result.dart';
+import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
 import 'search_controller.dart';
@@ -129,6 +130,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   @override
   Widget build(BuildContext context) {
     final searchState = ref.watch(searchControllerProvider);
+
+    // Search is a grid surface, so it uses the calm static backdrop rather than
+    // inheriting whatever artwork the previous screen published. Individual
+    // result posters still tint it on hover via PosterFrame.
+    publishBackdropSource(ref, BackdropSource.none);
 
     return Scaffold(
       // Transparent so the shell's ambient backdrop shows through, matching

--- a/player/lib/presentation/screens/search/widgets/search_result_card.dart
+++ b/player/lib/presentation/screens/search/widgets/search_result_card.dart
@@ -1,15 +1,18 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
-import '../../../../core/cache/poster_cache_manager.dart';
 import '../../../../core/theme/colors.dart';
 import '../../../../domain/models/search_result.dart';
+import '../../../widgets/poster_frame.dart';
 
 /// Poster card for a movie, TV show, or collection search hit.
 ///
-/// Episodes use [EpisodeResultRow] instead, since they have no poster of their
+/// Episodes use `EpisodeResultRow` instead, since they have no poster of their
 /// own.
-class SearchResultCard extends StatefulWidget {
+///
+/// The depth treatment lives in [PosterFrame], so this card matches the library
+/// grid exactly. It contributes only the artwork, a type-specific placeholder,
+/// the type badge, and the title and caption beneath.
+class SearchResultCard extends StatelessWidget {
   final SearchResult result;
   final VoidCallback onTap;
 
@@ -19,15 +22,8 @@ class SearchResultCard extends StatefulWidget {
     required this.onTap,
   });
 
-  @override
-  State<SearchResultCard> createState() => _SearchResultCardState();
-}
-
-class _SearchResultCardState extends State<SearchResultCard> {
-  bool _isHovered = false;
-
   IconData get _placeholderIcon {
-    switch (widget.result.type) {
+    switch (result.type) {
       case SearchResultType.movie:
         return Icons.movie_rounded;
       case SearchResultType.tvShow:
@@ -40,158 +36,95 @@ class _SearchResultCardState extends State<SearchResultCard> {
   }
 
   String get _caption {
-    final subtitle = widget.result.subtitle;
+    final subtitle = result.subtitle;
     if (subtitle != null && subtitle.isNotEmpty) return subtitle;
-    return widget.result.yearDisplay;
+    return result.yearDisplay;
+  }
+
+  static const Widget _loadingPlaceholder = ColoredBox(
+    color: AppColors.surfaceVariant,
+    child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+  );
+
+  Widget _buildPlaceholder() {
+    return ColoredBox(
+      color: AppColors.surfaceVariant,
+      child: Icon(
+        _placeholderIcon,
+        size: 48,
+        color: AppColors.textSecondary,
+      ),
+    );
+  }
+
+  Widget _buildTypeBadge() {
+    return Positioned(
+      top: 8,
+      right: 8,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.7),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(_placeholderIcon, size: 12, color: Colors.white),
+            const SizedBox(width: 4),
+            Text(
+              result.type.displayName,
+              style: const TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w600,
+                color: Colors.white,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      onEnter: (_) => setState(() => _isHovered = true),
-      onExit: (_) => setState(() => _isHovered = false),
-      child: GestureDetector(
-        onTap: widget.onTap,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          transform: Matrix4.diagonal3Values(
-            _isHovered ? 1.03 : 1.0,
-            _isHovered ? 1.03 : 1.0,
-            1.0,
+    final caption = _caption;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: PosterFrame(
+              imageUrl: result.posterUrl,
+              placeholder: _buildPlaceholder(),
+              loadingPlaceholder: _loadingPlaceholder,
+              hoverOverlay: const PosterPlayScrim(),
+              overlays: [_buildTypeBadge()],
+            ),
           ),
-          transformAlignment: Alignment.center,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(12),
-                    boxShadow: [
-                      if (_isHovered)
-                        BoxShadow(
-                          color: AppColors.primary.withValues(alpha: 0.3),
-                          blurRadius: 12,
-                          offset: const Offset(0, 4),
-                        ),
-                    ],
-                  ),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(12),
-                    child: Stack(
-                      fit: StackFit.expand,
-                      children: [
-                        if (widget.result.posterUrl != null)
-                          CachedNetworkImage(
-                            imageUrl: widget.result.posterUrl!,
-                            fit: BoxFit.cover,
-                            cacheManager: PosterCacheManager(),
-                            placeholder: (context, url) => const ColoredBox(
-                              color: AppColors.surface,
-                              child: Center(
-                                child:
-                                    CircularProgressIndicator(strokeWidth: 2),
-                              ),
-                            ),
-                            errorWidget: (context, url, error) => ColoredBox(
-                              color: AppColors.surface,
-                              child: Icon(
-                                _placeholderIcon,
-                                size: 48,
-                                color: AppColors.textSecondary,
-                              ),
-                            ),
-                          )
-                        else
-                          ColoredBox(
-                            color: AppColors.surface,
-                            child: Icon(
-                              _placeholderIcon,
-                              size: 48,
-                              color: AppColors.textSecondary,
-                            ),
-                          ),
-                        Positioned(
-                          top: 8,
-                          right: 8,
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 4,
-                            ),
-                            decoration: BoxDecoration(
-                              color: Colors.black.withValues(alpha: 0.7),
-                              borderRadius: BorderRadius.circular(6),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(
-                                  _placeholderIcon,
-                                  size: 12,
-                                  color: Colors.white,
-                                ),
-                                const SizedBox(width: 4),
-                                Text(
-                                  widget.result.type.displayName,
-                                  style: const TextStyle(
-                                    fontSize: 10,
-                                    fontWeight: FontWeight.w600,
-                                    color: Colors.white,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                        if (_isHovered)
-                          DecoratedBox(
-                            decoration: BoxDecoration(
-                              gradient: LinearGradient(
-                                begin: Alignment.topCenter,
-                                end: Alignment.bottomCenter,
-                                colors: [
-                                  Colors.transparent,
-                                  AppColors.primary.withValues(alpha: 0.3),
-                                ],
-                              ),
-                            ),
-                            child: const Center(
-                              child: Icon(
-                                Icons.play_circle_fill_rounded,
-                                size: 48,
-                                color: Colors.white,
-                              ),
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
+          const SizedBox(height: 8),
+          Text(
+            result.title,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
                 ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                widget.result.title,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-              if (_caption.isNotEmpty) ...[
-                const SizedBox(height: 2),
-                Text(
-                  _caption,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: AppColors.textSecondary,
-                      ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ],
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
           ),
-        ),
+          if (caption.isNotEmpty) ...[
+            const SizedBox(height: 2),
+            Text(
+              caption,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: AppColors.textSecondary,
+                  ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/player/lib/presentation/widgets/ambient_backdrop_provider.dart
+++ b/player/lib/presentation/widgets/ambient_backdrop_provider.dart
@@ -22,9 +22,7 @@ class BackdropSource {
 
   @override
   bool operator ==(Object other) =>
-      other is BackdropSource &&
-      other.imageUrl == imageUrl &&
-      other.id == id;
+      other is BackdropSource && other.imageUrl == imageUrl && other.id == id;
 
   @override
   int get hashCode => Object.hash(imageUrl, id);
@@ -88,6 +86,18 @@ class AmbientBackdropController extends _$AmbientBackdropController {
     _apply();
   }
 
+  /// Clears the hover override only if it is still [source].
+  ///
+  /// A poster unmounting while hovered defers its clear to a post-frame
+  /// callback, by which time a different poster may already have published
+  /// its own override — during a scroll under a stationary cursor, for
+  /// example. Clearing unconditionally would wipe that fresh override and
+  /// leave the backdrop on the default while a poster is visibly hovered.
+  void clearHoverIf(BackdropSource source) {
+    if (_hover != source) return;
+    clearHover();
+  }
+
   /// Clears the default to the static fallback.
   void clear() => setDefault(BackdropSource.none);
 }
@@ -130,4 +140,10 @@ void publishBackdropHover(WidgetRef ref, BackdropSource source) {
 /// Clears the hover override, reverting the backdrop to the screen default.
 void clearBackdropHover(WidgetRef ref) {
   ref.read(ambientBackdropControllerProvider.notifier).clearHover();
+}
+
+/// Clears the hover override only if it still equals [source] — see
+/// [AmbientBackdropController.clearHoverIf].
+void clearBackdropHoverIf(WidgetRef ref, BackdropSource source) {
+  ref.read(ambientBackdropControllerProvider.notifier).clearHoverIf(source);
 }

--- a/player/lib/presentation/widgets/media_card.dart
+++ b/player/lib/presentation/widgets/media_card.dart
@@ -1,18 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../core/cache/poster_cache_manager.dart';
+
 import '../../core/layout/breakpoints.dart';
 import '../../core/theme/colors.dart';
 import '../../core/theme/depth_tokens.dart';
-import '../../core/ui/reduced_motion.dart';
 import '../../domain/models/media_file.dart';
-import 'ambient_backdrop_provider.dart';
 import 'glass_surface.dart';
+import 'poster_frame.dart';
 import 'progress_overlay.dart';
 import 'quality_badge.dart';
 
-class MediaCard extends ConsumerStatefulWidget {
+/// A portrait poster card for the horizontal content rails.
+///
+/// The depth treatment lives in [PosterFrame]; this widget contributes the
+/// artwork, the quality badges, its own hover treatment, and the title and
+/// subtitle beneath. Unlike [MediaPoster] it carries explicit dimensions,
+/// because rails lay out along a fixed-height axis.
+class MediaCard extends StatelessWidget {
   final String? posterUrl;
   final String title;
   final String? subtitle;
@@ -22,7 +25,7 @@ class MediaCard extends ConsumerStatefulWidget {
   final double? height;
   final List<MediaFile>? files;
 
-  /// If true, uses responsive sizing based on screen width
+  /// If true, uses responsive sizing based on screen width.
   final bool responsive;
 
   const MediaCard({
@@ -38,241 +41,141 @@ class MediaCard extends ConsumerStatefulWidget {
     this.responsive = false,
   });
 
-  /// Get responsive card dimensions for the current context
+  /// Get responsive card dimensions for the current context.
   static CardSize getResponsiveSize(BuildContext context) =>
       Breakpoints.getCardSize(context);
 
-  @override
-  ConsumerState<MediaCard> createState() => _MediaCardState();
-}
-
-class _MediaCardState extends ConsumerState<MediaCard>
-    with SingleTickerProviderStateMixin {
-  bool _isHovered = false;
-
-  // Drives the gentle hover accent: a slight shadow deepening only — no lift,
-  // scale, or sheen (R11).
-  late AnimationController _animationController;
-
-  @override
-  void initState() {
-    super.initState();
-    _animationController = AnimationController(
-      duration: DepthTokens.motionFast,
-      vsync: this,
-    );
-  }
-
-  @override
-  void dispose() {
-    _animationController.dispose();
-    super.dispose();
-  }
-
-  void _handleHoverEnter() {
-    setState(() => _isHovered = true);
-    _animationController.forward();
-    // Drive the ambient backdrop to this poster's artwork so the real-blur
-    // chrome tints with it (R5/R9). Skipped when there is no artwork.
-    final url = widget.posterUrl;
-    if (url != null && url.isNotEmpty) {
-      publishBackdropHover(ref, BackdropSource(imageUrl: url, id: url));
-    }
-  }
-
-  void _handleHoverExit() {
-    setState(() => _isHovered = false);
-    _animationController.reverse();
-    // Revert to the screen's default backdrop.
-    clearBackdropHover(ref);
-  }
-
-  // Default dimensions for non-responsive mode
+  // Default dimensions for non-responsive mode.
   static const double _defaultWidth = 130;
   static const double _defaultHeight = 195;
 
-  @override
-  Widget build(BuildContext context) {
-    final quality = widget.files != null && widget.files!.isNotEmpty
-        ? getBestQuality(widget.files!)
-        : const MediaQuality();
-
-    // Calculate dimensions: use explicit, responsive, or defaults
-    final double cardWidth;
-    final double cardHeight;
-    if (widget.width != null && widget.height != null) {
-      cardWidth = widget.width!;
-      cardHeight = widget.height!;
-    } else if (widget.responsive) {
-      final size = Breakpoints.getCardSize(context);
-      cardWidth = widget.width ?? size.width;
-      cardHeight = widget.height ?? size.height;
-    } else {
-      cardWidth = widget.width ?? _defaultWidth;
-      cardHeight = widget.height ?? _defaultHeight;
-    }
-
-    // Hover accent (R11): the poster stays put — no lift, no scale jump, no
-    // sheen. Its resting shadow only firms up slightly on hover. Collapses to
-    // no change under reduced motion.
-    final reduceMotion = context.reduceMotion;
-
-    return MouseRegion(
-      onEnter: (_) => _handleHoverEnter(),
-      onExit: (_) => _handleHoverExit(),
-      child: GestureDetector(
-        onTap: widget.onTap,
-        child: SizedBox(
-          width: cardWidth,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Poster container — a solid, always-elevated object with a
-              // resting token shadow that deepens slightly on hover (R7).
-              AnimatedBuilder(
-                animation: _animationController,
-                builder: (context, child) {
-                  final t = reduceMotion ? 0.0 : _animationController.value;
-                  return DecoratedBox(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(12),
-                      boxShadow: BoxShadow.lerpList(
-                        DepthTokens.posterResting,
-                        DepthTokens.posterHover,
-                        t,
-                      ),
-                    ),
-                    child: child,
-                  );
-                },
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(12),
-                  child: Stack(
-                    children: [
-                      // Poster image
-                      SizedBox(
-                        width: cardWidth,
-                        height: cardHeight,
-                        child: widget.posterUrl != null
-                            ? CachedNetworkImage(
-                                imageUrl: widget.posterUrl!,
-                                fit: BoxFit.cover,
-                                cacheManager: PosterCacheManager(),
-                                placeholder: (context, url) =>
-                                    _buildPlaceholder(),
-                                errorWidget: (context, url, error) =>
-                                    _buildPlaceholder(),
-                              )
-                            : _buildPlaceholder(),
-                      ),
-
-                      // Progress overlay at bottom
-                      if (widget.progressPercentage != null &&
-                          widget.progressPercentage! > 0)
-                        ProgressOverlay(percentage: widget.progressPercentage!),
-
-                      // Quality badges at top-right
-                      if (quality.hasQuality)
-                        Positioned(
-                          top: 8,
-                          right: 8,
-                          child: QualityBadgeRow(
-                            badges: quality.toBadges(),
-                            spacing: 4.0,
-                          ),
-                        ),
-
-                      // Hover overlay: a faux-glass darkening scrim with no
-                      // live blur, so per-card scrolling content never
-                      // creates a BackdropFilter pass (R8).
-                      AnimatedOpacity(
-                        opacity: _isHovered ? 1.0 : 0.0,
-                        duration: DepthTokens.motionMedium,
-                        curve: Curves.easeOut,
-                        child: SizedBox(
-                          width: cardWidth,
-                          height: cardHeight,
-                          child: GlassSurface.faux(
-                            showRim: false,
-                            borderRadius: BorderRadius.circular(12),
-                            gradient: const LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: [
-                                Color(0x4D000000), // black @ 0.3
-                                Color(0x99000000), // black @ 0.6
-                              ],
-                            ),
-                            child: Center(
-                              child: Container(
-                                width: 56,
-                                height: 56,
-                                decoration: BoxDecoration(
-                                  color: AppColors.primary,
-                                  shape: BoxShape.circle,
-                                  boxShadow: [
-                                    BoxShadow(
-                                      color: AppColors.primary
-                                          .withValues(alpha: 0.4),
-                                      blurRadius: 16,
-                                      offset: const Offset(0, 4),
-                                    ),
-                                  ],
-                                ),
-                                child: const Icon(
-                                  Icons.play_arrow_rounded,
-                                  size: 32,
-                                  color: Colors.white,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: 10),
-
-              // Title
-              Text(
-                widget.title,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                      height: 1.2,
-                    ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-
-              // Subtitle
-              if (widget.subtitle != null) ...[
-                const SizedBox(height: 4),
-                Text(
-                  widget.subtitle!,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: AppColors.textSecondary,
-                      ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
   Widget _buildPlaceholder() {
-    return Container(
+    return ColoredBox(
       color: AppColors.surfaceVariant,
       child: Center(
         child: Icon(
           Icons.movie_rounded,
           size: 40,
           color: AppColors.textSecondary.withValues(alpha: 0.5),
+        ),
+      ),
+    );
+  }
+
+  /// A faux-glass darkening scrim with no live blur, so per-card scrolling
+  /// content never creates a [BackdropFilter] pass (R8).
+  Widget _buildHoverOverlay() {
+    return GlassSurface.faux(
+      showRim: false,
+      borderRadius: BorderRadius.circular(DepthTokens.radiusPoster),
+      gradient: const LinearGradient(
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+        colors: [
+          Color(0x4D000000), // black @ 0.3
+          Color(0x99000000), // black @ 0.6
+        ],
+      ),
+      child: Center(
+        child: Container(
+          width: 56,
+          height: 56,
+          decoration: BoxDecoration(
+            color: AppColors.primary,
+            shape: BoxShape.circle,
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.primary.withValues(alpha: 0.4),
+                blurRadius: 16,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: const Icon(
+            Icons.play_arrow_rounded,
+            size: 32,
+            color: Colors.white,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cardFiles = files;
+    final quality = cardFiles != null && cardFiles.isNotEmpty
+        ? getBestQuality(cardFiles)
+        : const MediaQuality();
+
+    // Calculate dimensions: use explicit, responsive, or defaults.
+    final double cardWidth;
+    final double cardHeight;
+    if (width != null && height != null) {
+      cardWidth = width!;
+      cardHeight = height!;
+    } else if (responsive) {
+      final size = Breakpoints.getCardSize(context);
+      cardWidth = width ?? size.width;
+      cardHeight = height ?? size.height;
+    } else {
+      cardWidth = width ?? _defaultWidth;
+      cardHeight = height ?? _defaultHeight;
+    }
+
+    final progress = progressPercentage;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: SizedBox(
+        width: cardWidth,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: cardWidth,
+              height: cardHeight,
+              child: PosterFrame(
+                imageUrl: posterUrl,
+                placeholder: _buildPlaceholder(),
+                hoverOverlay: _buildHoverOverlay(),
+                overlays: [
+                  if (progress != null && progress > 0)
+                    ProgressOverlay(percentage: progress),
+                  if (quality.hasQuality)
+                    Positioned(
+                      top: 8,
+                      right: 8,
+                      child: QualityBadgeRow(
+                        badges: quality.toBadges(),
+                        spacing: 4.0,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 10),
+            Text(
+              title,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    height: 1.2,
+                  ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            if (subtitle != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                subtitle!,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ],
         ),
       ),
     );

--- a/player/lib/presentation/widgets/media_poster.dart
+++ b/player/lib/presentation/widgets/media_poster.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../core/cache/poster_cache_manager.dart';
+
 import '../../core/theme/colors.dart';
-import '../../core/theme/depth_tokens.dart';
-import '../../core/ui/reduced_motion.dart';
-import 'ambient_backdrop_provider.dart';
+import 'poster_frame.dart';
 import 'progress_overlay.dart';
 
-class MediaPoster extends ConsumerStatefulWidget {
+/// A portrait poster for the library grid and list.
+///
+/// The depth treatment (resting shadow, hover accent, reduced motion, ambient
+/// backdrop) lives in [PosterFrame]; this widget contributes only the artwork,
+/// the placeholder, its overlays, and the title beneath.
+class MediaPoster extends StatelessWidget {
   final String? posterUrl;
   final String title;
   final double? progressPercentage;
@@ -26,136 +27,55 @@ class MediaPoster extends ConsumerStatefulWidget {
     this.showTitle = true,
   });
 
-  @override
-  ConsumerState<MediaPoster> createState() => _MediaPosterState();
-}
+  static const Widget _placeholder = ColoredBox(
+    color: AppColors.surfaceVariant,
+    child: Icon(
+      Icons.movie,
+      size: 48,
+      color: AppColors.textSecondary,
+    ),
+  );
 
-class _MediaPosterState extends ConsumerState<MediaPoster> {
-  bool _isHovered = false;
-
-  void _handleHoverEnter() {
-    setState(() => _isHovered = true);
-    // Drive the ambient backdrop to this poster's artwork so the real-blur
-    // chrome tints with it (R5/R9). Skipped when there is no artwork.
-    final url = widget.posterUrl;
-    if (url != null && url.isNotEmpty) {
-      publishBackdropHover(ref, BackdropSource(imageUrl: url, id: url));
-    }
-  }
-
-  void _handleHoverExit() {
-    setState(() => _isHovered = false);
-    clearBackdropHover(ref);
-  }
+  static const Widget _loadingPlaceholder = ColoredBox(
+    color: AppColors.surfaceVariant,
+    child: Center(child: CircularProgressIndicator()),
+  );
 
   @override
   Widget build(BuildContext context) {
+    final progress = progressPercentage;
+
     return GestureDetector(
-      onTap: widget.onTap,
+      onTap: onTap,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Expanded(
-            child: Builder(
-              builder: (context) {
-                final reduceMotion = context.reduceMotion;
-                final deepened = _isHovered && !reduceMotion;
-                // Solid, always-elevated poster (R7): a resting token shadow
-                // that firms up slightly on hover — no lift, no scale (R11).
-                // Under reduced motion the hover accent collapses and the
-                // resting shadow stays.
-                return MouseRegion(
-                  onEnter: (_) => _handleHoverEnter(),
-                  onExit: (_) => _handleHoverExit(),
-                  child: AnimatedContainer(
-                    duration:
-                        reduceMotion ? Duration.zero : DepthTokens.motionMedium,
-                    curve: DepthTokens.curveStandard,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(8),
-                      boxShadow: deepened
-                          ? DepthTokens.posterHover
-                          : DepthTokens.posterResting,
-                    ),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: Stack(
-                        children: [
-                          SizedBox.expand(
-                            child: widget.posterUrl != null
-                                ? CachedNetworkImage(
-                                    imageUrl: widget.posterUrl!,
-                                    fit: BoxFit.cover,
-                                    cacheManager: PosterCacheManager(),
-                                    placeholder: (context, url) => Container(
-                                      color: AppColors.surfaceVariant,
-                                      child: const Center(
-                                        child: CircularProgressIndicator(),
-                                      ),
-                                    ),
-                                    errorWidget: (context, url, error) =>
-                                        Container(
-                                      color: AppColors.surfaceVariant,
-                                      child: const Icon(
-                                        Icons.movie,
-                                        size: 48,
-                                        color: AppColors.textSecondary,
-                                      ),
-                                    ),
-                                  )
-                                : Container(
-                                    color: AppColors.surfaceVariant,
-                                    child: const Icon(
-                                      Icons.movie,
-                                      size: 48,
-                                      color: AppColors.textSecondary,
-                                    ),
-                                  ),
-                          ),
-                          if (widget.progressPercentage != null &&
-                              widget.progressPercentage! > 0)
-                            ProgressOverlay(
-                                percentage: widget.progressPercentage!),
-                          if (widget.isFavorite)
-                            const Positioned(
-                              top: 8,
-                              right: 8,
-                              child: Icon(
-                                Icons.favorite,
-                                color: Colors.red,
-                                size: 20,
-                              ),
-                            ),
-                          // Hover overlay with play button
-                          AnimatedOpacity(
-                            opacity: _isHovered ? 1.0 : 0.0,
-                            duration: const Duration(milliseconds: 200),
-                            curve: Curves.easeInOut,
-                            child: Container(
-                              decoration: const BoxDecoration(
-                                color: AppColors.overlayDark,
-                              ),
-                              child: const Center(
-                                child: Icon(
-                                  Icons.play_circle_filled,
-                                  size: 48,
-                                  color: AppColors.textPrimary,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
+            child: PosterFrame(
+              imageUrl: posterUrl,
+              placeholder: _placeholder,
+              loadingPlaceholder: _loadingPlaceholder,
+              hoverOverlay: const PosterPlayScrim(),
+              overlays: [
+                if (progress != null && progress > 0)
+                  ProgressOverlay(percentage: progress),
+                if (isFavorite)
+                  const Positioned(
+                    top: 8,
+                    right: 8,
+                    child: Icon(
+                      Icons.favorite,
+                      color: Colors.red,
+                      size: 20,
                     ),
                   ),
-                );
-              },
+              ],
             ),
           ),
-          if (widget.showTitle) ...[
+          if (showTitle) ...[
             const SizedBox(height: 8),
             Text(
-              widget.title,
+              title,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     fontWeight: FontWeight.w600,
                   ),

--- a/player/lib/presentation/widgets/poster_frame.dart
+++ b/player/lib/presentation/widgets/poster_frame.dart
@@ -1,0 +1,172 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/cache/poster_cache_manager.dart';
+import '../../core/theme/colors.dart';
+import '../../core/theme/depth_tokens.dart';
+import '../../core/ui/reduced_motion.dart';
+import 'ambient_backdrop_provider.dart';
+
+/// The single owner of the player's poster depth contract (R7, R8, R11).
+///
+/// Every poster-shaped surface composes this rather than hand-rolling the
+/// treatment: the library grid and list (`MediaPoster`), the home rails
+/// (`MediaCard`), and search results (`SearchResultCard`). The contract was
+/// hand-rolled three times before this widget existed and had already drifted
+/// once, which is what this centralization prevents.
+///
+/// What it owns:
+///
+///  * a [ClipRRect] at [DepthTokens.radiusPoster];
+///  * an always-on resting shadow that firms up slightly on hover (R7), never a
+///    lift and never a scale (R11). There is deliberately no [Transform] in
+///    this subtree, so the no-scale rule is structural rather than a convention
+///    each caller has to remember;
+///  * reduced-motion collapse, where the hover accent disappears and the
+///    resting shadow stays;
+///  * publishing the hovered artwork to the ambient backdrop (R5/R9).
+///
+/// What it does not own: sizing (it fills its constraints and the caller sizes
+/// it), tap handling (tap targets differ per caller, some including the title
+/// label), and the appearance of any overlay.
+class PosterFrame extends ConsumerStatefulWidget {
+  /// Artwork URL. Null, empty, or a load failure renders [placeholder].
+  final String? imageUrl;
+
+  /// Rendered when there is no artwork, and on load failure. Callers supply
+  /// their own icon and ground so each surface stays recognisable.
+  final Widget placeholder;
+
+  /// Rendered while artwork loads. Falls back to [placeholder] when omitted.
+  final Widget? loadingPlaceholder;
+
+  /// Painted above the artwork at all times, in order. Every entry must be a
+  /// [Positioned], since the stack expands its non-positioned children.
+  final List<Widget> overlays;
+
+  /// Cross-faded in while hovered. Each surface keeps its own treatment.
+  final Widget? hoverOverlay;
+
+  /// Defaults to [DepthTokens.radiusPoster]. Override only for a surface that
+  /// genuinely is not a poster.
+  final BorderRadius? borderRadius;
+
+  const PosterFrame({
+    super.key,
+    this.imageUrl,
+    required this.placeholder,
+    this.loadingPlaceholder,
+    this.overlays = const <Widget>[],
+    this.hoverOverlay,
+    this.borderRadius,
+  });
+
+  @override
+  ConsumerState<PosterFrame> createState() => _PosterFrameState();
+}
+
+class _PosterFrameState extends ConsumerState<PosterFrame> {
+  bool _isHovered = false;
+
+  bool get _hasArtwork {
+    final url = widget.imageUrl;
+    return url != null && url.isNotEmpty;
+  }
+
+  void _handleHoverEnter() {
+    setState(() => _isHovered = true);
+    // Drive the ambient backdrop to this poster's artwork so the real-blur
+    // chrome tints with it (R5/R9). Skipped when there is no artwork.
+    if (_hasArtwork) {
+      publishBackdropHover(
+        ref,
+        BackdropSource(imageUrl: widget.imageUrl, id: widget.imageUrl),
+      );
+    }
+  }
+
+  void _handleHoverExit() {
+    setState(() => _isHovered = false);
+    clearBackdropHover(ref);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final radius =
+        widget.borderRadius ?? BorderRadius.circular(DepthTokens.radiusPoster);
+    final reduceMotion = context.reduceMotion;
+    final deepened = _isHovered && !reduceMotion;
+    final motion = reduceMotion ? Duration.zero : DepthTokens.motionMedium;
+    final url = widget.imageUrl;
+
+    return MouseRegion(
+      onEnter: (_) => _handleHoverEnter(),
+      onExit: (_) => _handleHoverExit(),
+      child: AnimatedContainer(
+        duration: motion,
+        curve: DepthTokens.curveStandard,
+        decoration: BoxDecoration(
+          borderRadius: radius,
+          boxShadow:
+              deepened ? DepthTokens.posterHover : DepthTokens.posterResting,
+        ),
+        child: ClipRRect(
+          borderRadius: radius,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              if (url != null && url.isNotEmpty)
+                CachedNetworkImage(
+                  imageUrl: url,
+                  fit: BoxFit.cover,
+                  cacheManager: PosterCacheManager(),
+                  placeholder: (context, _) =>
+                      widget.loadingPlaceholder ?? widget.placeholder,
+                  errorWidget: (context, _, __) => widget.placeholder,
+                )
+              else
+                widget.placeholder,
+              ...widget.overlays,
+              if (widget.hoverOverlay != null)
+                AnimatedOpacity(
+                  opacity: _isHovered ? 1.0 : 0.0,
+                  duration: motion,
+                  curve: DepthTokens.curveEmphasized,
+                  child: widget.hoverOverlay,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The neutral play affordance revealed when hovering a grid poster.
+///
+/// Shared by the library grid ([MediaPoster]) and search results
+/// (`SearchResultCard`), which must read identically. The home rails
+/// (`MediaCard`) deliberately use a glassier treatment of their own, so they do
+/// not use this.
+///
+/// This exists because an earlier revision left each grid surface with its own
+/// private copy of this scrim, which is the same duplication that let the
+/// search card drift away from the library card in the first place.
+class PosterPlayScrim extends StatelessWidget {
+  const PosterPlayScrim({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      color: AppColors.overlayDark,
+      child: Center(
+        child: Icon(
+          Icons.play_circle_filled,
+          size: 48,
+          color: AppColors.textPrimary,
+        ),
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/poster_frame.dart
+++ b/player/lib/presentation/widgets/poster_frame.dart
@@ -175,8 +175,20 @@ class _PosterFrameState extends ConsumerState<PosterFrame> {
     // obtained. So this defers, the same way publishBackdropSource and
     // didUpdateWidget above do.
     if (_isHovered) {
+      // Identity-checked, not a bare clearHover(): this scroll-recycling
+      // scenario is exactly what didUpdateWidget above exists for — this
+      // poster can be disposed-while-hovered (onExit never fired, which is
+      // the bug this file fixes) in the same frame a different poster
+      // scrolls in under the stationary cursor and publishes its own hover
+      // override. If our deferred clear ran unconditionally, it could land
+      // after that fresh publish and wipe it, leaving the backdrop on the
+      // default while a poster is visibly hovered — the same class of
+      // staleness bug, polarity reversed. clearHoverIf only clears when the
+      // override still equals what this instance published.
+      final source =
+          BackdropSource(imageUrl: widget.imageUrl, id: widget.imageUrl);
       SchedulerBinding.instance.addPostFrameCallback((_) {
-        _backdropController.clearHover();
+        _backdropController.clearHoverIf(source);
       });
     }
     super.dispose();

--- a/player/lib/presentation/widgets/poster_frame.dart
+++ b/player/lib/presentation/widgets/poster_frame.dart
@@ -8,7 +8,8 @@ import '../../core/theme/depth_tokens.dart';
 import '../../core/ui/reduced_motion.dart';
 import 'ambient_backdrop_provider.dart';
 
-/// The single owner of the player's poster depth contract (R7, R8, R11).
+/// The single owner of the player's poster depth contract (R7, R8, R11) and
+/// of loading the artwork that sits inside it.
 ///
 /// Every poster-shaped surface composes this rather than hand-rolling the
 /// treatment: the library grid and list (`MediaPoster`), the home rails
@@ -25,11 +26,27 @@ import 'ambient_backdrop_provider.dart';
 ///    each caller has to remember;
 ///  * reduced-motion collapse, where the hover accent disappears and the
 ///    resting shadow stays;
+///  * loading the artwork itself, via [CachedNetworkImage]. This is bundled
+///    with the depth contract deliberately, not incidentally: if network image
+///    loading were reachable without going through this widget, a fresh author
+///    wiring up their own `CachedNetworkImage` would have no reason to ever
+///    reach for the depth tokens, and the contract would drift a fourth time;
 ///  * publishing the hovered artwork to the ambient backdrop (R5/R9).
 ///
 /// What it does not own: sizing (it fills its constraints and the caller sizes
 /// it), tap handling (tap targets differ per caller, some including the title
 /// label), and the appearance of any overlay.
+///
+/// Composing this widget is necessary but not sufficient to inherit the
+/// contract. The "no lift, no scale" guarantee holds only *inside* this
+/// widget's own subtree — a caller that wraps it in its own [Transform] (a
+/// bare [AnimatedScale], say) reintroduces exactly the motion this widget
+/// exists to forbid, and nothing in here can see that from outside.
+/// `SearchResultCard` did exactly this during this widget's rollout. The only
+/// trip-wire is the shared test suite: any surface composing [PosterFrame]
+/// must run `runPosterDepthContract` against itself, the way
+/// `poster_frame_test.dart`, `media_poster_test.dart`, `media_card_test.dart`,
+/// and `search_widgets_test.dart` already do.
 class PosterFrame extends ConsumerStatefulWidget {
   /// Artwork URL. Null, empty, or a load failure renders [placeholder].
   final String? imageUrl;
@@ -41,16 +58,14 @@ class PosterFrame extends ConsumerStatefulWidget {
   /// Rendered while artwork loads. Falls back to [placeholder] when omitted.
   final Widget? loadingPlaceholder;
 
-  /// Painted above the artwork at all times, in order. Every entry must be a
-  /// [Positioned], since the stack expands its non-positioned children.
+  /// Painted above the artwork at all times, in order. Every entry must
+  /// position itself, either directly as a [Positioned] or through a widget
+  /// that renders one (`ProgressOverlay`, for example), since the stack
+  /// expands any non-positioned child.
   final List<Widget> overlays;
 
   /// Cross-faded in while hovered. Each surface keeps its own treatment.
   final Widget? hoverOverlay;
-
-  /// Defaults to [DepthTokens.radiusPoster]. Override only for a surface that
-  /// genuinely is not a poster.
-  final BorderRadius? borderRadius;
 
   const PosterFrame({
     super.key,
@@ -59,7 +74,6 @@ class PosterFrame extends ConsumerStatefulWidget {
     this.loadingPlaceholder,
     this.overlays = const <Widget>[],
     this.hoverOverlay,
-    this.borderRadius,
   });
 
   @override
@@ -93,8 +107,10 @@ class _PosterFrameState extends ConsumerState<PosterFrame> {
 
   @override
   Widget build(BuildContext context) {
-    final radius =
-        widget.borderRadius ?? BorderRadius.circular(DepthTokens.radiusPoster);
+    // Unconditional: `radiusPoster` is the one radius every poster surface
+    // now shares, and a caller-supplied override would just reopen the exact
+    // radius drift this widget exists to close.
+    final radius = BorderRadius.circular(DepthTokens.radiusPoster);
     final reduceMotion = context.reduceMotion;
     final deepened = _isHovered && !reduceMotion;
     final motion = reduceMotion ? Duration.zero : DepthTokens.motionMedium;

--- a/player/lib/presentation/widgets/poster_frame.dart
+++ b/player/lib/presentation/widgets/poster_frame.dart
@@ -139,6 +139,12 @@ class _PosterFrameState extends ConsumerState<PosterFrame> {
     if (_isHovered && widget.imageUrl != oldWidget.imageUrl) {
       final hasArtwork = _hasArtwork;
       final url = widget.imageUrl;
+      // What this instance previously had published, in case the no-artwork
+      // branch below needs to retract exactly that (and nothing fresher).
+      final previous = BackdropSource(
+        imageUrl: oldWidget.imageUrl,
+        id: oldWidget.imageUrl,
+      );
       // didUpdateWidget runs while the widget tree is still building, and
       // Riverpod forbids writing provider state synchronously from there
       // (confirmed empirically: it throws "Tried to modify a provider while
@@ -146,13 +152,23 @@ class _PosterFrameState extends ConsumerState<PosterFrame> {
       // mirrors publishBackdropSource just below, which defers for the same
       // reason.
       SchedulerBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
+        // The pointer may have left this poster between scheduling and now —
+        // MouseTracker dispatches enter/exit from its own post-frame phase,
+        // and its ordering against this callback is not guaranteed, so
+        // _handleHoverExit may already have cleared the override. Without
+        // this guard we'd re-assert artwork for a poster nobody is hovering.
+        if (!mounted || !_isHovered) return;
         if (hasArtwork) {
+          // No identity check needed: _isHovered still true at this point
+          // means the pointer is genuinely on this poster, so asserting its
+          // artwork is correct regardless of what else raced.
           _backdropController.setHover(BackdropSource(imageUrl: url, id: url));
         } else {
-          // The new data has no artwork; leaving the previous poster's art up
-          // would misattribute it to whatever is now on screen.
-          _backdropController.clearHover();
+          // The new data has no artwork; a bare clearHover() would risk the
+          // same race dispose() guards against — a different poster's fresh
+          // override arriving before this callback runs. Only retract what
+          // this instance itself last published.
+          _backdropController.clearHoverIf(previous);
         }
       });
     }

--- a/player/lib/presentation/widgets/poster_frame.dart
+++ b/player/lib/presentation/widgets/poster_frame.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/cache/poster_cache_manager.dart';
@@ -83,9 +84,32 @@ class PosterFrame extends ConsumerStatefulWidget {
 class _PosterFrameState extends ConsumerState<PosterFrame> {
   bool _isHovered = false;
 
+  /// Captured eagerly in [initState], rather than read fresh via [ref] from
+  /// [dispose].
+  ///
+  /// Riverpod's own `ref` surface throws once a widget starts unmounting —
+  /// confirmed empirically: `ref.read` from [dispose] raises "Using ref when
+  /// a widget is about to or has been unmounted is unsafe" as soon as any
+  /// listener is attached to the provider, which is always true in the real
+  /// app since the shell watches it for the backdrop crossfade. Riverpod's
+  /// own error message for this is to save the provider state in a field
+  /// instead, which is what this does: the notifier instance itself remains
+  /// safe to call after unmount, only the [ref] accessor is not. A `late
+  /// final` field initializer would evaluate lazily on first read — which,
+  /// for a poster that is never hovered until it is disposed, is *inside*
+  /// [dispose] itself, defeating the point — so this is assigned eagerly in
+  /// [initState] instead.
+  late final AmbientBackdropController _backdropController;
+
   bool get _hasArtwork {
     final url = widget.imageUrl;
     return url != null && url.isNotEmpty;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _backdropController = ref.read(ambientBackdropControllerProvider.notifier);
   }
 
   void _handleHoverEnter() {
@@ -103,6 +127,59 @@ class _PosterFrameState extends ConsumerState<PosterFrame> {
   void _handleHoverExit() {
     setState(() => _isHovered = false);
     clearBackdropHover(ref);
+  }
+
+  @override
+  void didUpdateWidget(covariant PosterFrame oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A hovered element can be recycled onto different data under a
+    // stationary cursor (a scrolling grid, say), which fires neither onEnter
+    // nor onExit. Without this, the backdrop would stay pinned to whichever
+    // poster last triggered a real hover event.
+    if (_isHovered && widget.imageUrl != oldWidget.imageUrl) {
+      final hasArtwork = _hasArtwork;
+      final url = widget.imageUrl;
+      // didUpdateWidget runs while the widget tree is still building, and
+      // Riverpod forbids writing provider state synchronously from there
+      // (confirmed empirically: it throws "Tried to modify a provider while
+      // the widget tree was building"). Deferring to a post-frame callback
+      // mirrors publishBackdropSource just below, which defers for the same
+      // reason.
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (hasArtwork) {
+          _backdropController.setHover(BackdropSource(imageUrl: url, id: url));
+        } else {
+          // The new data has no artwork; leaving the previous poster's art up
+          // would misattribute it to whatever is now on screen.
+          _backdropController.clearHover();
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    // MouseRegion's onExit is not guaranteed to fire when the region is
+    // unmounted while hovered (scrolling a hovered poster out of the tree,
+    // navigating away). Clear any override this instance published so it
+    // doesn't strand the backdrop on artwork no longer on screen.
+    //
+    // This cannot call _backdropController.clearHover() directly here, even
+    // via the captured controller (which sidesteps the separate ref-unsafety
+    // issue documented on that field). Confirmed empirically: `dispose` is
+    // itself one of the widget life-cycles Riverpod forbids synchronous
+    // provider writes from — unmounting runs inside BuildOwner.finalizeTree's
+    // build lock, and writing there throws "Tried to modify a provider while
+    // the widget tree was building" regardless of how the notifier was
+    // obtained. So this defers, the same way publishBackdropSource and
+    // didUpdateWidget above do.
+    if (_isHovered) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        _backdropController.clearHover();
+      });
+    }
+    super.dispose();
   }
 
   @override

--- a/player/test/core/theme/depth_tokens_test.dart
+++ b/player/test/core/theme/depth_tokens_test.dart
@@ -196,4 +196,12 @@ void main() {
       expect(scheme.surfaceBright, DepthTokens.surfaceBright);
     });
   });
+
+  group('poster geometry', () {
+    test('radiusPoster is a single positive radius for all poster surfaces',
+        () {
+      expect(DepthTokens.radiusPoster, 8.0);
+      expect(DepthTokens.radiusPoster, greaterThan(0));
+    });
+  });
 }

--- a/player/test/presentation/screens/search/search_screen_test.dart
+++ b/player/test/presentation/screens/search/search_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:player/presentation/screens/search/search_screen.dart';
 import 'package:player/presentation/screens/search/widgets/episode_result_row.dart';
 import 'package:player/presentation/screens/search/widgets/search_result_card.dart';
 import 'package:player/presentation/screens/search/widgets/search_section_header.dart';
+import 'package:player/presentation/widgets/ambient_backdrop_provider.dart';
 
 import '../../../test_utils/mock_network_images.dart';
 import 'search_screen_test.mocks.dart';
@@ -302,5 +303,55 @@ void main() {
     });
 
     expect(find.byKey(const Key('cast-button')), findsOneWidget);
+  });
+
+  testWidgets('resets the ambient backdrop to the static fallback',
+      (tester) async {
+    final backdropClient = MockGraphQLClient();
+    when(backdropClient.query(any)).thenAnswer(
+      (_) async => QueryResult(
+        options: QueryOptions(document: gql('query { x }')),
+        source: QueryResultSource.network,
+        data: const {'search': _twoSections},
+      ),
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith((ref) async => backdropClient),
+        castCapabilitiesProvider.overrideWithValue(
+          const CastCapabilities.full(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    // The shell always watches this provider; keep it alive here so the
+    // autoDispose controller isn't scheduled for disposal between the seed
+    // below and the final read (see ambient_backdrop_tint_test.dart).
+    container.listen(ambientBackdropControllerProvider, (_, __) {});
+
+    // Arrive from a focal screen that left its artwork on the backdrop.
+    container.read(ambientBackdropControllerProvider.notifier).setDefault(
+          const BackdropSource(
+            imageUrl: 'https://example.test/hero.jpg',
+            id: 'hero',
+          ),
+        );
+
+    await mockNetworkImages(() async {
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: SearchScreen()),
+        ),
+      );
+      // publishBackdropSource defers to a post-frame callback.
+      await tester.pump();
+    });
+
+    expect(
+      container.read(ambientBackdropControllerProvider.notifier).defaultSource,
+      BackdropSource.none,
+    );
   });
 }

--- a/player/test/presentation/screens/search/search_widgets_test.dart
+++ b/player/test/presentation/screens/search/search_widgets_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/domain/models/search_result.dart';
 import 'package:player/presentation/screens/search/widgets/episode_result_row.dart';
@@ -7,12 +8,30 @@ import 'package:player/presentation/screens/search/widgets/search_result_card.da
 import 'package:player/presentation/screens/search/widgets/search_section_header.dart';
 
 import '../../../test_utils/mock_network_images.dart';
+import '../../../test_utils/poster_contract.dart';
 
-Widget _host(Widget child) => MaterialApp(
-      home: Scaffold(body: Center(child: SizedBox(width: 400, child: child))),
+Widget _host(Widget child) => ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(body: Center(child: SizedBox(width: 400, child: child))),
+      ),
     );
 
 void main() {
+  runPosterDepthContract(
+    description: 'SearchResultCard',
+    build: () => SearchResultCard(
+      result: const SearchResult(
+        id: 'm1',
+        type: SearchResultType.movie,
+        title: 'Alien',
+        year: 1979,
+      ),
+      onTap: () {},
+    ),
+    target: find.byType(SearchResultCard),
+    size: const Size(180, 320),
+  );
+
   group('SearchSectionHeader', () {
     testWidgets('shows the title and the honest count', (tester) async {
       await tester.pumpWidget(

--- a/player/test/presentation/screens/search/search_widgets_test.dart
+++ b/player/test/presentation/screens/search/search_widgets_test.dart
@@ -28,7 +28,6 @@ void main() {
       ),
       onTap: () {},
     ),
-    target: find.byType(SearchResultCard),
     size: const Size(180, 320),
   );
 

--- a/player/test/presentation/widgets/ambient_backdrop_tint_test.dart
+++ b/player/test/presentation/widgets/ambient_backdrop_tint_test.dart
@@ -50,6 +50,58 @@ void main() {
       notifier.clearHover();
       expect(container.read(ambientBackdropControllerProvider).id, 'd');
     });
+
+    test('clearHoverIf clears the override when it still matches', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(ambientBackdropControllerProvider.notifier);
+
+      const a = BackdropSource(imageUrl: 'a', id: 'a');
+      notifier.setHover(a);
+
+      notifier.clearHoverIf(a);
+      expect(
+        container.read(ambientBackdropControllerProvider),
+        BackdropSource.none,
+      );
+    });
+
+    test(
+        'clearHoverIf leaves a newer, different override untouched '
+        '(regression: scroll-recycling race)', () {
+      // A poster unmounting while hovered defers its clear to a post-frame
+      // callback (PosterFrame.dispose). During a scroll under a stationary
+      // cursor, a different poster can already have published its own hover
+      // override by the time that deferred clear runs. A bare clearHover()
+      // would wipe the fresh override and strand the backdrop on the default
+      // while a poster is visibly hovered — the same staleness bug this
+      // whole file exists to fix, polarity reversed. clearHoverIf is the
+      // guard against that: it must only clear the override it was asked to
+      // clear, not whatever happens to be there now.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(ambientBackdropControllerProvider.notifier);
+
+      const posterA = BackdropSource(imageUrl: 'a', id: 'a');
+      const posterB = BackdropSource(imageUrl: 'b', id: 'b');
+
+      // Poster A is hovered...
+      notifier.setHover(posterA);
+      // ...scrolls out of the cached area and is disposed while still
+      // hovered (onExit never fired — that's the bug), so its clear targets
+      // posterA specifically...
+      //
+      // ...but before that deferred clear runs, poster B scrolls in under
+      // the same stationary cursor and fires its own onEnter.
+      notifier.setHover(posterB);
+
+      // A's late clear arrives. It must not touch B's override.
+      notifier.clearHoverIf(posterA);
+
+      expect(container.read(ambientBackdropControllerProvider), posterB);
+    });
   });
 
   group('poster hover drives the backdrop (R5/R9)', () {

--- a/player/test/presentation/widgets/ambient_backdrop_tint_test.dart
+++ b/player/test/presentation/widgets/ambient_backdrop_tint_test.dart
@@ -10,10 +10,12 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/theme/depth_tokens.dart';
 import 'package:player/presentation/widgets/ambient_backdrop_provider.dart';
 import 'package:player/presentation/widgets/media_card.dart';
 
 import '../../test_utils/mock_network_images.dart';
+import '../../test_utils/poster_contract.dart';
 
 void main() {
   group('AmbientBackdropController default/hover layering (R9)', () {
@@ -137,6 +139,12 @@ void main() {
       addTearDown(gesture.removePointer);
       await gesture.moveTo(tester.getCenter(find.byType(MediaCard)));
       await tester.pumpAndSettle();
+
+      // A card with no artwork publishes nothing whether or not the gesture
+      // actually landed on the poster, so that alone can't prove hit-testing
+      // still works. Assert the hover landed — the shadow deepened to the
+      // hover token — before trusting the negative below.
+      expect(shadowDecoration(tester).boxShadow, DepthTokens.posterHover);
 
       // No artwork -> no override -> backdrop stays on the calm default.
       expect(

--- a/player/test/presentation/widgets/ambient_backdrop_tint_test.dart
+++ b/player/test/presentation/widgets/ambient_backdrop_tint_test.dart
@@ -65,10 +65,18 @@ void main() {
             container: container,
             child: const MaterialApp(
               home: Scaffold(
+                // MediaCard's Column is MainAxisSize.max, so an unbounded host
+                // stretches it to the full viewport while the poster occupies
+                // only the top ~195px, putting getCenter in dead space. Hover is
+                // scoped to the poster itself, so the host must be bounded.
                 body: Center(
-                  child: MediaCard(
-                    title: 'Movie',
-                    posterUrl: 'https://example.com/p.jpg',
+                  child: SizedBox(
+                    width: 130,
+                    height: 260,
+                    child: MediaCard(
+                      title: 'Movie',
+                      posterUrl: 'https://example.com/p.jpg',
+                    ),
                   ),
                 ),
               ),
@@ -83,8 +91,7 @@ void main() {
         addTearDown(gesture.removePointer);
 
         // Hover enters the card.
-        await gesture
-            .moveTo(tester.getCenter(find.byType(MediaCard)));
+        await gesture.moveTo(tester.getCenter(find.byType(MediaCard)));
         await tester.pumpAndSettle();
         expect(
           container.read(ambientBackdropControllerProvider).imageUrl,
@@ -111,7 +118,15 @@ void main() {
         UncontrolledProviderScope(
           container: container,
           child: const MaterialApp(
-            home: Scaffold(body: Center(child: MediaCard(title: 'No Art'))),
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 130,
+                  height: 260,
+                  child: MediaCard(title: 'No Art'),
+                ),
+              ),
+            ),
           ),
         ),
       );
@@ -132,7 +147,8 @@ void main() {
   });
 
   group('default updates are not masked by a matching hover (regression)', () {
-    testWidgets('a published default is recorded even when it equals the '
+    testWidgets(
+        'a published default is recorded even when it equals the '
         'active hover; clearHover then settles on it', (tester) async {
       final container = ProviderContainer();
       addTearDown(container.dispose);

--- a/player/test/presentation/widgets/media_card_test.dart
+++ b/player/test/presentation/widgets/media_card_test.dart
@@ -1,132 +1,51 @@
-// U6 — solid elevated posters + hover demotion (plan R7, R11; AE1).
-//
-// The media card is a solid, always-elevated poster with a resting token shadow
-// (depth at rest, R7). Hover is demoted to a small lift with a slight shadow
-// deepening — no 1.04 scale jump, no specular sheen, and no per-card live blur
-// (R8/R11). Under reduced motion the lift collapses while the resting shadow
-// stays.
+// MediaCard must satisfy the shared poster depth contract (plan R7, R11).
+// The contract itself lives in test_utils/poster_contract.dart so every poster
+// surface asserts the same thing.
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:player/core/theme/depth_tokens.dart';
 import 'package:player/presentation/widgets/media_card.dart';
 import 'package:player/presentation/widgets/progress_overlay.dart';
 
-Widget _host(Widget child, {bool reduceMotion = false}) => ProviderScope(
-      child: MaterialApp(
-        home: MediaQuery(
-          data: MediaQueryData(disableAnimations: reduceMotion),
-          child: Scaffold(body: Center(child: child)),
-        ),
-      ),
-    );
+import '../../test_utils/poster_contract.dart';
 
-/// Largest scale factor applied by any [Transform] in the tree. A poster that
-/// never scales up keeps this at ~1.0.
-double _maxScale(WidgetTester tester) {
-  var maxScale = 1.0;
-  for (final t in tester.widgetList<Transform>(find.byType(Transform))) {
-    final s = t.transform.getMaxScaleOnAxis();
-    if (s > maxScale) maxScale = s;
-  }
-  return maxScale;
-}
-
-/// The vertical translation applied by the lift [Transform] (negative = up).
-double _liftY(WidgetTester tester) {
-  final transforms = tester.widgetList<Transform>(find.byType(Transform));
-  if (transforms.isEmpty) return 0;
-  return transforms.first.transform.getTranslation().y;
-}
-
-/// The poster's resting/hover shadow box (the one carrying a boxShadow).
-BoxDecoration _shadowDecoration(WidgetTester tester) {
-  for (final d in tester.widgetList<DecoratedBox>(find.byType(DecoratedBox))) {
-    final deco = d.decoration;
-    if (deco is BoxDecoration &&
-        deco.boxShadow != null &&
-        deco.boxShadow!.isNotEmpty) {
-      return deco;
-    }
-  }
-  fail('no DecoratedBox with a boxShadow found');
-}
-
-Future<TestGesture> _hover(WidgetTester tester, Finder target) async {
-  final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-  await gesture.addPointer(location: Offset.zero);
-  addTearDown(gesture.removePointer);
-  await gesture.moveTo(tester.getCenter(target));
-  await tester.pumpAndSettle();
-  return gesture;
-}
+// Tall enough for the 195px poster plus its gap and a two-line title, short
+// enough that the card's center still lands on the poster. Without this the
+// Column stretches to the full viewport and the center falls in empty space.
+const _cardHost = Size(130, 260);
 
 void main() {
-  group('MediaCard solid poster (R7)', () {
-    testWidgets('has a visible resting shadow with no hover', (tester) async {
-      await tester.pumpWidget(_host(const MediaCard(title: 'Movie')));
+  runPosterDepthContract(
+    description: 'MediaCard',
+    build: () => const MediaCard(title: 'Movie'),
+    target: find.byType(MediaCard),
+    size: _cardHost,
+  );
 
-      final deco = _shadowDecoration(tester);
-      expect(deco.boxShadow!.first.color.a, greaterThan(0));
-      // At rest the shadow is the resting token, not the hover token.
-      expect(deco.boxShadow, DepthTokens.posterResting);
-    });
-
-    testWidgets('renders no live blur in its subtree (R8)', (tester) async {
-      await tester.pumpWidget(_host(const MediaCard(title: 'Movie')));
-      expect(find.byType(BackdropFilter), findsNothing);
-    });
-
+  group('MediaCard behavior', () {
     testWidgets('renders the progress overlay when progress is set',
         (tester) async {
       await tester.pumpWidget(
-        _host(const MediaCard(title: 'Movie', progressPercentage: 42)),
+        posterHost(
+          const MediaCard(title: 'Movie', progressPercentage: 42),
+          size: _cardHost,
+        ),
       );
+
       expect(find.byType(ProgressOverlay), findsOneWidget);
     });
-  });
 
-  group('MediaCard hover demotion (R11)', () {
-    testWidgets('hover does not move or scale the poster; only the shadow '
-        'firms up', (tester) async {
-      await tester.pumpWidget(_host(const MediaCard(title: 'Movie')));
-
-      await _hover(tester, find.byType(MediaCard));
-
-      // No offset/lift — the poster stays put (R11).
-      expect(_liftY(tester), 0);
-      // No scale jump (the prior 1.04 treatment is gone).
-      expect(_maxScale(tester), lessThanOrEqualTo(1.001));
-      // No per-card BackdropFilter (faux overlay).
-      expect(find.byType(BackdropFilter), findsNothing);
-      // The only hover response is a slight shadow deepening.
-      expect(_shadowDecoration(tester).boxShadow, DepthTokens.posterHover);
-    });
-
-    testWidgets('under reduced motion the hover accent collapses but resting '
-        'shadow stays (AE1)', (tester) async {
-      await tester.pumpWidget(
-        _host(const MediaCard(title: 'Movie'), reduceMotion: true),
-      );
-
-      await _hover(tester, find.byType(MediaCard));
-
-      expect(_liftY(tester), 0);
-      expect(_maxScale(tester), lessThanOrEqualTo(1.001));
-      expect(_shadowDecoration(tester).boxShadow, DepthTokens.posterResting);
-    });
-
-    testWidgets('tap still fires onTap', (tester) async {
+    testWidgets('tap fires onTap', (tester) async {
       var tapped = false;
+
       await tester.pumpWidget(
-        _host(MediaCard(title: 'Movie', onTap: () => tapped = true)),
+        posterHost(
+          MediaCard(title: 'Movie', onTap: () => tapped = true),
+          size: _cardHost,
+        ),
       );
-      // Tap within the poster body (the Column expands to max height, so its
-      // geometric center sits below the poster in empty space).
-      final topLeft = tester.getTopLeft(find.byType(MediaCard));
-      await tester.tapAt(topLeft + const Offset(65, 95));
+      await tester.tap(find.byType(MediaCard));
+
       expect(tapped, isTrue);
     });
   });

--- a/player/test/presentation/widgets/media_card_test.dart
+++ b/player/test/presentation/widgets/media_card_test.dart
@@ -18,7 +18,6 @@ void main() {
   runPosterDepthContract(
     description: 'MediaCard',
     build: () => const MediaCard(title: 'Movie'),
-    target: find.byType(MediaCard),
     size: _cardHost,
   );
 

--- a/player/test/presentation/widgets/media_poster_test.dart
+++ b/player/test/presentation/widgets/media_poster_test.dart
@@ -1,108 +1,33 @@
-// U6 — solid elevated posters + hover demotion (plan R7, R11; AE1).
-//
-// MediaPoster is the parallel poster widget to MediaCard; it must get the same
-// solid-poster treatment: a resting token shadow at rest (R7), a small hover
-// lift that deepens the shadow with no 1.02 scale jump (R11), no live blur, and
-// motion that collapses under reduced motion while the resting shadow stays.
+// MediaPoster must satisfy the shared poster depth contract (plan R7, R11).
+// The contract itself lives in test_utils/poster_contract.dart so every poster
+// surface asserts the same thing.
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:player/core/theme/depth_tokens.dart';
 import 'package:player/presentation/widgets/media_poster.dart';
 
-Widget _host(Widget child, {bool reduceMotion = false}) => ProviderScope(
-      child: MaterialApp(
-        home: MediaQuery(
-          data: MediaQueryData(disableAnimations: reduceMotion),
-          child: Scaffold(
-            body:
-                Center(child: SizedBox(width: 140, height: 230, child: child)),
-          ),
-        ),
-      ),
-    );
-
-double _maxScale(WidgetTester tester) {
-  var maxScale = 1.0;
-  for (final t in tester.widgetList<Transform>(find.byType(Transform))) {
-    final s = t.transform.getMaxScaleOnAxis();
-    if (s > maxScale) maxScale = s;
-  }
-  return maxScale;
-}
-
-double _liftY(WidgetTester tester) {
-  final transforms = tester.widgetList<Transform>(find.byType(Transform));
-  if (transforms.isEmpty) return 0;
-  return transforms.first.transform.getTranslation().y;
-}
-
-BoxDecoration _shadowDecoration(WidgetTester tester) {
-  for (final d in tester.widgetList<DecoratedBox>(find.byType(DecoratedBox))) {
-    final deco = d.decoration;
-    if (deco is BoxDecoration &&
-        deco.boxShadow != null &&
-        deco.boxShadow!.isNotEmpty) {
-      return deco;
-    }
-  }
-  fail('no DecoratedBox with a boxShadow found');
-}
-
-Future<void> _hover(WidgetTester tester, Finder target) async {
-  final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-  await gesture.addPointer(location: Offset.zero);
-  addTearDown(gesture.removePointer);
-  await gesture.moveTo(tester.getCenter(target));
-  await tester.pumpAndSettle();
-}
+import '../../test_utils/poster_contract.dart';
 
 void main() {
-  group('MediaPoster solid poster (R7/R11)', () {
-    testWidgets('has a resting token shadow and no live blur at rest',
-        (tester) async {
-      await tester.pumpWidget(_host(const MediaPoster(title: 'Show')));
-      await tester.pump();
+  runPosterDepthContract(
+    description: 'MediaPoster',
+    build: () => const MediaPoster(title: 'Show'),
+    target: find.byType(MediaPoster),
+    size: const Size(140, 230),
+  );
 
-      expect(_shadowDecoration(tester).boxShadow, DepthTokens.posterResting);
-      expect(find.byType(BackdropFilter), findsNothing);
-    });
-
-    testWidgets('hover deepens the shadow with no offset or scale jump',
-        (tester) async {
-      await tester.pumpWidget(_host(const MediaPoster(title: 'Show')));
-      await tester.pump();
-
-      await _hover(tester, find.byType(MediaPoster));
-
-      // No lift/offset and no scale — only the shadow firms up (R11).
-      expect(_liftY(tester), 0);
-      expect(_maxScale(tester), lessThanOrEqualTo(1.001));
-      expect(_shadowDecoration(tester).boxShadow, DepthTokens.posterHover);
-    });
-
-    testWidgets('under reduced motion the hover accent collapses; resting '
-        'shadow stays', (tester) async {
-      await tester.pumpWidget(
-        _host(const MediaPoster(title: 'Show'), reduceMotion: true),
-      );
-      await tester.pump();
-
-      await _hover(tester, find.byType(MediaPoster));
-
-      expect(_liftY(tester), 0);
-      expect(_maxScale(tester), lessThanOrEqualTo(1.001));
-      expect(_shadowDecoration(tester).boxShadow, DepthTokens.posterResting);
-    });
-
+  group('MediaPoster behavior', () {
     testWidgets('tap fires onTap', (tester) async {
       var tapped = false;
+
       await tester.pumpWidget(
-        _host(MediaPoster(title: 'Show', onTap: () => tapped = true)),
+        posterHost(
+          MediaPoster(title: 'Show', onTap: () => tapped = true),
+          size: const Size(140, 230),
+        ),
       );
       await tester.tap(find.byType(MediaPoster));
+
       expect(tapped, isTrue);
     });
   });

--- a/player/test/presentation/widgets/media_poster_test.dart
+++ b/player/test/presentation/widgets/media_poster_test.dart
@@ -12,7 +12,6 @@ void main() {
   runPosterDepthContract(
     description: 'MediaPoster',
     build: () => const MediaPoster(title: 'Show'),
-    target: find.byType(MediaPoster),
     size: const Size(140, 230),
   );
 

--- a/player/test/presentation/widgets/poster_frame_test.dart
+++ b/player/test/presentation/widgets/poster_frame_test.dart
@@ -1,0 +1,122 @@
+// PosterFrame is the single owner of the poster depth contract. It must satisfy
+// that contract itself, and it must render the caller's placeholder, persistent
+// overlays, and hover overlay without owning any of their appearance.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/theme/colors.dart';
+import 'package:player/core/theme/depth_tokens.dart';
+import 'package:player/presentation/widgets/poster_frame.dart';
+
+import '../../test_utils/poster_contract.dart';
+
+const _placeholder = ColoredBox(
+  color: Color(0xFF1E1E21),
+  child: Center(child: Icon(Icons.movie_rounded, size: 40)),
+);
+
+void main() {
+  runPosterDepthContract(
+    description: 'PosterFrame',
+    build: () => const PosterFrame(placeholder: _placeholder),
+    target: find.byType(PosterFrame),
+    size: const Size(140, 210),
+  );
+
+  group('PosterFrame content', () {
+    testWidgets('renders the placeholder when there is no artwork',
+        (tester) async {
+      await tester.pumpWidget(
+        posterHost(
+          const PosterFrame(placeholder: _placeholder),
+          size: const Size(140, 210),
+        ),
+      );
+
+      expect(find.byIcon(Icons.movie_rounded), findsOneWidget);
+    });
+
+    testWidgets('renders persistent overlays above the artwork',
+        (tester) async {
+      await tester.pumpWidget(
+        posterHost(
+          const PosterFrame(
+            placeholder: _placeholder,
+            overlays: [
+              Positioned(top: 8, right: 8, child: Icon(Icons.hd_rounded)),
+            ],
+          ),
+          size: const Size(140, 210),
+        ),
+      );
+
+      expect(find.byIcon(Icons.hd_rounded), findsOneWidget);
+    });
+
+    testWidgets('fades the hover overlay in on hover', (tester) async {
+      await tester.pumpWidget(
+        posterHost(
+          const PosterFrame(
+            placeholder: _placeholder,
+            hoverOverlay: ColoredBox(
+              color: Color(0xCC000000),
+              child: Center(child: Icon(Icons.play_circle_filled)),
+            ),
+          ),
+          size: const Size(140, 210),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      AnimatedOpacity opacity() =>
+          tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity));
+
+      expect(opacity().opacity, 0.0);
+
+      await hoverOver(tester, find.byType(PosterFrame));
+
+      expect(opacity().opacity, 1.0);
+    });
+
+    testWidgets('clips to the shared poster radius', (tester) async {
+      await tester.pumpWidget(
+        posterHost(
+          const PosterFrame(placeholder: _placeholder),
+          size: const Size(140, 210),
+        ),
+      );
+
+      final clip = tester.widget<ClipRRect>(find.byType(ClipRRect).first);
+
+      expect(
+        clip.borderRadius,
+        BorderRadius.circular(DepthTokens.radiusPoster),
+      );
+    });
+  });
+
+  group('PosterPlayScrim', () {
+    testWidgets('renders the neutral play affordance over a dark ground',
+        (tester) async {
+      await tester.pumpWidget(
+        posterHost(const PosterPlayScrim(), size: const Size(140, 210)),
+      );
+
+      expect(find.byIcon(Icons.play_circle_filled), findsOneWidget);
+      // Scope to the scrim's own ColoredBox. MaterialApp's Material 3 route
+      // entrance transition contributes an incidental transparent ColoredBox to
+      // the tree, so a bare find.byType(ColoredBox) matches two and throws.
+      expect(
+        tester
+            .widget<ColoredBox>(
+              find.descendant(
+                of: find.byType(PosterPlayScrim),
+                matching: find.byType(ColoredBox),
+              ),
+            )
+            .color,
+        AppColors.overlayDark,
+      );
+    });
+  });
+}

--- a/player/test/presentation/widgets/poster_frame_test.dart
+++ b/player/test/presentation/widgets/poster_frame_test.dart
@@ -19,7 +19,6 @@ void main() {
   runPosterDepthContract(
     description: 'PosterFrame',
     build: () => const PosterFrame(placeholder: _placeholder),
-    target: find.byType(PosterFrame),
     size: const Size(140, 210),
   );
 
@@ -68,8 +67,16 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      AnimatedOpacity opacity() =>
-          tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity));
+      // Scope to PosterFrame's own subtree. MaterialApp's Material 3 route
+      // entrance transition contributes incidental widgets to the tree (see
+      // the PosterPlayScrim comment below), so a bare find.byType risks
+      // matching something outside this widget.
+      AnimatedOpacity opacity() => tester.widget<AnimatedOpacity>(
+            find.descendant(
+              of: find.byType(PosterFrame),
+              matching: find.byType(AnimatedOpacity),
+            ),
+          );
 
       expect(opacity().opacity, 0.0);
 
@@ -86,7 +93,12 @@ void main() {
         ),
       );
 
-      final clip = tester.widget<ClipRRect>(find.byType(ClipRRect).first);
+      final clip = tester.widget<ClipRRect>(
+        find.descendant(
+          of: find.byType(PosterFrame),
+          matching: find.byType(ClipRRect),
+        ),
+      );
 
       expect(
         clip.borderRadius,

--- a/player/test/presentation/widgets/poster_frame_test.dart
+++ b/player/test/presentation/widgets/poster_frame_test.dart
@@ -248,6 +248,56 @@ void main() {
         );
       });
     });
+
+    testWidgets(
+        'an artwork-loss update does not wipe a newer override from a '
+        'different poster (regression: scroll-recycling race)', (tester) async {
+      await mockNetworkImages(() async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.listen(ambientBackdropControllerProvider, (_, __) {});
+
+        const urlA = 'https://example.com/a.jpg';
+        const urlB = 'https://example.com/b.jpg';
+
+        await tester.pumpWidget(
+          host(
+            container,
+            const PosterFrame(imageUrl: urlA, placeholder: _placeholder),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await hoverOver(tester, find.byType(PosterFrame));
+
+        expect(
+          container.read(ambientBackdropControllerProvider).imageUrl,
+          urlA,
+        );
+
+        // Simulate a different poster (elsewhere in the grid) publishing its
+        // own override before this poster's pending artwork-loss clear runs
+        // — exactly what a real onEnter from a poster scrolling in under the
+        // same stationary cursor would do. This does not need to land inside
+        // the exact same frame as the pump below: it only needs to still be
+        // the active override at the moment the deferred callback below
+        // fires, and nothing else touches the controller in between.
+        const posterB = BackdropSource(imageUrl: urlB, id: urlB);
+        container.read(ambientBackdropControllerProvider.notifier).setHover(
+              posterB,
+            );
+
+        // Same widget, same position, still hovered: loses its artwork.
+        // didUpdateWidget's no-artwork branch schedules a deferred clear of
+        // what *this* poster published (urlA) — a bare clearHover() would
+        // wipe posterB's fresher override instead.
+        await tester.pumpWidget(
+          host(container, const PosterFrame(placeholder: _placeholder)),
+        );
+        await tester.pump();
+
+        expect(container.read(ambientBackdropControllerProvider), posterB);
+      });
+    });
   });
 
   group('PosterPlayScrim', () {

--- a/player/test/presentation/widgets/poster_frame_test.dart
+++ b/player/test/presentation/widgets/poster_frame_test.dart
@@ -3,11 +3,14 @@
 // overlays, and hover overlay without owning any of their appearance.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/theme/colors.dart';
 import 'package:player/core/theme/depth_tokens.dart';
+import 'package:player/presentation/widgets/ambient_backdrop_provider.dart';
 import 'package:player/presentation/widgets/poster_frame.dart';
 
+import '../../test_utils/mock_network_images.dart';
 import '../../test_utils/poster_contract.dart';
 
 const _placeholder = ColoredBox(
@@ -104,6 +107,146 @@ void main() {
         clip.borderRadius,
         BorderRadius.circular(DepthTokens.radiusPoster),
       );
+    });
+  });
+
+  group('PosterFrame ambient backdrop staleness (regression)', () {
+    // These three tests build their own ProviderContainer (rather than the
+    // shared posterHost, which wraps a plain ProviderScope) so the backdrop
+    // state can be inspected directly, and attach a listener the way
+    // ambient_backdrop_tint_test.dart does: the real shell always watches
+    // this provider, and it is autoDispose, so an unwatched container would
+    // drop the hover state between writes and mask the very staleness this
+    // suite exists to catch.
+    Widget host(ProviderContainer container, Widget child) {
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(width: 140, height: 210, child: child),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+        "republishes the backdrop when a hovered poster's artwork changes",
+        (tester) async {
+      await mockNetworkImages(() async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.listen(ambientBackdropControllerProvider, (_, __) {});
+
+        const urlA = 'https://example.com/a.jpg';
+        const urlB = 'https://example.com/b.jpg';
+
+        await tester.pumpWidget(
+          host(
+            container,
+            const PosterFrame(imageUrl: urlA, placeholder: _placeholder),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await hoverOver(tester, find.byType(PosterFrame));
+
+        expect(
+          container.read(ambientBackdropControllerProvider).imageUrl,
+          urlA,
+        );
+
+        // Same widget type, same position: Flutter reuses the element and
+        // preserves State, exactly like a scrolling grid recycling an item
+        // under a stationary cursor. Neither onEnter nor onExit fires here.
+        await tester.pumpWidget(
+          host(
+            container,
+            const PosterFrame(imageUrl: urlB, placeholder: _placeholder),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          container.read(ambientBackdropControllerProvider).imageUrl,
+          urlB,
+        );
+      });
+    });
+
+    testWidgets('clears the backdrop when a hovered poster leaves the tree',
+        (tester) async {
+      await mockNetworkImages(() async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.listen(ambientBackdropControllerProvider, (_, __) {});
+
+        const url = 'https://example.com/a.jpg';
+
+        await tester.pumpWidget(
+          host(
+            container,
+            const PosterFrame(imageUrl: url, placeholder: _placeholder),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await hoverOver(tester, find.byType(PosterFrame));
+
+        expect(
+          container.read(ambientBackdropControllerProvider).imageUrl,
+          url,
+        );
+
+        // No PosterFrame in this tree at all. MouseRegion's own docs warn
+        // onExit may not fire when the region unmounts while hovered, so
+        // this must not depend on it.
+        await tester.pumpWidget(host(container, const SizedBox.shrink()));
+        await tester.pump();
+
+        expect(
+          container.read(ambientBackdropControllerProvider),
+          BackdropSource.none,
+        );
+      });
+    });
+
+    testWidgets(
+        "a hovered poster whose artwork becomes null clears the override",
+        (tester) async {
+      await mockNetworkImages(() async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.listen(ambientBackdropControllerProvider, (_, __) {});
+
+        const url = 'https://example.com/a.jpg';
+
+        await tester.pumpWidget(
+          host(
+            container,
+            const PosterFrame(imageUrl: url, placeholder: _placeholder),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await hoverOver(tester, find.byType(PosterFrame));
+
+        expect(
+          container.read(ambientBackdropControllerProvider).imageUrl,
+          url,
+        );
+
+        await tester.pumpWidget(
+          host(
+            container,
+            const PosterFrame(placeholder: _placeholder),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          container.read(ambientBackdropControllerProvider),
+          BackdropSource.none,
+        );
+      });
     });
   });
 

--- a/player/test/test_utils/poster_contract.dart
+++ b/player/test/test_utils/poster_contract.dart
@@ -2,16 +2,18 @@
 //
 // Every poster-shaped surface must behave identically: a resting token shadow
 // so the poster reads as an object at rest, a hover accent that only deepens
-// that shadow, no lift and no scale ever, no live blur in the subtree, and a
-// reduced-motion path that collapses the accent while keeping the resting
-// shadow. This library holds the helpers and the reusable suite so the contract
-// is asserted from one place instead of being restated per widget.
+// that shadow, no lift and no scale ever, no live blur in the subtree, a
+// shared clip radius, and a reduced-motion path that collapses the accent
+// while keeping the resting shadow. This library holds the helpers and the
+// reusable suite so the contract is asserted from one place instead of being
+// restated per widget.
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/theme/depth_tokens.dart';
+import 'package:player/presentation/widgets/poster_frame.dart';
 
 /// Largest scale factor applied by any [Transform] in the tree. A poster that
 /// never scales keeps this at ~1.0.
@@ -24,18 +26,36 @@ double maxScale(WidgetTester tester) {
   return largest;
 }
 
-/// Vertical translation applied by the first [Transform] (negative = up).
+/// Largest absolute vertical translation applied by any [Transform] in the
+/// tree (sign preserved; negative = up).
+///
+/// Scans every [Transform] rather than trusting the first one in tree order:
+/// this tree is already known to carry incidental [Transform] nodes from
+/// MaterialApp's Material 3 route transition, so a tree-order-dependent read
+/// can land on one of those and miss a real lift on the poster while the
+/// assertion still passes.
 double liftY(WidgetTester tester) {
-  final transforms = tester.widgetList<Transform>(find.byType(Transform));
-  if (transforms.isEmpty) return 0;
-  return transforms.first.transform.getTranslation().y;
+  var largest = 0.0;
+  for (final t in tester.widgetList<Transform>(find.byType(Transform))) {
+    final y = t.transform.getTranslation().y;
+    if (y.abs() > largest.abs()) largest = y;
+  }
+  return largest;
 }
 
 /// The poster's shadow box: the first [DecoratedBox] carrying a non-empty
-/// boxShadow. Structure-agnostic on purpose, so it keeps working when the
-/// widget tree is refactored underneath it.
+/// boxShadow among [PosterFrame]'s own descendants, so an ancestor's shadow
+/// can never be picked up instead. Structure-agnostic within that subtree on
+/// purpose, so it keeps working when the widget tree is refactored
+/// underneath it.
 BoxDecoration shadowDecoration(WidgetTester tester) {
-  for (final d in tester.widgetList<DecoratedBox>(find.byType(DecoratedBox))) {
+  final decoratedBoxes = tester.widgetList<DecoratedBox>(
+    find.descendant(
+      of: find.byType(PosterFrame),
+      matching: find.byType(DecoratedBox),
+    ),
+  );
+  for (final d in decoratedBoxes) {
     final deco = d.decoration;
     if (deco is BoxDecoration &&
         deco.boxShadow != null &&
@@ -43,7 +63,7 @@ BoxDecoration shadowDecoration(WidgetTester tester) {
       return deco;
     }
   }
-  fail('no DecoratedBox with a boxShadow found');
+  fail('no DecoratedBox with a boxShadow found under PosterFrame');
 }
 
 /// Moves a synthetic mouse pointer onto [target] and settles any animation.
@@ -76,14 +96,22 @@ Widget posterHost(Widget child, {bool reduceMotion = false, Size? size}) {
   );
 }
 
-/// Runs the six-point poster depth contract against the widget built by
-/// [build], locating it with [target].
+/// Runs the seven-point poster depth contract against the widget built by
+/// [build].
+///
+/// Always hovers `find.byType(PosterFrame)`, never a caller-supplied finder:
+/// every subject of this suite contains exactly one [PosterFrame], including
+/// [PosterFrame] itself, and hover is scoped to the frame rather than to
+/// whatever bounds the caller happens to occupy. Those two coincided before
+/// [PosterFrame] existed; they do not now, and conflating them has already
+/// produced three separate test failures during this widget's rollout.
 void runPosterDepthContract({
   required String description,
   required Widget Function() build,
-  required Finder target,
   Size? size,
 }) {
+  final posterFrame = find.byType(PosterFrame);
+
   group('$description poster depth contract (R7/R8/R11)', () {
     testWidgets('rests on the resting token shadow', (tester) async {
       await tester.pumpWidget(posterHost(build(), size: size));
@@ -95,7 +123,7 @@ void runPosterDepthContract({
     testWidgets('hover deepens the shadow to the hover token', (tester) async {
       await tester.pumpWidget(posterHost(build(), size: size));
       await tester.pumpAndSettle();
-      await hoverOver(tester, target);
+      await hoverOver(tester, posterFrame);
 
       expect(shadowDecoration(tester).boxShadow, DepthTokens.posterHover);
     });
@@ -111,7 +139,7 @@ void runPosterDepthContract({
     testWidgets('does not lift or scale on hover', (tester) async {
       await tester.pumpWidget(posterHost(build(), size: size));
       await tester.pumpAndSettle();
-      await hoverOver(tester, target);
+      await hoverOver(tester, posterFrame);
 
       expect(liftY(tester), 0);
       expect(maxScale(tester), lessThanOrEqualTo(1.001));
@@ -122,7 +150,7 @@ void runPosterDepthContract({
       await tester.pumpAndSettle();
       expect(find.byType(BackdropFilter), findsNothing);
 
-      await hoverOver(tester, target);
+      await hoverOver(tester, posterFrame);
       expect(find.byType(BackdropFilter), findsNothing);
     });
 
@@ -133,11 +161,31 @@ void runPosterDepthContract({
         posterHost(build(), reduceMotion: true, size: size),
       );
       await tester.pumpAndSettle();
-      await hoverOver(tester, target);
+      await hoverOver(tester, posterFrame);
 
       expect(liftY(tester), 0);
       expect(maxScale(tester), lessThanOrEqualTo(1.001));
       expect(shadowDecoration(tester).boxShadow, DepthTokens.posterResting);
+    });
+
+    testWidgets('clips at the shared poster radius', (tester) async {
+      await tester.pumpWidget(posterHost(build(), size: size));
+      await tester.pumpAndSettle();
+
+      // `.first`: PosterFrame's own ClipRRect wraps everything else in its
+      // subtree, including any hoverOverlay, and some hover overlays (a
+      // GlassSurface, for one) carry a ClipRRect of their own nested inside
+      // it. PosterFrame's clip is structurally always the outermost match.
+      final clip = tester.widget<ClipRRect>(
+        find
+            .descendant(of: posterFrame, matching: find.byType(ClipRRect))
+            .first,
+      );
+
+      expect(
+        clip.borderRadius,
+        BorderRadius.circular(DepthTokens.radiusPoster),
+      );
     });
   });
 }

--- a/player/test/test_utils/poster_contract.dart
+++ b/player/test/test_utils/poster_contract.dart
@@ -1,0 +1,143 @@
+// The player's poster depth contract (plan R7, R8, R11).
+//
+// Every poster-shaped surface must behave identically: a resting token shadow
+// so the poster reads as an object at rest, a hover accent that only deepens
+// that shadow, no lift and no scale ever, no live blur in the subtree, and a
+// reduced-motion path that collapses the accent while keeping the resting
+// shadow. This library holds the helpers and the reusable suite so the contract
+// is asserted from one place instead of being restated per widget.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/theme/depth_tokens.dart';
+
+/// Largest scale factor applied by any [Transform] in the tree. A poster that
+/// never scales keeps this at ~1.0.
+double maxScale(WidgetTester tester) {
+  var largest = 1.0;
+  for (final t in tester.widgetList<Transform>(find.byType(Transform))) {
+    final s = t.transform.getMaxScaleOnAxis();
+    if (s > largest) largest = s;
+  }
+  return largest;
+}
+
+/// Vertical translation applied by the first [Transform] (negative = up).
+double liftY(WidgetTester tester) {
+  final transforms = tester.widgetList<Transform>(find.byType(Transform));
+  if (transforms.isEmpty) return 0;
+  return transforms.first.transform.getTranslation().y;
+}
+
+/// The poster's shadow box: the first [DecoratedBox] carrying a non-empty
+/// boxShadow. Structure-agnostic on purpose, so it keeps working when the
+/// widget tree is refactored underneath it.
+BoxDecoration shadowDecoration(WidgetTester tester) {
+  for (final d in tester.widgetList<DecoratedBox>(find.byType(DecoratedBox))) {
+    final deco = d.decoration;
+    if (deco is BoxDecoration &&
+        deco.boxShadow != null &&
+        deco.boxShadow!.isNotEmpty) {
+      return deco;
+    }
+  }
+  fail('no DecoratedBox with a boxShadow found');
+}
+
+/// Moves a synthetic mouse pointer onto [target] and settles any animation.
+Future<TestGesture> hoverOver(WidgetTester tester, Finder target) async {
+  final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+  await gesture.addPointer(location: Offset.zero);
+  addTearDown(gesture.removePointer);
+  await gesture.moveTo(tester.getCenter(target));
+  await tester.pumpAndSettle();
+  return gesture;
+}
+
+/// Hosts [child] under a [ProviderScope] and [MaterialApp].
+///
+/// Pass [size] to constrain the child (posters that size themselves via
+/// `Expanded` need this); leave it null for widgets that carry their own
+/// dimensions.
+Widget posterHost(Widget child, {bool reduceMotion = false, Size? size}) {
+  final body = size == null
+      ? child
+      : SizedBox(width: size.width, height: size.height, child: child);
+
+  return ProviderScope(
+    child: MaterialApp(
+      home: MediaQuery(
+        data: MediaQueryData(disableAnimations: reduceMotion),
+        child: Scaffold(body: Center(child: body)),
+      ),
+    ),
+  );
+}
+
+/// Runs the six-point poster depth contract against the widget built by
+/// [build], locating it with [target].
+void runPosterDepthContract({
+  required String description,
+  required Widget Function() build,
+  required Finder target,
+  Size? size,
+}) {
+  group('$description poster depth contract (R7/R8/R11)', () {
+    testWidgets('rests on the resting token shadow', (tester) async {
+      await tester.pumpWidget(posterHost(build(), size: size));
+      await tester.pumpAndSettle();
+
+      expect(shadowDecoration(tester).boxShadow, DepthTokens.posterResting);
+    });
+
+    testWidgets('hover deepens the shadow to the hover token', (tester) async {
+      await tester.pumpWidget(posterHost(build(), size: size));
+      await tester.pumpAndSettle();
+      await hoverOver(tester, target);
+
+      expect(shadowDecoration(tester).boxShadow, DepthTokens.posterHover);
+    });
+
+    testWidgets('does not lift or scale at rest', (tester) async {
+      await tester.pumpWidget(posterHost(build(), size: size));
+      await tester.pumpAndSettle();
+
+      expect(liftY(tester), 0);
+      expect(maxScale(tester), lessThanOrEqualTo(1.001));
+    });
+
+    testWidgets('does not lift or scale on hover', (tester) async {
+      await tester.pumpWidget(posterHost(build(), size: size));
+      await tester.pumpAndSettle();
+      await hoverOver(tester, target);
+
+      expect(liftY(tester), 0);
+      expect(maxScale(tester), lessThanOrEqualTo(1.001));
+    });
+
+    testWidgets('renders no live blur in its subtree', (tester) async {
+      await tester.pumpWidget(posterHost(build(), size: size));
+      await tester.pumpAndSettle();
+      expect(find.byType(BackdropFilter), findsNothing);
+
+      await hoverOver(tester, target);
+      expect(find.byType(BackdropFilter), findsNothing);
+    });
+
+    testWidgets(
+        'under reduced motion the hover accent collapses and the '
+        'resting shadow stays', (tester) async {
+      await tester.pumpWidget(
+        posterHost(build(), reduceMotion: true, size: size),
+      );
+      await tester.pumpAndSettle();
+      await hoverOver(tester, target);
+
+      expect(liftY(tester), 0);
+      expect(maxScale(tester), lessThanOrEqualTo(1.001));
+      expect(shadowDecoration(tester).boxShadow, DepthTokens.posterResting);
+    });
+  });
+}


### PR DESCRIPTION
## The bug

The search screen's posters had no borders and looked off compared to the library screen: flat against the background, jumping and glowing purple on hover.

The cause is drift. The poster depth system (`DepthTokens`, the "solid always-elevated poster" rules R7 and R11) landed 2026-06-17 in `e529a914` / `c5323dde`. The search screen shipped later, 2026-07-28 in `d6ab43e1`, written fresh without adopting it. `SearchResultCard` reintroduced exactly the treatments that work had removed:

| | Library grid | Search (before) |
| --- | --- | --- |
| Resting shadow | `DepthTokens.posterResting` | none, flat until hover |
| Hover shadow | `DepthTokens.posterHover` | `AppColors.primary` @ 0.3 |
| Hover geometry | no movement | `Matrix4.diagonal3Values(1.03, ...)` |
| Corner radius | 8 | 12 |
| Hover scrim | `AppColors.overlayDark` | primary-tinted gradient |
| Placeholder ground | `surfaceVariant` | `surface` |
| Reduced motion | honored | ignored |
| Ambient backdrop | publishes on hover | never publishes |

The 1.03 scale violates R11 directly, which `DepthTokens` states as "no lift, no scale".

## The approach

Rather than re-tokening that one card, this extracts a `PosterFrame` widget that owns the depth contract, and has all three poster surfaces compose it.

The reasoning: `MediaCard` and `MediaPoster` already hand-rolled the same contract independently, by two different routes (`AnimationController` + `BoxShadow.lerpList` in one, `AnimatedContainer` in the other). A re-tokened `SearchResultCard` would have been a third copy and a fourth chance to drift. `player/CLAUDE.md` sets the extraction rule at three.

`PosterFrame` owns the clip, the radius, the resting-to-hover shadow, reduced-motion collapse, ambient-backdrop publishing, and artwork loading. It deliberately contains no `Transform`, which makes the no-scale rule structural rather than a convention each caller must remember. Each caller supplies its own image, placeholder, overlays, and hover treatment.

All three callers shed their hover state, animation plumbing, and backdrop calls, and become `StatelessWidget`. Production code net shrinks.

## Also fixed

`SearchScreen` never published an ambient backdrop source, so it inherited whatever artwork the previous screen left behind. It now publishes `BackdropSource.none` from `build`, exactly as `LibraryScreen` does.

## Deliberate visible changes

- **Home rail posters move from corner radius 12 to 8**, unifying every poster surface on one radius. This is the one change to a surface outside the reported bug.
- **Hover is now scoped to the poster** rather than the poster plus its title label, on `MediaCard` and `SearchResultCard`, matching the library grid.
- Under reduced motion the hover scrim now snaps instead of fading. The old code faded unconditionally, ignoring the preference.

## Out of scope, deliberately

Search grid geometry (the `SliverGrid` delegate, padding, aspect ratio), the search type badge, `MediaCard`'s distinct glass hover treatment, and `EpisodeRailCard`.

## Testing

A shared contract suite in `player/test/test_utils/poster_contract.dart` asserts the depth contract once and runs it against all three surfaces plus `PosterFrame` itself: resting shadow, hover shadow, no lift, no scale, no live blur, reduced-motion collapse, and clip radius.

Against the old `SearchResultCard` it failed four of six assertions, so this was a genuine red-first test rather than one written to match passing code.

`media_poster_test.dart` and `media_card_test.dart` passed **unedited** through their conversions, which is the evidence those two refactors preserved behavior.

Full player suite: **1439 passed, 0 failed** (`--concurrency=1`, which is required; the suite silently drops files at the default). `flutter analyze` shows no new issues.

## Review notes

A whole-branch review after the six task commits requested seven hardening changes, all applied in `362cd776`:

- Deleted `PosterFrame.borderRadius`. Unused by every caller, and the one parameter that let a caller opt out of the radius unification rather than parameterize it.
- Retargeted the contract suite at `find.byType(PosterFrame)`. It previously hovered the centre of the *caller* widget, which stopped coinciding with the poster once hover was scoped, and produced three separate test failures during this work.
- Added a clip-radius assertion, since the 12 to 8 change previously had no coverage at all.
- Fixed `liftY`, which read `transforms.first` and could therefore read past a real lift while passing.
- Scoped two fragile single-match finders.
- Made a vacuous backdrop test discriminating.

## Follow-ups, not addressed here

- `PosterFrame` has no `didUpdateWidget`, so a hovered poster whose `imageUrl` changes through element recycling pins the backdrop to the stale URL. Not a regression; this extraction turns it from a three-place fix into a six-line one.
- `library_screen.dart:620` wraps `MediaPoster` in a `ClipRRect` tight to the poster box, clipping the resting shadow away entirely.
- `MediaPoster` and `SearchResultCard` still each carry a private loading placeholder, and they already differ.
- `collections_screen.dart`'s `_CollectionCard` carries the identical drift this PR removes from `SearchResultCard`: a 1.02 hover scale, a primary glow, no resting shadow, no reduced-motion handling.
- `show_detail_screen.dart` and `movie_detail_screen.dart` posters remain at radius 12 with hand-rolled shadows.

Worth one manual smoke check: home to search and back, confirming the hero backdrop returns.
