### PR TITLE
fix(media): stop episode refresh from ignoring injected relay config

### DIFF
--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -155,6 +155,9 @@ defmodule Mydia.Media do
     - `:actor_id` - The ID of the actor (user_id, job name, etc.)
     - `:season_monitoring` - For TV shows, which seasons to fetch ("all", "first", "latest", "none") - defaults to "all"
     - `:skip_episode_refresh` - Skip automatic episode fetching (for tests or special cases) - defaults to false
+    - `:config` - Metadata relay config forwarded to `refresh_episodes_for_tv_show/2`.
+      Callers that inject a Bypass (or any non-default relay) must pass it here;
+      otherwise the automatic refresh silently uses `Metadata.default_relay_config/0`.
   """
   @spec create_media_item(map(), keyword()) :: {:ok, MediaItem.t()} | {:error, Ecto.Changeset.t()}
   def create_media_item(attrs \\ %{}, opts \\ []) do
@@ -178,7 +181,11 @@ defmodule Mydia.Media do
       if media_item.type == "tv_show" and not Keyword.get(opts, :skip_episode_refresh, false) do
         season_monitoring = Keyword.get(opts, :season_monitoring, "all")
 
-        case refresh_episodes_for_tv_show(media_item, season_monitoring: season_monitoring) do
+        refresh_opts =
+          [season_monitoring: season_monitoring]
+          |> maybe_put_refresh_config(Keyword.get(opts, :config))
+
+        case refresh_episodes_for_tv_show(media_item, refresh_opts) do
           {:ok, count} ->
             Logger.info("Created #{count} episodes for #{media_item.title}")
 
@@ -192,6 +199,9 @@ defmodule Mydia.Media do
       {:ok, media_item}
     end
   end
+
+  defp maybe_put_refresh_config(opts, nil), do: opts
+  defp maybe_put_refresh_config(opts, config), do: Keyword.put(opts, :config, config)
 
   @doc """
   Updates a media item.
@@ -1114,6 +1124,9 @@ defmodule Mydia.Media do
     - `media_item` - The TV show media item (must be type "tv_show")
     - `opts` - Options for episode creation
       - `:season_monitoring` - Which seasons to fetch ("all", "first", "latest", "none")
+      - `:config` - Metadata relay config. Defaults to `Metadata.default_relay_config/0`.
+        Callers that inject a Bypass (or any non-default relay) must pass it;
+        otherwise the refresh silently uses the global default.
 
   ## Returns
     - `{:ok, count}` - Number of episodes created
@@ -1135,7 +1148,12 @@ defmodule Mydia.Media do
     alias Mydia.Metadata
 
     season_monitoring = Keyword.get(opts, :season_monitoring, "all")
-    config = Metadata.default_relay_config()
+    # Honour an injected relay config (Bypass in tests, or a caller-specific
+    # relay). Ignoring opts[:config] silently falls back to the global default
+    # and was the root of the MediaAddHelpers CI timeout flake: the Bypass
+    # stubs covered the add-path fetch, then create_media_item refreshed
+    # against the real relay with Task.async_stream timeout: :infinity.
+    config = Keyword.get(opts, :config) || Metadata.default_relay_config()
 
     # Resolve the provider to fetch from. `metadata_source` (when set) is the
     # authoritative provenance; only fall back to the legacy TVDB-precedence
@@ -1196,9 +1214,6 @@ defmodule Mydia.Media do
 
         {:ok, episode_count}
       else
