### PR TITLE
fix(player): put the detail hero play button back on the title row

### DIFF
--- a/player/lib/presentation/screens/movie/movie_detail_screen.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_screen.dart
@@ -519,18 +519,25 @@ class MovieDetailScreen extends ConsumerWidget {
                     ),
                   ),
                   const SizedBox(width: 16),
-                  HeroPlayControl(
-                    files: movie.files,
-                    onFileSelected: (file) => context.push(
-                      '/player/movie/${movie.id}?fileId=${file.id}'
-                      '&title=${Uri.encodeComponent(movie.title)}',
-                    ),
-                  ),
+                  _buildHeroPlayControl(context, movie),
                 ],
               ),
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  /// The hero's Play affordance, extracted (like the other `_buildX` helpers
+  /// in this file) for readability: the overlay `Row` it lives in is already
+  /// deeply nested inside the `SliverAppBar`'s `FlexibleSpaceBar`/`Stack`.
+  Widget _buildHeroPlayControl(BuildContext context, MovieDetail movie) {
+    return HeroPlayControl(
+      files: movie.files,
+      onFileSelected: (file) => context.push(
+        '/player/movie/${movie.id}?fileId=${file.id}'
+        '&title=${Uri.encodeComponent(movie.title)}',
       ),
     );
   }

--- a/player/lib/presentation/screens/movie/movie_detail_screen.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_screen.dart
@@ -19,7 +19,7 @@ import '../../widgets/cast_rail.dart';
 import '../../widgets/content_rail.dart';
 import '../../widgets/detail_action_row.dart';
 import '../../widgets/movie_watched_controls.dart';
-import '../../widgets/smart_play_button.dart';
+import '../../widgets/hero_play_control.dart';
 
 /// Below this width the hero's action column and tag column stack instead
 /// of sitting side by side. Matches the wide-layout mockup's tablet/desktop
@@ -262,37 +262,17 @@ class MovieDetailScreen extends ConsumerWidget {
 
   Widget _buildActionColumn(
       BuildContext context, WidgetRef ref, MovieDetail movie) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('Play', style: TextStyle(fontWeight: FontWeight.bold)),
-            const SizedBox(width: 8),
-            SmartPlayButton(
-              files: movie.files,
-              onFileSelected: (file) => context.push(
-                '/player/movie/${movie.id}?fileId=${file.id}&title=${Uri.encodeComponent(movie.title)}',
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 18),
-        DetailActionRow(
-          watched: movie.isWatched,
-          onToggleWatched: () => _toggleWatched(context, ref, movie.isWatched),
-          isFavorite: movie.isFavorite,
-          onToggleFavorite: () => ref
-              .read(movieDetailControllerProvider(id).notifier)
-              .toggleFavorite(),
-          onDownload: () => _startDownload(context, ref, movie),
-          trailerUrl: movie.trailerUrl,
-          showDownload: isDownloadSupported && movie.files.isNotEmpty,
-          isDownloaded:
-              ref.watch(isMediaDownloadedProvider(movie.id)).value ?? false,
-        ),
-      ],
+    return DetailActionRow(
+      watched: movie.isWatched,
+      onToggleWatched: () => _toggleWatched(context, ref, movie.isWatched),
+      isFavorite: movie.isFavorite,
+      onToggleFavorite: () =>
+          ref.read(movieDetailControllerProvider(id).notifier).toggleFavorite(),
+      onDownload: () => _startDownload(context, ref, movie),
+      trailerUrl: movie.trailerUrl,
+      showDownload: isDownloadSupported && movie.files.isNotEmpty,
+      isDownloaded:
+          ref.watch(isMediaDownloadedProvider(movie.id)).value ?? false,
     );
   }
 
