### PR TITLE
feat(player): offer skip intro and credits while casting

### DIFF
--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1829,15 +1829,37 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// inside [SegmentSkipTracker.takeAutoSkip] rather than here: a segment is
   /// consumed by the same call that reports it, and seeking back into one that
   /// has already been skipped does nothing.
-  void _maybeAutoSkipSegment(Player player) {
+  void _maybeAutoSkipSegment(Player player) =>
+      _maybeAutoSkipAt(_timeline.toReal(player.state.position), seekToReal);
+
+  /// The auto-skip decision itself, in real media coordinates.
+  ///
+  /// Shared by local playback and casting because only the two ends differ:
+  /// where a position comes from, and what a seek means. The preference, the
+  /// once-per-session tracker and the segment lookup are one rule, and a
+  /// second copy of it is the thing that would drift.
+  void _maybeAutoSkipAt(
+    Duration position,
+    Future<void> Function(Duration) seek,
+  ) {
     if (!_autoSkipSegments || _segments.isEmpty) return;
 
-    final position = _timeline.toReal(player.state.position);
     final target = _skipTracker.takeAutoSkip(_segments, position);
     if (target == null) return;
 
     debugPrint('[PlayerScreen] Auto-skipping to ${target.end}');
-    unawaited(seekToReal(target.end));
+    unawaited(seek(target.end));
+  }
+
+  /// Seek the receiver, in the same real coordinates [seekToReal] takes.
+  ///
+  /// `CastSessionManager.seek` owns both the mapping onto receiver coordinates
+  /// and the session restart for a target the running stream cannot reach, so
+  /// nothing here needs to know which of the two a given skip requires.
+  /// Skipping credits well past the start offset is squarely the second case.
+  Future<void> _castSeekToReal(Duration target) async {
+    final manager = await ref.read(castSessionManagerProvider.future);
+    await manager.seek(target);
   }
 
   /// The segment covering [position], or null when playback is between them.
@@ -2665,6 +2687,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       }
     });
 
+    // Auto-skip while casting. Local playback rides the player's own position
+    // listener, which casting never builds, so the session stream stands in
+    // for it: `CastSessionManager` republishes the session on every receiver
+    // position tick, already mapped into real media coordinates.
+    //
+    // Only as reliable as the app being awake, which is the honest limit of
+    // driving this from the phone. A backgrounded player sails through the
+    // intro, and fixing that properly means a custom receiver.
+    ref.listen<AsyncValue<CastSession?>>(castSessionProvider, (_, next) {
+      final session = next.value;
+      final position = session?.mediaInfo?.position;
+      if (session == null || position == null || session.isStale) return;
+      _maybeAutoSkipAt(position, _castSeekToReal);
+    });
+
     final isCasting = ref.watch(isCastingProvider);
     final castSession = ref.watch(castSessionProvider).value;
     Widget body = isCasting && castSession != null
@@ -3008,6 +3045,17 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     final device = session.device;
     final isStale = session.isStale;
 
+    // The one control this screen does own while casting. It is not the
+    // duplication the doc comment above warns about: `CastMiniController`
+    // has no skip, so there is no second copy to disagree with, and the
+    // alternative is the feature simply not existing on a TV.
+    //
+    // Withheld over a stale session for the reason the glyph goes outline —
+    // the receiver is gone, and a control that silently does nothing is that
+    // same false "connected" claim wearing a different hat.
+    final castPosition = session.mediaInfo?.position ?? Duration.zero;
+    final skipSegment = isStale ? null : _segmentAt(castPosition);
+
     return Stack(
       children: [
         Center(
@@ -3052,6 +3100,18 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
             ),
           ),
         ),
