### PR TITLE
feat(player): make the quality switcher actually switch quality

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -354,16 +354,14 @@ config :mydia, :streaming,
   # Transcoding policy: :copy_when_compatible or :always
   # :copy_when_compatible - Use stream copy for compatible codecs (H.264/AAC) - 10-100x faster, zero quality loss
   # :always - Always re-encode (original behavior, slower but ensures consistent output)
-  transcode_policy: :copy_when_compatible,
-  # Ceiling, in pixels, on the output height of any HLS transcode. nil means
-  # no ceiling: a transcode keeps the source resolution.
-  #
-  # This exists because dropping the old hardcoded 720p output means a 4K file
-  # with an incompatible codec now transcodes at 4K, which a small home server
-  # may not sustain in realtime. Operators on constrained hardware set this
-  # once rather than configuring every client. It composes with the
-  # per-request height from the player by taking whichever is lower.
-  max_transcode_height: nil
+  transcode_policy: :copy_when_compatible
+
+# The transcode height ceiling is deliberately NOT here. This file is
+# compile-time and baked into the release, so a key here is unreachable to an
+# operator running the published image. It lives in the layered runtime config
+# instead (lib/mydia/config/schema.ex, the :streaming embed), which makes it
+# settable through MAX_TRANSCODE_HEIGHT, config.yml, or the settings UI. See
+# Mydia.Streaming.FfmpegHlsTranscoder.effective_max_height/1.
 
 # Episode monitor search limits
 # Prevents excessive API usage that exhausts indexer quotas

--- a/config/config.exs
+++ b/config/config.exs
@@ -354,7 +354,16 @@ config :mydia, :streaming,
   # Transcoding policy: :copy_when_compatible or :always
   # :copy_when_compatible - Use stream copy for compatible codecs (H.264/AAC) - 10-100x faster, zero quality loss
   # :always - Always re-encode (original behavior, slower but ensures consistent output)
-  transcode_policy: :copy_when_compatible
+  transcode_policy: :copy_when_compatible,
+  # Ceiling, in pixels, on the output height of any HLS transcode. nil means
+  # no ceiling: a transcode keeps the source resolution.
+  #
+  # This exists because dropping the old hardcoded 720p output means a 4K file
+  # with an incompatible codec now transcodes at 4K, which a small home server
+  # may not sustain in realtime. Operators on constrained hardware set this
+  # once rather than configuring every client. It composes with the
+  # per-request height from the player by taking whichever is lower.
+  max_transcode_height: nil
 
 # Episode monitor search limits
 # Prevents excessive API usage that exhausts indexer quotas

--- a/docs/using/reference/environment-variables.md
+++ b/docs/using/reference/environment-variables.md
@@ -306,6 +306,16 @@ These pace the daily upgrade sweep instance-wide. Which items it considers is se
 
 See [Automatic Quality Upgrades](../how-to/automatic-quality-upgrades.md) for what these cost you in disk.
 
+## Streaming
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MAX_TRANSCODE_HEIGHT` | Ceiling in pixels on the output height of any transcode, for example `720`. Unset means no ceiling and a transcode keeps the source resolution | No limit |
+
+A transcode only happens when a file's codec is not playable as-is, or when a player asks for a quality below the source. This ceiling bounds those; it never
+upscales, and it does not apply when a file is streamed without re-encoding. Set it on a server that cannot encode 4K in realtime, which is what an
+incompatible 4K file would otherwise ask of it. Also settable under **Admin > Configuration > Settings > Streaming**.
+
 ## Advanced Configuration
 
 | Variable | Description | Default |

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -166,6 +166,7 @@ defmodule Mydia.Config.Loader do
       metadata: load_metadata_env(),
       downloads: load_downloads_env(),
       upgrades: load_upgrades_env(),
+      streaming: load_streaming_env(),
       logging: load_logging_env(),
       oban: load_oban_env(),
       flaresolverr: load_flaresolverr_env(),
@@ -262,6 +263,15 @@ defmodule Mydia.Config.Loader do
     |> put_if_present(
       :sweep_batch_size,
       System.get_env("UPGRADE_SWEEP_BATCH_SIZE"),
+      &parse_integer/1
+    )
+  end
+
+  defp load_streaming_env do
+    %{}
+    |> put_if_present(
+      :max_transcode_height,
+      System.get_env("MAX_TRANSCODE_HEIGHT"),
       &parse_integer/1
     )
   end

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -27,6 +27,7 @@ defmodule Mydia.Config.Schema do
           metadata: __MODULE__.Metadata.t() | nil,
           downloads: __MODULE__.Downloads.t() | nil,
           upgrades: __MODULE__.Upgrades.t() | nil,
+          streaming: __MODULE__.Streaming.t() | nil,
           logging: __MODULE__.Logging.t() | nil,
           oban: __MODULE__.Oban.t() | nil,
           plugins: __MODULE__.Plugins.t() | nil,
@@ -105,6 +106,20 @@ defmodule Mydia.Config.Schema do
       # Caps indexer searches (not items) a single sweep run may cost, since
       # upgrade-eligible items can be the whole library.
       field :sweep_batch_size, :integer, default: 50
+    end
+
+    embeds_one :streaming, Streaming, on_replace: :update, primary_key: false do
+      # Ceiling, in pixels, on the output height of any HLS transcode. nil
+      # means no ceiling: a transcode keeps the source resolution.
+      #
+      # This exists because a forced transcode no longer downgrades to 720p
+      # on its own, so a 4K file with an incompatible codec now encodes at 4K,
+      # which a small home server may not sustain in realtime. An operator on
+      # constrained hardware sets this once instead of configuring every
+      # client. It composes with the per-request height a player asks for by
+      # taking whichever is lower. See
+      # Mydia.Streaming.FfmpegHlsTranscoder.effective_max_height/1.
+      field :max_transcode_height, :integer
     end
 
     embeds_one :logging, Logging, on_replace: :update, primary_key: false do
@@ -241,6 +256,7 @@ defmodule Mydia.Config.Schema do
     |> cast_embed(:metadata, with: &metadata_changeset/2)
     |> cast_embed(:downloads, with: &downloads_changeset/2)
     |> cast_embed(:upgrades, with: &upgrades_changeset/2)
+    |> cast_embed(:streaming, with: &streaming_changeset/2)
     |> cast_embed(:logging, with: &logging_changeset/2)
     |> cast_embed(:oban, with: &oban_changeset/2)
     |> cast_embed(:plugins, with: &plugins_changeset/2)
@@ -344,6 +360,15 @@ defmodule Mydia.Config.Schema do
     |> cast(attrs, [:sweep_enabled, :sweep_batch_size])
     |> validate_required([:sweep_enabled, :sweep_batch_size])
     |> validate_number(:sweep_batch_size, greater_than: 0)
+  end
+
+  defp streaming_changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:max_transcode_height])
+    # Not validate_required: nil is the default and means "no ceiling". A
+    # zero or negative ceiling would scale every transcode to nothing, so it
+    # is rejected here rather than discovered as a dead encoder later.
+    |> validate_number(:max_transcode_height, greater_than: 0)
   end
 
   defp logging_changeset(schema, attrs) do
@@ -715,6 +740,7 @@ defmodule Mydia.Config.Schema do
       metadata: %__MODULE__.Metadata{},
       downloads: %__MODULE__.Downloads{},
       upgrades: %__MODULE__.Upgrades{},
+      streaming: %__MODULE__.Streaming{},
       logging: %__MODULE__.Logging{},
       oban: %__MODULE__.Oban{},
       plugins: %__MODULE__.Plugins{},

--- a/lib/mydia/settings/config_setting.ex
+++ b/lib/mydia/settings/config_setting.ex
@@ -69,6 +69,7 @@ defmodule Mydia.Settings.ConfigSetting do
     :media,
     :metadata,
     :downloads,
+    :streaming,
     :notifications,
     :crash_reporting,
     :feedback,

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -653,7 +653,8 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     end
   end
 
-  # Builds the video scale filter, or nothing at all when no height is capped.
+  # Builds the video scale filter. Every encode gets one; only the ceiling is
+  # optional.
   #
   # `-2` keeps the width proportional to the source and divisible by two,
   # which H.264 requires; hardcoding both dimensions (the previous `-s
@@ -667,16 +668,24 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   # to a port with no shell, so the quotes would arrive literally and the
   # filter would fail to parse.
   #
-  # `2*trunc(.../2)` rounds the clamped height down to an even number, and it
-  # is not decoration. Whenever the clamp picks `ih` — a source shorter than
-  # the cap — the height passes through untouched, and an odd `ih` then makes
-  # libx264 with `-pix_fmt yuv420p` refuse to open the encoder at all
-  # ("Could not open encoder before EOF"). The transcode dies before writing
-  # a playlist, so the client's playlist wait times out and the viewer gets a
-  # generic playback error. VP9 and AV1 both permit odd frame heights and are
-  # exactly the codecs this module force-transcodes, and the paths that cap a
-  # height without knowing the source — the relay clamp and the configured
-  # ceiling — reach any source at all. `-2` already guarantees an even width.
+  # `2*trunc(.../2)` rounds the height down to an even number, and it is the
+  # reason the uncapped clause emits a filter at all rather than nothing. An
+  # odd frame height makes libx264 with `-pix_fmt yuv420p` refuse to open the
+  # encoder outright ("height not divisible by 2", exit 187): the transcode
+  # dies before writing a playlist, the client's playlist wait times out, and
+  # the viewer gets a generic playback error with nothing in it pointing here.
+  #
+  # That is reachable on the DEFAULT path, not just under a cap. The old
+  # hardcoded `-s 1280x720` evened every transcode as a side effect; removing
+  # it (correctly, since it also squished everything that was not 16:9) took
+  # the evening with it. VP9 and AV1 both permit odd frame heights and are
+  # exactly the codecs this module force-transcodes, and ordinary rips like
+  # 720x405 and 848x477 are odd too. Rounding down rather than up is what
+  # keeps the no-upscale guarantee; `-2` then tracks the width to it, which is
+  # what preserves the aspect ratio.
+  #
+  # Only ever reached on the encode branch — a stream copy returns before
+  # this, so no filter can turn a copy into a transcode.
   defp scale_args(height) when is_integer(height) and height > 0 do
     ["-vf", "scale=-2:2*trunc(min(#{height}\\,ih)/2)"]
   end
@@ -684,18 +693,22 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   # A zero or negative ceiling would scale to nothing. It can only arrive from
   # a misconfigured `streaming.max_transcode_height` (the schema rejects it,
   # but a stale cached runtime config could still carry one), so say so rather
-  # than silently encoding at native resolution and leaving the operator to
-  # wonder why their cap does nothing.
+  # than silently ignoring it and leaving the operator to wonder why their cap
+  # does nothing. The encode still gets the evening filter: a bad ceiling is
+  # no reason to hand libx264 an odd height.
   defp scale_args(height) when is_integer(height) do
     Logger.warning(
       "Ignoring a non-positive transcode height ceiling (#{height}); " <>
         "encoding at the source resolution"
     )
 
-    []
+    even_height_args()
   end
 
-  defp scale_args(_), do: []
+  defp scale_args(_), do: even_height_args()
+
+  # No ceiling: keep the source resolution, rounded down to an even height.
+  defp even_height_args, do: ["-vf", "scale=-2:2*trunc(ih/2)"]
 
   @doc """
   Composes a requested output height with the operator's configured ceiling

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -45,8 +45,8 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
           audio_codec: String.t(),
           preset: String.t(),
           crf: integer(),
-          width: integer(),
-          height: integer()
+          max_bitrate: integer() | nil,
+          max_height: integer() | nil
         ]
 
   defmodule State do
@@ -101,8 +101,9 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     * `:audio_codec` - (optional) Audio codec (default: auto-detect from media_file or "aac")
     * `:preset` - (optional) FFmpeg preset (default: "medium")
     * `:crf` - (optional) Constant Rate Factor for quality (default: 23)
-    * `:width` - (optional) Output width (default: 1280)
-    * `:height` - (optional) Output height (default: 720)
+    * `:max_bitrate` - (optional) Total kbps cap; forces a transcode when set
+    * `:max_height` - (optional) Output height ceiling in pixels. Preserves
+      aspect ratio and never upscales. Omitted means native resolution.
 
   ## Stream Copy Optimization
 
@@ -403,6 +404,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   def build_ffmpeg_args(input_path, output_dir, opts) do
     media_file = Keyword.get(opts, :media_file)
     max_bitrate = Keyword.get(opts, :max_bitrate)
+    max_height = effective_max_height(Keyword.get(opts, :max_height))
 
     # Get transcode policy from config
     transcode_policy =
@@ -474,8 +476,6 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
 
     preset = Keyword.get(opts, :preset, "medium")
     crf = Keyword.get(opts, :crf, 23)
-    width = Keyword.get(opts, :width, 1280)
-    height = Keyword.get(opts, :height, 720)
 
     # Use index.m3u8 to match HLS controller expectations
     playlist_path = Path.join(output_dir, "index.m3u8")
@@ -517,8 +517,6 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
           "yuv420p",
           "-profile:v",
           "high",
-          "-s",
-          "#{width}x#{height}",
           "-g",
           "60",
           "-bf",
@@ -544,7 +542,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
             ["-crf", to_string(crf)]
           end
 
-        base_video ++ rate_control
+        base_video ++ scale_args(max_height) ++ rate_control
       end
 
     # Build audio encoding args
@@ -652,6 +650,41 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
 
       true ->
         :no_match
+    end
+  end
+
+  # Builds the video scale filter, or nothing at all when no height is capped.
+  #
+  # `-2` keeps the width proportional to the source and divisible by two,
+  # which H.264 requires; hardcoding both dimensions (the previous `-s
+  # WxH`) distorted anything that was not 16:9. `min(h, ih)` clamps against
+  # the *input* height so a rung above the source never upscales, which
+  # would burn CPU to produce a larger, blurrier picture.
+  #
+  # The comma inside `min()` is backslash-escaped because FFmpeg reads a
+  # bare comma in a filtergraph as a filter separator. The usual shell form
+  # `-vf scale=-2:'min(720,ih)'` is wrong here: these arguments go straight
+  # to a port with no shell, so the quotes would arrive literally and the
+  # filter would fail to parse.
+  defp scale_args(height) when is_integer(height) and height > 0 do
+    ["-vf", "scale=-2:min(#{height}\\,ih)"]
+  end
+
+  defp scale_args(_), do: []
+
+  # Composes the per-request height with the operator's configured ceiling by
+  # taking whichever is lower. Either may be nil, meaning "no limit from this
+  # source"; nil from both means native resolution.
+  defp effective_max_height(requested) do
+    configured =
+      Application.get_env(:mydia, :streaming, [])
+      |> Keyword.get(:max_transcode_height)
+
+    case {requested, configured} do
+      {nil, nil} -> nil
+      {nil, cap} -> cap
+      {height, nil} -> height
+      {height, cap} -> min(height, cap)
     end
   end
 end

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -666,8 +666,32 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   # `-vf scale=-2:'min(720,ih)'` is wrong here: these arguments go straight
   # to a port with no shell, so the quotes would arrive literally and the
   # filter would fail to parse.
+  #
+  # `2*trunc(.../2)` rounds the clamped height down to an even number, and it
+  # is not decoration. Whenever the clamp picks `ih` — a source shorter than
+  # the cap — the height passes through untouched, and an odd `ih` then makes
+  # libx264 with `-pix_fmt yuv420p` refuse to open the encoder at all
+  # ("Could not open encoder before EOF"). The transcode dies before writing
+  # a playlist, so the client's playlist wait times out and the viewer gets a
+  # generic playback error. VP9 and AV1 both permit odd frame heights and are
+  # exactly the codecs this module force-transcodes, and the paths that cap a
+  # height without knowing the source — the relay clamp and the configured
+  # ceiling — reach any source at all. `-2` already guarantees an even width.
   defp scale_args(height) when is_integer(height) and height > 0 do
-    ["-vf", "scale=-2:min(#{height}\\,ih)"]
+    ["-vf", "scale=-2:2*trunc(min(#{height}\\,ih)/2)"]
+  end
+
+  # A zero or negative ceiling would scale to nothing. It can only arrive from
+  # a misconfigured transcode height ceiling, so say so rather than silently
+  # encoding at native resolution and leaving the operator to wonder why their
+  # cap does nothing.
+  defp scale_args(height) when is_integer(height) do
+    Logger.warning(
+      "Ignoring a non-positive transcode height ceiling (#{height}); " <>
+        "encoding at the source resolution"
+    )
+
+    []
   end
 
   defp scale_args(_), do: []

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -682,9 +682,10 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   end
 
   # A zero or negative ceiling would scale to nothing. It can only arrive from
-  # a misconfigured transcode height ceiling, so say so rather than silently
-  # encoding at native resolution and leaving the operator to wonder why their
-  # cap does nothing.
+  # a misconfigured `streaming.max_transcode_height` (the schema rejects it,
+  # but a stale cached runtime config could still carry one), so say so rather
+  # than silently encoding at native resolution and leaving the operator to
+  # wonder why their cap does nothing.
   defp scale_args(height) when is_integer(height) do
     Logger.warning(
       "Ignoring a non-positive transcode height ceiling (#{height}); " <>
@@ -696,19 +697,39 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
 
   defp scale_args(_), do: []
 
-  # Composes the per-request height with the operator's configured ceiling by
-  # taking whichever is lower. Either may be nil, meaning "no limit from this
-  # source"; nil from both means native resolution.
-  defp effective_max_height(requested) do
-    configured =
-      Application.get_env(:mydia, :streaming, [])
-      |> Keyword.get(:max_transcode_height)
+  @doc """
+  Composes a requested output height with the operator's configured ceiling
+  by taking whichever is lower.
 
