### PR TITLE
fix(site): correct the 404ing Linux how-to link on the download page

### DIFF
--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -69,7 +69,7 @@ flatpak install mydia dev.mydia.player`,
     note: 'The tarball is x64 and bundles no dependencies, so it needs libmpv, libsecret and GTK 3 already installed. The Flatpak carries its own.',
     docs: {
       label: 'Beta channel and tarball instructions',
-      href: 'https://docs.mydia.dev/using/how-to/install-player-linux/',
+      href: 'https://docs.mydia.dev/latest/using/how-to/install-player-linux/',
     },
     sizeFor: 'linux',
   },


### PR DESCRIPTION
Follow-up to #385, caught during post-deploy verification of the new `/download` page.

The Linux card's "Beta channel and tarball instructions" link 404s:

```
https://docs.mydia.dev/using/how-to/install-player-linux/          404
https://docs.mydia.dev/latest/using/how-to/install-player-linux/   200
```

The docs site requires the `/latest/` version prefix. #385 carried this URL over verbatim from the old Flatpak block in `Player.astro`, where it was already broken, so this is a pre-existing bug that moved rather than a new one. Since #385 deleted that block, `download.astro` is now the only place it appears and this fixes it outright.

The other docs link on the page (`/latest/using/how-to/`) was already correct, and the header's `getmydia.github.io/mydia/latest/` link resolves to `docs.mydia.dev/latest/` fine, so neither needed touching.

## Verification

```
https://docs.mydia.dev/latest/using/how-to/install-player-linux/   200
https://docs.mydia.dev/latest/using/how-to/                        200
```

Both docs links in the rebuilt `dist/download/index.html` now use the `/latest/` form. Build clean, 10/10 tests pass.

## Context: #385 is verified live

Everything else from #385 checks out in production:

```
mydia.dev/download/android   ->  ...v0.13.0/mydia-player-android-v0.13.0.apk
mydia.dev/download/macos     ->  ...v0.13.0/mydia-player-macos-v0.13.0.dmg
mydia.dev/download/windows   ->  ...v0.13.0/mydia-player-windows-v0.13.0.exe
mydia.dev/download/linux     ->  ...v0.13.0/mydia-player-linux-v0.13.0.tar.gz
mydia.dev/download/ios       ->  testflight.apple.com/join/KFSYxaQP
mydia.dev/download/flatpak   ->  flatpak.mydia.dev/mydia.flatpakrepo
```

Following the Android chain all the way lands on a signed asset URL with `filename=mydia-player-android-v0.13.0.apk` at 200, and `/api/player-release` returns `{"ok":true,"version":"0.13.0",...}` with all four sizes. Pages picked up `site/functions/` on the real deploy with no `--functions` flag.

One observation worth recording: the apex `mydia.dev` 301s to `www.mydia.dev`, so the README's `mydia.dev/download/<platform>` links take one extra hop before hitting the Function. Harmless, and left as is since the apex form is the nicer thing to read and to share.
