### PR TITLE
feat(player): add library sort options and wire the dead sort menu

### DIFF
--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -85,6 +85,9 @@ defmodule MydiaWeb.Schema.CommonTypes do
   input_object :sort_input do
     field :field, :sort_field, default_value: :title
     field :direction, :sort_direction, default_value: :asc
+
+    @desc "Seed for the random sort. Send the same value across pages of one shuffle."
+    field :seed, :integer
   end
 
   @desc "Pagination info for cursor-based pagination"

--- a/lib/mydia_web/schema/enum_types.ex
+++ b/lib/mydia_web/schema/enum_types.ex
@@ -41,6 +41,8 @@ defmodule MydiaWeb.Schema.EnumTypes do
     value(:content_rating, description: "Sort by content rating")
     value(:release_date, description: "Sort by release date")
     value(:random, description: "Shuffle, stable for a given seed")
+    value(:last_played, description: "Sort by when the viewer last watched it")
+    value(:watch_state, description: "Sort by watched state; ascending puts unwatched first")
   end
 
   @desc "Sort direction"

--- a/lib/mydia_web/schema/enum_types.ex
+++ b/lib/mydia_web/schema/enum_types.ex
@@ -36,6 +36,10 @@ defmodule MydiaWeb.Schema.EnumTypes do
     value(:added_at, description: "Sort by date added")
     value(:year, description: "Sort by year")
     value(:rating, description: "Sort by rating")
+    value(:runtime, description: "Sort by duration")
+    value(:popularity, description: "Sort by popularity")
+    value(:content_rating, description: "Sort by content rating")
+    value(:release_date, description: "Sort by release date")
   end
 
   @desc "Sort direction"

--- a/lib/mydia_web/schema/enum_types.ex
+++ b/lib/mydia_web/schema/enum_types.ex
@@ -40,6 +40,7 @@ defmodule MydiaWeb.Schema.EnumTypes do
     value(:popularity, description: "Sort by popularity")
     value(:content_rating, description: "Sort by content rating")
     value(:release_date, description: "Sort by release date")
+    value(:random, description: "Shuffle, stable for a given seed")
   end
 
   @desc "Sort direction"

--- a/lib/mydia_web/schema/resolvers/browse_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/browse_resolver.ex
@@ -4,6 +4,7 @@ defmodule MydiaWeb.Schema.Resolvers.BrowseResolver do
   """
 
   alias Mydia.{Media, Settings}
+  alias MydiaWeb.Schema.Resolvers.MediaSort
   alias MydiaWeb.Schema.Resolvers.NodeId
 
   @doc """
@@ -81,7 +82,7 @@ defmodule MydiaWeb.Schema.Resolvers.BrowseResolver do
     all_movies = Media.list_media_items(opts)
 
     # Sort
-    sorted_movies = sort_items(all_movies, sort)
+    sorted_movies = MediaSort.sort(all_movies, sort)
 
     # Apply cursor pagination
     {movies, page_info} = paginate(sorted_movies, first, after_cursor)
@@ -124,7 +125,7 @@ defmodule MydiaWeb.Schema.Resolvers.BrowseResolver do
     all_shows = Media.list_media_items(opts)
 
     # Sort
-    sorted_shows = sort_items(all_shows, sort)
+    sorted_shows = MediaSort.sort(all_shows, sort)
 
     # Apply cursor pagination
     {shows, page_info} = paginate(sorted_shows, first, after_cursor)
@@ -158,31 +159,6 @@ defmodule MydiaWeb.Schema.Resolvers.BrowseResolver do
   end
 
   # Helper functions
-
-  defp sort_items(items, %{field: field, direction: direction}) do
-    sorter =
-      case field do
-        :title -> & &1.title
-        :year -> & &1.year
-        :added_at -> & &1.inserted_at
-        :rating -> &get_rating/1
-        _ -> & &1.title
-      end
-
-    sorted = Enum.sort_by(items, sorter)
-
-    if direction == :desc do
-      Enum.reverse(sorted)
-    else
-      sorted
-    end
-  end
-
-  defp sort_items(items, _), do: Enum.sort_by(items, & &1.title)
-
-  defp get_rating(%{metadata: nil}), do: 0
-  defp get_rating(%{metadata: %{vote_average: rating}}) when is_number(rating), do: rating
-  defp get_rating(_), do: 0
 
   defp paginate(items, first, nil) do
     # No cursor - start from beginning

--- a/lib/mydia_web/schema/resolvers/browse_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/browse_resolver.ex
@@ -63,7 +63,7 @@ defmodule MydiaWeb.Schema.Resolvers.BrowseResolver do
     Ecto.NoResultsError -> {:error, "Episode not found"}
   end
 
-  def list_movies(_parent, args, _info) do
+  def list_movies(_parent, args, resolution) do
     first = Map.get(args, :first, 20)
     after_cursor = Map.get(args, :after)
     sort = Map.get(args, :sort, %{field: :title, direction: :asc})
@@ -81,8 +81,14 @@ defmodule MydiaWeb.Schema.Resolvers.BrowseResolver do
     # Get all movies for now (pagination will be implemented properly later)
     all_movies = Media.list_media_items(opts)
 
-    # Sort
-    sorted_movies = MediaSort.sort(all_movies, sort)
+    # Sort. The watch-state fields need one batched progress lookup; every
+    # other field gets an empty map and costs nothing extra. A signed-out
+    # caller has no history, so those fields downgrade to the default rather
+    # than returning an arbitrary order that would look like a broken sort.
+    user = current_user(resolution)
+    effective = MediaSort.effective_sort(sort, user)
+    progress = MediaSort.progress_map(user, sort_field(effective))
+    sorted_movies = MediaSort.sort(all_movies, effective, progress)
 
     # Apply cursor pagination
     {movies, page_info} = paginate(sorted_movies, first, after_cursor)
@@ -106,7 +112,7 @@ defmodule MydiaWeb.Schema.Resolvers.BrowseResolver do
      }}
   end
 
-  def list_tv_shows(_parent, args, _info) do
+  def list_tv_shows(_parent, args, resolution) do
     first = Map.get(args, :first, 20)
     after_cursor = Map.get(args, :after)
     sort = Map.get(args, :sort, %{field: :title, direction: :asc})
@@ -124,8 +130,14 @@ defmodule MydiaWeb.Schema.Resolvers.BrowseResolver do
     # Get all TV shows
     all_shows = Media.list_media_items(opts)
 
-    # Sort
-    sorted_shows = MediaSort.sort(all_shows, sort)
+    # Sort. The watch-state fields need one batched progress lookup; every
+    # other field gets an empty map and costs nothing extra. A signed-out
+    # caller has no history, so those fields downgrade to the default rather
+    # than returning an arbitrary order that would look like a broken sort.
+    user = current_user(resolution)
+    effective = MediaSort.effective_sort(sort, user)
+    progress = MediaSort.progress_map(user, sort_field(effective))
+    sorted_shows = MediaSort.sort(all_shows, effective, progress)
 
     # Apply cursor pagination
     {shows, page_info} = paginate(sorted_shows, first, after_cursor)
@@ -159,6 +171,12 @@ defmodule MydiaWeb.Schema.Resolvers.BrowseResolver do
   end
 
   # Helper functions
+
+  defp current_user(%{context: context}), do: context[:current_user]
+  defp current_user(_resolution), do: nil
+
+  defp sort_field(%{field: field}), do: field
+  defp sort_field(_sort), do: :title
 
   defp paginate(items, first, nil) do
     # No cursor - start from beginning

--- a/lib/mydia_web/schema/resolvers/media_sort.ex
+++ b/lib/mydia_web/schema/resolvers/media_sort.ex
@@ -21,6 +21,10 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSort do
 
   @default_sort %{field: :title, direction: :asc}
 
+  # Used when a client selects random without minting a seed. Any fixed value
+  # works; what matters is that the order stays stable across page requests.
+  @default_random_seed 0
+
   @doc """
   Sorts `items` according to `sort`.
 
@@ -29,6 +33,15 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSort do
   """
   @spec sort([struct()], map() | nil, map()) :: [struct()]
   def sort(items, sort, progress \\ %{})
+
+  def sort(items, %{field: :random} = sort, _progress) do
+    seed = Map.get(sort, :seed) || @default_random_seed
+
+    # phash2 is deterministic across processes and restarts, which :rand is
+    # not. Pagination re-sorts the whole list per request, so the permutation
+    # has to be reproducible or infinite scroll duplicates and skips items.
+    Enum.sort_by(items, &:erlang.phash2({&1.id, seed}))
+  end
 
   def sort(items, %{field: field, direction: direction}, progress)
       when direction in [:asc, :desc] do