-    case {requested, configured} do
+  Either may be nil, meaning "no limit from this source"; nil from both means
+  native resolution.
+
+  Public because the GraphQL resolver echoes back the height it actually
+  applied, and that echo has to be derived from the same expression the
+  filter is. Computing it separately meant an operator who set
+  `streaming.max_transcode_height` made the server tell a direct-connection
+  client "Original" while this module really did scale.
+
+  The ceiling comes from the layered runtime config (env > DB/UI > YAML >
+  schema defaults; see `Mydia.Config.Loader`) rather than a flat
+  `Application.get_env(:mydia, :streaming, ...)` key. Nothing explodes the
+  resolved config struct back out to flat keys, so a flat read here would
+  silently ignore both `MAX_TRANSCODE_HEIGHT` and the settings UI.
+  """
+  @spec effective_max_height(integer() | nil) :: integer() | nil
+  def effective_max_height(requested) do
+    case {requested, configured_max_height()} do
       {nil, nil} -> nil
       {nil, cap} -> cap
       {height, nil} -> height
       {height, cap} -> min(height, cap)
+    end
+  end
+
+  defp configured_max_height do
+    case Mydia.Config.get() do
+      %{streaming: %{max_transcode_height: height}} -> height
+      _ -> nil
     end
   end
 end

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -55,6 +55,7 @@ defmodule Mydia.Streaming.HlsSession do
       :mode,
       :start_position,
       :max_bitrate,
+      :max_height,
       :backend,
       :backend_pid,
       :temp_dir,
@@ -181,6 +182,7 @@ defmodule Mydia.Streaming.HlsSession do
     registry_key = Keyword.fetch!(opts, :registry_key)
     mode = Keyword.get(opts, :mode, :transcode)
     max_bitrate = Keyword.get(opts, :max_bitrate)
+    max_height = Keyword.get(opts, :max_height)
     start_position = Keyword.get(opts, :start_position, 0)
 
     # Load media file with metadata
@@ -207,6 +209,8 @@ defmodule Mydia.Streaming.HlsSession do
                user_id: user_id,
                mode: mode,
                start_position: start_position,
+               max_bitrate: max_bitrate,
+               max_height: max_height,
                started_at: DateTime.utc_now()
              }
            ) do
@@ -216,6 +220,7 @@ defmodule Mydia.Streaming.HlsSession do
             user_id,
             mode,
             max_bitrate,
+            max_height,
             start_position,
             media_file
           )
@@ -238,6 +243,7 @@ defmodule Mydia.Streaming.HlsSession do
          user_id,
          mode,
          max_bitrate,
+         max_height,
          start_position,
          media_file
        ) do
@@ -289,6 +295,7 @@ defmodule Mydia.Streaming.HlsSession do
         # Start FFmpeg backend
         case start_backend(:ffmpeg, media_file, temp_dir, job.id,
                max_bitrate: max_bitrate,
+               max_height: max_height,
                start_position: start_position
              ) do
           {:ok, backend_pid} ->
@@ -303,6 +310,7 @@ defmodule Mydia.Streaming.HlsSession do
               mode: mode,
               start_position: start_position,
               max_bitrate: max_bitrate,
+              max_height: max_height,
               backend: :ffmpeg,
               backend_pid: backend_pid,
               temp_dir: temp_dir,
@@ -477,14 +485,16 @@ defmodule Mydia.Streaming.HlsSession do
     # Capture self() to notify when FFmpeg is ready
     session_pid = self()
 
-    # Build transcoder opts, including max_bitrate if set
+    # Build transcoder opts, including max_bitrate and max_height if set
     base_opts =
       [
         input_path: absolute_path,
         output_dir: temp_dir,
         media_file: media_file,
         start_position: Keyword.get(opts, :start_position, 0)
-      ] ++ if(opts[:max_bitrate], do: [max_bitrate: opts[:max_bitrate]], else: [])
+      ] ++
+        if(opts[:max_bitrate], do: [max_bitrate: opts[:max_bitrate]], else: []) ++
+        if(opts[:max_height], do: [max_height: opts[:max_height]], else: [])
 
     transcoder_opts =
       base_opts ++

--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -54,16 +54,21 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   def start_session(media_file_id, user_id, mode \\ :transcode, opts \\ []) do
     session_key = session_key(media_file_id, user_id)
     start_position = Keyword.get(opts, :start_position, 0)
+    max_bitrate = Keyword.get(opts, :max_bitrate)
+    max_height = Keyword.get(opts, :max_height)
 
     case Registry.lookup(@registry_name, session_key) do
       [{pid, metadata}] ->
-        if session_matches_offset?(metadata, start_position) do
+        if session_matches?(metadata, start_position, max_bitrate, max_height) do
           {:ok, pid}
         else
           # A session transcoding from a different offset cannot serve this
-          # request: its playlist simply does not contain the wanted range.
-          # Replace it rather than keying sessions by offset, so a user
-          # scrubbing around does not accumulate concurrent FFmpeg processes.
+          # request: its playlist simply does not contain the wanted range. A
+          # session running at a different quality cannot serve it either: its
+          # segments are already encoded at the old rung. Replace it rather
+          # than keying sessions by offset and quality, so a user scrubbing
+          # around or flipping rungs does not accumulate concurrent FFmpeg
+          # processes.
           stop_gracefully(pid)
           start_new_session(media_file_id, user_id, mode, opts, session_key)
         end
@@ -74,10 +79,13 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   end
 
   @doc false
-  # Public for unit testing. Metadata registered before :start_position existed
-  # is treated as offset zero rather than as a wildcard match.
-  def session_matches_offset?(metadata, start_position) do
-    Map.get(metadata, :start_position, 0) == start_position
+  # Public for unit testing. Metadata registered before the quality fields
+  # existed is treated as an uncapped session at offset zero rather than as a
+  # wildcard that matches any request.
+  def session_matches?(metadata, start_position, max_bitrate, max_height) do
+    Map.get(metadata, :start_position, 0) == start_position and
+      Map.get(metadata, :max_bitrate) == max_bitrate and
+      Map.get(metadata, :max_height) == max_height
   end
 
   # Stops a session the way `endStreamingSession` does, rather than through

--- a/lib/mydia_web/live/admin_settings_live/components.ex
+++ b/lib/mydia_web/live/admin_settings_live/components.ex
@@ -26,6 +26,9 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
                       <.setting_source_badge source={setting.source} />
                     </div>
                     <div class="text-xs opacity-50 font-mono truncate">{setting.key}</div>
+                    <%= if Map.get(setting, :description) do %>
+                      <div class="text-xs opacity-60 mt-1">{setting.description}</div>
+                    <% end %>
                   </div>
                   <div class="sm:ml-auto">
                     <.setting_value_control
@@ -213,6 +216,7 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
   defp category_icon("Media"), do: "hero-film"
   defp category_icon("Metadata"), do: "hero-language"
   defp category_icon("Downloads"), do: "hero-arrow-down-tray"
+  defp category_icon("Streaming"), do: "hero-play-circle"
   defp category_icon("Crash Reporting"), do: "hero-bug-ant"
   defp category_icon("Notifications"), do: "hero-bell"
   defp category_icon("Library"), do: "hero-folder-open"

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -23,6 +23,21 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
 
   ## General Settings Events
 
+  # A text or number input reports through `phx-blur`, which sends the
+  # element's own value alongside its `phx-value-*` metadata — never the
+  # `settings` map the clause below expects. Without this clause every
+  # typed setting in this screen raised FunctionClauseError on edit, so the
+  # database layer was reachable for toggles and selects but not for
+  # anything you type, `streaming.max_transcode_height` included.
+  @impl true
+  def handle_event(
+        "update_setting_form",
+        %{"key" => key, "category" => category, "value" => value},
+        socket
+      ) do
+    save_setting(socket, key, category, to_string(value))
+  end
+
   @impl true
   def handle_event(
         "update_setting_form",
@@ -204,6 +219,48 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
 
   ## Private Helpers
 
+  # Validates, persists, and reloads a single key. Shared by the typed-input
+  # path above; the toggle and select paths predate it and still inline the
+  # same steps.
+  defp save_setting(socket, key, category, value) do
+    changeset =
+      validate_config_setting(%{
+        key: key,
+        value: value,
+        category: category_string_to_atom(category)
+      })
+
+    if changeset.valid? do
+      attrs =
+        changeset
+        |> Ecto.Changeset.apply_changes()
+        |> Map.put(:updated_by_id, socket.assigns.current_user.id)
+
+      case Settings.upsert_config_setting(attrs) do
+        {:ok, _setting} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Setting updated successfully")
+           |> load_data()}
+
+        {:error, error} ->
+          MydiaLogger.log_error(:liveview, "Failed to update setting",
+            error: error,
+            error_details: inspect(error, pretty: true),
+            operation: :update_setting,
+            category: category,
+            setting_key: key,
+            user_id: socket.assigns.current_user.id
+          )
+
+          {:noreply,
+           put_flash(socket, :error, MydiaLogger.user_error_message(:update_setting, error))}
+      end
+    else
+      {:noreply, put_flash(socket, :error, "Invalid setting value")}
+    end
+  end
+
   defp load_data(socket) do
     socket
     |> assign(:config_settings_with_sources, get_all_settings_with_sources())
@@ -221,6 +278,7 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
       end
 
     metadata = config.metadata || %Mydia.Config.Schema.Metadata{}
+    streaming = config.streaming || %Mydia.Config.Schema.Streaming{}
 
     # Fetch all DB settings in one query to avoid N+1 per-key lookups
     all_db_settings = Settings.list_config_settings() |> Map.new(&{&1.key, &1})
@@ -328,6 +386,26 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
             Settings.config_source(
               "DOWNLOAD_MONITOR_INTERVAL_MINUTES",
               "downloads.monitor_interval_minutes",
+              all_db_settings
+            )
+        }
+      ],
+      "Streaming" => [
+        %{
+          key: "streaming.max_transcode_height",
+          label: "Max Transcode Height",
+          description:
+            "Ceiling in pixels on the output height of any transcode, for example 720. " <>
+              "Empty means no ceiling and a transcode keeps the source resolution, which " <>
+              "a small server may not sustain in realtime for a 4K file. Never upscales, " <>
+              "and never applies when the file is streamed without re-encoding.",
+          type: :integer,
+          value: streaming.max_transcode_height,
+          placeholder: "no limit",
+          source:
+            Settings.config_source(
+              "MAX_TRANSCODE_HEIGHT",
+              "streaming.max_transcode_height",
               all_db_settings
             )
         }
@@ -486,6 +564,7 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
       "Media" -> :media
       "Metadata" -> :metadata
       "Downloads" -> :downloads
+      "Streaming" -> :streaming
       "Crash Reporting" -> :crash_reporting
       "Feedback" -> :feedback
       "Notifications" -> :notifications

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -230,34 +230,69 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
         category: category_string_to_atom(category)
       })
 
-    if changeset.valid? do
-      attrs =
-        changeset
-        |> Ecto.Changeset.apply_changes()
-        |> Map.put(:updated_by_id, socket.assigns.current_user.id)
+    cond do
+      unchanged?(socket, key, value) ->
+        # `phx-blur` fires on every blur, including one that only tabbed
+        # through. Writing then would insert a ConfigSetting row holding the
+        # value the field was already showing, flipping the provenance badge
+        # from Default or YAML to DB and permanently shadowing that key from
+        # any later YAML or default change. The layered config is only
+        # honest if the database layer holds values an operator actually
+        # chose, so an unchanged field writes nothing at all.
+        {:noreply, socket}
 
-      case Settings.upsert_config_setting(attrs) do
-        {:ok, _setting} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Setting updated successfully")
-           |> load_data()}
+      changeset.valid? ->
+        persist_setting(socket, changeset, key, category)
 
-        {:error, error} ->
-          MydiaLogger.log_error(:liveview, "Failed to update setting",
-            error: error,
-            error_details: inspect(error, pretty: true),
-            operation: :update_setting,
-            category: category,
-            setting_key: key,
-            user_id: socket.assigns.current_user.id
-          )
+      true ->
+        {:noreply, put_flash(socket, :error, "Invalid setting value")}
+    end
+  end
 
-          {:noreply,
-           put_flash(socket, :error, MydiaLogger.user_error_message(:update_setting, error))}
-      end
-    else
-      {:noreply, put_flash(socket, :error, "Invalid setting value")}
+  # Compares against the value the screen is currently showing, which is the
+  # *resolved* one across every layer — not just the database row. Comparing
+  # against the row alone would still write a first row for a key whose
+  # displayed value came from YAML or a schema default, which is the case
+  # that matters.
+  defp unchanged?(socket, key, value) do
+    current =
+      socket.assigns
+      |> Map.get(:config_settings_with_sources, %{})
+      |> Map.values()
+      |> List.flatten()
+      |> Enum.find(&(&1.key == key))
+
+    case current do
+      nil -> false
+      setting -> to_string(value) == to_string(setting.value || "")
+    end
+  end
+
+  defp persist_setting(socket, changeset, key, category) do
+    attrs =
+      changeset
+      |> Ecto.Changeset.apply_changes()
+      |> Map.put(:updated_by_id, socket.assigns.current_user.id)
+
+    case Settings.upsert_config_setting(attrs) do
+      {:ok, _setting} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Setting updated successfully")
+         |> load_data()}
+
+      {:error, error} ->
+        MydiaLogger.log_error(:liveview, "Failed to update setting",
+          error: error,
+          error_details: inspect(error, pretty: true),
+          operation: :update_setting,
+          category: category,
+          setting_key: key,
+          user_id: socket.assigns.current_user.id
+        )
+
+        {:noreply,
+         put_flash(socket, :error, MydiaLogger.user_error_message(:update_setting, error))}
     end
   end
 

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -282,6 +282,19 @@ defmodule MydiaWeb.Schema.CommonTypes do
         "Real media position, in seconds, at which the stream begins. " <>
           "Clients must map stream-local positions by this offset. " <>
           "Absent or 0 means the stream starts at the beginning."
+
+    field :max_bitrate, :integer,
+      description:
+        "Total kbps cap the server actually applied, which may be lower " <>
+          "than requested on a relay connection. Null means uncapped. " <>
+          "Clients should label the quality control from this, not from " <>
+          "what they asked for."
+
+    field :max_height, :integer,
+      description:
+        "Output height ceiling the server actually applied, which may be " <>
+          "lower than requested on a relay connection. Null means the " <>
+          "source resolution is preserved."
   end
 
   @desc "A download quality option"

--- a/lib/mydia_web/schema/mutation_types.ex
+++ b/lib/mydia_web/schema/mutation_types.ex
@@ -143,6 +143,10 @@ defmodule MydiaWeb.Schema.MutationTypes do
       arg(:strategy, non_null(:streaming_strategy))
       arg(:max_bitrate, :integer, description: "Total kbps cap (video + audio), e.g. 2000")
 
+      arg(:max_height, :integer,
+        description: "Output height ceiling in pixels, e.g. 720. Preserves aspect ratio"
+      )
+
       arg(:start_position, :integer,
         description:
           "Real media position, in seconds, at which to begin transcoding. " <>

--- a/lib/mydia_web/schema/resolvers/streaming_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/streaming_resolver.ex
@@ -159,14 +159,31 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
   # its ceiling is not negotiable by the client: an uncapped request becomes
   # capped, and an over-cap request is lowered. A direct connection is
   # peer-to-peer or local, so the client's choice stands.
-  def effective_quality("relay", requested_bitrate, requested_height) do
-    {min(requested_bitrate || @relay_bitrate_cap, @relay_bitrate_cap),
-     min(requested_height || @relay_height_cap, @relay_height_cap)}
+  def effective_quality(connection_type, requested_bitrate, requested_height) do
+    clamp_for_connection(
+      connection_type,
+      positive_or_nil(requested_bitrate),
+      positive_or_nil(requested_height)
+    )
   end
 
-  def effective_quality(_connection_type, requested_bitrate, requested_height) do
-    {requested_bitrate, requested_height}
+  defp clamp_for_connection("relay", bitrate, height) do
+    {min(bitrate || @relay_bitrate_cap, @relay_bitrate_cap),
+     min(height || @relay_height_cap, @relay_height_cap)}
   end
+
+  defp clamp_for_connection(_connection_type, bitrate, height), do: {bitrate, height}
+
+  # A non-positive cap is not a smaller cap, it is no cap: the transcoder
+  # declines to scale to a non-positive height, so a relay client could
+  # otherwise bypass the relay ceiling entirely by asking for `maxHeight: 0`
+  # and get native resolution over infrastructure the cap exists to protect.
+  #
+  # `requested || @cap` does not catch it, because Elixir treats 0 as truthy —
+  # `min(0 || 720, 720)` is 0, not 720. Normalising before the clamp is what
+  # makes the `|| @cap` fallback mean what it reads like it means.
+  defp positive_or_nil(value) when is_integer(value) and value > 0, do: value
+  defp positive_or_nil(_), do: nil
 
   defp start_session_for_user(
          file_id,

--- a/lib/mydia_web/schema/resolvers/streaming_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/streaming_resolver.ex
@@ -77,6 +77,10 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
   @spec start_streaming_session(map(), map(), Absinthe.Resolution.t()) ::
           {:ok, term()} | {:error, term()}
   @relay_bitrate_cap 2000
+  # A 2000kbps ceiling cannot carry 1080p at watchable quality, so the height
+  # ceiling that accompanies it is 720p. The two move together: raising one
+  # without the other produces either wasted pixels or wasted bits.
+  @relay_height_cap 720
 
   def start_streaming_session(_parent, args, %{context: context}) do
     %{file_id: file_id, strategy: strategy} = args
@@ -86,19 +90,21 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
         {:error, "Authentication required"}
 
       user ->
-        # Determine effective max_bitrate:
-        # - For relay connections, cap at @relay_bitrate_cap regardless of request
-        # - For direct connections, use player-requested value (nil means CRF default)
-        max_bitrate =
-          case context[:peer_connection_type] do
-            "relay" ->
-              min(args[:max_bitrate] || @relay_bitrate_cap, @relay_bitrate_cap)
+        {max_bitrate, max_height} =
+          effective_quality(
+            context[:peer_connection_type],
+            args[:max_bitrate],
+            args[:max_height]
+          )
 
-            _ ->
-              args[:max_bitrate]
-          end
-
-        start_session_for_user(file_id, user.id, strategy, max_bitrate, args[:start_position])
+        start_session_for_user(
+          file_id,
+          user.id,
+          strategy,
+          max_bitrate,
+          max_height,
+          args[:start_position]
+        )
     end
   end
 
@@ -136,14 +142,38 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
 
   def clamp_start_position(position, _duration), do: position
 
-  defp start_session_for_user(file_id, user_id, strategy, max_bitrate, requested_position) do
+  @doc false
+  # Public for unit testing. Resolves what the server will actually apply,
+  # which is not always what the client asked for.
+  #
+  # A relay connection carries media through Mydia's own infrastructure, so
+  # its ceiling is not negotiable by the client: an uncapped request becomes
+  # capped, and an over-cap request is lowered. A direct connection is
+  # peer-to-peer or local, so the client's choice stands.
+  def effective_quality("relay", requested_bitrate, requested_height) do
+    {min(requested_bitrate || @relay_bitrate_cap, @relay_bitrate_cap),
+     min(requested_height || @relay_height_cap, @relay_height_cap)}
+  end
+
+  def effective_quality(_connection_type, requested_bitrate, requested_height) do
+    {requested_bitrate, requested_height}
+  end
+
+  defp start_session_for_user(
+         file_id,
+         user_id,
+         strategy,
+         max_bitrate,
+         max_height,
+         requested_position
+       ) do
     mode = strategy_to_mode(strategy)
 
     with {:ok, media_file} <- load_media_file(file_id),
          media_file <- ensure_duration_known(media_file),
          duration <- get_duration_from_metadata(media_file),
          start_position <- clamp_start_position(requested_position, duration),
-         session_opts <- build_session_opts(max_bitrate, start_position),
+         session_opts <- build_session_opts(max_bitrate, max_height, start_position),
          {:ok, pid} <-
            HlsSessionSupervisor.start_session(media_file.id, user_id, mode, session_opts),
          {:ok, info} <- HlsSession.get_info(pid) do
@@ -173,7 +203,9 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
        %{
          session_id: info.session_id,
          duration: duration,
-         start_position: session_start_position
+         start_position: session_start_position,
+         max_bitrate: max_bitrate,
+         max_height: max_height
        }}
     else
       {:error, reason} ->
@@ -182,8 +214,9 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
     end
   end
 
-  defp build_session_opts(max_bitrate, start_position) do
+  defp build_session_opts(max_bitrate, max_height, start_position) do
     opts = if max_bitrate, do: [max_bitrate: max_bitrate], else: []
+    opts = if max_height, do: [{:max_height, max_height} | opts], else: opts
     if start_position > 0, do: [{:start_position, start_position} | opts], else: opts
   end
 

--- a/lib/mydia_web/schema/resolvers/streaming_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/streaming_resolver.ex
@@ -11,6 +11,7 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
   alias Mydia.Library
   alias Mydia.Library.MediaFile
   alias Mydia.Streaming.Candidates
+  alias Mydia.Streaming.FfmpegHlsTranscoder
   alias Mydia.Streaming.HlsSessionSupervisor
   alias Mydia.Streaming.HlsSession
 
@@ -90,12 +91,20 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
         {:error, "Authentication required"}
 
       user ->
-        {max_bitrate, max_height} =
+        {max_bitrate, clamped_height} =
           effective_quality(
             context[:peer_connection_type],
             args[:max_bitrate],
             args[:max_height]
           )
+
+        # Composed here, not left to the transcoder, so the height this
+        # mutation echoes back is the one that will actually be encoded.
+        # The operator's ceiling used to be applied inside the transcoder
+        # alone, which made a server with a ceiling set report "Original" to
+        # a client that asked for no cap while really scaling it — the one
+        # thing echoing the applied value exists to prevent.
+        max_height = FfmpegHlsTranscoder.effective_max_height(clamped_height)
 
         start_session_for_user(
           file_id,

--- a/player/lib/domain/models/quality_rung.dart
+++ b/player/lib/domain/models/quality_rung.dart
@@ -1,0 +1,110 @@
+/// One rung of the playback quality ladder.
+///
+/// A rung is a deliberate viewer choice, not an adaptive-bitrate level: the
+/// server emits a single rendition per session, so switching rungs restarts
+/// the session at new encoder settings. See
+/// `docs/superpowers/specs/2026-08-04-player-quality-switcher-design.md`.
+class QualityRung {
+  /// Shown in the picker and on the control's tooltip.
+  final String label;
+
+  /// Output height ceiling in pixels, or null for the source resolution.
+  final int? height;
+
+  /// Total kbps cap covering video and audio, or null for no cap.
+  ///
+  /// Kilobits, deliberately: the GraphQL `maxBitrate` argument is kbps while
+  /// `streamingMetadata.bitrate` is bits per second. Mixing them yields a
+  /// 1000x error that presents as the cap being ignored.
+  final int? maxBitrateKbps;
+
+  const QualityRung({
+    required this.label,
+    this.height,
+    this.maxBitrateKbps,
+  });
+
+  /// No caps at all, which preserves the copy-when-compatible path and is the
+  /// cheapest option for the server.
+  static const original = QualityRung(label: 'Original');
+
+  bool get isOriginal => height == null;
+
+  /// Key used in secure storage.
+  ///
+  /// Original persists as `auto` rather than `Original` because
+  /// `settings_service.dart` has defaulted `default_quality` to `auto` since
+  /// long before any of this was wired up. Reusing that key means an
+  /// existing install reads its stored value as Original instead of failing
+  /// to parse it.
+  String get storageKey => isOriginal ? 'auto' : label;
+
+  /// Parses a stored key, returning null if it is unrecognised.
+  ///
+  /// Callers fall back to [original] rather than treating an unknown value
+  /// as fatal: it may have been written by a newer build.
+  static QualityRung? fromStorageKey(String key) {
+    if (key == 'auto') return original;
+    for (final rung in _allRungs) {
+      if (rung.label == key) return rung;
+    }
+    return null;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is QualityRung &&
+          runtimeType == other.runtimeType &&
+          label == other.label &&
+          height == other.height &&
+          maxBitrateKbps == other.maxBitrateKbps;
+
+  @override
+  int get hashCode => Object.hash(label, height, maxBitrateKbps);
+
+  @override
+  String toString() => 'QualityRung($label)';
+}
+
+/// The full ladder, highest quality first, before filtering against a source.
+const _allRungs = <QualityRung>[
+  QualityRung(label: '1080p', height: 1080, maxBitrateKbps: 8000),
+  QualityRung(label: '720p', height: 720, maxBitrateKbps: 4000),
+  QualityRung(label: '480p', height: 480, maxBitrateKbps: 1500),
+  QualityRung(label: '360p', height: 360, maxBitrateKbps: 800),
+];
+
+/// Builds the ladder offered for a source of [sourceHeight] pixels.
+///
+/// Rungs at or above the source are omitted: one equal to it is Original with
+/// extra CPU cost, and one above it would upscale, burning encode time to
+/// produce a larger, blurrier picture. A source shorter than every rung, or
+/// one whose height is unknown, yields Original alone, and callers should
+/// hide the control rather than open a one-item menu.
+List<QualityRung> deriveQualityLadder({int? sourceHeight}) {
+  if (sourceHeight == null || sourceHeight <= 0) {
+    return const [QualityRung.original];
+  }
+  return [
+    QualityRung.original,
+    ..._allRungs.where((rung) => rung.height! < sourceHeight),
+  ];
+}
+
+/// Names what the server actually applied, for labelling the control.
+///
+/// The server may clamp below what was requested, and a relay clamps to a
+/// pair that is not on the ladder at all (2000kbps with 720p). Height is the
+/// more meaningful half of that pair to a viewer, so it decides the label and
+/// the bitrate is only a tiebreak.
+QualityRung? effectiveRungLabel({int? maxHeight, int? maxBitrateKbps}) {
+  if (maxHeight == null && maxBitrateKbps == null) {
+    return QualityRung.original;
+  }
+  if (maxHeight == null) return null;
+  for (final rung in _allRungs) {
+    if (rung.height == maxHeight) return rung;
+  }
+  return null;
+}

--- a/player/lib/domain/models/quality_rung.dart
+++ b/player/lib/domain/models/quality_rung.dart
@@ -98,13 +98,29 @@ List<QualityRung> deriveQualityLadder({int? sourceHeight}) {
 /// pair that is not on the ladder at all (2000kbps with 720p). Height is the
 /// more meaningful half of that pair to a viewer, so it decides the label and
 /// the bitrate is only a tiebreak.
+///
+/// A height that matches no rung is still named, from the height itself. The
+/// caller displays `effective ?? selected`, so returning null for an
+/// unrecognised height would label the stream with the rung that was *asked*
+/// for — the one thing labelling from the applied value exists to prevent.
+/// Only a genuinely unnameable answer returns null: a bitrate cap with no
+/// height, where there is no honest resolution to report and falling back to
+/// the request is the least wrong option available.
 QualityRung? effectiveRungLabel({int? maxHeight, int? maxBitrateKbps}) {
   if (maxHeight == null && maxBitrateKbps == null) {
     return QualityRung.original;
   }
-  if (maxHeight == null) return null;
+  if (maxHeight == null || maxHeight <= 0) return null;
   for (final rung in _allRungs) {
     if (rung.height == maxHeight) return rung;
   }
-  return null;
+
+  // Off-ladder, so synthesised rather than looked up. Deliberately built with
+  // the echoed bitrate, not a ladder rung's: this describes what the server
+  // did, and nothing sends it back.
+  return QualityRung(
+    label: '${maxHeight}p',
+    height: maxHeight,
+    maxBitrateKbps: maxBitrateKbps,
+  );
 }

--- a/player/lib/graphql/mutations/start_streaming_session.graphql
+++ b/player/lib/graphql/mutations/start_streaming_session.graphql
@@ -1,7 +1,9 @@
-mutation StartStreamingSession($fileId: ID!, $strategy: StreamingStrategy!, $maxBitrate: Int, $startPosition: Int) {
-  startStreamingSession(fileId: $fileId, strategy: $strategy, maxBitrate: $maxBitrate, startPosition: $startPosition) {
+mutation StartStreamingSession($fileId: ID!, $strategy: StreamingStrategy!, $maxBitrate: Int, $maxHeight: Int, $startPosition: Int) {
+  startStreamingSession(fileId: $fileId, strategy: $strategy, maxBitrate: $maxBitrate, maxHeight: $maxHeight, startPosition: $startPosition) {
     sessionId
     duration
     startPosition
+    maxBitrate
+    maxHeight
   }
 }

--- a/player/lib/graphql/mutations/start_streaming_session_legacy.graphql
+++ b/player/lib/graphql/mutations/start_streaming_session_legacy.graphql
@@ -1,0 +1,21 @@
+# The shape StartStreamingSession had before the server learned about height
+# caps: no $maxHeight argument, and no maxBitrate/maxHeight echo in the
+# selection set.
+#
+# Kept as its own document because the fallback cannot be expressed by simply
+# omitting a variable. An argument the schema does not declare, and a field
+# the result type does not have, are both GraphQL *validation* errors against
+# the document text, decided before any variable value is looked at. Sending
+# the current document with maxHeight left out of the variables map would be
+# rejected exactly as it was the first time.
+#
+# A newer player meets an older server routinely — Mydia installs update on
+# their own schedule and the native player ships separately from the server —
+# so this is the request that lets playback degrade instead of failing.
+mutation StartStreamingSessionLegacy($fileId: ID!, $strategy: StreamingStrategy!, $maxBitrate: Int, $startPosition: Int) {
+  startStreamingSession(fileId: $fileId, strategy: $strategy, maxBitrate: $maxBitrate, startPosition: $startPosition) {
+    sessionId
+    duration
+    startPosition
+  }
+}

--- a/player/lib/graphql/queries/streaming_candidates.graphql
+++ b/player/lib/graphql/queries/streaming_candidates.graphql
@@ -12,6 +12,8 @@ query StreamingCandidates($contentType: String!, $id: ID!) {
       duration
       width
       height
+      bitrate
+      resolution
     }
   }
 }

--- a/player/lib/graphql/queries/streaming_candidates.graphql
+++ b/player/lib/graphql/queries/streaming_candidates.graphql
@@ -12,8 +12,6 @@ query StreamingCandidates($contentType: String!, $id: ID!) {
       duration
       width
       height
-      bitrate
-      resolution
     }
   }
 }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -253,8 +253,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   // Whether current playback is direct play (vs HLS)
   bool _isDirectPlay = false;
 
+  /// The rung in effect, or null before anything has settled one for this
+  /// playback.
+  ///
+  /// Null is what makes secure storage a *seed* rather than a channel.
+  /// [_resolveQualityForFile] consults storage only while this is null; once
+  /// a rung is settled, every later re-initialization — a quality change, a
+  /// seek past the transcoded window, the next episode — carries this value
+  /// forward. A viewer's choice therefore reaches the restart it triggers in
+  /// memory, and never has to survive a round trip through a platform
+  /// channel that can fail. [_resumeOverrideSeconds] hands the position
+  /// across the same restart for the same reason.
+  QualityRung? _settledQuality;
+
   /// The rung the viewer chose, which is what gets requested.
-  QualityRung _selectedQuality = QualityRung.original;
+  QualityRung get _selectedQuality => _settledQuality ?? QualityRung.original;
 
   /// The rung the server reported actually applying, which is what gets
   /// displayed. These differ on a relay connection, where the cap is not
@@ -950,10 +963,16 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// Rebuilds the quality ladder for the file about to play and settles which
   /// rung this playback will request.
   ///
-  /// Both are per-file, not per-widget: the ladder depends on the source
-  /// height, and a rung persisted while watching a taller file may not exist
-  /// in this one's ladder. Falling back to Original there beats requesting an
+  /// The ladder is per-file, not per-widget: it depends on the source height,
+  /// and a rung chosen while watching a taller file may not exist in this
+  /// one's ladder. Falling back to Original there beats requesting an
   /// upscale, which costs encode time to produce a larger, blurrier picture.
+  ///
+  /// The rung is *seeded* from storage and then carried in memory. Re-reading
+  /// it here on every re-initialization would put a fallible platform channel
+  /// on the only path carrying the viewer's choice: a swallowed write failure
+  /// would make the restart negotiate the rung they just replaced, and the
+  /// label would revert in front of them. See [_settledQuality].
   Future<void> _resolveQualityForFile(
     Query$StreamingCandidates$streamingCandidates? candidatesResult,
   ) async {
@@ -961,20 +980,26 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       sourceHeight: candidatesResult?.metadata.height,
     );
 
-    _selectedQuality = QualityRung.original;
+    final requested = _settledQuality ?? await _storedDefaultQuality();
 
-    // Secure storage being unreadable is no reason to fail playback, and the
-    // safe answer is the cheapest one for the server. Matches how
-    // `_loadAutoSkipPreference` treats the same failure.
+    _settledQuality =
+        _qualityLadder.contains(requested) ? requested : QualityRung.original;
+  }
+
+  /// The rung stored as this install's default, for the first session of a
+  /// playback.
+  ///
+  /// Secure storage being unreadable is no reason to fail playback, and the
+  /// safe answer is the cheapest one for the server. Matches how
+  /// `_loadAutoSkipPreference` treats the same failure.
+  Future<QualityRung> _storedDefaultQuality() async {
     try {
       final storedKey =
           await ref.read(settingsServiceProvider).getDefaultQuality();
-      final storedRung = QualityRung.fromStorageKey(storedKey);
-      if (storedRung != null && _qualityLadder.contains(storedRung)) {
-        _selectedQuality = storedRung;
-      }
+      return QualityRung.fromStorageKey(storedKey) ?? QualityRung.original;
     } catch (e) {
       debugPrint('[PlayerScreen] Could not read default quality: $e');
+      return QualityRung.original;
     }
   }
 
@@ -2210,10 +2235,15 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     await applyQualityChoice(
       selected: selected,
       previous: previous,
-      persist: (rung) async {
-        if (mounted) setState(() => _selectedQuality = rung);
-        await _persistQuality(rung);
+      adopt: (rung) {
+        // In memory, and only in memory. This is the channel the restart
+        // below reads the rung from — [_resolveQualityForFile] carries
+        // `_settledQuality` forward rather than re-reading storage.
+        _settledQuality = rung;
+        if (mounted) setState(() {});
       },
+      remember: (rung) =>
+          ref.read(settingsServiceProvider).setDefaultQuality(rung.storageKey),
       restart: (rung, {required bool isFallback}) => _restartSessionAt(
         position,
         loadingMessage: isFallback
@@ -2226,18 +2256,6 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         _isLoading = false;
       }),
     );
-  }
-
-  /// Remembers the chosen rung for the next playback. A storage failure is
-  /// logged and dropped: it costs the preference, not the playback.
-  Future<void> _persistQuality(QualityRung rung) async {
-    try {
-      await ref
-          .read(settingsServiceProvider)
-          .setDefaultQuality(rung.storageKey);
-    } catch (e) {
-      debugPrint('[PlayerScreen] Could not save default quality: $e');
-    }
   }
 
   /// Explains a server-side limit when the applied rung is below the chosen
@@ -2963,12 +2981,13 @@ Future<void> trackRestartInFlight(
 /// in the quality change and the one most worth pinning, so it lives where a
 /// fake [restart] that throws can exercise it.
 ///
-/// [persist] records a rung as the one now in effect — the widget both
-/// displays and stores it. [restart] tears the session down and brings it
-/// back at that rung, throwing if it cannot; [isFallback] distinguishes the
-/// two attempts, which the viewer is told apart. [stillActive] reports
-/// whether the caller can still act at all (its widget is still mounted).
-/// [onGaveUp] receives the second failure.
+/// [adopt] puts a rung into effect in memory — the widget both requests and
+/// displays it from there. [remember] writes it to storage for the *next*
+/// playback and is allowed to fail. [restart] tears the session down and
+/// brings it back at that rung, throwing if it cannot; [isFallback]
+/// distinguishes the two attempts, which the viewer is told apart.
+/// [stillActive] reports whether the caller can still act at all (its widget
+/// is still mounted). [onGaveUp] receives the second failure.
 ///
 /// The retry is deliberately single. If returning to the rung that was
 /// already working also fails, the problem is not the quality choice, and
@@ -2978,13 +2997,14 @@ Future<void> trackRestartInFlight(
 Future<void> applyQualityChoice({
   required QualityRung selected,
   required QualityRung previous,
-  required Future<void> Function(QualityRung rung) persist,
+  required void Function(QualityRung rung) adopt,
+  required Future<void> Function(QualityRung rung) remember,
   required Future<void> Function(QualityRung rung, {required bool isFallback})
       restart,
   required bool Function() stillActive,
   required void Function(Object error) onGaveUp,
 }) async {
-  await persist(selected);
+  await _adoptAndRemember(selected, adopt, remember);
 
   try {
     await restart(selected, isFallback: false);
@@ -2994,7 +3014,7 @@ Future<void> applyQualityChoice({
     debugPrint(
         '[PlayerScreen] Quality change to ${selected.label} failed: $error');
     if (!stillActive()) return;
-    await persist(previous);
+    await _adoptAndRemember(previous, adopt, remember);
 
     try {
       await restart(previous, isFallback: true);
@@ -3004,5 +3024,31 @@ Future<void> applyQualityChoice({
       if (!stillActive()) return;
       onGaveUp(fallbackError);
     }
+  }
+}
+
+/// Puts [rung] into effect in memory, then tries to remember it for the next
+/// playback.
+///
+/// Both the order and the swallow are load-bearing. [adopt] is the only
+/// channel the restart reads the rung from, so it happens first and is
+/// synchronous — nothing can fail between choosing a rung and the restart
+/// seeing it. [remember] goes through secure storage, which needs a keyring
+/// on Linux desktop and can genuinely be unavailable, so its failure costs
+/// the preference for next time and nothing else. Before this split, the
+/// choice reached the restart *through* storage, and a swallowed write
+/// failure silently restarted the session at the rung the viewer had just
+/// replaced.
+Future<void> _adoptAndRemember(
+  QualityRung rung,
+  void Function(QualityRung rung) adopt,
+  Future<void> Function(QualityRung rung) remember,
+) async {
+  adopt(rung);
+
+  try {
+    await remember(rung);
+  } catch (e) {
+    debugPrint('[PlayerScreen] Could not save default quality: $e');
   }
 }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -40,6 +40,7 @@ import '../../widgets/video_controls/skip_segment_button.dart';
 import '../../widgets/up_next_overlay.dart';
 import '../../../domain/models/audio_track.dart' as app_models_audio;
 import '../../../domain/models/media_segment.dart';
+import '../../../domain/models/quality_rung.dart';
 import '../../../domain/models/subtitle_track.dart' as app_models;
 import '../../../domain/models/cast_device.dart';
 import '../../../graphql/fragments/media_file_fragment.graphql.dart';
@@ -48,6 +49,7 @@ import '../../../graphql/queries/episode_detail.graphql.dart';
 import '../../../graphql/queries/media_segments.graphql.dart';
 import '../../../graphql/queries/season_episodes.graphql.dart';
 import '../../../graphql/mutations/start_streaming_session.graphql.dart';
+import '../../../graphql/mutations/start_streaming_session_legacy.graphql.dart';
 import '../../../graphql/mutations/end_streaming_session.graphql.dart';
 import '../../../graphql/queries/streaming_candidates.graphql.dart';
 import '../../../graphql/schema.graphql.dart';
@@ -251,8 +253,29 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   // Whether current playback is direct play (vs HLS)
   bool _isDirectPlay = false;
 
-  // HLS quality selection (web only)
-  HlsQualityLevel _selectedQuality = HlsQualityLevel.auto;
+  /// The rung the viewer chose, which is what gets requested.
+  QualityRung _selectedQuality = QualityRung.original;
+
+  /// The rung the server reported actually applying, which is what gets
+  /// displayed. These differ on a relay connection, where the cap is not
+  /// negotiable by the client. Null until a session echoes its caps back,
+  /// and reset on every re-initialization so a value from the previous
+  /// session cannot label the new one.
+  QualityRung? _effectiveQuality;
+
+  /// Ladder for the current file, derived from its source height.
+  ///
+  /// Original alone — the initial value, and what the downloaded and offline
+  /// branches leave in place — hides the control: a local file has no
+  /// session to restart and nothing to switch between.
+  List<QualityRung> _qualityLadder = const [QualityRung.original];
+
+  /// Set when this server rejected the maxHeight argument, meaning it
+  /// predates height support. Rungs still work through maxBitrate alone;
+  /// they just land at whatever resolution the old server picks. Sticky for
+  /// the widget's lifetime so the detection costs one extra round trip per
+  /// session rather than one per request.
+  bool _serverLacksHeightSupport = false;
 
   // HLS session tracking for cleanup
   String? _hlsSessionId;
@@ -455,6 +478,14 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
   Future<void> _initializePlayer() async {
     _resetSegmentsIfMediaChanged();
+
+    // Cleared up front so the branches that never reach a streaming session —
+    // offline, and already-downloaded — cannot inherit a ladder derived for a
+    // previous one. Both return early below, and a local file has no session
+    // to restart and nothing to switch between, so Original alone is right
+    // for them and hides the control.
+    _qualityLadder = const [QualityRung.original];
+    _effectiveQuality = null;
 
     try {
       setState(() {
@@ -691,10 +722,19 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         widget.mediaId,
       );
 
-      // Determine if direct play is possible
+      await _resolveQualityForFile(candidatesResult);
+
+      // Determine if direct play is possible.
+      //
+      // A chosen rung vetoes direct play. Direct play hands the file over
+      // untouched, so there is no encoder to give a cap to — honouring the
+      // choice means going through a transcoded HLS session instead. Original
+      // is the only rung with nothing to ask for, so it is the only one that
+      // leaves the cheap path available.
       final canDirect = !kIsWeb &&
           candidatesResult != null &&
-          _canDirectPlay(candidatesResult.candidates);
+          _canDirectPlay(candidatesResult.candidates) &&
+          _selectedQuality.isOriginal;
 
       _isDirectPlay = canDirect;
 
@@ -775,16 +815,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         final startPositionSeconds = plan.position.inSeconds;
 
         // Start HLS session via GraphQL mutation (works for both modes)
-        final result = await graphqlClient.mutate(
-          MutationOptions(
-            document: documentNodeMutationStartStreamingSession,
-            variables: Variables$Mutation$StartStreamingSession(
-              fileId: widget.fileId,
-              strategy: hlsStrategy,
-              startPosition:
-                  startPositionSeconds > 0 ? startPositionSeconds : null,
-            ).toJson(),
-          ),
+        final result = await _startSessionMutation(
+          graphqlClient: graphqlClient,
+          hlsStrategy: hlsStrategy,
+          startPositionSeconds: startPositionSeconds,
         );
 
         if (result.hasException) {
@@ -801,6 +835,22 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
         _hlsSessionId = sessionResult.sessionId;
         debugPrint('[PlayerScreen] HLS session started: $_hlsSessionId');
+
+        // Label from what the server applied, not what was asked for: a relay
+        // connection clamps to 2000kbps and 720p regardless of the request.
+        //
+        // Only a server that echoes at all gets to decide the label. The
+        // legacy request does not select the echo fields, so reading them
+        // there would report "no caps applied" for every rung and label a
+        // capped stream Original. Null instead, which falls the label back to
+        // what was requested and suppresses the clamp note — the honest
+        // answer when the server never said.
+        _effectiveQuality = _serverLacksHeightSupport
+            ? null
+            : effectiveRungLabel(
+                maxHeight: sessionResult.maxHeight,
+                maxBitrateKbps: sessionResult.maxBitrate,
+              );
 
         // Use the echoed offset, not the requested one. The server clamps the
         // value, and `-ss` lands on the nearest keyframe, so the stream can
@@ -895,6 +945,117 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       }
     }
     return Enum$StreamingStrategy.TRANSCODE;
+  }
+
+  /// Rebuilds the quality ladder for the file about to play and settles which
+  /// rung this playback will request.
+  ///
+  /// Both are per-file, not per-widget: the ladder depends on the source
+  /// height, and a rung persisted while watching a taller file may not exist
+  /// in this one's ladder. Falling back to Original there beats requesting an
+  /// upscale, which costs encode time to produce a larger, blurrier picture.
+  Future<void> _resolveQualityForFile(
+    Query$StreamingCandidates$streamingCandidates? candidatesResult,
+  ) async {
+    _qualityLadder = deriveQualityLadder(
+      sourceHeight: candidatesResult?.metadata.height,
+    );
+
+    _selectedQuality = QualityRung.original;
+
+    // Secure storage being unreadable is no reason to fail playback, and the
+    // safe answer is the cheapest one for the server. Matches how
+    // `_loadAutoSkipPreference` treats the same failure.
+    try {
+      final storedKey =
+          await ref.read(settingsServiceProvider).getDefaultQuality();
+      final storedRung = QualityRung.fromStorageKey(storedKey);
+      if (storedRung != null && _qualityLadder.contains(storedRung)) {
+        _selectedQuality = storedRung;
+      }
+    } catch (e) {
+      debugPrint('[PlayerScreen] Could not read default quality: $e');
+    }
+  }
+
+  /// Starts the streaming session, degrading gracefully on a server that
+  /// predates the height cap.
+  ///
+  /// Mydia installs update on their own schedule and the native player ships
+  /// separately from the server, so a newer player routinely meets an older
+  /// one. Against such a server the current document is rejected outright —
+  /// the `maxHeight` argument and the echo fields it selects are both
+  /// validation errors, which fail the whole request rather than degrading —
+  /// so the first failure of that shape is retried through the legacy
+  /// document, which asks only for what every server since the bitrate cap
+  /// has had. [_serverLacksHeightSupport] makes that a once-per-session cost
+  /// rather than once per request.
+  Future<QueryResult<Object?>> _startSessionMutation({
+    required GraphQLClient graphqlClient,
+    required Enum$StreamingStrategy hlsStrategy,
+    required int startPositionSeconds,
+  }) async {
+    final startPosition =
+        startPositionSeconds > 0 ? startPositionSeconds : null;
+
+    Future<QueryResult<Object?>> runLegacy() {
+      return graphqlClient.mutate(
+        MutationOptions(
+          document: documentNodeMutationStartStreamingSessionLegacy,
+          variables: Variables$Mutation$StartStreamingSessionLegacy(
+            fileId: widget.fileId,
+            strategy: hlsStrategy,
+            maxBitrate: _selectedQuality.maxBitrateKbps,
+            startPosition: startPosition,
+          ).toJson(),
+        ),
+      );
+    }
+
+    if (_serverLacksHeightSupport) return runLegacy();
+
+    final result = await graphqlClient.mutate(
+      MutationOptions(
+        document: documentNodeMutationStartStreamingSession,
+        variables: Variables$Mutation$StartStreamingSession(
+          fileId: widget.fileId,
+          strategy: hlsStrategy,
+          maxBitrate: _selectedQuality.maxBitrateKbps,
+          maxHeight: _selectedQuality.height,
+          startPosition: startPosition,
+        ).toJson(),
+      ),
+    );
+
+    if (_looksLikeMissingHeightSupport(result)) {
+      debugPrint(
+        '[PlayerScreen] Server does not know maxHeight; '
+        'retrying without the height cap',
+      );
+      _serverLacksHeightSupport = true;
+      return runLegacy();
+    }
+
+    return result;
+  }
+
+  /// True when the failure is this server's schema not knowing about
+  /// `maxHeight`, rather than a transport, authorization, or resolver
+  /// problem. Only the former is worth retrying through the legacy document.
+  ///
+  /// Both messages are Absinthe's verbatim validation text — see
+  /// `Absinthe.Phase.Document.Validation.KnownArgumentNames` and
+  /// `.FieldsOnCorrectType`. An old server emits both at once (the argument
+  /// and the echoed fields arrived in the same change), so either is enough.
+  /// Matching the exact phrasing rather than loose keywords keeps a genuine
+  /// failure from being mistaken for version skew and silently retried.
+  bool _looksLikeMissingHeightSupport(QueryResult<Object?> result) {
+    final graphqlErrors = result.exception?.graphqlErrors ?? const [];
+    return graphqlErrors.any((error) {
+      final message = error.message;
+      return message.contains('Unknown argument "maxHeight"') ||
+          message.contains('Cannot query field "maxHeight"');
+    });
   }
 
   /// Shared tail of _initializePlayer: create player, open the media, start
@@ -1791,13 +1952,22 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// [_isRestartingSession] on before anything else and guarantees it is
   /// cleared afterward — including if any step throws — so [seekToReal]'s
   /// re-entrancy guard can never wedge shut for the rest of the session.
-  Future<void> _restartSessionAt(Duration target) async {
+  ///
+  /// [loadingMessage] names what the viewer asked for, since a restart is the
+  /// same machinery behind two different requests: seeking past the
+  /// transcoded window, and changing quality. Telling someone who picked
+  /// 720p that the player is "Seeking" describes the implementation rather
+  /// than what they did.
+  Future<void> _restartSessionAt(
+    Duration target, {
+    String loadingMessage = 'Seeking...',
+  }) async {
     await trackRestartInFlight(
       (inFlight) => _isRestartingSession = inFlight,
       () async {
         if (mounted) {
           setState(() {
-            _loadingMessage = 'Seeking...';
+            _loadingMessage = loadingMessage;
             _isLoading = true;
           });
         }
@@ -1989,34 +2159,93 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     }
   }
 
-  /// Show HLS quality selector (web only)
+  /// Shows the quality picker and applies the choice by restarting the
+  /// session at the current position.
+  ///
+  /// A rung change cannot be applied to a running session: its segments are
+  /// already encoded at the old settings, and the playlist is live-style, so
+  /// there is nothing to re-request. [_restartSessionAt] already handles the
+  /// teardown correctly, including saving progress before the old session
+  /// goes away, and guards against a concurrent restart leaking an FFmpeg
+  /// process.
   Future<void> _showQualitySelector() async {
-    final selected = await showHlsQualitySelector(
+    // A restart already in flight owns the player this would act on, exactly
+    // as in [seekToReal]. Dropping the request beats queueing one against a
+    // session on its way out.
+    if (_isRestartingSession) return;
+
+    final previous = _selectedQuality;
+
+    final selected = await showQualityPicker(
       context,
+      _qualityLadder,
       _selectedQuality,
+      clampNote: _clampNote(),
     );
 
-    if (selected != null && selected != _selectedQuality && mounted) {
-      setState(() {
-        _selectedQuality = selected;
-      });
-
-      debugPrint('Selected quality: ${selected.label}');
-
-      // Note: media_kit on web with hls.js handles quality selection automatically
-      // The HLS.js library manages adaptive bitrate switching based on network conditions
-      // For manual quality selection, we would need to access the hls.js instance
-      // which is not directly exposed by media_kit's web implementation
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Quality preference set to ${selected.label}. '
-            'Note: HLS adaptive streaming is handled automatically by the player.',
-          ),
-          duration: const Duration(seconds: 3),
-        ),
-      );
+    // `_isRestartingSession` is re-checked, not just `mounted`: the modal
+    // barrier stops taps, not the position stream. [_maybeAutoSkipSegment]
+    // fires on every tick and reaches [_restartSessionAt] through
+    // `seekToReal` whenever the segment end lies past what FFmpeg has
+    // transcoded, so a restart can begin behind the open dialog. Applying a
+    // rung on top of that would run a second teardown concurrently, leaving
+    // the first session id overwritten and its FFmpeg process never ended —
+    // the exact leak [trackRestartInFlight] exists to prevent.
+    if (selected == null ||
+        selected == _selectedQuality ||
+        !mounted ||
+        _isRestartingSession) {
+      return;
     }
+
+    // Read after the choice, not before it: playback carries on behind the
+    // open dialog, so a position captured when the picker appeared would
+    // rewind the viewer by however long they spent deciding.
+    //
+    // Real coordinates, not the player's: on a resumed session the player's
+    // zero is [StreamTimeline.startOffset] into the media, and
+    // [_restartSessionAt] takes a real target.
+    final position = _timeline.toReal(_player?.state.position ?? Duration.zero);
+
+    await applyQualityChoice(
+      selected: selected,
+      previous: previous,
+      persist: (rung) async {
+        if (mounted) setState(() => _selectedQuality = rung);
+        await _persistQuality(rung);
+      },
+      restart: (rung, {required bool isFallback}) => _restartSessionAt(
+        position,
+        loadingMessage: isFallback
+            ? 'Returning to ${rung.label}...'
+            : 'Switching to ${rung.label}...',
+      ),
+      stillActive: () => mounted,
+      onGaveUp: (error) => setState(() {
+        _error = error.toString();
+        _isLoading = false;
+      }),
+    );
+  }
+
+  /// Remembers the chosen rung for the next playback. A storage failure is
+  /// logged and dropped: it costs the preference, not the playback.
+  Future<void> _persistQuality(QualityRung rung) async {
+    try {
+      await ref
+          .read(settingsServiceProvider)
+          .setDefaultQuality(rung.storageKey);
+    } catch (e) {
+      debugPrint('[PlayerScreen] Could not save default quality: $e');
+    }
+  }
+
+  /// Explains a server-side limit when the applied rung is below the chosen
+  /// one, or null when the viewer got what they picked.
+  String? _clampNote() {
+    final effective = _effectiveQuality;
+    if (effective == null || effective == _selectedQuality) return null;
+    return 'Limited to ${effective.label} by your connection';
   }
 
   /// Handle keyboard shortcuts (desktop only)
@@ -2318,7 +2547,11 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           },
           onAudioTap: _showAudioSelector,
           onSubtitleTap: _showSubtitleSelector,
-          onQualityTap: PlatformFeatures.isWeb ? _showQualitySelector : null,
+          // Hidden when the ladder collapsed to Original alone — a source
+          // shorter than every rung, a local file, or a height the server
+          // never reported — matching how subtitles and audio disable
+          // themselves at zero tracks rather than opening a one-item menu.
+          onQualityTap: _qualityLadder.length > 1 ? _showQualitySelector : null,
           onFullscreenTap: _toggleFullscreen,
           onPreviousEpisode: _hasPreviousEpisode ? _playPreviousEpisode : null,
           onNextEpisode: _hasNextEpisode ? _playNextEpisode : null,
@@ -2327,7 +2560,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           subtitleTrackCount: _subtitleTracks.length,
           selectedAudioLabel: _selectedAudioTrack?.displayName,
           selectedSubtitleLabel: _selectedSubtitleTrack?.displayName,
-          selectedQualityLabel: _selectedQuality.label,
+          selectedQualityLabel: (_effectiveQuality ?? _selectedQuality).label,
         ),
         fill: Colors.black,
       ),
@@ -2716,5 +2949,60 @@ Future<void> trackRestartInFlight(
     await restart();
   } finally {
     setInFlight(false);
+  }
+}
+
+/// Puts [selected] into effect, restoring [previous] if that fails.
+///
+/// Extracted from [_PlayerScreenState._showQualitySelector] for the same
+/// reason as [trackRestartInFlight]: the widget path cannot be driven under
+/// `flutter test`. `_waitForPlaylist` polls a real URL that `flutter_test`'s
+/// `HttpOverrides` answers with 400 on every attempt, so the screen reaches
+/// its error state before the chrome that owns the quality button is ever
+/// built, and the picker can never be tapped. This is the riskiest decision
+/// in the quality change and the one most worth pinning, so it lives where a
+/// fake [restart] that throws can exercise it.
+///
+/// [persist] records a rung as the one now in effect — the widget both
+/// displays and stores it. [restart] tears the session down and brings it
+/// back at that rung, throwing if it cannot; [isFallback] distinguishes the
+/// two attempts, which the viewer is told apart. [stillActive] reports
+/// whether the caller can still act at all (its widget is still mounted).
+/// [onGaveUp] receives the second failure.
+///
+/// The retry is deliberately single. If returning to the rung that was
+/// already working also fails, the problem is not the quality choice, and
+/// another teardown would only cost the viewer more time before showing them
+/// the same error. [onGaveUp] is where they land on the error screen instead.
+@visibleForTesting
+Future<void> applyQualityChoice({
+  required QualityRung selected,
+  required QualityRung previous,
+  required Future<void> Function(QualityRung rung) persist,
+  required Future<void> Function(QualityRung rung, {required bool isFallback})
+      restart,
+  required bool Function() stillActive,
+  required void Function(Object error) onGaveUp,
+}) async {
+  await persist(selected);
+
+  try {
+    await restart(selected, isFallback: false);
+  } catch (error) {
+    // Fall back to the rung that was working rather than stranding the
+    // viewer on a black screen at a rung this file or server cannot serve.
+    debugPrint(
+        '[PlayerScreen] Quality change to ${selected.label} failed: $error');
+    if (!stillActive()) return;
+    await persist(previous);
+
+    try {
+      await restart(previous, isFallback: true);
+    } catch (fallbackError) {
+      debugPrint('[PlayerScreen] Restoring ${previous.label} failed too: '
+          '$fallbackError');
+      if (!stillActive()) return;
+      onGaveUp(fallbackError);
+    }
   }
 }

--- a/player/lib/presentation/screens/settings_screen.dart
+++ b/player/lib/presentation/screens/settings_screen.dart
@@ -149,7 +149,7 @@ class SettingsScreen extends ConsumerWidget {
                   deriveQualityLadder(sourceHeight: 2160),
                   current,
                 );
-                if (picked != null) {
+                if (picked != null && context.mounted) {
                   await ref
                       .read(settingsControllerProvider.notifier)
                       .setDefaultQuality(picked.storageKey);

--- a/player/lib/presentation/screens/settings_screen.dart
+++ b/player/lib/presentation/screens/settings_screen.dart
@@ -9,10 +9,12 @@ import '../../core/graphql/graphql_provider.dart';
 import '../../core/update/platform_updater.dart';
 import '../../core/update/update_provider.dart';
 import '../../core/update/updaters/macos_updater.dart';
+import '../../domain/models/quality_rung.dart';
 import '../widgets/ambient_backdrop_provider.dart';
 import '../widgets/cast_actions.dart';
 import '../widgets/cast_button.dart';
 import '../widgets/connection_status_indicator.dart';
+import '../widgets/hls_quality_selector.dart';
 import '../widgets/update_tile.dart';
 import 'settings/settings_controller.dart';
 
@@ -125,6 +127,35 @@ class SettingsScreen extends ConsumerWidget {
 
             // Playback section
             const _SectionHeader(title: 'Playback'),
+            ListTile(
+              key: const Key('default-quality-tile'),
+              leading: const Icon(Icons.hd),
+              title: const Text('Default quality'),
+              subtitle: Text(
+                QualityRung.fromStorageKey(settings.defaultQuality)?.label ??
+                    QualityRung.original.label,
+              ),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () async {
+                // The full ladder, not a per-file one: this is a standing
+                // preference set outside playback, where there is no source
+                // to derive against. Playback narrows it per file and falls
+                // back to Original if the stored rung would upscale.
+                final current =
+                    QualityRung.fromStorageKey(settings.defaultQuality) ??
+                        QualityRung.original;
+                final picked = await showQualityPicker(
+                  context,
+                  deriveQualityLadder(sourceHeight: 2160),
+                  current,
+                );
+                if (picked != null) {
+                  await ref
+                      .read(settingsControllerProvider.notifier)
+                      .setDefaultQuality(picked.storageKey);
+                }
+              },
+            ),
             SwitchListTile(
               key: const Key('auto-skip-segments-switch'),
               secondary: const Icon(Icons.fast_forward),

--- a/player/lib/presentation/widgets/hls_quality_selector.dart
+++ b/player/lib/presentation/widgets/hls_quality_selector.dart
@@ -1,55 +1,21 @@
 import 'package:flutter/material.dart';
 
-/// Represents a quality/bitrate level for HLS adaptive streaming
-class HlsQualityLevel {
-  final String label;
-  final int? height;
-  final int? bitrate;
-  final bool isAuto;
+import '../../domain/models/quality_rung.dart';
 
-  const HlsQualityLevel({
-    required this.label,
-    this.height,
-    this.bitrate,
-    this.isAuto = false,
-  });
-
-  /// Auto quality - lets HLS automatically select based on bandwidth
-  static const auto = HlsQualityLevel(
-    label: 'Auto',
-    isAuto: true,
-  );
-
-  /// Predefined quality levels that match common HLS variants
-  static const List<HlsQualityLevel> standardLevels = [
-    auto,
-    HlsQualityLevel(label: '1080p', height: 1080),
-    HlsQualityLevel(label: '720p', height: 720),
-    HlsQualityLevel(label: '480p', height: 480),
-    HlsQualityLevel(label: '360p', height: 360),
-  ];
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is HlsQualityLevel &&
-          runtimeType == other.runtimeType &&
-          label == other.label &&
-          height == other.height &&
-          bitrate == other.bitrate &&
-          isAuto == other.isAuto;
-
-  @override
-  int get hashCode =>
-      label.hashCode ^ height.hashCode ^ bitrate.hashCode ^ isAuto.hashCode;
-}
-
-/// Shows a quality selector dialog for HLS adaptive streaming
-Future<HlsQualityLevel?> showHlsQualitySelector(
+/// Shows the playback quality picker and returns the chosen rung, or null if
+/// the viewer dismissed it.
+///
+/// [ladder] comes from `deriveQualityLadder`, so it already excludes rungs
+/// that would upscale the source. [clampNote], when present, explains that
+/// the server is limiting the stream below what was chosen, which happens on
+/// a relay connection where the cap is not negotiable by the client.
+Future<QualityRung?> showQualityPicker(
   BuildContext context,
-  HlsQualityLevel currentQuality,
-) async {
-  return showDialog<HlsQualityLevel>(
+  List<QualityRung> ladder,
+  QualityRung current, {
+  String? clampNote,
+}) {
+  return showDialog<QualityRung>(
     context: context,
     builder: (context) => AlertDialog(
       backgroundColor: Colors.grey[900],
@@ -61,42 +27,54 @@ Future<HlsQualityLevel?> showHlsQualitySelector(
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
-          children: HlsQualityLevel.standardLevels.map((level) {
-            final isSelected = level == currentQuality;
-            return ListTile(
-              leading: Icon(
-                isSelected ? Icons.check_circle : Icons.circle_outlined,
-                color: isSelected ? Colors.red : Colors.grey,
-              ),
-              title: Text(
-                level.label,
-                style: TextStyle(
-                  color: isSelected ? Colors.white : Colors.grey[300],
-                  fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (clampNote != null)
+              Padding(
+                key: const Key('quality-clamp-note'),
+                padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
+                child: Text(
+                  clampNote,
+                  style: TextStyle(color: Colors.amber[300], fontSize: 12),
                 ),
               ),
-              subtitle: level.isAuto
-                  ? const Text(
-                      'Adapts to your connection',
-                      style: TextStyle(color: Colors.grey, fontSize: 12),
-                    )
-                  : null,
-              onTap: () {
-                Navigator.of(context).pop(level);
-              },
-            );
-          }).toList(),
+            for (final rung in ladder) _rungTile(context, rung, current),
+          ],
         ),
       ),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: const Text(
-            'Cancel',
-            style: TextStyle(color: Colors.grey),
-          ),
+          child: const Text('Cancel', style: TextStyle(color: Colors.grey)),
         ),
       ],
     ),
+  );
+}
+
+Widget _rungTile(BuildContext context, QualityRung rung, QualityRung current) {
+  final isSelected = rung == current;
+  return ListTile(
+    key: isSelected
+        ? Key('quality-rung-selected-${rung.label}')
+        : Key('quality-rung-${rung.label}'),
+    leading: Icon(
+      isSelected ? Icons.check_circle : Icons.circle_outlined,
+      color: isSelected ? Colors.red : Colors.grey,
+    ),
+    title: Text(
+      rung.label,
+      style: TextStyle(
+        color: isSelected ? Colors.white : Colors.grey[300],
+        fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+      ),
+    ),
+    subtitle: Text(
+      rung.isOriginal
+          ? 'Source quality, no re-encoding'
+          : 'Up to ${rung.maxBitrateKbps} kbps',
+      style: const TextStyle(color: Colors.grey, fontSize: 12),
+    ),
+    onTap: () => Navigator.of(context).pop(rung),
   );
 }

--- a/player/lib/presentation/widgets/video_controls/chrome_panel.dart
+++ b/player/lib/presentation/widgets/video_controls/chrome_panel.dart
@@ -26,40 +26,43 @@ class PanelMetrics {
   /// Whether controls should use enlarged touch hit areas.
   final bool touchTargets;
 
-  /// Whether `SecondaryCluster`'s web-only quality button may render.
+  /// Whether `SecondaryCluster`'s quality button renders.
   ///
-  /// True only at the desktop tier (>= [Breakpoints.tablet] in this file's
-  /// own three-tier scheme). This is a real overflow-budget lever, not a
-  /// platform check in disguise: `onQualityTap` being non-null is a *web*
-  /// signal (native builds never pass it — see `player_screen.dart`), but
-  /// whether the resulting 4th 40px button actually *fits* is a *width*
-  /// question, so the gate belongs here, next to the rest of the per-tier
-  /// budget, rather than on `SecondaryCluster` (which has no business
-  /// knowing about platforms) or on a bare `kIsWeb` check at the call site.
+  /// True at every tier. It was previously true only on desktop, for two
+  /// reasons that no longer hold. The first was that a non-null
+  /// `onQualityTap` was a *web* signal, because `player_screen.dart` gated
+  /// the callback on `PlatformFeatures.isWeb`; that gate is gone and the
+  /// control is wired on every platform. The second was budget: a 4th 40px
+  /// button raised `SecondaryCluster`'s floor from 120 to 160px each side,
+  /// which genuinely could not be closed at the tablet or mobile tiers by
+  /// any padding or width-factor lever.
   ///
-  /// A 4th button raises `SecondaryCluster`'s own floor from 120px (3
-  /// buttons, 0 gap) to 160px (4 buttons) each side. At the tablet and mobile
-  /// tiers that is not closeable by any padding/width-factor combination —
-  /// 600px would need the *entire* viewport as panel — so the button is
-  /// simply not shown there; a narrow web window falls back to the same
-  /// 3-button layout native mobile/tablet already use. Desktop closes with
-  /// real margin once its own width factor is widened (see the desktop
-  /// branch of [PanelMetrics.forWidth] and `chrome_panel_overflow_test.dart`'s
-  /// `quality: true` cases).
+  /// Compaction closed it structurally rather than by lever. The transport
+  /// cluster dropped from 256px to 192px, secondary buttons from 40 to 32,
+  /// and padding from 20/12 to 12/8, so the four-button floor is now 128px
+  /// on mobile against 142px available at 360px wide. See
+  /// `chrome_panel_overflow_test.dart` for the full per-width budget.
+  ///
+  /// This field is kept rather than deleted because it stays a real
+  /// per-tier lever: if a 5th control is ever added, this is where the tier
+  /// that cannot afford it says so.
   final bool showQuality;
 
   /// Horizontal padding on both sides of the panel. Previously a single
   /// global constant on [ChromePanel] itself; now tier-dependent, so it
   /// lives here alongside the other per-tier values.
   ///
-  /// 12px on the mobile and tablet tiers, 20px on desktop. This is a real
-  /// overflow-budget lever, not a cosmetic tweak: at the 650px tablet width
-  /// (episode-nav wired, `SecondaryCluster` at its 40px-button floor), 20px
-  /// of padding each side left `SecondaryCluster` 8px short of fitting in
-  /// its equal-flex slot — see `chrome_panel_overflow_test.dart` for the
-  /// full per-width budget. Desktop keeps 20px: it was never short of room,
-  /// and this wasn't asked to change there.
+  /// 8px on the mobile and tablet tiers, 12px on desktop. This is a real
+  /// overflow-budget lever, not a cosmetic tweak — see
+  /// `chrome_panel_overflow_test.dart` for the full per-width budget.
   final double horizontalPadding;
+
+  /// Horizontal gap between `SecondaryCluster`'s buttons, supplied per tier.
+  ///
+  /// Desktop and tablet can afford real separation once the transport
+  /// cluster is compacted; mobile runs at the 0px floor, which is what makes
+  /// four discrete 32px buttons fit at 360px at all.
+  final double secondaryGap;
 
   const PanelMetrics({
     required this.maxWidth,
@@ -67,6 +70,7 @@ class PanelMetrics {
     required this.showVolume,
     required this.touchTargets,
     required this.showQuality,
+    required this.secondaryGap,
     required this.horizontalPadding,
   });
 
@@ -76,49 +80,36 @@ class PanelMetrics {
   factory PanelMetrics.forWidth(double width) {
     if (width >= Breakpoints.tablet) {
       return PanelMetrics(
-        // 0.70, not the original 0.60: with the web-only quality button
-        // wired (see [showQuality]), `SecondaryCluster`'s floor rises from
-        // 120px to 160px each side. At the tightest desktop width, 900px,
-        // 0.60 left `avail` at 500 against a 576px need (256 transport +
-        // 2*160) — 38px short, the whole fullscreen button clipped. 0.70
-        // gives 630 -> avail 590 -> eachSide 167 >= 160, with real margin.
-        // The `min(720, …)` cap is untouched, so nothing changes above
-        // ~1029px, where both factors already saturate at 720 — see
-        // `chrome_panel_test.dart`'s "70% of width" case and
-        // `chrome_panel_overflow_test.dart`'s `quality: true` matrix.
         maxWidth: math.min(720.0, width * 0.70),
         bottomOffset: 48,
         showVolume: true,
         touchTargets: false,
         showQuality: true,
-        horizontalPadding: 20,
+        secondaryGap: 8,
+        horizontalPadding: 12,
       );
     }
     if (width >= Breakpoints.mobile) {
       return PanelMetrics(
-        // 0.9, not the original 0.8: at 600px (the tightest point of this
-        // branch, with episode-nav wired) 0.8 left this tier's equal-flex
-        // slot 28px short of `SecondaryCluster`'s 120px floor — closeable
-        // only by widening the panel itself, since neither the padding nor
-        // gap levers reach a shortfall that size. See
-        // `chrome_panel_overflow_test.dart`'s budget table.
         maxWidth: math.min(640.0, width * 0.90),
         bottomOffset: 32,
         showVolume: true,
         touchTargets: false,
-        showQuality: false,
-        horizontalPadding: 12,
+        showQuality: true,
+        secondaryGap: 6,
+        horizontalPadding: 8,
       );
     }
     return PanelMetrics(
-      // Clamp: below a 32px-wide viewport this would otherwise go negative,
+      // Clamp: below a 20px-wide viewport this would otherwise go negative,
       // which trips BoxConstraints' normalization assert downstream.
-      maxWidth: math.max(0.0, width - 32),
+      maxWidth: math.max(0.0, width - 20),
       bottomOffset: 24,
       showVolume: false,
       touchTargets: true,
-      showQuality: false,
-      horizontalPadding: 12,
+      showQuality: true,
+      secondaryGap: 0,
+      horizontalPadding: 8,
     );
   }
 }
@@ -169,12 +160,12 @@ class ChromePanel extends StatelessWidget {
   });
 
   /// Vertical gap between the controls row and the scrubber row.
-  static const double rowGap = 18.0;
+  static const double rowGap = 10.0;
 
   /// Vertical padding above row 1 and below row 2. Public so tests (e.g.
   /// `glass_legibility_test`) can derive real panel-geometry fractions
   /// instead of hand-rounded literals.
-  static const double verticalPadding = 16.0;
+  static const double verticalPadding = 10.0;
 
   @override
   Widget build(BuildContext context) {

--- a/player/lib/presentation/widgets/video_controls/panel_controls.dart
+++ b/player/lib/presentation/widgets/video_controls/panel_controls.dart
@@ -179,7 +179,10 @@ class SecondaryCluster extends StatelessWidget {
   final VoidCallback? onSubtitleTap;
   final VoidCallback? onAudioTap;
 
-  /// Web-only. When null the quality button is omitted entirely.
+  /// When null the quality button is omitted entirely, which is how the
+  /// player screen hides it for a source that has only one rung to offer.
+  /// Not a platform signal: it was web-only while `player_screen.dart` gated
+  /// the callback on `PlatformFeatures.isWeb`, and that gate is gone.
   final VoidCallback? onQualityTap;
   final VoidCallback? onFullscreenTap;
 
@@ -259,7 +262,13 @@ class SecondaryCluster extends StatelessWidget {
             icon: Icons.hd_rounded,
             iconSize: 18,
             size: 32,
-            tooltip: 'Quality: ${selectedQualityLabel ?? 'Auto'}',
+            // No invented default. This used to read "Auto", describing
+            // adaptive streaming the server has never done — it emits a
+            // single rendition per session. A caller that cannot name the
+            // current rung gets the bare noun rather than a fiction.
+            tooltip: selectedQualityLabel == null
+                ? 'Quality'
+                : 'Quality: $selectedQualityLabel',
             onTap: onQualityTap,
           ),
         ],

--- a/player/lib/presentation/widgets/video_controls/panel_controls.dart
+++ b/player/lib/presentation/widgets/video_controls/panel_controls.dart
@@ -202,6 +202,7 @@ class SecondaryCluster extends StatelessWidget {
     this.selectedSubtitleLabel,
     this.selectedQualityLabel,
     this.isFullscreen = false,
+    this.gap = 0.0,
   });
 
   static const Key subtitlesKey = Key('secondary-subtitles');
@@ -209,16 +210,16 @@ class SecondaryCluster extends StatelessWidget {
   static const Key qualityKey = Key('secondary-quality');
   static const Key fullscreenKey = Key('secondary-fullscreen');
 
-  /// Trimmed from 4 to 0 to close real overflows in `ChromePanel`'s
-  /// equal-flex right slot. Still load-bearing after `PanelMetrics`'
-  /// tablet-branch width factor and per-tier `horizontalPadding` closed the
-  /// worse 600–689px shortfall: at 4px this cluster's 3 buttons cost 128px,
-  /// which still doesn't fit the desktop breakpoint's own slot (900px was
-  /// -6px short, 920px exactly 0px, at 4px gap) — 0 gaps is the narrowest
-  /// this cluster can get without shrinking a button below its own 40px
-  /// spec. See `chrome_panel_overflow_test.dart` for the full per-width
-  /// budget with this value.
-  static const double gap = 0.0;
+  /// Horizontal gap between this cluster's buttons.
+  ///
+  /// Tier-dependent, supplied by the caller from `PanelMetrics`: 8 on
+  /// desktop, 6 on tablet, 0 on mobile. This used to be a hard `0.0`
+  /// constant, which was the narrowest the cluster could go and was needed
+  /// to squeeze a 4th 40px button into the desktop tier at all. Compacting
+  /// the transport cluster (see `transport_cluster.dart`) freed enough width
+  /// that desktop and tablet can afford real separation again, while mobile
+  /// still runs at the floor.
+  final double gap;
 
   @override
   Widget build(BuildContext context) {
@@ -231,20 +232,20 @@ class SecondaryCluster extends StatelessWidget {
         ControlButton(
           key: subtitlesKey,
           icon: Icons.subtitles_rounded,
-          iconSize: 20,
-          size: 40,
+          iconSize: 18,
+          size: 32,
           enabled: subtitlesEnabled,
           tooltip: subtitlesEnabled
               ? 'Subtitles: ${selectedSubtitleLabel ?? 'Off'}'
               : 'No subtitles',
           onTap: subtitlesEnabled ? onSubtitleTap : null,
         ),
-        const SizedBox(width: gap),
+        SizedBox(width: gap),
         ControlButton(
           key: audioKey,
           icon: Icons.audiotrack_rounded,
-          iconSize: 20,
-          size: 40,
+          iconSize: 18,
+          size: 32,
           enabled: audioEnabled,
           tooltip: audioEnabled
               ? 'Audio: ${selectedAudioLabel ?? 'Default'}'
@@ -252,24 +253,24 @@ class SecondaryCluster extends StatelessWidget {
           onTap: audioEnabled ? onAudioTap : null,
         ),
         if (onQualityTap != null) ...[
-          const SizedBox(width: gap),
+          SizedBox(width: gap),
           ControlButton(
             key: qualityKey,
             icon: Icons.hd_rounded,
-            iconSize: 20,
-            size: 40,
+            iconSize: 18,
+            size: 32,
             tooltip: 'Quality: ${selectedQualityLabel ?? 'Auto'}',
             onTap: onQualityTap,
           ),
         ],
-        const SizedBox(width: gap),
+        SizedBox(width: gap),
         ControlButton(
           key: fullscreenKey,
           icon: isFullscreen
               ? Icons.fullscreen_exit_rounded
               : Icons.fullscreen_rounded,
-          iconSize: 20,
-          size: 40,
+          iconSize: 18,
+          size: 32,
           tooltip: isFullscreen ? 'Exit fullscreen' : 'Fullscreen',
           onTap: onFullscreenTap,
         ),

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -528,14 +528,11 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
                         secondary: SecondaryCluster(
                           onSubtitleTap: widget.onSubtitleTap,
                           onAudioTap: widget.onAudioTap,
-                          // Gated on the panel's own tier, not passed through
-                          // bare: a 4th 40px button raises SecondaryCluster's
-                          // floor from 120 to 160px each side, which only the
-                          // desktop tier's width budget can absorb (see
-                          // PanelMetrics.showQuality's dartdoc). Below that,
-                          // a narrow web window falls back to the same
-                          // 3-button layout native mobile/tablet already
-                          // show, since onQualityTap is web-only regardless.
+                          // Passed through `metrics.showQuality` rather than
+                          // bare, even though every tier shows it today: see
+                          // that field's dartdoc — it stays a real per-tier
+                          // lever for the tier that can't absorb a future
+                          // 5th control.
                           onQualityTap:
                               metrics.showQuality ? widget.onQualityTap : null,
                           onFullscreenTap: widget.onFullscreenTap,
@@ -545,6 +542,7 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
                           selectedSubtitleLabel: widget.selectedSubtitleLabel,
                           selectedQualityLabel: widget.selectedQualityLabel,
                           isFullscreen: widget.isFullscreen,
+                          gap: metrics.secondaryGap,
                         ),
                         scrubber: _ScrubberRow(
                           player: widget.player,

--- a/player/lib/presentation/widgets/video_controls/transport_cluster.dart
+++ b/player/lib/presentation/widgets/video_controls/transport_cluster.dart
@@ -21,7 +21,7 @@ class TransportSurface extends StatelessWidget {
   final VoidCallback? onPreviousEpisode;
   final VoidCallback? onNextEpisode;
 
-  /// Renders only the play/pause button (48px) — no ±10s seek, no episode
+  /// Renders only the play/pause button (40px) — no ±10s seek, no episode
   /// nav — regardless of which callbacks are supplied. Used below the mobile
   /// breakpoint (`PanelMetrics.touchTargets`): ±10s already has a gesture
   /// equivalent there (double-tap, see `gesture_controls.dart`), and the

--- a/player/lib/presentation/widgets/video_controls/transport_cluster.dart
+++ b/player/lib/presentation/widgets/video_controls/transport_cluster.dart
@@ -53,7 +53,13 @@ class TransportSurface extends StatelessWidget {
   static const Key nextEpisodeKey = Key('transport-next-episode');
 
   /// Uniform gap between transport glyphs.
-  static const double gap = 8.0;
+  ///
+  /// 2, not the original 8: the transport cluster was the only part of the
+  /// control row never squeezed, at 256px with episode navigation wired, and
+  /// that width was what kept a 4th `SecondaryCluster` button from fitting
+  /// below the desktop tier. See `chrome_panel_overflow_test.dart` for the
+  /// per-width budget this feeds.
+  static const double gap = 2.0;
 
   /// The play/pause glyph, cross-fading and scaling between states.
   ///
@@ -79,8 +85,8 @@ class TransportSurface extends StatelessWidget {
         child: ControlButton(
           key: playPauseKey,
           icon: isPlaying ? Icons.pause_rounded : Icons.play_arrow_rounded,
-          size: 48,
-          iconSize: 30,
+          size: 40,
+          iconSize: 24,
           tooltip: isPlaying ? 'Pause' : 'Play',
           onTap: onPlayPause,
         ),
@@ -101,8 +107,8 @@ class TransportSurface extends StatelessWidget {
           ControlButton(
             key: previousEpisodeKey,
             icon: Icons.skip_previous_rounded,
-            size: 44,
-            iconSize: 22,
+            size: 36,
+            iconSize: 18,
             tooltip: 'Previous episode',
             onTap: onPreviousEpisode,
           ),
@@ -111,8 +117,8 @@ class TransportSurface extends StatelessWidget {
         ControlButton(
           key: back10Key,
           icon: Icons.replay_10_rounded,
-          size: 44,
-          iconSize: 24,
+          size: 36,
+          iconSize: 20,
           tooltip: 'Rewind 10 seconds',
           onTap: onBack10,
         ),
@@ -122,8 +128,8 @@ class TransportSurface extends StatelessWidget {
         ControlButton(
           key: forward10Key,
           icon: Icons.forward_10_rounded,
-          size: 44,
-          iconSize: 24,
+          size: 36,
+          iconSize: 20,
           tooltip: 'Forward 10 seconds',
           onTap: onForward10,
         ),
@@ -132,8 +138,8 @@ class TransportSurface extends StatelessWidget {
           ControlButton(
             key: nextEpisodeKey,
             icon: Icons.skip_next_rounded,
-            size: 44,
-            iconSize: 22,
+            size: 36,
+            iconSize: 18,
             tooltip: 'Next episode',
             onTap: onNextEpisode,
           ),

--- a/player/test/domain/models/quality_rung_test.dart
+++ b/player/test/domain/models/quality_rung_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/quality_rung.dart';
+
+void main() {
+  group('deriveQualityLadder', () {
+    test('offers only Original when the source height is unknown', () {
+      // Without metadata there is no honest way to know which rungs would
+      // upscale, so offering a ladder would be guessing.
+      final ladder = deriveQualityLadder(sourceHeight: null);
+
+      expect(ladder, [QualityRung.original]);
+    });
+
+    test('offers every rung below a 4K source', () {
+      final ladder = deriveQualityLadder(sourceHeight: 2160);
+
+      expect(
+        ladder.map((r) => r.label),
+        ['Original', '1080p', '720p', '480p', '360p'],
+      );
+    });
+
+    test('never offers a rung at or above the source height', () {
+      // A 1080p rung on a 1080p source is just Original with extra CPU cost,
+      // and anything above it would upscale.
+      final ladder = deriveQualityLadder(sourceHeight: 1080);
+
+      expect(ladder.map((r) => r.label), ['Original', '720p', '480p', '360p']);
+    });
+
+    test('collapses to Original alone for a source below every rung', () {
+      final ladder = deriveQualityLadder(sourceHeight: 360);
+
+      expect(ladder, [QualityRung.original]);
+    });
+
+    test('carries a bitrate cap on every rung except Original', () {
+      final ladder = deriveQualityLadder(sourceHeight: 2160);
+
+      expect(ladder.first.maxBitrateKbps, isNull);
+      expect(ladder.first.height, isNull);
+      for (final rung in ladder.skip(1)) {
+        expect(rung.maxBitrateKbps, isNotNull);
+        expect(rung.height, isNotNull);
+      }
+    });
+
+    test('orders rungs from highest quality down', () {
+      final heights = deriveQualityLadder(sourceHeight: 2160)
+          .skip(1)
+          .map((r) => r.height!)
+          .toList();
+
+      expect(heights, [1080, 720, 480, 360]);
+    });
+  });
+
+  group('storage round-trip', () {
+    test('Original uses the legacy "auto" key already in secure storage', () {
+      // settings_service.dart has persisted 'auto' as the default since
+      // before any of this worked; treating it as Original means an existing
+      // install does not silently start capping quality after an update.
+      expect(QualityRung.original.storageKey, 'auto');
+      expect(QualityRung.fromStorageKey('auto'), QualityRung.original);
+    });
+
+    test('round-trips a capped rung', () {
+      const rung =
+          QualityRung(label: '720p', height: 720, maxBitrateKbps: 4000);
+
+      expect(rung.storageKey, '720p');
+      expect(QualityRung.fromStorageKey('720p'), rung);
+    });
+
+    test('returns null for an unrecognised key', () {
+      // A key written by a newer build, or corrupted storage. Callers fall
+      // back to Original rather than crashing on startup.
+      expect(QualityRung.fromStorageKey('4320p'), isNull);
+      expect(QualityRung.fromStorageKey(''), isNull);
+    });
+  });
+
+  group('effectiveRungLabel', () {
+    test('reports Original when the server applied no caps', () {
+      expect(
+        effectiveRungLabel(maxHeight: null, maxBitrateKbps: null),
+        QualityRung.original,
+      );
+    });
+
+    test('names the rung matching what the server actually applied', () {
+      expect(
+        effectiveRungLabel(maxHeight: 720, maxBitrateKbps: 4000)?.label,
+        '720p',
+      );
+    });
+
+    test(
+        'falls back to the height when the server clamped to an off-ladder pair',
+        () {
+      // A relay clamps to 2000kbps and 720p, which is not a ladder pair. The
+      // viewer still needs an honest label, so height wins.
+      expect(
+        effectiveRungLabel(maxHeight: 720, maxBitrateKbps: 2000)?.label,
+        '720p',
+      );
+    });
+  });
+}

--- a/player/test/domain/models/quality_rung_test.dart
+++ b/player/test/domain/models/quality_rung_test.dart
@@ -90,6 +90,20 @@ void main() {
       expect(QualityRung.fromStorageKey('4320p'), isNull);
       expect(QualityRung.fromStorageKey(''), isNull);
     });
+
+    test('an unreadable stored key falls back to Original for display', () {
+      // Exactly the expression the Settings tile renders. A key written by a
+      // newer build, or corrupted storage, must show a sensible label rather
+      // than an empty subtitle or a crash on the settings screen.
+      String label(String stored) =>
+          QualityRung.fromStorageKey(stored)?.label ??
+          QualityRung.original.label;
+
+      expect(label('720p'), '720p');
+      expect(label('auto'), 'Original');
+      expect(label('4320p'), 'Original');
+      expect(label(''), 'Original');
+    });
   });
 
   group('effectiveRungLabel', () {

--- a/player/test/domain/models/quality_rung_test.dart
+++ b/player/test/domain/models/quality_rung_test.dart
@@ -34,6 +34,18 @@ void main() {
       expect(ladder, [QualityRung.original]);
     });
 
+    test('treats a zero source height as unknown', () {
+      // A source height of 0 is not a real resolution; the guard clause
+      // treats it the same as missing metadata rather than deriving a
+      // ladder from a bogus value.
+      expect(deriveQualityLadder(sourceHeight: 0), [QualityRung.original]);
+    });
+
+    test('treats a negative source height as unknown', () {
+      // Defensive against malformed metadata, same reasoning as zero.
+      expect(deriveQualityLadder(sourceHeight: -1), [QualityRung.original]);
+    });
+
     test('carries a bitrate cap on every rung except Original', () {
       final ladder = deriveQualityLadder(sourceHeight: 2160);
 
@@ -104,6 +116,44 @@ void main() {
         effectiveRungLabel(maxHeight: 720, maxBitrateKbps: 2000)?.label,
         '720p',
       );
+    });
+
+    test(
+        'returns null when only a bitrate cap is reported, pinning current behaviour',
+        () {
+      // This pins the current null return as intended, not as a gap: with no
+      // height there is no honest rung to name. The caller (the player
+      // screen, Task 11) does `(_effectiveQuality ?? _selectedQuality).label`,
+      // so null here falls back to displaying the rung the viewer actually
+      // selected rather than showing nothing. The function must not start
+      // inferring a rung from bitrate alone, since that would change what
+      // the control displays.
+      expect(effectiveRungLabel(maxHeight: null, maxBitrateKbps: 4000), isNull);
+    });
+  });
+
+  group('equality', () {
+    test('compares by field, not just identity, for non-identical instances',
+        () {
+      // Two `const QualityRung(...)` literals with equal fields get
+      // canonicalized into the same object by Dart, so comparing them only
+      // exercises the `identical(this, other)` fast path in `==` and never
+      // proves the field-by-field branch works. Deriving the height from a
+      // runtime value (not a literal) forces a genuinely distinct instance,
+      // the same situation Task 11 hits when it rebuilds a rung from
+      // GraphQL response fields at runtime instead of a compile-time const.
+      final runtimeHeight = int.parse('720');
+      final rebuilt = QualityRung(
+        label: '720p',
+        height: runtimeHeight,
+        maxBitrateKbps: 4000,
+      );
+      const literal =
+          QualityRung(label: '720p', height: 720, maxBitrateKbps: 4000);
+
+      expect(identical(rebuilt, literal), isFalse);
+      expect(rebuilt, literal);
+      expect(rebuilt.hashCode, literal.hashCode);
     });
   });
 }

--- a/player/test/domain/models/quality_rung_test.dart
+++ b/player/test/domain/models/quality_rung_test.dart
@@ -130,6 +130,49 @@ void main() {
       // the control displays.
       expect(effectiveRungLabel(maxHeight: null, maxBitrateKbps: 4000), isNull);
     });
+
+    test('names a height that matches no rung from the height itself', () {
+      // Falling back to null here would let the caller's
+      // `effective ?? selected` label the stream with the rung that was
+      // *asked* for, which is the one thing labelling from the applied value
+      // exists to prevent. A server free to clamp anywhere is not obliged to
+      // land on one of the four ladder heights.
+      final effective =
+          effectiveRungLabel(maxHeight: 540, maxBitrateKbps: 1800);
+
+      expect(effective?.label, '540p');
+      expect(effective?.height, 540);
+      expect(effective?.maxBitrateKbps, 1800,
+          reason: 'the synthesised rung describes what the server applied, '
+              'not a ladder entry');
+    });
+
+    test('names an off-ladder height even with no bitrate reported', () {
+      expect(
+        effectiveRungLabel(maxHeight: 540, maxBitrateKbps: null)?.label,
+        '540p',
+      );
+    });
+
+    test('prefers the canonical ladder rung over a synthesised one', () {
+      // 720p is on the ladder, so the relay pair (720p at 2000kbps) must
+      // resolve to the ladder's own 720p rung rather than a look-alike built
+      // from the echoed bitrate. Equality against `_selectedQuality` is what
+      // decides whether the clamp note appears, and two rungs that differ
+      // only in bitrate are not equal.
+      const ladderRung =
+          QualityRung(label: '720p', height: 720, maxBitrateKbps: 4000);
+
+      expect(
+          effectiveRungLabel(maxHeight: 720, maxBitrateKbps: 2000), ladderRung);
+    });
+
+    test('treats a non-positive height as unnameable', () {
+      // Same defence as `deriveQualityLadder`: 0 is not a resolution, and
+      // "0p" would be a worse label than falling back to the request.
+      expect(effectiveRungLabel(maxHeight: 0, maxBitrateKbps: 2000), isNull);
+      expect(effectiveRungLabel(maxHeight: -1, maxBitrateKbps: 2000), isNull);
+    });
   });
 
   group('equality', () {

--- a/player/test/presentation/screens/player/player_screen_quality_caps_test.dart
+++ b/player/test/presentation/screens/player/player_screen_quality_caps_test.dart
@@ -40,6 +40,17 @@ void main() {
       .where((r) => r.variables.containsKey('strategy'))
       .toList(growable: false);
 
+  /// True when [request] carries the named GraphQL operation. Lets a stub
+  /// answer by document rather than by call index, which is what a test with
+  /// more than one `_initializePlayer` pass needs.
+  ///
+  /// Reads the document off `Operation.toString()`, which prints the query
+  /// source. `DocumentNode.toString()` does not — it is the default
+  /// `Instance of 'DocumentNode'`, so matching on it silently matches
+  /// nothing and every request falls through to the stub's default.
+  bool isOperation(Request request, String name) =>
+      request.operation.toString().contains(name);
+
   Future<void> pumpUntilSessionStarted(WidgetTester tester, StubLink link,
       {int count = 1}) async {
     await pumpUntil(tester, () => sessionRequests(link).length >= count);
@@ -186,6 +197,103 @@ void main() {
           'without this the test proves only that a retry was sent, not that '
           'an old server response is usable',
     );
+  });
+
+  testWidgets(
+      'reads the stored default once and carries the rung across a '
+      're-initialization', (tester) async {
+    // The rung the viewer is watching at must not round-trip through secure
+    // storage to survive a restart. It used to: `_resolveQualityForFile`
+    // re-read the stored key on every re-initialization, so a write that
+    // failed — deliberately swallowed, and `flutter_secure_storage` needs a
+    // keyring on Linux desktop — silently put the session back at the rung
+    // they had just replaced.
+    //
+    // Driven through the error screen's Retry button, which is the only way
+    // to reach a second `_initializePlayer` under `flutter_test`: the chrome
+    // that owns the quality picker is never built here (see
+    // `quality_choice_test.dart` for why).
+    //
+    // Answered by operation rather than by call index. A second pass does not
+    // re-issue every query — the client's default cache-and-network policy
+    // serves some of them from the cache — so a positional script silently
+    // hands the wrong payload to the wrong document.
+    var sessionAttempts = 0;
+    final link = StubLink((request, _) {
+      if (isOperation(request, 'MovieDetail')) return movieDetailResponse();
+      if (isOperation(request, 'MovieSegments')) return movieSegmentsResponse();
+      if (isOperation(request, 'StreamingCandidates')) {
+        return streamingCandidatesResponse(duration: 5400, height: 2160);
+      }
+      if (isOperation(request, 'StartStreamingSession')) {
+        sessionAttempts++;
+        return sessionAttempts == 1
+            ? graphqlErrorResponse('Failed to start streaming session')
+            : startStreamingSessionResponse(maxBitrate: 4000, maxHeight: 720);
+      }
+      return endStreamingSessionResponse();
+    });
+
+    final settings = FakeSettingsService(defaultQuality: '720p');
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      settingsService: settings,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(tester, () => find.text('Retry').evaluate().isNotEmpty);
+
+    // Storage now disagrees with what is in effect — exactly the state a
+    // failed or stale write leaves behind.
+    settings.defaultQuality = '360p';
+
+    await tester.tap(find.text('Retry'));
+    await pumpUntilSessionStarted(tester, link, count: 2);
+
+    final attempts = sessionRequests(link);
+    expect(attempts, hasLength(2),
+        reason: 'without a second pass this test proves nothing; the whole '
+            'point is what the re-initialization requests');
+    expect(settings.getDefaultQualityCalls, 1,
+        reason: 'storage seeds the rung, it does not carry it');
+    expect(attempts.last.variables['maxHeight'], 720,
+        reason: 'the rung in effect wins over whatever storage now holds');
+  });
+
+  testWidgets('an unreadable preference plays at Original rather than failing',
+      (tester) async {
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      streamingCandidatesResponse(duration: 5400, height: 2160),
+      startStreamingSessionResponse(),
+      endStreamingSessionResponse(),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      settingsService: FakeSettingsService(
+        defaultQuality: '720p',
+        readError: StateError('secure storage is unavailable'),
+      ),
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntilSessionStarted(tester, link);
+
+    final variables = sessionRequests(link).single.variables;
+    expect(variables.containsKey('maxHeight'), isFalse,
+        reason: 'a locked keyring costs the preference, not the playback, and '
+            'the safe answer is the cheapest one for the server');
   });
 
   testWidgets('does not retry a genuine failure', (tester) async {

--- a/player/test/presentation/screens/player/player_screen_quality_caps_test.dart
+++ b/player/test/presentation/screens/player/player_screen_quality_caps_test.dart
@@ -1,0 +1,222 @@
+// Coverage for the quality control's server-facing half: which caps reach
+// `startStreamingSession`, and what happens against a server whose schema
+// predates them.
+//
+// These assert on `StubLink.requests` rather than on the chrome. The rung a
+// viewer picks only matters if it reaches the mutation, and the request is
+// where that is decidable — the control's own visibility is a function of
+// `_qualityLadder.length`, which `quality_rung_test.dart` already pins.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+void main() {
+  /// Collects `debugPrint` output for the duration of [body], restoring it
+  /// inside the body's own scope rather than via `tearDown` — see
+  /// `player_screen_resume_offset_test.dart` for why that timing matters.
+  Future<T> withCapturedDebugPrint<T>(
+    List<String> into,
+    Future<T> Function() body,
+  ) async {
+    final original = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) into.add(message);
+    };
+    try {
+      return await body();
+    } finally {
+      debugPrint = original;
+    }
+  }
+
+  /// Every `startStreamingSession` request the screen made, old document or
+  /// legacy one. `strategy` is the variable only these two carry.
+  List<Request> sessionRequests(StubLink link) => link.requests
+      .where((r) => r.variables.containsKey('strategy'))
+      .toList(growable: false);
+
+  Future<void> pumpUntilSessionStarted(WidgetTester tester, StubLink link,
+      {int count = 1}) async {
+    await pumpUntil(tester, () => sessionRequests(link).length >= count);
+    // Drains `_waitForPlaylist`'s retry loop so no timer outlives the test;
+    // see `player_screen_resume_offset_test.dart` for the full explanation.
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('sends the stored rung as a bitrate and height cap',
+      (tester) async {
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      streamingCandidatesResponse(duration: 5400, height: 2160),
+      startStreamingSessionResponse(maxBitrate: 4000, maxHeight: 720),
+      endStreamingSessionResponse(),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      settingsService: FakeSettingsService(defaultQuality: '720p'),
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntilSessionStarted(tester, link);
+
+    final variables = sessionRequests(link).single.variables;
+    expect(variables['maxBitrate'], 4000);
+    expect(variables['maxHeight'], 720,
+        reason: 'the rung is a pair; sending the bitrate alone leaves the '
+            'server free to spend it on a resolution nobody asked for');
+  });
+
+  testWidgets(
+      'falls back to Original when the source cannot offer the '
+      'stored rung', (tester) async {
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      // A 720p source: the 1080p rung would upscale, so it is not on this
+      // file's ladder at all.
+      streamingCandidatesResponse(duration: 5400, height: 720),
+      startStreamingSessionResponse(),
+      endStreamingSessionResponse(),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      settingsService: FakeSettingsService(defaultQuality: '1080p'),
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntilSessionStarted(tester, link);
+
+    final variables = sessionRequests(link).single.variables;
+    expect(variables.containsKey('maxBitrate'), isFalse);
+    expect(variables.containsKey('maxHeight'), isFalse,
+        reason: 'Original asks for no caps, which is what keeps the '
+            'copy-when-compatible path available');
+  });
+
+  testWidgets('a chosen rung takes precedence over direct play',
+      (tester) async {
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      // Direct play is on offer and would normally win on native, handing the
+      // file over untouched — with no encoder to apply the cap to.
+      streamingCandidatesResponse(
+          duration: 5400, height: 2160, directPlay: true),
+      startStreamingSessionResponse(maxBitrate: 1500, maxHeight: 480),
+      endStreamingSessionResponse(),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      settingsService: FakeSettingsService(defaultQuality: '480p'),
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntilSessionStarted(tester, link);
+
+    expect(sessionRequests(link).single.variables['maxHeight'], 480,
+        reason: 'a streaming session must be negotiated at all: taking the '
+            'direct-play shortcut would silently ignore the rung');
+  });
+
+  testWidgets(
+      'retries through the legacy document when the server does not '
+      'know maxHeight', (tester) async {
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      streamingCandidatesResponse(duration: 5400, height: 2160),
+      // Absinthe's verbatim text for an argument the schema does not declare.
+      graphqlErrorResponse(
+        'Unknown argument "maxHeight" on field "startStreamingSession" of '
+        'type "RootMutationType".',
+      ),
+      // The retry must survive a reply with no echoed caps at all, which is
+      // the only kind an old server can send.
+      legacyStartStreamingSessionResponse(),
+      endStreamingSessionResponse(),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      settingsService: FakeSettingsService(defaultQuality: '720p'),
+    );
+    addTearDown(container.dispose);
+
+    final logged = <String>[];
+    await withCapturedDebugPrint(logged, () async {
+      await pumpPlayerScreen(tester, container);
+      await pumpUntilSessionStarted(tester, link, count: 2);
+    });
+
+    final attempts = sessionRequests(link);
+    expect(attempts.length, 2, reason: 'exactly one retry, not a loop');
+    expect(attempts.first.variables['maxHeight'], 720);
+    expect(attempts.last.variables.containsKey('maxHeight'), isFalse);
+    expect(attempts.last.variables['maxBitrate'], 4000,
+        reason: 'the bitrate cap predates the height cap, so it survives the '
+            'fallback — the rung still means something on an old server');
+    expect(
+      logged.any((l) => l.contains('HLS session started: sess-1')),
+      isTrue,
+      reason: 'the reply with no echoed caps must parse into a real session; '
+          'without this the test proves only that a retry was sent, not that '
+          'an old server response is usable',
+    );
+  });
+
+  testWidgets('does not retry a genuine failure', (tester) async {
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      streamingCandidatesResponse(duration: 5400, height: 2160),
+      graphqlErrorResponse('Failed to start streaming session'),
+      endStreamingSessionResponse(),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+      settingsService: FakeSettingsService(defaultQuality: '720p'),
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(
+      tester,
+      () => find
+          .textContaining('Failed to start streaming session')
+          .evaluate()
+          .isNotEmpty,
+    );
+
+    expect(sessionRequests(link).length, 1,
+        reason: 'a resolver failure is not version skew; retrying it would '
+            'double every real error');
+  });
+}

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -28,9 +28,11 @@ import 'package:player/core/p2p/local_proxy_service.dart';
 import 'package:player/core/playback/local_playback_progress.dart';
 import 'package:player/core/playback/playback_progress_providers.dart';
 import 'package:player/core/playback/playback_progress_store.dart';
+import 'package:player/core/settings/settings_service.dart';
 import 'package:player/domain/models/cast_device.dart';
 import 'package:player/domain/models/download.dart';
 import 'package:player/presentation/screens/player/player_screen.dart';
+import 'package:player/presentation/screens/settings/settings_controller.dart';
 
 import '../../../test_utils/stub_graphql_client.dart';
 
@@ -87,6 +89,35 @@ class CapturingCastSessionManager extends Fake implements CastSessionManager {
     final error = startCastError;
     if (error != null) throw error;
   }
+}
+
+/// Answers the preference reads `PlayerScreen` makes at startup from memory.
+///
+/// The real [SettingsService] goes through `flutter_secure_storage`, whose
+/// platform channel is not registered under `testWidgets`: the awaiting
+/// Future never completes (the same trap documented on
+/// [mockPathProviderDocumentsDirectory]). `_initializePlayer` awaits the
+/// default-quality read before it decides anything, so an un-overridden
+/// provider wedges initialization short of the resume prompt — every test
+/// that mounts the screen fails on a dialog that never appears, with no
+/// error to explain it.
+class FakeSettingsService extends Fake implements SettingsService {
+  FakeSettingsService({this.defaultQuality = 'auto'});
+
+  /// The persisted `default_quality` key. `auto` — the real service's own
+  /// default — reads back as `QualityRung.original`.
+  String defaultQuality;
+
+  @override
+  Future<String> getDefaultQuality() async => defaultQuality;
+
+  @override
+  Future<void> setDefaultQuality(String quality) async {
+    defaultQuality = quality;
+  }
+
+  @override
+  Future<bool> getAutoSkipSegments() async => false;
 }
 
 /// Tracks whether `stop()` ran, without touching a real P2P/HTTP stack.
@@ -254,9 +285,20 @@ Map<String, dynamic> movieSegmentsResponse({
 /// `_canDirectPlay` declines an empty list. Pass [directPlay] to put a
 /// `DIRECT_PLAY` candidate first instead, which is what makes
 /// `_initializePlayer` take its native direct-play branch.
+///
+/// Every field the document selects must be present, including the ones a
+/// given test does not care about: the normalized cache refuses a partial
+/// write, which surfaces as `result.hasException` and makes
+/// `_fetchStreamingCandidates` return null — indistinguishable, from the
+/// screen's point of view, from a server that knows nothing about the file.
+///
+/// [height] feeds `deriveQualityLadder`. Null (the default) collapses the
+/// ladder to Original alone, which hides the quality control — what every
+/// test that is not about quality wants.
 Map<String, dynamic> streamingCandidatesResponse({
   double? duration,
   bool directPlay = false,
+  int? height,
 }) {
   return {
     '__typename': 'Query',
@@ -278,17 +320,47 @@ Map<String, dynamic> streamingCandidatesResponse({
         '__typename': 'StreamingMetadata',
         'duration': duration,
         'width': null,
-        'height': null,
+        'height': height,
+        'bitrate': null,
+        'resolution': null,
       },
     },
   };
 }
 
-/// A well-formed `StartStreamingSession` response. [startPosition] is the
-/// *echoed* value the server claims to have used — deliberately a separate
-/// parameter from whatever the client requested, so tests can make them
-/// differ on purpose.
+/// A well-formed `StartStreamingSession` response. [startPosition],
+/// [maxBitrate] and [maxHeight] are the *echoed* values the server claims to
+/// have applied — deliberately separate parameters from whatever the client
+/// requested, so tests can make them differ on purpose (a relay clamps both
+/// caps below the request).
 Map<String, dynamic> startStreamingSessionResponse({
+  String sessionId = 'sess-1',
+  double? duration,
+  int? startPosition,
+  int? maxBitrate,
+  int? maxHeight,
+}) {
+  return {
+    '__typename': 'RootMutationType',
+    'startStreamingSession': {
+      '__typename': 'StreamingSessionResult',
+      'sessionId': sessionId,
+      'duration': duration,
+      'startPosition': startPosition,
+      'maxBitrate': maxBitrate,
+      'maxHeight': maxHeight,
+    },
+  };
+}
+
+/// What a server that predates the height cap answers the legacy document
+/// with: no `maxBitrate` or `maxHeight` keys at all, because its schema has
+/// no such fields for that document to select.
+///
+/// Distinct from passing nulls to [startStreamingSessionResponse], which
+/// still sends the keys and so would not exercise the generated `fromJson`
+/// reading them as absent.
+Map<String, dynamic> legacyStartStreamingSessionResponse({
   String sessionId = 'sess-1',
   double? duration,
   int? startPosition,
@@ -329,8 +401,11 @@ ProviderContainer buildPlayerScreenContainer({
   DownloadedMedia? downloaded,
   AuthStatus authStatus = AuthStatus.authenticated,
   PlaybackProgressStore? progressStore,
+  SettingsService? settingsService,
 }) {
   return ProviderContainer(overrides: [
+    settingsServiceProvider
+        .overrideWithValue(settingsService ?? FakeSettingsService()),
     authStateProvider.overrideWith(
       () => FakeAuthNotifier(AsyncValue.data(authStatus)),
     ),

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -102,17 +102,41 @@ class CapturingCastSessionManager extends Fake implements CastSessionManager {
 /// that mounts the screen fails on a dialog that never appears, with no
 /// error to explain it.
 class FakeSettingsService extends Fake implements SettingsService {
-  FakeSettingsService({this.defaultQuality = 'auto'});
+  FakeSettingsService({
+    this.defaultQuality = 'auto',
+    this.readError,
+    this.writeError,
+  });
 
   /// The persisted `default_quality` key. `auto` — the real service's own
   /// default — reads back as `QualityRung.original`.
   String defaultQuality;
 
+  /// When set, reads throw it. `flutter_secure_storage` needs a keyring on
+  /// Linux desktop, so an unreadable preference is a real state, not a
+  /// hypothetical one.
+  final Object? readError;
+
+  /// When set, writes throw it.
+  final Object? writeError;
+
+  /// How many times the screen has asked storage for the default rung.
+  /// Storage seeds the rung once per playback; the in-memory value carries
+  /// it across every later re-initialization.
+  int getDefaultQualityCalls = 0;
+
   @override
-  Future<String> getDefaultQuality() async => defaultQuality;
+  Future<String> getDefaultQuality() async {
+    getDefaultQualityCalls++;
+    final error = readError;
+    if (error != null) throw error;
+    return defaultQuality;
+  }
 
   @override
   Future<void> setDefaultQuality(String quality) async {
+    final error = writeError;
+    if (error != null) throw error;
     defaultQuality = quality;
   }
 

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -321,8 +321,6 @@ Map<String, dynamic> streamingCandidatesResponse({
         'duration': duration,
         'width': null,
         'height': height,
-        'bitrate': null,
-        'resolution': null,
       },
     },
   };

--- a/player/test/presentation/screens/player/quality_choice_test.dart
+++ b/player/test/presentation/screens/player/quality_choice_test.dart
@@ -31,24 +31,46 @@ class _RestartCall {
 /// Records every callback `applyQualityChoice` makes, and fails whichever
 /// restarts [failing] names.
 class _Recorder {
-  _Recorder({this.failing = const <int>{}});
+  _Recorder({this.failing = const <int>{}, this.storageFails = false});
 
   /// Zero-based indices of `restart` calls that throw.
   final Set<int> failing;
+
+  /// Stands in for secure storage being unavailable — a locked or missing
+  /// keyring on Linux desktop, which `flutter_secure_storage` needs.
+  final bool storageFails;
 
   /// Stands in for the widget still being mounted. Set through a cascade at
   /// the call site rather than the constructor, since only one test cares.
   bool active = true;
 
-  final List<QualityRung> persisted = [];
+  /// The rung each restart saw in memory when it ran. This is the property
+  /// that matters: the viewer's choice has to reach the restart, whatever
+  /// storage did.
+  final List<QualityRung> inEffectAtRestart = [];
+
+  QualityRung? adopted;
+  final List<QualityRung> adoptedRungs = [];
+  final List<QualityRung> remembered = [];
   final List<_RestartCall> restarts = [];
   final List<Object> gaveUp = [];
 
-  Future<void> persist(QualityRung rung) async => persisted.add(rung);
+  void adopt(QualityRung rung) {
+    adopted = rung;
+    adoptedRungs.add(rung);
+  }
+
+  Future<void> remember(QualityRung rung) async {
+    if (storageFails) {
+      throw StateError('secure storage is unavailable');
+    }
+    remembered.add(rung);
+  }
 
   Future<void> restart(QualityRung rung, {required bool isFallback}) async {
     final index = restarts.length;
     restarts.add(_RestartCall(rung, isFallback));
+    inEffectAtRestart.add(adopted ?? QualityRung.original);
     if (failing.contains(index)) {
       throw StateError('restart #$index refused ${rung.label}');
     }
@@ -61,7 +83,8 @@ class _Recorder {
   Future<void> run() => applyQualityChoice(
         selected: _selected,
         previous: _previous,
-        persist: persist,
+        adopt: adopt,
+        remember: remember,
         restart: restart,
         stillActive: stillActive,
         onGaveUp: onGaveUp,
@@ -69,12 +92,14 @@ class _Recorder {
 }
 
 void main() {
-  test('a choice that works persists it and restarts once', () async {
+  test('a choice that works adopts it, remembers it, and restarts once',
+      () async {
     final recorder = _Recorder();
 
     await recorder.run();
 
-    expect(recorder.persisted, [_selected]);
+    expect(recorder.adoptedRungs, [_selected]);
+    expect(recorder.remembered, [_selected]);
     expect(recorder.restarts.map((c) => c.rung), [_selected]);
     expect(recorder.restarts.single.isFallback, isFalse,
         reason: 'the first attempt is what the viewer asked for, and is told '
@@ -82,23 +107,44 @@ void main() {
     expect(recorder.gaveUp, isEmpty);
   });
 
-  test('persists before restarting, not after', () async {
-    // Ordering is load-bearing rather than cosmetic: `_initializePlayer`
-    // re-reads the stored rung on its way through, so a restart that ran
-    // before the write would negotiate the session at the *old* rung and the
-    // viewer's choice would silently not apply.
+  test(
+      'adopts in memory before writing to storage, and both before the '
+      'restart', () async {
+    // Ordering is load-bearing rather than cosmetic. `_resolveQualityForFile`
+    // carries the in-memory rung into the session it negotiates, so a restart
+    // that ran before `adopt` would request the *old* rung and the viewer's
+    // choice would silently not apply.
     final order = <String>[];
     await applyQualityChoice(
       selected: _selected,
       previous: _previous,
-      persist: (rung) async => order.add('persist:${rung.label}'),
+      adopt: (rung) => order.add('adopt:${rung.label}'),
+      remember: (rung) async => order.add('remember:${rung.label}'),
       restart: (rung, {required bool isFallback}) async =>
           order.add('restart:${rung.label}'),
       stillActive: () => true,
       onGaveUp: (_) {},
     );
 
-    expect(order, ['persist:720p', 'restart:720p']);
+    expect(order, ['adopt:720p', 'remember:720p', 'restart:720p']);
+  });
+
+  test('a restart still gets the chosen rung when persistence fails', () async {
+    // The regression this split exists for. The choice used to reach the
+    // restart *through* secure storage, whose write failure is deliberately
+    // swallowed, so a locked keyring meant the session came back at the rung
+    // the viewer had just replaced — a restart that visibly changed nothing.
+    final recorder = _Recorder(storageFails: true);
+
+    await recorder.run();
+
+    expect(recorder.remembered, isEmpty, reason: 'the write threw');
+    expect(recorder.restarts.map((c) => c.rung), [_selected],
+        reason: 'the restart happens anyway; losing the preference for next '
+            'time is not a reason to abandon this playback');
+    expect(recorder.inEffectAtRestart, [_selected],
+        reason: 'and it runs with the chosen rung in effect, not the old one');
+    expect(recorder.gaveUp, isEmpty);
   });
 
   test('a failing choice restores the previous rung and retries once',
@@ -107,14 +153,28 @@ void main() {
 
     await recorder.run();
 
-    expect(recorder.persisted, [_selected, _previous],
-        reason: 'the rung that was working has to be stored again, or the '
-            'retry re-reads the failing one');
+    expect(recorder.adoptedRungs, [_selected, _previous],
+        reason: 'the rung that was working has to be back in effect, or the '
+            'retry re-requests the failing one');
+    expect(recorder.remembered, [_selected, _previous]);
     expect(recorder.restarts.map((c) => c.rung), [_selected, _previous]);
+    expect(recorder.inEffectAtRestart, [_selected, _previous]);
     expect(recorder.restarts.last.isFallback, isTrue);
     expect(recorder.gaveUp, isEmpty,
         reason: 'the rollback succeeded, so the viewer keeps watching and '
             'never sees the error screen');
+  });
+
+  test('the rollback survives a storage failure too', () async {
+    final recorder = _Recorder(failing: {0}, storageFails: true);
+
+    await recorder.run();
+
+    expect(recorder.restarts.map((c) => c.rung), [_selected, _previous]);
+    expect(recorder.inEffectAtRestart, [_selected, _previous],
+        reason: 'an unwritable keyring must not strand the viewer at a rung '
+            'that could not be served');
+    expect(recorder.gaveUp, isEmpty);
   });
 
   test('a second failure gives up instead of retrying again', () async {
@@ -139,14 +199,14 @@ void main() {
   });
 
   test('stops without rolling back when the caller is gone', () async {
-    // The widget was disposed mid-restart. Persisting and restarting against
+    // The widget was disposed mid-restart. Adopting and restarting against
     // a dead `State` is at best wasted work and at worst a `setState` after
     // dispose.
     final recorder = _Recorder(failing: {0})..active = false;
 
     await recorder.run();
 
-    expect(recorder.persisted, [_selected]);
+    expect(recorder.adoptedRungs, [_selected]);
     expect(recorder.restarts, hasLength(1));
     expect(recorder.gaveUp, isEmpty);
   });
@@ -159,7 +219,8 @@ void main() {
     await applyQualityChoice(
       selected: _selected,
       previous: _previous,
-      persist: recorder.persist,
+      adopt: recorder.adopt,
+      remember: recorder.remember,
       restart: recorder.restart,
       stillActive: () => ++checks == 1,
       onGaveUp: recorder.onGaveUp,

--- a/player/test/presentation/screens/player/quality_choice_test.dart
+++ b/player/test/presentation/screens/player/quality_choice_test.dart
@@ -1,0 +1,172 @@
+// Unit coverage for `applyQualityChoice`, the decision behind the quality
+// picker: put the chosen rung into effect, and if that fails, put the one
+// that was already working back and try exactly once more.
+//
+// Extracted from `_showQualitySelector` and tested here rather than through
+// the widget for the reason spelled out on the function itself: the chrome
+// that owns the quality button is never built under `flutter test`, because
+// `_waitForPlaylist` polls a real URL that `flutter_test`'s `HttpOverrides`
+// answers with 400 every time, so the screen reaches its error state first.
+// Same precedent as `trackRestartInFlight` and `shouldRestartForSeek`, both
+// pulled out of this file for the same reason.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/quality_rung.dart';
+import 'package:player/presentation/screens/player/player_screen.dart';
+
+const _selected = QualityRung(label: '720p', height: 720, maxBitrateKbps: 4000);
+const _previous = QualityRung.original;
+
+/// One call to the `restart` callback.
+class _RestartCall {
+  _RestartCall(this.rung, this.isFallback);
+
+  final QualityRung rung;
+  final bool isFallback;
+
+  @override
+  String toString() => '${rung.label}(isFallback: $isFallback)';
+}
+
+/// Records every callback `applyQualityChoice` makes, and fails whichever
+/// restarts [failing] names.
+class _Recorder {
+  _Recorder({this.failing = const <int>{}});
+
+  /// Zero-based indices of `restart` calls that throw.
+  final Set<int> failing;
+
+  /// Stands in for the widget still being mounted. Set through a cascade at
+  /// the call site rather than the constructor, since only one test cares.
+  bool active = true;
+
+  final List<QualityRung> persisted = [];
+  final List<_RestartCall> restarts = [];
+  final List<Object> gaveUp = [];
+
+  Future<void> persist(QualityRung rung) async => persisted.add(rung);
+
+  Future<void> restart(QualityRung rung, {required bool isFallback}) async {
+    final index = restarts.length;
+    restarts.add(_RestartCall(rung, isFallback));
+    if (failing.contains(index)) {
+      throw StateError('restart #$index refused ${rung.label}');
+    }
+  }
+
+  bool stillActive() => active;
+
+  void onGaveUp(Object error) => gaveUp.add(error);
+
+  Future<void> run() => applyQualityChoice(
+        selected: _selected,
+        previous: _previous,
+        persist: persist,
+        restart: restart,
+        stillActive: stillActive,
+        onGaveUp: onGaveUp,
+      );
+}
+
+void main() {
+  test('a choice that works persists it and restarts once', () async {
+    final recorder = _Recorder();
+
+    await recorder.run();
+
+    expect(recorder.persisted, [_selected]);
+    expect(recorder.restarts.map((c) => c.rung), [_selected]);
+    expect(recorder.restarts.single.isFallback, isFalse,
+        reason: 'the first attempt is what the viewer asked for, and is told '
+            'so; only the rollback is a fallback');
+    expect(recorder.gaveUp, isEmpty);
+  });
+
+  test('persists before restarting, not after', () async {
+    // Ordering is load-bearing rather than cosmetic: `_initializePlayer`
+    // re-reads the stored rung on its way through, so a restart that ran
+    // before the write would negotiate the session at the *old* rung and the
+    // viewer's choice would silently not apply.
+    final order = <String>[];
+    await applyQualityChoice(
+      selected: _selected,
+      previous: _previous,
+      persist: (rung) async => order.add('persist:${rung.label}'),
+      restart: (rung, {required bool isFallback}) async =>
+          order.add('restart:${rung.label}'),
+      stillActive: () => true,
+      onGaveUp: (_) {},
+    );
+
+    expect(order, ['persist:720p', 'restart:720p']);
+  });
+
+  test('a failing choice restores the previous rung and retries once',
+      () async {
+    final recorder = _Recorder(failing: {0});
+
+    await recorder.run();
+
+    expect(recorder.persisted, [_selected, _previous],
+        reason: 'the rung that was working has to be stored again, or the '
+            'retry re-reads the failing one');
+    expect(recorder.restarts.map((c) => c.rung), [_selected, _previous]);
+    expect(recorder.restarts.last.isFallback, isTrue);
+    expect(recorder.gaveUp, isEmpty,
+        reason: 'the rollback succeeded, so the viewer keeps watching and '
+            'never sees the error screen');
+  });
+
+  test('a second failure gives up instead of retrying again', () async {
+    final recorder = _Recorder(failing: {0, 1});
+
+    await recorder.run();
+
+    expect(recorder.restarts, hasLength(2),
+        reason: 'exactly two teardowns, ever: another one would only cost '
+            'the viewer more time before showing them the same error');
+    expect(recorder.gaveUp, hasLength(1));
+    expect(recorder.gaveUp.single, isA<StateError>());
+  });
+
+  test('does not rethrow when both attempts fail', () async {
+    // The caller invokes this from a `VoidCallback` on the chrome, where an
+    // escaping exception becomes an unhandled async error rather than
+    // anything the viewer can act on. `onGaveUp` is the whole exit path.
+    final recorder = _Recorder(failing: {0, 1});
+
+    await expectLater(recorder.run(), completes);
+  });
+
+  test('stops without rolling back when the caller is gone', () async {
+    // The widget was disposed mid-restart. Persisting and restarting against
+    // a dead `State` is at best wasted work and at worst a `setState` after
+    // dispose.
+    final recorder = _Recorder(failing: {0})..active = false;
+
+    await recorder.run();
+
+    expect(recorder.persisted, [_selected]);
+    expect(recorder.restarts, hasLength(1));
+    expect(recorder.gaveUp, isEmpty);
+  });
+
+  test('stops before giving up when the caller disappears mid-rollback',
+      () async {
+    final recorder = _Recorder(failing: {0, 1});
+    // Still alive for the rollback decision, gone by the time it has failed.
+    var checks = 0;
+    await applyQualityChoice(
+      selected: _selected,
+      previous: _previous,
+      persist: recorder.persist,
+      restart: recorder.restart,
+      stillActive: () => ++checks == 1,
+      onGaveUp: recorder.onGaveUp,
+    );
+
+    expect(recorder.restarts, hasLength(2));
+    expect(recorder.gaveUp, isEmpty,
+        reason: 'no error screen to put it on; the widget is gone');
+  });
+}

--- a/player/test/presentation/widgets/hls_quality_selector_test.dart
+++ b/player/test/presentation/widgets/hls_quality_selector_test.dart
@@ -1,181 +1,116 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/quality_rung.dart';
 import 'package:player/presentation/widgets/hls_quality_selector.dart';
 
+Widget _host(void Function(BuildContext) onReady) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Builder(
+        builder: (context) => ElevatedButton(
+          onPressed: () => onReady(context),
+          child: const Text('open'),
+        ),
+      ),
+    ),
+  );
+}
+
 void main() {
-  group('HlsQualityLevel', () {
-    test('auto quality is marked as isAuto', () {
-      expect(HlsQualityLevel.auto.isAuto, isTrue);
-      expect(HlsQualityLevel.auto.label, equals('Auto'));
-    });
+  final ladder = deriveQualityLadder(sourceHeight: 2160);
 
-    test('standard quality levels have correct properties', () {
-      final levels = HlsQualityLevel.standardLevels;
+  testWidgets('lists every rung in the supplied ladder', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        (context) => showQualityPicker(context, ladder, QualityRung.original),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
 
-      expect(levels.length, equals(5));
-      expect(levels[0].label, equals('Auto'));
-      expect(levels[1].label, equals('1080p'));
-      expect(levels[1].height, equals(1080));
-      expect(levels[2].label, equals('720p'));
-      expect(levels[2].height, equals(720));
-      expect(levels[3].label, equals('480p'));
-      expect(levels[3].height, equals(480));
-      expect(levels[4].label, equals('360p'));
-      expect(levels[4].height, equals(360));
-    });
-
-    test('equality operator works correctly', () {
-      const level1 = HlsQualityLevel(label: '720p', height: 720);
-      const level2 = HlsQualityLevel(label: '720p', height: 720);
-      const level3 = HlsQualityLevel(label: '1080p', height: 1080);
-
-      expect(level1, equals(level2));
-      expect(level1, isNot(equals(level3)));
-      expect(HlsQualityLevel.auto, equals(HlsQualityLevel.auto));
-    });
-
-    test('hashCode is consistent', () {
-      const level1 = HlsQualityLevel(label: '720p', height: 720);
-      const level2 = HlsQualityLevel(label: '720p', height: 720);
-
-      expect(level1.hashCode, equals(level2.hashCode));
-    });
+    for (final rung in ladder) {
+      expect(find.text(rung.label), findsOneWidget);
+    }
   });
 
-  group('showHlsQualitySelector', () {
-    testWidgets('shows all quality levels', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Builder(
-              builder: (context) => ElevatedButton(
-                onPressed: () {
-                  showHlsQualitySelector(context, HlsQualityLevel.auto);
-                },
-                child: const Text('Show Selector'),
-              ),
-            ),
-          ),
-        ),
-      );
+  testWidgets('returns the tapped rung', (tester) async {
+    QualityRung? result;
+    await tester.pumpWidget(
+      _host((context) async {
+        result = await showQualityPicker(context, ladder, QualityRung.original);
+      }),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
 
-      // Tap button to show dialog
-      await tester.tap(find.text('Show Selector'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('720p'));
+    await tester.pumpAndSettle();
 
-      // Verify dialog is shown
-      expect(find.text('Video Quality'), findsOneWidget);
+    expect(result?.label, '720p');
+    expect(result?.maxBitrateKbps, 4000);
+  });
 
-      // Verify all quality levels are shown
-      expect(find.text('Auto'), findsOneWidget);
-      expect(find.text('1080p'), findsOneWidget);
-      expect(find.text('720p'), findsOneWidget);
-      expect(find.text('480p'), findsOneWidget);
-      expect(find.text('360p'), findsOneWidget);
+  testWidgets('returns null when dismissed', (tester) async {
+    QualityRung? result;
+    var completed = false;
+    await tester.pumpWidget(
+      _host((context) async {
+        result = await showQualityPicker(context, ladder, QualityRung.original);
+        completed = true;
+      }),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
 
-      // Verify auto has subtitle
-      expect(find.text('Adapts to your connection'), findsOneWidget);
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
 
-      // Verify cancel button
-      expect(find.text('Cancel'), findsOneWidget);
-    });
+    expect(completed, isTrue);
+    expect(result, isNull);
+  });
 
-    testWidgets('shows selected quality with check icon', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Builder(
-              builder: (context) => ElevatedButton(
-                onPressed: () {
-                  showHlsQualitySelector(
-                    context,
-                    const HlsQualityLevel(label: '720p', height: 720),
-                  );
-                },
-                child: const Text('Show Selector'),
-              ),
-            ),
-          ),
-        ),
-      );
+  testWidgets('marks the current rung as selected', (tester) async {
+    const current =
+        QualityRung(label: '480p', height: 480, maxBitrateKbps: 1500);
+    await tester.pumpWidget(
+      _host((context) => showQualityPicker(context, ladder, current)),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
 
-      // Tap button to show dialog
-      await tester.tap(find.text('Show Selector'));
-      await tester.pumpAndSettle();
+    expect(find.byKey(const Key('quality-rung-selected-480p')), findsOneWidget);
+  });
 
-      // Verify check_circle icon exists (for selected item)
-      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  testWidgets('shows a clamp note when the server limited the stream',
+      (tester) async {
+    // A relay caps at 2000kbps and 720p regardless of what was asked for.
+    // Saying so beats letting the viewer think their choice was applied.
+    await tester.pumpWidget(
+      _host((context) => showQualityPicker(
+            context,
+            ladder,
+            QualityRung.original,
+            clampNote: 'Limited to 720p by your remote connection',
+          )),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
 
-      // Verify circle_outlined icons exist (for unselected items)
-      expect(find.byIcon(Icons.circle_outlined), findsNWidgets(4));
-    });
+    expect(
+      find.text('Limited to 720p by your remote connection'),
+      findsOneWidget,
+    );
+  });
 
-    testWidgets('returns selected quality when tapped', (tester) async {
-      HlsQualityLevel? result;
+  testWidgets('omits the note when nothing was clamped', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        (context) => showQualityPicker(context, ladder, QualityRung.original),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Builder(
-              builder: (context) => ElevatedButton(
-                onPressed: () async {
-                  result = await showHlsQualitySelector(
-                    context,
-                    HlsQualityLevel.auto,
-                  );
-                },
-                child: const Text('Show Selector'),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      // Tap button to show dialog
-      await tester.tap(find.text('Show Selector'));
-      await tester.pumpAndSettle();
-
-      // Tap 1080p option
-      await tester.tap(find.text('1080p'));
-      await tester.pumpAndSettle();
-
-      // Verify the result
-      expect(result, isNotNull);
-      expect(result?.label, equals('1080p'));
-      expect(result?.height, equals(1080));
-    });
-
-    testWidgets('returns null when cancelled', (tester) async {
-      HlsQualityLevel? result;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Builder(
-              builder: (context) => ElevatedButton(
-                onPressed: () async {
-                  result = await showHlsQualitySelector(
-                    context,
-                    HlsQualityLevel.auto,
-                  );
-                },
-                child: const Text('Show Selector'),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      // Tap button to show dialog
-      await tester.tap(find.text('Show Selector'));
-      await tester.pumpAndSettle();
-
-      // Tap cancel button
-      await tester.tap(find.text('Cancel'));
-      await tester.pumpAndSettle();
-
-      // Verify the result is null
-      expect(result, isNull);
-    });
+    expect(find.byKey(const Key('quality-clamp-note')), findsNothing);
   });
 }

--- a/player/test/presentation/widgets/video_controls/chrome_panel_golden_test.dart
+++ b/player/test/presentation/widgets/video_controls/chrome_panel_golden_test.dart
@@ -103,9 +103,21 @@ Widget _panel(double width) {
                         onToggleMute: () {},
                       )
                     : null,
-                secondary: const SecondaryCluster(
+                // `gap` and `onQualityTap` mirror real wiring too (see
+                // `playback_chrome.dart`'s `SecondaryCluster` construction):
+                // production passes `metrics.secondaryGap` unconditionally
+                // and wires the quality button at every tier now (see
+                // `PanelMetrics.showQuality`'s dartdoc). Omitting either, as
+                // an earlier version of this file did, would freeze these
+                // goldens at the 0.0 gap default even for the desktop/tablet
+                // images (where production now separates the buttons) and
+                // would never exercise the 4-button layout this whole change
+                // exists to enable.
+                secondary: SecondaryCluster(
                   subtitleTrackCount: 1,
                   audioTrackCount: 2,
+                  gap: metrics.secondaryGap,
+                  onQualityTap: () {},
                 ),
                 // `touchTarget` mirrors real wiring (see
                 // `playback_chrome.dart`'s `_ScrubberRow`, which always

--- a/player/test/presentation/widgets/video_controls/chrome_panel_overflow_test.dart
+++ b/player/test/presentation/widgets/video_controls/chrome_panel_overflow_test.dart
@@ -8,18 +8,23 @@
 // it is the CI-visible half of the regression guard for this whole class of
 // bug.
 //
-// Only 320px remains broken, and it is broken *by construction*, not
-// pending: `SecondaryCluster`'s 3 buttons at their own 40px spec cost 120px
-// with zero gap (the floor — already guarded by the passing-width
-// assertions below), but 320px's equal-flex slot only ever offers 108px, and
-// even removing 100% of `ChromePanel`'s horizontal padding (not just
-// trimming it) only gets to 120px available — exactly matching, with zero
-// margin for the padding itself to occupy. There is no gap/slider/padding
-// lever left to pull; closing this needs either shrinking a button below
-// its spec or abandoning the equal-flex centering guarantee for this one
-// width, and neither is this file's call. If that changes, *move* 320px
+// Only 320px remains broken, and it is still broken *by construction*, not
+// pending: four 32px buttons at zero gap cost 128px, and 320px's equal-flex
+// slot offers 122px after compaction. Closing the remaining 6px needs either
+// a sub-32px button or abandoning the equal-flex centering guarantee for this
+// one width, and neither is this file's call. If that changes, *move* 320px
 // from `_knownBrokenWidths` to `_passingWidths` — don't just delete its
 // assertion.
+//
+// 320px is the one width whose outcome now depends on `quality`, unlike
+// every other width tested here: the 128px figure above is the 4-button
+// (quality: true) case. With only 3 buttons (quality: false) — the same
+// count every other width's "worst case" no longer forces once `_panel`
+// stopped replicating the old platform gate — the need drops to 96px
+// against the same 122px slot, a comfortable 26px margin. So 320px's
+// quality:false case is asserted passing, separately, right after the main
+// passing-widths loop below, rather than inside the uniform
+// `_knownBrokenWidths` loop with quality:true.
 //
 // 600px and 650px *were* asserted broken in an earlier revision of this
 // file — that escalation was wrong. Both close with two more one-constant
@@ -27,22 +32,15 @@
 // and per-tier `horizontalPadding` on `PanelMetrics` (20 -> 12 for mobile and
 // tablet). See the constants' own dartdocs for the exact arithmetic.
 //
-// **`quality` axis:** a whole-branch review found this file's own header
-// claim — "the worst case PlaybackChrome can present" — was false: it never
-// wired the web-only quality button, so it missed a real Critical (a 4th
-// `SecondaryCluster` button, raising its floor from 120 to 160px each side,
-// overflowed <424px, 600-666px, and 900-1026px in production, clipping the
-// fullscreen button on a mid-size browser window). The fix gates the button
-// on `PanelMetrics.showQuality` (true only at the desktop tier, 900+ in this
-// file's three-tier scheme) rather than showing it whenever the caller has
-// something to wire it to — see that field's dartoc for why the tablet/
-// mobile tiers cannot be widened to fit a 4th button at all. `_panel` below
-// replicates that exact gate (mirroring `PlaybackChrome`'s own composition,
-// not `SecondaryCluster`'s, which deliberately has no platform knowledge),
-// so `quality: true` at desktop widths genuinely exercises the widened
-// 0.60 -> 0.70 desktop width factor, while below that tier it exercises
-// "the button was requested but the tier can't show it" — both real
-// production paths.
+// **`quality` axis:** the quality button used to be gated to the desktop
+// tier, because a 4th `SecondaryCluster` button raised its floor from 120 to
+// 160px each side and overflowed below 424px, 600-666px, and 900-1026px in
+// production. That gate is gone: the control is wired on every platform and
+// every tier now shows it. What closed the budget was compaction rather than
+// a lever — transport 256 -> 192, secondary buttons 40 -> 32, padding 20/12
+// -> 12/8 — so `_panel` below no longer needs to replicate a platform gate.
+// `quality: true` now genuinely exercises the 4-button layout at every width
+// in `_passingWidths`.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -57,11 +55,11 @@ import 'package:player/presentation/widgets/video_controls/video_progress_bar.da
 /// — see its wiring comment), `compact` following `metrics.touchTargets`
 /// (dropping seek/episode-nav to play/pause-only below the mobile
 /// breakpoint), `volume` supplied whenever `metrics.showVolume`, and the
-/// quality button gated on `metrics.showQuality` whenever [quality] requests
-/// it (mirroring `PlaybackChrome`'s own gate — see the file header). This is
-/// deliberately the *worst case* PlaybackChrome can present at a given
-/// width — a caller with no adjacent episodes, or not on web, gets an
-/// easier layout, not a harder one.
+/// quality button shown whenever [quality] requests it — every tier's
+/// `metrics.showQuality` is true now, so there is no gate left to replicate
+/// (see the file header's `quality` axis note). This is deliberately the
+/// *worst case* PlaybackChrome can present at a given width — a caller with
+/// no adjacent episodes gets an easier layout, not a harder one.
 Widget _panel(double width, {bool quality = false}) {
   final metrics = PanelMetrics.forWidth(width);
   return MaterialApp(
@@ -86,7 +84,8 @@ Widget _panel(double width, {bool quality = false}) {
           secondary: SecondaryCluster(
             subtitleTrackCount: 1,
             audioTrackCount: 2,
-            onQualityTap: (quality && metrics.showQuality) ? () {} : null,
+            gap: metrics.secondaryGap,
+            onQualityTap: quality ? () {} : null,
           ),
           scrubber: ProgressBarSurface(
             progress: 0.35,
@@ -126,7 +125,11 @@ const _passingWidths = <double>[
   1600,
 ];
 
-/// Widths that still overflow, by construction — see the file header.
+/// Widths that still overflow, by construction, in their `quality: true`
+/// case — see the file header. 320px's `quality: false` case does *not*
+/// overflow (3 buttons fit with real margin), so it is exercised separately,
+/// right after the passing-widths loop below, rather than looped here
+/// uniformly with `quality: true`.
 const _knownBrokenWidths = <double>[320];
 
 /// Consumes every exception `tester` recorded, rather than just the first —
@@ -144,6 +147,63 @@ List<Object> _takeAllExceptions(WidgetTester tester) {
   return exceptions;
 }
 
+/// Shared body for a width/quality combination expected to render every
+/// control at its own full, natural size with no overflow. Used both by the
+/// main [_passingWidths] loop and, separately, by 320px's `quality: false`
+/// case (see [_knownBrokenWidths]'s dartdoc for why that one is not looped
+/// alongside the rest).
+Future<void> _expectFitsAtFullSize(
+  WidgetTester tester,
+  double width, {
+  required bool quality,
+}) async {
+  tester.view.physicalSize = Size(width, 600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(_panel(width, quality: quality));
+  await tester.pumpAndSettle();
+
+  expect(_takeAllExceptions(tester), isEmpty);
+
+  // Effective on-screen size — not `tester.getSize`, which reports
+  // the pre-transform intrinsic size and would silently miss a
+  // `FittedBox`-style scale-down applied by an ancestor. `getRect` is
+  // transform-aware: it independently maps each corner through
+  // `RenderBox.localToGlobal`, so its width reflects any ancestor
+  // scaling.
+  //
+  // 32, not 40: the whole control row was compacted so four discrete
+  // buttons fit down to 360px. See `PanelMetrics.showQuality`'s
+  // dartdoc for the arithmetic that replaced the old desktop gate.
+  final secondaryRect = tester.getRect(
+    find.byKey(SecondaryCluster.fullscreenKey),
+  );
+  expect(secondaryRect.width, greaterThanOrEqualTo(32));
+  expect(secondaryRect.height, greaterThanOrEqualTo(32));
+
+  final metrics = PanelMetrics.forWidth(width);
+  if (metrics.showVolume) {
+    final volumeRect = tester.getRect(find.byKey(VolumeSurface.muteKey));
+    expect(volumeRect.width, greaterThanOrEqualTo(40));
+    expect(volumeRect.height, greaterThanOrEqualTo(40));
+  }
+
+  // Every tier shows the quality button now, so requesting it is
+  // enough — there is no tier that suppresses it.
+  expect(
+    find.byKey(SecondaryCluster.qualityKey),
+    quality ? findsOneWidget : findsNothing,
+  );
+  if (quality) {
+    final qualityRect = tester.getRect(
+      find.byKey(SecondaryCluster.qualityKey),
+    );
+    expect(qualityRect.width, greaterThanOrEqualTo(32));
+    expect(qualityRect.height, greaterThanOrEqualTo(32));
+  }
+}
+
 void main() {
   for (final width in _passingWidths) {
     for (final quality in const [false, true]) {
@@ -151,90 +211,43 @@ void main() {
         'ChromePanel at ${width}px (quality: $quality): no RenderFlex '
         'overflow, and every control renders at its own full natural size '
         '(not squeezed)',
-        (tester) async {
-          tester.view.physicalSize = Size(width, 600);
-          tester.view.devicePixelRatio = 1.0;
-          addTearDown(tester.view.reset);
-
-          await tester.pumpWidget(_panel(width, quality: quality));
-          await tester.pumpAndSettle();
-
-          expect(_takeAllExceptions(tester), isEmpty);
-
-          // Effective on-screen size — not `tester.getSize`, which reports
-          // the pre-transform intrinsic size and would silently miss a
-          // `FittedBox`-style scale-down applied by an ancestor. `getRect` is
-          // transform-aware: it independently maps each corner through
-          // `RenderBox.localToGlobal`, so its width reflects any ancestor
-          // scaling.
-          //
-          // 40, not 44: `SecondaryCluster` hard-codes `size: 40` for these
-          // buttons (see `panel_controls.dart`) — a deliberately smaller
-          // target than `ControlButton`'s own 44px default, which is what
-          // `control_button_test.dart`'s "default target meets the 44px touch
-          // minimum" test measures in isolation.
-          final secondaryRect = tester.getRect(
-            find.byKey(SecondaryCluster.fullscreenKey),
-          );
-          expect(secondaryRect.width, greaterThanOrEqualTo(40));
-          expect(secondaryRect.height, greaterThanOrEqualTo(40));
-
-          final metrics = PanelMetrics.forWidth(width);
-          if (metrics.showVolume) {
-            final volumeRect =
-                tester.getRect(find.byKey(VolumeSurface.muteKey));
-            expect(volumeRect.width, greaterThanOrEqualTo(40));
-            expect(volumeRect.height, greaterThanOrEqualTo(40));
-          }
-
-          // The quality button only ever renders when both requested AND
-          // the tier allows it (desktop only, see PanelMetrics.showQuality)
-          // — this is the exact gate PlaybackChrome applies, replicated in
-          // `_panel`. At non-desktop widths `quality: true` still requests
-          // it, but the tier suppresses it, same as `quality: false`.
-          final showsQuality = quality && metrics.showQuality;
-          expect(
-            find.byKey(SecondaryCluster.qualityKey),
-            showsQuality ? findsOneWidget : findsNothing,
-          );
-          if (showsQuality) {
-            final qualityRect = tester.getRect(
-              find.byKey(SecondaryCluster.qualityKey),
-            );
-            expect(qualityRect.width, greaterThanOrEqualTo(40));
-            expect(qualityRect.height, greaterThanOrEqualTo(40));
-          }
-        },
+        (tester) => _expectFitsAtFullSize(tester, width, quality: quality),
       );
     }
   }
 
+  // 320px, quality: false only — see _knownBrokenWidths' dartdoc. Its
+  // quality: true case is covered by the broken-widths loop below.
+  testWidgets(
+    'ChromePanel at 320.0px (quality: false): no RenderFlex overflow, and '
+    'every control renders at its own full natural size (not squeezed)',
+    (tester) => _expectFitsAtFullSize(tester, 320, quality: false),
+  );
+
   for (final width in _knownBrokenWidths) {
-    for (final quality in const [false, true]) {
-      testWidgets(
-        'ChromePanel at ${width}px (quality: $quality): out of budget by '
-        'construction, not pending — see this file\'s header',
-        (tester) async {
-          tester.view.physicalSize = Size(width, 600);
-          tester.view.devicePixelRatio = 1.0;
-          addTearDown(tester.view.reset);
+    testWidgets(
+      'ChromePanel at ${width}px (quality: true): out of budget by '
+      'construction, not pending — see this file\'s header',
+      (tester) async {
+        tester.view.physicalSize = Size(width, 600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
 
-          await tester.pumpWidget(_panel(width, quality: quality));
-          await tester.pumpAndSettle();
+        await tester.pumpWidget(_panel(width, quality: true));
+        await tester.pumpAndSettle();
 
-          final exceptions = _takeAllExceptions(tester);
-          expect(
-            exceptions,
-            isNotEmpty,
-            reason: 'this width was expected to still overflow; if it no '
-                'longer does, move ${width}px from _knownBrokenWidths to '
-                '_passingWidths above instead of loosening this assertion',
-          );
-          for (final exception in exceptions) {
-            expect(exception.toString(), contains('RenderFlex'));
-          }
-        },
-      );
-    }
+        final exceptions = _takeAllExceptions(tester);
+        expect(
+          exceptions,
+          isNotEmpty,
+          reason: 'this width was expected to still overflow; if it no '
+              'longer does, move ${width}px from _knownBrokenWidths to '
+              '_passingWidths above instead of loosening this assertion',
+        );
+        for (final exception in exceptions) {
+          expect(exception.toString(), contains('RenderFlex'));
+        }
+      },
+    );
   }
 }

--- a/player/test/presentation/widgets/video_controls/chrome_panel_overflow_test.dart
+++ b/player/test/presentation/widgets/video_controls/chrome_panel_overflow_test.dart
@@ -176,6 +176,18 @@ Future<void> _expectFitsAtFullSize(
   // 32, not 40: the whole control row was compacted so four discrete
   // buttons fit down to 360px. See `PanelMetrics.showQuality`'s
   // dartdoc for the arithmetic that replaced the old desktop gate.
+  //
+  // 32 is also below `ControlButton`'s own 44px default hit target
+  // (`control_button.dart`), which `control_button_test.dart`'s "default
+  // target meets the 44px touch minimum" test pins as this codebase's
+  // stated minimum. `SecondaryCluster` has deliberately undercut that
+  // default since before this change — it hard-codes its own smaller size
+  // rather than inheriting `ControlButton`'s default, and never receives
+  // `touchTargets`, so nothing expands the hit area to compensate. That
+  // trade-off is intentional and this commit doesn't revisit it, but
+  // compaction raises its stakes: `showQuality` is now true at the mobile
+  // tier too, so phones move from three 40px sub-44px targets to four 32px
+  // ones.
   final secondaryRect = tester.getRect(
     find.byKey(SecondaryCluster.fullscreenKey),
   );

--- a/player/test/presentation/widgets/video_controls/chrome_panel_test.dart
+++ b/player/test/presentation/widgets/video_controls/chrome_panel_test.dart
@@ -57,7 +57,9 @@ void main() {
 
     test('mobile: full width less margins, 24px offset, no volume', () {
       final mobile = PanelMetrics.forWidth(400);
-      expect(mobile.maxWidth, 400 - 32);
+      // 20, not the previous 32: the panel margin was trimmed along with
+      // every other spacing constant so four secondary buttons fit at 360px.
+      expect(mobile.maxWidth, 400 - 20);
       expect(mobile.bottomOffset, 24);
       expect(mobile.showVolume, isFalse);
       expect(mobile.touchTargets, isTrue);
@@ -70,25 +72,33 @@ void main() {
       expect(PanelMetrics.forWidth(599).bottomOffset, 24);
     });
 
-    test('horizontalPadding: 12 on mobile/tablet, 20 on desktop', () {
-      expect(PanelMetrics.forWidth(400).horizontalPadding, 12);
-      expect(PanelMetrics.forWidth(599).horizontalPadding, 12);
-      expect(PanelMetrics.forWidth(800).horizontalPadding, 12);
-      expect(PanelMetrics.forWidth(899).horizontalPadding, 12);
-      expect(PanelMetrics.forWidth(900).horizontalPadding, 20);
-      expect(PanelMetrics.forWidth(1600).horizontalPadding, 20);
+    test('horizontalPadding: 8 on mobile/tablet, 12 on desktop', () {
+      expect(PanelMetrics.forWidth(400).horizontalPadding, 8);
+      expect(PanelMetrics.forWidth(599).horizontalPadding, 8);
+      expect(PanelMetrics.forWidth(800).horizontalPadding, 8);
+      expect(PanelMetrics.forWidth(899).horizontalPadding, 8);
+      expect(PanelMetrics.forWidth(900).horizontalPadding, 12);
+      expect(PanelMetrics.forWidth(1600).horizontalPadding, 12);
     });
 
-    test(
-      'showQuality: true only at the desktop tier (900+), never below',
-      () {
-        expect(PanelMetrics.forWidth(400).showQuality, isFalse);
-        expect(PanelMetrics.forWidth(599).showQuality, isFalse);
-        expect(PanelMetrics.forWidth(899).showQuality, isFalse);
-        expect(PanelMetrics.forWidth(900).showQuality, isTrue);
-        expect(PanelMetrics.forWidth(1600).showQuality, isTrue);
-      },
-    );
+    test('secondaryGap: 8 on desktop, 6 on tablet, 0 on mobile', () {
+      // Mobile runs at the zero floor deliberately: it is what makes four
+      // discrete 32px buttons fit at 360px. See PanelMetrics.showQuality.
+      expect(PanelMetrics.forWidth(1600).secondaryGap, 8);
+      expect(PanelMetrics.forWidth(900).secondaryGap, 8);
+      expect(PanelMetrics.forWidth(800).secondaryGap, 6);
+      expect(PanelMetrics.forWidth(600).secondaryGap, 6);
+      expect(PanelMetrics.forWidth(400).secondaryGap, 0);
+    });
+
+    test('showQuality is true at every tier', () {
+      // Was desktop-only. Compaction closed the tablet and mobile budgets;
+      // see the field's dartdoc for the arithmetic.
+      expect(PanelMetrics.forWidth(1600).showQuality, isTrue);
+      expect(PanelMetrics.forWidth(900).showQuality, isTrue);
+      expect(PanelMetrics.forWidth(800).showQuality, isTrue);
+      expect(PanelMetrics.forWidth(400).showQuality, isTrue);
+    });
   });
 
   group('ChromePanel', () {
@@ -306,7 +316,7 @@ void main() {
     }
 
     testWidgets(
-      'renders the 20h/16v padding and the 18px row gap as real geometry',
+      'renders the 12h/10v padding and the 10px row gap as real geometry',
       (tester) async {
         await tester.pumpWidget(
           host(
@@ -319,18 +329,22 @@ void main() {
         final transportRect = tester.getRect(find.byKey(const Key('t')));
         final scrubberRect = tester.getRect(find.byKey(const Key('s')));
 
-        // 16px vertical padding above row 1.
-        expect(transportRect.top - panelRect.top, closeTo(16, 0.5));
-        // 18px gap between row 1 (48 tall) and row 2.
+        // 10px vertical padding above row 1. Was 16 before compaction; see
+        // `ChromePanel.verticalPadding`'s dartdoc.
+        expect(transportRect.top - panelRect.top, closeTo(10, 0.5));
+        // 10px gap between row 1 (48 tall) and row 2. Was 18 before
+        // compaction; see `ChromePanel.rowGap`'s dartdoc.
         expect(
           scrubberRect.top - transportRect.top,
           closeTo(48 + ChromePanel.rowGap, 0.5),
         );
-        // 16px vertical padding below row 2.
-        expect(panelRect.bottom - scrubberRect.bottom, closeTo(16, 0.5));
-        // 20px horizontal padding on the left (volume sits flush left).
+        // 10px vertical padding below row 2.
+        expect(panelRect.bottom - scrubberRect.bottom, closeTo(10, 0.5));
+        // 12px horizontal padding on the left (volume sits flush left). Was
+        // 20 before compaction; see `PanelMetrics.horizontalPadding`'s
+        // dartdoc.
         final volumeRect = tester.getRect(find.byKey(const Key('v')));
-        expect(volumeRect.left - panelRect.left, closeTo(20, 0.5));
+        expect(volumeRect.left - panelRect.left, closeTo(12, 0.5));
       },
     );
 

--- a/player/test/presentation/widgets/video_controls/glass_legibility_test.dart
+++ b/player/test/presentation/widgets/video_controls/glass_legibility_test.dart
@@ -256,10 +256,10 @@ void main() {
   final row2Top = row1Bottom + ChromePanel.rowGap;
 
   // The tallest icon glyph actually used in row 1 is TransportSurface's
-  // play/pause button (`iconSize: 30`, in a `size: 48` button matching the
-  // row's own height) — the worst case, since a taller glyph reaches closer
-  // to the row's edges where fill is sheerest.
-  const controlGlyphHeight = 30.0;
+  // play/pause button (`iconSize: 24`, in a `size: 40` button) — the worst
+  // case, since a taller glyph reaches closer to the row's edges where fill
+  // is sheerest.
+  const controlGlyphHeight = 24.0;
   final controlGlyphTop = row1Top + (row1Height - controlGlyphHeight) / 2;
   final controlGlyphBottom = controlGlyphTop + controlGlyphHeight;
 

--- a/player/test/presentation/widgets/video_controls/glass_legibility_test.dart
+++ b/player/test/presentation/widgets/video_controls/glass_legibility_test.dart
@@ -243,8 +243,9 @@ void main() {
   // --- Panel geometry, derived from ChromePanel's own public constants plus
   // representative row/glyph dimensions (ChromePanel doesn't own row content
   // sizing, so these mirror what the rest of this test suite already uses:
-  // a 48px transport row and a 32px scrubber row).
-  const row1Height = 48.0;
+  // a 40px transport row — TransportSurface's play/pause button, its
+  // tallest element — and a 32px scrubber row).
+  const row1Height = 40.0;
   const row2Height = 32.0;
   const panelHeight = ChromePanel.verticalPadding * 2 +
       row1Height +

--- a/player/test/presentation/widgets/video_controls/panel_controls_test.dart
+++ b/player/test/presentation/widgets/video_controls/panel_controls_test.dart
@@ -325,8 +325,12 @@ void main() {
       final fullscreenRect =
           tester.getRect(find.byKey(SecondaryCluster.fullscreenKey));
 
-      // Not strict `lessThan`: `SecondaryCluster.gap` was trimmed to 0 to
-      // help close a real `ChromePanel` overflow (see the constant's own
+      // 32, not the previous 40: the whole control row was compacted so four
+      // discrete buttons fit down to 360px. See `chrome_panel.dart`'s
+      // PanelMetrics dartdocs for the per-width budget.
+      //
+      // Not strict `lessThan`: `SecondaryCluster.gap` defaults to 0 to
+      // help close a real `ChromePanel` overflow (see the field's own
       // dartdoc and `chrome_panel_overflow_test.dart`), so adjacent buttons
       // may legitimately share an edge rather than have a visible gap.
       expect(subtitlesRect.right, lessThanOrEqualTo(audioRect.left));
@@ -339,10 +343,15 @@ void main() {
       // buttons from a totally broken layout) — it stops discriminating a
       // real gap regression from "buttons happen to be near each other".
       // Pitch anchored to each button's own *measured* width (not a
-      // hardcoded 40) stays meaningful at any `gap` value, including 0: a
+      // hardcoded 32) stays meaningful at any `gap` value, including 0: a
       // widened, narrowed, overlapping, or displaced button all move the
       // pitch away from `buttonWidth + gap`.
-      const gap = SecondaryCluster.gap;
+      //
+      // `gap` is `SecondaryCluster`'s own default (0.0), not a static
+      // constant: the field became instance-level and tier-dependent in
+      // this same change, supplied by `PanelMetrics.secondaryGap` in real
+      // usage. This widget doesn't pass one, so it renders at the default.
+      const gap = 0.0;
       expect(
         audioRect.left - subtitlesRect.left,
         closeTo(subtitlesRect.width + gap, 0.5),

--- a/player/test/presentation/widgets/video_controls/transport_cluster_test.dart
+++ b/player/test/presentation/widgets/video_controls/transport_cluster_test.dart
@@ -42,11 +42,15 @@ void main() {
       expect(find.byKey(TransportSurface.previousEpisodeKey), findsNothing);
       expect(find.byKey(TransportSurface.nextEpisodeKey), findsNothing);
 
-      // Still the same 48px play/pause button, not some other size.
+      // Still the same 40px play/pause button, not some other size.
+      //
+      // 40, not the original 48: the transport cluster was compacted so a
+      // 4th secondary button fits below the desktop tier. See
+      // transport_cluster.dart's `gap` dartdoc.
       final button = tester.widget<ControlButton>(
         find.byKey(TransportSurface.playPauseKey),
       );
-      expect(button.size, 48);
+      expect(button.size, 40);
     });
 
     testWidgets('shows episode buttons when callbacks are given',
@@ -65,7 +69,12 @@ void main() {
       expect(find.byKey(TransportSurface.nextEpisodeKey), findsOneWidget);
     });
 
-    testWidgets('play is 1.25x its skip neighbours, not 1.7x', (tester) async {
+    testWidgets('play is 1.2x its skip neighbours, not 1.7x', (tester) async {
+      // Play/skip iconSizes dropped from 30/24 to 24/20 alongside the
+      // transport cluster's compaction (48/44px buttons to 40/36px), but the
+      // proportion between them is deliberately preserved at roughly the
+      // same ratio as before (1.25x -> 1.2x), not left at the old absolute
+      // sizes. See transport_cluster.dart's `gap` dartdoc.
       await tester.pumpWidget(
         _host(const TransportSurface(isPlaying: false)),
       );
@@ -77,12 +86,15 @@ void main() {
         find.byKey(TransportSurface.back10Key),
       );
 
-      expect(play.iconSize, 30);
-      expect(skip.iconSize, 24);
-      expect(play.iconSize / skip.iconSize, closeTo(1.25, 0.01));
+      expect(play.iconSize, 24);
+      expect(skip.iconSize, 20);
+      expect(play.iconSize / skip.iconSize, closeTo(1.2, 0.01));
     });
 
-    testWidgets('every target meets the 44px minimum', (tester) async {
+    testWidgets('every target meets the 36px minimum', (tester) async {
+      // 36, not ControlButton's 44px default: the transport cluster was
+      // compacted so a 4th secondary button fits below the desktop tier.
+      // See transport_cluster.dart's `gap` dartdoc.
       await tester.pumpWidget(
         _host(
           TransportSurface(
@@ -101,7 +113,7 @@ void main() {
         TransportSurface.nextEpisodeKey,
       ]) {
         final button = tester.widget<ControlButton>(find.byKey(key));
-        expect(button.size, greaterThanOrEqualTo(44), reason: '$key');
+        expect(button.size, greaterThanOrEqualTo(36), reason: '$key');
       }
     });
 
@@ -189,9 +201,13 @@ void main() {
     });
 
     testWidgets(
-        'targets stay left-to-right ordered with uniform 8px gaps, '
+        'targets stay left-to-right ordered with uniform 2px gaps, '
         'with or without episode buttons', (tester) async {
-      // Without episode buttons: back10, play, forward10 in order with 8px
+      // 2, not the original 8: the transport cluster was compacted so a 4th
+      // secondary button fits below the desktop tier. See
+      // transport_cluster.dart's `gap` dartdoc.
+      //
+      // Without episode buttons: back10, play, forward10 in order with 2px
       // gaps between each hit-target edge.
       await tester.pumpWidget(
         _host(const TransportSurface(isPlaying: false)),
@@ -205,11 +221,11 @@ void main() {
 
       expect(backRect.right, lessThan(playRect.left));
       expect(playRect.right, lessThan(forwardRect.left));
-      expect(playRect.left - backRect.right, closeTo(8, 0.5));
-      expect(forwardRect.left - playRect.right, closeTo(8, 0.5));
+      expect(playRect.left - backRect.right, closeTo(2, 0.5));
+      expect(forwardRect.left - playRect.right, closeTo(2, 0.5));
 
       // With episode buttons: prev sits left of back10 and next sits right of
-      // forward10, each separated by the same 8px gap, and the whole row
+      // forward10, each separated by the same 2px gap, and the whole row
       // stays centred (the added prev/next mass is symmetric).
       await tester.pumpWidget(
         _host(
@@ -237,10 +253,10 @@ void main() {
       expect(playRect2.right, lessThan(forwardRect2.left));
       expect(forwardRect2.right, lessThan(nextRect.left));
 
-      expect(backRect2.left - prevRect.right, closeTo(8, 0.5));
-      expect(playRect2.left - backRect2.right, closeTo(8, 0.5));
-      expect(forwardRect2.left - playRect2.right, closeTo(8, 0.5));
-      expect(nextRect.left - forwardRect2.right, closeTo(8, 0.5));
+      expect(backRect2.left - prevRect.right, closeTo(2, 0.5));
+      expect(playRect2.left - backRect2.right, closeTo(2, 0.5));
+      expect(forwardRect2.left - playRect2.right, closeTo(2, 0.5));
+      expect(nextRect.left - forwardRect2.right, closeTo(2, 0.5));
 
       // The row is symmetric about its own centre: prev/next add equal
       // widths on either side, so the play button's centre doesn't shift.

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -133,6 +133,9 @@ type RootMutationType {
     "Total kbps cap (video + audio), e.g. 2000"
     maxBitrate: Int
 
+    "Output height ceiling in pixels, e.g. 720. Preserves aspect ratio"
+    maxHeight: Int
+
     "Real media position, in seconds, at which to begin transcoding. Optional; omitted or 0 starts at the beginning."
     startPosition: Int
   ): StreamingSessionResult
@@ -904,6 +907,12 @@ type StreamingSessionResult {
 
   "Real media position, in seconds, at which the stream begins. Clients must map stream-local positions by this offset. Absent or 0 means the stream starts at the beginning."
   startPosition: Int
+
+  "Total kbps cap the server actually applied, which may be lower than requested on a relay connection. Null means uncapped. Clients should label the quality control from this, not from what they asked for."
+  maxBitrate: Int
+
+  "Output height ceiling the server actually applied, which may be lower than requested on a relay connection. Null means the source resolution is preserved."
+  maxHeight: Int
 }
 
 "A download quality option"

--- a/test/mydia/config/loader_test.exs
+++ b/test/mydia/config/loader_test.exs
@@ -42,7 +42,8 @@ defmodule Mydia.Config.LoaderTest do
         "TV_PATH",
         "METADATA_LANGUAGE",
         "LOG_LEVEL",
-        "OBAN_POLL_INTERVAL"
+        "OBAN_POLL_INTERVAL",
+        "MAX_TRANSCODE_HEIGHT"
       ] ++ download_client_vars ++ library_path_vars
 
     # Store original values
@@ -621,6 +622,43 @@ defmodule Mydia.Config.LoaderTest do
       # YAML values should be used where no database override exists
       assert config.server.host == "yaml.example.com"
       assert config.logging.level == "debug"
+    end
+
+    test "the transcode height ceiling is reachable from every layer" do
+      # This setting is the stated escape hatch for operators whose hardware
+      # cannot encode a 4K file in realtime. It shipped once as a bare key in
+      # config/config.exs, which is compile-time and baked into the release,
+      # so the only way to set it was to rebuild the image.
+      File.mkdir_p!("test/fixtures")
+
+      File.write!(@test_yaml_path, """
+      streaming:
+        max_transcode_height: 1080
+      """)
+
+      {:ok, from_yaml} = Loader.load(config_file: @test_yaml_path)
+      assert from_yaml.streaming.max_transcode_height == 1080
+
+      {:ok, _} =
+        Repo.insert(%ConfigSetting{
+          key: "streaming.max_transcode_height",
+          value: "720",
+          category: :streaming
+        })
+
+      {:ok, from_db} = Loader.load(config_file: @test_yaml_path)
+      assert from_db.streaming.max_transcode_height == 720
+
+      System.put_env("MAX_TRANSCODE_HEIGHT", "480")
+
+      {:ok, from_env} = Loader.load(config_file: @test_yaml_path)
+      assert from_env.streaming.max_transcode_height == 480
+    end
+
+    test "the transcode height ceiling defaults to no ceiling" do
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert config.streaming.max_transcode_height == nil
     end
 
     test "environment variables override database settings" do

--- a/test/mydia/config/schema_test.exs
+++ b/test/mydia/config/schema_test.exs
@@ -425,6 +425,27 @@ defmodule Mydia.Config.SchemaTest do
     end
   end
 
+  describe "streaming max_transcode_height (MAX_TRANSCODE_HEIGHT)" do
+    test "round-trips a configured ceiling" do
+      changeset = Schema.changeset(%Schema{}, %{streaming: %{max_transcode_height: 720}})
+      assert changeset.valid?
+
+      config = Ecto.Changeset.apply_changes(changeset)
+      assert config.streaming.max_transcode_height == 720
+    end
+
+    test "defaults to nil, which means a transcode keeps the source resolution" do
+      assert Schema.defaults().streaming.max_transcode_height == nil
+    end
+
+    test "rejects a non-positive ceiling rather than scaling to nothing" do
+      changeset = Schema.changeset(%Schema{}, %{streaming: %{max_transcode_height: 0}})
+
+      refute changeset.valid?
+      assert "must be greater than 0" in errors_on(changeset).streaming.max_transcode_height
+    end
+  end
+
   describe "plugins override_dir (PLUGINS_OVERRIDE_DIR)" do
     test "round-trips a configured override directory" do
       changeset = Schema.changeset(%Schema{}, %{plugins: %{override_dir: "/data/plugins"}})

--- a/test/mydia/streaming/ffmpeg_scale_cap_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_cap_test.exs
@@ -59,10 +59,13 @@ defmodule Mydia.Streaming.FfmpegScaleCapTest do
                "scale=-2:2*trunc(min(480\\,ih)/2)"
     end
 
-    test "defaults to unlimited so nothing scales unasked" do
+    test "defaults to unlimited so nothing downscales unasked" do
       put_cap(nil)
 
-      assert filter(video_codec: "libx264") == nil
+      # No ceiling still emits the evening filter, which cannot reduce a
+      # resolution — only round an odd height down by one line. "Unlimited"
+      # is about the ceiling, not about whether a filter exists.
+      assert filter(video_codec: "libx264") == "scale=-2:2*trunc(ih/2)"
     end
   end
 

--- a/test/mydia/streaming/ffmpeg_scale_cap_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_cap_test.exs
@@ -1,0 +1,59 @@
+defmodule Mydia.Streaming.FfmpegScaleCapTest do
+  # async: false and an explicit restore: this mutates application env, which
+  # is global. A concurrent test reading :streaming config would otherwise see
+  # this file's value and fail nondeterministically.
+  use ExUnit.Case, async: false
+
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+
+  setup do
+    original = Application.get_env(:mydia, :streaming, [])
+    on_exit(fn -> Application.put_env(:mydia, :streaming, original) end)
+    {:ok, original: original}
+  end
+
+  defp put_cap(original, value) do
+    Application.put_env(
+      :mydia,
+      :streaming,
+      Keyword.put(original, :max_transcode_height, value)
+    )
+  end
+
+  defp filter(opts) do
+    args = FfmpegHlsTranscoder.build_ffmpeg_args("/tmp/in.mkv", "/tmp/out", opts)
+    index = Enum.find_index(args, &(&1 == "-vf"))
+    if index, do: Enum.at(args, index + 1), else: nil
+  end
+
+  describe "max_transcode_height configuration" do
+    test "applies the configured ceiling when no height was requested",
+         %{original: original} do
+      put_cap(original, 1080)
+
+      assert filter(video_codec: "libx264") == "scale=-2:min(1080\\,ih)"
+    end
+
+    test "takes the lower of the request and the ceiling",
+         %{original: original} do
+      put_cap(original, 720)
+
+      assert filter(video_codec: "libx264", max_height: 1080) ==
+               "scale=-2:min(720\\,ih)"
+    end
+
+    test "honours a request below the ceiling", %{original: original} do
+      put_cap(original, 1080)
+
+      assert filter(video_codec: "libx264", max_height: 480) ==
+               "scale=-2:min(480\\,ih)"
+    end
+
+    test "defaults to unlimited so nothing scales unasked",
+         %{original: original} do
+      put_cap(original, nil)
+
+      assert filter(video_codec: "libx264") == nil
+    end
+  end
+end

--- a/test/mydia/streaming/ffmpeg_scale_cap_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_cap_test.exs
@@ -31,7 +31,7 @@ defmodule Mydia.Streaming.FfmpegScaleCapTest do
          %{original: original} do
       put_cap(original, 1080)
 
-      assert filter(video_codec: "libx264") == "scale=-2:min(1080\\,ih)"
+      assert filter(video_codec: "libx264") == "scale=-2:2*trunc(min(1080\\,ih)/2)"
     end
 
     test "takes the lower of the request and the ceiling",
@@ -39,14 +39,14 @@ defmodule Mydia.Streaming.FfmpegScaleCapTest do
       put_cap(original, 720)
 
       assert filter(video_codec: "libx264", max_height: 1080) ==
-               "scale=-2:min(720\\,ih)"
+               "scale=-2:2*trunc(min(720\\,ih)/2)"
     end
 
     test "honours a request below the ceiling", %{original: original} do
       put_cap(original, 1080)
 
       assert filter(video_codec: "libx264", max_height: 480) ==
-               "scale=-2:min(480\\,ih)"
+               "scale=-2:2*trunc(min(480\\,ih)/2)"
     end
 
     test "defaults to unlimited so nothing scales unasked",

--- a/test/mydia/streaming/ffmpeg_scale_cap_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_cap_test.exs
@@ -1,23 +1,35 @@
 defmodule Mydia.Streaming.FfmpegScaleCapTest do
-  # async: false and an explicit restore: this mutates application env, which
-  # is global. A concurrent test reading :streaming config would otherwise see
+  # async: false and an explicit restore: this mutates the cached runtime
+  # config, which is global. A concurrent test reading it would otherwise see
   # this file's value and fail nondeterministically.
   use ExUnit.Case, async: false
 
   alias Mydia.Streaming.FfmpegHlsTranscoder
 
   setup do
-    original = Application.get_env(:mydia, :streaming, [])
-    on_exit(fn -> Application.put_env(:mydia, :streaming, original) end)
-    {:ok, original: original}
+    original = Application.get_env(:mydia, :runtime_config)
+
+    on_exit(fn ->
+      if original do
+        Application.put_env(:mydia, :runtime_config, original)
+      else
+        Application.delete_env(:mydia, :runtime_config)
+      end
+    end)
+
+    :ok
   end
 
-  defp put_cap(original, value) do
-    Application.put_env(
-      :mydia,
-      :streaming,
-      Keyword.put(original, :max_transcode_height, value)
-    )
+  # Overrides only the :streaming embed of the layered runtime config
+  # (Mydia.Config.get().streaming), which is what effective_max_height/1
+  # reads. Writing the old flat Application.put_env(:mydia, :streaming, ...)
+  # key here would be silently ignored — and that flat key is exactly what
+  # made this setting unreachable to an operator, since config/config.exs is
+  # compile-time and baked into the release.
+  defp put_cap(value) do
+    defaults = Mydia.Config.Schema.defaults()
+    streaming = %{defaults.streaming | max_transcode_height: value}
+    Application.put_env(:mydia, :runtime_config, %{defaults | streaming: streaming})
   end
 
   defp filter(opts) do
@@ -27,33 +39,50 @@ defmodule Mydia.Streaming.FfmpegScaleCapTest do
   end
 
   describe "max_transcode_height configuration" do
-    test "applies the configured ceiling when no height was requested",
-         %{original: original} do
-      put_cap(original, 1080)
+    test "applies the configured ceiling when no height was requested" do
+      put_cap(1080)
 
       assert filter(video_codec: "libx264") == "scale=-2:2*trunc(min(1080\\,ih)/2)"
     end
 
-    test "takes the lower of the request and the ceiling",
-         %{original: original} do
-      put_cap(original, 720)
+    test "takes the lower of the request and the ceiling" do
+      put_cap(720)
 
       assert filter(video_codec: "libx264", max_height: 1080) ==
                "scale=-2:2*trunc(min(720\\,ih)/2)"
     end
 
-    test "honours a request below the ceiling", %{original: original} do
-      put_cap(original, 1080)
+    test "honours a request below the ceiling" do
+      put_cap(1080)
 
       assert filter(video_codec: "libx264", max_height: 480) ==
                "scale=-2:2*trunc(min(480\\,ih)/2)"
     end
 
-    test "defaults to unlimited so nothing scales unasked",
-         %{original: original} do
-      put_cap(original, nil)
+    test "defaults to unlimited so nothing scales unasked" do
+      put_cap(nil)
 
       assert filter(video_codec: "libx264") == nil
+    end
+  end
+
+  describe "effective_max_height/1" do
+    test "is the single source both the filter and the GraphQL echo derive from" do
+      # The resolver composes through this same function so a server with a
+      # ceiling set cannot tell a client "Original" while really scaling. If
+      # this ever goes private again, that echo silently starts lying.
+      put_cap(720)
+
+      assert FfmpegHlsTranscoder.effective_max_height(nil) == 720
+      assert FfmpegHlsTranscoder.effective_max_height(1080) == 720
+      assert FfmpegHlsTranscoder.effective_max_height(480) == 480
+    end
+
+    test "leaves the request alone when no ceiling is configured" do
+      put_cap(nil)
+
+      assert FfmpegHlsTranscoder.effective_max_height(nil) == nil
+      assert FfmpegHlsTranscoder.effective_max_height(720) == 720
     end
   end
 end

--- a/test/mydia/streaming/ffmpeg_scale_live_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_live_test.exs
@@ -1,0 +1,155 @@
+defmodule Mydia.Streaming.FfmpegScaleLiveTest do
+  # Runs the scale filter the transcoder actually emits through a real FFmpeg.
+  #
+  # Every other test in this directory asserts on the argument *string*, which
+  # is why a filter that FFmpeg rejects outright reached a final review: a
+  # source shorter than the cap passes its own height through the clamp
+  # untouched, and an odd height there makes libx264 with -pix_fmt yuv420p
+  # refuse to open the encoder. No playlist is ever written, so the client's
+  # playlist wait times out and the viewer sees a generic playback error with
+  # nothing in it that points at the filter.
+  #
+  # Tagged :requires_ffmpeg, which test_helper.exs deliberately does NOT
+  # exclude — this is meant to run.
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.ThumbnailGenerator
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+
+  @moduletag :requires_ffmpeg
+
+  # The filter exactly as the transcoder builds it, not a copy of it. A test
+  # that hardcoded the string would keep passing after the transcoder drifted.
+  defp emitted_filter(max_height) do
+    args =
+      FfmpegHlsTranscoder.build_ffmpeg_args(
+        "/tmp/unused-input.mkv",
+        "/tmp/unused-output",
+        video_codec: "libx264",
+        max_height: max_height
+      )
+
+    index = Enum.find_index(args, &(&1 == "-vf"))
+    refute is_nil(index), "expected a -vf filter for max_height #{max_height}"
+    Enum.at(args, index + 1)
+  end
+
+  # Encodes one frame of a synthetic source through the filter, exactly as
+  # production does: a bare argument list handed to a port, no shell.
+  defp encode(source_size, max_height) do
+    output =
+      Path.join(
+        System.tmp_dir!(),
+        "mydia_scale_#{source_size}_#{max_height}_#{:rand.uniform(1_000_000)}.mp4"
+      )
+
+    on_exit(fn -> File.rm(output) end)
+
+    {out, status} =
+      System.cmd(
+        "ffmpeg",
+        [
+          "-hide_banner",
+          "-loglevel",
+          "error",
+          "-f",
+          "lavfi",
+          "-i",
+          "testsrc=size=#{source_size}:rate=30:duration=0.2",
+          "-frames:v",
+          "1",
+          "-c:v",
+          "libx264",
+          "-pix_fmt",
+          "yuv420p",
+          "-vf",
+          emitted_filter(max_height),
+          "-y",
+          output
+        ],
+        stderr_to_stdout: true
+      )
+
+    {status, out, output}
+  end
+
+  defp dimensions(path) do
+    {out, 0} =
+      System.cmd(
+        "ffprobe",
+        [
+          "-v",
+          "error",
+          "-select_streams",
+          "v:0",
+          "-show_entries",
+          "stream=width,height",
+          "-of",
+          "csv=p=0",
+          path
+        ],
+        stderr_to_stdout: true
+      )
+
+    out |> String.trim() |> String.split(",") |> Enum.map(&String.to_integer/1)
+  end
+
+  defp assert_encodes(source_size, max_height) do
+    {status, out, output} = encode(source_size, max_height)
+
+    assert status == 0,
+           "ffmpeg refused #{source_size} at a #{max_height} cap:\n#{out}"
+
+    dimensions(output)
+  end
+
+  describe "the emitted scale filter, through FFmpeg" do
+    @tag :requires_ffmpeg
+    test "encodes an odd-height source that is shorter than the cap" do
+      if ThumbnailGenerator.ffmpeg_available?() do
+        # The regression case. 405 is below the 720 ceiling, so the clamp
+        # returns it unchanged and libx264 sees an odd height. Both dimensions
+        # come back even, and the width tracks the rounded height rather than
+        # staying at 640, which is what keeps the aspect ratio.
+        assert assert_encodes("640x405", 720) == [638, 404]
+      else
+        IO.puts("Skipping test: FFmpeg not available")
+        assert true
+      end
+    end
+
+    @tag :requires_ffmpeg
+    test "downscales a wider-than-16:9 source to the cap without distorting it" do
+      if ThumbnailGenerator.ffmpeg_available?() do
+        # 1920x804 is 2.39:1. The old `-s 1280x720` squished this; the filter
+        # keeps the aspect ratio and lands on the cap exactly.
+        assert assert_encodes("1920x804", 720) == [1720, 720]
+      else
+        IO.puts("Skipping test: FFmpeg not available")
+        assert true
+      end
+    end
+
+    @tag :requires_ffmpeg
+    test "leaves a source below the cap at its own size" do
+      if ThumbnailGenerator.ffmpeg_available?() do
+        assert assert_encodes("640x480", 1080) == [640, 480]
+      else
+        IO.puts("Skipping test: FFmpeg not available")
+        assert true
+      end
+    end
+
+    @tag :requires_ffmpeg
+    test "rounds an odd source height down rather than up" do
+      if ThumbnailGenerator.ffmpeg_available?() do
+        # 1079 -> 1078, never 1080: rounding up would upscale by a line, which
+        # the no-upscale clamp exists to prevent.
+        assert assert_encodes("1920x1079", 1080) == [1918, 1078]
+      else
+        IO.puts("Skipping test: FFmpeg not available")
+        assert true
+      end
+    end
+  end
+end

--- a/test/mydia/streaming/ffmpeg_scale_live_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_live_test.exs
@@ -2,24 +2,44 @@ defmodule Mydia.Streaming.FfmpegScaleLiveTest do
   # Runs the scale filter the transcoder actually emits through a real FFmpeg.
   #
   # Every other test in this directory asserts on the argument *string*, which
-  # is why a filter that FFmpeg rejects outright reached a final review: a
-  # source shorter than the cap passes its own height through the clamp
-  # untouched, and an odd height there makes libx264 with -pix_fmt yuv420p
-  # refuse to open the encoder. No playlist is ever written, so the client's
-  # playlist wait times out and the viewer sees a generic playback error with
-  # nothing in it that points at the filter.
+  # is why a filter FFmpeg rejects outright reached a final review twice. Both
+  # escapes were the same mechanism: an odd frame height reaching libx264 with
+  # -pix_fmt yuv420p, which refuses to open the encoder ("height not divisible
+  # by 2", exit 187). No playlist is ever written, so the client's playlist
+  # wait times out and the viewer sees a generic playback error with nothing
+  # in it that points at the filter.
+  #
+  # The two ways an odd height gets there:
+  #   * under a cap, when the source is shorter than it and the clamp returns
+  #     `ih` untouched;
+  #   * with no cap at all, which used to emit no filter whatsoever. That is
+  #     the default path — direct connection, Original rung, no configured
+  #     ceiling — so it is the one that matters most.
   #
   # Tagged :requires_ffmpeg, which test_helper.exs deliberately does NOT
-  # exclude — this is meant to run.
+  # exclude: this is meant to run. On a host genuinely without FFmpeg the
+  # whole module skips (reported as skipped, never as passed) — run with
+  # `--exclude requires_ffmpeg` to leave it out on purpose.
   use ExUnit.Case, async: true
 
-  alias Mydia.Library.ThumbnailGenerator
   alias Mydia.Streaming.FfmpegHlsTranscoder
 
   @moduletag :requires_ffmpeg
 
+  # A real ExUnit skip rather than an `if available? do ... else assert true`
+  # branch. The branch shape reports green on a host with no FFmpeg, which for
+  # a test whose entire value is "FFmpeg accepted this argument" is the worst
+  # possible outcome: it looks like coverage and is not.
+  if is_nil(System.find_executable("ffmpeg")) or
+       is_nil(System.find_executable("ffprobe")) do
+    @moduletag skip: "ffmpeg/ffprobe not found on PATH"
+  end
+
   # The filter exactly as the transcoder builds it, not a copy of it. A test
   # that hardcoded the string would keep passing after the transcoder drifted.
+  #
+  # `max_height: nil` is a real case, not a degenerate one: it is what an
+  # uncapped session passes, and it must still produce a filter.
   defp emitted_filter(max_height) do
     args =
       FfmpegHlsTranscoder.build_ffmpeg_args(
@@ -30,12 +50,15 @@ defmodule Mydia.Streaming.FfmpegScaleLiveTest do
       )
 
     index = Enum.find_index(args, &(&1 == "-vf"))
-    refute is_nil(index), "expected a -vf filter for max_height #{max_height}"
+
+    assert index, "the transcoder emitted no -vf filter for max_height #{inspect(max_height)}"
+
     Enum.at(args, index + 1)
   end
 
-  # Encodes one frame of a synthetic source through the filter, exactly as
-  # production does: a bare argument list handed to a port, no shell.
+  # Encodes one frame of a synthetic source through the filter, with the same
+  # encoder settings production uses (ffmpeg_hls_transcoder.ex:511-524) and the
+  # same delivery: a bare argument list handed to a port, no shell.
   defp encode(source_size, max_height) do
     output =
       Path.join(
@@ -62,6 +85,8 @@ defmodule Mydia.Streaming.FfmpegScaleLiveTest do
           "libx264",
           "-pix_fmt",
           "yuv420p",
+          "-profile:v",
+          "high",
           "-vf",
           emitted_filter(max_height),
           "-y",
@@ -74,7 +99,7 @@ defmodule Mydia.Streaming.FfmpegScaleLiveTest do
   end
 
   defp dimensions(path) do
-    {out, 0} =
+    {out, status} =
       System.cmd(
         "ffprobe",
         [
@@ -91,6 +116,10 @@ defmodule Mydia.Streaming.FfmpegScaleLiveTest do
         stderr_to_stdout: true
       )
 
+    # Asserted rather than pattern-matched: a MatchError here reports as a
+    # crash in the helper and buries ffprobe's own explanation.
+    assert status == 0, "ffprobe failed on #{path}:\n#{out}"
+
     out |> String.trim() |> String.split(",") |> Enum.map(&String.to_integer/1)
   end
 
@@ -98,58 +127,61 @@ defmodule Mydia.Streaming.FfmpegScaleLiveTest do
     {status, out, output} = encode(source_size, max_height)
 
     assert status == 0,
-           "ffmpeg refused #{source_size} at a #{max_height} cap:\n#{out}"
+           "ffmpeg refused #{source_size} at #{inspect(max_height)}:\n#{out}"
 
     dimensions(output)
   end
 
   describe "the emitted scale filter, through FFmpeg" do
     @tag :requires_ffmpeg
+    test "encodes an odd-height source with no cap at all" do
+      # The default path: no rung chosen, no relay clamp, no configured
+      # ceiling. Emitting no filter here is what the old `-s 1280x720` used to
+      # make impossible by accident, and removing that hardcoded geometry took
+      # the accidental evening with it. 405 -> 404, and the width follows.
+      assert assert_encodes("640x405", nil) == [638, 404]
+    end
+
+    @tag :requires_ffmpeg
+    test "encodes an ordinary odd-height rip with no cap" do
+      # 848x477 is a common SD rip shape. Same failure, no exotic source
+      # needed to reach it.
+      assert assert_encodes("848x477", nil) == [846, 476]
+    end
+
+    @tag :requires_ffmpeg
+    test "leaves an even source untouched when there is no cap" do
+      # The uncapped filter must not be a downscale in disguise: an even
+      # source has to come back at exactly its own size.
+      assert assert_encodes("1920x1080", nil) == [1920, 1080]
+    end
+
+    @tag :requires_ffmpeg
     test "encodes an odd-height source that is shorter than the cap" do
-      if ThumbnailGenerator.ffmpeg_available?() do
-        # The regression case. 405 is below the 720 ceiling, so the clamp
-        # returns it unchanged and libx264 sees an odd height. Both dimensions
-        # come back even, and the width tracks the rounded height rather than
-        # staying at 640, which is what keeps the aspect ratio.
-        assert assert_encodes("640x405", 720) == [638, 404]
-      else
-        IO.puts("Skipping test: FFmpeg not available")
-        assert true
-      end
+      # 405 is below the 720 ceiling, so the clamp returns it unchanged and
+      # libx264 sees an odd height. Both dimensions come back even, and the
+      # width tracks the rounded height rather than staying at 640, which is
+      # what keeps the aspect ratio.
+      assert assert_encodes("640x405", 720) == [638, 404]
     end
 
     @tag :requires_ffmpeg
     test "downscales a wider-than-16:9 source to the cap without distorting it" do
-      if ThumbnailGenerator.ffmpeg_available?() do
-        # 1920x804 is 2.39:1. The old `-s 1280x720` squished this; the filter
-        # keeps the aspect ratio and lands on the cap exactly.
-        assert assert_encodes("1920x804", 720) == [1720, 720]
-      else
-        IO.puts("Skipping test: FFmpeg not available")
-        assert true
-      end
+      # 1920x804 is 2.39:1. The old `-s 1280x720` squished this; the filter
+      # keeps the aspect ratio and lands on the cap exactly.
+      assert assert_encodes("1920x804", 720) == [1720, 720]
     end
 
     @tag :requires_ffmpeg
     test "leaves a source below the cap at its own size" do
-      if ThumbnailGenerator.ffmpeg_available?() do
-        assert assert_encodes("640x480", 1080) == [640, 480]
-      else
-        IO.puts("Skipping test: FFmpeg not available")
-        assert true
-      end
+      assert assert_encodes("640x480", 1080) == [640, 480]
     end
 
     @tag :requires_ffmpeg
     test "rounds an odd source height down rather than up" do
-      if ThumbnailGenerator.ffmpeg_available?() do
-        # 1079 -> 1078, never 1080: rounding up would upscale by a line, which
-        # the no-upscale clamp exists to prevent.
-        assert assert_encodes("1920x1079", 1080) == [1918, 1078]
-      else
-        IO.puts("Skipping test: FFmpeg not available")
-        assert true
-      end
+      # 1079 -> 1078, never 1080: rounding up would upscale by a line, which
+      # the no-upscale clamp exists to prevent.
+      assert assert_encodes("1920x1079", 1080) == [1918, 1078]
     end
   end
 end

--- a/test/mydia/streaming/ffmpeg_scale_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_test.exs
@@ -1,0 +1,59 @@
+defmodule Mydia.Streaming.FfmpegScaleTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+
+  defp args(opts) do
+    FfmpegHlsTranscoder.build_ffmpeg_args("/tmp/in.mkv", "/tmp/out", opts)
+  end
+
+  defp index_of(args, value), do: Enum.find_index(args, &(&1 == value))
+
+  defp filter(args), do: Enum.at(args, index_of(args, "-vf") + 1)
+
+  describe "build_ffmpeg_args/3 scaling" do
+    test "emits no scale filter when no height is requested" do
+      # Native resolution is the correct default: a forced transcode caused by
+      # an incompatible codec should not also silently downgrade resolution.
+      refute "-vf" in args(video_codec: "libx264")
+    end
+
+    test "never emits the old fixed -s geometry" do
+      # -s forces exact dimensions with no aspect handling, which squishes
+      # anything that is not 16:9. It must not come back.
+      refute "-s" in args(video_codec: "libx264", max_height: 720)
+    end
+
+    test "emits an aspect-preserving scale filter for a requested height" do
+      assert filter(args(video_codec: "libx264", max_height: 720)) ==
+               "scale=-2:min(720\\,ih)"
+    end
+
+    test "escapes the comma rather than shell-quoting the expression" do
+      # Arguments go to a port with no shell, so a shell-quoted
+      # 'min(1080,ih)' arrives with its quotes intact and fails to parse.
+      # FFmpeg reads a bare comma as a filter separator, so it must be
+      # backslash-escaped instead.
+      result = filter(args(video_codec: "libx264", max_height: 1080))
+
+      assert result == "scale=-2:min(1080\\,ih)"
+      refute String.contains?(result, "'")
+    end
+
+    test "clamps rather than upscales, via min() against the input height" do
+      # A 480p source with the 1080p rung selected must stay 480p. The clamp
+      # lives in the filter itself so the transcoder needs no probe.
+      assert filter(args(video_codec: "libx264", max_height: 1080)) =~ "ih"
+    end
+
+    test "emits no scale filter on a stream-copy path" do
+      # There is no decoded frame to scale when the video stream is copied.
+      refute "-vf" in args(video_codec: "copy", max_height: 720)
+    end
+
+    test "still ends with the playlist path" do
+      assert List.last(args(video_codec: "libx264", max_height: 720)) ==
+               "/tmp/out/index.m3u8"
+    end
+  end
+end

--- a/test/mydia/streaming/ffmpeg_scale_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_test.exs
@@ -1,6 +1,8 @@
 defmodule Mydia.Streaming.FfmpegScaleTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Mydia.Streaming.FfmpegHlsTranscoder
 
   defp args(opts) do
@@ -26,7 +28,7 @@ defmodule Mydia.Streaming.FfmpegScaleTest do
 
     test "emits an aspect-preserving scale filter for a requested height" do
       assert filter(args(video_codec: "libx264", max_height: 720)) ==
-               "scale=-2:min(720\\,ih)"
+               "scale=-2:2*trunc(min(720\\,ih)/2)"
     end
 
     test "escapes the comma rather than shell-quoting the expression" do
@@ -36,8 +38,32 @@ defmodule Mydia.Streaming.FfmpegScaleTest do
       # backslash-escaped instead.
       result = filter(args(video_codec: "libx264", max_height: 1080))
 
-      assert result == "scale=-2:min(1080\\,ih)"
+      assert result == "scale=-2:2*trunc(min(1080\\,ih)/2)"
       refute String.contains?(result, "'")
+    end
+
+    test "rounds the clamped height down to an even number" do
+      # The clamp returns `ih` untouched whenever the source is shorter than
+      # the cap, so an odd-height source reaches libx264 as-is. With
+      # -pix_fmt yuv420p that fails to open the encoder outright, killing the
+      # transcode before a playlist exists — see ffmpeg_scale_live_test.exs,
+      # which runs this exact filter through FFmpeg.
+      assert filter(args(video_codec: "libx264", max_height: 720)) =~ "2*trunc("
+    end
+
+    test "ignores a non-positive height rather than scaling to nothing" do
+      # Only reachable through a misconfigured streaming.max_transcode_height;
+      # the config schema rejects it, but a stale cached runtime config could
+      # still carry one. Silently encoding at native resolution would leave
+      # the operator wondering why their ceiling does nothing, so it logs.
+      log =
+        capture_log(fn ->
+          refute "-vf" in args(video_codec: "libx264", max_height: 0)
+          refute "-vf" in args(video_codec: "libx264", max_height: -720)
+        end)
+
+      assert log =~ "non-positive transcode height ceiling (0)"
+      assert log =~ "non-positive transcode height ceiling (-720)"
     end
 
     test "clamps rather than upscales, via min() against the input height" do

--- a/test/mydia/streaming/ffmpeg_scale_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_test.exs
@@ -14,10 +14,25 @@ defmodule Mydia.Streaming.FfmpegScaleTest do
   defp filter(args), do: Enum.at(args, index_of(args, "-vf") + 1)
 
   describe "build_ffmpeg_args/3 scaling" do
-    test "emits no scale filter when no height is requested" do
+    test "still evens the height when no ceiling is requested" do
       # Native resolution is the correct default: a forced transcode caused by
       # an incompatible codec should not also silently downgrade resolution.
-      refute "-vf" in args(video_codec: "libx264")
+      # But "no ceiling" cannot mean "no filter": an odd source height then
+      # reaches libx264 untouched and kills the encode. This is the DEFAULT
+      # path — direct connection, Original rung, no configured ceiling — so it
+      # is the one most worth pinning.
+      assert filter(args(video_codec: "libx264")) == "scale=-2:2*trunc(ih/2)"
+    end
+
+    test "the uncapped filter cannot downscale" do
+      # `2*trunc(ih/2)` is at most `ih` and never below `ih - 1`, so the only
+      # thing it can do to an even source is nothing at all. Anything that
+      # clamped here would be a silent resolution downgrade on every
+      # transcode, which is the behaviour this branch exists to remove.
+      result = filter(args(video_codec: "libx264"))
+
+      refute String.contains?(result, "min(")
+      refute result =~ ~r/\d{3,}/
     end
 
     test "never emits the old fixed -s geometry" do
@@ -51,15 +66,20 @@ defmodule Mydia.Streaming.FfmpegScaleTest do
       assert filter(args(video_codec: "libx264", max_height: 720)) =~ "2*trunc("
     end
 
-    test "ignores a non-positive height rather than scaling to nothing" do
+    test "ignores a non-positive ceiling but still evens the height" do
       # Only reachable through a misconfigured streaming.max_transcode_height;
       # the config schema rejects it, but a stale cached runtime config could
-      # still carry one. Silently encoding at native resolution would leave
-      # the operator wondering why their ceiling does nothing, so it logs.
+      # still carry one. Silently ignoring it would leave the operator
+      # wondering why their ceiling does nothing, so it logs — and the encode
+      # still gets the evening filter, since a bad ceiling is no reason to
+      # hand libx264 an odd height.
       log =
         capture_log(fn ->
-          refute "-vf" in args(video_codec: "libx264", max_height: 0)
-          refute "-vf" in args(video_codec: "libx264", max_height: -720)
+          assert filter(args(video_codec: "libx264", max_height: 0)) ==
+                   "scale=-2:2*trunc(ih/2)"
+
+          assert filter(args(video_codec: "libx264", max_height: -720)) ==
+                   "scale=-2:2*trunc(ih/2)"
         end)
 
       assert log =~ "non-positive transcode height ceiling (0)"

--- a/test/mydia/streaming/hls_session_offset_test.exs
+++ b/test/mydia/streaming/hls_session_offset_test.exs
@@ -3,20 +3,62 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
 
   alias Mydia.Streaming.HlsSessionSupervisor
 
-  describe "session_matches_offset?/2" do
-    test "matches when the requested offset equals the running one" do
-      assert HlsSessionSupervisor.session_matches_offset?(%{start_position: 600}, 600)
+  describe "session_matches?/4" do
+    test "matches when offset and both quality values are equal" do
+      assert HlsSessionSupervisor.session_matches?(
+               %{start_position: 600, max_bitrate: 4000, max_height: 720},
+               600,
+               4000,
+               720
+             )
     end
 
     test "does not match a different offset" do
-      refute HlsSessionSupervisor.session_matches_offset?(%{start_position: 0}, 4200)
+      refute HlsSessionSupervisor.session_matches?(
+               %{start_position: 0, max_bitrate: nil, max_height: nil},
+               4200,
+               nil,
+               nil
+             )
     end
 
-    test "treats metadata with no start_position as offset zero" do
-      # Registry metadata is in-memory, but a session registered before this
-      # field existed must not be mistaken for an offset session.
-      assert HlsSessionSupervisor.session_matches_offset?(%{mode: :transcode}, 0)
-      refute HlsSessionSupervisor.session_matches_offset?(%{mode: :transcode}, 4200)
+    test "does not match a different bitrate at the same offset" do
+      # This is the whole point of widening the match: without it, picking a
+      # new rung hands back the session already running at the old one.
+      refute HlsSessionSupervisor.session_matches?(
+               %{start_position: 600, max_bitrate: 4000, max_height: 720},
+               600,
+               1500,
+               720
+             )
+    end
+
+    test "does not match a different height at the same offset and bitrate" do
+      refute HlsSessionSupervisor.session_matches?(
+               %{start_position: 600, max_bitrate: 4000, max_height: 720},
+               600,
+               4000,
+               480
+             )
+    end
+
+    test "treats metadata missing the new keys as an uncapped session" do
+      # Registry metadata is in-memory, but a session registered before these
+      # fields existed must not be mistaken for a capped one, nor treated as
+      # a wildcard that matches every request.
+      assert HlsSessionSupervisor.session_matches?(%{mode: :transcode}, 0, nil, nil)
+      refute HlsSessionSupervisor.session_matches?(%{mode: :transcode}, 0, 4000, 720)
+      refute HlsSessionSupervisor.session_matches?(%{mode: :transcode}, 4200, nil, nil)
+    end
+
+    test "matches an explicitly uncapped session against an uncapped request" do
+      # Original quality: no cap on either side.
+      assert HlsSessionSupervisor.session_matches?(
+               %{start_position: 0, max_bitrate: nil, max_height: nil},
+               0,
+               nil,
+               nil
+             )
     end
   end
 

--- a/test/mydia_web/live/admin_settings_live_test.exs
+++ b/test/mydia_web/live/admin_settings_live_test.exs
@@ -153,6 +153,29 @@ defmodule MydiaWeb.AdminSettingsLiveTest do
       assert setting.value == "720"
       assert setting.category == :streaming
     end
+
+    test "blurring an unchanged field writes nothing", %{view: view} do
+      # `phx-blur` fires on every blur, including one that only tabbed through.
+      # A write there would pin the currently displayed value — which may come
+      # from YAML or a schema default — into the database overlay, flipping the
+      # provenance badge to DB and shadowing that key from every later YAML or
+      # default change.
+      html =
+        view
+        |> element("input[phx-value-key='server.host']")
+        |> render_blur(%{"value" => "0.0.0.0"})
+
+      refute html =~ "Setting updated successfully"
+      assert Settings.get_config_setting_by_key("server.host") == nil
+    end
+
+    test "blurring a changed field still writes", %{view: view} do
+      view
+      |> element("input[phx-value-key='server.host']")
+      |> render_blur(%{"value" => "127.0.0.1"})
+
+      assert Settings.get_config_setting_by_key("server.host").value == "127.0.0.1"
+    end
   end
 
   describe "Crash report widget" do

--- a/test/mydia_web/live/admin_settings_live_test.exs
+++ b/test/mydia_web/live/admin_settings_live_test.exs
@@ -126,6 +126,33 @@ defmodule MydiaWeb.AdminSettingsLiveTest do
       refute html =~ "FlareSolverr"
       refute has_element?(view, "input[phx-value-key='flaresolverr.url']")
     end
+
+    test "offers the transcode height ceiling", %{view: view} do
+      # The escape hatch for an operator whose hardware cannot encode a 4K
+      # file in realtime. It shipped once as a compile-time key in
+      # config/config.exs, reachable only by rebuilding the image.
+      assert has_element?(
+               view,
+               "input[phx-value-key='streaming.max_transcode_height']"
+             )
+    end
+
+    test "persists a typed setting instead of crashing on blur", %{view: view} do
+      # `phx-blur` sends the element's value and its phx-value-* metadata, not
+      # a `settings` map. Every typed setting in this screen used to raise
+      # FunctionClauseError here, which left the database layer reachable for
+      # toggles but not for anything an operator types.
+      html =
+        view
+        |> element("input[phx-value-key='streaming.max_transcode_height']")
+        |> render_blur(%{"value" => "720"})
+
+      assert html =~ "Setting updated successfully"
+
+      setting = Settings.get_config_setting_by_key("streaming.max_transcode_height")
+      assert setting.value == "720"
+      assert setting.category == :streaming
+    end
   end
 
   describe "Crash report widget" do

--- a/test/mydia_web/schema/streaming_test.exs
+++ b/test/mydia_web/schema/streaming_test.exs
@@ -52,6 +52,16 @@ defmodule MydiaWeb.Schema.StreamingTest do
   }
   """
 
