### PR TITLE
Hide macOS traffic lights when playback controls hide

### DIFF
--- a/player/lib/core/window/traffic_lights.dart
+++ b/player/lib/core/window/traffic_lights.dart
@@ -1,0 +1,13 @@
+/// Hides/shows the macOS traffic-light window buttons (close/minimize/zoom)
+/// to match the playback controls' own visibility.
+///
+/// Conditional import so the web build never links a `MethodChannel` call
+/// that could never succeed there. Mirrors `desktop_window.dart`.
+///
+/// `dart.library.io` is also true on iOS and Android, so
+/// [shouldControlTrafficLights] additionally gates on the target platform
+/// being macOS.
+library;
+
+export 'traffic_lights_stub.dart'
+    if (dart.library.io) 'traffic_lights_native.dart';

--- a/player/lib/core/window/traffic_lights_native.dart
+++ b/player/lib/core/window/traffic_lights_native.dart
@@ -16,17 +16,28 @@ import 'window_fullscreen.dart';
 
 const MethodChannel _channel = MethodChannel('dev.mydia.player/window_chrome');
 
-/// Whether [setTrafficLightsHidden] should touch the native buttons at all.
+/// Whether [setTrafficLightsHidden] should forward a call for the given
+/// [hidden] direction to the native buttons.
 ///
-/// False off macOS (no traffic lights to control) and while fullscreen,
-/// where macOS already hides them on its own — forcing them visible there
-/// would fight the OS's own transition.
+/// False off macOS regardless of [hidden] — there are no traffic lights to
+/// control there. On macOS, a hide (`hidden: true`) is additionally blocked
+/// while [isFullscreen]: the OS already hides the buttons there on its own,
+/// so forcing them hidden ourselves would fight its own transition. A
+/// restore (`hidden: false`) is never blocked by fullscreen — `isHidden =
+/// false` is the stock state every unmodified macOS app has there, so
+/// passing a restore through is always safe. That asymmetry matters:
+/// [ChromeVisibility]'s `dispose()` safety net calls this with `hidden:
+/// false` unconditionally, and it must actually reach the native side even
+/// when the player is torn down while still fullscreen — otherwise a window
+/// could be left with its close/minimize/zoom buttons stranded hidden after
+/// returning to windowed mode.
 @visibleForTesting
 bool shouldControlTrafficLights({
   required TargetPlatform platform,
+  required bool hidden,
   required bool isFullscreen,
 }) =>
-    platform == TargetPlatform.macOS && !isFullscreen;
+    platform == TargetPlatform.macOS && !(hidden && isFullscreen);
 
 /// Hides or shows the native close/minimize/zoom buttons.
 ///