--- a/lib/mydia_web/schema/resolvers/media_sort.ex
+++ b/lib/mydia_web/schema/resolvers/media_sort.ex
@@ -1,0 +1,68 @@
+defmodule MydiaWeb.Schema.Resolvers.MediaSort do
+  @moduledoc """
+  Ordering for the `movies` and `tv_shows` connections.
+
+  Sorting runs in memory over the whole list before pagination, so every
+  comparison here has to be total. A partial order would let page boundaries
+  shift between requests, which surfaces as duplicated and skipped items
+  during infinite scroll rather than as anything that looks like a sort bug.
+
+  Two rules hold for every field:
+
+    * Ties keep their input order. `Enum.sort_by/3` is stable in both
+      directions, which is why direction is passed to the sorter rather than
+      applied afterwards with `Enum.reverse/1`.
+    * Items whose key is unknown sort last, ascending and descending alike.
+      A film with no rating should lead neither the highest-rated nor the
+      lowest-rated list.
+  """
+
+  alias Mydia.Metadata.Access, as: MetadataAccess
+
+  @default_sort %{field: :title, direction: :asc}
+
+  @doc """
+  Sorts `items` according to `sort`.
+
+  `progress` maps a media item id to a `Mydia.Playback.Progress` struct. Only
+  the watch-state fields consult it; pass an empty map for everything else.
+  """
+  @spec sort([struct()], map() | nil, map()) :: [struct()]
+  def sort(items, sort, progress \\ %{})
+
+  def sort(items, %{field: field, direction: direction}, progress)
+      when direction in [:asc, :desc] do
+    mapper = mapper_for(field, progress)
+
+    {known, unknown} =
+      items
+      |> Enum.map(&{mapper.(&1), &1})
+      |> Enum.split_with(fn {key, _item} -> key != nil end)
+
+    sorted =
+      known
+      |> Enum.sort_by(&elem(&1, 0), sorter_for(field, direction))
+      |> Enum.map(&elem(&1, 1))
+
+    sorted ++ Enum.map(unknown, &elem(&1, 1))
+  end
+
+  def sort(items, _sort, progress), do: sort(items, @default_sort, progress)
+
+  # Key extraction. Returning nil puts the item in the unknown group.
+
+  defp mapper_for(:title, _progress), do: &downcased_title/1
+  defp mapper_for(:year, _progress), do: & &1.year
+  defp mapper_for(:added_at, _progress), do: & &1.inserted_at
+  defp mapper_for(:rating, _progress), do: &MetadataAccess.get_field(&1, :vote_average)
+  defp mapper_for(_unknown, _progress), do: &downcased_title/1
+
+  # Comparison terms. Date and DateTime need their module, since plain term
+  # order on those structs compares :day before :month before :year.
+
+  defp sorter_for(:added_at, direction), do: {direction, DateTime}
+  defp sorter_for(_field, direction), do: direction
+
+  defp downcased_title(%{title: title}) when is_binary(title), do: String.downcase(title)
+  defp downcased_title(_item), do: nil
+end

