### PR TITLE
feat(player): beta update channel for macOS via Sparkle channels

### DIFF
--- a/.github/workflows/ci-appcast.yml
+++ b/.github/workflows/ci-appcast.yml
@@ -1,0 +1,54 @@
+name: CI / Appcast
+
+# The appcast generator is a small Node package with no dependency on the rest
+# of the tree, so it gets its own workflow rather than a job inside ci.yml,
+# matching how site/, player/ and relay/ are split.
+#
+# Deliberately not path-filtered, for the reason ci-site.yml gives: a workflow
+# skipped by a paths: filter never reports a status, so a required check
+# pointing at it would sit Pending forever. The job costs a few seconds.
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: "ci-appcast-${{ github.ref }}"
+  cancel-in-progress: true
+
+# The job only reads the checked-out tree; nothing here writes.
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test / Appcast
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: scripts/appcast
+
+    steps:
+      # npm ci runs whatever install scripts the pull request's lockfile names,
+      # so the job must not leave the token in .git/config where that code can
+      # read it. Nothing here needs git credentials.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: scripts/appcast/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/deploy-appcast.yml
+++ b/.github/workflows/deploy-appcast.yml
@@ -96,16 +96,25 @@ jobs:
         run: |
           # Turns a broken Pages project, a wrong production branch, or a missing
           # DNS record into a failed job instead of a green one over a stale feed.
