### PR TITLE
feat(search): link release rows to the indexer's page

### DIFF
--- a/lib/mydia/indexers/search_result.ex
+++ b/lib/mydia/indexers/search_result.ex
@@ -106,6 +106,8 @@ defmodule Mydia.Indexers.SearchResult do
     :guid
   ]
 
+  @info_url_schemes ~w(http https)
+
   @doc """
   Creates a new search result with default values.
 
@@ -209,7 +211,59 @@ defmodule Mydia.Indexers.SearchResult do
     end
   end
 
+  @doc """
+  Returns a URL safe to render as a link to the release's page on the indexer.
+
+  Returns `nil` unless `:info_url` is an absolute `http`/`https` URL with a host
+  that differs from `:download_url`.
+
+  Indexers supply this value, and Cardigann definitions are fetched from an
+  external repository, so the scheme allowlist is a security boundary: HEEx does
+  not validate URL schemes, and a `javascript:` string would otherwise render as
+  a live script URL. The `:download_url` check exists because Prowlarr and
+  Jackett fall back to the torznab `<guid>`, which on some indexers is the
+  `.torrent` link rather than a details page.
+
+  ## Examples
+
+      iex> result = %SearchResult{title: "T", size: 1, seeders: 1, leechers: 1,
+      ...>   download_url: "magnet:?xt=urn:btih:abc", indexer: "X",
+      ...>   info_url: "https://tracker.example/details/42"}
+      iex> SearchResult.info_page_url(result)
+      "https://tracker.example/details/42"
+
+      iex> result = %SearchResult{title: "T", size: 1, seeders: 1, leechers: 1,
+      ...>   download_url: "magnet:?xt=urn:btih:abc", indexer: "X",
+      ...>   info_url: "javascript:alert(1)"}
+      iex> SearchResult.info_page_url(result)
+      nil
+  """
+  @spec info_page_url(t()) :: String.t() | nil
+  def info_page_url(%__MODULE__{info_url: info_url, download_url: download_url})
+      when is_binary(info_url) do
+    trimmed = String.trim(info_url)
+
+    cond do
+      trimmed == "" -> nil
+      trimmed == download_url -> nil
+      not linkable_scheme?(trimmed) -> nil
+      true -> trimmed
+    end
+  end
+
+  def info_page_url(%__MODULE__{}), do: nil
+
   # Private helpers
+
+  defp linkable_scheme?(url) do
+    case URI.parse(url) do
+      %URI{scheme: scheme, host: host} when scheme in @info_url_schemes ->
+        is_binary(host) and host != ""
+
+      _ ->
+        false
+    end
+  end
 
   defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
 

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -882,7 +882,11 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                         <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" />
                       </a>
                     <% else %>
-                      <span class="badge badge-outline badge-sm">{result.indexer}</span>
+                      <%!-- No usable URL: keep the pre-existing xs-screen hiding, since a
+                           non-actionable badge earns no room in a dense mobile row. --%>
+                      <span class="badge badge-outline badge-sm hidden sm:inline-flex">
+                        {result.indexer}
+                      </span>
                     <% end %>
                   </div>
                   <%= if reason = Map.get(result, :grab_failed) do %>

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -10,6 +10,8 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   import MydiaWeb.Formatters, only: [format_progress: 1]
   import MydiaWeb.MediaLive.Show.SearchHelpers
 
+  alias Mydia.Indexers.SearchResult
+
   @doc """
   Delete confirmation modal for removing media item from library.
   Allows user to choose whether to delete files from disk.
@@ -866,10 +868,22 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                       <.icon name="hero-arrow-up" class="w-3 h-3 mr-0.5" />
                       {result.seeders}
                     </span>