@@ -500,33 +480,52 @@ class MovieDetailScreen extends ConsumerWidget {
               left: 20,
               right: 20,
               bottom: 20,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
-                  Text(
-                    movie.title,
-                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      shadows: [
-                        Shadow(
-                          color: Colors.black.withValues(alpha: 0.8),
-                          blurRadius: 8,
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          movie.title,
+                          style: Theme.of(context)
+                              .textTheme
+                              .headlineMedium
+                              ?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            shadows: [
+                              Shadow(
+                                color: Colors.black.withValues(alpha: 0.8),
+                                blurRadius: 8,
+                              ),
+                            ],
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
                         ),
+                        if (movie.yearDisplay.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            movie.yearDisplay,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(color: AppColors.textSecondary),
+                          ),
+                        ],
                       ],
                     ),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
                   ),
-                  if (movie.yearDisplay.isNotEmpty) ...[
-                    const SizedBox(height: 4),
-                    Text(
-                      movie.yearDisplay,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color: AppColors.textSecondary,
-                          ),
+                  const SizedBox(width: 16),
+                  HeroPlayControl(
+                    files: movie.files,
+                    onFileSelected: (file) => context.push(
+                      '/player/movie/${movie.id}?fileId=${file.id}'
+                      '&title=${Uri.encodeComponent(movie.title)}',
                     ),
-                  ],
+                  ),
                 ],
               ),
             ),

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -469,10 +469,9 @@ class ShowDetailScreen extends ConsumerWidget {
     );
   }
 
-  /// The hero's Play affordance, built here rather than inline so the
-  /// `onFileSelected` closure captures a non-nullable [episode] instead of
-  /// relying on flow promotion of the nullable `selectedEpisode` parameter
-  /// across a closure boundary.
+  /// The hero's Play affordance, extracted (like the other `_buildX` helpers
+  /// in this file) for readability: the overlay `Row` it lives in is already
+  /// deeply nested inside the `SliverAppBar`'s `FlexibleSpaceBar`/`Stack`.
   Widget _buildHeroPlayControl(
     BuildContext context,
     ShowDetail show,

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -25,7 +25,7 @@ import '../../widgets/cast_button.dart';
 import '../../widgets/cast_rail.dart';
 import '../../widgets/content_rail.dart';
 import '../../widgets/detail_action_row.dart';
-import '../../widgets/smart_play_button.dart';
+import '../../widgets/hero_play_control.dart';
 
 /// Below this width the hero's action column and tag column stack instead
 /// of sitting side by side. Matches the movie detail hero's breakpoint — see
@@ -388,36 +388,53 @@ class ShowDetailScreen extends ConsumerWidget {
               left: 20,
               right: 20,
               bottom: 20,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
-                  Text(
-                    show.title,
-                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      shadows: [
-                        Shadow(
-                          color: Colors.black.withValues(alpha: 0.8),
-                          blurRadius: 8,
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          show.title,
+                          style: Theme.of(context)
+                              .textTheme
+                              .headlineMedium
+                              ?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            shadows: [
+                              Shadow(
+                                color: Colors.black.withValues(alpha: 0.8),
+                                blurRadius: 8,
+                              ),
+                            ],
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
                         ),
+                        if (show.yearDisplay.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            show.yearDisplay,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(color: AppColors.textSecondary),
+                          ),
+                        ],
+                        if (selectedEpisode != null) ...[
+                          const SizedBox(height: 8),
+                          _buildEpisodeContextPill(show, selectedEpisode),
+                        ],
                       ],
                     ),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
                   ),
-                  if (show.yearDisplay.isNotEmpty) ...[
-                    const SizedBox(height: 4),
-                    Text(
-                      show.yearDisplay,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color: AppColors.textSecondary,
-                          ),
-                    ),
-                  ],
+                  // Gap and control are emitted together so a null episode
+                  // leaves no dangling spacer.
                   if (selectedEpisode != null) ...[
-                    const SizedBox(height: 8),
-                    _buildEpisodeContextPill(show, selectedEpisode),
+                    const SizedBox(width: 16),
+                    _buildHeroPlayControl(context, show, selectedEpisode),
                   ],
                 ],
               ),