-          sleep 10
-          served=$(curl -fsSL https://updates.mydia.dev/appcast.xml || true)
-          if [ -z "$served" ]; then
-            echo "::error::updates.mydia.dev/appcast.xml served nothing after deploy."
-            exit 1
-          fi
+          #
+          # Retries because Cloudflare propagation timing is not guaranteed, and a
+          # release going red over ordinary propagation variance would train
+          # everyone to ignore this check.
           local_count=$(grep -c '<item>' dist/appcast.xml)
-          served_count=$(printf '%s' "$served" | grep -c '<item>' || true)
-          if [ "$served_count" -ne "$local_count" ]; then
-            echo "::error::Served feed has $served_count item(s), expected $local_count. The deploy may have landed on a preview URL."
-            exit 1
-          fi
-          echo "updates.mydia.dev is serving $served_count item(s)."
+
+          for attempt in 1 2 3 4 5 6; do
+            served=$(curl -fsSL --max-time 20 https://updates.mydia.dev/appcast.xml || true)
+            served_count=$(printf '%s' "$served" | grep -c '<item>' || true)
+
+            if [ -n "$served" ] && [ "$served_count" -eq "$local_count" ]; then
+              echo "updates.mydia.dev is serving $served_count item(s) after $attempt attempt(s)."
+              exit 0
+            fi
+
+            echo "Attempt $attempt: served $served_count item(s), expected $local_count. Retrying."
+            sleep 15
+          done
+
+          echo "::error::updates.mydia.dev did not serve the expected $local_count item(s) after 6 attempts."
+          echo "::error::Check the mydia-appcast Pages project, its production branch, and the updates.mydia.dev DNS record."
+          exit 1

--- a/.github/workflows/deploy-appcast.yml
+++ b/.github/workflows/deploy-appcast.yml
@@ -97,24 +97,40 @@ jobs:
           # Turns a broken Pages project, a wrong production branch, or a missing
           # DNS record into a failed job instead of a green one over a stale feed.
           #
+          # The newest sparkle:version is the discriminator, not the item count.
+          # buildItems caps the feed at MAX_ITEMS, so once enough releases carry
+          # a DMG every feed has exactly that many items and a count comparison
+          # is satisfied by any feed at all, including the stale one a preview
+          # deployment leaves in place. The build number is what actually moves
+          # on every release, and it is what Sparkle compares.
+          #
           # Retries because Cloudflare propagation timing is not guaranteed, and a
           # release going red over ordinary propagation variance would train
           # everyone to ignore this check.
+          newest() { grep -o '<sparkle:version>[0-9]*' "$1" | head -1 | grep -o '[0-9]*'; }
+
           local_count=$(grep -c '<item>' dist/appcast.xml)
+          local_newest=$(newest dist/appcast.xml)
+          echo "Expecting $local_count item(s), newest build $local_newest."
 
           for attempt in 1 2 3 4 5 6; do
-            served=$(curl -fsSL --max-time 20 https://updates.mydia.dev/appcast.xml || true)
-            served_count=$(printf '%s' "$served" | grep -c '<item>' || true)
+            if curl -fsSL --max-time 20 https://updates.mydia.dev/appcast.xml -o served.xml; then
+              served_count=$(grep -c '<item>' served.xml || true)
+              served_newest=$(newest served.xml)
 
-            if [ -n "$served" ] && [ "$served_count" -eq "$local_count" ]; then
-              echo "updates.mydia.dev is serving $served_count item(s) after $attempt attempt(s)."
-              exit 0
+              if [ "$served_count" -eq "$local_count" ] && [ "$served_newest" = "$local_newest" ]; then
+                echo "updates.mydia.dev is serving $served_count item(s), newest build $served_newest, after $attempt attempt(s)."
+                exit 0
+              fi
+
+              echo "Attempt $attempt: served $served_count item(s), newest build ${served_newest:-none}. Retrying."
+            else
+              echo "Attempt $attempt: could not fetch the feed. Retrying."
             fi
 
-            echo "Attempt $attempt: served $served_count item(s), expected $local_count. Retrying."
             sleep 15
           done
 
-          echo "::error::updates.mydia.dev did not serve the expected $local_count item(s) after 6 attempts."
+          echo "::error::updates.mydia.dev did not serve $local_count item(s) with newest build $local_newest after 6 attempts."
           echo "::error::Check the mydia-appcast Pages project, its production branch, and the updates.mydia.dev DNS record."
           exit 1

--- a/.github/workflows/deploy-appcast.yml
+++ b/.github/workflows/deploy-appcast.yml
@@ -23,6 +23,12 @@ concurrency:
   group: appcast
   cancel-in-progress: false
 
+# Reads the release list and checks out the generator; writes nothing back to
+# the repository. The Cloudflare deploy authenticates with CLOUDFLARE_API_TOKEN,
+# not GITHUB_TOKEN, so no write scope is needed anywhere in this workflow.
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Build and deploy appcast

--- a/.github/workflows/deploy-appcast.yml
+++ b/.github/workflows/deploy-appcast.yml
@@ -78,7 +78,11 @@ jobs:
       - name: Deploy to Cloudflare Pages
         if: env.CLOUDFLARE_API_TOKEN != ''
         working-directory: scripts/appcast
-        run: npx wrangler pages deploy dist/ --project-name=mydia-appcast
+        # --branch is required, not optional. The checkout above pins a commit
+        # SHA, so the runner is in detached HEAD and wrangler cannot infer the
+        # branch. Without it the upload can land as a preview deployment, which
+        # succeeds loudly while updates.mydia.dev serves nothing new.
+        run: npx wrangler pages deploy dist/ --project-name=mydia-appcast --branch master
 
       - name: Note skipped deploy
         if: env.CLOUDFLARE_API_TOKEN == ''

--- a/.github/workflows/deploy-appcast.yml
+++ b/.github/workflows/deploy-appcast.yml
@@ -1,0 +1,85 @@
+name: Deploy Appcast
+
+# Rebuilds the merged Sparkle feed served at updates.mydia.dev.
+#
+# The feed is a pure function of the published releases, so this is safe to run
+# at any time. release.yml calls it after publishing; the dispatch entry point
+# is the manual rebuild, and the way to backfill the feed for the first time.
+#
+# The per-release appcast.xml asset that release.yml uploads is untouched by
+# this workflow. That asset remains the feed for every app installed before the
+# SUFeedURL change, and it is also this generator's input.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Commit to check out for the generator source'
+        required: false
+        type: string
+  workflow_dispatch:
+
+concurrency:
+  group: appcast
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy appcast
+    runs-on: ubuntu-latest
+    # Declared at job level so the step-level `if` below can read it. A secret
+    # referenced only in a step's own `env` is not reliably visible to that
+    # step's `if`.
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: scripts/appcast/package-lock.json
+
+      - name: Install generator dependencies
+        working-directory: scripts/appcast
+        run: npm ci
+
+      - name: Generate merged appcast
+        working-directory: scripts/appcast
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node generate.mjs dist/appcast.xml
+
+      # ubuntu-latest does not ship xmllint. release.yml's publish job installs
+      # it the same way; without this, validate.sh exits 1 on every run.
+      - name: Install xmllint
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libxml2-utils
+
+      - name: Validate merged appcast
+        working-directory: scripts/appcast
+        run: ./validate.sh dist/appcast.xml
+
+      - name: Summarise
+        working-directory: scripts/appcast
+        run: |
+          {
+            echo "### Merged appcast"
+            echo
+            echo "Items: $(grep -c '<item>' dist/appcast.xml)"
+            echo "Beta items: $(grep -c '<sparkle:channel>beta</sparkle:channel>' dist/appcast.xml || true)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Deploy to Cloudflare Pages
+        if: env.CLOUDFLARE_API_TOKEN != ''
+        working-directory: scripts/appcast
+        run: npx wrangler pages deploy dist/ --project-name=mydia-appcast
+
+      - name: Note skipped deploy
+        if: env.CLOUDFLARE_API_TOKEN == ''
+        run: echo "::warning::CLOUDFLARE_API_TOKEN absent; generated and validated the feed but did not deploy it."

--- a/.github/workflows/deploy-appcast.yml
+++ b/.github/workflows/deploy-appcast.yml
@@ -75,8 +75,15 @@ jobs:
             echo "Beta items: $(grep -c '<sparkle:channel>beta</sparkle:channel>' dist/appcast.xml || true)"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Require the Cloudflare token
+        run: |
+          if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN is not set, so the feed cannot be deployed."
+            echo "::error::Failing loudly: a silent skip would leave updates.mydia.dev serving a stale feed while the release reports success."
+            exit 1
+          fi
+
       - name: Deploy to Cloudflare Pages
-        if: env.CLOUDFLARE_API_TOKEN != ''
         working-directory: scripts/appcast
         # --branch is required, not optional. The checkout above pins a commit
         # SHA, so the runner is in detached HEAD and wrangler cannot infer the
@@ -84,6 +91,21 @@ jobs:
         # succeeds loudly while updates.mydia.dev serves nothing new.
         run: npx wrangler pages deploy dist/ --project-name=mydia-appcast --branch master
 
-      - name: Note skipped deploy
-        if: env.CLOUDFLARE_API_TOKEN == ''
-        run: echo "::warning::CLOUDFLARE_API_TOKEN absent; generated and validated the feed but did not deploy it."
+      - name: Verify the deployed feed
+        working-directory: scripts/appcast
+        run: |
+          # Turns a broken Pages project, a wrong production branch, or a missing
+          # DNS record into a failed job instead of a green one over a stale feed.
+          sleep 10
+          served=$(curl -fsSL https://updates.mydia.dev/appcast.xml || true)
+          if [ -z "$served" ]; then
+            echo "::error::updates.mydia.dev/appcast.xml served nothing after deploy."
+            exit 1
+          fi
+          local_count=$(grep -c '<item>' dist/appcast.xml)
+          served_count=$(printf '%s' "$served" | grep -c '<item>' || true)
+          if [ "$served_count" -ne "$local_count" ]; then
+            echo "::error::Served feed has $served_count item(s), expected $local_count. The deploy may have landed on a preview URL."
+            exit 1
+          fi
+          echo "updates.mydia.dev is serving $served_count item(s)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1550,3 +1550,14 @@ jobs:
           flatpak install --user -y "$REMOTE" dev.mydia.player
           flatpak info --user dev.mydia.player
           echo "Verified: dev.mydia.player installs from $REPOFILE"
+
+  appcast:
+    name: Deploy Appcast
+    if: ${{ !inputs.dry_run }}
+    needs:
+      - prepare
+      - publish
+    uses: ./.github/workflows/deploy-appcast.yml
+    with:
+      ref: ${{ needs.prepare.outputs.sha }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1563,6 +1563,12 @@ jobs:
     needs:
       - prepare
       - publish
+    # A reusable workflow gets the calling job's token scopes, so the callee's
+    # own permissions block cannot widen this. Reading the release list and
+    # checking out the generator is all it does; the Cloudflare deploy
+    # authenticates with CLOUDFLARE_API_TOKEN, not GITHUB_TOKEN.
+    permissions:
+      contents: read
     uses: ./.github/workflows/deploy-appcast.yml
     with:
       ref: ${{ needs.prepare.outputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -818,6 +818,11 @@ jobs:
             exit 1
           fi
 
+          # The built app's Info.plist has LSMinimumSystemVersion resolved from
+          # MACOSX_DEPLOYMENT_TARGET, so this can never drift from the binary it
+          # describes the way a hardcoded constant in the appcast generator would.
+          MIN_OS=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "Mydia Player.app/Contents/Info.plist")
+
           # sparkle:version must be the integer CFBundleVersion (VERSION_CODE) that
           # `flutter build macos` writes into the bundle — Sparkle compares
           # <sparkle:version> against the installed app's CFBundleVersion. The
@@ -831,6 +836,7 @@ jobs:
                 <title>Version ${VERSION}</title>
                 <sparkle:version>${VERSION_CODE}</sparkle:version>
                 <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
+                <sparkle:minimumSystemVersion>${MIN_OS}</sparkle:minimumSystemVersion>
                 <pubDate>$(date -R)</pubDate>
                 <enclosure url="${DMG_URL}"
                            ${SIGNATURE}

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -152,6 +152,20 @@ Because `releases/latest/download/` never resolves to a prerelease, a change to
 `SUFeedURL` only reaches users through a **stable** release. Shipping such a
 change in a prerelease migrates nobody.
 
+**Backfill before the first release, not after.** Before cutting the first
+release that ships an `SUFeedURL` pointing at `updates.mydia.dev`, dispatch
+`deploy-appcast.yml` manually and confirm `https://updates.mydia.dev/appcast.xml`
+serves a feed:
+
+```bash
+gh workflow run deploy-appcast.yml --repo getmydia/mydia
+curl -fsSL https://updates.mydia.dev/appcast.xml
+```
+
+Doing this after that release ships instead of before it means every app that
+updates in the meantime starts polling a URL serving nothing, and has no
+recovery path until the feed exists.
+
 ### When the workflow refuses
 
 **"Draft targets 'master', which is a branch, not a commit."**

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -115,6 +115,36 @@ The rehearsal does not exercise TestFlight or Play Store credentials, since it
 stops before those calls. Credential expiry still surfaces for the first time
 during a real release.
 
+### The macOS update feeds
+
+Two Sparkle feeds exist, and they serve different populations.
+
+| Feed | Contents | Who reads it |
+| --- | --- | --- |
+| `releases/latest/download/appcast.xml` | One item, the newest stable | Apps installed before the beta channel shipped |
+| `updates.mydia.dev/appcast.xml` | Up to 20 items across both channels | Every app installed since |
+
+The first is the per-release `appcast.xml` asset the `player-macos` job signs and
+uploads. It must keep shipping on every release. It is the only route by which
+an older install reaches a build that points at the new feed, and it is the
+input the merged feed is built from. Its two validation steps in `release.yml`
+assume a single item and must not be rewritten.
+
+The second is rebuilt by `deploy-appcast.yml`, which `release.yml` calls after a
+successful publish. It is regenerated from scratch each time, so re-running it is
+always safe:
+
+```bash
+gh workflow run deploy-appcast.yml --repo getmydia/mydia
+```
+
+Run that after any release where the appcast job failed, and after manually
+editing or deleting a release.
+
+Because `releases/latest/download/` never resolves to a prerelease, a change to
+`SUFeedURL` only reaches users through a **stable** release. Shipping such a
+change in a prerelease migrates nobody.
+
 ### When the workflow refuses
 
 **"Draft targets 'master', which is a branch, not a commit."**

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -141,6 +141,13 @@ gh workflow run deploy-appcast.yml --repo getmydia/mydia
 Run that after any release where the appcast job failed, and after manually
 editing or deleting a release.
 
+The Pages project must be created with `master` as its production branch,
+for example `wrangler pages project create mydia-appcast --production-branch master`.
+The deploy passes `--branch master` explicitly because the workflow checks
+out a pinned commit and cannot infer a branch name. If the project's
+production branch is anything else, every deploy lands on a preview URL and
+`updates.mydia.dev` keeps serving the previous feed.
+
 Because `releases/latest/download/` never resolves to a prerelease, a change to
 `SUFeedURL` only reaches users through a **stable** release. Shipping such a
 change in a prerelease migrates nobody.

--- a/player/lib/core/update/updaters/macos_updater.dart
+++ b/player/lib/core/update/updaters/macos_updater.dart
@@ -4,14 +4,18 @@ import 'package:flutter/services.dart';
 import '../../../domain/models/app_update.dart';
 import '../platform_updater.dart';
 
+/// Method channel to the Sparkle host in AppDelegate.swift.
+///
+/// Exposed rather than private so tests can mock it, and so every entry point
+/// below can take it as an injectable default.
+const MethodChannel kSparkleChannel = MethodChannel('dev.mydia.player/sparkle');
+
 /// macOS updater: delegates to Sparkle 2 via a method channel.
 ///
 /// Sparkle handles the entire update lifecycle natively: checking for updates,
 /// showing UI, downloading, verifying EdDSA signatures, replacing the app
 /// bundle, and relaunching.
 class MacOSUpdater extends PlatformUpdater {
-  static const _channel = MethodChannel('dev.mydia.player/sparkle');
-
   @override
   bool get canUpdateInPlace => true;
 
@@ -25,11 +29,42 @@ class MacOSUpdater extends PlatformUpdater {
 
   /// Triggers Sparkle's "Check for Updates" flow, which shows its own native
   /// macOS UI for download progress, release notes, and restart prompt.
-  static Future<void> checkForUpdates() async {
+  static Future<void> checkForUpdates({
+    MethodChannel channel = kSparkleChannel,
+  }) async {
     try {
-      await _channel.invokeMethod('checkForUpdates');
+      await channel.invokeMethod('checkForUpdates');
     } on PlatformException catch (e) {
       debugPrint('[MacOSUpdater] Sparkle checkForUpdates failed: $e');
+    }
+  }
+
+  /// Whether the user has opted into prerelease builds.
+  ///
+  /// The value lives in macOS user defaults, owned by the Swift side, because
+  /// Sparkle asks for the allowed channels through a synchronous callback that
+  /// cannot wait on Dart.
+  static Future<bool> betaChannelEnabled({
+    MethodChannel channel = kSparkleChannel,
+  }) async {
+    try {
+      return await channel.invokeMethod<bool>('getBetaChannel') ?? false;
+    } on PlatformException catch (e) {
+      debugPrint('[MacOSUpdater] Sparkle getBetaChannel failed: $e');
+      return false;
+    }
+  }
+
+  /// Opts into or out of prerelease builds. Opting in also runs a check
+  /// immediately, so the change is visible without waiting for the schedule.
+  static Future<void> setBetaChannel(
+    bool enabled, {
+    MethodChannel channel = kSparkleChannel,
+  }) async {
+    try {
+      await channel.invokeMethod('setBetaChannel', enabled);
+    } on PlatformException catch (e) {
+      debugPrint('[MacOSUpdater] Sparkle setBetaChannel failed: $e');
     }
   }
 }

--- a/player/lib/core/update/updaters/macos_updater.dart
+++ b/player/lib/core/update/updaters/macos_updater.dart
@@ -36,6 +36,8 @@ class MacOSUpdater extends PlatformUpdater {
       await channel.invokeMethod('checkForUpdates');
     } on PlatformException catch (e) {
       debugPrint('[MacOSUpdater] Sparkle checkForUpdates failed: $e');
+    } on MissingPluginException catch (e) {
+      debugPrint('[MacOSUpdater] Sparkle host unavailable: $e');
     }
   }
 
@@ -52,19 +54,33 @@ class MacOSUpdater extends PlatformUpdater {
     } on PlatformException catch (e) {
       debugPrint('[MacOSUpdater] Sparkle getBetaChannel failed: $e');
       return false;
+    } on MissingPluginException catch (e) {
+      debugPrint('[MacOSUpdater] Sparkle host unavailable: $e');
+      return false;
     }
   }
 
-  /// Opts into or out of prerelease builds. Opting in also runs a check
-  /// immediately, so the change is visible without waiting for the schedule.
-  static Future<void> setBetaChannel(
+  /// Opts into or out of prerelease builds.
+  ///
+  /// Returns true when the host accepted the change. On false the preference
+  /// was not written, so a caller showing an optimistic toggle must revert it.
+  ///
+  /// On opt-in the host also runs an update check immediately, so the change
+  /// is visible without waiting for the next scheduled check. That happens on
+  /// the Swift side, not here.
+  static Future<bool> setBetaChannel(
     bool enabled, {
     MethodChannel channel = kSparkleChannel,
   }) async {
     try {
       await channel.invokeMethod('setBetaChannel', enabled);
+      return true;
     } on PlatformException catch (e) {
       debugPrint('[MacOSUpdater] Sparkle setBetaChannel failed: $e');
+      return false;
+    } on MissingPluginException catch (e) {
+      debugPrint('[MacOSUpdater] Sparkle host unavailable: $e');
+      return false;
     }
   }
 }

--- a/player/lib/presentation/screens/settings/settings_screen.dart
+++ b/player/lib/presentation/screens/settings/settings_screen.dart
@@ -23,6 +23,7 @@ import '../../widgets/cast_button.dart';
 import '../../widgets/connection_tone_color.dart';
 import '../../widgets/hls_quality_selector.dart';
 import 'settings_controller.dart';
+import 'widgets/beta_channel_row.dart';
 import 'widgets/settings_identity.dart';
 import 'widgets/settings_row.dart';
 import 'widgets/settings_section.dart';
@@ -262,6 +263,10 @@ class _ManageSection extends ConsumerWidget {
             subtitle: 'Try to make this device discoverable again',
             onTap: () => ref.read(nodeRegistrationProvider.notifier).retry(),
           ),
+        // Sparkle channels are macOS-only. Linux beta ships as a separate
+        // Flatpak branch, chosen at install time rather than in-app, and
+        // Windows has no channel support at all.
+        if (PlatformFeatures.isMacOS) const BetaChannelRow(),
         if (PlatformUpdater.supportedOnCurrentPlatform)
           SettingsRow.action(
             key: const Key('check-for-updates-row'),

--- a/player/lib/presentation/screens/settings/widgets/beta_channel_row.dart
+++ b/player/lib/presentation/screens/settings/widgets/beta_channel_row.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/update/updaters/macos_updater.dart';
+import 'settings_row.dart';
+
+/// macOS-only opt-in for Sparkle's beta channel.
+///
+/// The stored value lives in macOS user defaults on the Swift side, so this
+/// reads it once on mount rather than holding it in app state. Sparkle asks
+/// for the allowed channels through a synchronous callback that cannot wait
+/// on Dart, which is why Swift owns it.
+///
+/// The platform gate lives at the call site, not in here, so a `flutter test`
+/// host on Linux can still exercise the row.
+class BetaChannelRow extends StatefulWidget {
+  const BetaChannelRow({super.key});
+
+  @override
+  State<BetaChannelRow> createState() => _BetaChannelRowState();
+}
+
+class _BetaChannelRowState extends State<BetaChannelRow> {
+  bool _enabled = false;
+  int _generation = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final generation = _generation;
+    final enabled = await MacOSUpdater.betaChannelEnabled();
+    if (mounted && generation == _generation) {
+      setState(() => _enabled = enabled);
+    }
+  }
+
+  Future<void> _set(bool value) async {
+    final generation = ++_generation;
+    setState(() => _enabled = value);
+
+    final accepted = await MacOSUpdater.setBetaChannel(value);
+    if (!mounted || generation != _generation) return;
+    if (accepted) return;
+
+    // The write did not land, so the optimistic value is a lie. Ask the host
+    // what it actually holds rather than reverting to the previous value,
+    // which may itself have been an unconfirmed optimistic update from a tap
+    // that is still in flight.
+    final actual = await MacOSUpdater.betaChannelEnabled();
+    if (mounted && generation == _generation) {
+      setState(() => _enabled = actual);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsRow.toggle(
+      key: const Key('beta-channel-switch'),
+      icon: Icons.science_outlined,
+      title: 'Include beta versions',
+      // Sparkle has no downgrade path, so opting back out leaves you where you
+      // are. Saying so here is cheaper than building a rollback nobody expects.
+      subtitle: 'Prerelease builds see less testing, and turning this back off '
+          'keeps your current version until a stable release catches up.',
+      value: _enabled,
+      onChanged: _set,
+    );
+  }
+}

--- a/player/macos/Runner/AppDelegate.swift
+++ b/player/macos/Runner/AppDelegate.swift
@@ -2,14 +2,45 @@ import Cocoa
 import FlutterMacOS
 import Sparkle
 
+/// User-defaults key backing the beta channel opt-in.
+///
+/// Swift owns this rather than Flutter because Sparkle's automatic check fires
+/// inside applicationDidFinishLaunching, before the Flutter engine has booted.
+/// The delegate has to be able to answer without asking Dart.
+///
+/// Settable without the UI for testing:
+///   defaults write dev.mydia.player MydiaBetaChannel -bool true
+let betaChannelDefaultsKey = "MydiaBetaChannel"
+
+/// The Sparkle channel prerelease items are tagged with in the appcast.
+let betaChannelName = "beta"
+
+/// Reports the user's channel choice to Sparkle on every update check.
+///
+/// Items with no <sparkle:channel> are visible to everyone, so a user on the
+/// beta channel still sees stable releases and returns to the stable track on
+/// their own once a stable build number passes the beta they are running.
+///
+/// Lives in this file rather than its own because adding a Swift file to the
+/// Runner target means hand-editing project.pbxproj, which is not worth it for
+/// ten lines.
+class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
+  func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+    UserDefaults.standard.bool(forKey: betaChannelDefaultsKey) ? [betaChannelName] : []
+  }
+}
+
 @main
 class AppDelegate: FlutterAppDelegate {
   private var updaterController: SPUStandardUpdaterController!
 
+  // Held here because SPUStandardUpdaterController does not retain its delegate.
+  private let updaterDelegate = UpdaterDelegate()
+
   override func applicationDidFinishLaunching(_ notification: Notification) {
     updaterController = SPUStandardUpdaterController(
       startingUpdater: true,
-      updaterDelegate: nil,
+      updaterDelegate: updaterDelegate,
       userDriverDelegate: nil
     )
 
@@ -23,6 +54,29 @@ class AppDelegate: FlutterAppDelegate {
       case "checkForUpdates":
         self?.updaterController.checkForUpdates(nil)
         result(nil)
+
+      case "getBetaChannel":
+        result(UserDefaults.standard.bool(forKey: betaChannelDefaultsKey))
+
+      case "setBetaChannel":
+        guard let enabled = call.arguments as? Bool else {
+          result(
+            FlutterError(
+              code: "bad-arguments",
+              message: "setBetaChannel expects a boolean argument",
+              details: nil
+            ))
+          return
+        }
+        UserDefaults.standard.set(enabled, forKey: betaChannelDefaultsKey)
+        // Sparkle reads allowedChannels on every check, so this takes effect
+        // without a restart. Check immediately on opt-in so the toggle does
+        // something visible instead of waiting for the next scheduled check.
+        if enabled {
+          self?.updaterController.checkForUpdates(nil)
+        }
+        result(nil)
+
       default:
         result(FlutterMethodNotImplemented)
       }

--- a/player/macos/Runner/AppDelegate.swift
+++ b/player/macos/Runner/AppDelegate.swift
@@ -4,9 +4,11 @@ import Sparkle
 
 /// User-defaults key backing the beta channel opt-in.
 ///
-/// Swift owns this rather than Flutter because Sparkle's automatic check fires
-/// inside applicationDidFinishLaunching, before the Flutter engine has booted.
-/// The delegate has to be able to answer without asking Dart.
+/// Swift owns this rather than Flutter because `allowedChannels(for:)` is a
+/// synchronous Objective-C callback that must return a value immediately.
+/// It cannot await an asynchronous round trip to Dart, so the source of
+/// truth has to live on this side. Flutter reads and writes it through the
+/// method channel below.
 ///
 /// Settable without the UI for testing:
 ///   defaults write dev.mydia.player MydiaBetaChannel -bool true
@@ -69,13 +71,15 @@ class AppDelegate: FlutterAppDelegate {
           return
         }
         UserDefaults.standard.set(enabled, forKey: betaChannelDefaultsKey)
+        result(nil)
         // Sparkle reads allowedChannels on every check, so this takes effect
         // without a restart. Check immediately on opt-in so the toggle does
         // something visible instead of waiting for the next scheduled check.
+        // result is answered first so the Dart future never depends on how
+        // long Sparkle's check takes.
         if enabled {
           self?.updaterController.checkForUpdates(nil)
         }
-        result(nil)
 
       default:
         result(FlutterMethodNotImplemented)

--- a/player/macos/Runner/Info.plist
+++ b/player/macos/Runner/Info.plist
@@ -29,7 +29,7 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUFeedURL</key>
-	<string>https://github.com/getmydia/mydia/releases/latest/download/appcast.xml</string>
+	<string>https://updates.mydia.dev/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>+n3C1GhBlCOwA2CLLwdh/kJjqPLNGNlVkZNLUVtkwMo=</string>
 	<key>SUEnableAutomaticChecks</key>

--- a/player/test/core/update/macos_updater_test.dart
+++ b/player/test/core/update/macos_updater_test.dart
@@ -61,4 +61,26 @@ void main() {
     await expectLater(MacOSUpdater.setBetaChannel(true), completes);
     expect(await MacOSUpdater.betaChannelEnabled(), isFalse);
   });
+
+  test('setBetaChannel reports success', () async {
+    expect(await MacOSUpdater.setBetaChannel(true), isTrue);
+  });
+
+  test('setBetaChannel reports failure when the host errors', () async {
+    mock((_) async => throw PlatformException(code: 'boom'));
+
+    expect(await MacOSUpdater.setBetaChannel(true), isFalse);
+  });
+
+  test('an unregistered host never propagates', () async {
+    // Clearing the handler is what a real macOS build looks like before the
+    // native side registers, and MissingPluginException is not a
+    // PlatformException, so it needs its own catch clause.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kSparkleChannel, null);
+
+    await expectLater(MacOSUpdater.checkForUpdates(), completes);
+    expect(await MacOSUpdater.betaChannelEnabled(), isFalse);
+    expect(await MacOSUpdater.setBetaChannel(true), isFalse);
+  });
 }

--- a/player/test/core/update/macos_updater_test.dart
+++ b/player/test/core/update/macos_updater_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/update/updaters/macos_updater.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<MethodCall> calls;
+
+  void mock(Future<Object?> Function(MethodCall call) handler) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kSparkleChannel, (call) async {
+      calls.add(call);
+      return handler(call);
+    });
+  }
+
+  setUp(() {
+    calls = [];
+    mock((_) async => null);
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kSparkleChannel, null);
+  });
+
+  test('checkForUpdates reaches the host', () async {
+    await MacOSUpdater.checkForUpdates();
+
+    expect(calls.map((c) => c.method), ['checkForUpdates']);
+  });
+
+  test('betaChannelEnabled returns what the host reports', () async {
+    mock((_) async => true);
+
+    expect(await MacOSUpdater.betaChannelEnabled(), isTrue);
+    expect(calls.map((c) => c.method), ['getBetaChannel']);
+  });
+
+  test('betaChannelEnabled defaults to false when the host returns null',
+      () async {
+    mock((_) async => null);
+
+    expect(await MacOSUpdater.betaChannelEnabled(), isFalse);
+  });
+
+  test('setBetaChannel forwards the boolean', () async {
+    await MacOSUpdater.setBetaChannel(true);
+
+    expect(calls.single.method, 'setBetaChannel');
+    expect(calls.single.arguments, isTrue);
+  });
+
+  test('a host failure never propagates to the caller', () async {
+    // The updater is called from settings taps. A PlatformException escaping
+    // here would surface as an unhandled error in the widget tree.
+    mock((_) async => throw PlatformException(code: 'boom'));
+
+    await expectLater(MacOSUpdater.checkForUpdates(), completes);
+    await expectLater(MacOSUpdater.setBetaChannel(true), completes);
+    expect(await MacOSUpdater.betaChannelEnabled(), isFalse);
+  });
+}

--- a/player/test/presentation/screens/settings/widgets/beta_channel_row_test.dart
+++ b/player/test/presentation/screens/settings/widgets/beta_channel_row_test.dart
@@ -144,6 +144,46 @@ void main() {
     expect(row(tester).toggleValue, isFalse);
   });
 
+  testWidgets(
+      'a tap that lands before the initial load resolves is not clobbered by it',
+      (tester) async {
+    // The initial getBetaChannel read is gated so it is still in flight when
+    // the tap's own round trip (ungated) completes first. Without a
+    // generation guard on _load, its setState would land after the tap's and
+    // stomp the already-confirmed optimistic value back to the stale read.
+    final loadGate = Completer<void>();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kSparkleChannel, (call) async {
+      calls.add(call);
+      if (call.method == 'getBetaChannel') {
+        await loadGate.future;
+        return false;
+      }
+      if (call.method == 'setBetaChannel') {
+        hostValue = call.arguments as bool;
+        return null;
+      }
+      return null;
+    });
+
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: BetaChannelRow())),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+
+    expect(row(tester).toggleValue, isTrue,
+        reason: 'the confirmed tap must already be reflected');
+
+    loadGate.complete();
+    await tester.pumpAndSettle();
+
+    expect(row(tester).toggleValue, isTrue,
+        reason: 'the stale load must not clobber the confirmed tap');
+  });
+
   testWidgets('uses no em dashes in its copy', (tester) async {
     await pump(tester);
 

--- a/player/test/presentation/screens/settings/widgets/beta_channel_row_test.dart
+++ b/player/test/presentation/screens/settings/widgets/beta_channel_row_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/update/updaters/macos_updater.dart';
+import 'package:player/presentation/screens/settings/widgets/beta_channel_row.dart';
+import 'package:player/presentation/screens/settings/widgets/settings_row.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<MethodCall> calls;
+  late bool hostValue;
+
+  setUp(() {
+    calls = [];
+    hostValue = false;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kSparkleChannel, (call) async {
+      calls.add(call);
+      if (call.method == 'getBetaChannel') return hostValue;
+      if (call.method == 'setBetaChannel') hostValue = call.arguments as bool;
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kSparkleChannel, null);
+  });
+
+  Future<void> pump(WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: BetaChannelRow())),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  SettingsRow row(WidgetTester tester) =>
+      tester.widget<SettingsRow>(find.byKey(const Key('beta-channel-switch')));
+
+  testWidgets('starts off when the host reports opted out', (tester) async {
+    await pump(tester);
+
+    expect(row(tester).toggleValue, isFalse);
+    expect(calls.map((c) => c.method), contains('getBetaChannel'));
+  });
+
+  testWidgets('reflects an existing opt-in on first build', (tester) async {
+    hostValue = true;
+
+    await pump(tester);
+
+    expect(row(tester).toggleValue, isTrue);
+  });
+
+  testWidgets('writes the new value to the host when toggled', (tester) async {
+    await pump(tester);
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    final setCall = calls.lastWhere((c) => c.method == 'setBetaChannel');
+    expect(setCall.arguments, isTrue);
+    expect(row(tester).toggleValue, isTrue);
+  });
+
+  testWidgets('explains that opting out does not downgrade', (tester) async {
+    await pump(tester);
+
+    expect(find.text('Include beta versions'), findsOneWidget);
+    expect(
+      find.textContaining('until a stable release catches up'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('reverts the switch when the host rejects the write',
+      (tester) async {
+    // A silently-failed write would leave the switch showing a channel the
+    // updater will never honor, which is worse than not moving at all.
+    await pump(tester);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kSparkleChannel, (call) async {
+      if (call.method == 'getBetaChannel') return false;
+      throw PlatformException(code: 'boom');
+    });
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(row(tester).toggleValue, isFalse);
+  });
+
+  testWidgets('uses no em dashes in its copy', (tester) async {
+    await pump(tester);
+
+    final texts = tester.widgetList<Text>(find.byType(Text));
+    for (final text in texts) {
+      expect(text.data ?? '', isNot(contains('—')));
+    }
+  });
+}

--- a/player/test/presentation/screens/settings/widgets/beta_channel_row_test.dart
+++ b/player/test/presentation/screens/settings/widgets/beta_channel_row_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -78,14 +80,65 @@ void main() {
       (tester) async {
     // A silently-failed write would leave the switch showing a channel the
     // updater will never honor, which is worse than not moving at all.
+    //
+    // The write is gated behind a Completer rather than failing immediately:
+    // flutter_test's mocked MethodChannel resolves an immediately-throwing
+    // handler entirely within the `tester.tap()` call that triggers it (no
+    // real async delay), so without a gate there is no frame at which the
+    // optimistic, not-yet-confirmed value is observable at all.
     await pump(tester);
+    final gate = Completer<void>();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(kSparkleChannel, (call) async {
       if (call.method == 'getBetaChannel') return false;
+      await gate.future;
       throw PlatformException(code: 'boom');
     });
 
     await tester.tap(find.byType(Switch));
+    await tester.pump();
+    expect(row(tester).toggleValue, isTrue,
+        reason: 'the switch should move optimistically');
+
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(row(tester).toggleValue, isFalse,
+        reason: 'a rejected write must revert');
+  });
+
+  testWidgets('two failing taps settle on the host value', (tester) async {
+    await pump(tester);
+    // Both writes fail and the host keeps reporting false. The row must
+    // converge on that, not on the inverse of whatever it last sent.
+    //
+    // Both writes are gated so the second tap's write genuinely overlaps the
+    // first's still-pending one. Without gating, flutter_test's mocked
+    // MethodChannel resolves each tap's entire write-then-catch chain inside
+    // that tap's own `tester.tap()` call, so the two calls never actually
+    // overlap and the race this guards against cannot occur.
+    final gates = <Completer<void>>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kSparkleChannel, (call) async {
+      if (call.method == 'getBetaChannel') return false;
+      final gate = Completer<void>();
+      gates.add(gate);
+      await gate.future;
+      throw PlatformException(code: 'boom');
+    });
+
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+    expect(gates, hasLength(2),
+        reason: 'both writes must be in flight at once');
+
+    // Resolve the writes in the order they were sent, matching the trace
+    // this test guards against: the first tap's write fails, then the
+    // second's.
+    gates[0].complete();
+    await tester.pump();
+    gates[1].complete();
     await tester.pumpAndSettle();
 
     expect(row(tester).toggleValue, isFalse);

--- a/scripts/appcast/.gitignore
+++ b/scripts/appcast/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/scripts/appcast/generate.mjs
+++ b/scripts/appcast/generate.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { marked } from 'marked'
+
+import { buildItems, assertFeedInvariants } from './lib/build.mjs'
+import { renderFeed } from './lib/render.mjs'
+
+const REPO = process.env.APPCAST_REPO ?? 'getmydia/mydia'
+const OUTPUT = process.argv[2] ?? 'dist/appcast.xml'
+const USER_AGENT = 'mydia-appcast-generator'
+
+function apiHeaders() {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': USER_AGENT,
+  }
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+  }
+  return headers
+}
+
+async function fetchReleases() {
+  const url = `https://api.github.com/repos/${REPO}/releases?per_page=100`
+  const response = await fetch(url, { headers: apiHeaders() })
+  if (!response.ok) {
+    throw new Error(`GitHub releases request failed: ${response.status} ${response.statusText}`)
+  }
+  return response.json()
+}
+
+async function loadAppcast(asset) {
+  const response = await fetch(asset.browser_download_url, {
+    headers: { 'User-Agent': USER_AGENT },
+  })
+  if (!response.ok) {
+    throw new Error(`appcast asset fetch failed: ${response.status} ${response.statusText}`)
+  }
+  return response.text()
+}
+
+// Rendered locally rather than through GitHub's /markdown endpoint so the
+// output stays deterministic and testable offline. The tradeoff is that a bare
+// #123 reference renders as literal text instead of a link.
+const renderNotes = (markdown) => marked.parse(markdown, { async: false, gfm: true })
+
+const releases = await fetchReleases()
+const { items, warnings } = await buildItems(releases, { loadAppcast, renderNotes })
+
+for (const warning of warnings) {
+  console.warn(`::warning::${warning}`)
+}
+
+// Throws before anything is written, so a failed run leaves the previously
+// deployed feed live. A stale feed is far less harmful than an empty one, which
+// every client reads as "no updates exist".
+assertFeedInvariants(items)
+
+await mkdir(dirname(OUTPUT), { recursive: true })
+await writeFile(OUTPUT, renderFeed(items), 'utf8')
+
+const betaCount = items.filter((item) => item.prerelease).length
+console.log(`Wrote ${OUTPUT}: ${items.length} item(s), ${betaCount} on the beta channel.`)

--- a/scripts/appcast/generate.mjs
+++ b/scripts/appcast/generate.mjs
@@ -6,7 +6,11 @@ import { marked } from 'marked'
 import { buildItems, assertFeedInvariants } from './lib/build.mjs'
 import { renderFeed } from './lib/render.mjs'
 
-const REPO = process.env.APPCAST_REPO ?? 'getmydia/mydia'
+// APPCAST_REPO is the explicit override for a manual run. GITHUB_REPOSITORY is
+// set by Actions and keeps a fork or a renamed repo from building a feed out of
+// somebody else's releases. The literal is only the local-development fallback.
+const REPO =
+  process.env.APPCAST_REPO ?? process.env.GITHUB_REPOSITORY ?? 'getmydia/mydia'
 const OUTPUT = process.argv[2] ?? 'dist/appcast.xml'
 const USER_AGENT = 'mydia-appcast-generator'
 

--- a/scripts/appcast/lib/build.mjs
+++ b/scripts/appcast/lib/build.mjs
@@ -1,0 +1,120 @@
+import { parseReleaseAppcast } from './parse.mjs'
+
+export const DMG_PATTERN = /^mydia-player-macos-v.*\.dmg$/
+export const APPCAST_ASSET = 'appcast.xml'
+export const MINIMUM_SYSTEM_VERSION = '14.0'
+export const BETA_CHANNEL = 'beta'
+export const MAX_ITEMS = 20
+
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+/**
+ * Formats an ISO timestamp as RFC 822 in UTC.
+ *
+ * Derived from the release's published_at rather than the clock, so a rebuild
+ * of an unchanged repo produces a byte-identical feed and the tests stay
+ * deterministic.
+ */
+export function toRfc822(iso) {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`invalid published_at: ${JSON.stringify(iso)}`)
+  }
+  const pad = (n) => String(n).padStart(2, '0')
+  return (
+    `${DAYS[date.getUTCDay()]}, ${pad(date.getUTCDate())} ${MONTHS[date.getUTCMonth()]} ` +
+    `${date.getUTCFullYear()} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:` +
+    `${pad(date.getUTCSeconds())} +0000`
+  )
+}
+
+/**
+ * Builds the merged item list from GitHub release payloads.
+ *
+ * loadAppcast and renderNotes are injected so this module performs no IO and
+ * carries no markdown dependency, which keeps it testable with plain fixtures.
+ *
+ * A release that cannot contribute an item is warned about and skipped rather
+ * than failing the run, so one bad historical release cannot block every future
+ * feed update. A run in which everything is skipped still fails, via
+ * assertFeedInvariants.
+ */
+export async function buildItems(releases, { loadAppcast, renderNotes }) {
+  const items = []
+  const warnings = []
+
+  for (const release of releases) {
+    const tag = release.tag_name ?? '(untagged)'
+
+    if (release.draft) {
+      continue
+    }
+
+    const assets = release.assets ?? []
+    if (!assets.some((asset) => DMG_PATTERN.test(asset.name))) {
+      warnings.push(`${tag}: skipped, no macOS DMG asset`)
+      continue
+    }
+
+    const appcastAsset = assets.find((asset) => asset.name === APPCAST_ASSET)
+    if (!appcastAsset) {
+      warnings.push(`${tag}: skipped, no ${APPCAST_ASSET} asset`)
+      continue
+    }
+
+    let parsed
+    try {
+      parsed = parseReleaseAppcast(await loadAppcast(appcastAsset))
+    } catch (error) {
+      warnings.push(`${tag}: skipped, ${error.message}`)
+      continue
+    }
+
+    const prerelease = Boolean(release.prerelease)
+    items.push({
+      title: `Version ${parsed.shortVersionString}`,
+      version: parsed.version,
+      shortVersionString: parsed.shortVersionString,
+      channel: prerelease ? BETA_CHANNEL : null,
+      minimumSystemVersion: MINIMUM_SYSTEM_VERSION,
+      pubDate: toRfc822(release.published_at),
+      descriptionHtml: renderNotes(release.body ?? ''),
+      enclosure: parsed.enclosure,
+      prerelease,
+    })
+  }
+
+  items.sort((a, b) => Number(b.version) - Number(a.version))
+
+  return { items: items.slice(0, MAX_ITEMS), warnings }
+}
+
+/**
+ * Checks what the finished XML can no longer express.
+ *
+ * Once rendered, nothing records which release was a prerelease, so the
+ * channel-correctness check has to happen here while the source flag is still
+ * attached. The workflow's xmllint pass covers document shape independently.
+ */
+export function assertFeedInvariants(items) {
+  if (items.length === 0) {
+    throw new Error('refusing to emit an empty appcast: no release produced an item')
+  }
+
+  for (const item of items) {
+    if (item.prerelease && item.channel !== BETA_CHANNEL) {
+      throw new Error(`${item.title}: prerelease item must carry the ${BETA_CHANNEL} channel`)
+    }
+    if (!item.prerelease && item.channel !== null) {
+      throw new Error(`${item.title}: stable item must carry no channel, got ${item.channel}`)
+    }
+    if (!/^\d+$/.test(item.version)) {
+      throw new Error(`${item.title}: sparkle:version must be an integer, got ${item.version}`)
+    }
+    const { url, signature, length } = item.enclosure ?? {}
+    if (!url || !signature || !/^\d+$/.test(String(length))) {
+      throw new Error(`${item.title}: enclosure needs a url, a signature and an integer length`)
+    }
+  }
+}

