### PR TITLE
fix(downloads): reject torrents with no importable files before completion

### DIFF
--- a/lib/mydia/downloads/client/transmission.ex
+++ b/lib/mydia/downloads/client/transmission.ex
@@ -147,7 +147,8 @@ defmodule Mydia.Downloads.Client.Transmission do
       "uploadRatio",
       "downloadDir",
       "addedDate",
-      "doneDate"
+      "doneDate",
+      "files"
     ]
 
     arguments = %{
@@ -189,7 +190,8 @@ defmodule Mydia.Downloads.Client.Transmission do
       "downloadDir",
       "addedDate",
       "doneDate",
-      "labels"
+      "labels",
+      "files"
     ]
 
     arguments = %{"fields" => fields}
@@ -427,9 +429,23 @@ defmodule Mydia.Downloads.Client.Transmission do
       eta: parse_eta(torrent["eta"]),
       ratio: torrent["uploadRatio"] || 0.0,
       save_path: save_path,
+      files: resolve_torrent_files(download_dir, torrent["files"]),
       added_at: Helpers.parse_timestamp_unix(torrent["addedDate"]),
       completed_at: Helpers.parse_timestamp_unix(torrent["doneDate"])
     })
+  end
+
+  # Transmission's `files[].name` is already the path relative to
+  # `downloadDir` (it includes the torrent's own subfolder for multi-file
+  # torrents, and is just the bare filename for single-file torrents), so it
+  # joins directly onto `download_dir` rather than `save_path` — `save_path`
+  # itself is `download_dir/torrent_name`, which for a single-file torrent
+  # names the file, not a directory, and would double the filename.
+  defp resolve_torrent_files(_download_dir, files) when not is_list(files), do: nil
+  defp resolve_torrent_files(_download_dir, []), do: nil
+
+  defp resolve_torrent_files(download_dir, files) do
+    Enum.map(files, fn file -> Path.join(download_dir, file["name"] || "") end)
   end
 
   defp parse_state(status) when is_integer(status) do

--- a/lib/mydia/downloads/client/transmission.ex
+++ b/lib/mydia/downloads/client/transmission.ex
@@ -442,10 +442,18 @@ defmodule Mydia.Downloads.Client.Transmission do
   # itself is `download_dir/torrent_name`, which for a single-file torrent
   # names the file, not a directory, and would double the filename.
   defp resolve_torrent_files(_download_dir, files) when not is_list(files), do: nil
-  defp resolve_torrent_files(_download_dir, []), do: nil
 
   defp resolve_torrent_files(download_dir, files) do
-    Enum.map(files, fn file -> Path.join(download_dir, file["name"] || "") end)
+    paths =
+      files
+      |> Enum.map(& &1["name"])
+      |> Enum.filter(&(is_binary(&1) and &1 != ""))
+      |> Enum.map(&Path.join(download_dir, &1))
+
+    case paths do
+      [] -> nil
+      list -> list
+    end
   end
 
   defp parse_state(status) when is_integer(status) do

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -536,6 +536,7 @@ defmodule Mydia.Downloads.History do
       seeders: if(metadata, do: metadata.seeders, else: nil),
       leechers: if(metadata, do: metadata.leechers, else: nil),
       save_path: torrent_status.save_path,
+      files: torrent_status.files,
       completed_at: download.completed_at || torrent_status.completed_at,
       error_message: download.error_message,
       client_failure_category: torrent_status.failure_category,

--- a/lib/mydia/downloads/structs/enriched_download.ex
+++ b/lib/mydia/downloads/structs/enriched_download.ex
@@ -41,6 +41,13 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
     :seeders,
     :leechers,
     :save_path,
+    # Absolute paths of the files inside this torrent, when the client reports
+    # them (rqbit, qBittorrent, rtorrent, Transmission). Populated as soon as
+    # the client knows the torrent's metadata, which for a direct .torrent add
+    # is immediate and for a magnet is typically seconds — well before the
+    # payload finishes downloading. `nil` when the client doesn't report a
+    # file list or hasn't resolved one yet.
+    :files,
     :completed_at,
     :error_message,
     # Client-reported failure detail. Deliberately SEPARATE from
