### PR TITLE
feat(player): Infuse-style movie and TV show detail pages

### DIFF
--- a/player/lib/domain/models/cast_member.dart
+++ b/player/lib/domain/models/cast_member.dart
@@ -1,0 +1,19 @@
+class CastMember {
+  final String name;
+  final String? character;
+  final String? profileUrl;
+
+  const CastMember({
+    required this.name,
+    this.character,
+    this.profileUrl,
+  });
+
+  factory CastMember.fromJson(Map<String, dynamic> json) {
+    return CastMember(
+      name: json['name'] as String,
+      character: json['character'] as String?,
+      profileUrl: json['profileUrl'] as String?,
+    );
+  }
+}

--- a/player/lib/domain/models/movie_detail.dart
+++ b/player/lib/domain/models/movie_detail.dart
@@ -1,6 +1,8 @@
 import 'artwork.dart';
 import 'progress.dart';
 import 'media_file.dart';
+import 'cast_member.dart';
+import 'recently_added_item.dart';
 
 class MovieDetail {
   final String id;
@@ -21,6 +23,9 @@ class MovieDetail {
   final Progress? progress;
   final List<MediaFile> files;
   final bool isFavorite;
+  final List<CastMember> cast;
+  final String? trailerUrl;
+  final List<RecentlyAddedItem> similar;
 
   const MovieDetail({
     required this.id,
@@ -41,6 +46,9 @@ class MovieDetail {
     this.progress,
     this.files = const [],
     required this.isFavorite,
+    this.cast = const [],
+    this.trailerUrl,
+    this.similar = const [],
   });
 
   factory MovieDetail.fromJson(Map<String, dynamic> json) {
@@ -73,6 +81,16 @@ class MovieDetail {
               .toList() ??
           [],
       isFavorite: json['isFavorite'] as bool? ?? false,
+      cast: (json['cast'] as List<dynamic>?)
+              ?.map((e) => CastMember.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      trailerUrl: json['trailerUrl'] as String?,
+      similar: (json['similar'] as List<dynamic>?)
+              ?.map(
+                  (e) => RecentlyAddedItem.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
     );
   }
 
@@ -121,6 +139,9 @@ class MovieDetail {
       progress: clearProgress ? null : (progress ?? this.progress),
       files: files,
       isFavorite: isFavorite ?? this.isFavorite,
+      cast: cast,
+      trailerUrl: trailerUrl,
+      similar: similar,
     );
   }
 

--- a/player/lib/domain/models/show_detail.dart
+++ b/player/lib/domain/models/show_detail.dart
@@ -2,6 +2,8 @@ import 'artwork.dart';
 import 'season_info.dart';
 import 'next_episode.dart';
 import 'show_next_up.dart';
+import 'cast_member.dart';
+import 'recently_added_item.dart';
 
 class ShowDetail {
   final String id;
@@ -25,6 +27,9 @@ class ShowDetail {
   final NextEpisode? nextEpisode;
   final ShowNextUp? nextUp;
   final bool isFavorite;
+  final List<CastMember> cast;
+  final String? trailerUrl;
+  final List<RecentlyAddedItem> similar;
 
   const ShowDetail({
     required this.id,
@@ -48,6 +53,9 @@ class ShowDetail {
     this.nextEpisode,
     this.nextUp,
     required this.isFavorite,
+    this.cast = const [],
+    this.trailerUrl,
+    this.similar = const [],
   });
 
   factory ShowDetail.fromJson(Map<String, dynamic> json) {
@@ -85,6 +93,16 @@ class ShowDetail {
           ? ShowNextUp.fromJson(json['nextUp'] as Map<String, dynamic>)
           : null,
       isFavorite: json['isFavorite'] as bool? ?? false,
+      cast: (json['cast'] as List<dynamic>?)
+              ?.map((e) => CastMember.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      trailerUrl: json['trailerUrl'] as String?,
+      similar: (json['similar'] as List<dynamic>?)
+              ?.map(
+                  (e) => RecentlyAddedItem.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
     );
   }
 

--- a/player/lib/presentation/screens/movie/movie_detail_controller.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_controller.dart
@@ -54,6 +54,23 @@ query MovieDetail($id: ID!) {
       directPlayUrl
     }
     isFavorite
+    cast {
+      name
+      character
+      profileUrl
+    }
+    trailerUrl
+    similar {
+      id
+      type
+      title
+      year
+      artwork {
+        posterUrl
+        backdropUrl
+        thumbnailUrl
+      }
+    }
   }
 }
 ''';

--- a/player/lib/presentation/screens/movie/movie_detail_screen.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_screen.dart
@@ -289,6 +289,8 @@ class MovieDetailScreen extends ConsumerWidget {
           onDownload: () => _startDownload(context, ref, movie),
           trailerUrl: movie.trailerUrl,
           showDownload: isDownloadSupported,
+          isDownloaded:
+              ref.watch(isMediaDownloadedProvider(movie.id)).value ?? false,
         ),
       ],
     );
@@ -498,19 +500,34 @@ class MovieDetailScreen extends ConsumerWidget {
               left: 20,
               right: 20,
               bottom: 20,
-              child: Text(
-                movie.title,
-                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                  shadows: [
-                    Shadow(
-                      color: Colors.black.withValues(alpha: 0.8),
-                      blurRadius: 8,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    movie.title,
+                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      shadows: [
+                        Shadow(
+                          color: Colors.black.withValues(alpha: 0.8),
+                          blurRadius: 8,
+                        ),
+                      ],
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (movie.yearDisplay.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      movie.yearDisplay,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: AppColors.textSecondary,
+                          ),
                     ),
                   ],
-                ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
+                ],
               ),
             ),
           ],

--- a/player/lib/presentation/screens/movie/movie_detail_screen.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_screen.dart
@@ -6,7 +6,6 @@ import '../../../core/cache/poster_cache_manager.dart';
 import 'movie_detail_controller.dart';
 import '../../widgets/freshness_header.dart';
 import '../../widgets/quality_download_dialog.dart';
-import '../../../core/downloads/download_service.dart' show isDownloadSupported;
 import '../../../core/downloads/download_providers.dart';
 import '../../../core/downloads/download_job_providers.dart';
 import '../../../core/graphql/watch/query_key.dart';
@@ -15,8 +14,15 @@ import '../../../core/theme/colors.dart';
 import '../../../domain/models/movie_detail.dart';
 import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
-import '../../widgets/movie_watched_controls.dart';
+import '../../widgets/cast_rail.dart';
+import '../../widgets/content_rail.dart';
+import '../../widgets/detail_action_row.dart';
 import '../../widgets/smart_play_button.dart';
+
+/// Below this width the hero's action column and tag column stack instead
+/// of sitting side by side. Matches the wide-layout mockup's tablet/desktop
+/// target — see docs/superpowers/specs/2026-08-05-player-detail-page-infuse-redesign-design.md.
+const double _kHeroBreakpoint = 700;
 
 class MovieDetailScreen extends ConsumerWidget {
   final String id;
@@ -197,29 +203,162 @@ class MovieDetailScreen extends ConsumerWidget {
       slivers: [
         _buildHeroSection(context, ref, movie),
         SliverToBoxAdapter(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(height: 20),
-              if (movie.isWatched) ...[
-                MovieWatchedLine(dateLabel: movie.watchedAtDisplay),
-                const SizedBox(height: 24),
-              ] else if (movie.hasResumableProgress) ...[
-                _buildProgressBar(context, movie),
-                const SizedBox(height: 24),
-              ],
-              if (movie.overview != null) ...[
-                _buildOverview(context, movie),
-                const SizedBox(height: 24),
-              ],
-              if (movie.genres.isNotEmpty) ...[
-                _buildGenres(context, movie),
-                const SizedBox(height: 24),
-              ],
-              const SizedBox(height: 32),
-            ],
+          child: Padding(
+            padding: const EdgeInsets.only(top: 24),
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final wide = constraints.maxWidth >= _kHeroBreakpoint;
+                final actionColumn = _buildActionColumn(context, ref, movie);
+                final tagColumn = _buildTagColumn(context, movie);
+
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: wide
+                      ? Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            SizedBox(width: 248, child: actionColumn),
+                            const SizedBox(width: 40),
+                            Expanded(child: tagColumn),
+                          ],
+                        )
+                      : Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            actionColumn,
+                            const SizedBox(height: 20),
+                            tagColumn,
+                          ],
+                        ),
+                );
+              },
+            ),
           ),
         ),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.only(top: 28),
+            child: CastRail(members: movie.cast),
+          ),
+        ),
+        if (movie.similar.isNotEmpty)
+          SliverToBoxAdapter(
+            child: ContentRail(
+              title: 'Similar in your library',
+              items: movie.similar,
+              onItemTap: (id, type) {
+                context.push(
+                  type.toLowerCase() == 'movie' ? '/movie/$id' : '/show/$id',
+                );
+              },
+            ),
+          ),
+        const SliverToBoxAdapter(child: SizedBox(height: 32)),
+      ],
+    );
+  }
+
+  Widget _buildActionColumn(
+      BuildContext context, WidgetRef ref, MovieDetail movie) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Play', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(width: 8),
+            SmartPlayButton(
+              files: movie.files,
+              onFileSelected: (file) => context.push(
+                '/player/movie/${movie.id}?fileId=${file.id}&title=${Uri.encodeComponent(movie.title)}',
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 18),
+        DetailActionRow(
+          watched: movie.isWatched,
+          onToggleWatched: () => _toggleWatched(context, ref, movie.isWatched),
+          isFavorite: movie.isFavorite,
+          onToggleFavorite: () => ref
+              .read(movieDetailControllerProvider(id).notifier)
+              .toggleFavorite(),
+          onDownload: () => _startDownload(context, ref, movie),
+          trailerUrl: movie.trailerUrl,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTagColumn(BuildContext context, MovieDetail movie) {
+    final tags = <String>[
+      if (movie.runtimeDisplay.isNotEmpty) movie.runtimeDisplay,
+      if (movie.files.isNotEmpty && movie.files.first.resolution != null)
+        movie.files.first.resolution!,
+      if (movie.contentRating != null) movie.contentRating!,
+      ...movie.genres,
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (tags.isNotEmpty) ...[
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: tags.map((tag) => _buildTagChip(context, tag)).toList(),
+          ),
+          const SizedBox(height: 18),
+        ],
+        if (movie.overview != null) ...[
+          Text(
+            movie.overview!,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: AppColors.textSecondary,
+                  height: 1.6,
+                ),
+          ),
+          const SizedBox(height: 14),
+        ],
+        if (movie.ratingDisplay.isNotEmpty)
+          _buildRatingLine(movie.ratingDisplay),
+      ],
+    );
+  }
+
+  Widget _buildTagChip(BuildContext context, String label) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 6),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceVariant,
+        border: Border.all(color: AppColors.border),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 12.5,
+          fontWeight: FontWeight.w600,
+          color: AppColors.textPrimary,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRatingLine(String ratingDisplay) {
+    return Row(
+      children: [
+        const Icon(Icons.star_rounded, size: 16, color: AppColors.primary),
+        const SizedBox(width: 6),
+        Text(
+          ratingDisplay,
+          style: const TextStyle(
+              fontWeight: FontWeight.bold, color: AppColors.textPrimary),
+        ),
+        const SizedBox(width: 6),
+        const Text('TMDB',
+            style: TextStyle(fontSize: 12, color: AppColors.textSecondary)),
       ],
     );
   }
@@ -257,40 +396,6 @@ class MovieDetailScreen extends ConsumerWidget {
       backgroundColor: AppColors.background,
       leading: _buildBackButton(context),
       actions: [
-        if (isDownloadSupported)
-          Padding(
-            padding: const EdgeInsets.all(8),
-            child: _buildAppBarDownloadButton(context, ref, movie),
-          ),
-        Padding(
-          padding: const EdgeInsets.all(8),
-          child: MovieWatchedButton(
-            watched: movie.isWatched,
-            onPressed: () => _toggleWatched(context, ref, movie.isWatched),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8),
-          child: Material(
-            color: Colors.black.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(12),
-            child: InkWell(
-              borderRadius: BorderRadius.circular(12),
-              onTap: () => ref
-                  .read(movieDetailControllerProvider(id).notifier)
-                  .toggleFavorite(),
-              child: Padding(
-                padding: const EdgeInsets.all(8),
-                child: Icon(
-                  movie.isFavorite
-                      ? Icons.favorite_rounded
-                      : Icons.favorite_border_rounded,
-                  color: movie.isFavorite ? AppColors.error : Colors.white,
-                ),
-              ),
-            ),
-          ),
-        ),
         Padding(
           padding: const EdgeInsets.all(8),
           child: CastButton(onPressed: () => pickCastDevice(context, ref)),
@@ -340,58 +445,19 @@ class MovieDetailScreen extends ConsumerWidget {
               left: 20,
               right: 20,
               bottom: 20,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  _buildPoster(movie),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          movie.title,
-                          style: Theme.of(context)
-                              .textTheme
-                              .headlineSmall
-                              ?.copyWith(
-                            fontWeight: FontWeight.bold,
-                            shadows: [
-                              Shadow(
-                                color: Colors.black.withValues(alpha: 0.8),
-                                blurRadius: 8,
-                              ),
-                            ],
-                          ),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        if (movie.yearDisplay.isNotEmpty) ...[
-                          const SizedBox(height: 6),
-                          Text(
-                            movie.yearDisplay,
-                            style:
-                                Theme.of(context).textTheme.bodyLarge?.copyWith(
-                                      color: AppColors.textSecondary,
-                                    ),
-                          ),
-                        ],
-                        const SizedBox(height: 8),
-                        _buildQuickStats(context, movie),
-                      ],
+              child: Text(
+                movie.title,
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  shadows: [
+                    Shadow(
+                      color: Colors.black.withValues(alpha: 0.8),
+                      blurRadius: 8,
                     ),
-                  ),
-                  const SizedBox(width: 12),
-                  SmartPlayButton(
-                    files: movie.files,
-                    onFileSelected: (file) {
-                      context.push(
-                        '/player/movie/${movie.id}?fileId=${file.id}&title=${Uri.encodeComponent(movie.title)}',
-                      );
-                    },
-                  ),
-                ],
+                  ],
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
               ),
             ),
           ],
@@ -400,332 +466,103 @@ class MovieDetailScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildPoster(dynamic movie) {
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.4),
-            blurRadius: 16,
-            offset: const Offset(0, 8),
-          ),
-        ],
-      ),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: SizedBox(
-          width: 100,
-          height: 150,
-          child: movie.artwork.posterUrl != null
-              ? CachedNetworkImage(
-                  imageUrl: movie.artwork.posterUrl!,
-                  fit: BoxFit.cover,
-                  cacheManager: PosterCacheManager(),
-                  placeholder: (context, url) => Container(
-                    color: AppColors.surfaceVariant,
-                  ),
-                  errorWidget: (context, url, error) => Container(
-                    color: AppColors.surfaceVariant,
-                    child: const Icon(Icons.movie_rounded,
-                        color: AppColors.textSecondary),
-                  ),
-                )
-              : Container(
-                  color: AppColors.surfaceVariant,
-                  child: const Icon(Icons.movie_rounded,
-                      color: AppColors.textSecondary),
-                ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildQuickStats(BuildContext context, movie) {
-    return Row(
-      children: [
-        if (movie.runtimeDisplay.isNotEmpty) ...[
-          _buildStatBadge(
-            context,
-            Icons.schedule_rounded,
-            movie.runtimeDisplay,
-          ),
-          const SizedBox(width: 12),
-        ],
-        if (movie.ratingDisplay.isNotEmpty) ...[
-          _buildStatBadge(
-            context,
-            Icons.star_rounded,
-            movie.ratingDisplay,
-            iconColor: Colors.amber,
-          ),
-          const SizedBox(width: 12),
-        ],
-        if (movie.contentRating != null)
-          _buildStatBadge(
-            context,
-            Icons.shield_rounded,
-            movie.contentRating!,
-          ),
-      ],
-    );
-  }
-
-  Widget _buildStatBadge(
+  Future<void> _startDownload(
     BuildContext context,
-    IconData icon,
-    String label, {
-    Color? iconColor,
-  }) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: Colors.black.withValues(alpha: 0.4),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 14, color: iconColor ?? AppColors.textSecondary),
-          const SizedBox(width: 4),
-          Text(
-            label,
-            style: const TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: Colors.white,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAppBarDownloadButton(
-      BuildContext context, WidgetRef ref, movie) {
-    final isDownloadedAsync = ref.watch(isMediaDownloadedProvider(movie.id));
+    WidgetRef ref,
+    MovieDetail movie,
+  ) async {
+    final isDownloadedAsync = ref.read(isMediaDownloadedProvider(movie.id));
     final isDownloaded = isDownloadedAsync.value ?? false;
     final hasFiles = movie.files.isNotEmpty;
+    if (!hasFiles) return;
 
-    return Material(
-      color: Colors.black.withValues(alpha: 0.3),
-      borderRadius: BorderRadius.circular(12),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: hasFiles
-            ? () async {
-                if (isDownloaded) {
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('Already downloaded'),
-                        duration: Duration(seconds: 2),
-                      ),
-                    );
-                  }
-                } else {
-                  final selectedResolution = await showQualityDownloadDialog(
-                    context,
-                    contentType: 'movie',
-                    contentId: movie.id,
-                    title: movie.title,
-                  );
-
-                  if (selectedResolution != null && context.mounted) {
-                    final downloadService =
-                        ref.read(unifiedDownloadJobServiceProvider);
-                    final downloadManager =
-                        await ref.read(downloadManagerProvider.future);
-
-                    if (downloadService != null) {
-                      try {
-                        await downloadManager.startProgressiveDownload(
-                          mediaId: movie.id,
-                          title: movie.title,
-                          contentType: 'movie',
-                          resolution: selectedResolution,
-                          mediaType: MediaType.movie,
-                          posterUrl: movie.artwork.posterUrl,
-                          overview: movie.overview,
-                          runtime: movie.runtime,
-                          genres: movie.genres,
-                          rating: movie.rating,
-                          backdropUrl: movie.artwork.backdropUrl,
-                          year: movie.year,
-                          contentRating: movie.contentRating,
-                          getDownloadUrl: (jobId) async {
-                            return await downloadService.getDownloadUrl(jobId);
-                          },
-                          prepareDownload: () async {
-                            final status =
-                                await downloadService.prepareDownload(
-                              contentType: 'movie',
-                              id: movie.id,
-                              resolution: selectedResolution,
-                            );
-                            return (
-                              jobId: status.jobId,
-                              status: status.status.name,
-                              progress: status.progress,
-                              fileSize: status.currentFileSize,
-                            );
-                          },
-                          getJobStatus: (jobId) async {
-                            final status =
-                                await downloadService.getJobStatus(jobId);
-                            return (
-                              status: status.status.name,
-                              progress: status.progress,
-                              fileSize: status.currentFileSize,
-                              error: status.error,
-                            );
-                          },
-                          cancelJob: (jobId) async {
-                            await downloadService.cancelJob(jobId);
-                          },
-                        );
-
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Download started'),
-                              duration: Duration(seconds: 2),
-                            ),
-                          );
-                        }
-                      } catch (e) {
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text('Failed to start download: $e'),
-                              backgroundColor: AppColors.error,
-                            ),
-                          );
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            : null,
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: Icon(
-            isDownloaded ? Icons.download_done_rounded : Icons.download_rounded,
-            color: isDownloaded ? AppColors.success : Colors.white,
+    if (isDownloaded) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Already downloaded'),
+            duration: Duration(seconds: 2),
           ),
-        ),
-      ),
-    );
-  }
+        );
+      }
+    } else {
+      final selectedResolution = await showQualityDownloadDialog(
+        context,
+        contentType: 'movie',
+        contentId: movie.id,
+        title: movie.title,
+      );
 
-  Widget _buildProgressBar(BuildContext context, movie) {
-    final progress = movie.progress!;
-    final percentage = progress.percentage / 100;
-    final remaining = progress.durationSeconds != null
-        ? progress.durationSeconds! - progress.positionSeconds
-        : null;
+      if (selectedResolution != null && context.mounted) {
+        final downloadService = ref.read(unifiedDownloadJobServiceProvider);
+        final downloadManager = await ref.read(downloadManagerProvider.future);
 
-    String remainingText = '';
-    if (remaining != null && remaining > 0) {
-      final hours = remaining ~/ 3600;
-      final minutes = (remaining % 3600) ~/ 60;
-      if (hours > 0) {
-        remainingText = '${hours}h ${minutes}m remaining';
-      } else {
-        remainingText = '${minutes}m remaining';
+        if (downloadService != null) {
+          try {
+            await downloadManager.startProgressiveDownload(
+              mediaId: movie.id,
+              title: movie.title,
+              contentType: 'movie',
+              resolution: selectedResolution,
+              mediaType: MediaType.movie,
+              posterUrl: movie.artwork.posterUrl,
+              overview: movie.overview,
+              runtime: movie.runtime,
+              genres: movie.genres,
+              rating: movie.rating,
+              backdropUrl: movie.artwork.backdropUrl,
+              year: movie.year,
+              contentRating: movie.contentRating,
+              getDownloadUrl: (jobId) async {
+                return await downloadService.getDownloadUrl(jobId);
+              },
+              prepareDownload: () async {
+                final status = await downloadService.prepareDownload(
+                  contentType: 'movie',
+                  id: movie.id,
+                  resolution: selectedResolution,
+                );
+                return (
+                  jobId: status.jobId,
+                  status: status.status.name,
+                  progress: status.progress,
+                  fileSize: status.currentFileSize,
+                );
+              },
+              getJobStatus: (jobId) async {
+                final status = await downloadService.getJobStatus(jobId);
+                return (
+                  status: status.status.name,
+                  progress: status.progress,
+                  fileSize: status.currentFileSize,
+                  error: status.error,
+                );
+              },
+              cancelJob: (jobId) async {
+                await downloadService.cancelJob(jobId);
+              },
+            );
+
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Download started'),
+                  duration: Duration(seconds: 2),
+                ),
+              );
+            }
+          } catch (e) {
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('Failed to start download: $e'),
+                  backgroundColor: AppColors.error,
+                ),
+              );
+            }
+          }
+        }
       }
     }
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(3),
-            child: LinearProgressIndicator(
-              value: percentage.clamp(0.0, 1.0),
-              minHeight: 4,
-              backgroundColor: AppColors.surfaceVariant,
-              valueColor:
-                  const AlwaysStoppedAnimation<Color>(AppColors.primary),
-            ),
-          ),
-          if (remainingText.isNotEmpty) ...[
-            const SizedBox(height: 6),
-            Text(
-              remainingText,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: AppColors.textSecondary,
-                  ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildOverview(BuildContext context, movie) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Container(
-                width: 4,
-                height: 20,
-                decoration: BoxDecoration(
-                  color: AppColors.primary,
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              const SizedBox(width: 10),
-              Text(
-                'Overview',
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          Text(
-            movie.overview!,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: AppColors.textSecondary,
-                  height: 1.6,
-                ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildGenres(BuildContext context, movie) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: movie.genres.map<Widget>((genre) {
-          return Container(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-            decoration: BoxDecoration(
-              color: AppColors.surfaceVariant,
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: Text(
-              genre,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    fontWeight: FontWeight.w500,
-                  ),
-            ),
-          );
-        }).toList(),
-      ),
-    );
   }
 }

--- a/player/lib/presentation/screens/movie/movie_detail_screen.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_screen.dart
@@ -6,6 +6,7 @@ import '../../../core/cache/poster_cache_manager.dart';
 import 'movie_detail_controller.dart';
 import '../../widgets/freshness_header.dart';
 import '../../widgets/quality_download_dialog.dart';
+import '../../../core/downloads/download_service.dart' show isDownloadSupported;
 import '../../../core/downloads/download_providers.dart';
 import '../../../core/downloads/download_job_providers.dart';
 import '../../../core/graphql/watch/query_key.dart';
@@ -17,6 +18,7 @@ import '../../widgets/cast_button.dart';
 import '../../widgets/cast_rail.dart';
 import '../../widgets/content_rail.dart';
 import '../../widgets/detail_action_row.dart';
+import '../../widgets/movie_watched_controls.dart';
 import '../../widgets/smart_play_button.dart';
 
 /// Below this width the hero's action column and tag column stack instead
@@ -286,6 +288,7 @@ class MovieDetailScreen extends ConsumerWidget {
               .toggleFavorite(),
           onDownload: () => _startDownload(context, ref, movie),
           trailerUrl: movie.trailerUrl,
+          showDownload: isDownloadSupported,
         ),
       ],
     );
@@ -303,6 +306,13 @@ class MovieDetailScreen extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        if (movie.isWatched) ...[
+          MovieWatchedLine(dateLabel: movie.watchedAtDisplay),
+          const SizedBox(height: 18),
+        ] else if (movie.hasResumableProgress) ...[
+          _buildProgressBar(context, movie),
+          const SizedBox(height: 18),
+        ],
         if (tags.isNotEmpty) ...[
           Wrap(
             spacing: 8,
@@ -359,6 +369,49 @@ class MovieDetailScreen extends ConsumerWidget {
         const SizedBox(width: 6),
         const Text('TMDB',
             style: TextStyle(fontSize: 12, color: AppColors.textSecondary)),
+      ],
+    );
+  }
+
+  Widget _buildProgressBar(BuildContext context, MovieDetail movie) {
+    final progress = movie.progress!;
+    final percentage = progress.percentage / 100;
+    final remaining = progress.durationSeconds != null
+        ? progress.durationSeconds! - progress.positionSeconds
+        : null;
+
+    String remainingText = '';
+    if (remaining != null && remaining > 0) {
+      final hours = remaining ~/ 3600;
+      final minutes = (remaining % 3600) ~/ 60;
+      if (hours > 0) {
+        remainingText = '${hours}h ${minutes}m remaining';
+      } else {
+        remainingText = '${minutes}m remaining';
+      }
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(3),
+          child: LinearProgressIndicator(
+            value: percentage.clamp(0.0, 1.0),
+            minHeight: 4,
+            backgroundColor: AppColors.surfaceVariant,
+            valueColor: const AlwaysStoppedAnimation<Color>(AppColors.primary),
+          ),
+        ),
+        if (remainingText.isNotEmpty) ...[
+          const SizedBox(height: 6),
+          Text(
+            remainingText,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: AppColors.textSecondary,
+                ),
+          ),
+        ],
       ],
     );
   }

--- a/player/lib/presentation/screens/movie/movie_detail_screen.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_screen.dart
@@ -288,7 +288,7 @@ class MovieDetailScreen extends ConsumerWidget {
               .toggleFavorite(),
           onDownload: () => _startDownload(context, ref, movie),
           trailerUrl: movie.trailerUrl,
-          showDownload: isDownloadSupported,
+          showDownload: isDownloadSupported && movie.files.isNotEmpty,
           isDownloaded:
               ref.watch(isMediaDownloadedProvider(movie.id)).value ?? false,
         ),

--- a/player/lib/presentation/screens/show/show_detail_controller.dart
+++ b/player/lib/presentation/screens/show/show_detail_controller.dart
@@ -215,3 +215,22 @@ class SelectedSeason extends _$SelectedSeason {
     state = seasonNumber;
   }
 }
+
+// Provider for the episode the hero currently describes on the TV show
+// detail page. Deliberately starts at `null` rather than deriving a default
+// from `showDetailControllerProvider` here: doing so would need `ref.watch`,
+// which would make this provider rebuild — resetting any explicit tap the
+// user already made — every time the show query re-resolves (e.g. after an
+// unrelated favorite toggle invalidation). `ShowDetailScreen` sets the actual
+// default (next-unwatched episode) via a post-frame callback once, the same
+// self-correction idiom `_buildSeasonSelector` already uses for season
+// selection — see show_detail_screen.dart.
+@riverpod
+class SelectedEpisode extends _$SelectedEpisode {
+  @override
+  String? build(String showId) => null;
+
+  void select(String episodeId) {
+    state = episodeId;
+  }
+}

--- a/player/lib/presentation/screens/show/show_detail_controller.dart
+++ b/player/lib/presentation/screens/show/show_detail_controller.dart
@@ -77,6 +77,23 @@ query TvShowDetail($id: ID!) {
       }
     }
     isFavorite
+    cast {
+      name
+      character
+      profileUrl
+    }
+    trailerUrl
+    similar {
+      id
+      type
+      title
+      year
+      artwork {
+        posterUrl
+        backdropUrl
+        thumbnailUrl
+      }
+    }
   }
 }
 ''';
@@ -148,6 +165,9 @@ class ShowDetailController extends _$ShowDetailController {
         nextEpisode: currentState.nextEpisode,
         nextUp: currentState.nextUp,
         isFavorite: !currentState.isFavorite,
+        cast: currentState.cast,
+        trailerUrl: currentState.trailerUrl,
+        similar: currentState.similar,
       ),
     );
 

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -549,7 +549,7 @@ class ShowDetailScreen extends ConsumerWidget {
               .toggleFavorite(),
           onDownload: () => _startEpisodeDownload(context, ref, show, episode),
           trailerUrl: show.trailerUrl,
-          showDownload: isDownloadSupported,
+          showDownload: isDownloadSupported && episode.files.isNotEmpty,
           // Per-episode, not per-show: the hero's Download action downloads
           // the selected episode.
           isDownloaded:

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -11,18 +11,25 @@ import 'show_detail_controller.dart';
 import 'season_episodes_controller.dart';
 import '../../../domain/models/show_detail.dart';
 import '../../../domain/models/season_info.dart';
+import '../../../domain/models/download.dart';
 import '../../../domain/models/episode.dart';
 import '../../widgets/episode_rail.dart';
 import '../../widgets/freshness_header.dart';
 import '../../widgets/quality_download_dialog.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/player/media_file_selector.dart';
-import '../../../core/player/resume_plan.dart';
 import '../../../core/theme/colors.dart';
-import '../../../domain/models/show_next_up.dart';
 import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
+import '../../widgets/cast_rail.dart';
+import '../../widgets/content_rail.dart';
+import '../../widgets/detail_action_row.dart';
 import '../../widgets/smart_play_button.dart';
+
+/// Below this width the hero's action column and tag column stack instead
+/// of sitting side by side. Matches the movie detail hero's breakpoint — see
+/// docs/superpowers/specs/2026-08-05-player-detail-page-infuse-redesign-design.md.
+const double _kHeroBreakpoint = 700;
 
 class ShowDetailScreen extends ConsumerWidget {
   final String id;
@@ -182,9 +189,49 @@ class ShowDetailScreen extends ConsumerWidget {
   }
 
   Widget _buildContent(BuildContext context, WidgetRef ref, ShowDetail show) {
+    final selectedEpisodeId = ref.watch(selectedEpisodeProvider(id));
+
+    if (selectedEpisodeId == null && show.nextUp != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final nextUp = show.nextUp!.episode;
+        ref.read(selectedEpisodeProvider(id).notifier).select(nextUp.id);
+        ref
+            .read(selectedSeasonProvider(id).notifier)
+            .select(nextUp.seasonNumber);
+      });
+    }
+
+    final selectedSeason = ref.watch(selectedSeasonProvider(id));
+    final episodesAsync = ref.watch(
+      seasonEpisodesControllerProvider(
+        showId: id,
+        seasonNumber: selectedSeason,
+      ),
+    );
+    final episodes = episodesAsync.value ?? const <Episode>[];
+    final selectedEpisode = selectedEpisodeId == null
+        ? null
+        : episodes.where((e) => e.id == selectedEpisodeId).firstOrNull;
+
     return CustomScrollView(
       slivers: [
-        _buildHeroSection(context, ref, show),
+        _buildHeroSection(context, ref, show, selectedEpisodeId),
+        SliverToBoxAdapter(
+          child: _buildEpisodeHeroBody(context, ref, show, selectedEpisode),
+        ),
+        SliverToBoxAdapter(child: CastRail(members: show.cast)),
+        if (show.similar.isNotEmpty)
+          SliverToBoxAdapter(
+            child: ContentRail(
+              title: 'Similar in your library',
+              items: show.similar,
+              onItemTap: (itemId, type) => context.push(
+                type.toLowerCase() == 'movie'
+                    ? '/movie/$itemId'
+                    : '/show/$itemId',
+              ),
+            ),
+          ),
         SliverToBoxAdapter(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -239,7 +286,23 @@ class ShowDetailScreen extends ConsumerWidget {
   }
 
   Widget _buildHeroSection(
-      BuildContext context, WidgetRef ref, ShowDetail show) {
+    BuildContext context,
+    WidgetRef ref,
+    ShowDetail show,
+    String? selectedEpisodeId,
+  ) {
+    final selectedSeason = ref.watch(selectedSeasonProvider(id));
+    final episodesAsync = ref.watch(
+      seasonEpisodesControllerProvider(
+        showId: id,
+        seasonNumber: selectedSeason,
+      ),
+    );
+    final episodes = episodesAsync.value ?? const <Episode>[];
+    final selectedEpisode = selectedEpisodeId == null
+        ? null
+        : episodes.where((e) => e.id == selectedEpisodeId).firstOrNull;
+
     return SliverAppBar(
       expandedHeight: 380,
       pinned: true,
@@ -247,28 +310,6 @@ class ShowDetailScreen extends ConsumerWidget {
       backgroundColor: AppColors.background,
       leading: _buildBackButton(context),
       actions: [
-        Padding(
-          padding: const EdgeInsets.all(8),
-          child: Material(
-            color: Colors.black.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(12),
-            child: InkWell(
-              borderRadius: BorderRadius.circular(12),
-              onTap: () => ref
-                  .read(showDetailControllerProvider(id).notifier)
-                  .toggleFavorite(),
-              child: Padding(
-                padding: const EdgeInsets.all(8),
-                child: Icon(
-                  show.isFavorite
-                      ? Icons.favorite_rounded
-                      : Icons.favorite_border_rounded,
-                  color: show.isFavorite ? AppColors.error : Colors.white,
-                ),
-              ),
-            ),
-          ),
-        ),
         Padding(
           padding: const EdgeInsets.all(8),
           child: CastButton(onPressed: () => pickCastDevice(context, ref)),
@@ -321,94 +362,28 @@ class ShowDetailScreen extends ConsumerWidget {
               left: 20,
               right: 20,
               bottom: 20,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
                 children: [
-                  // Poster
-                  _buildPoster(show),
-                  const SizedBox(width: 16),
-                  // Title and info
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          show.title,
-                          style: Theme.of(context)
-                              .textTheme
-                              .headlineSmall
-                              ?.copyWith(
-                            fontWeight: FontWeight.bold,
-                            shadows: [
-                              Shadow(
-                                color: Colors.black.withValues(alpha: 0.8),
-                                blurRadius: 8,
-                              ),
-                            ],
-                          ),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
+                  Text(
+                    show.title,
+                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      shadows: [
+                        Shadow(
+                          color: Colors.black.withValues(alpha: 0.8),
+                          blurRadius: 8,
                         ),
-                        if (show.yearDisplay.isNotEmpty) ...[
-                          const SizedBox(height: 6),
-                          Text(
-                            show.yearDisplay,
-                            style:
-                                Theme.of(context).textTheme.bodyLarge?.copyWith(
-                                      color: AppColors.textSecondary,
-                                    ),
-                          ),
-                        ],
-                        const SizedBox(height: 8),
-                        _buildQuickStats(context, show),
                       ],
                     ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(width: 12),
-                  if (show.nextUp != null)
-                    // Flexible gives SmartPlayButton's internal LayoutBuilder a
-                    // bounded maxWidth to key its narrow-layout collapse off of.
-                    // Without it, a non-flex trailing Row child gets unbounded
-                    // main-axis constraints, so the pill never collapses and
-                    // can overflow on narrow screens.
-                    Flexible(
-                      child: Builder(builder: (context) {
-                        final nextUp = show.nextUp!;
-                        final episode = nextUp.episode;
-                        if (episode.files.isEmpty) {
-                          return const SizedBox.shrink();
-                        }
-
-                        return SmartPlayButton(
-                          files: episode.files,
-                          state: nextUp.state,
-                          episode: episode,
-                          onFileSelected: (file) {
-                            final title =
-                                '${show.title} - ${episode.episodeCode}';
-                            final progress = episode.progress;
-                            final resume = shouldPassResume(
-                              isContinueState:
-                                  nextUp.state == NextUpState.continueWatching,
-                              positionSeconds: progress?.positionSeconds,
-                              watched: progress?.watched ?? false,
-                            )
-                                ? '&resume=${progress!.positionSeconds}'
-                                : '';
-
-                            context.push(
-                              '/player/episode/${episode.id}'
-                              '?fileId=${file.id}'
-                              '&title=${Uri.encodeComponent(title)}'
-                              '&showId=$id'
-                              '&seasonNumber=${episode.seasonNumber}'
-                              '$resume',
-                            );
-                          },
-                        );
-                      }),
-                    ),
+                  if (selectedEpisode != null) ...[
+                    const SizedBox(height: 8),
+                    _buildEpisodeContextPill(show, selectedEpisode),
+                  ],
                 ],
               ),
             ),
@@ -418,102 +393,306 @@ class ShowDetailScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildPoster(dynamic show) {
+  Widget _buildEpisodeContextPill(ShowDetail show, Episode episode) {
+    final isNextUp = show.nextUp?.episode.id == episode.id;
+    final label = isNextUp
+        ? 'Next Up · S${episode.seasonNumber} E${episode.episodeNumber}'
+        : 'S${episode.seasonNumber} · E${episode.episodeNumber}';
+
     return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.4),
-            blurRadius: 16,
-            offset: const Offset(0, 8),
-          ),
-        ],
+        color: AppColors.surfaceVariant,
+        border: Border.all(color: AppColors.border),
+        borderRadius: BorderRadius.circular(20),
       ),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: SizedBox(
-          width: 100,
-          height: 150,
-          child: show.artwork.posterUrl != null
-              ? CachedNetworkImage(
-                  imageUrl: show.artwork.posterUrl!,
-                  fit: BoxFit.cover,
-                  cacheManager: PosterCacheManager(),
-                  placeholder: (context, url) => Container(
-                    color: AppColors.surfaceVariant,
-                  ),
-                  errorWidget: (context, url, error) => Container(
-                    color: AppColors.surfaceVariant,
-                    child: const Icon(Icons.tv_rounded,
-                        color: AppColors.textSecondary),
-                  ),
-                )
-              : Container(
-                  color: AppColors.surfaceVariant,
-                  child: const Icon(Icons.tv_rounded,
-                      color: AppColors.textSecondary),
-                ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 12.5,
+          fontWeight: FontWeight.w600,
+          color: AppColors.textPrimary,
         ),
       ),
     );
   }
 
-  Widget _buildQuickStats(BuildContext context, show) {
-    return Row(
+  Widget _buildEpisodeHeroBody(
+    BuildContext context,
+    WidgetRef ref,
+    ShowDetail show,
+    Episode? selectedEpisode,
+  ) {
+    if (selectedEpisode == null) {
+      return const Padding(
+        padding: EdgeInsets.all(20),
+        child: SizedBox(
+          height: 160,
+          child: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 24),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final wide = constraints.maxWidth >= _kHeroBreakpoint;
+          final actionColumn =
+              _buildActionColumn(context, ref, show, selectedEpisode);
+          final tagColumn = _buildTagColumn(context, show, selectedEpisode);
+
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: wide
+                ? Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(width: 248, child: actionColumn),
+                      const SizedBox(width: 40),
+                      Expanded(child: tagColumn),
+                    ],
+                  )
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      actionColumn,
+                      const SizedBox(height: 20),
+                      tagColumn,
+                    ],
+                  ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildActionColumn(
+    BuildContext context,
+    WidgetRef ref,
+    ShowDetail show,
+    Episode episode,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _buildStatBadge(
-          context,
-          Icons.folder_rounded,
-          '${show.seasonCount} Season${show.seasonCount != 1 ? 's' : ''}',
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Play', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(width: 8),
+            SmartPlayButton(
+              files: episode.files,
+              onFileSelected: (file) {
+                final title = '${show.title} - ${episode.episodeCode}';
+                context.push(
+                  '/player/episode/${episode.id}?fileId=${file.id}'
+                  '&title=${Uri.encodeComponent(title)}&showId=$id&seasonNumber=${episode.seasonNumber}',
+                );
+              },
+            ),
+          ],
         ),
-        const SizedBox(width: 12),
-        _buildStatBadge(
-          context,
-          Icons.movie_rounded,
-          '${show.episodeCount} Ep',
+        const SizedBox(height: 18),
+        DetailActionRow(
+          watched: episode.progress?.watched ?? false,
+          onToggleWatched: () => episode.progress?.watched ?? false
+              ? ref
+                  .read(seasonEpisodesControllerProvider(
+                          showId: id, seasonNumber: episode.seasonNumber)
+                      .notifier)
+                  .markEpisodeUnwatched(episode)
+              : ref
+                  .read(seasonEpisodesControllerProvider(
+                          showId: id, seasonNumber: episode.seasonNumber)
+                      .notifier)
+                  .markEpisodeWatched(episode),
+          isFavorite: show.isFavorite,
+          onToggleFavorite: () => ref
+              .read(showDetailControllerProvider(id).notifier)
+              .toggleFavorite(),
+          onDownload: () => _startEpisodeDownload(context, ref, show, episode),
+          trailerUrl: show.trailerUrl,
+          showDownload: isDownloadSupported,
         ),
-        if (show.ratingDisplay.isNotEmpty) ...[
-          const SizedBox(width: 12),
-          _buildStatBadge(
-            context,
-            Icons.star_rounded,
-            show.ratingDisplay,
-            iconColor: Colors.amber,
-          ),
-        ],
       ],
     );
   }
 
-  Widget _buildStatBadge(
-    BuildContext context,
-    IconData icon,
-    String label, {
-    Color? iconColor,
-  }) {
+  Widget _buildTagColumn(
+      BuildContext context, ShowDetail show, Episode episode) {
+    final tags = <String>[
+      if (episode.runtimeDisplay.isNotEmpty) episode.runtimeDisplay,
+      if (episode.files.isNotEmpty && episode.files.first.resolution != null)
+        episode.files.first.resolution!,
+      if (show.contentRating != null) show.contentRating!,
+      ...show.genres,
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (tags.isNotEmpty) ...[
+          Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: tags.map(_buildTagChip).toList()),
+          const SizedBox(height: 18),
+        ],
+        if (episode.overview != null) ...[
+          Text(
+            episode.overview!,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: AppColors.textSecondary,
+                  height: 1.6,
+                ),
+          ),
+          const SizedBox(height: 14),
+        ],
+        if (show.ratingDisplay.isNotEmpty) _buildRatingLine(show.ratingDisplay),
+      ],
+    );
+  }
+
+  Widget _buildTagChip(String label) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 6),
       decoration: BoxDecoration(
-        color: Colors.black.withValues(alpha: 0.4),
+        color: AppColors.surfaceVariant,
+        border: Border.all(color: AppColors.border),
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 14, color: iconColor ?? AppColors.textSecondary),
-          const SizedBox(width: 4),
-          Text(
-            label,
-            style: const TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: Colors.white,
-            ),
-          ),
-        ],
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 12.5,
+          fontWeight: FontWeight.w600,
+          color: AppColors.textPrimary,
+        ),
       ),
     );
+  }
+
+  Widget _buildRatingLine(String ratingDisplay) {
+    return Row(
+      children: [
+        const Icon(Icons.star_rounded, size: 16, color: AppColors.primary),
+        const SizedBox(width: 6),
+        Text(
+          ratingDisplay,
+          style: const TextStyle(
+              fontWeight: FontWeight.bold, color: AppColors.textPrimary),
+        ),
+        const SizedBox(width: 6),
+        const Text('TMDB',
+            style: TextStyle(fontSize: 12, color: AppColors.textSecondary)),
+      ],
+    );
+  }
+
+  /// Progressive-download flow for the hero's Download action, adapted from
+  /// `EpisodeDownloadButton._handleDownload` since the hero isn't that
+  /// widget — it needs the same quality-dialog → `startProgressiveDownload`
+  /// sequence, just driven by whichever episode is currently selected.
+  Future<void> _startEpisodeDownload(
+    BuildContext context,
+    WidgetRef ref,
+    ShowDetail show,
+    Episode episode,
+  ) async {
+    final isDownloadedAsync = ref.read(isMediaDownloadedProvider(episode.id));
+    final isDownloaded = isDownloadedAsync.value ?? false;
+
+    if (isDownloaded) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Already downloaded'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+    } else if (episode.files.isNotEmpty) {
+      final selectedResolution = await showQualityDownloadDialog(
+        context,
+        contentType: 'episode',
+        contentId: episode.id,
+        title: '${show.title} - ${episode.episodeCode}',
+      );
+
+      if (selectedResolution != null && context.mounted) {
+        final downloadService = ref.read(unifiedDownloadJobServiceProvider);
+        final downloadManager = await ref.read(downloadManagerProvider.future);
+
+        if (downloadService != null) {
+          try {
+            await downloadManager.startProgressiveDownload(
+              mediaId: episode.id,
+              title: '${show.title} - ${episode.episodeCode}: ${episode.title}',
+              contentType: 'episode',
+              resolution: selectedResolution,
+              mediaType: MediaType.episode,
+              posterUrl: episode.thumbnailUrl,
+              overview: episode.overview,
+              runtime: episode.runtime,
+              seasonNumber: episode.seasonNumber,
+              episodeNumber: episode.episodeNumber,
+              showId: show.id,
+              showTitle: show.title,
+              showPosterUrl: show.artwork.posterUrl,
+              thumbnailUrl: episode.thumbnailUrl,
+              airDate: episode.airDate,
+              getDownloadUrl: (jobId) async {
+                return await downloadService.getDownloadUrl(jobId);
+              },
+              prepareDownload: () async {
+                final status = await downloadService.prepareDownload(
+                  contentType: 'episode',
+                  id: episode.id,
+                  resolution: selectedResolution,
+                );
+                return (
+                  jobId: status.jobId,
+                  status: status.status.name,
+                  progress: status.progress,
+                  fileSize: status.currentFileSize,
+                );
+              },
+              getJobStatus: (jobId) async {
+                final status = await downloadService.getJobStatus(jobId);
+                return (
+                  status: status.status.name,
+                  progress: status.progress,
+                  fileSize: status.currentFileSize,
+                  error: status.error,
+                );
+              },
+              cancelJob: (jobId) async {
+                await downloadService.cancelJob(jobId);
+              },
+            );
+
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Download started'),
+                  duration: Duration(seconds: 2),
+                ),
+              );
+            }
+          } catch (e) {
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('Failed to start download: $e'),
+                  backgroundColor: AppColors.error,
+                ),
+              );
+            }
+          }
+        }
+      }
+    }
   }
 
   Widget _buildMetadata(BuildContext context, show) {
@@ -783,6 +962,14 @@ class ShowDetailScreen extends ConsumerWidget {
               showId: show?.id,
               showPosterUrl: show?.artwork.posterUrl,
               onEpisodeTap: (episode) async {
+                ref
+                    .read(selectedEpisodeProvider(id).notifier)
+                    .select(episode.id);
+                if (episode.seasonNumber != selectedSeason) {
+                  ref
+                      .read(selectedSeasonProvider(id).notifier)
+                      .select(episode.seasonNumber);
+                }
                 if (episode.files.isNotEmpty) {
                   final screenWidth = MediaQuery.sizeOf(context).width;
                   final deviceContext = await DeviceContext.detect(screenWidth);

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -961,6 +961,7 @@ class ShowDetailScreen extends ConsumerWidget {
               showTitle: show?.title ?? 'Unknown Show',
               showId: show?.id,
               showPosterUrl: show?.artwork.posterUrl,
+              selectedEpisodeId: ref.watch(selectedEpisodeProvider(id)),
               onEpisodeTap: (episode) async {
                 ref
                     .read(selectedEpisodeProvider(id).notifier)

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -18,6 +18,7 @@ import '../../widgets/freshness_header.dart';
 import '../../widgets/quality_download_dialog.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/player/media_file_selector.dart';
+import '../../../core/player/resume_plan.dart';
 import '../../../core/theme/colors.dart';
 import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
@@ -30,6 +31,24 @@ import '../../widgets/smart_play_button.dart';
 /// of sitting side by side. Matches the movie detail hero's breakpoint — see
 /// docs/superpowers/specs/2026-08-05-player-detail-page-infuse-redesign-design.md.
 const double _kHeroBreakpoint = 700;
+
+/// The `&resume=` suffix for a hero Play tap, or an empty string when playback
+/// should start from the beginning.
+///
+/// The pre-redesign next-up button asked the server's `nextUp.state` whether
+/// this was a continue-watching item. The redesigned hero can point at any
+/// episode in the season, not just next-up, so eligibility comes from that
+/// episode's own progress: saved progress present, not yet watched, and past
+/// the minimum position [shouldPassResume] enforces.
+String _resumeSuffix(Episode episode) {
+  final progress = episode.progress;
+  final pass = shouldPassResume(
+    isContinueState: progress != null,
+    positionSeconds: progress?.positionSeconds,
+    watched: progress?.watched ?? false,
+  );
+  return pass ? '&resume=${progress!.positionSeconds}' : '';
+}
 
 class ShowDetailScreen extends ConsumerWidget {
   final String id;
@@ -188,6 +207,25 @@ class ShowDetailScreen extends ConsumerWidget {
     );
   }
 
+  /// Resolves which episode the hero describes: the one matching
+  /// [selectedEpisodeId] if it's in the currently-loaded [episodes] list,
+  /// otherwise the first episode of that list. The fallback matters for two
+  /// real cases: a fully-watched show has no `nextUp`, so the
+  /// default-selection seed in `_buildContent` never fires and
+  /// `selectedEpisodeId` stays null forever; and switching seasons leaves
+  /// `selectedEpisodeId` pointing at an episode from the *previous* season,
+  /// which never matches the newly-loaded list. Either case previously left
+  /// the hero stuck on a permanent loading spinner instead of falling back
+  /// to something sensible.
+  Episode? _resolveSelectedEpisode(
+    String? selectedEpisodeId,
+    List<Episode> episodes,
+  ) {
+    if (episodes.isEmpty) return null;
+    return episodes.where((e) => e.id == selectedEpisodeId).firstOrNull ??
+        episodes.first;
+  }
+
   Widget _buildContent(BuildContext context, WidgetRef ref, ShowDetail show) {
     final selectedEpisodeId = ref.watch(selectedEpisodeProvider(id));
 
@@ -209,17 +247,21 @@ class ShowDetailScreen extends ConsumerWidget {
       ),
     );
     final episodes = episodesAsync.value ?? const <Episode>[];
-    final selectedEpisode = selectedEpisodeId == null
-        ? null
-        : episodes.where((e) => e.id == selectedEpisodeId).firstOrNull;
+    final selectedEpisode =
+        _resolveSelectedEpisode(selectedEpisodeId, episodes);
 
     return CustomScrollView(
       slivers: [
-        _buildHeroSection(context, ref, show, selectedEpisodeId),
+        _buildHeroSection(context, ref, show, selectedEpisode),
         SliverToBoxAdapter(
           child: _buildEpisodeHeroBody(context, ref, show, selectedEpisode),
         ),
-        SliverToBoxAdapter(child: CastRail(members: show.cast)),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.only(top: 28),
+            child: CastRail(members: show.cast),
+          ),
+        ),
         if (show.similar.isNotEmpty)
           SliverToBoxAdapter(
             child: ContentRail(
@@ -241,10 +283,6 @@ class ShowDetailScreen extends ConsumerWidget {
               const SizedBox(height: 24),
               if (show.overview != null) ...[
                 _buildOverview(context, show),
-                const SizedBox(height: 24),
-              ],
-              if (show.genres.isNotEmpty) ...[
-                _buildGenres(context, show),
                 const SizedBox(height: 24),
               ],
               if (show.seasons.isNotEmpty)
@@ -289,20 +327,8 @@ class ShowDetailScreen extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     ShowDetail show,
-    String? selectedEpisodeId,
+    Episode? selectedEpisode,
   ) {
-    final selectedSeason = ref.watch(selectedSeasonProvider(id));
-    final episodesAsync = ref.watch(
-      seasonEpisodesControllerProvider(
-        showId: id,
-        seasonNumber: selectedSeason,
-      ),
-    );
-    final episodes = episodesAsync.value ?? const <Episode>[];
-    final selectedEpisode = selectedEpisodeId == null
-        ? null
-        : episodes.where((e) => e.id == selectedEpisodeId).firstOrNull;
-
     return SliverAppBar(
       expandedHeight: 380,
       pinned: true,
@@ -380,6 +406,15 @@ class ShowDetailScreen extends ConsumerWidget {
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),
+                  if (show.yearDisplay.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      show.yearDisplay,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: AppColors.textSecondary,
+                          ),
+                    ),
+                  ],
                   if (selectedEpisode != null) ...[
                     const SizedBox(height: 8),
                     _buildEpisodeContextPill(show, selectedEpisode),
@@ -487,7 +522,8 @@ class ShowDetailScreen extends ConsumerWidget {
                 final title = '${show.title} - ${episode.episodeCode}';
                 context.push(
                   '/player/episode/${episode.id}?fileId=${file.id}'
-                  '&title=${Uri.encodeComponent(title)}&showId=$id&seasonNumber=${episode.seasonNumber}',
+                  '&title=${Uri.encodeComponent(title)}&showId=$id&seasonNumber=${episode.seasonNumber}'
+                  '${_resumeSuffix(episode)}',
                 );
               },
             ),
@@ -514,6 +550,10 @@ class ShowDetailScreen extends ConsumerWidget {
           onDownload: () => _startEpisodeDownload(context, ref, show, episode),
           trailerUrl: show.trailerUrl,
           showDownload: isDownloadSupported,
+          // Per-episode, not per-show: the hero's Download action downloads
+          // the selected episode.
+          isDownloaded:
+              ref.watch(isMediaDownloadedProvider(episode.id)).value ?? false,
         ),
       ],
     );
@@ -695,6 +735,8 @@ class ShowDetailScreen extends ConsumerWidget {
     }
   }
 
+  /// Status chip only. Content rating and genres live in the hero's tag row
+  /// now — repeating them here rendered each one twice on the page.
   Widget _buildMetadata(BuildContext context, show) {
     final items = <Widget>[];
 
@@ -706,11 +748,6 @@ class ShowDetailScreen extends ConsumerWidget {
             ? AppColors.textSecondary
             : AppColors.success,
       ));
-    }
-
-    if (show.contentRating != null) {
-      items.add(_buildMetadataChip(
-          context, show.contentRating!, AppColors.textSecondary));
     }
 
     if (items.isEmpty) return const SizedBox.shrink();
@@ -778,31 +815,6 @@ class ShowDetailScreen extends ConsumerWidget {
                 ),
           ),
         ],
-      ),
-    );
-  }
-
-  Widget _buildGenres(BuildContext context, show) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        children: show.genres.map<Widget>((genre) {
-          return Container(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-            decoration: BoxDecoration(
-              color: AppColors.surfaceVariant,
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: Text(
-              genre,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    fontWeight: FontWeight.w500,
-                  ),
-            ),
-          );
-        }).toList(),
       ),
     );
   }
