### PR TITLE
feat(player): label direct play vs re-encoding in quality menu

### DIFF
--- a/player/lib/domain/models/quality_delivery_subtitle.dart
+++ b/player/lib/domain/models/quality_delivery_subtitle.dart
@@ -24,3 +24,25 @@ String originalDeliverySubtitle({
 /// Subtitle for a capped ladder rung (always re-encodes today).
 String cappedRungDeliverySubtitle(int maxBitrateKbps) =>
     'Transcodes · up to $maxBitrateKbps kbps';
+
+/// Whether native direct play is offered for this ordered candidate list.
+///
+/// Mirrors `PlayerScreen._canDirectPlay`: first strategy must be DIRECT_PLAY,
+/// REMUX, or HLS_COPY.
+bool strategiesAllowNativeDirectPlay(Iterable<String> strategyValues) {
+  final iterator = strategyValues.iterator;
+  if (!iterator.moveNext()) return false;
+  final first = iterator.current;
+  return first == 'DIRECT_PLAY' || first == 'REMUX' || first == 'HLS_COPY';
+}
+
+/// Whether any candidate is a no-re-encode delivery (HLS_COPY or REMUX).
+///
+/// A bare DIRECT_PLAY without HLS_COPY/REMUX is intentionally false: on web
+/// that list still plays via TRANSCODE HLS today.
+bool strategiesAllowLosslessDelivery(Iterable<String> strategyValues) {
+  for (final value in strategyValues) {
+    if (value == 'HLS_COPY' || value == 'REMUX') return true;
+  }
+  return false;
+}

--- a/player/lib/domain/models/quality_delivery_subtitle.dart
+++ b/player/lib/domain/models/quality_delivery_subtitle.dart
@@ -1,0 +1,26 @@
+/// User-facing subtitles for how a quality rung will be delivered.
+///
+/// See `docs/superpowers/specs/2026-08-09-player-quality-delivery-labels-design.md`.
+
+const kOriginalDirectPlaySubtitle = 'Direct Play';
+const kOriginalLosslessSubtitle = 'Original · no re-encoding';
+const kOriginalTranscodeSubtitle = 'Original · re-encoding required';
+
+/// Subtitle for the Original rung given what the player could do.
+///
+/// [canDirectPlay] means native and the same candidate gate as
+/// `PlayerScreen._canDirectPlay` (ignore the currently selected rung).
+/// [hasLosslessDelivery] means any candidate is HLS_COPY or REMUX.
+/// Ordering: Direct Play, then lossless, then re-encoding required.
+String originalDeliverySubtitle({
+  required bool canDirectPlay,
+  required bool hasLosslessDelivery,
+}) {
+  if (canDirectPlay) return kOriginalDirectPlaySubtitle;
+  if (hasLosslessDelivery) return kOriginalLosslessSubtitle;
+  return kOriginalTranscodeSubtitle;
+}
+
+/// Subtitle for a capped ladder rung (always re-encodes today).
+String cappedRungDeliverySubtitle(int maxBitrateKbps) =>
+    'Transcodes · up to $maxBitrateKbps kbps';

--- a/player/lib/domain/models/quality_delivery_subtitle.dart
+++ b/player/lib/domain/models/quality_delivery_subtitle.dart
@@ -6,6 +6,9 @@ const kOriginalDirectPlaySubtitle = 'Direct Play';
 const kOriginalLosslessSubtitle = 'Original · no re-encoding';
 const kOriginalTranscodeSubtitle = 'Original · re-encoding required';
 
+/// Neutral Original subtitle when there is no delivery context (e.g. Settings).
+const kOriginalPreferenceSubtitle = 'Source quality';
+
 /// Subtitle for the Original rung given what the player could do.
 ///
 /// [canDirectPlay] means native and the same candidate gate as
@@ -22,14 +25,20 @@ String originalDeliverySubtitle({
 }
 
 /// Subtitle for a capped ladder rung (always re-encodes today).
-String cappedRungDeliverySubtitle(int maxBitrateKbps) =>
-    'Transcodes · up to $maxBitrateKbps kbps';
-
-/// Whether native direct play is offered for this ordered candidate list.
 ///
-/// Mirrors `PlayerScreen._canDirectPlay`: first strategy must be DIRECT_PLAY,
-/// REMUX, or HLS_COPY.
-bool strategiesAllowNativeDirectPlay(Iterable<String> strategyValues) {
+/// When [maxBitrateKbps] is null, returns a bitrate-free label rather than
+/// crashing — off-ladder synthesised rungs can omit a cap.
+String cappedRungDeliverySubtitle(int? maxBitrateKbps) {
+  if (maxBitrateKbps == null) return 'Transcodes';
+  return 'Transcodes · up to $maxBitrateKbps kbps';
+}
+
+/// Whether the first candidate strategy is one `PlayerScreen._canDirectPlay`
+/// would accept (DIRECT_PLAY, REMUX, or HLS_COPY).
+///
+/// Platform gating (`!kIsWeb`) is intentionally left to the caller — this
+/// only inspects strategy ordering.
+bool firstStrategyAllowsDirectPlay(Iterable<String> strategyValues) {
   final iterator = strategyValues.iterator;
   if (!iterator.moveNext()) return false;
   final first = iterator.current;

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -44,6 +44,7 @@ import '../../widgets/video_controls/skip_segment_button.dart';
 import '../../widgets/up_next_overlay.dart';
 import '../../../domain/models/audio_track.dart' as app_models_audio;
 import '../../../domain/models/media_segment.dart';
+import '../../../domain/models/quality_delivery_subtitle.dart';
 import '../../../domain/models/quality_rung.dart';
 import '../../../domain/models/subtitle_track.dart' as app_models;
 import '../../../domain/models/cast_device.dart';
@@ -2524,6 +2525,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       context,
       _qualityLadder,
       _selectedQuality,
+      // Temporary until Task 3 wires the cached delivery subtitle.
+      originalSubtitle: kOriginalTranscodeSubtitle,
       clampNote: _clampNote(),
     );
 

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1383,7 +1383,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     final values = candidates?.map((c) => c.strategy.toJson()).toList() ??
         const <String>[];
 
-    final canDirect = !kIsWeb && strategiesAllowNativeDirectPlay(values);
+    final canDirect = !kIsWeb && firstStrategyAllowsDirectPlay(values);
     final lossless = strategiesAllowLosslessDelivery(values);
     _originalDeliverySubtitle = originalDeliverySubtitle(
       canDirectPlay: canDirect,

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -319,6 +319,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// session to restart and nothing to switch between.
   List<QualityRung> _qualityLadder = const [QualityRung.original];
 
+  /// What the Original rung would do for this file's candidates.
+  ///
+  /// Cached because the candidate list is not retained after
+  /// [_initializePlayer]. Defaults to re-encoding required until candidates
+  /// resolve (honest worst case; matches the spec fallback).
+  String _originalDeliverySubtitle = kOriginalTranscodeSubtitle;
+
   /// Set when this server rejected the maxHeight argument, meaning it
   /// predates height support. Rungs still work through maxBitrate alone;
   /// they just land at whatever resolution the old server picks. Sticky for
@@ -553,6 +560,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     // for them and hides the control.
     _qualityLadder = const [QualityRung.original];
     _effectiveQuality = null;
+    _originalDeliverySubtitle = kOriginalTranscodeSubtitle;
 
     try {
       setState(() {
@@ -846,6 +854,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
           : widget.fileId;
 
       await _resolveQualityForFile(candidatesResult);
+      _rememberOriginalDeliverySubtitle(candidatesResult?.candidates);
 
       // Determine if direct play is possible.
       //
@@ -1363,6 +1372,23 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     return first.strategy == Enum$StreamingCandidateStrategy.DIRECT_PLAY ||
         first.strategy == Enum$StreamingCandidateStrategy.REMUX ||
         first.strategy == Enum$StreamingCandidateStrategy.HLS_COPY;
+  }
+
+  /// Cache the Original-rung delivery subtitle from resolved candidates.
+  ///
+  /// Labels only — does not change the [_canDirectPlay] playback gate.
+  void _rememberOriginalDeliverySubtitle(
+    List<Query$StreamingCandidates$streamingCandidates$candidates>? candidates,
+  ) {
+    final values = candidates?.map((c) => c.strategy.toJson()).toList() ??
+        const <String>[];
+
+    final canDirect = !kIsWeb && strategiesAllowNativeDirectPlay(values);
+    final lossless = strategiesAllowLosslessDelivery(values);
+    _originalDeliverySubtitle = originalDeliverySubtitle(
+      canDirectPlay: canDirect,
+      hasLosslessDelivery: lossless,
+    );
   }
 
   /// Fetch streaming candidates from the server via GraphQL.
@@ -2525,8 +2551,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       context,
       _qualityLadder,
       _selectedQuality,
-      // Temporary until Task 3 wires the cached delivery subtitle.
-      originalSubtitle: kOriginalTranscodeSubtitle,
+      originalSubtitle: _originalDeliverySubtitle,
       clampNote: _clampNote(),
     );
 

--- a/player/lib/presentation/screens/settings_screen.dart
+++ b/player/lib/presentation/screens/settings_screen.dart
@@ -9,6 +9,7 @@ import '../../core/graphql/graphql_provider.dart';
 import '../../core/update/platform_updater.dart';
 import '../../core/update/update_provider.dart';
 import '../../core/update/updaters/macos_updater.dart';
+import '../../domain/models/quality_delivery_subtitle.dart';
 import '../../domain/models/quality_rung.dart';
 import '../widgets/ambient_backdrop_provider.dart';
 import '../widgets/cast_actions.dart';
@@ -148,6 +149,8 @@ class SettingsScreen extends ConsumerWidget {
                   context,
                   deriveQualityLadder(sourceHeight: 2160),
                   current,
+                  // Temporary placeholder; settings has no delivery context yet.
+                  originalSubtitle: kOriginalTranscodeSubtitle,
                 );
                 if (picked != null && context.mounted) {
                   await ref

--- a/player/lib/presentation/screens/settings_screen.dart
+++ b/player/lib/presentation/screens/settings_screen.dart
@@ -149,8 +149,9 @@ class SettingsScreen extends ConsumerWidget {
                   context,
                   deriveQualityLadder(sourceHeight: 2160),
                   current,
-                  // Temporary placeholder; settings has no delivery context yet.
-                  originalSubtitle: kOriginalTranscodeSubtitle,
+                  // Preference picker has no streaming candidates — keep a
+                  // neutral Original subtitle rather than asserting delivery.
+                  originalSubtitle: kOriginalPreferenceSubtitle,
                 );
                 if (picked != null && context.mounted) {
                   await ref

--- a/player/lib/presentation/widgets/hls_quality_selector.dart
+++ b/player/lib/presentation/widgets/hls_quality_selector.dart
@@ -67,7 +67,7 @@ Widget _rungTile(
   final isSelected = rung == current;
   final subtitle = rung.isOriginal
       ? originalSubtitle
-      : cappedRungDeliverySubtitle(rung.maxBitrateKbps!);
+      : cappedRungDeliverySubtitle(rung.maxBitrateKbps);
   return ListTile(
     key: isSelected
         ? Key('quality-rung-selected-${rung.label}')

--- a/player/lib/presentation/widgets/hls_quality_selector.dart
+++ b/player/lib/presentation/widgets/hls_quality_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../domain/models/quality_delivery_subtitle.dart';
 import '../../domain/models/quality_rung.dart';
 
 /// Shows the playback quality picker and returns the chosen rung, or null if
@@ -9,10 +10,14 @@ import '../../domain/models/quality_rung.dart';
 /// that would upscale the source. [clampNote], when present, explains that
 /// the server is limiting the stream below what was chosen, which happens on
 /// a relay connection where the cap is not negotiable by the client.
+///
+/// [originalSubtitle] is the delivery-mode line for the Original rung
+/// (Direct Play / lossless / re-encoding), computed by the caller.
 Future<QualityRung?> showQualityPicker(
   BuildContext context,
   List<QualityRung> ladder,
   QualityRung current, {
+  required String originalSubtitle,
   String? clampNote,
 }) {
   return showDialog<QualityRung>(
@@ -38,7 +43,8 @@ Future<QualityRung?> showQualityPicker(
                   style: TextStyle(color: Colors.amber[300], fontSize: 12),
                 ),
               ),
-            for (final rung in ladder) _rungTile(context, rung, current),
+            for (final rung in ladder)
+              _rungTile(context, rung, current, originalSubtitle),
           ],
         ),
       ),
@@ -52,8 +58,16 @@ Future<QualityRung?> showQualityPicker(
   );
 }
 
-Widget _rungTile(BuildContext context, QualityRung rung, QualityRung current) {
+Widget _rungTile(
+  BuildContext context,
+  QualityRung rung,
+  QualityRung current,
+  String originalSubtitle,
+) {
   final isSelected = rung == current;
+  final subtitle = rung.isOriginal
+      ? originalSubtitle
+      : cappedRungDeliverySubtitle(rung.maxBitrateKbps!);
   return ListTile(
     key: isSelected
         ? Key('quality-rung-selected-${rung.label}')
@@ -70,9 +84,7 @@ Widget _rungTile(BuildContext context, QualityRung rung, QualityRung current) {
       ),
     ),
     subtitle: Text(
-      rung.isOriginal
-          ? 'Source quality, no re-encoding'
-          : 'Up to ${rung.maxBitrateKbps} kbps',
+      subtitle,
       style: const TextStyle(color: Colors.grey, fontSize: 12),
     ),
     onTap: () => Navigator.of(context).pop(rung),

--- a/player/test/domain/models/quality_delivery_subtitle_test.dart
+++ b/player/test/domain/models/quality_delivery_subtitle_test.dart
@@ -16,7 +16,7 @@ void main() {
           canDirectPlay: true,
           hasLosslessDelivery: false,
         ),
-        'Direct Play',
+        kOriginalDirectPlaySubtitle,
       );
     });
 
@@ -48,27 +48,31 @@ void main() {
         'Transcodes · up to 4000 kbps',
       );
     });
+
+    test('falls back when bitrate is null', () {
+      expect(cappedRungDeliverySubtitle(null), 'Transcodes');
+    });
   });
 
-  group('strategiesAllowNativeDirectPlay', () {
+  group('firstStrategyAllowsDirectPlay', () {
     test('true when first is DIRECT_PLAY, REMUX, or HLS_COPY', () {
       expect(
-        strategiesAllowNativeDirectPlay(['DIRECT_PLAY', 'TRANSCODE']),
+        firstStrategyAllowsDirectPlay(['DIRECT_PLAY', 'TRANSCODE']),
         isTrue,
       );
       expect(
-        strategiesAllowNativeDirectPlay(['REMUX', 'HLS_COPY', 'TRANSCODE']),
+        firstStrategyAllowsDirectPlay(['REMUX', 'HLS_COPY', 'TRANSCODE']),
         isTrue,
       );
       expect(
-        strategiesAllowNativeDirectPlay(['HLS_COPY', 'TRANSCODE']),
+        firstStrategyAllowsDirectPlay(['HLS_COPY', 'TRANSCODE']),
         isTrue,
       );
     });
 
     test('false when empty or first is TRANSCODE', () {
-      expect(strategiesAllowNativeDirectPlay([]), isFalse);
-      expect(strategiesAllowNativeDirectPlay(['TRANSCODE']), isFalse);
+      expect(firstStrategyAllowsDirectPlay([]), isFalse);
+      expect(firstStrategyAllowsDirectPlay(['TRANSCODE']), isFalse);
     });
   });
 

--- a/player/test/domain/models/quality_delivery_subtitle_test.dart
+++ b/player/test/domain/models/quality_delivery_subtitle_test.dart
@@ -49,4 +49,46 @@ void main() {
       );
     });
   });