-        # Fetch fresh metadata to get seasons info
-        config = Metadata.default_relay_config()
-
         case Metadata.fetch_by_id(config, provider_id,
                media_type: :tv_show,
                provider: provider_source

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -763,11 +763,15 @@ defmodule Mydia.Metadata.Provider.Relay do
         |> Task.async_stream(
           fn ep -> fetch_tvdb_episode_translations(req, ep) end,
           max_concurrency: 5,
-          timeout: :infinity
+          # Bound each episode fetch. `:infinity` let a single hung Bypass/relay
+          # request pin the whole ExUnit case until the 60s wall-clock timeout.
+          timeout: 15_000,
+          on_timeout: :kill_task
         )
-        |> Enum.flat_map(fn
-          {:ok, ep} -> [ep]
-          {:exit, _reason} -> []
+        |> Enum.zip(episodes)
+        |> Enum.map(fn
+          {{:ok, ep}, _orig} -> ep
+          {{:exit, _reason}, orig} -> orig
         end)
 
       Map.put(data, "episodes", enriched)

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -750,6 +750,10 @@ defmodule Mydia.Metadata.Provider.Relay do
     end
   end
 
+  # Bound each episode translation fetch. `:infinity` let a single hung
+  # Bypass/relay request pin the whole ExUnit case until the 60s wall clock.
+  @episode_translation_timeout_ms 15_000
+
   # TVDB season extended responses include episodes but without translation text.
   # Fetch each episode's extended data to get its translation bundle (all languages).
   defp enrich_tvdb_episodes_with_translations(req, data) do
@@ -763,15 +767,22 @@ defmodule Mydia.Metadata.Provider.Relay do
         |> Task.async_stream(
           fn ep -> fetch_tvdb_episode_translations(req, ep) end,
           max_concurrency: 5,
-          # Bound each episode fetch. `:infinity` let a single hung Bypass/relay
-          # request pin the whole ExUnit case until the 60s wall-clock timeout.
-          timeout: 15_000,
+          timeout: @episode_translation_timeout_ms,
           on_timeout: :kill_task
         )
         |> Enum.zip(episodes)
         |> Enum.map(fn
-          {{:ok, ep}, _orig} -> ep
-          {{:exit, _reason}, orig} -> orig
+          {{:ok, ep}, _orig} ->
+            ep
+
+          {{:exit, reason}, orig} ->
+            Logger.warning(
+              "TVDB episode translation fetch exited; keeping untranslated episode",
+              episode_id: orig["id"],
+              reason: inspect(reason)
+            )
+
+            orig
         end)
 
       Map.put(data, "episodes", enriched)

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -242,7 +242,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       {:ok, tmdb_metadata} ->
         tmdb_metadata
         |> build_tv_show_attrs(provider_id_int, derived, fetch_provider, config)
-        |> create_media_item_result()
+        |> create_media_item_result(config)
 
       {:error, reason} ->
         {:error, {:metadata, reason}}
@@ -280,8 +280,8 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
     end
   end
 
-  defp create_media_item_result(attrs) do
-    case Media.create_media_item(attrs) do
+  defp create_media_item_result(attrs, config) do
+    case Media.create_media_item(attrs, config: config) do
       {:ok, media_item} -> {:ok, media_item}
       {:error, changeset} -> {:error, {:changeset, changeset}}
     end

--- a/test/mydia/media/refresh_episodes_config_test.exs
+++ b/test/mydia/media/refresh_episodes_config_test.exs
@@ -1,0 +1,109 @@
+defmodule Mydia.Media.RefreshEpisodesConfigTest do
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Media
+
+  # REGRESSION: refresh_episodes_for_tv_show/2 previously ignored opts[:config]
+  # and always called Metadata.default_relay_config/0. Callers that inject a
+  # Bypass (MediaAddHelpersTest, media_controller manual match) therefore hit
+  # the real relay. When the fabricated tvdb_id happened to resolve, episode
+  # translation enrichment ran with Task.async_stream timeout: :infinity and
+  # the ExUnit 60s wall clock killed the test — the flaky CI failure on
+  # master CI run 31296248692.
+  describe "refresh_episodes_for_tv_show/2 opts[:config]" do
+    test "uses the injected relay config instead of the global default" do
+      bypass = Bypass.open()
+      tvdb_id = System.unique_integer([:positive])
+      hits = :atomics.new(1, signed: false)
+
+      Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+        :atomics.add(hits, 1, 1)
+
+        body = %{
+          "data" => %{
+            "id" => tvdb_id,
+            "tvdb_id" => tvdb_id,
+            "name" => "Config Injection Show",
+            "overview" => "x",
+            "first_air_date" => "2019-01-01",
+            "genres" => [],
+            "seasons" => []
+          }
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      config = %{
+        type: :metadata_relay,
+        base_url: "http://localhost:#{bypass.port}",
+        options: %{language: "en-US", include_adult: false}
+      }
+
+      item =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Config Injection Show",
+          year: 2019,
+          tvdb_id: tvdb_id,
+          metadata_source: :tvdb
+        })
+
+      assert {:ok, 0} = Media.refresh_episodes_for_tv_show(item, config: config)
+      assert :atomics.get(hits, 1) >= 1
+    end
+  end
+
+  describe "create_media_item/2 opts[:config]" do
+    test "forwards the injected config into the automatic episode refresh" do
+      bypass = Bypass.open()
+      tvdb_id = System.unique_integer([:positive])
+      hits = :atomics.new(1, signed: false)
+
+      Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+        :atomics.add(hits, 1, 1)
+
+        body = %{
+          "data" => %{
+            "id" => tvdb_id,
+            "tvdb_id" => tvdb_id,
+            "name" => "Create Forward Show",
+            "overview" => "x",
+            "first_air_date" => "2019-01-01",
+            "genres" => [],
+            "seasons" => []
+          }
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      config = %{
+        type: :metadata_relay,
+        base_url: "http://localhost:#{bypass.port}",
+        options: %{language: "en-US", include_adult: false}
+      }
+
+      assert {:ok, _item} =
+               Media.create_media_item(
+                 %{
+                   type: "tv_show",
+                   title: "Create Forward Show",
+                   year: 2019,
+                   tvdb_id: tvdb_id,
+                   metadata_source: :tvdb,
+                   monitored: true
+                 },
+                 config: config
+               )
+
+      assert :atomics.get(hits, 1) >= 1
+    end
+  end
+end

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -113,7 +113,6 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
       tvdb_id = System.unique_integer([:positive])
 
       stub_tmdb_show(bypass, id, "TMDB Lib Show", 2019)
-      stub_tmdb_season(bypass, id, 1, [1])
       stub_tvdb_search(bypass, tvdb_id, "TMDB Lib Show", 2019)
 
       assert {:ok, item, _map} =
@@ -242,30 +241,13 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
       "overview" => "x",
       "credits" => %{"cast" => [], "crew" => []},
       "genres" => [],
-      "seasons" => [%{"season_number" => 1, "name" => "Season 1"}]
+      # Empty on purpose: these tests assert provenance stamping, not episode
+      # import. A non-empty seasons list would drive refresh_episodes_for_tv_show
+      # into per-season Bypass calls that the stubs do not cover.
+      "seasons" => []
     }
 
     Bypass.stub(bypass, "GET", "/tmdb/tv/shows/#{id}", fn conn ->
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.resp(200, Jason.encode!(body))
-    end)
-  end
-
-  defp stub_tmdb_season(bypass, id, season_number, episode_numbers) do
-    episodes =
-      Enum.map(episode_numbers, fn n ->
-        %{
-          "season_number" => season_number,
-          "episode_number" => n,
-          "name" => "Episode #{n}",
-          "air_date" => "2019-01-0#{n}"
-        }
-      end)
-
-    body = %{"season_number" => season_number, "episodes" => episodes}
-
-    Bypass.stub(bypass, "GET", "/tmdb/tv/shows/#{id}/#{season_number}", fn conn ->
       conn
       |> Plug.Conn.put_resp_content_type("application/json")
       |> Plug.Conn.resp(200, Jason.encode!(body))


### PR DESCRIPTION
## Summary
- `refresh_episodes_for_tv_show/2` ignored `opts[:config]` and always used `Metadata.default_relay_config/0`, so Bypass-backed add-media tests hit the real relay after create
- That caused the flaky 60s `ExUnit.TimeoutError` in `MediaAddHelpersTest` on master (CI run 31296248692) when a fabricated `tvdb_id` resolved and episode translation enrichment ran with `Task.async_stream` `timeout: :infinity`
- Honour/forward injected config through `create_media_item/2` and `MediaAddHelpers`, and bound per-episode translation fetches to 15s

## Test plan
- [x] `./dev mix test test/mydia/media/refresh_episodes_config_test.exs` (regression: injected config is used)
- [x] `./dev mix test test/mydia_web/live/helpers/media_add_helpers_test.exs` (previously flaky case now ~ms)
- [x] Related refresh/enricher suites green
- [ ] CI green on this PR (especially Test / PostgreSQL)