@@ -449,6 +466,29 @@ class ShowDetailScreen extends ConsumerWidget {
           color: AppColors.textPrimary,
         ),
       ),
+    );
+  }
+
+  /// The hero's Play affordance, built here rather than inline so the
+  /// `onFileSelected` closure captures a non-nullable [episode] instead of
+  /// relying on flow promotion of the nullable `selectedEpisode` parameter
+  /// across a closure boundary.
+  Widget _buildHeroPlayControl(
+    BuildContext context,
+    ShowDetail show,
+    Episode episode,
+  ) {
+    return HeroPlayControl(
+      files: episode.files,
+      onFileSelected: (file) {
+        final title = '${show.title} - ${episode.episodeCode}';
+        context.push(
+          '/player/episode/${episode.id}?fileId=${file.id}'
+          '&title=${Uri.encodeComponent(title)}&showId=$id'
+          '&seasonNumber=${episode.seasonNumber}'
+          '${_resumeSuffix(episode)}',
+        );
+      },
     );
   }
 
@@ -508,54 +548,29 @@ class ShowDetailScreen extends ConsumerWidget {
     ShowDetail show,
     Episode episode,
   ) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('Play', style: TextStyle(fontWeight: FontWeight.bold)),
-            const SizedBox(width: 8),
-            SmartPlayButton(
-              files: episode.files,
-              onFileSelected: (file) {
-                final title = '${show.title} - ${episode.episodeCode}';
-                context.push(
-                  '/player/episode/${episode.id}?fileId=${file.id}'
-                  '&title=${Uri.encodeComponent(title)}&showId=$id&seasonNumber=${episode.seasonNumber}'
-                  '${_resumeSuffix(episode)}',
-                );
-              },
-            ),
-          ],
-        ),
-        const SizedBox(height: 18),
-        DetailActionRow(
-          watched: episode.progress?.watched ?? false,
-          onToggleWatched: () => episode.progress?.watched ?? false
-              ? ref
-                  .read(seasonEpisodesControllerProvider(
-                          showId: id, seasonNumber: episode.seasonNumber)
-                      .notifier)
-                  .markEpisodeUnwatched(episode)
-              : ref
-                  .read(seasonEpisodesControllerProvider(
-                          showId: id, seasonNumber: episode.seasonNumber)
-                      .notifier)
-                  .markEpisodeWatched(episode),
-          isFavorite: show.isFavorite,
-          onToggleFavorite: () => ref
-              .read(showDetailControllerProvider(id).notifier)
-              .toggleFavorite(),
-          onDownload: () => _startEpisodeDownload(context, ref, show, episode),
-          trailerUrl: show.trailerUrl,
-          showDownload: isDownloadSupported && episode.files.isNotEmpty,
-          // Per-episode, not per-show: the hero's Download action downloads
-          // the selected episode.
-          isDownloaded:
-              ref.watch(isMediaDownloadedProvider(episode.id)).value ?? false,
-        ),
-      ],
+    return DetailActionRow(
+      watched: episode.progress?.watched ?? false,
+      onToggleWatched: () => episode.progress?.watched ?? false
+          ? ref
+              .read(seasonEpisodesControllerProvider(
+                      showId: id, seasonNumber: episode.seasonNumber)
+                  .notifier)
+              .markEpisodeUnwatched(episode)
+          : ref
+              .read(seasonEpisodesControllerProvider(
+                      showId: id, seasonNumber: episode.seasonNumber)
+                  .notifier)
+              .markEpisodeWatched(episode),
+      isFavorite: show.isFavorite,
+      onToggleFavorite: () =>
+          ref.read(showDetailControllerProvider(id).notifier).toggleFavorite(),
+      onDownload: () => _startEpisodeDownload(context, ref, show, episode),
+      trailerUrl: show.trailerUrl,
+      showDownload: isDownloadSupported && episode.files.isNotEmpty,
+      // Per-episode, not per-show: the hero's Download action downloads
+      // the selected episode.
+      isDownloaded:
+          ref.watch(isMediaDownloadedProvider(episode.id)).value ?? false,
     );
   }
 

