### PR TITLE
feat(player): series downloads episode rails

### DIFF
--- a/player/lib/core/downloads/download_service_native.dart
+++ b/player/lib/core/downloads/download_service_native.dart
@@ -20,6 +20,7 @@ import 'download_notification_service.dart';
 import 'download_service.dart';
 import 'download_job_service.dart';
 import 'download_speed_tracker.dart';
+import 'thumbnail_cache_warmer.dart';
 
 /// Downloads are fully supported on native platforms.
 const bool isDownloadSupported = true;
@@ -1011,6 +1012,10 @@ class _NativeDownloadService implements DownloadService {
       final media = DownloadedMedia.fromTask(updatedTask);
       await _database!.saveMedia(media);
 
+      // Best-effort, and deliberately not awaited: the download is already on
+      // disk and must not be delayed or failed by an image fetch.
+      unawaited(warmThumbnailCache(updatedTask));
+
       _progressController.add(updatedTask);
       _cancelTokens.remove(task.id);
       _pausedTasks.remove(task.id);
@@ -1113,6 +1118,10 @@ class _NativeDownloadService implements DownloadService {
       // Save to downloaded media
       final media = DownloadedMedia.fromTask(updatedTask);
       await _database!.saveMedia(media);
+
+      // Best-effort, and deliberately not awaited: the download is already on
+      // disk and must not be delayed or failed by an image fetch.
+      unawaited(warmThumbnailCache(updatedTask));
 
       _progressController.add(updatedTask);
       _cancelTokens.remove(task.id);

--- a/player/lib/core/downloads/thumbnail_cache_warmer.dart
+++ b/player/lib/core/downloads/thumbnail_cache_warmer.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+import '../../domain/models/download.dart';
+import '../cache/poster_cache_manager.dart';
+
+/// Warms a completed download's episode thumbnail into the shared image cache
+/// so the downloads rails still have artwork when the device is offline.
+///
+/// Best-effort by design. A download that already succeeded on disk must never
+/// be failed by an image fetch, so every error is swallowed.
+///
+/// [cache] is injectable so tests can supply a fake instead of touching the
+/// network or the real cache directory.
+Future<void> warmThumbnailCache(
+  DownloadTask task, {
+  BaseCacheManager? cache,
+}) async {
+  final url = task.thumbnailUrl;
+  if (url == null || url.isEmpty) return;
+
+  try {
+    await (cache ?? EpisodeThumbnailCacheManager()).downloadFile(url);
+  } catch (e) {
+    debugPrint('[Downloads] Thumbnail warm skipped: $e');
+  }
+}

--- a/player/lib/core/layout/breakpoints.dart
+++ b/player/lib/core/layout/breakpoints.dart
@@ -90,6 +90,17 @@ abstract class Breakpoints {
     return getEpisodeCardSize(context).height + labelStrip;
   }
 
+  /// Rail height for the downloads screen's episode cards.
+  ///
+  /// Downloads cards carry a third label line (file size) beneath the episode
+  /// code and title, so they need a taller strip than
+  /// [getEpisodeRailHeight]'s two-line allowance.
+  static double getDownloadedEpisodeRailHeight(BuildContext context) {
+    // Allowance for the code + title + size strip rendered below each card.
+    const double labelStrip = 84;
+    return getEpisodeCardSize(context).height + labelStrip;
+  }
+
   /// Get responsive horizontal padding based on screen width
   static double getHorizontalPadding(BuildContext context) {
     final width = MediaQuery.sizeOf(context).width;

--- a/player/lib/domain/models/download.dart
+++ b/player/lib/domain/models/download.dart
@@ -313,6 +313,12 @@ class DownloadTask {
     return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB';
   }
 
+  /// e.g. "S01E03". Renders "S??E??" when the numbers are absent, which is
+  /// what a movie or an unmatched file looks like.
+  String get episodeCode =>
+      'S${seasonNumber?.toString().padLeft(2, '0') ?? '??'}'
+      'E${episodeNumber?.toString().padLeft(2, '0') ?? '??'}';
+
   String get fileSizeDisplay {
     if (fileSize == null) return 'Unknown size';
     return formatBytes(fileSize!);
@@ -441,6 +447,12 @@ class DownloadedMedia {
   MediaType get type {
     return mediaType == 'episode' ? MediaType.episode : MediaType.movie;
   }
+
+  /// e.g. "S01E03". Renders "S??E??" when the numbers are absent, which is
+  /// what a movie or an unmatched file looks like.
+  String get episodeCode =>
+      'S${seasonNumber?.toString().padLeft(2, '0') ?? '??'}'
+      'E${episodeNumber?.toString().padLeft(2, '0') ?? '??'}';
 
   String get fileSizeDisplay => DownloadTask.formatBytes(fileSize);
 

--- a/player/lib/presentation/screens/downloads/series_downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/series_downloads_screen.dart
@@ -7,6 +7,8 @@ import '../../../core/downloads/download_providers.dart';
 import '../../../domain/models/download.dart';
 import '../../../core/theme/colors.dart';
 import '../../widgets/quality_badge.dart';
+import 'widgets/download_queue_row.dart';
+import 'widgets/downloaded_episode_rail.dart';
 import 'widgets/series_downloads_dialogs.dart';
 
 class SeriesDownloadsScreen extends ConsumerWidget {
@@ -64,7 +66,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
           _buildHeroSection(context, ref, showDownloads, showQueue),
           _buildStatsBar(context, showDownloads, showQueue),
           SliverPadding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+            padding: const EdgeInsets.fromLTRB(0, 8, 0, 16),
             sliver: SliverList(
               delegate: SliverChildListDelegate([
                 if (showQueue.isNotEmpty) ...[
@@ -76,7 +78,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
                 if (showQueue.isEmpty && showDownloads.isEmpty)
                   const Padding(
                     padding: EdgeInsets.all(32),
-                    child: Center(child: Text("No episodes found")),
+                    child: Center(child: Text('No episodes found')),
                   ),
               ]),
             ),
@@ -359,166 +361,44 @@ class SeriesDownloadsScreen extends ConsumerWidget {
     );
   }
 
-  /// Shared compact row for queue and downloaded episode items.
-  Widget _buildEpisodeRow({
-    required BuildContext context,
-    required String episodeCode,
-    required String title,
-    required Widget trailing,
-    VoidCallback? onTap,
-  }) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(8),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
-            child: Row(
-              children: [
-                // Episode code badge
-                Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
-                  decoration: BoxDecoration(
-                    color: AppColors.primary.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(5),
-                  ),
-                  child: Text(
-                    episodeCode,
-                    style: const TextStyle(
-                      fontSize: 11,
-                      fontWeight: FontWeight.w700,
-                      color: AppColors.primary,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 10),
-                // Title
-                Expanded(
-                  child: Text(
-                    title,
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyMedium
-                        ?.copyWith(fontWeight: FontWeight.w500),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                // Trailing section (metrics + actions)
-                trailing,
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDownloadedRow(
-      BuildContext context, WidgetRef ref, DownloadedMedia media) {
-    final episodeCode = media.episodeCode;
-
-    final trailing = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (media.quality.isNotEmpty) ...[
-          QualityBadge.resolution(media.quality),
-          const SizedBox(width: 8),
-        ],
-        Text(
-          media.fileSizeDisplay,
-          style: const TextStyle(
-            color: AppColors.textSecondary,
-            fontSize: 11,
-          ),
-        ),
-        const SizedBox(width: 4),
-        IconButton(
-          icon: const Icon(Icons.play_arrow_rounded, color: AppColors.primary),
-          iconSize: 22,
-          padding: EdgeInsets.zero,
-          constraints: const BoxConstraints(),
-          onPressed: () {
-            context.push(
-              '/player/episode/${media.mediaId}?fileId=offline&title=${Uri.encodeComponent(media.title)}&showId=$showId&seasonNumber=${media.seasonNumber}',
-            );
-          },
-        ),
-        IconButton(
-          icon:
-              const Icon(Icons.delete_outline_rounded, color: AppColors.error),
-          iconSize: 20,
-          padding: EdgeInsets.zero,
-          constraints: const BoxConstraints(),
-          onPressed: () => showDeleteEpisodeDialog(context, ref, media),
-        ),
-      ],
-    );
-
-    return _buildEpisodeRow(
-      context: context,
-      episodeCode: episodeCode,
-      title: media.title,
-      trailing: trailing,
-      onTap: () {
-        context.push(
-          '/player/episode/${media.mediaId}?fileId=offline&title=${Uri.encodeComponent(media.title)}&showId=$showId&seasonNumber=${media.seasonNumber}',
-        );
-      },
-    );
-  }
-
   // ---------------------------------------------------------------------------
   // Downloaded Section with Season Grouping
   // ---------------------------------------------------------------------------
 
   List<Widget> _buildDownloadedSection(
       BuildContext context, WidgetRef ref, List<DownloadedMedia> downloads) {
-    final widgets = <Widget>[];
+    final widgets = <Widget>[
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Text(
+          'Downloaded',
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: AppColors.success,
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+      ),
+      const SizedBox(height: 12),
+    ];
 
     final seasonMap = _groupBySeason(downloads, (d) => d.seasonNumber ?? 0);
-    final hasMultipleSeasons = seasonMap.length > 1;
 
-    if (!hasMultipleSeasons) {
-      widgets.add(Text(
-        'Downloaded',
-        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              color: AppColors.success,
-              fontWeight: FontWeight.bold,
-            ),
-      ));
-      widgets.add(const SizedBox(height: 8));
-      for (final media in downloads) {
-        widgets.add(_buildDownloadedRow(context, ref, media));
-      }
-    } else {
-      widgets.add(Text(
-        'Downloaded',
-        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              color: AppColors.success,
-              fontWeight: FontWeight.bold,
-            ),
+    var first = true;
+    for (final entry in seasonMap.entries) {
+      if (!first) widgets.add(const SizedBox(height: 20));
+      first = false;
+
+      widgets.add(Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: _buildSeasonHeader(context, ref, entry.key, entry.value.length),
       ));
       widgets.add(const SizedBox(height: 12));
-
-      var first = true;
-      for (final entry in seasonMap.entries) {
-        final season = entry.key;
-        final seasonEpisodes = entry.value;
-        if (!first) widgets.add(const SizedBox(height: 16));
-        first = false;
-        widgets.add(
-            _buildSeasonHeader(context, ref, season, seasonEpisodes.length));
-        widgets.add(const SizedBox(height: 8));
-        for (final media in seasonEpisodes) {
-          widgets.add(_buildDownloadedRow(context, ref, media));
-        }
-      }
+      widgets.add(DownloadedEpisodeRail(
+        key: ValueKey('downloaded-season-${entry.key}'),
+        episodes: entry.value,
+        showId: showId,
+        seasonNumber: entry.key,
+      ));
     }
 
     return widgets;
@@ -593,15 +473,18 @@ class SeriesDownloadsScreen extends ConsumerWidget {
 
   List<Widget> _buildQueueSection(
       BuildContext context, WidgetRef ref, List<DownloadTask> queue) {
-    final widgets = <Widget>[];
-
-    widgets.add(Text(
-      'Downloading',
-      style: Theme.of(context).textTheme.titleSmall?.copyWith(
-            color: AppColors.primary,
-            fontWeight: FontWeight.bold,
-          ),
-    ));
+    final widgets = <Widget>[
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Text(
+          'Downloading',
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: AppColors.primary,
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+      ),
+    ];
 
     final seasonMap = _groupBySeason(queue, (t) => t.seasonNumber ?? 0);
     final hasMultipleSeasons = seasonMap.length > 1;
@@ -609,93 +492,33 @@ class SeriesDownloadsScreen extends ConsumerWidget {
     if (!hasMultipleSeasons) {
       widgets.add(const SizedBox(height: 8));
       for (final task in queue) {
-        widgets.add(_buildQueueRow(context, ref, task));
+        widgets.add(Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: DownloadQueueRow(key: ValueKey(task.id), task: task),
+        ));
       }
     } else {
       widgets.add(const SizedBox(height: 12));
       var first = true;
       for (final entry in seasonMap.entries) {
-        final season = entry.key;
-        final seasonTasks = entry.value;
         if (!first) widgets.add(const SizedBox(height: 16));
         first = false;
-        widgets
-            .add(_buildQueueSeasonHeader(context, season, seasonTasks.length));
+        widgets.add(Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child:
+              _buildQueueSeasonHeader(context, entry.key, entry.value.length),
+        ));
         widgets.add(const SizedBox(height: 8));
-        for (final task in seasonTasks) {
-          widgets.add(_buildQueueRow(context, ref, task));
+        for (final task in entry.value) {
+          widgets.add(Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: DownloadQueueRow(key: ValueKey(task.id), task: task),
+          ));
         }
       }
     }
 
     return widgets;
-  }
-
-  Widget _buildQueueRow(
-      BuildContext context, WidgetRef ref, DownloadTask task) {
-    final progress = task.isProgressive ? task.combinedProgress : task.progress;
-    final episodeCode =
-        'S${task.seasonNumber?.toString().padLeft(2, '0') ?? '??'}E${task.episodeNumber?.toString().padLeft(2, '0') ?? '??'}';
-
-    final trailing = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Consumer(
-          builder: (context, ref, _) {
-            final speedAsync = ref.watch(downloadSpeedInfoProvider);
-            return speedAsync.when(
-              data: (speedMap) {
-                final info = speedMap[task.id];
-                final parts = <String>[];
-                final bytesText =
-                    task.progressBytesDisplay ?? task.fileSizeDisplay;
-                parts.add(bytesText);
-                if (info != null && info.bytesPerSecond > 0) {
-                  parts.add(info.speedDisplay);
-                }
-                return Text(
-                  parts.join(' \u00B7 '),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  softWrap: false,
-                  style: const TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 10,
-                  ),
-                );
-              },
-              loading: () => const SizedBox.shrink(),
-              error: (_, __) => const SizedBox.shrink(),
-            );
-          },
-        ),
-        const SizedBox(width: 6),
-        Text(
-          '${(progress * 100).toStringAsFixed(0)}%',
-          style: const TextStyle(
-            color: AppColors.primary,
-            fontSize: 11,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-        const SizedBox(width: 4),
-        IconButton(
-          onPressed: () => showCancelDownloadDialog(context, ref, task),
-          icon: const Icon(Icons.close_rounded),
-          color: AppColors.textSecondary,
-          iconSize: 18,
-          padding: EdgeInsets.zero,
-          constraints: const BoxConstraints(),
-        ),
-      ],
-    );
-
-    return _buildEpisodeRow(
-      context: context,
-      episodeCode: episodeCode,
-      title: task.title,
-      trailing: trailing,
-    );
   }
 
   Widget _buildQueueSeasonHeader(

--- a/player/lib/presentation/screens/downloads/series_downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/series_downloads_screen.dart
@@ -7,6 +7,7 @@ import '../../../core/downloads/download_providers.dart';
 import '../../../domain/models/download.dart';
 import '../../../core/theme/colors.dart';
 import '../../widgets/quality_badge.dart';
+import 'widgets/series_downloads_dialogs.dart';
 
 class SeriesDownloadsScreen extends ConsumerWidget {
   final String showId;
@@ -105,8 +106,18 @@ class SeriesDownloadsScreen extends ConsumerWidget {
               borderRadius: BorderRadius.circular(12),
               child: InkWell(
                 borderRadius: BorderRadius.circular(12),
-                onTap: () => _showDeleteAllDialog(
-                    context, ref, showDownloads, showQueue),
+                onTap: () async {
+                  final deleted = await showDeleteAllDialog(
+                    context,
+                    ref,
+                    showId: showId,
+                    showTitle: showTitle,
+                    totalCount: showDownloads.length + showQueue.length,
+                  );
+                  if (deleted && context.mounted) {
+                    Navigator.of(context).pop();
+                  }
+                },
                 child: const Padding(
                   padding: EdgeInsets.all(8),
                   child: Icon(Icons.delete_outline_rounded,
@@ -410,8 +421,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
 
   Widget _buildDownloadedRow(
       BuildContext context, WidgetRef ref, DownloadedMedia media) {
-    final episodeCode =
-        'S${media.seasonNumber?.toString().padLeft(2, '0') ?? '??'}E${media.episodeNumber?.toString().padLeft(2, '0') ?? '??'}';
+    final episodeCode = media.episodeCode;
 
     final trailing = Row(
       mainAxisSize: MainAxisSize.min,
@@ -445,33 +455,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
           iconSize: 20,
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(),
-          onPressed: () async {
-            final confirm = await showDialog<bool>(
-              context: context,
-              builder: (context) => AlertDialog(
-                backgroundColor: AppColors.surface,
-                title: const Text('Delete Episode'),
-                content: Text('Delete $episodeCode?'),
-                actions: [
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(false),
-                    child: const Text('Cancel'),
-                  ),
-                  FilledButton(
-                    onPressed: () => Navigator.of(context).pop(true),
-                    style: FilledButton.styleFrom(
-                        backgroundColor: AppColors.error),
-                    child: const Text('Delete'),
-                  ),
-                ],
-              ),
-            );
-
-            if (confirm == true) {
-              final manager = await ref.read(downloadManagerProvider.future);
-              await manager.deleteDownload(media.mediaId);
-            }
-          },
+          onPressed: () => showDeleteEpisodeDialog(context, ref, media),
         ),
       ],
     );
@@ -542,7 +526,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
 
   Widget _buildSeasonHeader(
       BuildContext context, WidgetRef ref, int seasonNumber, int episodeCount) {
-    final label = seasonNumber == 0 ? 'Specials' : 'Season $seasonNumber';
+    final label = seasonLabel(seasonNumber);
     return Padding(
       padding: const EdgeInsets.only(top: 4),
       child: Container(
@@ -583,8 +567,14 @@ class SeriesDownloadsScreen extends ConsumerWidget {
               width: 32,
               height: 32,
               child: IconButton(
-                onPressed: () => _showDeleteSeasonDialog(
-                    context, ref, seasonNumber, episodeCount),
+                onPressed: () => showDeleteSeasonDialog(
+                  context,
+                  ref,
+                  showId: showId,
+                  showTitle: showTitle,
+                  seasonNumber: seasonNumber,
+                  episodeCount: episodeCount,
+                ),
                 icon: const Icon(Icons.delete_outline_rounded, size: 18),
                 color: AppColors.error,
                 padding: EdgeInsets.zero,
@@ -690,7 +680,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
         ),
         const SizedBox(width: 4),
         IconButton(
-          onPressed: () => _showCancelDialog(context, ref, task),
+          onPressed: () => showCancelDownloadDialog(context, ref, task),
           icon: const Icon(Icons.close_rounded),
           color: AppColors.textSecondary,
           iconSize: 18,
@@ -710,7 +700,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
 
   Widget _buildQueueSeasonHeader(
       BuildContext context, int seasonNumber, int taskCount) {
-    final label = seasonNumber == 0 ? 'Specials' : 'Season $seasonNumber';
+    final label = seasonLabel(seasonNumber);
     return Padding(
       padding: const EdgeInsets.only(top: 4),
       child: Container(
@@ -758,41 +748,6 @@ class SeriesDownloadsScreen extends ConsumerWidget {
     return DownloadTask.formatBytes(totalBytes);
   }
 
-  // ---------------------------------------------------------------------------
-  // Dialogs
-  // ---------------------------------------------------------------------------
-
-  Future<void> _showCancelDialog(
-      BuildContext context, WidgetRef ref, DownloadTask task) async {
-    final manager = await ref.read(downloadManagerProvider.future);
-
-    if (!context.mounted) return;
-
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: AppColors.surface,
-        title: const Text('Cancel Download?'),
-        content: const Text('Stop downloading this episode?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Keep',
-                style: TextStyle(color: AppColors.textSecondary)),
-          ),
-          FilledButton(
-            onPressed: () {
-              manager.cancelDownload(task.id);
-              Navigator.pop(context);
-            },
-            style: FilledButton.styleFrom(backgroundColor: AppColors.error),
-            child: const Text('Cancel Download'),
-          ),
-        ],
-      ),
-    );
-  }
-
   /// Groups items by season number, returning a sorted map (Specials=0 first,
   /// then ascending).
   Map<int, List<T>> _groupBySeason<T>(List<T> items, int Function(T) seasonOf) {
@@ -805,72 +760,5 @@ class SeriesDownloadsScreen extends ConsumerWidget {
       map.entries.toList()..sort((a, b) => a.key.compareTo(b.key)),
     );
     return sorted;
-  }
-
-  Future<void> _showDeleteAllDialog(BuildContext context, WidgetRef ref,
-      List<DownloadedMedia> showDownloads, List<DownloadTask> showQueue) async {
-    final totalCount = showDownloads.length + showQueue.length;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: AppColors.surface,
-        title: const Text('Delete All Episodes'),
-        content: Text(
-          'Delete all $totalCount episode${totalCount == 1 ? '' : 's'} of "$showTitle"?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel',
-                style: TextStyle(color: AppColors.textSecondary)),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            style: FilledButton.styleFrom(backgroundColor: AppColors.error),
-            child: const Text('Delete All'),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed == true && context.mounted) {
-      final manager = await ref.read(downloadManagerProvider.future);
-      await manager.deleteSeriesDownloads(showId);
-      if (context.mounted) {
-        Navigator.of(context).pop();
-      }
-    }
-  }
-
-  Future<void> _showDeleteSeasonDialog(BuildContext context, WidgetRef ref,
-      int seasonNumber, int episodeCount) async {
-    final seasonLabel = seasonNumber == 0 ? 'Specials' : 'Season $seasonNumber';
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: AppColors.surface,
-        title: Text('Delete $seasonLabel?'),
-        content: Text(
-          'Delete $episodeCount episode${episodeCount == 1 ? '' : 's'} from $seasonLabel of "$showTitle"?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel',
-                style: TextStyle(color: AppColors.textSecondary)),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            style: FilledButton.styleFrom(backgroundColor: AppColors.error),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed == true && context.mounted) {
-      final manager = await ref.read(downloadManagerProvider.future);
-      await manager.deleteSeasonDownloads(showId, seasonNumber);
-    }
   }
 }

--- a/player/lib/presentation/screens/downloads/widgets/download_queue_row.dart
+++ b/player/lib/presentation/screens/downloads/widgets/download_queue_row.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/downloads/download_providers.dart';
+import '../../../../core/theme/colors.dart';
+import '../../../../domain/models/download.dart';
+import 'series_downloads_dialogs.dart';
+
+/// One in-progress download, as three legible lines: title, progress bar, and
+/// a single metrics line.
+///
+/// The previous compact row put every field on one line at 10-11px, which was
+/// unreadable. This trades vertical space for legibility, which is the right
+/// trade for a section that is usually one or two items long.
+class DownloadQueueRow extends ConsumerWidget {
+  final DownloadTask task;
+
+  const DownloadQueueRow({super.key, required this.task});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final progress = task.isProgressive ? task.combinedProgress : task.progress;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+                decoration: BoxDecoration(
+                  color: AppColors.primary.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(5),
+                ),
+                child: Text(
+                  task.episodeCode,
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.primary,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  task.title,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(fontWeight: FontWeight.w500),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: 8),
+              IconButton(
+                key: const ValueKey('download-queue-row-cancel'),
+                onPressed: () => showCancelDownloadDialog(context, ref, task),
+                icon: const Icon(Icons.close_rounded),
+                color: AppColors.textSecondary,
+                iconSize: 20,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                tooltip: 'Cancel download',
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(2),
+            child: LinearProgressIndicator(
+              key: const ValueKey('download-queue-row-bar'),
+              value: progress.clamp(0.0, 1.0),
+              minHeight: 4,
+              backgroundColor: AppColors.surfaceVariant,
+              valueColor:
+                  const AlwaysStoppedAnimation<Color>(AppColors.primary),
+            ),
+          ),
+          const SizedBox(height: 6),
+          _buildMetrics(ref, progress),
+        ],
+      ),
+    );
+  }
+
+  /// Scoped to its own [Consumer] so a speed tick rebuilds this line alone and
+  /// leaves the title and the progress bar untouched.
+  Widget _buildMetrics(WidgetRef ref, double progress) {
+    return Consumer(
+      builder: (context, ref, _) {
+        final speedAsync = ref.watch(downloadSpeedInfoProvider);
+        final info = speedAsync.value?[task.id];
+
+        final parts = <String>[
+          '${(progress * 100).toStringAsFixed(0)}%',
+          task.progressBytesDisplay ?? task.fileSizeDisplay,
+        ];
+        if (info != null && info.bytesPerSecond > 0) {
+          parts.add(info.speedDisplay);
+        }
+
+        return Text(
+          parts.join('  ·  '),
+          key: const ValueKey('download-queue-row-metrics'),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            fontSize: 11,
+            color: AppColors.textSecondary,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/player/lib/presentation/screens/downloads/widgets/downloaded_episode_card.dart
+++ b/player/lib/presentation/screens/downloads/widgets/downloaded_episode_card.dart
@@ -242,12 +242,13 @@ class DownloadedEpisodeCard extends ConsumerWidget {
   /// `fileId=offline` is what tells the player screen to resolve the local
   /// file instead of asking the server for a stream.
   void _play(BuildContext context) {
+    final season = media.seasonNumber;
     context.push(
       '/player/episode/${media.mediaId}'
       '?fileId=offline'
       '&title=${Uri.encodeComponent(media.title)}'
       '&showId=$showId'
-      '&seasonNumber=${media.seasonNumber}',
+      '${season != null ? '&seasonNumber=$season' : ''}',
     );
   }
 }

--- a/player/lib/presentation/screens/downloads/widgets/downloaded_episode_card.dart
+++ b/player/lib/presentation/screens/downloads/widgets/downloaded_episode_card.dart
@@ -1,0 +1,253 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/cache/poster_cache_manager.dart';
+import '../../../../core/layout/breakpoints.dart';
+import '../../../../core/playback/playback_progress_providers.dart';
+import '../../../../core/theme/colors.dart';
+import '../../../../domain/models/download.dart';
+import '../../../widgets/quality_badge.dart';
+import 'series_downloads_dialogs.dart';
+
+/// A landscape (16:9) card for one downloaded episode.
+///
+/// Geometry is shared with the show detail page's episode rail via
+/// [Breakpoints.getEpisodeCardSize], so the two surfaces line up exactly. What
+/// differs is the payload: this card is offline-first, so it shows the stored
+/// file size and reads resume position from the local Hive store rather than
+/// from the server.
+///
+/// No watched checkmark and no mark-watched menu. Offline there is a position
+/// but no explicit watched flag, and inferring one from a percentage threshold
+/// is the class of guess that produced the Up Next bug fixed in `cfdcc546`.
+class DownloadedEpisodeCard extends ConsumerWidget {
+  final DownloadedMedia media;
+  final String showId;
+
+  const DownloadedEpisodeCard({
+    super.key,
+    required this.media,
+    required this.showId,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cardSize = Breakpoints.getEpisodeCardSize(context);
+
+    return SizedBox(
+      width: cardSize.width,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          GestureDetector(
+            onTap: () => _play(context),
+            child: _buildThumbnail(context, ref, cardSize),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            media.episodeCode,
+            style: const TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: AppColors.primary,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            media.title,
+            style: Theme.of(context)
+                .textTheme
+                .titleSmall
+                ?.copyWith(fontWeight: FontWeight.w600),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 2),
+          Text(
+            media.fileSizeDisplay,
+            style: const TextStyle(
+              fontSize: 11,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildThumbnail(
+    BuildContext context,
+    WidgetRef ref,
+    CardSize cardSize,
+  ) {
+    final thumbnailUrl = media.thumbnailUrl;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: SizedBox(
+        width: cardSize.width,
+        height: cardSize.height,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: thumbnailUrl != null && thumbnailUrl.isNotEmpty
+                  ? CachedNetworkImage(
+                      imageUrl: thumbnailUrl,
+                      fit: BoxFit.cover,
+                      cacheManager: EpisodeThumbnailCacheManager(),
+                      placeholder: (context, url) =>
+                          Container(color: AppColors.surfaceVariant),
+                      errorWidget: (context, url, error) => _buildPlaceholder(),
+                    )
+                  : _buildPlaceholder(),
+            ),
+            if (media.quality.isNotEmpty)
+              Positioned(
+                right: 6,
+                bottom: 10,
+                child: QualityBadge.resolution(media.quality),
+              ),
+            _buildResumeBar(ref),
+            Positioned(
+              top: 4,
+              right: 4,
+              child: _buildMenu(context, ref),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Reads the offline Hive store synchronously once it has opened. While the
+  /// provider is still loading the bar is simply absent, which is correct: an
+  /// unwatched episode shows nothing either.
+  Widget _buildResumeBar(WidgetRef ref) {
+    final store = ref.watch(playbackProgressStoreProvider).value;
+    if (store == null) return const SizedBox.shrink();
+
+    final progress = store.get(media.mediaId);
+    if (progress == null || progress.durationSeconds <= 0) {
+      return const SizedBox.shrink();
+    }
+
+    final fraction =
+        (progress.positionSeconds / progress.durationSeconds).clamp(0.0, 1.0);
+
+    return Positioned(
+      key: const ValueKey('downloaded-episode-resume-bar'),
+      bottom: 0,
+      left: 0,
+      right: 0,
+      child: Container(
+        height: 4,
+        decoration: const BoxDecoration(color: AppColors.surfaceVariant),
+        child: FractionallySizedBox(
+          alignment: Alignment.centerLeft,
+          widthFactor: fraction,
+          child: const DecoratedBox(
+            decoration: BoxDecoration(
+              color: AppColors.primary,
+              borderRadius: BorderRadius.only(
+                topRight: Radius.circular(2),
+                bottomRight: Radius.circular(2),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMenu(BuildContext context, WidgetRef ref) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.45),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: PopupMenuButton<String>(
+        key: const ValueKey('downloaded-episode-menu'),
+        icon: const Icon(
+          Icons.more_vert_rounded,
+          color: Colors.white,
+          size: 20,
+        ),
+        tooltip: 'Episode actions',
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(),
+        style: const ButtonStyle(
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          visualDensity: VisualDensity.compact,
+        ),
+        color: AppColors.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+        onSelected: (value) {
+          switch (value) {
+            case 'play':
+              _play(context);
+              break;
+            case 'delete':
+              showDeleteEpisodeDialog(context, ref, media);
+              break;
+          }
+        },
+        itemBuilder: (context) => [
+          const PopupMenuItem(
+            value: 'play',
+            child: Row(
+              children: [
+                Icon(Icons.play_arrow_rounded, size: 18),
+                SizedBox(width: 12),
+                Text('Play'),
+              ],
+            ),
+          ),
+          const PopupMenuItem(
+            value: 'delete',
+            child: Row(
+              children: [
+                Icon(
+                  Icons.delete_outline_rounded,
+                  size: 18,
+                  color: AppColors.error,
+                ),
+                SizedBox(width: 12),
+                Text('Delete', style: TextStyle(color: AppColors.error)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlaceholder() {
+    return Container(
+      color: AppColors.surfaceVariant,
+      child: const Center(
+        child: Icon(
+          Icons.tv_rounded,
+          size: 32,
+          color: AppColors.textSecondary,
+        ),
+      ),
+    );
+  }
+
+  /// `fileId=offline` is what tells the player screen to resolve the local
+  /// file instead of asking the server for a stream.
+  void _play(BuildContext context) {
+    context.push(
+      '/player/episode/${media.mediaId}'
+      '?fileId=offline'
+      '&title=${Uri.encodeComponent(media.title)}'
+      '&showId=$showId'
+      '&seasonNumber=${media.seasonNumber}',
+    );
+  }
+}

--- a/player/lib/presentation/screens/downloads/widgets/downloaded_episode_rail.dart
+++ b/player/lib/presentation/screens/downloads/widgets/downloaded_episode_rail.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/layout/breakpoints.dart';
+import '../../../../domain/models/download.dart';
+import '../../../widgets/horizontal_rail.dart';
+import 'downloaded_episode_card.dart';
+
+/// One season's downloaded episodes, as a horizontal rail of 16:9 cards.
+///
+/// Fade keys are namespaced by season so a show with several seasons keeps
+/// each rail's fades individually assertable.
+class DownloadedEpisodeRail extends StatelessWidget {
+  final List<DownloadedMedia> episodes;
+  final String showId;
+  final int seasonNumber;
+
+  const DownloadedEpisodeRail({
+    super.key,
+    required this.episodes,
+    required this.showId,
+    required this.seasonNumber,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return HorizontalRail(
+      itemCount: episodes.length,
+      height: Breakpoints.getDownloadedEpisodeRailHeight(context),
+      leftFadeKey: ValueKey('downloaded-rail-$seasonNumber-left-fade'),
+      rightFadeKey: ValueKey('downloaded-rail-$seasonNumber-right-fade'),
+      itemBuilder: (context, index) {
+        final media = episodes[index];
+        return DownloadedEpisodeCard(
+          key: ValueKey(media.mediaId),
+          media: media,
+          showId: showId,
+        );
+      },
+    );
+  }
+}

--- a/player/lib/presentation/screens/downloads/widgets/series_downloads_dialogs.dart
+++ b/player/lib/presentation/screens/downloads/widgets/series_downloads_dialogs.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/downloads/download_providers.dart';
+import '../../../../core/theme/colors.dart';
+import '../../../../domain/models/download.dart';
+
+/// "Specials" for season 0, "Season N" otherwise. Season 0 is the conventional
+/// home for specials in both TVDB and TMDB data.
+String seasonLabel(int seasonNumber) =>
+    seasonNumber == 0 ? 'Specials' : 'Season $seasonNumber';
+
+/// Confirms stopping an in-progress download.
+Future<void> showCancelDownloadDialog(
+  BuildContext context,
+  WidgetRef ref,
+  DownloadTask task,
+) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      backgroundColor: AppColors.surface,
+      title: const Text('Cancel Download?'),
+      content: Text('Stop downloading ${task.episodeCode}?'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text(
+            'Keep',
+            style: TextStyle(color: AppColors.textSecondary),
+          ),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, true),
+          style: FilledButton.styleFrom(backgroundColor: AppColors.error),
+          child: const Text('Cancel Download'),
+        ),
+      ],
+    ),
+  );
+
+  if (confirmed != true) return;
+
+  final service = await ref.read(downloadManagerProvider.future);
+  await service.cancelDownload(task.id);
+}
+
+/// Confirms deleting one downloaded episode from disk.
+Future<void> showDeleteEpisodeDialog(
+  BuildContext context,
+  WidgetRef ref,
+  DownloadedMedia media,
+) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      backgroundColor: AppColors.surface,
+      title: const Text('Delete Episode'),
+      content: Text('Delete ${media.episodeCode}?'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          style: FilledButton.styleFrom(backgroundColor: AppColors.error),
+          child: const Text('Delete'),
+        ),
+      ],
+    ),
+  );
+
+  if (confirmed != true) return;
+
+  final service = await ref.read(downloadManagerProvider.future);
+  await service.deleteDownload(media.mediaId);
+}
+
+/// Confirms deleting every downloaded episode in one season.
+Future<void> showDeleteSeasonDialog(
+  BuildContext context,
+  WidgetRef ref, {
+  required String showId,
+  required String showTitle,
+  required int seasonNumber,
+  required int episodeCount,
+}) async {
+  final label = seasonLabel(seasonNumber);
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      backgroundColor: AppColors.surface,
+      title: Text('Delete $label?'),
+      content: Text(
+        'Delete $episodeCount episode${episodeCount == 1 ? '' : 's'} '
+        'from $label of "$showTitle"?',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text(
+            'Cancel',
+            style: TextStyle(color: AppColors.textSecondary),
+          ),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, true),
+          style: FilledButton.styleFrom(backgroundColor: AppColors.error),
+          child: const Text('Delete'),
+        ),
+      ],
+    ),
+  );
+
+  if (confirmed != true) return;
+
+  final service = await ref.read(downloadManagerProvider.future);
+  await service.deleteSeasonDownloads(showId, seasonNumber);
+}
+
+/// Confirms deleting every download for the show, queued or complete.
+///
+/// Returns true when the delete ran, so the caller can pop the now-empty
+/// screen. Popping is the caller's job because this function does not know
+/// whether it was opened from the screen itself.
+Future<bool> showDeleteAllDialog(
+  BuildContext context,
+  WidgetRef ref, {
+  required String showId,
+  required String showTitle,
+  required int totalCount,
+}) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      backgroundColor: AppColors.surface,
+      title: const Text('Delete All Episodes'),
+      content: Text(
+        'Delete all $totalCount episode${totalCount == 1 ? '' : 's'} '
+        'of "$showTitle"?',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text(
+            'Cancel',
+            style: TextStyle(color: AppColors.textSecondary),
+          ),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, true),
+          style: FilledButton.styleFrom(backgroundColor: AppColors.error),
+          child: const Text('Delete All'),
+        ),
+      ],
+    ),
+  );
+
+  if (confirmed != true) return false;
+
+  final service = await ref.read(downloadManagerProvider.future);
+  await service.deleteSeriesDownloads(showId);
+  return true;
+}

--- a/player/lib/presentation/widgets/episode_rail.dart
+++ b/player/lib/presentation/widgets/episode_rail.dart
@@ -1,18 +1,15 @@
 import 'package:flutter/material.dart';
 import '../../core/layout/breakpoints.dart';
-import '../../core/theme/colors.dart';
 import '../../domain/models/episode.dart';
 import 'episode_rail_card.dart';
+import 'horizontal_rail.dart';
 
-/// A horizontal rail of [EpisodeRailCard]s with edge-fade gradients and
-/// responsive spacing.
+/// A horizontal rail of [EpisodeRailCard]s.
 ///
-/// Mirrors `ContentRail`'s scroll mechanics — a [ScrollController] driving
-/// left/right fade visibility and a horizontal [ListView.builder] sized via
-/// [Breakpoints] — but renders landscape episode cards instead of portrait
-/// posters. The fade/scroll shell is deliberately duplicated rather than
-/// abstracted; extracting a shared shell is deferred follow-up.
-class EpisodeRail extends StatefulWidget {
+/// Scroll mechanics and edge fades come from [HorizontalRail]; this widget
+/// only maps episodes onto landscape cards and sizes the rail for the two-line
+/// label strip beneath each thumbnail.
+class EpisodeRail extends StatelessWidget {
   final List<Episode> episodes;
   final String showTitle;
   final String? showId;
@@ -33,158 +30,26 @@ class EpisodeRail extends StatefulWidget {
   });
 
   @override
-  State<EpisodeRail> createState() => _EpisodeRailState();
-}
-
-class _EpisodeRailState extends State<EpisodeRail> {
-  final ScrollController _scrollController = ScrollController();
-
-  // Both fades start hidden and are turned on once layout reports how far the
-  // rail can actually scroll. Assuming a right fade up front would leave one
-  // stranded over a rail whose episodes already fit on screen.
-  bool _showLeftFade = false;
-  bool _showRightFade = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _scrollController.addListener(_updateFadeState);
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // Runs once on mount and again whenever the width changes (rotation,
-    // resize, window drag), both of which change how far the rail can scroll.
-    _scheduleFadeUpdate();
-  }
-
-  @override
-  void didUpdateWidget(covariant EpisodeRail oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.episodes.length != widget.episodes.length) {
-      _scheduleFadeUpdate();
-    }
-  }
-
-  @override
-  void dispose() {
-    _scrollController.removeListener(_updateFadeState);
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  /// Scroll extent is only known once the list has been laid out, so anything
-  /// that changes it has to defer the recompute to the end of the frame.
-  void _scheduleFadeUpdate() {
-    WidgetsBinding.instance.addPostFrameCallback((_) => _updateFadeState());
-  }
-
-  void _updateFadeState() {
-    if (!mounted || !_scrollController.hasClients) return;
-
-    final position = _scrollController.position;
-    final showLeft = position.pixels > 10;
-    final showRight = position.pixels < position.maxScrollExtent - 10;
-
-    if (showLeft != _showLeftFade || showRight != _showRightFade) {
-      setState(() {
-        _showLeftFade = showLeft;
-        _showRightFade = showRight;
-      });
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
-    if (widget.episodes.isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    final railHeight = Breakpoints.getEpisodeRailHeight(context);
-    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
-    final cardSpacing = Breakpoints.getCardSpacing(context);
-
-    return SizedBox(
-      height: railHeight,
-      child: Stack(
-        children: [
-          // Main scrollable list of episode cards.
-          ListView.builder(
-            controller: _scrollController,
-            scrollDirection: Axis.horizontal,
-            padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-            itemCount: widget.episodes.length,
-            itemBuilder: (context, index) {
-              final episode = widget.episodes[index];
-              return Padding(
-                key: ValueKey(episode.id),
-                padding: EdgeInsets.only(
-                  right: index < widget.episodes.length - 1 ? cardSpacing : 0,
-                ),
-                child: EpisodeRailCard(
-                  episode: episode,
-                  showTitle: widget.showTitle,
-                  showId: widget.showId,
-                  showPosterUrl: widget.showPosterUrl,
-                  selected: episode.id == widget.selectedEpisodeId,
-                  onTap: episode.hasFile && widget.onEpisodeTap != null
-                      ? () => widget.onEpisodeTap!(episode)
-                      : null,
-                ),
-              );
-            },
-          ),
-
-          // Left fade gradient.
-          if (_showLeftFade)
-            Positioned(
-              left: 0,
-              top: 0,
-              bottom: 0,
-              child: IgnorePointer(
-                child: Container(
-                  key: const ValueKey('episode-rail-left-fade'),
-                  width: 40,
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.centerLeft,
-                      end: Alignment.centerRight,
-                      colors: [
-                        AppColors.background,
-                        AppColors.background.withValues(alpha: 0),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-
-          // Right fade gradient.
-          if (_showRightFade)
-            Positioned(
-              right: 0,
-              top: 0,
-              bottom: 0,
-              child: IgnorePointer(
-                child: Container(
-                  key: const ValueKey('episode-rail-right-fade'),
-                  width: 40,
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.centerRight,
-                      end: Alignment.centerLeft,
-                      colors: [
-                        AppColors.background,
-                        AppColors.background.withValues(alpha: 0),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-        ],
-      ),
+    return HorizontalRail(
+      itemCount: episodes.length,
+      height: Breakpoints.getEpisodeRailHeight(context),
+      leftFadeKey: const ValueKey('episode-rail-left-fade'),
+      rightFadeKey: const ValueKey('episode-rail-right-fade'),
+      itemBuilder: (context, index) {
+        final episode = episodes[index];
+        return EpisodeRailCard(
+          key: ValueKey(episode.id),
+          episode: episode,
+          showTitle: showTitle,
+          showId: showId,
+          showPosterUrl: showPosterUrl,
+          selected: episode.id == selectedEpisodeId,
+          onTap: episode.hasFile && onEpisodeTap != null
+              ? () => onEpisodeTap!(episode)
+              : null,
+        );
+      },
     );
   }
 }

--- a/player/lib/presentation/widgets/horizontal_rail.dart
+++ b/player/lib/presentation/widgets/horizontal_rail.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import '../../core/layout/breakpoints.dart';
+import '../../core/theme/colors.dart';
+
+/// The scroll-and-fade shell shared by the app's horizontal rails.
+///
+/// Owns the [ScrollController], the left/right edge-fade visibility, and the
+/// post-frame recompute that has to run whenever the scrollable extent
+/// changes. Callers supply the item count, an item builder, and the rail
+/// height; inter-card spacing and horizontal padding come from [Breakpoints]
+/// so every rail lines up with every other.
+///
+/// Fade keys are caller-supplied so a screen showing several rails keeps each
+/// one's fades individually assertable in tests.
+class HorizontalRail extends StatefulWidget {
+  final int itemCount;
+  final Widget Function(BuildContext context, int index) itemBuilder;
+  final double height;
+  final Key leftFadeKey;
+  final Key rightFadeKey;
+
+  const HorizontalRail({
+    super.key,
+    required this.itemCount,
+    required this.itemBuilder,
+    required this.height,
+    required this.leftFadeKey,
+    required this.rightFadeKey,
+  });
+
+  @override
+  State<HorizontalRail> createState() => _HorizontalRailState();
+}
+
+class _HorizontalRailState extends State<HorizontalRail> {
+  final ScrollController _scrollController = ScrollController();
+
+  // Both fades start hidden and are turned on once layout reports how far the
+  // rail can actually scroll. Assuming a right fade up front would leave one
+  // stranded over a rail whose items already fit on screen.
+  bool _showLeftFade = false;
+  bool _showRightFade = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_updateFadeState);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Runs once on mount and again whenever the width changes (rotation,
+    // resize, window drag), both of which change how far the rail can scroll.
+    _scheduleFadeUpdate();
+  }
+
+  @override
+  void didUpdateWidget(covariant HorizontalRail oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.itemCount != widget.itemCount) {
+      _scheduleFadeUpdate();
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_updateFadeState);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  /// Scroll extent is only known once the list has been laid out, so anything
+  /// that changes it has to defer the recompute to the end of the frame.
+  void _scheduleFadeUpdate() {
+    WidgetsBinding.instance.addPostFrameCallback((_) => _updateFadeState());
+  }
+
+  void _updateFadeState() {
+    if (!mounted || !_scrollController.hasClients) return;
+
+    final position = _scrollController.position;
+    final showLeft = position.pixels > 10;
+    final showRight = position.pixels < position.maxScrollExtent - 10;
+
+    if (showLeft != _showLeftFade || showRight != _showRightFade) {
+      setState(() {
+        _showLeftFade = showLeft;
+        _showRightFade = showRight;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.itemCount == 0) {
+      return const SizedBox.shrink();
+    }
+
+    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
+    final cardSpacing = Breakpoints.getCardSpacing(context);
+
+    return SizedBox(
+      height: widget.height,
+      child: Stack(
+        children: [
+          ListView.builder(
+            controller: _scrollController,
+            scrollDirection: Axis.horizontal,
+            padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+            itemCount: widget.itemCount,
+            itemBuilder: (context, index) {
+              return Padding(
+                padding: EdgeInsets.only(
+                  right: index < widget.itemCount - 1 ? cardSpacing : 0,
+                ),
+                child: widget.itemBuilder(context, index),
+              );
+            },
+          ),
+          if (_showLeftFade) _buildFade(widget.leftFadeKey, atStart: true),
+          if (_showRightFade) _buildFade(widget.rightFadeKey, atStart: false),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFade(Key key, {required bool atStart}) {
+    return Positioned(
+      left: atStart ? 0 : null,
+      right: atStart ? null : 0,
+      top: 0,
+      bottom: 0,
+      child: IgnorePointer(
+        child: Container(
+          key: key,
+          width: 40,
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: atStart ? Alignment.centerLeft : Alignment.centerRight,
+              end: atStart ? Alignment.centerRight : Alignment.centerLeft,
+              colors: [
+                AppColors.background,
+                AppColors.background.withValues(alpha: 0),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/player/test/core/downloads/thumbnail_cache_warmer_test.dart
+++ b/player/test/core/downloads/thumbnail_cache_warmer_test.dart
@@ -1,0 +1,90 @@
+import 'package:file/memory.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/downloads/thumbnail_cache_warmer.dart';
+import 'package:player/domain/models/download.dart';
+
+/// Records the URLs it is asked for and, when [throwOnDownload] is set,
+/// simulates an offline or 404 fetch. Every other member of the interface is
+/// unused here and routed to [noSuchMethod].
+class _FakeCacheManager implements BaseCacheManager {
+  _FakeCacheManager({this.throwOnDownload = false});
+
+  final bool throwOnDownload;
+  final List<String> requested = <String>[];
+
+  @override
+  Future<FileInfo> downloadFile(
+    String url, {
+    String? key,
+    Map<String, String>? authHeaders,
+    bool force = false,
+  }) async {
+    requested.add(url);
+    if (throwOnDownload) {
+      throw Exception('network unavailable');
+    }
+    return FileInfo(
+      MemoryFileSystem().file('unused'),
+      FileSource.Online,
+      DateTime(2026, 1, 1),
+      url,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} is not used in tests');
+}
+
+DownloadTask _task({String? thumbnailUrl}) {
+  return DownloadTask(
+    id: 't1',
+    mediaId: 'm1',
+    title: 'Pilot',
+    quality: '1080p',
+    createdAt: DateTime(2026, 1, 1),
+    thumbnailUrl: thumbnailUrl,
+  );
+}
+
+void main() {
+  test('fetches the thumbnail url when one is present', () async {
+    final cache = _FakeCacheManager();
+
+    await warmThumbnailCache(
+      _task(thumbnailUrl: 'https://example.test/ep.jpg'),
+      cache: cache,
+    );
+
+    expect(cache.requested, ['https://example.test/ep.jpg']);
+  });
+
+  test('fetches nothing when the thumbnail url is null', () async {
+    final cache = _FakeCacheManager();
+
+    await warmThumbnailCache(_task(), cache: cache);
+
+    expect(cache.requested, isEmpty);
+  });
+
+  test('fetches nothing when the thumbnail url is empty', () async {
+    final cache = _FakeCacheManager();
+
+    await warmThumbnailCache(_task(thumbnailUrl: ''), cache: cache);
+
+    expect(cache.requested, isEmpty);
+  });
+
+  test('returns normally when the fetch throws', () async {
+    final cache = _FakeCacheManager(throwOnDownload: true);
+
+    await expectLater(
+      warmThumbnailCache(
+        _task(thumbnailUrl: 'https://example.test/ep.jpg'),
+        cache: cache,
+      ),
+      completes,
+    );
+  });
+}

--- a/player/test/core/layout/breakpoints_test.dart
+++ b/player/test/core/layout/breakpoints_test.dart
@@ -77,4 +77,30 @@ void main() {
       }
     });
   });
+
+  group('getDownloadedEpisodeRailHeight', () {
+    testWidgets('exceeds the episode rail height at every breakpoint',
+        (tester) async {
+      for (final width in <double>[400, 800, 1400]) {
+        late double downloadsHeight;
+        late double showHeight;
+
+        await tester.pumpWidget(
+          MediaQuery(
+            data: MediaQueryData(size: Size(width, 900)),
+            child: Builder(
+              builder: (context) {
+                downloadsHeight =
+                    Breakpoints.getDownloadedEpisodeRailHeight(context);
+                showHeight = Breakpoints.getEpisodeRailHeight(context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+
+        expect(downloadsHeight, greaterThan(showHeight));
+      }
+    });
+  });
 }

--- a/player/test/domain/models/download_task_test.dart
+++ b/player/test/domain/models/download_task_test.dart
@@ -138,7 +138,8 @@ void main() {
           expect(task.statusDisplay, equals('Preparing & Downloading'));
         });
 
-        test('shows "Starting Download..." when transcode complete but download at 0',
+        test(
+            'shows "Starting Download..." when transcode complete but download at 0',
             () {
           final task = _createTask(
             status: 'downloading',
@@ -394,6 +395,34 @@ void main() {
 
         expect(updated.transcodeProgress, equals(0.5));
         expect(updated.downloadProgress, equals(0.8));
+      });
+    });
+
+    group('episodeCode', () {
+      test('pads season and episode to two digits', () {
+        final task = DownloadTask(
+          id: 't1',
+          mediaId: 'm1',
+          title: 'Pilot',
+          quality: '1080p',
+          createdAt: DateTime(2026, 1, 1),
+          seasonNumber: 1,
+          episodeNumber: 3,
+        );
+
+        expect(task.episodeCode, 'S01E03');
+      });
+
+      test('renders question marks when the numbers are missing', () {
+        final task = DownloadTask(
+          id: 't1',
+          mediaId: 'm1',
+          title: 'A Movie',
+          quality: '1080p',
+          createdAt: DateTime(2026, 1, 1),
+        );
+
+        expect(task.episodeCode, 'S??E??');
       });
     });
   });

--- a/player/test/domain/models/downloaded_media_test.dart
+++ b/player/test/domain/models/downloaded_media_test.dart
@@ -158,8 +158,10 @@ void main() {
         expect(media.episodeNumber, equals(1));
         expect(media.showId, equals('show-789'));
         expect(media.showTitle, equals('Test Show'));
-        expect(media.showPosterUrl, equals('https://example.com/show-poster.jpg'));
-        expect(media.thumbnailUrl, equals('https://example.com/episode-thumb.jpg'));
+        expect(
+            media.showPosterUrl, equals('https://example.com/show-poster.jpg'));
+        expect(media.thumbnailUrl,
+            equals('https://example.com/episode-thumb.jpg'));
         expect(media.airDate, equals('2024-01-15'));
       });
 
@@ -179,10 +181,14 @@ void main() {
         final media = DownloadedMedia.fromTask(task);
         final after = DateTime.now();
 
-        expect(media.downloadedAt.isAfter(before) ||
-            media.downloadedAt.isAtSameMomentAs(before), isTrue);
-        expect(media.downloadedAt.isBefore(after) ||
-            media.downloadedAt.isAtSameMomentAs(after), isTrue);
+        expect(
+            media.downloadedAt.isAfter(before) ||
+                media.downloadedAt.isAtSameMomentAs(before),
+            isTrue);
+        expect(
+            media.downloadedAt.isBefore(after) ||
+                media.downloadedAt.isAtSameMomentAs(after),
+            isTrue);
       });
 
       test('handles null genres from task', () {
@@ -247,6 +253,38 @@ void main() {
         );
 
         expect(media.genres, isEmpty);
+      });
+    });
+
+    group('episodeCode', () {
+      test('pads season and episode to two digits', () {
+        final media = DownloadedMedia(
+          id: 'd1',
+          mediaId: 'm1',
+          title: 'Pilot',
+          quality: '1080p',
+          filePath: '/tmp/a.mp4',
+          fileSize: 1024,
+          downloadedAt: DateTime(2026, 1, 1),
+          seasonNumber: 12,
+          episodeNumber: 7,
+        );
+
+        expect(media.episodeCode, 'S12E07');
+      });
+
+      test('renders question marks when the numbers are missing', () {
+        final media = DownloadedMedia(
+          id: 'd1',
+          mediaId: 'm1',
+          title: 'A Movie',
+          quality: '1080p',
+          filePath: '/tmp/a.mp4',
+          fileSize: 1024,
+          downloadedAt: DateTime(2026, 1, 1),
+        );
+
+        expect(media.episodeCode, 'S??E??');
       });
     });
   });

--- a/player/test/presentation/screens/downloads/download_queue_row_test.dart
+++ b/player/test/presentation/screens/downloads/download_queue_row_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/downloads/download_providers.dart';
+import 'package:player/domain/models/download.dart';
+import 'package:player/presentation/screens/downloads/widgets/download_queue_row.dart';
+
+DownloadTask _task({
+  double progress = 0.5,
+  bool isProgressive = false,
+  double transcodeProgress = 0.0,
+  double downloadProgress = 0.0,
+  int? fileSize = 3221225472, // exactly 3 GiB -> "3.00 GB"
+  int? downloadedBytes = 1610612736, // exactly 1.5 GiB -> "1.50 GB"
+}) {
+  return DownloadTask(
+    id: 't1',
+    mediaId: 'ep-3',
+    title: 'A Rather Long Episode Title',
+    quality: '1080p',
+    progress: progress,
+    status: 'downloading',
+    mediaType: 'episode',
+    fileSize: fileSize,
+    downloadedBytes: downloadedBytes,
+    createdAt: DateTime(2026, 1, 1),
+    isProgressive: isProgressive,
+    transcodeProgress: transcodeProgress,
+    downloadProgress: downloadProgress,
+    seasonNumber: 1,
+    episodeNumber: 3,
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required DownloadTask task,
+  double bytesPerSecond = 0,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        downloadSpeedInfoProvider.overrideWith(
+          (ref) => Stream.value({
+            task.id: DownloadSpeedInfo(bytesPerSecond: bytesPerSecond),
+          }),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(body: DownloadQueueRow(task: task)),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('renders the episode code and title', (tester) async {
+    await _pump(tester, task: _task());
+
+    expect(find.text('S01E03'), findsOneWidget);
+    expect(find.text('A Rather Long Episode Title'), findsOneWidget);
+  });
+
+  testWidgets('renders percentage and byte progress', (tester) async {
+    await _pump(tester, task: _task());
+
+    expect(
+      find.byKey(const ValueKey('download-queue-row-metrics')),
+      findsOneWidget,
+    );
+    final metrics = tester.widget<Text>(
+      find.byKey(const ValueKey('download-queue-row-metrics')),
+    );
+    expect(metrics.data, startsWith('50%'));
+    expect(metrics.data, contains('1.50 GB / 3.00 GB'));
+  });
+
+  testWidgets('omits the speed segment when the rate is zero', (tester) async {
+    await _pump(tester, task: _task());
+
+    final metrics = tester.widget<Text>(
+      find.byKey(const ValueKey('download-queue-row-metrics')),
+    );
+    expect(metrics.data, isNot(contains('/s')));
+  });
+
+  testWidgets('includes the speed segment when the rate is positive',
+      (tester) async {
+    await _pump(tester, task: _task(), bytesPerSecond: 4718592);
+
+    final metrics = tester.widget<Text>(
+      find.byKey(const ValueKey('download-queue-row-metrics')),
+    );
+    expect(metrics.data, contains('/s'));
+  });
+
+  testWidgets('uses combined progress for progressive tasks', (tester) async {
+    await _pump(
+      tester,
+      task: _task(
+        progress: 0.0,
+        isProgressive: true,
+        transcodeProgress: 1.0,
+        downloadProgress: 0.5,
+      ),
+    );
+
+    final bar = tester.widget<LinearProgressIndicator>(
+      find.byKey(const ValueKey('download-queue-row-bar')),
+    );
+    // 1.0 * 0.3 + 0.5 * 0.7 = 0.65
+    expect(bar.value, closeTo(0.65, 0.001));
+  });
+
+  testWidgets('cancel opens the confirmation dialog', (tester) async {
+    await _pump(tester, task: _task());
+
+    await tester.tap(find.byKey(const ValueKey('download-queue-row-cancel')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Cancel Download?'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/screens/downloads/downloaded_episode_card_test.dart
+++ b/player/test/presentation/screens/downloads/downloaded_episode_card_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/playback/local_playback_progress.dart';
+import 'package:player/core/playback/playback_progress_store.dart';
+import 'package:player/core/playback/playback_progress_providers.dart';
+import 'package:player/domain/models/download.dart';
+import 'package:player/presentation/screens/downloads/widgets/downloaded_episode_card.dart';
+import 'package:player/presentation/widgets/quality_badge.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+
+DownloadedMedia _media({
+  String quality = '1080p',
+  String? thumbnailUrl = 'https://example.test/ep.jpg',
+}) {
+  return DownloadedMedia(
+    id: 'd1',
+    mediaId: 'ep-1',
+    title: 'Pilot',
+    quality: quality,
+    filePath: '/tmp/ep.mp4',
+    fileSize: 1610612736, // exactly 1.5 GiB -> "1.50 GB"
+    mediaType: 'episode',
+    downloadedAt: DateTime(2026, 1, 1),
+    seasonNumber: 1,
+    episodeNumber: 1,
+    showId: 'show-1',
+    thumbnailUrl: thumbnailUrl,
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required DownloadedMedia media,
+  LocalPlaybackProgress? progress,
+}) async {
+  final store = InMemoryPlaybackProgressStore();
+  if (progress != null) {
+    await store.save(progress);
+  }
+
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          playbackProgressStoreProvider.overrideWith((ref) async => store),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: DownloadedEpisodeCard(media: media, showId: 'show-1'),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+}
+
+void main() {
+  testWidgets('renders the episode code, title and file size', (tester) async {
+    await _pump(tester, media: _media());
+
+    expect(find.text('S01E01'), findsOneWidget);
+    expect(find.text('Pilot'), findsOneWidget);
+    expect(find.text('1.50 GB'), findsOneWidget);
+  });
+
+  testWidgets('renders the quality badge when quality is set', (tester) async {
+    await _pump(tester, media: _media());
+
+    expect(find.byType(QualityBadge), findsOneWidget);
+  });
+
+  testWidgets('omits the quality badge when quality is empty', (tester) async {
+    await _pump(tester, media: _media(quality: ''));
+
+    expect(find.byType(QualityBadge), findsNothing);
+  });
+
+  testWidgets('omits the resume bar when there is no stored progress',
+      (tester) async {
+    await _pump(tester, media: _media());
+
+    expect(
+      find.byKey(const ValueKey('downloaded-episode-resume-bar')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('renders the resume bar when progress is stored', (tester) async {
+    await _pump(
+      tester,
+      media: _media(),
+      progress: LocalPlaybackProgress(
+        mediaId: 'ep-1',
+        mediaType: 'episode',
+        positionSeconds: 300,
+        durationSeconds: 1200,
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+    );
+
+    expect(
+      find.byKey(const ValueKey('downloaded-episode-resume-bar')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('the action menu offers play and delete', (tester) async {
+    await _pump(tester, media: _media());
+
+    await tester.tap(find.byKey(const ValueKey('downloaded-episode-menu')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Play'), findsOneWidget);
+    expect(find.text('Delete'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/screens/downloads/downloaded_episode_rail_test.dart
+++ b/player/test/presentation/screens/downloads/downloaded_episode_rail_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/playback/playback_progress_store.dart';
+import 'package:player/core/playback/playback_progress_providers.dart';
+import 'package:player/domain/models/download.dart';
+import 'package:player/presentation/screens/downloads/widgets/downloaded_episode_card.dart';
+import 'package:player/presentation/screens/downloads/widgets/downloaded_episode_rail.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+
+DownloadedMedia _media(int episodeNumber) {
+  return DownloadedMedia(
+    id: 'd$episodeNumber',
+    mediaId: 'ep-$episodeNumber',
+    title: 'Episode $episodeNumber',
+    quality: '1080p',
+    filePath: '/tmp/$episodeNumber.mp4',
+    fileSize: 1024,
+    mediaType: 'episode',
+    downloadedAt: DateTime(2026, 1, 1),
+    seasonNumber: 1,
+    episodeNumber: episodeNumber,
+    showId: 'show-1',
+    thumbnailUrl: 'https://example.test/$episodeNumber.jpg',
+  );
+}
+
+Future<void> _pump(WidgetTester tester, int count) async {
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          playbackProgressStoreProvider
+              .overrideWith((ref) async => InMemoryPlaybackProgressStore()),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: DownloadedEpisodeRail(
+              episodes: List.generate(count, (i) => _media(i + 1)),
+              showId: 'show-1',
+              seasonNumber: 1,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+}
+
+void main() {
+  testWidgets('renders one card per episode', (tester) async {
+    await _pump(tester, 3);
+
+    expect(find.byType(DownloadedEpisodeCard), findsNWidgets(3));
+    expect(find.byKey(const ValueKey('ep-1')), findsOneWidget);
+    expect(find.byKey(const ValueKey('ep-3')), findsOneWidget);
+  });
+
+  testWidgets('renders nothing when the season has no downloads',
+      (tester) async {
+    await _pump(tester, 0);
+
+    expect(find.byType(DownloadedEpisodeCard), findsNothing);
+  });
+
+  testWidgets('carries a season-scoped right fade key', (tester) async {
+    await _pump(tester, 12);
+
+    expect(
+      find.byKey(const ValueKey('downloaded-rail-1-right-fade')),
+      findsOneWidget,
+    );
+  });
+}

--- a/player/test/presentation/screens/downloads/series_downloads_screen_test.dart
+++ b/player/test/presentation/screens/downloads/series_downloads_screen_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/downloads/download_providers.dart';
+import 'package:player/core/playback/playback_progress_store.dart';
+import 'package:player/core/playback/playback_progress_providers.dart';
+import 'package:player/domain/models/download.dart';
+import 'package:player/presentation/screens/downloads/series_downloads_screen.dart';
+import 'package:player/presentation/screens/downloads/widgets/download_queue_row.dart';
+import 'package:player/presentation/screens/downloads/widgets/downloaded_episode_rail.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+
+DownloadedMedia _downloaded(int season, int episode) {
+  return DownloadedMedia(
+    id: 'd-$season-$episode',
+    mediaId: 'ep-$season-$episode',
+    title: 'Episode $episode',
+    quality: '1080p',
+    filePath: '/tmp/$season-$episode.mp4',
+    fileSize: 1024,
+    mediaType: 'episode',
+    downloadedAt: DateTime(2026, 1, 1),
+    seasonNumber: season,
+    episodeNumber: episode,
+    showId: 'show-1',
+    thumbnailUrl: 'https://example.test/$season-$episode.jpg',
+  );
+}
+
+DownloadTask _queued(int season, int episode) {
+  return DownloadTask(
+    id: 't-$season-$episode',
+    mediaId: 'ep-$season-$episode',
+    title: 'Episode $episode',
+    quality: '1080p',
+    progress: 0.25,
+    status: 'downloading',
+    mediaType: 'episode',
+    fileSize: 2048,
+    createdAt: DateTime(2026, 1, 1),
+    seasonNumber: season,
+    episodeNumber: episode,
+    showId: 'show-1',
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  List<DownloadedMedia> downloaded = const [],
+  List<DownloadTask> queue = const [],
+}) async {
+  // Tall enough that multi-season rails stay in the buildable viewport —
+  // SliverList does not build off-screen children.
+  await tester.binding.setSurfaceSize(const Size(800, 2000));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          downloadedMediaProvider
+              .overrideWith((ref) => Stream.value(downloaded)),
+          downloadQueueProvider.overrideWith((ref) => Stream.value(queue)),
+          downloadSpeedInfoProvider.overrideWith((ref) => Stream.value({})),
+          playbackProgressStoreProvider
+              .overrideWith((ref) async => InMemoryPlaybackProgressStore()),
+        ],
+        child: const MaterialApp(
+          home: SeriesDownloadsScreen(
+            showId: 'show-1',
+            showTitle: 'Test Show',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+}
+
+void main() {
+  testWidgets('renders one rail per season', (tester) async {
+    await _pump(tester, downloaded: [
+      _downloaded(1, 1),
+      _downloaded(1, 2),
+      _downloaded(2, 1),
+    ]);
+
+    expect(find.byType(DownloadedEpisodeRail), findsNWidgets(2));
+  });
+
+  testWidgets('season headers carry the episode count', (tester) async {
+    await _pump(tester, downloaded: [_downloaded(1, 1), _downloaded(1, 2)]);
+
+    expect(find.text('Season 1'), findsOneWidget);
+    expect(find.text('(2 episodes)'), findsOneWidget);
+  });
+
+  testWidgets('renders a season header even for a single season',
+      (tester) async {
+    await _pump(tester, downloaded: [_downloaded(1, 1)]);
+
+    expect(find.text('Season 1'), findsOneWidget);
+    expect(find.text('(1 episode)'), findsOneWidget);
+  });
+
+  testWidgets('labels season zero as Specials', (tester) async {
+    await _pump(tester, downloaded: [_downloaded(0, 1)]);
+
+    expect(find.text('Specials'), findsOneWidget);
+  });
+
+  testWidgets('renders a queue row per in-progress task', (tester) async {
+    await _pump(tester, queue: [_queued(1, 3), _queued(1, 4)]);
+
+    expect(find.byType(DownloadQueueRow), findsNWidgets(2));
+  });
+
+  testWidgets('shows the empty state when there is nothing', (tester) async {
+    await _pump(tester);
+
+    expect(find.text('No episodes found'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/widgets/horizontal_rail_test.dart
+++ b/player/test/presentation/widgets/horizontal_rail_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/horizontal_rail.dart';
+
+const _leftKey = ValueKey('test-rail-left-fade');
+const _rightKey = ValueKey('test-rail-right-fade');
+
+Future<void> _pump(WidgetTester tester, int itemCount) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: HorizontalRail(
+          itemCount: itemCount,
+          height: 120,
+          leftFadeKey: _leftKey,
+          rightFadeKey: _rightKey,
+          itemBuilder: (context, index) => SizedBox(
+            key: ValueKey('item-$index'),
+            width: 200,
+            height: 100,
+            child: Text('Item $index'),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('renders nothing when there are no items', (tester) async {
+    await _pump(tester, 0);
+
+    expect(find.byKey(const ValueKey('item-0')), findsNothing);
+    expect(find.byKey(_leftKey), findsNothing);
+    expect(find.byKey(_rightKey), findsNothing);
+  });
+
+  testWidgets('builds one child per item', (tester) async {
+    await _pump(tester, 3);
+
+    expect(find.byKey(const ValueKey('item-0')), findsOneWidget);
+    expect(find.byKey(const ValueKey('item-1')), findsOneWidget);
+    expect(find.byKey(const ValueKey('item-2')), findsOneWidget);
+  });
+
+  testWidgets('shows only the right fade before scrolling', (tester) async {
+    await _pump(tester, 12);
+
+    expect(find.byKey(_rightKey), findsOneWidget);
+    expect(find.byKey(_leftKey), findsNothing);
+  });
+
+  testWidgets('shows the left fade once scrolled away from the start',
+      (tester) async {
+    await _pump(tester, 12);
+
+    await tester.drag(find.byType(ListView), const Offset(-400, 0));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(_leftKey), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Rebuilds the Flutter series downloads screen so completed episodes render as per-season horizontal 16:9 card rails, with readable three-line in-progress queue rows
- Extracts shared `HorizontalRail` (migrates `EpisodeRail`), splits the 876-line screen into focused widgets, and warms episode thumbnails at download completion for offline artwork
- Adds `episodeCode` getters on download models and `getDownloadedEpisodeRailHeight` for the taller downloads label strip

## Test plan
- [x] `flutter test --concurrency=1` (1686 tests)
- [x] `flutter analyze` (no errors; pre-existing infos only)
- [ ] Manual: multi-season show shows one rail per season with edge fades
- [ ] Manual: cards show artwork, code, title, size, quality badge; resume bar when progress exists
- [ ] Manual: ⋮ menu play/delete; queue row cancel; airplane-mode artwork after online download