+
+  group('strategiesAllowNativeDirectPlay', () {
+    test('true when first is DIRECT_PLAY, REMUX, or HLS_COPY', () {
+      expect(
+        strategiesAllowNativeDirectPlay(['DIRECT_PLAY', 'TRANSCODE']),
+        isTrue,
+      );
+      expect(
+        strategiesAllowNativeDirectPlay(['REMUX', 'HLS_COPY', 'TRANSCODE']),
+        isTrue,
+      );
+      expect(
+        strategiesAllowNativeDirectPlay(['HLS_COPY', 'TRANSCODE']),
+        isTrue,
+      );
+    });
+
+    test('false when empty or first is TRANSCODE', () {
+      expect(strategiesAllowNativeDirectPlay([]), isFalse);
+      expect(strategiesAllowNativeDirectPlay(['TRANSCODE']), isFalse);
+    });
+  });
+
+  group('strategiesAllowLosslessDelivery', () {
+    test('true when any HLS_COPY or REMUX is present', () {
+      expect(
+        strategiesAllowLosslessDelivery(['REMUX', 'TRANSCODE']),
+        isTrue,
+      );
+      expect(
+        strategiesAllowLosslessDelivery(['HLS_COPY', 'TRANSCODE']),
+        isTrue,
+      );
+    });
+
+    test('false for DIRECT_PLAY + TRANSCODE only (web direct-play shape)', () {
+      expect(
+        strategiesAllowLosslessDelivery(['DIRECT_PLAY', 'TRANSCODE']),
+        isFalse,
+      );
+    });
+  });
 }