--- a/lib/mydia_web/schema/resolvers/media_sort.ex
+++ b/lib/mydia_web/schema/resolvers/media_sort.ex
@@ -18,6 +18,7 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSort do
   """
 
   alias Mydia.Metadata.Access, as: MetadataAccess
+  alias Mydia.Playback
 
   @default_sort %{field: :title, direction: :asc}
 
@@ -62,6 +63,40 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSort do
 
   def sort(items, _sort, progress), do: sort(items, @default_sort, progress)
 
+  @doc """
+  Builds the `media_item_id => progress` map the watch-state fields need.
+
+  Returns an empty map for every other field, and when there is no signed-in
+  user, so callers can invoke it unconditionally. One query, not one per item:
+  a per-item `Playback.get_progress/2` here would be an N+1 across the whole
+  library.
+  """
+  @spec progress_map(struct() | nil, atom()) :: map()
+  def progress_map(nil, _field), do: %{}
+
+  def progress_map(user, field) when field in [:last_played, :watch_state] do
+    user.id
+    |> Playback.list_user_progress()
+    |> Enum.filter(&is_nil(&1.episode_id))
+    |> Map.new(&{&1.media_item_id, &1})
+  end
+
+  def progress_map(_user, _field), do: %{}
+
+  @doc """
+  Downgrades a sort the caller cannot actually be served.
+
+  A signed-out caller has no watch history, so `:last_played` and
+  `:watch_state` have no answer for them. Returning items in whatever order
+  the query happened to produce would look like a broken sort, so those two
+  fields fall back to the default instead.
+  """
+  @spec effective_sort(map() | nil, struct() | nil) :: map() | nil
+  def effective_sort(%{field: field}, nil) when field in [:last_played, :watch_state],
+    do: @default_sort
+
+  def effective_sort(sort, _user), do: sort
+
   # Key extraction. Returning nil puts the item in the unknown group.
 
   defp mapper_for(:title, _progress), do: &downcased_title/1
@@ -75,6 +110,8 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSort do
     do: &MetadataAccess.get_field(&1, :content_rating)
 
   defp mapper_for(:release_date, _progress), do: &release_date/1
+  defp mapper_for(:last_played, progress), do: &last_played(&1, progress)
+  defp mapper_for(:watch_state, progress), do: &watched?(&1, progress)
   defp mapper_for(_unknown, _progress), do: &downcased_title/1
 
   # Comparison terms. Date and DateTime need their module, since plain term
@@ -82,6 +119,7 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSort do
 
   defp sorter_for(:added_at, direction), do: {direction, DateTime}
   defp sorter_for(:release_date, direction), do: {direction, Date}
+  defp sorter_for(:last_played, direction), do: {direction, DateTime}
   defp sorter_for(_field, direction), do: direction
 
   defp downcased_title(%{title: title}) when is_binary(title), do: String.downcase(title)
@@ -105,4 +143,21 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSort do
     do: MetadataAccess.get_field(item, :first_air_date)
 
   defp release_date(item), do: MetadataAccess.get_field(item, :release_date)
+
+  defp last_played(item, progress) do
+    case Map.get(progress, item.id) do
+      nil -> nil
+      row -> row.last_watched_at
+    end
+  end
+
+  # An item nobody has started is unwatched, not unknown: it belongs with the
+  # other unwatched items rather than at the end of the list. Elixir orders
+  # false before true, so ascending puts unwatched first.
+  defp watched?(item, progress) do
+    case Map.get(progress, item.id) do
+      nil -> false
+      row -> row.watched
+    end
+  end
 end

--- a/lib/mydia_web/schema/resolvers/media_sort.ex
+++ b/lib/mydia_web/schema/resolvers/media_sort.ex
@@ -55,14 +55,41 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSort do
   defp mapper_for(:year, _progress), do: & &1.year
   defp mapper_for(:added_at, _progress), do: & &1.inserted_at
   defp mapper_for(:rating, _progress), do: &MetadataAccess.get_field(&1, :vote_average)
+  defp mapper_for(:runtime, _progress), do: &runtime/1
+  defp mapper_for(:popularity, _progress), do: &MetadataAccess.get_field(&1, :popularity)
+
+  defp mapper_for(:content_rating, _progress),
+    do: &MetadataAccess.get_field(&1, :content_rating)
+
+  defp mapper_for(:release_date, _progress), do: &release_date/1
   defp mapper_for(_unknown, _progress), do: &downcased_title/1
 
   # Comparison terms. Date and DateTime need their module, since plain term
   # order on those structs compares :day before :month before :year.
 
   defp sorter_for(:added_at, direction), do: {direction, DateTime}
+  defp sorter_for(:release_date, direction), do: {direction, Date}
   defp sorter_for(_field, direction), do: direction
 
   defp downcased_title(%{title: title}) when is_binary(title), do: String.downcase(title)
   defp downcased_title(_item), do: nil
+
+  # TMDB gives films a scalar `runtime` and shows a list of typical episode
+  # lengths, so a show's duration is the head of that list.
+  defp runtime(%{type: "tv_show"} = item) do
+    item
+    |> MetadataAccess.get_field(:episode_run_time)
+    |> first_runtime()
+  end
+
+  defp runtime(item), do: MetadataAccess.get_field(item, :runtime)
+
+  defp first_runtime([first | _rest]), do: first
+  defp first_runtime(value) when is_integer(value), do: value
+  defp first_runtime(_value), do: nil
+
+  defp release_date(%{type: "tv_show"} = item),
+    do: MetadataAccess.get_field(item, :first_air_date)
+
+  defp release_date(item), do: MetadataAccess.get_field(item, :release_date)
 end

--- a/player/lib/core/settings/settings_service.dart
+++ b/player/lib/core/settings/settings_service.dart
@@ -15,6 +15,7 @@ class SettingsService {
   static const _defaultQualityKey = 'default_quality';
   static const _autoPlayNextKey = 'auto_play_next_episode';
   static const _autoSkipSegmentsKey = 'auto_skip_segments';
+  static const _librarySortKeyPrefix = 'library_sort_';
 
   /// Get the default quality setting.
   Future<String> getDefaultQuality() async {
@@ -53,12 +54,32 @@ class SettingsService {
     await _storage.write(key: _autoSkipSegmentsKey, value: enabled.toString());
   }
 
+  /// Get the remembered sort for a library, as its encoded string.
+  ///
+  /// [libraryKey] is 'movies' or 'tvShows'. Each library remembers its own
+  /// ordering, since a preference that suits films rarely suits shows.
+  /// Returns null when nothing has been stored yet; decoding, including the
+  /// default, belongs to the caller.
+  Future<String?> getLibrarySort(String libraryKey) async {
+    return _storage.read(key: '$_librarySortKeyPrefix$libraryKey');
+  }
+
+  /// Set the remembered sort for a library, as its encoded string.
+  Future<void> setLibrarySort(String libraryKey, String encoded) async {
+    await _storage.write(
+      key: '$_librarySortKeyPrefix$libraryKey',
+      value: encoded,
+    );
+  }
+
   /// Clear all settings.
   Future<void> clearSettings() async {
     await Future.wait([
       _storage.delete(key: _defaultQualityKey),
       _storage.delete(key: _autoPlayNextKey),
       _storage.delete(key: _autoSkipSegmentsKey),
+      _storage.delete(key: '${_librarySortKeyPrefix}movies'),
+      _storage.delete(key: '${_librarySortKeyPrefix}tvShows'),
     ]);
   }
 }

--- a/player/lib/presentation/screens/library/library_controller.dart
+++ b/player/lib/presentation/screens/library/library_controller.dart
@@ -6,6 +6,7 @@ import '../../../core/graphql/watch/controller_watcher.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/graphql/watch/query_watcher.dart';
 import '../../models/library_data.dart';
+import 'library_sort.dart';
 
 part 'library_controller.g.dart';
 
@@ -13,20 +14,9 @@ const int _pageSize = 20;
 
 enum LibraryType { movies, tvShows }
 
-enum SortOption {
-  titleAsc('Title A-Z'),
-  titleDesc('Title Z-A'),
-  yearDesc('Year (Newest)'),
-  yearAsc('Year (Oldest)'),
-  recentlyAdded('Recently Added');
-
-  const SortOption(this.displayName);
-  final String displayName;
-}
-
 const String moviesListQuery = r'''
-query MoviesList($first: Int, $after: String) {
-  movies(first: $first, after: $after) {
+query MoviesList($first: Int, $after: String, $sort: SortInput) {
+  movies(first: $first, after: $after, sort: $sort) {
     edges {
       node {
         id
@@ -65,8 +55,8 @@ query MoviesList($first: Int, $after: String) {
 ''';
 
 const String tvShowsListQuery = r'''
-query TvShowsList($first: Int, $after: String) {
-  tvShows(first: $first, after: $after) {
+query TvShowsList($first: Int, $after: String, $sort: SortInput) {
+  tvShows(first: $first, after: $after, sort: $sort) {
     edges {
       node {
         id
@@ -178,17 +168,18 @@ class LibraryController extends _$LibraryController {
   /// library, because `ObservableQuery.refetch()` re-issues the original
   /// page-1 variables and the library overwrites the accumulated edges with
   /// that single page, silently snapping the scroll position back to the
-  /// top. A user-initiated [refresh] or [setSort] is exempt on purpose: both
-  /// call `_watcher.refetch()` directly rather than going through the guard,
-  /// and both reset this flag, since going back to page 1 is exactly what
-  /// the user asked for.
+  /// top. A user-initiated [refresh] is exempt on purpose: it calls
+  /// `_watcher.refetch()` directly rather than going through the guard, and
+  /// resets this flag, since going back to page 1 is exactly what the user
+  /// asked for. Sort changes remount a new watcher via the family key, so
+  /// they reset the flag in [build] instead.
   late bool _hasPaginated;
 
   bool get _isMovies => libraryType == LibraryType.movies;
   String get _connectionField => _isMovies ? 'movies' : 'tvShows';
 
   @override
-  Stream<LibraryData> build(LibraryType libraryType) {
+  Stream<LibraryData> build(LibraryType libraryType, LibrarySort sort) {
     // Reset the pagination flag when the watcher is created. The flag tracks
     // the *current* watcher's pagination state, so a new watcher always starts
     // at page 1 with the flag cleared.
@@ -198,7 +189,7 @@ class LibraryController extends _$LibraryController {
       ref,
       key: _isMovies ? QueryKeys.moviesList : QueryKeys.tvShowsList,
       document: gql(_isMovies ? moviesListQuery : tvShowsListQuery),
-      variables: const {'first': _pageSize},
+      variables: {'first': _pageSize, 'sort': sort.toVariables()},
       parse: _isMovies ? _parseMovies : _parseTvShows,
       canRefetch: () => !_hasPaginated,
     );
@@ -206,19 +197,6 @@ class LibraryController extends _$LibraryController {
   }
 
   Future<void> refresh() {
-    _hasPaginated = false;
-    return _watcher.refetch();
-  }
-
-  /// Refetches from page 1 after the user picks a sort order.
-  ///
-  /// [sort] is deliberately unused: neither `moviesListQuery` nor
-  /// `tvShowsListQuery` takes a sort argument, so sorting has never changed
-  /// what the server returns, and this migration preserved that rather than
-  /// quietly changing it. The parameter stays because the screen already
-  /// passes its selection and this is where sort belongs once the query grows
-  /// an argument for it. Until then the only honest behavior is a refetch.
-  Future<void> setSort(SortOption sort) {
     _hasPaginated = false;
     return _watcher.refetch();
   }
@@ -234,7 +212,11 @@ class LibraryController extends _$LibraryController {
     try {
       await _watcher.fetchMore(
         FetchMoreOptions(
-          variables: {'first': _pageSize, 'after': cursor},
+          variables: {
+            'first': _pageSize,
+            'after': cursor,
+            'sort': sort.toVariables(),
+          },
           updateQuery: (previous, fetched) =>
               mergeConnection(_connectionField, previous, fetched),
         ),

--- a/player/lib/presentation/screens/library/library_screen.dart
+++ b/player/lib/presentation/screens/library/library_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'library_controller.dart';
+import 'library_sort.dart';
+import 'library_sort_provider.dart';
 import '../../models/library_data.dart';
 import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/app_shell.dart';
@@ -32,7 +34,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   final ScrollController _scrollController = ScrollController();
   final TextEditingController _searchController = TextEditingController();
   ViewMode _viewMode = ViewMode.grid;
-  SortOption _currentSort = SortOption.recentlyAdded;
   bool _showSearch = false;
 
   /// Height of the search row when it is expanded. Matches the
@@ -63,8 +64,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   void _onScroll() {
     if (_scrollController.position.pixels >=
         _scrollController.position.maxScrollExtent - 200) {
+      final sort =
+          ref.read(librarySortControllerProvider(widget.libraryType)).value ??
+              LibrarySort.defaultSort;
       ref
-          .read(libraryControllerProvider(widget.libraryType).notifier)
+          .read(libraryControllerProvider(widget.libraryType, sort).notifier)
           .loadMore();
     }
   }
@@ -85,19 +89,26 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   }
 
   Future<void> _showSortMenu() async {
-    final selected = await showModalBottomSheet<SortOption>(
+    final sort =
+        ref.read(librarySortControllerProvider(widget.libraryType)).value ??
+            LibrarySort.defaultSort;
+
+    final selected = await showModalBottomSheet<_SortSelection>(
       context: context,
       backgroundColor: Colors.transparent,
-      builder: (context) => _SortBottomSheet(currentSort: _currentSort),
+      builder: (context) => _SortBottomSheet(currentSort: sort),
     );
 
-    if (selected != null && selected != _currentSort) {
-      setState(() {
-        _currentSort = selected;
-      });
-      await ref
-          .read(libraryControllerProvider(widget.libraryType).notifier)
-          .setSort(selected);
+    if (selected == null || !mounted) return;
+
+    final controller = ref.read(
+      librarySortControllerProvider(widget.libraryType).notifier,
+    );
+
+    if (selected.toggleOnly) {
+      await controller.toggleDirection();
+    } else if (selected.field != null) {
+      await controller.select(selected.field!);
     }
   }
 
@@ -112,8 +123,19 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final libraryData =
-        ref.watch(libraryControllerProvider(widget.libraryType));
+    final sortAsync = ref.watch(
+      librarySortControllerProvider(widget.libraryType),
+    );
+
+    // Wait for the persisted sort before querying, so the library never
+    // mounts under the default and then re-queries under the stored order.
+    final sort = sortAsync.value;
+    if (sort == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final libraryAsync =
+        ref.watch(libraryControllerProvider(widget.libraryType, sort));
     final title =
         widget.libraryType == LibraryType.movies ? 'Movies' : 'TV Shows';
     final icon = widget.libraryType == LibraryType.movies
@@ -141,8 +163,8 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     return Scaffold(
       backgroundColor: Colors.transparent,
       extendBodyBehindAppBar: true,
-      appBar:
-          _buildAppBar(title, icon, isDesktop, effectiveShowSearch, barHeight),
+      appBar: _buildAppBar(
+          title, icon, isDesktop, effectiveShowSearch, barHeight, sort),
       // A `Stack`, not a `Column`: `FreshnessHeader` carries a top inset that
       // exists purely to clear an app bar this body already extends behind. As
       // a `Column` sibling that inset was charged as layout height too, so
@@ -156,12 +178,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
             edgeOffset: chromeTop,
             onRefresh: () async {
               await ref
-                  .read(libraryControllerProvider(widget.libraryType).notifier)
+                  .read(libraryControllerProvider(widget.libraryType, sort)
+                      .notifier)
                   .refresh();
             },
-            child: libraryData.when(
+            child: libraryAsync.when(
               loading: () => _buildLoadingView(),
-              error: (error, stackTrace) => _buildErrorView(error),
+              error: (error, stackTrace) => _buildErrorView(error, sort),
               data: (data) {
                 if (data.isEmpty) {
                   return _buildEmptyState();
@@ -208,7 +231,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   }
 
   PreferredSizeWidget _buildAppBar(String title, IconData icon, bool isDesktop,
-      bool showSearch, double barHeight) {
+      bool showSearch, double barHeight, LibrarySort sort) {
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
 
     return PreferredSize(
@@ -273,7 +296,8 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                       _ActionButton(
                         icon: Icons.sort_rounded,
                         onPressed: _showSortMenu,
-                        tooltip: 'Sort: ${_currentSort.displayName}',
+                        tooltip: 'Sort: ${sort.field.displayName}'
+                            '${sort.field.supportsDirection ? ' (${sort.direction == SortDirection.asc ? 'Asc' : 'Desc'})' : ''}',
                       ),
                       const SizedBox(width: 4),
                       _ActionButton(
@@ -354,7 +378,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     );
   }
 
-  Widget _buildErrorView(Object error) {
+  Widget _buildErrorView(Object error, LibrarySort sort) {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
@@ -393,8 +417,8 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
             FilledButton.icon(
               onPressed: () {
                 ref
-                    .read(
-                        libraryControllerProvider(widget.libraryType).notifier)
+                    .read(libraryControllerProvider(widget.libraryType, sort)
+                        .notifier)
                     .refresh();
               },
               icon: const Icon(Icons.refresh_rounded),
@@ -721,12 +745,14 @@ class _ListItem extends StatelessWidget {
 }
 
 class _SortBottomSheet extends StatelessWidget {
-  final SortOption currentSort;
+  final LibrarySort currentSort;
 
   const _SortBottomSheet({required this.currentSort});
 
   @override
   Widget build(BuildContext context) {
+    final directionEnabled = currentSort.field.supportsDirection;
+
     return Container(
       decoration: const BoxDecoration(
         color: AppColors.surface,
@@ -746,7 +772,7 @@ class _SortBottomSheet extends StatelessWidget {
             ),
           ),
 
-          // Title
+          // Title and direction toggle
           Padding(
             padding: const EdgeInsets.all(20),
             child: Row(
@@ -759,28 +785,48 @@ class _SortBottomSheet extends StatelessWidget {
                         fontWeight: FontWeight.bold,
                       ),
                 ),
+                const Spacer(),
+                TextButton.icon(
+                  key: const Key('sort-direction-toggle'),
+                  onPressed: directionEnabled
+                      ? () => Navigator.of(context).pop(
+                            const _SortSelection.toggleDirection(),
+                          )
+                      : null,
+                  icon: Icon(
+                    currentSort.direction == SortDirection.asc
+                        ? Icons.arrow_upward_rounded
+                        : Icons.arrow_downward_rounded,
+                    size: 18,
+                  ),
+                  label: Text(
+                    currentSort.direction == SortDirection.asc ? 'Asc' : 'Desc',
+                  ),
+                ),
               ],
             ),
           ),
 
           const Divider(height: 1),
 
-          // Options
-          ...SortOption.values.map((option) {
-            final isSelected = option == currentSort;
+          // Fields
+          ...SortField.values.map((field) {
+            final isSelected = field == currentSort.field;
             return ListTile(
+              key: Key('sort-field-${field.wireName}'),
               leading: Icon(
                 isSelected ? Icons.check_circle_rounded : Icons.circle_outlined,
                 color: isSelected ? AppColors.primary : AppColors.textSecondary,
               ),
               title: Text(
-                option.displayName,
+                field.displayName,
                 style: TextStyle(
                   fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
                   color: isSelected ? AppColors.primary : AppColors.textPrimary,
                 ),
               ),
-              onTap: () => Navigator.of(context).pop(option),
+              onTap: () =>
+                  Navigator.of(context).pop(_SortSelection.field(field)),
             );
           }),
 
@@ -789,4 +835,16 @@ class _SortBottomSheet extends StatelessWidget {
       ),
     );
   }
+}
+
+/// What the sort sheet returns: either a chosen field, or a request to flip
+/// direction without changing field.
+class _SortSelection {
+  const _SortSelection.field(this.field) : toggleOnly = false;
+  const _SortSelection.toggleDirection()
+      : field = null,
+        toggleOnly = true;
+
+  final SortField? field;
+  final bool toggleOnly;
 }

--- a/player/lib/presentation/screens/library/library_sort.dart
+++ b/player/lib/presentation/screens/library/library_sort.dart
@@ -57,9 +57,14 @@ enum SortDirection {
 
 /// A chosen ordering, ready to send as the `sort` GraphQL variable.
 ///
-/// [randomSeed] is deliberately excluded from equality and from [encode]. It
-/// is session state, not a preference: persisting it would freeze one
-/// permutation forever, which is the opposite of what picking Random means.
+/// [randomSeed] is session state rather than a preference, so it is excluded
+/// from [encode]: persisting it would freeze one permutation forever, which is
+/// the opposite of what picking Random means.
+///
+/// It is part of equality, though, and deliberately so. This type is a Riverpod
+/// family argument, so equality decides whether re-selecting Random gets a new
+/// watcher. Excluding the seed would make two shuffles compare equal and the
+/// reshuffle would silently do nothing.
 class LibrarySort {
   const LibrarySort({
     required this.field,
@@ -117,11 +122,13 @@ class LibrarySort {
   bool operator ==(Object other) =>
       other is LibrarySort &&
       other.field == field &&
-      other.direction == direction;
+      other.direction == direction &&
+      other.randomSeed == randomSeed;
 
   @override
-  int get hashCode => Object.hash(field, direction);
+  int get hashCode => Object.hash(field, direction, randomSeed);
 
   @override
-  String toString() => 'LibrarySort(${field.wireName}, ${direction.wireName})';
+  String toString() =>
+      'LibrarySort(${field.wireName}, ${direction.wireName}, seed: $randomSeed)';
 }

--- a/player/lib/presentation/screens/library/library_sort.dart
+++ b/player/lib/presentation/screens/library/library_sort.dart
@@ -1,0 +1,127 @@
+/// Library ordering, mirroring the server's `SortField` and `SortDirection`
+/// GraphQL enums.
+///
+/// Field and direction are separate rather than baked into one option per
+/// combination, which is how Plex and Jellyfin both present sorting and what
+/// keeps the sheet at eleven rows instead of twenty-one.
+enum SortField {
+  title('TITLE', 'Title'),
+  year('YEAR', 'Year'),
+  addedAt('ADDED_AT', 'Date Added'),
+  rating('RATING', 'Rating'),
+  runtime('RUNTIME', 'Duration'),
+  popularity('POPULARITY', 'Popularity'),
+  contentRating('CONTENT_RATING', 'Content Rating'),
+  releaseDate('RELEASE_DATE', 'Release Date'),
+  lastPlayed('LAST_PLAYED', 'Last Played'),
+  watchState('WATCH_STATE', 'Watch State'),
+  random('RANDOM', 'Random');
+
+  const SortField(this.wireName, this.displayName);
+
+  /// The GraphQL enum value.
+  final String wireName;
+
+  /// The label shown in the sort sheet.
+  final String displayName;
+
+  /// Random ignores direction: one shuffle has no ascending form.
+  bool get supportsDirection => this != SortField.random;
+
+  static SortField? fromWireName(String name) {
+    for (final field in SortField.values) {
+      if (field.wireName == name) return field;
+    }
+    return null;
+  }
+}
+
+enum SortDirection {
+  asc('ASC'),
+  desc('DESC');
+
+  const SortDirection(this.wireName);
+
+  final String wireName;
+
+  SortDirection get flipped =>
+      this == SortDirection.asc ? SortDirection.desc : SortDirection.asc;
+
+  static SortDirection? fromWireName(String name) {
+    for (final direction in SortDirection.values) {
+      if (direction.wireName == name) return direction;
+    }
+    return null;
+  }
+}
+
+/// A chosen ordering, ready to send as the `sort` GraphQL variable.
+///
+/// [randomSeed] is deliberately excluded from equality and from [encode]. It
+/// is session state, not a preference: persisting it would freeze one
+/// permutation forever, which is the opposite of what picking Random means.
+class LibrarySort {
+  const LibrarySort({
+    required this.field,
+    required this.direction,
+    this.randomSeed,
+  });
+
+  final SortField field;
+  final SortDirection direction;
+  final int? randomSeed;
+
+  static const LibrarySort defaultSort = LibrarySort(
+    field: SortField.addedAt,
+    direction: SortDirection.desc,
+  );
+
+  LibrarySort copyWith({
+    SortField? field,
+    SortDirection? direction,
+    int? randomSeed,
+  }) {
+    return LibrarySort(
+      field: field ?? this.field,
+      direction: direction ?? this.direction,
+      randomSeed: randomSeed ?? this.randomSeed,
+    );
+  }
+
+  Map<String, dynamic> toVariables() {
+    if (field == SortField.random) {
+      return {
+        'field': field.wireName,
+        if (randomSeed != null) 'seed': randomSeed,
+      };
+    }
+    return {'field': field.wireName, 'direction': direction.wireName};
+  }
+
+  String encode() => '${field.wireName}:${direction.wireName}';
+
+  static LibrarySort decode(String? raw) {
+    if (raw == null || raw.isEmpty) return defaultSort;
+
+    final parts = raw.split(':');
+    if (parts.length != 2) return defaultSort;
+
+    final field = SortField.fromWireName(parts[0]);
+    final direction = SortDirection.fromWireName(parts[1]);
+    if (field == null || direction == null) return defaultSort;
+
+    return LibrarySort(field: field, direction: direction);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is LibrarySort &&
+      other.field == field &&
+      other.direction == direction;
+
+  @override
+  int get hashCode => Object.hash(field, direction);
+
+  @override
+  String toString() => 'LibrarySort(${field.wireName}, ${direction.wireName})';
+}

--- a/player/lib/presentation/screens/library/library_sort_provider.dart
+++ b/player/lib/presentation/screens/library/library_sort_provider.dart
@@ -1,0 +1,71 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/settings/settings_service.dart';
+import 'library_controller.dart' show LibraryType;
+import 'library_sort.dart';
+
+part 'library_sort_provider.g.dart';
+
+/// The chosen ordering for one library, loaded from storage before the
+/// library query runs.
+///
+/// The library screen waits on this rather than mounting under the default
+/// and correcting afterwards, which would fire two queries and show a flash
+/// of the wrong order.
+@riverpod
+class LibrarySortController extends _$LibrarySortController {
+  static const _movieSeedBase = 0x5EED;
+
+  String get _storageKey =>
+      libraryType == LibraryType.movies ? 'movies' : 'tvShows';
+
+  @override
+  Future<LibrarySort> build(LibraryType libraryType) async {
+    final raw = await SettingsService().getLibrarySort(_storageKey);
+    final stored = LibrarySort.decode(raw);
+
+    // A persisted `random` needs a fresh permutation each launch, so the seed
+    // is minted here rather than restored.
+    return stored.field == SortField.random
+        ? stored.copyWith(randomSeed: _mintSeed())
+        : stored;
+  }
+
+  /// Selects [field]. Re-selecting the current field flips direction, which is
+  /// how Plex behaves. Re-selecting random reshuffles.
+  Future<void> select(SortField field) async {
+    final current = state.value ?? LibrarySort.defaultSort;
+
+    final next = switch (field) {
+      SortField.random => LibrarySort(
+          field: SortField.random,
+          direction: current.direction,
+          randomSeed: _mintSeed(),
+        ),
+      _ when field == current.field => current.copyWith(
+          field: field,
+          direction: current.direction.flipped,
+        ),
+      _ => LibrarySort(field: field, direction: current.direction),
+    };
+
+    state = AsyncData(next);
+    await SettingsService().setLibrarySort(_storageKey, next.encode());
+  }
+
+  /// Flips direction without changing field. A no-op for random.
+  Future<void> toggleDirection() async {
+    final current = state.value ?? LibrarySort.defaultSort;
+    if (!current.field.supportsDirection) return;
+
+    final next = current.copyWith(direction: current.direction.flipped);
+    state = AsyncData(next);
+    await SettingsService().setLibrarySort(_storageKey, next.encode());
+  }
+
+  // DateTime rather than Random so the seed varies per selection without
+  // pulling in another dependency. Collisions only mean a repeated shuffle.
+  int _mintSeed() =>
+      DateTime.now().microsecondsSinceEpoch.remainder(0x7FFFFFFF) ^
+      _movieSeedBase;
+}

--- a/player/lib/presentation/screens/library/library_sort_provider.dart
+++ b/player/lib/presentation/screens/library/library_sort_provider.dart
@@ -14,7 +14,7 @@ part 'library_sort_provider.g.dart';
 /// of the wrong order.
 @riverpod
 class LibrarySortController extends _$LibrarySortController {
-  static const _movieSeedBase = 0x5EED;
+  static const _seedBase = 0x5EED;
 
   String get _storageKey =>
       libraryType == LibraryType.movies ? 'movies' : 'tvShows';
@@ -66,6 +66,5 @@ class LibrarySortController extends _$LibrarySortController {
   // DateTime rather than Random so the seed varies per selection without
   // pulling in another dependency. Collisions only mean a repeated shuffle.
   int _mintSeed() =>
-      DateTime.now().microsecondsSinceEpoch.remainder(0x7FFFFFFF) ^
-      _movieSeedBase;
+      DateTime.now().microsecondsSinceEpoch.remainder(0x7FFFFFFF) ^ _seedBase;
 }

--- a/player/test/core/settings/settings_service_sort_test.dart
+++ b/player/test/core/settings/settings_service_sort_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:player/core/settings/settings_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  test('an unset library sort reads back as null', () async {
+    final service = SettingsService();
+
+    expect(await service.getLibrarySort('movies'), isNull);
+  });
+
+  test('a stored sort round-trips', () async {
+    final service = SettingsService();
+
+    await service.setLibrarySort('movies', 'RATING:DESC');
+
+    expect(await service.getLibrarySort('movies'), 'RATING:DESC');
+  });
+
+  test('movies and tv shows are remembered independently', () async {
+    final service = SettingsService();
+
+    await service.setLibrarySort('movies', 'RUNTIME:ASC');
+    await service.setLibrarySort('tvShows', 'LAST_PLAYED:DESC');
+
+    expect(await service.getLibrarySort('movies'), 'RUNTIME:ASC');
+    expect(await service.getLibrarySort('tvShows'), 'LAST_PLAYED:DESC');
+  });
+
+  test('clearSettings drops both library sorts', () async {
+    final service = SettingsService();
+    await service.setLibrarySort('movies', 'YEAR:ASC');
+
+    await service.clearSettings();
+
+    expect(await service.getLibrarySort('movies'), isNull);
+  });
+}

--- a/player/test/presentation/screens/library/library_controller_test.dart
+++ b/player/test/presentation/screens/library/library_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/presentation/screens/library/library_controller.dart';
+import 'package:player/presentation/screens/library/library_sort.dart';
 
 import '../../../test_utils/riverpod_helpers.dart';
 import '../../../test_utils/stub_graphql_client.dart';
@@ -122,7 +123,7 @@ void main() {
 
     final data = await waitForValue(
       container,
-      libraryControllerProvider(LibraryType.movies),
+      libraryControllerProvider(LibraryType.movies, LibrarySort.defaultSort),
       (value) => value.items.isNotEmpty,
     );
 
@@ -148,7 +149,8 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    final provider = libraryControllerProvider(LibraryType.movies);
+    final provider =
+        libraryControllerProvider(LibraryType.movies, LibrarySort.defaultSort);
     await waitForValue(container, provider, (value) => value.items.isNotEmpty);
 
     await container.read(provider.notifier).loadMore();
@@ -190,7 +192,8 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    final provider = libraryControllerProvider(LibraryType.movies);
+    final provider =
+        libraryControllerProvider(LibraryType.movies, LibrarySort.defaultSort);
     await waitForValue(container, provider, (value) => value.items.isNotEmpty);
 
     await container.read(provider.notifier).loadMore();
@@ -220,7 +223,8 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    final provider = libraryControllerProvider(LibraryType.movies);
+    final provider =
+        libraryControllerProvider(LibraryType.movies, LibrarySort.defaultSort);
     await waitForValue(container, provider, (value) => value.items.isNotEmpty);
     final before = link.requests.length;
 
@@ -245,7 +249,8 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    final provider = libraryControllerProvider(LibraryType.movies);
+    final provider =
+        libraryControllerProvider(LibraryType.movies, LibrarySort.defaultSort);
     await waitForValue(container, provider, (value) => value.items.isNotEmpty);
     final before = link.requests.length;
 
@@ -277,7 +282,7 @@ void main() {
 
     final data = await waitForValue(
       container,
-      libraryControllerProvider(LibraryType.movies),
+      libraryControllerProvider(LibraryType.movies, LibrarySort.defaultSort),
       (value) => value.items.isNotEmpty,
     );
 
@@ -300,7 +305,7 @@ void main() {
 
     final data = await waitForValue(
       container,
-      libraryControllerProvider(LibraryType.movies),
+      libraryControllerProvider(LibraryType.movies, LibrarySort.defaultSort),
       (value) => value.items.isNotEmpty,
     );
 
@@ -326,7 +331,7 @@ void main() {
 
     final data = await waitForValue(
       container,
-      libraryControllerProvider(LibraryType.tvShows),
+      libraryControllerProvider(LibraryType.tvShows, LibrarySort.defaultSort),
       (value) => value.items.isNotEmpty,
     );
 
@@ -350,10 +355,72 @@ void main() {
 
     final data = await waitForValue(
       container,
-      libraryControllerProvider(LibraryType.tvShows),
+      libraryControllerProvider(LibraryType.tvShows, LibrarySort.defaultSort),
       (value) => value.items.isNotEmpty,
     );
 
     expect(data.items.single.rating, isNull);
+  });
+
+  test('sends the selected sort as a GraphQL variable', () async {
+    final link = StubLink.responses([
+      _moviesPage(['1', '2'], hasNextPage: false)
+    ]);
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider
+            .overrideWith((ref) async => stubClient(link)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await waitForValue(
+      container,
+      libraryControllerProvider(
+        LibraryType.movies,
+        const LibrarySort(
+          field: SortField.rating,
+          direction: SortDirection.desc,
+        ),
+      ),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(link.requests, isNotEmpty);
+    expect(
+      link.requests.first.variables['sort'],
+      {'field': 'RATING', 'direction': 'DESC'},
+    );
+  });
+
+  test('sends the seed and omits direction when sorting randomly', () async {
+    final link = StubLink.responses([
+      _moviesPage(['1'], hasNextPage: false)
+    ]);
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider
+            .overrideWith((ref) async => stubClient(link)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await waitForValue(
+      container,
+      libraryControllerProvider(
+        LibraryType.movies,
+        const LibrarySort(
+          field: SortField.random,
+          direction: SortDirection.asc,
+          randomSeed: 777,
+        ),
+      ),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(
+      link.requests.first.variables['sort'],
+      {'field': 'RANDOM', 'seed': 777},
+    );
   });
 }

--- a/player/test/presentation/screens/library/library_screen_layout_test.dart
+++ b/player/test/presentation/screens/library/library_screen_layout_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 // `Override` is not re-exported by the main `flutter_riverpod.dart` barrel in
 // Riverpod 3.x; it lives in the `misc.dart` sub-library.
 import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/cast/cast_capabilities.dart';
@@ -231,6 +232,15 @@ List<Override> refreshingOverrides() => [
     ];
 
 void main() {
+  // LibraryScreen now awaits LibrarySortController before querying, and that
+  // controller reads flutter_secure_storage. Without the mock, the read never
+  // completes in widget tests, the sort spinner spins forever, and
+  // pumpAndSettle times out. StubLink scripting is unchanged: still one
+  // library page response after the sort resolves.
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
   testWidgets('grid starts just below the app bar on desktop', (tester) async {
     await pumpLibrary(tester, size: kDesktopSize);
 

--- a/player/test/presentation/screens/library/library_sort_sheet_test.dart
+++ b/player/test/presentation/screens/library/library_sort_sheet_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/screens/library/library_sort.dart';
+
+void main() {
+  testWidgets('every sort field gets a row', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: Column(
+              children: [
+                for (final field in SortField.values)
+                  ListTile(
+                    key: Key('sort-field-${field.wireName}'),
+                    title: Text(field.displayName),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for (final field in SortField.values) {
+      expect(find.byKey(Key('sort-field-${field.wireName}')), findsOneWidget);
+    }
+  });
+
+  test('selecting the current field flips direction', () {
+    const current = LibrarySort(
+      field: SortField.title,
+      direction: SortDirection.asc,
+    );
+
+    expect(current.direction.flipped, SortDirection.desc);
+    expect(current.direction.flipped.flipped, SortDirection.asc);
+  });
+
+  test('random does not support a direction toggle', () {
+    expect(SortField.random.supportsDirection, isFalse);
+  });
+}

--- a/player/test/presentation/screens/library/library_sort_test.dart
+++ b/player/test/presentation/screens/library/library_sort_test.dart
@@ -72,14 +72,51 @@ void main() {
     expect(LibrarySort.defaultSort.direction, SortDirection.desc);
   });
 
-  test('the seed is not part of equality, so it never busts persistence', () {
-    const a = LibrarySort(field: SortField.title, direction: SortDirection.asc);
-    const b = LibrarySort(
-      field: SortField.title,
+  // LibrarySort is a Riverpod family argument, so equality decides whether
+  // re-selecting Random gets a new watcher. If two shuffles compared equal the
+  // provider would be reused and the reshuffle would silently do nothing.
+  test('two random shuffles with different seeds are not equal', () {
+    const a = LibrarySort(
+      field: SortField.random,
       direction: SortDirection.asc,
-      randomSeed: 9,
+      randomSeed: 1,
+    );
+    const b = LibrarySort(
+      field: SortField.random,
+      direction: SortDirection.asc,
+      randomSeed: 2,
+    );
+
+    expect(a, isNot(b));
+    expect(a.hashCode, isNot(b.hashCode));
+  });
+
+  test('the same seed compares equal', () {
+    const a = LibrarySort(
+      field: SortField.random,
+      direction: SortDirection.asc,
+      randomSeed: 7,
+    );
+    const b = LibrarySort(
+      field: SortField.random,
+      direction: SortDirection.asc,
+      randomSeed: 7,
     );
 
     expect(a, b);
+    expect(a.hashCode, b.hashCode);
+  });
+
+  // The seed drives the family key but must not reach storage, or one
+  // permutation would be frozen forever.
+  test('the seed never reaches the encoded form', () {
+    const sort = LibrarySort(
+      field: SortField.random,
+      direction: SortDirection.asc,
+      randomSeed: 12345,
+    );
+
+    expect(sort.encode(), isNot(contains('12345')));
+    expect(sort.encode(), 'RANDOM:ASC');
   });
 }

--- a/player/test/presentation/screens/library/library_sort_test.dart
+++ b/player/test/presentation/screens/library/library_sort_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/screens/library/library_sort.dart';
+
+void main() {
+  test('wire names match the GraphQL enum values', () {
+    expect(SortField.title.wireName, 'TITLE');
+    expect(SortField.addedAt.wireName, 'ADDED_AT');
+    expect(SortField.contentRating.wireName, 'CONTENT_RATING');
+    expect(SortField.releaseDate.wireName, 'RELEASE_DATE');
+    expect(SortField.lastPlayed.wireName, 'LAST_PLAYED');
+    expect(SortField.watchState.wireName, 'WATCH_STATE');
+    expect(SortField.random.wireName, 'RANDOM');
+    expect(SortDirection.asc.wireName, 'ASC');
+    expect(SortDirection.desc.wireName, 'DESC');
+  });
+
+  test('exposes eleven fields', () {
+    expect(SortField.values.length, 11);
+  });
+
+  test('every field has a display name and none uses an em dash', () {
+    for (final field in SortField.values) {
+      expect(field.displayName, isNotEmpty);
+      expect(field.displayName.contains('—'), isFalse);
+    }
+  });
+
+  test('random is the only direction-less field', () {
+    expect(SortField.random.supportsDirection, isFalse);
+    for (final field in SortField.values.where((f) => f != SortField.random)) {
+      expect(field.supportsDirection, isTrue);
+    }
+  });
+
+  test('toVariables carries field and direction', () {
+    const sort = LibrarySort(
+      field: SortField.rating,
+      direction: SortDirection.desc,
+    );
+
+    expect(sort.toVariables(), {'field': 'RATING', 'direction': 'DESC'});
+  });
+
+  test('toVariables carries the seed and omits direction for random', () {
+    const sort = LibrarySort(
+      field: SortField.random,
+      direction: SortDirection.asc,
+      randomSeed: 4242,
+    );
+
+    expect(sort.toVariables(), {'field': 'RANDOM', 'seed': 4242});
+  });
+
+  test('encode and decode round-trip field and direction', () {
+    const sort = LibrarySort(
+      field: SortField.lastPlayed,
+      direction: SortDirection.asc,
+    );
+
+    expect(LibrarySort.decode(sort.encode()), sort);
+  });
+
+  test('decode falls back to the default for null or malformed input', () {
+    expect(LibrarySort.decode(null), LibrarySort.defaultSort);
+    expect(LibrarySort.decode(''), LibrarySort.defaultSort);
+    expect(LibrarySort.decode('garbage'), LibrarySort.defaultSort);
+    expect(LibrarySort.decode('NOT_A_FIELD:ASC'), LibrarySort.defaultSort);
+  });
+
+  test('the default is date added, descending', () {
+    expect(LibrarySort.defaultSort.field, SortField.addedAt);
+    expect(LibrarySort.defaultSort.direction, SortDirection.desc);
+  });
+
+  test('the seed is not part of equality, so it never busts persistence', () {
+    const a = LibrarySort(field: SortField.title, direction: SortDirection.asc);
+    const b = LibrarySort(
+      field: SortField.title,
+      direction: SortDirection.asc,
+      randomSeed: 9,
+    );
+
+    expect(a, b);
+  });
+}

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -676,7 +676,11 @@ type Progress {
 "Input for sorting lists"
 input SortInput {
   field: SortField
+
   direction: SortDirection
+
+  "Seed for the random sort. Send the same value across pages of one shuffle."
+  seed: Int
 }
 
 "Pagination info for cursor-based pagination"
@@ -1156,6 +1160,27 @@ enum SortField {
 
   "Sort by rating"
   RATING
+
+  "Sort by duration"
+  RUNTIME
+
+  "Sort by popularity"
+  POPULARITY
+
+  "Sort by content rating"
+  CONTENT_RATING
+
+  "Sort by release date"
+  RELEASE_DATE
+
+  "Shuffle, stable for a given seed"
+  RANDOM
+
+  "Sort by when the viewer last watched it"
+  LAST_PLAYED
+
+  "Sort by watched state; ascending puts unwatched first"
+  WATCH_STATE
 }
 
 "Sort direction"

--- a/server/crates/api/src/query.rs
+++ b/server/crates/api/src/query.rs
@@ -535,9 +535,25 @@ fn browse_sort(sort: Option<&SortInput>) -> BrowseSort {
         Some(SortField::Year) => BrowseField::Year,
         Some(SortField::AddedAt) => BrowseField::AddedAt,
         Some(SortField::Rating) => BrowseField::Rating,
-        // Title is the default and the fallback, matching sort_items/2's
+        // The contract carries seven more fields that this server cannot
+        // answer yet: runtime, popularity, content rating and release date
+        // need the metadata JSON, last played and watch state need the
+        // progress join, and random needs seeded ordering. Listing them
+        // explicitly rather than letting them vanish into the wildcard, so
+        // adding one here is a compile-time prompt rather than a silent
+        // fallback nobody notices.
+        Some(
+            SortField::Runtime
+            | SortField::Popularity
+            | SortField::ContentRating
+            | SortField::ReleaseDate
+            | SortField::LastPlayed
+            | SortField::WatchState
+            | SortField::Random,
+        ) => BrowseField::Title,
+        // Title is the default and the fallback, matching MediaSort's
         // catch-all clause.
-        _ => BrowseField::Title,
+        Some(SortField::Title) | None => BrowseField::Title,
     };
 
     BrowseSort {

--- a/server/crates/api/src/types/common.rs
+++ b/server/crates/api/src/types/common.rs
@@ -34,6 +34,9 @@ pub struct NodeConnection {
 pub struct SortInput {
     pub field: Option<SortField>,
     pub direction: Option<SortDirection>,
+    /// Seed for the random sort, held so the permutation stays stable across
+    /// pages. Unused here until this server implements `SortField::Random`.
+    pub seed: Option<i32>,
 }
 
 #[derive(Interface)]
@@ -90,12 +93,26 @@ pub enum LibraryType {
     Adult,
 }
 
+/// Every value the contract carries.
+///
+/// This server serves only the first four today; the rest are accepted and
+/// fall back to title in `browse_sort`. That is deliberate. The player talks to
+/// both servers and GraphQL rejects an entire document containing an unknown
+/// enum value, so omitting one here would fail every library query rather than
+/// degrade one sort.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub enum SortField {
     Title,
     AddedAt,
     Year,
     Rating,
+    Runtime,
+    Popularity,
+    ContentRating,
+    ReleaseDate,
+    LastPlayed,
+    WatchState,
+    Random,
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]

--- a/server/crates/db/src/media_items.rs
+++ b/server/crates/db/src/media_items.rs
@@ -107,9 +107,16 @@ pub enum BrowseField {
 #[derive(Debug, Clone, Copy)]
 pub struct BrowseSort {
     pub field: BrowseField,
-    /// The Elixir server reverses the ascending sort rather than sorting
-    /// descending (browse_resolver.ex:172-176), which moves nulls to the
-    /// front. The ORDER BY clauses below reproduce that.
+    /// The ORDER BY clauses below reproduce the Elixir server's *old*
+    /// behaviour: it reversed the ascending sort rather than sorting
+    /// descending, which moved nulls to the front and flipped tie groups.
+    ///
+    /// Elixir no longer does that. `MydiaWeb.Schema.Resolvers.MediaSort` now
+    /// sorts by direction and puts unknown keys last in both directions, so
+    /// these clauses are a known behavioural divergence from the contract
+    /// partner. Structural parity is what the contract gate enforces; matching
+    /// this ordering is follow-up work, and the clauses below are the thing to
+    /// change when it happens.
     pub descending: bool,
 }
 

--- a/test/mydia_web/schema/resolvers/media_sort_test.exs
+++ b/test/mydia_web/schema/resolvers/media_sort_test.exs
@@ -6,19 +6,38 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSortTest do
   alias MydiaWeb.Schema.Resolvers.MediaSort
 
   defp item(id, attrs) do
-    {meta_attrs, item_attrs} = Map.split(attrs, [:vote_average])
+    {meta_attrs, item_attrs} =
+      Map.split(attrs, [
+        :vote_average,
+        :popularity,
+        :content_rating,
+        :runtime,
+        :release_date,
+        :episode_run_time,
+        :first_air_date
+      ])
+
+    type = Map.get(item_attrs, :type, "movie")
 
     metadata =
       if map_size(meta_attrs) == 0 do
         nil
       else
         struct(
-          %MediaMetadata{provider_id: "x", provider: :tmdb, media_type: :movie},
+          %MediaMetadata{
+            provider_id: "x",
+            provider: :tmdb,
+            media_type: if(type == "tv_show", do: :tv_show, else: :movie)
+          },
           meta_attrs
         )
       end
 
-    struct(%MediaItem{id: id, type: "movie", metadata: metadata}, item_attrs)
+    struct(%MediaItem{id: id, metadata: metadata}, Map.put(item_attrs, :type, type))
+  end
+
+  defp many(count) do
+    for n <- 1..count, do: item("#{n}", %{title: "Title #{n}"})
   end
 
   defp ids(items), do: Enum.map(items, & &1.id)
@@ -104,6 +123,94 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSortTest do
 
       assert ids(MediaSort.sort(items, %{field: :nonsense, direction: :asc})) == ["2", "1"]
       assert ids(MediaSort.sort(items, %{field: :nonsense, direction: :desc})) == ["1", "2"]
+    end
+  end
+
+  describe "runtime" do
+    test "sorts movies by runtime" do
+      items = [
+        item("long", %{title: "A", runtime: 180}),
+        item("short", %{title: "B", runtime: 90})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :runtime, direction: :asc})) == ["short", "long"]
+      assert ids(MediaSort.sort(items, %{field: :runtime, direction: :desc})) == ["long", "short"]
+    end
+
+    test "falls back to the first episode_run_time for shows" do
+      items = [
+        item("hour", %{type: "tv_show", title: "A", episode_run_time: [60]}),
+        item("half", %{type: "tv_show", title: "B", episode_run_time: [30]})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :runtime, direction: :asc})) == ["half", "hour"]
+    end
+
+    test "a show with an empty episode_run_time sorts last" do
+      items = [
+        item("none", %{type: "tv_show", title: "A", episode_run_time: []}),
+        item("half", %{type: "tv_show", title: "B", episode_run_time: [30]})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :runtime, direction: :desc})) == ["half", "none"]
+    end
+  end
+
+  describe "popularity" do
+    test "sorts by popularity" do
+      items = [
+        item("hot", %{title: "A", popularity: 900.5}),
+        item("cold", %{title: "B", popularity: 1.2})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :popularity, direction: :desc})) == [
+               "hot",
+               "cold"
+             ]
+    end
+  end
+
+  describe "content_rating" do
+    test "sorts by content rating and keeps ties in input order" do
+      items = [
+        item("pg1", %{title: "A", content_rating: "PG"}),
+        item("g", %{title: "B", content_rating: "G"}),
+        item("pg2", %{title: "C", content_rating: "PG"})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :content_rating, direction: :asc})) ==
+               ["g", "pg1", "pg2"]
+
+      # The tie group keeps its order even reversed. This is the defect that
+      # Enum.reverse/1 used to introduce.
+      assert ids(MediaSort.sort(items, %{field: :content_rating, direction: :desc})) ==
+               ["pg1", "pg2", "g"]
+    end
+  end
+
+  describe "release_date" do
+    test "sorts movies by release date chronologically" do
+      items = [
+        item("new", %{title: "A", release_date: ~D[2026-01-01]}),
+        item("old", %{title: "B", release_date: ~D[1999-12-31]})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :release_date, direction: :asc})) == [
+               "old",
+               "new"
+             ]
+    end
+
+    test "falls back to first_air_date for shows" do
+      items = [
+        item("new", %{type: "tv_show", title: "A", first_air_date: ~D[2026-01-01]}),
+        item("old", %{type: "tv_show", title: "B", first_air_date: ~D[1999-12-31]})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :release_date, direction: :desc})) == [
+               "new",
+               "old"
+             ]
     end
   end
 end

--- a/test/mydia_web/schema/resolvers/media_sort_test.exs
+++ b/test/mydia_web/schema/resolvers/media_sort_test.exs
@@ -1,0 +1,109 @@
+defmodule MydiaWeb.Schema.Resolvers.MediaSortTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Media.MediaItem
+  alias Mydia.Metadata.Structs.MediaMetadata
+  alias MydiaWeb.Schema.Resolvers.MediaSort
+
+  defp item(id, attrs) do
+    {meta_attrs, item_attrs} = Map.split(attrs, [:vote_average])
+
+    metadata =
+      if map_size(meta_attrs) == 0 do
+        nil
+      else
+        struct(
+          %MediaMetadata{provider_id: "x", provider: :tmdb, media_type: :movie},
+          meta_attrs
+        )
+      end
+
+    struct(%MediaItem{id: id, type: "movie", metadata: metadata}, item_attrs)
+  end
+
+  defp ids(items), do: Enum.map(items, & &1.id)
+
+  describe "title" do
+    test "sorts case-insensitively in both directions" do
+      items = [item("1", %{title: "banana"}), item("2", %{title: "Apple"})]
+
+      assert ids(MediaSort.sort(items, %{field: :title, direction: :asc})) == ["2", "1"]
+      assert ids(MediaSort.sort(items, %{field: :title, direction: :desc})) == ["1", "2"]
+    end
+  end
+
+  describe "added_at" do
+    test "orders chronologically rather than by day-of-month" do
+      # Plain term comparison on DateTime structs compares :day before :year,
+      # so this pair is ordered wrongly by any non-DateTime-aware sort.
+      early = ~U[2020-12-31 00:00:00Z]
+      late = ~U[2026-01-01 00:00:00Z]
+
+      items = [
+        item("old", %{title: "A", inserted_at: early}),
+        item("new", %{title: "B", inserted_at: late})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :added_at, direction: :asc})) == ["old", "new"]
+      assert ids(MediaSort.sort(items, %{field: :added_at, direction: :desc})) == ["new", "old"]
+    end
+  end
+
+  describe "tie stability" do
+    test "equal keys keep input order in both directions" do
+      items = [
+        item("a", %{title: "same", year: 2000}),
+        item("b", %{title: "same", year: 2000}),
+        item("c", %{title: "same", year: 2000})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :year, direction: :asc})) == ["a", "b", "c"]
+      assert ids(MediaSort.sort(items, %{field: :year, direction: :desc})) == ["a", "b", "c"]
+    end
+  end
+
+  describe "nil placement" do
+    test "unknown keys sort last in both directions" do
+      items = [
+        item("none", %{title: "A", year: nil}),
+        item("low", %{title: "B", year: 1990}),
+        item("high", %{title: "C", year: 2020})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :year, direction: :asc})) ==
+               ["low", "high", "none"]
+
+      assert ids(MediaSort.sort(items, %{field: :year, direction: :desc})) ==
+               ["high", "low", "none"]
+    end
+
+    test "an unrated item leads neither end of a rating sort" do
+      items = [
+        item("unrated", %{title: "A"}),
+        item("bad", %{title: "B", vote_average: 2.0}),
+        item("good", %{title: "C", vote_average: 9.0})
+      ]
+
+      assert ids(MediaSort.sort(items, %{field: :rating, direction: :asc})) ==
+               ["bad", "good", "unrated"]
+
+      assert ids(MediaSort.sort(items, %{field: :rating, direction: :desc})) ==
+               ["good", "bad", "unrated"]
+    end
+  end
+
+  describe "defaults" do
+    test "a nil sort falls back to title ascending" do
+      items = [item("1", %{title: "b"}), item("2", %{title: "a"})]
+
+      assert ids(MediaSort.sort(items, nil)) == ["2", "1"]
+    end
+
+    test "an unknown field falls back to title but keeps the requested direction" do
+      items = [item("1", %{title: "b"}), item("2", %{title: "a"})]
+
+      assert ids(MediaSort.sort(items, %{field: :nonsense, direction: :asc})) == ["2", "1"]
+      assert ids(MediaSort.sort(items, %{field: :nonsense, direction: :desc})) == ["1", "2"]
+    end
+  end
+end

--- a/test/mydia_web/schema/resolvers/media_sort_test.exs
+++ b/test/mydia_web/schema/resolvers/media_sort_test.exs
@@ -213,4 +213,60 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSortTest do
              ]
     end
   end
+
+  describe "random" do
+    test "the same seed always yields the same order" do
+      items = many(50)
+
+      first = MediaSort.sort(items, %{field: :random, direction: :asc, seed: 12_345})
+      second = MediaSort.sort(items, %{field: :random, direction: :asc, seed: 12_345})
+
+      assert ids(first) == ids(second)
+    end
+
+    test "different seeds yield different orders" do
+      items = many(50)
+
+      a = MediaSort.sort(items, %{field: :random, direction: :asc, seed: 1})
+      b = MediaSort.sort(items, %{field: :random, direction: :asc, seed: 2})
+
+      assert ids(a) != ids(b)
+    end
+
+    test "it is a permutation, losing and duplicating nothing" do
+      items = many(50)
+
+      shuffled = MediaSort.sort(items, %{field: :random, direction: :asc, seed: 7})
+
+      assert Enum.sort(ids(shuffled)) == Enum.sort(ids(items))
+    end
+
+    test "paging under one seed produces no overlap and no gap" do
+      items = many(50)
+      sorted = MediaSort.sort(items, %{field: :random, direction: :asc, seed: 99})
+
+      # What the resolver does: re-sort the full list per request, then slice.
+      page_one = sorted |> Enum.take(20) |> ids()
+
+      page_two =
+        items
+        |> MediaSort.sort(%{field: :random, direction: :asc, seed: 99})
+        |> Enum.drop(20)
+        |> Enum.take(20)
+        |> ids()
+
+      assert page_one -- page_two == page_one
+      assert length(Enum.uniq(page_one ++ page_two)) == 40
+    end
+
+    test "a missing seed still returns a stable permutation" do
+      items = many(20)
+
+      first = MediaSort.sort(items, %{field: :random, direction: :asc})
+      second = MediaSort.sort(items, %{field: :random, direction: :asc})
+
+      assert ids(first) == ids(second)
+      assert Enum.sort(ids(first)) == Enum.sort(ids(items))
+    end
+  end
 end

--- a/test/mydia_web/schema/resolvers/media_sort_test.exs
+++ b/test/mydia_web/schema/resolvers/media_sort_test.exs
@@ -269,4 +269,113 @@ defmodule MydiaWeb.Schema.Resolvers.MediaSortTest do
       assert Enum.sort(ids(first)) == Enum.sort(ids(items))
     end
   end
+
+  describe "watch_state" do
+    test "ascending puts unwatched first, descending puts watched first" do
+      items = [
+        item("seen", %{title: "A"}),
+        item("unseen", %{title: "B"})
+      ]
+
+      progress = %{"seen" => %{watched: true, last_watched_at: ~U[2026-01-01 00:00:00Z]}}
+
+      assert ids(MediaSort.sort(items, %{field: :watch_state, direction: :asc}, progress)) ==
+               ["unseen", "seen"]
+
+      assert ids(MediaSort.sort(items, %{field: :watch_state, direction: :desc}, progress)) ==
+               ["seen", "unseen"]
+    end
+
+    test "an item with no progress row counts as unwatched, not unknown" do
+      items = [
+        item("seen", %{title: "A"}),
+        item("never", %{title: "B"})
+      ]
+
+      progress = %{"seen" => %{watched: true, last_watched_at: nil}}
+
+      # "never" groups with the unwatched items rather than falling to the end.
+      assert ids(MediaSort.sort(items, %{field: :watch_state, direction: :asc}, progress)) ==
+               ["never", "seen"]
+    end
+  end
+
+  describe "last_played" do
+    test "sorts by last watched time chronologically" do
+      items = [
+        item("recent", %{title: "A"}),
+        item("stale", %{title: "B"})
+      ]
+
+      progress = %{
+        "recent" => %{watched: true, last_watched_at: ~U[2026-08-01 00:00:00Z]},
+        "stale" => %{watched: true, last_watched_at: ~U[2020-01-01 00:00:00Z]}
+      }
+
+      assert ids(MediaSort.sort(items, %{field: :last_played, direction: :desc}, progress)) ==
+               ["recent", "stale"]
+
+      assert ids(MediaSort.sort(items, %{field: :last_played, direction: :asc}, progress)) ==
+               ["stale", "recent"]
+    end
+
+    test "never-played items sort last in both directions" do
+      items = [
+        item("never", %{title: "A"}),
+        item("played", %{title: "B"})
+      ]
+
+      progress = %{"played" => %{watched: true, last_watched_at: ~U[2026-08-01 00:00:00Z]}}
+
+      assert ids(MediaSort.sort(items, %{field: :last_played, direction: :asc}, progress)) ==
+               ["played", "never"]
+
+      assert ids(MediaSort.sort(items, %{field: :last_played, direction: :desc}, progress)) ==
+               ["played", "never"]
+    end
+
+    test "an empty progress map leaves every item unknown and preserves input order" do
+      items = [item("1", %{title: "b"}), item("2", %{title: "a"})]
+
+      assert ids(MediaSort.sort(items, %{field: :last_played, direction: :desc}, %{})) ==
+               ["1", "2"]
+    end
+  end
+
+  describe "progress_map/2" do
+    test "returns an empty map for fields that do not need progress" do
+      assert MediaSort.progress_map(nil, :title) == %{}
+      assert MediaSort.progress_map(%{id: "u1"}, :title) == %{}
+    end
+
+    test "returns an empty map when there is no user" do
+      assert MediaSort.progress_map(nil, :last_played) == %{}
+      assert MediaSort.progress_map(nil, :watch_state) == %{}
+    end
+  end
+
+  describe "effective_sort/2" do
+    test "downgrades watch-state fields to title ascending with no user" do
+      default = %{field: :title, direction: :asc}
+
+      assert MediaSort.effective_sort(%{field: :last_played, direction: :desc}, nil) == default
+      assert MediaSort.effective_sort(%{field: :watch_state, direction: :asc}, nil) == default
+    end
+
+    test "leaves every other field alone with no user" do
+      sort = %{field: :year, direction: :desc}
+
+      assert MediaSort.effective_sort(sort, nil) == sort
+    end
+
+    test "leaves watch-state fields alone when there is a user" do
+      sort = %{field: :last_played, direction: :desc}
+
+      assert MediaSort.effective_sort(sort, %{id: "u1"}) == sort
+    end
+
+    test "a nil sort stays nil so sort/3 applies its own default" do
+      assert MediaSort.effective_sort(nil, nil) == nil
+    end
+  end
 end


### PR DESCRIPTION
## What

The player's library sort menu never sorted anything. `LibraryController.setSort/1` ignored its argument, and the comment explaining why claimed the GraphQL queries took no sort argument. That comment was stale: the server had grown `sort: SortInput` on `movies` and `tvShows`, and the player never caught up.

This wires the menu up and grows the server's sort field set from 4 to 11.

## Sort fields

Existing: title, year, date added, rating.

New: duration, popularity, content rating, release date, last played, watch state, random.

The set was chosen by comparing against Plex (19 movie sorts) and Jellyfin (26 comparers) and keeping what Mydia can actually answer. Everything added reads from embedded metadata at no extra query cost, except the two watch-state fields, which share one batched lookup.

Shows fall back where TMDB shapes them differently: `runtime` uses the head of `episode_run_time`, and `release_date` uses `first_air_date`.

## Three pre-existing ordering bugs

Reading `sort_items/2` before extending it turned up three defects, all fixed here:

1. **Descending was `Enum.reverse` of ascending**, which also reverses tie groups so equal-keyed items flip relative order. Close to invisible across four high-cardinality fields, clearly wrong once content rating and watch state arrive, where most of a library ties.

2. **"Date added" was not chronological.** `MediaItem` uses `timestamps(type: :utc_datetime)`, so `inserted_at` is a `DateTime` struct, and plain term comparison on two structs with identical keys compares values in sorted-key order. That puts `:day` before `:month` before `:year`, so the sort ordered by day-of-month.

3. **Nil keys sorted inconsistently between fields.** Elixir orders numbers before atoms before binaries, so a nil `year` landed after every real year while a nil `content_rating` would land before every real one. The rating path masked this by coercing nil to `0`, which then made unrated items lead the "lowest rated" list. Unknown keys now sort last in both directions.

## Notable decisions

**Sorting moved out of the resolver.** `browse_resolver.ex` was already near 500 LOC and this would have added well over a hundred more. `MydiaWeb.Schema.Resolvers.MediaSort` is unit-testable against plain structs, so the ordering rules are covered without a database or fixtures.

**Random is seeded.** The resolver re-sorts the whole list on every page request, so a fresh shuffle per request would duplicate and skip items during infinite scroll. The client mints a seed and sends it with every `fetchMore`; the server orders by `:erlang.phash2({id, seed})`, which is deterministic across processes and restarts in a way `:rand` is not.

**Watch-state sorts use one query, not N.** `Playback.list_user_progress/1` returns every row for a user at once, indexed by `media_item_id` with episode rows dropped. A per-item `get_progress/2` here would have been an N+1 across the whole library.

**Signed-out callers degrade gracefully.** They have no history, so `last_played` and `watch_state` fall back to the default rather than returning an arbitrary order that would look broken.

**Field and direction are separate in the UI**, as in Plex and Jellyfin. Eleven rows plus a header direction toggle rather than twenty-one baked-in pairs. Tapping the selected field flips direction; random disables the toggle.

**Sort persists per library type.** Movies and TV Shows each remember their own choice. The screen waits for the persisted value before querying, so the library does not mount under the default and then re-fire. The random seed is deliberately not persisted, since freezing one permutation forever is the opposite of what picking Random means.

This also fixes a live mismatch: the sheet defaulted to "Recently Added" while the server defaulted to title, so it labelled title-sorted data as recently added.

## Contract

`priv/graphql/schema.graphql` is regenerated. It is the contract shared by the Elixir server, the Rust server, and the Flutter player, and the diff is exactly the seven new enum values plus `SortInput.seed`.

## Out of scope

File-based sorts (size, resolution, bitrate) need a `:media_files` preload on every library query. Episode count would compound an existing N+1 in `resolve_episode_count/3`. Play count, user rating, a critic-versus-audience split, budget, and revenue all need new schema. The Phoenix LiveView grid keeps its current options; it already had rating.

## Testing

- 381 lines of new sort tests covering every field in both directions, plus tie stability, nil placement, seeded-random pagination with no overlap or gap, and the signed-out fallback.
- Player: sort model round-trips, per-library persistence, controller variable wiring, and the sheet contract.
- `mix precommit`: 6703 tests, 0 failures. Player: 1728 tests passing, no new analyzer findings.
