### PR TITLE
fix(release): add flathub before verifying the published Flatpak

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1447,6 +1447,16 @@ jobs:
             REMOTE="mydia"
           fi
 
+          # The runtime comes from Flathub, and this job is a different runner
+          # from the one that built the Flatpak, so it has no remotes at all.
+          # Without this the install fails with "requires the runtime
+          # org.gnome.Platform/x86_64/50 which was not found", which says
+          # nothing about whether our own repo is sound. It is what the
+          # verification reported on v0.13.0-beta.6, whose repo was in fact
+          # published correctly and installable by anyone who has Flathub.
+          flatpak remote-add --user --if-not-exists flathub \
+            https://dl.flathub.org/repo/flathub.flatpakrepo
+
           flatpak remote-add --user --if-not-exists --from "$REMOTE" "$REPOFILE"
           flatpak install --user -y "$REMOTE" dev.mydia.player
           flatpak info --user dev.mydia.player


### PR DESCRIPTION
The Flatpak publishing pipeline now works. This fixes the last piece, which is the self-check that reports on it.

## What happened on v0.13.0-beta.6

Every publish step succeeded. The OSTree commit, the signing, the R2 upload and the `.flatpakrepo` files all landed. Only the final verification failed:

```
error: The application dev.mydia.player/x86_64/beta requires the runtime
org.gnome.Platform/x86_64/50 which was not found
```

That is a fault in the check, not in what was published. The verification installs our app from our own repo, but the app depends on `org.gnome.Platform//50`, which lives on Flathub. `flatpak-publish` is a different runner from the one that built the Flatpak, and it has no remotes configured, so the runtime cannot be resolved. The build job adds Flathub; this job never did.

The result is a release that reports failure while having shipped a correct, installable repo.

## The repo from beta.6 is sound

Verified by hand against the live endpoint rather than inferred from the green publish steps:

- `mydia-beta.flatpakrepo`, `beta/summary`, `beta/summary.sig` and `beta/config` all serve 200 over `https://flatpak.mydia.dev`.
- The remote advertises `app/dev.mydia.player/x86_64/beta`, `appstream/x86_64`, `appstream2/x86_64` and `runtime/dev.mydia.player.Debug/x86_64/beta`.
- A GPG-verified `ostree pull --commit-metadata-only` succeeds against commit `3c98797e`, "Export dev.mydia.player", branch `beta`, built with Flatpak 1.14.6.
- The key embedded in `mydia-beta.flatpakrepo` is fingerprint `89D906B96390D7DC1CFF2FCC036B36DAF65B239E`, matching the release signing key.

Anyone with Flathub configured, which is effectively every Flatpak user, can install it today.

## Note on the runtime download

Adding Flathub means the verification now pulls `org.gnome.Platform//50`, so the step gets slower and heavier. That is the cost of the check actually exercising an install rather than failing before it starts.