### PR TITLE
fix(player): make card taps honest about what they do

### DIFF
--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -17,7 +17,6 @@ import '../../widgets/episode_rail.dart';
 import '../../widgets/freshness_header.dart';
 import '../../widgets/quality_download_dialog.dart';
 import '../../../core/graphql/watch/query_key.dart';
-import '../../../core/player/media_file_selector.dart';
 import '../../../core/player/resume_plan.dart';
 import '../../../core/theme/colors.dart';
 import '../../widgets/cast_actions.dart';
@@ -224,6 +223,26 @@ class ShowDetailScreen extends ConsumerWidget {
     if (episodes.isEmpty) return null;
     return episodes.where((e) => e.id == selectedEpisodeId).firstOrNull ??
         episodes.first;
+  }
+
+  /// Carries the viewport back to the hero after a rail selection.
+  ///
+  /// The rail sits at the foot of a long page while the hero it feeds sits at
+  /// the head, so on a phone a selection lands entirely off-screen and the tap
+  /// reads as dead. Drives the enclosing [Scrollable] rather than a
+  /// [ScrollController], because [ShowDetailScreen] is a [ConsumerWidget] with
+  /// no state to own one; the hero is the first sliver, so the minimum extent
+  /// is the hero by construction.
+  void _revealHero(BuildContext railContext) {
+    final position = Scrollable.maybeOf(railContext)?.position;
+    if (position == null || position.pixels <= position.minScrollExtent) {
+      return;
+    }
+    position.animateTo(
+      position.minScrollExtent,
+      duration: const Duration(milliseconds: 400),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   Widget _buildContent(BuildContext context, WidgetRef ref, ShowDetail show) {
@@ -982,48 +1001,40 @@ class ShowDetailScreen extends ConsumerWidget {
         return SliverToBoxAdapter(
           child: Padding(
             padding: const EdgeInsets.only(top: 16),
-            child: EpisodeRail(
-              episodes: episodes,
-              showTitle: show?.title ?? 'Unknown Show',
-              showId: show?.id,
-              showPosterUrl: show?.artwork.posterUrl,
-              // Resolved through the same helper the hero uses, so the rail
-              // highlights whichever episode the hero describes — including
-              // the fallback cases where the selected id matches nothing in
-              // this season's list.
-              selectedEpisodeId: _resolveSelectedEpisode(
-                ref.watch(selectedEpisodeProvider(id)),
-                episodes,
-              )?.id,
-              onEpisodeTap: (episode) async {
-                ref
-                    .read(selectedEpisodeProvider(id).notifier)
-                    .select(episode.id);
-                if (episode.seasonNumber != selectedSeason) {
+            // Builder so the tap handler closes over a context *inside* the
+            // CustomScrollView. _buildEpisodeList receives _buildContent's
+            // context, which sits outside it, and _revealHero needs the
+            // enclosing Scrollable.
+            child: Builder(
+              builder: (railContext) => EpisodeRail(
+                episodes: episodes,
+                showTitle: show?.title ?? 'Unknown Show',
+                showId: show?.id,
+                showPosterUrl: show?.artwork.posterUrl,
+                // Resolved through the same helper the hero uses, so the rail
+                // highlights whichever episode the hero describes — including
+                // the fallback cases where the selected id matches nothing in
+                // this season's list.
+                selectedEpisodeId: _resolveSelectedEpisode(
+                  ref.watch(selectedEpisodeProvider(id)),
+                  episodes,
+                )?.id,
+                // The rail picks; the hero plays. Tapping a card used to
+                // resolve a file and launch the player, which gave the show
+                // page's own tap a different meaning from every other card in
+                // the app and left no route to the episode's details.
+                onEpisodeTap: (episode) {
                   ref
-                      .read(selectedSeasonProvider(id).notifier)
-                      .select(episode.seasonNumber);
-                }
-                if (episode.files.isNotEmpty) {
-                  final screenWidth = MediaQuery.sizeOf(context).width;
-                  final deviceContext = await DeviceContext.detect(screenWidth);
-                  final selectedFile = MediaFileSelector.selectBest(
-                    episode.files,
-                    deviceContext,
-                  );
-                  if (selectedFile != null && context.mounted) {
-                    final showAsync =
-                        ref.read(showDetailControllerProvider(id));
-                    final show = showAsync.value;
-                    final title = show != null
-                        ? '${show.title} - ${episode.episodeCode}'
-                        : episode.title;
-                    context.push(
-                      '/player/episode/${episode.id}?fileId=${selectedFile.id}&title=${Uri.encodeComponent(title)}&showId=$id&seasonNumber=${episode.seasonNumber}',
-                    );
+                      .read(selectedEpisodeProvider(id).notifier)
+                      .select(episode.id);
+                  if (episode.seasonNumber != selectedSeason) {
+                    ref
+                        .read(selectedSeasonProvider(id).notifier)
+                        .select(episode.seasonNumber);
                   }
-                }
-              },
+                  _revealHero(railContext);
+                },
+              ),
             ),
           ),
         );

--- a/player/lib/presentation/widgets/content_rail.dart
+++ b/player/lib/presentation/widgets/content_rail.dart
@@ -203,6 +203,7 @@ class _ContentRailState extends State<ContentRail> {
         progressPercentage: item.progress?.percentage,
         width: cardSize.width,
         height: cardSize.height,
+        action: MediaCardAction.play,
         onTap: () => widget.onItemActivate != null
             ? widget.onItemActivate!(item)
             : widget.onItemTap?.call(item.id, item.type),
@@ -214,6 +215,7 @@ class _ContentRailState extends State<ContentRail> {
         subtitle: item.newContentLabel ?? item.year?.toString(),
         width: cardSize.width,
         height: cardSize.height,
+        action: MediaCardAction.open,
         onTap: () => widget.onItemTap?.call(item.id, item.type),
       );
     } else if (item is UpNextItem) {
@@ -223,6 +225,7 @@ class _ContentRailState extends State<ContentRail> {
         subtitle: item.episode.episodeCode,
         width: cardSize.width,
         height: cardSize.height,
+        action: MediaCardAction.play,
         onTap: () => widget.onItemActivate != null
             ? widget.onItemActivate!(item)
             : widget.onItemTap?.call(item.episode.id, 'episode'),

--- a/player/lib/presentation/widgets/content_rail.dart
+++ b/player/lib/presentation/widgets/content_rail.dart
@@ -5,6 +5,7 @@ import '../../domain/models/continue_watching_item.dart';
 import '../../domain/models/recently_added_item.dart';
 import '../../domain/models/up_next_item.dart';
 import 'media_card.dart';
+import 'media_context_menu.dart';
 
 class ContentRail extends StatefulWidget {
   final String title;
@@ -196,6 +197,13 @@ class _ContentRailState extends State<ContentRail> {
     final cardSize = Breakpoints.getCardSize(context);
 
     if (item is ContinueWatchingItem) {
+      final target = MediaContextTarget(
+        id: item.id,
+        type: item.type,
+        showId: item.showId,
+        hasFile: item.files.isNotEmpty,
+        tapPlays: widget.onItemActivate != null,
+      );
       return MediaCard(
         posterUrl: item.posterUrl,
         title: item.title,
@@ -203,34 +211,67 @@ class _ContentRailState extends State<ContentRail> {
         progressPercentage: item.progress?.percentage,
         width: cardSize.width,
         height: cardSize.height,
-        action: MediaCardAction.play,
+        action: _actionFor(target),
         onTap: () => widget.onItemActivate != null
             ? widget.onItemActivate!(item)
             : widget.onItemTap?.call(item.id, item.type),
+        onContextMenu: (cardContext) => _openMenu(cardContext, target, item),
       );
     } else if (item is RecentlyAddedItem) {
+      final target = MediaContextTarget(id: item.id, type: item.type);
       return MediaCard(
         posterUrl: item.posterUrl,
         title: item.title,
         subtitle: item.newContentLabel ?? item.year?.toString(),
         width: cardSize.width,
         height: cardSize.height,
-        action: MediaCardAction.open,
+        action: _actionFor(target),
         onTap: () => widget.onItemTap?.call(item.id, item.type),
+        onContextMenu: (cardContext) => _openMenu(cardContext, target, item),
       );
     } else if (item is UpNextItem) {
+      final target = MediaContextTarget(
+        id: item.episode.id,
+        type: 'episode',
+        showId: item.show.id,
+        hasFile: item.episode.hasFile,
+        tapPlays: widget.onItemActivate != null,
+      );
       return MediaCard(
         posterUrl: item.posterUrl,
         title: item.show.title,
         subtitle: item.episode.episodeCode,
         width: cardSize.width,
         height: cardSize.height,
-        action: MediaCardAction.play,
+        action: _actionFor(target),
         onTap: () => widget.onItemActivate != null
             ? widget.onItemActivate!(item)
             : widget.onItemTap?.call(item.episode.id, 'episode'),
+        onContextMenu: (cardContext) => _openMenu(cardContext, target, item),
       );
     }
     return const SizedBox.shrink();
+  }
+
+  /// A card promises playback exactly when its tap delivers it, which is when
+  /// this rail was given an activate handler and the target is playable.
+  MediaCardAction _actionFor(MediaContextTarget target) =>
+      target.tapPlays && target.hasFile
+          ? MediaCardAction.play
+          : MediaCardAction.open;
+
+  /// The rail owns the menu rather than forwarding it to the screen: it
+  /// already knows how to turn each item type into a target, and it already
+  /// holds the play handler the menu's Play entry needs.
+  void _openMenu(
+    BuildContext cardContext,
+    MediaContextTarget target,
+    Object item,
+  ) {
+    showMediaContextMenu(
+      cardContext,
+      target: target,
+      onPlay: () => widget.onItemActivate?.call(item),
+    );
   }
 }

--- a/player/lib/presentation/widgets/episode_rail_card.dart
+++ b/player/lib/presentation/widgets/episode_rail_card.dart
@@ -30,6 +30,9 @@ class EpisodeRailCard extends ConsumerStatefulWidget {
   /// episode has no file.
   final VoidCallback? onTap;
 
+  /// Finder handle for the hover preview of the selection ring.
+  static const selectionPreviewKey = ValueKey('episode-card-selection-preview');
+
   const EpisodeRailCard({
     super.key,
     required this.episode,
@@ -136,37 +139,23 @@ class _EpisodeRailCardState extends ConsumerState<EpisodeRailCard> {
                     : _buildPlaceholder(),
               ),
 
-              // Hover overlay with play button (solid scrim — no live blur, to
-              // keep the scrolling rail cheap). Only when the episode is playable.
-              if (_episode.hasFile)
+              // Hover preview of the selection ring. The tap selects this
+              // episode into the hero rather than playing it, so a play glyph
+              // here would promise something the tap does not do. The ring
+              // previews what the tap will actually leave behind.
+              if (!widget.selected)
                 Positioned.fill(
                   child: IgnorePointer(
                     child: AnimatedOpacity(
+                      key: EpisodeRailCard.selectionPreviewKey,
                       opacity: _isHovered ? 1.0 : 0.0,
                       duration: const Duration(milliseconds: 200),
-                      child: Container(
-                        color: Colors.black.withValues(alpha: 0.4),
-                        child: Center(
-                          child: Container(
-                            width: 44,
-                            height: 44,
-                            decoration: BoxDecoration(
-                              color: AppColors.primary,
-                              shape: BoxShape.circle,
-                              boxShadow: [
-                                BoxShadow(
-                                  color:
-                                      AppColors.primary.withValues(alpha: 0.4),
-                                  blurRadius: 12,
-                                  offset: const Offset(0, 4),
-                                ),
-                              ],
-                            ),
-                            child: const Icon(
-                              Icons.play_arrow_rounded,
-                              size: 26,
-                              color: Colors.white,
-                            ),
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(
+                            color: AppColors.primary.withValues(alpha: 0.6),
+                            width: 2,
                           ),
                         ),
                       ),

--- a/player/lib/presentation/widgets/media_card.dart
+++ b/player/lib/presentation/widgets/media_card.dart
@@ -7,6 +7,16 @@ import 'poster_frame.dart';
 import 'progress_overlay.dart';
 import 'quality_badge.dart';
 
+/// What tapping a [MediaCard] does.
+///
+/// The card's affordance follows from this: an [open] card offers a click
+/// cursor and nothing else, a [play] card draws an always-visible badge so a
+/// touch user can see the tap will launch playback. Required rather than
+/// defaulted, because the promise and the behavior drifted apart once already.
+/// The widget took an opaque `onTap` plus a doc comment claiming it never
+/// played, while two of the four home rails handed it a callback that did.
+enum MediaCardAction { open, play }
+
 /// A portrait poster card for the horizontal content rails.
 ///
 /// The depth treatment lives in [PosterFrame]; this widget contributes the
@@ -23,6 +33,9 @@ class MediaCard extends StatelessWidget {
   final double? height;
   final List<MediaFile>? files;
 
+  /// What tapping this card does. Drives the affordance, so it is required.
+  final MediaCardAction action;
+
   /// If true, uses responsive sizing based on screen width.
   final bool responsive;
 
@@ -36,6 +49,7 @@ class MediaCard extends StatelessWidget {
     this.width,
     this.height,
     this.files,
+    required this.action,
     this.responsive = false,
   });
 
@@ -46,6 +60,10 @@ class MediaCard extends StatelessWidget {
   // Default dimensions for non-responsive mode.
   static const double _defaultWidth = 130;
   static const double _defaultHeight = 195;
+
+  /// Finder handle for the play badge, so tests assert on the badge itself
+  /// rather than on whichever glyph happens to be inside it.
+  static const playBadgeKey = ValueKey('media-card-play-badge');
 
   Widget _buildPlaceholder() {
     return ColoredBox(
@@ -84,9 +102,9 @@ class MediaCard extends StatelessWidget {
 
     final progress = progressPercentage;
 
-    // A click cursor and nothing more: tapping a card opens the title, it does
-    // not start playback, so there is no play glyph and no hoverOverlay here.
-    // The cursor wraps the whole tap target, title and subtitle included.
+    // The tap target wraps the whole card, title and subtitle included. What
+    // the tap promises comes from `action`: an opening card offers a click
+    // cursor and no glyph, a playing card also carries the badge below.
     return MouseRegion(
       cursor: onTap != null ? SystemMouseCursors.click : MouseCursor.defer,
       child: GestureDetector(
@@ -105,6 +123,7 @@ class MediaCard extends StatelessWidget {
                   overlays: [
                     if (progress != null && progress > 0)
                       ProgressOverlay(percentage: progress),
+                    if (action == MediaCardAction.play) const _PlayBadge(),
                     if (quality.hasQuality)
                       Positioned(
                         top: 8,
@@ -139,6 +158,39 @@ class MediaCard extends StatelessWidget {
                 ),
               ],
             ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The touch-visible promise that this card's tap starts playback.
+///
+/// Always painted rather than revealed on hover, because hover never fires on
+/// a phone and the phone is where the ambiguity was reported. Sits inset above
+/// [ProgressOverlay]'s 4px bar rather than flush in the corner: every Continue
+/// Watching card carries both at once.
+class _PlayBadge extends StatelessWidget {
+  const _PlayBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Positioned(
+      left: 8,
+      bottom: 10,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: AppColors.primary,
+          shape: BoxShape.circle,
+        ),
+        child: Padding(
+          padding: EdgeInsets.all(4),
+          child: Icon(
+            Icons.play_arrow_rounded,
+            key: MediaCard.playBadgeKey,
+            size: 18,
+            color: Colors.white,
           ),
         ),
       ),

--- a/player/lib/presentation/widgets/media_card.dart
+++ b/player/lib/presentation/widgets/media_card.dart
@@ -36,6 +36,10 @@ class MediaCard extends StatelessWidget {
   /// What tapping this card does. Drives the affordance, so it is required.
   final MediaCardAction action;
 
+  /// Called on long press and on secondary tap, with a context inside this
+  /// card so the menu can anchor to it. Null means the card has no menu.
+  final void Function(BuildContext cardContext)? onContextMenu;
+
   /// If true, uses responsive sizing based on screen width.
   final bool responsive;
 
@@ -50,6 +54,7 @@ class MediaCard extends StatelessWidget {
     this.height,
     this.files,
     required this.action,
+    this.onContextMenu,
     this.responsive = false,
   });
 
@@ -102,6 +107,8 @@ class MediaCard extends StatelessWidget {
 
     final progress = progressPercentage;
 
+    final contextMenu = onContextMenu;
+
     // The tap target wraps the whole card, title and subtitle included. What
     // the tap promises comes from `action`: an opening card offers a click
     // cursor and no glyph, a playing card also carries the badge below.
@@ -109,6 +116,11 @@ class MediaCard extends StatelessWidget {
       cursor: onTap != null ? SystemMouseCursors.click : MouseCursor.defer,
       child: GestureDetector(
         onTap: onTap,
+        // Long press for touch, secondary tap for a desktop right-click. Both
+        // reach the same menu, the way Infuse exposes the same actions on iOS
+        // and on the Mac.
+        onLongPress: contextMenu == null ? null : () => contextMenu(context),
+        onSecondaryTap: contextMenu == null ? null : () => contextMenu(context),
         child: SizedBox(
           width: cardWidth,
           child: Column(

--- a/player/lib/presentation/widgets/media_context_menu.dart
+++ b/player/lib/presentation/widgets/media_context_menu.dart
@@ -47,11 +47,19 @@ class MediaContextTarget {
 /// Pure, so the visibility rules are unit-testable without pumping a menu.
 /// An empty result means the card gets no menu at all.
 List<MediaContextAction> mediaContextActionsFor(MediaContextTarget target) {
+  // A card whose own tap opens the title earns no menu at all. Gating only
+  // `movieDetails` on this left two holes: an episode target got
+  // `episodeDetails` regardless, duplicating what its tap already did, and any
+  // target with a file got `play` even where the rail had no play handler to
+  // run, since `_openMenu` routes Play through a nullable `onItemActivate`.
+  // That is a Play entry that silently does nothing.
+  if (!target.tapPlays) return const [];
+
   return [
     if (target.hasFile) MediaContextAction.play,
     if (target.showId != null) MediaContextAction.goToShow,
     if (target.isEpisode) MediaContextAction.episodeDetails,
-    if (target.isMovie && target.tapPlays) MediaContextAction.movieDetails,
+    if (target.isMovie) MediaContextAction.movieDetails,
   ];
 }
 

--- a/player/lib/presentation/widgets/media_context_menu.dart
+++ b/player/lib/presentation/widgets/media_context_menu.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/theme/colors.dart';
+
+/// What a card's long-press menu can offer.
+enum MediaContextAction { play, goToShow, episodeDetails, movieDetails }
+
+/// The subject of a long-press menu, flattened out of whichever rail item the
+/// card was built from.
+///
+/// The menu deliberately knows nothing about `ContinueWatchingItem`,
+/// `UpNextItem` or `RecentlyAddedItem`. Each converts itself into one of these
+/// where the card is built, so a new rail item type needs no change here.
+class MediaContextTarget {
+  /// What the card depicts: a movie id or an episode id.
+  final String id;
+
+  /// 'movie', 'tv_show', or 'episode'.
+  final String type;
+
+  /// The owning series, when the target is an episode that knows it.
+  final String? showId;
+
+  /// Whether the target has a playable file.
+  final bool hasFile;
+
+  /// Whether the card body already starts playback. Only a card that plays
+  /// earns a details entry, because a card that already opens the title would
+  /// be offering a second route to where its own tap goes.
+  final bool tapPlays;
+
+  const MediaContextTarget({
+    required this.id,
+    required this.type,
+    this.showId,
+    this.hasFile = false,
+    this.tapPlays = false,
+  });
+
+  bool get isEpisode => type.toLowerCase() == 'episode';
+  bool get isMovie => type.toLowerCase() == 'movie';
+}
+
+/// The entries [target] earns, in display order.
+///
+/// Pure, so the visibility rules are unit-testable without pumping a menu.
+/// An empty result means the card gets no menu at all.
+List<MediaContextAction> mediaContextActionsFor(MediaContextTarget target) {
+  return [
+    if (target.hasFile) MediaContextAction.play,
+    if (target.showId != null) MediaContextAction.goToShow,
+    if (target.isEpisode) MediaContextAction.episodeDetails,
+    if (target.isMovie && target.tapPlays) MediaContextAction.movieDetails,
+  ];
+}
+
+/// Menu copy for [action].
+String mediaContextLabel(MediaContextAction action) => switch (action) {
+      MediaContextAction.play => 'Play',
+      MediaContextAction.goToShow => 'Go to show',
+      MediaContextAction.episodeDetails => 'Episode details',
+      MediaContextAction.movieDetails => 'Movie details',
+    };
+
+/// Menu glyph for [action].
+IconData mediaContextIcon(MediaContextAction action) => switch (action) {
+      MediaContextAction.play => Icons.play_arrow_rounded,
+      MediaContextAction.goToShow => Icons.tv_rounded,
+      MediaContextAction.episodeDetails => Icons.info_outline_rounded,
+      MediaContextAction.movieDetails => Icons.info_outline_rounded,
+    };
+
+/// Opens the card's secondary menu, anchored under the card.
+///
+/// Wired to long-press on touch and to secondary tap on desktop, which is how
+/// Infuse exposes the same actions on iOS and on the Mac. [context] must be a
+/// context inside the card, since its render object is the anchor.
+///
+/// A [showMenu] popup rather than a modal bottom sheet: this reads correctly at
+/// 400px and at 1600px, and matches the `PopupMenuButton` already used by
+/// `EpisodeRailCard`, `ShowDetailScreen` and `CollectionDetailScreen`.
+Future<void> showMediaContextMenu(
+  BuildContext context, {
+  required MediaContextTarget target,
+  required VoidCallback onPlay,
+}) async {
+  final actions = mediaContextActionsFor(target);
+  if (actions.isEmpty) return;
+
+  final anchor = context.findRenderObject();
+  final overlay = Overlay.of(context).context.findRenderObject();
+  if (anchor is! RenderBox || overlay is! RenderBox) return;
+
+  final topLeft = anchor.localToGlobal(Offset.zero, ancestor: overlay);
+  final position = RelativeRect.fromLTRB(
+    topLeft.dx,
+    topLeft.dy + anchor.size.height,
+    overlay.size.width - topLeft.dx - anchor.size.width,
+    0,
+  );
+
+  final selected = await showMenu<MediaContextAction>(
+    context: context,
+    position: position,
+    items: [
+      for (final action in actions)
+        PopupMenuItem<MediaContextAction>(
+          value: action,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                mediaContextIcon(action),
+                size: 18,
+                color: AppColors.textSecondary,
+              ),
+              const SizedBox(width: 12),
+              Text(mediaContextLabel(action)),
+            ],
+          ),
+        ),
+    ],
+  );
+
+  if (selected == null || !context.mounted) return;
+
+  switch (selected) {
+    case MediaContextAction.play:
+      onPlay();
+    case MediaContextAction.goToShow:
+      final showId = target.showId;
+      if (showId != null) context.push('/show/$showId');
+    case MediaContextAction.episodeDetails:
+      context.push('/episode/${target.id}');
+    case MediaContextAction.movieDetails:
+      context.push('/movie/${target.id}');
+  }
+}

--- a/player/test/presentation/screens/show/show_detail_screen_test.dart
+++ b/player/test/presentation/screens/show/show_detail_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/presentation/screens/show/show_detail_screen.dart';
 import 'package:player/presentation/widgets/cast_rail.dart';
 import 'package:player/presentation/widgets/detail_action_row.dart';
+import 'package:player/presentation/widgets/episode_rail_card.dart';
 import 'package:player/presentation/widgets/play_button.dart';
 
 import '../../../test_utils/mock_network_images.dart';
@@ -459,5 +460,33 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.text('Play'), findsOneWidget);
+  });
+
+  testWidgets(
+      'tapping a rail card selects the episode without starting playback',
+      (tester) async {
+    final pushed = <String>[];
+    final playable = _episodeJson(3, files: [_fileJson('file-3')]);
+
+    await _pumpScreen(
+      tester,
+      size: const Size(1000, 2200),
+      episodesBySeason: {
+        1: [_episodeJson(1, watched: true), _episodeJson(2), playable],
+      },
+      pushedRoutes: pushed,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byType(EpisodeRailCard).last,
+      warnIfMissed: false,
+    );
+    await tester.pumpAndSettle();
+
+    // The rail picks; the hero plays. Nothing here reaches the player.
+    expect(pushed, isEmpty);
+    // And the pick landed: the hero now describes the episode that was tapped.
+    expect(find.textContaining('E3'), findsWidgets);
   });
 }

--- a/player/test/presentation/screens/show/show_detail_screen_test.dart
+++ b/player/test/presentation/screens/show/show_detail_screen_test.dart
@@ -484,9 +484,58 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // The rail picks; the hero plays. Nothing here reaches the player.
+    // Cheap defense: the old hero path awaited DeviceContext.detect, which
+    // never completes in a widget test, so the player route was unreachable
+    // anyway. This is not the regression guard.
     expect(pushed, isEmpty);
-    // And the pick landed: the hero now describes the episode that was tapped.
-    expect(find.textContaining('E3'), findsWidgets);
+    final cards = tester
+        .widgetList<EpisodeRailCard>(find.byType(EpisodeRailCard))
+        .toList();
+    expect(cards.last.selected, isTrue);
+  });
+
+  testWidgets('tapping a rail card carries the viewport back to the hero',
+      (tester) async {
+    final playable = _episodeJson(3, files: [_fileJson('file-3')]);
+
+    await _pumpScreen(
+      tester,
+      // Phone-shaped, so the rail sits well below the fold and there is real
+      // scroll extent for _revealHero to travel back across. 1200px tall is
+      // the minimum height where the episode sliver is built but still below
+      // the fold; at 800px the lazy sliver never mounts and at 1400px+ the
+      // rail is already visible without scrolling.
+      size: const Size(400, 1200),
+      episodesBySeason: {
+        1: [_episodeJson(1, watched: true), _episodeJson(2), playable],
+      },
+    );
+    await tester.pumpAndSettle();
+
+    final verticalScrollable = find
+        .descendant(
+          of: find.byType(CustomScrollView),
+          matching: find.byType(Scrollable),
+        )
+        .first;
+
+    await tester.scrollUntilVisible(
+      find.byType(EpisodeRailCard).first,
+      300,
+      scrollable: verticalScrollable,
+    );
+    await tester.pumpAndSettle();
+
+    final position = tester.state<ScrollableState>(verticalScrollable).position;
+    expect(
+      position.pixels,
+      greaterThan(position.minScrollExtent),
+      reason: 'the rail must start below the fold or this test is vacuous',
+    );
+
+    await tester.tap(find.byType(EpisodeRailCard).first);
+    await tester.pumpAndSettle();
+
+    expect(position.pixels, position.minScrollExtent);
   });
 }

--- a/player/test/presentation/widgets/ambient_backdrop_tint_test.dart
+++ b/player/test/presentation/widgets/ambient_backdrop_tint_test.dart
@@ -130,6 +130,7 @@ void main() {
                     child: MediaCard(
                       title: 'Movie',
                       posterUrl: 'https://example.com/p.jpg',
+                      action: MediaCardAction.open,
                     ),
                   ),
                 ),
@@ -177,7 +178,8 @@ void main() {
                 child: SizedBox(
                   width: 130,
                   height: 260,
-                  child: MediaCard(title: 'No Art'),
+                  child:
+                      MediaCard(title: 'No Art', action: MediaCardAction.open),
                 ),
               ),
             ),

--- a/player/test/presentation/widgets/content_rail_test.dart
+++ b/player/test/presentation/widgets/content_rail_test.dart
@@ -15,6 +15,7 @@ import 'package:player/domain/models/recently_added_item.dart';
 import 'package:player/domain/models/up_next_item.dart';
 import 'package:player/presentation/widgets/content_rail.dart';
 import 'package:player/presentation/widgets/media_card.dart';
+import 'package:player/presentation/widgets/media_context_menu.dart';
 
 List<RecentlyAddedItem> _items(int n) => List.generate(
       n,
@@ -180,6 +181,73 @@ void main() {
       await tester.pump();
 
       expect(actionOf(tester), MediaCardAction.open);
+    });
+
+    // A rail card with nothing playable behind it must not promise playback:
+    // home_screen.dart:128 falls back to the detail screen for exactly this
+    // case, so the badge would be advertising a tap that navigates.
+    testWidgets('an unplayable Continue Watching card promises navigation',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(
+          title: 'Continue Watching',
+          items: const [
+            ContinueWatchingItem(id: 'cw-2', type: 'movie', title: 'No Files'),
+          ],
+          onItemActivate: (_) {},
+        )),
+      );
+      await tester.pump();
+
+      expect(actionOf(tester), MediaCardAction.open);
+    });
+  });
+
+  group('ContentRail context menu', () {
+    testWidgets('long-pressing an Up Next card offers its show and details',
+        (tester) async {
+      const upNext = UpNextItem(
+        progressState: 'next_up',
+        episode: UpNextEpisode(
+          id: 'ep-1',
+          seasonNumber: 1,
+          episodeNumber: 2,
+          title: 'Pilot',
+          hasFile: true,
+        ),
+        show: UpNextShow(id: 'show-1', title: 'The Bear'),
+      );
+
+      await tester.pumpWidget(
+        _host(ContentRail(
+          title: 'Up Next',
+          items: const [upNext],
+          onItemActivate: (_) {},
+        )),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.byType(MediaCard));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Play'), findsOneWidget);
+      expect(find.text('Go to show'), findsOneWidget);
+      expect(find.text('Episode details'), findsOneWidget);
+    });
+
+    // The rails that already open the title on tap earn nothing from a menu
+    // offering to open the title, so they get none.
+    testWidgets('long-pressing a Recently Added card opens no menu',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(title: 'Recently Added', items: _items(1))),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.byType(MediaCard));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PopupMenuItem<MediaContextAction>), findsNothing);
     });
   });
 }

--- a/player/test/presentation/widgets/content_rail_test.dart
+++ b/player/test/presentation/widgets/content_rail_test.dart
@@ -9,7 +9,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/continue_watching_item.dart';
+import 'package:player/domain/models/media_file.dart';
 import 'package:player/domain/models/recently_added_item.dart';
+import 'package:player/domain/models/up_next_item.dart';
 import 'package:player/presentation/widgets/content_rail.dart';
 import 'package:player/presentation/widgets/media_card.dart';
 
@@ -112,6 +115,71 @@ void main() {
       await tester.pump();
 
       expect(find.text('2023'), findsOneWidget);
+    });
+  });
+
+  // The regression guard for the reported bug: two of these four rails start
+  // playback on tap and two open the title, and before MediaCardAction the
+  // widget could not tell which it was doing.
+  group('ContentRail card actions', () {
+    const file = MediaFile(id: 'file-1', directPlaySupported: true);
+
+    const continueWatching = ContinueWatchingItem(
+      id: 'cw-1',
+      type: 'movie',
+      title: 'In Progress',
+      files: [file],
+    );
+
+    const upNext = UpNextItem(
+      progressState: 'next_up',
+      episode: UpNextEpisode(
+        id: 'ep-1',
+        seasonNumber: 1,
+        episodeNumber: 2,
+        title: 'Pilot',
+        hasFile: true,
+        files: [file],
+      ),
+      show: UpNextShow(id: 'show-1', title: 'The Bear'),
+    );
+
+    MediaCardAction actionOf(WidgetTester tester) =>
+        tester.widget<MediaCard>(find.byType(MediaCard)).action;
+
+    testWidgets('the Continue Watching rail promises playback', (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(
+          title: 'Continue Watching',
+          items: const [continueWatching],
+          onItemActivate: (_) {},
+        )),
+      );
+      await tester.pump();
+
+      expect(actionOf(tester), MediaCardAction.play);
+    });
+
+    testWidgets('the Up Next rail promises playback', (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(
+          title: 'Up Next',
+          items: const [upNext],
+          onItemActivate: (_) {},
+        )),
+      );
+      await tester.pump();
+
+      expect(actionOf(tester), MediaCardAction.play);
+    });
+
+    testWidgets('the Recently Added rail promises navigation', (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(title: 'Recently Added', items: _items(1))),
+      );
+      await tester.pump();
+
+      expect(actionOf(tester), MediaCardAction.open);
     });
   });
 }

