### PR TITLE
feat(indexers): add Custom Formats for release title filtering

### DIFF
--- a/docs/configuration/custom-formats.md
+++ b/docs/configuration/custom-formats.md
@@ -1,0 +1,97 @@
+# Custom Formats
+
+Custom formats match release titles with regular expressions and let a quality
+profile decide what each match is worth. Use them to prefer a particular audio
+dub, favour a release group, or refuse a tag outright.
+
+A format on its own means nothing. It gets meaning when a quality profile
+assigns it a score or marks it as rejecting, so the same format can be worth
+100 points in one profile and be grounds for refusal in another.
+
+## Where things live
+
+- **Admin > Custom Formats** defines formats: their name and their patterns.
+- **Admin > Quality Profiles > (a profile)** assigns each format a score or a
+  reject flag for that profile only.
+
+## Scoring
+
+Within a resolution tier, a higher total format score wins. Format score is
+compared before seeders, file size, and source, and after the profile's
+resolution preference. A format score never promotes a 720p release over a
+1080p one when the profile prefers 1080p.
+
+Scores are only meaningful relative to each other. A format worth 100 simply
+outranks one worth 50; the number does not compete with the general quality
+score.
+
+A rejecting format drops the release entirely. It never appears as a grab
+candidate, and the rejection shows up in Activity with the reason
+`custom_format: <name>`.
+
+## Built-in formats
+
+Mydia ships formats for the common French audio tags. They start unassigned, so
+they do nothing until you give them a score.
+
+| Format | Matches | Meaning |
+|---|---|---|
+| VFF | `VFF`, `TRUEFRENCH` | France French dub |
+| VF2 | `VF2` | Second French dub, usually a France redub |
+| VFI | `VFI` | International French dub, produced in France |
+| VFQ | `VFQ`, `VQ` | Quebec French dub |
+| MULTI | `MULTI` | Multiple audio tracks |
+| VOSTFR | `VOSTFR` | Original audio with French subtitles, not a dub |
+
+Built-in definitions ship with Mydia, so a later release can improve one of
+these patterns and you get the fix automatically. If you edit a built-in, your
+version wins from then on and later improvements no longer apply to it. Use
+**Reset** to go back to the shipped definition.
+
+## Example: prefer France French, refuse Quebec French
+
+In the quality profile you use for French content:
+
+| Format | Score | Reject |
+|---|---|---|
+| VFF | 100 | no |
+| VF2 | 100 | no |
+| VFI | 50 | no |
+| MULTI | 50 | no |
+| VFQ | 0 | **yes** |
+
+With this set:
+
+- `Film.2024.VFF.1080p.WEB-DL` scores 100 and is preferred over a
+  better-seeded release with no French tag.
+- `Film.2024.MULTI.VFF.1080p` scores 150, because both formats match.
+- `Film.2024.VFQ.1080p.WEB-DL` is rejected and never grabbed.
+
+## Writing patterns
+
+Patterns are regular expressions matched against the raw release title. They
+are always case-insensitive, so do not add an `(?i)` flag.
+
+Wrap tags in `\b` word boundaries. Scene titles separate words with dots and
+underscores, which count as boundaries, so `\bVFF\b` matches
+`Film.2024.VFF.1080p` and does not match a release group whose name happens to
+contain those letters.
+
+A format matches when any one of its patterns matches. Put each pattern on its
+own line.
+
+The edit dialog has a test box: paste a real release title and see which
+patterns match before saving.
+
+### Limits
+
+A pattern must compile, or the format cannot be saved. Patterns are capped at
+500 characters and 20 per format. Matching is bounded, so a pattern that would
+otherwise backtrack forever is abandoned and treated as a miss rather than
+stalling your searches.
+
+## What custom formats do not do
+
+Custom formats apply when deciding what to download. They do not re-evaluate
+files already in your library, so a file you already have is never automatically
+replaced because of a format score. To replace one, delete it and search again.

--- a/lib/mydia/indexers/ranking_options.ex
+++ b/lib/mydia/indexers/ranking_options.ex
@@ -40,9 +40,18 @@ defmodule Mydia.Indexers.RankingOptions do
   `Mydia.Indexers.QualityProfileResolver`. Call sites must resolve through
   that function rather than reading `media_item.quality_profile` directly,
   otherwise the fallback drifts out of one search path the way `min_ratio` did.
+
+  ## Custom formats (resolved upstream)
+
+  `:custom_formats` arrives already resolved and compiled from
+  `Mydia.Settings.CustomFormats.resolve_for_profile/1`. Resolution stays
+  outside this module so it remains database-free; call sites pass the
+  resolved list in the input map and this builder threads it through.
   """
 
   alias Mydia.Settings.QualityProfile
+
+  require Logger
 
   @type media_type :: :movie | :episode
 
@@ -56,7 +65,8 @@ defmodule Mydia.Indexers.RankingOptions do
           optional(:expected_season) => non_neg_integer() | nil,
           optional(:expected_episode) => non_neg_integer() | nil,
           optional(:blocked_tags) => [String.t()] | nil,
-          optional(:preferred_tags) => [String.t()] | nil
+          optional(:preferred_tags) => [String.t()] | nil,
+          optional(:custom_formats) => [map()] | nil
         }
 
   @doc """
@@ -85,6 +95,8 @@ defmodule Mydia.Indexers.RankingOptions do
     opts_with_quality =
       case quality_profile do
         %QualityProfile{} = profile ->
+          warn_on_missing_custom_formats(input)
+
           base_opts
           |> Keyword.put(:quality_profile, profile)
           |> Keyword.merge(build_quality_options(profile, media_type))
@@ -96,6 +108,20 @@ defmodule Mydia.Indexers.RankingOptions do
     opts_with_quality
     |> maybe_add_option(:blocked_tags, Map.get(input, :blocked_tags))
     |> maybe_add_option(:preferred_tags, Map.get(input, :preferred_tags))
+    |> maybe_add_option(:custom_formats, Map.get(input, :custom_formats))
+  end
+
+  # Six call sites build ranking options, and a forgotten one would silently
+  # ignore every custom format for that search path. That is exactly the drift
+  # this module's moduledoc exists to prevent, so an absent key is loud. An
+  # explicitly empty list is silent: it means "resolved, nothing scored".
+  defp warn_on_missing_custom_formats(input) do
+    unless Map.has_key?(input, :custom_formats) do
+      Logger.warning(
+        "[RankingOptions] built with a quality profile but no :custom_formats key; " <>
+          "custom formats will be ignored for this search"
+      )
+    end
   end
 
   @doc """

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -57,6 +57,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
   alias Mydia.Library.ReleaseParser
   alias Mydia.Library.Structs.ParsedFileInfo
   alias Mydia.Quality.Sources
+  alias Mydia.Settings.CustomFormats.Matcher
   alias Mydia.Settings.QualityProfile
 
   @type ranked_result :: RankedResult.t()
@@ -77,7 +78,8 @@ defmodule Mydia.Indexers.ReleaseRanker do
           expected_episode: non_neg_integer() | nil,
           min_post_age_minutes: non_neg_integer() | nil,
           now: DateTime.t() | nil,
-          apply_source_exclusion: boolean() | nil
+          apply_source_exclusion: boolean() | nil,
+          custom_formats: [map()]
         ]
 
   @default_min_seeders 0
@@ -193,6 +195,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
   @spec filter_acceptable([SearchResult.t()], ranking_options()) :: [SearchResult.t()]
   def filter_acceptable(results, opts \\ []) do
     blocked_tags = Keyword.get(opts, :blocked_tags, [])
+    custom_formats = Keyword.get(opts, :custom_formats, [])
     min_post_age_minutes = Keyword.get(opts, :min_post_age_minutes)
     now = Keyword.get(opts, :now) || DateTime.utc_now()
 
@@ -204,6 +207,13 @@ defmodule Mydia.Indexers.ReleaseRanker do
       cond do
         not not_blocked?(result, blocked_tags) ->
           Logger.info("[ReleaseRanker] Filtered out (blocked tag): #{result.title}")
+          false
+
+        rejecting = rejecting_format(result, custom_formats) ->
+          Logger.info(
+            "[ReleaseRanker] Filtered out (custom format #{rejecting}): #{result.title}"
+          )
+
           false
 
         not meets_post_age_minimum?(result, min_post_age_minutes, now) ->
@@ -337,6 +347,17 @@ defmodule Mydia.Indexers.ReleaseRanker do
     end)
   end
 
+  # Returns the name of the first rejecting format that matches, or nil.
+  # Rejection is a hard removal for the same reason excluded_sources is: there
+  # is no minimum-score threshold before grabbing, so a merely down-scored
+  # release is still downloaded when it is the only survivor.
+  defp rejecting_format(%SearchResult{title: title}, custom_formats) do
+    case Matcher.score_title(title, Enum.filter(custom_formats, & &1.reject)) do
+      %{matched: [name | _]} -> name
+      _ -> nil
+    end
+  end
+
   ## Scoring Functions
 
   @doc """
@@ -385,6 +406,11 @@ defmodule Mydia.Indexers.ReleaseRanker do
     # Calculate tag bonus from preferred_tags
     tag_bonus = calculate_tag_bonus(result.title, preferred_tags)
 
+    custom_format_score =
+      result.title
+      |> Matcher.score_title(Keyword.get(opts, :custom_formats, []))
+      |> Map.fetch!(:score)
+
     # Soft penalties derived per-result from the ranking options. Each helper
     # returns a value <= 0.0 that is layered onto the base score. They stay at
     # 0.0 when the relevant option is absent or the result is within bounds.
@@ -414,6 +440,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
         - Seeders:  #{Float.round(seeder_score, 2)} (30% weight in combined score)
         - Title:    #{Float.round(title_bonus, 2)} (10% weight in combined score)
         - Tag bonus: #{Float.round(tag_bonus, 2)}
+        - Custom formats: #{custom_format_score}
         - Zero-seeder penalty: #{Map.get(breakdown, :zero_seeder_penalty, 1.0)}
       TOTAL: #{Float.round(total_score, 2)}
     """)
@@ -426,6 +453,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
       age: 0.0,
       title_match: round_score(title_bonus),
       tag_bonus: round_score(tag_bonus),
+      custom_format_score: custom_format_score,
       total: round_score(total_score),
       size_penalty: round_score(size_penalty),
       seeder_penalty: round_score(seeder_penalty),
@@ -565,16 +593,22 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
   ## Private Functions - Sorting
 
+  # Sort keys, outermost first:
+  #   1. resolution preference index, so a profile's resolution choice is never
+  #      overridden by a format score
+  #   2. custom format score, so within a tier a preferred-language release
+  #      beats a better-seeded one
+  #   3. the base composite score
   defp sort_by_score_and_preferences(ranked_results, nil) do
-    Enum.sort_by(ranked_results, & &1.score, :desc)
+    Enum.sort_by(ranked_results, fn %{score: score, breakdown: breakdown} ->
+      {-breakdown.custom_format_score, -score}
+    end)
   end
 
   defp sort_by_score_and_preferences(ranked_results, preferred_qualities) do
-    ranked_results
-    |> Enum.sort_by(fn %{result: result, score: score} ->
-      quality_index = quality_preference_index(result, preferred_qualities)
-      # Sort by: quality preference (lower index = higher priority), then score
-      {quality_index, -score}
+    Enum.sort_by(ranked_results, fn %{result: result, score: score, breakdown: breakdown} ->
+      {quality_preference_index(result, preferred_qualities), -breakdown.custom_format_score,
+       -score}
     end)
   end
 
@@ -627,12 +661,14 @@ defmodule Mydia.Indexers.ReleaseRanker do
       iex> ReleaseRanker.score_all_with_reasons(results, min_seeders: 10)
       [
         %{title: "Movie.2024.1080p", score: 75.5, status: :accepted, ...},
-        %{title: "Movie.2024.CAM", score: 0, status: :rejected, rejection_reason: "blocked_tag: CAM", ...}
+        %{title: "Movie.2024.CAM", score: 0, status: :rejected, rejection_reason: "blocked_tag: CAM", ...},
+        %{title: "Movie.2024.VFQ", score: 0, status: :rejected, rejection_reason: "custom_format: VFQ", ...}
       ]
   """
   @spec score_all_with_reasons([SearchResult.t()], ranking_options()) :: [map()]
   def score_all_with_reasons(results, opts \\ []) do
     blocked_tags = Keyword.get(opts, :blocked_tags, [])
+    custom_formats = Keyword.get(opts, :custom_formats, [])
     expected_title = Keyword.get(opts, :expected_title)
 
     results
@@ -650,7 +686,13 @@ defmodule Mydia.Indexers.ReleaseRanker do
       # Only hard removals are reported as rejections now; size/seeders/ratio
       # shortcomings are penalties on accepted results (mirrors filter_acceptable
       # and the identity penalty, which must stay in lockstep — see Risks).
-      case get_rejection_reason(result, blocked_tags, expected_title, excluded_sources(opts)) do
+      case get_rejection_reason(
+             result,
+             blocked_tags,
+             expected_title,
+             excluded_sources(opts),
+             custom_formats
+           ) do
         nil ->
           # Accepted — record the full breakdown (including penalties) so the
           # Activity view can render the penalized-but-kept state.
