### PR TITLE
feat(player): compact per-season download rows in series downloads

### DIFF
--- a/player/lib/presentation/screens/downloads/series_downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/series_downloads_screen.dart
@@ -665,6 +665,9 @@ class SeriesDownloadsScreen extends ConsumerWidget {
                 }
                 return Text(
                   parts.join(' \u00B7 '),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  softWrap: false,
                   style: const TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 10,

--- a/player/lib/presentation/screens/downloads/series_downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/series_downloads_screen.dart
@@ -67,17 +67,8 @@ class SeriesDownloadsScreen extends ConsumerWidget {
             sliver: SliverList(
               delegate: SliverChildListDelegate([
                 if (showQueue.isNotEmpty) ...[
-                  Text(
-                    'Downloading',
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          color: AppColors.primary,
-                          fontWeight: FontWeight.bold,
-                        ),
-                  ),
-                  const SizedBox(height: 8),
-                  ...showQueue
-                      .map((task) => _buildQueueItem(context, ref, task)),
-                  const SizedBox(height: 24),
+                  ..._buildQueueSection(context, ref, showQueue),
+                  if (showDownloads.isNotEmpty) const SizedBox(height: 24),
                 ],
                 if (showDownloads.isNotEmpty)
                   ..._buildDownloadedSection(context, ref, showDownloads),
@@ -607,247 +598,155 @@ class SeriesDownloadsScreen extends ConsumerWidget {
   }
 
   // ---------------------------------------------------------------------------
-  // Queue Item Card (Downloading)
+  // Queue Section with Season Grouping
   // ---------------------------------------------------------------------------
 
-  Widget _buildQueueItem(
+  List<Widget> _buildQueueSection(
+      BuildContext context, WidgetRef ref, List<DownloadTask> queue) {
+    final widgets = <Widget>[];
+
+    widgets.add(Text(
+      'Downloading',
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            color: AppColors.primary,
+            fontWeight: FontWeight.bold,
+          ),
+    ));
+
+    final seasonMap = _groupBySeason(queue, (t) => t.seasonNumber ?? 0);
+    final hasMultipleSeasons = seasonMap.length > 1;
+
+    if (!hasMultipleSeasons) {
+      widgets.add(const SizedBox(height: 8));
+      for (final task in queue) {
+        widgets.add(_buildQueueRow(context, ref, task));
+      }
+    } else {
+      widgets.add(const SizedBox(height: 12));
+      var first = true;
+      for (final entry in seasonMap.entries) {
+        final season = entry.key;
+        final seasonTasks = entry.value;
+        if (!first) widgets.add(const SizedBox(height: 16));
+        first = false;
+        widgets
+            .add(_buildQueueSeasonHeader(context, season, seasonTasks.length));
+        widgets.add(const SizedBox(height: 8));
+        for (final task in seasonTasks) {
+          widgets.add(_buildQueueRow(context, ref, task));
+        }
+      }
+    }
+
+    return widgets;
+  }
+
+  Widget _buildQueueRow(
       BuildContext context, WidgetRef ref, DownloadTask task) {
     final progress = task.isProgressive ? task.combinedProgress : task.progress;
     final episodeCode =
         'S${task.seasonNumber?.toString().padLeft(2, '0') ?? '??'}E${task.episodeNumber?.toString().padLeft(2, '0') ?? '??'}';
 
-    return Container(
-      margin: const EdgeInsets.only(bottom: 12),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: AppColors.primary.withValues(alpha: 0.3),
-        ),
-      ),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: IntrinsicHeight(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Thumbnail with progress overlay
-              SizedBox(
-                width: 120,
-                child: Stack(
-                  children: [
-                    Positioned.fill(
-                      child: task.thumbnailUrl != null
-                          ? CachedNetworkImage(
-                              imageUrl: task.thumbnailUrl!,
-                              fit: BoxFit.cover,
-                              cacheManager: EpisodeThumbnailCacheManager(),
-                              placeholder: (_, __) =>
-                                  _buildThumbnailPlaceholder(),
-                              errorWidget: (_, __, ___) =>
-                                  _buildThumbnailPlaceholder(),
-                            )
-                          : _buildThumbnailPlaceholder(),
-                    ),
-                    // Semi-transparent overlay
-                    Positioned.fill(
-                      child: Container(
-                        color: Colors.black.withValues(alpha: 0.4),
-                      ),
-                    ),
-                    // Progress ring centered
-                    Center(
-                      child: SizedBox(
-                        width: 40,
-                        height: 40,
-                        child: CircularProgressIndicator(
-                          value: progress,
-                          color: AppColors.primary,
-                          backgroundColor: Colors.white.withValues(alpha: 0.2),
-                          strokeWidth: 3,
-                          strokeCap: StrokeCap.round,
-                        ),
-                      ),
-                    ),
-                    Center(
-                      child: Text(
-                        '${(progress * 100).toStringAsFixed(0)}%',
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 11,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-
-              // Info area
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      // Episode code badge + runtime + quality
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 6,
-                        crossAxisAlignment: WrapCrossAlignment.center,
-                        children: [
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8, vertical: 4),
-                            decoration: BoxDecoration(
-                              color: AppColors.primary.withValues(alpha: 0.15),
-                              borderRadius: BorderRadius.circular(6),
-                            ),
-                            child: Text(
-                              episodeCode,
-                              style: const TextStyle(
-                                fontSize: 11,
-                                fontWeight: FontWeight.w700,
-                                color: AppColors.primary,
-                              ),
-                            ),
-                          ),
-                          if (task.runtime != null && task.runtime! > 0)
-                            Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const Icon(
-                                  Icons.access_time_rounded,
-                                  size: 14,
-                                  color: AppColors.textSecondary,
-                                ),
-                                const SizedBox(width: 4),
-                                Text(
-                                  _formatRuntime(task.runtime!),
-                                  style: const TextStyle(
-                                    fontSize: 12,
-                                    color: AppColors.textSecondary,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          if (task.quality.isNotEmpty)
-                            QualityBadge.resolution(task.quality),
-                        ],
-                      ),
-                      const SizedBox(height: 6),
-
-                      // Episode title
-                      if (task.title.isNotEmpty)
-                        Text(
-                          task.title,
-                          style: Theme.of(context)
-                              .textTheme
-                              .titleSmall
-                              ?.copyWith(fontWeight: FontWeight.w600),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      const SizedBox(height: 8),
-
-                      // Progress bar
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(2),
-                        child: LinearProgressIndicator(
-                          value: progress,
-                          minHeight: 4,
-                          backgroundColor: AppColors.surfaceVariant,
-                          valueColor: const AlwaysStoppedAnimation<Color>(
-                              AppColors.primary),
-                        ),
-                      ),
-                      const SizedBox(height: 6),
-
-                      // Status + bytes
-                      Row(
-                        children: [
-                          Text(
-                            task.statusDisplay,
-                            style: const TextStyle(
-                              color: AppColors.primary,
-                              fontSize: 11,
-                              fontWeight: FontWeight.w500,
-                            ),
-                          ),
-                          const Spacer(),
-                          Consumer(
-                            builder: (context, ref, _) {
-                              final speedAsync =
-                                  ref.watch(downloadSpeedInfoProvider);
-                              return speedAsync.when(
-                                data: (speedMap) {
-                                  final info = speedMap[task.id];
-                                  final parts = <String>[];
-                                  final bytesText = task.progressBytesDisplay ??
-                                      task.fileSizeDisplay;
-                                  parts.add(bytesText);
-                                  if (info != null && info.bytesPerSecond > 0) {
-                                    parts.add(info.speedDisplay);
-                                  }
-                                  return Text(
-                                    parts.join(' \u00B7 '),
-                                    style: const TextStyle(
-                                      color: AppColors.textSecondary,
-                                      fontSize: 10,
-                                    ),
-                                  );
-                                },
-                                loading: () => const SizedBox.shrink(),
-                                error: (_, __) => const SizedBox.shrink(),
-                              );
-                            },
-                          ),
-                        ],
-                      ),
-                    ],
+    final trailing = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Consumer(
+          builder: (context, ref, _) {
+            final speedAsync = ref.watch(downloadSpeedInfoProvider);
+            return speedAsync.when(
+              data: (speedMap) {
+                final info = speedMap[task.id];
+                final parts = <String>[];
+                final bytesText =
+                    task.progressBytesDisplay ?? task.fileSizeDisplay;
+                parts.add(bytesText);
+                if (info != null && info.bytesPerSecond > 0) {
+                  parts.add(info.speedDisplay);
+                }
+                return Text(
+                  parts.join(' \u00B7 '),
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 10,
                   ),
-                ),
-              ),
-
-              // Cancel button
-              Center(
-                child: IconButton(
-                  onPressed: () => _showCancelDialog(context, ref, task),
-                  icon: const Icon(Icons.close_rounded),
-                  color: AppColors.textSecondary,
-                  iconSize: 20,
-                ),
-              ),
-            ],
+                );
+              },
+              loading: () => const SizedBox.shrink(),
+              error: (_, __) => const SizedBox.shrink(),
+            );
+          },
+        ),
+        const SizedBox(width: 6),
+        Text(
+          '${(progress * 100).toStringAsFixed(0)}%',
+          style: const TextStyle(
+            color: AppColors.primary,
+            fontSize: 11,
+            fontWeight: FontWeight.w500,
           ),
         ),
-      ),
+        const SizedBox(width: 4),
+        IconButton(
+          onPressed: () => _showCancelDialog(context, ref, task),
+          icon: const Icon(Icons.close_rounded),
+          color: AppColors.textSecondary,
+          iconSize: 18,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+        ),
+      ],
+    );
+
+    return _buildEpisodeRow(
+      context: context,
+      episodeCode: episodeCode,
+      title: task.title,
+      trailing: trailing,
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // Shared Helpers
-  // ---------------------------------------------------------------------------
-
-  Widget _buildThumbnailPlaceholder() {
-    return Container(
-      color: AppColors.surfaceVariant,
-      child: const Center(
-        child: Icon(
-          Icons.tv_rounded,
-          size: 28,
-          color: AppColors.textSecondary,
+  Widget _buildQueueSeasonHeader(
+      BuildContext context, int seasonNumber, int taskCount) {
+    final label = seasonNumber == 0 ? 'Specials' : 'Season $seasonNumber';
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Container(
+        padding: const EdgeInsets.only(bottom: 8),
+        decoration: const BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: AppColors.divider,
+              width: 0.5,
+            ),
+          ),
+        ),
+        child: Row(
+          children: [
+            Text(
+              label,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.textSecondary,
+                  ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              '($taskCount downloading)',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: AppColors.textSecondary.withValues(alpha: 0.7),
+                  ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Container(
+                height: 1,
+                color: AppColors.divider.withValues(alpha: 0.3),
+              ),
+            ),
+          ],
         ),
       ),
     );
-  }
-
-  String _formatRuntime(int minutes) {
-    if (minutes < 60) return '$minutes min';
-    final h = minutes ~/ 60;
-    final m = minutes % 60;
-    return m > 0 ? '${h}h ${m}m' : '${h}h';
   }
 
   String _totalSizeDisplay(List<DownloadedMedia> downloads) {

--- a/player/lib/presentation/screens/downloads/series_downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/series_downloads_screen.dart
@@ -365,10 +365,8 @@ class SeriesDownloadsScreen extends ConsumerWidget {
       BuildContext context, WidgetRef ref, List<DownloadedMedia> downloads) {
     final widgets = <Widget>[];
 
-    // Collect all unique seasons
-    final seasons = downloads.map((d) => d.seasonNumber ?? 0).toSet().toList()
-      ..sort();
-    final hasMultipleSeasons = seasons.length > 1;
+    final seasonMap = _groupBySeason(downloads, (d) => d.seasonNumber ?? 0);
+    final hasMultipleSeasons = seasonMap.length > 1;
 
     if (!hasMultipleSeasons) {
       widgets.add(Text(
@@ -392,12 +390,12 @@ class SeriesDownloadsScreen extends ConsumerWidget {
       ));
       widgets.add(const SizedBox(height: 12));
 
-      for (int i = 0; i < seasons.length; i++) {
-        final season = seasons[i];
-        final seasonEpisodes =
-            downloads.where((d) => (d.seasonNumber ?? 0) == season).toList();
-
-        if (i > 0) widgets.add(const SizedBox(height: 16));
+      var first = true;
+      for (final entry in seasonMap.entries) {
+        final season = entry.key;
+        final seasonEpisodes = entry.value;
+        if (!first) widgets.add(const SizedBox(height: 16));
+        first = false;
         widgets.add(
             _buildSeasonHeader(context, ref, season, seasonEpisodes.length));
         widgets.add(const SizedBox(height: 8));
@@ -956,6 +954,20 @@ class SeriesDownloadsScreen extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  /// Groups items by season number, returning a sorted map (Specials=0 first,
+  /// then ascending).
+  Map<int, List<T>> _groupBySeason<T>(List<T> items, int Function(T) seasonOf) {
+    final map = <int, List<T>>{};
+    for (final item in items) {
+      final season = seasonOf(item);
+      map.putIfAbsent(season, () => []).add(item);
+    }
+    final sorted = Map.fromEntries(
+      map.entries.toList()..sort((a, b) => a.key.compareTo(b.key)),
+    );
+    return sorted;
   }
 
   Future<void> _showDeleteAllDialog(BuildContext context, WidgetRef ref,

--- a/player/lib/presentation/screens/downloads/series_downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/series_downloads_screen.dart
@@ -417,6 +417,87 @@ class SeriesDownloadsScreen extends ConsumerWidget {
     );
   }
 
+  Widget _buildDownloadedRow(
+      BuildContext context, WidgetRef ref, DownloadedMedia media) {
+    final episodeCode =
+        'S${media.seasonNumber?.toString().padLeft(2, '0') ?? '??'}E${media.episodeNumber?.toString().padLeft(2, '0') ?? '??'}';
+
+    final trailing = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (media.quality.isNotEmpty) ...[
+          QualityBadge.resolution(media.quality),
+          const SizedBox(width: 8),
+        ],
+        Text(
+          media.fileSizeDisplay,
+          style: const TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 11,
+          ),
+        ),
+        const SizedBox(width: 4),
+        IconButton(
+          icon: const Icon(Icons.play_arrow_rounded, color: AppColors.primary),
+          iconSize: 22,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+          onPressed: () {
+            context.push(
+              '/player/episode/${media.mediaId}?fileId=offline&title=${Uri.encodeComponent(media.title)}&showId=$showId&seasonNumber=${media.seasonNumber}',
+            );
+          },
+        ),
+        IconButton(
+          icon:
+              const Icon(Icons.delete_outline_rounded, color: AppColors.error),
+          iconSize: 20,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+          onPressed: () async {
+            final confirm = await showDialog<bool>(
+              context: context,
+              builder: (context) => AlertDialog(
+                backgroundColor: AppColors.surface,
+                title: const Text('Delete Episode'),
+                content: Text('Delete $episodeCode?'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    child: const Text('Cancel'),
+                  ),
+                  FilledButton(
+                    onPressed: () => Navigator.of(context).pop(true),
+                    style: FilledButton.styleFrom(
+                        backgroundColor: AppColors.error),
+                    child: const Text('Delete'),
+                  ),
+                ],
+              ),
+            );
+
+            if (confirm == true) {
+              final manager = await ref.read(downloadManagerProvider.future);
+              await manager.deleteDownload(media.mediaId);
+            }
+          },
+        ),
+      ],
+    );
+
+    return _buildEpisodeRow(
+      context: context,
+      episodeCode: episodeCode,
+      title: media.title,
+      trailing: trailing,
+      onTap: () {
+        context.push(
+          '/player/episode/${media.mediaId}?fileId=offline&title=${Uri.encodeComponent(media.title)}&showId=$showId&seasonNumber=${media.seasonNumber}',
+        );
+      },
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Downloaded Section with Season Grouping
   // ---------------------------------------------------------------------------
@@ -438,7 +519,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
       ));
       widgets.add(const SizedBox(height: 8));
       for (final media in downloads) {
-        widgets.add(_buildDownloadedItem(context, ref, media));
+        widgets.add(_buildDownloadedRow(context, ref, media));
       }
     } else {
       widgets.add(Text(
@@ -460,7 +541,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
             _buildSeasonHeader(context, ref, season, seasonEpisodes.length));
         widgets.add(const SizedBox(height: 8));
         for (final media in seasonEpisodes) {
-          widgets.add(_buildDownloadedItem(context, ref, media));
+          widgets.add(_buildDownloadedRow(context, ref, media));
         }
       }
     }
@@ -739,212 +820,6 @@ class SeriesDownloadsScreen extends ConsumerWidget {
                 ),
               ),
             ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Downloaded Item Card
-  // ---------------------------------------------------------------------------
-
-  Widget _buildDownloadedItem(
-      BuildContext context, WidgetRef ref, DownloadedMedia media) {
-    final episodeCode =
-        'S${media.seasonNumber?.toString().padLeft(2, '0') ?? '??'}E${media.episodeNumber?.toString().padLeft(2, '0') ?? '??'}';
-
-    return GestureDetector(
-      onTap: () {
-        context.push(
-          '/player/episode/${media.mediaId}?fileId=offline&title=${Uri.encodeComponent(media.title)}&showId=$showId&seasonNumber=${media.seasonNumber}',
-        );
-      },
-      child: Container(
-        margin: const EdgeInsets.only(bottom: 12),
-        decoration: BoxDecoration(
-          color: AppColors.surface,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(12),
-          child: IntrinsicHeight(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Thumbnail with play button overlay
-                SizedBox(
-                  width: 120,
-                  child: Stack(
-                    children: [
-                      Positioned.fill(
-                        child: media.thumbnailUrl != null
-                            ? CachedNetworkImage(
-                                imageUrl: media.thumbnailUrl!,
-                                fit: BoxFit.cover,
-                                cacheManager: EpisodeThumbnailCacheManager(),
-                                placeholder: (_, __) =>
-                                    _buildThumbnailPlaceholder(),
-                                errorWidget: (_, __, ___) =>
-                                    _buildThumbnailPlaceholder(),
-                              )
-                            : _buildThumbnailPlaceholder(),
-                      ),
-                      // Play button overlay
-                      Center(
-                        child: Container(
-                          width: 36,
-                          height: 36,
-                          decoration: BoxDecoration(
-                            color: AppColors.primary.withValues(alpha: 0.9),
-                            shape: BoxShape.circle,
-                          ),
-                          child: const Icon(
-                            Icons.play_arrow_rounded,
-                            color: Colors.white,
-                            size: 22,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-
-                // Info area
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.all(12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        // Episode code badge + runtime + quality
-                        Wrap(
-                          spacing: 8,
-                          runSpacing: 6,
-                          crossAxisAlignment: WrapCrossAlignment.center,
-                          children: [
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 8, vertical: 4),
-                              decoration: BoxDecoration(
-                                color:
-                                    AppColors.primary.withValues(alpha: 0.15),
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                              child: Text(
-                                episodeCode,
-                                style: const TextStyle(
-                                  fontSize: 11,
-                                  fontWeight: FontWeight.w700,
-                                  color: AppColors.primary,
-                                ),
-                              ),
-                            ),
-                            if (media.runtime != null && media.runtime! > 0)
-                              Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  const Icon(
-                                    Icons.access_time_rounded,
-                                    size: 14,
-                                    color: AppColors.textSecondary,
-                                  ),
-                                  const SizedBox(width: 4),
-                                  Text(
-                                    _formatRuntime(media.runtime!),
-                                    style: const TextStyle(
-                                      fontSize: 12,
-                                      color: AppColors.textSecondary,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            if (media.quality.isNotEmpty)
-                              QualityBadge.resolution(media.quality),
-                          ],
-                        ),
-                        const SizedBox(height: 6),
-
-                        // Episode title
-                        Text(
-                          media.title,
-                          style: Theme.of(context)
-                              .textTheme
-                              .titleSmall
-                              ?.copyWith(fontWeight: FontWeight.w600),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-
-                        // Overview
-                        if (media.overview != null &&
-                            media.overview!.isNotEmpty) ...[
-                          const SizedBox(height: 6),
-                          Text(
-                            media.overview!,
-                            style:
-                                Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: AppColors.textSecondary,
-                                      height: 1.4,
-                                    ),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ],
-                        const SizedBox(height: 6),
-
-                        // File size
-                        Text(
-                          media.fileSizeDisplay,
-                          style: const TextStyle(
-                            color: AppColors.textSecondary,
-                            fontSize: 11,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-
-                // Delete button
-                Center(
-                  child: IconButton(
-                    icon: const Icon(Icons.delete_outline_rounded,
-                        color: AppColors.error),
-                    iconSize: 20,
-                    onPressed: () async {
-                      final confirm = await showDialog<bool>(
-                        context: context,
-                        builder: (context) => AlertDialog(
-                          backgroundColor: AppColors.surface,
-                          title: const Text('Delete Episode'),
-                          content: Text('Delete $episodeCode?'),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.of(context).pop(false),
-                              child: const Text('Cancel'),
-                            ),
-                            FilledButton(
-                              onPressed: () => Navigator.of(context).pop(true),
-                              style: FilledButton.styleFrom(
-                                  backgroundColor: AppColors.error),
-                              child: const Text('Delete'),
-                            ),
-                          ],
-                        ),
-                      );
-
-                      if (confirm == true) {
-                        final manager =
-                            await ref.read(downloadManagerProvider.future);
-                        await manager.deleteDownload(media.mediaId);
-                      }
-                    },
-                  ),
-                ),
-              ],
-            ),
           ),
         ),
       ),

--- a/player/lib/presentation/screens/downloads/series_downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/series_downloads_screen.dart
@@ -357,6 +357,66 @@ class SeriesDownloadsScreen extends ConsumerWidget {
     );
   }
 
+  /// Shared compact row for queue and downloaded episode items.
+  Widget _buildEpisodeRow({
+    required BuildContext context,
+    required String episodeCode,
+    required String title,
+    required Widget trailing,
+    VoidCallback? onTap,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+            child: Row(
+              children: [
+                // Episode code badge
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: AppColors.primary.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(5),
+                  ),
+                  child: Text(
+                    episodeCode,
+                    style: const TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                // Title
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium
+                        ?.copyWith(fontWeight: FontWeight.w500),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                // Trailing section (metrics + actions)
+                trailing,
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Downloaded Section with Season Grouping
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces full-width thumbnail cards (~120px) in the series downloads screen with compact thin rows (~48px) — a ~3x density improvement. Also adds season grouping to the queue (downloading) section, which previously showed a flat list.

| Before | After |
|---|---|
| Full-width cards with 120px thumbnails, overview text, runtime, progress rings | Thin rows: episode code badge + title + metrics + action icons |
| Queue items: flat list, no seasons | Queue items: grouped by season (2+ seasons only) |

## Changes

- **`series_downloads_screen.dart`** (+295/−449, net −154 lines)
  - Extract `_groupBySeason<T>` shared season-grouping helper
  - Add `_buildEpisodeRow` shared compact row builder used by both queue and downloaded items
  - Replace `_buildDownloadedItem` with compact `_buildDownloadedRow`
  - Replace `_buildQueueItem` with compact `_buildQueueRow` + season grouping via `_buildQueueSection`
  - Remove `_buildThumbnailPlaceholder`, `_formatRuntime` (no longer needed)

## Verification

- Flutter analyze: 0 new errors (11 pre-existing codegen errors from absent generated files)
- No model/provider/service changes — single-file UI refactor
- No changes to `DownloadsScreen` grid or any other screen