--- a/player/lib/presentation/widgets/detail_action_row.dart
+++ b/player/lib/presentation/widgets/detail_action_row.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../core/theme/colors.dart';
 
-/// Four-button action row under the hero's big Play button: mark
+/// Four-button action row in the detail body, below the hero: mark
 /// watched/unwatched, favorite, download, and (when a trailer exists) open it
-/// on YouTube in a new tab. Shared between the movie and TV show hero, since
-/// both need the identical row.
+/// on YouTube in a new tab. Shared between the movie and TV show detail
+/// screens, since both need the identical row.
 class DetailActionRow extends StatelessWidget {
   final bool watched;
   final VoidCallback onToggleWatched;

--- a/player/lib/presentation/widgets/hero_play_control.dart
+++ b/player/lib/presentation/widgets/hero_play_control.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/models/media_file.dart';
+import 'smart_play_button.dart';
+
+/// The detail hero's primary Play affordance: a bold "Play" label beside
+/// [SmartPlayButton]'s auto-selecting play control.
+///
+/// Sits in the backdrop overlay's title row on both the show and movie detail
+/// heroes, as the Row's non-flex trailing child. That is what pins it to the
+/// hero's right edge: the sibling title column is [Expanded] and absorbs all
+/// leftover width, while this control takes only its intrinsic size.
+class HeroPlayControl extends StatelessWidget {
+  final List<MediaFile> files;
+  final void Function(MediaFile) onFileSelected;
+
+  const HeroPlayControl({
+    super.key,
+    required this.files,
+    required this.onFileSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // MainAxisSize.min because a non-flex Row child receives unbounded
+    // main-axis constraints. Under those RenderFlex sets canFlex = false and
+    // falls back to the children's intrinsic size, so MainAxisSize.max happens
+    // to behave identically here and MainAxisAlignment has no free space to
+    // distribute. Stating min keeps the intent readable and keeps the widget
+    // correct if it is ever placed under bounded constraints.
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Text('Play', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(width: 8),
+        SmartPlayButton(files: files, onFileSelected: onFileSelected),
+      ],
+    );
+  }
+}

--- a/player/lib/presentation/widgets/hero_play_control.dart
+++ b/player/lib/presentation/widgets/hero_play_control.dart
@@ -10,6 +10,14 @@ import 'smart_play_button.dart';
 /// heroes, as the Row's non-flex trailing child. That is what pins it to the
 /// hero's right edge: the sibling title column is [Expanded] and absorbs all
 /// leftover width, while this control takes only its intrinsic size.
+///
+/// That non-flex position gives [SmartPlayButton] unbounded main-axis
+/// constraints, which is only safe because `state:` is never passed through
+/// here. If a future caller threads `state:` to this widget to restore the
+/// labelled pill form, it must first give this control a bounded width —
+/// otherwise `SmartPlayButton`'s `kPillCollapseWidth` check sees an infinite
+/// `constraints.maxWidth`, the pill never collapses, and it overflows narrow
+/// heroes.
 class HeroPlayControl extends StatelessWidget {
   final List<MediaFile> files;
   final void Function(MediaFile) onFileSelected;

--- a/player/test/presentation/screens/movie/movie_detail_screen_test.dart
+++ b/player/test/presentation/screens/movie/movie_detail_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/presentation/screens/movie/movie_detail_screen.dart';
 import 'package:player/presentation/widgets/cast_rail.dart';
 import 'package:player/presentation/widgets/detail_action_row.dart';
+import 'package:player/presentation/widgets/play_button.dart';
 
 import '../../../test_utils/mock_network_images.dart';
 import '../../../test_utils/stub_graphql_client.dart';
@@ -160,5 +161,30 @@ void main() {
     );
 
     expect(find.byType(LinearProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('hero play control sits flush against the overlay right edge',
+      (tester) async {
+    await _pumpScreen(tester, const Size(1000, 900));
+    await tester.pumpAndSettle();
+
+    // The content overlay is inset 20 from the right of the 1000px surface.
+    // The fixture supplies no files, so SmartPlayButton renders neither a
+    // resolution label nor a dropdown and PlayButton is its only child.
+    expect(tester.getRect(find.byType(PlayButton)).right, closeTo(980, 0.5));
+  });
+
+  testWidgets('hero play control lives in the hero, not the body',
+      (tester) async {
+    await _pumpScreen(tester, const Size(1000, 900));
+    await tester.pumpAndSettle();
+
+    // 380 is the hero SliverAppBar's expandedHeight
+    // (movie_detail_screen.dart:448). Unscrolled, anything below that line is
+    // in the body, where _buildActionColumn lives.
+    final play = tester.getRect(find.byType(PlayButton));
+    final actions = tester.getRect(find.byType(DetailActionRow));
+    expect(play.bottom, lessThan(380));
+    expect(play.bottom, lessThan(actions.top));
   });
 }

--- a/player/test/presentation/screens/movie/movie_detail_screen_test.dart
+++ b/player/test/presentation/screens/movie/movie_detail_screen_test.dart
@@ -179,9 +179,9 @@ void main() {
     await _pumpScreen(tester, const Size(1000, 900));
     await tester.pumpAndSettle();
 
-    // 380 is the hero SliverAppBar's expandedHeight
-    // (movie_detail_screen.dart:448). Unscrolled, anything below that line is
-    // in the body, where _buildActionColumn lives.
+    // 380 is the hero SliverAppBar's expandedHeight, set in
+    // _buildHeroSection. Unscrolled, anything below that line is in the
+    // body, where _buildActionColumn lives.
     final play = tester.getRect(find.byType(PlayButton));
     final actions = tester.getRect(find.byType(DetailActionRow));
     expect(play.bottom, lessThan(380));

--- a/player/test/presentation/screens/show/show_detail_screen_test.dart
+++ b/player/test/presentation/screens/show/show_detail_screen_test.dart
@@ -393,4 +393,48 @@ void main() {
     expect(pushed, hasLength(1));
     expect(pushed.single, isNot(contains('resume=')));
   });
+
+  testWidgets('hero play control sits flush against the overlay right edge',
+      (tester) async {
+    final playable = _episodeJson(2, files: [_fileJson('file-1')]);
+
+    await _pumpScreen(
+      tester,
+      size: const Size(1000, 1200),
+      showJson: _showJson(nextUpEpisode: playable),
+      episodesBySeason: {
+        1: [_episodeJson(1, watched: true), playable, _episodeJson(3)],
+      },
+    );
+    await tester.pumpAndSettle();
+
+    // The content overlay is inset 20 from the right of the 1000px surface.
+    // The fixture supplies a single file, so SmartPlayButton renders no
+    // quality dropdown and PlayButton is the control's last child.
+    expect(tester.getRect(find.byType(PlayButton)).right, closeTo(980, 0.5));
+  });
+
+  testWidgets('hero play control lives in the hero, not the body',
+      (tester) async {
+    final playable = _episodeJson(2, files: [_fileJson('file-1')]);
+
+    await _pumpScreen(
+      tester,
+      size: const Size(1000, 1200),
+      showJson: _showJson(nextUpEpisode: playable),
+      episodesBySeason: {
+        1: [_episodeJson(1, watched: true), playable, _episodeJson(3)],
+      },
+    );
+    await tester.pumpAndSettle();
+
+    // 380 is the hero SliverAppBar's expandedHeight
+    // (show_detail_screen.dart:333). Unscrolled, anything below that line is
+    // in the body, where _buildActionColumn lives. This is what distinguishes
+    // "moved to the title row" from "merely re-aligned in the action column".
+    final play = tester.getRect(find.byType(PlayButton));
+    final actions = tester.getRect(find.byType(DetailActionRow));
+    expect(play.bottom, lessThan(380));
+    expect(play.bottom, lessThan(actions.top));
+  });
 }

--- a/player/test/presentation/screens/show/show_detail_screen_test.dart
+++ b/player/test/presentation/screens/show/show_detail_screen_test.dart
@@ -428,13 +428,36 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // 380 is the hero SliverAppBar's expandedHeight
-    // (show_detail_screen.dart:333). Unscrolled, anything below that line is
-    // in the body, where _buildActionColumn lives. This is what distinguishes
+    // 380 is the hero SliverAppBar's expandedHeight, set in
+    // _buildHeroSection. Unscrolled, anything below that line is in the
+    // body, where _buildActionColumn lives. This is what distinguishes
     // "moved to the title row" from "merely re-aligned in the action column".
     final play = tester.getRect(find.byType(PlayButton));
     final actions = tester.getRect(find.byType(DetailActionRow));
     expect(play.bottom, lessThan(380));
     expect(play.bottom, lessThan(actions.top));
+  });
+
+  testWidgets('hero overlay does not overflow at phone width', (tester) async {
+    // The show hero is the wider of the two detail heroes — it carries the
+    // episode context pill alongside the title and Play control — so it is
+    // the most likely to overflow a narrow viewport, and until now it was
+    // the untested one (the movie hero already has phone-width coverage at
+    // Size(400, 900)). A layout overflow surfaces as a FlutterError, which
+    // fails the test even without an explicit assertion for it.
+    final playable = _episodeJson(2, files: [_fileJson('file-1')]);
+
+    await _pumpScreen(
+      tester,
+      size: const Size(400, 1200),
+      showJson: _showJson(nextUpEpisode: playable),
+      episodesBySeason: {
+        1: [_episodeJson(1, watched: true), playable, _episodeJson(3)],
+      },
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Play'), findsOneWidget);
   });
 }