@@ -658,6 +700,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
           Map.merge(base_info, %{
             score: breakdown.total,
+            custom_format_score: breakdown.custom_format_score,
             status: :accepted,
             rejection_reason: nil,
             breakdown: %{
@@ -667,6 +710,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
               age: breakdown.age,
               title_match: breakdown.title_match,
               tag_bonus: breakdown.tag_bonus,
+              custom_format_score: breakdown.custom_format_score,
               size_penalty: breakdown.size_penalty,
               seeder_penalty: breakdown.seeder_penalty,
               identity_penalty: breakdown.identity_penalty
@@ -676,13 +720,14 @@ defmodule Mydia.Indexers.ReleaseRanker do
         reason ->
           Map.merge(base_info, %{
             score: 0.0,
+            custom_format_score: 0,
             status: :rejected,
             rejection_reason: reason,
             breakdown: nil
           })
       end
     end)
-    |> Enum.sort_by(& &1.score, :desc)
+    |> Enum.sort_by(&{-&1.custom_format_score, -&1.score})
   end
 
   @doc """
@@ -764,7 +809,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
   # removals are invalid releases (validator), blocked tags, and wrong-show
   # title mismatches. Size/seeders/ratio are no longer rejection reasons — they
   # are soft penalties on accepted results.
-  defp get_rejection_reason(result, blocked_tags, expected_title, excluded) do
+  defp get_rejection_reason(result, blocked_tags, expected_title, excluded, custom_formats) do
     cond do
       invalid_reason = invalid_release_reason(result) ->
         "invalid: #{invalid_reason}"
@@ -774,6 +819,9 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
       (source = result_source(result)) && source in excluded ->
         "excluded_source: #{source}"
+
+      rejecting = rejecting_format(result, custom_formats) ->
+        "custom_format: #{rejecting}"
 
       expected_title_mismatch?(result, expected_title) ->
         "title_mismatch"

--- a/lib/mydia/indexers/structs/score_breakdown.ex
+++ b/lib/mydia/indexers/structs/score_breakdown.ex
@@ -14,6 +14,8 @@ defmodule Mydia.Indexers.Structs.ScoreBreakdown do
   - `:age` - Score from release age (slight preference for newer)
   - `:title_match` - Score from title matching relevance to search query
   - `:tag_bonus` - Bonus points from preferred tags
+  - `:custom_format_score` - Summed score of every matching custom format. A
+    separate sort axis, deliberately NOT folded into `:total`.
   - `:total` - Final total score (sum of all components minus penalties)
 
   Penalty fields are optional floats `<= 0.0` (default `0.0`) recording the
@@ -23,7 +25,16 @@ defmodule Mydia.Indexers.Structs.ScoreBreakdown do
   - `:identity_penalty` - Penalty for episode/season identity mismatch or absence
   """
 
-  @enforce_keys [:quality, :seeders, :size, :age, :title_match, :tag_bonus, :total]
+  @enforce_keys [
+    :quality,
+    :seeders,
+    :size,
+    :age,
+    :title_match,
+    :tag_bonus,
+    :custom_format_score,
+    :total
+  ]
   defstruct [
     :quality,
     :seeders,
@@ -31,6 +42,7 @@ defmodule Mydia.Indexers.Structs.ScoreBreakdown do
     :age,
     :title_match,
     :tag_bonus,
+    :custom_format_score,
     :total,
     size_penalty: 0.0,
     seeder_penalty: 0.0,
@@ -44,6 +56,7 @@ defmodule Mydia.Indexers.Structs.ScoreBreakdown do
           age: float(),
           title_match: float(),
           tag_bonus: float(),
+          custom_format_score: integer(),
           total: float(),
           size_penalty: float(),
           seeder_penalty: float(),

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -41,6 +41,7 @@ defmodule Mydia.Jobs.MovieSearch do
   alias Mydia.Library
   alias Mydia.Library.MediaFile
   alias Mydia.Media.MediaItem
+  alias Mydia.Settings.CustomFormats
   alias Mydia.Settings.QualityProfile
   alias Mydia.Upgrades
   alias Phoenix.PubSub
@@ -629,8 +630,11 @@ defmodule Mydia.Jobs.MovieSearch do
     # one option-building path. A movie expects no season/episode identity, so
     # no expected_season/expected_episode are supplied (a TV-pattern release is
     # softly penalized as an identity mismatch inside the ranker).
+    profile = QualityProfileResolver.resolve(movie)
+
     RankingOptions.build(%{
-      quality_profile: QualityProfileResolver.resolve(movie),
+      quality_profile: profile,
+      custom_formats: CustomFormats.resolve_for_profile(profile),
       media_type: :movie,
       min_seeders: args.min_seeders || get_min_seeders(),
       size_range: args.size_range,

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -62,6 +62,7 @@ defmodule Mydia.Jobs.TVShowSearch do
   alias Mydia.Library
   alias Mydia.Media.{MediaItem, Episode}
   alias Mydia.Library.MediaFile
+  alias Mydia.Settings.CustomFormats
   alias Mydia.Settings.QualityProfile
   alias Mydia.Upgrades
   alias Phoenix.PubSub
@@ -1433,8 +1434,11 @@ defmodule Mydia.Jobs.TVShowSearch do
     # the expected season AND episode so the ranker's identity penalty can rank
     # the requested episode above wrong episodes and season packs (which match
     # the season but lack the episode).
+    profile = QualityProfileResolver.resolve(episode.media_item)
+
     RankingOptions.build(%{
-      quality_profile: QualityProfileResolver.resolve(episode.media_item),
+      quality_profile: profile,
+      custom_formats: CustomFormats.resolve_for_profile(profile),
       media_type: :episode,
       min_seeders: args.min_seeders || get_min_seeders(),
       size_range: args.size_range,
@@ -1452,8 +1456,11 @@ defmodule Mydia.Jobs.TVShowSearch do
     # supplies only the expected season (no episode), so the identity penalty
     # matches on season alone — a season pack for the requested season matches,
     # a wrong-season pack is penalized.
+    profile = QualityProfileResolver.resolve(media_item)
+
     RankingOptions.build(%{
-      quality_profile: QualityProfileResolver.resolve(media_item),
+      quality_profile: profile,
+      custom_formats: CustomFormats.resolve_for_profile(profile),
       media_type: :episode,
       min_seeders: args.min_seeders || get_min_seeders(),
       size_range: args.size_range,

--- a/lib/mydia/settings/custom_format.ex
+++ b/lib/mydia/settings/custom_format.ex
@@ -1,0 +1,112 @@
+defmodule Mydia.Settings.CustomFormat do
+  @moduledoc """
+  A named set of release-title regexes.
+
+  Rows here are either operator-created formats or overrides of a built-in
+  defined in `Mydia.Settings.CustomFormats.Manifest`. An override shares the
+  built-in's `slug` and sets `overrides_builtin: true`; deleting it restores
+  the shipped definition.
+
+  Per-profile meaning does not live here. A format's score and reject flag are
+  properties of the profile-to-format pair, held in
+  `Mydia.Settings.QualityProfileCustomFormat`.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Mydia.Settings.CustomFormats.Matcher
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @max_pattern_length 500
+  @max_patterns 20
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          slug: String.t() | nil,
+          name: String.t() | nil,
+          description: String.t() | nil,
+          patterns: [String.t()],
+          overrides_builtin: boolean(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "custom_formats" do
+    field :slug, :string
+    field :name, :string
+    field :description, :string
+    field :patterns, {:array, :string}, default: []
+    field :overrides_builtin, :boolean, default: false
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Changeset for creating or updating a format.
+
+  Every pattern must compile, because an uncompilable pattern would otherwise
+  fail at search time where there is no one to show the error to.
+  """
+  def changeset(custom_format, attrs) do
+    custom_format
+    |> cast(attrs, [:slug, :name, :description, :patterns, :overrides_builtin])
+    |> validate_required([:slug, :name])
+    |> unique_constraint(:slug)
+    |> validate_patterns()
+  end
+
+  @doc """
+  Converts a display name into a url-safe slug.
+
+  Slugs are assigned once at creation and never change on rename, so a
+  profile's scores survive renaming a format.
+  """
+  @spec slugify(String.t()) :: String.t()
+  def slugify(name) when is_binary(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/u, "-")
+    |> String.trim("-")
+  end
+
+  @doc "The maximum number of patterns a single format may carry."
+  @spec max_patterns() :: pos_integer()
+  def max_patterns, do: @max_patterns
+
+  @doc "The maximum length of a single pattern, in characters."
+  @spec max_pattern_length() :: pos_integer()
+  def max_pattern_length, do: @max_pattern_length
+
+  defp validate_patterns(changeset) do
+    patterns = get_field(changeset, :patterns) || []
+
+    cond do
+      patterns == [] ->
+        add_error(changeset, :patterns, "must include at least one pattern")
+
+      length(patterns) > @max_patterns ->
+        add_error(changeset, :patterns, "cannot exceed #{@max_patterns} patterns")
+
+      Enum.any?(patterns, &(String.length(&1) > @max_pattern_length)) ->
+        add_error(
+          changeset,
+          :patterns,
+          "each pattern must be #{@max_pattern_length} characters or fewer"
+        )
+
+      true ->
+        validate_pattern_syntax(changeset, patterns)
+    end
+  end
+
+  defp validate_pattern_syntax(changeset, patterns) do
+    Enum.reduce(patterns, changeset, fn pattern, acc ->
+      case Matcher.compile_pattern(pattern) do
+        {:ok, _} -> acc
+        {:error, message} -> add_error(acc, :patterns, "#{pattern}: #{message}")
+      end
+    end)
+  end
+end

--- a/lib/mydia/settings/custom_formats.ex
+++ b/lib/mydia/settings/custom_formats.ex
@@ -1,0 +1,290 @@
+defmodule Mydia.Settings.CustomFormats do
+  @moduledoc """
+  Custom format definitions and their per-profile scores.
+
+  Definitions come from two layers. `Mydia.Settings.CustomFormats.Manifest`
+  ships built-ins in code; the `custom_formats` table holds operator-created
+  formats plus overrides of a built-in. `list_all/0` is the only place that
+  merge happens. Shipping built-ins in code rather than seeding them is what
+  lets a later release improve a regex for every operator who has not
+  explicitly edited that format.
+
+  Per-profile meaning lives in `quality_profile_custom_formats`. A format has
+  no inherent score; a profile decides whether it is worth 100 points, worth
+  nothing, or grounds for refusing the release.
+  """
+
+  import Ecto.Query
+  require Logger
+
+  alias Mydia.Repo
+  alias Mydia.Settings.CustomFormat
+  alias Mydia.Settings.CustomFormats.Manifest
+  alias Mydia.Settings.CustomFormats.Matcher
+  alias Mydia.Settings.QualityProfile
+  alias Mydia.Settings.QualityProfileCustomFormat
+
+  @type format_view :: %{
+          slug: String.t(),
+          name: String.t(),
+          description: String.t() | nil,
+          patterns: [String.t()],
+          builtin?: boolean(),
+          overridden?: boolean()
+        }
+
+  @doc """
+  Every known format, built-ins first in manifest order, then user-created ones
+  by name.
+  """
+  @spec list_all() :: [format_view()]
+  def list_all do
+    rows = Repo.all(CustomFormat)
+    by_slug = Map.new(rows, &{&1.slug, &1})
+
+    builtins =
+      Enum.map(Manifest.all(), fn entry ->
+        case Map.get(by_slug, entry.slug) do
+          nil -> view(entry, builtin?: true, overridden?: false)
+          row -> view(row, builtin?: true, overridden?: true)
+        end
+      end)
+
+    user =
+      rows
+      |> Enum.reject(&(&1.slug in Manifest.slugs()))
+      |> Enum.sort_by(& &1.name)
+      |> Enum.map(&view(&1, builtin?: false, overridden?: false))
+
+    builtins ++ user
+  end
+
+  @doc "The resolved view for `slug`, or nil."
+  @spec get(String.t()) :: format_view() | nil
+  def get(slug) when is_binary(slug), do: Enum.find(list_all(), &(&1.slug == slug))
+  def get(_), do: nil
+
+  @doc """
+  Creates an operator-defined format. Rejects a slug that belongs to a built-in;
+  editing a built-in goes through `override_builtin/2`.
+  """
+  @spec create_format(map()) :: {:ok, CustomFormat.t()} | {:error, Ecto.Changeset.t()}
+  def create_format(attrs) do
+    attrs = Map.put_new_lazy(attrs, :slug, fn -> unique_slug(Map.get(attrs, :name, "")) end)
+
+    %CustomFormat{}
+    |> CustomFormat.changeset(attrs)
+    |> reject_builtin_slug()
+    |> Repo.insert()
+  end
+
+  @doc "Updates an operator-defined format."
+  @spec update_format(String.t(), map()) ::
+          {:ok, CustomFormat.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def update_format(slug, attrs) do
+    case Repo.get_by(CustomFormat, slug: slug) do
+      nil -> {:error, :not_found}
+      row -> row |> CustomFormat.changeset(attrs) |> Repo.update()
+    end
+  end
+
+  @doc """
+  Creates or updates the override row for a built-in format.
+  """
+  @spec override_builtin(String.t(), map()) ::
+          {:ok, CustomFormat.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def override_builtin(slug, attrs) do
+    case Manifest.get(slug) do
+      nil ->
+        {:error, :not_found}
+
+      entry ->
+        attrs =
+          attrs
+          |> Map.put(:slug, slug)
+          |> Map.put(:overrides_builtin, true)
+          |> Map.put_new(:name, entry.name)
+          |> Map.put_new(:description, entry.description)
+
+        case Repo.get_by(CustomFormat, slug: slug) do
+          nil -> %CustomFormat{} |> CustomFormat.changeset(attrs) |> Repo.insert()
+          row -> row |> CustomFormat.changeset(attrs) |> Repo.update()
+        end
+    end
+  end
+
+  @doc "Drops the override row for a built-in, restoring the shipped definition."
+  @spec reset_builtin(String.t()) :: :ok
+  def reset_builtin(slug) do
+    from(f in CustomFormat, where: f.slug == ^slug and f.overrides_builtin == true)
+    |> Repo.delete_all()
+
+    :ok
+  end
+
+  @doc """
+  Deletes an operator-defined format and every profile assignment naming it.
+
+  Built-ins cannot be deleted; reset them instead.
+  """
+  @spec delete_format(String.t()) :: :ok | {:error, :builtin}
+  def delete_format(slug) do
+    if slug in Manifest.slugs() do
+      {:error, :builtin}
+    else
+      Repo.transaction(fn ->
+        from(a in QualityProfileCustomFormat, where: a.format_slug == ^slug) |> Repo.delete_all()
+        from(f in CustomFormat, where: f.slug == ^slug) |> Repo.delete_all()
+      end)
+
+      :ok
+    end
+  end
+
+  @doc "Every assignment row for a profile."
+  @spec list_assignments(QualityProfile.t()) :: [QualityProfileCustomFormat.t()]
+  def list_assignments(%QualityProfile{id: id}) do
+    from(a in QualityProfileCustomFormat, where: a.quality_profile_id == ^id)
+    |> Repo.all()
+  end
+
+  @doc """
+  Replaces a profile's assignments wholesale.
+
+  Entries that are neither scored nor rejecting are not stored, so the table
+  holds only assignments that mean something.
+  """
+  @spec set_assignments(QualityProfile.t(), [map()]) :: :ok | {:error, Ecto.Changeset.t()}
+  def set_assignments(%QualityProfile{id: profile_id}, entries) do
+    meaningful =
+      Enum.filter(entries, fn e ->
+        Map.get(e, :reject, false) or Map.get(e, :score, 0) != 0
+      end)
+
+    changesets =
+      Enum.map(meaningful, fn e ->
+        QualityProfileCustomFormat.changeset(%QualityProfileCustomFormat{}, %{
+          quality_profile_id: profile_id,
+          format_slug: Map.get(e, :format_slug),
+          score: Map.get(e, :score, 0),
+          reject: Map.get(e, :reject, false)
+        })
+      end)
+
+    case Enum.find(changesets, &(not &1.valid?)) do
+      nil ->
+        Repo.transaction(fn ->
+          from(a in QualityProfileCustomFormat, where: a.quality_profile_id == ^profile_id)
+          |> Repo.delete_all()
+
+          Enum.each(changesets, &Repo.insert!/1)
+        end)
+
+        :ok
+
+      invalid ->
+        {:error, invalid}
+    end
+  end
+
+  @doc """
+  The profile's scored formats, patterns already compiled, ready for
+  `Mydia.Settings.CustomFormats.Matcher.score_title/2`.
+
+  Takes a profile rather than a media item because two of the six
+  `RankingOptions.build/1` call sites never see one: the back-compat entries in
+  `MydiaWeb.MediaLive.Show.SearchHelpers` receive an already-resolved profile.
+  """
+  @spec resolve_for_profile(QualityProfile.t() | nil) :: [Matcher.compiled_format()]
+  def resolve_for_profile(nil), do: []
+
+  def resolve_for_profile(%QualityProfile{} = profile) do
+    by_slug = Map.new(list_all(), &{&1.slug, &1})
+
+    profile
+    |> list_assignments()
+    |> Enum.filter(&(&1.reject or &1.score != 0))
+    |> Enum.flat_map(&compile_assignment(&1, by_slug))
+  end
+
+  defp compile_assignment(assignment, by_slug) do
+    case Map.get(by_slug, assignment.format_slug) do
+      nil ->
+        Logger.warning(
+          "[CustomFormats] profile references unknown format #{assignment.format_slug}; skipping"
+        )
+
+        []
+
+      format ->
+        case Matcher.compile_patterns(format.patterns) do
+          {:ok, compiled} ->
+            [
+              %{
+                slug: format.slug,
+                name: format.name,
+                score: assignment.score,
+                reject: assignment.reject,
+                patterns: compiled
+              }
+            ]
+
+          {:error, message} ->
+            Logger.warning(
+              "[CustomFormats] format #{format.slug} has an uncompilable pattern " <>
+                "(#{message}); skipping"
+            )
+
+            []
+        end
+    end
+  end
+
+  defp view(%CustomFormat{} = row, opts) do
+    %{
+      slug: row.slug,
+      name: row.name,
+      description: row.description,
+      patterns: row.patterns,
+      builtin?: Keyword.fetch!(opts, :builtin?),
+      overridden?: Keyword.fetch!(opts, :overridden?)
+    }
+  end
+
+  defp view(entry, opts) when is_map(entry) do
+    %{
+      slug: entry.slug,
+      name: entry.name,
+      description: Map.get(entry, :description),
+      patterns: entry.patterns,
+      builtin?: Keyword.fetch!(opts, :builtin?),
+      overridden?: Keyword.fetch!(opts, :overridden?)
+    }
+  end
+
+  defp reject_builtin_slug(changeset) do
+    slug = Ecto.Changeset.get_field(changeset, :slug)
+    overrides? = Ecto.Changeset.get_field(changeset, :overrides_builtin)
+
+    if slug in Manifest.slugs() and not overrides? do
+      Ecto.Changeset.add_error(changeset, :slug, "is reserved by a built-in format")
+    else
+      changeset
+    end
+  end
+
+  defp unique_slug(name) do
+    base = CustomFormat.slugify(name)
+    base = if base == "", do: "format", else: base
+    taken = Manifest.slugs() ++ Repo.all(from f in CustomFormat, select: f.slug)
+
+    if base in taken do
+      Enum.find_value(2..1000, fn n ->
+        candidate = "#{base}-#{n}"
+        if candidate not in taken, do: candidate
+      end)
+    else
+      base
+    end
+  end
+end

--- a/lib/mydia/settings/custom_formats/manifest.ex
+++ b/lib/mydia/settings/custom_formats/manifest.ex
@@ -1,0 +1,86 @@
+defmodule Mydia.Settings.CustomFormats.Manifest do
+  @moduledoc """
+  Compile-time loader for the built-in custom format definitions in
+  `priv/custom_formats/*.exs`.
+
+  Files are read with `Code.eval_file/1` at compile time and registered as
+  `@external_resource`, so `mix compile` re-runs this module whenever a
+  manifest file changes. This mirrors `Mydia.Library.ReleaseParser.Vocabulary`.
+
+  Built-ins are always present and need no seeding. A DB row in
+  `custom_formats` sharing a slug overrides the entry here; see
+  `Mydia.Settings.CustomFormats.list_all/0` for the merge. Shipping the
+  definitions in code is what lets a later release improve a regex for every
+  operator who has not explicitly edited that format.
+  """
+
+  @manifest_dir Path.expand("../../../../priv/custom_formats", __DIR__)
+
+  @manifest_files ~w(languages.exs)
+
+  for file <- @manifest_files do
+    @external_resource Path.join(@manifest_dir, file)
+  end
+
+  @entries (for file <- @manifest_files do
+              path = Path.join(@manifest_dir, file)
+              {entries, _bindings} = Code.eval_file(path)
+
+              unless is_list(entries) do
+                raise CompileError,
+                  description:
+                    "Custom format manifest #{file} must return a list, got: #{inspect(entries)}"
+              end
+
+              for entry <- entries do
+                unless is_map(entry) and is_binary(Map.get(entry, :slug)) and
+                         is_binary(Map.get(entry, :name)) and
+                         is_list(Map.get(entry, :patterns)) and
+                         Map.get(entry, :patterns) != [] and
+                         Enum.all?(entry.patterns, &is_binary/1) do
+                  raise CompileError,
+                    description:
+                      "Custom format manifest #{file} contains a malformed entry: " <>
+                        inspect(entry)
+                end
+
+                for pattern <- entry.patterns do
+                  case :re.compile(pattern, [:caseless, :unicode]) do
+                    {:ok, _} ->
+                      :ok
+
+                    {:error, {reason, at}} ->
+                      raise CompileError,
+                        description:
+                          "Custom format #{entry.slug} has an uncompilable pattern " <>
+                            "#{inspect(pattern)}: #{List.to_string(reason)} at #{at}"
+                  end
+                end
+              end
+
+              entries
+            end)
+           |> List.flatten()
+
+  @slugs Enum.map(@entries, & &1.slug)
+
+  if length(@slugs) != length(Enum.uniq(@slugs)) do
+    raise CompileError,
+      description:
+        "Duplicate custom format slug in the manifest: " <>
+          inspect(@slugs -- Enum.uniq(@slugs))
+  end
+
+  @doc "All built-in format entries, in manifest order."
+  @spec all() :: [map()]
+  def all, do: @entries
+
+  @doc "Every built-in slug."
+  @spec slugs() :: [String.t()]
+  def slugs, do: @slugs
+
+  @doc "The built-in entry for `slug`, or nil."
+  @spec get(String.t()) :: map() | nil
+  def get(slug) when is_binary(slug), do: Enum.find(@entries, &(&1.slug == slug))
+  def get(_), do: nil
+end

--- a/lib/mydia/settings/custom_formats/matcher.ex
+++ b/lib/mydia/settings/custom_formats/matcher.ex
@@ -1,0 +1,129 @@
+defmodule Mydia.Settings.CustomFormats.Matcher do
+  @moduledoc """
+  Compiles and applies custom format patterns against release titles.
+
+  Pure: no database access, no application config. Every function takes a
+  plain string and already-compiled patterns, which is what lets the upgrade
+  path reuse this later against a stored file name (see the spec's Deferred
+  section).
+
+  ## Why `:re` directly instead of `Regex`
+
+  Patterns are operator-authored, so a catastrophic one could otherwise
+  backtrack until an Oban job dies. `:re.run/3` accepts `{:match_limit, n}`,
+  which bounds backtracking; `Regex.match?/2` does not expose it. With
+  `:report_errors`, exhausting the limit surfaces as `{:error, :match_limit}`
+  rather than being indistinguishable from a genuine miss, so it can be logged.
+
+  Patterns compile with `:caseless`, so matching is always case-insensitive and
+  format authors must not add inline `(?i)` flags.
+  """
+
+  require Logger
+
+  @compile_opts [:caseless, :unicode]
+  @match_opts [
+    {:match_limit, 10_000},
+    {:match_limit_recursion, 10_000},
+    {:capture, :none},
+    :report_errors
+  ]
+
+  @type compiled_format :: %{
+          slug: String.t(),
+          name: String.t(),
+          score: integer(),
+          reject: boolean(),
+          patterns: [:re.mp()]
+        }
+
+  @type score_result :: %{score: integer(), reject: boolean(), matched: [String.t()]}
+
+  @doc """
+  Compiles one pattern. Returns a human-readable message on failure, suitable
+  for surfacing in a changeset error.
+  """
+  @spec compile_pattern(String.t()) :: {:ok, :re.mp()} | {:error, String.t()}
+  def compile_pattern(pattern) when is_binary(pattern) do
+    case :re.compile(pattern, @compile_opts) do
+      {:ok, mp} ->
+        {:ok, mp}
+
+      # :re returns the reason as a charlist, not a binary.
+      {:error, {reason, at}} ->
+        {:error, "#{List.to_string(reason)} at position #{at}"}
+
+      {:error, reason} ->
+        {:error, inspect(reason)}
+    end
+  end
+
+  def compile_pattern(_), do: {:error, "pattern must be a string"}
+
+  @doc """
+  Compiles a list of patterns, failing on the first bad one.
+  """
+  @spec compile_patterns([String.t()]) :: {:ok, [:re.mp()]} | {:error, String.t()}
+  def compile_patterns(patterns) when is_list(patterns) do
+    Enum.reduce_while(patterns, {:ok, []}, fn pattern, {:ok, acc} ->
+      case compile_pattern(pattern) do
+        {:ok, mp} -> {:cont, {:ok, [mp | acc]}}
+        {:error, message} -> {:halt, {:error, message}}
+      end
+    end)
+    |> case do
+      {:ok, compiled} -> {:ok, Enum.reverse(compiled)}
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  def compile_patterns(_), do: {:error, "patterns must be a list"}
+
+  @doc """
+  True when any of the format's patterns match the title.
+
+  A pattern that exhausts the match limit is treated as a miss and logged, so
+  one pathological format degrades to inert instead of stalling a search.
+  """
+  @spec matches?(String.t(), compiled_format()) :: boolean()
+  def matches?(title, %{patterns: patterns, name: name}) when is_binary(title) do
+    Enum.any?(patterns, fn mp ->
+      case :re.run(title, mp, @match_opts) do
+        :match ->
+          true
+
+        :nomatch ->
+          false
+
+        {:error, reason} ->
+          Logger.warning(
+            "[CustomFormats] pattern for #{name} aborted with #{inspect(reason)} on " <>
+              "#{String.slice(title, 0, 80)}; treating as no match"
+          )
+
+          false
+      end
+    end)
+  end
+
+  def matches?(_title, _format), do: false
+
+  @doc """
+  Scores a title against resolved formats.
+
+  Rejecting formats contribute no score. The caller decides what to do with
+  `:reject`; this function only reports it.
+  """
+  @spec score_title(String.t(), [compiled_format()]) :: score_result()
+  def score_title(title, formats) when is_binary(title) and is_list(formats) do
+    matched = Enum.filter(formats, &matches?(title, &1))
+
+    %{
+      score: matched |> Enum.reject(& &1.reject) |> Enum.map(& &1.score) |> Enum.sum(),
+      reject: Enum.any?(matched, & &1.reject),
+      matched: Enum.map(matched, & &1.name)
+    }
+  end
+
+  def score_title(_title, _formats), do: %{score: 0, reject: false, matched: []}
+end

--- a/lib/mydia/settings/quality_profile_custom_format.ex
+++ b/lib/mydia/settings/quality_profile_custom_format.ex
@@ -1,0 +1,54 @@
+defmodule Mydia.Settings.QualityProfileCustomFormat do
+  @moduledoc """
+  What a single custom format means to a single quality profile.
+
+  `format_slug` is deliberately not a foreign key. A built-in format has no row
+  in `custom_formats` until someone overrides it, so an FK would make it
+  impossible to score a built-in. A slug that resolves to nothing is skipped
+  and logged at search time; see `Mydia.Settings.CustomFormats.resolve_for_profile/1`.
+
+  `score` and `reject` are separate columns. `reject` wins when both are set.
+  The UI presents them as one mutually exclusive control, so the combination is
+  not reachable through normal use, but the schema tolerates it rather than
+  failing.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @score_limit 10_000
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          quality_profile_id: binary() | nil,
+          format_slug: String.t() | nil,
+          score: integer(),
+          reject: boolean()
+        }
+
+  schema "quality_profile_custom_formats" do
+    field :quality_profile_id, :binary_id
+    field :format_slug, :string
+    field :score, :integer, default: 0
+    field :reject, :boolean, default: false
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(assignment, attrs) do
+    assignment
+    |> cast(attrs, [:quality_profile_id, :format_slug, :score, :reject])
+    |> validate_required([:quality_profile_id, :format_slug])
+    |> validate_number(:score,
+      greater_than_or_equal_to: -@score_limit,
+      less_than_or_equal_to: @score_limit
+    )
+    |> unique_constraint([:quality_profile_id, :format_slug])
+  end
+
+  @doc "The inclusive bound on an assignment score."
+  @spec score_limit() :: pos_integer()
+  def score_limit, do: @score_limit
+end

--- a/lib/mydia_web/components/admin_components.ex
+++ b/lib/mydia_web/components/admin_components.ex
@@ -40,6 +40,13 @@ defmodule MydiaWeb.AdminComponents do
         Quality
       </.tab_link>
       <.tab_link
+        active={@active_tab == :custom_formats}
+        to="/admin/config/custom-formats"
+        icon="hero-language"
+      >
+        Custom Formats
+      </.tab_link>
+      <.tab_link
         active={@active_tab == :clients}
         to="/admin/config/clients"
         icon="hero-arrow-down-tray"

--- a/lib/mydia_web/live/activity_live/index.ex
+++ b/lib/mydia_web/live/activity_live/index.ex
@@ -403,6 +403,8 @@ defmodule MydiaWeb.ActivityLive.Index do
       "tag_bonus" -> "Tag bonus"
       "preferred_tags" -> "Preferred"
       "blocked_tags" -> "Blocked"
+      "custom_format" -> "Custom format"
+      "custom_format_score" -> "Custom format"
       "title_relevance" -> "Title match"
       "title_match" -> "Title match"
       # Soft-penalty contributions

--- a/lib/mydia_web/live/admin_custom_formats_live/index.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.ex
@@ -100,6 +100,17 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
          socket
          |> assign(:form, save_error_form(changeset, params, socket.assigns.editing))
          |> put_flash(:error, changeset_message(changeset))}
+
+      # The format disappeared between opening the modal and submitting it:
+      # another admin deleted it, or an upgrade dropped a built-in from the
+      # manifest. Close the modal and re-read the list rather than letting the
+      # unmatched tuple crash the LiveView.
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "That format no longer exists. The list has been refreshed.")
+         |> assign(:editing, nil)
+         |> load_formats()}
     end
   end
 

--- a/lib/mydia_web/live/admin_custom_formats_live/index.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.ex
@@ -1,0 +1,159 @@
+defmodule MydiaWeb.AdminCustomFormatsLive.Index do
+  @moduledoc """
+  Admin page for the custom format library.
+
+  Formats defined here are global. What a format *means* is per profile and is
+  set in the quality profile editor, not here.
+  """
+  use MydiaWeb, :live_view
+
+  alias Mydia.Settings.CustomFormats
+  alias Mydia.Settings.CustomFormats.Matcher
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Custom Formats")
+     |> assign(:editing, nil)
+     |> assign(:test_title, "")
+     |> assign(:test_results, [])
+     |> load_formats()}
+  end
+
+  @impl true
+  def handle_event("new", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:editing, %{slug: nil, name: "", description: "", patterns: [], builtin?: false})
+     |> assign(
+       :form,
+       to_form(%{"name" => "", "description" => "", "patterns_text" => ""},
+         as: :custom_format
+       )
+     )
+     |> assign(:test_title, "")
+     |> assign(:test_results, [])}
+  end
+
+  def handle_event("edit", %{"slug" => slug}, socket) do
+    format = CustomFormats.get(slug)
+
+    {:noreply,
+     socket
+     |> assign(:editing, format)
+     |> assign(
+       :form,
+       to_form(
+         %{
+           "name" => format.name,
+           "description" => format.description || "",
+           "patterns_text" => Enum.join(format.patterns, "\n")
+         },
+         as: :custom_format
+       )
+     )
+     |> assign(:test_title, "")
+     |> assign(:test_results, [])}
+  end
+
+  def handle_event("cancel", _params, socket) do
+    {:noreply, assign(socket, :editing, nil)}
+  end
+
+  def handle_event("validate", %{"custom_format" => params}, socket) do
+    title = Map.get(params, "test_title", "")
+    patterns = split_patterns(Map.get(params, "patterns_text", ""))
+
+    {:noreply,
+     socket
+     |> assign(:form, to_form(params, as: :custom_format))
+     |> assign(:test_title, title)
+     |> assign(:test_results, test_patterns(patterns, title))}
+  end
+
+  def handle_event("save", %{"custom_format" => params}, socket) do
+    attrs = %{
+      name: Map.get(params, "name", ""),
+      description: Map.get(params, "description"),
+      patterns: split_patterns(Map.get(params, "patterns_text", ""))
+    }
+
+    result =
+      case socket.assigns.editing do
+        %{slug: nil} -> CustomFormats.create_format(attrs)
+        %{builtin?: true, slug: slug} -> CustomFormats.override_builtin(slug, attrs)
+        %{slug: slug} -> CustomFormats.update_format(slug, attrs)
+      end
+
+    case result do
+      {:ok, _format} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Format saved")
+         |> assign(:editing, nil)
+         |> load_formats()}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply,
+         socket
+         |> assign(:form, to_form(changeset, as: :custom_format))
+         |> put_flash(:error, changeset_message(changeset))}
+    end
+  end
+
+  def handle_event("reset", %{"slug" => slug}, socket) do
+    :ok = CustomFormats.reset_builtin(slug)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, "Format reset to the shipped definition")
+     |> load_formats()}
+  end
+
+  def handle_event("delete", %{"slug" => slug}, socket) do
+    case CustomFormats.delete_format(slug) do
+      :ok ->
+        {:noreply, socket |> put_flash(:info, "Format deleted") |> load_formats()}
+
+      {:error, :builtin} ->
+        {:noreply,
+         put_flash(socket, :error, "Built-in formats cannot be deleted. Reset instead.")}
+    end
+  end
+
+  defp load_formats(socket), do: assign(socket, :formats, CustomFormats.list_all())
+
+  defp split_patterns(text) do
+    text
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp test_patterns(_patterns, ""), do: []
+
+  defp test_patterns(patterns, title) do
+    Enum.map(patterns, fn pattern ->
+      case Matcher.compile_pattern(pattern) do
+        {:ok, mp} ->
+          format = %{slug: "test", name: "test", score: 0, reject: false, patterns: [mp]}
+
+          %{
+            pattern: pattern,
+            status: if(Matcher.matches?(title, format), do: :match, else: :miss)
+          }
+
+        {:error, message} ->
+          %{pattern: pattern, status: {:error, message}}
+      end
+    end)
+  end
+
+  defp changeset_message(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, _opts} -> msg end)
+    |> Enum.map(fn {field, messages} -> "#{field}: #{Enum.join(messages, ", ")}" end)
+    |> Enum.join("; ")
+  end
+end

--- a/lib/mydia_web/live/admin_custom_formats_live/index.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.ex
@@ -74,7 +74,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
 
   def handle_event("save", %{"custom_format" => params}, socket) do
     attrs = %{
-      name: Map.get(params, "name", ""),
+      name: save_name(socket.assigns.editing, params),
       description: Map.get(params, "description"),
       patterns: split_patterns(Map.get(params, "patterns_text", ""))
     }
@@ -97,7 +97,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply,
          socket
-         |> assign(:form, to_form(changeset, as: :custom_format))
+         |> assign(:form, save_error_form(changeset, params, socket.assigns.editing))
          |> put_flash(:error, changeset_message(changeset))}
     end
   end
@@ -154,5 +154,29 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
     changeset
     |> Ecto.Changeset.traverse_errors(fn {msg, _opts} -> msg end)
     |> Enum.map_join("; ", fn {field, messages} -> "#{field}: #{Enum.join(messages, ", ")}" end)
+  end
+
+  defp save_name(%{builtin?: true, name: name}, _params), do: name
+  defp save_name(_editing, params), do: Map.get(params, "name", "")
+
+  defp save_error_form(changeset, params, editing) do
+    patterns_text =
+      Map.get(params, "patterns_text") ||
+        changeset |> Ecto.Changeset.get_field(:patterns, []) |> Enum.join("\n")
+
+    form_params = %{
+      "name" => save_name(editing, params),
+      "description" =>
+        Map.get(params, "description", Ecto.Changeset.get_field(changeset, :description) || ""),
+      "patterns_text" => patterns_text
+    }
+
+    errors =
+      Enum.flat_map(changeset.errors, fn
+        {:patterns, error} -> [{:patterns_text, error}]
+        other -> [other]
+      end)
+
+    to_form(form_params, as: :custom_format, errors: errors, action: :insert)
   end
 end

--- a/lib/mydia_web/live/admin_custom_formats_live/index.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.ex
@@ -153,7 +153,6 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
   defp changeset_message(changeset) do
     changeset
     |> Ecto.Changeset.traverse_errors(fn {msg, _opts} -> msg end)
-    |> Enum.map(fn {field, messages} -> "#{field}: #{Enum.join(messages, ", ")}" end)
-    |> Enum.join("; ")
+    |> Enum.map_join("; ", fn {field, messages} -> "#{field}: #{Enum.join(messages, ", ")}" end)
   end
 end

--- a/lib/mydia_web/live/admin_custom_formats_live/index.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.ex
@@ -15,6 +15,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
     {:ok,
      socket
      |> assign(:page_title, "Custom Formats")
+     |> assign(:active_tab, :custom_formats)
      |> assign(:editing, nil)
      |> assign(:test_title, "")
      |> assign(:test_results, [])

--- a/lib/mydia_web/live/admin_custom_formats_live/index.html.heex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.html.heex
@@ -1,116 +1,118 @@
-<Layouts.app flash={@flash} current_scope={@current_scope}>
-  <div class="max-w-4xl mx-auto p-4 space-y-4">
-    <div class="flex items-center justify-between">
-      <div>
-        <h1 class="text-2xl font-bold">Custom Formats</h1>
-        <p class="text-sm opacity-70">
-          Match release titles by regex. Assign scores per quality profile.
-        </p>
+<Layouts.app {assigns}>
+  <.admin_page active_tab={@active_tab}>
+    <div class="space-y-4">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-2xl font-bold">Custom Formats</h1>
+          <p class="text-sm opacity-70">
+            Match release titles by regex. Assign scores per quality profile.
+          </p>
+        </div>
+        <.button id="custom-format-new" phx-click="new" class="btn-primary">
+          <.icon name="hero-plus" class="w-4 h-4" /> New format
+        </.button>
       </div>
-      <.button id="custom-format-new" phx-click="new" class="btn-primary">
-        <.icon name="hero-plus" class="w-4 h-4" /> New format
-      </.button>
-    </div>
 
-    <div class="card bg-base-100 shadow">
-      <div class="card-body p-0 divide-y divide-base-200">
-        <div
-          :for={format <- @formats}
-          id={"custom-format-row-#{format.slug}"}
-          class="flex items-center gap-3 p-4"
-        >
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-2">
-              <span class="font-medium">{format.name}</span>
-              <span :if={format.builtin?} class="badge badge-sm badge-ghost">Built-in</span>
-              <span :if={format.overridden?} class="badge badge-sm badge-warning">Edited</span>
+      <div class="card bg-base-100 shadow">
+        <div class="card-body p-0 divide-y divide-base-200">
+          <div
+            :for={format <- @formats}
+            id={"custom-format-row-#{format.slug}"}
+            class="flex items-center gap-3 p-4"
+          >
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="font-medium">{format.name}</span>
+                <span :if={format.builtin?} class="badge badge-sm badge-ghost">Built-in</span>
+                <span :if={format.overridden?} class="badge badge-sm badge-warning">Edited</span>
+              </div>
+              <div class="text-xs opacity-60 truncate font-mono">
+                {Enum.join(format.patterns, "  ")}
+              </div>
             </div>
-            <div class="text-xs opacity-60 truncate font-mono">
-              {Enum.join(format.patterns, "  ")}
-            </div>
+
+            <.button
+              id={"custom-format-edit-#{format.slug}"}
+              phx-click="edit"
+              phx-value-slug={format.slug}
+              class="btn-sm btn-ghost"
+            >
+              Edit
+            </.button>
+
+            <.button
+              :if={format.overridden?}
+              id={"custom-format-reset-#{format.slug}"}
+              phx-click="reset"
+              phx-value-slug={format.slug}
+              class="btn-sm btn-ghost"
+            >
+              Reset
+            </.button>
+
+            <.button
+              :if={not format.builtin?}
+              id={"custom-format-delete-#{format.slug}"}
+              phx-click="delete"
+              phx-value-slug={format.slug}
+              data-confirm={"Delete #{format.name}?"}
+              class="btn-sm btn-ghost text-error"
+            >
+              Delete
+            </.button>
           </div>
-
-          <.button
-            id={"custom-format-edit-#{format.slug}"}
-            phx-click="edit"
-            phx-value-slug={format.slug}
-            class="btn-sm btn-ghost"
-          >
-            Edit
-          </.button>
-
-          <.button
-            :if={format.overridden?}
-            id={"custom-format-reset-#{format.slug}"}
-            phx-click="reset"
-            phx-value-slug={format.slug}
-            class="btn-sm btn-ghost"
-          >
-            Reset
-          </.button>
-
-          <.button
-            :if={not format.builtin?}
-            id={"custom-format-delete-#{format.slug}"}
-            phx-click="delete"
-            phx-value-slug={format.slug}
-            data-confirm={"Delete #{format.name}?"}
-            class="btn-sm btn-ghost text-error"
-          >
-            Delete
-          </.button>
         </div>
       </div>
-    </div>
 
-    <div :if={@editing} class="modal modal-open">
-      <div class="modal-box max-w-2xl">
-        <h3 class="font-bold text-lg mb-4">
-          {if @editing.slug, do: "Edit #{@editing.name}", else: "New format"}
-        </h3>
+      <div :if={@editing} class="modal modal-open">
+        <div class="modal-box max-w-2xl">
+          <h3 class="font-bold text-lg mb-4">
+            {if @editing.slug, do: "Edit #{@editing.name}", else: "New format"}
+          </h3>
 
-        <.form for={@form} id="custom-format-form" phx-change="validate" phx-submit="save">
-          <.input field={@form[:name]} type="text" label="Name" disabled={@editing.builtin?} />
-          <.input field={@form[:description]} type="text" label="Description" />
-          <.input
-            field={@form[:patterns_text]}
-            type="textarea"
-            label="Patterns (one per line)"
-            rows="6"
-          />
+          <.form for={@form} id="custom-format-form" phx-change="validate" phx-submit="save">
+            <.input field={@form[:name]} type="text" label="Name" disabled={@editing.builtin?} />
+            <.input field={@form[:description]} type="text" label="Description" />
+            <.input
+              field={@form[:patterns_text]}
+              type="textarea"
+              label="Patterns (one per line)"
+              rows="6"
+            />
 
-          <div class="divider">Test</div>
+            <div class="divider">Test</div>
 
-          <.input
-            field={@form[:test_title]}
-            id="custom-format-test-input"
-            type="text"
-            label="Paste a release title"
-            placeholder="Film.2024.VFF.1080p.WEB-DL.x264-GROUP"
-          />
+            <.input
+              field={@form[:test_title]}
+              id="custom-format-test-input"
+              type="text"
+              label="Paste a release title"
+              placeholder="Film.2024.VFF.1080p.WEB-DL.x264-GROUP"
+            />
 
-          <ul :if={@test_results != []} class="mt-2 space-y-1 text-sm">
-            <li :for={r <- @test_results} class="flex items-center gap-2 font-mono">
-              <span :if={r.status == :match} class="custom-format-test-match text-success">
-                <.icon name="hero-check-circle" class="w-4 h-4" />
-              </span>
-              <span :if={r.status == :miss} class="opacity-40">
-                <.icon name="hero-x-circle" class="w-4 h-4" />
-              </span>
-              <span :if={match?({:error, _}, r.status)} class="text-error">
-                <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
-              </span>
-              <span>{r.pattern}</span>
-            </li>
-          </ul>
+            <ul :if={@test_results != []} class="mt-2 space-y-1 text-sm">
+              <li :for={r <- @test_results} class="flex items-center gap-2 font-mono">
+                <span :if={r.status == :match} class="custom-format-test-match text-success">
+                  <.icon name="hero-check-circle" class="w-4 h-4" />
+                </span>
+                <span :if={r.status == :miss} class="opacity-40">
+                  <.icon name="hero-x-circle" class="w-4 h-4" />
+                </span>
+                <span :if={match?({:error, _}, r.status)} class="text-error">
+                  <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
+                </span>
+                <span>{r.pattern}</span>
+              </li>
+            </ul>
 
-          <div class="modal-action">
-            <.button type="button" phx-click="cancel" class="btn-ghost">Cancel</.button>
-            <.button type="submit" class="btn-primary">Save</.button>
-          </div>
-        </.form>
+            <div class="modal-action">
+              <.button type="button" phx-click="cancel" class="btn-ghost">Cancel</.button>
+              <.button type="submit" class="btn-primary">Save</.button>
+            </div>
+          </.form>
+        </div>
+        <div class="modal-backdrop" phx-click="cancel"></div>
       </div>
-      <div class="modal-backdrop" phx-click="cancel"></div>
     </div>
-  </div>
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_custom_formats_live/index.html.heex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.html.heex
@@ -1,0 +1,116 @@
+<Layouts.app flash={@flash} current_scope={@current_scope}>
+  <div class="max-w-4xl mx-auto p-4 space-y-4">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold">Custom Formats</h1>
+        <p class="text-sm opacity-70">
+          Match release titles by regex. Assign scores per quality profile.
+        </p>
+      </div>
+      <.button id="custom-format-new" phx-click="new" class="btn-primary">
+        <.icon name="hero-plus" class="w-4 h-4" /> New format
+      </.button>
+    </div>
+
+    <div class="card bg-base-100 shadow">
+      <div class="card-body p-0 divide-y divide-base-200">
+        <div
+          :for={format <- @formats}
+          id={"custom-format-row-#{format.slug}"}
+          class="flex items-center gap-3 p-4"
+        >
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="font-medium">{format.name}</span>
+              <span :if={format.builtin?} class="badge badge-sm badge-ghost">Built-in</span>
+              <span :if={format.overridden?} class="badge badge-sm badge-warning">Edited</span>
+            </div>
+            <div class="text-xs opacity-60 truncate font-mono">
+              {Enum.join(format.patterns, "  ")}
+            </div>
+          </div>
+
+          <.button
+            id={"custom-format-edit-#{format.slug}"}
+            phx-click="edit"
+            phx-value-slug={format.slug}
+            class="btn-sm btn-ghost"
+          >
+            Edit
+          </.button>
+
+          <.button
+            :if={format.overridden?}
+            id={"custom-format-reset-#{format.slug}"}
+            phx-click="reset"
+            phx-value-slug={format.slug}
+            class="btn-sm btn-ghost"
+          >
+            Reset
+          </.button>
+
+          <.button
+            :if={not format.builtin?}
+            id={"custom-format-delete-#{format.slug}"}
+            phx-click="delete"
+            phx-value-slug={format.slug}
+            data-confirm={"Delete #{format.name}?"}
+            class="btn-sm btn-ghost text-error"
+          >
+            Delete
+          </.button>
+        </div>
+      </div>
+    </div>
+
+    <div :if={@editing} class="modal modal-open">
+      <div class="modal-box max-w-2xl">
+        <h3 class="font-bold text-lg mb-4">
+          {if @editing.slug, do: "Edit #{@editing.name}", else: "New format"}
+        </h3>
+
+        <.form for={@form} id="custom-format-form" phx-change="validate" phx-submit="save">
+          <.input field={@form[:name]} type="text" label="Name" disabled={@editing.builtin?} />
+          <.input field={@form[:description]} type="text" label="Description" />
+          <.input
+            field={@form[:patterns_text]}
+            type="textarea"
+            label="Patterns (one per line)"
+            rows="6"
+          />
+
+          <div class="divider">Test</div>
+
+          <.input
+            field={@form[:test_title]}
+            id="custom-format-test-input"
+            type="text"
+            label="Paste a release title"
+            placeholder="Film.2024.VFF.1080p.WEB-DL.x264-GROUP"
+          />
+
+          <ul :if={@test_results != []} class="mt-2 space-y-1 text-sm">
+            <li :for={r <- @test_results} class="flex items-center gap-2 font-mono">
+              <span :if={r.status == :match} class="custom-format-test-match text-success">
+                <.icon name="hero-check-circle" class="w-4 h-4" />
+              </span>
+              <span :if={r.status == :miss} class="opacity-40">
+                <.icon name="hero-x-circle" class="w-4 h-4" />
+              </span>
+              <span :if={match?({:error, _}, r.status)} class="text-error">
+                <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
+              </span>
+              <span>{r.pattern}</span>
+            </li>
+          </ul>
+
+          <div class="modal-action">
+            <.button type="button" phx-click="cancel" class="btn-ghost">Cancel</.button>
+            <.button type="submit" class="btn-primary">Save</.button>
+          </div>
+        </.form>
+      </div>
+      <div class="modal-backdrop" phx-click="cancel"></div>
+    </div>
+  </div>
+</Layouts.app>

--- a/lib/mydia_web/live/admin_quality_profiles_live/components.ex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/components.ex
@@ -2,6 +2,8 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Components do
   @moduledoc false
   use MydiaWeb, :html
 
+  import MydiaWeb.AdminQualityProfilesLive.CustomFormatSection
+
   @doc """
   Renders the Quality Profiles tab content.
   """
@@ -233,6 +235,8 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Components do
   attr :quality_profile_form, :any, required: true
   attr :quality_profile_mode, :atom, required: true
   attr :quality_profile_active_tab, :string, required: true
+  attr :custom_formats, :list, required: true
+  attr :custom_format_assignments, :map, required: true
 
   def quality_profile_modal(assigns) do
     ~H"""
@@ -289,6 +293,10 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Components do
           <%!-- Quality Standards Tab - Always rendered, hidden when not active --%>
           <div class={if @quality_profile_active_tab != "standards", do: "hidden"}>
             <.quality_profile_standards_tab form={@quality_profile_form} />
+            <.custom_format_section
+              formats={@custom_formats}
+              assignments={@custom_format_assignments}
+            />
           </div>
 
           <%!-- Exclude Tab - Always rendered, hidden when not active --%>

--- a/lib/mydia_web/live/admin_quality_profiles_live/custom_format_section.ex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/custom_format_section.ex
@@ -1,0 +1,70 @@
+defmodule MydiaWeb.AdminQualityProfilesLive.CustomFormatSection do
+  @moduledoc """
+  Custom format score assignment inside the quality profile editor.
+
+  Definitions are global and edited on the Custom Formats admin page. This
+  section only assigns what each format is worth to one profile.
+
+  Lives in its own module because the sibling `components.ex` is already well
+  past the project's ~500 LOC per component file guidance.
+  """
+  use MydiaWeb, :html
+
+  attr :formats, :list, required: true
+  attr :assignments, :map, required: true, doc: "slug => %{score: integer, reject: boolean}"
+
+  def custom_format_section(assigns) do
+    ~H"""
+    <div id="profile-custom-formats" class="space-y-2">
+      <div>
+        <h3 class="font-semibold">Custom Formats</h3>
+        <p class="text-sm opacity-70">
+          Score releases by what their title contains. A rejected format is never grabbed.
+          Define formats on the
+          <.link navigate={~p"/admin/config/custom-formats"} class="link">
+            Custom Formats
+          </.link>
+          page.
+        </p>
+      </div>
+
+      <div class="space-y-1">
+        <div
+          :for={format <- @formats}
+          class="flex items-center gap-3 py-1"
+        >
+          <div class="flex-1 min-w-0">
+            <span class="font-medium">{format.name}</span>
+            <span class="text-xs opacity-60 ml-2 truncate">{format.description}</span>
+          </div>
+
+          <input
+            type="number"
+            id={"custom-format-score-#{format.slug}"}
+            name={"custom_formats[#{format.slug}][score]"}
+            value={assignment(@assignments, format.slug).score}
+            class="input input-bordered input-sm w-24"
+          />
+
+          <label class="label cursor-pointer gap-2">
+            <input type="hidden" name={"custom_formats[#{format.slug}][reject]"} value="false" />
+            <input
+              type="checkbox"
+              id={"custom-format-reject-#{format.slug}"}
+              name={"custom_formats[#{format.slug}][reject]"}
+              value="true"
+              checked={assignment(@assignments, format.slug).reject}
+              class="checkbox checkbox-sm checkbox-error"
+            />
+            <span class="label-text">Reject</span>
+          </label>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp assignment(assignments, slug) do
+    Map.get(assignments, slug, %{score: 0, reject: false})
+  end
+end

--- a/lib/mydia_web/live/admin_quality_profiles_live/index.ex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/index.ex
@@ -2,6 +2,7 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
   use MydiaWeb, :live_view
 
   alias Mydia.Settings
+  alias Mydia.Settings.CustomFormats
   alias Mydia.Settings.QualityProfile
 
   require Logger
@@ -13,6 +14,7 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
      socket
      |> assign(:page_title, "Configuration - Quality Profiles")
      |> assign(:active_tab, :quality)
+     |> assign(:custom_formats, CustomFormats.list_all())
      |> load_data()}
   end
 
@@ -56,7 +58,8 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
      |> assign(:show_quality_profile_modal, true)
      |> assign(:quality_profile_form, to_form(changeset))
      |> assign(:quality_profile_mode, :new)
-     |> assign(:quality_profile_active_tab, "basic")}
+     |> assign(:quality_profile_active_tab, "basic")
+     |> assign(:custom_format_assignments, %{})}
   end
 
   @impl true
@@ -70,7 +73,8 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
      |> assign(:quality_profile_form, to_form(changeset))
      |> assign(:quality_profile_mode, :edit)
      |> assign(:editing_quality_profile, profile)
-     |> assign(:quality_profile_active_tab, "basic")}
+     |> assign(:quality_profile_active_tab, "basic")
+     |> assign_custom_format_assignments(profile)}
   end
 
   @impl true
@@ -92,7 +96,7 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
   end
 
   @impl true
-  def handle_event("save_quality_profile", %{"quality_profile" => params}, socket) do
+  def handle_event("save_quality_profile", %{"quality_profile" => params} = all_params, socket) do
     transformed_params = transform_quality_profile_params(params)
 
     result =
@@ -108,7 +112,9 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
       end
 
     case result do
-      {:ok, _profile} ->
+      {:ok, profile} ->
+        save_custom_formats(profile, all_params)
+
         {:noreply,
          socket
          |> assign(:show_quality_profile_modal, false)
@@ -360,6 +366,40 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
   end
 
   ## Private Helpers
+
+  defp assign_custom_format_assignments(socket, profile) do
+    assignments =
+      profile
+      |> CustomFormats.list_assignments()
+      |> Map.new(&{&1.format_slug, %{score: &1.score, reject: &1.reject}})
+
+    assign(socket, :custom_format_assignments, assignments)
+  end
+
+  defp save_custom_formats(profile, params) do
+    entries =
+      params
+      |> Map.get("custom_formats", %{})
+      |> Enum.map(fn {slug, attrs} ->
+        %{
+          format_slug: slug,
+          score: parse_score(Map.get(attrs, "score")),
+          reject: Map.get(attrs, "reject") == "true"
+        }
+      end)
+
+    CustomFormats.set_assignments(profile, entries)
+  end
+
+  defp parse_score(nil), do: 0
+  defp parse_score(""), do: 0
+
+  defp parse_score(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, _} -> n
+      :error -> 0
+    end
+  end
 
   defp load_data(socket) do
     socket

--- a/lib/mydia_web/live/admin_quality_profiles_live/index.ex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/index.ex
@@ -113,13 +113,25 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
 
     case result do
       {:ok, profile} ->
-        save_custom_formats(profile, all_params)
+        case save_custom_formats(profile, all_params) do
+          :ok ->
+            {:noreply,
+             socket
+             |> assign(:show_quality_profile_modal, false)
+             |> put_flash(:info, "Quality profile saved successfully")
+             |> load_data()}
 
-        {:noreply,
-         socket
-         |> assign(:show_quality_profile_modal, false)
-         |> put_flash(:info, "Quality profile saved successfully")
-         |> load_data()}
+          {:error, %Ecto.Changeset{} = assignment_changeset} ->
+            {:noreply,
+             socket
+             |> assign(:show_quality_profile_modal, false)
+             |> put_flash(
+               :error,
+               "Quality profile saved, but custom format settings could not be saved: " <>
+                 assignment_error_message(assignment_changeset)
+             )
+             |> load_data()}
+        end
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, :quality_profile_form, to_form(changeset))}
@@ -399,6 +411,12 @@ defmodule MydiaWeb.AdminQualityProfilesLive.Index do
       {n, _} -> n
       :error -> 0
     end
+  end
+
+  defp assignment_error_message(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, _opts} -> msg end)
+    |> Enum.map_join("; ", fn {field, messages} -> "#{field}: #{Enum.join(messages, ", ")}" end)
   end
 
   defp load_data(socket) do

--- a/lib/mydia_web/live/admin_quality_profiles_live/index.html.heex
+++ b/lib/mydia_web/live/admin_quality_profiles_live/index.html.heex
@@ -11,6 +11,8 @@
         quality_profile_form={@quality_profile_form}
         quality_profile_mode={@quality_profile_mode}
         quality_profile_active_tab={@quality_profile_active_tab}
+        custom_formats={@custom_formats}
+        custom_format_assignments={@custom_format_assignments}
       />
     <% end %>
 

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -11,6 +11,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   alias Mydia.Indexers.SearchResult
   alias Mydia.Indexers.SearchScorer
   alias Mydia.Media
+  alias Mydia.Settings.CustomFormats
 
   def generate_result_id(%SearchResult{} = result) do
     # Generate a unique ID based on the download URL and indexer
@@ -148,6 +149,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
     ranking_opts =
       RankingOptions.build(%{
         quality_profile: quality_profile,
+        custom_formats: CustomFormats.resolve_for_profile(quality_profile),
         media_type: media_type,
         search_query: search_query
       })
@@ -240,8 +242,11 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
 
     {expected_season, expected_episode} = expected_identity(context)
 
+    profile = QualityProfileResolver.resolve(media_item)
+
     RankingOptions.build(%{
-      quality_profile: QualityProfileResolver.resolve(media_item),
+      quality_profile: profile,
+      custom_formats: CustomFormats.resolve_for_profile(profile),
       media_type: get_media_type(media_item),
       min_seeders: Map.get(assigns, :min_seeders),
       search_query: Map.get(assigns, :manual_search_query),
@@ -310,7 +315,11 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   def profile_score_breakdown(%SearchResult{} = result, quality_profile, media_type) do
     profile_score_breakdown(
       result,
-      RankingOptions.build(%{quality_profile: quality_profile, media_type: media_type})
+      RankingOptions.build(%{
+        quality_profile: quality_profile,
+        custom_formats: CustomFormats.resolve_for_profile(quality_profile),
+        media_type: media_type
+      })
     )
   end
 

--- a/lib/mydia_web/router.ex
+++ b/lib/mydia_web/router.ex
@@ -194,6 +194,7 @@ defmodule MydiaWeb.Router do
       live "/config/status", AdminSystemLive.Index, :index
       live "/config/settings", AdminSettingsLive.Index, :index
       live "/config/quality", AdminQualityProfilesLive.Index, :index
+      live "/config/custom-formats", AdminCustomFormatsLive.Index, :index
       live "/config/clients", AdminDownloadClientsLive.Index, :index
       live "/config/indexers", AdminIndexersLive.Index, :index
       live "/config/library-paths", AdminLibraryPathsLive.Index, :index

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,8 @@ nav:
           - using/explanation/remote-access.md
           - using/explanation/how-mydia-runs.md
           - using/explanation/vs-radarr-sonarr.md
+  - Configuration:
+      - configuration/custom-formats.md
   - Building Plugins:
       - plugins/index.md
       - Tutorial:

--- a/priv/custom_formats/languages.exs
+++ b/priv/custom_formats/languages.exs
@@ -1,0 +1,47 @@
+# Built-in custom formats for French-language audio tags.
+#
+# Loaded at compile time by Mydia.Settings.CustomFormats.Manifest. Each entry is
+# a plain map. Patterns are Erlang :re source strings compiled with :caseless,
+# so do not add inline (?i) flags.
+#
+# Editing this file changes the shipped definition for every install that has
+# not overridden that format in the database.
+
+[
+  %{
+    slug: "lang-vff",
+    name: "VFF",
+    description: "France French dub. TRUEFRENCH is the older name for the same thing.",
+    patterns: ["\\bVFF\\b", "\\bTRUEFRENCH\\b"]
+  },
+  %{
+    slug: "lang-vf2",
+    name: "VF2",
+    description: "Second French dub, typically a France redub of an older release.",
+    patterns: ["\\bVF2\\b"]
+  },
+  %{
+    slug: "lang-vfi",
+    name: "VFI",
+    description: "International French dub, produced in France for non-France markets.",
+    patterns: ["\\bVFI\\b"]
+  },
+  %{
+    slug: "lang-vfq",
+    name: "VFQ",
+    description: "Quebec French dub.",
+    patterns: ["\\bVFQ\\b", "\\bVQ\\b"]
+  },
+  %{
+    slug: "lang-multi",
+    name: "MULTI",
+    description: "Multiple audio tracks, usually the original plus one or more dubs.",
+    patterns: ["\\bMULTI\\b"]
+  },
+  %{
+    slug: "lang-vostfr",
+    name: "VOSTFR",
+    description: "Original audio with French subtitles. Not a dub.",
+    patterns: ["\\bVOSTFR\\b"]
+  }
+]

--- a/priv/repo/migrations/20260809202500_create_custom_formats.exs
+++ b/priv/repo/migrations/20260809202500_create_custom_formats.exs
@@ -1,0 +1,35 @@
+defmodule Mydia.Repo.Migrations.CreateCustomFormats do
+  use Ecto.Migration
+
+  def change do
+    create table(:custom_formats, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :slug, :string, null: false
+      add :name, :string, null: false
+      add :description, :string
+      add :patterns, {:array, :string}, default: []
+      add :overrides_builtin, :boolean, default: false, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:custom_formats, [:slug])
+
+    create table(:quality_profile_custom_formats, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :quality_profile_id,
+          references(:quality_profiles, type: :binary_id, on_delete: :delete_all),
+          null: false
+
+      add :format_slug, :string, null: false
+      add :score, :integer, default: 0, null: false
+      add :reject, :boolean, default: false, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:quality_profile_custom_formats, [:quality_profile_id, :format_slug])
+    create index(:quality_profile_custom_formats, [:format_slug])
+  end
+end

--- a/priv/repo/migrations/20260809202500_create_custom_formats.exs
+++ b/priv/repo/migrations/20260809202500_create_custom_formats.exs
@@ -7,7 +7,9 @@ defmodule Mydia.Repo.Migrations.CreateCustomFormats do
       add :slug, :string, null: false
       add :name, :string, null: false
       add :description, :string
-      add :patterns, {:array, :string}, default: []
+      # NOT NULL because every consumer assumes a list: the changeset validates
+      # non-empty, and both the admin list and the matcher would fail on nil.
+      add :patterns, {:array, :string}, default: [], null: false
       add :overrides_builtin, :boolean, default: false, null: false
 
       timestamps(type: :utc_datetime)

--- a/test/mydia/indexers/custom_format_call_sites_test.exs
+++ b/test/mydia/indexers/custom_format_call_sites_test.exs
@@ -1,0 +1,53 @@
+defmodule Mydia.Indexers.CustomFormatCallSitesTest do
+  @moduledoc """
+  Guards against a RankingOptions.build/1 call site forgetting :custom_formats.
+
+  A forgotten site makes custom formats silently inert for one search path,
+  which is hard to notice and easy to reintroduce.
+  """
+  use Mydia.DataCase, async: false
+
+  import ExUnit.CaptureLog
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Settings.CustomFormats
+  alias MydiaWeb.MediaLive.Show.SearchHelpers
+
+  setup do
+    profile = quality_profile_fixture()
+
+    :ok =
+      CustomFormats.set_assignments(profile, [
+        %{format_slug: "lang-vff", score: 100, reject: false}
+      ])
+
+    %{profile: profile}
+  end
+
+  test "sort_search_results/5 passes formats", %{profile: profile} do
+    log =
+      capture_log(fn ->
+        SearchHelpers.sort_search_results([], :quality, profile, :movie, "query")
+      end)
+
+    refute log =~ "custom formats will be ignored"
+  end
+
+  test "profile_score_breakdown/3 passes formats", %{profile: profile} do
+    result = %Mydia.Indexers.SearchResult{
+      title: "Film.2024.VFF.1080p",
+      size: 5 * 1024 * 1024 * 1024,
+      seeders: 10,
+      leechers: 2,
+      download_url: "magnet:?xt=urn:btih:test",
+      indexer: "TestIndexer"
+    }
+
+    log =
+      capture_log(fn ->
+        SearchHelpers.profile_score_breakdown(result, profile, :movie)
+      end)
+
+    refute log =~ "custom formats will be ignored"
+  end
+end

--- a/test/mydia/indexers/ranking_options_test.exs
+++ b/test/mydia/indexers/ranking_options_test.exs
@@ -1,5 +1,8 @@
 defmodule Mydia.Indexers.RankingOptionsTest do
-  use ExUnit.Case, async: true
+  use Mydia.DataCase, async: true
+
+  import ExUnit.CaptureLog
+  import Mydia.SettingsFixtures
 
   alias Mydia.Indexers.RankingOptions
   alias Mydia.Settings.QualityProfile
@@ -221,6 +224,53 @@ defmodule Mydia.Indexers.RankingOptionsTest do
         })
 
       assert Keyword.get(opts, :preferred_qualities) == ["1080p"]
+    end
+  end
+
+  describe "custom formats" do
+    test "passes :custom_formats through when given" do
+      formats = [%{slug: "lang-vff", name: "VFF", score: 100, reject: false, patterns: []}]
+
+      opts =
+        RankingOptions.build(%{
+          media_type: :movie,
+          quality_profile: quality_profile_fixture(),
+          custom_formats: formats
+        })
+
+      assert Keyword.get(opts, :custom_formats) == formats
+    end
+
+    test "omits :custom_formats when the list is empty" do
+      opts =
+        RankingOptions.build(%{
+          media_type: :movie,
+          quality_profile: quality_profile_fixture(),
+          custom_formats: []
+        })
+
+      refute Keyword.has_key?(opts, :custom_formats)
+    end
+
+    test "warns when a profile is given but the :custom_formats key is absent" do
+      log =
+        capture_log(fn ->
+          RankingOptions.build(%{
+            media_type: :movie,
+            quality_profile: quality_profile_fixture()
+          })
+        end)
+
+      assert log =~ "custom formats will be ignored"
+    end
+
+    test "does not warn when there is no profile" do
+      log =
+        capture_log(fn ->
+          RankingOptions.build(%{media_type: :movie})
+        end)
+
+      refute log =~ "custom formats will be ignored"
     end
   end
 end

--- a/test/mydia/indexers/release_ranker_test.exs
+++ b/test/mydia/indexers/release_ranker_test.exs
@@ -2526,4 +2526,143 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       refute Map.has_key?(stats["rejection_counts"], "size_out_of_range")
     end
   end
+
+  describe "custom formats" do
+    defp compiled_format(name, patterns, opts) do
+      {:ok, compiled} = Mydia.Settings.CustomFormats.Matcher.compile_patterns(patterns)
+
+      %{
+        slug: String.downcase(name),
+        name: name,
+        score: Keyword.get(opts, :score, 0),
+        reject: Keyword.get(opts, :reject, false),
+        patterns: compiled
+      }
+    end
+
+    test "a rejecting format drops the release" do
+      vfq = compiled_format("VFQ", ["\\bVFQ\\b"], reject: true)
+
+      title_vfq = "Film.2024.VFQ.1080p.WEB-DL"
+      title_vff = "Film.2024.VFF.1080p.WEB-DL"
+
+      results = [
+        build_result(%{title: title_vfq, seeders: 500}),
+        build_result(%{title: title_vff, seeders: 5})
+      ]
+
+      kept = ReleaseRanker.filter_acceptable(results, custom_formats: [vfq])
+      assert Enum.map(kept, & &1.title) == [title_vff]
+    end
+
+    test "format score outranks seeders within a resolution tier" do
+      vff = compiled_format("VFF", ["\\bVFF\\b"], score: 100)
+
+      title_vfq = "Film.2024.VFQ.1080p.WEB-DL"
+      title_vff = "Film.2024.VFF.1080p.WEB-DL"
+
+      results = [
+        build_result(%{
+          title: title_vfq,
+          seeders: 500,
+          quality: QualityParser.parse(title_vfq)
+        }),
+        build_result(%{
+          title: title_vff,
+          seeders: 5,
+          quality: QualityParser.parse(title_vff)
+        })
+      ]
+
+      ranked =
+        ReleaseRanker.rank_all(results,
+          media_type: :movie,
+          preferred_qualities: ["1080p"],
+          custom_formats: [vff]
+        )
+
+      assert hd(ranked).result.title == title_vff
+    end
+
+    test "format score does not promote across resolution tiers" do
+      vff = compiled_format("VFF", ["\\bVFF\\b"], score: 1000)
+
+      title_vff_720 = "Film.2024.VFF.720p.WEB-DL"
+      title_vfq_1080 = "Film.2024.VFQ.1080p.WEB-DL"
+
+      results = [
+        build_result(%{
+          title: title_vff_720,
+          seeders: 5,
+          quality: QualityParser.parse(title_vff_720)
+        }),
+        build_result(%{
+          title: title_vfq_1080,
+          seeders: 5,
+          quality: QualityParser.parse(title_vfq_1080)
+        })
+      ]
+
+      ranked =
+        ReleaseRanker.rank_all(results,
+          media_type: :movie,
+          preferred_qualities: ["1080p", "720p"],
+          custom_formats: [vff]
+        )
+
+      assert hd(ranked).result.title == title_vfq_1080
+    end
+
+    test "with no formats the ordering is unchanged" do
+      title_vfq = "Film.2024.VFQ.1080p.WEB-DL"
+      title_vff = "Film.2024.VFF.1080p.WEB-DL"
+
+      results = [
+        build_result(%{
+          title: title_vfq,
+          seeders: 500,
+          quality: QualityParser.parse(title_vfq)
+        }),
+        build_result(%{
+          title: title_vff,
+          seeders: 5,
+          quality: QualityParser.parse(title_vff)
+        })
+      ]
+
+      with_formats =
+        ReleaseRanker.rank_all(results, media_type: :movie, preferred_qualities: ["1080p"])
+
+      without_key =
+        ReleaseRanker.rank_all(results,
+          media_type: :movie,
+          preferred_qualities: ["1080p"],
+          custom_formats: []
+        )
+
+      assert Enum.map(with_formats, & &1.result.title) ==
+               Enum.map(without_key, & &1.result.title)
+    end
+
+    test "breakdown carries the summed format score" do
+      vff = compiled_format("VFF", ["\\bVFF\\b"], score: 100)
+      title = "Film.2024.VFF.1080p.WEB-DL"
+      result = build_result(%{title: title, seeders: 10})
+
+      breakdown =
+        ReleaseRanker.calculate_score_breakdown(result, media_type: :movie, custom_formats: [vff])
+
+      assert breakdown.custom_format_score == 100
+    end
+
+    test "score_all_with_reasons reports the rejection reason" do
+      vfq = compiled_format("VFQ", ["\\bVFQ\\b"], reject: true)
+      title = "Film.2024.VFQ.1080p.WEB-DL"
+      results = [build_result(%{title: title, seeders: 10})]
+
+      [row] = ReleaseRanker.score_all_with_reasons(results, custom_formats: [vfq])
+      assert row.status == :rejected
+      assert row.rejection_reason == "custom_format: VFQ"
+    end
+  end
 end

--- a/test/mydia/settings/custom_format_test.exs
+++ b/test/mydia/settings/custom_format_test.exs
@@ -1,0 +1,91 @@
+defmodule Mydia.Settings.CustomFormatTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Settings.CustomFormat
+  alias Mydia.Settings.QualityProfileCustomFormat
+
+  describe "CustomFormat.changeset/2" do
+    test "accepts a valid format" do
+      changeset =
+        CustomFormat.changeset(%CustomFormat{}, %{
+          slug: "my-format",
+          name: "My Format",
+          patterns: ["\\bVFF\\b"]
+        })
+
+      assert changeset.valid?
+    end
+
+    test "requires a name and at least one pattern" do
+      changeset = CustomFormat.changeset(%CustomFormat{}, %{slug: "x", name: "X", patterns: []})
+      refute changeset.valid?
+      assert %{patterns: _} = errors_on(changeset)
+    end
+
+    test "rejects an uncompilable pattern with a readable message" do
+      changeset =
+        CustomFormat.changeset(%CustomFormat{}, %{
+          slug: "bad",
+          name: "Bad",
+          patterns: ["(unclosed"]
+        })
+
+      refute changeset.valid?
+      assert [message] = errors_on(changeset).patterns
+      assert message =~ "parenthesis"
+    end
+
+    test "rejects a pattern longer than 500 characters" do
+      changeset =
+        CustomFormat.changeset(%CustomFormat{}, %{
+          slug: "long",
+          name: "Long",
+          patterns: [String.duplicate("a", 501)]
+        })
+
+      refute changeset.valid?
+    end
+
+    test "rejects more than 20 patterns" do
+      changeset =
+        CustomFormat.changeset(%CustomFormat{}, %{
+          slug: "many",
+          name: "Many",
+          patterns: Enum.map(1..21, &"pattern#{&1}")
+        })
+
+      refute changeset.valid?
+    end
+
+    test "slugify/1 produces a url-safe slug" do
+      assert CustomFormat.slugify("My Format!") == "my-format"
+      assert CustomFormat.slugify("  Spaces  Everywhere  ") == "spaces-everywhere"
+      assert CustomFormat.slugify("VF2") == "vf2"
+    end
+  end
+
+  describe "QualityProfileCustomFormat.changeset/2" do
+    test "accepts a score assignment" do
+      changeset =
+        QualityProfileCustomFormat.changeset(%QualityProfileCustomFormat{}, %{
+          quality_profile_id: Ecto.UUID.generate(),
+          format_slug: "lang-vff",
+          score: 100,
+          reject: false
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects a score outside the supported range" do
+      changeset =
+        QualityProfileCustomFormat.changeset(%QualityProfileCustomFormat{}, %{
+          quality_profile_id: Ecto.UUID.generate(),
+          format_slug: "lang-vff",
+          score: 100_000
+        })
+
+      refute changeset.valid?
+    end
+  end
+end

--- a/test/mydia/settings/custom_formats/manifest_test.exs
+++ b/test/mydia/settings/custom_formats/manifest_test.exs
@@ -1,0 +1,42 @@
+defmodule Mydia.Settings.CustomFormats.ManifestTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Settings.CustomFormats.Manifest
+
+  test "ships the six French language formats" do
+    assert Enum.sort(Manifest.slugs()) == [
+             "lang-multi",
+             "lang-vf2",
+             "lang-vff",
+             "lang-vfi",
+             "lang-vfq",
+             "lang-vostfr"
+           ]
+  end
+
+  test "every entry has a slug, name, description, and at least one pattern" do
+    for entry <- Manifest.all() do
+      assert is_binary(entry.slug) and entry.slug != ""
+      assert is_binary(entry.name) and entry.name != ""
+      assert is_binary(entry.description)
+      assert is_list(entry.patterns) and entry.patterns != []
+      assert Enum.all?(entry.patterns, &is_binary/1)
+    end
+  end
+
+  test "every shipped pattern compiles" do
+    for entry <- Manifest.all(), pattern <- entry.patterns do
+      assert {:ok, _} = :re.compile(pattern, [:caseless, :unicode]),
+             "#{entry.slug} has an uncompilable pattern: #{pattern}"
+    end
+  end
+
+  test "get/1 returns an entry by slug and nil for an unknown one" do
+    assert %{name: "VFF"} = Manifest.get("lang-vff")
+    assert Manifest.get("nope") == nil
+  end
+
+  test "VFF covers TRUEFRENCH" do
+    assert "\\bTRUEFRENCH\\b" in Manifest.get("lang-vff").patterns
+  end
+end

--- a/test/mydia/settings/custom_formats/matcher_test.exs
+++ b/test/mydia/settings/custom_formats/matcher_test.exs
@@ -1,0 +1,105 @@
+defmodule Mydia.Settings.CustomFormats.MatcherTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Settings.CustomFormats.Matcher
+
+  defp format(name, patterns, opts \\ []) do
+    {:ok, compiled} = Matcher.compile_patterns(patterns)
+
+    %{
+      slug: String.downcase(name),
+      name: name,
+      score: Keyword.get(opts, :score, 0),
+      reject: Keyword.get(opts, :reject, false),
+      patterns: compiled
+    }
+  end
+
+  describe "compile_pattern/1" do
+    test "compiles a valid pattern" do
+      assert {:ok, _} = Matcher.compile_pattern("\\bVFF\\b")
+    end
+
+    test "returns a readable string error for an invalid pattern" do
+      assert {:error, message} = Matcher.compile_pattern("(unclosed")
+      assert is_binary(message)
+      assert message =~ "parenthesis"
+    end
+  end
+
+  describe "matches?/2" do
+    test "matches a tag in a dotted scene title" do
+      vff = format("VFF", ["\\bVFF\\b"])
+      assert Matcher.matches?("Film.2024.VFF.1080p.WEB-DL.x264-GROUP", vff)
+    end
+
+    test "is case insensitive" do
+      vff = format("VFF", ["\\bVFF\\b"])
+      assert Matcher.matches?("film.2024.vff.1080p", vff)
+    end
+
+    test "matches when any one pattern matches" do
+      vff = format("VFF", ["\\bVFF\\b", "\\bTRUEFRENCH\\b"])
+      assert Matcher.matches?("Film.2024.TRUEFRENCH.1080p", vff)
+    end
+
+    test "VQ does not match a release group containing those letters" do
+      vfq = format("VFQ", ["\\bVFQ\\b", "\\bVQ\\b"])
+      refute Matcher.matches?("Film.2024.1080p.WEB-DL-VQMD", vfq)
+    end
+
+    test "MULTI does not match the bare string MULT" do
+      multi = format("MULTI", ["\\bMULTI\\b"])
+      refute Matcher.matches?("Film.2024.MULT.1080p", multi)
+      assert Matcher.matches?("Film.2024.MULTi.1080p", multi)
+    end
+
+    test "a catastrophic pattern is bounded and treated as no match" do
+      evil = format("Evil", ["(a+)+$"])
+      subject = String.duplicate("a", 60) <> "!"
+
+      task = Task.async(fn -> Matcher.matches?(subject, evil) end)
+      assert Task.await(task, 2_000) == false
+    end
+  end
+
+  describe "score_title/2" do
+    test "sums the scores of every matching format" do
+      formats = [
+        format("VFF", ["\\bVFF\\b"], score: 100),
+        format("MULTI", ["\\bMULTI\\b"], score: 50)
+      ]
+
+      assert %{score: 150, reject: false, matched: matched} =
+               Matcher.score_title("Film.2024.MULTI.VFF.1080p", formats)
+
+      assert Enum.sort(matched) == ["MULTI", "VFF"]
+    end
+
+    test "reports reject when any matching format rejects" do
+      formats = [
+        format("VFF", ["\\bVFF\\b"], score: 100),
+        format("VFQ", ["\\bVFQ\\b"], reject: true)
+      ]
+
+      assert %{reject: true, matched: ["VFQ"]} =
+               Matcher.score_title("Film.2024.VFQ.1080p", formats)
+    end
+
+    test "a rejecting format contributes no score" do
+      formats = [format("VFQ", ["\\bVFQ\\b"], score: 999, reject: true)]
+      assert %{score: 0, reject: true} = Matcher.score_title("Film.VFQ.1080p", formats)
+    end
+
+    test "returns a zero result when nothing matches" do
+      formats = [format("VFF", ["\\bVFF\\b"], score: 100)]
+
+      assert %{score: 0, reject: false, matched: []} =
+               Matcher.score_title("Film.2024.1080p", formats)
+    end
+
+    test "returns a zero result for an empty format list" do
+      assert %{score: 0, reject: false, matched: []} = Matcher.score_title("anything", [])
+    end
+  end
+end

--- a/test/mydia/settings/custom_formats_test.exs
+++ b/test/mydia/settings/custom_formats_test.exs
@@ -1,0 +1,143 @@
+defmodule Mydia.Settings.CustomFormatsTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Settings.CustomFormats
+
+  describe "list_all/0" do
+    test "returns built-ins when no DB rows exist" do
+      slugs = Enum.map(CustomFormats.list_all(), & &1.slug)
+      assert "lang-vff" in slugs
+      assert "lang-vfq" in slugs
+    end
+
+    test "marks built-ins as builtin? and not overridden" do
+      vff = Enum.find(CustomFormats.list_all(), &(&1.slug == "lang-vff"))
+      assert vff.builtin?
+      refute vff.overridden?
+      assert vff.patterns == ["\\bVFF\\b", "\\bTRUEFRENCH\\b"]
+    end
+
+    test "a DB row shadows the built-in it overrides" do
+      {:ok, _} =
+        CustomFormats.override_builtin("lang-vff", %{patterns: ["\\bVFF\\b"], name: "VFF"})
+
+      vff = Enum.find(CustomFormats.list_all(), &(&1.slug == "lang-vff"))
+      assert vff.builtin?
+      assert vff.overridden?
+      assert vff.patterns == ["\\bVFF\\b"]
+    end
+
+    test "reset_builtin/1 restores the shipped definition" do
+      {:ok, _} = CustomFormats.override_builtin("lang-vff", %{patterns: ["x"], name: "VFF"})
+      :ok = CustomFormats.reset_builtin("lang-vff")
+
+      vff = Enum.find(CustomFormats.list_all(), &(&1.slug == "lang-vff"))
+      refute vff.overridden?
+      assert vff.patterns == ["\\bVFF\\b", "\\bTRUEFRENCH\\b"]
+    end
+
+    test "includes user-created formats alongside built-ins" do
+      format = custom_format_fixture(%{name: "Anime Dual Audio", slug: "anime-dual"})
+      view = Enum.find(CustomFormats.list_all(), &(&1.slug == format.slug))
+      assert view
+      refute view.builtin?
+    end
+
+    test "a user format may not take a built-in slug" do
+      assert {:error, changeset} =
+               CustomFormats.create_format(%{
+                 name: "Fake VFF",
+                 slug: "lang-vff",
+                 patterns: ["x"]
+               })
+
+      assert %{slug: _} = errors_on(changeset)
+    end
+  end
+
+  describe "delete_format/1" do
+    test "deletes a user format and its assignments" do
+      profile = quality_profile_fixture()
+      format = custom_format_fixture()
+
+      :ok =
+        CustomFormats.set_assignments(profile, [
+          %{format_slug: format.slug, score: 100, reject: false}
+        ])
+
+      :ok = CustomFormats.delete_format(format.slug)
+
+      assert CustomFormats.list_assignments(profile) == []
+    end
+
+    test "refuses to delete a built-in" do
+      assert {:error, :builtin} = CustomFormats.delete_format("lang-vff")
+    end
+  end
+
+  describe "resolve_for_profile/1" do
+    test "returns [] for nil" do
+      assert CustomFormats.resolve_for_profile(nil) == []
+    end
+
+    test "returns [] when the profile scores nothing" do
+      assert CustomFormats.resolve_for_profile(quality_profile_fixture()) == []
+    end
+
+    test "returns compiled formats for scored assignments" do
+      profile = quality_profile_fixture()
+
+      :ok =
+        CustomFormats.set_assignments(profile, [
+          %{format_slug: "lang-vff", score: 100, reject: false},
+          %{format_slug: "lang-vfq", score: 0, reject: true}
+        ])
+
+      resolved = CustomFormats.resolve_for_profile(profile)
+      assert length(resolved) == 2
+
+      vff = Enum.find(resolved, &(&1.slug == "lang-vff"))
+      assert vff.score == 100
+      refute vff.reject
+      assert Enum.all?(vff.patterns, &is_tuple/1)
+    end
+
+    test "omits assignments that are neither scored nor rejecting" do
+      profile = quality_profile_fixture()
+
+      :ok =
+        CustomFormats.set_assignments(profile, [
+          %{format_slug: "lang-vff", score: 0, reject: false}
+        ])
+
+      assert CustomFormats.resolve_for_profile(profile) == []
+    end
+
+    test "skips an assignment naming an unresolvable slug" do
+      profile = quality_profile_fixture()
+
+      :ok =
+        CustomFormats.set_assignments(profile, [
+          %{format_slug: "lang-vff", score: 100, reject: false},
+          %{format_slug: "removed-in-a-later-release", score: 50, reject: false}
+        ])
+
+      resolved = CustomFormats.resolve_for_profile(profile)
+      assert [%{slug: "lang-vff"}] = resolved
+    end
+
+    test "deleting a profile removes its assignments" do
+      profile = quality_profile_fixture()
+
+      :ok =
+        CustomFormats.set_assignments(profile, [
+          %{format_slug: "lang-vff", score: 100, reject: false}
+        ])
+
+      {:ok, _} = Mydia.Settings.delete_quality_profile(profile)
+      assert CustomFormats.list_assignments(profile) == []
+    end
+  end
+end

--- a/test/mydia_web/live/admin_custom_formats_live_test.exs
+++ b/test/mydia_web/live/admin_custom_formats_live_test.exs
@@ -16,6 +16,20 @@ defmodule MydiaWeb.AdminCustomFormatsLiveTest do
     assert has_element?(view, "#custom-format-row-lang-vfq")
   end
 
+  # Without a nav entry the page is reachable only by typing the URL, which for
+  # a self-hosted operator means the feature may as well not exist.
+  test "is reachable from the admin tab nav", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    assert has_element?(view, ~s|a[href="/admin/config/custom-formats"]|)
+  end
+
+  test "the admin nav on a sibling page links here", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/quality")
+
+    assert has_element?(view, ~s|a[href="/admin/config/custom-formats"]|)
+  end
+
   test "opens the edit modal for a built-in", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
 

--- a/test/mydia_web/live/admin_custom_formats_live_test.exs
+++ b/test/mydia_web/live/admin_custom_formats_live_test.exs
@@ -16,6 +16,26 @@ defmodule MydiaWeb.AdminCustomFormatsLiveTest do
     assert has_element?(view, "#custom-format-row-lang-vfq")
   end
 
+  # Two admin tabs: the format is deleted in one while the other has its edit
+  # modal open. The save must not crash the LiveView.
+  test "saving a format that was deleted meanwhile does not crash", %{conn: conn} do
+    format = Mydia.SettingsFixtures.custom_format_fixture(%{name: "Doomed", slug: "doomed"})
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    view |> element("#custom-format-edit-#{format.slug}") |> render_click()
+
+    :ok = Mydia.Settings.CustomFormats.delete_format(format.slug)
+
+    html =
+      view
+      |> form("#custom-format-form", custom_format: %{name: "Doomed", patterns_text: "\\bX\\b"})
+      |> render_submit()
+
+    assert html =~ "no longer exists"
+    refute has_element?(view, "#custom-format-row-doomed")
+  end
+
   # Without a nav entry the page is reachable only by typing the URL, which for
   # a self-hosted operator means the feature may as well not exist.
   test "is reachable from the admin tab nav", %{conn: conn} do

--- a/test/mydia_web/live/admin_custom_formats_live_test.exs
+++ b/test/mydia_web/live/admin_custom_formats_live_test.exs
@@ -23,6 +23,29 @@ defmodule MydiaWeb.AdminCustomFormatsLiveTest do
     assert has_element?(view, "#custom-format-form")
   end
 
+  test "saves an override for a built-in format without submitting the disabled name", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    view |> element("#custom-format-edit-lang-vff") |> render_click()
+
+    view
+    |> form("#custom-format-form",
+      custom_format: %{
+        description: "French true dub",
+        patterns_text: "\\bVFF\\b\n\\bONLYVFF\\b"
+      }
+    )
+    |> render_submit()
+
+    format = Mydia.Settings.CustomFormats.get("lang-vff")
+    assert format.overridden?
+    assert format.name == "VFF"
+    assert "\\bONLYVFF\\b" in format.patterns
+    assert has_element?(view, "#custom-format-row-lang-vff .badge-warning", "Edited")
+  end
+
   test "creates a user format", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
 
@@ -48,6 +71,7 @@ defmodule MydiaWeb.AdminCustomFormatsLiveTest do
       |> render_submit()
 
     assert html =~ "parenthesis"
+    assert html =~ "(unclosed"
     refute has_element?(view, "#custom-format-row-bad")
   end
 

--- a/test/mydia_web/live/admin_custom_formats_live_test.exs
+++ b/test/mydia_web/live/admin_custom_formats_live_test.exs
@@ -1,0 +1,81 @@
+defmodule MydiaWeb.AdminCustomFormatsLiveTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin)}
+  end
+
+  test "lists the built-in formats", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    assert has_element?(view, "#custom-format-row-lang-vff")
+    assert has_element?(view, "#custom-format-row-lang-vfq")
+  end
+
+  test "opens the edit modal for a built-in", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    view |> element("#custom-format-edit-lang-vff") |> render_click()
+    assert has_element?(view, "#custom-format-form")
+  end
+
+  test "creates a user format", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    view |> element("#custom-format-new") |> render_click()
+
+    view
+    |> form("#custom-format-form",
+      custom_format: %{name: "Dual Audio", patterns_text: "\\bDUAL\\b"}
+    )
+    |> render_submit()
+
+    assert has_element?(view, "#custom-format-row-dual-audio")
+  end
+
+  test "rejects an invalid pattern with a visible error", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    view |> element("#custom-format-new") |> render_click()
+
+    html =
+      view
+      |> form("#custom-format-form", custom_format: %{name: "Bad", patterns_text: "(unclosed"})
+      |> render_submit()
+
+    assert html =~ "parenthesis"
+    refute has_element?(view, "#custom-format-row-bad")
+  end
+
+  test "the test box reports which patterns match a title", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    view |> element("#custom-format-edit-lang-vff") |> render_click()
+
+    html =
+      view
+      |> form("#custom-format-form", custom_format: %{test_title: "Film.2024.VFF.1080p"})
+      |> render_change()
+
+    assert html =~ "custom-format-test-match"
+  end
+
+  test "resetting a built-in restores its shipped patterns", %{conn: conn} do
+    {:ok, _} =
+      Mydia.Settings.CustomFormats.override_builtin("lang-vff", %{
+        name: "VFF",
+        patterns: ["\\bONLYVFF\\b"]
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    view |> element("#custom-format-reset-lang-vff") |> render_click()
+
+    assert Mydia.Settings.CustomFormats.get("lang-vff").patterns ==
+             ["\\bVFF\\b", "\\bTRUEFRENCH\\b"]
+  end
+end

--- a/test/mydia_web/live/admin_quality_profiles_custom_formats_test.exs
+++ b/test/mydia_web/live/admin_quality_profiles_custom_formats_test.exs
@@ -1,0 +1,77 @@
+defmodule MydiaWeb.AdminQualityProfilesCustomFormatsTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Settings.CustomFormats
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    profile = quality_profile_fixture(%{name: "French HD"})
+    %{conn: log_in_user(conn, admin), profile: profile}
+  end
+
+  test "lists every known format when editing a profile", %{conn: conn, profile: profile} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/quality")
+
+    view
+    |> element(~s{button[phx-click="edit_quality_profile"][phx-value-id="#{profile.id}"]})
+    |> render_click()
+
+    assert has_element?(view, "#profile-custom-formats")
+    assert has_element?(view, "#custom-format-score-lang-vff")
+    assert has_element?(view, "#custom-format-reject-lang-vfq")
+  end
+
+  test "saves scores and reject flags", %{conn: conn, profile: profile} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/quality")
+
+    view
+    |> element(~s{button[phx-click="edit_quality_profile"][phx-value-id="#{profile.id}"]})
+    |> render_click()
+
+    view
+    |> form("#quality-profile-form", %{
+      "quality_profile" => %{
+        "name" => profile.name,
+        "quality_standards" => %{"preferred_resolutions" => ["1080p"]}
+      },
+      "custom_formats" => %{
+        "lang-vff" => %{"score" => "100", "reject" => "false"},
+        "lang-vfq" => %{"score" => "0", "reject" => "true"}
+      }
+    })
+    |> render_submit()
+
+    assignments =
+      profile
+      |> CustomFormats.list_assignments()
+      |> Map.new(&{&1.format_slug, &1})
+
+    assert assignments["lang-vff"].score == 100
+    refute assignments["lang-vff"].reject
+    assert assignments["lang-vfq"].reject
+  end
+
+  test "an unscored format is not persisted", %{conn: conn, profile: profile} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/quality")
+
+    view
+    |> element(~s{button[phx-click="edit_quality_profile"][phx-value-id="#{profile.id}"]})
+    |> render_click()
+
+    view
+    |> form("#quality-profile-form", %{
+      "quality_profile" => %{
+        "name" => profile.name,
+        "quality_standards" => %{"preferred_resolutions" => ["1080p"]}
+      },
+      "custom_formats" => %{"lang-vff" => %{"score" => "0", "reject" => "false"}}
+    })
+    |> render_submit()
+
+    assert CustomFormats.list_assignments(profile) == []
+  end
+end

--- a/test/mydia_web/live/admin_quality_profiles_custom_formats_test.exs
+++ b/test/mydia_web/live/admin_quality_profiles_custom_formats_test.exs
@@ -74,4 +74,29 @@ defmodule MydiaWeb.AdminQualityProfilesCustomFormatsTest do
 
     assert CustomFormats.list_assignments(profile) == []
   end
+
+  test "reports an error when custom format scores are invalid", %{conn: conn, profile: profile} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/quality")
+
+    view
+    |> element(~s{button[phx-click="edit_quality_profile"][phx-value-id="#{profile.id}"]})
+    |> render_click()
+
+    html =
+      view
+      |> form("#quality-profile-form", %{
+        "quality_profile" => %{
+          "name" => profile.name,
+          "quality_standards" => %{"preferred_resolutions" => ["1080p"]}
+        },
+        "custom_formats" => %{
+          "lang-vff" => %{"score" => "99999", "reject" => "false"}
+        }
+      })
+      |> render_submit()
+
+    assert html =~ "custom format settings could not be saved"
+    assert html =~ "score"
+    refute html =~ "Quality profile saved successfully"
+  end
 end

--- a/test/mydia_web/live/media_live/show/search_helpers_test.exs
+++ b/test/mydia_web/live/media_live/show/search_helpers_test.exs
@@ -1,5 +1,7 @@
 defmodule MydiaWeb.MediaLive.Show.SearchHelpersTest do
-  use ExUnit.Case, async: true
+  use Mydia.DataCase, async: true
+
+  import Mydia.SettingsFixtures
 
   alias MydiaWeb.MediaLive.Show.SearchHelpers
   alias Mydia.Indexers.{QualityParser, RankingOptions, ReleaseRanker, SearchResult}
@@ -24,12 +26,12 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpersTest do
   end
 
   defp build_quality_profile do
-    %QualityProfile{
+    quality_profile_fixture(%{
       name: "Test Profile",
       quality_standards: %{
         preferred_resolutions: ["1080p", "720p"]
       }
-    }
+    })
   end
 
   describe "sort_search_results/5 with title relevance" do
@@ -306,10 +308,14 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpersTest do
     end
 
     test "sort_search_results/5 (the back-compat manual entry point) also does not exclude" do
-      profile = %QualityProfile{
-        name: "Excludes telesync",
-        quality_standards: %{excluded_sources: ["Telesync"]}
-      }
+      profile =
+        quality_profile_fixture(%{
+          name: "Excludes telesync",
+          quality_standards: %{
+            preferred_resolutions: ["1080p"],
+            excluded_sources: ["Telesync"]
+          }
+        })
 
       telesync_title = "The.Odyssey.2026.1080p.TELESYNC.HEVC.AAC2.0-SLH"
 

--- a/test/support/fixtures/settings_fixtures.ex
+++ b/test/support/fixtures/settings_fixtures.ex
@@ -80,4 +80,22 @@ defmodule Mydia.SettingsFixtures do
     {:ok, library_path} = Settings.create_library_path(attrs)
     library_path
   end
+
+  @doc """
+  Generate a user-created custom format.
+  """
+  def custom_format_fixture(attrs \\ %{}) do
+    n = System.unique_integer([:positive])
+
+    default_attrs = %{
+      name: "Format #{n}",
+      slug: "format-#{n}",
+      patterns: ["\\bTAG#{n}\\b"]
+    }
+
+    attrs = Map.merge(default_attrs, attrs)
+
+    {:ok, format} = Mydia.Settings.CustomFormats.create_format(attrs)
+    format
+  end
 end


### PR DESCRIPTION
Adds Custom Formats: named, reusable sets of release-title regexes that a quality profile can score or reject. Closes the gap where Mydia had no way to distinguish release variants that differ only by a title tag.

The motivating case is French audio. A Quebec dub (`VFQ`) and a France dub (`VFF`) of the same film at the same resolution are identical to the ranker today, so which one gets grabbed comes down to seeder count. There was no way to express "prefer VFF, never grab VFQ."

## What this adds

Built-in formats ship for the common French audio tags and are available immediately, with no seeding step:

| Format | Matches | Meaning |
|---|---|---|
| VFF | `VFF`, `TRUEFRENCH` | France French dub |
| VF2 | `VF2` | Second French dub, usually a France redub |
| VFI | `VFI` | International French dub, produced in France |
| VFQ | `VFQ`, `VQ` | Quebec French dub |
| MULTI | `MULTI` | Multiple audio tracks |
| VOSTFR | `VOSTFR` | Original audio with French subtitles, not a dub |

They start unassigned, so installing this changes nothing until an operator assigns a score.

To reproduce the motivating request: set VFF and VF2 to 100, MULTI to 50, and mark VFQ reject. A VFQ release is then dropped before ranking and appears in Activity as `custom_format: VFQ`.

Admin > Custom Formats owns the definitions. Score assignment lives in the quality profile editor, since what a format is worth is a property of the profile, not the format.

## Design decisions worth reviewing

**Built-ins live in code, overridable by a DB row.** Definitions come from a compile-time manifest in `priv/custom_formats/`, mirroring how `ReleaseParser.Vocabulary` loads `priv/release_parser/*.exs`. Editing a built-in writes an override row sharing its slug; Reset deletes that row. This means a later release can tighten a regex and every operator who has not edited that format gets the fix, which a seeded-rows approach cannot do without either clobbering user edits or never reaching them.

**Format score is its own sort tier, not part of the composite score.** The sort key goes from `{quality_index, -score}` to `{quality_index, -custom_format_score, -score}`. Resolution preference stays primary, so a format score can never promote a 720p release over a 1080p one. Within a tier, format score outranks seeders and size. Folding it into the 0-100 composite instead would have forced operators to calibrate format scores against seeder counts.

**Scores live in a join table, not in `quality_standards`.** `quality_standards` uses `JsonAtomMapType`, which calls `String.to_atom/1` on every key on load. Format slugs are user-authored, so keying a map by them would atomize user input on every profile load.

**Matching uses `:re` directly, not `Regex`.** Patterns are operator-authored, so a catastrophic one could otherwise backtrack until an Oban job dies. `:re.run/3` accepts `{:match_limit, 10_000}`, which `Regex.match?/2` does not expose. With `:report_errors`, exhausting the limit surfaces as `{:error, :match_limit}` and is logged rather than being indistinguishable from a genuine miss. Verified: `(a+)+$` against an adversarial input returns `:nomatch` immediately instead of hanging.

**`patterns` is declared `{:array, :string}` in the migration.** SQLite stores an array column as text regardless of what the migration says, so declaring it `:text` passes locally and breaks on PostgreSQL. Four columns in this repo were created that way and needed `20260223100000_fix_array_columns_for_postgres.exs` to repair. Confirmed on a live PostgreSQL database that the column is `ARRAY` / `_varchar`.

## Testing

- `mix precommit` on SQLite: 6770 tests, 0 failures. Credo, format, and compile clean.
- PostgreSQL pass over `settings/`, `indexers/`, and both admin LiveView suites: 1144 tests, 0 failures.
- Coverage includes the adversarial cases that motivate regex over substring matching: `VQ` must not match a release group containing those letters, and `MULTI` must not match the bare string `MULT`.
- One test per `RankingOptions.build/1` call site. There are six, and a forgotten one would silently make formats inert for that search path, so `build/1` also logs a warning when it receives a profile with no `:custom_formats` key.

## Not included

Custom formats apply at grab time only. A file already imported is never re-evaluated, so an existing VFQ file is not automatically replaced by a VFF release; that needs a delete and re-search. Closing this later needs a per-file score column, a library backfill, and a change to the cutoff comparison. `CustomFormats.score_title/2` is a pure function over a string specifically so that work can reuse it unchanged.

The existing `blocked_release_tokens` config and the `preferred_tags` option are untouched. Worth noting that `preferred_tags` and its `tag_bonus` are dead today: nothing populates them, so the bonus is always `0.0`. Custom formats supersede that path, but removing it is a separate change.
