### PR TITLE
fix(player): restore the cast button during playback

### DIFF
--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -2685,6 +2685,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
               context.go('/');
             }
           },
+          // The chrome's own cast pill. Null on a build that cannot cast at
+          // all, which drops the pill rather than drawing an empty one.
+          castAction: castChromeActionFor(ref),
+          onCastTap: _showCastDevicePicker,
           onAudioTap: _showAudioSelector,
           onSubtitleTap: _showSubtitleSelector,
           // Hidden when the ladder collapsed to Original alone — a source

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -36,6 +36,7 @@ import '../../widgets/gesture_controls.dart';
 import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
 import '../../widgets/cast_device_picker.dart';
+import '../../widgets/video_controls/cast_chrome_icon.dart';
 import '../../widgets/video_controls/custom_video_controls.dart';
 import '../../widgets/video_controls/skip_segment_button.dart';
 import '../../widgets/up_next_overlay.dart';

--- a/player/lib/presentation/widgets/cast_button.dart
+++ b/player/lib/presentation/widgets/cast_button.dart
@@ -3,15 +3,43 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/cast/cast_providers.dart';
 
+/// How a cast affordance looks in a given [CastConnection].
+///
+/// Shared by [CastButton] and [CastChromeIcon] so the two cannot drift into
+/// disagreeing about what a state means. `Icons.cast_connected` is the
+/// platform's "this app owns that receiver" glyph, so it appears only when a
+/// connection is genuinely live — a device that has merely been chosen gets
+/// the hollow `Icons.cast` in the same blue.
+(IconData, Color, String) _castVisuals(CastConnection connection, String name) {
+  return switch (connection) {
+    CastConnection.none => (Icons.cast, Colors.white, 'Cast to device'),
+    CastConnection.connecting => (
+        Icons.cast,
+        Colors.blue,
+        'Connecting to $name…',
+      ),
+    CastConnection.connectedIdle => (
+        Icons.cast_connected,
+        Colors.blue,
+        'Connected to $name',
+      ),
+    CastConnection.casting => (
+        Icons.cast_connected,
+        Colors.blue,
+        'Casting to $name',
+      ),
+    CastConnection.chosenOffline => (
+        Icons.cast,
+        Colors.blue,
+        '$name — not connected',
+      ),
+  };
+}
+
 /// The cast affordance, shown in app bars and as the shell overlay.
 ///
 /// Renders nothing when the current build has no cast capability at all
 /// (e.g. web), so unsupported builds show no dead affordance.
-///
-/// Every visual comes from [castConnectionProvider]. `Icons.cast_connected` is
-/// the platform's "this app owns that receiver" glyph, so it appears only when
-/// a connection is genuinely live — a device that has merely been chosen gets
-/// the hollow `Icons.cast` in the same blue.
 class CastButton extends ConsumerWidget {
   final VoidCallback onPressed;
 
@@ -25,31 +53,8 @@ class CastButton extends ConsumerWidget {
 
     final connection = ref.watch(castConnectionProvider);
     final device = ref.watch(castDisplayDeviceProvider);
-    final name = device?.name ?? 'device';
-
-    final (IconData glyph, Color color, String tooltip) = switch (connection) {
-      CastConnection.none => (Icons.cast, Colors.white, 'Cast to device'),
-      CastConnection.connecting => (
-          Icons.cast,
-          Colors.blue,
-          'Connecting to $name…',
-        ),
-      CastConnection.connectedIdle => (
-          Icons.cast_connected,
-          Colors.blue,
-          'Connected to $name',
-        ),
-      CastConnection.casting => (
-          Icons.cast_connected,
-          Colors.blue,
-          'Casting to $name',
-        ),
-      CastConnection.chosenOffline => (
-          Icons.cast,
-          Colors.blue,
-          '$name — not connected',
-        ),
-    };
+    final (glyph, color, tooltip) =
+        _castVisuals(connection, device?.name ?? 'device');
 
     return IconButton(
       key: const Key('cast-button'),
@@ -77,3 +82,65 @@ class CastButton extends ConsumerWidget {
     );
   }
 }
+
+/// The cast glyph for the playback chrome's top bar.
+///
+/// [CastButton] cannot be reused there: it is a 48px `IconButton` carrying its
+/// own opaque background, which neither fits `GlassPill`'s 36px height nor
+/// wants a second surface behind the one the pill already draws. This renders
+/// the glyph alone and lets the pill own the surface, the tap target and the
+/// hover cursor — so it is deliberately *not* tappable itself.
+///
+/// Unlike [CastButton] this does not check capability, because `ChromeTopBar`
+/// decides whether to draw the pill from whether its `castAction` is null: a
+/// glyph that shrank itself to nothing would leave an empty glass pill
+/// floating in the corner. Build it through [castChromeActionFor] instead.
+class CastChromeIcon extends ConsumerWidget {
+  const CastChromeIcon({super.key});
+
+  static const Key iconKey = Key('cast-chrome-icon');
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connection = ref.watch(castConnectionProvider);
+    final device = ref.watch(castDisplayDeviceProvider);
+    final (glyph, color, tooltip) =
+        _castVisuals(connection, device?.name ?? 'device');
+
+    // Idle inherits the pill's own IconTheme (white @ 0.80) so the cast glyph
+    // matches the back chevron beside it; CastButton's opaque white would
+    // read brighter than every other pill glyph. Every other state keeps the
+    // shared blue, which is the entire point of the state being visible.
+    final resolved = connection == CastConnection.none ? null : color;
+
+    return Tooltip(
+      message: tooltip,
+      child: connection == CastConnection.connecting
+          // Sized down from CastButton's 24px ring: this one has to sit
+          // inside a 36px pill without forcing the top bar to grow.
+          ? Stack(
+              alignment: Alignment.center,
+              children: [
+                Icon(glyph, key: iconKey, color: resolved, size: 12),
+                const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.blue,
+                  ),
+                ),
+              ],
+            )
+          : Icon(glyph, key: iconKey, color: resolved),
+    );
+  }
+}
+
+/// The chrome's cast affordance, or null when this build cannot cast at all.
+///
+/// The capability check lives here rather than inside [CastChromeIcon] so that
+/// an incapable build omits the whole pill instead of drawing an empty one —
+/// see [CastChromeIcon]'s dartdoc.
+Widget? castChromeActionFor(WidgetRef ref) =>
+    ref.watch(castCapabilitiesProvider).any ? const CastChromeIcon() : null;