--- a/player/test/presentation/widgets/hero_play_control_test.dart
+++ b/player/test/presentation/widgets/hero_play_control_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/media_file.dart';
+import 'package:player/presentation/widgets/hero_play_control.dart';
+import 'package:player/presentation/widgets/play_button.dart';
+
+const _files = [
+  MediaFile(id: 'f1', resolution: '1080p', directPlaySupported: true),
+];
+
+/// Mirrors how both detail heroes embed the control: a Row whose leading child
+/// is Expanded (the title column) and whose trailing child is non-flex.
+Widget _host(Widget control) => MaterialApp(
+      home: Scaffold(
+        body: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            const Expanded(child: Text('Some Title')),
+            const SizedBox(width: 16),
+            control,
+          ],
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('renders the Play label beside a play button', (tester) async {
+    await tester.pumpWidget(_host(
+      HeroPlayControl(files: _files, onFileSelected: (_) {}),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Play'), findsOneWidget);
+    expect(find.byType(PlayButton), findsOneWidget);
+  });
+
+  testWidgets('tapping reports the auto-selected file', (tester) async {
+    MediaFile? picked;
+    await tester.pumpWidget(_host(
+      HeroPlayControl(files: _files, onFileSelected: (f) => picked = f),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PlayButton));
+    await tester.pumpAndSettle();
+
+    expect(picked?.id, 'f1');
+  });
+
+  testWidgets('as a non-flex trailing Row child it sits flush right',
+      (tester) async {
+    // This is the property the whole placement fix rests on: a non-flex Row
+    // child takes its intrinsic width, so Expanded absorbs the slack and the
+    // control lands against the parent's right edge.
+    await tester.pumpWidget(_host(
+      HeroPlayControl(files: _files, onFileSelected: (_) {}),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    // Default test surface is 800x600. With a single file SmartPlayButton
+    // renders no quality dropdown, so PlayButton is the control's last child
+    // and its right edge is the control's right edge.
+    expect(tester.getRect(find.byType(PlayButton)).right, closeTo(800, 0.5));
+  });
+}

--- a/player/test/presentation/widgets/hero_play_control_test.dart
+++ b/player/test/presentation/widgets/hero_play_control_test.dart
@@ -8,6 +8,11 @@ const _files = [
   MediaFile(id: 'f1', resolution: '1080p', directPlaySupported: true),
 ];
 
+const _twoFiles = [
+  MediaFile(id: 'f1', resolution: '1080p', directPlaySupported: true),
+  MediaFile(id: 'f2', resolution: '720p', directPlaySupported: true),
+];
+
 /// Mirrors how both detail heroes embed the control: a Row whose leading child
 /// is Expanded (the title column) and whose trailing child is non-flex.
 Widget _host(Widget control) => MaterialApp(
@@ -51,16 +56,37 @@ void main() {
       (tester) async {
     // This is the property the whole placement fix rests on: a non-flex Row
     // child takes its intrinsic width, so Expanded absorbs the slack and the
-    // control lands against the parent's right edge.
+    // control lands against the parent's right edge. Asserted against the
+    // host's own right edge rather than a hard-coded surface width, so this
+    // expresses "flush with the host" instead of a coordinate that merely
+    // happens to match it.
     await tester.pumpWidget(_host(
       HeroPlayControl(files: _files, onFileSelected: (_) {}),
     ));
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
-    // Default test surface is 800x600. With a single file SmartPlayButton
-    // renders no quality dropdown, so PlayButton is the control's last child
-    // and its right edge is the control's right edge.
-    expect(tester.getRect(find.byType(PlayButton)).right, closeTo(800, 0.5));
+    expect(
+      tester.getRect(find.byType(HeroPlayControl)).right,
+      closeTo(tester.getRect(find.byType(Scaffold)).right, 0.5),
+    );
+  });
+
+  testWidgets('stays flush right when a quality dropdown is present (2+ files)',
+      (tester) async {
+    // With 2+ files, SmartPlayButton renders a quality dropdown that becomes
+    // the rightmost child instead of PlayButton, so this asserts on the
+    // control's own edge rather than PlayButton's — the two are not
+    // interchangeable once the dropdown exists.
+    await tester.pumpWidget(_host(
+      HeroPlayControl(files: _twoFiles, onFileSelected: (_) {}),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(
+      tester.getRect(find.byType(HeroPlayControl)).right,
+      closeTo(tester.getRect(find.byType(Scaffold)).right, 0.5),
+    );
   });
 }

--- a/player/test/presentation/widgets/smart_play_button_test.dart
+++ b/player/test/presentation/widgets/smart_play_button_test.dart
@@ -165,14 +165,17 @@ void main() {
         'collapses to the icon form without overflow inside a real Row '
         'embedding (Expanded metadata sibling + Flexible-wrapped button)',
         (tester) async {
-      // Reproduces how the show detail hero actually embeds this widget: a
-      // Row whose other child is Expanded (the title/metadata column) and
-      // whose SmartPlayButton is wrapped in Flexible. A bare (non-flex)
-      // trailing Row child gets UNBOUNDED main-axis constraints from Flutter,
-      // so SmartPlayButton's internal LayoutBuilder would see an effectively
-      // infinite maxWidth, "compact" would never trigger, and the full-width
-      // pill would overflow the narrow box below. Flexible is what gives the
-      // LayoutBuilder a bounded, real maxWidth to collapse against.
+      // Verifies the actual invariant under test: a bounded maxWidth is what
+      // makes the pill collapse to the icon form. Wrapping SmartPlayButton in
+      // Flexible here gives its internal LayoutBuilder a real, finite width
+      // to measure instead of the unbounded width a bare non-flex Row child
+      // would receive, in which case "compact" would never trigger and the
+      // full-width pill would overflow the narrow box below.
+      //
+      // This does not mirror how either detail hero actually embeds the
+      // widget: neither wraps it in Flexible (see HeroPlayControl's doc
+      // comment for the hazard that creates if `state:` is ever threaded
+      // through without first bounding the control's width).
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(


### PR DESCRIPTION
## The problem

On the TV show detail page the play button sits in a floating centered position instead of being right-aligned beside the show title.

The hero rebuild in `4e63ed7a` moved the play button out of the title row into `_buildActionColumn`, where it lives inside a centered Row in a stretched Column:

```dart
Column(
  crossAxisAlignment: CrossAxisAlignment.stretch,   // the Row fills the column
  children: [
    Row(
      mainAxisAlignment: MainAxisAlignment.center,  // the centering
      children: [Text('Play'), SizedBox(width: 8), SmartPlayButton(...)],
    ),
```

`CrossAxisAlignment.stretch` makes that Row fill the action column. At hero body widths at or above `_kHeroBreakpoint` (700) the column is a fixed `SizedBox(width: 248)`, so the "Play ▶" pair of roughly 100px gets centered with about 74px of dead space on each side, lining up with nothing. Below 700 it centers within the action row's width instead.

`movie_detail_screen.dart` carried the identical pattern, so both pages are fixed here. The two files are deliberate mirrors, sharing `_kHeroBreakpoint` and their method names.

## The fix

The title column becomes `Expanded` and absorbs all leftover width, while the play control is the Row's non-flex trailing child, so it takes only its intrinsic width and lands against the overlay's right edge. `episode_detail_screen.dart:196-211` already used this exact shape, so this brings the two heroes in line with the third detail screen rather than introducing a new idiom.

- `85376ef9` extracts the duplicated "Play" label plus `SmartPlayButton` pair into a shared `HeroPlayControl`
- `aee3e054` converts the show hero
- `91d2e7ed` converts the movie hero
- `5a2c8208` corrects comments and adds coverage from review

Each `_buildActionColumn` drops its Play row and returns `DetailActionRow` directly. That is layout-neutral: `DetailActionRow` is a `Row` with `mainAxisSize.max`, so under the wide branch's `SizedBox(width: 248)` it occupies exactly the width the removed stretch Column gave it.

`SmartPlayButton` is called without `state:`, so it renders its plain icon form and its internal `LayoutBuilder` never runs. There is no pill-collapse behaviour involved and no width bound to supply.

## Measured before and after

Show hero at a 1000px surface, from the tests:

| | Play button right edge | Play button bottom |
|---|---|---|
| Before | 234.6 (centered in the 248px column) | 456.0 (in the body) |
| After | 980 (overlay's right inset) | above 380 (inside the hero) |

## Tests

New `hero_play_control_test.dart` covers the label, the tap callback, flush-right placement asserted against the host's right edge, and that placement holding when a quality dropdown is present.

Both screen test files gain a right-edge assertion and a "lives in the hero, not the body" assertion. The second one is what distinguishes "moved onto the title row" from "merely re-aligned inside the action column": it asserts the button's bottom is above 380, the hero `SliverAppBar`'s `expandedHeight`, since anything below that line is in the body. The show hero also gains phone-width coverage at 400px, which it previously lacked while the movie hero had it.

The pre-existing Play navigation and resume tests were left untouched and still pass, which is the regression guard that the move did not disturb route building.

Full player suite: 1636/1636 passing under `flutter test --concurrency=1`. 0 `flutter analyze` errors. `dart format` clean.

## Out of scope

Restoring `SmartPlayButton`'s labelled pill form to the hero. The redesign deliberately chose the icon form; this change is about placement. `hero_play_control.dart` carries a warning that `state:` must not be threaded through without first giving the control a bounded width, since the trailing-child position is unbounded and `kPillCollapseWidth` would never fire there.