--- a/player/test/domain/models/quality_delivery_subtitle_test.dart
+++ b/player/test/domain/models/quality_delivery_subtitle_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/quality_delivery_subtitle.dart';
+
+void main() {
+  group('originalDeliverySubtitle', () {
+    test('prefers Direct Play when canDirectPlay is true', () {
+      expect(
+        originalDeliverySubtitle(
+          canDirectPlay: true,
+          hasLosslessDelivery: true,
+        ),
+        kOriginalDirectPlaySubtitle,
+      );
+      expect(
+        originalDeliverySubtitle(
+          canDirectPlay: true,
+          hasLosslessDelivery: false,
+        ),
+        'Direct Play',
+      );
+    });
+
+    test('uses lossless copy when direct play is unavailable', () {
+      expect(
+        originalDeliverySubtitle(
+          canDirectPlay: false,
+          hasLosslessDelivery: true,
+        ),
+        kOriginalLosslessSubtitle,
+      );
+    });
+
+    test('falls back to re-encoding required', () {
+      expect(
+        originalDeliverySubtitle(
+          canDirectPlay: false,
+          hasLosslessDelivery: false,
+        ),
+        kOriginalTranscodeSubtitle,
+      );
+    });
+  });
+
+  group('cappedRungDeliverySubtitle', () {
+    test('names the transcode and bitrate cap', () {
+      expect(
+        cappedRungDeliverySubtitle(4000),
+        'Transcodes · up to 4000 kbps',
+      );
+    });
+  });
+}