--- a/player/test/presentation/widgets/episode_rail_card_test.dart
+++ b/player/test/presentation/widgets/episode_rail_card_test.dart
@@ -7,7 +7,9 @@ import 'package:player/domain/models/episode.dart';
 import 'package:player/domain/models/progress.dart';
 import 'package:player/presentation/widgets/episode_rail_card.dart';
 
+import '../../test_utils/hover_affordance.dart';
 import '../../test_utils/mock_network_images.dart';
+import '../../test_utils/poster_contract.dart';
 
 Episode _episode({
   bool hasFile = true,
@@ -179,5 +181,47 @@ void main() {
     final unselectedBorder = unselectedDecoration.border as Border;
     expect(unselectedBorder.top.color, Colors.transparent);
     expect(unselectedBorder.top.width, 2);
+  });
+
+  testWidgets(
+      'offers no play glyph at rest or on hover, because tapping a rail card '
+      'selects the episode into the hero rather than playing it',
+      (tester) async {
+    await _pump(tester, _episode());
+    await tester.pumpAndSettle();
+
+    expect(findPlayGlyph(), findsNothing);
+
+    await hoverOver(tester, find.byType(EpisodeRailCard));
+
+    expect(findPlayGlyph(), findsNothing);
+  });
+
+  testWidgets('hover previews the selection ring on an unselected card',
+      (tester) async {
+    await _pump(tester, _episode());
+    await tester.pumpAndSettle();
+
+    // Keyed rather than found by type: MaterialApp's own route machinery
+    // contributes AnimatedOpacity widgets, so a bare byType finder would be
+    // reading whichever one happened to come first in tree order.
+    final ring = find.byKey(EpisodeRailCard.selectionPreviewKey);
+
+    expect(tester.widget<AnimatedOpacity>(ring).opacity, 0.0);
+
+    await hoverOver(tester, find.byType(EpisodeRailCard));
+
+    expect(tester.widget<AnimatedOpacity>(ring).opacity, 1.0);
+  });
+
+  testWidgets('an already-selected card previews nothing on hover',
+      (tester) async {
+    await _pump(tester, _episode(), selected: true);
+    await tester.pumpAndSettle();
+
+    await hoverOver(tester, find.byType(EpisodeRailCard));
+
+    // The card already draws its real ring; a preview of it would be noise.
+    expect(find.byKey(EpisodeRailCard.selectionPreviewKey), findsNothing);
   });
 }

