### PR TITLE
feat(graphql): expose cast, trailer, similar titles, and fix content rating

### DIFF
--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -260,7 +260,7 @@ defmodule Mydia.Library.MetadataEnricher do
   defp fetch_full_metadata(provider_id, media_type, config, provider_type) do
     fetch_opts = [
       media_type: media_type,
-      append_to_response: ["credits", "images", "videos", "keywords"]
+      append_to_response: Metadata.default_append_to_response()
     ]
 
     # For TV shows, fetch from the provider that supplied the match so a

--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -260,7 +260,7 @@ defmodule Mydia.Library.MetadataEnricher do
   defp fetch_full_metadata(provider_id, media_type, config, provider_type) do
     fetch_opts = [
       media_type: media_type,
-      append_to_response: Metadata.default_append_to_response()
+      append_to_response: Metadata.default_append_to_response(media_type)
     ]
 
     # For TV shows, fetch from the provider that supplied the match so a

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -649,26 +649,28 @@ defmodule Mydia.Media do
   end
 
   @doc """
-  Returns library status for a specific set of TMDB movie ids.
+  Returns library status for a specific set of TMDB ids, scoped to one type.
 
   Same value shape as `get_library_status_map/0`, but scoped to the ids asked
-  for. Use this when checking a handful of ids (a franchise's members, say)
-  rather than loading the whole library.
+  for. Use this when checking a handful of ids (a franchise's members, TMDB
+  recommendations for a title) rather than loading the whole library.
 
-  Movies only. A TV row that happens to share a TMDB id with a movie is not a
-  match for a franchise member.
+  `type` is required and must be `"movie"` or `"tv_show"` — the caller already
+  knows which, since a title's franchise members and recommendations are
+  always its own type. A row of the other type that happens to share a TMDB id
+  is not a match.
 
   ## Examples
 
-      iex> library_status_for_tmdb_ids([671, 672])
+      iex> library_status_for_tmdb_ids([671, 672], "movie")
       %{671 => %{in_library: true, monitored: true, type: "movie", id: "..."}}
   """
-  @spec library_status_for_tmdb_ids([integer()]) :: map()
-  def library_status_for_tmdb_ids([]), do: %{}
+  @spec library_status_for_tmdb_ids([integer()], String.t()) :: map()
+  def library_status_for_tmdb_ids([], _type), do: %{}
 
-  def library_status_for_tmdb_ids(tmdb_ids) when is_list(tmdb_ids) do
+  def library_status_for_tmdb_ids(tmdb_ids, type) when is_list(tmdb_ids) and is_binary(type) do
     MediaItem