@@ -35,6 +46,7 @@ bool shouldControlTrafficLights({
 void setTrafficLightsHidden(bool hidden) {
   if (!shouldControlTrafficLights(
     platform: defaultTargetPlatform,
+    hidden: hidden,
     isFullscreen: windowFullscreen.value,
   )) {
     return;

--- a/player/lib/core/window/traffic_lights_native.dart
+++ b/player/lib/core/window/traffic_lights_native.dart
@@ -1,0 +1,55 @@
+/// Native traffic-light control, backed by a custom `MethodChannel` to
+/// `AppDelegate.swift`.
+///
+/// Nothing here is allowed to throw — this runs as a side effect of
+/// [ChromeVisibility]'s show/hide, never awaited, so a failure must be
+/// caught and logged rather than surface as a red screen mid-playback.
+/// Mirrors `desktop_window_native.dart`.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'window_fullscreen.dart';
+
+const MethodChannel _channel = MethodChannel('dev.mydia.player/window_chrome');
+
+/// Whether [setTrafficLightsHidden] should touch the native buttons at all.
+///
+/// False off macOS (no traffic lights to control) and while fullscreen,
+/// where macOS already hides them on its own — forcing them visible there
+/// would fight the OS's own transition.
+@visibleForTesting
+bool shouldControlTrafficLights({
+  required TargetPlatform platform,
+  required bool isFullscreen,
+}) =>
+    platform == TargetPlatform.macOS && !isFullscreen;
+
+/// Hides or shows the native close/minimize/zoom buttons.
+///
+/// Fire-and-forget: callers do not await this, so any failure is caught and
+/// logged here rather than propagating.
+void setTrafficLightsHidden(bool hidden) {
+  if (!shouldControlTrafficLights(
+    platform: defaultTargetPlatform,
+    isFullscreen: windowFullscreen.value,
+  )) {
+    return;
+  }
+
+  try {
+    unawaited(
+      _channel.invokeMethod<void>(
+          'setTrafficLightsHidden', {'hidden': hidden}).catchError(
+        (Object e) => debugPrint(
+          '[TrafficLights] Failed to toggle traffic lights: $e',
+        ),
+      ),
+    );
+  } catch (e) {
+    debugPrint('[TrafficLights] Failed to toggle traffic lights: $e');
+  }
+}

--- a/player/lib/core/window/traffic_lights_stub.dart
+++ b/player/lib/core/window/traffic_lights_stub.dart
@@ -1,0 +1,2 @@
+/// No-op on web: there is no native window to control.
+void setTrafficLightsHidden(bool hidden) {}

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -6,6 +6,7 @@ import 'package:media_kit/media_kit.dart';
 import '../../../core/player/platform_features.dart';
 import '../../../core/player/stream_timeline.dart';
 import '../../../core/window/desktop_window.dart';
+import '../../../core/window/traffic_lights.dart';
 import '../../../core/theme/depth_tokens.dart';
 import 'center_play_button.dart';
 import 'chrome_panel.dart';
@@ -56,6 +57,11 @@ class ChromeVisibility extends StatefulWidget {
   /// Starts an OS window drag from the background. Null by default.
   final VoidCallback? onWindowDrag;
 
+  /// Hides/shows the macOS traffic-light window buttons in step with chrome
+  /// visibility. Injected by tests; defaults to the real native bridge
+  /// (`setTrafficLightsHidden` from `core/window/traffic_lights.dart`).
+  final void Function(bool hidden)? onTrafficLightsHidden;
+
   const ChromeVisibility({
     super.key,
     required this.isPlaying,
@@ -64,6 +70,7 @@ class ChromeVisibility extends StatefulWidget {
     this.autoHide = const Duration(seconds: 3),
     this.onDoubleTap,
     this.onWindowDrag,
+    this.onTrafficLightsHidden,
   });
 
   static const Key contentKey = Key('chrome-content');
@@ -176,6 +183,7 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
     _hideTimer?.cancel();
     _curved.dispose();
     _controller.dispose();
+    _setTrafficLightsHidden(false);
     super.dispose();
   }
 
@@ -190,9 +198,14 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
     });
   }
 
+  /// Resolves to the injected test callback, or the real native bridge.
+  void Function(bool hidden) get _setTrafficLightsHidden =>
+      widget.onTrafficLightsHidden ?? setTrafficLightsHidden;
+
   void _show() {
     if (!_visible) {
       setState(() => _visible = true);
+      _setTrafficLightsHidden(false);
     }
     _controller.forward();
     _restartTimer();
@@ -202,6 +215,7 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
     _hideTimer?.cancel();
     if (_visible) {
       setState(() => _visible = false);
+      _setTrafficLightsHidden(true);
     }
     _controller.reverse();
   }

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -162,6 +162,15 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
       reverseCurve: DepthTokens.curveEmphasized,
     );
     _restartTimer();
+    // `_visible` starts true and `_show()` only calls the bridge on a
+    // false -> true transition, so a freshly-mounted ChromeVisibility would
+    // otherwise never assert "buttons are visible" to the native side. This
+    // makes that invariant self-healing: even if some other bug left the
+    // native buttons stranded hidden, the next mount (e.g. re-entering the
+    // player) restores them. Safe to fire even if the app happens to
+    // already be fullscreen at mount time — see shouldControlTrafficLights'
+    // doc comment for why a restore always gets through.
+    _setTrafficLightsHidden(false);
   }
 
   @override