+  @echo_quality_mutation """
+  mutation StartStreamingSession($fileId: ID!, $strategy: StreamingStrategy!) {
+    startStreamingSession(fileId: $fileId, strategy: $strategy) {
+      sessionId
+      maxBitrate
+      maxHeight
+    }
+  }
+  """
+
   describe "startStreamingSession mutation" do
     @tag :tmp_dir
     test "a cold file (analyzed_at: nil) returns a non-nil duration", %{tmp_dir: tmp_dir} do
@@ -110,7 +120,48 @@ defmodule MydiaWeb.Schema.StreamingTest do
         stop_session(session["sessionId"], user)
       end
     end
+
+    @tag :tmp_dir
+    test "echoes the operator's transcode ceiling to a client that asked for nothing",
+         %{tmp_dir: tmp_dir} do
+      # The echo exists to be honest with clients. Composing the ceiling only
+      # inside the transcoder made this reply say "no height cap" while the
+      # encode really did scale, so a viewer on a direct connection saw
+      # "Original" over a downscaled stream.
+      user = AccountsFixtures.user_fixture()
+      media_file = cold_media_file(tmp_dir)
+
+      original = Application.get_env(:mydia, :runtime_config)
+      on_exit(fn -> restore_runtime_config(original) end)
+      put_transcode_ceiling(480)
+
+      result =
+        Absinthe.run(
+          @echo_quality_mutation,
+          MydiaWeb.Schema,
+          variables: %{"fileId" => media_file.id, "strategy" => "TRANSCODE"},
+          context: %{current_user: user}
+        )
+
+      assert {:ok, %{data: %{"startStreamingSession" => session}}} = result
+
+      try do
+        assert session["maxHeight"] == 480
+        assert session["maxBitrate"] == nil
+      after
+        stop_session(session["sessionId"], user)
+      end
+    end
   end