-    |> where([m], m.type == "movie" and m.tmdb_id in ^tmdb_ids)
+    |> where([m], m.type == ^type and m.tmdb_id in ^tmdb_ids)
     |> select([m], {m.tmdb_id, m.monitored, m.type, m.id})
     |> Repo.all()
     |> Map.new(fn {tmdb_id, monitored, type, id} ->

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -19,6 +19,7 @@ defmodule Mydia.Media do
 
   ## Options
     - `:type` - Filter by type ("movie" or "tv_show")
+    - `:ids` - Filter to a specific list of media item ids
     - `:monitored` - Filter by monitored status (true/false)
     - `:category` - Filter by category (atom or string, e.g., :anime_movie or "anime_movie")
     - `:library_path_type` - Filter by library path type (:adult, :music, :books, etc.)
@@ -1603,6 +1604,9 @@ defmodule Mydia.Media do
 
       {:monitored, monitored}, query ->
         where(query, [m], m.monitored == ^monitored)
+
+      {:ids, ids}, query when is_list(ids) ->
+        where(query, [m], m.id in ^ids)
 
       {:category, category}, query when is_atom(category) ->
         where(query, [m], m.category == ^to_string(category))

--- a/lib/mydia/media/franchises.ex
+++ b/lib/mydia/media/franchises.ex
@@ -132,7 +132,7 @@ defmodule Mydia.Media.Franchises do
     if length(entries) < 2 do
       :none
     else
-      status = Media.library_status_for_tmdb_ids(Enum.map(entries, & &1.tmdb_id))
+      status = Media.library_status_for_tmdb_ids(Enum.map(entries, & &1.tmdb_id), "movie")
 
       entries =
         entries

--- a/lib/mydia/media/metadata_type.ex
+++ b/lib/mydia/media/metadata_type.ex
@@ -110,6 +110,7 @@ defmodule Mydia.Media.MetadataType do
       tagline: data[:tagline],
       runtime: data[:runtime],
       status: data[:status],
+      content_rating: data[:content_rating],
       genres: data[:genres],
       poster_path: data[:poster_path],
       backdrop_path: data[:backdrop_path],

--- a/lib/mydia/media/metadata_type.ex
+++ b/lib/mydia/media/metadata_type.ex
@@ -126,6 +126,7 @@ defmodule Mydia.Media.MetadataType do
       crew: parse_crew_list(data[:crew]),
       alternative_titles: data[:alternative_titles],
       videos: parse_videos_list(data[:videos]),
+      recommended_tmdb_ids: data[:recommended_tmdb_ids],
       origin_country: data[:origin_country],
       original_language: data[:original_language],
       collection_id: data[:collection_id],

--- a/lib/mydia/media/provider_switch.ex
+++ b/lib/mydia/media/provider_switch.ex
@@ -209,7 +209,7 @@ defmodule Mydia.Media.ProviderSwitch do
            Mydia.Metadata.fetch_by_id(config, new_id,
              media_type: :tv_show,
              provider: target_provider,
-             append_to_response: ["credits", "images", "videos", "keywords"]
+             append_to_response: Mydia.Metadata.default_append_to_response()
            ),
          {:ok, season_datas, expected_episode_count} <-
            prefetch_provider_seasons(

--- a/lib/mydia/media/provider_switch.ex
+++ b/lib/mydia/media/provider_switch.ex
@@ -209,7 +209,7 @@ defmodule Mydia.Media.ProviderSwitch do
            Mydia.Metadata.fetch_by_id(config, new_id,
              media_type: :tv_show,
              provider: target_provider,
-             append_to_response: Mydia.Metadata.default_append_to_response()
+             append_to_response: Mydia.Metadata.default_append_to_response(:tv_show)
            ),
          {:ok, season_datas, expected_episode_count} <-
            prefetch_provider_seasons(

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -99,7 +99,7 @@ defmodule Mydia.Media.Refresh do
     fetch_opts = [
       media_type: media_type,
       provider: source,
-      append_to_response: ["credits", "images", "videos", "keywords"]
+      append_to_response: Metadata.default_append_to_response()
     ]
 
     Metadata.fetch_by_id(config, to_string(provider_id), fetch_opts)

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -99,7 +99,7 @@ defmodule Mydia.Media.Refresh do
     fetch_opts = [
       media_type: media_type,
       provider: source,
-      append_to_response: Metadata.default_append_to_response()
+      append_to_response: Metadata.default_append_to_response(media_type)
     ]
 
     Metadata.fetch_by_id(config, to_string(provider_id), fetch_opts)

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -439,24 +439,28 @@ defmodule Mydia.Metadata do
     end
   end
 
+  # Resources common to both movie and TV detail fetches.
+  @shared_append_to_response ["credits", "images", "videos", "keywords", "recommendations"]
+
   @doc """
-  The `append_to_response` list used by every full-detail metadata fetch
-  (initial match, refresh, provider switch). Extending this list is the only
-  way to pull in another TMDB resource — metadata-relay forwards
-  `append_to_response` straight through to TMDB with no allowlist, so nothing
-  outside this module needs to change to add one.
+  The `append_to_response` list for a full-detail metadata fetch (initial
+  match, refresh, provider switch), scoped to `media_type`.
+
+  Movies and TV shows have different valid TMDB append resources — movies
+  carry certification under `release_dates`, TV shows under
+  `content_ratings` — and TMDB validates `append_to_response` per endpoint,
+  so mixing the two risks breaking the fetch for one media type. Extending
+  either list is the only way to pull in another TMDB resource —
+  metadata-relay forwards `append_to_response` straight through to TMDB with
+  no allowlist, so nothing outside this module needs to change to add one.
   """
-  @spec default_append_to_response() :: [String.t()]
-  def default_append_to_response do
-    [
-      "credits",
-      "images",
-      "videos",
-      "keywords",
-      "release_dates",
-      "content_ratings",
-      "recommendations"
-    ]
+  @spec default_append_to_response(:movie | :tv_show) :: [String.t()]
+  def default_append_to_response(:movie) do
+    @shared_append_to_response ++ ["release_dates"]
+  end
+
+  def default_append_to_response(:tv_show) do
+    @shared_append_to_response ++ ["content_ratings"]
   end
 
   @doc """

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -440,6 +440,26 @@ defmodule Mydia.Metadata do
   end
 
   @doc """
+  The `append_to_response` list used by every full-detail metadata fetch
+  (initial match, refresh, provider switch). Extending this list is the only
+  way to pull in another TMDB resource — metadata-relay forwards
+  `append_to_response` straight through to TMDB with no allowlist, so nothing
+  outside this module needs to change to add one.
+  """
+  @spec default_append_to_response() :: [String.t()]
+  def default_append_to_response do
+    [
+      "credits",
+      "images",
+      "videos",
+      "keywords",
+      "release_dates",
+      "content_ratings",
+      "recommendations"
+    ]
+  end
+
+  @doc """
   Gets the default metadata relay configuration.
 
   This provides a ready-to-use configuration for the metadata-relay service

--- a/lib/mydia/metadata/structs/media_metadata.ex
+++ b/lib/mydia/metadata/structs/media_metadata.ex
@@ -26,6 +26,7 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
     :tagline,
     :runtime,
     :status,
+    :content_rating,
     :genres,
     :poster_path,
     :backdrop_path,
@@ -70,6 +71,7 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
           tagline: String.t() | nil,
           runtime: integer() | nil,
           status: String.t() | nil,
+          content_rating: String.t() | nil,
           genres: [String.t()] | nil,
           poster_path: String.t() | nil,
           backdrop_path: String.t() | nil,
@@ -125,6 +127,7 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
       tagline: data["tagline"],
       runtime: get_runtime(data, media_type),
       status: data["status"],
+      content_rating: parse_content_rating(data, media_type),
       genres: parse_genres(data["genres"]),
       poster_path: data["poster_path"],
       backdrop_path: data["backdrop_path"],
@@ -220,6 +223,51 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
   defp parse_genres(nil), do: []
   defp parse_genres(genres) when is_list(genres), do: Enum.map(genres, & &1["name"])
   defp parse_genres(_), do: []
+
+  # US and GB certifications cover the overwhelming majority of libraries,
+  # matching how most trackers default certification lookups. Anything else
+  # falls back to the first non-blank certification TMDB reports, since a
+  # certification in the wrong region still beats showing none.
+  @certification_region_preference ["US", "GB"]
+
+  defp parse_content_rating(data, :movie) do
+    data["release_dates"]["results"]
+    |> extract_certification(fn entry ->
+      entry["release_dates"]
+      |> List.wrap()
+      |> Enum.find_value(&presence(&1["certification"]))
+    end)
+  end
+
+  defp parse_content_rating(data, :tv_show) do
+    data["content_ratings"]["results"]
+    |> extract_certification(&presence(&1["rating"]))
+  end
+
+  defp parse_content_rating(_data, _media_type), do: nil
+
+  defp extract_certification(nil, _value_fn), do: nil
+
+  defp extract_certification(results, value_fn) when is_list(results) do
+    by_country = Map.new(results, &{&1["iso_3166_1"], &1})
+
+    @certification_region_preference
+    |> Enum.find_value(fn code ->
+      case Map.get(by_country, code) do
+        nil -> nil
+        entry -> value_fn.(entry)
+      end
+    end)
+    |> case do
+      nil -> Enum.find_value(results, value_fn)
+      value -> value
+    end
+  end
+
+  defp extract_certification(_results, _value_fn), do: nil
+
+  defp presence(value) when is_binary(value) and value != "", do: value
+  defp presence(_value), do: nil
 
   defp parse_names(nil), do: []
   defp parse_names(items) when is_list(items), do: Enum.map(items, & &1["name"])

--- a/lib/mydia/metadata/structs/media_metadata.ex
+++ b/lib/mydia/metadata/structs/media_metadata.ex
@@ -42,6 +42,7 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
     :crew,
     :alternative_titles,
     :videos,
+    :recommended_tmdb_ids,
     # Classification fields (for category auto-detection)
     :origin_country,
     :original_language,
@@ -87,6 +88,7 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
           crew: [CrewMember.t()] | nil,
           alternative_titles: [String.t()] | nil,
           videos: [Video.t()] | nil,
+          recommended_tmdb_ids: [integer()] | nil,
           origin_country: [String.t()] | nil,
           original_language: String.t() | nil,
           collection_id: integer() | nil,
@@ -143,6 +145,7 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
       crew: parse_crew(data["credits"]["crew"]),
       alternative_titles: parse_alternative_titles(data["alternative_titles"]),
       videos: parse_videos(data["videos"]),
+      recommended_tmdb_ids: parse_recommended_ids(data["recommendations"]),
       origin_country: parse_origin_country(data["origin_country"]),
       original_language: data["original_language"],
       collection_id: collection_id,
@@ -376,4 +379,14 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
   end
 
   defp parse_videos(_), do: []
+
+  defp parse_recommended_ids(nil), do: []
+
+  defp parse_recommended_ids(%{"results" => results}) when is_list(results) do
+    results
+    |> Enum.take(20)
+    |> Enum.map(& &1["id"])
+  end
+
+  defp parse_recommended_ids(_), do: []
 end

--- a/lib/mydia/metadata/structs/media_metadata.ex
+++ b/lib/mydia/metadata/structs/media_metadata.ex
@@ -369,8 +369,10 @@ defmodule Mydia.Metadata.Structs.MediaMetadata do
     end)
     |> Enum.sort_by(
       fn video ->
-        # Prioritize official trailers, then by most recent
-        {!video["official"], video["published_at"]}
+        # Prioritize official trailers, then by most recent. `:desc` on a
+        # boolean puts `true` (official) ahead of `false`, matching Erlang
+        # term ordering (true > false).
+        {video["official"], video["published_at"]}
       end,
       :desc
     )

--- a/lib/mydia/metadata/structs/video.ex
+++ b/lib/mydia/metadata/structs/video.ex
@@ -125,6 +125,29 @@ defmodule Mydia.Metadata.Structs.Video do
   def youtube_embed_url(_), do: nil
 
   @doc """
+  Returns the YouTube watch-page URL for this video (as opposed to the embed
+  URL `youtube_embed_url/1` returns) — for opening in a new browser tab rather
+  than embedding a player.
+
+  Returns nil if the video is not hosted on YouTube.
+
+  ## Examples
+
+      iex> video = %Video{key: "dQw4w9WgXcQ", site: "YouTube"}
+      iex> youtube_watch_url(video)
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+      iex> video = %Video{key: "abc123", site: "Vimeo"}
+      iex> youtube_watch_url(video)
+      nil
+  """
+  def youtube_watch_url(%__MODULE__{site: "YouTube", key: key}) when is_binary(key) do
+    "https://www.youtube.com/watch?v=#{key}"
+  end
+
+  def youtube_watch_url(_), do: nil
+
+  @doc """
   Builds a Video struct from a raw TVDB trailer map.
 
   TVDB trailer entries from `/series/{id}/extended` look like:

--- a/lib/mydia_web/schema/media_types.ex
+++ b/lib/mydia_web/schema/media_types.ex
@@ -66,6 +66,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
       resolve(&MediaResolver.resolve_content_rating/3)
     end
 
+    @desc "Watch-page URL for the first available YouTube trailer"
+    field :trailer_url, :string do
+      resolve(&MediaResolver.resolve_trailer_url/3)
+    end
+
     @desc "Average rating (0-10)"
     field :rating, :float do
       resolve(&MediaResolver.resolve_rating/3)
@@ -157,6 +162,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
     @desc "Content rating"
     field :content_rating, :string do
       resolve(&MediaResolver.resolve_content_rating/3)
+    end
+
+    @desc "Watch-page URL for the first available YouTube trailer"
+    field :trailer_url, :string do
+      resolve(&MediaResolver.resolve_trailer_url/3)
     end
 
     @desc "Average rating (0-10)"

--- a/lib/mydia_web/schema/media_types.ex
+++ b/lib/mydia_web/schema/media_types.ex
@@ -7,6 +7,13 @@ defmodule MydiaWeb.Schema.MediaTypes do
 
   alias MydiaWeb.Schema.Resolvers.MediaResolver
 
+  @desc "A cast member (actor) on a movie or TV show"
+  object :cast_member do
+    field :name, non_null(:string)
+    field :character, :string
+    field :profile_url, :string
+  end
+
   @desc "A movie"
   object :movie do
     interface(:node)
@@ -69,6 +76,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
     @desc "Watch-page URL for the first available YouTube trailer"
     field :trailer_url, :string do
       resolve(&MediaResolver.resolve_trailer_url/3)
+    end
+
+    @desc "Cast members"
+    field :cast, list_of(:cast_member) do
+      resolve(&MediaResolver.resolve_cast/3)
     end
 
     @desc "Average rating (0-10)"
@@ -167,6 +179,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
     @desc "Watch-page URL for the first available YouTube trailer"
     field :trailer_url, :string do
       resolve(&MediaResolver.resolve_trailer_url/3)
+    end
+
+    @desc "Cast members"
+    field :cast, list_of(:cast_member) do
+      resolve(&MediaResolver.resolve_cast/3)
     end
 
     @desc "Average rating (0-10)"

--- a/lib/mydia_web/schema/media_types.ex
+++ b/lib/mydia_web/schema/media_types.ex
@@ -83,6 +83,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
       resolve(&MediaResolver.resolve_cast/3)
     end
 
+    @desc "Recommended titles that are also in this library"
+    field :similar, list_of(:recently_added_item) do
+      resolve(&MediaResolver.resolve_similar/3)
+    end
+
     @desc "Average rating (0-10)"
     field :rating, :float do
       resolve(&MediaResolver.resolve_rating/3)
@@ -184,6 +189,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
     @desc "Cast members"
     field :cast, list_of(:cast_member) do
       resolve(&MediaResolver.resolve_cast/3)
+    end
+
+    @desc "Recommended titles that are also in this library"
+    field :similar, list_of(:recently_added_item) do
+      resolve(&MediaResolver.resolve_similar/3)
     end
 
     @desc "Average rating (0-10)"

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -7,6 +7,7 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
 
   alias Mydia.Metadata.Access, as: MetadataAccess
   alias Mydia.Metadata.ImageUrl
+  alias Mydia.Metadata.Structs.Video
   alias Mydia.Repo
 
   # Detections below this floor are persisted, so the operator can see and
@@ -40,6 +41,20 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
           {:ok, term()} | {:error, term()}
   def resolve_content_rating(parent, _args, _info) do
     {:ok, MetadataAccess.get_field(parent, :content_rating)}
+  end
+
+  @spec resolve_trailer_url(map(), map(), Absinthe.Resolution.t()) ::
+          {:ok, term()} | {:error, term()}
+  def resolve_trailer_url(parent, _args, _info) do
+    videos = MetadataAccess.get_field(parent, :videos) || []
+
+    url =
+      case List.first(videos) do
+        nil -> nil
+        video -> Video.youtube_watch_url(video)
+      end
+
+    {:ok, url}
   end
 
   @spec resolve_rating(map(), map(), Absinthe.Resolution.t()) :: {:ok, term()} | {:error, term()}

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -85,8 +85,7 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
       |> Enum.reject(&is_nil/1)
 
     items_by_id =
-      matched_ids
-      |> then(&Media.list_media_items(ids: &1))
+      Media.list_media_items(ids: matched_ids)
       |> Map.new(&{&1.id, &1})
 
     items =

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -38,9 +38,8 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
 
   @spec resolve_content_rating(map(), map(), Absinthe.Resolution.t()) ::
           {:ok, term()} | {:error, term()}
-  def resolve_content_rating(_parent, _args, _info) do
-    # Content rating isn't stored in our current metadata
-    {:ok, nil}
+  def resolve_content_rating(parent, _args, _info) do
+    {:ok, MetadataAccess.get_field(parent, :content_rating)}
   end
 
   @spec resolve_rating(map(), map(), Absinthe.Resolution.t()) :: {:ok, term()} | {:error, term()}

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -9,6 +9,7 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
   alias Mydia.Metadata.ImageUrl
   alias Mydia.Metadata.Structs.Video
   alias Mydia.Repo
+  alias MydiaWeb.Schema.Resolvers.ItemBuilder
 
   # Detections below this floor are persisted, so the operator can see and
   # diagnose them, but are not shown to players. 0.4 is exactly 2 agreeing
@@ -71,6 +72,30 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
       end)
 
     {:ok, members}
+  end
+
+  @spec resolve_similar(map(), map(), Absinthe.Resolution.t()) :: {:ok, term()} | {:error, term()}
+  def resolve_similar(parent, _args, _info) do
+    tmdb_ids = MetadataAccess.get_field(parent, :recommended_tmdb_ids) || []
+    status = Media.library_status_for_tmdb_ids(tmdb_ids, parent.type)
+
+    matched_ids =
+      tmdb_ids
+      |> Enum.map(&get_in(status, [&1, :id]))
+      |> Enum.reject(&is_nil/1)
+
+    items_by_id =
+      matched_ids
+      |> then(&Media.list_media_items(ids: &1))
+      |> Map.new(&{&1.id, &1})
+
+    items =
+      matched_ids
+      |> Enum.map(&Map.get(items_by_id, &1))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(&ItemBuilder.recently_added_item/1)
+
+    {:ok, items}
   end
 
   @spec resolve_rating(map(), map(), Absinthe.Resolution.t()) :: {:ok, term()} | {:error, term()}

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -57,6 +57,22 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
     {:ok, url}
   end
 
+  @spec resolve_cast(map(), map(), Absinthe.Resolution.t()) :: {:ok, term()} | {:error, term()}
+  def resolve_cast(parent, _args, _info) do
+    cast = MetadataAccess.get_field(parent, :cast) || []
+
+    members =
+      Enum.map(cast, fn member ->
+        %{
+          name: member.name,
+          character: member.character,
+          profile_url: ImageUrl.profile_url(member.profile_path)
+        }
+      end)
+
+    {:ok, members}
+  end
+
   @spec resolve_rating(map(), map(), Absinthe.Resolution.t()) :: {:ok, term()} | {:error, term()}
   def resolve_rating(parent, _args, _info) do
     {:ok, MetadataAccess.get_field(parent, :vote_average)}

--- a/test/mydia/media/library_status_test.exs
+++ b/test/mydia/media/library_status_test.exs
@@ -9,7 +9,7 @@ defmodule Mydia.Media.LibraryStatusTest do
     owned = media_item_fixture(%{type: "movie", title: "Owned", year: 2001, tmdb_id: 671})
     _other = media_item_fixture(%{type: "movie", title: "Other", year: 2002, tmdb_id: 672})
 
-    status = Media.library_status_for_tmdb_ids([671, 999_001])
+    status = Media.library_status_for_tmdb_ids([671, 999_001], "movie")
 
     assert %{671 => entry} = status
     assert entry.in_library == true
@@ -21,18 +21,18 @@ defmodule Mydia.Media.LibraryStatusTest do
   end
 
   test "returns an empty map for an empty id list" do
-    assert Media.library_status_for_tmdb_ids([]) == %{}
+    assert Media.library_status_for_tmdb_ids([], "movie") == %{}
   end
 
   test "returns an empty map when nothing matches" do
-    assert Media.library_status_for_tmdb_ids([999_002, 999_003]) == %{}
+    assert Media.library_status_for_tmdb_ids([999_002, 999_003], "movie") == %{}
   end
 
   test "ignores TV rows sharing a tmdb id with a franchise member" do
     _show =
       media_item_fixture(%{type: "tv_show", title: "Collides", tmdb_id: 999_004, year: 2010})
 
-    assert Media.library_status_for_tmdb_ids([999_004]) == %{}
+    assert Media.library_status_for_tmdb_ids([999_004], "movie") == %{}
   end
 
   test "reflects the monitored flag" do
@@ -45,7 +45,9 @@ defmodule Mydia.Media.LibraryStatusTest do
         monitored: false
       })
 
-    assert %{673 => %{monitored: false, id: id}} = Media.library_status_for_tmdb_ids([673])
+    assert %{673 => %{monitored: false, id: id}} =
+             Media.library_status_for_tmdb_ids([673], "movie")
+
     assert id == unmonitored.id
   end
 end

--- a/test/mydia/media/metadata_type_test.exs
+++ b/test/mydia/media/metadata_type_test.exs
@@ -209,6 +209,27 @@ defmodule Mydia.Media.MetadataTypeTest do
 
       assert reloaded.metadata.content_rating == "R"
     end
+
+    test "recommended tmdb ids survive a database round trip" do
+      {:ok, media_item} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: "The Matrix",
+          year: 1999,
+          tmdb_id: 603,
+          metadata: %{
+            "provider_id" => "603",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "The Matrix",
+            "recommended_tmdb_ids" => [604, 605, 606]
+          }
+        })
+
+      reloaded = Media.get_media_item!(media_item.id)
+
+      assert reloaded.metadata.recommended_tmdb_ids == [604, 605, 606]
+    end
   end
 
   describe "Ecto.Type callbacks" do

--- a/test/mydia/media/metadata_type_test.exs
+++ b/test/mydia/media/metadata_type_test.exs
@@ -188,6 +188,27 @@ defmodule Mydia.Media.MetadataTypeTest do
       assert reloaded.metadata.collection_id == nil
       assert reloaded.metadata.collection_name == nil
     end
+
+    test "content rating survives a database round trip" do
+      {:ok, media_item} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: "The Matrix",
+          year: 1999,
+          tmdb_id: 603,
+          metadata: %{
+            "provider_id" => "603",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "The Matrix",
+            "content_rating" => "R"
+          }
+        })
+
+      reloaded = Media.get_media_item!(media_item.id)
+
+      assert reloaded.metadata.content_rating == "R"
+    end
   end
 
   describe "Ecto.Type callbacks" do

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -2088,4 +2088,38 @@ defmodule Mydia.MediaTest do
       assert Enum.sort(Enum.map(items, & &1.id)) == Enum.sort([movie.id, show.id])
     end
   end
+
+  describe "library_status_for_tmdb_ids/2" do
+    import Mydia.MediaFixtures
+
+    test "matches movies by tmdb id and type" do
+      movie = media_item_fixture(%{type: "movie", tmdb_id: 603, monitored: true})
+
+      status = Media.library_status_for_tmdb_ids([603, 999], "movie")
+
+      assert %{in_library: true, monitored: true, type: "movie", id: id} = status[603]
+      assert id == movie.id
+      refute Map.has_key?(status, 999)
+    end
+
+    test "does not match a tv show when asked for movies" do
+      media_item_fixture(%{type: "tv_show", tmdb_id: 603})
+
+      status = Media.library_status_for_tmdb_ids([603], "movie")
+
+      refute Map.has_key?(status, 603)
+    end
+
+    test "matches tv shows when asked for tv_show" do
+      show = media_item_fixture(%{type: "tv_show", tmdb_id: 1396})
+
+      status = Media.library_status_for_tmdb_ids([1396], "tv_show")
+
+      assert status[1396].id == show.id
+    end
+
+    test "returns an empty map for an empty id list" do
+      assert Media.library_status_for_tmdb_ids([], "movie") == %{}
+    end
+  end
 end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -2122,4 +2122,25 @@ defmodule Mydia.MediaTest do
       assert Media.library_status_for_tmdb_ids([], "movie") == %{}
     end
   end
+
+  describe "list_media_items/1 :ids filter" do
+    import Mydia.MediaFixtures
+
+    test "returns only the requested ids" do
+      a = media_item_fixture(%{type: "movie", title: "A"})
+      _b = media_item_fixture(%{type: "movie", title: "B"})
+      c = media_item_fixture(%{type: "movie", title: "C"})
+
+      results = Media.list_media_items(ids: [a.id, c.id])
+
+      assert length(results) == 2
+      assert Enum.map(results, & &1.id) |> Enum.sort() == Enum.sort([a.id, c.id])
+    end
+
+    test "returns an empty list for an empty id list" do
+      media_item_fixture(%{type: "movie"})
+
+      assert Media.list_media_items(ids: []) == []
+    end
+  end
 end

--- a/test/mydia/metadata/structs/media_metadata_test.exs
+++ b/test/mydia/metadata/structs/media_metadata_test.exs
@@ -1,0 +1,116 @@
+defmodule Mydia.Metadata.Structs.MediaMetadataTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.Structs.MediaMetadata
+
+  describe "content_rating for movies" do
+    test "picks the US certification when present" do
+      body = %{
+        "id" => 603,
+        "title" => "The Matrix",
+        "release_date" => "1999-03-30",
+        "credits" => %{"cast" => [], "crew" => []},
+        "release_dates" => %{
+          "results" => [
+            %{
+              "iso_3166_1" => "FR",
+              "release_dates" => [%{"certification" => "U"}]
+            },
+            %{
+              "iso_3166_1" => "US",
+              "release_dates" => [%{"certification" => ""}, %{"certification" => "R"}]
+            }
+          ]
+        }
+      }
+
+      metadata = MediaMetadata.from_api_response(body, :movie, "603")
+
+      assert metadata.content_rating == "R"
+    end
+
+    test "falls back to GB, then to the first non-blank certification" do
+      body_gb = %{
+        "id" => 1,
+        "title" => "Import",
+        "credits" => %{"cast" => [], "crew" => []},
+        "release_dates" => %{
+          "results" => [
+            %{"iso_3166_1" => "GB", "release_dates" => [%{"certification" => "15"}]}
+          ]
+        }
+      }
+
+      assert MediaMetadata.from_api_response(body_gb, :movie, "1").content_rating == "15"
+
+      body_other = %{
+        "id" => 2,
+        "title" => "Obscure",
+        "credits" => %{"cast" => [], "crew" => []},
+        "release_dates" => %{
+          "results" => [
+            %{"iso_3166_1" => "JP", "release_dates" => [%{"certification" => "PG12"}]}
+          ]
+        }
+      }
+
+      assert MediaMetadata.from_api_response(body_other, :movie, "2").content_rating == "PG12"
+    end
+
+    test "is nil when no country has a non-blank certification" do
+      body = %{
+        "id" => 3,
+        "title" => "Uncertified",
+        "credits" => %{"cast" => [], "crew" => []},
+        "release_dates" => %{
+          "results" => [
+            %{"iso_3166_1" => "US", "release_dates" => [%{"certification" => ""}]}
+          ]
+        }
+      }
+
+      assert MediaMetadata.from_api_response(body, :movie, "3").content_rating == nil
+    end
+
+    test "is nil when release_dates is absent entirely" do
+      body = %{
+        "id" => 4,
+        "title" => "No Data",
+        "credits" => %{"cast" => [], "crew" => []}
+      }
+
+      assert MediaMetadata.from_api_response(body, :movie, "4").content_rating == nil
+    end
+  end
+
+  describe "content_rating for TV shows" do
+    test "picks the US rating when present" do
+      body = %{
+        "id" => 1396,
+        "name" => "Breaking Bad",
+        "first_air_date" => "2008-01-20",
+        "credits" => %{"cast" => [], "crew" => []},
+        "content_ratings" => %{
+          "results" => [
+            %{"iso_3166_1" => "GB", "rating" => "18"},
+            %{"iso_3166_1" => "US", "rating" => "TV-MA"}
+          ]
+        }
+      }
+
+      metadata = MediaMetadata.from_api_response(body, :tv_show, "1396")
+
+      assert metadata.content_rating == "TV-MA"
+    end
+
+    test "is nil when content_ratings is absent entirely" do
+      body = %{
+        "id" => 1,
+        "name" => "No Data",
+        "credits" => %{"cast" => [], "crew" => []}
+      }
+
+      assert MediaMetadata.from_api_response(body, :tv_show, "1").content_rating == nil
+    end
+  end
+end

--- a/test/mydia/metadata/structs/media_metadata_test.exs
+++ b/test/mydia/metadata/structs/media_metadata_test.exs
@@ -83,6 +83,34 @@ defmodule Mydia.Metadata.Structs.MediaMetadataTest do
     end
   end
 
+  describe "recommended_tmdb_ids" do
+    test "extracts ids from the recommendations response, capped at 20" do
+      results = for id <- 1..25, do: %{"id" => id, "title" => "Movie #{id}"}
+
+      body = %{
+        "id" => 603,
+        "title" => "The Matrix",
+        "credits" => %{"cast" => [], "crew" => []},
+        "recommendations" => %{"results" => results}
+      }
+
+      metadata = MediaMetadata.from_api_response(body, :movie, "603")
+
+      assert length(metadata.recommended_tmdb_ids) == 20
+      assert metadata.recommended_tmdb_ids == Enum.to_list(1..20)
+    end
+
+    test "is an empty list when recommendations is absent" do
+      body = %{
+        "id" => 603,
+        "title" => "The Matrix",
+        "credits" => %{"cast" => [], "crew" => []}
+      }
+
+      assert MediaMetadata.from_api_response(body, :movie, "603").recommended_tmdb_ids == []
+    end
+  end
+
   describe "content_rating for TV shows" do
     test "picks the US rating when present" do
       body = %{

--- a/test/mydia/metadata/structs/media_metadata_test.exs
+++ b/test/mydia/metadata/structs/media_metadata_test.exs
@@ -111,6 +111,39 @@ defmodule Mydia.Metadata.Structs.MediaMetadataTest do
     end
   end
 
+  describe "videos" do
+    test "sorts the official trailer before an unofficial one, regardless of publish date" do
+      body = %{
+        "id" => 603,
+        "title" => "The Matrix",
+        "credits" => %{"cast" => [], "crew" => []},
+        "videos" => %{
+          "results" => [
+            %{
+              "site" => "YouTube",
+              "type" => "Trailer",
+              "key" => "unofficial",
+              "official" => false,
+              "published_at" => "2020-01-01T00:00:00.000Z"
+            },
+            %{
+              "site" => "YouTube",
+              "type" => "Trailer",
+              "key" => "official",
+              "official" => true,
+              "published_at" => "2019-01-01T00:00:00.000Z"
+            }
+          ]
+        }
+      }
+
+      metadata = MediaMetadata.from_api_response(body, :movie, "603")
+
+      assert hd(metadata.videos).official == true
+      assert hd(metadata.videos).key == "official"
+    end
+  end
+
   describe "content_rating for TV shows" do
     test "picks the US rating when present" do
       body = %{

--- a/test/mydia/metadata/structs/video_test.exs
+++ b/test/mydia/metadata/structs/video_test.exs
@@ -1,0 +1,23 @@
+defmodule Mydia.Metadata.Structs.VideoTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.Structs.Video
+
+  describe "youtube_watch_url/1" do
+    test "builds a watch URL for a YouTube video" do
+      video = %Video{key: "dQw4w9WgXcQ", site: "YouTube"}
+
+      assert Video.youtube_watch_url(video) == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    end
+
+    test "returns nil for a non-YouTube video" do
+      video = %Video{key: "abc123", site: "Vimeo"}
+
+      assert Video.youtube_watch_url(video) == nil
+    end
+
+    test "returns nil for nil" do
+      assert Video.youtube_watch_url(nil) == nil
+    end
+  end
+end

--- a/test/mydia/metadata_test.exs
+++ b/test/mydia/metadata_test.exs
@@ -436,17 +436,29 @@ defmodule Mydia.MetadataTest do
     end
   end
 
-  describe "default_append_to_response/0" do
-    test "includes the resources every full-detail fetch needs" do
-      resources = Mydia.Metadata.default_append_to_response()
+  describe "default_append_to_response/1" do
+    test "movie fetches ask for release_dates, not content_ratings" do
+      resources = Mydia.Metadata.default_append_to_response(:movie)
 
       assert "credits" in resources
       assert "images" in resources
       assert "videos" in resources
       assert "keywords" in resources
-      assert "release_dates" in resources
-      assert "content_ratings" in resources
       assert "recommendations" in resources
+      assert "release_dates" in resources
+      refute "content_ratings" in resources
+    end
+
+    test "tv_show fetches ask for content_ratings, not release_dates" do
+      resources = Mydia.Metadata.default_append_to_response(:tv_show)
+
+      assert "credits" in resources
+      assert "images" in resources
+      assert "videos" in resources
+      assert "keywords" in resources
+      assert "recommendations" in resources
+      assert "content_ratings" in resources
+      refute "release_dates" in resources
     end
   end
 end

--- a/test/mydia/metadata_test.exs
+++ b/test/mydia/metadata_test.exs
@@ -435,4 +435,18 @@ defmodule Mydia.MetadataTest do
       assert Metadata.metadata_language() == "en-US"
     end
   end
+
+  describe "default_append_to_response/0" do
+    test "includes the resources every full-detail fetch needs" do
+      resources = Mydia.Metadata.default_append_to_response()
+
+      assert "credits" in resources
+      assert "images" in resources
+      assert "videos" in resources
+      assert "keywords" in resources
+      assert "release_dates" in resources
+      assert "content_ratings" in resources
+      assert "recommendations" in resources
+    end
+  end
 end

--- a/test/mydia_web/schema/media_types_test.exs
+++ b/test/mydia_web/schema/media_types_test.exs
@@ -22,6 +22,24 @@ defmodule MydiaWeb.Schema.MediaTypesTest do
   }
   """
 
+  @movie_trailer_query """
+  query MovieTrailer($id: ID!) {
+    movie(id: $id) {
+      id
+      trailerUrl
+    }
+  }
+  """
+
+  @show_trailer_query """
+  query ShowTrailer($id: ID!) {
+    tvShow(id: $id) {
+      id
+      trailerUrl
+    }
+  }
+  """
+
   setup do
     %{user: AccountsFixtures.user_fixture()}
   end
@@ -68,6 +86,66 @@ defmodule MydiaWeb.Schema.MediaTypesTest do
 
       assert {:ok, %{data: %{"tvShow" => %{"contentRating" => "TV-MA"}}}} =
                run_query(@show_query, %{"id" => show.id}, ctx.user)
+    end
+  end
+
+  describe "movie.trailerUrl" do
+    test "returns the first persisted trailer's watch URL", ctx do
+      movie =
+        MediaFixtures.media_item_fixture(%{
+          type: "movie",
+          metadata: %{
+            "provider_id" => "603",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "The Matrix",
+            "videos" => [
+              %{"key" => "vKQi3bBA1y8", "site" => "YouTube", "type" => "Trailer"}
+            ]
+          }
+        })
+
+      assert {:ok, %{data: %{"movie" => %{"trailerUrl" => url}}}} =
+               run_query(@movie_trailer_query, %{"id" => movie.id}, ctx.user)
+
+      assert url == "https://www.youtube.com/watch?v=vKQi3bBA1y8"
+    end
+
+    test "is null when there are no videos", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+      assert {:ok, %{data: %{"movie" => %{"trailerUrl" => nil}}}} =
+               run_query(@movie_trailer_query, %{"id" => movie.id}, ctx.user)
+    end
+  end
+
+  describe "tvShow.trailerUrl" do
+    test "returns the first persisted trailer's watch URL", ctx do
+      show =
+        MediaFixtures.media_item_fixture(%{
+          type: "tv_show",
+          metadata: %{
+            "provider_id" => "1396",
+            "provider" => "metadata_relay",
+            "media_type" => "tv_show",
+            "title" => "Breaking Bad",
+            "videos" => [
+              %{"key" => "xyz123abc", "site" => "YouTube", "type" => "Trailer"}
+            ]
+          }
+        })
+
+      assert {:ok, %{data: %{"tvShow" => %{"trailerUrl" => url}}}} =
+               run_query(@show_trailer_query, %{"id" => show.id}, ctx.user)
+
+      assert url == "https://www.youtube.com/watch?v=xyz123abc"
+    end
+
+    test "is null when there are no videos", ctx do
+      show = MediaFixtures.media_item_fixture(%{type: "tv_show"})
+
+      assert {:ok, %{data: %{"tvShow" => %{"trailerUrl" => nil}}}} =
+               run_query(@show_trailer_query, %{"id" => show.id}, ctx.user)
     end
   end
 

--- a/test/mydia_web/schema/media_types_test.exs
+++ b/test/mydia_web/schema/media_types_test.exs
@@ -40,6 +40,32 @@ defmodule MydiaWeb.Schema.MediaTypesTest do
   }
   """
 
+  @movie_cast_query """
+  query MovieCast($id: ID!) {
+    movie(id: $id) {
+      id
+      cast {
+        name
+        character
+        profileUrl
+      }
+    }
+  }
+  """
+
+  @show_cast_query """
+  query ShowCast($id: ID!) {
+    tvShow(id: $id) {
+      id
+      cast {
+        name
+        character
+        profileUrl
+      }
+    }
+  }
+  """
+
   setup do
     %{user: AccountsFixtures.user_fixture()}
   end
@@ -146,6 +172,80 @@ defmodule MydiaWeb.Schema.MediaTypesTest do
 
       assert {:ok, %{data: %{"tvShow" => %{"trailerUrl" => nil}}}} =
                run_query(@show_trailer_query, %{"id" => show.id}, ctx.user)
+    end
+  end
+
+  describe "movie.cast" do
+    test "returns cast members with a built profile URL", ctx do
+      movie =
+        MediaFixtures.media_item_fixture(%{
+          type: "movie",
+          metadata: %{
+            "provider_id" => "603",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "The Matrix",
+            "cast" => [
+              %{
+                "name" => "Keanu Reeves",
+                "character" => "Neo",
+                "order" => 0,
+                "profile_path" => "/abc.jpg"
+              }
+            ]
+          }
+        })
+
+      assert {:ok, %{data: %{"movie" => %{"cast" => [member]}}}} =
+               run_query(@movie_cast_query, %{"id" => movie.id}, ctx.user)
+
+      assert member["name"] == "Keanu Reeves"
+      assert member["character"] == "Neo"
+      assert member["profileUrl"] == "https://image.tmdb.org/t/p/w185/abc.jpg"
+    end
+
+    test "is an empty list when there is no cast", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+      assert {:ok, %{data: %{"movie" => %{"cast" => []}}}} =
+               run_query(@movie_cast_query, %{"id" => movie.id}, ctx.user)
+    end
+  end
+
+  describe "tvShow.cast" do
+    test "returns cast members with a built profile URL", ctx do
+      show =
+        MediaFixtures.media_item_fixture(%{
+          type: "tv_show",
+          metadata: %{
+            "provider_id" => "1396",
+            "provider" => "metadata_relay",
+            "media_type" => "tv_show",
+            "title" => "Breaking Bad",
+            "cast" => [
+              %{
+                "name" => "Bryan Cranston",
+                "character" => "Walter White",
+                "order" => 0,
+                "profile_path" => "/def.jpg"
+              }
+            ]
+          }
+        })
+
+      assert {:ok, %{data: %{"tvShow" => %{"cast" => [member]}}}} =
+               run_query(@show_cast_query, %{"id" => show.id}, ctx.user)
+
+      assert member["name"] == "Bryan Cranston"
+      assert member["character"] == "Walter White"
+      assert member["profileUrl"] == "https://image.tmdb.org/t/p/w185/def.jpg"
+    end
+
+    test "is an empty list when there is no cast", ctx do
+      show = MediaFixtures.media_item_fixture(%{type: "tv_show"})
+
+      assert {:ok, %{data: %{"tvShow" => %{"cast" => []}}}} =
+               run_query(@show_cast_query, %{"id" => show.id}, ctx.user)
     end
   end
 

--- a/test/mydia_web/schema/media_types_test.exs
+++ b/test/mydia_web/schema/media_types_test.exs
@@ -66,6 +66,18 @@ defmodule MydiaWeb.Schema.MediaTypesTest do
   }
   """
 
+  @movie_similar_query """
+  query MovieSimilar($id: ID!) {
+    movie(id: $id) {
+      id
+      similar {
+        id
+        title
+      }
+    }
+  }
+  """
+
   setup do
     %{user: AccountsFixtures.user_fixture()}
   end
@@ -246,6 +258,62 @@ defmodule MydiaWeb.Schema.MediaTypesTest do
 
       assert {:ok, %{data: %{"tvShow" => %{"cast" => []}}}} =
                run_query(@show_cast_query, %{"id" => show.id}, ctx.user)
+    end
+  end
+
+  describe "movie.similar" do
+    test "returns only recommended titles that are in the library, in TMDB order", ctx do
+      owned_second =
+        MediaFixtures.media_item_fixture(%{
+          type: "movie",
+          title: "Owned Second",
+          tmdb_id: 605
+        })
+
+      owned_first =
+        MediaFixtures.media_item_fixture(%{
+          type: "movie",
+          title: "Owned First",
+          tmdb_id: 604
+        })
+
+      movie =
+        MediaFixtures.media_item_fixture(%{
+          type: "movie",
+          title: "The Matrix",
+          tmdb_id: 603,
+          metadata: %{
+            "provider_id" => "603",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "The Matrix",
+            # 604 first, then 606 (not owned), then 605 - order must survive.
+            "recommended_tmdb_ids" => [604, 606, 605]
+          }
+        })
+
+      assert {:ok, %{data: %{"movie" => %{"similar" => similar}}}} =
+               run_query(@movie_similar_query, %{"id" => movie.id}, ctx.user)
+
+      assert Enum.map(similar, & &1["id"]) == [owned_first.id, owned_second.id]
+    end
+
+    test "is an empty list when nothing recommended is owned", ctx do
+      movie =
+        MediaFixtures.media_item_fixture(%{
+          type: "movie",
+          tmdb_id: 603,
+          metadata: %{
+            "provider_id" => "603",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "The Matrix",
+            "recommended_tmdb_ids" => [999]
+          }
+        })
+
+      assert {:ok, %{data: %{"movie" => %{"similar" => []}}}} =
+               run_query(@movie_similar_query, %{"id" => movie.id}, ctx.user)
     end
   end
 

--- a/test/mydia_web/schema/media_types_test.exs
+++ b/test/mydia_web/schema/media_types_test.exs
@@ -1,0 +1,77 @@
+defmodule MydiaWeb.Schema.MediaTypesTest do
+  use MydiaWeb.ConnCase
+
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
+
+  @movie_query """
+  query MovieDetail($id: ID!) {
+    movie(id: $id) {
+      id
+      contentRating
+    }
+  }
+  """
+
+  @show_query """
+  query ShowDetail($id: ID!) {
+    tvShow(id: $id) {
+      id
+      contentRating
+    }
+  }
+  """
+
+  setup do
+    %{user: AccountsFixtures.user_fixture()}
+  end
+
+  describe "movie.contentRating" do
+    test "returns the persisted certification", ctx do
+      movie =
+        MediaFixtures.media_item_fixture(%{
+          type: "movie",
+          metadata: %{
+            "provider_id" => "603",
+            "provider" => "metadata_relay",
+            "media_type" => "movie",
+            "title" => "The Matrix",
+            "content_rating" => "R"
+          }
+        })
+
+      assert {:ok, %{data: %{"movie" => %{"contentRating" => "R"}}}} =
+               run_query(@movie_query, %{"id" => movie.id}, ctx.user)
+    end
+
+    test "is null when nothing was parsed", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+      assert {:ok, %{data: %{"movie" => %{"contentRating" => nil}}}} =
+               run_query(@movie_query, %{"id" => movie.id}, ctx.user)
+    end
+  end
+
+  describe "tvShow.contentRating" do
+    test "returns the persisted rating", ctx do
+      show =
+        MediaFixtures.media_item_fixture(%{
+          type: "tv_show",
+          metadata: %{
+            "provider_id" => "1396",
+            "provider" => "metadata_relay",
+            "media_type" => "tv_show",
+            "title" => "Breaking Bad",
+            "content_rating" => "TV-MA"
+          }
+        })
+
+      assert {:ok, %{data: %{"tvShow" => %{"contentRating" => "TV-MA"}}}} =
+               run_query(@show_query, %{"id" => show.id}, ctx.user)
+    end
+  end
+
+  defp run_query(query, variables, user) do
+    Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: %{current_user: user})
+  end
+end