--- a/scripts/appcast/lib/build.mjs
+++ b/scripts/appcast/lib/build.mjs
@@ -63,26 +63,24 @@ export async function buildItems(releases, { loadAppcast, renderNotes }) {
       continue
     }
 
-    let parsed
     try {
-      parsed = parseReleaseAppcast(await loadAppcast(appcastAsset))
+      const parsed = parseReleaseAppcast(await loadAppcast(appcastAsset))
+      const prerelease = Boolean(release.prerelease)
+
+      items.push({
+        title: `Version ${parsed.shortVersionString}`,
+        version: parsed.version,
+        shortVersionString: parsed.shortVersionString,
+        channel: prerelease ? BETA_CHANNEL : null,
+        minimumSystemVersion: MINIMUM_SYSTEM_VERSION,
+        pubDate: toRfc822(release.published_at),
+        descriptionHtml: renderNotes(release.body ?? ''),
+        enclosure: parsed.enclosure,
+        prerelease,
+      })
     } catch (error) {
       warnings.push(`${tag}: skipped, ${error.message}`)
-      continue
     }
-
-    const prerelease = Boolean(release.prerelease)
-    items.push({
-      title: `Version ${parsed.shortVersionString}`,
-      version: parsed.version,
-      shortVersionString: parsed.shortVersionString,
-      channel: prerelease ? BETA_CHANNEL : null,
-      minimumSystemVersion: MINIMUM_SYSTEM_VERSION,
-      pubDate: toRfc822(release.published_at),
-      descriptionHtml: renderNotes(release.body ?? ''),
-      enclosure: parsed.enclosure,
-      prerelease,
-    })
   }
 
   items.sort((a, b) => Number(b.version) - Number(a.version))

