### PR TITLE
fix(media): stack poster quality and playback badges instead of overlapping

### DIFF
--- a/lib/mydia_web/components/core_components.ex
+++ b/lib/mydia_web/components/core_components.ex
@@ -1068,6 +1068,61 @@ defmodule MydiaWeb.CoreComponents do
   end
 
   @doc """
+  Renders the badge stack overlaid on a media poster's top-right corner.
+
+  Owns that corner so playback state and quality cannot collide. Both badges
+  live in one flex column instead of each independently claiming
+  `absolute top-2 right-2`.
+
+  Renders nothing when neither a playback badge nor a quality badge applies,
+  so no empty positioned container is emitted.
+
+  ## Examples
+
+      <.poster_badges id="poster-badges-1" progress={@progress} quality="1080p" />
+  """
+  attr :id, :string, default: nil, doc: "DOM id for the container"
+  attr :progress, :map, default: nil, doc: "The progress struct, or nil"
+  attr :quality, :string, default: nil, doc: "Quality resolution string, or nil"
+  attr :class, :string, default: "", doc: "Additional CSS classes"
+
+  def poster_badges(assigns) do
+    ~H"""
+    <div
+      :if={playback_badge?(@progress) or @quality != nil}
+      id={@id}
+      class={["absolute top-2 right-2 z-10 flex flex-col items-end gap-1", @class]}
+    >
+      <span :if={continue_badge?(@progress)} class="badge badge-primary badge-sm shadow-md">
+        Continue
+      </span>
+
+      <span
+        :if={watched_badge?(@progress)}
+        class="badge badge-success badge-sm shadow-md gap-1"
+      >
+        <.icon name="hero-check" class="w-3 h-3" /> Watched
+      </span>
+
+      <span :if={@quality} class="badge badge-neutral badge-sm shadow-md">{@quality}</span>
+    </div>
+    """
+  end
+
+  # The container gate and the two badge branches are derived from the same
+  # predicates, so they can never disagree and leave an empty container.
+  defp continue_badge?(%{watched: false, completion_percentage: pct}) when is_number(pct),
+    do: pct > 0
+
+  defp continue_badge?(_), do: false
+
+  defp watched_badge?(%{watched: true}), do: true
+  defp watched_badge?(_), do: false
+
+  defp playback_badge?(progress),
+    do: continue_badge?(progress) or watched_badge?(progress)
+
+  @doc """
   Formats time remaining from progress data.
 
   Returns a human-readable string like "1h 23m left" or "5m left".

--- a/lib/mydia_web/components/core_components.ex
+++ b/lib/mydia_web/components/core_components.ex
@@ -1039,35 +1039,6 @@ defmodule MydiaWeb.CoreComponents do
   end
 
   @doc """
-  Renders a progress badge for media cards.
-
-  Shows "Continue Watching" for in-progress content or "Watched" for completed content.
-
-  ## Examples
-
-      <.progress_badge progress={@progress} />
-  """
-  attr :progress, :map, required: true, doc: "The progress struct"
-  attr :class, :string, default: "", doc: "Additional CSS classes"
-
-  def progress_badge(assigns) do
-    ~H"""
-    <div :if={@progress} class={["absolute top-2 right-2 z-10", @class]}>
-      <span
-        :if={@progress.completion_percentage > 0 && !@progress.watched}
-        class="badge badge-primary badge-sm shadow-md"
-      >
-        Continue
-      </span>
-
-      <span :if={@progress.watched} class="badge badge-success badge-sm shadow-md gap-1">
-        <.icon name="hero-check" class="w-3 h-3" /> Watched
-      </span>
-    </div>
-    """
-  end
-
-  @doc """
   Renders the badge stack overlaid on a media poster's top-right corner.
 
   Owns that corner so playback state and quality cannot collide. Both badges

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -10,7 +10,7 @@ defmodule MydiaWeb.LibraryComponents do
   alias Phoenix.LiveView.JS
 
   # Import only what we need to avoid circular dependency
-  import MydiaWeb.CoreComponents, only: [icon: 1, progress_bar: 1, progress_badge: 1, modal: 1]
+  import MydiaWeb.CoreComponents, only: [icon: 1, progress_bar: 1, poster_badges: 1, modal: 1]
 
   use Phoenix.VerifiedRoutes,
     endpoint: MydiaWeb.Endpoint,
@@ -200,13 +200,12 @@ defmodule MydiaWeb.LibraryComponents do
             />
             <%!-- Progress indicators --%>
             <.progress_bar :if={@progress} progress={@progress} />
