### PR TITLE
fix(player): make fullscreen work in the web player on iPhone Safari

### DIFF
--- a/player/lib/core/player/fullscreen/fullscreen_backend.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_backend.dart
@@ -1,0 +1,27 @@
+import 'package:media_kit/media_kit.dart';
+
+import 'fullscreen_mode.dart';
+
+/// The platform half of fullscreen.
+///
+/// Implementations own writing state: they call the `onChange` handed to
+/// [createFullscreenBackend] whenever the platform *reports* a transition,
+/// which for three of the four live modes means a real platform event rather
+/// than an assumption. `FullscreenController` never writes its own notifier.
+///
+/// [enter] and [exit] are synchronous by contract. `webkitEnterFullscreen`
+/// requires live user activation and any `await` before the call spends it.
+abstract class FullscreenBackend {
+  /// Resolved once at construction. Stable for the life of the process.
+  FullscreenMode get mode;
+
+  /// Hands over the media_kit player once it exists, so a web backend can
+  /// reach the underlying `HTMLVideoElement`. A no-op on native.
+  void attach(Player player);
+
+  void enter();
+
+  void exit();
+
+  void dispose();
+}

--- a/player/lib/core/player/fullscreen/fullscreen_backend_factory.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_backend_factory.dart
@@ -1,0 +1,8 @@
+/// Picks the platform backend.
+///
+/// Mirrors `core/window/desktop_window.dart`: the default target is the one
+/// that must not link platform-only packages, and the conditional target is
+/// the specialised one. Here the web build is the specialised case, since
+/// `package:web` has no native implementation.
+export 'fullscreen_backend_native.dart'
+    if (dart.library.js_interop) 'fullscreen_backend_web.dart';

--- a/player/lib/core/player/fullscreen/fullscreen_backend_factory.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_backend_factory.dart
@@ -4,5 +4,7 @@
 /// that must not link platform-only packages, and the conditional target is
 /// the specialised one. Here the web build is the specialised case, since
 /// `package:web` has no native implementation.
+library;
+
 export 'fullscreen_backend_native.dart'
     if (dart.library.js_interop) 'fullscreen_backend_web.dart';

--- a/player/lib/core/player/fullscreen/fullscreen_backend_native.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_backend_native.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:media_kit_video/media_kit_video.dart';
+
+import '../../window/window_fullscreen.dart';
+import '../platform_features.dart';
+import 'fullscreen_backend.dart';
+import 'fullscreen_mode.dart';
+
+FullscreenBackend createFullscreenBackend({
+  required ValueChanged<bool> onChange,
+}) =>
+    NativeFullscreenBackend(onChange: onChange);
+
+/// Native fullscreen, behaviour-identical to what `PlayerScreen` did before
+/// this controller existed: it calls the same two media_kit helpers, which
+/// branch internally between `SystemUiMode.immersiveSticky` on mobile and a
+/// method channel on desktop (`video_texture.dart:479`).
+///
+/// What is new is where state comes from. On desktop it republishes the
+/// existing `windowFullscreen` signal rather than assuming, so the green
+/// button, the View menu and Cmd+Ctrl+F are all reflected — the exact reason
+/// `WindowFullscreenController` was written. That controller stays the only
+/// writer of the signal; this only listens.
+class NativeFullscreenBackend implements FullscreenBackend {
+  NativeFullscreenBackend({required this.onChange});
+
+  final ValueChanged<bool> onChange;
+
+  @override
+  FullscreenMode get mode => PlatformFeatures.isDesktop
+      ? FullscreenMode.osWindow
+      : FullscreenMode.systemUi;
+
+  bool _listening = false;
+
+  @override
+  void attach(Player player) {
+    if (mode != FullscreenMode.osWindow || _listening) return;
+    windowFullscreen.addListener(_republish);
+    _listening = true;
+    _republish();
+  }
+
+  void _republish() => onChange(windowFullscreen.value);
+
+  @override
+  void enter() {
+    defaultEnterNativeFullscreen();
+    // The one mode with no event source: `setEnabledSystemUIMode` has no
+    // callback, so mobile reports optimistically. No worse than before, and
+    // isolated to the platform that cannot do better.
+    if (mode == FullscreenMode.systemUi) onChange(true);
+  }
+
+  @override
+  void exit() {
+    defaultExitNativeFullscreen();
+    if (mode == FullscreenMode.systemUi) onChange(false);
+  }
+
+  @override
+  void dispose() {
+    if (_listening) {
+      windowFullscreen.removeListener(_republish);
+      _listening = false;
+    }
+  }
+}

--- a/player/lib/core/player/fullscreen/fullscreen_backend_web.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_backend_web.dart
@@ -1,0 +1,113 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter/foundation.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:web/web.dart' as web;
+
+import 'fullscreen_backend.dart';
+import 'fullscreen_mode.dart';
+
+FullscreenBackend createFullscreenBackend({
+  required ValueChanged<bool> onChange,
+}) =>
+    WebFullscreenBackend(onChange: onChange);
+
+/// Browser fullscreen, over whichever route the browser actually offers.
+///
+/// Both routes are event-sourced. That is the point: media_kit's own
+/// `defaultEnterNativeFullscreen` catches every failure to `debugPrint` and
+/// returns, leaving the caller believing it worked, which is exactly how the
+/// icon came to lie on iPhone Safari.
+class WebFullscreenBackend implements FullscreenBackend {
+  WebFullscreenBackend({required this.onChange}) {
+    _mode = resolveWebMode(
+      documentFullscreenEnabled: _documentFullscreenEnabled,
+      videoElementFullscreenSupported: _videoElementFullscreenSupported,
+    );
+    if (_mode == FullscreenMode.documentElement) {
+      _documentListener = _onDocumentFullscreenChange.toJS;
+      web.document.addEventListener('fullscreenchange', _documentListener);
+    }
+  }
+
+  final ValueChanged<bool> onChange;
+
+  late final FullscreenMode _mode;
+  JSFunction? _documentListener;
+
+  @override
+  FullscreenMode get mode => _mode;
+
+  /// `document.fullscreenEnabled`, not a probe for `requestFullscreen`. It is
+  /// also false inside an iframe lacking `allow="fullscreen"`, so one read
+  /// covers both cases that must fall back.
+  static bool get _documentFullscreenEnabled {
+    try {
+      return web.document.fullscreenEnabled;
+    } catch (e) {
+      debugPrint('[Fullscreen] fullscreenEnabled read failed: $e');
+      return false;
+    }
+  }
+
+  /// Probed on the prototype, never on a live element:
+  /// `video.webkitSupportsFullscreen` stays false until metadata loads, and
+  /// the button has to decide whether to exist before then.
+  static bool get _videoElementFullscreenSupported {
+    try {
+      final ctor = globalContext['HTMLVideoElement'];
+      if (ctor.isUndefinedOrNull) return false;
+      final proto = (ctor as JSObject)['prototype'];
+      if (proto.isUndefinedOrNull) return false;
+      return (proto as JSObject).has('webkitEnterFullscreen');
+    } catch (e) {
+      debugPrint('[Fullscreen] video prototype probe failed: $e');
+      return false;
+    }
+  }
+
+  void _onDocumentFullscreenChange(web.Event _) {
+    onChange(web.document.fullscreenElement != null);
+  }
+
+  @override
+  void attach(Player player) {
+    // Task 6 reaches the HTMLVideoElement here for the nativeVideoElement
+    // route. Nothing to do for documentElement.
+  }
+
+  @override
+  void enter() {
+    if (_mode != FullscreenMode.documentElement) return;
+    final element = web.document.documentElement;
+    if (element == null) return;
+    // Not awaited on purpose: an `await` here would be harmless for this route
+    // but the sibling route cannot afford one, and a single synchronous shape
+    // keeps the user-activation contract obvious. The rejection is still
+    // handled so it never surfaces as an unhandled promise.
+    element.requestFullscreen().toDart.catchError((Object e) {
+      debugPrint('[Fullscreen] requestFullscreen rejected: $e');
+      return null;
+    });
+  }
+
+  @override
+  void exit() {
+    if (_mode != FullscreenMode.documentElement) return;
+    if (web.document.fullscreenElement == null) return;
+    web.document.exitFullscreen().toDart.catchError((Object e) {
+      debugPrint('[Fullscreen] exitFullscreen rejected: $e');
+      return null;
+    });
+  }
+
+  @override
+  void dispose() {
+    final listener = _documentListener;
+    if (listener != null) {
+      web.document.removeEventListener('fullscreenchange', listener);
+      _documentListener = null;
+    }
+  }
+}