+
+  defp put_transcode_ceiling(height) do
+    defaults = Mydia.Config.Schema.defaults()
+    streaming = %{defaults.streaming | max_transcode_height: height}
+    Application.put_env(:mydia, :runtime_config, %{defaults | streaming: streaming})
+  end
+
+  defp restore_runtime_config(nil), do: Application.delete_env(:mydia, :runtime_config)
+  defp restore_runtime_config(config), do: Application.put_env(:mydia, :runtime_config, config)
 
   # A real, tiny (2s) H.264+AAC file so the cold-file path runs an actual
   # ffprobe and an actual FFmpeg HLS transcode, not a stub. Video+audio
@@ -175,6 +226,14 @@ defmodule MydiaWeb.Schema.StreamingTest do
 
     test "honours a relay request already below the ceiling" do
       assert StreamingResolver.effective_quality("relay", 800, 360) == {800, 360}
+    end
+
+    test "clamps each half of the pair independently" do
+      # The two min/2 calls are separate, so a request that is under the
+      # ceiling on one axis and over it on the other must come back mixed
+      # rather than clamped or passed through wholesale.
+      assert StreamingResolver.effective_quality("relay", 800, 1080) == {800, 720}
+      assert StreamingResolver.effective_quality("relay", 8000, 360) == {2000, 360}
     end
   end
 