@@ -124,6 +131,7 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
           seeders: integer() | nil,
           leechers: integer() | nil,
           save_path: String.t() | nil,
+          files: [String.t()] | nil,
           completed_at: DateTime.t() | nil,
           error_message: String.t() | nil,
           client_failure_category: FailureCategory.t() | nil,

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -55,6 +55,8 @@ defmodule Mydia.Jobs.DownloadMonitor do
   alias Mydia.Downloads.Blacklists
   alias Mydia.Downloads.ClientAdoption
   alias Mydia.Downloads.Client.FailureCategory
+  alias Mydia.Downloads.ImportCandidates
+  alias Mydia.Downloads.Queue
   alias Mydia.Downloads.StallDetector
   alias Mydia.Downloads.ExternalTorrents
   alias Mydia.Downloads.UntrackedMatcher
@@ -165,8 +167,21 @@ defmodule Mydia.Jobs.DownloadMonitor do
           is_nil(d.imported_at)
       end)
 
+    # A torrent's file list is known as soon as the client has its metadata —
+    # immediately for a direct .torrent add, within seconds for a magnet —
+    # long before the payload itself finishes downloading. Reject on sight
+    # rather than waiting for completion: this is what stops a malware
+    # torrent (a single disguised .exe with no video file at all) from
+    # pulling its full multi-hundred-MB-to-multi-GB payload just to be
+    # thrown away by the post-completion importer.
+    bad_content =
+      Enum.filter(active_for_stall_check, fn d -> is_list(d.files) and d.files != [] end)
+      |> Enum.reject(&any_importable_file?/1)
+
+    active_for_stall_check = active_for_stall_check -- bad_content
+
     Logger.info(
-      "Found #{length(completed)} newly completed, #{length(failed)} newly failed, #{length(missing)} missing downloads, #{length(stale_grabs)} stale grabs, #{length(active_for_stall_check)} active for stall check"
+      "Found #{length(completed)} newly completed, #{length(failed)} newly failed, #{length(missing)} missing downloads, #{length(stale_grabs)} stale grabs, #{length(bad_content)} bad-content downloads, #{length(active_for_stall_check)} active for stall check"
     )
 
     # Handle completions
@@ -177,6 +192,10 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
     # Handle missing downloads
     Enum.each(missing, &handle_missing/1)
+
+    # Reject torrents whose file list is already known to contain nothing
+    # importable, before they finish downloading.
+    Enum.each(bad_content, &reject_bad_content/1)
 
     # Self-heal abandoned grabs (persist the timeout so occupancy is released)
     Enum.each(stale_grabs, &handle_stale_grab/1)
@@ -346,6 +365,51 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
         :ok
     end
+  end
+
+  # --- Pre-completion content check --------------------------------------
+
+  # `downloads.media_item_id` only ever points at a `movie` or `tv_show`
+  # media item (the only two `MediaItem.valid_types/0`), so every download
+  # reaching this check wants a video file regardless of which of the two it
+  # is — `ImportCandidates.importable?/2` treats `:movies`/`:series`/`:mixed`
+  # identically. Passing `:series` unconditionally is exact, not a guess.
+  defp any_importable_file?(%{files: files}) do
+    Enum.any?(files, fn path ->
+      ImportCandidates.importable?(%{name: Path.basename(path)}, :series)
+    end)
+  end
+
+  # Rejects a still-downloading torrent whose already-known file list
+  # contains not a single file with a video extension — same treatment as an
+  # operator manually rejecting a release from the Issues tab (blacklist the
+  # `(indexer, guid)`, remove the torrent and its data from the client,
+  # delete the row, queue a replacement search), just triggered automatically
+  # and before the payload finishes downloading instead of after.
+  defp reject_bad_content(download_map) do
+    Logger.warning(
+      "Rejecting download before completion — no importable files in torrent",
+      download_id: download_map.id,
+      title: download_map.title,
+      files: Enum.map(download_map.files, &Path.basename/1)
+    )
+
+    download = Downloads.get_download!(download_map.id)
+
+    case Queue.reject_release(download, actor_type: :system, actor_id: "download_monitor") do
+      {:ok, :rejected} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Could not auto-reject bad-content download",
+          download_id: download_map.id,
+          reason: inspect(reason)
+        )
+
+        :ok
+    end
+  rescue
+    Ecto.NoResultsError -> :ok
   end
 
   # --- Release blacklist (#123) ------------------------------------------

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -386,12 +386,18 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # `(indexer, guid)`, remove the torrent and its data from the client,
   # delete the row, queue a replacement search), just triggered automatically
   # and before the payload finishes downloading instead of after.