@@ -181,9 +190,9 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
   @override
   void dispose() {
     _hideTimer?.cancel();
+    _setTrafficLightsHidden(false);
     _curved.dispose();
     _controller.dispose();
-    _setTrafficLightsHidden(false);
     super.dispose();
   }
 

--- a/player/macos/Runner/AppDelegate.swift
+++ b/player/macos/Runner/AppDelegate.swift
@@ -27,6 +27,23 @@ class AppDelegate: FlutterAppDelegate {
         result(FlutterMethodNotImplemented)
       }
     }
+
+    let chromeChannel = FlutterMethodChannel(
+      name: "dev.mydia.player/window_chrome",
+      binaryMessenger: controller.engine.binaryMessenger
+    )
+    chromeChannel.setMethodCallHandler { [weak self] call, result in
+      switch call.method {
+      case "setTrafficLightsHidden":
+        let hidden = (call.arguments as? [String: Any])?["hidden"] as? Bool ?? false
+        self?.mainFlutterWindow?.standardWindowButton(.closeButton)?.isHidden = hidden
+        self?.mainFlutterWindow?.standardWindowButton(.miniaturizeButton)?.isHidden = hidden
+        self?.mainFlutterWindow?.standardWindowButton(.zoomButton)?.isHidden = hidden
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
   }
 
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/player/macos/Runner/MainFlutterWindow.swift
+++ b/player/macos/Runner/MainFlutterWindow.swift
@@ -15,11 +15,6 @@ class MainFlutterWindow: NSWindow {
     self.titleVisibility = .hidden
     self.styleMask.insert(.fullSizeContentView)
 
-    // Optional: hide traffic light buttons (close/minimize/zoom)
-    // self.standardWindowButton(.closeButton)?.isHidden = true
-    // self.standardWindowButton(.miniaturizeButton)?.isHidden = true
-    // self.standardWindowButton(.zoomButton)?.isHidden = true
-
     super.awakeFromNib()
   }
 }

