### PR TITLE
fix(release): correct floating-tag selection and bound the iOS job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,17 +330,24 @@ jobs:
           # patching an older line (v0.11.2 after v0.12.0) cannot drag
           # :latest, :0 and :0.11 backwards onto the older build. The same
           # applies to :beta against other prereleases.
+          #
+          # Only Mydia's own `vX.Y.Z` tags count. This repository also
+          # publishes the metadata-relay under `metadata-relay-vX.Y.Z`, and
+          # `ltrimstr("v")` leaves that prefix intact, so an unfiltered list
+          # hands `sort -V` a string beginning with a letter. That sorts above
+          # every numeric version, which made v0.13.0 look older than
+          # metadata-relay-v0.9.0 and silently skipped :latest, :0.13 and :0.
           if [ "$IS_PRERELEASE" = "true" ]; then
             CLASS="prerelease"
             NEWEST=$(gh release list --repo "$REPO" --limit 100 \
               --json tagName,isDraft,isPrerelease \
-              --jq '[.[] | select(.isDraft == false and .isPrerelease == true) | .tagName | ltrimstr("v")] | .[]' \
+              --jq '[.[] | select(.isDraft == false and .isPrerelease == true) | .tagName | select(test("^v[0-9]")) | ltrimstr("v")] | .[]' \
               | sort -V | tail -n1)
           else
             CLASS="stable"
             NEWEST=$(gh release list --repo "$REPO" --limit 100 \
               --json tagName,isDraft,isPrerelease \
-              --jq '[.[] | select(.isDraft == false and .isPrerelease == false) | .tagName | ltrimstr("v")] | .[]' \
+              --jq '[.[] | select(.isDraft == false and .isPrerelease == false) | .tagName | select(test("^v[0-9]")) | ltrimstr("v")] | .[]' \
               | sort -V | tail -n1)
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,17 +337,23 @@ jobs:
           # hands `sort -V` a string beginning with a letter. That sorts above
           # every numeric version, which made v0.13.0 look older than
           # metadata-relay-v0.9.0 and silently skipped :latest, :0.13 and :0.
+          #
+          # The pattern requires all three numeric components so it admits only
+          # what `sort -V` can order sensibly. A trailing prerelease suffix
+          # still matches, since `test` is not anchored at the end. `[.]` is
+          # used rather than an escaped dot to keep the expression readable
+          # through the YAML, shell and jq quoting layers.
           if [ "$IS_PRERELEASE" = "true" ]; then
             CLASS="prerelease"
             NEWEST=$(gh release list --repo "$REPO" --limit 100 \
               --json tagName,isDraft,isPrerelease \
-              --jq '[.[] | select(.isDraft == false and .isPrerelease == true) | .tagName | select(test("^v[0-9]")) | ltrimstr("v")] | .[]' \
+              --jq '[.[] | select(.isDraft == false and .isPrerelease == true) | .tagName | select(test("^v[0-9]+[.][0-9]+[.][0-9]+")) | ltrimstr("v")] | .[]' \
               | sort -V | tail -n1)
           else
             CLASS="stable"
             NEWEST=$(gh release list --repo "$REPO" --limit 100 \
               --json tagName,isDraft,isPrerelease \
-              --jq '[.[] | select(.isDraft == false and .isPrerelease == false) | .tagName | select(test("^v[0-9]")) | ltrimstr("v")] | .[]' \
+              --jq '[.[] | select(.isDraft == false and .isPrerelease == false) | .tagName | select(test("^v[0-9]+[.][0-9]+[.][0-9]+")) | ltrimstr("v")] | .[]' \
               | sort -V | tail -n1)
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,6 +485,16 @@ jobs:
     name: Player / iOS
     needs: prepare
     runs-on: macos-26
+    # `upload_to_testflight` uses `distribute_external: true`, which cannot skip
+    # waiting for Apple to finish processing the build, so a slow processing
+    # queue parks this job in a poll loop with no upper bound of its own. On
+    # v0.13.0 that ran 5h49m before the 6h default killed it, on a runner billed
+    # at 10x. The job normally finishes in 17-20 minutes; this bounds the wait
+    # while leaving generous headroom. Hitting it fails the publish gate, which
+    # is the correct outcome: re-dispatch with `allow_missing=ios` to ship
+    # without it, since the IPA reaches TestFlight whenever Apple is done
+    # regardless of what this job reports.
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Two independent faults the v0.13.0 release run exposed.

## 1. Floating Docker tags were silently skipped

The run pushed `:0.13.0` and `:0.13.0-pg` but moved no floating tag. `:latest`, `:0.13` and `:0` never updated, and `:latest` still resolves to the v0.12.0 digest.

`docker-merge` decides whether to apply floating tags by comparing this release against the newest already-published release of its class. That list is built from every release in the repository, stripping only a leading `v`:

    .tagName | ltrimstr("v")

This repository also publishes the metadata-relay under `metadata-relay-vX.Y.Z`. `ltrimstr("v")` does not match that prefix, so the tag survives intact, and `sort -V` places a string beginning with a letter above every numeric version. `NEWEST` resolved to `metadata-relay-v0.9.0`, and the job concluded:

    ##[warning]0.13.0 is older than the newest published stable release (metadata-relay-v0.9.0).
    Applying only :0.13.0 and skipping the floating tags so they keep pointing at metadata-relay-v0.9.0.

Filtering to Mydia's own `vX.Y.Z` tags fixes it. Applied to both the stable and prerelease branches: the prerelease path is correct today only because the metadata-relay releases are not marked prerelease, which is incidental rather than guaranteed.

**Why this did not surface earlier.** The `IS_NEWEST` guard was introduced in #299, during this release cycle. v0.12.0 predates it and applied floating tags unconditionally. The six v0.13.0 betas exercised only the prerelease branch. This run was the logic's first stable exercise.

**Severity.** Had the run reached publish, v0.13.0 would have shipped with `:latest` pointing at v0.12.0. Every user tracking `:latest` would have stayed on the old release with no signal.

## 2. The iOS job had no upper bound

`Player / iOS` spent 5h49m in `Upload to TestFlight` before the 6-hour default killed it, on a runner billed at 10x. The lane calls `upload_to_testflight(distribute_external: true)`, and external distribution cannot skip waiting for Apple to finish processing, so a slow processing queue parks the job in an unbounded poll loop.

`timeout-minutes: 45` bounds it. The job normally finishes in 17-20 minutes (19m42s on beta.5, 17m8s on beta.2), so this leaves generous headroom. Hitting the timeout fails the publish gate, which is correct: the operator re-dispatches with `allow_missing=ios`, and the IPA reaches TestFlight whenever Apple finishes regardless of what the job reports.

## Verification

`NEWEST` against the live release list:

| query | result |
| --- | --- |
| before | `metadata-relay-v0.9.0` |
| after, stable | `0.12.0` |
| after, prerelease | `0.13.0-beta.6` |

With `NEWEST=0.12.0`, sorting `0.13.0` and `0.12.0` with `sort -V` yields `0.13.0` last, so `IS_NEWEST=true` and the floating tags apply.

- [x] `release.yml` parses (`yaml.safe_load`, 12 jobs); `player-ios.timeout-minutes` reads back as `45`
- [x] Registry state confirming fault 1: `:latest` and `:latest-pg` both resolve to their v0.12.0 digests, `:0.13` does not exist, and `:beta` correctly resolves to `:0.13.0-beta.6`