--- a/scripts/appcast/lib/build.mjs
+++ b/scripts/appcast/lib/build.mjs
@@ -2,7 +2,6 @@ import { parseReleaseAppcast } from './parse.mjs'
 
 export const DMG_PATTERN = /^mydia-player-macos-v.*\.dmg$/
 export const APPCAST_ASSET = 'appcast.xml'
-export const MINIMUM_SYSTEM_VERSION = '14.0'
 export const BETA_CHANNEL = 'beta'
 export const MAX_ITEMS = 20
 
@@ -17,6 +16,9 @@ const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', '
  * deterministic.
  */
 export function toRfc822(iso) {
+  if (typeof iso !== 'string') {
+    throw new Error(`invalid published_at: ${JSON.stringify(iso)}`)
+  }
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) {
     throw new Error(`invalid published_at: ${JSON.stringify(iso)}`)
@@ -72,7 +74,7 @@ export async function buildItems(releases, { loadAppcast, renderNotes }) {
         version: parsed.version,
         shortVersionString: parsed.shortVersionString,
         channel: prerelease ? BETA_CHANNEL : null,
-        minimumSystemVersion: MINIMUM_SYSTEM_VERSION,
+        minimumSystemVersion: parsed.minimumSystemVersion,
         pubDate: toRfc822(release.published_at),
         descriptionHtml: renderNotes(release.body ?? ''),
         enclosure: parsed.enclosure,
@@ -85,7 +87,30 @@ export async function buildItems(releases, { loadAppcast, renderNotes }) {
 
   items.sort((a, b) => Number(b.version) - Number(a.version))
 
-  return { items: items.slice(0, MAX_ITEMS), warnings }
+  return { items: capItems(items), warnings }
+}
+
+export const MIN_STABLE_ITEMS = 5
+
+/**
+ * Caps the feed while guaranteeing the newest stable items survive.
+ *
+ * Sparkle filters by allowed channel after fetching, so a stable-channel
+ * user only ever sees channel-less items. A long prerelease cycle could
+ * otherwise push every stable item past the cap and leave those users with
+ * no update offered at all, silently and indefinitely.
+ */
+export function capItems(items) {
+  const stable = items.filter((item) => !item.prerelease)
+  const reserved = stable.slice(0, MIN_STABLE_ITEMS)
+  const reservedVersions = new Set(reserved.map((item) => item.version))
+  const fill = items
+    .filter((item) => !reservedVersions.has(item.version))
+    .slice(0, Math.max(0, MAX_ITEMS - reserved.length))
+
+  return [...reserved, ...fill].sort(
+    (a, b) => Number(b.version) - Number(a.version),
+  )
 }
 
 /**
@@ -100,6 +125,8 @@ export function assertFeedInvariants(items) {
     throw new Error('refusing to emit an empty appcast: no release produced an item')
   }
 
+  const seenVersions = new Set()
+
   for (const item of items) {
     if (item.prerelease && item.channel !== BETA_CHANNEL) {
       throw new Error(`${item.title}: prerelease item must carry the ${BETA_CHANNEL} channel`)
@@ -110,6 +137,13 @@ export function assertFeedInvariants(items) {
     if (!/^\d+$/.test(item.version)) {
       throw new Error(`${item.title}: sparkle:version must be an integer, got ${item.version}`)
     }
+    // Sparkle would pick between duplicates non-deterministically, so two
+    // items claiming the same build number is a generator bug, not something
+    // to ship and hope Sparkle sorts out.
+    if (seenVersions.has(item.version)) {
+      throw new Error(`${item.title}: duplicate sparkle:version ${item.version}`)
+    }
+    seenVersions.add(item.version)
     const { url, signature, length } = item.enclosure ?? {}
     if (!url || !signature || !/^\d+$/.test(String(length))) {
       throw new Error(`${item.title}: enclosure needs a url, a signature and an integer length`)

--- a/scripts/appcast/lib/parse.mjs
+++ b/scripts/appcast/lib/parse.mjs
@@ -1,0 +1,63 @@
+import { XMLParser } from 'fast-xml-parser'
+
+// parseTagValue/parseAttributeValue must stay false. With them on, a short
+// version of "1.5" comes back as the number 1.5 and a length of "0123" loses
+// its leading zero, both of which corrupt the feed silently.
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  parseTagValue: false,
+  parseAttributeValue: false,
+})
+
+/**
+ * Reads one release's single-item appcast asset, the artifact release.yml
+ * generates and signs, and returns the fields the merged feed reuses verbatim.
+ *
+ * The enclosure is copied through untouched so the signature Sparkle verifies
+ * is always the one produced at build time. Nothing here re-signs anything.
+ */
+export function parseReleaseAppcast(xml) {
+  const doc = parser.parse(xml)
+  const channel = doc?.rss?.channel
+  if (!channel) {
+    throw new Error('appcast has no rss > channel element')
+  }
+
+  const items = Array.isArray(channel.item) ? channel.item : channel.item ? [channel.item] : []
+  if (items.length !== 1) {
+    throw new Error(`expected exactly 1 item in a per-release appcast, got ${items.length}`)
+  }
+  const item = items[0]
+
+  const version = String(item['sparkle:version'] ?? '')
+  if (!/^\d+$/.test(version)) {
+    throw new Error(`sparkle:version must be an integer build number, got ${JSON.stringify(version)}`)
+  }
+
+  const shortVersionString = String(item['sparkle:shortVersionString'] ?? '')
+  if (!shortVersionString) {
+    throw new Error('missing sparkle:shortVersionString')
+  }
+
+  const enclosure = item.enclosure
+  if (!enclosure) {
+    throw new Error('item has no enclosure')
+  }
+
+  const url = String(enclosure['@_url'] ?? '')
+  const signature = String(enclosure['@_sparkle:edSignature'] ?? '')
+  const length = String(enclosure['@_length'] ?? '')
+
+  if (!url) {
+    throw new Error('enclosure has no url')
+  }
+  if (!signature) {
+    throw new Error('enclosure has no sparkle:edSignature')
+  }
+  if (!/^\d+$/.test(length)) {
+    throw new Error(`enclosure length must be an integer, got ${JSON.stringify(length)}`)
+  }
+
+  return { version, shortVersionString, enclosure: { url, signature, length } }
+}

--- a/scripts/appcast/lib/parse.mjs
+++ b/scripts/appcast/lib/parse.mjs
@@ -40,6 +40,12 @@ export function parseReleaseAppcast(xml) {
     throw new Error('missing sparkle:shortVersionString')
   }
 
+  // Absent on every release published before this field started being
+  // emitted, so null (not a default) is the correct value for those items:
+  // making no claim about minimum OS is what the legacy feed already does.
+  const minimumSystemVersion =
+    item['sparkle:minimumSystemVersion'] != null ? String(item['sparkle:minimumSystemVersion']) : null
+
   const enclosure = item.enclosure
   if (!enclosure) {
     throw new Error('item has no enclosure')
@@ -59,5 +65,5 @@ export function parseReleaseAppcast(xml) {
     throw new Error(`enclosure length must be an integer, got ${JSON.stringify(length)}`)
   }
 
-  return { version, shortVersionString, enclosure: { url, signature, length } }
+  return { version, shortVersionString, minimumSystemVersion, enclosure: { url, signature, length } }
 }

--- a/scripts/appcast/lib/render.mjs
+++ b/scripts/appcast/lib/render.mjs
@@ -26,11 +26,18 @@ export function renderItem(item) {
     ? `\n      <sparkle:channel>${escapeXml(item.channel)}</sparkle:channel>`
     : ''
 
+  // Historical releases published before minimumSystemVersion was tracked
+  // carry null here. Omitting the element makes no claim about the minimum
+  // OS for those builds, which matches the legacy feed's behavior and is
+  // strictly more honest than stamping today's deployment target on them.
+  const minimumSystemVersionLine = item.minimumSystemVersion
+    ? `\n      <sparkle:minimumSystemVersion>${escapeXml(item.minimumSystemVersion)}</sparkle:minimumSystemVersion>`
+    : ''
+
   return `    <item>
       <title>${escapeXml(item.title)}</title>
       <sparkle:version>${escapeXml(item.version)}</sparkle:version>
-      <sparkle:shortVersionString>${escapeXml(item.shortVersionString)}</sparkle:shortVersionString>${channelLine}
-      <sparkle:minimumSystemVersion>${escapeXml(item.minimumSystemVersion)}</sparkle:minimumSystemVersion>
+      <sparkle:shortVersionString>${escapeXml(item.shortVersionString)}</sparkle:shortVersionString>${channelLine}${minimumSystemVersionLine}
       <pubDate>${escapeXml(item.pubDate)}</pubDate>
       <description>${wrapCdata(item.descriptionHtml)}</description>
       <enclosure url="${escapeXml(item.enclosure.url)}"

--- a/scripts/appcast/lib/render.mjs
+++ b/scripts/appcast/lib/render.mjs
@@ -18,7 +18,7 @@ export function escapeXml(value) {
  * ]]> truncate the document mid-item and Sparkle rejects the entire feed.
  */
 export function wrapCdata(html) {
-  return `<![CDATA[${String(html).replaceAll(']]>', ']]<![CDATA[>')}]]>`
+  return `<![CDATA[${String(html).replaceAll(']]>', ']]]]><![CDATA[>')}]]>`
 }
 
 export function renderItem(item) {

--- a/scripts/appcast/lib/render.mjs
+++ b/scripts/appcast/lib/render.mjs
@@ -1,0 +1,54 @@
+const XML_ESCAPES = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+}
+
+export function escapeXml(value) {
+  return String(value).replace(/[&<>"']/g, (char) => XML_ESCAPES[char])
+}
+
+/**
+ * Wraps rendered release notes in a CDATA section.
+ *
+ * A CDATA section ends at the first ]]> in its payload, so any occurrence has
+ * to be split across two sections. Without this, notes that happen to contain
+ * ]]> truncate the document mid-item and Sparkle rejects the entire feed.
+ */
+export function wrapCdata(html) {
+  return `<![CDATA[${String(html).replaceAll(']]>', ']]<![CDATA[>')}]]>`
+}
+
+export function renderItem(item) {
+  const channelLine = item.channel
+    ? `\n      <sparkle:channel>${escapeXml(item.channel)}</sparkle:channel>`
+    : ''
+
+  return `    <item>
+      <title>${escapeXml(item.title)}</title>
+      <sparkle:version>${escapeXml(item.version)}</sparkle:version>
+      <sparkle:shortVersionString>${escapeXml(item.shortVersionString)}</sparkle:shortVersionString>${channelLine}
+      <sparkle:minimumSystemVersion>${escapeXml(item.minimumSystemVersion)}</sparkle:minimumSystemVersion>
+      <pubDate>${escapeXml(item.pubDate)}</pubDate>
+      <description>${wrapCdata(item.descriptionHtml)}</description>
+      <enclosure url="${escapeXml(item.enclosure.url)}"
+                 sparkle:edSignature="${escapeXml(item.enclosure.signature)}"
+                 length="${escapeXml(item.enclosure.length)}"
+                 type="application/octet-stream" />
+    </item>`
+}
+
+export function renderFeed(items) {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Mydia Player</title>
+    <link>https://mydia.dev</link>
+    <description>Updates for the Mydia Player macOS app.</description>
+${items.map(renderItem).join('\n')}
+  </channel>
+</rss>
+`
+}

--- a/scripts/appcast/package-lock.json
+++ b/scripts/appcast/package-lock.json
@@ -1,0 +1,146 @@
+{
+  "name": "mydia-appcast",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mydia-appcast",
+      "dependencies": {
+        "fast-xml-parser": "^5.10.1",
+        "marked": "^18.0.9"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    }
+  }
+}

--- a/scripts/appcast/package.json
+++ b/scripts/appcast/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "type": "module",
   "description": "Generates the merged Sparkle appcast served at updates.mydia.dev",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "test": "node --test test/*.test.mjs",
     "generate": "node generate.mjs"

--- a/scripts/appcast/package.json
+++ b/scripts/appcast/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Generates the merged Sparkle appcast served at updates.mydia.dev",
   "scripts": {
-    "test": "node --test test/",
+    "test": "node --test test/*.test.mjs",
     "generate": "node generate.mjs"
   },
   "dependencies": {

--- a/scripts/appcast/package.json
+++ b/scripts/appcast/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mydia-appcast",
+  "private": true,
+  "type": "module",
+  "description": "Generates the merged Sparkle appcast served at updates.mydia.dev",
+  "scripts": {
+    "test": "node --test test/",
+    "generate": "node generate.mjs"
+  },
+  "dependencies": {
+    "fast-xml-parser": "^5.10.1",
+    "marked": "^18.0.9"
+  }
+}

--- a/scripts/appcast/test/build.test.mjs
+++ b/scripts/appcast/test/build.test.mjs
@@ -79,9 +79,12 @@ test('a prerelease newer than the newest stable is tagged beta and sorts first',
 })
 
 test('sorts by build number, not by marketing version string', async () => {
+  // Build numbers deliberately invert the lexicographic order of the
+  // marketing strings: "1.9.0" sorts above "1.10.0" as plain text, so a
+  // string sort would return these the other way round.
   const { items } = await build([
-    release({ tag: 'v1.10.0', short: '1.10.0', versionCode: '10200' }),
-    release({ tag: 'v1.9.0', short: '1.9.0', versionCode: '10300' }),
+    release({ tag: 'v1.10.0', short: '1.10.0', versionCode: '10300' }),
+    release({ tag: 'v1.9.0', short: '1.9.0', versionCode: '10200' }),
   ])
 
   assert.deepEqual(items.map((i) => i.version), ['10300', '10200'])
@@ -106,6 +109,17 @@ test('skips a release whose appcast asset is missing without failing the run', a
 
   assert.deepEqual(items.map((i) => i.version), ['10100'])
   assert.match(warnings.join('\n'), /v1\.3\.0/)
+})
+
+test('skips a release with an unparseable published_at instead of failing the run', async () => {
+  const good = release({ tag: 'v1.4.9', short: '1.4.9', versionCode: '10100' })
+  const broken = release({ tag: 'v1.3.0', short: '1.3.0', versionCode: '10050' })
+  broken.published_at = 'not-a-date'
+
+  const { items, warnings } = await build([good, broken])
+
+  assert.deepEqual(items.map((i) => i.version), ['10100'])
+  assert.match(warnings.join('\n'), /v1\.3\.0.*invalid published_at/)
 })
 
 test('skips a draft release', async () => {

--- a/scripts/appcast/test/build.test.mjs
+++ b/scripts/appcast/test/build.test.mjs
@@ -1,0 +1,155 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildItems, assertFeedInvariants, toRfc822, MAX_ITEMS } from '../lib/build.mjs'
+
+function perReleaseAppcast(version, short) {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel><item>
+    <sparkle:version>${version}</sparkle:version>
+    <sparkle:shortVersionString>${short}</sparkle:shortVersionString>
+    <enclosure url="https://example.test/${short}.dmg" sparkle:edSignature="SIG${version}" length="99" />
+  </item></channel>
+</rss>`
+}
+
+function release({ tag, short, versionCode, prerelease = false, assets, body = 'notes', draft = false }) {
+  return {
+    tag_name: tag,
+    prerelease,
+    draft,
+    body,
+    published_at: '2026-08-04T12:00:00Z',
+    assets: assets ?? [
+      { name: `mydia-player-macos-${tag}.dmg`, browser_download_url: `https://example.test/${short}.dmg` },
+      { name: 'appcast.xml', browser_download_url: `https://example.test/${short}-appcast.xml` },
+    ],
+    _appcast: perReleaseAppcast(versionCode, short),
+  }
+}
+
+/** Serves each release its own appcast body, keyed by download URL. */
+function resolverFor(releases) {
+  const byUrl = new Map()
+  for (const r of releases) {
+    const asset = r.assets.find((a) => a.name === 'appcast.xml')
+    if (asset) byUrl.set(asset.browser_download_url, r._appcast)
+  }
+  return async (asset) => {
+    if (!byUrl.has(asset.browser_download_url)) throw new Error('404')
+    return byUrl.get(asset.browser_download_url)
+  }
+}
+
+const identityNotes = (markdown) => `<p>${markdown}</p>`
+
+async function build(releases) {
+  return buildItems(releases, { loadAppcast: resolverFor(releases), renderNotes: identityNotes })
+}
+
+test('formats published_at as RFC 822 in UTC', () => {
+  assert.equal(toRfc822('2026-08-04T12:00:00Z'), 'Tue, 04 Aug 2026 12:00:00 +0000')
+})
+
+test('a stable-only repo produces items with no channel', async () => {
+  const { items } = await build([release({ tag: 'v1.4.9', short: '1.4.9', versionCode: '10100' })])
+
+  assert.equal(items.length, 1)
+  assert.equal(items[0].channel, null)
+  assert.equal(items[0].prerelease, false)
+  assert.equal(items[0].title, 'Version 1.4.9')
+  assert.equal(items[0].enclosure.signature, 'SIG10100')
+})
+
+test('a prerelease newer than the newest stable is tagged beta and sorts first', async () => {
+  // This is the case that is broken today: releases/latest/download never
+  // resolves to a prerelease, so this item is unreachable without the merge.
+  const { items } = await build([
+    release({ tag: 'v1.4.9', short: '1.4.9', versionCode: '10100' }),
+    release({ tag: 'v1.5.0-beta.2', short: '1.5.0-beta.2', versionCode: '10123', prerelease: true }),
+  ])
+
+  assert.deepEqual(
+    items.map((i) => [i.shortVersionString, i.channel]),
+    [
+      ['1.5.0-beta.2', 'beta'],
+      ['1.4.9', null],
+    ],
+  )
+})
+
+test('sorts by build number, not by marketing version string', async () => {
+  const { items } = await build([
+    release({ tag: 'v1.10.0', short: '1.10.0', versionCode: '10200' }),
+    release({ tag: 'v1.9.0', short: '1.9.0', versionCode: '10300' }),
+  ])
+
+  assert.deepEqual(items.map((i) => i.version), ['10300', '10200'])
+})
+
+test('skips a release with no macOS DMG', async () => {
+  const noDmg = release({ tag: 'v1.4.9', short: '1.4.9', versionCode: '10100' })
+  noDmg.assets = [{ name: 'appcast.xml', browser_download_url: 'https://example.test/1.4.9-appcast.xml' }]
+
+  const { items, warnings } = await build([noDmg])
+
+  assert.equal(items.length, 0)
+  assert.match(warnings.join('\n'), /v1\.4\.9.*no macOS DMG/)
+})
+
+test('skips a release whose appcast asset is missing without failing the run', async () => {
+  const good = release({ tag: 'v1.4.9', short: '1.4.9', versionCode: '10100' })
+  const broken = release({ tag: 'v1.3.0', short: '1.3.0', versionCode: '10050' })
+  broken.assets = broken.assets.filter((a) => a.name !== 'appcast.xml')
+
+  const { items, warnings } = await build([good, broken])
+
+  assert.deepEqual(items.map((i) => i.version), ['10100'])
+  assert.match(warnings.join('\n'), /v1\.3\.0/)
+})
+
+test('skips a draft release', async () => {
+  const { items } = await build([release({ tag: 'v9.9.9', short: '9.9.9', versionCode: '99999', draft: true })])
+
+  assert.equal(items.length, 0)
+})
+
+test('caps the feed at MAX_ITEMS, keeping the newest', async () => {
+  const many = Array.from({ length: MAX_ITEMS + 5 }, (_, i) =>
+    release({ tag: `v1.0.${i}`, short: `1.0.${i}`, versionCode: String(10000 + i) }),
+  )
+
+  const { items } = await build(many)
+
+  assert.equal(items.length, MAX_ITEMS)
+  assert.equal(items[0].version, String(10000 + MAX_ITEMS + 4))
+})
+
+test('assertFeedInvariants rejects an empty feed', () => {
+  assert.throws(() => assertFeedInvariants([]), /empty appcast/)
+})
+
+test('assertFeedInvariants rejects a prerelease item missing the beta channel', async () => {
+  const { items } = await build([
+    release({ tag: 'v1.5.0-beta.2', short: '1.5.0-beta.2', versionCode: '10123', prerelease: true }),
+  ])
+  items[0].channel = null
+
+  assert.throws(() => assertFeedInvariants(items), /prerelease.*beta/)
+})
+
+test('assertFeedInvariants rejects a stable item that acquired a channel', async () => {
+  const { items } = await build([release({ tag: 'v1.4.9', short: '1.4.9', versionCode: '10100' })])
+  items[0].channel = 'beta'
+
+  assert.throws(() => assertFeedInvariants(items), /stable/)
+})
+
+test('assertFeedInvariants accepts a well-formed mixed feed', async () => {
+  const { items } = await build([
+    release({ tag: 'v1.4.9', short: '1.4.9', versionCode: '10100' }),
+    release({ tag: 'v1.5.0-beta.2', short: '1.5.0-beta.2', versionCode: '10123', prerelease: true }),
+  ])
+
+  assert.doesNotThrow(() => assertFeedInvariants(items))
+})