--- a/test/mydia_web/schema/streaming_test.exs
+++ b/test/mydia_web/schema/streaming_test.exs
@@ -210,6 +210,24 @@ defmodule MydiaWeb.Schema.StreamingTest do
       assert StreamingResolver.effective_quality(nil, 8000, 1080) == {8000, 1080}
     end
 
+    test "a relay cannot be talked out of its ceiling with a zero height" do
+      # Elixir treats 0 as truthy, so `requested || @cap` does not fall back and
+      # `min(0, 720)` is 0. The transcoder declines to scale to a non-positive
+      # height, so without normalisation a relay client got native resolution
+      # over the very infrastructure the ceiling protects.
+      assert StreamingResolver.effective_quality("relay", 0, 0) == {2000, 720}
+    end
+
+    test "a relay cannot be talked out of its ceiling with a negative height" do
+      assert StreamingResolver.effective_quality("relay", -1, -1) == {2000, 720}
+    end
+
+    test "a non-positive cap on a direct connection reads as no cap" do
+      # Nothing to protect here, but the echo must not report 0 as an applied
+      # ceiling — the client labels its quality control from these values.
+      assert StreamingResolver.effective_quality(nil, 0, 0) == {nil, nil}
+    end
+
     test "leaves an uncapped direct request uncapped" do
       assert StreamingResolver.effective_quality(nil, nil, nil) == {nil, nil}
     end