-                    <%!-- Indexer badge (visible on larger screens) --%>
-                    <span class="badge badge-outline badge-sm hidden sm:inline-flex">
-                      {result.indexer}
-                    </span>
+                    <%!-- Indexer badge, linking to the release's tracker page when usable --%>
+                    <% info_page_url = SearchResult.info_page_url(result) %>
+                    <%= if info_page_url do %>
+                      <a
+                        href={info_page_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="badge badge-outline badge-sm gap-1 hover:border-primary hover:text-primary transition-colors"
+                        title={"View this release on #{result.indexer}"}
+                      >
+                        {result.indexer}
+                        <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" />
+                      </a>
+                    <% else %>
+                      <span class="badge badge-outline badge-sm">{result.indexer}</span>
+                    <% end %>
                   </div>
                   <%= if reason = Map.get(result, :grab_failed) do %>
                     <div class="text-xs text-error mt-1 line-clamp-2">{reason}</div>

--- a/lib/mydia_web/live/search_live/index.html.heex
+++ b/lib/mydia_web/live/search_live/index.html.heex
@@ -346,7 +346,21 @@
                       <span class={["badge badge-sm", library_type_badge_class(lib_type)]}>
                         {library_type_label(lib_type)}
                       </span>
-                      <span class="badge badge-outline badge-sm">{result.indexer}</span>
+                      <% info_page_url = SearchResult.info_page_url(result) %>
+                      <%= if info_page_url do %>
+                        <a
+                          href={info_page_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="badge badge-outline badge-sm gap-1 hover:border-primary hover:text-primary transition-colors"
+                          title={"View this release on #{result.indexer}"}
+                        >
+                          {result.indexer}
+                          <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" />
+                        </a>
+                      <% else %>
+                        <span class="badge badge-outline badge-sm">{result.indexer}</span>
+                      <% end %>
                     </div>
                     <%= if result.published_at do %>
                       <span class="text-xs text-base-content/60">
@@ -491,7 +505,21 @@
             <div class="stat bg-base-200 rounded-lg p-4">
               <div class="stat-title text-xs">Source</div>
               <div class="stat-value text-base">
-                <span class="badge badge-outline">{@selected_result.indexer}</span>
+                <% info_page_url = SearchResult.info_page_url(@selected_result) %>
+                <%= if info_page_url do %>
+                  <a
+                    href={info_page_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="badge badge-outline gap-1 hover:border-primary hover:text-primary transition-colors"
+                    title={"View this release on #{@selected_result.indexer}"}
+                  >
+                    {@selected_result.indexer}
+                    <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" />
+                  </a>
+                <% else %>
+                  <span class="badge badge-outline">{@selected_result.indexer}</span>
+                <% end %>
               </div>
             </div>
           </div>

--- a/test/mydia/indexers/search_result_test.exs
+++ b/test/mydia/indexers/search_result_test.exs
@@ -3,6 +3,19 @@ defmodule Mydia.Indexers.SearchResultTest do
 
   alias Mydia.Indexers.SearchResult
 
+  defp search_result(attrs) do
+    defaults = %{
+      title: "Test.Release.2024.1080p.BluRay.x264-GROUP",
+      size: 4_000_000_000,
+      seeders: 25,
+      leechers: 5,
+      download_url: "magnet:?xt=urn:btih:abc123",
+      indexer: "Test Indexer"
+    }
+
+    struct!(SearchResult, Map.merge(defaults, Map.new(attrs)))
+  end
+
   describe "new/1" do
     test "creates search result with required fields" do
       result =
@@ -299,6 +312,91 @@ defmodule Mydia.Indexers.SearchResultTest do
       }
 
       assert SearchResult.quality_description(result) == "720p x264"
+    end
+  end
+
+  describe "info_page_url/1" do
+    test "returns an https URL unchanged" do
+      result = search_result(info_url: "https://tracker.example/details/42")
+
+      assert SearchResult.info_page_url(result) == "https://tracker.example/details/42"
+    end
+
+    test "returns an http URL unchanged" do
+      result = search_result(info_url: "http://tracker.example/details/42")
+
+      assert SearchResult.info_page_url(result) == "http://tracker.example/details/42"
+    end
+
+    test "trims surrounding whitespace" do
+      result = search_result(info_url: "  https://tracker.example/details/42\n")
+
+      assert SearchResult.info_page_url(result) == "https://tracker.example/details/42"
+    end
+
+    test "rejects a javascript: URL" do
+      result = search_result(info_url: "javascript:alert(1)")
+
+      assert SearchResult.info_page_url(result) == nil
+    end
+
+    test "rejects a data: URL" do
+      result = search_result(info_url: "data:text/html,<script>alert(1)</script>")
+
+      assert SearchResult.info_page_url(result) == nil
+    end
+
+    test "rejects a protocol-relative URL" do
+      result = search_result(info_url: "//evil.example/details/42")
+
+      assert SearchResult.info_page_url(result) == nil
+    end
+
+    test "rejects a relative path" do
+      result = search_result(info_url: "/details/42")
+
+      assert SearchResult.info_page_url(result) == nil
+    end
+
+    test "rejects a magnet link" do
+      result = search_result(info_url: "magnet:?xt=urn:btih:def456")
+
+      assert SearchResult.info_page_url(result) == nil
+    end
+
+    test "rejects an http URL with no host" do
+      result = search_result(info_url: "http://")
+
+      assert SearchResult.info_page_url(result) == nil
+    end
+
+    test "returns nil when info_url is nil" do
+      result = search_result(info_url: nil)
+
+      assert SearchResult.info_page_url(result) == nil
+    end
+
+    test "returns nil for an empty or whitespace-only info_url" do
+      assert SearchResult.info_page_url(search_result(info_url: "")) == nil
+      assert SearchResult.info_page_url(search_result(info_url: "   ")) == nil
+    end
+
+    test "returns nil when info_url is identical to download_url" do
+      result =
+        search_result(
+          download_url: "https://tracker.example/download/42.torrent",
+          info_url: "https://tracker.example/download/42.torrent"
+        )
+
+      assert SearchResult.info_page_url(result) == nil
+    end
+
+    test "still resolves for a struct carrying the stream_position key" do
+      streamed =
+        search_result(info_url: "https://tracker.example/details/42")
+        |> Map.put(:stream_position, 3)
+
+      assert SearchResult.info_page_url(streamed) == "https://tracker.example/details/42"
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/manual_search_info_link_test.exs
+++ b/test/mydia_web/live/media_live/show/manual_search_info_link_test.exs
@@ -73,6 +73,23 @@ defmodule MydiaWeb.MediaLive.Show.ManualSearchInfoLinkTest do
     refute has_element?(view, "#manual-search-results a[href]")
   end
 
+  test "the no-URL fallback badge keeps its pre-existing xs-screen hiding", %{conn: conn} do
+    view = open_manual_search(conn, [result_with_info_url(nil)])
+
+    # The badge was `hidden sm:inline-flex` before this feature existed. A
+    # non-actionable badge should stay hidden on xs; only the linked one earns
+    # room in a dense mobile row.
+    assert has_element?(view, "#manual-search-results span.badge.hidden.sm\\:inline-flex")
+  end
+
+  test "the linked badge is visible at every breakpoint", %{conn: conn} do
+    view = open_manual_search(conn, [result_with_info_url(@info_url)])
+
+    # Hiding the link below `sm` would make the tracker page unreachable on a
+    # phone, which is the gap this feature exists to close.
+    refute has_element?(view, "#manual-search-results a.hidden")
+  end
+
   test "refuses to render a javascript: info_url as a link", %{conn: conn} do
     view = open_manual_search(conn, [result_with_info_url("javascript:alert(1)")])
 

--- a/test/mydia_web/live/media_live/show/manual_search_info_link_test.exs
+++ b/test/mydia_web/live/media_live/show/manual_search_info_link_test.exs
@@ -1,0 +1,82 @@
+defmodule MydiaWeb.MediaLive.Show.ManualSearchInfoLinkTest do
+  # async: false — disables and creates indexer configs, which is process-wide
+  # state (same reasoning as ManualSearchQualityGateTest).
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.IndexerMock
+  alias Mydia.Settings
+
+  @info_url "https://tracker.example/details/42"
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin)}
+  end
+
+  # NOTE: movie_result/1 builds a fixed map and does NOT forward an :info_url
+  # key, so `movie_result(%{info_url: ...})` silently does nothing and the
+  # IndexerMock default ("https://example.com") applies. The key has to be put
+  # on the returned map, which is what build_search_result/1 reads.
+  defp result_with_info_url(info_url) do
+    IndexerMock.movie_result(%{title: "The Matrix", year: 1999})
+    |> Map.put(:info_url, info_url)
+  end
+
+  defp open_manual_search(conn, results) do
+    Settings.list_indexer_configs()
+    |> Enum.reject(&Settings.runtime_config?/1)
+    |> Enum.each(&Settings.update_indexer_config(&1, %{enabled: false}))
+
+    bypass = Bypass.open()
+    IndexerMock.mock_prowlarr_all(bypass, results: results)
+
+    {:ok, _indexer} =
+      Settings.create_indexer_config(%{
+        name: "Test Movie Indexer",
+        type: :prowlarr,
+        base_url: "http://localhost:#{bypass.port}",
+        api_key: "test-key",
+        enabled: true
+      })
+
+    movie = media_item_fixture(%{type: "movie", title: "The Matrix", year: 1999})
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+
+    render_click(view, "manual_search", %{})
+    render_async(view)
+
+    assert has_element?(view, "#manual-search-results")
+
+    view
+  end
+
+  test "links the indexer badge to the release page when info_url is usable", %{conn: conn} do
+    view = open_manual_search(conn, [result_with_info_url(@info_url)])
+
+    assert has_element?(view, ~s(#manual-search-results a[href="#{@info_url}"]))
+
+    assert has_element?(
+             view,
+             ~s(#manual-search-results a[target="_blank"][rel="noopener noreferrer"])
+           )
+  end
+
+  test "renders no link when the indexer supplies no info_url", %{conn: conn} do
+    view = open_manual_search(conn, [result_with_info_url(nil)])
+
+    refute has_element?(view, "#manual-search-results a[href]")
+  end
+
+  test "refuses to render a javascript: info_url as a link", %{conn: conn} do
+    view = open_manual_search(conn, [result_with_info_url("javascript:alert(1)")])
+
+    refute has_element?(view, "#manual-search-results a[href]")
+    refute render(view) =~ "javascript:alert(1)"
+  end
+end

--- a/test/mydia_web/live/search_live/info_link_test.exs
+++ b/test/mydia_web/live/search_live/info_link_test.exs
@@ -1,0 +1,92 @@
+defmodule MydiaWeb.SearchLive.InfoLinkTest do
+  # async: false — disables and creates indexer configs, which is process-wide
+  # state (same reasoning as ManualSearchQualityGateTest).
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.IndexerMock
+  alias Mydia.Settings
+
+  @info_url "https://tracker.example/details/42"
+  @magnet "magnet:?xt=urn:btih:" <> String.duplicate("a", 40)
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin)}
+  end
+
+  # movie_result/1 randomizes :magnet_url and ignores :info_url, so both are
+  # overridden on the returned map, which is what build_search_result/1 reads.
+  # The predictable magnet is needed to trigger "show_detail", whose handler
+  # looks the result up by download_url in search_results_map.
+  defp result_with_info_url(info_url) do
+    IndexerMock.movie_result(%{title: "The Matrix", year: 1999})
+    |> Map.put(:info_url, info_url)
+    |> Map.put(:magnet_url, @magnet)
+  end
+
+  defp search_page(conn, results) do
+    Settings.list_indexer_configs()
+    |> Enum.reject(&Settings.runtime_config?/1)
+    |> Enum.each(&Settings.update_indexer_config(&1, %{enabled: false}))
+
+    bypass = Bypass.open()
+    IndexerMock.mock_prowlarr_all(bypass, results: results)
+
+    {:ok, _indexer} =
+      Settings.create_indexer_config(%{
+        name: "Test Movie Indexer",
+        type: :prowlarr,
+        base_url: "http://localhost:#{bypass.port}",
+        api_key: "test-key",
+        enabled: true
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+
+    view
+    |> form("#indexer-search-form", %{"search" => "The Matrix"})
+    |> render_submit()
+
+    render_async(view)
+
+    assert has_element?(view, "#search-results")
+
+    view
+  end
+
+  test "links the indexer badge in the Source column when info_url is usable", %{conn: conn} do
+    view = search_page(conn, [result_with_info_url(@info_url)])
+
+    assert has_element?(view, ~s(#search-results a[href="#{@info_url}"]))
+
+    assert has_element?(
+             view,
+             ~s(#search-results a[target="_blank"][rel="noopener noreferrer"])
+           )
+  end
+
+  test "renders no link in the Source column when info_url is missing", %{conn: conn} do
+    view = search_page(conn, [result_with_info_url(nil)])
+
+    refute has_element?(view, "#search-results a[href]")
+  end
+
+  test "refuses to render a javascript: info_url as a link", %{conn: conn} do
+    view = search_page(conn, [result_with_info_url("javascript:alert(1)")])
+
+    refute has_element?(view, "#search-results a[href]")
+    refute render(view) =~ "javascript:alert(1)"
+  end
+
+  test "links the Source badge in the detail modal", %{conn: conn} do
+    view = search_page(conn, [result_with_info_url(@info_url)])
+
+    render_click(view, "show_detail", %{"download_url" => @magnet})
+
+    assert has_element?(view, ~s(a[href="#{@info_url}"]))
+  end
+end


### PR DESCRIPTION
Adds a click-through from a release row to that release's page on the tracker.

Comes from user feedback on the manual search interface:

> Mydia's manual search interface is hands down the best I've used. It's user-friendly, visually polished, and the quality sort option is exceptionally useful. The only enhancement I'd suggest is adding the ability to click through directly to the torrent page.

## What changed

The indexer badge becomes a link when the release has a usable details URL. It keeps its existing look, gains an external-link glyph and a hover treatment, and opens in a new tab. When there's no usable URL it renders exactly as it does today, so indexers that supply nothing look unchanged.

Three surfaces:

- Manual search modal (`media_live/show/modals.ex`)
- Global search page, Source column (`search_live/index.html.heex`)
- Global search page, detail modal. That Source column is `hidden lg:table-cell`, so without this there'd be no click-through at all on phone or tablet.

The detail modal shows the indexer twice (a Source stat badge and an `Indexer:` row). Only the badge is linked, so the same link doesn't appear twice.

## Why this is mostly a template change

`SearchResult` has carried an `:info_url` all along, populated by all four adapter paths: Prowlarr (`infoUrl || guid`), Jackett and NZBHydra2 (`comments || guid`), and the Cardigann parser (`details`, resolved against the indexer base URL). It survived filtering, sorting, and streaming to the browser, and nothing ever rendered it. No migration, no adapter changes, no new dependency.

## The guard

`SearchResult.info_page_url/1` returns a linkable URL or `nil`. It requires both an allowed scheme and a non-empty host, which rejects `javascript:`, `data:`, protocol-relative, and relative URLs in one rule.

This is a security boundary, not a tidiness check. `info_url` is indexer-supplied, and Cardigann definitions are fetched from an external repo by `DefinitionSync`. HEEx does not validate `href` schemes, and `javascript:alert(1)` contains no HTML special characters, so escaping passes it straight through into a live script URL. There's a dedicated regression test asserting such a URL produces no anchor.

It also returns `nil` when `info_url` is byte-identical to `download_url`. Prowlarr and Jackett fall back to the torznab `<guid>`, which on some indexers is the `.torrent` link; linking it would make the badge silently start a download.

## Known gap

If an indexer returns a magnet for download and an http `.torrent` link as its guid, the two differ, both pass the scheme check, and the badge would start a download. Neither guard catches this. It needs a real-world report to characterize, and guessing at a heuristic now (extension sniffing, path comparison) would be speculative.

## Testing

- 13 unit tests on the guard: http/https pass, whitespace trimming, rejection of `javascript:`, `data:`, protocol-relative, relative, `magnet:`, and hostless URLs, nil and blank handling, duplicate suppression, and one asserting it still resolves for a struct carrying the `:stream_position` key that `prepare_for_stream/1` adds.
- LiveView tests per surface, asserting the anchor's presence and `href` when a URL is usable and its absence when it isn't, keyed off element selectors.
- The search page had no indexer-search harness at all (its only test file had those tests `@tag :skip` with a note that mocking was never implemented), so this adds one.

`mix precommit` green locally: 6797 tests, 0 failures, plus format and `credo --strict`.