### PR DESCRIPTION
## Summary

Backend half of the Infuse-style player detail-page redesign. Exposes four pieces of data on the `Movie`/`TvShow` GraphQL types that the (upcoming) Flutter player hero needs:

- **`contentRating`** — fixes a resolver that always returned `nil`; now parses TMDB `release_dates` (movies) / `content_ratings` (TV) with a US → GB → first-available region fallback.
- **`trailerUrl`** — YouTube watch-page URL for the first official trailer (also fixes a pre-existing sort bug where unofficial trailers were ranked ahead of official ones).
- **`cast`** — actor name/character/profile photo, already fetched from TMDB but never exposed.
- **`similar`** — TMDB's recommended titles, filtered to only what's already in the library (matched by tmdb id), reusing the existing `recentlyAdded`-style item shape.

No metadata-relay changes — all four ride the existing `append_to_response` mechanism (now shares one list instead of three duplicated copies across `refresh.ex`/`metadata_enricher.ex`/`provider_switch.ex`).

Known limitation (not introduced here, flagged for follow-up): TV shows matched via TVDB rather than TMDB won't get `contentRating`/`similar` populated, since the TVDB→TMDB shape transform doesn't carry those fields yet.

## Test plan

- [x] `mix precommit` clean (compile --warnings-as-errors, format, credo --strict)
- [x] Full suite green: 6611 tests, 0 failures
- [x] Each of the 8 implementation commits individually reviewed (spec compliance + code quality)
- [x] Final whole-branch review passed; one real bug it caught (trailer sort inversion) fixed in the last commit