--- a/test/mydia_web/schema/streaming_test.exs
+++ b/test/mydia_web/schema/streaming_test.exs
@@ -22,6 +22,7 @@ defmodule MydiaWeb.Schema.StreamingTest do
   alias Mydia.AccountsFixtures
   alias Mydia.MediaFixtures
   alias Mydia.SettingsFixtures
+  alias MydiaWeb.Schema.Resolvers.StreamingResolver
 
   @moduletag :requires_ffmpeg
 
@@ -151,6 +152,30 @@ defmodule MydiaWeb.Schema.StreamingTest do
       # these tests override that on purpose.
       analyzed_at: nil
     })
+  end
+
+  describe "start_streaming_session quality clamping" do
+    test "passes a direct connection's requested values through unchanged" do
+      assert StreamingResolver.effective_quality(nil, 8000, 1080) == {8000, 1080}
+    end
+
+    test "leaves an uncapped direct request uncapped" do
+      assert StreamingResolver.effective_quality(nil, nil, nil) == {nil, nil}
+    end
+
+    test "clamps a relay connection to the relay ceiling" do
+      # A relay carries the stream through Mydia's own infrastructure, so the
+      # cap is not negotiable by the client.
+      assert StreamingResolver.effective_quality("relay", 8000, 1080) == {2000, 720}
+    end
+
+    test "caps an uncapped relay request rather than letting it run free" do
+      assert StreamingResolver.effective_quality("relay", nil, nil) == {2000, 720}
+    end
+
+    test "honours a relay request already below the ceiling" do
+      assert StreamingResolver.effective_quality("relay", 800, 360) == {800, 360}
+    end
   end
 
   defp stop_session(session_id, user) do