--- a/player/lib/presentation/widgets/cast_button.dart
+++ b/player/lib/presentation/widgets/cast_button.dart
@@ -2,44 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/cast/cast_providers.dart';
-
-/// How a cast affordance looks in a given [CastConnection].
-///
-/// Shared by [CastButton] and [CastChromeIcon] so the two cannot drift into
-/// disagreeing about what a state means. `Icons.cast_connected` is the
-/// platform's "this app owns that receiver" glyph, so it appears only when a
-/// connection is genuinely live — a device that has merely been chosen gets
-/// the hollow `Icons.cast` in the same blue.
-(IconData, Color, String) _castVisuals(CastConnection connection, String name) {
-  return switch (connection) {
-    CastConnection.none => (Icons.cast, Colors.white, 'Cast to device'),
-    CastConnection.connecting => (
-        Icons.cast,
-        Colors.blue,
-        'Connecting to $name…',
-      ),
-    CastConnection.connectedIdle => (
-        Icons.cast_connected,
-        Colors.blue,
-        'Connected to $name',
-      ),
-    CastConnection.casting => (
-        Icons.cast_connected,
-        Colors.blue,
-        'Casting to $name',
-      ),
-    CastConnection.chosenOffline => (
-        Icons.cast,
-        Colors.blue,
-        '$name — not connected',
-      ),
-  };
-}
+import 'cast_visuals.dart';
 
 /// The cast affordance, shown in app bars and as the shell overlay.
 ///
 /// Renders nothing when the current build has no cast capability at all
 /// (e.g. web), so unsupported builds show no dead affordance.