--- a/player/test/presentation/widgets/media_card_test.dart
+++ b/player/test/presentation/widgets/media_card_test.dart
@@ -18,7 +18,7 @@ const _cardHost = Size(130, 260);
 void main() {
   runPosterDepthContract(
     description: 'MediaCard',
-    build: () => const MediaCard(title: 'Movie'),
+    build: () => const MediaCard(title: 'Movie', action: MediaCardAction.open),
     size: _cardHost,
   );
 
@@ -27,7 +27,11 @@ void main() {
         (tester) async {
       await tester.pumpWidget(
         posterHost(
-          const MediaCard(title: 'Movie', progressPercentage: 42),
+          const MediaCard(
+            title: 'Movie',
+            progressPercentage: 42,
+            action: MediaCardAction.open,
+          ),
           size: _cardHost,
         ),
       );
@@ -36,10 +40,13 @@ void main() {
     });
 
     testWidgets(
-        'offers no play affordance at rest or on hover, because tapping a '
-        'card opens the title rather than playing it', (tester) async {
+        'an open card offers no play affordance at rest or on hover, because '
+        'tapping it opens the title rather than playing it', (tester) async {
       await tester.pumpWidget(
-        posterHost(const MediaCard(title: 'Movie'), size: _cardHost),
+        posterHost(
+          const MediaCard(title: 'Movie', action: MediaCardAction.open),
+          size: _cardHost,
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -50,11 +57,51 @@ void main() {
       expect(findPlayGlyph(), findsNothing);
     });
 
+    testWidgets(
+        'a play card shows its badge at rest, so a touch user can see the tap '
+        'will start playback', (tester) async {
+      await tester.pumpWidget(
+        posterHost(
+          const MediaCard(title: 'Movie', action: MediaCardAction.play),
+          size: _cardHost,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // At rest, with no pointer anywhere near it: this is the whole point of
+      // the badge, since hover never fires on a phone.
+      expect(find.byKey(MediaCard.playBadgeKey), findsOneWidget);
+      expect(findPlayGlyph(), findsOneWidget);
+    });
+
+    testWidgets('the play badge clears the progress bar', (tester) async {
+      await tester.pumpWidget(
+        posterHost(
+          const MediaCard(
+            title: 'Movie',
+            progressPercentage: 42,
+            action: MediaCardAction.play,
+          ),
+          size: _cardHost,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final badge = tester.getRect(find.byKey(MediaCard.playBadgeKey));
+      final bar = tester.getRect(find.byType(ProgressOverlay));
+
+      expect(badge.bottom, lessThanOrEqualTo(bar.top));
+    });
+
     testWidgets('a tappable card offers a click cursor, an inert one defers',
         (tester) async {
       await tester.pumpWidget(
         posterHost(
-          MediaCard(title: 'Movie', onTap: () {}),
+          MediaCard(
+            title: 'Movie',
+            action: MediaCardAction.open,
+            onTap: () {},
+          ),
           size: _cardHost,
         ),
       );
@@ -66,7 +113,10 @@ void main() {
       );
 
       await tester.pumpWidget(
-        posterHost(const MediaCard(title: 'Movie'), size: _cardHost),
+        posterHost(
+          const MediaCard(title: 'Movie', action: MediaCardAction.open),
+          size: _cardHost,
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -81,7 +131,11 @@ void main() {
 
       await tester.pumpWidget(
         posterHost(
-          MediaCard(title: 'Movie', onTap: () => tapped = true),
+          MediaCard(
+            title: 'Movie',
+            action: MediaCardAction.open,
+            onTap: () => tapped = true,
+          ),
           size: _cardHost,
         ),
       );

--- a/player/test/presentation/widgets/media_card_test.dart
+++ b/player/test/presentation/widgets/media_card_test.dart
@@ -144,4 +144,43 @@ void main() {
       expect(tapped, isTrue);
     });
   });
+
+  group('MediaCard secondary gestures', () {
+    testWidgets('long press hands back a context inside the card',
+        (tester) async {
+      BuildContext? received;
+
+      await tester.pumpWidget(
+        posterHost(
+          MediaCard(
+            title: 'Movie',
+            action: MediaCardAction.play,
+            onContextMenu: (context) => received = context,
+          ),
+          size: _cardHost,
+        ),
+      );
+      await tester.longPress(find.byType(MediaCard));
+      await tester.pump();
+
+      expect(received, isNotNull);
+      // The menu anchors to the card's own render box, so the context handed
+      // back has to resolve to one.
+      expect(received?.findRenderObject(), isA<RenderBox>());
+    });
+
+    testWidgets('a card with no menu ignores a long press', (tester) async {
+      await tester.pumpWidget(
+        posterHost(
+          const MediaCard(title: 'Movie', action: MediaCardAction.open),
+          size: _cardHost,
+        ),
+      );
+
+      await tester.longPress(find.byType(MediaCard));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+    });
+  });
 }

--- a/player/test/presentation/widgets/media_context_menu_test.dart
+++ b/player/test/presentation/widgets/media_context_menu_test.dart
@@ -77,6 +77,38 @@ void main() {
       expect(mediaContextActionsFor(target), isEmpty);
     });
 
+    // Regression for the two holes left by gating only movieDetails on
+    // tapPlays. A playable episode on a rail with no play handler used to be
+    // offered Play, which routes through a nullable onItemActivate and would
+    // have done nothing, plus an Episode details entry duplicating its own tap.
+    test('a playable episode whose tap navigates earns an empty menu', () {
+      const target = MediaContextTarget(
+        id: 'ep-4',
+        type: 'episode',
+        showId: 'show-1',
+        hasFile: true,
+      );
+
+      expect(mediaContextActionsFor(target), isEmpty);
+    });
+
+    test('no target that navigates on tap is ever offered Play', () {
+      for (final type in ['movie', 'tv_show', 'episode']) {
+        final target = MediaContextTarget(
+          id: 'x',
+          type: type,
+          showId: 'show-1',
+          hasFile: true,
+        );
+
+        expect(
+          mediaContextActionsFor(target),
+          isEmpty,
+          reason: '$type with tapPlays false must earn no menu',
+        );
+      }
+    });
+
     test('every action has a label and an icon', () {
       for (final action in MediaContextAction.values) {
         expect(mediaContextLabel(action), isNotEmpty);

--- a/player/test/presentation/widgets/media_context_menu_test.dart
+++ b/player/test/presentation/widgets/media_context_menu_test.dart
@@ -1,0 +1,87 @@
+// The long-press menu's visibility rules, asserted as pure logic.
+//
+// mediaContextActionsFor is deliberately a plain function rather than a widget
+// concern: what a card's menu offers depends only on the target, so the rules
+// are tested without pumping a menu, and showMediaContextMenu is left with
+// nothing but presentation and routing.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/media_context_menu.dart';
+
+void main() {
+  group('mediaContextActionsFor', () {
+    test('an Up Next episode offers play, its show, and its own details', () {
+      const target = MediaContextTarget(
+        id: 'ep-1',
+        type: 'episode',
+        showId: 'show-1',
+        hasFile: true,
+        tapPlays: true,
+      );
+
+      expect(mediaContextActionsFor(target), [
+        MediaContextAction.play,
+        MediaContextAction.goToShow,
+        MediaContextAction.episodeDetails,
+      ]);
+    });
+
+    test('a Continue Watching movie offers play and its own details', () {
+      const target = MediaContextTarget(
+        id: 'mv-1',
+        type: 'movie',
+        hasFile: true,
+        tapPlays: true,
+      );
+
+      expect(mediaContextActionsFor(target), [
+        MediaContextAction.play,
+        MediaContextAction.movieDetails,
+      ]);
+    });
+
+    test('a target with no playable file offers no play', () {
+      const target = MediaContextTarget(
+        id: 'ep-2',
+        type: 'episode',
+        showId: 'show-1',
+        tapPlays: true,
+      );
+
+      expect(
+        mediaContextActionsFor(target),
+        isNot(contains(MediaContextAction.play)),
+      );
+    });
+
+    test('an episode with no known show omits Go to show', () {
+      const target = MediaContextTarget(
+        id: 'ep-3',
+        type: 'episode',
+        hasFile: true,
+        tapPlays: true,
+      );
+
+      expect(
+        mediaContextActionsFor(target),
+        isNot(contains(MediaContextAction.goToShow)),
+      );
+    });
+
+    // A card whose tap already opens the title earns nothing from a menu that
+    // would only offer to open the title, so it gets no menu at all. This is
+    // what keeps the Recently Added and Favorites rails untouched.
+    test('a movie whose tap already navigates earns an empty menu', () {
+      const target = MediaContextTarget(id: 'mv-2', type: 'movie');
+
+      expect(mediaContextActionsFor(target), isEmpty);
+    });
+
+    test('every action has a label and an icon', () {
+      for (final action in MediaContextAction.values) {
+        expect(mediaContextLabel(action), isNotEmpty);
+        expect(mediaContextIcon(action), isNotNull);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Tapping an episode card in the player starts playback immediately. On mobile that is confusing, and there was no way to reach the series details page from a card that plays.

Three surfaces played on tap: the home Continue Watching rail, the home Up Next rail, and the episode rail inside a show's detail page. Everything else already navigated.

Two things made this worse on touch than it sounds. The play affordance on those cards was a **hover** overlay, which never fires on a phone, so identical-looking cards had opposite behavior with nothing to tell them apart. And no card anywhere in the player had an `onLongPress`, so once a tap launched fullscreen playback there was nothing to recover to.

## What Infuse and Plex actually do

The convention both follow comes from the Apple TV app, which states it as two clauses: selecting an item in Continue Watching resumes immediately, and selecting artwork anywhere else opens that item's page.

Plex applies this almost universally. Every poster, card, and episode row opens the preplay screen, which carries Play plus Resume when partially watched. The one documented bypass is Continue Watching, which Plex's own settings docs distinguish from "the Resume button on the details page". Infuse has the same shape and adds a long-press context menu as the escape hatch.

Neither app branches on platform for *where* a tap goes. What changes is how many targets the input can address: Plex Web puts a play button and a "..." menu on hover, and on mobile those collapse into the preplay screen and a long press.

## The rule this implements

> A card's body opens what it depicts. The resume rails are the exception: Continue Watching and Up Next resume on tap. Playback anywhere else comes from a labelled control. Long press opens the paths the tap did not take.

Nothing branches on screen width. `Breakpoints.isDesktop` is width-only (`>= 900px`), so an iPad in landscape reads as desktop; touch affordances here are always present and hover is additive on top.

## Changes

**`MediaCard` now declares what its tap does.** It previously took an opaque `onTap` alongside a doc comment asserting it never started playback, which was false for two of the four rails using it. A required `MediaCardAction` settles it at the call site, and a `play` card draws an always-visible badge instead of relying on hover. The value is derived from the target, so a rail card with nothing playable behind it stops promising a playback its tap cannot deliver.

**A long-press context menu.** New `media_context_menu.dart` offering Play, Go to show, and the episode or movie details screen. Its visibility rules are a pure function over a flattened target, so they are unit-testable without pumping a menu and the rails stay free of item-type knowledge. Wired to long press and to secondary tap, so desktop right-click reaches the same menu. This gives `/episode/:id` a way in from the home screen for the first time, and that screen already links back to its series.

**The show page episode rail picks, the hero plays.** Tapping a card used to resolve a file and push the player route. The hero above it already renders the selected episode with its title, description, and Play button, so the rail now only selects and carries the viewport back to the hero. This costs one extra tap to play the next episode from the show page, which is what Plex charges for the same interaction.

Unchanged: the library, favorites, recently added, unwatched, and collection grids, search results, the home hero, and the player screen. None of them played on tap.

## Testing

Full player suite: 1673 passed, 0 failed. `flutter analyze`: 0 errors, 0 warnings (51 pre-existing info lints, against a baseline of 52 on master).

Worth calling out for reviewers: the `expect(pushed, isEmpty)` assertion in the show-detail rail test is **cheap defense, not the regression guard**. The old code awaited `DeviceContext.detect`, which goes through `connectivity_plus`'s platform channel and never reached the push in a widget test, so that assertion passed against the buggy code too. The discriminating test is the scroll one, which proves `_revealHero` works and could not have passed before this change.

## Still to verify on a device

Widget tests cannot cover either of these:

- Long press versus drag-to-scroll in the horizontal rails. A stationary long press should win the gesture arena, but it needs a real touch device.
- The hero reveal on a phone-sized window: scroll to the episode rail, tap a card, confirm the viewport animates back to a hero describing the tapped episode.