+        // `Positioned.fill` for the same reason the local path uses it: the
+        // button aligns itself bottom-right, which needs the Stack's full
+        // constraints rather than the loose ones a bare child would get.
+        if (skipSegment != null)
+          Positioned.fill(
+            child: SkipSegmentButton(
+              key: ValueKey(skipSegment.key),
+              segment: skipSegment,
+              position: castPosition,
+              onSkip: (target) => _castSeekToReal(target.end),
+            ),
+          ),
         Positioned(
           top: 8,
           left: 8,

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1857,9 +1857,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// and the session restart for a target the running stream cannot reach, so
   /// nothing here needs to know which of the two a given skip requires.
   /// Skipping credits well past the start offset is squarely the second case.
+  ///
+  /// Never completes with an error, because neither caller can catch one. The
+  /// button's `onSkip` is a void callback and auto-skip fires from a provider
+  /// listener, so a rejected seek would escape into the zone as a crash rather
+  /// than a failed skip. A receiver that has gone away is routine, and it
+  /// already announces itself: the session goes stale, which withdraws this
+  /// button and turns the placeholder to "Lost connection". Failing a skip
+  /// loudly on top of that would be the second telling of one story.
   Future<void> _castSeekToReal(Duration target) async {
-    final manager = await ref.read(castSessionManagerProvider.future);
-    await manager.seek(target);
+    try {
+      final manager = await ref.read(castSessionManagerProvider.future);
+      await manager.seek(target);
+    } catch (e) {
+      debugPrint('[PlayerScreen] Cast skip to $target failed: $e');
+    }
   }
 
   /// The segment covering [position], or null when playback is between them.

--- a/player/test/presentation/screens/player/player_screen_cast_skip_segments_test.dart
+++ b/player/test/presentation/screens/player/player_screen_cast_skip_segments_test.dart
@@ -1,0 +1,263 @@
+// Skip Intro / Skip Credits while the media is on a receiver.
+//
+// The local path drives the button from `Player.stream.position` and seeks
+// with `seekToReal`, both of which need a local `Player` that casting never
+// builds — `_castToTargetIfSet` returns before one is constructed, on purpose,
+// so a chosen device never pays for local streaming infrastructure. That left
+// the whole feature silently absent on the one surface where an intro is most
+// annoying to sit through, since a remote is further away than a keyboard.
+//
+// The cast path substitutes the two coordinates it lacks. Position comes from
+// `CastSession.mediaInfo`, which `CastSessionManager` already publishes in
+// real media coordinates (it maps the receiver's own position through
+// `_timeline.toReal` before publishing), and the seek goes to
+// `CastSessionManager.seek`, which is specified in those same coordinates and
+// internally restarts the session when the target is out of the receiver's
+// reach. Both were already there; nothing about segment handling needed to
+// move for this.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/cast/cast_target.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+import 'package:player/domain/models/cast_device.dart';
+import 'package:player/presentation/widgets/video_controls/skip_segment_button.dart';
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+/// A credits segment covering 40:00 to 45:00 of the 90 minute test movie.
+const _creditsStartMs = 2400000;
+const _creditsEndMs = 2700000;
+
+const _insideCredits = Duration(milliseconds: 2450000);
+const _outsideCredits = Duration(minutes: 10);
+
+/// The `MediaSegment` shape the server sends.
+///
+/// `__typename` matters as much as the three selected fields: the normalized
+/// cache refuses a partial write, and a refused write surfaces as
+/// `result.hasException`, which `_fetchSegments` treats as "no segments" —
+/// indistinguishable from the bug this file is guarding against.
+Map<String, dynamic> _creditsSegment() => {
+      '__typename': 'MediaSegment',
+      'type': 'CREDITS',
+      'startMs': _creditsStartMs,
+      'endMs': _creditsEndMs,
+    };
+
+/// Whether [request] carries the named query. See
+/// `player_screen_segments_isolation_test.dart` for why the operation name is
+/// read out of the printed document rather than `operationName`.
+bool _isQuery(Request request, String name) =>
+    request.operation.toString().contains('query $name');
+
+/// Answers per operation rather than by index, so this script does not break
+/// the moment the screen reorders its startup queries.
+StubLink _link({List<Map<String, dynamic>> segments = const []}) {
+  return StubLink((request, index) {
+    if (_isQuery(request, 'MovieSegments')) {
+      return movieSegmentsResponse(segments: segments);
+    }
+    if (_isQuery(request, 'MovieDetail')) return movieDetailResponse();
+    return streamingCandidatesResponse(duration: 5400);
+  });
+}
+
+CastSession _sessionAt(
+  Duration position, {
+  CastConnectionState connectionState = CastConnectionState.connected,
+}) =>
+    CastSession(
+      device: testDevice,
+      mediaInfo: CastMediaInfo(
+        title: 'Arrival',
+        duration: const Duration(seconds: 5400),
+        position: position,
+      ),
+      playbackState: CastPlaybackState.playing,
+      connectionState: connectionState,
+    );
+
+/// Pumps while republishing the receiver's position until [condition] holds.
+///
+/// Republishing is what makes this work: `_fetchSegments` assigns `_segments`
+/// without a `setState` (the local path relies on its position `StreamBuilder`
+/// to rebuild), so on the cast path a session event is the only thing that
+/// repaints the placeholder once the segments actually arrive.
+Future<void> pumpCastUntil(
+  WidgetTester tester,
+  StreamController<CastSession?> session,
+  Duration position,
+  bool Function() condition, {
+  CastConnectionState connectionState = CastConnectionState.connected,
+  int maxTries = 100,
+}) async {
+  for (var i = 0; i < maxTries && !condition(); i++) {
+    session.add(_sessionAt(position, connectionState: connectionState));
+    await tester.pump(const Duration(milliseconds: 20));
+  }
+}
+
+bool get _buttonShowing =>
+    find.byKey(SkipSegmentButton.buttonKey).evaluate().isNotEmpty;
+
+void main() {
+  late StreamController<CastSession?> session;
+
+  setUp(() => session = StreamController<CastSession?>.broadcast());
+  tearDown(() => session.close());
+
+  testWidgets('offers a skip on the cast placeholder and seeks the receiver',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    final container = buildPlayerScreenContainer(
+      link: _link(segments: [_creditsSegment()]),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: castManager,
+      proxyService: proxyService,
+      castSessionStream: session.stream,
+    );
+    addTearDown(container.dispose);
+
+    // Chosen before playback, exactly like `CastButton` on a detail screen, so
+    // `_castToTargetIfSet` short-circuits and no local `Player` is ever built.
+    container.read(castTargetProvider.notifier).set(testDevice);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpCastUntil(tester, session, _insideCredits, () => _buttonShowing);
+
+    expect(
+      find.text('Skip Credits'),
+      findsOneWidget,
+      reason: 'The receiver is sitting inside a detected credits segment, so '
+          'the placeholder has to offer the same affordance local playback '
+          'would.',
+    );
+
+    await tester.tap(find.text('Skip Credits'));
+    await tester.pump();
+
+    expect(
+      castManager.seekTargets,
+      [const Duration(milliseconds: _creditsEndMs)],
+      reason: 'A skip while casting must move the receiver to the end of the '
+          'segment, in real media coordinates — the space '
+          'CastSessionManager.seek is specified in.',
+    );
+  });
+
+  testWidgets('withdraws the skip once the receiver leaves the segment',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    final container = buildPlayerScreenContainer(
+      link: _link(segments: [_creditsSegment()]),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: castManager,
+      proxyService: proxyService,
+      castSessionStream: session.stream,
+    );
+    addTearDown(container.dispose);
+
+    container.read(castTargetProvider.notifier).set(testDevice);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpCastUntil(tester, session, _insideCredits, () => _buttonShowing);
+
+    // Proves the absence below is position-driven rather than a screen that
+    // simply never renders the button.
+    expect(_buttonShowing, isTrue);
+
+    session.add(_sessionAt(_outsideCredits));
+    await tester.pump();
+
+    expect(find.byKey(SkipSegmentButton.buttonKey), findsNothing);
+  });
+
+  testWidgets('offers no skip over a receiver that has dropped off',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    final container = buildPlayerScreenContainer(
+      link: _link(segments: [_creditsSegment()]),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: castManager,
+      proxyService: proxyService,
+      castSessionStream: session.stream,
+    );
+    addTearDown(container.dispose);
+
+    container.read(castTargetProvider.notifier).set(testDevice);
+
+    await pumpPlayerScreen(tester, container);
+
+    // A stale session keeps its `mediaInfo`, so position alone would still put
+    // the receiver inside the credits. The placeholder already refuses to
+    // claim "connected" here; a skip button that silently does nothing would
+    // be the same false claim in another form.
+    await pumpCastUntil(
+      tester,
+      session,
+      _insideCredits,
+      () => castManager.capturedRequest != null,
+      connectionState: CastConnectionState.lost,
+    );
+
+    expect(find.byKey(SkipSegmentButton.buttonKey), findsNothing);
+  });
+
+  testWidgets('auto-skips the receiver exactly once when the setting is on',
+      (tester) async {
+    final castManager = CapturingCastSessionManager();
+    final proxyService = TrackingLocalProxyService();
+
+    final container = buildPlayerScreenContainer(
+      link: _link(segments: [_creditsSegment()]),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: castManager,
+      proxyService: proxyService,
+      castSessionStream: session.stream,
+      settingsService: FakeSettingsService(autoSkipSegments: true),
+    );
+    addTearDown(container.dispose);
+
+    container.read(castTargetProvider.notifier).set(testDevice);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpCastUntil(
+      tester,
+      session,
+      _insideCredits,
+      () => castManager.seekTargets.isNotEmpty,
+    );
+
+    expect(
+      castManager.seekTargets,
+      [const Duration(milliseconds: _creditsEndMs)],
+      reason: 'Auto-skip has to reach the receiver without the viewer '
+          'touching anything.',
+    );
+
+    // The receiver keeps reporting positions inside the segment until its seek
+    // lands, and a viewer may deliberately seek back in afterwards. Neither
+    // may produce a second automatic skip.
+    for (var i = 0; i < 5; i++) {
+      session.add(_sessionAt(_insideCredits));
+      await tester.pump(const Duration(milliseconds: 20));
+    }
+
+    expect(
+      castManager.seekTargets,
+      hasLength(1),
+      reason: 'SegmentSkipTracker spends a segment on first use, so later '
+          'positions inside it must not re-fire.',
+    );
+  });
+}

