### PR TITLE
fix(release): recreate the staged repo skeleton with mkdir, not ostree init

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1354,10 +1354,27 @@ jobs:
           # in the build job, which never goes through an artifact, so the
           # skeleton is still intact there.
           #
-          # Same idempotent trick publish.sh already uses on the live repo:
-          # ostree init recreates the skeleton and leaves config and objects be.
-          ostree init --repo=staged-repo --mode=archive
-          test -d staged-repo/refs/remotes
+          # mkdir, not `ostree init`. Whether init repairs an existing repo is
+          # version dependent: libostree 2026.2 recreates the missing skeleton,
+          # but the 2024.5 on ubuntu-latest returns 0 and changes nothing, so
+          # the repair silently did not happen and build-commit-from still died.
+          # That is what failed the flatpak publish on v0.13.0-beta.5. Creating
+          # the directories outright does not depend on any of that.
+          #
+          # Only the directories that are still empty after a build are listed.
+          # objects/ and refs/heads/ carry content and survive the round trip.
+          mkdir -p \
+            staged-repo/refs/heads \
+            staged-repo/refs/mirrors \
+            staged-repo/refs/remotes \
+            staged-repo/extensions \
+            staged-repo/state \
+            staged-repo/tmp/cache
+          # Fail here rather than inside flatpak build-commit-from, where the
+          # same problem surfaces as an opaque refs error.
+          for d in refs/heads refs/mirrors refs/remotes extensions state tmp/cache; do
+            test -d "staged-repo/$d" || { echo "::error::staged-repo/$d missing" >&2; exit 1; }
+          done
 
       - name: Import the signing key
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1361,8 +1361,14 @@ jobs:
           # That is what failed the flatpak publish on v0.13.0-beta.5. Creating
           # the directories outright does not depend on any of that.
           #
-          # Only the directories that are still empty after a build are listed.
-          # objects/ and refs/heads/ carry content and survive the round trip.
+          # The whole refs skeleton is recreated rather than just the subset a
+          # given build happens to leave empty, because mkdir -p on a directory
+          # that already exists costs nothing and does not require reasoning
+          # about which refs a build produced. refs/heads normally survives, in
+          # that it holds the app ref; it is listed for that reason, not because
+          # it is expected to be missing. objects/ is omitted because it always
+          # carries content, so its absence would mean a broken artifact rather
+          # than a dropped empty directory, and should fail loudly.
           mkdir -p \
             staged-repo/refs/heads \
             staged-repo/refs/mirrors \


### PR DESCRIPTION
Follow-up to #353. The skeleton restore it added did not actually work, and the flatpak publish on **v0.13.0-beta.5** failed because of it.

## What went wrong

`ostree init` on an existing repo repairs a missing `refs/` skeleton on libostree **2026.2**, which is what I verified against locally. On the **2024.5** that `ubuntu-latest` installs it returns 0 and changes nothing. The directories stayed missing, the guard caught it, and the step failed.

The guard is the one part that behaved well: it failed loudly at the restore step instead of letting `flatpak build-commit-from` die later on an opaque refs error, and it failed before anything touched R2.

## The fix

Create the directories outright. That does not depend on any ostree version behavior. Only the ones still empty after a build are listed; `objects/` and `refs/heads/` carry content and survive the artifact round trip.

## Verification

Reproduced the failure end to end rather than reasoning about it:

- Built a real archive repo with a commit, then deleted every empty directory, which is what `upload-artifact` does.
- `ostree refs` then fails with `error: Listing refs: opendir(refs/remotes): No such file or directory`, the exact error from the beta.5 run.
- After this block, the guard passes, `ostree refs` lists `app/test/x86_64/beta`, and `ostree fsck` reports no errors.

Confirmed versions: `libostree 2024.5-1build2` in CI (from the beta.5 install log), `2026.2` locally.

## State of v0.13.0-beta.5

It published successfully with all platform assets. Only the Flatpak is missing, and nothing was written to R2, so the bucket is still empty and there is nothing to roll back. The next beta will be the first to exercise a complete publish.