### PR TITLE
fix(player): trigger Up Next from real credits, not 90% of runtime

### DIFF
--- a/player/lib/domain/models/media_segment.dart
+++ b/player/lib/domain/models/media_segment.dart
@@ -105,6 +105,8 @@ class MediaSegment {
     return ms >= startMs && ms < endMs;
   }
 
+  Duration get start => Duration(milliseconds: startMs);
+
   Duration get end => Duration(milliseconds: endMs);
 
   /// Stable identity for once-per-session skip tracking.

--- a/player/lib/domain/models/media_segment.dart
+++ b/player/lib/domain/models/media_segment.dart
@@ -105,8 +105,6 @@ class MediaSegment {
     return ms >= startMs && ms < endMs;
   }
 
-  Duration get start => Duration(milliseconds: startMs);
-
   Duration get end => Duration(milliseconds: endMs);
 
   /// Stable identity for once-per-session skip tracking.

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -45,6 +45,7 @@ import '../../../domain/models/media_segment.dart';
 import '../../../domain/models/quality_rung.dart';
 import '../../../domain/models/subtitle_track.dart' as app_models;
 import '../../../domain/models/cast_device.dart';
+import '../../../domain/models/download.dart';
 import '../../../graphql/fragments/media_file_fragment.graphql.dart';
 import '../../../graphql/queries/movie_detail.graphql.dart';
 import '../../../graphql/queries/episode_detail.graphql.dart';