+///
+/// Every visual comes from [castVisualsFor]. Glyphs are the bare Material
+/// family, which is what the app bars this sits in use; the playback chrome's
+/// own affordance is `CastChromeIcon`, which draws the `_rounded` family
+/// instead.
 class CastButton extends ConsumerWidget {
   final VoidCallback onPressed;
 
@@ -53,8 +26,8 @@ class CastButton extends ConsumerWidget {
 
     final connection = ref.watch(castConnectionProvider);
     final device = ref.watch(castDisplayDeviceProvider);
-    final (glyph, color, tooltip) =
-        _castVisuals(connection, device?.name ?? 'device');
+    final visuals = castVisualsFor(connection, device?.name ?? 'device');
+    final glyph = visuals.connected ? Icons.cast_connected : Icons.cast;
 
     return IconButton(
       key: const Key('cast-button'),
@@ -62,7 +35,7 @@ class CastButton extends ConsumerWidget {
           ? Stack(
               alignment: Alignment.center,
               children: [
-                Icon(glyph, color: color, size: 16),
+                Icon(glyph, color: visuals.color, size: 16),
                 const SizedBox(
                   width: 24,
                   height: 24,
@@ -73,74 +46,12 @@ class CastButton extends ConsumerWidget {
                 ),
               ],
             )
-          : Icon(glyph, color: color),
+          : Icon(glyph, color: visuals.color),
       onPressed: onPressed,
       style: IconButton.styleFrom(
         backgroundColor: Colors.black.withValues(alpha: 0.5),
       ),
-      tooltip: tooltip,
+      tooltip: visuals.tooltip,
     );
   }
 }
-
-/// The cast glyph for the playback chrome's top bar.
-///
-/// [CastButton] cannot be reused there: it is a 48px `IconButton` carrying its
-/// own opaque background, which neither fits `GlassPill`'s 36px height nor
-/// wants a second surface behind the one the pill already draws. This renders
-/// the glyph alone and lets the pill own the surface, the tap target and the
-/// hover cursor — so it is deliberately *not* tappable itself.
-///
-/// Unlike [CastButton] this does not check capability, because `ChromeTopBar`
-/// decides whether to draw the pill from whether its `castAction` is null: a
-/// glyph that shrank itself to nothing would leave an empty glass pill
-/// floating in the corner. Build it through [castChromeActionFor] instead.
-class CastChromeIcon extends ConsumerWidget {
-  const CastChromeIcon({super.key});
-
-  static const Key iconKey = Key('cast-chrome-icon');
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final connection = ref.watch(castConnectionProvider);
-    final device = ref.watch(castDisplayDeviceProvider);
-    final (glyph, color, tooltip) =
-        _castVisuals(connection, device?.name ?? 'device');
-
-    // Idle inherits the pill's own IconTheme (white @ 0.80) so the cast glyph
-    // matches the back chevron beside it; CastButton's opaque white would
-    // read brighter than every other pill glyph. Every other state keeps the
-    // shared blue, which is the entire point of the state being visible.
-    final resolved = connection == CastConnection.none ? null : color;
-
-    return Tooltip(
-      message: tooltip,
-      child: connection == CastConnection.connecting
-          // Sized down from CastButton's 24px ring: this one has to sit
-          // inside a 36px pill without forcing the top bar to grow.
-          ? Stack(
-              alignment: Alignment.center,
-              children: [
-                Icon(glyph, key: iconKey, color: resolved, size: 12),
-                const SizedBox(
-                  width: 18,
-                  height: 18,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: Colors.blue,
-                  ),
-                ),
-              ],
-            )
-          : Icon(glyph, key: iconKey, color: resolved),
-    );
-  }
-}
-
-/// The chrome's cast affordance, or null when this build cannot cast at all.
-///
-/// The capability check lives here rather than inside [CastChromeIcon] so that
-/// an incapable build omits the whole pill instead of drawing an empty one —
-/// see [CastChromeIcon]'s dartdoc.
-Widget? castChromeActionFor(WidgetRef ref) =>
-    ref.watch(castCapabilitiesProvider).any ? const CastChromeIcon() : null;

--- a/player/lib/presentation/widgets/cast_visuals.dart
+++ b/player/lib/presentation/widgets/cast_visuals.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../../core/cast/cast_providers.dart';
+
+/// How a cast affordance reads in a given [CastConnection].
+///
+/// Shared by `CastButton` and `CastChromeIcon` so the two cannot drift into
+/// disagreeing about what a connection state means.
+///
+/// Deliberately returns whether the receiver is *connected* rather than an
+/// [IconData]: the two affordances draw from different Material icon families
+/// — the playback chrome is `_rounded` throughout (see
+/// `video_controls/icon_family_test.dart`), while app bars and the shell
+/// overlay use the bare family. Handing back a concrete glyph would force one
+/// of them into the wrong family, which is the exact drift that test exists to
+/// catch. Colour and tooltip, which must match everywhere, are shared.
+typedef CastVisuals = ({bool connected, Color color, String tooltip});
+
+/// `connected` is true only when a connection is genuinely live, because
+/// `cast_connected` is the platform's "this app owns that receiver" glyph. A
+/// device that has merely been chosen stays hollow, in the same blue.
+CastVisuals castVisualsFor(CastConnection connection, String name) {
+  return switch (connection) {
+    CastConnection.none => (
+        connected: false,
+        color: Colors.white,
+        tooltip: 'Cast to device',
+      ),
+    CastConnection.connecting => (
+        connected: false,
+        color: Colors.blue,
+        tooltip: 'Connecting to $name…',
+      ),
+    CastConnection.connectedIdle => (
+        connected: true,
+        color: Colors.blue,
+        tooltip: 'Connected to $name',
+      ),
+    CastConnection.casting => (
+        connected: true,
+        color: Colors.blue,
+        tooltip: 'Casting to $name',
+      ),
+    CastConnection.chosenOffline => (
+        connected: false,
+        color: Colors.blue,
+        tooltip: '$name — not connected',
+      ),
+  };
+}