+  # Capped so a large season pack (hundreds of files) doesn't blow up this
+  # warning into an outsized log line.
+  @bad_content_log_sample 10
+
   defp reject_bad_content(download_map) do
     Logger.warning(
       "Rejecting download before completion — no importable files in torrent",
       download_id: download_map.id,
       title: download_map.title,
-      files: Enum.map(download_map.files, &Path.basename/1)
+      file_count: length(download_map.files),
+      files_sample:
+        download_map.files |> Enum.take(@bad_content_log_sample) |> Enum.map(&Path.basename/1)
     )
 
     download = Downloads.get_download!(download_map.id)

--- a/test/mydia/downloads/client/transmission_test.exs
+++ b/test/mydia/downloads/client/transmission_test.exs
@@ -328,6 +328,94 @@ defmodule Mydia.Downloads.Client.TransmissionTest do
     end
   end
 
+  describe "get_status/2 file list (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+
+      config = %{
+        @config
+        | host: "localhost",
+          port: bypass.port
+      }
+
+      {:ok, bypass: bypass, config: config}
+    end
+
+    defp respond_torrent_get(conn, session_id, arguments_assertion, torrents) do
+      case Plug.Conn.get_req_header(conn, "x-transmission-session-id") do
+        [] ->
+          conn
+          |> Plug.Conn.put_resp_header("x-transmission-session-id", session_id)
+          |> Plug.Conn.resp(409, "")
+
+        [^session_id] ->
+          {:ok, body, conn} = Plug.Conn.read_body(conn, length: 1_000_000)
+          decoded = Jason.decode!(body)
+          assert decoded["method"] == "torrent-get"
+          arguments_assertion.(decoded["arguments"])
+
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.resp(
+            200,
+            Jason.encode!(%{"result" => "success", "arguments" => %{"torrents" => torrents}})
+          )
+      end
+    end
+
+    test "requests the files field and resolves it to absolute paths",
+         %{bypass: bypass, config: config} do
+      torrent = %{
+        "hashString" => "abc123",
+        "name" => "House.of.the.Dragon.S03E07.1080p.AMZN.WEB-DL.DDP5.1.Atmos.H.264-QAsH",
+        "status" => 4,
+        "percentDone" => 0.1,
+        "downloadDir" => "/downloads",
+        "files" => [
+          %{"name" => "C7466DBA33FE8C5F53F0F80ED8BCFC62242EF310.exe", "length" => 891_885_056}
+        ]
+      }
+
+      Bypass.expect(bypass, "POST", "/transmission/rpc", fn conn ->
+        respond_torrent_get(
+          conn,
+          "session-files",
+          fn args ->
+            assert "files" in args["fields"]
+            assert args["ids"] == ["abc123"]
+          end,
+          [torrent]
+        )
+      end)
+
+      assert {:ok, status} = Transmission.get_status(config, "abc123")
+      assert status.files == ["/downloads/C7466DBA33FE8C5F53F0F80ED8BCFC62242EF310.exe"]
+    end
+
+    test "returns nil when the client reports no files yet",
+         %{bypass: bypass, config: config} do
+      torrent = %{
+        "hashString" => "def456",
+        "name" => "Some.Show.S01E01",
+        "status" => 4,
+        "percentDone" => 0.0,
+        "downloadDir" => "/downloads"
+      }
+
+      Bypass.expect(bypass, "POST", "/transmission/rpc", fn conn ->
+        respond_torrent_get(
+          conn,
+          "session-nofiles",
+          fn args -> assert "files" in args["fields"] end,
+          [torrent]
+        )
+      end)
+
+      assert {:ok, status} = Transmission.get_status(config, "def456")
+      assert status.files == nil
+    end
+  end
+
   # Note: Full integration tests would require either:
   # 1. A real Transmission instance (can be configured via environment variables)
   # 2. HTTP mocking library like Bypass or Mox to simulate Transmission RPC responses