-            <.progress_badge :if={@progress} progress={@progress} />
-            <%!-- Quality badge --%>
-            <%= if @quality do %>
-              <div class="badge badge-primary badge-sm absolute top-2 right-2 z-10 shadow-md">
-                {@quality}
-              </div>
-            <% end %>
+            <%!-- Playback status and quality, stacked in one top-right container --%>
+            <.poster_badges
+              id={"poster-badges-#{@item.id}"}
+              progress={@progress}
+              quality={@quality}
+            />
             <%!-- Custom badges slot --%>
             {render_slot(@badges)}
           </figure>

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -369,13 +369,13 @@
                   <%!-- Progress indicators --%>
                   <% progress = get_progress(item) %>
                   <.progress_bar :if={progress} progress={progress} class="hide-on-select" />
-                  <.progress_badge :if={progress} progress={progress} class="hide-on-select" />
-                  <%!-- Quality badge --%>
-                  <%= if quality = get_quality_badge(item) do %>
-                    <div class="badge badge-primary badge-sm absolute top-2 right-2 z-10 shadow-md hide-on-select">
-                      {quality}
-                    </div>
-                  <% end %>
+                  <%!-- Playback status and quality, stacked in one top-right container --%>
+                  <.poster_badges
+                    id={"poster-badges-#{item.id}"}
+                    progress={progress}
+                    quality={get_quality_badge(item)}
+                    class="hide-on-select"
+                  />
                 </figure>
               </.link>
               <div class="card-body p-3">

--- a/test/mydia_web/live/media_live/index_test.exs
+++ b/test/mydia_web/live/media_live/index_test.exs
@@ -817,4 +817,118 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       assert Mydia.Repo.all(Oban.Job) == []
     end
   end
+
+  describe "poster badge stack" do
+    setup %{conn: conn} do
+      admin = admin_user_fixture()
+      %{conn: log_in_user(conn, admin), admin: admin}
+    end
+
+    test "paused movie stacks Continue and quality in one container", %{
+      conn: conn,
+      admin: admin
+    } do
+      movie = media_item_fixture(%{title: "Paused Movie", type: "movie"})
+      media_file_fixture(%{media_item_id: movie.id, resolution: "1080p"})
+
+      # 1800/7200 = 25%, which is below the 90% auto-watched threshold.
+      {:ok, progress} =
+        Mydia.Playback.save_progress(admin.id, [media_item_id: movie.id], %{
+          position_seconds: 1800,
+          duration_seconds: 7200
+        })
+
+      assert progress.completion_percentage == 25.0
+      refute progress.watched
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      container = "#poster-badges-#{movie.id}"
+
+      assert has_element?(view, container)
+      assert has_element?(view, "#{container} .badge-primary", "Continue")
+      assert has_element?(view, "#{container} .badge-neutral", "1080p")
+
+      # The actual regression: only one element may claim the poster's
+      # top-right anchor. Two would render on top of each other.
+      anchors =
+        view
+        |> render()
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query("#grid-item-#{movie.id} .absolute.top-2.right-2")
+        |> LazyHTML.attribute("class")
+
+      assert length(anchors) == 1
+    end
+
+    test "finished movie stacks Watched and quality in one container", %{
+      conn: conn,
+      admin: admin
+    } do
+      movie = media_item_fixture(%{title: "Finished Movie", type: "movie"})
+      media_file_fixture(%{media_item_id: movie.id, resolution: "2160p"})
+
+      # 7000/7200 = 97.2%, which crosses the 90% auto-watched threshold.
+      {:ok, progress} =
+        Mydia.Playback.save_progress(admin.id, [media_item_id: movie.id], %{
+          position_seconds: 7000,
+          duration_seconds: 7200
+        })
+
+      assert progress.watched
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      container = "#poster-badges-#{movie.id}"
+
+      assert has_element?(view, container)
+      assert has_element?(view, "#{container} .badge-success", "Watched")
+      assert has_element?(view, "#{container} .badge-neutral", "2160p")
+
+      anchors =
+        view
+        |> render()
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query("#grid-item-#{movie.id} .absolute.top-2.right-2")
+        |> LazyHTML.attribute("class")
+
+      assert length(anchors) == 1
+    end
+
+    test "movie with quality but no progress still renders the quality badge", %{conn: conn} do
+      movie = media_item_fixture(%{title: "Unwatched Movie", type: "movie"})
+      media_file_fixture(%{media_item_id: movie.id, resolution: "720p"})
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      container = "#poster-badges-#{movie.id}"
+
+      assert has_element?(view, container)
+      assert has_element?(view, "#{container} .badge-neutral", "720p")
+      refute has_element?(view, "#{container} .badge-primary")
+      refute has_element?(view, "#{container} .badge-success")
+    end
+
+    test "movie with zero progress and no quality renders no badge container", %{
+      conn: conn,
+      admin: admin
+    } do
+      movie = media_item_fixture(%{title: "Barely Started Movie", type: "movie"})
+
+      {:ok, progress} =
+        Mydia.Playback.save_progress(admin.id, [media_item_id: movie.id], %{
+          position_seconds: 0,
+          duration_seconds: 7200
+        })
+
+      assert progress.completion_percentage == 0.0
+      refute progress.watched
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      # The card renders, so the refute below is not vacuous.
+      assert has_element?(view, "#grid-item-#{movie.id}")
+      refute has_element?(view, "#poster-badges-#{movie.id}")
+    end
+  end
 end