### PR DESCRIPTION
## What this does

Gives the player a working quality switcher, on every platform, backed by real server-side bitrate and resolution limits.

## Why

The switcher wasn't broken. It never worked.

`player_screen.dart` gated the callback on `PlatformFeatures.isWeb`, so desktop, macOS, Android and iOS never rendered the button at all. On web it was a placebo: it set a state field and popped a snackbar saying "HLS adaptive streaming is handled automatically by the player." There is no adaptive streaming here. `EXT-X-STREAM-INF` appears nowhere in the repo and the transcoder emits a single rendition, so the dialog's "Auto, adapts to your connection" described something that did not exist.

Three separate quality mechanisms had accumulated, none connected to another:

- the placebo dialog
- a `default_quality` preference persisted to secure storage that nothing read or surfaced
- a working `maxBitrate` GraphQL argument the player declared in its mutation document and never passed

Two live defects sat underneath. Every forced transcode emitted `-s 1280x720` with no aspect handling, so a 2.39:1 film or a 4:3 show came out geometrically squished. And `session_matches_offset?/2` compared only playback position, so asking for a different bitrate returned the session already running at the old one.

## What changed

**Server.** The transcoder scales with an aspect-preserving filter instead of forcing exact dimensions, and never upscales. `startStreamingSession` accepts `maxHeight` alongside `maxBitrate` and echoes back the values it actually applied, so a relay-clamped viewer can be told the truth rather than shown their own request. Session matching compares position plus both caps, so a rung change replaces the session rather than reusing it. A `max_transcode_height` ceiling is available to operators through the layered config (YAML, env, DB overlay, admin UI).

