### PR TITLE
feat: make recently added mean when content arrived, not when the record was created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,9 @@ jobs:
         run: flutter pub run build_runner build
 
       - name: Run tests
-        run: flutter test
+        # --concurrency=1: the default concurrency silently drops 2-4 test
+        # files while still exiting 0, so this is load-bearing, not cosmetic.
+        run: flutter test --concurrency=1
 
   test-e2e:
     name: Test / E2E Browser

--- a/lib/mydia/media/recently_added.ex
+++ b/lib/mydia/media/recently_added.ex
@@ -34,6 +34,11 @@ defmodule Mydia.Media.RecentlyAdded do
   alias Mydia.Media.RecentlyAdded.Entry
   alias Mydia.Repo
 
+  # Keeps a single `:ids` query under both SQLite's 32,766 and PostgreSQL's
+  # 65,535 bind-parameter ceilings with plenty of headroom, regardless of how
+  # many other parameters the same query carries.
+  @id_chunk_size 500
+
   @doc """
   Maps media item id to the time its newest content arrived.
 
@@ -43,7 +48,14 @@ defmodule Mydia.Media.RecentlyAdded do
   Options:
 
     * `:ids` - restrict to these media item ids. An empty list returns `%{}`
-      without hitting the database.
+      without hitting the database. A larger list is chunked into batches of
+      #{@id_chunk_size} and queried separately, with the per-chunk maps
+      merged, so a caller scoping to an entire library (a sort on the media
+      library page, or an unwatched/favorites rail) can never build a single
+      query past a bind-parameter ceiling. Chunking is chosen over dropping
+      the filter on a large list because the filter is what keeps the query
+      cheap: an unfiltered aggregate re-scans and re-groups every media file
+      in the library, which is exactly the cost this option exists to avoid.
   """
   @spec added_at_map(keyword()) :: %{binary() => DateTime.t()}
   def added_at_map(opts \\ [])
@@ -54,7 +66,11 @@ defmodule Mydia.Media.RecentlyAdded do
         %{}
 
       {:ok, ids} ->
-        ids |> item_timestamps_query() |> Repo.all() |> Map.new()
+        ids
+        |> Enum.chunk_every(@id_chunk_size)
+        |> Enum.reduce(%{}, fn chunk, acc ->
+          Map.merge(acc, chunk |> item_timestamps_query() |> Repo.all() |> Map.new())
+        end)
 
       :error ->
         nil |> item_timestamps_query() |> Repo.all() |> Map.new()
@@ -62,14 +78,22 @@ defmodule Mydia.Media.RecentlyAdded do
   end
 
   # One row per (owning item, episode) slot, carrying the slot's earliest file.
-  # Public to this module only; Task 3 reuses it for windowed counts.
+  # Public to this module only.
+  #
+  # `ids`, when given, filters slots to those whose owning item is in the
+  # list. The filter is a `where` on the media_files/episodes join, applied
+  # *before* `group_by`, rather than a filter on the outer aggregate: a caller
+  # that only needs a handful of items (added_at_map/1's per-chunk scoping,
+  # load_latest_episodes/1's lookup for the rail) never pays for grouping the
+  # whole table first and discarding most of the result.
   @doc false
-  @spec slots_query() :: Ecto.Query.t()
-  def slots_query do
+  @spec slots_query([binary()] | nil) :: Ecto.Query.t()
+  def slots_query(ids \\ nil) do
     from f in MediaFile,
       left_join: e in Episode,
       on: f.episode_id == e.id,
       where: not is_nil(e.media_item_id) or not is_nil(f.media_item_id),
+      where: ^id_filter(ids),
       group_by: [coalesce(e.media_item_id, f.media_item_id), f.episode_id],
       select: %{
         media_item_id: coalesce(e.media_item_id, f.media_item_id),
@@ -78,19 +102,29 @@ defmodule Mydia.Media.RecentlyAdded do
       }
   end
 
+  defp id_filter(nil), do: dynamic([f, e], true)
+
+  defp id_filter(ids) do
+    # `coalesce(...) in ^ids` alone leaves Postgrex to guess the comparison's
+    # type from a bare `coalesce/2` expression, which it cannot: it falls back
+    # to `:binary` and then rejects every UUID string with an "expected a
+    # binary of 16 bytes" encode error. Typing the *left* side as `:binary_id`
+    # (the type `media_item_id` already has on both `f` and `e`) lets Ecto
+    # infer the correct encoding for `^ids` from it, on both adapters — SQLite
+    # never needed this (it has no binary UUID representation to get wrong),
+    # but tagging the RHS list directly with `{:array, :binary_id}` instead
+    # breaks *SQLite's* plain `IN (?, ?, ...)` expansion, so the type belongs
+    # on the expression being compared, not the list.
+    dynamic(
+      [f, e],
+      type(coalesce(e.media_item_id, f.media_item_id), :binary_id) in ^ids
+    )
+  end
+
   defp item_timestamps_query(ids) do
-    slots = slots_query()
-
-    query =
-      from s in subquery(slots),
-        group_by: s.media_item_id,
-        select: {s.media_item_id, type(max(s.first_added_at), :utc_datetime)}
-
-    if is_nil(ids) do
-      query
-    else
-      where(query, [s], s.media_item_id in ^ids)
-    end
+    from s in subquery(slots_query(ids)),
+      group_by: s.media_item_id,
+      select: {s.media_item_id, type(max(s.first_added_at), :utc_datetime)}
   end
 
   @doc """
@@ -191,12 +225,13 @@ defmodule Mydia.Media.RecentlyAdded do
   defp load_latest_episodes(rows) do
     ids = Enum.map(rows, & &1.media_item_id)
 
-    slots = slots_query()
-
-    # `subquery/1` returns an %Ecto.SubQuery{}, not a query, so it cannot be
-    # piped into `where/3`. It has to be the source of a `from`.
+    # Filtering inside slots_query/1 means this scan-and-group only ever
+    # touches the handful of items the caller already resolved (the rail's
+    # page, after list_recent/1's :limit), rather than repeating the full
+    # unfiltered aggregate windowed_rows_query/2 already ran.
     newest_episode_ids =
-      from(s in subquery(slots), where: s.media_item_id in ^ids)
+      ids
+      |> slots_query()
       |> Repo.all()
       |> Enum.group_by(& &1.media_item_id)
       |> Map.new(fn {item_id, item_slots} ->

--- a/lib/mydia/media/recently_added.ex
+++ b/lib/mydia/media/recently_added.ex
@@ -1,0 +1,93 @@
+defmodule Mydia.Media.RecentlyAdded do
+  @moduledoc """
+  Derives when an item's *content* arrived, as opposed to when its record was
+  created.
+
+  `media_items.inserted_at` answers "when did I start tracking this", which for
+  a long-running show is years before its newest episode. This module answers
+  "when did I last get something new to watch".
+
+  ## Slots
+
+  Files are grouped into slots: one per episode of a show, one per movie. A
+  slot's timestamp is the *earliest* file in it, counting trashed rows. A
+  quality upgrade inserts a later row into a slot that already has an earlier
+  one, so it cannot move the timestamp. An item's timestamp is the newest of
+  its slots.
+
+  ## Linking
+
+  The two file kinds are linked to their item differently. A movie's file sets
+  `media_item_id` and leaves `episode_id` NULL. An episode's file is the
+  mirror image: `MetadataEnricher` stamps `episode_id` and `media_item_id`
+  stays NULL. Grouping on `media_files.media_item_id` alone therefore yields
+  nothing at all for TV shows, so the owning item is
+  `coalesce(episodes.media_item_id, media_files.media_item_id)` over a left
+  join.
+  """
+
+  import Ecto.Query
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.Episode
+  alias Mydia.Repo
+
+  @doc """
+  Maps media item id to the time its newest content arrived.
+
+  Items with no files are absent rather than nil, so a caller can distinguish
+  "nothing yet" with `Map.get/2` and its own default.
+
+  Options:
+
+    * `:ids` - restrict to these media item ids. An empty list returns `%{}`
+      without hitting the database.
+  """
+  @spec added_at_map(keyword()) :: %{binary() => DateTime.t()}
+  def added_at_map(opts \\ [])
+
+  def added_at_map(opts) do
+    case Keyword.fetch(opts, :ids) do
+      {:ok, []} ->
+        %{}
+
+      {:ok, ids} ->
+        ids |> item_timestamps_query() |> Repo.all() |> Map.new()
+
+      :error ->
+        nil |> item_timestamps_query() |> Repo.all() |> Map.new()
+    end
+  end
+
+  # One row per (owning item, episode) slot, carrying the slot's earliest file.
+  # Public to this module only; Task 3 reuses it for windowed counts.
+  @doc false
+  @spec slots_query() :: Ecto.Query.t()
+  def slots_query do
+    from f in MediaFile,
+      left_join: e in Episode,
+      on: f.episode_id == e.id,
+      where: not is_nil(e.media_item_id) or not is_nil(f.media_item_id),
+      group_by: [coalesce(e.media_item_id, f.media_item_id), f.episode_id],
+      select: %{
+        media_item_id: coalesce(e.media_item_id, f.media_item_id),
+        episode_id: f.episode_id,
+        first_added_at: type(min(f.inserted_at), :utc_datetime)
+      }
+  end
+
+  defp item_timestamps_query(ids) do
+    slots = slots_query()
+
+    query =
+      from s in subquery(slots),
+        group_by: s.media_item_id,
+        select: {s.media_item_id, type(max(s.first_added_at), :utc_datetime)}
+
+    if is_nil(ids) do
+      query
+    else
+      where(query, [s], s.media_item_id in ^ids)
+    end
+  end
+end

--- a/lib/mydia/media/recently_added.ex
+++ b/lib/mydia/media/recently_added.ex
@@ -30,6 +30,8 @@ defmodule Mydia.Media.RecentlyAdded do
 
   alias Mydia.Library.MediaFile
   alias Mydia.Media.Episode
+  alias Mydia.Media.MediaItem
+  alias Mydia.Media.RecentlyAdded.Entry
   alias Mydia.Repo
 
   @doc """
@@ -90,4 +92,128 @@ defmodule Mydia.Media.RecentlyAdded do
       where(query, [s], s.media_item_id in ^ids)
     end
   end