@@ -1926,8 +1927,20 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// viewer already dismissed a still-pending offer some other way.
   Future<void> _maybeShowUpNextForDownloadedNext() async {
     final nextEpisode = _seasonEpisodes![_currentEpisodeIndex! + 1];
-    final manager = await ref.read(downloadManagerProvider.future);
-    final downloaded = manager.getDownloadedMediaById(nextEpisode.id);
+
+    final DownloadedMedia? downloaded;
+    try {
+      final manager = await ref.read(downloadManagerProvider.future);
+      downloaded = manager.getDownloadedMediaById(nextEpisode.id);
+    } catch (e) {
+      // Simply not offering Up Next is the right failure mode here: this
+      // runs fired-and-forgotten off a position tick, with no return value
+      // and no caller waiting on it, so there is nothing to propagate an
+      // error to.
+      debugPrint('[PlayerScreen] Could not check next-episode download: $e');
+      return;
+    }
+
     if (!mounted || downloaded == null) return;
     if (_showUpNext || _autoPlayCancelled) return;
 

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1778,12 +1778,20 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
     _maybeAutoSkipSegment(player);
 
-    // Check if video is near completion (90%)
+    // Offer the next episode once real credits are known to have started;
+    // only a file with no detected credits segment falls back to a fixed
+    // window before the real end. See [shouldOfferUpNext].
+    if (shouldOfferUpNext(
+      segments: _segments,
+      position: _timeline.toReal(player.state.position),
+      duration: _timeline.resolveDuration(player.state.duration),
+    )) {
+      _maybeShowUpNext();
+    }
+
     final isWatched = _progressService?.isWatched(player) == true;
     if (isWatched) {
       debugPrint('Content is considered watched (90% complete)');
-      // Trigger "Up Next" overlay for episodes with a next episode available
-      _maybeShowUpNext();
 
       if (!_watchedInvalidationSent) {
         _watchedInvalidationSent = true;
@@ -1899,7 +1907,34 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       return;
     }
 
-    // Show the overlay and start countdown
+    // Offline/local playback can only ever autoplay into a next episode
+    // that is itself already on disk — the next one existing in the season
+    // is not enough, since there may be no connection to stream or fetch it
+    // when the countdown lands.
+    if (_isDownloadedSource) {
+      unawaited(_maybeShowUpNextForDownloadedNext());
+      return;
+    }
+
+    _showUpNextOverlay();
+  }
+
+  /// The download-gated half of [_maybeShowUpNext].
+  ///
+  /// Re-checks [_showUpNext]/[_autoPlayCancelled] after the lookup: both can
+  /// change while the (async) download-manager query is in flight, e.g. the
+  /// viewer already dismissed a still-pending offer some other way.
+  Future<void> _maybeShowUpNextForDownloadedNext() async {
+    final nextEpisode = _seasonEpisodes![_currentEpisodeIndex! + 1];
+    final manager = await ref.read(downloadManagerProvider.future);
+    final downloaded = manager.getDownloadedMediaById(nextEpisode.id);
+    if (!mounted || downloaded == null) return;
+    if (_showUpNext || _autoPlayCancelled) return;
+
+    _showUpNextOverlay();
+  }
+
+  void _showUpNextOverlay() {
     setState(() {
       _showUpNext = true;
       _autoPlayCountdown = _autoPlayCountdownDuration;

--- a/player/lib/presentation/widgets/up_next_overlay.dart
+++ b/player/lib/presentation/widgets/up_next_overlay.dart
@@ -32,11 +32,18 @@ bool shouldOfferUpNext({
   required Duration position,
   required Duration duration,
 }) {
-  final creditsSegments =
-      segments.where((segment) => segment.type == SegmentType.credits);
-  if (creditsSegments.isNotEmpty) {
-    return creditsSegments.any((segment) => position >= segment.start);
+  // A single pass, comparing raw milliseconds: this runs on every position
+  // tick, and `segments` rarely holds more than an intro and a credits
+  // marker, but there is no reason to walk the list twice or allocate a
+  // `Duration` per comparison when an int compare does the same job.
+  final positionMs = position.inMilliseconds;
+  var hasCredits = false;
+  for (final segment in segments) {
+    if (segment.type != SegmentType.credits) continue;
+    hasCredits = true;
+    if (positionMs >= segment.startMs) return true;
   }
+  if (hasCredits) return false;
   if (duration <= Duration.zero) return false;
   return duration - position <= upNextFallbackWindow;
 }

--- a/player/lib/presentation/widgets/up_next_overlay.dart
+++ b/player/lib/presentation/widgets/up_next_overlay.dart
@@ -1,5 +1,46 @@
 import 'package:flutter/material.dart';
 
+import '../../domain/models/media_segment.dart';
+
+/// Fallback trigger window, used only when no credits segment was detected
+/// for the file.
+///
+/// A remaining-time window tracks real credits length far better than a
+/// percentage of total runtime does: real credits run roughly the same
+/// length (tens of seconds) on a 20-minute sitcom and a 90-minute movie
+/// alike, while a fixed percentage of runtime does not — the 90% heuristic
+/// this replaced fired 7 minutes before the end of a 70-minute episode,
+/// long before credits actually rolled. Jellyfin's Android TV client, the
+/// one other client in the space with an in-player next-episode prompt,
+/// avoids the guess entirely by waiting for the item to actually finish;
+/// that loses the "still-plenty-of-runtime-left" auto-play countdown Mydia
+/// already offers via real credits detection, so this keeps a small
+/// prediction window rather than none for files without detection data.
+const upNextFallbackWindow = Duration(seconds: 60);
+
+/// Decides whether the "Up Next" overlay should be offered at [position],
+/// given a [duration] for the file.
+///
+/// A detected credits segment is the trigger once the server found one for
+/// this file: waiting for real credits beats guessing, which used to fire
+/// the overlay while the episode was still mid-scene whenever the credits
+/// ran long or a cold open pushed them later than usual. Only when no
+/// credits segment was detected does [upNextFallbackWindow] before the real
+/// end stand in on its own.
+bool shouldOfferUpNext({
+  required List<MediaSegment> segments,
+  required Duration position,
+  required Duration duration,
+}) {
+  final creditsSegments =
+      segments.where((segment) => segment.type == SegmentType.credits);
+  if (creditsSegments.isNotEmpty) {
+    return creditsSegments.any((segment) => position >= segment.start);
+  }
+  if (duration <= Duration.zero) return false;
+  return duration - position <= upNextFallbackWindow;
+}
+
 /// A Netflix-style "Up Next" overlay that appears when an episode is near completion.
 ///
 /// Shows the next episode's information with a countdown timer for auto-play,

--- a/player/test/presentation/widgets/up_next_overlay_test.dart
+++ b/player/test/presentation/widgets/up_next_overlay_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/media_segment.dart';
+import 'package:player/presentation/widgets/up_next_overlay.dart';
+
+void main() {
+  group('shouldOfferUpNext', () {
+    const duration = Duration(minutes: 45);
+    const credits = MediaSegment(
+      type: SegmentType.credits,
+      startMs: 2640000, // 44:00
+      endMs: 2700000, // 45:00
+    );
+
+    test('is false before credits start, even in the old 90% window', () {
+      // 40:30 into a 45-minute episode: past the old 90% threshold
+      // (40:30 = 90% of 45:00) but two and a half minutes before the
+      // detected credits actually begin.
+      expect(
+        shouldOfferUpNext(
+          segments: [credits],
+          position: const Duration(minutes: 40, seconds: 30),
+          duration: duration,
+        ),
+        isFalse,
+      );
+    });
+
+    test('is true once playback reaches the credits segment', () {
+      expect(
+        shouldOfferUpNext(
+          segments: [credits],
+          position: const Duration(minutes: 44),
+          duration: duration,
+        ),
+        isTrue,
+      );
+    });
+
+    test('is true past the credits start even outside the fallback window', () {
+      // A credits segment is authoritative regardless of how far from the
+      // real end it sits.
+      const earlyCredits = MediaSegment(
+        type: SegmentType.credits,
+        startMs: 600000, // 10:00
+        endMs: 660000, // 11:00
+      );
+      expect(
+        shouldOfferUpNext(
+          segments: [earlyCredits],
+          position: const Duration(minutes: 10, seconds: 30),
+          duration: duration,
+        ),
+        isTrue,
+      );
+    });
+
+    group('fallback window (no credits segment detected)', () {
+      test('is false outside the last 60 seconds', () {
+        expect(
+          shouldOfferUpNext(
+            segments: const [],
+            position: const Duration(minutes: 43, seconds: 59),
+            duration: duration,
+          ),
+          isFalse,
+        );
+      });
+
+      test('is true within the last 60 seconds', () {
+        expect(
+          shouldOfferUpNext(
+            segments: const [],
+            position: const Duration(minutes: 44),
+            duration: duration,
+          ),
+          isTrue,
+        );
+      });
+
+      test('is false for zero duration', () {
+        expect(
+          shouldOfferUpNext(
+            segments: const [],
+            position: Duration.zero,
+            duration: Duration.zero,
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    test('ignores a non-credits segment (e.g. intro) for the fallback', () {
+      const intro = MediaSegment(
+        type: SegmentType.intro,
+        startMs: 0,
+        endMs: 60000,
+      );
+
+      expect(
+        shouldOfferUpNext(
+          segments: [intro],
+          position: const Duration(minutes: 44),
+          duration: duration,
+        ),
+        isTrue,
+        reason: 'no credits segment was detected, so the fallback window '
+            'still applies',
+      );
+      expect(
+        shouldOfferUpNext(
+          segments: [intro],
+          position: const Duration(minutes: 40),
+          duration: duration,
+        ),
+        isFalse,
+        reason: '40:00 is outside the fallback window on a 45-minute '
+            'episode, unlike the old 90% heuristic',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- The "Up Next" overlay fired at a flat 90% of total episode duration, which lands minutes before the end on anything longer than a sitcom — e.g. 7 minutes early on a 70-minute episode, well before credits actually roll.
- It now offers the next episode as soon as playback reaches a server-detected credits `MediaSegment` for the file (the intro/credits detection pipeline already exists but wasn't wired to this trigger).
- When no credits segment was detected for a file, the fallback is now a fixed 60-second window before the real end instead of a percentage of total runtime — a fixed window tracks real credits length far better than a percentage does, since credits run roughly the same length regardless of episode length.
- Up Next no longer offers to auto-play into a next episode during offline/local playback unless that next episode is itself already downloaded — a next episode existing in the season server-side doesn't mean it's playable without a connection.

## Test plan
- [x] `flutter analyze` clean on all touched files
- [x] New unit tests in `up_next_overlay_test.dart` cover: credits-segment gating, the fallback window replacing the old 90% threshold, and the intro-segment-doesn't-count-as-credits case
- [x] Full `test/presentation/screens/player/` + `test/domain/models/` suites pass (no regressions)