--- a/player/test/core/window/traffic_lights_native_test.dart
+++ b/player/test/core/window/traffic_lights_native_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/window/traffic_lights_native.dart';
+
+void main() {
+  group('shouldControlTrafficLights', () {
+    test('true on windowed macOS', () {
+      expect(
+        shouldControlTrafficLights(
+          platform: TargetPlatform.macOS,
+          isFullscreen: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('false on fullscreen macOS — the OS already hides them there', () {
+      expect(
+        shouldControlTrafficLights(
+          platform: TargetPlatform.macOS,
+          isFullscreen: true,
+        ),
+        isFalse,
+      );
+    });
+
+    for (final platform in [
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+      TargetPlatform.iOS,
+      TargetPlatform.android,
+    ]) {
+      test('false on ${platform.name} — no traffic lights there', () {
+        expect(
+          shouldControlTrafficLights(
+            platform: platform,
+            isFullscreen: false,
+          ),
+          isFalse,
+        );
+      });
+    }
+  });
+}

--- a/player/test/core/window/traffic_lights_native_test.dart
+++ b/player/test/core/window/traffic_lights_native_test.dart
@@ -4,23 +4,52 @@ import 'package:player/core/window/traffic_lights_native.dart';
 
 void main() {
   group('shouldControlTrafficLights', () {
-    test('true on windowed macOS', () {
+    test('true hiding on windowed macOS', () {
       expect(
         shouldControlTrafficLights(
           platform: TargetPlatform.macOS,
+          hidden: true,
           isFullscreen: false,
         ),
         isTrue,
       );
     });
 
-    test('false on fullscreen macOS — the OS already hides them there', () {
+    test('true restoring on windowed macOS', () {
       expect(
         shouldControlTrafficLights(
           platform: TargetPlatform.macOS,
+          hidden: false,
+          isFullscreen: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+        'false hiding on fullscreen macOS — the OS already hides them '
+        'there', () {
+      expect(
+        shouldControlTrafficLights(
+          platform: TargetPlatform.macOS,
+          hidden: true,
           isFullscreen: true,
         ),
         isFalse,
+      );
+    });
+
+    test(
+        'true restoring on fullscreen macOS — a restore is always safe to '
+        'pass through, so the dispose() safety net still reaches native '
+        'code even when the player is torn down while still fullscreen', () {
+      expect(
+        shouldControlTrafficLights(
+          platform: TargetPlatform.macOS,
+          hidden: false,
+          isFullscreen: true,
+        ),
+        isTrue,
       );
     });
 
@@ -30,10 +59,24 @@ void main() {
       TargetPlatform.iOS,
       TargetPlatform.android,
     ]) {
-      test('false on ${platform.name} — no traffic lights there', () {
+      test('false hiding on ${platform.name} — no traffic lights there', () {
         expect(
           shouldControlTrafficLights(
             platform: platform,
+            hidden: true,
+            isFullscreen: false,
+          ),
+          isFalse,
+        );
+      });
+
+      test(
+          'false restoring on ${platform.name} — no traffic lights there '
+          'either', () {
+        expect(
+          shouldControlTrafficLights(
+            platform: platform,
+            hidden: false,
             isFullscreen: false,
           ),
           isFalse,

--- a/player/test/presentation/widgets/video_controls/playback_chrome_test.dart
+++ b/player/test/presentation/widgets/video_controls/playback_chrome_test.dart
@@ -525,6 +525,94 @@ void main() {
     });
   });
 
+  group('ChromeVisibility traffic lights', () {
+    testWidgets('hides the traffic lights when chrome auto-hides',
+        (tester) async {
+      final calls = <bool>[];
+      await tester.pumpWidget(
+        _host(
+          ChromeVisibility(
+            isPlaying: true,
+            onTrafficLightsHidden: calls.add,
+            child: const Text('chrome'),
+          ),
+        ),
+      );
+
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+
+      expect(calls, [true]);
+    });
+
+    testWidgets('shows the traffic lights again when chrome reappears on tap',
+        (tester) async {
+      final calls = <bool>[];
+      await tester.pumpWidget(
+        _host(
+          ChromeVisibility(
+            isPlaying: true,
+            onTrafficLightsHidden: calls.add,
+            child: const Text('chrome'),
+          ),
+        ),
+      );
+
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+      expect(calls, [true]);
+
+      await tester.tapAt(const Offset(400, 300));
+      await tester.pumpAndSettle();
+
+      expect(calls, [true, false]);
+    });
+
+    testWidgets(
+        'never calls the callback while paused, since chrome never hides',
+        (tester) async {
+      final calls = <bool>[];
+      await tester.pumpWidget(
+        _host(
+          ChromeVisibility(
+            isPlaying: false,
+            onTrafficLightsHidden: calls.add,
+            child: const Text('chrome'),
+          ),
+        ),
+      );
+
+      await tester.pump(const Duration(seconds: 10));
+      await tester.pumpAndSettle();
+
+      expect(calls, isEmpty);
+    });
+
+    testWidgets(
+        'restores the traffic lights on dispose even if chrome was hidden',
+        (tester) async {
+      final calls = <bool>[];
+      await tester.pumpWidget(
+        _host(
+          ChromeVisibility(
+            isPlaying: true,
+            onTrafficLightsHidden: calls.add,
+            child: const Text('chrome'),
+          ),
+        ),
+      );
+
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+      expect(calls, [true]);
+
+      // Replace the tree so ChromeVisibility disposes.
+      await tester.pumpWidget(_host(const Text('gone')));
+
+      expect(calls, [true, false]);
+    });
+  });
+
   group('PlaybackChrome gating', () {
     late Player player;
 

--- a/player/test/presentation/widgets/video_controls/playback_chrome_test.dart
+++ b/player/test/presentation/widgets/video_controls/playback_chrome_test.dart
@@ -526,6 +526,29 @@ void main() {
   });
 
   group('ChromeVisibility traffic lights', () {
+    testWidgets('asserts the traffic lights visible once on mount',
+        (tester) async {
+      final calls = <bool>[];
+      await tester.pumpWidget(
+        _host(
+          ChromeVisibility(
+            isPlaying: true,
+            onTrafficLightsHidden: calls.add,
+            child: const Text('chrome'),
+          ),
+        ),
+      );
+
+      expect(
+        calls,
+        [false],
+        reason: '_visible starts true and _show() only calls the bridge on '
+            'a false -> true transition, so a freshly-mounted '
+            'ChromeVisibility must assert visibility itself in initState, '
+            'or the native side never learns the buttons should be shown',
+      );
+    });
+
     testWidgets('hides the traffic lights when chrome auto-hides',
         (tester) async {
       final calls = <bool>[];
@@ -542,7 +565,9 @@ void main() {
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
 
-      expect(calls, [true]);
+      // The leading `false` is the initState mount assertion; the trailing
+      // `true` is the auto-hide.
+      expect(calls, [false, true]);
     });
 
     testWidgets('shows the traffic lights again when chrome reappears on tap',
@@ -560,16 +585,17 @@ void main() {
 
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
-      expect(calls, [true]);
+      expect(calls, [false, true]);
 
       await tester.tapAt(const Offset(400, 300));
       await tester.pumpAndSettle();
 
-      expect(calls, [true, false]);
+      expect(calls, [false, true, false]);
     });
 
     testWidgets(
-        'never calls the callback while paused, since chrome never hides',
+        'never calls the callback for auto-hide while paused, since chrome '
+        'never hides (only the initState mount assertion fires)',
         (tester) async {
       final calls = <bool>[];
       await tester.pumpWidget(
@@ -585,7 +611,7 @@ void main() {
       await tester.pump(const Duration(seconds: 10));
       await tester.pumpAndSettle();
 
-      expect(calls, isEmpty);
+      expect(calls, [false]);
     });
 
     testWidgets(
@@ -604,12 +630,12 @@ void main() {
 
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
-      expect(calls, [true]);
+      expect(calls, [false, true]);
 
       // Replace the tree so ChromeVisibility disposes.
       await tester.pumpWidget(_host(const Text('gone')));
 
-      expect(calls, [true, false]);
+      expect(calls, [false, true, false]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Native `dev.mydia.player/window_chrome` MethodChannel toggles the three standard `NSWindow` traffic-light buttons' `isHidden` state on macOS.
- New `player/lib/core/window/traffic_lights.dart` bridge module (stub on web, native elsewhere) wraps that channel behind `setTrafficLightsHidden(bool)`, gated to macOS and — for the hide direction only — non-fullscreen.
- `ChromeVisibility` (the existing playback-controls auto-hide state machine) calls the bridge from `_show()`/`_hide()` on actual visibility transitions, plus once from `initState()` and once from `dispose()` as self-healing safety nets, so the window can never end up stranded with hidden traffic lights.
- A final whole-branch review caught a cross-task bug where a symmetric fullscreen gate defeated the `dispose()` safety net; fixed by making the gate asymmetric (always allow restore-to-visible, even in fullscreen).

## Test plan
- [x] `./dev flutter test --concurrency=1` — full suite green, 1572/1572
- [x] `./dev flutter analyze` — no new issues
- [ ] **`./dev player macos run` on a real Mac** — this branch was implemented and reviewed entirely on Linux (no Xcode available), so the Swift channel was verified by inspection only, never actually built or run. Needs a real macOS run before this ships. The implementation plan's Task 4 (`docs/superpowers/plans/2026-08-05-hide-traffic-lights-with-controls.md`, local scratch, not in this diff) has the full manual QA checklist, including two fullscreen-specific edge cases flagged by review that also need hardware to confirm.