+
+  @doc """
+  Lists items whose content arrived on or after `:since`, newest first.
+
+  Options:
+
+    * `:since` - required `DateTime` cutoff.
+    * `:types` - restrict to these `media_items.type` values.
+    * `:limit` - cap the number of entries.
+
+  Items with no files never appear, since they have no slots.
+  """
+  @spec list_recent(keyword()) :: [Entry.t()]
+  def list_recent(opts) do
+    since = Keyword.fetch!(opts, :since)
+
+    rows =
+      since
+      |> windowed_rows_query(Keyword.get(opts, :types))
+      |> Repo.all()
+
+    rows =
+      case Keyword.get(opts, :limit) do
+        nil -> rows
+        limit -> Enum.take(rows, limit)
+      end
+
+    items = load_items(Enum.map(rows, & &1.media_item_id))
+    latest = load_latest_episodes(rows)
+
+    Enum.flat_map(rows, fn row ->
+      case Map.fetch(items, row.media_item_id) do
+        # An item deleted between the aggregate and the load.
+        :error ->
+          []
+
+        {:ok, item} ->
+          show? = item.type == "tv_show"
+
+          [
+            %Entry{
+              media_item: item,
+              content_added_at: row.content_added_at,
+              new_episode_count: if(show?, do: to_integer(row.new_episode_count)),
+              latest_episode: if(show?, do: Map.get(latest, row.media_item_id))
+            }
+          ]
+      end
+    end)
+  end
+
+  defp windowed_rows_query(since, types) do
+    slots = slots_query()
+
+    query =
+      from s in subquery(slots),
+        group_by: s.media_item_id,
+        having: type(max(s.first_added_at), :utc_datetime) >= ^since,
+        order_by: [desc: type(max(s.first_added_at), :utc_datetime)],
+        select: %{
+          media_item_id: s.media_item_id,
+          content_added_at: type(max(s.first_added_at), :utc_datetime),
+          new_episode_count:
+            sum(fragment("CASE WHEN ? >= ? THEN 1 ELSE 0 END", s.first_added_at, ^since))
+        }
+
+    case types do
+      nil ->
+        query
+
+      [] ->
+        query
+
+      types ->
+        item_ids = from(m in MediaItem, where: m.type in ^types, select: m.id)
+        where(query, [s], s.media_item_id in subquery(item_ids))
+    end
+  end
+
+  defp load_items([]), do: %{}
+
+  defp load_items(ids) do
+    MediaItem
+    |> where([m], m.id in ^ids)
+    |> Repo.all()
+    |> Map.new(&{&1.id, &1})
+  end
+
+  # The newest slot per item, resolved to an episode. Slots whose episode_id is
+  # NULL (unmatched files) contribute a timestamp but no episode to name.
+  defp load_latest_episodes([]), do: %{}
+
+  defp load_latest_episodes(rows) do
+    ids = Enum.map(rows, & &1.media_item_id)
+
+    slots = slots_query()
+
+    # `subquery/1` returns an %Ecto.SubQuery{}, not a query, so it cannot be
+    # piped into `where/3`. It has to be the source of a `from`.
+    newest_episode_ids =
+      from(s in subquery(slots),
+        where: s.media_item_id in ^ids and not is_nil(s.episode_id)
+      )
+      |> Repo.all()
+      |> Enum.group_by(& &1.media_item_id)
+      |> Map.new(fn {item_id, slots} ->
+        {item_id, Enum.max_by(slots, & &1.first_added_at, DateTime).episode_id}
+      end)
+
+    episodes =
+      Episode
+      |> where([e], e.id in ^Map.values(newest_episode_ids))
+      |> Repo.all()
+      |> Map.new(&{&1.id, &1})
+
+    Map.new(newest_episode_ids, fn {item_id, episode_id} ->
+      {item_id, Map.get(episodes, episode_id)}
+    end)
+  end
+
+  # `sum/1` returns a plain integer on SQLite but a `Decimal` on PostgreSQL.
+  # Normalize here so callers always see an integer, regardless of adapter.
+  defp to_integer(%Decimal{} = decimal), do: Decimal.to_integer(decimal)
+  defp to_integer(count) when is_integer(count), do: count
 end

--- a/lib/mydia/media/recently_added.ex
+++ b/lib/mydia/media/recently_added.ex
@@ -144,14 +144,8 @@ defmodule Mydia.Media.RecentlyAdded do
 
     rows =
       since
-      |> windowed_rows_query(Keyword.get(opts, :types))
+      |> windowed_rows_query(Keyword.get(opts, :types), Keyword.get(opts, :limit))
       |> Repo.all()
-
-    rows =
-      case Keyword.get(opts, :limit) do
-        nil -> rows
-        limit -> Enum.take(rows, limit)
-      end
 
     items = load_items(Enum.map(rows, & &1.media_item_id))
     latest = load_latest_episodes(rows)
@@ -177,7 +171,7 @@ defmodule Mydia.Media.RecentlyAdded do
     end)
   end
 
-  defp windowed_rows_query(since, types) do
+  defp windowed_rows_query(since, types, limit) do
     slots = slots_query()
 
     query =
@@ -192,18 +186,29 @@ defmodule Mydia.Media.RecentlyAdded do
             sum(fragment("CASE WHEN ? >= ? THEN 1 ELSE 0 END", s.first_added_at, ^since))
         }
 
-    case types do
-      nil ->
-        query
+    query =
+      case types do
+        nil ->
+          query
 
-      [] ->
-        query
+        [] ->
+          query
 
-      types ->
-        item_ids = from(m in MediaItem, where: m.type in ^types, select: m.id)
-        where(query, [s], s.media_item_id in subquery(item_ids))
-    end
+        types ->
+          item_ids = from(m in MediaItem, where: m.type in ^types, select: m.id)
+          where(query, [s], s.media_item_id in subquery(item_ids))
+      end
+
+    # Applied last, after any type filter, so the cap counts rows the caller
+    # will actually see. The rows are already ordered newest-first, so a SQL
+    # LIMIT returns the same top-N a post-hoc Enum.take would, without the
+    # database handing back the whole 30-day window for the process to discard
+    # most of.
+    maybe_limit(query, limit)
   end
+
+  defp maybe_limit(query, nil), do: query
+  defp maybe_limit(query, limit) when is_integer(limit) and limit > 0, do: limit(query, ^limit)
 
   defp load_items([]), do: %{}
 

--- a/lib/mydia/media/recently_added.ex
+++ b/lib/mydia/media/recently_added.ex
@@ -180,8 +180,12 @@ defmodule Mydia.Media.RecentlyAdded do
     |> Map.new(&{&1.id, &1})
   end
 
-  # The newest slot per item, resolved to an episode. Slots whose episode_id is
-  # NULL (unmatched files) contribute a timestamp but no episode to name.
+  # The newest slot per item, resolved to an episode. The max must be taken
+  # over ALL of an item's slots, not just the matched ones — filtering out
+  # unmatched slots before the max would name an older matched episode for an
+  # item whose newest arrival was actually an unmatched file. Slots whose
+  # episode_id is NULL (unmatched files) contribute a timestamp but no episode
+  # to name.
   defp load_latest_episodes([]), do: %{}
 
   defp load_latest_episodes(rows) do
@@ -192,23 +196,24 @@ defmodule Mydia.Media.RecentlyAdded do
     # `subquery/1` returns an %Ecto.SubQuery{}, not a query, so it cannot be
     # piped into `where/3`. It has to be the source of a `from`.
     newest_episode_ids =
-      from(s in subquery(slots),
-        where: s.media_item_id in ^ids and not is_nil(s.episode_id)
-      )
+      from(s in subquery(slots), where: s.media_item_id in ^ids)
       |> Repo.all()
       |> Enum.group_by(& &1.media_item_id)
-      |> Map.new(fn {item_id, slots} ->
-        {item_id, Enum.max_by(slots, & &1.first_added_at, DateTime).episode_id}
+      |> Map.new(fn {item_id, item_slots} ->
+        newest = Enum.max_by(item_slots, & &1.first_added_at, DateTime)
+        {item_id, newest.episode_id}
       end)
+
+    episode_ids = newest_episode_ids |> Map.values() |> Enum.reject(&is_nil/1)
 
     episodes =
       Episode
-      |> where([e], e.id in ^Map.values(newest_episode_ids))
+      |> where([e], e.id in ^episode_ids)
       |> Repo.all()
       |> Map.new(&{&1.id, &1})
 
     Map.new(newest_episode_ids, fn {item_id, episode_id} ->
-      {item_id, Map.get(episodes, episode_id)}
+      {item_id, episode_id && Map.get(episodes, episode_id)}
     end)
   end
 

--- a/lib/mydia/media/recently_added/entry.ex
+++ b/lib/mydia/media/recently_added/entry.ex
@@ -1,0 +1,15 @@
+defmodule Mydia.Media.RecentlyAdded.Entry do
+  @moduledoc """
+  One item in the recently-added list, with the context needed to say what
+  arrived rather than only when.
+  """
+
+  @type t :: %__MODULE__{
+          media_item: struct(),
+          content_added_at: DateTime.t(),
+          new_episode_count: non_neg_integer() | nil,
+          latest_episode: Mydia.Media.Episode.t() | nil
+        }
+
+  defstruct [:media_item, :content_added_at, :new_episode_count, :latest_episode]
+end

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -695,8 +695,10 @@ defmodule MydiaWeb.MediaLive.Index do
     items = apply_progress_filter(items, socket.assigns.filter_progress)
     Logger.debug("load_media_items: after progress filter=#{length(items)}")
 
-    # Apply sorting
-    items = apply_sorting(items, socket.assigns.sort_by)
+    # Apply sorting. The added-* sorts need content arrival times, which are
+    # one aggregate rather than a per-item lookup.
+    items =
+      apply_sorting(items, socket.assigns.sort_by, added_at_map(items, socket.assigns.sort_by))
 
     # Apply pagination
     paginated_items = items |> Enum.drop(offset) |> Enum.take(limit)
@@ -816,7 +818,15 @@ defmodule MydiaWeb.MediaLive.Index do
     end)
   end
 
-  defp apply_sorting(items, sort_by) do
+  # Only the added-* sorts need it, and the aggregate is not free, so skip it
+  # for every other sort.
+  defp added_at_map(items, sort_by) when sort_by in ["added_asc", "added_desc"] do
+    Mydia.Media.RecentlyAdded.added_at_map(ids: Enum.map(items, & &1.id))
+  end
+
+  defp added_at_map(_items, _sort_by), do: %{}
+
+  defp apply_sorting(items, sort_by, added_at) do
     Logger.debug("Applying sort: #{inspect(sort_by)} to #{length(items)} items")
 
     case sort_by do
@@ -833,10 +843,10 @@ defmodule MydiaWeb.MediaLive.Index do
         Enum.sort_by(items, &(&1.year || 0), :desc)
 
       "added_asc" ->
-        Enum.sort_by(items, & &1.inserted_at, {:asc, DateTime})
+        Enum.sort_by(items, &effective_added_at(&1, added_at), {:asc, DateTime})
 
       "added_desc" ->
-        Enum.sort_by(items, & &1.inserted_at, {:desc, DateTime})
+        Enum.sort_by(items, &effective_added_at(&1, added_at), {:desc, DateTime})
 
       "rating_asc" ->
         Enum.sort_by(items, &get_rating(&1), :asc)
@@ -866,6 +876,13 @@ defmodule MydiaWeb.MediaLive.Index do
         # Default to title ascending
         Enum.sort_by(items, &String.downcase(&1.title || ""), :asc)
     end
+  end
+
+  # A wanted item with no files has no content arrival time. Its own
+  # inserted_at is then the only meaningful answer for "when was this added",
+  # and it keeps the sort total.
+  defp effective_added_at(item, added_at) do
+    Map.get(added_at, item.id) || item.inserted_at
   end
 
   defp get_rating(media_item) do

--- a/lib/mydia_web/schema/query_types.ex
+++ b/lib/mydia_web/schema/query_types.ex
@@ -220,6 +220,15 @@ defmodule MydiaWeb.Schema.QueryTypes do
     field :year, :integer
     field :artwork, :artwork
     field :added_at, non_null(:datetime)
+
+    @desc "Episodes whose first file arrived inside the recently-added window. Null for movies and for unwindowed lists."
+    field :new_episode_count, :integer
+
+    @desc "Season of the newest arrived episode. Null for movies and for unmatched files."
+    field :latest_season_number, :integer
+
+    @desc "Number of the newest arrived episode. Null for movies and for unmatched files."
+    field :latest_episode_number, :integer
   end
 
   @desc "An item in the up next rail (next episode to watch)"

--- a/lib/mydia_web/schema/resolvers/collection_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/collection_resolver.ex
@@ -40,10 +40,12 @@ defmodule MydiaWeb.Schema.Resolvers.CollectionResolver do
     first = Map.get(args, :first, 50)
     collection = Collections.get_collection!(user, id)
     items = Collections.list_collection_items(collection, limit: first)
+    added_at = Mydia.Media.RecentlyAdded.added_at_map(ids: Enum.map(items, & &1.id))
 
     result =
-      items
-      |> Enum.map(&ItemBuilder.recently_added_item/1)
+      Enum.map(items, fn item ->
+        ItemBuilder.recently_added_item(item, added_at: Map.get(added_at, item.id))
+      end)
 
     {:ok, result}
   rescue

--- a/lib/mydia_web/schema/resolvers/collection_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/collection_resolver.ex
@@ -5,8 +5,8 @@ defmodule MydiaWeb.Schema.Resolvers.CollectionResolver do
 
   alias Mydia.Collections
 