--- a/test/mydia/downloads/client/transmission_test.exs
+++ b/test/mydia/downloads/client/transmission_test.exs
@@ -414,6 +414,58 @@ defmodule Mydia.Downloads.Client.TransmissionTest do
       assert {:ok, status} = Transmission.get_status(config, "def456")
       assert status.files == nil
     end
+
+    test "filters out entries with a blank or missing name instead of joining an empty path",
+         %{bypass: bypass, config: config} do
+      torrent = %{
+        "hashString" => "ghi789",
+        "name" => "Some.Show.S01E02",
+        "status" => 4,
+        "percentDone" => 0.2,
+        "downloadDir" => "/downloads",
+        "files" => [
+          %{"name" => "", "length" => 0},
+          %{"length" => 0},
+          %{"name" => "Some.Show.S01E02.mkv", "length" => 500}
+        ]
+      }
+
+      Bypass.expect(bypass, "POST", "/transmission/rpc", fn conn ->
+        respond_torrent_get(
+          conn,
+          "session-blank-name",
+          fn args -> assert "files" in args["fields"] end,
+          [torrent]
+        )
+      end)
+
+      assert {:ok, status} = Transmission.get_status(config, "ghi789")
+      assert status.files == ["/downloads/Some.Show.S01E02.mkv"]
+    end
+
+    test "returns nil when every file has a blank or missing name",
+         %{bypass: bypass, config: config} do
+      torrent = %{
+        "hashString" => "jkl012",
+        "name" => "Some.Show.S01E03",
+        "status" => 4,
+        "percentDone" => 0.0,
+        "downloadDir" => "/downloads",
+        "files" => [%{"name" => "", "length" => 0}, %{"length" => 0}]
+      }
+
+      Bypass.expect(bypass, "POST", "/transmission/rpc", fn conn ->
+        respond_torrent_get(
+          conn,
+          "session-all-blank",
+          fn args -> assert "files" in args["fields"] end,
+          [torrent]
+        )
+      end)
+
+      assert {:ok, status} = Transmission.get_status(config, "jkl012")
+      assert status.files == nil
+    end
   end
 
   # Note: Full integration tests would require either:

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1075,6 +1075,171 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
     end
   end
 