**Player.** A ladder derived from the source height, so a 720p file never offers 1080p. Picking a rung persists it and restarts the session at the current position through the existing `_restartSessionAt` path. The control labels itself from the server's echo. A server predating `maxHeight` degrades to a bitrate-only retry once per session instead of failing to play.

**Chrome.** The button couldn't simply be un-gated: a fourth button raised the secondary cluster's floor past what tablet and mobile could fit, and that cluster was already pinned at a zero gap. The transport cluster had never been squeezed, so it went from 256px to 192px, secondary buttons 40 to 32, padding 20/12 to 12/8. Four discrete buttons now fit down to 360px, and desktop gains real 8px gaps instead of cramming at zero.

## Notable during review

A chosen rung now vetoes direct play. Handing the file over untouched leaves no encoder for a cap to act on, so without this the control was inert on native. Original still direct-plays.

The old-server fallback needed a second GraphQL document. Nulling the variable can't work, because Absinthe validates document text — an undeclared argument is an error regardless of what the variables carry.

Removing the hardcoded `-s 1280x720` also removed the accidental evening it performed. libx264 with `yuv420p` refuses an odd frame height, and VP9 and AV1 permit odd heights, so uncapped transcodes of such sources would have failed to open the encoder. Both the capped and uncapped paths now round to an even height, covered by tests that run the filter through real ffmpeg.

Wiring the config ceiling surfaced a pre-existing bug: `phx-blur` on every typed setting in Admin → Configuration raised a `FunctionClauseError`, so the DB overlay worked for toggles but not for anything you type. Fixed here, along with not writing a row when the value hasn't changed.

## Testing

Elixir 6437 tests, 0 failures. Player 1453 tests across 153 of 154 files (`--concurrency=1`; the 154th is a macOS-only golden).

## Before merging

Two things can't be done on Linux and need a human:

- **Regenerate the chrome goldens on macOS.** `chrome_panel_golden_test.dart` is `@TestOn('mac-os')` and its three PNGs still encode pre-compaction geometry. The test now constructs production geometry, so `--update-goldens` will capture the right picture. It won't fail Linux CI, so nothing will stop this merging stale for macOS developers.
- **Eye-verify against a real server.** The rung-change restart has no end-to-end test: the chrome never renders under `flutter_test` (the playlist poll always 400s), so the picker can't be tapped. The decision logic is covered by a `@visibleForTesting` seam and the request path is asserted through `StubLink`, but the tap itself is verified by reading.

## Known follow-ups

- The echo reports a `maxHeight` for `HLS_COPY` sessions where no scaling happens, so a copy session under a ceiling labels as scaled.
- Writing a config setting doesn't refresh the cached runtime config, so a new ceiling takes effect on restart while the provenance badge flips immediately. Pre-existing and shared by every DB-overlay setting.
- `use_build_context_synchronously` doesn't catch post-await `ref` use in a `ConsumerWidget`, so that class of bug is guarded by convention across the repo, not tooling.
- Secondary controls are 32px, under the 44px minimum this repo pins in `control_button_test.dart`, and mobile now carries four of them. A deliberate call, worth a real-device check.