--- a/scripts/appcast/test/build.test.mjs
+++ b/scripts/appcast/test/build.test.mjs
@@ -51,6 +51,14 @@ test('formats published_at as RFC 822 in UTC', () => {
   assert.equal(toRfc822('2026-08-04T12:00:00Z'), 'Tue, 04 Aug 2026 12:00:00 +0000')
 })
 
+test('rejects a null published_at instead of silently returning the epoch', () => {
+  // new Date(null) coerces to 1970-01-01T00:00:00.000Z, so Number.isNaN never
+  // fires on its getTime(). GitHub returns an explicit null for published_at
+  // on releases that lack one, and that must fail the same way any other bad
+  // input does rather than backdating the item by five decades.
+  assert.throws(() => toRfc822(null), /invalid published_at/)
+})
+
 test('a stable-only repo produces items with no channel', async () => {
   const { items } = await build([release({ tag: 'v1.4.9', short: '1.4.9', versionCode: '10100' })])
 
@@ -139,6 +147,28 @@ test('caps the feed at MAX_ITEMS, keeping the newest', async () => {
   assert.equal(items[0].version, String(10000 + MAX_ITEMS + 4))
 })
 
+test('reserves the newest stable items so a long prerelease run cannot evict all of them', async () => {
+  // Sparkle filters by allowed channel after fetching the feed, so a
+  // stable-channel user only ever sees channel-less items. A bare
+  // slice(0, MAX_ITEMS) applied after sorting across both channels would let
+  // enough prereleases push the one stable item below the cutoff, leaving
+  // stable users with no update offered at all.
+  const stable = release({ tag: 'v1.0.0', short: '1.0.0', versionCode: '10000' })
+  const betas = Array.from({ length: 30 }, (_, i) =>
+    release({
+      tag: `v1.1.0-beta.${i}`,
+      short: `1.1.0-beta.${i}`,
+      versionCode: String(20000 + i),
+      prerelease: true,
+    }),
+  )
+
+  const { items } = await build([stable, ...betas])
+
+  assert.equal(items.length, MAX_ITEMS)
+  assert.ok(items.some((item) => item.version === '10000'), 'the stable item must survive the cap')
+})
+
 test('assertFeedInvariants rejects an empty feed', () => {
   assert.throws(() => assertFeedInvariants([]), /empty appcast/)
 })
@@ -166,4 +196,14 @@ test('assertFeedInvariants accepts a well-formed mixed feed', async () => {
   ])
 
   assert.doesNotThrow(() => assertFeedInvariants(items))
+})
+
+test('assertFeedInvariants rejects two items sharing the same sparkle:version', async () => {
+  // Sparkle would pick between duplicates non-deterministically, so this is a
+  // generator bug to fail loudly on, not something to ship and hope resolves
+  // itself.
+  const { items } = await build([release({ tag: 'v1.4.9', short: '1.4.9', versionCode: '10100' })])
+  const duplicate = { ...items[0] }
+
+  assert.throws(() => assertFeedInvariants([...items, duplicate]), /duplicate/)
 })