+  describe "pre-completion content rejection" do
+    # Transmission reports a torrent's file list as soon as it knows the
+    # torrent's metadata (immediately for a direct .torrent add), well before
+    # the payload finishes downloading. DownloadMonitor must reject a torrent
+    # whose known file list contains no importable video file rather than
+    # waiting for it to complete — see the House of the Dragon S03E07/QAsH
+    # incident, where a single disguised .exe downloaded to completion every
+    # search cycle before the post-completion importer ever saw it.
+    defp start_transmission_bypass(name \\ "Trans") do
+      bypass = Bypass.open()
+
+      client_config =
+        build_test_client_config(%{
+          name: name,
+          type: :transmission,
+          host: "localhost",
+          port: bypass.port
+        })
+
+      {bypass, client_config}
+    end
+
+    defp mock_transmission_torrent_get(bypass, torrents) do
+      Bypass.expect(bypass, "POST", "/transmission/rpc", fn conn ->
+        case Plug.Conn.get_req_header(conn, "x-transmission-session-id") do
+          [] ->
+            conn
+            |> Plug.Conn.put_resp_header("x-transmission-session-id", "test-session")
+            |> Plug.Conn.resp(409, "")
+
+          ["test-session"] ->
+            {:ok, body, conn} = Plug.Conn.read_body(conn, length: 1_000_000)
+            decoded = Jason.decode!(body)
+
+            case decoded["method"] do
+              "torrent-get" ->
+                json_resp(conn, 200, %{
+                  "result" => "success",
+                  "arguments" => %{"torrents" => torrents}
+                })
+
+              "torrent-remove" ->
+                json_resp(conn, 200, %{"result" => "success", "arguments" => %{}})
+            end
+        end
+      end)
+    end
+
+    test "rejects a still-downloading torrent whose only file is a disguised .exe" do
+      {bypass, client_config} = start_transmission_bypass()
+
+      torrent = %{
+        "hashString" => "qash-hash",
+        "name" => "House.of.the.Dragon.S03E07.1080p.AMZN.WEB-DL.DDP5.1.Atmos.H.264-QAsH",
+        "status" => 4,
+        "percentDone" => 0.05,
+        "downloadDir" => "/downloads",
+        "files" => [
+          %{"name" => "C7466DBA33FE8C5F53F0F80ED8BCFC62242EF310.exe", "length" => 891_885_056}
+        ]
+      }
+
+      mock_transmission_torrent_get(bypass, [torrent])
+
+      setup_runtime_config([client_config])
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "House.of.the.Dragon.S03E07.1080p.AMZN.WEB-DL.DDP5.1.Atmos.H.264-QAsH",
+          indexer: "1337x",
+          download_client: client_config.name,
+          download_client_id: "qash-hash",
+          metadata: %{
+            size: 4_520_571_190,
+            indexer: "1337x",
+            guid: "https://1337x.to/torrent/6695392/qash/"
+          }
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      # Rejected before completion: blacklisted, and the row is gone —
+      # exactly as if an operator had rejected it from the Issues tab.
+      assert Mydia.Downloads.Blacklists.blacklisted?(
+               "1337x",
+               "https://1337x.to/torrent/6695392/qash/"
+             )
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Mydia.Downloads.get_download!(download.id)
+      end
+    end
+
+    test "does not reject a still-downloading torrent that has a video file" do
+      {bypass, client_config} = start_transmission_bypass()
+
+      torrent = %{
+        "hashString" => "good-hash",
+        "name" => "Show.S01E01.1080p.WEB-DL",
+        "status" => 4,
+        "percentDone" => 0.4,
+        "downloadDir" => "/downloads",
+        "files" => [
+          %{"name" => "Show.S01E01.1080p.WEB-DL.mkv", "length" => 2_000_000_000},
+          %{"name" => "Show.S01E01.1080p.WEB-DL.nfo", "length" => 2_048}
+        ]
+      }
+
+      mock_transmission_torrent_get(bypass, [torrent])
+
+      setup_runtime_config([client_config])
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Show.S01E01.1080p.WEB-DL",
+          indexer: "1337x",
+          download_client: client_config.name,
+          download_client_id: "good-hash",
+          metadata: %{size: 2_000_000_000, indexer: "1337x", guid: "guid-good"}
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      refute Mydia.Downloads.Blacklists.blacklisted?("1337x", "guid-good")
+      assert Mydia.Downloads.get_download!(download.id)
+    end
+
+    test "does not reject a torrent whose file list is not yet known" do
+      {bypass, client_config} = start_transmission_bypass()
+
+      torrent = %{
+        "hashString" => "pending-hash",
+        "name" => "Show.S01E02.1080p.WEB-DL",
+        "status" => 4,
+        "percentDone" => 0.0,
+        "downloadDir" => "/downloads"
+        # No "files" key — metadata not resolved yet (e.g. a fresh magnet).
+      }
+
+      mock_transmission_torrent_get(bypass, [torrent])
+
+      setup_runtime_config([client_config])
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Show.S01E02.1080p.WEB-DL",
+          indexer: "1337x",
+          download_client: client_config.name,
+          download_client_id: "pending-hash",
+          metadata: %{size: 2_000_000_000, indexer: "1337x", guid: "guid-pending"}
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      refute Mydia.Downloads.Blacklists.blacklisted?("1337x", "guid-pending")
+      assert Mydia.Downloads.get_download!(download.id)
+    end
+  end
+
   describe "handle_failure/1 with a classified debrid failure" do
     setup do
       alias Mydia.Downloads.Client.Debrid.StubProvider

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -11,6 +11,7 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
   alias Mydia.Repo
   import Mydia.MediaFixtures
   import Mydia.DownloadsFixtures