-  alias Mydia.Metadata.Access, as: MetadataAccess
   alias Mydia.Metadata.ImageUrl
+  alias MydiaWeb.Schema.Resolvers.ItemBuilder
 
   @spec list_collections(map(), map(), Absinthe.Resolution.t()) ::
           {:ok, term()} | {:error, term()}
@@ -43,7 +43,7 @@ defmodule MydiaWeb.Schema.Resolvers.CollectionResolver do
 
     result =
       items
-      |> Enum.map(&build_recently_added_item/1)
+      |> Enum.map(&ItemBuilder.recently_added_item/1)
 
     {:ok, result}
   rescue
@@ -68,30 +68,4 @@ defmodule MydiaWeb.Schema.Resolvers.CollectionResolver do
       poster_paths: Enum.map(posters, &ImageUrl.poster_url/1)
     }
   end
-
-  defp build_recently_added_item(media_item) do
-    %{
-      id: media_item.id,
-      type: String.to_existing_atom(media_item.type),
-      title: media_item.title,
-      year: media_item.year,
-      artwork: build_artwork(media_item),
-      added_at: media_item.inserted_at
-    }
-  end
-
-  defp build_artwork(%{metadata: nil}), do: nil
-
-  defp build_artwork(%{metadata: metadata}) do
-    poster_path = MetadataAccess.get(metadata, :poster_path)
-    backdrop_path = MetadataAccess.get(metadata, :backdrop_path)
-
-    %{
-      poster_url: ImageUrl.poster_url(poster_path),
-      backdrop_url: ImageUrl.backdrop_url(backdrop_path),
-      thumbnail_url: nil
-    }
-  end
-
-  defp build_artwork(_), do: nil
 end

--- a/lib/mydia_web/schema/resolvers/discovery_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/discovery_resolver.ex
@@ -47,7 +47,8 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
     entries =
       RecentlyAdded.list_recent(
         since: thirty_days_ago,
-        types: requested_types(Map.get(args, :types))
+        types: requested_types(Map.get(args, :types)),
+        limit: pagination_limit(first, after_cursor)
       )
 
     all_items =
@@ -212,6 +213,15 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
         0
     end
   end
+
+  # `list_recent/1` takes `Enum.take` on this limit BEFORE loading each item's
+  # metadata and resolving its latest episode, so the limit here has to cover
+  # everything `paginate_simple/3` can slice from — the offset the cursor
+  # encodes, plus the page itself — or a page past the first would silently
+  # come back empty. Without a limit at all, every mount rebuilds and loads
+  # the entire 30-day window just to show `first` cards.
+  defp pagination_limit(first, nil), do: first
+  defp pagination_limit(first, after_cursor), do: decode_cursor(after_cursor) + 1 + first
 
   defp build_continue_watching_item(%{media_item_id: media_item_id} = progress, _user_id)
        when not is_nil(media_item_id) do

--- a/lib/mydia_web/schema/resolvers/discovery_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/discovery_resolver.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
 
   alias Mydia.{Library, Media, Playback}
 
+  alias Mydia.Media.RecentlyAdded
   alias Mydia.Metadata.Access, as: MetadataAccess
   alias Mydia.Metadata.ImageUrl
   alias MydiaWeb.Schema.Resolvers.ItemBuilder
@@ -41,39 +42,35 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
   def recently_added(_parent, args, _info) do
     first = Map.get(args, :first, 20)
     after_cursor = Map.get(args, :after)
-    types = Map.get(args, :types)
+    thirty_days_ago = DateTime.add(DateTime.utc_now(), -30, :day)
 
-    # Filter to items added in last 30 days
-    thirty_days_ago = DateTime.utc_now() |> DateTime.add(-30, :day)
+    entries =
+      RecentlyAdded.list_recent(
+        since: thirty_days_ago,
+        types: requested_types(Map.get(args, :types))
+      )
 
-    # Build query options
-    opts = [preload: [], added_since: thirty_days_ago, has_files: true]
-
-    opts =
-      if types do
-        type_filter =
-          cond do
-            :movie in types and :tv_show in types -> nil
-            :movie in types -> "movie"
-            :tv_show in types -> "tv_show"
-            true -> nil
-          end
-
-        if type_filter, do: Keyword.put(opts, :type, type_filter), else: opts
-      else
-        opts
-      end
-
-    # Get recently added items (sorted by most recent first)
     all_items =
-      Media.list_media_items(opts)
-      |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
-      |> Enum.map(&ItemBuilder.recently_added_item/1)
+      Enum.map(entries, fn entry ->
+        ItemBuilder.recently_added_item(entry.media_item,
+          added_at: entry.content_added_at,
+          new_episode_count: entry.new_episode_count,
+          latest_episode: entry.latest_episode
+        )
+      end)
 
-    # Apply cursor pagination
-    items = paginate_simple(all_items, first, after_cursor)
+    {:ok, paginate_simple(all_items, first, after_cursor)}
+  end
 
-    {:ok, items}
+  # The GraphQL arg is a list of atoms; RecentlyAdded filters on the string
+  # column. Nil and a list covering both types both mean "no filter".
+  defp requested_types(nil), do: nil
+  defp requested_types([]), do: nil
+
+  defp requested_types(types) do
+    strings = Enum.map(types, &to_string/1)
+
+    if "movie" in strings and "tv_show" in strings, do: nil, else: strings
   end
 
   @spec up_next(map(), map(), Absinthe.Resolution.t()) :: {:ok, term()} | {:error, term()}
@@ -127,10 +124,13 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
         {:ok, []}
 
       user ->
+        favorites = Media.list_user_favorites(user.id) |> maybe_filter_by_type(types)
+        added_at = RecentlyAdded.added_at_map(ids: Enum.map(favorites, & &1.id))
+
         all_items =
-          Media.list_user_favorites(user.id)
-          |> maybe_filter_by_type(types)
-          |> Enum.map(&ItemBuilder.recently_added_item/1)
+          Enum.map(favorites, fn item ->
+            ItemBuilder.recently_added_item(item, added_at: Map.get(added_at, item.id))
+          end)
 
         items = paginate_simple(all_items, first, after_cursor)
         {:ok, items}
@@ -158,12 +158,19 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
           |> Enum.reject(&is_nil/1)
           |> MapSet.new()
 
-        all_items =
+        unwatched =
           media_items
           |> Enum.reject(&MapSet.member?(watched_ids, &1.id))
           |> maybe_filter_by_type(types)
-          |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
-          |> Enum.map(&ItemBuilder.recently_added_item/1)
+
+        added_at = RecentlyAdded.added_at_map(ids: Enum.map(unwatched, & &1.id))
+
+        all_items =
+          unwatched
+          |> Enum.sort_by(&(Map.get(added_at, &1.id) || &1.inserted_at), {:desc, DateTime})
+          |> Enum.map(fn item ->
+            ItemBuilder.recently_added_item(item, added_at: Map.get(added_at, item.id))
+          end)
 
         items = paginate_simple(all_items, first, after_cursor)
         {:ok, items}

--- a/lib/mydia_web/schema/resolvers/discovery_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/discovery_resolver.ex
@@ -7,6 +7,7 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
 
   alias Mydia.Metadata.Access, as: MetadataAccess
   alias Mydia.Metadata.ImageUrl
+  alias MydiaWeb.Schema.Resolvers.ItemBuilder
 
   @spec continue_watching(map(), map(), Absinthe.Resolution.t()) ::
           {:ok, term()} | {:error, term()}
@@ -67,7 +68,7 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
     all_items =
       Media.list_media_items(opts)
       |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
-      |> Enum.map(&build_recently_added_item/1)
+      |> Enum.map(&ItemBuilder.recently_added_item/1)
 
     # Apply cursor pagination
     items = paginate_simple(all_items, first, after_cursor)
@@ -129,7 +130,7 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
         all_items =
           Media.list_user_favorites(user.id)
           |> maybe_filter_by_type(types)
-          |> Enum.map(&build_recently_added_item/1)
+          |> Enum.map(&ItemBuilder.recently_added_item/1)
 
         items = paginate_simple(all_items, first, after_cursor)
         {:ok, items}
@@ -162,7 +163,7 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
           |> Enum.reject(&MapSet.member?(watched_ids, &1.id))
           |> maybe_filter_by_type(types)
           |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
-          |> Enum.map(&build_recently_added_item/1)
+          |> Enum.map(&ItemBuilder.recently_added_item/1)
 
         items = paginate_simple(all_items, first, after_cursor)
         {:ok, items}
@@ -218,7 +219,7 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
           id: media_item.id,
           type: String.to_existing_atom(media_item.type),
           title: media_item.title,
-          artwork: build_artwork(media_item),
+          artwork: ItemBuilder.artwork(media_item),
           progress: format_progress(progress),
           files: files,
           show_title: nil,
@@ -260,37 +261,10 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
 
   defp build_continue_watching_item(_, _), do: nil
 
-  defp build_recently_added_item(media_item) do
-    %{
-      id: media_item.id,
-      type: String.to_existing_atom(media_item.type),
-      title: media_item.title,
-      year: media_item.year,
-      artwork: build_artwork(media_item),
-      added_at: media_item.inserted_at
-    }
-  end
+  defp build_episode_artwork(%{metadata: metadata} = episode, show) when not is_nil(metadata) do
+    still_path = MetadataAccess.get(episode.metadata, :still_path)
+    show_artwork = ItemBuilder.artwork(show)
 
-  defp build_artwork(%{metadata: nil}), do: nil
-
-  defp build_artwork(%{metadata: metadata}) do
-    poster_path = MetadataAccess.get(metadata, :poster_path)
-    backdrop_path = MetadataAccess.get(metadata, :backdrop_path)
-
-    %{
-      poster_url: ImageUrl.poster_url(poster_path),
-      backdrop_url: ImageUrl.backdrop_url(backdrop_path),
-      thumbnail_url: nil
-    }
-  end
-
-  defp build_artwork(_), do: nil
-
-  defp build_episode_artwork(%{metadata: metadata}, show) when not is_nil(metadata) do
-    still_path = MetadataAccess.get(metadata, :still_path)
-    show_artwork = build_artwork(show)
-
-    # Always include show's poster/backdrop, plus episode thumbnail if available
     %{
       poster_url: show_artwork && show_artwork.poster_url,
       backdrop_url: show_artwork && show_artwork.backdrop_url,
@@ -298,7 +272,7 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
     }
   end
 