--- a/scripts/appcast/test/parse.test.mjs
+++ b/scripts/appcast/test/parse.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { parseReleaseAppcast } from '../lib/parse.mjs'
+
+/** A per-release appcast in exactly the shape release.yml emits. */
+function releaseAppcast({ version = '10123', short = '1.5.0', enclosure } = {}) {
+  const enc =
+    enclosure ??
+    '<enclosure url="https://example.test/a.dmg" sparkle:edSignature="AAAA" length="123" type="application/octet-stream" />'
+  return `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Mydia Player</title>
+    <item>
+      <title>Version ${short}</title>
+      <sparkle:version>${version}</sparkle:version>
+      <sparkle:shortVersionString>${short}</sparkle:shortVersionString>
+      <pubDate>Mon, 04 Aug 2026 12:00:00 +0000</pubDate>
+      ${enc}
+    </item>
+  </channel>
+</rss>`
+}
+
+test('extracts version, short version and the signed enclosure', () => {
+  const result = parseReleaseAppcast(releaseAppcast())
+
+  assert.deepEqual(result, {
+    version: '10123',
+    shortVersionString: '1.5.0',
+    enclosure: {
+      url: 'https://example.test/a.dmg',
+      signature: 'AAAA',
+      length: '123',
+    },
+  })
+})
+
+test('keeps a numeric-looking short version as a string', () => {
+  // fast-xml-parser coerces "1.5" to the number 1.5 unless told not to, which
+  // would silently rewrite the marketing version shown to users.
+  const result = parseReleaseAppcast(releaseAppcast({ short: '1.5' }))
+
+  assert.equal(result.shortVersionString, '1.5')
+})
+
+test('rejects a feed with more than one item', () => {
+  const two = releaseAppcast().replace('</item>', '</item><item><title>x</title></item>')
+
+  assert.throws(() => parseReleaseAppcast(two), /exactly 1 item/)
+})
+
+test('rejects a non-integer sparkle:version', () => {
+  assert.throws(() => parseReleaseAppcast(releaseAppcast({ version: '1.5.0' })), /must be an integer/)
+})
+
+test('rejects an enclosure with no signature', () => {
+  const unsigned = '<enclosure url="https://example.test/a.dmg" length="123" />'
+
+  assert.throws(() => parseReleaseAppcast(releaseAppcast({ enclosure: unsigned })), /edSignature/)
+})
+
+test('rejects an enclosure with a non-integer length', () => {
+  const bad = '<enclosure url="https://example.test/a.dmg" sparkle:edSignature="AAAA" length="12 34" />'
+
+  assert.throws(() => parseReleaseAppcast(releaseAppcast({ enclosure: bad })), /length must be an integer/)
+})