--- a/player/test/presentation/screens/player/player_screen_cast_skip_segments_test.dart
+++ b/player/test/presentation/screens/player/player_screen_cast_skip_segments_test.dart
@@ -213,6 +213,39 @@ void main() {
     expect(find.byKey(SkipSegmentButton.buttonKey), findsNothing);
   });
 
+  testWidgets('survives a receiver that fails the skip', (tester) async {
+    // Neither call site can await this seek: `onSkip` is a void callback and
+    // auto-skip fires from a provider listener. A rejected seek therefore has
+    // nobody to catch it, and an error escaping into the zone is a crash, not
+    // a failed skip. `unawaited()` would document the drop without changing
+    // any of that, so the handling belongs at the source instead.
+    final castManager = CapturingCastSessionManager()
+      ..seekError = StateError('receiver went away');
+    final proxyService = TrackingLocalProxyService();
+
+    final container = buildPlayerScreenContainer(
+      link: _link(segments: [_creditsSegment()]),
+      connectionState: conn.ConnectionState.direct(),
+      castManager: castManager,
+      proxyService: proxyService,
+      castSessionStream: session.stream,
+    );
+    addTearDown(container.dispose);
+
+    container.read(castTargetProvider.notifier).set(testDevice);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpCastUntil(tester, session, _insideCredits, () => _buttonShowing);
+
+    await tester.tap(find.text('Skip Credits'));
+    await tester.pump();
+
+    // The seek was attempted; the test surviving to this line is the assertion
+    // that its rejection did not escape. An unhandled async error fails the
+    // enclosing `testWidgets` outright.
+    expect(castManager.seekTargets, hasLength(1));
+  });
+
   testWidgets('auto-skips the receiver exactly once when the setting is on',
       (tester) async {
     final castManager = CapturingCastSessionManager();

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -89,6 +89,11 @@ class CapturingCastSessionManager extends Fake implements CastSessionManager {
   /// receiver-relative value here would be asserting against the wrong space.
   final List<Duration> seekTargets = [];
 
+  /// When set, `seek` throws it. A receiver that has gone away mid-playback is
+  /// a routine state, not a hypothetical: the target is reachable over the
+  /// network right up until it is not.
+  Object? seekError;
+
   @override
   Future<void> startCast({
     required CastDevice device,
@@ -102,6 +107,8 @@ class CapturingCastSessionManager extends Fake implements CastSessionManager {
   @override
   Future<void> seek(Duration position) async {
     seekTargets.add(position);
+    final error = seekError;
+    if (error != null) throw error;
   }
 }
 

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -81,6 +81,14 @@ class CapturingCastSessionManager extends Fake implements CastSessionManager {
   /// can offer a reconnect).
   Object? startCastError;
 
+  /// Every real-media position `seek` has been asked for, in order.
+  ///
+  /// Real positions, not receiver ones: `CastSessionManager.seek` is specified
+  /// in the same coordinates `mediaInfo` publishes, and it owns the mapping
+  /// (and the out-of-reach session restart) internally. A skip that recorded a
+  /// receiver-relative value here would be asserting against the wrong space.
+  final List<Duration> seekTargets = [];
+
   @override
   Future<void> startCast({
     required CastDevice device,
@@ -89,6 +97,11 @@ class CapturingCastSessionManager extends Fake implements CastSessionManager {
     capturedRequest = request;
     final error = startCastError;
     if (error != null) throw error;
+  }
+
+  @override
+  Future<void> seek(Duration position) async {
+    seekTargets.add(position);
   }
 }
 
@@ -107,6 +120,7 @@ class FakeSettingsService extends Fake implements SettingsService {
     this.defaultQuality = 'auto',
     this.readError,
     this.writeError,
+    this.autoSkipSegments = false,
   });
 
   /// The persisted `default_quality` key. `auto` — the real service's own
@@ -141,8 +155,13 @@ class FakeSettingsService extends Fake implements SettingsService {
     defaultQuality = quality;
   }
 
+  /// Whether detected segments are skipped without asking. Off by default,
+  /// matching the real preference, so a test that never mentions auto-skip
+  /// exercises the manual button rather than racing against a seek.
+  final bool autoSkipSegments;
+
   @override
-  Future<bool> getAutoSkipSegments() async => false;
+  Future<bool> getAutoSkipSegments() async => autoSkipSegments;
 }
 
 /// Tracks whether `stop()` ran, without touching a real P2P/HTTP stack.
@@ -445,6 +464,7 @@ ProviderContainer buildPlayerScreenContainer({
   PlaybackProgressStore? progressStore,
   SettingsService? settingsService,
   GraphQLCache? cache,
+  Stream<CastSession?>? castSessionStream,
 }) {
   return ProviderContainer(overrides: [
     settingsServiceProvider
@@ -462,7 +482,13 @@ ProviderContainer buildPlayerScreenContainer({
         .overrideWith(() => FixedConnectionNotifier(connectionState)),
     localProxyServiceProvider.overrideWithValue(proxyService),
     castSessionManagerProvider.overrideWith((ref) async => castManager),
-    castSessionProvider.overrideWith((ref) => Stream.value(null)),
+    // Null by default: no receiver, so `isCastingProvider` stays false and the
+    // screen builds its local body. Pass a stream to stand in for a live cast,
+    // which is the only way to reach `_buildCastPlaceholder` — the real
+    // provider derives from `CastSessionManager`, and the fake above has no
+    // session machinery to drive it.
+    castSessionProvider
+        .overrideWith((ref) => castSessionStream ?? Stream.value(null)),
     playbackProgressStoreProvider.overrideWith(
         (ref) async => progressStore ?? InMemoryPlaybackProgressStore()),
   ]);


### PR DESCRIPTION
Skip Intro and Skip Credits did nothing while casting. Both were bound to the local media_kit `Player`, and casting never builds one.

## Why it was broken

`_castToTargetIfSet` returns before a `Player` is constructed, deliberately, so a chosen device never pays for local streaming infrastructure it would immediately throw away. Three consequences followed:

- the button was gated on `player != null`, so it never rendered
- auto-skip read `player.state.position`, driven by a listener that does not exist while casting
- both routed through `seekToReal`, which opens with `if (player == null) return`

Net effect: the feature was missing on the surface where sitting through an intro is most annoying, given a remote is further away than a keyboard.

## Why the fix is small

Nothing about segment handling had to move.

- `CastSessionManager` already republishes the receiver's position through `mediaInfo`, mapped with `_timeline.toReal` before publishing. That is the same coordinate space `MediaSegment` bounds use, so no conversion is needed.
- `CastSessionManager.seek()` is specified in those same real coordinates and already restarts the session when the target lies outside what the receiver can reach. Skipping credits mid-stream is routinely that case, and it was solved before this change.
- `_segments` is already populated before every cast fork that can actually cast. The offline branch fetches none, and it refuses to cast regardless.
- `SkipSegmentButton` holds no player reference by design, and `SegmentSkipTracker` is pure. Neither needed touching.

## What changed

- `_maybeAutoSkipSegment` now delegates to `_maybeAutoSkipAt(position, seek)`, so local and cast playback share one rule rather than keeping two copies that can drift.
- `_castSeekToReal` seeks the receiver in real coordinates.
- `build` listens on `castSessionProvider` to drive auto-skip, standing in for the local position listener.
- `_buildCastPlaceholder` renders `SkipSegmentButton` when the receiver sits inside a segment.

The placeholder's doc comment says it is deliberately inert because every control belongs to `CastMiniController`. That warning was about duplicating the *same* controls across two surfaces (title, device, play/pause, stop). `CastMiniController` has no skip, so there is no second copy here to disagree with.

A stale session gets no button, matching the outline glyph beside it. A control that silently does nothing would be the same false "connected" claim in another form.

## Known limits

- Auto-skip only fires while the app is awake and foregrounded. A backgrounded phone still sails through the intro. All skipping is the phone issuing a seek, because the receiver knows nothing about segments, and changing that means shipping a custom receiver app instead of the stock Default Media Receiver.
- Skip is available on the player screen only. Back out to browse while casting and you are left with `CastMiniController`, which has no skip. Covering that means moving segment fetching into the cast session layer, which is a larger change than this one.

## Testing

New `player_screen_cast_skip_segments_test.dart` covers four behaviours:

- the button appears on the placeholder and seeks the receiver to the segment end
- it withdraws once the receiver leaves the segment (asserted after confirming it appeared, so the absence is position-driven rather than vacuous)
- a stale session offers no skip
- auto-skip reaches the receiver once and does not re-fire on later positions inside the same segment

Full player suite passes: 1554 tests at `--concurrency=1`. `flutter analyze` reports no new issues (the 51 pre-existing infos are all in untouched files).