### PR DESCRIPTION
## Problem

On the media grid (`/movies` and `/tv`), the quality badge in a poster's top-right corner renders on top of the Continue/Watched playback badge. Any item with both playback progress and a known file resolution shows two badges occupying the same pixels.

Two absolutely positioned children of the poster `<figure>` claimed the same anchor, and neither knew the other existed:

| Element | Location | Classes |
| --- | --- | --- |
| Playback status badge | `core_components.ex:1055` (`progress_badge/1`) | `absolute top-2 right-2 z-10` |
| Quality badge | `media_live/index.html.heex:375` (inline) | `absolute top-2 right-2 z-10` |

`progress_badge/1` renders "Continue" for a paused item and "Watched" for a finished one, which is exactly the affected set. `MediaLive.Index` backs both `/movies` and `/tv`, so the bug appeared on both.

## Fix

Give the corner a single owner. A new `poster_badges/1` component in `core_components.ex` renders the whole stack in one `flex flex-col items-end gap-1` container, so no two elements can independently claim the anchor.

`progress_badge/1` is deleted. Both of its call sites migrate, and leaving it in place would keep a second way to claim the same corner.

The quality badge changes from `badge-primary` to `badge-neutral`. Stacked under a primary-colored "Continue" badge, two primary chips read as one block; neutral keeps the playback state as the element that draws the eye. This also changes the quality badge color on cards with no playback progress, which is intended.

### Container gate

The container renders only when at least one badge inside it would render. Gating on `@progress != nil` is not sufficient: `get_progress/1` returns the raw progress struct, so a record at `completion_percentage: 0.0, watched: false` is reachable and satisfies neither badge condition, which would emit an empty positioned container. Three private predicates (`continue_badge?/1`, `watched_badge?/1`, `playback_badge?/1`) drive both the container gate and the two playback branches, so they cannot disagree.

### Call sites

- `media_live/index.html.heex` grid card, covering `/movies` and `/tv`. Keeps `hide-on-select` on the container so badges still hide in selection mode.
- `library_components.ex` `library_card/1`, which carries the identical collision. It has no call sites today, so this is a correctness fix for a component that is not currently rendered. Deleting it outright is a separate decision and out of scope here.

`progress_bar/1` is untouched. It is the 1px strip at `bottom-0` and does not conflict with the corner.

Not changed: `discover_components.ex:46`, `collection_components.ex:123`, and the music/books/adult grids all place content at `top-2 right-2` but render no playback badge, so none of them collide. The list-row view lays badges out inline and is unaffected.

## Testing

Four tests in `test/mydia_web/live/media_live/index_test.exs`:

- Paused movie (1800/7200 = 25%) stacks Continue and quality in one container
- Finished movie (7000/7200 = 97.2%, crossing the auto-watched threshold) stacks Watched and quality
- Quality with no progress still renders the quality badge, so the container is not gated on progress alone
- Zero progress with no quality renders no container at all

Note that `completion_percentage` and `watched` are derived in the changeset via `put_change`, so the tests control them through `position_seconds` and `duration_seconds` rather than setting them directly.

The first two tests also assert the regression directly: exactly one element matches `#grid-item-<id> .absolute.top-2.right-2`. Two would mean the badges are back on top of each other.

## Verification

- `./dev mix test test/mydia_web/live/media_live/index_test.exs`: 31 tests, 0 failures, up from 27 on master
- `./dev mix precommit`: 6781 tests, 0 failures, with Compile, Format, Credo, Unused deps, and Database all green
- `grep -rn "progress_badge" lib/ test/` returns nothing

Not yet checked in a browser. The tests prove the structural fix, but how the stacked pair reads on a narrow poster at the 6-column xl breakpoint is worth a visual glance.
