### PR TITLE
fix: DownloadMonitorTest flake (global adapter registry leak) + hardening

### DIFF
--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -389,7 +389,7 @@ defmodule Mydia.Downloads.History do
           kind, reason ->
             Logger.error(
               "Adapter #{inspect(adapter)} for client #{client_config.name} " <>
-                "(type=#{client_config.type}) #{kind}ed: #{inspect(reason)}"
+                "(type=#{client_config.type}) raised via #{kind}: #{inspect(reason)}"
             )
 
             {client_config.name, :unreachable}

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -379,6 +379,20 @@ defmodule Mydia.Downloads.History do
             )
 
             {client_config.name, :unreachable}
+        catch
+          # `rescue` only catches raised exceptions. A pool checkout timeout
+          # or a GenServer.call timeout inside the adapter terminates via
+          # `exit/1`, not `raise/1` — uncaught, that unwinds this task and,
+          # since Task.async_stream links tasks to the caller, takes down
+          # the entire list_downloads_with_status/1 call (and whatever
+          # LiveView or job called it) over one misbehaving client.
+          kind, reason ->
+            Logger.error(
+              "Adapter #{inspect(adapter)} for client #{client_config.name} " <>
+                "(type=#{client_config.type}) #{kind}ed: #{inspect(reason)}"
+            )
+
+            {client_config.name, :unreachable}
         end
       end,
       timeout: :infinity,

--- a/test/mydia/downloads/history_client_state_test.exs
+++ b/test/mydia/downloads/history_client_state_test.exs
@@ -201,7 +201,13 @@ defmodule Mydia.Downloads.HistoryClientStateTest do
         end
 
       Registry.register(:qbittorrent, CrashingAdapter)
-      on_exit(fn -> if original, do: Registry.register(:qbittorrent, original) end)
+
+      on_exit(fn ->
+        case original do
+          nil -> Registry.unregister(:qbittorrent)
+          adapter -> Registry.register(:qbittorrent, adapter)
+        end
+      end)
 
       setup_runtime_config([client_config(%{name: "flaky", enabled: true})])
       media_item = media_item_fixture()

--- a/test/mydia/downloads/history_client_state_test.exs
+++ b/test/mydia/downloads/history_client_state_test.exs
@@ -165,6 +165,63 @@ defmodule Mydia.Downloads.HistoryClientStateTest do
     end
   end
 