--- a/player/lib/presentation/widgets/video_controls/cast_chrome_icon.dart
+++ b/player/lib/presentation/widgets/video_controls/cast_chrome_icon.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/cast/cast_providers.dart';
+import '../cast_visuals.dart';
+
+/// The cast glyph for the playback chrome's top bar.
+///
+/// Lives under `video_controls/` rather than beside `CastButton` so the
+/// icon-family guard (`icon_family_test.dart`) covers it: this glyph sits in
+/// the same pill row as `Icons.chevron_left_rounded`, and a bare-family cast
+/// icon next to a rounded chevron is exactly the mixed-fill drift that test
+/// exists to catch.
+///
+/// `CastButton` cannot be reused here: it is a 48px `IconButton` carrying its
+/// own opaque background, which neither fits `GlassPill`'s 36px height nor
+/// wants a second surface behind the one the pill already draws. This renders
+/// the glyph alone and lets the pill own the surface, the tap target and the
+/// hover cursor — so it is deliberately *not* tappable itself.
+///
+/// Unlike `CastButton` this does not check capability, because `ChromeTopBar`
+/// decides whether to draw the pill from whether its `castAction` is null: a
+/// glyph that shrank itself to nothing would leave an empty glass pill
+/// floating in the corner. Build it through [castChromeActionFor] instead.
+class CastChromeIcon extends ConsumerWidget {
+  const CastChromeIcon({super.key});
+
+  static const Key iconKey = Key('cast-chrome-icon');
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connection = ref.watch(castConnectionProvider);
+    final device = ref.watch(castDisplayDeviceProvider);
+    final visuals = castVisualsFor(connection, device?.name ?? 'device');
+    final glyph =
+        visuals.connected ? Icons.cast_connected_rounded : Icons.cast_rounded;
+
+    // Idle inherits the pill's own IconTheme (white @ 0.80) so the cast glyph
+    // matches the back chevron beside it; CastButton's opaque white would
+    // read brighter than every other pill glyph. Every other state keeps the
+    // shared blue, which is the entire point of the state being visible.
+    final color = connection == CastConnection.none ? null : visuals.color;
+
+    return Tooltip(
+      message: visuals.tooltip,
+      child: connection == CastConnection.connecting
+          // Sized down from CastButton's 24px ring: this one has to sit
+          // inside a 36px pill without forcing the top bar to grow.
+          ? Stack(
+              alignment: Alignment.center,
+              children: [
+                Icon(glyph, key: iconKey, color: color, size: 12),
+                const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.blue,
+                  ),
+                ),
+              ],
+            )
+          : Icon(glyph, key: iconKey, color: color),
+    );
+  }
+}
+
+/// The chrome's cast affordance, or null when this build cannot cast at all.
+///
+/// The capability check lives here rather than inside [CastChromeIcon] so that
+/// an incapable build omits the whole pill instead of drawing an empty one —
+/// see [CastChromeIcon]'s dartdoc.
+Widget? castChromeActionFor(WidgetRef ref) =>
+    ref.watch(castCapabilitiesProvider).any ? const CastChromeIcon() : null;

