### PR TITLE
Remove stale metadata-relay.fly.dev references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,8 @@ SQLITE_BUSY_TIMEOUT=5000
 # Metadata Provider Configuration
 # --------------------------------
 # URL for the self-hosted metadata relay service
-# Defaults to https://metadata-relay.fly.dev if not set
-# METADATA_RELAY_URL=https://metadata-relay.fly.dev
+# Defaults to https://relay.mydia.dev if not set
+# METADATA_RELAY_URL=https://relay.mydia.dev
 
 # Language sent to TMDB/TVDB through the metadata relay (ISO 639-1 or BCP 47).
 # Affects displayed titles, descriptions, and posters. Defaults to en-US.

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -81,7 +81,16 @@ services:
     environment:
       PORT: "4001"
       SQLITE_DB_PATH: /data/relay.db
-      # No API keys needed: these tests don't exercise real TMDB/TVDB fetches.
+      # Required at boot (config/runtime.exs raises without it); the value
+      # only matters for the relay's own libp2p rendezvous namespace, so any
+      # fixed string is fine for a throwaway local instance.
+      RENDEZVOUS_MASTER_PEPPER: "test-pepper-not-for-production"
+      # Optional: the current Playwright suite's metadata-search tests are
+      # all test.skip() today, so this relay never actually calls out to
+      # TMDB/TVDB. Set these to exercise real fetches once that suite is
+      # enabled — the relay itself boots fine without them.
+      TMDB_API_KEY: "${TMDB_API_KEY:-}"
+      TVDB_API_KEY: "${TVDB_API_KEY:-}"
     volumes:
       - test_relay_data:/data
     healthcheck:

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -79,18 +79,22 @@ services:
     image: ${METADATA_RELAY_IMAGE:-ghcr.io/getmydia/mydia/metadata-relay:master}
     container_name: mydia_test_relay
     environment:
-      PORT: "4001"
-      SQLITE_DB_PATH: /data/relay.db
-      # Required at boot (config/runtime.exs raises without it); the value
-      # only matters for the relay's own libp2p rendezvous namespace, so any
-      # fixed string is fine for a throwaway local instance.
-      RENDEZVOUS_MASTER_PEPPER: "test-pepper-not-for-production"
-      # Optional: the current Playwright suite's metadata-search tests are
-      # all test.skip() today, so this relay never actually calls out to
-      # TMDB/TVDB. Set these to exercise real fetches once that suite is
-      # enabled — the relay itself boots fine without them.
-      TMDB_API_KEY: "${TMDB_API_KEY:-}"
-      TVDB_API_KEY: "${TVDB_API_KEY:-}"
+      - PORT=4001
+      - SQLITE_DB_PATH=/data/relay.db
+      # Required at boot: config/runtime.exs raises without it. Any fixed
+      # string is fine for a throwaway local instance.
+      - RENDEZVOUS_MASTER_PEPPER=test-pepper-not-for-production
+      # Bare (no `=value`): passed through from the host env only when set,
+      # otherwise omitted entirely — an empty string is a distinct, worse
+      # failure mode than unset (metadata-relay's client raises a clear error
+      # for a missing key; an empty one can reach TMDB/TVDB as a confusing
+      # auth failure instead). Unset by default since the current Playwright
+      # suite's metadata-search tests are all test.skip() today, so this
+      # relay never actually calls out to TMDB/TVDB. Export TMDB_API_KEY /
+      # TVDB_API_KEY before `docker compose up` to exercise real fetches once
+      # that suite is enabled.
+      - TMDB_API_KEY
+      - TVDB_API_KEY
     volumes:
       - test_relay_data:/data
     healthcheck:

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -1,7 +1,7 @@
 # Production image testing with optional E2E mock services
 #
 # Profiles:
-#   - (default): app + mock-oauth2 only
+#   - (default): app + mock-oauth2 + relay only
 #   - test: includes playwright for running E2E tests
 #   - e2e: includes mock-prowlarr and mock-qbittorrent
 #
@@ -28,7 +28,10 @@ services:
       GUARDIAN_SECRET_KEY: "VlPUd2fbnWjh6Di+7SGc2SSXpNhI0hN766FFAlct65wU5ARyiGvK9r3TqSqKyu0K"
       DATABASE_PATH: /config/mydia.db
       MIX_ENV: prod