+  # Simulates a status-fetch task dying via `exit` (a GenServer.call or pool
+  # checkout timeout) rather than raising — `try/rescue` in
+  # `fetch_all_client_statuses/2` cannot catch an exit, so this is the only
+  # way to reach that code path from a test.
+  defmodule CrashingAdapter do
+    @behaviour Mydia.Downloads.Client
+
+    @impl true
+    def supported_protocols, do: [:torrent]
+    @impl true
+    def test_connection(_config), do: {:ok, %{version: "1.0.0", api_version: "1.0"}}
+    @impl true
+    def add_torrent(_config, _torrent, _opts), do: {:ok, "crash-id"}
+    @impl true
+    def get_status(_config, _client_id), do: {:ok, %{}}
+    @impl true
+    def list_torrents(_config, _opts), do: exit(:simulated_crash)
+    @impl true
+    def pause_torrent(_config, _client_id), do: :ok
+    @impl true
+    def resume_torrent(_config, _client_id), do: :ok
+    @impl true
+    def remove_torrent(_config, _client_id, _opts), do: :ok
+  end
+
+  describe "list_downloads_with_status/1 client status fetch crashes" do
+    test "degrades a crashed status-fetch task to :unreachable instead of vanishing" do
+      alias Mydia.Downloads.Client.Registry
+
+      original =
+        case Registry.get_adapter(:qbittorrent) do
+          {:ok, adapter} -> adapter
+          {:error, _} -> nil
+        end
+
+      Registry.register(:qbittorrent, CrashingAdapter)
+      on_exit(fn -> if original, do: Registry.register(:qbittorrent, original) end)
+
+      setup_runtime_config([client_config(%{name: "flaky", enabled: true})])
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        download_client: "flaky",
+        download_client_id: "hash-crash"
+      })
+
+      [enriched] = Downloads.list_downloads_with_status(filter: :all)
+
+      # Must read the same as a client that answered "down" cleanly, not as
+      # a disabled/removed one — a crash mid-poll must not flip this
+      # download to "missing" (see DownloadMonitor's missing-handler).
+      assert enriched.client_config_state == :present
+      assert enriched.status == "unknown"
+    end
+  end
+
   defp torrent_payload(hash) do
     %{
       "hash" => hash,

--- a/test/mydia/jobs/movie_search_test.exs
+++ b/test/mydia/jobs/movie_search_test.exs
@@ -61,8 +61,20 @@ defmodule Mydia.Jobs.MovieSearchTest do
   end
 
   setup do
-    # Register mock download client adapter
+    # Register mock download client adapter. Client.Registry is a single
+    # global Agent shared by the whole app, not sandboxed per test — without
+    # restoring it, every test that runs afterward in the same suite (any
+    # file, any order) gets MockDownloadAdapter instead of the real
+    # Transmission adapter for :transmission.
+    previous_transmission_adapter = Registry.lookup(:transmission)
     Registry.register(:transmission, MockDownloadAdapter)
+
+    on_exit(fn ->
+      case previous_transmission_adapter do
+        nil -> Registry.unregister(:transmission)
+        adapter -> Registry.register(:transmission, adapter)
+      end
+    end)
 
     # Create test user for client configs
     user = user_fixture()

--- a/test/mydia/jobs/tv_show_search_test.exs
+++ b/test/mydia/jobs/tv_show_search_test.exs
@@ -63,8 +63,20 @@ defmodule Mydia.Jobs.TVShowSearchTest do
   end
 
   setup do
-    # Register mock download client adapter
+    # Register mock download client adapter. Client.Registry is a single
+    # global Agent shared by the whole app, not sandboxed per test — without
+    # restoring it, every test that runs afterward in the same suite (any
+    # file, any order) gets MockDownloadAdapter instead of the real
+    # Transmission adapter for :transmission.
+    previous_transmission_adapter = Registry.lookup(:transmission)
     Registry.register(:transmission, MockDownloadAdapter)
+
+    on_exit(fn ->
+      case previous_transmission_adapter do
+        nil -> Registry.unregister(:transmission)
+        adapter -> Registry.register(:transmission, adapter)
+      end
+    end)
 
     # Create test user for client configs
     user = user_fixture()


### PR DESCRIPTION
## Summary

Master's CI kept failing on `Mydia.Jobs.DownloadMonitorTest`'s "pre-completion content rejection" tests — a flake PR #357 already fought once. Root cause found and fixed, confirmed by reproducing it locally and then resolving it with the same seed.

### The real root cause

`test/mydia/jobs/movie_search_test.exs` and `test/mydia/jobs/tv_show_search_test.exs` each register a `MockDownloadAdapter` into `Mydia.Downloads.Client.Registry` for `:transmission` in `setup`, but neither restores the real adapter afterward. `Client.Registry` is a single `Agent` for the whole app — not sandboxed per test like the DB is — so once either suite runs, **every later test in the same run, in any file, gets the mock instead of the real Transmission adapter.** `MockDownloadAdapter.list_torrents/2` unconditionally returns `{:ok, []}`.

`DownloadMonitorTest`'s pre-completion tests spin up a real Bypass server and expect the real Transmission adapter to hit it. When the registry is poisoned:
- The adapter never makes an HTTP call at all → two tests report `"No HTTP request arrived at Bypass"`.
- The client "answers" with an empty torrent list → the third test's download reads as genuinely missing instead of being evaluated for bad-content rejection, so it's never blacklisted.

**Reproduction:** running `download_monitor_test.exs` in isolation never hits this (nothing else touches the registry), which is why 25 isolated runs across different seeds never reproduced it. Running the *full suite* did, on the first try, deterministically with a fixed seed. Temporary diagnostic logging (added and removed in this branch's history) confirmed `raw_count=0` from the transmission fetch at the exact failure point. Reverting the fix reproduces the exact CI failure locally; applying it gives 0 failures on the same seed, twice.

**Fix:** capture the previously-registered adapter and restore it (or unregister if there wasn't one) in `on_exit`, matching the pattern already used correctly elsewhere (`media_import_scoping_test.exs`, `queue_test.exs`'s `CaptureAdapter`).

### Also included: a real hardening fix found along the way

While investigating, I found (and fixed, with its own regression test) an unrelated but genuine bug: `fetch_all_client_statuses/2`'s `try/rescue` only catches raised exceptions, not `exit/1`. Since `Task.async_stream` links its tasks to the caller, an adapter that terminates via `exit` (a `GenServer.call` or pool-checkout timeout) currently crashes the *entire* `list_downloads_with_status/1` call — every configured client's poll along with it — instead of degrading just that one client to `:unreachable`, which is exactly the failure mode the existing `rescue` comment says it's guarding against. Added a `catch` clause alongside the `rescue`. This is not what caused the flake above (confirmed empirically: an uncaught exit crashes the test process outright, which isn't what CI showed), but it's a real latent bug worth fixing regardless.

## Test plan

- [x] Reproduced the exact CI failure locally via a full-suite run (`mix test --seed 0`), twice
- [x] Applied the registry-restore fix; same seed now passes with 0 failures
- [x] `mix precommit` (format, credo, full suite — 6620 tests, 0 failures)
- [x] New regression test for the `exit`-handling fix, verified to fail without it and pass with it
- [x] Addressed Copilot's two review comments (adapter-leak in the new test's own cleanup, log message grammar)