### PR TITLE
feat(player): show the TMDB rating on library grid posters

### DIFF
--- a/player/lib/presentation/models/library_data.dart
+++ b/player/lib/presentation/models/library_data.dart
@@ -23,6 +23,11 @@ class LibraryItem {
   final int? year;
   final String? posterUrl;
   final double? progressPercentage;
+
+  /// TMDB's score on a 0 to 10 scale, or null when the server sent none.
+  /// `0.0` is TMDB's value for a title nobody has voted on and is passed
+  /// through as-is; deciding what that means is the UI's job, not the model's.
+  final double? rating;
   final bool isFavorite;
   final String type;
   final String? subtitle;
@@ -35,6 +40,7 @@ class LibraryItem {
     this.year,
     this.posterUrl,
     this.progressPercentage,
+    this.rating,
     required this.isFavorite,
     required this.type,
     this.subtitle,

--- a/player/lib/presentation/screens/library/library_controller.dart
+++ b/player/lib/presentation/screens/library/library_controller.dart
@@ -137,6 +137,7 @@ LibraryData _parseTvShows(Map<String, dynamic> data) {
           (node['artwork'] as Map<String, dynamic>?)?['posterUrl'] as String?,
       // TV shows have no overall progress.
       progressPercentage: null,
+      rating: (node['rating'] as num?)?.toDouble(),
       isFavorite: node['isFavorite'] as bool,
       type: 'tv_show',
       subtitle: node['year'] != null ? '${node['year']}' : null,

--- a/player/lib/presentation/screens/library/library_controller.dart
+++ b/player/lib/presentation/screens/library/library_controller.dart
@@ -117,6 +117,7 @@ LibraryData _parseMovies(Map<String, dynamic> data) {
           (node['artwork'] as Map<String, dynamic>?)?['posterUrl'] as String?,
       progressPercentage:
           (node['progress'] as Map<String, dynamic>?)?['percentage'] as double?,
+      rating: (node['rating'] as num?)?.toDouble(),
       isFavorite: node['isFavorite'] as bool,
       type: 'movie',
       subtitle: node['year']?.toString(),

--- a/player/lib/presentation/screens/library/library_screen.dart
+++ b/player/lib/presentation/screens/library/library_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'library_controller.dart';
+import '../../models/library_data.dart';
 import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/app_shell.dart';
 import '../../widgets/cast_actions.dart';
@@ -506,7 +507,8 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     );
   }
 
-  Widget _buildGridView(BuildContext context, List items, double topPadding) {
+  Widget _buildGridView(
+      BuildContext context, List<LibraryItem> items, double topPadding) {
     final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
@@ -535,6 +537,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
               posterUrl: item.posterUrl,
               title: item.title,
               progressPercentage: item.progressPercentage,
+              rating: item.rating,
               isFavorite: item.isFavorite,
               onTap: () => _handleItemTap(item.id, item.type),
             );
@@ -544,7 +547,8 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     );
   }
 
-  Widget _buildListView(BuildContext context, List items, double topPadding) {
+  Widget _buildListView(
+      BuildContext context, List<LibraryItem> items, double topPadding) {
     final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final bottomPadding = isDesktop ? 32.0 : 100.0;
@@ -617,7 +621,7 @@ class _ActionButton extends StatelessWidget {
 }
 
 class _ListItem extends StatelessWidget {
-  final dynamic item;
+  final LibraryItem item;
   final VoidCallback onTap;
 
   const _ListItem({

--- a/player/lib/presentation/widgets/media_poster.dart
+++ b/player/lib/presentation/widgets/media_poster.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../core/theme/colors.dart';
 import 'poster_frame.dart';
 import 'progress_overlay.dart';
+import 'rating_badge.dart';
 
 /// A portrait poster for the library grid and list.
 ///
@@ -14,6 +15,10 @@ class MediaPoster extends StatelessWidget {
   final String title;
   final String? subtitle;
   final double? progressPercentage;
+
+  /// TMDB's score on a 0 to 10 scale. Null, or `0.0` for a title nobody has
+  /// voted on, renders no chip at all.
+  final double? rating;
   final bool isFavorite;
   final VoidCallback? onTap;
   final bool showTitle;
@@ -24,6 +29,7 @@ class MediaPoster extends StatelessWidget {
     required this.title,
     this.subtitle,
     this.progressPercentage,
+    this.rating,
     this.isFavorite = false,
     this.onTap,
     this.showTitle = true,
@@ -46,6 +52,7 @@ class MediaPoster extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final progress = progressPercentage;
+    final rating = this.rating;
 
     // The cursor sits out here rather than on the PosterFrame, because the
     // GestureDetector's tap target includes the title label and the affordance
@@ -69,6 +76,16 @@ class MediaPoster extends StatelessWidget {
                 overlays: [
                   if (progress != null && progress > 0)
                     ProgressOverlay(percentage: progress),
+                  // TMDB reports 0.0 for a title nobody has voted on, so 0 and
+                  // null both mean "no rating" and the overlay is omitted
+                  // rather than rendered empty. RatingBadge's doc explains why
+                  // the widget cannot hide itself from in here.
+                  if (rating != null && rating > 0)
+                    Positioned(
+                      top: 8,
+                      left: 8,
+                      child: RatingBadge(rating: rating),
+                    ),
                   if (isFavorite)
                     const Positioned(
                       top: 8,

--- a/player/lib/presentation/widgets/media_poster.dart
+++ b/player/lib/presentation/widgets/media_poster.dart
@@ -79,7 +79,7 @@ class MediaPoster extends StatelessWidget {
                   // TMDB reports 0.0 for a title nobody has voted on, so 0 and
                   // null both mean "no rating" and the overlay is omitted
                   // rather than rendered empty. RatingBadge's doc explains why
-                  // the widget cannot hide itself from in here.
+                  // the widget cannot hide itself.
                   if (rating != null && rating > 0)
                     Positioned(
                       top: 8,

--- a/player/lib/presentation/widgets/rating_badge.dart
+++ b/player/lib/presentation/widgets/rating_badge.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+/// The TMDB rating pill drawn over poster artwork.
+///
+/// Mirrors the treatment `movie_detail_screen.dart`'s `_buildStatBadge` uses
+/// for ratings, so a rating reads the same wherever the app shows one. The
+/// black scrim is deliberate rather than a palette surface: this chip sits
+/// directly on artwork and has to stay legible over a bright poster.
+///
+/// Takes a non-nullable [rating] on purpose. TMDB reports `0.0` for a title
+/// nobody has voted on and the server passes `vote_average` through unchanged,
+/// so `0.0` and "no rating" arrive indistinguishable and both must render
+/// nothing at all. That rule cannot live in here: `PosterFrame` requires every
+/// entry in its `overlays` list to position itself, and its stack is
+/// `StackFit.expand`, so a `SizedBox.shrink()` returned from [build] would
+/// inflate to cover the whole poster instead of disappearing. Callers omit the
+/// overlay entirely instead.
+class RatingBadge extends StatelessWidget {
+  /// The score on TMDB's 0 to 10 scale. Rendered to one decimal place.
+  final double rating;
+
+  const RatingBadge({
+    super.key,
+    required this.rating,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.star_rounded, size: 14, color: Colors.amber),
+          const SizedBox(width: 4),
+          Text(
+            rating.toStringAsFixed(1),
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/rating_badge.dart
+++ b/player/lib/presentation/widgets/rating_badge.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../core/theme/colors.dart';
+
 /// The TMDB rating pill drawn over poster artwork.
 ///
 /// Structurally this is the same chip as `_buildStatBadge` in
@@ -9,6 +11,9 @@ import 'package:flutter/material.dart';
 /// bright poster. Note that the movie detail screen renders ratings
 /// differently, as a plain unscrimmed row (`_buildRatingLine`), since it has a
 /// solid background to sit on.
+///
+/// The star takes `AppColors.primary` rather than a literal amber so it
+/// matches the rating star on the movie detail screen (`_buildRatingLine`).
 ///
 /// Takes a non-nullable [rating] on purpose. TMDB reports `0.0` for a title
 /// nobody has voted on and the server passes `vote_average` through unchanged,
@@ -38,7 +43,7 @@ class RatingBadge extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(Icons.star_rounded, size: 14, color: Colors.amber),
+          const Icon(Icons.star_rounded, size: 14, color: AppColors.primary),
           const SizedBox(width: 4),
           Text(
             rating.toStringAsFixed(1),

--- a/player/lib/presentation/widgets/rating_badge.dart
+++ b/player/lib/presentation/widgets/rating_badge.dart
@@ -24,7 +24,8 @@ import '../../core/theme/colors.dart';
 /// inflate to cover the whole poster instead of disappearing. Callers omit the
 /// overlay entirely instead.
 class RatingBadge extends StatelessWidget {
-  /// The score on TMDB's 0 to 10 scale. Rendered to one decimal place.
+  /// The score on TMDB's 0 to 10 scale. A whole score still renders with
+  /// its decimal, so 8 reads as "8.0".
   final double rating;
 
   const RatingBadge({

--- a/player/lib/presentation/widgets/rating_badge.dart
+++ b/player/lib/presentation/widgets/rating_badge.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 
 /// The TMDB rating pill drawn over poster artwork.
 ///
-/// Mirrors the treatment `movie_detail_screen.dart`'s `_buildStatBadge` uses
-/// for ratings, so a rating reads the same wherever the app shows one. The
-/// black scrim is deliberate rather than a palette surface: this chip sits
-/// directly on artwork and has to stay legible over a bright poster.
+/// Structurally this is the same chip as `_buildStatBadge` in
+/// `series_downloads_screen.dart`: the same padding, scrim, radius and row
+/// layout. The black scrim is deliberate rather than a palette surface,
+/// because this chip sits directly on artwork and has to stay legible over a
+/// bright poster. Note that the movie detail screen renders ratings
+/// differently, as a plain unscrimmed row (`_buildRatingLine`), since it has a
+/// solid background to sit on.
 ///
 /// Takes a non-nullable [rating] on purpose. TMDB reports `0.0` for a title
 /// nobody has voted on and the server passes `vote_average` through unchanged,

--- a/player/test/presentation/screens/library/library_controller_test.dart
+++ b/player/test/presentation/screens/library/library_controller_test.dart
@@ -9,6 +9,7 @@ import '../../../test_utils/stub_graphql_client.dart';
 Map<String, dynamic> _moviesPage(
   List<String> ids, {
   required bool hasNextPage,
+  double? rating,
 }) {
   return {
     '__typename': 'Query',
@@ -28,7 +29,7 @@ Map<String, dynamic> _moviesPage(
               'runtime': null,
               'genres': <String>[],
               'contentRating': null,
-              'rating': null,
+              'rating': rating,
               'artwork': {
                 '__typename': 'Artwork',
                 'posterUrl': null,
@@ -206,5 +207,51 @@ void main() {
     await Future.wait([first, second]);
 
     expect(link.requests.length, before + 1);
+  });
+
+  test('carries the TMDB rating onto each movie item', () async {
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith(
+          (ref) async => stubClient(
+            StubLink.responses([
+              _moviesPage(['1'], hasNextPage: false, rating: 7.8)
+            ]),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await waitForValue(
+      container,
+      libraryControllerProvider(LibraryType.movies),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(data.items.single.rating, 7.8);
+  });
+
+  test('leaves an unrated movie null rather than defaulting it', () async {
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith(
+          (ref) async => stubClient(
+            StubLink.responses([
+              _moviesPage(['1'], hasNextPage: false)
+            ]),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await waitForValue(
+      container,
+      libraryControllerProvider(LibraryType.movies),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(data.items.single.rating, isNull);
   });
 }

--- a/player/test/presentation/screens/library/library_controller_test.dart
+++ b/player/test/presentation/screens/library/library_controller_test.dart
@@ -53,6 +53,58 @@ Map<String, dynamic> _moviesPage(
   };
 }
 
+/// The TV shows connection. Its node shape differs from a movie's: no
+/// `progress` and no `runtime`, plus `status`, `seasonCount`, `episodeCount`
+/// and `nextEpisode`.
+Map<String, dynamic> _tvShowsPage(
+  List<String> ids, {
+  required bool hasNextPage,
+  double? rating,
+}) {
+  return {
+    '__typename': 'Query',
+    'tvShows': {
+      '__typename': 'TvShowConnection',
+      'edges': [
+        for (final id in ids)
+          {
+            '__typename': 'TvShowEdge',
+            'cursor': 'c-$id',
+            'node': {
+              '__typename': 'TvShow',
+              'id': id,
+              'title': 'Show $id',
+              'year': 2026,
+              'overview': null,
+              'status': null,
+              'genres': <String>[],
+              'contentRating': null,
+              'rating': rating,
+              'seasonCount': 1,
+              'episodeCount': 8,
+              'artwork': {
+                '__typename': 'Artwork',
+                'posterUrl': null,
+                'backdropUrl': null,
+                'thumbnailUrl': null,
+              },
+              'isFavorite': false,
+              'nextEpisode': null,
+            },
+          }
+      ],
+      'pageInfo': {
+        '__typename': 'PageInfo',
+        'hasNextPage': hasNextPage,
+        'hasPreviousPage': false,
+        'startCursor': 'c-${ids.first}',
+        'endCursor': 'c-${ids.last}',
+      },
+      'totalCount': ids.length,
+    },
+  };
+}
+
 void main() {
   test('emits the first page with its cursor and hasMore', () async {
     final container = ProviderContainer(
@@ -249,6 +301,56 @@ void main() {
     final data = await waitForValue(
       container,
       libraryControllerProvider(LibraryType.movies),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(data.items.single.rating, isNull);
+  });
+
+  test('carries the TMDB rating onto each TV show item', () async {
+    // Its own container and its own stub, never shared with the movies tests:
+    // StubLink.responses is index-based and repeats its last entry, so a
+    // shared script silently mis-answers whichever query runs second.
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith(
+          (ref) async => stubClient(
+            StubLink.responses([
+              _tvShowsPage(['1'], hasNextPage: false, rating: 9.1)
+            ]),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await waitForValue(
+      container,
+      libraryControllerProvider(LibraryType.tvShows),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(data.items.single.rating, 9.1);
+    expect(data.items.single.type, 'tv_show');
+  });
+
+  test('leaves an unrated TV show null rather than defaulting it', () async {
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith(
+          (ref) async => stubClient(
+            StubLink.responses([
+              _tvShowsPage(['1'], hasNextPage: false)
+            ]),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await waitForValue(
+      container,
+      libraryControllerProvider(LibraryType.tvShows),
       (value) => value.items.isNotEmpty,
     );
 

--- a/player/test/presentation/screens/library/library_screen_layout_test.dart
+++ b/player/test/presentation/screens/library/library_screen_layout_test.dart
@@ -13,6 +13,7 @@ import 'package:player/core/graphql/watch/query_key.dart';
 import 'package:player/presentation/screens/library/library_controller.dart';
 import 'package:player/presentation/screens/library/library_screen.dart';
 import 'package:player/presentation/widgets/media_poster.dart';
+import 'package:player/presentation/widgets/rating_badge.dart';
 
 import '../../../test_utils/mock_network_images.dart';
 import '../../../test_utils/stub_graphql_client.dart';
@@ -321,5 +322,35 @@ void main() {
 
     final poster = tester.widget<MediaPoster>(find.byType(MediaPoster).first);
     expect(poster.rating, 9.1);
+    expect(find.text('9.1'), findsOneWidget);
+  });
+
+  testWidgets(
+      'an unvoted title shows no chip, since TMDB reports 0.0 for no votes',
+      (tester) async {
+    await pumpLibrary(
+      tester,
+      size: kDesktopSize,
+      itemCount: 1,
+      rating: 0,
+    );
+
+    expect(find.byType(RatingBadge), findsNothing);
+  });
+
+  testWidgets('list view omits the rating chip even when the data has one',
+      (tester) async {
+    await pumpLibrary(
+      tester,
+      size: kDesktopSize,
+      itemCount: 1,
+      rating: 8.4,
+    );
+
+    // In grid mode the toggle button shows the *list* icon.
+    await tester.tap(find.byIcon(Icons.view_list_rounded));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RatingBadge), findsNothing);
   });
 }

--- a/player/test/presentation/screens/library/library_screen_layout_test.dart
+++ b/player/test/presentation/screens/library/library_screen_layout_test.dart
@@ -36,7 +36,7 @@ const Size kMobileSize = Size(600, 900);
 /// `__typename` selection into every selection set, and the normalized cache
 /// refuses to write data that lacks a matching one. A miss surfaces as a
 /// spurious `hasException`, not as an obvious error.
-Map<String, dynamic> moviesPage(List<String> ids) => {
+Map<String, dynamic> moviesPage(List<String> ids, {double? rating}) => {
       '__typename': 'Query',
       'movies': {
         '__typename': 'MovieConnection',
@@ -54,7 +54,7 @@ Map<String, dynamic> moviesPage(List<String> ids) => {
                 'runtime': null,
                 'genres': <String>[],
                 'contentRating': null,
-                'rating': null,
+                'rating': rating,
                 'artwork': {
                   '__typename': 'Artwork',
                   'posterUrl': null,
@@ -79,7 +79,7 @@ Map<String, dynamic> moviesPage(List<String> ids) => {
 
 /// The TV shows connection, whose node shape differs from a movie's: no
 /// `progress`, plus `status`, `seasonCount`, `episodeCount` and `nextEpisode`.
-Map<String, dynamic> tvShowsPage(List<String> ids) => {
+Map<String, dynamic> tvShowsPage(List<String> ids, {double? rating}) => {
       '__typename': 'Query',
       'tvShows': {
         '__typename': 'TvShowConnection',
@@ -97,7 +97,7 @@ Map<String, dynamic> tvShowsPage(List<String> ids) => {
                 'status': null,
                 'genres': <String>[],
                 'contentRating': null,
-                'rating': null,
+                'rating': rating,
                 'seasonCount': 1,
                 'episodeCount': 8,
                 'artwork': {
@@ -134,6 +134,7 @@ Future<void> pumpLibrary(
   required Size size,
   LibraryType libraryType = LibraryType.movies,
   int itemCount = 40,
+  double? rating,
   List<Override> extraOverrides = const [],
   bool settle = true,
 }) async {
@@ -143,8 +144,9 @@ Future<void> pumpLibrary(
   addTearDown(tester.view.reset);
 
   final ids = List.generate(itemCount, (i) => '$i');
-  final page =
-      libraryType == LibraryType.movies ? moviesPage(ids) : tvShowsPage(ids);
+  final page = libraryType == LibraryType.movies
+      ? moviesPage(ids, rating: rating)
+      : tvShowsPage(ids, rating: rating);
 
   await mockNetworkImages(() async {
     await tester.pumpWidget(
@@ -292,5 +294,32 @@ void main() {
     await tester.pump();
 
     expect(before - firstPosterTop(tester), 120);
+  });
+
+  testWidgets('the grid hands each poster its TMDB rating', (tester) async {
+    await pumpLibrary(
+      tester,
+      size: kDesktopSize,
+      itemCount: 1,
+      rating: 8.4,
+    );
+
+    final poster = tester.widget<MediaPoster>(find.byType(MediaPoster).first);
+    expect(poster.rating, 8.4);
+    expect(find.text('8.4'), findsOneWidget);
+  });
+
+  testWidgets('a TV shows grid hands its posters the rating too',
+      (tester) async {
+    await pumpLibrary(
+      tester,
+      size: kDesktopSize,
+      libraryType: LibraryType.tvShows,
+      itemCount: 1,
+      rating: 9.1,
+    );
+
+    final poster = tester.widget<MediaPoster>(find.byType(MediaPoster).first);
+    expect(poster.rating, 9.1);
   });
 }

--- a/player/test/presentation/widgets/media_poster_test.dart
+++ b/player/test/presentation/widgets/media_poster_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/presentation/widgets/media_poster.dart';
+import 'package:player/presentation/widgets/rating_badge.dart';
 
 import '../../test_utils/hover_affordance.dart';
 import '../../test_utils/poster_contract.dart';
@@ -86,6 +87,60 @@ void main() {
       await tester.tap(find.byType(MediaPoster));
 
       expect(tapped, isTrue);
+    });
+
+    testWidgets('renders the rating chip when a title has one', (tester) async {
+      await tester.pumpWidget(
+        posterHost(
+          const MediaPoster(title: 'Show', rating: 7.8),
+          size: _posterHost,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RatingBadge), findsOneWidget);
+      expect(find.text('7.8'), findsOneWidget);
+    });
+
+    testWidgets('renders no chip when a title has no rating', (tester) async {
+      await tester.pumpWidget(
+        posterHost(const MediaPoster(title: 'Show'), size: _posterHost),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RatingBadge), findsNothing);
+    });
+
+    testWidgets('renders no chip for 0.0, which TMDB uses for "no votes yet"',
+        (tester) async {
+      // The server passes vote_average through unchanged, so an unvoted title
+      // is indistinguishable from an unrated one and both must show nothing.
+      await tester.pumpWidget(
+        posterHost(
+          const MediaPoster(title: 'Show', rating: 0),
+          size: _posterHost,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RatingBadge), findsNothing);
+    });
+
+    testWidgets('the chip clears the favorite heart', (tester) async {
+      // The heart holds top-right and the chip holds top-left, so a favorite
+      // with a rating shows both without either covering the other.
+      await tester.pumpWidget(
+        posterHost(
+          const MediaPoster(title: 'Show', rating: 7.8, isFavorite: true),
+          size: _posterHost,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final chip = tester.getRect(find.byType(RatingBadge));
+      final heart = tester.getRect(find.byIcon(Icons.favorite));
+
+      expect(chip.right, lessThan(heart.left));
     });
   });
 }

--- a/player/test/presentation/widgets/rating_badge_test.dart
+++ b/player/test/presentation/widgets/rating_badge_test.dart
@@ -14,8 +14,8 @@ void main() {
   });
 
   testWidgets('keeps a trailing decimal on a whole score', (tester) async {
-    // TMDB sends whole values as JSON integers, so this is the shape a title
-    // rated exactly 8 arrives in. It must read "8.0", not "8".
+    // A whole-valued score must still show its decimal place, so the chip
+    // reads "8.0" rather than "8".
     await tester.pumpWidget(_host(const RatingBadge(rating: 8)));
 
     expect(find.text('8.0'), findsOneWidget);

--- a/player/test/presentation/widgets/rating_badge_test.dart
+++ b/player/test/presentation/widgets/rating_badge_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/theme/colors.dart';
 import 'package:player/presentation/widgets/rating_badge.dart';
 
 Widget _host(Widget child) =>
@@ -20,11 +21,12 @@ void main() {
     expect(find.text('8.0'), findsOneWidget);
   });
 
-  testWidgets('carries an amber star', (tester) async {
+  testWidgets('carries a star in the app accent, matching the detail screen',
+      (tester) async {
     await tester.pumpWidget(_host(const RatingBadge(rating: 6.1)));
 
     final icon = tester.widget<Icon>(find.byIcon(Icons.star_rounded));
-    expect(icon.color, Colors.amber);
+    expect(icon.color, AppColors.primary);
   });
 
   testWidgets('sits on a dark scrim rather than a palette surface',

--- a/player/test/presentation/widgets/rating_badge_test.dart
+++ b/player/test/presentation/widgets/rating_badge_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/rating_badge.dart';
+
+Widget _host(Widget child) =>
+    MaterialApp(home: Scaffold(body: Center(child: child)));
+
+void main() {
+  testWidgets('rounds the score to one decimal place', (tester) async {
+    await tester.pumpWidget(_host(const RatingBadge(rating: 7.75)));
+
+    expect(find.text('7.8'), findsOneWidget);
+  });
+
+  testWidgets('keeps a trailing decimal on a whole score', (tester) async {
+    // TMDB sends whole values as JSON integers, so this is the shape a title
+    // rated exactly 8 arrives in. It must read "8.0", not "8".
+    await tester.pumpWidget(_host(const RatingBadge(rating: 8)));
+
+    expect(find.text('8.0'), findsOneWidget);
+  });
+
+  testWidgets('carries an amber star, matching the detail screen',
+      (tester) async {
+    await tester.pumpWidget(_host(const RatingBadge(rating: 6.1)));
+
+    final icon = tester.widget<Icon>(find.byIcon(Icons.star_rounded));
+    expect(icon.color, Colors.amber);
+  });
+
+  testWidgets('sits on a dark scrim rather than a palette surface',
+      (tester) async {
+    // The chip is drawn straight onto poster artwork, so its legibility comes
+    // from the scrim. A palette surface colour would wash out over a bright
+    // poster.
+    await tester.pumpWidget(_host(const RatingBadge(rating: 6.1)));
+
+    final container = tester.widget<Container>(
+      find.descendant(
+        of: find.byType(RatingBadge),
+        matching: find.byType(Container),
+      ),
+    );
+    final decoration = container.decoration as BoxDecoration;
+    expect(decoration.color, Colors.black.withValues(alpha: 0.4));
+  });
+}

--- a/player/test/presentation/widgets/rating_badge_test.dart
+++ b/player/test/presentation/widgets/rating_badge_test.dart
@@ -20,8 +20,7 @@ void main() {
     expect(find.text('8.0'), findsOneWidget);
   });
 
-  testWidgets('carries an amber star, matching the detail screen',
-      (tester) async {
+  testWidgets('carries an amber star', (tester) async {
     await tester.pumpWidget(_host(const RatingBadge(rating: 6.1)));
 
     final icon = tester.widget<Icon>(find.byIcon(Icons.star_rounded));


### PR DESCRIPTION
Shows each title's TMDB rating on the library grid, so you can judge a title while scanning without opening it.

The rating chip sits in the poster's top-left corner, clear of the favorite heart at top-right and the progress bar along the bottom. Movies and TV Shows both get it.

## Why this is small

The rating already arrived on every library page and was thrown away. Both queries have always selected `rating` (TMDB's `vote_average`, resolved server-side from `vote_average`), and the two parsers in `library_controller.dart` just never copied it onto `LibraryItem`. So there is no GraphQL, schema, or backend change here, and no cache migration: because the field was already in both query documents, persisted Hive cache entries carry it, and users upgrading mid-flight see ratings immediately rather than after a refetch.

## What's here

- `RatingBadge`, a new widget owning the chip: black scrim at 40%, `AppColors.primary` star, score to one decimal.
- `MediaPoster` gains an optional `rating` and renders the chip as a positioned overlay.
- Both library parsers carry the rating onto `LibraryItem`.
- The grid passes it through, and `_buildGridView` / `_buildListView` / `_ListItem` get concrete `LibraryItem` types instead of a bare `List` and `dynamic`, so the new field is checked at compile time rather than at runtime.

## An absent rating renders nothing

TMDB reports `0.0` for a title nobody has voted on and the server passes `vote_average` through unchanged, so `0.0` and "no rating" arrive indistinguishable. Both render no chip. A film genuinely voted to 0.0 would also show nothing, which is vanishingly rare and better than a star chip reading `0.0` on every unmatched or freshly added title.

## Scope

Library grid only. The library list view, favorites, recently added, unwatched, and collection detail all render `MediaPoster` too, but none of their queries select `rating`; `MediaPoster`'s new parameter is optional so all five are untouched. No settings toggle and no sort-by-rating (no library query accepts a sort argument today).

## Testing

Full player suite: 1643 passing at `--concurrency=1` (the default silently drops files while exiting 0). `flutter analyze`: 0 errors, 0 warnings.

New coverage includes the chip's formatting and colour, the null and `0.0` hide rules at the widget level and driven end to end through the screen, a test pinning the list view's deliberate omission, and the first-ever tests of `_parseTvShows`, which had none.

## Two known issues, neither introduced here

- Unvoted titles still render "0.0 TMDB" on the movie and show **detail** screens, whose `ratingDisplay` getters return empty only for null. The grid now hides those, so the two surfaces disagree. Pre-existing; worth a follow-up one-liner on both getters.
- The scrim at 40% puts white 12px text at roughly 2.9:1 over bright artwork, under WCAG AA, despite the scrim existing for legibility. It matches the existing download stat chips. 0.55 alpha or a text shadow would close it.