-  defp build_episode_artwork(_episode, show), do: build_artwork(show)
+  defp build_episode_artwork(_episode, show), do: ItemBuilder.artwork(show)
 
   defp format_progress(progress) do
     %{

--- a/lib/mydia_web/schema/resolvers/item_builder.ex
+++ b/lib/mydia_web/schema/resolvers/item_builder.ex
@@ -1,0 +1,58 @@
+defmodule MydiaWeb.Schema.Resolvers.ItemBuilder do
+  @moduledoc """
+  Builds the `:recently_added_item` GraphQL payload from a media item.
+
+  Both the discovery and collection resolvers render this object. They used to
+  carry byte-for-byte copies of this function, which meant two definitions of
+  "added" that could drift apart. There is one here now.
+  """
+
+  alias Mydia.Metadata.Access, as: MetadataAccess
+  alias Mydia.Metadata.ImageUrl
+
+  @doc """
+  Builds the payload.
+
+  Options:
+
+    * `:added_at` - overrides the timestamp. Defaults to the item's
+      `inserted_at`, which is only correct for callers that have no better
+      answer.
+    * `:new_episode_count` - episodes whose first file landed inside the
+      caller's window. Nil for movies and for unwindowed views.
+    * `:latest_episode` - an `%Mydia.Media.Episode{}` whose numbers are
+      flattened onto the payload, or nil.
+  """
+  @spec recently_added_item(struct(), keyword()) :: map()
+  def recently_added_item(media_item, opts \\ []) do
+    latest_episode = Keyword.get(opts, :latest_episode)
+
+    %{
+      id: media_item.id,
+      type: String.to_existing_atom(media_item.type),
+      title: media_item.title,
+      year: media_item.year,
+      artwork: artwork(media_item),
+      added_at: Keyword.get(opts, :added_at) || media_item.inserted_at,
+      new_episode_count: Keyword.get(opts, :new_episode_count),
+      latest_season_number: latest_episode && latest_episode.season_number,
+      latest_episode_number: latest_episode && latest_episode.episode_number
+    }
+  end
+
+  @doc """
+  Builds the artwork sub-object from an item's metadata.
+  """
+  @spec artwork(struct()) :: map() | nil
+  def artwork(%{metadata: nil}), do: nil
+
+  def artwork(%{metadata: metadata}) do
+    %{
+      poster_url: metadata |> MetadataAccess.get(:poster_path) |> ImageUrl.poster_url(),
+      backdrop_url: metadata |> MetadataAccess.get(:backdrop_path) |> ImageUrl.backdrop_url(),
+      thumbnail_url: nil
+    }
+  end
+
+  def artwork(_), do: nil
+end

--- a/player/lib/core/graphql/watch/controller_watcher.dart
+++ b/player/lib/core/graphql/watch/controller_watcher.dart
@@ -22,6 +22,7 @@ QueryWatcher<T> createWatcher<T>(
   Ref ref, {
   required QueryKey key,
   required DocumentNode document,
+  DocumentNode? fallbackDocument,
   Map<String, dynamic> variables = const {},
   required T Function(Map<String, dynamic> data) parse,
   Duration maxAge = kFreshnessThreshold,
@@ -37,6 +38,7 @@ QueryWatcher<T> createWatcher<T>(
     client: ref.watch(asyncGraphqlClientProvider.future),
     fetchLog: ref.read(fetchLogProvider),
     document: document,
+    fallbackDocument: fallbackDocument,
     variables: variables,
     parse: parse,
     maxAge: maxAge,

--- a/player/lib/core/graphql/watch/query_watcher.dart
+++ b/player/lib/core/graphql/watch/query_watcher.dart
@@ -11,6 +11,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'fetch_log.dart';
 import 'freshness.dart';
 import 'query_key.dart';
+import 'schema_downgrade.dart';
 
 /// The age gate: which fetch policy a watcher starts with.
 ///
@@ -43,6 +44,7 @@ class QueryWatcher<T> {
     required Future<GraphQLClient> client,
     required this.fetchLog,
     required this.document,
+    this.fallbackDocument,
     this.variables = const {},
     required this.parse,
     this.maxAge = kFreshnessThreshold,
@@ -57,6 +59,16 @@ class QueryWatcher<T> {
   final QueryKey key;
   final FetchLog fetchLog;
   final DocumentNode document;
+
+  /// Document to retry with once, if the server rejects [document] for
+  /// selecting a field it does not define. Null means no fallback: a rejection
+  /// surfaces as a stream error like any other.
+  final DocumentNode? fallbackDocument;
+
+  /// Set once a downgrade has happened, so a server that rejects both
+  /// documents cannot loop.
+  bool _downgraded = false;
+
   final Map<String, dynamic> variables;
   final T Function(Map<String, dynamic> data) parse;
   final Duration maxAge;
@@ -97,13 +109,20 @@ class QueryWatcher<T> {
 
   Stream<T> get stream => _controller.stream;
 
+  /// The document currently in play: [document] until a schema downgrade has
+  /// happened, [fallbackDocument] (or [document] again, if there is none)
+  /// after. [document] itself is final, so `_start()` reads through here
+  /// instead.
+  DocumentNode get _activeDocument =>
+      _downgraded ? (fallbackDocument ?? document) : document;
+
   Future<void> _start() async {
     try {
       final client = await _clientFuture;
       if (_closed) return;
 
       final probe = WatchQueryOptions<Map<String, dynamic>>(
-        document: document,
+        document: _activeDocument,
         variables: variables,
       );
 
@@ -120,7 +139,7 @@ class QueryWatcher<T> {
           fetchPolicy == FetchPolicy.cacheAndNetwork;
 
       final options = WatchQueryOptions<Map<String, dynamic>>(
-        document: document,
+        document: _activeDocument,
         variables: variables,
         fetchPolicy: fetchPolicy,
         // Library default is false, which produces a watcher that never
@@ -135,6 +154,21 @@ class QueryWatcher<T> {
       _query = null;
       _addError(error, stackTrace);
     }
+  }
+
+  /// Tears down the current observable and starts a new one against
+  /// [_activeDocument]. Only reached after a schema downgrade.
+  Future<void> _restart() async {
+    await _subscription?.cancel();
+    _subscription = null;
+    // ObservableQuery.close returns FutureOr<QueryLifecycle>, matching how
+    // close() below tears the same objects down.
+    await _query?.close();
+    _query = null;
+
+    if (_closed) return;
+    _started = _start();
+    await _started;
   }
 
   bool _cacheHasData(GraphQLClient client, Request request) {
@@ -202,7 +236,17 @@ class QueryWatcher<T> {
     }
 
     if (result.hasException) {
-      _addError(result.exception!, StackTrace.current);
+      final exception = result.exception!;
+
+      if (!_downgraded &&
+          fallbackDocument != null &&
+          isUnknownFieldError(exception)) {
+        _downgraded = true;
+        unawaited(_restart());
+        return;
+      }
+
+      _addError(exception, StackTrace.current);
     }
   }
 

--- a/player/lib/core/graphql/watch/schema_downgrade.dart
+++ b/player/lib/core/graphql/watch/schema_downgrade.dart
@@ -1,0 +1,16 @@
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+/// Whether [exception] is the server rejecting a field this client asked for.
+///
+/// A player installed independently of its server (APK, Flatpak) can be newer
+/// than the server it talks to. GraphQL validates the whole document up front,
+/// so one unknown field fails the entire query rather than degrading. Watchers
+/// use this to fall back to a document that omits newer fields.
+///
+/// The message is pinned by a server-side test in `schema_test.exs`; if
+/// Absinthe rephrases it, that test fails in the same change.
+bool isUnknownFieldError(OperationException exception) {
+  return exception.graphqlErrors.any(
+    (error) => error.message.contains('Cannot query field'),
+  );
+}

--- a/player/lib/domain/models/recently_added_item.dart
+++ b/player/lib/domain/models/recently_added_item.dart
@@ -7,6 +7,9 @@ class RecentlyAddedItem {
   final int? year;
   final Artwork? artwork;
   final String? addedAt;
+  final int? newEpisodeCount;
+  final int? latestSeasonNumber;
+  final int? latestEpisodeNumber;
 
   const RecentlyAddedItem({
     required this.id,
@@ -15,6 +18,9 @@ class RecentlyAddedItem {
     this.year,
     this.artwork,
     this.addedAt,
+    this.newEpisodeCount,
+    this.latestSeasonNumber,
+    this.latestEpisodeNumber,
   });
 
   factory RecentlyAddedItem.fromJson(Map<String, dynamic> json) {
@@ -27,6 +33,9 @@ class RecentlyAddedItem {
           ? Artwork.fromJson(json['artwork'] as Map<String, dynamic>)
           : null,
       addedAt: json['addedAt'] as String?,
+      newEpisodeCount: json['newEpisodeCount'] as int?,
+      latestSeasonNumber: json['latestSeasonNumber'] as int?,
+      latestEpisodeNumber: json['latestEpisodeNumber'] as int?,
     );
   }
 
@@ -43,5 +52,25 @@ class RecentlyAddedItem {
       return '$title ($year)';
     }
     return title;
+  }
+
+  /// What arrived, for the card subtitle.
+  ///
+  /// Null for movies, for lists that are not windowed, and for a server too
+  /// old to send the count. Names the episode when exactly one arrived and its
+  /// numbers are known, since that is more useful than "1 new episode".
+  String? get newContentLabel {
+    final count = newEpisodeCount;
+    if (count == null || count == 0) return null;
+
+    if (count == 1 &&
+        latestSeasonNumber != null &&
+        latestEpisodeNumber != null) {
+      final season = latestSeasonNumber!.toString().padLeft(2, '0');
+      final episode = latestEpisodeNumber!.toString().padLeft(2, '0');
+      return 'S${season}E$episode';
+    }
+
+    return count == 1 ? '1 new episode' : '$count new episodes';
   }
 }

--- a/player/lib/presentation/screens/home/home_controller.dart
+++ b/player/lib/presentation/screens/home/home_controller.dart
@@ -54,6 +54,115 @@ query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $upNextL
       thumbnailUrl
     }
     addedAt
+    newEpisodeCount
+    latestSeasonNumber
+    latestEpisodeNumber
+  }
+
+  upNext(first: $upNextLimit) {
+    progressState
+    episode {
+      id
+      seasonNumber
+      episodeNumber
+      title
+      airDate
+      thumbnailUrl
+      hasFile
+      files {
+        id
+        resolution
+        codec
+        audioCodec
+        hdrFormat
+        size
+        bitrate
+        directPlaySupported
+        streamUrl
+        directPlayUrl
+      }
+      progress {
+        positionSeconds
+        durationSeconds
+        percentage
+        watched
+        lastWatchedAt
+      }
+    }
+    show {
+      id
+      title
+      artwork {
+        posterUrl
+        backdropUrl
+        thumbnailUrl
+      }
+    }
+  }
+
+  favorites(first: $favoritesLimit) {
+    id
+    type
+    title
+    year
+    artwork {
+      posterUrl
+      backdropUrl
+      thumbnailUrl
+    }
+    addedAt
+  }
+}
+''';
+
+/// The pre-episode-context shape, for a server older than this build.
+const String homeScreenQueryLegacy = r'''
+query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $upNextLimit: Int, $favoritesLimit: Int) {
+  continueWatching(first: $continueWatchingLimit) {
+    id
+    type
+    title
+    artwork {
+      posterUrl
+      backdropUrl
+      thumbnailUrl
+    }
+    progress {
+      positionSeconds
+      durationSeconds
+      percentage
+      watched
+      lastWatchedAt
+    }
+    showId
+    showTitle
+    seasonNumber
+    episodeNumber
+    files {
+      id
+      resolution
+      codec
+      audioCodec
+      hdrFormat
+      size
+      bitrate
+      directPlaySupported
+      streamUrl
+      directPlayUrl
+    }
+  }
+
+  recentlyAdded(first: $recentlyAddedLimit) {
+    id
+    type
+    title
+    year
+    artwork {
+      posterUrl
+      backdropUrl
+      thumbnailUrl
+    }
+    addedAt
   }
 
   upNext(first: $upNextLimit) {
@@ -131,6 +240,7 @@ class HomeController extends _$HomeController {
       ref,
       key: QueryKeys.home,
       document: gql(homeScreenQuery),
+      fallbackDocument: gql(homeScreenQueryLegacy),
       variables: homeScreenVariables,
       parse: HomeData.fromJson,
     );

--- a/player/lib/presentation/screens/recently_added/recently_added_controller.dart
+++ b/player/lib/presentation/screens/recently_added/recently_added_controller.dart
@@ -20,6 +20,27 @@ query RecentlyAddedFull($first: Int) {
       thumbnailUrl
     }
     addedAt
+    newEpisodeCount
+    latestSeasonNumber
+    latestEpisodeNumber
+  }
+}
+''';
+
+/// The pre-episode-context shape, for a server older than this build.
+const String recentlyAddedFullQueryLegacy = r'''
+query RecentlyAddedFull($first: Int) {
+  recentlyAdded(first: $first) {
+    id
+    type
+    title
+    year
+    artwork {
+      posterUrl
+      backdropUrl
+      thumbnailUrl
+    }
+    addedAt
   }
 }
 ''';
@@ -41,6 +62,7 @@ class RecentlyAddedController extends _$RecentlyAddedController {
       ref,
       key: QueryKeys.recentlyAdded,
       document: gql(recentlyAddedFullQuery),
+      fallbackDocument: gql(recentlyAddedFullQueryLegacy),
       variables: const {'first': 50},
       parse: (data) => _parseItems(data, 'recentlyAdded'),
     );

--- a/player/lib/presentation/screens/recently_added/recently_added_screen.dart
+++ b/player/lib/presentation/screens/recently_added/recently_added_screen.dart
@@ -245,6 +245,7 @@ class RecentlyAddedScreen extends ConsumerWidget {
               key: ValueKey(item.id),
               posterUrl: item.posterUrl,
               title: item.title,
+              subtitle: item.newContentLabel,
               onTap: () => _handleItemTap(context, item.id, item.type),
             );
           },

--- a/player/lib/presentation/widgets/content_rail.dart
+++ b/player/lib/presentation/widgets/content_rail.dart
@@ -211,7 +211,7 @@ class _ContentRailState extends State<ContentRail> {
       return MediaCard(
         posterUrl: item.posterUrl,
         title: item.title,
-        subtitle: item.year?.toString(),
+        subtitle: item.newContentLabel ?? item.year?.toString(),
         width: cardSize.width,
         height: cardSize.height,
         onTap: () => widget.onItemTap?.call(item.id, item.type),

--- a/player/lib/presentation/widgets/media_poster.dart
+++ b/player/lib/presentation/widgets/media_poster.dart
@@ -84,10 +84,10 @@ class MediaPoster extends StatelessWidget {
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
             ),
-            if (widget.subtitle != null) ...[
+            if (subtitle != null) ...[
               const SizedBox(height: 2),
               Text(
-                widget.subtitle!,
+                subtitle!,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: AppColors.textSecondary,
                     ),

--- a/player/lib/presentation/widgets/media_poster.dart
+++ b/player/lib/presentation/widgets/media_poster.dart
@@ -11,6 +11,7 @@ import 'progress_overlay.dart';
 class MediaPoster extends ConsumerStatefulWidget {
   final String? posterUrl;
   final String title;
+  final String? subtitle;
   final double? progressPercentage;
   final bool isFavorite;
   final VoidCallback? onTap;
@@ -20,6 +21,7 @@ class MediaPoster extends ConsumerStatefulWidget {
     super.key,
     this.posterUrl,
     required this.title,
+    this.subtitle,
     this.progressPercentage,
     this.isFavorite = false,
     this.onTap,
@@ -162,6 +164,17 @@ class _MediaPosterState extends ConsumerState<MediaPoster> {
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
             ),
+            if (widget.subtitle != null) ...[
+              const SizedBox(height: 2),
+              Text(
+                widget.subtitle!,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
           ],
         ],
       ),

--- a/player/test/core/graphql/watch/schema_downgrade_test.dart
+++ b/player/test/core/graphql/watch/schema_downgrade_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/graphql/watch/fetch_log.dart';
+import 'package:player/core/graphql/watch/query_key.dart';
+import 'package:player/core/graphql/watch/query_watcher.dart';
+import 'package:player/core/graphql/watch/schema_downgrade.dart';
+
+import '../../../test_utils/stub_graphql_client.dart';
+
+void main() {
+  group('isUnknownFieldError', () {
+    test('detects an Absinthe unknown-field rejection', () {
+      final exception = OperationException(
+        graphqlErrors: [
+          const GraphQLError(
+            message:
+                'Cannot query field "newEpisodeCount" on type "RecentlyAddedItem".',
+          ),
+        ],
+      );
+
+      expect(isUnknownFieldError(exception), isTrue);
+    });
+
+    test('ignores an ordinary field-level error', () {
+      final exception = OperationException(
+        graphqlErrors: [const GraphQLError(message: 'Not authenticated')],
+      );
+
+      expect(isUnknownFieldError(exception), isFalse);
+    });
+
+    test('ignores a transport failure', () {
+      final exception = OperationException(
+        linkException: NetworkException(
+          originalException: Exception('connection refused'),
+          message: 'connection refused',
+          uri: Uri.parse('https://example.invalid/graphql'),
+        ),
+      );
+
+      expect(isUnknownFieldError(exception), isFalse);
+    });
+  });
+
+  group('QueryWatcher downgrade', () {
+    // Every response `data` map must carry `__typename` on each object,
+    // including the response root itself: `gql()` injects a `__typename`
+    // selection into every selection set in the outgoing document, root
+    // included, and the normalized cache refuses to write data that lacks a
+    // matching one (surfacing as a spurious `result.hasException`, not as an
+    // obvious error). See `query_watcher_test.dart`'s `_pingData` for the
+    // same pattern.
+    Map<String, dynamic> thingData(String id) => {
+          '__typename': 'Query',
+          'thing': {
+            '__typename': 'Thing',
+            'id': id,
+          },
+        };
+
+    test('retries with the fallback document and emits its data', () async {
+      // Script two responses against the same watcher: the extended document
+      // is rejected, the fallback succeeds. Reuses the same `StubLink` /
+      // `stubClient` fake-link harness the existing query_watcher tests in
+      // this directory already use, rather than inventing a second one.
+      final extended = gql('query Q { thing { id newField } }');
+      final legacy = gql('query Q { thing { id } }');
+
+      final link = StubLink.responses([
+        graphqlErrorResponse(
+          'Cannot query field "newField" on type "Thing".',
+        ),
+        thingData('abc'),
+      ]);
+
+      final watcher = QueryWatcher<String>(
+        key: QueryKeys.recentlyAdded,
+        client: Future<GraphQLClient>.value(stubClient(link)),
+        fetchLog: InMemoryFetchLog(),
+        document: extended,
+        fallbackDocument: legacy,
+        parse: (data) =>
+            (data['thing'] as Map<String, dynamic>)['id'] as String,
+      );
+      addTearDown(watcher.close);
+
+      await expectLater(watcher.stream, emits('abc'));
+      expect(link.requests.length, 2);
+    });
+
+    test('surfaces the error when there is no fallback', () async {
+      final link = StubLink.responses([
+        graphqlErrorResponse(
+          'Cannot query field "newField" on type "Thing".',
+        ),
+      ]);
+
+      final watcher = QueryWatcher<String>(
+        key: QueryKeys.recentlyAdded,
+        client: Future<GraphQLClient>.value(stubClient(link)),
+        fetchLog: InMemoryFetchLog(),
+        document: gql('query Q { thing { id newField } }'),
+        parse: (_) => 'unused',
+      );
+      addTearDown(watcher.close);
+
+      await expectLater(watcher.stream, emitsError(isA<OperationException>()));
+    });
+  });
+}

--- a/player/test/core/graphql/watch/schema_downgrade_test.dart
+++ b/player/test/core/graphql/watch/schema_downgrade_test.dart
@@ -87,6 +87,12 @@ void main() {
 
       await expectLater(watcher.stream, emits('abc'));
       expect(link.requests.length, 2);
+      // `StubLink.responses` scripts by call index, so a second request
+      // alone doesn't prove the retry used the fallback document — a
+      // watcher that always resent `extended` would produce the same
+      // request count and the same stubbed response. Pin the actual
+      // document the retry sent.
+      expect(link.requests[1].operation.document, legacy);
     });
 
     test('surfaces the error when there is no fallback', () async {

--- a/player/test/domain/models/recently_added_item_test.dart
+++ b/player/test/domain/models/recently_added_item_test.dart
@@ -42,6 +42,16 @@ void main() {
       expect(item.newContentLabel, 'S04E02');
     });
 
+    test('pads a two-digit season without truncating it', () {
+      final item = RecentlyAddedItem.fromJson(json({
+        'newEpisodeCount': 1,
+        'latestSeasonNumber': 12,
+        'latestEpisodeNumber': 5,
+      }));
+
+      expect(item.newContentLabel, 'S12E05');
+    });
+
     test('counts when there is one but no numbers', () {
       final item = RecentlyAddedItem.fromJson(json({'newEpisodeCount': 1}));
 

--- a/player/test/domain/models/recently_added_item_test.dart
+++ b/player/test/domain/models/recently_added_item_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/recently_added_item.dart';
+
+void main() {
+  Map<String, dynamic> json(Map<String, dynamic> overrides) => {
+        'id': 'abc',
+        'type': 'tv_show',
+        'title': 'The Bear',
+        ...overrides,
+      };
+
+  group('fromJson', () {
+    test('parses the episode context fields', () {
+      final item = RecentlyAddedItem.fromJson(json({
+        'newEpisodeCount': 3,
+        'latestSeasonNumber': 4,
+        'latestEpisodeNumber': 2,
+      }));
+
+      expect(item.newEpisodeCount, 3);
+      expect(item.latestSeasonNumber, 4);
+      expect(item.latestEpisodeNumber, 2);
+    });
+
+    test('tolerates every context field being absent', () {
+      final item = RecentlyAddedItem.fromJson(json({}));
+
+      expect(item.newEpisodeCount, isNull);
+      expect(item.latestSeasonNumber, isNull);
+      expect(item.latestEpisodeNumber, isNull);
+    });
+  });
+
+  group('newContentLabel', () {
+    test('names the episode when there is exactly one with numbers', () {
+      final item = RecentlyAddedItem.fromJson(json({
+        'newEpisodeCount': 1,
+        'latestSeasonNumber': 4,
+        'latestEpisodeNumber': 2,
+      }));
+
+      expect(item.newContentLabel, 'S04E02');
+    });
+
+    test('counts when there is one but no numbers', () {
+      final item = RecentlyAddedItem.fromJson(json({'newEpisodeCount': 1}));
+
+      expect(item.newContentLabel, '1 new episode');
+    });
+
+    test('pluralizes above one', () {
+      final item = RecentlyAddedItem.fromJson(json({
+        'newEpisodeCount': 3,
+        'latestSeasonNumber': 4,
+        'latestEpisodeNumber': 2,
+      }));
+
+      expect(item.newContentLabel, '3 new episodes');
+    });
+
+    test('is null when the count is absent', () {
+      expect(RecentlyAddedItem.fromJson(json({})).newContentLabel, isNull);
+    });
+
+    test('is null when the count is zero', () {
+      final item = RecentlyAddedItem.fromJson(json({'newEpisodeCount': 0}));
+
+      expect(item.newContentLabel, isNull);
+    });
+  });
+}

--- a/player/test/presentation/screens/home/home_controller_test.dart
+++ b/player/test/presentation/screens/home/home_controller_test.dart
@@ -26,6 +26,9 @@ Map<String, dynamic> _homeData(String title) => {
             'thumbnailUrl': null,
           },
           'addedAt': '2026-07-01T00:00:00Z',
+          'newEpisodeCount': null,
+          'latestSeasonNumber': null,
+          'latestEpisodeNumber': null,
         }
       ],
       'upNext': <dynamic>[],

--- a/player/test/presentation/widgets/content_rail_test.dart
+++ b/player/test/presentation/widgets/content_rail_test.dart
@@ -69,4 +69,48 @@ void main() {
       expect(find.byType(MediaCard), findsNothing);
     });
   });
+
+  group('ContentRail RecentlyAddedItem subtitle', () {
+    // Regression guard for `item.newContentLabel ?? item.year?.toString()`:
+    // if that coalescing order is ever flipped, this is the test that catches
+    // it, since the item carries both a year and episode context.
+    testWidgets(
+        'a show with one new episode shows the episode code, not the year',
+        (tester) async {
+      const item = RecentlyAddedItem(
+        id: 'show-1',
+        type: 'tv_show',
+        title: 'The Bear',
+        year: 2023,
+        newEpisodeCount: 1,
+        latestSeasonNumber: 4,
+        latestEpisodeNumber: 2,
+      );
+
+      await tester.pumpWidget(
+        _host(const ContentRail(title: 'Recently Added', items: [item])),
+      );
+      await tester.pump();
+
+      expect(find.text('S04E02'), findsOneWidget);
+      expect(find.text('2023'), findsNothing);
+    });
+
+    testWidgets('a movie with no episode context falls back to the year',
+        (tester) async {
+      const item = RecentlyAddedItem(
+        id: 'movie-1',
+        type: 'movie',
+        title: 'A Movie',
+        year: 2023,
+      );
+
+      await tester.pumpWidget(
+        _host(const ContentRail(title: 'Recently Added', items: [item])),
+      );
+      await tester.pump();
+
+      expect(find.text('2023'), findsOneWidget);
+    });
+  });
 }

--- a/player/test/presentation/widgets/recently_added_card_test.dart
+++ b/player/test/presentation/widgets/recently_added_card_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/recently_added_item.dart';
+import 'package:player/presentation/widgets/media_poster.dart';
+
+void main() {
+  Widget wrap(Widget child) =>
+      ProviderScope(child: MaterialApp(home: Scaffold(body: child)));
+
+  RecentlyAddedItem item(Map<String, dynamic> overrides) =>
+      RecentlyAddedItem.fromJson({
+        'id': 'abc',
+        'type': 'tv_show',
+        'title': 'The Bear',
+        ...overrides,
+      });
+
+  testWidgets('names the episode when one arrived', (tester) async {
+    final subject = item({
+      'newEpisodeCount': 1,
+      'latestSeasonNumber': 4,
+      'latestEpisodeNumber': 2,
+    });
+
+    await tester.pumpWidget(
+      wrap(
+          MediaPoster(title: subject.title, subtitle: subject.newContentLabel)),
+    );
+
+    expect(find.text('S04E02'), findsOneWidget);
+  });
+
+  testWidgets('counts when more than one arrived', (tester) async {
+    final subject = item({'newEpisodeCount': 3});
+
+    await tester.pumpWidget(
+      wrap(
+          MediaPoster(title: subject.title, subtitle: subject.newContentLabel)),
+    );
+
+    expect(find.text('3 new episodes'), findsOneWidget);
+  });
+
+  testWidgets('shows no subtitle when there is no count', (tester) async {
+    final subject = item({});
+
+    await tester.pumpWidget(
+      wrap(
+          MediaPoster(title: subject.title, subtitle: subject.newContentLabel)),
+    );
+
+    expect(find.text('The Bear'), findsOneWidget);
+    expect(find.textContaining('new episode'), findsNothing);
+  });
+}

--- a/test/mydia/media/recently_added_test.exs
+++ b/test/mydia/media/recently_added_test.exs
@@ -1,0 +1,111 @@
+defmodule Mydia.Media.RecentlyAddedTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Media.RecentlyAdded
+
+  # Two years back, well outside any 30-day window.
+  @long_ago ~U[2024-08-04 12:00:00Z]
+  @yesterday ~U[2026-08-03 12:00:00Z]
+  @last_week ~U[2026-07-28 12:00:00Z]
+
+  describe "added_at_map/1" do
+    test "a long-owned show reports its newest episode's arrival, not its own inserted_at" do
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 4, episode_number: 2})
+
+      # Built the way production builds it: episode_id set, media_item_id NULL.
+      # A fixture that set both would pass even against a query that only
+      # groups on media_files.media_item_id, which is the defect this guards.
+      file = media_file_fixture(%{episode_id: episode.id})
+      assert file.media_item_id == nil
+      backdate_media_file(file, @yesterday)
+
+      assert RecentlyAdded.added_at_map() == %{show.id => @yesterday}
+    end
+
+    test "an upgrade does not move the timestamp" do
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id})
+
+      original = media_file_fixture(%{episode_id: episode.id})
+      backdate_media_file(original, @long_ago)
+
+      # The upgrade path inserts a second row on the same episode and trashes
+      # the first. The slot's minimum must ignore the newer row.
+      replacement = media_file_fixture(%{episode_id: episode.id})
+      backdate_media_file(replacement, @yesterday)
+
+      assert RecentlyAdded.added_at_map() == %{show.id => @long_ago}
+    end
+
+    test "a trashed original still counts as its episode's first file" do
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id})
+
+      original =
+        media_file_fixture(%{
+          episode_id: episode.id,
+          trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      backdate_media_file(original, @long_ago)
+
+      replacement = media_file_fixture(%{episode_id: episode.id})
+      backdate_media_file(replacement, @yesterday)
+
+      assert RecentlyAdded.added_at_map() == %{show.id => @long_ago}
+    end
+
+    test "a show reports the newest of its episodes" do
+      show = media_item_fixture(%{type: "tv_show"})
+      old_ep = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+      new_ep = episode_fixture(%{media_item_id: show.id, season_number: 4, episode_number: 2})
+
+      backdate_media_file(media_file_fixture(%{episode_id: old_ep.id}), @long_ago)
+      backdate_media_file(media_file_fixture(%{episode_id: new_ep.id}), @yesterday)
+
+      assert RecentlyAdded.added_at_map() == %{show.id => @yesterday}
+    end
+
+    test "a movie reports its file's arrival, not the item's inserted_at" do
+      movie = media_item_fixture(%{type: "movie"})
+      file = media_file_fixture(%{media_item_id: movie.id})
+      backdate_media_file(file, @yesterday)
+
+      assert RecentlyAdded.added_at_map() == %{movie.id => @yesterday}
+    end
+
+    test "an unmatched show file with no episode still resolves to its show" do
+      show = media_item_fixture(%{type: "tv_show"})
+      file = media_file_fixture(%{media_item_id: show.id})
+      backdate_media_file(file, @yesterday)
+
+      assert RecentlyAdded.added_at_map() == %{show.id => @yesterday}
+    end
+
+    test "an item with no files is absent" do
+      media_item_fixture(%{type: "movie"})
+
+      assert RecentlyAdded.added_at_map() == %{}
+    end
+
+    test "scopes to the given ids" do
+      movie_a = media_item_fixture(%{type: "movie"})
+      movie_b = media_item_fixture(%{type: "movie"})
+
+      backdate_media_file(media_file_fixture(%{media_item_id: movie_a.id}), @yesterday)
+      backdate_media_file(media_file_fixture(%{media_item_id: movie_b.id}), @last_week)
+
+      assert RecentlyAdded.added_at_map(ids: [movie_a.id]) == %{movie_a.id => @yesterday}
+    end
+
+    test "an empty id list returns an empty map without querying everything" do
+      movie = media_item_fixture(%{type: "movie"})
+      backdate_media_file(media_file_fixture(%{media_item_id: movie.id}), @yesterday)
+
+      assert RecentlyAdded.added_at_map(ids: []) == %{}
+    end
+  end
+end

--- a/test/mydia/media/recently_added_test.exs
+++ b/test/mydia/media/recently_added_test.exs
@@ -108,4 +108,96 @@ defmodule Mydia.Media.RecentlyAddedTest do
       assert RecentlyAdded.added_at_map(ids: []) == %{}
     end
   end
+
+  describe "list_recent/1" do
+    setup do
+      %{since: @last_week}
+    end
+
+    test "returns a long-owned show whose episode arrived inside the window", %{since: since} do
+      show = media_item_fixture(%{type: "tv_show", title: "The Bear"})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 4, episode_number: 2})
+      backdate_media_file(media_file_fixture(%{episode_id: episode.id}), @yesterday)
+
+      assert [entry] = RecentlyAdded.list_recent(since: since)
+      assert entry.media_item.id == show.id
+      assert entry.content_added_at == @yesterday
+      assert entry.new_episode_count == 1
+      assert entry.latest_episode.id == episode.id
+    end
+
+    test "excludes items whose content predates the window", %{since: since} do
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id})
+      backdate_media_file(media_file_fixture(%{episode_id: episode.id}), @long_ago)
+
+      assert RecentlyAdded.list_recent(since: since) == []
+    end
+
+    test "counts only episodes first filled inside the window", %{since: since} do
+      show = media_item_fixture(%{type: "tv_show"})
+      old_ep = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+      new_ep = episode_fixture(%{media_item_id: show.id, season_number: 4, episode_number: 2})
+
+      backdate_media_file(media_file_fixture(%{episode_id: old_ep.id}), @long_ago)
+      backdate_media_file(media_file_fixture(%{episode_id: new_ep.id}), @yesterday)
+
+      assert [entry] = RecentlyAdded.list_recent(since: since)
+      assert entry.new_episode_count == 1
+      assert entry.latest_episode.id == new_ep.id
+    end
+
+    test "a movie reports nil context rather than a count of one", %{since: since} do
+      movie = media_item_fixture(%{type: "movie"})
+      backdate_media_file(media_file_fixture(%{media_item_id: movie.id}), @yesterday)
+
+      assert [entry] = RecentlyAdded.list_recent(since: since)
+      assert entry.media_item.id == movie.id
+      assert entry.new_episode_count == nil
+      assert entry.latest_episode == nil
+    end
+
+    test "a show whose newest slot is unmatched files has a count but no episode",
+         %{since: since} do
+      show = media_item_fixture(%{type: "tv_show"})
+      backdate_media_file(media_file_fixture(%{media_item_id: show.id}), @yesterday)
+
+      assert [entry] = RecentlyAdded.list_recent(since: since)
+      assert entry.new_episode_count == 1
+      assert entry.latest_episode == nil
+    end
+
+    test "orders newest first", %{since: since} do
+      older = media_item_fixture(%{type: "movie", title: "Older"})
+      newer = media_item_fixture(%{type: "movie", title: "Newer"})
+
+      backdate_media_file(media_file_fixture(%{media_item_id: older.id}), @last_week)
+      backdate_media_file(media_file_fixture(%{media_item_id: newer.id}), @yesterday)
+
+      assert [first, second] = RecentlyAdded.list_recent(since: since)
+      assert first.media_item.id == newer.id
+      assert second.media_item.id == older.id
+    end
+
+    test "filters by type", %{since: since} do
+      movie = media_item_fixture(%{type: "movie"})
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id})
+
+      backdate_media_file(media_file_fixture(%{media_item_id: movie.id}), @yesterday)
+      backdate_media_file(media_file_fixture(%{episode_id: episode.id}), @yesterday)
+
+      assert [entry] = RecentlyAdded.list_recent(since: since, types: ["movie"])
+      assert entry.media_item.id == movie.id
+    end
+
+    test "honors the limit", %{since: since} do
+      for _ <- 1..3 do
+        movie = media_item_fixture(%{type: "movie"})
+        backdate_media_file(media_file_fixture(%{media_item_id: movie.id}), @yesterday)
+      end
+
+      assert length(RecentlyAdded.list_recent(since: since, limit: 2)) == 2
+    end
+  end
 end

--- a/test/mydia/media/recently_added_test.exs
+++ b/test/mydia/media/recently_added_test.exs
@@ -167,6 +167,19 @@ defmodule Mydia.Media.RecentlyAddedTest do
       assert entry.latest_episode == nil
     end
 
+    test "a show reports no latest episode when its newest slot is unmatched files",
+         %{since: since} do
+      show = media_item_fixture(%{type: "tv_show"})
+      old_ep = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+      backdate_media_file(media_file_fixture(%{episode_id: old_ep.id}), @long_ago)
+      backdate_media_file(media_file_fixture(%{media_item_id: show.id}), @yesterday)
+
+      assert [entry] = RecentlyAdded.list_recent(since: since)
+      assert entry.new_episode_count == 1
+      assert entry.latest_episode == nil
+    end
+
     test "orders newest first", %{since: since} do
       older = media_item_fixture(%{type: "movie", title: "Older"})
       newer = media_item_fixture(%{type: "movie", title: "Newer"})

--- a/test/mydia/media/recently_added_test.exs
+++ b/test/mydia/media/recently_added_test.exs
@@ -107,6 +107,32 @@ defmodule Mydia.Media.RecentlyAddedTest do
 
       assert RecentlyAdded.added_at_map(ids: []) == %{}
     end
+
+    test "a library-sized id list is chunked rather than raising on a bind-parameter ceiling" do
+      # Enough synthetic ids to force multiple chunks (well past @id_chunk_size)
+      # without paying for thousands of real media items and files. None of
+      # these match a real row, so the correct answer is an empty map; the
+      # point is that the query executes at all.
+      ids = for _ <- 1..5000, do: Ecto.UUID.generate()
+
+      assert RecentlyAdded.added_at_map(ids: ids) == %{}
+    end
+
+    test "chunking still returns real matches scattered across chunk boundaries" do
+      movie_a = media_item_fixture(%{type: "movie"})
+      movie_b = media_item_fixture(%{type: "movie"})
+
+      backdate_media_file(media_file_fixture(%{media_item_id: movie_a.id}), @yesterday)
+      backdate_media_file(media_file_fixture(%{media_item_id: movie_b.id}), @last_week)
+
+      noise_ids = for _ <- 1..5000, do: Ecto.UUID.generate()
+      ids = [movie_a.id | noise_ids] ++ [movie_b.id]
+
+      assert RecentlyAdded.added_at_map(ids: ids) == %{
+               movie_a.id => @yesterday,
+               movie_b.id => @last_week
+             }
+    end
   end
 
   describe "list_recent/1" do

--- a/test/mydia_web/live/media_live/added_sort_test.exs
+++ b/test/mydia_web/live/media_live/added_sort_test.exs
@@ -51,4 +51,48 @@ defmodule MydiaWeb.MediaLive.AddedSortTest do
 
     assert fresh_position < stale_position
   end
+
+  test "a fileless wanted item sorts by its own inserted_at, not a missing content timestamp",
+       %{conn: conn} do
+    fresh = media_item_fixture(%{type: "tv_show", title: "Fresh Show"})
+    fresh_ep = episode_fixture(%{media_item_id: fresh.id})
+    backdate_media_file(media_file_fixture(%{episode_id: fresh_ep.id}), ~U[2026-08-03 00:00:00Z])
+
+    stale = media_item_fixture(%{type: "tv_show", title: "Stale Show"})
+    stale_ep = episode_fixture(%{media_item_id: stale.id})
+    backdate_media_file(media_file_fixture(%{episode_id: stale_ep.id}), ~U[2024-01-01 00:00:00Z])
+
+    # A wanted item with no files at all has no content_added_at, so its sort
+    # key must fall back to its own inserted_at (effective_added_at/2). If
+    # that fallback ever regresses from `Map.get` to `Map.fetch!`, this item
+    # blows up the whole page instead of just sorting oddly.
+    wanted = media_item_fixture(%{type: "tv_show", title: "Wanted Show"})
+
+    Mydia.Repo.update_all(
+      from(m in Mydia.Media.MediaItem, where: m.id == ^wanted.id),
+      set: [inserted_at: ~U[2025-06-01 00:00:00Z]]
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/tv")
+
+    html =
+      view
+      |> element("#library-filter-form")
+      |> render_change(%{"sort_by" => "added_desc"})
+
+    fresh_marker = "media_items-#{fresh.id}"
+    wanted_marker = "media_items-#{wanted.id}"
+    stale_marker = "media_items-#{stale.id}"
+
+    assert html =~ fresh_marker
+    assert html =~ wanted_marker
+    assert html =~ stale_marker
+
+    {fresh_position, _} = :binary.match(html, fresh_marker)
+    {wanted_position, _} = :binary.match(html, wanted_marker)
+    {stale_position, _} = :binary.match(html, stale_marker)
+
+    assert fresh_position < wanted_position
+    assert wanted_position < stale_position
+  end
 end

--- a/test/mydia_web/live/media_live/added_sort_test.exs
+++ b/test/mydia_web/live/media_live/added_sort_test.exs
@@ -1,0 +1,54 @@
+defmodule MydiaWeb.MediaLive.AddedSortTest do
+  # async: false — the Postgres non-shared sandbox hides these rows from the
+  # LiveView mount process otherwise.
+  use MydiaWeb.ConnCase, async: false
+
+  import Ecto.Query
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+
+  setup %{conn: conn} do
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  test "sorts shows by newest episode arrival, not by show creation", %{conn: conn} do
+    stale = media_item_fixture(%{type: "tv_show", title: "Stale Show"})
+    stale_ep = episode_fixture(%{media_item_id: stale.id})
+    backdate_media_file(media_file_fixture(%{episode_id: stale_ep.id}), ~U[2024-01-01 00:00:00Z])
+
+    fresh = media_item_fixture(%{type: "tv_show", title: "Fresh Show"})
+    fresh_ep = episode_fixture(%{media_item_id: fresh.id})
+    backdate_media_file(media_file_fixture(%{episode_id: fresh_ep.id}), ~U[2026-08-03 00:00:00Z])
+
+    # Make the *records* the opposite order, so a passing test cannot be
+    # explained by media_items.inserted_at.
+    Mydia.Repo.update_all(
+      from(m in Mydia.Media.MediaItem, where: m.id == ^fresh.id),
+      set: [inserted_at: ~U[2023-01-01 00:00:00Z]]
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/tv")
+
+    # The sort select lives in the filter form (index.html.heex:119), which
+    # fires phx-change="filter".
+    html =
+      view
+      |> element("#library-filter-form")
+      |> render_change(%{"sort_by" => "added_desc"})
+
+    # Stream children are keyed `media_items-<item id>` by `stream/3`, and
+    # exist in both grid and list view modes.
+    fresh_marker = "media_items-#{fresh.id}"
+    stale_marker = "media_items-#{stale.id}"
+
+    assert html =~ fresh_marker
+    assert html =~ stale_marker
+
+    {fresh_position, _} = :binary.match(html, fresh_marker)
+    {stale_position, _} = :binary.match(html, stale_marker)
+
+    assert fresh_position < stale_position
+  end
+end

--- a/test/mydia_web/schema/resolvers/item_builder_test.exs
+++ b/test/mydia_web/schema/resolvers/item_builder_test.exs
@@ -1,0 +1,58 @@
+defmodule MydiaWeb.Schema.Resolvers.ItemBuilderTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+
+  alias MydiaWeb.Schema.Resolvers.ItemBuilder
+
+  describe "recently_added_item/2" do
+    test "defaults added_at to the item's inserted_at" do
+      item = media_item_fixture(%{type: "movie", title: "Heat", year: 1995})
+
+      built = ItemBuilder.recently_added_item(item)
+
+      assert built.id == item.id
+      assert built.type == :movie
+      assert built.title == "Heat"
+      assert built.year == 1995
+      assert built.added_at == item.inserted_at
+      assert built.new_episode_count == nil
+      assert built.latest_season_number == nil
+      assert built.latest_episode_number == nil
+    end
+
+    test "overrides added_at when given" do
+      item = media_item_fixture(%{type: "movie"})
+      stamp = ~U[2026-01-02 03:04:05Z]
+
+      built = ItemBuilder.recently_added_item(item, added_at: stamp)
+
+      assert built.added_at == stamp
+    end
+
+    test "flattens the latest episode into season and episode numbers" do
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 4, episode_number: 2})
+
+      built =
+        ItemBuilder.recently_added_item(show,
+          new_episode_count: 3,
+          latest_episode: episode
+        )
+
+      assert built.new_episode_count == 3
+      assert built.latest_season_number == 4
+      assert built.latest_episode_number == 2
+    end
+
+    test "leaves episode numbers nil when there is no latest episode" do
+      show = media_item_fixture(%{type: "tv_show"})
+
+      built = ItemBuilder.recently_added_item(show, new_episode_count: 2)
+
+      assert built.new_episode_count == 2
+      assert built.latest_season_number == nil
+      assert built.latest_episode_number == nil
+    end
+  end
+end

--- a/test/mydia_web/schema_test.exs
+++ b/test/mydia_web/schema_test.exs
@@ -430,6 +430,55 @@ defmodule MydiaWeb.SchemaTest do
       assert Enum.map(items, & &1["id"]) |> Enum.sort() == Enum.sort([show.id, movie.id])
     end
 
+    test "a second page after the cursor returns the next item, not an empty list",
+         %{user: user} do
+      newest = MediaFixtures.media_item_fixture(%{type: "movie", title: "Newest"})
+      middle = MediaFixtures.media_item_fixture(%{type: "movie", title: "Middle"})
+      oldest = MediaFixtures.media_item_fixture(%{type: "movie", title: "Oldest"})
+
+      MediaFixtures.backdate_media_file(
+        MediaFixtures.media_file_fixture(%{media_item_id: newest.id}),
+        DateTime.add(DateTime.utc_now(), -1, :day)
+      )
+
+      MediaFixtures.backdate_media_file(
+        MediaFixtures.media_file_fixture(%{media_item_id: middle.id}),
+        DateTime.add(DateTime.utc_now(), -2, :day)
+      )
+
+      MediaFixtures.backdate_media_file(
+        MediaFixtures.media_file_fixture(%{media_item_id: oldest.id}),
+        DateTime.add(DateTime.utc_now(), -3, :day)
+      )
+
+      first_page_query = "query { recentlyAdded(first: 1) { id } }"
+
+      assert {:ok, %{data: %{"recentlyAdded" => [first_item]}}} =
+               run_query(first_page_query, %{}, user)
+
+      assert first_item["id"] == newest.id
+
+      # The schema exposes no cursor field on recentlyAdded items; the
+      # resolver's own encoding (see decode_cursor/1 in DiscoveryResolver) is
+      # base64("cursor:<offset>"), built here directly rather than through a
+      # field the API doesn't provide.
+      cursor = Base.encode64("cursor:0")
+
+      second_page_query = """
+      query {
+        recentlyAdded(first: 1, after: "#{cursor}") {
+          id
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"recentlyAdded" => [second_item]}}} =
+               run_query(second_page_query, %{}, user)
+
+      assert second_item["id"] == middle.id
+      refute second_item["id"] == oldest.id
+    end
+
     test "favorites reports the corrected timestamp with nil context", %{user: user} do
       movie = MediaFixtures.media_item_fixture(%{type: "movie"})
       file = MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
@@ -452,6 +501,67 @@ defmodule MydiaWeb.SchemaTest do
       assert item["id"] == movie.id
       assert item["addedAt"] =~ "2026-08-03"
       assert item["newEpisodeCount"] == nil
+    end
+
+    test "unwatched orders by content arrival, not by record creation", %{user: user} do
+      stale = MediaFixtures.media_item_fixture(%{type: "movie", title: "Stale"})
+      stale_file = MediaFixtures.media_file_fixture(%{media_item_id: stale.id})
+      MediaFixtures.backdate_media_file(stale_file, ~U[2024-01-01 12:00:00Z])
+
+      fresh = MediaFixtures.media_item_fixture(%{type: "movie", title: "Fresh"})
+      fresh_file = MediaFixtures.media_file_fixture(%{media_item_id: fresh.id})
+      MediaFixtures.backdate_media_file(fresh_file, ~U[2026-08-03 12:00:00Z])
+
+      # Make the records themselves disagree with the content order, so a
+      # passing test cannot be explained by inserted_at.
+      Mydia.Repo.update_all(
+        from(m in Mydia.Media.MediaItem, where: m.id == ^fresh.id),
+        set: [inserted_at: ~U[2023-01-01 00:00:00Z]]
+      )
+
+      query = """
+      query {
+        unwatched(first: 10) {
+          id
+          addedAt
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"unwatched" => items}}} = run_query(query, %{}, user)
+
+      assert Enum.map(items, & &1["id"]) == [fresh.id, stale.id]
+    end
+
+    test "collectionItems reports the corrected addedAt", %{user: user} do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+      file = MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+      MediaFixtures.backdate_media_file(file, ~U[2026-08-03 12:00:00Z])
+
+      # The record itself is old; only its content is new.
+      Mydia.Repo.update_all(
+        from(m in Mydia.Media.MediaItem, where: m.id == ^movie.id),
+        set: [inserted_at: ~U[2024-01-01 00:00:00Z]]
+      )
+
+      collection = Mydia.CollectionsFixtures.collection_fixture(%{user: user})
+      {:ok, _count} = Mydia.Collections.add_items(collection, [movie.id])
+
+      query = """
+      query($collectionId: ID!) {
+        collectionItems(collectionId: $collectionId, first: 10) {
+          id
+          addedAt
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"collectionItems" => [item]}}} =
+               run_query(query, %{"collectionId" => collection.id}, user)
+
+      assert item["id"] == movie.id
+      assert item["addedAt"] =~ "2026-08-03"
+      refute item["addedAt"] =~ "2024-01-01"
     end
 
     test "rejects the new fields with a recognizable message when absent" do

--- a/test/mydia_web/schema_test.exs
+++ b/test/mydia_web/schema_test.exs
@@ -1,7 +1,11 @@
 defmodule MydiaWeb.SchemaTest do
-  use ExUnit.Case
+  use MydiaWeb.ConnCase
+
+  import Ecto.Query
 
   alias Absinthe.Schema
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
 
   describe "GraphQL Schema" do
     test "schema compiles and introspects successfully" do
@@ -307,5 +311,117 @@ defmodule MydiaWeb.SchemaTest do
       assert "REVOKED" in enum_values
       assert "DELETED" in enum_values
     end
+  end
+
+  describe "recentlyAdded with content timestamps" do
+    setup do
+      %{user: AccountsFixtures.user_fixture()}
+    end
+
+    test "surfaces a long-owned show after a new episode arrives", %{user: user} do
+      show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "The Bear"})
+
+      episode =
+        MediaFixtures.episode_fixture(%{
+          media_item_id: show.id,
+          season_number: 4,
+          episode_number: 2
+        })
+
+      file = MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+      MediaFixtures.backdate_media_file(file, DateTime.add(DateTime.utc_now(), -2, :day))
+
+      # The show record itself is ancient; only its content is new.
+      Mydia.Repo.update_all(
+        from(m in Mydia.Media.MediaItem, where: m.id == ^show.id),
+        set: [inserted_at: ~U[2024-01-01 00:00:00Z]]
+      )
+
+      query = """
+      query {
+        recentlyAdded(first: 10) {
+          id
+          title
+          addedAt
+          newEpisodeCount
+          latestSeasonNumber
+          latestEpisodeNumber
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"recentlyAdded" => [item]}}} = run_query(query, %{}, user)
+
+      assert item["id"] == show.id
+      assert item["newEpisodeCount"] == 1
+      assert item["latestSeasonNumber"] == 4
+      assert item["latestEpisodeNumber"] == 2
+      refute String.starts_with?(item["addedAt"], "2024")
+    end
+
+    test "a movie reports nil episode context", %{user: user} do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+      file = MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+      MediaFixtures.backdate_media_file(file, DateTime.add(DateTime.utc_now(), -2, :day))
+
+      query = """
+      query {
+        recentlyAdded(first: 10) {
+          id
+          newEpisodeCount
+          latestSeasonNumber
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"recentlyAdded" => [item]}}} = run_query(query, %{}, user)
+
+      assert item["id"] == movie.id
+      assert item["newEpisodeCount"] == nil
+      assert item["latestSeasonNumber"] == nil
+    end
+
+    test "favorites reports the corrected timestamp with nil context", %{user: user} do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+      file = MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+      MediaFixtures.backdate_media_file(file, ~U[2026-08-03 12:00:00Z])
+
+      favorite_item(user, movie)
+
+      query = """
+      query {
+        favorites(first: 10) {
+          id
+          addedAt
+          newEpisodeCount
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"favorites" => [item]}}} = run_query(query, %{}, user)
+
+      assert item["id"] == movie.id
+      assert item["addedAt"] =~ "2026-08-03"
+      assert item["newEpisodeCount"] == nil
+    end
+
+    test "rejects the new fields with a recognizable message when absent" do
+      # Pins the string that the player's downgrade detector matches on. If
+      # Absinthe ever rephrases this, the player guard must be updated in the
+      # same change.
+      query = "query { recentlyAdded(first: 1) { id noSuchField } }"
+
+      {:ok, %{errors: [error | _]}} = Absinthe.run(query, MydiaWeb.Schema)
+
+      assert error.message =~ "Cannot query field"
+    end
+  end
+
+  defp run_query(query, variables, user) do
+    Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: %{current_user: user})
+  end
+
+  defp favorite_item(user, media_item) do
+    {:ok, _} = Mydia.Media.toggle_favorite(user.id, media_item.id)
   end
 end

--- a/test/mydia_web/schema_test.exs
+++ b/test/mydia_web/schema_test.exs
@@ -381,6 +381,55 @@ defmodule MydiaWeb.SchemaTest do
       assert item["latestSeasonNumber"] == nil
     end
 
+    test "types: [TV_SHOW] excludes a recently-arrived movie", %{user: user} do
+      {show, _movie} = seed_recently_added_show_and_movie()
+
+      query = """
+      query {
+        recentlyAdded(first: 10, types: [TV_SHOW]) {
+          id
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"recentlyAdded" => items}}} = run_query(query, %{}, user)
+
+      assert Enum.map(items, & &1["id"]) == [show.id]
+    end
+
+    test "types: [MOVIE] excludes a recently-arrived show", %{user: user} do
+      {_show, movie} = seed_recently_added_show_and_movie()
+
+      query = """
+      query {
+        recentlyAdded(first: 10, types: [MOVIE]) {
+          id
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"recentlyAdded" => items}}} = run_query(query, %{}, user)
+
+      assert Enum.map(items, & &1["id"]) == [movie.id]
+    end
+
+    test "types: [MOVIE, TV_SHOW] returns both, since requesting every type means no filter",
+         %{user: user} do
+      {show, movie} = seed_recently_added_show_and_movie()
+
+      query = """
+      query {
+        recentlyAdded(first: 10, types: [MOVIE, TV_SHOW]) {
+          id
+        }
+      }
+      """
+
+      assert {:ok, %{data: %{"recentlyAdded" => items}}} = run_query(query, %{}, user)
+
+      assert Enum.map(items, & &1["id"]) |> Enum.sort() == Enum.sort([show.id, movie.id])
+    end
+
     test "favorites reports the corrected timestamp with nil context", %{user: user} do
       movie = MediaFixtures.media_item_fixture(%{type: "movie"})
       file = MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
@@ -423,5 +472,28 @@ defmodule MydiaWeb.SchemaTest do
 
   defp favorite_item(user, media_item) do
     {:ok, _} = Mydia.Media.toggle_favorite(user.id, media_item.id)
+  end
+
+  # A show (linked the way production links episode files: episode_id set,
+  # media_item_id left NULL) and a movie, both with a file inside the 30-day
+  # window, so a `types:` filter has something real to exclude.
+  defp seed_recently_added_show_and_movie do
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "The Bear"})
+
+    episode =
+      MediaFixtures.episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 1,
+        episode_number: 1
+      })
+
+    show_file = MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+    MediaFixtures.backdate_media_file(show_file, DateTime.add(DateTime.utc_now(), -2, :day))
+
+    movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+    movie_file = MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+    MediaFixtures.backdate_media_file(movie_file, DateTime.add(DateTime.utc_now(), -3, :day))
+
+    {show, movie}
   end
 end

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -3,6 +3,7 @@ defmodule Mydia.MediaFixtures do
   This module defines test helpers for creating entities via the `Mydia.Media` context.
   """
 
+  import Ecto.Query
   import Mydia.SettingsFixtures
 
   @doc """
@@ -129,5 +130,23 @@ defmodule Mydia.MediaFixtures do
     {:ok, media_file} = Mydia.Library.create_media_file(final_attrs)
 
     media_file
+  end
+
+  @doc """
+  Rewrites a media file's `inserted_at`.
+
+  `Mydia.Library.create_media_file/1` cannot set it (timestamps are not cast),
+  so any test that needs a file to look old has to go around the changeset.
+  """
+  def backdate_media_file(%Mydia.Library.MediaFile{} = media_file, %DateTime{} = at) do
+    at = DateTime.truncate(at, :second)
+
+    {1, _} =
+      Mydia.Repo.update_all(
+        from(f in Mydia.Library.MediaFile, where: f.id == ^media_file.id),
+        set: [inserted_at: at]
+      )
+
+    %{media_file | inserted_at: at}
   end
 end


### PR DESCRIPTION
## What

"Recently added" meant `media_items.inserted_at` — when the *record* was created. For a show added two years ago that got a new episode last night, that made the show invisible to Recently Added. For a weekly-airing show, that is the normal case, which made the rail useless for exactly the content you are most likely to want.

It now means when content actually arrived.

## How

Files are grouped into **slots**: one per episode of a show, one per movie. A slot's timestamp is its *earliest* file, counting trashed rows. An item's timestamp is the *newest* of its slots.

That min-then-max shape is what makes quality upgrades invisible: an upgrade adds a later file to a slot that already has an earlier one, so it cannot bump a show back to the top. Deriving the owning item needs care, because the two file kinds link in opposite directions — a movie's file sets `media_item_id` with `episode_id` NULL, while an episode's file is the mirror image and reaches its show only through `episodes.media_item_id`. Grouping on `media_files.media_item_id` alone returns nothing at all for TV shows, so the query resolves the owner via a left join plus `coalesce/2`.

The same rule fixes movies: one you added to the wanted list in January and downloaded yesterday now reads as added yesterday.

Computed at query time in a new `Mydia.Media.RecentlyAdded`. No migration, no denormalized column, nothing that can drift.

## Surfaces

- `recentlyAdded` reports content arrival and carries three new **nullable** fields: `newEpisodeCount`, `latestSeasonNumber`, `latestEpisodeNumber`. Cards now say `S04E02` or `3 new episodes` instead of leaving you to guess why a show moved.
- `favorites`, `unwatched`, and `collectionItems` report the corrected `addedAt`. Their episode-context fields stay null — those views are not windowed, so a count has nothing to be counted against.
- `/tv` and `/movies` "Added (Newest)" sorts read the same value, so the web UI and the player no longer disagree about when something was added. Fileless wanted items fall back to their own `inserted_at`, which is the only meaningful answer for them.

## Cross-version compatibility

Self-hosted installs have no coordinated deploy order, so both directions are handled. An old player omits the new fields and just works. A new player against an older server would otherwise lose the *entire* rail, since GraphQL rejects a whole document over one unknown field — so `QueryWatcher` gained a one-shot downgrade: on `Cannot query field` it retries once with a frozen legacy document. That exact server message is pinned by a test, so the two halves cannot drift apart silently.

## Notes for review

- Both adapters are exercised, not assumed portable. The datetime aggregation and the `IN`-list encoding both behaved differently on SQLite vs PostgreSQL during development and are now covered by tests on each.
- `ItemBuilder` was extracted first because `DiscoveryResolver` and `CollectionResolver` each carried their own copy of the payload builder — two definitions of "added", of which only one would have been fixed.
- The rail passes an explicit `:limit`. Without it the resolver materialized the whole 30-day window to return 20 items, which right after a library import *is* the whole library, and past ~32k items crosses SQLite's bind-parameter ceiling and becomes a hard error rather than merely slow.

## Known follow-up (not in this PR)

`Movie.addedAt`, `TvShow.addedAt`, and the `ADDED_AT` browse sort still use `inserted_at`, so the schema currently ships two `addedAt` semantics. Not user-visible today — the player's library sort deliberately ignores its sort argument — but worth a follow-up issue before anyone wires that up.

## Verification

- `mix precommit`: **6500 tests, 0 failures**, all gates green (format, Credo, unused deps, warnings-as-errors)
- Targeted suites re-run under `DATABASE_TYPE=postgres`: **168 tests, 0 failures**
- `flutter test --concurrency=1`: **1443 tests, all passing** (the flag is mandatory here — the default silently drops files while exiting 0, and CI was doing exactly that; this PR fixes the workflow too)
- `flutter analyze`: 51 issues, unchanged pre-existing baseline