--- a/player/lib/presentation/widgets/video_controls/chrome_top_bar.dart
+++ b/player/lib/presentation/widgets/video_controls/chrome_top_bar.dart
@@ -108,6 +108,12 @@ class ChromeTopBar extends StatelessWidget {
   /// Cast / AirPlay affordance. When null the pill is omitted.
   final Widget? castAction;
 
+  /// Cast tap handler. Lives here rather than inside [castAction] so the whole
+  /// pill is the tap target: an 18px glyph in a 36px pill would leave most of
+  /// the affordance dead to touch, and only the pill can offer the hover
+  /// cursor. When null the pill renders but is inert, like the back pill.
+  final VoidCallback? onCastTap;
+
   final PlayerGlassTier? tier;
 
   const ChromeTopBar({
@@ -115,6 +121,7 @@ class ChromeTopBar extends StatelessWidget {
     this.title,
     this.onBack,
     this.castAction,
+    this.onCastTap,
     this.tier,
   });
 
@@ -186,6 +193,7 @@ class ChromeTopBar extends StatelessWidget {
                 : GlassPill(
                     key: castKey,
                     tier: tier,
+                    onTap: onCastTap,
                     child: cast,
                   ),
           ),

--- a/player/lib/presentation/widgets/video_controls/custom_video_controls.dart
+++ b/player/lib/presentation/widgets/video_controls/custom_video_controls.dart
@@ -8,12 +8,22 @@ import 'playback_chrome.dart';
 ///
 /// All chrome now lives in [PlaybackChrome]; this file is only the adapter
 /// between media_kit's builder signature and that widget.
+///
+/// [castAction] and [onCastTap] are `required` despite being nullable, which
+/// the other optional chrome parameters are not. Casting was invisible for the
+/// whole of playback once before: the refactor that introduced [PlaybackChrome]
+/// deleted the old top bar — cast button and all — and left the replacement's
+/// cast slot unfilled, so the affordance survived only in the loading and
+/// error states nobody demos. Requiring them turns "forgot the cast
+/// affordance" from something you have to notice into something that does not
+/// compile.
 Widget Function(VideoState) customVideoControlsBuilderWithCallback({
   required StreamTimeline timeline,
   required Future<void> Function(Duration realTarget) onSeekToReal,
+  required Widget? castAction,
+  required VoidCallback? onCastTap,
   String? title,
   VoidCallback? onBack,
-  Widget? castAction,
   VoidCallback? onAudioTap,
   VoidCallback? onSubtitleTap,
   VoidCallback? onQualityTap,
@@ -34,6 +44,7 @@ Widget Function(VideoState) customVideoControlsBuilderWithCallback({
         title: title,
         onBack: onBack,
         castAction: castAction,
+        onCastTap: onCastTap,
         onAudioTap: onAudioTap,
         onSubtitleTap: onSubtitleTap,
         onQualityTap: onQualityTap,

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -376,6 +376,7 @@ class PlaybackChrome extends StatefulWidget {
   final String? title;
   final VoidCallback? onBack;
   final Widget? castAction;
+  final VoidCallback? onCastTap;
 
   final VoidCallback? onAudioTap;
   final VoidCallback? onSubtitleTap;
@@ -399,6 +400,7 @@ class PlaybackChrome extends StatefulWidget {
     this.title,
     this.onBack,
     this.castAction,
+    this.onCastTap,
     this.onAudioTap,
     this.onSubtitleTap,
     this.onQualityTap,
@@ -467,6 +469,7 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
                       title: widget.title,
                       onBack: widget.onBack,
                       castAction: widget.castAction,
+                      onCastTap: widget.onCastTap,
                     ),
                   ),
                 ),

--- a/player/test/presentation/widgets/cast_chrome_icon_test.dart
+++ b/player/test/presentation/widgets/cast_chrome_icon_test.dart
@@ -1,0 +1,208 @@
+// The playback chrome's cast affordance.
+//
+// `CastButton` cannot be reused inside the top bar: it is a 48px `IconButton`
+// carrying its own opaque black background, which neither fits `GlassPill`'s
+// 36px height nor wants a second surface behind the one the pill already
+// draws. `CastChromeIcon` renders the glyph alone and lets the pill own the
+// surface, the tap target and the hover cursor.
+//
+// Both affordances read the same `castConnectionProvider` state machine
+// through one shared visuals helper, so the parity group at the bottom is the
+// guard that the two cannot drift into disagreeing about what a given
+// connection state looks like.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+// `Override` is not re-exported by the main `flutter_riverpod.dart` barrel in
+// Riverpod 3.x; it lives in the `misc.dart` sub-library.
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/domain/models/cast_device.dart';
+import 'package:player/presentation/widgets/cast_button.dart';
+
+const _device = CastDevice(
+  id: 'device-1',
+  name: 'Living Room TV',
+  protocol: CastProtocolKind.chromecast,
+);
+
+void main() {
+  Future<void> pumpIcon(
+    WidgetTester tester, {
+    List<Override> overrides = const [],
+  }) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: overrides,
+      child: const MaterialApp(
+        home: Scaffold(
+          // The pill's IconTheme, reproduced: an idle glyph must inherit this
+          // rather than hard-coding a colour of its own.
+          body: IconTheme(
+            data: IconThemeData(size: 18, color: Color(0xCCFFFFFF)),
+            child: CastChromeIcon(),
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+  }
+
+  Icon iconOf(WidgetTester tester) =>
+      tester.widget<Icon>(find.byKey(CastChromeIcon.iconKey));
+
+  String? tooltipOf(WidgetTester tester) =>
+      tester.widget<Tooltip>(find.byType(Tooltip)).message;
+
+  group('CastChromeIcon', () {
+    testWidgets(
+        'idle inherits the chrome icon colour instead of forcing its own, so '
+        'the cast glyph matches the back chevron beside it', (tester) async {
+      await pumpIcon(tester);
+
+      expect(iconOf(tester).icon, Icons.cast);
+      expect(iconOf(tester).color, isNull,
+          reason: 'a null colour is what makes Icon fall back to the '
+              "surrounding IconTheme — CastButton's opaque white would read "
+              'brighter than every other pill glyph');
+      expect(tooltipOf(tester), 'Cast to device');
+    });
+
+    testWidgets('a live cast shows the connected glyph in blue',
+        (tester) async {
+      await pumpIcon(tester, overrides: [
+        castConnectionProvider.overrideWithValue(CastConnection.casting),
+        castDisplayDeviceProvider.overrideWithValue(_device),
+      ]);
+
+      expect(iconOf(tester).icon, Icons.cast_connected);
+      expect(iconOf(tester).color, Colors.blue);
+      expect(tooltipOf(tester), 'Casting to ${_device.name}');
+    });
+
+    testWidgets('a chosen-but-offline device is blue but not "connected"',
+        (tester) async {
+      await pumpIcon(tester, overrides: [
+        castConnectionProvider.overrideWithValue(CastConnection.chosenOffline),
+        castDisplayDeviceProvider.overrideWithValue(_device),
+      ]);
+
+      expect(iconOf(tester).icon, Icons.cast);
+      expect(iconOf(tester).color, Colors.blue);
+      expect(tooltipOf(tester), '${_device.name} — not connected');
+    });
+
+    testWidgets('shows a progress ring while connecting', (tester) async {
+      await pumpIcon(tester, overrides: [
+        castConnectionProvider.overrideWithValue(CastConnection.connecting),
+        castDisplayDeviceProvider.overrideWithValue(_device),
+      ]);
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(tooltipOf(tester), 'Connecting to ${_device.name}…');
+    });
+
+    testWidgets(
+        'the connecting ring stays inside the 36px pill it has to sit in',
+        (tester) async {
+      await pumpIcon(tester, overrides: [
+        castConnectionProvider.overrideWithValue(CastConnection.connecting),
+        castDisplayDeviceProvider.overrideWithValue(_device),
+      ]);
+
+      // GlassPill is 36px tall with 12px of horizontal padding; anything
+      // taller than the pill's own icon slot would force the bar to grow.
+      expect(
+        tester.getSize(find.byType(CircularProgressIndicator)).height,
+        lessThanOrEqualTo(18),
+      );
+    });
+  });
+
+  group('castChromeActionFor', () {
+    // `ChromeTopBar` decides whether to draw the pill at all from whether this
+    // is null. The capability check therefore cannot live inside the glyph: a
+    // widget that returned an empty box would leave an empty glass pill
+    // floating in the top-right corner on web.
+    testWidgets('is null when the build cannot cast at all', (tester) async {
+      Widget? action;
+      await tester.pumpWidget(ProviderScope(
+        overrides: [
+          castCapabilitiesProvider
+              .overrideWithValue(const CastCapabilities.web()),
+        ],
+        child: Consumer(builder: (context, ref, _) {
+          action = castChromeActionFor(ref);
+          return const SizedBox.shrink();
+        }),
+      ));
+
+      expect(action, isNull);
+    });
+
+    testWidgets('is a glyph when any cast protocol is available',
+        (tester) async {
+      for (final capabilities in const [
+        CastCapabilities.full(),
+        CastCapabilities.iOS(),
+      ]) {
+        Widget? action;
+        await tester.pumpWidget(ProviderScope(
+          overrides: [
+            castCapabilitiesProvider.overrideWithValue(capabilities),
+          ],
+          child: Consumer(builder: (context, ref, _) {
+            action = castChromeActionFor(ref);
+            return const SizedBox.shrink();
+          }),
+        ));
+
+        expect(action, isA<CastChromeIcon>());
+      }
+    });
+  });
+
+  group('parity with CastButton', () {
+    // Both affordances render the same state machine. A glyph that agreed on
+    // four states and disagreed on the fifth is exactly the drift the shared
+    // visuals helper exists to prevent, and it would only ever be noticed on
+    // whichever screen the reviewer happened not to be looking at.
+    for (final connection in CastConnection.values) {
+      testWidgets('$connection renders the same glyph in both affordances',
+          (tester) async {
+        final overrides = [
+          castCapabilitiesProvider
+              .overrideWithValue(const CastCapabilities.full()),
+          castConnectionProvider.overrideWithValue(connection),
+          castDisplayDeviceProvider.overrideWithValue(_device),
+        ];
+
+        await pumpIcon(tester, overrides: overrides);
+        final chromeGlyph = iconOf(tester).icon;
+        final chromeTooltip = tooltipOf(tester);
+
+        await tester.pumpWidget(ProviderScope(
+          overrides: overrides,
+          child: MaterialApp(
+            home: Scaffold(body: CastButton(onPressed: () {})),
+          ),
+        ));
+        await tester.pump();
+
+        final button = tester.widget<IconButton>(
+          find.byKey(const Key('cast-button')),
+        );
+        final buttonGlyph = tester
+            .widget<Icon>(find.descendant(
+              of: find.byKey(const Key('cast-button')),
+              matching: find.byType(Icon),
+            ))
+            .icon;
+
+        expect(chromeGlyph, buttonGlyph);
+        expect(chromeTooltip, button.tooltip);
+      });
+    }
+  });
+}

--- a/player/test/presentation/widgets/video_controls/cast_chrome_icon_test.dart
+++ b/player/test/presentation/widgets/video_controls/cast_chrome_icon_test.dart
@@ -6,10 +6,10 @@
 // draws. `CastChromeIcon` renders the glyph alone and lets the pill own the
 // surface, the tap target and the hover cursor.
 //
-// Both affordances read the same `castConnectionProvider` state machine
-// through one shared visuals helper, so the parity group at the bottom is the
-// guard that the two cannot drift into disagreeing about what a given
-// connection state looks like.
+// The two draw from different Material icon families on purpose — the chrome
+// is `_rounded` throughout (see icon_family_test.dart), app bars are not — so
+// the parity group below asserts they agree on *meaning* (connected-ness,
+// colour, wording) rather than on identical `IconData`.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -21,6 +21,7 @@ import 'package:player/core/cast/cast_capabilities.dart';
 import 'package:player/core/cast/cast_providers.dart';
 import 'package:player/domain/models/cast_device.dart';
 import 'package:player/presentation/widgets/cast_button.dart';
+import 'package:player/presentation/widgets/video_controls/cast_chrome_icon.dart';
 
 const _device = CastDevice(
   id: 'device-1',
@@ -61,7 +62,7 @@ void main() {
         'the cast glyph matches the back chevron beside it', (tester) async {
       await pumpIcon(tester);
 
-      expect(iconOf(tester).icon, Icons.cast);
+      expect(iconOf(tester).icon, Icons.cast_rounded);
       expect(iconOf(tester).color, isNull,
           reason: 'a null colour is what makes Icon fall back to the '
               "surrounding IconTheme — CastButton's opaque white would read "
@@ -76,7 +77,7 @@ void main() {
         castDisplayDeviceProvider.overrideWithValue(_device),
       ]);
 
-      expect(iconOf(tester).icon, Icons.cast_connected);
+      expect(iconOf(tester).icon, Icons.cast_connected_rounded);
       expect(iconOf(tester).color, Colors.blue);
       expect(tooltipOf(tester), 'Casting to ${_device.name}');
     });
@@ -88,7 +89,7 @@ void main() {
         castDisplayDeviceProvider.overrideWithValue(_device),
       ]);
 
-      expect(iconOf(tester).icon, Icons.cast);
+      expect(iconOf(tester).icon, Icons.cast_rounded);
       expect(iconOf(tester).color, Colors.blue);
       expect(tooltipOf(tester), '${_device.name} — not connected');
     });
@@ -117,6 +118,24 @@ void main() {
         tester.getSize(find.byType(CircularProgressIndicator)).height,
         lessThanOrEqualTo(18),
       );
+    });
+
+    testWidgets('every glyph it can draw is from the _rounded family',
+        (tester) async {
+      // icon_family_test.dart scans this file's source for `Icons.*`, but only
+      // a render proves the branch actually selected a rounded glyph.
+      for (final connection in CastConnection.values) {
+        await pumpIcon(tester, overrides: [
+          castConnectionProvider.overrideWithValue(connection),
+          castDisplayDeviceProvider.overrideWithValue(_device),
+        ]);
+
+        expect(
+          iconOf(tester).icon,
+          anyOf(Icons.cast_rounded, Icons.cast_connected_rounded),
+          reason: '$connection drew a glyph outside the chrome icon family',
+        );
+      }
     });
   });
 
@@ -164,12 +183,19 @@ void main() {
   });
 
   group('parity with CastButton', () {
+    /// The chrome's rounded counterpart of a bare-family cast glyph.
+    IconData roundedCounterpart(IconData bare) {
+      if (bare == Icons.cast) return Icons.cast_rounded;
+      if (bare == Icons.cast_connected) return Icons.cast_connected_rounded;
+      fail('CastButton drew an unexpected cast glyph: $bare');
+    }
+
     // Both affordances render the same state machine. A glyph that agreed on
     // four states and disagreed on the fifth is exactly the drift the shared
     // visuals helper exists to prevent, and it would only ever be noticed on
     // whichever screen the reviewer happened not to be looking at.
     for (final connection in CastConnection.values) {
-      testWidgets('$connection renders the same glyph in both affordances',
+      testWidgets('$connection means the same thing in both affordances',
           (tester) async {
         final overrides = [
           castCapabilitiesProvider
@@ -200,7 +226,9 @@ void main() {
             ))
             .icon;
 
-        expect(chromeGlyph, buttonGlyph);
+        expect(chromeGlyph, roundedCounterpart(buttonGlyph!),
+            reason: 'the two families must stay in lockstep on whether this '
+                'state counts as connected');
         expect(chromeTooltip, button.tooltip);
       });
     }

--- a/player/test/presentation/widgets/video_controls/chrome_top_bar_test.dart
+++ b/player/test/presentation/widgets/video_controls/chrome_top_bar_test.dart
@@ -103,6 +103,46 @@ void main() {
       expect(find.byKey(ChromeTopBar.castKey), findsOneWidget);
     });
 
+    testWidgets('the cast pill fires onCastTap across its whole surface',
+        (tester) async {
+      // The tap target has to be the pill, not the glyph. An 18px icon in a
+      // 36px pill leaves most of the affordance dead to touch, so this taps
+      // the pill itself rather than the icon inside it.
+      var casted = false;
+      await tester.pumpWidget(
+        _host(
+          ChromeTopBar(
+            tier: PlayerGlassTier.full,
+            castAction: const Icon(Icons.cast_rounded),
+            onCastTap: () => casted = true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(ChromeTopBar.castKey));
+      expect(casted, isTrue);
+    });
+
+    testWidgets('the cast pill is inert when onCastTap is null, like back',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(
+          const ChromeTopBar(
+            tier: PlayerGlassTier.full,
+            castAction: Icon(Icons.cast_rounded),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byKey(ChromeTopBar.castKey),
+          matching: find.byType(GestureDetector),
+        ),
+        findsNothing,
+      );
+    });
+
     testWidgets(
         'title carries a small targeted shadow — measured (see '
         'pill_legibility_test.dart) to be load-bearing at this pill height, '


### PR DESCRIPTION
## The bug

There is no cast button on the playback screen once video starts.

## Root cause

`3648648b` ("refactor(player): consolidate playback chrome into PlaybackChrome") deleted `_buildTopBar`, whose last child was `CastButton(onPressed: _showCastDevicePicker)`. The replacement `ChromeTopBar` has a `castAction` slot — its own dartdoc calls it "back, title, and cast pills" — plumbed all the way down through `customVideoControlsBuilderWithCallback` → `PlaybackChrome` → `ChromeTopBar`.

`player_screen.dart` never passed it. `castAction` stayed `null`, so the right-hand pill rendered `SizedBox.shrink()` for the entire duration of playback.

The affordance survived only in the loading, error and no-controller branches, which `_withCastAffordance` wraps with a floating `CastButton`. That is why it flashes while the video loads and then disappears — and it disappears exactly when casting is most useful, since casting is the natural remedy for a file the local player cannot decode.

## The fix

Fill the slot. Two details were not free:

- **Tap target.** `ChromeTopBar` wrapped `castAction` in a `GlassPill` without passing `onTap`, so the pill was inert by construction. Added `onCastTap`, mirroring how the back pill already works, so the whole 36px pill responds rather than the 18px glyph inside it — and so it gets the hover cursor.
- **`CastButton` does not fit.** It is a 48px `IconButton` carrying its own opaque black background, which neither fits the pill's 36px height nor wants a second surface behind the one the pill draws. `CastChromeIcon` renders the glyph alone, and inherits the pill's own icon colour when idle so it matches the back chevron instead of reading brighter than every other pill glyph.

Capability gating lives in `castChromeActionFor`, because `ChromeTopBar` decides whether to draw the pill from whether `castAction` is null: a glyph that shrank itself to nothing would have left an empty glass pill floating in the corner on web.

## Icon family (second commit)

The first version of the new glyph used the bare Material family while sitting in the same pill row as `Icons.chevron_left_rounded`. Mixing fills and stroke weights in one control row is exactly what `icon_family_test.dart` guards against — and it passed only because the widget lived in `cast_button.dart`, outside the paths that test scans.

`CastChromeIcon` now lives under `video_controls/` so the guard covers it, and draws `cast_rounded` / `cast_connected_rounded`. Confirmed the guard is not vacuous: reverting the glyphs to the bare family makes it fail.

The shared connection-state visuals moved to `cast_visuals.dart` and return *whether the receiver is connected* rather than a concrete `IconData`, because the two affordances legitimately draw from different families — returning a glyph would force one of them into the wrong one. Colour and tooltip, which must agree everywhere, stay shared.

## Guard against the same regression

`castAction` and `onCastTap` are now `required` on `customVideoControlsBuilderWithCallback`, despite being nullable. Forgetting the cast affordance is what happened here, and it went unnoticed because the button still appeared during loading. It is now a compile error rather than something a reviewer has to spot.

## Verification

- New `video_controls/cast_chrome_icon_test.dart` — glyph/colour/tooltip per connection state, the connecting ring fitting inside the pill, every branch drawing a rounded glyph, `castChromeActionFor` gating, plus a parity group asserting both affordances agree on the meaning of all five `CastConnection` states.
- `chrome_top_bar_test.dart` — the cast pill fires `onCastTap` across its whole surface, and is inert without it.
- Full player suite green: **1522 passed** (`flutter test --concurrency=1`).
- `flutter analyze`: 0 errors, 0 warnings; no new issues in any changed file.

Not covered by an automated test: that `PlayerScreen` passes the slot through to a live `Video`. Mounting the screen that far needs a real media_kit controller and platform channels this suite does not construct — the same limitation `player_screen_frame_inset_test.dart` documents. The `required` parameters are the guard for that seam.