### PR TITLE
fix(crash_reporter): stop TowerReporterTest flaking on Postgres CI

### DIFF
--- a/lib/mydia/crash_reporter.ex
+++ b/lib/mydia/crash_reporter.ex
@@ -318,6 +318,22 @@ defmodule Mydia.CrashReporter do
   end
 
   defp get_ui_setting do
+    # Injectable so tests can simulate a DBConnection ownership EXIT without
+    # racing a live sandbox owner (see ReportResilienceTest).
+    lookup =
+      Application.get_env(:mydia, :crash_reporter_ui_setting_fun, &default_ui_setting_lookup/0)
+
+    lookup.()
+  rescue
+    # If database is not available (e.g., during startup), fall back
+    _ -> :not_configured
+  catch
+    # Sandbox ownership failures surface as EXIT, not exceptions. Without this,
+    # TowerReporter's async Task dies before enqueueing under Postgres CI.
+    :exit, _ -> :not_configured
+  end
+
+  defp default_ui_setting_lookup do
     # Try to get the setting from the database
     # This queries the config_settings table for "crash_reporting.enabled"
     case Mydia.Settings.get_config_setting_by_key("crash_reporting.enabled") do
@@ -327,9 +343,6 @@ defmodule Mydia.CrashReporter do
       setting ->
         {:ok, parse_boolean(setting.value)}
     end
-  rescue
-    # If database is not available (e.g., during startup), fall back
-    _ -> :not_configured
   end
 
   defp get_env_setting do

--- a/test/mydia/crash_reporter/report_resilience_test.exs
+++ b/test/mydia/crash_reporter/report_resilience_test.exs
@@ -1,0 +1,76 @@
+defmodule Mydia.CrashReporter.ReportResilienceTest do
+  use ExUnit.Case, async: false
+
+  alias Mydia.CrashReporter
+  alias Mydia.CrashReporter.Queue
+
+  # REGRESSION: TowerReporter spawns a Task that calls CrashReporter.report/3 →
+  # enabled?/0 → config_settings. Under Postgres CI that Task collides with a
+  # concurrent test's SQL-sandbox owner; when the owner has already stopped,
+  # DBConnection raises an EXIT (not an exception). `rescue` alone did not catch
+  # it, so the Task died before Queue.enqueue/1 — flaking TowerReporterTest on
+  # master (CI runs 31301699784, 30970448718, …).
+  setup do
+    original_enabled = System.get_env("CRASH_REPORTING_ENABLED")
+    System.put_env("CRASH_REPORTING_ENABLED", "true")
+    original_relay = System.get_env("METADATA_RELAY_URL")
+    System.put_env("METADATA_RELAY_URL", "http://127.0.0.1:1")
+    original_lookup = Application.get_env(:mydia, :crash_reporter_ui_setting_fun)
+    Queue.clear_all()
+
+    on_exit(fn ->
+      case original_enabled do
+        nil -> System.delete_env("CRASH_REPORTING_ENABLED")
+        val -> System.put_env("CRASH_REPORTING_ENABLED", val)
+      end
+
+      case original_relay do
+        nil -> System.delete_env("METADATA_RELAY_URL")
+        url -> System.put_env("METADATA_RELAY_URL", url)
+      end
+
+      if original_lookup do
+        Application.put_env(:mydia, :crash_reporter_ui_setting_fun, original_lookup)
+      else
+        Application.delete_env(:mydia, :crash_reporter_ui_setting_fun)
+      end
+
+      Queue.clear_all()
+    end)
+
+    :ok
+  end
+
+  test "enabled?/0 falls back to the env var when the settings lookup exits" do
+    Application.put_env(:mydia, :crash_reporter_ui_setting_fun, fn -> exit(:owner_exited) end)
+
+    assert CrashReporter.enabled?() == true
+  end
+
+  test "report/3 still enqueues when the settings lookup exits" do
+    Application.put_env(:mydia, :crash_reporter_ui_setting_fun, fn -> exit(:owner_exited) end)
+
+    assert :ok =
+             CrashReporter.report(%RuntimeError{message: "owner-exited boom"}, [], %{
+               request_id: "resilience"
+             })
+
+    assert wait_until(fn -> Queue.count() >= 1 end)
+
+    [%{report: report} | _] = Queue.list_all()
+    assert report.error_type == "RuntimeError"
+    assert report.error_message =~ "owner-exited boom"
+  end
+
+  defp wait_until(fun, deadline_ms \\ 2_000, step_ms \\ 25)
+  defp wait_until(_fun, deadline_ms, _step) when deadline_ms <= 0, do: false
+
+  defp wait_until(fun, deadline_ms, step_ms) do
+    if fun.() do
+      true
+    else
+      Process.sleep(step_ms)
+      wait_until(fun, deadline_ms - step_ms, step_ms)
+    end
+  end
+end

--- a/test/mydia/crash_reporter/tower_reporter_test.exs
+++ b/test/mydia/crash_reporter/tower_reporter_test.exs
@@ -1,5 +1,5 @@
 defmodule Mydia.CrashReporter.TowerReporterTest do
-  use ExUnit.Case, async: false
+  use Mydia.DataCase, async: false
 
   alias Mydia.CrashReporter.{Queue, Throttle, TowerReporter}
 
@@ -10,10 +10,11 @@ defmodule Mydia.CrashReporter.TowerReporterTest do
     start_supervised!({Throttle, name: name, max: 1000, window_ms: 60_000})
     Application.put_env(:mydia, :crash_reporter_throttle, name)
 
-    # Opt-in must be visible to the async reporting Task (a separate process),
-    # so it has to come from the env var, not a sandboxed DB setting. Point the
-    # relay at an unreachable address so the background queue processor can never
-    # POST to the real relay during the test.
+    # Opt-in must be visible to the async reporting Task (a separate process).
+    # DataCase (shared sandbox) lets that Task query config_settings safely;
+    # the env var remains the source of truth when no UI setting row exists.
+    # Point the relay at an unreachable address so the background queue
+    # processor can never POST to the real relay during the test.
     original_enabled = System.get_env("CRASH_REPORTING_ENABLED")
     System.put_env("CRASH_REPORTING_ENABLED", "true")
     original_relay = System.get_env("METADATA_RELAY_URL")


### PR DESCRIPTION
## Summary
- `TowerReporter`'s async Task calls `enabled?/0`, which queries `config_settings`. Under Postgres CI that Task can hit a dead SQL-sandbox owner; DBConnection raises an **EXIT** (not an exception), which `rescue` does not catch, so the Task dies before `Queue.enqueue/1`
- That is the recurring `TowerReporterTest` flake on master (CI runs 31301699784, 30970448718, 30916986333, …)
- Catch `:exit` in `get_ui_setting/0` so reporting falls back to `CRASH_REPORTING_ENABLED`, give `TowerReporterTest` a shared DataCase sandbox, and add a regression that injects the ownership EXIT

## Test plan
- [x] `./dev mix test test/mydia/crash_reporter/report_resilience_test.exs` (RED without catch, GREEN with it)
- [x] `./dev mix test test/mydia/crash_reporter/` on SQLite and `DATABASE_TYPE=postgres`
- [x] `./dev mix precommit` — 6711 tests, 0 failures