--- a/player/lib/core/player/fullscreen/fullscreen_backend_web.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_backend_web.dart
@@ -1,4 +1,8 @@
 import 'dart:js_interop';
+// `JSObject.operator []` and `JSObject.has` live here, not in
+// `dart:js_interop`, as of Dart 3.12.2. Omitting this import fails the web
+// build with "The operator '[]' isn't defined for the type 'JSObject'" and
+// "The method 'has' isn't defined for the type 'JSObject'".
 import 'dart:js_interop_unsafe';
 
 import 'package:flutter/foundation.dart';
@@ -35,6 +39,9 @@ class WebFullscreenBackend implements FullscreenBackend {
 
   late final FullscreenMode _mode;
   JSFunction? _documentListener;
+  web.HTMLVideoElement? _video;
+  JSFunction? _beginListener;
+  JSFunction? _endListener;
 
   @override
   FullscreenMode get mode => _mode;
@@ -71,43 +78,152 @@ class WebFullscreenBackend implements FullscreenBackend {
     onChange(web.document.fullscreenElement != null);
   }
 
+  /// Flips media_kit's subtitle `<track>` between browser-rendered and
+  /// Flutter-rendered.
+  ///
+  /// media_kit appends a real `<track>` element and immediately sets
+  /// `mode = 'hidden'` (`media_kit/lib/src/player/web/player/real.dart:1358`
+  /// and `:1379`), then pipes cue text into Dart for the Flutter layer to
+  /// paint. Apple's fullscreen shows only the video element, so without this
+  /// the subtitles vanish.
+  ///
+  /// Index 0 on purpose: it is the track media_kit's own cue listener binds to
+  /// (`real.dart:1376`), so fullscreen renders exactly what the inline player
+  /// renders. Note that media_kit appends a fresh `<track>` per
+  /// `setSubtitleTrack` and only ever removes stale `<source>` elements
+  /// (`real.dart:1282`), never stale `<track>` elements, so after a second
+  /// subtitle switch index 0 is the first subtitle chosen that session and the
+  /// inline player is *already* showing the wrong cues. Matching that is
+  /// deliberate: a fullscreen path that was correct while inline stayed wrong
+  /// would be harder to diagnose than consistent wrongness. Tracked as a
+  /// separate upstream issue.
+  void _setTextTrackMode(String mode) {
+    try {
+      final tracks = _video?.textTracks;
+      if (tracks == null || tracks.length == 0) return;
+      tracks[0].mode = mode;
+    } catch (e) {
+      debugPrint('[Fullscreen] text track mode $mode failed: $e');
+    }
+  }
+
   @override
   void attach(Player player) {
-    // Task 6 reaches the HTMLVideoElement here for the nativeVideoElement
-    // route. Nothing to do for documentElement.
+    if (_mode != FullscreenMode.nativeVideoElement || _video != null) return;
+
+    // media_kit exports its web player publicly:
+    // `package:media_kit/media_kit.dart` re-exports
+    // `src/player/web/player/player.dart`, itself
+    // `export 'stub.dart' if (dart.library.js_interop) 'real.dart';`. On a web
+    // build that resolves to `WebPlayer`, whose `element` field is public. This
+    // file only compiles on web, so the cast is safe and needs no `src/`
+    // import, no `$com.alexmercerind.media_kit.instances` global, and no
+    // `querySelector` guessing.
+    final platform = player.platform;
+    if (platform is! WebPlayer) {
+      debugPrint('[Fullscreen] player.platform is not a WebPlayer');
+      return;
+    }
+    // `WebPlayer.element` exists on media_kit's web `real.dart`, which
+    // `flutter build web` resolves. `dart analyze` / `flutter analyze` resolve
+    // the same conditional export to `stub.dart`, which has no `element`, so
+    // a static read fails analysis even though the web compiler accepts it.
+    // Same runtime API the plan specifies; dynamic only bridges the stub gap.
+    final video = (platform as dynamic).element as web.HTMLVideoElement;
+    _video = video;
+
+    _beginListener = ((web.Event _) {
+      // Apple renders only the video element, so hand the browser the cues
+      // media_kit normally keeps hidden and paints through Flutter.
+      _setTextTrackMode('showing');
+      onChange(true);
+    }).toJS;
+    _endListener = ((web.Event _) {
+      _setTextTrackMode('hidden');
+      onChange(false);
+    }).toJS;
+
+    video.addEventListener('webkitbeginfullscreen', _beginListener!);
+    video.addEventListener('webkitendfullscreen', _endListener!);
   }
 
   @override
   void enter() {
-    if (_mode != FullscreenMode.documentElement) return;
-    final element = web.document.documentElement;
-    if (element == null) return;
-    // Not awaited on purpose: an `await` here would be harmless for this route
-    // but the sibling route cannot afford one, and a single synchronous shape
-    // keeps the user-activation contract obvious. The rejection is still
-    // handled so it never surfaces as an unhandled promise.
-    element.requestFullscreen().toDart.catchError((Object e) {
-      debugPrint('[Fullscreen] requestFullscreen rejected: $e');
-      return null;
-    });
+    switch (_mode) {
+      case FullscreenMode.documentElement:
+        final element = web.document.documentElement;
+        if (element == null) return;
+        element.requestFullscreen().toDart.catchError((Object e) {
+          debugPrint('[Fullscreen] requestFullscreen rejected: $e');
+          return null;
+        });
+      case FullscreenMode.nativeVideoElement:
+        final video = _video;
+        if (video == null) {
+          debugPrint('[Fullscreen] no video element attached');
+          return;
+        }
+        try {
+          // Called synchronously on the tap frame. `webkitEnterFullscreen`
+          // requires live user activation and any await above would spend it.
+          (video as JSObject).callMethod('webkitEnterFullscreen'.toJS);
+        } catch (e) {
+          debugPrint('[Fullscreen] webkitEnterFullscreen failed: $e');
+        }
+      case FullscreenMode.osWindow:
+      case FullscreenMode.systemUi:
+      case FullscreenMode.unsupported:
+        return;
+    }
   }
 
   @override
   void exit() {
-    if (_mode != FullscreenMode.documentElement) return;
-    if (web.document.fullscreenElement == null) return;
-    web.document.exitFullscreen().toDart.catchError((Object e) {
-      debugPrint('[Fullscreen] exitFullscreen rejected: $e');
-      return null;
-    });
+    switch (_mode) {
+      case FullscreenMode.documentElement:
+        if (web.document.fullscreenElement == null) return;
+        web.document.exitFullscreen().toDart.catchError((Object e) {
+          debugPrint('[Fullscreen] exitFullscreen rejected: $e');
+          return null;
+        });
+      case FullscreenMode.nativeVideoElement:
+        final video = _video;
+        if (video == null) return;
+        try {
+          (video as JSObject).callMethod('webkitExitFullscreen'.toJS);
+        } catch (e) {
+          debugPrint('[Fullscreen] webkitExitFullscreen failed: $e');
+        }
+      case FullscreenMode.osWindow:
+      case FullscreenMode.systemUi:
+      case FullscreenMode.unsupported:
+        return;
+    }
   }
 
   @override
   void dispose() {
-    final listener = _documentListener;
-    if (listener != null) {
-      web.document.removeEventListener('fullscreenchange', listener);
+    final documentListener = _documentListener;
+    if (documentListener != null) {
+      web.document.removeEventListener('fullscreenchange', documentListener);
       _documentListener = null;
     }
+
+    // The player screen mounts repeatedly across SPA navigations, so leaked
+    // listeners on a long-lived video element would accumulate.
+    final video = _video;
+    if (video != null) {
+      final begin = _beginListener;
+      final end = _endListener;
+      if (begin != null) {
+        video.removeEventListener('webkitbeginfullscreen', begin);
+      }
+      if (end != null) {
+        video.removeEventListener('webkitendfullscreen', end);
+      }
+    }
+    _beginListener = null;
+    _endListener = null;
+    _video = null;
   }
 }

--- a/player/lib/core/player/fullscreen/fullscreen_controller.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_controller.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/foundation.dart';
+import 'package:media_kit/media_kit.dart';
+
+import 'fullscreen_backend.dart';
+import 'fullscreen_backend_factory.dart';
+import 'fullscreen_mode.dart';
+
+/// Fullscreen state that reports what happened rather than what was asked.
+///
+/// Replaces `PlayerScreen`'s `bool _isFullscreen`, which was flipped inside
+/// `setState` before the platform was asked and never corrected when the
+/// platform refused or when the viewer exited by some other route. The same
+/// defect was already fixed once for the desktop window; see
+/// `WindowFullscreenController`'s class comment.
+class FullscreenController {
+  FullscreenController({
+    FullscreenBackend Function(ValueChanged<bool>)? backendFactory,
+    ValueNotifier<bool>? state,
+  })  : _state = state ?? ValueNotifier<bool>(false),
+        _ownsState = state == null {
+    _backend = (backendFactory ?? _defaultBackend)(_set);
+  }
+
+  static FullscreenBackend _defaultBackend(ValueChanged<bool> onChange) =>
+      createFullscreenBackend(onChange: onChange);
+
+  final ValueNotifier<bool> _state;
+  final bool _ownsState;
+  late final FullscreenBackend _backend;
+
+  /// Observed fullscreen state. Never written by this class directly.
+  ValueListenable<bool> get isFullscreen => _state;
+
+  FullscreenMode get mode => _backend.mode;
+
+  /// False only where no fullscreen route exists, which is the signal to hide
+  /// the button rather than render a dead one.
+  bool get available => _backend.mode != FullscreenMode.unsupported;
+
+  void attach(Player player) => _backend.attach(player);
+
+  void _set(bool value) => _state.value = value;
+
+  /// Synchronous by contract, and must stay that way: `webkitEnterFullscreen`
+  /// needs live user activation, and an `await` between the tap and the call
+  /// spends it. Changing this to `Future<void>` would break iPhone Safari in a
+  /// way no test on a non-web host can catch.
+  void toggle() => _state.value ? exit() : enter();
+
+  void enter() => _backend.enter();
+
+  void exit() => _backend.exit();
+
+  void dispose() {
+    _backend.dispose();
+    if (_ownsState) _state.dispose();
+  }
+}

--- a/player/lib/core/player/fullscreen/fullscreen_mode.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_mode.dart
@@ -1,0 +1,58 @@
+/// How this build can present the player fullscreen.
+///
+/// Resolved once per `FullscreenController`. [osWindow] and [systemUi] do not
+/// change which platform call the native backend makes — media_kit's helper
+/// branches internally on `Platform.isAndroid || Platform.isIOS`
+/// (`media_kit_video/lib/src/video/video_texture.dart:479`). The distinction
+/// exists only to decide whether the controller's state can be event-sourced.
+enum FullscreenMode {
+  /// Native desktop. The OS window goes fullscreen and `windowFullscreen`
+  /// reports it, so state is authoritative.
+  osWindow,
+
+  /// Native mobile. `SystemChrome.setEnabledSystemUIMode` has no callback, so
+  /// this is the one mode whose state is necessarily optimistic.
+  systemUi,
+
+  /// Web with the standard Fullscreen API. Mydia's own chrome survives, which
+  /// is why this is preferred wherever it works.
+  documentElement,
+
+  /// iPhone Safari below iOS 26, which implements fullscreen only for
+  /// `HTMLVideoElement`. Apple draws the chrome and everything Flutter draws
+  /// is unreachable until the viewer exits.
+  nativeVideoElement,
+
+  /// No fullscreen route at all. The button is hidden rather than left dead.
+  unsupported,
+}
+
+/// Picks the web mode from two capability probes.
+///
+/// Deliberately NOT annotated `@visibleForTesting`, unlike its cousins
+/// `PlatformFeatures.computeSupportsKeyboardShortcuts` and
+/// `shouldReserveTitleBar`. Those are called from inside their own library
+/// file; this one is called from `fullscreen_backend_web.dart`, and the
+/// annotation fires `invalid_use_of_visible_for_testing_member` across files.
+/// `windowFullscreenSignal` in `core/window/window_fullscreen.dart` documents
+/// the same trap and skips the annotation for the same reason.
+///
+/// [documentFullscreenEnabled] must come from `document.fullscreenEnabled`,
+/// not from probing for a `requestFullscreen` method. That property is also
+/// false inside an iframe without `allow="fullscreen"`, which is the other
+/// case that has to fall back, so one read covers both.
+///
+/// [videoElementFullscreenSupported] must be probed on
+/// `HTMLVideoElement.prototype`, never on a live element:
+/// `video.webkitSupportsFullscreen` stays false until metadata loads, and the
+/// button has to decide whether to exist before then.
+FullscreenMode resolveWebMode({
+  required bool documentFullscreenEnabled,
+  required bool videoElementFullscreenSupported,
+}) {
+  if (documentFullscreenEnabled) return FullscreenMode.documentElement;
+  if (videoElementFullscreenSupported) {
+    return FullscreenMode.nativeVideoElement;
+  }
+  return FullscreenMode.unsupported;
+}

--- a/player/lib/core/player/input_capabilities.dart
+++ b/player/lib/core/player/input_capabilities.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
+
+import 'input_capabilities_native.dart'
+    if (dart.library.js_interop) 'input_capabilities_web.dart' as probe;
+import 'platform_features.dart';
+
+/// What the viewer is pointing with, as opposed to what the build target is.
+///
+/// Split out from [PlatformFeatures] because that class answers "which build
+/// is this", and every one of its getters short-circuits `if (kIsWeb) return
+/// false`. That is correct for a build-target question and wrong for an input
+/// question: a phone browser has fingers whether or not the Dart build target
+/// knows it is a phone.
+///
+/// Keyed on pointer rather than viewport on purpose. A phone in landscape is
+/// around 800px wide, which is exactly when someone is watching video, so any
+/// width-based rule would drop out of the touch tier at the worst possible
+/// moment. Viewport stays the right axis for layout, and
+/// `core/layout/breakpoints.dart` keeps that job.
+class InputCapabilities {
+  /// Whether the primary pointer is a finger.
+  static bool get touchPrimary => computeTouchPrimary(
+        isNativeMobile: PlatformFeatures.isMobile,
+        isWeb: kIsWeb,
+        coarsePointer: probe.coarsePointer,
+      );
+
+  /// Pure predicate behind [touchPrimary], exposed separately so it can be
+  /// unit-tested for every platform combination without running on each.
+  /// `kIsWeb` is compile-time per build target and always false under
+  /// `flutter test`, so a regression that deleted the web branch would pass
+  /// every test unless the logic is tested independently. Mirrors
+  /// `PlatformFeatures.computeSupportsKeyboardShortcuts`, which exists for
+  /// exactly the same reason.
+  ///
+  /// Safe to annotate here, unlike `resolveWebMode`: this is called from
+  /// [touchPrimary] in the same library file.
+  @visibleForTesting
+  static bool computeTouchPrimary({
+    required bool isNativeMobile,
+    required bool isWeb,
+    required bool coarsePointer,
+  }) =>
+      isNativeMobile || (isWeb && coarsePointer);
+
+  /// Whether tap and double-tap playback gestures should be wired.
+  ///
+  /// Moved off `PlatformFeatures`, where it read `isMobile` and was therefore
+  /// false on every phone browser.
+  static bool get supportsGestureControls => touchPrimary;
+}

--- a/player/lib/core/player/input_capabilities_native.dart
+++ b/player/lib/core/player/input_capabilities_native.dart
@@ -1,0 +1,7 @@
+/// Native half of the pointer probe.
+///
+/// Always false, and never actually consulted: `InputCapabilities.touchPrimary`
+/// answers from `PlatformFeatures.isMobile` off web. This exists so the
+/// conditional import in `input_capabilities.dart` has a target that compiles
+/// on a build with no DOM, mirroring `core/window/desktop_window_stub.dart`.
+bool get coarsePointer => false;

--- a/player/lib/core/player/input_capabilities_web.dart
+++ b/player/lib/core/player/input_capabilities_web.dart
@@ -1,0 +1,15 @@
+import 'package:web/web.dart' as web;
+
+/// Web half of the pointer probe.
+///
+/// `(pointer: coarse)` describes the *primary* pointer, which is what this
+/// needs: a laptop with a touchscreen but a mouse reports `fine` here and
+/// keeps its desktop chrome, while a phone or tablet browser reports
+/// `coarse`. `(any-pointer: coarse)` would wrongly catch the former.
+///
+/// Memoised because `touchPrimary` is read inside `build` methods
+/// (`playback_chrome.dart`), and a `matchMedia` call per frame is waste. The
+/// primary pointer type cannot change for the life of a document.
+final bool _coarsePointer = web.window.matchMedia('(pointer: coarse)').matches;
+
+bool get coarsePointer => _coarsePointer;

--- a/player/lib/core/player/platform_features.dart
+++ b/player/lib/core/player/platform_features.dart
@@ -68,9 +68,6 @@ class PlatformFeatures {
   /// Check if running on web
   static bool get isWeb => kIsWeb;
 
-  /// Check if gesture controls should be enabled (mobile only)
-  static bool get supportsGestureControls => isMobile;
-
   /// Check if keyboard shortcuts should be enabled: native desktop or web —
   /// both have a physical keyboard. This was previously `isDesktop` alone,
   /// which left a narrowed desktop *or web* browser window with no in-bar

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -2706,12 +2706,18 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
   @override
   void dispose() {
-    // Exit fullscreen if active, then tear down listeners. Order matters:
-    // exiting after disposal would write to a disposed notifier.
+    // Order matters twice over. Stop listening *first*: in `systemUi` mode
+    // `exit()` reports the transition synchronously, and the resulting
+    // `setState` would assert — by the time `State.dispose` runs, the element
+    // is already defunct (`StatefulElement.unmount` calls `super.unmount()`
+    // before `state.dispose()`), and `markNeedsBuild` asserts on exactly that.
+    // The `mounted` check in `_onFullscreenChanged` is not a guard here:
+    // `_element` is nulled only after dispose returns, so it still reads true.
+    // Then exit before `dispose()`, which disposes the notifier underneath it.
+    _fullscreen.isFullscreen.removeListener(_onFullscreenChanged);
     if (_fullscreen.isFullscreen.value) {
       _fullscreen.exit();
     }
-    _fullscreen.isFullscreen.removeListener(_onFullscreenChanged);
     _fullscreen.dispose();
 
     // Un-pin the window if it was pinned — never let always-on-top leak

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -20,6 +20,7 @@ import '../../../core/playback/playback_progress_providers.dart';
 import '../../../core/playback/playback_progress_store.dart';
 import '../../../core/utils/file_utils.dart' as file_utils;
 import '../../../core/utils/web_lifecycle.dart' as web_lifecycle;
+import '../../../core/player/fullscreen/fullscreen_controller.dart';
 import '../../../core/player/input_capabilities.dart';
 import '../../../core/player/platform_features.dart';
 import '../../../core/player/playback_error.dart';
@@ -342,8 +343,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   // Desktop feature state
   final FocusNode _focusNode = FocusNode();
 
-  // Fullscreen state
-  bool _isFullscreen = false;
+  /// Fullscreen state, owned by the controller and sourced from platform
+  /// events. Deliberately not a local bool: the previous field was flipped
+  /// optimistically and never learned that the platform had refused, which is
+  /// why the button reported "exit fullscreen" over an inline video on
+  /// iPhone Safari.
+  final FullscreenController _fullscreen = FullscreenController();
 
   // Always-on-top state. Not persisted — starts false for every playback
   // session and is force-disabled in dispose() if still true, so it never
@@ -422,6 +427,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     unawaited(windowSizer.attach());
 
     _loadAutoSkipPreference();
+    _fullscreen.isFullscreen.addListener(_onFullscreenChanged);
     _initializePlayer();
 
     // Force landscape orientation on mobile devices
@@ -1215,6 +1221,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     final player = Player();
     _player = player;
     _videoController = VideoController(player);
+    // Hands the backend the media_kit player so the web backend can reach the
+    // underlying HTMLVideoElement. A no-op on native.
+    _fullscreen.attach(player);
 
     // Bound before `open` deliberately: a source that fails to resolve at all
     // (a deleted file id, a dead HLS session) errors during the open itself,
@@ -2626,7 +2635,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         return KeyEventResult.handled;
 
       case LogicalKeyboardKey.keyF:
-        _toggleFullscreen();
+        _fullscreen.toggle();
         return KeyEventResult.handled;
 
       case LogicalKeyboardKey.keyT:
@@ -2644,8 +2653,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         return KeyEventResult.handled;
 
       case LogicalKeyboardKey.escape:
-        if (_isFullscreen) {
-          _toggleFullscreen();
+        if (_fullscreen.isFullscreen.value) {
+          _fullscreen.exit();
         }
         return KeyEventResult.handled;
 
@@ -2676,14 +2685,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     }
   }
 
-  /// Toggle fullscreen mode across all platforms.
-  void _toggleFullscreen() {
-    setState(() => _isFullscreen = !_isFullscreen);
-    if (_isFullscreen) {
-      defaultEnterNativeFullscreen();
-    } else {
-      defaultExitNativeFullscreen();
-    }
+  /// Rebuilds so the chrome's fullscreen icon follows observed state. Cheap:
+  /// the notifier only fires on a real transition.
+  void _onFullscreenChanged() {
+    if (mounted) setState(() {});
   }
 
   /// Toggle always-on-top across desktop platforms.
@@ -2701,10 +2706,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
   @override
   void dispose() {
-    // Exit fullscreen if active
-    if (_isFullscreen) {
-      defaultExitNativeFullscreen();
+    // Exit fullscreen if active, then tear down listeners. Order matters:
+    // exiting after disposal would write to a disposed notifier.
+    if (_fullscreen.isFullscreen.value) {
+      _fullscreen.exit();
     }
+    _fullscreen.isFullscreen.removeListener(_onFullscreenChanged);
+    _fullscreen.dispose();
 
     // Un-pin the window if it was pinned — never let always-on-top leak
     // into the browse/library window behind this one.
@@ -2929,11 +2937,14 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           // never reported — matching how subtitles and audio disable
           // themselves at zero tracks rather than opening a one-item menu.
           onQualityTap: _qualityLadder.length > 1 ? _showQualitySelector : null,
-          onFullscreenTap: _toggleFullscreen,
+          // Null where no fullscreen route exists, which hides the button
+          // rather than leaving a dead one — matching how `onQualityTap`
+          // above hides itself at a single quality rung.
+          onFullscreenTap: _fullscreen.available ? _fullscreen.toggle : null,
           onAlwaysOnTopTap: _toggleAlwaysOnTop,
           onPreviousEpisode: _hasPreviousEpisode ? _playPreviousEpisode : null,
           onNextEpisode: _hasNextEpisode ? _playNextEpisode : null,
-          isFullscreen: _isFullscreen,
+          isFullscreen: _fullscreen.isFullscreen.value,
           isAlwaysOnTop: _isAlwaysOnTop,
           audioTrackCount: _audioTracks.length,
           subtitleTrackCount: _subtitleTracks.length,

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -20,6 +20,7 @@ import '../../../core/playback/playback_progress_providers.dart';
 import '../../../core/playback/playback_progress_store.dart';
 import '../../../core/utils/file_utils.dart' as file_utils;
 import '../../../core/utils/web_lifecycle.dart' as web_lifecycle;
+import '../../../core/player/input_capabilities.dart';
 import '../../../core/player/platform_features.dart';
 import '../../../core/player/playback_error.dart';
 import '../../../core/player/stream_timeline.dart';
@@ -2946,7 +2947,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
     // Wrap with gesture controls for mobile
     final player = _player;
-    if (PlatformFeatures.supportsGestureControls && player != null) {
+    if (InputCapabilities.supportsGestureControls && player != null) {
       videoPlayer = GestureControls(
         player: player,
         timeline: _timeline,

--- a/player/lib/presentation/widgets/video_controls/chrome_panel.dart
+++ b/player/lib/presentation/widgets/video_controls/chrome_panel.dart
@@ -26,6 +26,17 @@ class PanelMetrics {
   /// Whether controls should use enlarged touch hit areas.
   final bool touchTargets;
 
+  /// Whether the in-bar transport collapses to play/pause only, dropping ±10s
+  /// and episode navigation.
+  ///
+  /// Split out of [touchTargets], which used to drive both this and the
+  /// enlarged seek hit area. They answer different questions: this one is
+  /// about horizontal room, [touchTargets] is about finger size. Keeping them
+  /// fused meant that making [touchTargets] follow input capability would have
+  /// silently taken episode navigation away from a landscape phone browser,
+  /// which sits around 800px and clears this breakpoint comfortably.
+  final bool compactTransport;
+
   /// Whether `SecondaryCluster`'s quality button renders.
   ///
   /// True at every tier. It was previously true only on desktop, for two
@@ -83,22 +94,32 @@ class PanelMetrics {
     required this.bottomOffset,
     required this.showVolume,
     required this.touchTargets,
+    required this.compactTransport,
     required this.showQuality,
     required this.showAlwaysOnTop,
     required this.secondaryGap,
     required this.horizontalPadding,
   });
 
-  /// Resolve metrics for a viewport [width], using the breakpoints in
-  /// `core/layout/breakpoints.dart` (mobile < 600, tablet 600–899,
-  /// desktop >= 900).
-  factory PanelMetrics.forWidth(double width) {
+  /// Resolve metrics for a viewport [width] and the viewer's input type,
+  /// using the breakpoints in `core/layout/breakpoints.dart`
+  /// (mobile < 600, tablet 600-899, desktop >= 900).
+  ///
+  /// [touchPrimary] governs finger-sized affordances only; [width] governs how
+  /// much fits. See [compactTransport] for why these are separate.
+  factory PanelMetrics.resolve({
+    required double width,
+    required bool touchPrimary,
+  }) {
+    final compactTransport = width < Breakpoints.mobile;
+
     if (width >= Breakpoints.tablet) {
       return PanelMetrics(
         maxWidth: math.min(720.0, width * 0.70),
         bottomOffset: 48,
         showVolume: true,
         touchTargets: false,
+        compactTransport: compactTransport,
         showQuality: true,
         showAlwaysOnTop: true,
         secondaryGap: 8,
@@ -111,6 +132,7 @@ class PanelMetrics {
         bottomOffset: 32,
         showVolume: true,
         touchTargets: false,
+        compactTransport: compactTransport,
         showQuality: true,
         // false, not true: measured against `chrome_panel_overflow_test.dart`
         // (per `showAlwaysOnTop`'s dartdoc), the tablet tier's tightest width
@@ -129,12 +151,23 @@ class PanelMetrics {
       bottomOffset: 24,
       showVolume: false,
       touchTargets: true,
+      compactTransport: compactTransport,
       showQuality: true,
       showAlwaysOnTop: false,
       secondaryGap: 0,
       horizontalPadding: 8,
     );
   }
+
+  /// Fine-pointer shorthand for [resolve], for the many assertions that are
+  /// about width alone.
+  ///
+  /// Annotated so production code cannot quietly take the fine-pointer default
+  /// on a touch device: `playback_chrome.dart` passes the real
+  /// `InputCapabilities.touchPrimary` through [resolve] instead.
+  @visibleForTesting
+  factory PanelMetrics.forWidth(double width) =>
+      PanelMetrics.resolve(width: width, touchPrimary: false);
 }
 
 /// The playback control panel.

--- a/player/lib/presentation/widgets/video_controls/chrome_panel.dart
+++ b/player/lib/presentation/widgets/video_controls/chrome_panel.dart
@@ -113,12 +113,16 @@ class PanelMetrics {
   }) {
     final compactTransport = width < Breakpoints.mobile;
 
+    // Finger size, not window size. A landscape phone is around 800px and
+    // would otherwise take the tablet tier's 32px scrubber.
+    final touchTargets = touchPrimary || width < Breakpoints.mobile;
+
     if (width >= Breakpoints.tablet) {
       return PanelMetrics(
         maxWidth: math.min(720.0, width * 0.70),
         bottomOffset: 48,
         showVolume: true,
-        touchTargets: false,
+        touchTargets: touchTargets,
         compactTransport: compactTransport,
         showQuality: true,
         showAlwaysOnTop: true,
@@ -131,7 +135,7 @@ class PanelMetrics {
         maxWidth: math.min(640.0, width * 0.90),
         bottomOffset: 32,
         showVolume: true,
-        touchTargets: false,
+        touchTargets: touchTargets,
         compactTransport: compactTransport,
         showQuality: true,
         // false, not true: measured against `chrome_panel_overflow_test.dart`
@@ -150,7 +154,7 @@ class PanelMetrics {
       maxWidth: math.max(0.0, width - 20),
       bottomOffset: 24,
       showVolume: false,
-      touchTargets: true,
+      touchTargets: touchTargets,
       compactTransport: compactTransport,
       showQuality: true,
       showAlwaysOnTop: false,

--- a/player/lib/presentation/widgets/video_controls/panel_controls.dart
+++ b/player/lib/presentation/widgets/video_controls/panel_controls.dart
@@ -186,6 +186,9 @@ class SecondaryCluster extends StatelessWidget {
   /// Not a platform signal: it was web-only while `player_screen.dart` gated
   /// the callback on `PlatformFeatures.isWeb`, and that gate is gone.
   final VoidCallback? onQualityTap;
+
+  /// When null the fullscreen button is omitted entirely, which is how the
+  /// player screen hides it on a browser with no fullscreen route.
   final VoidCallback? onFullscreenTap;
   final VoidCallback? onAlwaysOnTopTap;
 
@@ -281,17 +284,23 @@ class SecondaryCluster extends StatelessWidget {
             onTap: onQualityTap,
           ),
         ],
-        SizedBox(width: gap),
-        ControlButton(
-          key: fullscreenKey,
-          icon: isFullscreen
-              ? Icons.fullscreen_exit_rounded
-              : Icons.fullscreen_rounded,
-          iconSize: 18,
-          size: 32,
-          tooltip: isFullscreen ? 'Exit fullscreen' : 'Fullscreen',
-          onTap: onFullscreenTap,
-        ),
+        // Omitted entirely when null, matching `onQualityTap` above: null
+        // means the browser has no fullscreen route at all
+        // (`FullscreenMode.unsupported`), not that fullscreen is momentarily
+        // unavailable. A dead button would be worse than none.
+        if (onFullscreenTap != null) ...[
+          SizedBox(width: gap),
+          ControlButton(
+            key: fullscreenKey,
+            icon: isFullscreen
+                ? Icons.fullscreen_exit_rounded
+                : Icons.fullscreen_rounded,
+            iconSize: 18,
+            size: 32,
+            tooltip: isFullscreen ? 'Exit fullscreen' : 'Fullscreen',
+            onTap: onFullscreenTap,
+          ),
+        ],
         if (onAlwaysOnTopTap != null) ...[
           SizedBox(width: gap),
           SizedBox(

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 
+import '../../../core/player/input_capabilities.dart';
 import '../../../core/player/platform_features.dart';
 import '../../../core/player/stream_timeline.dart';
 import '../../../core/window/desktop_window.dart';
@@ -275,7 +276,10 @@ class _ChromeVisibilityState extends State<ChromeVisibility>
       ],
     );
 
-    if (!PlatformFeatures.isMobile) {
+    // Hover-to-reveal and cursor hiding need a pointer that can hover. This
+    // read `PlatformFeatures.isMobile`, which is false on web, so a phone
+    // browser installed a MouseRegion whose callbacks never fire.
+    if (!InputCapabilities.touchPrimary) {
       stack = MouseRegion(
         // Cursor disappears with the chrome.
         cursor: _visible ? MouseCursor.defer : SystemMouseCursors.none,
@@ -464,7 +468,7 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
   Widget build(BuildContext context) {
     final metrics = PanelMetrics.resolve(
       width: MediaQuery.sizeOf(context).width,
-      touchPrimary: false,
+      touchPrimary: InputCapabilities.touchPrimary,
     );
 
     return StreamBuilder<bool>(
@@ -508,7 +512,7 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
                 // a 48px in-bar button is worse than a centre target. No skip
                 // buttons here — `gesture_controls.dart` already does
                 // double-tap-left/right for ±10s.
-                if (PlatformFeatures.isMobile)
+                if (InputCapabilities.touchPrimary)
                   Center(
                     child: CenterPlayButton(player: widget.player),
                   ),

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -462,7 +462,10 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
 
   @override
   Widget build(BuildContext context) {
-    final metrics = PanelMetrics.forWidth(MediaQuery.sizeOf(context).width);
+    final metrics = PanelMetrics.resolve(
+      width: MediaQuery.sizeOf(context).width,
+      touchPrimary: false,
+    );
 
     return StreamBuilder<bool>(
       stream: widget.player.stream.playing,
@@ -546,7 +549,7 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
                           // below this breakpoint. See this task's report for
                           // the open follow-up; do not read this comment as
                           // "handled".
-                          compact: metrics.touchTargets,
+                          compact: metrics.compactTransport,
                         ),
                         // Unconditional per ChromePanel's `volume` dartdoc:
                         // it already gates visibility internally via

--- a/player/test/core/player/fullscreen/fullscreen_controller_test.dart
+++ b/player/test/core/player/fullscreen/fullscreen_controller_test.dart
@@ -1,0 +1,158 @@
+// The controller's whole job is that its notifier reports observed state
+// rather than requested state. Every test here is written against that: a
+// backend that accepts a request but never reports must leave the notifier
+// false, because that is precisely the bug this replaces — `PlayerScreen`
+// used to flip `_isFullscreen` inside `setState` before asking the platform,
+// so on iPhone Safari the icon said "exit fullscreen" over an inline video.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:player/core/player/fullscreen/fullscreen_backend.dart';
+import 'package:player/core/player/fullscreen/fullscreen_controller.dart';
+import 'package:player/core/player/fullscreen/fullscreen_mode.dart';
+
+void main() {
+  group('FullscreenController', () {
+    test('starts windowed', () {
+      final controller = FullscreenController(
+        backendFactory: (onChange) => _FakeBackend(onChange),
+      );
+      addTearDown(controller.dispose);
+
+      expect(controller.isFullscreen.value, isFalse);
+    });
+
+    test('enter forwards to the backend', () {
+      late _FakeBackend backend;
+      final controller = FullscreenController(
+        backendFactory: (onChange) => backend = _FakeBackend(onChange),
+      );
+      addTearDown(controller.dispose);
+
+      controller.enter();
+
+      expect(backend.enterCalls, 1);
+    });
+
+    test(
+        'a backend that accepts the request but never reports leaves the '
+        'notifier false — the iPhone Safari case', () {
+      final controller = FullscreenController(
+        backendFactory: (onChange) => _SilentBackend(onChange),
+      );
+      addTearDown(controller.dispose);
+
+      controller.enter();
+
+      expect(controller.isFullscreen.value, isFalse);
+    });
+
+    test('the notifier follows backend events', () {
+      late _FakeBackend backend;
+      final controller = FullscreenController(
+        backendFactory: (onChange) => backend = _FakeBackend(onChange),
+      );
+      addTearDown(controller.dispose);
+
+      backend.report(true);
+      expect(controller.isFullscreen.value, isTrue);
+
+      backend.report(false);
+      expect(controller.isFullscreen.value, isFalse);
+    });
+
+    test(
+        'toggle reads observed state, so a system-gesture exit that the '
+        'backend reported means the next tap enters rather than exits', () {
+      late _FakeBackend backend;
+      final controller = FullscreenController(
+        backendFactory: (onChange) => backend = _FakeBackend(onChange),
+      );
+      addTearDown(controller.dispose);
+
+      controller.toggle();
+      backend.report(true);
+      backend.report(false); // viewer pressed Apple's Done button
+
+      controller.toggle();
+
+      expect(backend.enterCalls, 2);
+      expect(backend.exitCalls, 0);
+    });
+
+    test('available is false only in unsupported mode', () {
+      final unsupported = FullscreenController(
+        backendFactory: (onChange) =>
+            _FakeBackend(onChange, mode: FullscreenMode.unsupported),
+      );
+      addTearDown(unsupported.dispose);
+      final supported = FullscreenController(
+        backendFactory: (onChange) =>
+            _FakeBackend(onChange, mode: FullscreenMode.nativeVideoElement),
+      );
+      addTearDown(supported.dispose);
+
+      expect(unsupported.available, isFalse);
+      expect(supported.available, isTrue);
+    });
+
+    test('dispose forwards to the backend', () {
+      late _FakeBackend backend;
+      final controller = FullscreenController(
+        backendFactory: (onChange) => backend = _FakeBackend(onChange),
+      );
+
+      controller.dispose();
+
+      expect(backend.disposed, isTrue);
+    });
+
+    test('an injected notifier is not disposed by the controller', () {
+      final state = ValueNotifier<bool>(false);
+      final controller = FullscreenController(
+        backendFactory: (onChange) => _FakeBackend(onChange),
+        state: state,
+      );
+
+      controller.dispose();
+
+      // Would throw if the controller had disposed a notifier it does not own.
+      expect(() => state.value = true, returnsNormally);
+      state.dispose();
+    });
+  });
+}
+
+class _FakeBackend implements FullscreenBackend {
+  _FakeBackend(this.onChange, {this.mode = FullscreenMode.osWindow});
+
+  final ValueChanged<bool> onChange;
+
+  @override
+  final FullscreenMode mode;
+
+  int enterCalls = 0;
+  int exitCalls = 0;
+  bool disposed = false;
+
+  void report(bool value) => onChange(value);
+
+  @override
+  void attach(Player player) {}
+
+  @override
+  void enter() => enterCalls++;
+
+  @override
+  void exit() => exitCalls++;
+
+  @override
+  void dispose() => disposed = true;
+}
+
+/// Accepts every request and reports nothing, like `requestFullscreen` failing
+/// on iPhone Safari inside media_kit's swallowing try/catch.
+class _SilentBackend extends _FakeBackend {
+  _SilentBackend(super.onChange);
+}

--- a/player/test/core/player/fullscreen/fullscreen_mode_test.dart
+++ b/player/test/core/player/fullscreen/fullscreen_mode_test.dart
@@ -1,0 +1,56 @@
+// Guards `resolveWebMode`'s branch order directly. `kIsWeb` is a compile-time
+// constant baked in per build target, so a `flutter test` run (always
+// non-web) can never observe the real web backend resolve anything. Testing
+// the extracted logic with explicit inputs is the only coverage available
+// without a browser test target — the same reasoning as
+// `platform_features_keyboard_test.dart` and `window_chrome_inset_test.dart`.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/fullscreen/fullscreen_mode.dart';
+
+void main() {
+  group('resolveWebMode', () {
+    test('prefers the standard API, which keeps Mydia chrome', () {
+      expect(
+        resolveWebMode(
+          documentFullscreenEnabled: true,
+          videoElementFullscreenSupported: true,
+        ),
+        FullscreenMode.documentElement,
+      );
+    });
+
+    test('standard API alone is enough', () {
+      expect(
+        resolveWebMode(
+          documentFullscreenEnabled: true,
+          videoElementFullscreenSupported: false,
+        ),
+        FullscreenMode.documentElement,
+      );
+    });
+
+    test(
+        'falls back to the video element when the document cannot go '
+        'fullscreen — iPhone Safari below iOS 26, and any iframe without '
+        'allow="fullscreen"', () {
+      expect(
+        resolveWebMode(
+          documentFullscreenEnabled: false,
+          videoElementFullscreenSupported: true,
+        ),
+        FullscreenMode.nativeVideoElement,
+      );
+    });
+
+    test('unsupported when neither route exists, so the button is hidden', () {
+      expect(
+        resolveWebMode(
+          documentFullscreenEnabled: false,
+          videoElementFullscreenSupported: false,
+        ),
+        FullscreenMode.unsupported,
+      );
+    });
+  });
+}

--- a/player/test/core/player/input_capabilities_test.dart
+++ b/player/test/core/player/input_capabilities_test.dart
@@ -1,0 +1,93 @@
+// Guards `InputCapabilities.touchPrimary`'s logic via its pure predicate.
+// `kIsWeb` is compile-time false under `flutter test`, so the real getter can
+// never be observed resolving the web branch on this host. Mirrors
+// `platform_features_keyboard_test.dart`.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/input_capabilities.dart';
+import 'package:player/core/player/platform_features.dart';
+
+void main() {
+  group('InputCapabilities.computeTouchPrimary', () {
+    test('true on a native phone or tablet', () {
+      expect(
+        InputCapabilities.computeTouchPrimary(
+          isNativeMobile: true,
+          isWeb: false,
+          coarsePointer: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+        'true on web with a coarse pointer — the actual defect this fixes: '
+        'PlatformFeatures.isMobile returns false on web, so a phone browser '
+        'was classified as neither mobile nor desktop and lost gestures', () {
+      expect(
+        InputCapabilities.computeTouchPrimary(
+          isNativeMobile: false,
+          isWeb: true,
+          coarsePointer: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('false on web with a fine pointer, so desktop browsers are unchanged',
+        () {
+      expect(
+        InputCapabilities.computeTouchPrimary(
+          isNativeMobile: false,
+          isWeb: true,
+          coarsePointer: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('false on native desktop', () {
+      expect(
+        InputCapabilities.computeTouchPrimary(
+          isNativeMobile: false,
+          isWeb: false,
+          coarsePointer: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+        'a coarse pointer off web is ignored, since native already answers '
+        'through isNativeMobile and a touchscreen laptop keeps its desktop '
+        'chrome', () {
+      expect(
+        InputCapabilities.computeTouchPrimary(
+          isNativeMobile: false,
+          isWeb: false,
+          coarsePointer: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('the real getter matches the pure predicate on this (non-web) host',
+        () {
+      expect(
+        InputCapabilities.touchPrimary,
+        InputCapabilities.computeTouchPrimary(
+          isNativeMobile: PlatformFeatures.isMobile,
+          isWeb: PlatformFeatures.isWeb,
+          coarsePointer: false,
+        ),
+      );
+    });
+
+    test('supportsGestureControls tracks touchPrimary', () {
+      expect(
+        InputCapabilities.supportsGestureControls,
+        InputCapabilities.touchPrimary,
+      );
+    });
+  });
+}

--- a/player/test/presentation/widgets/video_controls/chrome_panel_overflow_test.dart
+++ b/player/test/presentation/widgets/video_controls/chrome_panel_overflow_test.dart
@@ -96,6 +96,12 @@ Widget _panel(double width, {bool quality = false, bool alwaysOnTop = false}) {
             audioTrackCount: 2,
             gap: metrics.secondaryGap,
             onQualityTap: quality ? () {} : null,
+            // Unconditional, because this helper measures the worst case and
+            // the fullscreen button is present on every platform that has a
+            // fullscreen route at all. Passing null would omit it (see
+            // `SecondaryCluster.onFullscreenTap`), quietly shrinking the very
+            // budget these widths exist to measure.
+            onFullscreenTap: () {},
             onAlwaysOnTopTap: alwaysOnTop ? () {} : null,
           ),
           scrubber: ProgressBarSurface(

--- a/player/test/presentation/widgets/video_controls/chrome_panel_overflow_test.dart
+++ b/player/test/presentation/widgets/video_controls/chrome_panel_overflow_test.dart
@@ -52,9 +52,10 @@ import 'package:player/presentation/widgets/video_controls/video_progress_bar.da
 
 /// Mirrors `PlaybackChrome`'s real composition as closely as a `Player`-free
 /// test can: episode-nav wired unconditionally (as `PlaybackChrome` now does
-/// — see its wiring comment), `compact` following `metrics.touchTargets`
-/// (dropping seek/episode-nav to play/pause-only below the mobile
-/// breakpoint), `volume` supplied whenever `metrics.showVolume`, and the
+/// — see its wiring comment), `compact` following `metrics.compactTransport`
+/// (split from `touchTargets`; dropping seek/episode-nav to play/pause-only
+/// below the mobile breakpoint), `volume` supplied whenever
+/// `metrics.showVolume`, and the
 /// quality button shown whenever [quality] requests it — every tier's
 /// `metrics.showQuality` is true now, so there is no gate left to replicate
 /// (see the file header's `quality` axis note). This is deliberately the
@@ -82,7 +83,7 @@ Widget _panel(double width, {bool quality = false, bool alwaysOnTop = false}) {
             isPlaying: true,
             onPreviousEpisode: () {},
             onNextEpisode: () {},
-            compact: metrics.touchTargets,
+            compact: metrics.compactTransport,
           ),
           volume: metrics.showVolume
               ? VolumeSurface(

--- a/player/test/presentation/widgets/video_controls/chrome_panel_test.dart
+++ b/player/test/presentation/widgets/video_controls/chrome_panel_test.dart
@@ -109,6 +109,45 @@ void main() {
       expect(PanelMetrics.forWidth(600).showAlwaysOnTop, isFalse);
       expect(PanelMetrics.forWidth(400).showAlwaysOnTop, isFalse);
     });
+
+    group('touchPrimary', () {
+      test(
+          'a landscape phone browser gets the enlarged seek target, which it '
+          'previously missed: it sits around 800px and so landed in the '
+          'tablet tier with a 32px-high scrubber', () {
+        final metrics = PanelMetrics.resolve(width: 800, touchPrimary: true);
+
+        expect(metrics.touchTargets, isTrue);
+      });
+
+      test('a fine pointer at the same width does not', () {
+        final metrics = PanelMetrics.resolve(width: 800, touchPrimary: false);
+
+        expect(metrics.touchTargets, isFalse);
+      });
+
+      test('below the mobile breakpoint touch targets stay on regardless', () {
+        expect(
+          PanelMetrics.resolve(width: 400, touchPrimary: false).touchTargets,
+          isTrue,
+        );
+      });
+
+      test(
+          'touch does NOT collapse the transport, so a landscape phone keeps '
+          'its episode-nav buttons — the regression the compactTransport '
+          'split exists to prevent', () {
+        final metrics = PanelMetrics.resolve(width: 800, touchPrimary: true);
+
+        expect(metrics.compactTransport, isFalse);
+      });
+
+      test('touch does not remove the volume slider', () {
+        final metrics = PanelMetrics.resolve(width: 800, touchPrimary: true);
+
+        expect(metrics.showVolume, isTrue);
+      });
+    });
   });
 
   group('ChromePanel', () {

--- a/player/test/presentation/widgets/video_controls/panel_controls_test.dart
+++ b/player/test/presentation/widgets/video_controls/panel_controls_test.dart
@@ -273,6 +273,34 @@ void main() {
       expect(find.byKey(SecondaryCluster.qualityKey), findsOneWidget);
     });
 
+    testWidgets('omits fullscreen when no callback is supplied',
+        (tester) async {
+      // Null means the browser has no fullscreen route at all
+      // (`FullscreenMode.unsupported`), not that fullscreen is momentarily
+      // unavailable, so a dead button would be worse than none.
+      await tester.pumpWidget(_host(const SecondaryCluster()));
+      expect(find.byKey(SecondaryCluster.fullscreenKey), findsNothing);
+    });
+
+    testWidgets('shows fullscreen when a callback is supplied', (tester) async {
+      await tester.pumpWidget(
+        _host(SecondaryCluster(onFullscreenTap: () {})),
+      );
+      expect(find.byKey(SecondaryCluster.fullscreenKey), findsOneWidget);
+    });
+
+    testWidgets('taps reach the fullscreen callback', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _host(SecondaryCluster(onFullscreenTap: () => taps++)),
+      );
+
+      await tester.tap(find.byKey(SecondaryCluster.fullscreenKey));
+      await tester.pump();
+
+      expect(taps, 1);
+    });
+
     testWidgets('swaps the fullscreen glyph', (tester) async {
       await tester.pumpWidget(
         _host(SecondaryCluster(isFullscreen: true, onFullscreenTap: () {})),


### PR DESCRIPTION
## Problem

Tapping fullscreen in the web player on an iPhone flipped the button icon to "exit fullscreen" while nothing else happened. The video stayed inline and Safari's chrome stayed put.

Two separate defects stacked into that one symptom:

1. **The state was optimistic.** `PlayerScreen._toggleFullscreen` flipped a local `bool` inside `setState` and only then asked the platform. Nothing listened for `fullscreenchange`, so the flag also went stale when the viewer exited by any other route. The repo had already diagnosed this once for the desktop window, in `WindowFullscreenController`'s class comment.
2. **iPhone Safari cannot fullscreen an arbitrary element.** media_kit's web helper calls `document.documentElement.requestFullscreen()`, which does not exist on iPhone below iOS 26. It fails, the `catch` swallows it to `debugPrint`, and the caller carries on believing it worked.

A third gap sat next to them: `PlatformFeatures.isMobile` returns `false` on web, so a phone browser was classified as neither mobile nor desktop and lost touch gestures, the centre play button, and the enlarged seek target.

## What changed

Fullscreen state moves out of `PlayerScreen` into a `FullscreenController` whose `ValueNotifier<bool>` is written only by a platform backend, from platform events. Three of the four live modes are event-sourced, so the icon reports what happened rather than what was asked:

| backend | state written from | authoritative |
| --- | --- | --- |
| native desktop | the existing `windowFullscreen` signal, republished | yes |
| native mobile | optimistically; `setEnabledSystemUIMode` has no callback | no |
| web, standard API | `document.onFullscreenChange` | yes |
| web, iPhone Safari | `webkitbeginfullscreen` / `webkitendfullscreen` | yes |

On iPhone Safari the backend calls `webkitEnterFullscreen()` on media_kit's real `HTMLVideoElement`, which gives Apple's native player: true fullscreen, automatic landscape rotation, AirPlay and system gestures. Subtitles survive it by flipping media_kit's `<track>` from `hidden` to `showing` for the duration, since media_kit normally keeps the browser's cues hidden and paints them through Flutter. Where no fullscreen route exists at all, the button is omitted rather than left dead, matching how the quality button already hides itself.

A second module, `InputCapabilities`, asks what the viewer is pointing with instead of what the build target is. It is keyed on `matchMedia('(pointer: coarse)')` rather than viewport width on purpose: a phone in landscape is around 800px, which is exactly when someone is watching video, so any width rule would drop out of the touch tier at the worst moment.

Touch browsers now get the centre play button, tap and double-tap gestures, and the enlarged seek target. Native mobile picks up the seek target too, since it forces landscape and therefore also landed in the tablet tier.

**Nothing is removed on any platform.** `showVolume` is untouched, so both a landscape phone browser and the native app keep the volume slider.

## Notable

`PanelMetrics.touchTargets` was driving two unrelated things: the enlarged seek hit area, and `compact` on the transport cluster, which collapses it to play/pause only and drops episode navigation. Making `touchTargets` follow input capability without splitting them would have given a landscape phone browser a bigger scrubber and taken away its episode nav in the same commit. `compactTransport` is now its own field, still width-driven and unchanged in behaviour. Width governs horizontal room; input capability governs finger size.

Left alone deliberately: Picture in Picture (`PipService` is an all-`TODO` stub with no call sites), `supportsBackgroundAudio` (zero consumers), and orientation locking on web (absent on iPhone Safari, and iOS rotates on its own inside native fullscreen).

## Testing

`flutter test` never runs on web and `kIsWeb` is compile-time `false` there, so the pure decision functions are unit-tested independently of the real constants, following `computeSupportsKeyboardShortcuts` and `shouldReserveTitleBar`, which exist for the same reason. The controller is tested against a fake backend, including the case that matters most: a backend that accepts a request and never reports leaves the state `false`.

- Full player suite: **1736 passing**
- `flutter build web --release`: succeeds, which is the only compile check that exercises the web branch of every conditional import
- `dart analyze` across all touched files: clean

**Not verified: behaviour on a real iPhone.** Nothing on a Linux host can exercise `webkitEnterFullscreen`. The device checklist lives in the plan; the load-bearing step is tapping Apple's Done button and confirming the icon flips back, since that is the exact lie being fixed.

## Follow-ups worth filing separately

- media_kit appends a fresh `<track>` on every `setSubtitleTrack` and never removes stale ones, while its cue listener stays bound to `textTracks[0]`, so the inline player already shows stale subtitles after a second switch. Upstream.
- Episode navigation still has no touch-reachable equivalent below 600px width. Pre-existing and documented in `transport_cluster.dart`; not introduced or worsened here, and it affects portrait only.
- `assets/js/alpine_components/video_player.js` has the same `requestFullscreen` bug in the Phoenix playback page.