--- a/scripts/appcast/test/parse.test.mjs
+++ b/scripts/appcast/test/parse.test.mjs
@@ -3,10 +3,13 @@ import assert from 'node:assert/strict'
 import { parseReleaseAppcast } from '../lib/parse.mjs'
 
 /** A per-release appcast in exactly the shape release.yml emits. */
-function releaseAppcast({ version = '10123', short = '1.5.0', enclosure } = {}) {
+function releaseAppcast({ version = '10123', short = '1.5.0', minimumSystemVersion = '14.0', enclosure } = {}) {
   const enc =
     enclosure ??
     '<enclosure url="https://example.test/a.dmg" sparkle:edSignature="AAAA" length="123" type="application/octet-stream" />'
+  const minOsLine = minimumSystemVersion
+    ? `<sparkle:minimumSystemVersion>${minimumSystemVersion}</sparkle:minimumSystemVersion>`
+    : ''
   return `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
@@ -15,6 +18,7 @@ function releaseAppcast({ version = '10123', short = '1.5.0', enclosure } = {}) 
       <title>Version ${short}</title>
       <sparkle:version>${version}</sparkle:version>
       <sparkle:shortVersionString>${short}</sparkle:shortVersionString>
+      ${minOsLine}
       <pubDate>Mon, 04 Aug 2026 12:00:00 +0000</pubDate>
       ${enc}
     </item>
@@ -22,18 +26,28 @@ function releaseAppcast({ version = '10123', short = '1.5.0', enclosure } = {}) 
 </rss>`
 }
 
-test('extracts version, short version and the signed enclosure', () => {
+test('extracts version, short version, minimum OS and the signed enclosure', () => {
   const result = parseReleaseAppcast(releaseAppcast())
 
   assert.deepEqual(result, {
     version: '10123',
     shortVersionString: '1.5.0',
+    minimumSystemVersion: '14.0',
     enclosure: {
       url: 'https://example.test/a.dmg',
       signature: 'AAAA',
       length: '123',
     },
   })
+})
+
+test('returns a null minimumSystemVersion when the element is absent', () => {
+  // Every release published before this field started being emitted lacks
+  // it. null (not a default) is the only honest value: it makes no claim
+  // about those builds' minimum OS, matching the legacy feed's behavior.
+  const result = parseReleaseAppcast(releaseAppcast({ minimumSystemVersion: null }))
+
+  assert.equal(result.minimumSystemVersion, null)
 })
 
 test('keeps a numeric-looking short version as a string', () => {

--- a/scripts/appcast/test/render.test.mjs
+++ b/scripts/appcast/test/render.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { escapeXml, wrapCdata, renderItem, renderFeed } from '../lib/render.mjs'
+
+function item(overrides = {}) {
+  return {
+    title: 'Version 1.5.0',
+    version: '10123',
+    shortVersionString: '1.5.0',
+    channel: null,
+    minimumSystemVersion: '14.0',
+    pubDate: 'Mon, 04 Aug 2026 12:00:00 +0000',
+    descriptionHtml: '<p>Hello</p>',
+    enclosure: {
+      url: 'https://example.test/a.dmg',
+      signature: 'AAAA',
+      length: '123',
+    },
+    ...overrides,
+  }
+}
+
+test('escapes the five XML metacharacters', () => {
+  assert.equal(escapeXml(`a&b<c>d"e'f`), 'a&amp;b&lt;c&gt;d&quot;e&apos;f')
+})
+
+test('splits a CDATA terminator inside release notes', () => {
+  // A CDATA section ends at the first ]]>. Left alone, notes containing one
+  // truncate the document mid-item and Sparkle rejects the whole feed.
+  const wrapped = wrapCdata('before ]]> after')
+
+  assert.equal(wrapped, '<![CDATA[before ]]<![CDATA[> after]]>')
+  assert.ok(!wrapped.slice(9, -3).includes(']]>'))
+})
+
+test('omits the channel element for a stable item', () => {
+  assert.ok(!renderItem(item()).includes('sparkle:channel'))
+})
+
+test('emits the beta channel element for a prerelease item', () => {
+  assert.match(renderItem(item({ channel: 'beta' })), /<sparkle:channel>beta<\/sparkle:channel>/)
+})
+
+test('escapes an ampersand in the enclosure url', () => {
+  const xml = renderItem(item({ enclosure: { url: 'https://x.test/a.dmg?a=1&b=2', signature: 'AAAA', length: '123' } }))
+
+  assert.ok(xml.includes('a=1&amp;b=2'))
+  assert.ok(!xml.includes('a=1&b=2'))
+})
+
+test('renders a feed with the sparkle namespace and every item', () => {
+  const xml = renderFeed([item(), item({ title: 'Version 1.4.9', version: '10100' })])
+
+  assert.match(xml, /^<\?xml version="1\.0" encoding="utf-8"\?>/)
+  assert.ok(xml.includes('xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"'))
+  assert.equal(xml.match(/<item>/g).length, 2)
+  assert.ok(xml.includes('<title>Mydia Player</title>'))
+})

--- a/scripts/appcast/test/render.test.mjs
+++ b/scripts/appcast/test/render.test.mjs
@@ -54,6 +54,20 @@ test('emits the beta channel element for a prerelease item', () => {
   assert.match(renderItem(item({ channel: 'beta' })), /<sparkle:channel>beta<\/sparkle:channel>/)
 })
 
+test('emits the minimumSystemVersion element when known', () => {
+  assert.match(
+    renderItem(item({ minimumSystemVersion: '14.0' })),
+    /<sparkle:minimumSystemVersion>14\.0<\/sparkle:minimumSystemVersion>/,
+  )
+})
+
+test('omits the minimumSystemVersion element for a historical item with no known value', () => {
+  // Releases published before this field existed have no true answer, and
+  // omitting the element (rather than stamping today's deployment target on
+  // them) is what keeps the claim honest.
+  assert.ok(!renderItem(item({ minimumSystemVersion: null })).includes('minimumSystemVersion'))
+})
+
 test('escapes an ampersand in the enclosure url', () => {
   const xml = renderItem(item({ enclosure: { url: 'https://x.test/a.dmg?a=1&b=2', signature: 'AAAA', length: '123' } }))
 

--- a/scripts/appcast/test/render.test.mjs
+++ b/scripts/appcast/test/render.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { XMLParser } from 'fast-xml-parser'
 import { escapeXml, wrapCdata, renderItem, renderFeed } from '../lib/render.mjs'
 
 function item(overrides = {}) {
@@ -26,11 +27,23 @@ test('escapes the five XML metacharacters', () => {
 
 test('splits a CDATA terminator inside release notes', () => {
   // A CDATA section ends at the first ]]>. Left alone, notes containing one
-  // truncate the document mid-item and Sparkle rejects the whole feed.
+  // truncate the document mid-item and Sparkle rejects the whole feed. The
+  // fix ends the section and reopens it, so the ]]> straddles the boundary
+  // and neither section terminates early.
   const wrapped = wrapCdata('before ]]> after')
 
-  assert.equal(wrapped, '<![CDATA[before ]]<![CDATA[> after]]>')
-  assert.ok(!wrapped.slice(9, -3).includes(']]>'))
+  assert.equal(wrapped, '<![CDATA[before ]]]]><![CDATA[> after]]>')
+})
+
+test('a CDATA terminator survives an XML round trip', () => {
+  // The property that actually matters, and the one a string comparison
+  // cannot show: a parser hands back exactly what went in.
+  const notes = 'before ]]> after'
+  const parsed = new XMLParser({ parseTagValue: false }).parse(
+    `<d>${wrapCdata(notes)}</d>`,
+  )
+
+  assert.equal(parsed.d, notes)
 })
 
 test('omits the channel element for a stable item', () => {

--- a/scripts/appcast/validate.sh
+++ b/scripts/appcast/validate.sh
@@ -42,4 +42,14 @@ for i in $(seq 1 "$item_count"); do
   fi
 done
 
-echo "merged appcast validated: $item_count item(s)"
+# xmllint --xpath cannot resolve the sparkle: prefix without a namespace
+# declaration on the command line, so this matches on local-name() instead.
+# A stable-channel client only ever sees channel-less items, so a feed with
+# none silently tells every stable install "no updates available" forever.
+stable_count=$(count_xpath "count(/rss/channel/item[not(*[local-name()='channel'])])")
+if [ "$stable_count" -lt 1 ]; then
+  echo "::error::merged appcast has no channel-less (stable) item; every stable-channel client would see no updates"
+  exit 1
+fi
+
+echo "merged appcast validated: $item_count item(s), $stable_count stable"

--- a/scripts/appcast/validate.sh
+++ b/scripts/appcast/validate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Independent check on the merged feed, run after generate.mjs has written it.
+#
+# This deliberately duplicates some of assertFeedInvariants: a generator bug
+# must not be able to wave its own output through. It is also the per-item form
+# of the whole-file greps release.yml uses on the single-item per-release
+# appcast, which would pass a merged feed where one item carried two signatures
+# and another carried none.
+set -euo pipefail
+
+FEED="${1:?usage: validate.sh <appcast.xml>}"
+
+if ! command -v xmllint >/dev/null 2>&1; then
+  echo "::error::xmllint not found; cannot validate the merged appcast"
+  exit 1
+fi
+
+xmllint --noout "$FEED"
+
+# count() prints a float on some libxml2 builds ("2.000000") and an integer on
+# others. Truncating at the decimal point handles both; without it the [ -lt ]
+# below dies with "integer expression expected" on exactly the builds that pad.
+count_xpath() {
+  xmllint --xpath "$1" "$FEED" | cut -d. -f1
+}
+
+item_count=$(count_xpath 'count(/rss/channel/item)')
+if [ "$item_count" -lt 1 ]; then
+  echo "::error::merged appcast has no items"
+  exit 1
+fi
+
+for i in $(seq 1 "$item_count"); do
+  enclosures=$(count_xpath "count(/rss/channel/item[$i]/enclosure)")
+  sigs=$(count_xpath "count(/rss/channel/item[$i]/enclosure/@*[local-name()='edSignature'])")
+  lengths=$(count_xpath "count(/rss/channel/item[$i]/enclosure/@length)")
+
+  if [ "$enclosures" -ne 1 ] || [ "$sigs" -ne 1 ] || [ "$lengths" -ne 1 ]; then
+    echo "::error::item $i malformed: enclosure=$enclosures edSignature=$sigs length=$lengths (expected 1 each)"
+    xmllint --format "$FEED"
+    exit 1
+  fi
+done
+
+echo "merged appcast validated: $item_count item(s)"


### PR DESCRIPTION
## What this does

Lets macOS players opt into prerelease builds, using Sparkle 2's native channels.

Today `SUFeedURL` points at `releases/latest/download/appcast.xml`. GitHub's `/releases/latest/` only ever resolves to the newest non-prerelease, so prerelease builds are structurally unreachable no matter what they ship. We already sign and upload an `appcast.xml` asset to every prerelease; nothing could ever fetch it.

Four pieces:

1. **A generator** (`scripts/appcast/`) reads every published release, reuses each one's already-signed enclosure verbatim, tags prereleases with `<sparkle:channel>beta</sparkle:channel>`, embeds rendered release notes, and emits one merged feed. It never touches the EdDSA key.
2. **A workflow** (`deploy-appcast.yml`) regenerates and deploys that feed to `updates.mydia.dev`, called from `release.yml` after a successful publish and runnable manually as a rebuild.
3. **The app** points at the new feed and gains an `SPUUpdaterDelegate` reporting allowed channels from a `UserDefaults` bool.
4. **A Settings toggle**, macOS only.

Linux beta continues to ship through the Flatpak branches; this is macOS only, and Windows is untouched.

## Existing installs keep updating

This was the hard constraint, since Sparkle reads `SUFeedURL` from the installed bundle and shipped copies cannot be repointed remotely.

The legacy per-release `appcast.xml` asset keeps shipping on every release, and keeps being a single-item feed the two existing validation steps accept unchanged. It gains one element, `<sparkle:minimumSystemVersion>`, read from the built bundle's `LSMinimumSystemVersion`; Sparkle 2 has always understood it, and it stops offering a build to a machine that cannot run it. An existing app is offered the next stable through the old URL, installs it, and only then points at the new feed. Two feeds, two independent sets of guards:

| Feed | Contents | Consumers |
| --- | --- | --- |
| `releases/latest/download/appcast.xml` | One item, newest stable | Apps installed before this |
| `updates.mydia.dev/appcast.xml` | Up to 20 items, both channels | Apps installed from here on |

The two existing validation steps in `release.yml` are **byte-identical** to master (verified by hashing both at each ref), and `release.yml`'s whole diff is 17 insertions with 0 deletions.

## Verified against real data

A live run over the repo's 60 releases produced a correct 6-item feed: three `0.13.0-beta.*`, stable `0.12.0`, two `0.12.0-beta.*`, ordered by build number, with all five prereleases carrying the beta channel and the stable one carrying none. That output is also the bug in miniature: the newest build is `0.13.0-beta.3` at 10074, currently invisible to Sparkle because `releases/latest` resolves to `0.12.0` at 10071.

The signature and length the merged feed emits for `v0.12.0` are byte-identical to that release's own asset, so verbatim passthrough holds in practice.

Tests: 32 generator, 1447 player, both green.

## Before merging this into a release

Steps 1 and 2 below were done in August and are live now: `mydia-appcast.pages.dev` serves, and `updates.mydia.dev` resolves to it over HTTPS. **Step 3 is still outstanding**, and the feed it would refresh is a month stale: it currently serves 6 items ending at `0.13.0-beta.3` (build 10074), while the newest release is `v0.14.0`. Regenerating today produces 18 items, 5 stable and 13 beta, newest build 10089.

Note step 3 cannot be run until this merges, because `workflow_dispatch` only offers workflows present on the default branch.

1. ~~Create the Cloudflare Pages project `mydia-appcast` with `master` as its production branch.~~ Done. The production branch itself is the one thing not verifiable from outside the account; the deploy's verify step now fails loudly if it is wrong.
2. ~~Point `updates.mydia.dev` at it.~~ Done.
3. Run `deploy-appcast.yml` manually and confirm the URL serves a feed.

Doing step 3 after that release instead of before leaves everyone who updates in the meantime with a dead update path. This is written into `docs/contributing/releasing.md`.

Also: **ship this in a stable release, not a prerelease.** The old URL never resolves to a prerelease, so a beta-only rollout migrates nobody.

## Known and deliberate

- **The Swift has never been compiled.** It was written on Linux with no Xcode. The signature of `allowedChannels(for:)` matters more than usual, because it satisfies an *optional* Objective-C protocol requirement: a mismatch compiles cleanly and is simply never called, making the toggle a silent no-op. It was reviewed carefully against Sparkle 2.9.3's published signature, but a real build plus the end-to-end check below is the only thing that proves it.
- **Opting out does not downgrade you.** Sparkle has no downgrade flow, so unticking the box leaves you where you are until a stable release passes your build number. The toggle says so rather than pretending otherwise.
- No `CLOUDFLARE_ACCOUNT_ID` is set, matching `deploy-site.yml`, which proves this account's token resolves the account alone.

## End-to-end check, required before anyone relies on it

1. Publish a prerelease.
2. Confirm the feed contains it with `<sparkle:channel>beta</sparkle:channel>`.
3. On a release build with the toggle off, Check for Updates should offer nothing.
4. Turn it on; the prerelease should be offered, with notes shown.
5. Confirm an app still on the old `SUFeedURL` is offered the newest stable.

Step 5 is the migration guarantee. If it fails, this is not safe to ship.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a macOS setting to opt in to beta updates.
  - Enabling beta updates immediately checks for available releases.
  - macOS update feeds now include minimum supported system version information.

- **Improvements**
  - macOS updates are now served through a consolidated feed containing stable and beta releases.
  - Update feed generation and validation now improve reliability and preserve stable releases.

- **Documentation**
  - Added guidance for managing macOS update feeds and releasing updates safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Rebase notes (2026-09-04)

Rebased onto master across 2550 commits. Two conflicts, one substantive.

**`ci.yml`.** Master split CI into per-area workflows, and added `flutter test --concurrency=1` to `ci-player.yml` independently, so that half of this branch's change was already upstream. The appcast job moved to its own `.github/workflows/ci-appcast.yml`, following `ci-site.yml`: not path-filtered, because a workflow skipped by a `paths:` filter never reports a status and a required check pointing at it would sit Pending forever. This branch no longer touches `ci.yml` at all.

**`settings_screen.dart` was deleted on master**, rebuilt as `screens/settings/` with a status hero and grouped `SettingsRow` sections. `BetaChannelTile` was a `SwitchListTile`, which no longer exists anywhere in that screen, so it became `BetaChannelRow` built on `SettingsRow.toggle` and lives in `screens/settings/widgets/`. It sits in the Manage section directly above Check for updates, and the platform gate stays at the call site so the row is still reachable from a Linux test host. All seven tests ported, asserting on `SettingsRow.toggleValue` rather than `SwitchListTile.value`.

Two fixes on top of the original branch:

- **The deploy verification compared item counts** (`4e2707350`). `buildItems` caps the feed at `MAX_ITEMS = 20` and the live repo already generates 18, so within about two releases every feed has exactly 20 items and that comparison is satisfied by any feed at all, including the stale one a preview deployment leaves in place. Since this step is the only guard on the wrong-production-branch failure mode `releasing.md` describes, it would have quietly stopped guarding. It now asserts on the newest `sparkle:version` too, which is what actually moves per release and what Sparkle compares. Against the live deployment the two disagree exactly as intended: regenerated is 10089, deployed is 10074.
- **`permissions:` blocks** (`bf16dac03`), on both the reusable workflow and the `appcast` job that calls it, after CodeQL flagged both.

**Verified:** 32/32 generator tests; `macos_updater_test.dart` and `beta_channel_row_test.dart` green. The generator was also run against the live repo rather than fixtures alone, producing a correct 18-item feed that `validate.sh` accepts. `LSMinimumSystemVersion` is confirmed to be `$(MACOSX_DEPLOYMENT_TARGET)` = `14.0` in the source `Info.plist`, so the new `PlistBuddy` read in `release.yml` resolves rather than emitting an empty element.

The "never compiled" caveat on the Swift no longer holds as written: `Build / macOS` runs on this branch. That proves it compiles and that `allowedChannels(for:)` matches the protocol; it still does not prove the channel is honoured at runtime, so the end-to-end check below stands.