-      METADATA_RELAY_URL: ${METADATA_RELAY_URL:-https://relay.mydia.dev}
+      # Always the local relay container below, never the production
+      # relay.mydia.dev instance — prod-image smoke tests must not depend on
+      # or generate load against real infrastructure.
+      METADATA_RELAY_URL: "http://relay:4001"
 
       # OIDC configuration for testing
       OIDC_ENABLED: "true"
@@ -53,6 +56,8 @@ services:
     depends_on:
       mock-oauth2:
         condition: service_started
+      relay:
+        condition: service_healthy
       mock-prowlarr:
         condition: service_healthy
         required: false
@@ -65,6 +70,26 @@ services:
       timeout: 3s
       start_period: 40s
       retries: 3
+
+  # Real metadata-relay image, running locally so prod-image smoke tests get
+  # real relay behavior (caching, TVDB/TMDB routing) without ever reaching
+  # the internet-facing production deployment. Mirrors the `relay` service in
+  # compose.player-e2e.yml.
+  relay:
+    image: ${METADATA_RELAY_IMAGE:-ghcr.io/getmydia/mydia/metadata-relay:master}
+    container_name: mydia_test_relay
+    environment:
+      PORT: "4001"
+      SQLITE_DB_PATH: /data/relay.db
+      # No API keys needed: these tests don't exercise real TMDB/TVDB fetches.
+    volumes:
+      - test_relay_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4001/health"]
+      interval: 2s
+      timeout: 2s
+      start_period: 5s
+      retries: 10
 
   mock-oauth2:
     image: ghcr.io/navikt/mock-oauth2-server:2.1.10
@@ -182,4 +207,6 @@ volumes:
   test_data:
     driver: local
   test_media:
+    driver: local
+  test_relay_data:
     driver: local

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -470,8 +470,8 @@ defmodule Mydia.Metadata do
   that doesn't require an API key.
 
   The base URL can be configured via the METADATA_RELAY_URL environment variable,
-  defaulting to the self-hosted relay on Fly.io if not set. The metadata language
-  can be configured via the METADATA_LANGUAGE environment variable.
+  defaulting to the self-hosted relay at relay.mydia.dev if not set. The metadata
+  language can be configured via the METADATA_LANGUAGE environment variable.
 
   ## Examples
 
@@ -498,15 +498,15 @@ defmodule Mydia.Metadata do
   Gets the default TVDB relay configuration.
 
   The base URL can be configured via the METADATA_RELAY_URL environment variable,
-  defaulting to the self-hosted relay on Fly.io if not set. The metadata language
-  can be configured via the METADATA_LANGUAGE environment variable.
+  defaulting to the self-hosted relay at relay.mydia.dev if not set. The metadata
+  language can be configured via the METADATA_LANGUAGE environment variable.
 
   ## Examples
 
       iex> Mydia.Metadata.default_tvdb_relay_config()
       %{
         type: :metadata_relay,
-        base_url: "https://metadata-relay.fly.dev",
+        base_url: "https://relay.mydia.dev",
         options: %{language: "en-US"}
       }
   """

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -479,7 +479,7 @@ defmodule Mydia.Metadata do
       %{
         type: :metadata_relay,
         base_url: "https://relay.mydia.dev",
-        options: %{language: "en-US", include_adult: false}
+        options: %{language: "en-US", include_adult: false, timeout: 30_000}
       }
   """
   def default_relay_config do

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -507,7 +507,7 @@ defmodule Mydia.Metadata do
       %{
         type: :metadata_relay,
         base_url: "https://relay.mydia.dev",
-        options: %{language: "en-US"}
+        options: %{language: "en-US", timeout: 30_000}
       }
   """
   def default_tvdb_relay_config do

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -3,7 +3,8 @@ defmodule Mydia.Metadata.Provider.Relay do
   Metadata provider adapter for metadata-relay service.
 
   This adapter interfaces with the self-hosted metadata-relay service
-  (https://metadata-relay.fly.dev) which acts as a caching proxy for TMDB and TVDB APIs.
+  (defaults to https://relay.mydia.dev, configurable via `METADATA_RELAY_URL`)
+  which acts as a caching proxy for TMDB and TVDB APIs.
   Using the relay provides several benefits:
 
     * No API key required for basic usage
@@ -18,7 +19,7 @@ defmodule Mydia.Metadata.Provider.Relay do
 
       config = %{
         type: :metadata_relay,
-        base_url: "https://metadata-relay.fly.dev",
+        base_url: "https://relay.mydia.dev",
         options: %{
           language: "en-US",
           include_adult: false,

--- a/metadata-relay/README.md
+++ b/metadata-relay/README.md
@@ -360,7 +360,9 @@ secret setup, updating, and troubleshooting procedure (`kubectl apply -k .`,
 
 1. **Deployment fails during build:**
 
-   - Check Docker build locally: `docker build -f Dockerfile .`
+   - Check Docker build locally, from the repo root (the Dockerfile `COPY`s
+     from `metadata-relay/...`, so it needs the repo root as build context):
+     `docker build -f metadata-relay/Dockerfile .`
    - Verify all dependencies in `mix.exs` are available
    - Check the GitHub Actions build logs for `deploy-relay.yml`
 

--- a/metadata-relay/README.md
+++ b/metadata-relay/README.md
@@ -254,41 +254,16 @@ The service automatically determines cache TTL based on content type:
 
 ### Production Configuration
 
-In production (Fly.io), environment variables are managed through secrets:
-
-**Without Redis:**
-
-```bash
-# Set required secrets
-fly secrets set TMDB_API_KEY=your_key_here
-fly secrets set TVDB_API_KEY=your_key_here
-```
-
-**With Redis:**
-
-```bash
-# Set required secrets
-fly secrets set TMDB_API_KEY=your_key_here
-fly secrets set TVDB_API_KEY=your_key_here
-
-# Add Redis URL (e.g., Upstash, Redis Cloud, or self-hosted)
-fly secrets set REDIS_URL=redis://username:password@your-redis-host:6379
-```
-
-**Manage secrets:**
-
-```bash
-# View configured secrets (values are hidden)
-fly secrets list
-
-# Remove a secret
-fly secrets unset SECRET_NAME
-```
+In production, environment variables are managed through the Kubernetes manifests
+in `infra/kubernetes/apps/metadata-relay/` — non-secret config in `configmap.yaml`,
+credentials in a `secret.yaml` generated from `secret.yaml.example` and applied
+with `kubectl apply -f secret.yaml`. See that directory's README for the full
+setup and troubleshooting procedure.
 
 **Security Notes:**
 
-- Never commit API keys to version control
-- Use Fly.io secrets for production deployments
+- Never commit API keys to version control (`secret.yaml` is gitignored)
+- Use Kubernetes secrets for production deployments
 - API keys are loaded at runtime via `config/runtime.exs`
 - Keys are not logged or exposed in health checks
 
@@ -367,158 +342,19 @@ Each deployment build creates multi-platform Docker images:
 - **Platforms**: `linux/amd64`, `linux/arm64`
 - **Registry**: GitHub Container Registry (GHCR)
 - **Tags**: `latest`, `X.Y.Z`, `X.Y`, `X` (semantic versioning)
-- **Access**: `docker pull ghcr.io/yourusername/mydia/metadata-relay:latest`
+- **Access**: `docker pull ghcr.io/getmydia/mydia/metadata-relay:latest`
 
-### Manual Deployment (Fly.io)
+### Manual Kubernetes Deployment
 
-For manual deployments or initial setup, you can deploy directly using the Fly CLI.
+Production runs on Kubernetes via the manifests in
+`infra/kubernetes/apps/metadata-relay/` (namespace `metadata-relay`, deployment
+`metadata-relay`, served at `https://relay.mydia.dev`). New images published to
+GHCR are picked up automatically by [Keel](https://keel.sh/), so a manual
+deployment is only needed for initial setup or troubleshooting.
 
-#### Prerequisites
-
-- Install the Fly CLI: `curl -L https://fly.io/install.sh | sh`
-- Sign up and log in: `fly auth login`
-
-#### Initial Deployment
-
-1. **Navigate to the metadata-relay directory**:
-
-   ```bash
-   cd metadata-relay
-   ```
-
-2. **Launch the app** (first time only):
-
-   ```bash
-   fly launch --config fly.toml
-   ```
-
-   When prompted:
-
-   - Choose a unique app name (or accept the suggested name)
-   - Select a region (default: ewr - Newark, NJ)
-   - Skip database creation
-   - Skip deployment for now (we need to set secrets first)
-
-3. **Set required secrets**:
-
-   ```bash
-   fly secrets set TMDB_API_KEY=your_tmdb_key_here
-   fly secrets set TVDB_API_KEY=your_tvdb_key_here
-   ```
-
-4. **Deploy the application**:
-
-   ```bash
-   fly deploy
-   ```
-
-   Database migrations will run automatically on container startup.
-
-5. **Verify deployment**:
-
-   ```bash
-   fly open /health
-   ```
-
-   This should open your browser to the health check endpoint and show:
-
-   ```json
-   {
-     "status": "ok",
-     "service": "metadata-relay",
-     "version": "0.1.0"
-   }
-   ```
-
-#### Subsequent Deployments
-
-After the initial setup, deploy updates with:
-
-```bash
-fly deploy
-```
-
-Database migrations will run automatically on container startup.
-
-#### Monitoring
-
-- **View logs**: `fly logs`
-- **View real-time logs**: `fly logs -f`
-- **Check status**: `fly status`
-- **View metrics**: `fly dashboard`
-
-#### Scaling
-
-The default configuration runs 1 machine with 256MB RAM. To scale:
-
-- **Scale vertically** (more resources per machine):
-
-  ```bash
-  fly scale vm shared-cpu-2x --memory 512
-  ```
-
-- **Scale horizontally** (more machines):
-  ```bash
-  fly scale count 2
-  ```
-
-#### Custom Domain
-
-To use a custom domain:
-
-1. **Add certificate**:
-
-   ```bash
-   fly certs add metadata-relay.yourdomain.com
-   ```
-
-2. **Configure DNS**: Follow the instructions provided by Fly.io
-
-#### Troubleshooting Deployment
-
-**Check health status:**
-
-```bash
-curl https://metadata-relay.fly.dev/health
-```
-
-**View application logs:**
-
-```bash
-# Real-time logs
-fly logs -f
-
-# Last 100 lines
-fly logs --limit 100
-
-# Filter by log level
-fly logs -f | grep ERROR
-```
-
-**SSH into running machine:**
-
-```bash
-fly ssh console
-```
-
-**Check secrets configuration:**
-
-```bash
-fly secrets list
-```
-
-**Restart the application:**
-
-```bash
-fly apps restart metadata-relay
-```
-
-**Check machine status:**
-
-```bash
-fly status
-fly machines list
-```
+See `infra/kubernetes/apps/metadata-relay/README.md` for the full quick-start,
+secret setup, updating, and troubleshooting procedure (`kubectl apply -k .`,
+`kubectl logs`, `kubectl rollout restart`, etc.).
 
 **Common issues:**
 
@@ -526,22 +362,22 @@ fly machines list
 
    - Check Docker build locally: `docker build -f Dockerfile .`
    - Verify all dependencies in `mix.exs` are available
-   - Check build logs: `fly logs`
+   - Check the GitHub Actions build logs for `deploy-relay.yml`
 
 2. **App crashes after deployment:**
 
-   - Check if secrets are set: `fly secrets list`
-   - View crash logs: `fly logs --limit 200`
-   - Verify runtime.exs is reading environment variables correctly
+   - Check pod status: `kubectl describe pod -n metadata-relay -l app.kubernetes.io/name=metadata-relay`
+   - View logs: `kubectl logs -n metadata-relay -l app.kubernetes.io/name=metadata-relay`
+   - Verify `runtime.exs` is reading environment variables correctly
 
 3. **Health check failing:**
 
-   - Ensure PORT environment variable matches internal_port in fly.toml
-   - Check if application is listening on correct port
-   - SSH in and test: `curl localhost:4001/health`
+   - Ensure `PORT` in `configmap.yaml` matches the container port the deployment expects
+   - Check if the application is listening on the correct port
+   - Exec in and test: `kubectl exec -n metadata-relay deploy/metadata-relay -- curl localhost:4001/health`
 
 4. **Authentication errors with TMDB/TVDB:**
-   - Verify API keys are set correctly: `fly secrets list`
+   - Verify API keys are set correctly in `secret.yaml`
    - Test keys locally first
    - Check for key expiration or quota limits
 
@@ -738,20 +574,17 @@ iex -S mix
 docker-compose logs -f relay
 ```
 
-**Production (Fly.io):**
+**Production (Kubernetes):**
 
 ```bash
 # Real-time logs
-fly logs -f
-
-# Filter by application name
-fly logs -a metadata-relay
+kubectl logs -n metadata-relay -l app.kubernetes.io/name=metadata-relay -f
 
 # Show errors only
-fly logs -f | grep ERROR
+kubectl logs -n metadata-relay -l app.kubernetes.io/name=metadata-relay -f | grep ERROR
 
 # Export logs for analysis
-fly logs --limit 1000 > relay-logs.txt
+kubectl logs -n metadata-relay -l app.kubernetes.io/name=metadata-relay --tail=1000 > relay-logs.txt
 ```
 
 ### Metrics and Telemetry
@@ -777,7 +610,7 @@ The service is instrumented with Elixir's Telemetry library for metrics collecti
 The `/health` endpoint provides basic service status:
 
 ```bash
-curl https://metadata-relay.fly.dev/health
+curl https://relay.mydia.dev/health
 ```
 
 Response:
@@ -798,12 +631,12 @@ A `200 OK` status indicates the service is running and able to respond to reques
 
 - Cache is stored in-memory using ETS
 - Default TTL: 1 hour
-- No size limit (relies on Fly.io memory constraints)
-- Cache is lost on machine restart
+- No size limit (relies on the pod's memory limit — 512Mi by default, see `deployment.yaml`)
+- Cache is lost on pod restart
 
 **Recommended Monitoring:**
 
-1. Set up Fly.io metrics monitoring for:
+1. Set up metrics monitoring for:
 
    - CPU usage
    - Memory usage
@@ -864,7 +697,7 @@ All workflows must pass before code can be merged, ensuring production stability
 - [x] Update Mydia to use self-hosted relay (task 117.7)
 - [x] Add monitoring, logging, and deployment documentation (task 117.8)
 
-**Service URL**: https://metadata-relay.fly.dev
+**Service URL**: https://relay.mydia.dev
 
 ## License
 

--- a/metadata-relay/README.md
+++ b/metadata-relay/README.md
@@ -262,7 +262,7 @@ setup and troubleshooting procedure.
 
 **Security Notes:**
 
-- Never commit API keys to version control (`secret.yaml` is gitignored)
+- Never commit API keys to version control (`secret.yaml` is git-ignored)
 - Use Kubernetes secrets for production deployments
 - API keys are loaded at runtime via `config/runtime.exs`
 - Keys are not logged or exposed in health checks

--- a/test/mydia/metadata/provider/relay_test.exs
+++ b/test/mydia/metadata/provider/relay_test.exs
@@ -11,7 +11,9 @@ defmodule Mydia.Metadata.Provider.RelayTest do
   # long-abandoned deployment; use the current production default (or
   # METADATA_RELAY_URL, if the caller wants to point this at a different
   # instance) so `mix test --include external` exercises a service that
-  # actually exists.
+  # actually exists. `@config` is a module attribute, resolved once at
+  # compile time — export METADATA_RELAY_URL before running `mix test`
+  # (a stale `_build` won't pick up a later env change without a recompile).
   @config Mydia.Metadata.default_relay_config()
 
   describe "test_connection/1" do

--- a/test/mydia/metadata/provider/relay_test.exs
+++ b/test/mydia/metadata/provider/relay_test.exs
@@ -7,14 +7,12 @@ defmodule Mydia.Metadata.Provider.RelayTest do
 
   @moduletag :external
 
-  @config %{
-    type: :metadata_relay,
-    base_url: "https://metadata-relay.fly.dev",
-    options: %{
-      language: "en-US",
-      include_adult: false
-    }
-  }
+  # Live smoke test against the real relay. `metadata-relay.fly.dev` is a
+  # long-abandoned deployment; use the current production default (or
+  # METADATA_RELAY_URL, if the caller wants to point this at a different
+  # instance) so `mix test --include external` exercises a service that
+  # actually exists.
+  @config Mydia.Metadata.default_relay_config()
 
   describe "test_connection/1" do
     test "successfully connects to relay service" do


### PR DESCRIPTION
## Summary
- `metadata-relay.fly.dev` is an abandoned deployment — `deploy-relay.yml` only pushes to ghcr.io now, and the current production default is `relay.mydia.dev`.
- Repoint the live relay smoke test (`relay_test.exs`, tagged `:external`, never run by default) at `Mydia.Metadata.default_relay_config()` instead of the hardcoded dead host.
- Fix doc examples in `metadata.ex`/`relay.ex` and the `.env.example` fallback comment that all still claimed fly.dev was the default.
- Give `compose.test.yml` its own local metadata-relay container (mirroring the existing pattern in `compose.player-e2e.yml`), so prod-image smoke tests get real relay behavior without depending on or generating load against production infrastructure.

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes on changed files
- [x] `mix test test/mydia/metadata_test.exs test/mydia/metadata/provider/relay_tvdb_videos_test.exs test/mydia/metadata/provider/relay_test.exs` — 32 tests, 0 failures, 38 excluded (confirms `relay_test.exs` still compiles and stays excluded by default via its `:external` tag)
- [x] `docker compose -f compose.test.yml config` validates