+  import Mydia.SettingsFixtures
 
   describe "perform/1" do
     test "successfully monitors downloads with no active downloads" do
@@ -1083,16 +1084,21 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
     # waiting for it to complete — see the House of the Dragon S03E07/QAsH
     # incident, where a single disguised .exe downloaded to completion every
     # search cycle before the post-completion importer ever saw it.
-    defp start_transmission_bypass(name \\ "Trans") do
+    # Uses a DB-backed client config (`download_client_config_fixture/1`)
+    # rather than `setup_runtime_config/1`. The latter mutates the global
+    # `Application.env(:mydia, :runtime_config)`, which races against any
+    # other `async: true` test module doing the same (media_import_test.exs
+    # does) — usually too narrow a window to matter, but these tests hold it
+    # open for a real Bypass HTTP round-trip per poll, which is long enough
+    # to lose the race under CI's higher test concurrency. A DB row lives
+    # inside this test's own Ecto sandbox transaction, so it can't collide.
+    defp start_transmission_bypass(overrides \\ %{}) do
       bypass = Bypass.open()
 
       client_config =
-        build_test_client_config(%{
-          name: name,
-          type: :transmission,
-          host: "localhost",
-          port: bypass.port
-        })
+        download_client_config_fixture(
+          Map.merge(%{type: "transmission", host: "localhost", port: bypass.port}, overrides)
+        )
 
       {bypass, client_config}
     end
@@ -1139,7 +1145,6 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       mock_transmission_torrent_get(bypass, [torrent])
 
-      setup_runtime_config([client_config])
       media_item = media_item_fixture()
 
       download =
@@ -1187,7 +1192,6 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       mock_transmission_torrent_get(bypass, [torrent])
 
-      setup_runtime_config([client_config])
       media_item = media_item_fixture()
 
       download =
@@ -1220,7 +1224,6 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       mock_transmission_torrent_get(bypass, [torrent])
 
-      setup_runtime_config([client_config])
       media_item = media_item_fixture()
 
       download =

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1145,19 +1145,6 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       mock_transmission_torrent_get(bypass, [torrent])
 
-      require Logger
-
-      Logger.warning(
-        "DIAG pre-completion test: visible clients before perform_job = " <>
-          inspect(
-            Enum.map(
-              Mydia.Settings.list_download_client_configs(),
-              &{&1.name, &1.type, &1.enabled, &1.host, &1.port}
-            )
-          ) <>
-          ", ours = #{inspect({client_config.name, client_config.type, client_config.enabled, client_config.host, client_config.port})}"
-      )
-
       media_item = media_item_fixture()
 
       download =
@@ -1205,19 +1192,6 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       mock_transmission_torrent_get(bypass, [torrent])
 
-      require Logger
-
-      Logger.warning(
-        "DIAG pre-completion test: visible clients before perform_job = " <>
-          inspect(
-            Enum.map(
-              Mydia.Settings.list_download_client_configs(),
-              &{&1.name, &1.type, &1.enabled, &1.host, &1.port}
-            )
-          ) <>
-          ", ours = #{inspect({client_config.name, client_config.type, client_config.enabled, client_config.host, client_config.port})}"
-      )
-
       media_item = media_item_fixture()
 
       download =