@@ -961,7 +973,14 @@ class ShowDetailScreen extends ConsumerWidget {
               showTitle: show?.title ?? 'Unknown Show',
               showId: show?.id,
               showPosterUrl: show?.artwork.posterUrl,
-              selectedEpisodeId: ref.watch(selectedEpisodeProvider(id)),
+              // Resolved through the same helper the hero uses, so the rail
+              // highlights whichever episode the hero describes — including
+              // the fallback cases where the selected id matches nothing in
+              // this season's list.
+              selectedEpisodeId: _resolveSelectedEpisode(
+                ref.watch(selectedEpisodeProvider(id)),
+                episodes,
+              )?.id,
               onEpisodeTap: (episode) async {
                 ref
                     .read(selectedEpisodeProvider(id).notifier)

--- a/player/lib/presentation/widgets/cast_rail.dart
+++ b/player/lib/presentation/widgets/cast_rail.dart
@@ -1,0 +1,126 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import '../../core/theme/colors.dart';
+import '../../domain/models/cast_member.dart';
+
+/// Horizontal rail of cast members below the detail hero. Renders nothing
+/// when [members] is empty — there is no empty state, the section just
+/// doesn't exist for a title with no persisted cast.
+class CastRail extends StatelessWidget {
+  final List<CastMember> members;
+
+  const CastRail({super.key, required this.members});
+
+  @override
+  Widget build(BuildContext context) {
+    if (members.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Row(
+            children: [
+              Container(
+                width: 4,
+                height: 20,
+                decoration: BoxDecoration(
+                  color: AppColors.primary,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Text(
+                'Cast',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 14),
+        SizedBox(
+          height: 128,
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            itemCount: members.length,
+            itemBuilder: (context, index) {
+              final member = members[index];
+              return Padding(
+                key: ValueKey('cast-${member.name}-$index'),
+                padding: const EdgeInsets.only(right: 14),
+                child: _CastCard(member: member),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CastCard extends StatelessWidget {
+  final CastMember member;
+
+  const _CastCard({required this.member});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 84,
+      child: Column(
+        children: [
+          ClipOval(
+            child: SizedBox(
+              width: 72,
+              height: 72,
+              child: member.profileUrl != null
+                  ? CachedNetworkImage(
+                      imageUrl: member.profileUrl!,
+                      fit: BoxFit.cover,
+                      placeholder: (context, url) => Container(
+                        color: AppColors.surfaceVariant,
+                      ),
+                      errorWidget: (context, url, error) => _fallbackAvatar(),
+                    )
+                  : _fallbackAvatar(),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            member.name,
+            style: const TextStyle(
+              fontSize: 11.5,
+              fontWeight: FontWeight.w700,
+              color: AppColors.textPrimary,
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          if (member.character != null)
+            Text(
+              member.character!,
+              style: const TextStyle(
+                fontSize: 10.5,
+                color: AppColors.textSecondary,
+              ),
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _fallbackAvatar() {
+    return Container(
+      color: AppColors.surfaceVariant,
+      child: const Icon(Icons.person_rounded, color: AppColors.textSecondary),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/detail_action_row.dart
+++ b/player/lib/presentation/widgets/detail_action_row.dart
@@ -26,6 +26,7 @@ class DetailActionRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final trailerUrl = this.trailerUrl;
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -60,7 +61,7 @@ class DetailActionRow extends StatelessWidget {
             label: 'Trailer',
             highlighted: false,
             highlightColor: AppColors.primary,
-            onTap: () => _openTrailer(context, trailerUrl!),
+            onTap: () => _openTrailer(context, trailerUrl),
           ),
       ],
     );

--- a/player/lib/presentation/widgets/detail_action_row.dart
+++ b/player/lib/presentation/widgets/detail_action_row.dart
@@ -14,6 +14,12 @@ class DetailActionRow extends StatelessWidget {
   final VoidCallback onDownload;
   final String? trailerUrl;
 
+  /// Whether to show the Download button at all. Defaults to `true`; callers
+  /// on platforms without download support (e.g. gated by
+  /// `isDownloadSupported`) pass `false` to hide it entirely rather than
+  /// showing a button that can never do anything.
+  final bool showDownload;
+
   const DetailActionRow({
     super.key,
     required this.watched,
@@ -22,6 +28,7 @@ class DetailActionRow extends StatelessWidget {
     required this.onToggleFavorite,
     required this.onDownload,
     required this.trailerUrl,
+    this.showDownload = true,
   });
 
   @override
@@ -48,13 +55,14 @@ class DetailActionRow extends StatelessWidget {
           highlightColor: AppColors.error,
           onTap: onToggleFavorite,
         ),
-        _ActionButton(
-          icon: Icons.download_rounded,
-          label: 'Download',
-          highlighted: false,
-          highlightColor: AppColors.primary,
-          onTap: onDownload,
-        ),
+        if (showDownload)
+          _ActionButton(
+            icon: Icons.download_rounded,
+            label: 'Download',
+            highlighted: false,
+            highlightColor: AppColors.primary,
+            onTap: onDownload,
+          ),
         if (trailerUrl != null)
           _ActionButton(
             icon: Icons.smart_display_rounded,

--- a/player/lib/presentation/widgets/detail_action_row.dart
+++ b/player/lib/presentation/widgets/detail_action_row.dart
@@ -20,6 +20,13 @@ class DetailActionRow extends StatelessWidget {
   /// showing a button that can never do anything.
   final bool showDownload;
 
+  /// Whether this title is already downloaded. Defaults to `false`; callers
+  /// pass the current download state so the button reads as done (a filled
+  /// check icon in the success colour) instead of inviting a download that
+  /// only produces an "Already downloaded" snackbar — the state the
+  /// pre-redesign app-bar download button used to show.
+  final bool isDownloaded;
+
   const DetailActionRow({
     super.key,
     required this.watched,
@@ -29,6 +36,7 @@ class DetailActionRow extends StatelessWidget {
     required this.onDownload,
     required this.trailerUrl,
     this.showDownload = true,
+    this.isDownloaded = false,
   });
 
   @override
@@ -57,10 +65,12 @@ class DetailActionRow extends StatelessWidget {
         ),
         if (showDownload)
           _ActionButton(
-            icon: Icons.download_rounded,
+            icon: isDownloaded
+                ? Icons.download_done_rounded
+                : Icons.download_rounded,
             label: 'Download',
-            highlighted: false,
-            highlightColor: AppColors.primary,
+            highlighted: isDownloaded,
+            highlightColor: AppColors.success,
             onTap: onDownload,
           ),
         if (trailerUrl != null)

--- a/player/lib/presentation/widgets/detail_action_row.dart
+++ b/player/lib/presentation/widgets/detail_action_row.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../../core/theme/colors.dart';
+
+/// Four-button action row under the hero's big Play button: mark
+/// watched/unwatched, favorite, download, and (when a trailer exists) open it
+/// on YouTube in a new tab. Shared between the movie and TV show hero, since
+/// both need the identical row.
+class DetailActionRow extends StatelessWidget {
+  final bool watched;
+  final VoidCallback onToggleWatched;
+  final bool isFavorite;
+  final VoidCallback onToggleFavorite;
+  final VoidCallback onDownload;
+  final String? trailerUrl;
+
+  const DetailActionRow({
+    super.key,
+    required this.watched,
+    required this.onToggleWatched,
+    required this.isFavorite,
+    required this.onToggleFavorite,
+    required this.onDownload,
+    required this.trailerUrl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        _ActionButton(
+          icon: watched
+              ? Icons.check_circle_rounded
+              : Icons.check_circle_outline_rounded,
+          label: 'Watched',
+          highlighted: watched,
+          highlightColor: AppColors.success,
+          onTap: onToggleWatched,
+        ),
+        _ActionButton(
+          icon: isFavorite
+              ? Icons.favorite_rounded
+              : Icons.favorite_border_rounded,
+          label: 'Favorite',
+          highlighted: isFavorite,
+          highlightColor: AppColors.error,
+          onTap: onToggleFavorite,
+        ),
+        _ActionButton(
+          icon: Icons.download_rounded,
+          label: 'Download',
+          highlighted: false,
+          highlightColor: AppColors.primary,
+          onTap: onDownload,
+        ),
+        if (trailerUrl != null)
+          _ActionButton(
+            icon: Icons.smart_display_rounded,
+            label: 'Trailer',
+            highlighted: false,
+            highlightColor: AppColors.primary,
+            onTap: () => _openTrailer(context, trailerUrl!),
+          ),
+      ],
+    );
+  }
+
+  Future<void> _openTrailer(BuildContext context, String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!launched && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Could not open trailer'),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool highlighted;
+  final Color highlightColor;
+  final VoidCallback onTap;
+
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    required this.highlighted,
+    required this.highlightColor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = highlighted ? highlightColor : AppColors.textPrimary;
+
+    return Expanded(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(22),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: highlighted
+                    ? highlightColor.withValues(alpha: 0.15)
+                    : AppColors.surfaceVariant,
+                border: Border.all(
+                  color: highlighted
+                      ? highlightColor.withValues(alpha: 0.45)
+                      : AppColors.border,
+                ),
+              ),
+              child: Icon(icon, color: color, size: 20),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              label,
+              style: const TextStyle(
+                  fontSize: 10.5, color: AppColors.textSecondary),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/episode_rail.dart
+++ b/player/lib/presentation/widgets/episode_rail.dart
@@ -20,6 +20,7 @@ class EpisodeRail extends StatefulWidget {
 
   /// Invoked when a playable episode card is tapped.
   final ValueChanged<Episode>? onEpisodeTap;
+  final String? selectedEpisodeId;
 
   const EpisodeRail({
     super.key,
@@ -28,6 +29,7 @@ class EpisodeRail extends StatefulWidget {
     this.showId,
     this.showPosterUrl,
     this.onEpisodeTap,
+    this.selectedEpisodeId,
   });
 
   @override
@@ -125,6 +127,7 @@ class _EpisodeRailState extends State<EpisodeRail> {
                   showTitle: widget.showTitle,
                   showId: widget.showId,
                   showPosterUrl: widget.showPosterUrl,
+                  selected: episode.id == widget.selectedEpisodeId,
                   onTap: episode.hasFile && widget.onEpisodeTap != null
                       ? () => widget.onEpisodeTap!(episode)
                       : null,

--- a/player/lib/presentation/widgets/episode_rail_card.dart
+++ b/player/lib/presentation/widgets/episode_rail_card.dart
@@ -24,6 +24,7 @@ class EpisodeRailCard extends ConsumerStatefulWidget {
   final String showTitle;
   final String? showId;
   final String? showPosterUrl;
+  final bool selected;
 
   /// Invoked when a playable card is tapped. Ignored (and not wired) when the
   /// episode has no file.
@@ -35,6 +36,7 @@ class EpisodeRailCard extends ConsumerStatefulWidget {
     required this.showTitle,
     this.showId,
     this.showPosterUrl,
+    this.selected = false,
     this.onTap,
   });
 
@@ -102,139 +104,150 @@ class _EpisodeRailCardState extends ConsumerState<EpisodeRailCard> {
   }
 
   Widget _buildThumbnail(BuildContext context, CardSize cardSize) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(12),
-      child: SizedBox(
-        width: cardSize.width,
-        height: cardSize.height,
-        child: Stack(
-          children: [
-            // Thumbnail image (16:9 fills the card).
-            Positioned.fill(
-              child: _episode.thumbnailUrl != null
-                  ? CachedNetworkImage(
-                      imageUrl: _episode.thumbnailUrl!,
-                      fit: BoxFit.cover,
-                      cacheManager: EpisodeThumbnailCacheManager(),
-                      placeholder: (context, url) => Container(
-                        color: AppColors.surfaceVariant,
-                      ),
-                      errorWidget: (context, url, error) => _buildPlaceholder(),
-                    )
-                  : _buildPlaceholder(),
-            ),
-
-            // Hover overlay with play button (solid scrim — no live blur, to
-            // keep the scrolling rail cheap). Only when the episode is playable.
-            if (_episode.hasFile)
+    return Container(
+      key: const ValueKey('episode-card-border'),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: widget.selected
+            ? Border.all(color: AppColors.primary, width: 2)
+            : null,
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: SizedBox(
+          width: cardSize.width,
+          height: cardSize.height,
+          child: Stack(
+            children: [
+              // Thumbnail image (16:9 fills the card).
               Positioned.fill(
-                child: IgnorePointer(
-                  child: AnimatedOpacity(
-                    opacity: _isHovered ? 1.0 : 0.0,
-                    duration: const Duration(milliseconds: 200),
-                    child: Container(
-                      color: Colors.black.withValues(alpha: 0.4),
-                      child: Center(
-                        child: Container(
-                          width: 44,
-                          height: 44,
-                          decoration: BoxDecoration(
-                            color: AppColors.primary,
-                            shape: BoxShape.circle,
-                            boxShadow: [
-                              BoxShadow(
-                                color: AppColors.primary.withValues(alpha: 0.4),
-                                blurRadius: 12,
-                                offset: const Offset(0, 4),
-                              ),
-                            ],
-                          ),
-                          child: const Icon(
-                            Icons.play_arrow_rounded,
-                            size: 26,
-                            color: Colors.white,
+                child: _episode.thumbnailUrl != null
+                    ? CachedNetworkImage(
+                        imageUrl: _episode.thumbnailUrl!,
+                        fit: BoxFit.cover,
+                        cacheManager: EpisodeThumbnailCacheManager(),
+                        placeholder: (context, url) => Container(
+                          color: AppColors.surfaceVariant,
+                        ),
+                        errorWidget: (context, url, error) =>
+                            _buildPlaceholder(),
+                      )
+                    : _buildPlaceholder(),
+              ),
+
+              // Hover overlay with play button (solid scrim — no live blur, to
+              // keep the scrolling rail cheap). Only when the episode is playable.
+              if (_episode.hasFile)
+                Positioned.fill(
+                  child: IgnorePointer(
+                    child: AnimatedOpacity(
+                      opacity: _isHovered ? 1.0 : 0.0,
+                      duration: const Duration(milliseconds: 200),
+                      child: Container(
+                        color: Colors.black.withValues(alpha: 0.4),
+                        child: Center(
+                          child: Container(
+                            width: 44,
+                            height: 44,
+                            decoration: BoxDecoration(
+                              color: AppColors.primary,
+                              shape: BoxShape.circle,
+                              boxShadow: [
+                                BoxShadow(
+                                  color:
+                                      AppColors.primary.withValues(alpha: 0.4),
+                                  blurRadius: 12,
+                                  offset: const Offset(0, 4),
+                                ),
+                              ],
+                            ),
+                            child: const Icon(
+                              Icons.play_arrow_rounded,
+                              size: 26,
+                              color: Colors.white,
+                            ),
                           ),
                         ),
                       ),
                     ),
                   ),
                 ),
-              ),
 
-            // "Unavailable" badge for episodes with no playable file.
-            if (!_episode.hasFile)
-              const Positioned.fill(
-                child: Center(
-                  child: Icon(
-                    Icons.cloud_off_rounded,
-                    size: 28,
-                    color: AppColors.textSecondary,
+              // "Unavailable" badge for episodes with no playable file.
+              if (!_episode.hasFile)
+                const Positioned.fill(
+                  child: Center(
+                    child: Icon(
+                      Icons.cloud_off_rounded,
+                      size: 28,
+                      color: AppColors.textSecondary,
+                    ),
                   ),
                 ),
-              ),
 
-            // Progress bar pinned to the bottom edge.
-            if ((_episode.progress?.percentage ?? 0) > 0)
-              Positioned(
-                bottom: 0,
-                left: 0,
-                right: 0,
-                child: Container(
-                  height: 4,
-                  decoration: const BoxDecoration(
-                    color: AppColors.surfaceVariant,
-                  ),
-                  child: FractionallySizedBox(
-                    alignment: Alignment.centerLeft,
-                    widthFactor:
-                        (_episode.progress!.percentage / 100).clamp(0.0, 1.0),
-                    child: Container(
-                      decoration: const BoxDecoration(
-                        color: AppColors.primary,
-                        borderRadius: BorderRadius.only(
-                          topRight: Radius.circular(2),
-                          bottomRight: Radius.circular(2),
+              // Progress bar pinned to the bottom edge.
+              if ((_episode.progress?.percentage ?? 0) > 0)
+                Positioned(
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  child: Container(
+                    height: 4,
+                    decoration: const BoxDecoration(
+                      color: AppColors.surfaceVariant,
+                    ),
+                    child: FractionallySizedBox(
+                      alignment: Alignment.centerLeft,
+                      widthFactor:
+                          (_episode.progress!.percentage / 100).clamp(0.0, 1.0),
+                      child: Container(
+                        decoration: const BoxDecoration(
+                          color: AppColors.primary,
+                          borderRadius: BorderRadius.only(
+                            topRight: Radius.circular(2),
+                            bottomRight: Radius.circular(2),
+                          ),
                         ),
                       ),
                     ),
                   ),
                 ),
-              ),
 
-            // Watched checkmark (top-left, so it never collides with the
-            // top-right action overlay).
-            if (_episode.progress?.watched == true)
-              Positioned(
-                top: 8,
-                left: 8,
-                child: Container(
-                  padding: const EdgeInsets.all(4),
-                  decoration: BoxDecoration(
-                    color: AppColors.success,
-                    shape: BoxShape.circle,
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.3),
-                        blurRadius: 4,
-                      ),
-                    ],
-                  ),
-                  child: const Icon(
-                    Icons.check_rounded,
-                    size: 12,
-                    color: Colors.white,
+              // Watched checkmark (top-left, so it never collides with the
+              // top-right action overlay).
+              if (_episode.progress?.watched == true)
+                Positioned(
+                  top: 8,
+                  left: 8,
+                  child: Container(
+                    padding: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      color: AppColors.success,
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.3),
+                          blurRadius: 4,
+                        ),
+                      ],
+                    ),
+                    child: const Icon(
+                      Icons.check_rounded,
+                      size: 12,
+                      color: Colors.white,
+                    ),
                   ),
                 ),
-              ),
 
-            // Action overlay (top-right): download + watched-status menu, on a
-            // dark scrim pill for contrast against the thumbnail.
-            Positioned(
-              top: 4,
-              right: 4,
-              child: _buildActions(context),
-            ),
-          ],
+              // Action overlay (top-right): download + watched-status menu, on a
+              // dark scrim pill for contrast against the thumbnail.
+              Positioned(
+                top: 4,
+                right: 4,
+                child: _buildActions(context),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/player/lib/presentation/widgets/episode_rail_card.dart
+++ b/player/lib/presentation/widgets/episode_rail_card.dart
@@ -108,9 +108,10 @@ class _EpisodeRailCardState extends ConsumerState<EpisodeRailCard> {
       key: const ValueKey('episode-card-border'),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
-        border: widget.selected
-            ? Border.all(color: AppColors.primary, width: 2)
-            : null,
+        border: Border.all(
+          color: widget.selected ? AppColors.primary : Colors.transparent,
+          width: 2,
+        ),
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(12),

--- a/player/lib/presentation/widgets/movie_watched_controls.dart
+++ b/player/lib/presentation/widgets/movie_watched_controls.dart
@@ -47,6 +47,12 @@ class MovieWatchedButton extends StatelessWidget {
 ///
 /// The two states are mutually exclusive, so they never render together
 /// and the vertical rhythm stays stable across a toggle.
+///
+/// Carries no horizontal padding of its own — its one call site
+/// (`MovieDetailScreen._buildTagColumn`) already sits inside an ambient
+/// 20px-padded container, and adding padding here on top of that would
+/// double the inset and misalign the line against the tag chips/overview
+/// directly below it in the same column.
 class MovieWatchedLine extends StatelessWidget {
   const MovieWatchedLine({super.key, this.dateLabel = ''});
 
@@ -55,24 +61,21 @@ class MovieWatchedLine extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20),
-      child: Row(
-        children: [
-          const Icon(
-            Icons.check_circle_rounded,
-            size: 16,
-            color: AppColors.success,
-          ),
-          const SizedBox(width: 8),
-          Text(
-            dateLabel.isEmpty ? 'Watched' : 'Watched · $dateLabel',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: AppColors.textSecondary,
-                ),
-          ),
-        ],
-      ),
+    return Row(
+      children: [
+        const Icon(
+          Icons.check_circle_rounded,
+          size: 16,
+          color: AppColors.success,
+        ),
+        const SizedBox(width: 8),
+        Text(
+          dateLabel.isEmpty ? 'Watched' : 'Watched · $dateLabel',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AppColors.textSecondary,
+              ),
+        ),
+      ],
     );
   }
 }

--- a/player/test/domain/models/cast_member_test.dart
+++ b/player/test/domain/models/cast_member_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/cast_member.dart';
+
+void main() {
+  group('CastMember.fromJson', () {
+    test('parses a full cast member', () {
+      final member = CastMember.fromJson({
+        'name': 'Keanu Reeves',
+        'character': 'Neo',
+        'profileUrl': 'https://image.tmdb.org/t/p/w185/abc.jpg',
+      });
+
+      expect(member.name, 'Keanu Reeves');
+      expect(member.character, 'Neo');
+      expect(member.profileUrl, 'https://image.tmdb.org/t/p/w185/abc.jpg');
+    });
+
+    test('character and profileUrl are nullable', () {
+      final member = CastMember.fromJson({
+        'name': 'Keanu Reeves',
+        'character': null,
+        'profileUrl': null,
+      });
+
+      expect(member.character, isNull);
+      expect(member.profileUrl, isNull);
+    });
+  });
+}

--- a/player/test/domain/models/movie_detail_test.dart
+++ b/player/test/domain/models/movie_detail_test.dart
@@ -229,7 +229,16 @@ void main() {
           {'name': 'Ana Bergström', 'character': null, 'profileUrl': null},
         ],
         'trailerUrl': 'https://www.youtube.com/watch?v=abc123',
-        'similar': <dynamic>[],
+        'similar': [
+          {
+            'id': 's-1',
+            'type': 'movie',
+            'title': 'Low Orbit',
+            'year': 2021,
+            'artwork': null,
+            'addedAt': null,
+          },
+        ],
       };
 
       final movie = MovieDetail.fromJson(json);
@@ -237,6 +246,8 @@ void main() {
 
       expect(toggled.cast, hasLength(1));
       expect(toggled.trailerUrl, 'https://www.youtube.com/watch?v=abc123');
+      expect(toggled.similar, hasLength(1));
+      expect(toggled.similar.first.title, 'Low Orbit');
     });
   });
 }

--- a/player/test/domain/models/movie_detail_test.dart
+++ b/player/test/domain/models/movie_detail_test.dart
@@ -172,4 +172,71 @@ void main() {
       expect(movie.watchedAtDisplay, '');
     });
   });
+
+  group('MovieDetail.fromJson new hero fields', () {
+    Map<String, dynamic> baseJson() => {
+          'id': 'm-1',
+          'title': 'Meridian Drift',
+          'monitored': true,
+          'artwork': null,
+          'isFavorite': false,
+        };
+
+    test('parses cast, trailerUrl, and similar', () {
+      final json = {
+        ...baseJson(),
+        'cast': [
+          {
+            'name': 'Ana Bergström',
+            'character': 'Kira Solt',
+            'profileUrl': null
+          },
+        ],
+        'trailerUrl': 'https://www.youtube.com/watch?v=abc123',
+        'similar': [
+          {
+            'id': 's-1',
+            'type': 'movie',
+            'title': 'Low Orbit',
+            'year': 2021,
+            'artwork': null,
+            'addedAt': null,
+          },
+        ],
+      };
+
+      final movie = MovieDetail.fromJson(json);
+
+      expect(movie.cast, hasLength(1));
+      expect(movie.cast.first.name, 'Ana Bergström');
+      expect(movie.trailerUrl, 'https://www.youtube.com/watch?v=abc123');
+      expect(movie.similar, hasLength(1));
+      expect(movie.similar.first.title, 'Low Orbit');
+    });
+
+    test('defaults to empty/null when absent', () {
+      final movie = MovieDetail.fromJson(baseJson());
+
+      expect(movie.cast, isEmpty);
+      expect(movie.trailerUrl, isNull);
+      expect(movie.similar, isEmpty);
+    });
+
+    test('copyWith preserves cast, trailerUrl, and similar', () {
+      final json = {
+        ...baseJson(),
+        'cast': [
+          {'name': 'Ana Bergström', 'character': null, 'profileUrl': null},
+        ],
+        'trailerUrl': 'https://www.youtube.com/watch?v=abc123',
+        'similar': <dynamic>[],
+      };
+
+      final movie = MovieDetail.fromJson(json);
+      final toggled = movie.copyWith(isFavorite: true);
+
+      expect(toggled.cast, hasLength(1));
+      expect(toggled.trailerUrl, 'https://www.youtube.com/watch?v=abc123');
+    });
+  });
 }

--- a/player/test/domain/models/show_detail_test.dart
+++ b/player/test/domain/models/show_detail_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/show_detail.dart';
+
+void main() {
+  group('ShowDetail.fromJson new hero fields', () {
+    Map<String, dynamic> baseJson() => {
+          'id': 'sh-1',
+          'title': 'Harbor Lights',
+          'monitored': true,
+          'seasonCount': 2,
+          'episodeCount': 12,
+          'artwork': null,
+          'isFavorite': false,
+        };
+
+    test('parses cast, trailerUrl, and similar', () {
+      final json = {
+        ...baseJson(),
+        'cast': [
+          {'name': 'Del Osei', 'character': 'Det. Osei', 'profileUrl': null},
+        ],
+        'trailerUrl': 'https://www.youtube.com/watch?v=xyz789',
+        'similar': [
+          {
+            'id': 's-2',
+            'type': 'tv_show',
+            'title': 'Salt Line',
+            'year': 2020,
+            'artwork': null,
+            'addedAt': null,
+          },
+        ],
+      };
+
+      final show = ShowDetail.fromJson(json);
+
+      expect(show.cast, hasLength(1));
+      expect(show.cast.first.name, 'Del Osei');
+      expect(show.trailerUrl, 'https://www.youtube.com/watch?v=xyz789');
+      expect(show.similar, hasLength(1));
+      expect(show.similar.first.title, 'Salt Line');
+    });
+
+    test('defaults to empty/null when absent', () {
+      final show = ShowDetail.fromJson(baseJson());
+
+      expect(show.cast, isEmpty);
+      expect(show.trailerUrl, isNull);
+      expect(show.similar, isEmpty);
+    });
+  });
+}

--- a/player/test/presentation/screens/movie/movie_detail_controller_test.dart
+++ b/player/test/presentation/screens/movie/movie_detail_controller_test.dart
@@ -5,6 +5,12 @@ import 'package:flutter_test/flutter_test.dart';
 // The same pattern is used in season_episodes_controller_test.dart.
 // ignore: depend_on_referenced_packages
 import 'package:gql/ast.dart' show OperationDefinitionNode;
+// `DocumentNode` has no `toString()` override (it prints as `Instance of
+// 'DocumentNode'`), so getting the request's query text back out requires
+// the AST printer. Same pattern as `lib/core/graphql/p2p_link.dart` and
+// `lib/core/downloads/p2p_download_job_service.dart`.
+// ignore: depend_on_referenced_packages
+import 'package:gql/language.dart' show printNode;
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/domain/models/artwork.dart';
@@ -258,6 +264,31 @@ void main() {
       );
 
       expect(container.read(provider).value!.isWatched, isFalse);
+    });
+  });
+
+  group('MovieDetailController new hero fields', () {
+    test('requests cast, trailerUrl, and similar', () async {
+      final link = StubLink((request, _) {
+        return {'__typename': 'Query', 'movie': _movieJson()};
+      });
+
+      final container = ProviderContainer(
+        overrides: [
+          asyncGraphqlClientProvider.overrideWith(
+            (ref) async => stubClient(link),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final provider = movieDetailControllerProvider('m-1');
+      await waitForValue(container, provider, (v) => v.id == 'm-1');
+
+      final queryText = printNode(link.requests.first.operation.document);
+      expect(queryText, contains('cast'));
+      expect(queryText, contains('trailerUrl'));
+      expect(queryText, contains('similar'));
     });
   });
 }

--- a/player/test/presentation/screens/movie/movie_detail_screen_test.dart
+++ b/player/test/presentation/screens/movie/movie_detail_screen_test.dart
@@ -119,6 +119,12 @@ void main() {
     expect(find.byType(DetailActionRow), findsOneWidget);
   });
 
+  testWidgets('hero shows the release year under the title', (tester) async {
+    await _pumpScreen(tester, const Size(1000, 900));
+
+    expect(find.text('2024'), findsOneWidget);
+  });
+
   testWidgets('rating renders under the overview, not in the tag row',
       (tester) async {
     await _pumpScreen(tester, const Size(1000, 900));

--- a/player/test/presentation/screens/movie/movie_detail_screen_test.dart
+++ b/player/test/presentation/screens/movie/movie_detail_screen_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/presentation/screens/movie/movie_detail_screen.dart';
+import 'package:player/presentation/widgets/cast_rail.dart';
+import 'package:player/presentation/widgets/detail_action_row.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+import '../../../test_utils/stub_graphql_client.dart';
+
+Map<String, dynamic> _movieJson() {
+  return {
+    '__typename': 'Movie',
+    'id': 'm-1',
+    'title': 'Meridian Drift',
+    'originalTitle': null,
+    'year': 2024,
+    'overview': 'A drifting research platform runs out of air.',
+    'runtime': 146,
+    'genres': ['Sci-Fi', 'Adventure'],
+    'contentRating': 'PG-13',
+    'rating': 8.1,
+    'tmdbId': null,
+    'imdbId': null,
+    'category': null,
+    'monitored': true,
+    'addedAt': null,
+    'artwork': {
+      '__typename': 'Artwork',
+      'posterUrl': null,
+      'backdropUrl': null,
+      'thumbnailUrl': null,
+    },
+    'progress': null,
+    'files': <dynamic>[],
+    'isFavorite': false,
+    'cast': [
+      {
+        '__typename': 'CastMember',
+        'name': 'Ana Bergström',
+        'character': 'Kira Solt',
+        'profileUrl': null,
+      },
+    ],
+    'trailerUrl': null,
+    'similar': <dynamic>[],
+  };
+}
+
+Future<void> _pumpScreen(WidgetTester tester, Size size) async {
+  await tester.binding.setSurfaceSize(size);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final link = StubLink((request, _) {
+    return {'__typename': 'Query', 'movie': _movieJson()};
+  });
+
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          asyncGraphqlClientProvider
+              .overrideWith((ref) async => stubClient(link)),
+        ],
+        child: MaterialApp.router(
+          routerConfig: GoRouter(
+            initialLocation: '/movie/m-1',
+            routes: [
+              GoRoute(
+                path: '/movie/:id',
+                builder: (context, state) =>
+                    MovieDetailScreen(id: state.pathParameters['id']!),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+  });
+}
+
+void main() {
+  testWidgets('wide layout shows the action column beside the tag column',
+      (tester) async {
+    await _pumpScreen(tester, const Size(1000, 900));
+
+    expect(find.text('Play'), findsOneWidget);
+    expect(find.byType(DetailActionRow), findsOneWidget);
+    expect(find.byType(CastRail), findsOneWidget);
+  });
+
+  testWidgets('narrow layout still renders the action column and tags',
+      (tester) async {
+    await _pumpScreen(tester, const Size(400, 900));
+
+    expect(find.text('Play'), findsOneWidget);
+    expect(find.byType(DetailActionRow), findsOneWidget);
+  });
+
+  testWidgets('rating renders under the overview, not in the tag row',
+      (tester) async {
+    await _pumpScreen(tester, const Size(1000, 900));
+
+    expect(find.text('8.1'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/screens/movie/movie_detail_screen_test.dart
+++ b/player/test/presentation/screens/movie/movie_detail_screen_test.dart
@@ -10,7 +10,7 @@ import 'package:player/presentation/widgets/detail_action_row.dart';
 import '../../../test_utils/mock_network_images.dart';
 import '../../../test_utils/stub_graphql_client.dart';
 
-Map<String, dynamic> _movieJson() {
+Map<String, dynamic> _movieJson({Map<String, dynamic>? progress}) {
   return {
     '__typename': 'Movie',
     'id': 'm-1',
@@ -33,7 +33,7 @@ Map<String, dynamic> _movieJson() {
       'backdropUrl': null,
       'thumbnailUrl': null,
     },
-    'progress': null,
+    'progress': progress,
     'files': <dynamic>[],
     'isFavorite': false,
     'cast': [
@@ -49,12 +49,30 @@ Map<String, dynamic> _movieJson() {
   };
 }
 
-Future<void> _pumpScreen(WidgetTester tester, Size size) async {
+Map<String, dynamic> _progressJson({
+  required bool watched,
+  String? lastWatchedAt,
+}) {
+  return {
+    '__typename': 'Progress',
+    'positionSeconds': 4200,
+    'durationSeconds': 8760,
+    'percentage': 48.0,
+    'watched': watched,
+    'lastWatchedAt': lastWatchedAt,
+  };
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester,
+  Size size, {
+  Map<String, dynamic>? movieJson,
+}) async {
   await tester.binding.setSurfaceSize(size);
   addTearDown(() => tester.binding.setSurfaceSize(null));
 
   final link = StubLink((request, _) {
-    return {'__typename': 'Query', 'movie': _movieJson()};
+    return {'__typename': 'Query', 'movie': movieJson ?? _movieJson()};
   });
 
   await mockNetworkImages(() async {
@@ -106,5 +124,35 @@ void main() {
     await _pumpScreen(tester, const Size(1000, 900));
 
     expect(find.text('8.1'), findsOneWidget);
+  });
+
+  testWidgets('shows the watched line when the movie is marked watched',
+      (tester) async {
+    await _pumpScreen(
+      tester,
+      const Size(1000, 900),
+      movieJson: _movieJson(
+        progress: _progressJson(
+          watched: true,
+          lastWatchedAt: '2026-08-01T00:00:00Z',
+        ),
+      ),
+    );
+
+    // `find.text('Watched')` alone would also match DetailActionRow's
+    // static "Watched" button label, so this looks for the
+    // "Watched · <date>" separator that only MovieWatchedLine renders.
+    expect(find.textContaining('Watched ·'), findsOneWidget);
+  });
+
+  testWidgets('shows a resume progress bar when there is resumable progress',
+      (tester) async {
+    await _pumpScreen(
+      tester,
+      const Size(1000, 900),
+      movieJson: _movieJson(progress: _progressJson(watched: false)),
+    );
+
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
   });
 }

--- a/player/test/presentation/screens/show/selected_episode_provider_test.dart
+++ b/player/test/presentation/screens/show/selected_episode_provider_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/screens/show/show_detail_controller.dart';
+
+void main() {
+  group('selectedEpisodeProvider', () {
+    test('defaults to null', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(selectedEpisodeProvider('sh-1')), isNull);
+    });
+
+    test('select() sets the state', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(selectedEpisodeProvider('sh-1').notifier).select('ep-5');
+
+      expect(container.read(selectedEpisodeProvider('sh-1')), 'ep-5');
+    });
+
+    test('is scoped independently per show id', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(selectedEpisodeProvider('sh-1').notifier).select('ep-5');
+
+      expect(container.read(selectedEpisodeProvider('sh-2')), isNull);
+    });
+  });
+}

--- a/player/test/presentation/screens/show/show_detail_invalidation_test.dart
+++ b/player/test/presentation/screens/show/show_detail_invalidation_test.dart
@@ -8,6 +8,12 @@ import 'package:flutter_test/flutter_test.dart';
 // used throughout core/graphql/watch/*.dart.
 // ignore: depend_on_referenced_packages
 import 'package:gql/ast.dart' show OperationDefinitionNode;
+// `DocumentNode` has no `toString()` override (it prints as `Instance of
+// 'DocumentNode'`), so getting the request's query text back out requires
+// the AST printer. Same pattern as `lib/core/graphql/p2p_link.dart` and
+// `lib/core/downloads/p2p_download_job_service.dart`.
+// ignore: depend_on_referenced_packages
+import 'package:gql/language.dart' show printNode;
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/core/graphql/watch/fetch_log.dart';
@@ -219,5 +225,28 @@ void main() {
     expect(log.lastFetchedAt(QueryKeys.home), isNull);
     expect(log.lastFetchedAt(QueryKeys.favorites), isNull);
     expect(log.lastFetchedAt(QueryKeys.tvShowsList), isNull);
+  });
+
+  group('ShowDetailController new hero fields', () {
+    test('requests cast, trailerUrl, and similar', () async {
+      final link = StubLink((request, _) => _show(isFavorite: false));
+
+      final container = ProviderContainer(
+        overrides: [
+          asyncGraphqlClientProvider.overrideWith(
+            (ref) async => stubClient(link),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final provider = showDetailControllerProvider('s1');
+      await waitForValue(container, provider, (v) => v.id == 's1');
+
+      final queryText = printNode(link.requests.first.operation.document);
+      expect(queryText, contains('cast'));
+      expect(queryText, contains('trailerUrl'));
+      expect(queryText, contains('similar'));
+    });
   });
 }

--- a/player/test/presentation/screens/show/show_detail_screen_test.dart
+++ b/player/test/presentation/screens/show/show_detail_screen_test.dart
@@ -8,6 +8,8 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/presentation/screens/show/show_detail_screen.dart';
 import 'package:player/presentation/widgets/cast_rail.dart';
+import 'package:player/presentation/widgets/detail_action_row.dart';
+import 'package:player/presentation/widgets/play_button.dart';
 
 import '../../../test_utils/mock_network_images.dart';
 import '../../../test_utils/stub_graphql_client.dart';
@@ -18,11 +20,54 @@ String? _operationName(Request request) {
   return operations.isEmpty ? null : operations.first.name?.value;
 }
 
-Map<String, dynamic> _episodeJson(int number, {bool watched = false}) {
+Map<String, dynamic> _fileJson(String id) {
+  return {
+    '__typename': 'MediaFile',
+    'id': id,
+    'resolution': '1080p',
+    'codec': 'h264',
+    'audioCodec': 'aac',
+    'hdrFormat': null,
+    'size': 1200000000,
+    'bitrate': 4000000,
+    'directPlaySupported': true,
+    'streamUrl': null,
+    'directPlayUrl': null,
+  };
+}
+
+Map<String, dynamic> _episodeJson(
+  int number, {
+  int season = 1,
+  bool watched = false,
+  int? positionSeconds,
+  List<Map<String, dynamic>> files = const [],
+}) {
+  Map<String, dynamic>? progress;
+  if (watched) {
+    progress = {
+      '__typename': 'Progress',
+      'positionSeconds': 0,
+      'durationSeconds': 2580,
+      'percentage': 100.0,
+      'watched': true,
+      'lastWatchedAt': null,
+    };
+  } else if (positionSeconds != null) {
+    progress = {
+      '__typename': 'Progress',
+      'positionSeconds': positionSeconds,
+      'durationSeconds': 2580,
+      'percentage': positionSeconds / 2580 * 100,
+      'watched': false,
+      'lastWatchedAt': null,
+    };
+  }
+
   return {
     '__typename': 'Episode',
-    'id': 'ep-$number',
-    'seasonNumber': 1,
+    'id': 'ep-$season-$number',
+    'seasonNumber': season,
     'episodeNumber': number,
     'title': 'Episode $number',
     'overview': 'Overview for episode $number.',
@@ -31,21 +76,16 @@ Map<String, dynamic> _episodeJson(int number, {bool watched = false}) {
     'monitored': true,
     'thumbnailUrl': null,
     'hasFile': true,
-    'progress': watched
-        ? {
-            '__typename': 'Progress',
-            'positionSeconds': 0,
-            'durationSeconds': 2580,
-            'percentage': 100.0,
-            'watched': true,
-            'lastWatchedAt': null,
-          }
-        : null,
-    'files': <dynamic>[],
+    'progress': progress,
+    'files': files,
   };
 }
 
-Map<String, dynamic> _showJson() {
+Map<String, dynamic> _showJson({
+  Map<String, dynamic>? nextUpEpisode,
+  bool includeNextUp = true,
+  List<Map<String, dynamic>>? seasons,
+}) {
   return {
     '__typename': 'TvShow',
     'id': 'sh-1',
@@ -70,21 +110,24 @@ Map<String, dynamic> _showJson() {
       'backdropUrl': null,
       'thumbnailUrl': null,
     },
-    'seasons': [
-      {
-        '__typename': 'Season',
-        'seasonNumber': 1,
-        'episodeCount': 3,
-        'airedEpisodeCount': 3,
-        'hasFiles': true,
-      },
-    ],
+    'seasons': seasons ??
+        [
+          {
+            '__typename': 'Season',
+            'seasonNumber': 1,
+            'episodeCount': 3,
+            'airedEpisodeCount': 3,
+            'hasFiles': true,
+          },
+        ],
     'nextEpisode': null,
-    'nextUp': {
-      '__typename': 'ShowNextUp',
-      'progressState': 'next',
-      'episode': _episodeJson(2),
-    },
+    'nextUp': includeNextUp
+        ? {
+            '__typename': 'ShowNextUp',
+            'progressState': 'next',
+            'episode': nextUpEpisode ?? _episodeJson(2),
+          }
+        : null,
     'isFavorite': false,
     'cast': [
       {
@@ -99,20 +142,38 @@ Map<String, dynamic> _showJson() {
   };
 }
 
-Future<void> _pumpScreen(WidgetTester tester) async {
+Map<int, List<Map<String, dynamic>>> _defaultEpisodes() => {
+      1: [
+        _episodeJson(1, watched: true),
+        _episodeJson(2),
+        _episodeJson(3),
+      ],
+    };
+
+Future<void> _pumpScreen(
+  WidgetTester tester, {
+  Map<String, dynamic>? showJson,
+  Map<int, List<Map<String, dynamic>>>? episodesBySeason,
+  List<String>? pushedRoutes,
+  Size? size,
+}) async {
+  if (size != null) {
+    await tester.binding.setSurfaceSize(size);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+  }
+
+  final episodes = episodesBySeason ?? _defaultEpisodes();
+
   final link = StubLink((request, _) {
     final operation = _operationName(request);
     if (operation == 'SeasonEpisodes') {
+      final seasonNumber = request.variables['seasonNumber'] as int;
       return {
         '__typename': 'Query',
-        'seasonEpisodes': [
-          _episodeJson(1, watched: true),
-          _episodeJson(2),
-          _episodeJson(3),
-        ],
+        'seasonEpisodes': episodes[seasonNumber] ?? <dynamic>[],
       };
     }
-    return {'__typename': 'Query', 'tvShow': _showJson()};
+    return {'__typename': 'Query', 'tvShow': showJson ?? _showJson()};
   });
 
   await mockNetworkImages(() async {
@@ -130,6 +191,13 @@ Future<void> _pumpScreen(WidgetTester tester) async {
                 path: '/show/:id',
                 builder: (context, state) =>
                     ShowDetailScreen(id: state.pathParameters['id']!),
+              ),
+              GoRoute(
+                path: '/player/episode/:id',
+                builder: (context, state) {
+                  pushedRoutes?.add(state.uri.toString());
+                  return const Scaffold(body: SizedBox.shrink());
+                },
               ),
             ],
           ),
@@ -157,16 +225,172 @@ void main() {
     // The episode rail sits below the redesigned hero/cast/similar sections,
     // past the default test viewport — scroll it into view before tapping.
     await tester.scrollUntilVisible(
-      find.byKey(const ValueKey('ep-3')),
+      find.byKey(const ValueKey('ep-1-3')),
       200,
       // The screen has multiple Scrollables (cast rail, season chips, episode
       // rail are all horizontal ListViews); the first one found in the tree
       // is the outer vertical CustomScrollView, which is what needs to move.
       scrollable: find.byType(Scrollable).first,
     );
-    await tester.tap(find.byKey(const ValueKey('ep-3')));
+    // scrollUntilVisible stops as soon as the tile exists in the tree, which
+    // the sliver cache extent makes true while it is still below the viewport
+    // — ensureVisible actually brings it on screen so the tap lands.
+    await tester.ensureVisible(find.byKey(const ValueKey('ep-1-3')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('ep-1-3')));
     await tester.pumpAndSettle();
 
     expect(find.textContaining('E3'), findsWidgets);
+  });
+
+  testWidgets('fully-watched show (no nextUp) still renders the hero',
+      (tester) async {
+    // `resolve_next_up/3` returns nil once every episode is watched, so the
+    // hero's default-selection seed never fires and `selectedEpisodeId` stays
+    // null. The hero must fall back to the season's first episode rather than
+    // spinning forever.
+    await _pumpScreen(
+      tester,
+      showJson: _showJson(includeNextUp: false),
+      episodesBySeason: {
+        1: [
+          _episodeJson(1, watched: true),
+          _episodeJson(2, watched: true),
+          _episodeJson(3, watched: true),
+        ],
+      },
+    );
+
+    expect(find.text('Play'), findsOneWidget);
+    expect(find.byType(DetailActionRow), findsOneWidget);
+    expect(find.text('S1 · E1'), findsOneWidget);
+  });
+
+  testWidgets('switching seasons re-targets the hero at the new season',
+      (tester) async {
+    // The selected episode id still points at a season 1 episode after the
+    // switch, so it matches nothing in season 2's list — the hero has to fall
+    // back to season 2's first episode instead of spinning forever.
+    await _pumpScreen(
+      tester,
+      // A tall viewport keeps the hero and the season chips on screen at the
+      // same time, so the assertion sees the hero the tap re-targeted rather
+      // than an unbuilt sliver scrolled out of view.
+      size: const Size(1000, 2200),
+      showJson: _showJson(seasons: [
+        {
+          '__typename': 'Season',
+          'seasonNumber': 1,
+          'episodeCount': 3,
+          'airedEpisodeCount': 3,
+          'hasFiles': true,
+        },
+        {
+          '__typename': 'Season',
+          'seasonNumber': 2,
+          'episodeCount': 2,
+          'airedEpisodeCount': 2,
+          'hasFiles': true,
+        },
+      ]),
+      episodesBySeason: {
+        1: [
+          _episodeJson(1, watched: true),
+          _episodeJson(2),
+          _episodeJson(3),
+        ],
+        2: [
+          _episodeJson(1, season: 2),
+          _episodeJson(2, season: 2),
+        ],
+      },
+    );
+
+    await tester.tap(find.text('Season 2'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DetailActionRow), findsOneWidget);
+    expect(find.text('S2 · E1'), findsOneWidget);
+  });
+
+  testWidgets('hero shows the release year under the title', (tester) async {
+    await _pumpScreen(tester);
+
+    expect(find.text('2022'), findsOneWidget);
+  });
+
+  testWidgets('content rating and genres render once, in the hero tag row',
+      (tester) async {
+    // The tall viewport builds the lower metadata section too, so a
+    // reintroduced duplicate down there would be found, not silently
+    // scrolled out of the tree.
+    await _pumpScreen(tester, size: const Size(1000, 2200));
+
+    expect(find.text('TV-14'), findsOneWidget);
+    expect(find.text('Mystery'), findsOneWidget);
+    expect(find.text('Drama'), findsOneWidget);
+  });
+
+  testWidgets('Play passes a resume position for a part-watched episode',
+      (tester) async {
+    final pushed = <String>[];
+    final partWatched = _episodeJson(
+      2,
+      positionSeconds: 900,
+      files: [_fileJson('file-1')],
+    );
+
+    await _pumpScreen(
+      tester,
+      size: const Size(1000, 1200),
+      showJson: _showJson(nextUpEpisode: partWatched),
+      episodesBySeason: {
+        1: [
+          _episodeJson(1, watched: true),
+          partWatched,
+          _episodeJson(3),
+        ],
+      },
+      pushedRoutes: pushed,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PlayButton));
+    await tester.pumpAndSettle();
+
+    expect(pushed, hasLength(1));
+    expect(pushed.single, contains('/player/episode/ep-1-2'));
+    expect(pushed.single, contains('resume=900'));
+  });
+
+  testWidgets('Play omits resume for an already-watched episode',
+      (tester) async {
+    final pushed = <String>[];
+    final watched = _episodeJson(
+      2,
+      watched: true,
+      files: [_fileJson('file-1')],
+    );
+
+    await _pumpScreen(
+      tester,
+      size: const Size(1000, 1200),
+      showJson: _showJson(nextUpEpisode: watched),
+      episodesBySeason: {
+        1: [
+          _episodeJson(1, watched: true),
+          watched,
+          _episodeJson(3),
+        ],
+      },
+      pushedRoutes: pushed,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PlayButton));
+    await tester.pumpAndSettle();
+
+    expect(pushed, hasLength(1));
+    expect(pushed.single, isNot(contains('resume=')));
   });
 }

--- a/player/test/presentation/screens/show/show_detail_screen_test.dart
+++ b/player/test/presentation/screens/show/show_detail_screen_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+// ignore: depend_on_referenced_packages
+import 'package:gql/ast.dart' show OperationDefinitionNode;
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/presentation/screens/show/show_detail_screen.dart';
+import 'package:player/presentation/widgets/cast_rail.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+import '../../../test_utils/stub_graphql_client.dart';
+
+String? _operationName(Request request) {
+  final operations = request.operation.document.definitions
+      .whereType<OperationDefinitionNode>();
+  return operations.isEmpty ? null : operations.first.name?.value;
+}
+
+Map<String, dynamic> _episodeJson(int number, {bool watched = false}) {
+  return {
+    '__typename': 'Episode',
+    'id': 'ep-$number',
+    'seasonNumber': 1,
+    'episodeNumber': number,
+    'title': 'Episode $number',
+    'overview': 'Overview for episode $number.',
+    'airDate': null,
+    'runtime': 43,
+    'monitored': true,
+    'thumbnailUrl': null,
+    'hasFile': true,
+    'progress': watched
+        ? {
+            '__typename': 'Progress',
+            'positionSeconds': 0,
+            'durationSeconds': 2580,
+            'percentage': 100.0,
+            'watched': true,
+            'lastWatchedAt': null,
+          }
+        : null,
+    'files': <dynamic>[],
+  };
+}
+
+Map<String, dynamic> _showJson() {
+  return {
+    '__typename': 'TvShow',
+    'id': 'sh-1',
+    'title': 'Harbor Lights',
+    'originalTitle': null,
+    'year': 2022,
+    'overview': 'A coastal mystery series.',
+    'status': 'Continuing',
+    'genres': ['Mystery', 'Drama'],
+    'contentRating': 'TV-14',
+    'rating': 7.9,
+    'tmdbId': null,
+    'imdbId': null,
+    'category': null,
+    'monitored': true,
+    'addedAt': null,
+    'seasonCount': 1,
+    'episodeCount': 3,
+    'artwork': {
+      '__typename': 'Artwork',
+      'posterUrl': null,
+      'backdropUrl': null,
+      'thumbnailUrl': null,
+    },
+    'seasons': [
+      {
+        '__typename': 'Season',
+        'seasonNumber': 1,
+        'episodeCount': 3,
+        'airedEpisodeCount': 3,
+        'hasFiles': true,
+      },
+    ],
+    'nextEpisode': null,
+    'nextUp': {
+      '__typename': 'ShowNextUp',
+      'progressState': 'next',
+      'episode': _episodeJson(2),
+    },
+    'isFavorite': false,
+    'cast': [
+      {
+        '__typename': 'CastMember',
+        'name': 'Del Osei',
+        'character': 'Det. Osei',
+        'profileUrl': null,
+      },
+    ],
+    'trailerUrl': null,
+    'similar': <dynamic>[],
+  };
+}
+
+Future<void> _pumpScreen(WidgetTester tester) async {
+  final link = StubLink((request, _) {
+    final operation = _operationName(request);
+    if (operation == 'SeasonEpisodes') {
+      return {
+        '__typename': 'Query',
+        'seasonEpisodes': [
+          _episodeJson(1, watched: true),
+          _episodeJson(2),
+          _episodeJson(3),
+        ],
+      };
+    }
+    return {'__typename': 'Query', 'tvShow': _showJson()};
+  });
+
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          asyncGraphqlClientProvider
+              .overrideWith((ref) async => stubClient(link)),
+        ],
+        child: MaterialApp.router(
+          routerConfig: GoRouter(
+            initialLocation: '/show/sh-1',
+            routes: [
+              GoRoute(
+                path: '/show/:id',
+                builder: (context, state) =>
+                    ShowDetailScreen(id: state.pathParameters['id']!),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+  });
+}
+
+void main() {
+  testWidgets('hero defaults to the next-unwatched episode', (tester) async {
+    await _pumpScreen(tester);
+
+    expect(find.textContaining('E2'), findsWidgets);
+    expect(find.byType(CastRail), findsOneWidget);
+  });
+
+  testWidgets('tapping a different episode re-targets the hero',
+      (tester) async {
+    await _pumpScreen(tester);
+
+    // The episode rail sits below the redesigned hero/cast/similar sections,
+    // past the default test viewport — scroll it into view before tapping.
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('ep-3')),
+      200,
+      // The screen has multiple Scrollables (cast rail, season chips, episode
+      // rail are all horizontal ListViews); the first one found in the tree
+      // is the outer vertical CustomScrollView, which is what needs to move.
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(find.byKey(const ValueKey('ep-3')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('E3'), findsWidgets);
+  });
+}

--- a/player/test/presentation/widgets/cast_rail_test.dart
+++ b/player/test/presentation/widgets/cast_rail_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/cast_member.dart';
+import 'package:player/presentation/widgets/cast_rail.dart';
+
+Widget _host(Widget child) => ProviderScope(
+      child: MaterialApp(home: Scaffold(body: child)),
+    );
+
+void main() {
+  testWidgets('renders nothing when there is no cast', (tester) async {
+    await tester.pumpWidget(_host(const CastRail(members: [])));
+
+    expect(find.byType(CastRail), findsOneWidget);
+    expect(find.text('Cast'), findsNothing);
+  });
+
+  testWidgets('renders a card per cast member with name and character',
+      (tester) async {
+    await tester.pumpWidget(_host(const CastRail(
+      members: [
+        CastMember(name: 'Ana Bergström', character: 'Kira Solt'),
+        CastMember(name: 'Marcus Ijeoma', character: 'Deck Chief Reyes'),
+      ],
+    )));
+
+    expect(find.text('Cast'), findsOneWidget);
+    expect(find.text('Ana Bergström'), findsOneWidget);
+    expect(find.text('Kira Solt'), findsOneWidget);
+    expect(find.text('Marcus Ijeoma'), findsOneWidget);
+  });
+
+  testWidgets('falls back to a person icon when there is no profile photo',
+      (tester) async {
+    await tester.pumpWidget(_host(const CastRail(
+      members: [CastMember(name: 'Ana Bergström')],
+    )));
+
+    expect(find.byIcon(Icons.person_rounded), findsOneWidget);
+  });
+}

--- a/player/test/presentation/widgets/detail_action_row_test.dart
+++ b/player/test/presentation/widgets/detail_action_row_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/detail_action_row.dart';
+
+Widget _host(Widget child) => ProviderScope(
+      child: MaterialApp(home: Scaffold(body: child)),
+    );
+
+void main() {
+  testWidgets('tapping watched calls onToggleWatched', (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(_host(DetailActionRow(
+      watched: false,
+      onToggleWatched: () => tapped = true,
+      isFavorite: false,
+      onToggleFavorite: () {},
+      onDownload: () {},
+      trailerUrl: null,
+    )));
+
+    await tester.tap(find.byIcon(Icons.check_circle_outline_rounded));
+    expect(tapped, isTrue);
+  });
+
+  testWidgets('tapping favorite calls onToggleFavorite', (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(_host(DetailActionRow(
+      watched: false,
+      onToggleWatched: () {},
+      isFavorite: false,
+      onToggleFavorite: () => tapped = true,
+      onDownload: () {},
+      trailerUrl: null,
+    )));
+
+    await tester.tap(find.byIcon(Icons.favorite_border_rounded));
+    expect(tapped, isTrue);
+  });
+
+  testWidgets('trailer button is absent when trailerUrl is null',
+      (tester) async {
+    await tester.pumpWidget(_host(DetailActionRow(
+      watched: false,
+      onToggleWatched: () {},
+      isFavorite: false,
+      onToggleFavorite: () {},
+      onDownload: () {},
+      trailerUrl: null,
+    )));
+
+    expect(find.text('Trailer'), findsNothing);
+  });
+
+  testWidgets('trailer button is present when trailerUrl is set',
+      (tester) async {
+    await tester.pumpWidget(_host(DetailActionRow(
+      watched: false,
+      onToggleWatched: () {},
+      isFavorite: false,
+      onToggleFavorite: () {},
+      onDownload: () {},
+      trailerUrl: 'https://www.youtube.com/watch?v=abc123',
+    )));
+
+    expect(find.text('Trailer'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/widgets/detail_action_row_test.dart
+++ b/player/test/presentation/widgets/detail_action_row_test.dart
@@ -65,4 +65,32 @@ void main() {
 
     expect(find.text('Trailer'), findsOneWidget);
   });
+
+  testWidgets('download button is present by default', (tester) async {
+    await tester.pumpWidget(_host(DetailActionRow(
+      watched: false,
+      onToggleWatched: () {},
+      isFavorite: false,
+      onToggleFavorite: () {},
+      onDownload: () {},
+      trailerUrl: null,
+    )));
+
+    expect(find.text('Download'), findsOneWidget);
+  });
+
+  testWidgets('download button is absent when showDownload is false',
+      (tester) async {
+    await tester.pumpWidget(_host(DetailActionRow(
+      watched: false,
+      onToggleWatched: () {},
+      isFavorite: false,
+      onToggleFavorite: () {},
+      onDownload: () {},
+      trailerUrl: null,
+      showDownload: false,
+    )));
+
+    expect(find.text('Download'), findsNothing);
+  });
 }

--- a/player/test/presentation/widgets/detail_action_row_test.dart
+++ b/player/test/presentation/widgets/detail_action_row_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/theme/colors.dart';
 import 'package:player/presentation/widgets/detail_action_row.dart';
 
 Widget _host(Widget child) => ProviderScope(
@@ -92,5 +93,38 @@ void main() {
     )));
 
     expect(find.text('Download'), findsNothing);
+  });
+
+  testWidgets('download button is plain when the title is not downloaded',
+      (tester) async {
+    await tester.pumpWidget(_host(DetailActionRow(
+      watched: false,
+      onToggleWatched: () {},
+      isFavorite: false,
+      onToggleFavorite: () {},
+      onDownload: () {},
+      trailerUrl: null,
+    )));
+
+    expect(find.byIcon(Icons.download_done_rounded), findsNothing);
+    final icon = tester.widget<Icon>(find.byIcon(Icons.download_rounded));
+    expect(icon.color, AppColors.textPrimary);
+  });
+
+  testWidgets('download button shows the done icon in success when downloaded',
+      (tester) async {
+    await tester.pumpWidget(_host(DetailActionRow(
+      watched: false,
+      onToggleWatched: () {},
+      isFavorite: false,
+      onToggleFavorite: () {},
+      onDownload: () {},
+      trailerUrl: null,
+      isDownloaded: true,
+    )));
+
+    expect(find.byIcon(Icons.download_rounded), findsNothing);
+    final icon = tester.widget<Icon>(find.byIcon(Icons.download_done_rounded));
+    expect(icon.color, AppColors.success);
   });
 }

--- a/player/test/presentation/widgets/episode_rail_card_test.dart
+++ b/player/test/presentation/widgets/episode_rail_card_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/downloads/download_providers.dart';
+import 'package:player/core/theme/colors.dart';
 import 'package:player/domain/models/episode.dart';
 import 'package:player/domain/models/progress.dart';
 import 'package:player/presentation/widgets/episode_rail_card.dart';
@@ -164,7 +165,9 @@ void main() {
       find.byKey(const ValueKey('episode-card-border')),
     );
     final decoration = container.decoration as BoxDecoration;
-    expect(decoration.border, isNotNull);
+    final border = decoration.border as Border;
+    expect(border.top.color, AppColors.primary);
+    expect(border.top.width, 2);
 
     await _pump(tester, _episode());
 
@@ -173,6 +176,8 @@ void main() {
     );
     final unselectedDecoration =
         unselectedContainer.decoration as BoxDecoration;
-    expect(unselectedDecoration.border, isNull);
+    final unselectedBorder = unselectedDecoration.border as Border;
+    expect(unselectedBorder.top.color, Colors.transparent);
+    expect(unselectedBorder.top.width, 2);
   });
 }

--- a/player/test/presentation/widgets/episode_rail_card_test.dart
+++ b/player/test/presentation/widgets/episode_rail_card_test.dart
@@ -31,6 +31,7 @@ Future<void> _pump(
   WidgetTester tester,
   Episode episode, {
   VoidCallback? onTap,
+  bool selected = false,
 }) async {
   await mockNetworkImages(() async {
     await tester.pumpWidget(
@@ -45,6 +46,7 @@ Future<void> _pump(
               showTitle: 'Test Show',
               showId: 'show-1',
               onTap: onTap,
+              selected: selected,
             ),
           ),
         ),
@@ -152,5 +154,25 @@ void main() {
     await _pump(tester, _episode(thumbnailUrl: null));
 
     expect(find.byIcon(Icons.tv_rounded), findsOneWidget);
+  });
+
+  testWidgets('selected draws a highlighted border, unselected does not',
+      (tester) async {
+    await _pump(tester, _episode(), selected: true);
+
+    final container = tester.widget<Container>(
+      find.byKey(const ValueKey('episode-card-border')),
+    );
+    final decoration = container.decoration as BoxDecoration;
+    expect(decoration.border, isNotNull);
+
+    await _pump(tester, _episode());
+
+    final unselectedContainer = tester.widget<Container>(
+      find.byKey(const ValueKey('episode-card-border')),
+    );
+    final unselectedDecoration =
+        unselectedContainer.decoration as BoxDecoration;
+    expect(unselectedDecoration.border, isNull);
   });
 }


### PR DESCRIPTION
## Summary

Rebuilds the player app's movie and TV show detail screens around an Infuse-style layout: a big backdrop hero with a large Play button on the left, action buttons underneath (watched, favorite, download, trailer), a tag row (year, duration, resolution, content rating, genres) beside it, overview and rating below, then a cast rail and a similar-titles rail.

TV shows use the same hero, driven by a selected episode that defaults to the next unwatched episode (`nextUp`) and can be changed via season/episode selection; the hero updates to describe whichever episode is selected.

Builds on the backend work merged in #361 (cast, trailer URL, similar titles, and content rating already exposed over GraphQL).

- New shared `DetailActionRow` and `CastRail` widgets used by both screens
- `SelectedEpisode` provider drives the show hero independently of the show query, so unrelated invalidations (e.g. toggling favorite) don't reset a manual episode pick
- Resume passthrough on the Play button now derives eligibility from whichever episode is selected, not just next-up
- Download button reflects "already downloaded" state
- Episode rail highlights whichever episode the hero currently describes

## Process

Implemented via `superpowers:subagent-driven-development` — 11 tasks, each with a per-task spec/quality review and fix loop. A final whole-branch review found one critical bug (the hero could get stuck on a permanent loading spinner for a fully-watched show, or after switching seasons — a cross-task integration issue no single task's review could have caught) plus four important and three minor findings; all were addressed in one fix wave and independently re-reviewed.

Known follow-up, not blocking: a season whose `hasFiles` flag is stale relative to per-episode availability (a narrow TOCTOU race with the library scanner) can still leave the hero on the spinner while the episode list below correctly shows "No episodes found." Worth a follow-up to render the same empty state in the hero body.

## Test plan

- [x] Full player suite green: `flutter test --concurrency=1` — 1627 passed
- [x] `flutter analyze` clean (51 pre-existing info-level lints, none in touched files)
- [x] New regression tests for: fully-watched show hero, season-switch hero re-targeting, resume passthrough, duplicate metadata removal, download-state icon, release year display