--- a/player/test/presentation/widgets/hls_quality_selector_test.dart
+++ b/player/test/presentation/widgets/hls_quality_selector_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/quality_delivery_subtitle.dart';
 import 'package:player/domain/models/quality_rung.dart';
 import 'package:player/presentation/widgets/hls_quality_selector.dart';
 
@@ -22,7 +23,12 @@ void main() {
   testWidgets('lists every rung in the supplied ladder', (tester) async {
     await tester.pumpWidget(
       _host(
-        (context) => showQualityPicker(context, ladder, QualityRung.original),
+        (context) => showQualityPicker(
+          context,
+          ladder,
+          QualityRung.original,
+          originalSubtitle: kOriginalDirectPlaySubtitle,
+        ),
       ),
     );
     await tester.tap(find.text('open'));
@@ -37,7 +43,12 @@ void main() {
     QualityRung? result;
     await tester.pumpWidget(
       _host((context) async {
-        result = await showQualityPicker(context, ladder, QualityRung.original);
+        result = await showQualityPicker(
+          context,
+          ladder,
+          QualityRung.original,
+          originalSubtitle: kOriginalDirectPlaySubtitle,
+        );
       }),
     );
     await tester.tap(find.text('open'));
@@ -55,7 +66,12 @@ void main() {
     var completed = false;
     await tester.pumpWidget(
       _host((context) async {
-        result = await showQualityPicker(context, ladder, QualityRung.original);
+        result = await showQualityPicker(
+          context,
+          ladder,
+          QualityRung.original,
+          originalSubtitle: kOriginalDirectPlaySubtitle,
+        );
         completed = true;
       }),
     );
@@ -73,7 +89,14 @@ void main() {
     const current =
         QualityRung(label: '480p', height: 480, maxBitrateKbps: 1500);
     await tester.pumpWidget(
-      _host((context) => showQualityPicker(context, ladder, current)),
+      _host(
+        (context) => showQualityPicker(
+          context,
+          ladder,
+          current,
+          originalSubtitle: kOriginalDirectPlaySubtitle,
+        ),
+      ),
     );
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
@@ -90,6 +113,7 @@ void main() {
             context,
             ladder,
             QualityRung.original,
+            originalSubtitle: kOriginalDirectPlaySubtitle,
             clampNote: 'Limited to 720p by your remote connection',
           )),
     );
@@ -105,12 +129,78 @@ void main() {
   testWidgets('omits the note when nothing was clamped', (tester) async {
     await tester.pumpWidget(
       _host(
-        (context) => showQualityPicker(context, ladder, QualityRung.original),
+        (context) => showQualityPicker(
+          context,
+          ladder,
+          QualityRung.original,
+          originalSubtitle: kOriginalDirectPlaySubtitle,
+        ),
       ),
     );
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('quality-clamp-note')), findsNothing);
+  });
+
+  testWidgets('shows the supplied Original delivery subtitle', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        (context) => showQualityPicker(
+          context,
+          ladder,
+          QualityRung.original,
+          originalSubtitle: kOriginalTranscodeSubtitle,
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(kOriginalTranscodeSubtitle), findsOneWidget);
+    expect(find.text('Source quality, no re-encoding'), findsNothing);
+  });
+
+  testWidgets('shows Direct Play and lossless Original subtitles when supplied',
+      (tester) async {
+    for (final subtitle in [
+      kOriginalDirectPlaySubtitle,
+      kOriginalLosslessSubtitle,
+    ]) {
+      await tester.pumpWidget(
+        _host(
+          (context) => showQualityPicker(
+            context,
+            ladder,
+            QualityRung.original,
+            originalSubtitle: subtitle,
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(subtitle), findsOneWidget);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+    }
+  });
+
+  testWidgets('labels capped rungs as transcoding', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        (context) => showQualityPicker(
+          context,
+          ladder,
+          QualityRung.original,
+          originalSubtitle: kOriginalDirectPlaySubtitle,
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Transcodes · up to 4000 kbps'), findsOneWidget);
+    expect(find.text('Up to 4000 kbps'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- Quality picker subtitles now distinguish Direct Play, lossless Original, and re-encoding required based on streaming candidates
- Capped rungs label as `Transcodes · up to N kbps`
- PlayerScreen caches the Original delivery subtitle when candidates resolve (labels only; playback paths unchanged)

## Test plan
- [ ] Open quality menu on native with a direct-playable file — Original subtitle says `Direct Play`
- [ ] On web (or incompatible codecs) — Original shows lossless or `Original · re-encoding required` as appropriate
- [ ] Capped rungs show `Transcodes · up to … kbps`
- [ ] `./dev flutter test --concurrency=1 test/domain/models/quality_delivery_subtitle_test.dart test/presentation/widgets/hls_quality_selector_test.dart test/presentation/screens/player/quality_choice_test.dart test/presentation/screens/player/player_screen_quality_caps_test.dart`