@@ -1249,19 +1223,6 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       }
 
       mock_transmission_torrent_get(bypass, [torrent])
-
-      require Logger
-
-      Logger.warning(
-        "DIAG pre-completion test: visible clients before perform_job = " <>
-          inspect(
-            Enum.map(
-              Mydia.Settings.list_download_client_configs(),
-              &{&1.name, &1.type, &1.enabled, &1.host, &1.port}
-            )
-          ) <>
-          ", ours = #{inspect({client_config.name, client_config.type, client_config.enabled, client_config.host, client_config.port})}"
-      )
 
       media_item = media_item_fixture()
 

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1145,6 +1145,19 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       mock_transmission_torrent_get(bypass, [torrent])
 
+      require Logger
+
+      Logger.warning(
+        "DIAG pre-completion test: visible clients before perform_job = " <>
+          inspect(
+            Enum.map(
+              Mydia.Settings.list_download_client_configs(),
+              &{&1.name, &1.type, &1.enabled, &1.host, &1.port}
+            )
+          ) <>
+          ", ours = #{inspect({client_config.name, client_config.type, client_config.enabled, client_config.host, client_config.port})}"
+      )
+
       media_item = media_item_fixture()
 
       download =
@@ -1192,6 +1205,19 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       mock_transmission_torrent_get(bypass, [torrent])
 
+      require Logger
+
+      Logger.warning(
+        "DIAG pre-completion test: visible clients before perform_job = " <>
+          inspect(
+            Enum.map(
+              Mydia.Settings.list_download_client_configs(),
+              &{&1.name, &1.type, &1.enabled, &1.host, &1.port}
+            )
+          ) <>
+          ", ours = #{inspect({client_config.name, client_config.type, client_config.enabled, client_config.host, client_config.port})}"
+      )
+
       media_item = media_item_fixture()
 
       download =
@@ -1223,6 +1249,19 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       }
 
       mock_transmission_torrent_get(bypass, [torrent])
+
+      require Logger
+
+      Logger.warning(
+        "DIAG pre-completion test: visible clients before perform_job = " <>
+          inspect(
+            Enum.map(
+              Mydia.Settings.list_download_client_configs(),
+              &{&1.name, &1.type, &1.enabled, &1.host, &1.port}
+            )
+          ) <>
+          ", ours = #{inspect({client_config.name, client_config.type, client_config.enabled, client_config.host, client_config.port})}"
+      )
 
       media_item = media_item_fixture()
 


### PR DESCRIPTION
## Summary

- A torrent's file list is known as soon as the client has its metadata — immediately for a direct `.torrent` add, within seconds for a magnet — long before the payload finishes downloading. Content rejection (`ImportCandidates.importable?/2` + `ContentProbe`) previously only ran after `completed_at` was set, so a malware torrent disguised as a video release (a single `.exe`, in the incident that prompted this) downloaded its full payload every time, only to be thrown away by the post-completion importer.
- That failure also never blacklisted the release, so the next search cycle re-grabbed the exact same file and repeated the whole download.
- Transmission's adapter never requested the `files` field from its RPC (rqbit, qBittorrent, and rtorrent already did), so `DownloadStatus.files` was always `nil` for Transmission-backed downloads — the client actually involved in the incident.
- `DownloadMonitor` now rejects a still-downloading torrent as soon as its file list is known and contains no video-extension file, via the same `Queue.reject_release/2` path the Issues tab's manual "Reject" button uses: blacklist `(indexer, guid)`, remove the torrent and its data from the client, delete the row, queue a replacement search.

## Test plan

- [x] `mix precommit` (compile, format, Credo, DB, full test suite — 6,582 tests, 0 failures)
- [x] New Transmission adapter Bypass tests: `files` field requested and resolved to absolute paths; `nil` when the client hasn't reported files yet
- [x] New `DownloadMonitor` tests: rejects a torrent whose only file is a disguised `.exe` (reproduces the incident); does not reject a torrent with a legitimate video file present; does not reject a torrent whose file list isn't known yet