### PR TITLE
docs(changelog): add v0.13.1 release notes

### DIFF
--- a/priv/changelog/0.13.1.md
+++ b/priv/changelog/0.13.1.md
@@ -1,125 +1,44 @@
-A patch release on top of `v0.13.0`. Most of it is player fixes, but two additions are worth knowing about before you upgrade: Custom Formats, which adds one migration, and optional seedbox support. Neither changes behaviour until you configure it.
+A patch release on top of `v0.13.0`. Custom Formats brings the only migration, and it and seedbox support are both inert until you configure them.
 
 ## Server
 
-### Custom Formats
-
-Named, reusable sets of release-title regexes that a quality profile can score or reject (#389). This closes the gap where Mydia had no way to distinguish release variants that differ only by a title tag.
-
-The motivating case is French audio. A Quebec dub (`VFQ`) and a France dub (`VFF`) of the same film at the same resolution were identical to the ranker, so which one got grabbed came down to seeder count.
-
-- Built-in formats ship for the common French audio tags and are available immediately: VFF, VF2, VFI, VFQ, MULTI and VOSTFR. They start unassigned, so installing this changes nothing until you assign a score.
-- Admin → Custom Formats owns the definitions. Score assignment lives in the quality profile editor, since what a format is worth is a property of the profile.
-- Built-ins come from a compile-time manifest. Editing one writes an override row sharing its slug, and Reset deletes that row, so a later release can tighten a built-in regex and reach every operator who has not edited it.
-- Format score is its own sort tier rather than part of the composite score. Resolution preference stays primary, so a format score can never promote a 720p release over a 1080p one.
-- Matching runs through `:re` with a match limit rather than `Regex`, so an operator-authored pattern that backtracks catastrophically returns a miss instead of hanging an Oban job.
-- Rejected releases appear in Activity with the format that dropped them.
-
-### Seedbox support
-
-Optional SFTP pull from a remote torrent client (#368). When a torrent finishes on the seedbox, Mydia pulls the completed files down to local storage and hands off to the existing import pipeline unchanged.
-
-- Works with the existing `qbittorrent`, `transmission`, `rqbit` and `rtorrent` client types. Configuration lives in the download client edit modal, with password or SSH-key auth and a Test SFTP Connection action.
-- Transport is Erlang/OTP's built-in `:ssh` and `:ssh_sftp`, so there is no new dependency, and the config lives in the existing `connection_settings` column, so there is no migration.
-- Handles single-file and directory transfers, size verification, resume from partial files, retry with backoff, and best-effort remote cleanup after a verified transfer.
-- Status interception sits in the one place every download client adapter's status already flows through, so none of the four adapters changed.
-
-Building the admin UI surfaced a bug class worth naming. Several places read a value out of `connection_settings` and compared it as a native boolean or integer, when a real form submission always produces a string. Five instances were found and fixed. The worst was the seedbox `enabled` check itself, which matched only the literal boolean `true`, so the feature would never have engaged for any config saved through the admin UI while passing every test that used real Elixir booleans.
-
-### Missing status on unmonitored items
-
-An unmonitored movie never showed a Missing badge and never appeared under the library's Missing filter (#392). Anyone who adds titles as a reminder and downloads them by hand saw an empty Missing list, which is the workflow that needs it most.
-
-`get_media_status/1` treated monitoring and availability as one axis and returned `:not_monitored` without ever looking at the files. A new `AvailabilityStatus` struct splits them: state answers whether you have it, monitored answers whether Mydia is trying to get it. Three branches were collapsing into `:not_monitored` and all three are fixed, including a monitored show whose episodes are all unmonitored, which reported "Not Monitored" despite the show being monitored.
-
-Unmonitored items render their real availability at reduced weight, so Missing reads as missing without lighting up a library of deliberately ignored titles. Episode rows on the show detail page get the same treatment, so a show card and its own episode table cannot disagree.
-
-### Search
-
-Release rows link through to the tracker's own page for that release (#391). The indexer badge becomes a link on the manual search modal, the global search page's Source column, and the search detail modal. `SearchResult` has carried an `info_url` all along, populated by all four adapter paths; nothing ever rendered it.
-
-The link is guarded. `info_url` is indexer-supplied and Cardigann definitions are fetched from an external repo, and HEEx does not validate `href` schemes, so `javascript:` and `data:` URLs would otherwise pass straight through escaping into a live script URL. The guard requires an allowed scheme and a non-empty host, and it also suppresses the link when `info_url` is byte-identical to the download URL, since Prowlarr and Jackett fall back to the torznab guid, which on some indexers is the `.torrent` link.
-
-### Web UI
-
-- On the movie and TV grids, the quality badge rendered on top of the Continue and Watched badges. Any item with both playback progress and a known resolution showed two badges in the same pixels. A single `poster_badges/1` component now owns that corner, and the quality badge moves from primary to neutral so the playback state stays the element that draws the eye (#390).
-- Metadata refresh honours an injected relay configuration instead of always reaching for the default, and per-episode translation fetches are bounded at 15 seconds rather than running unbounded (#383).
+- Custom Formats: named release-title regexes a quality profile can score or reject, with built-ins for the French audio tags (VFF, VF2, VFI, VFQ, MULTI, VOSTFR). They start unassigned, so ranking is unchanged until you assign a score. Format score is its own sort tier, so it can never promote a 720p release over a 1080p one. Grab time only, so imported files are not re-evaluated (#389)
+- Seedbox support: optional SFTP pull from a remote qBittorrent, Transmission, rqbit or rtorrent, with directory transfers, resume, retry and remote cleanup, handing off to the normal import. No new dependency and no migration (#368)
+- Unmonitored items report their real availability, so they can show Missing and match the Missing filter. Also fixes a monitored show whose episodes are all unmonitored reporting "Not Monitored" (#392)
+- Release rows link through to the tracker's page for that release, on manual search and both global search surfaces. Guarded against `javascript:` and `data:` URLs, and against linking a guid that is really the `.torrent` file (#391)
+- Poster quality badge no longer renders on top of the Continue and Watched badges on the movie and TV grids (#390)
+- Metadata refresh honours injected relay config, and per-episode translation fetches are bounded at 15s instead of running unbounded (#383)
 
 ## Player
 
-### Settings
+- Settings rebuilt: identity band, connection state on its own row, sign out in an Account section, version in the footer, and connection internals moved to a diagnostics screen. The Updates section is hidden on iOS where its actions were no-ops, and a preferences load failure no longer hides sign out (#381, #384)
+- Sidebar is one flat reorderable list where built-in destinations and user-created saved filters are the same kind of thing, with hide, edit and delete in the overflow menu. Continue Watching becomes a real destination. `favorites` and `unwatched` gain `category` and `sort` arguments (#386)
+- The library sort menu actually sorts now, and sort fields go from 4 to 11, adding duration, popularity, content rating, release date, last played, watch state and random. Fixes three ordering bugs: descending reversed tie groups, "date added" sorted by day of the month, and nil keys sorted inconsistently between fields (#377)
+- Stuck downloads are recoverable, with new `interrupted` and `stalled` statuses, recovery at launch and on app resume, a stall watchdog, and Pause, Resume and Restart controls. Fixes resume writing the file tail at offset zero, pause silently cancelling a live download, unbounded retry loops, and the concurrency setting never reaching the downloader (#380)
+- Series downloads render as per-season card rails, with thumbnails warmed at completion so artwork survives going offline (#375)
+- A card's body opens what it depicts, while Continue Watching and Up Next still resume on tap. Long press, and right click on desktop, opens a Play, Go to show and details menu (#376)
+- The play button is back on the title row on the movie and TV show detail pages instead of floating centred in the action column (#372)
+- TMDB rating chip on library grid posters. Unrated titles render nothing (#371)
+- The quality menu labels each choice Direct Play, lossless Original, or re-encoding required, with capped rungs showing their bitrate ceiling (#382)
+- Fullscreen works in the browser player on iPhone, handing off to Apple's native player with subtitles preserved. Touch browsers also get the centre play button and enlarged seek targets they were missing (#379)
+- iOS minimum deployment target raised to 15.0, following an App Store Connect advisory (#367)
 
-The settings screen is rebuilt (#381) and then flattened (#384). It was 247 lines of stock `ListTile`s in a flat `ListView` that opted out of the app's own depth system and rendered edge to edge, so on a wide window a toggle's label sat a thousand pixels from its switch. Status and controls also wore identical clothes, so nothing signalled which rows did something and which merely reported.
+## Site
 
-- Identity, connection state, sign out and version each landed somewhere that suits them: a flat identity band, a live subtitle with a tone dot on the Connection details row, a danger row in a new Account section, and a centred footer line.
-- Connection internals moved to a diagnostics screen one tap away.
-- One vocabulary for connection state, replacing three switch statements that named the same states three ways, so the sidebar dot and the settings row can no longer describe one connection differently at the same moment. `P2P (Mixed)` became `Partly relayed` and `P2P (Relay)` became `Connected through a relay`.
-- The Updates section is hidden on iOS, where its actions were no-ops. The platform gate moved inside the update card so the screen cannot forget it.
-- A preferences load failure used to replace the whole screen body, hiding sign out from someone quite likely there to sign out. Now it disables the Playback controls and leaves everything else reachable.
-
-### Sidebar and saved filters
-
-The hardcoded two-level navigation tree is replaced by one flat, reorderable list where built-in destinations and user-created saved filters are the same kind of thing (#386).
-
-`Home` both navigated and toggled its own expansion, so one tap did two things. `Library` only toggled and had no route. It also started collapsed, burying Movies and TV Shows one level deep on every cold start, and expansion state reset every launch.
-
-- Drag to reorder, overflow menu to hide, edit or delete. Search anchors to the top; Downloads and Settings anchor to the bottom and cannot be hidden, Downloads because it is the only destination that works offline and Settings because it is where you go to un-hide something.
-- A saved filter is a media type, an optional category, a watch scope and a sort, routing to `/filter/<id>`. Every combination maps to exactly one query.
-- Continue Watching becomes a real destination with its own route.
-- Layout and filter definitions persist locally and reconcile on load: unknown ids are dropped, absent built-ins are inserted at their default position rather than appended, orphaned filters are appended, and any parse failure falls through to the defaults. Bad stored state can produce the default sidebar, never an empty one.
-- On the server side, `favorites` and `unwatched` gain `category` and `sort` arguments.
-
-### Library sort
-
-The sort menu never sorted anything (#377). `LibraryController.setSort` ignored its argument, and the comment explaining why claimed the queries took no sort argument, which had stopped being true.
-
-- Sort fields go from four to eleven. Duration, popularity, content rating, release date, last played, watch state and random join title, year, date added and rating.
-- Three pre-existing ordering bugs are fixed. Descending was `Enum.reverse` of ascending, which also reverses tie groups. "Date added" compared two `DateTime` structs by term order, which puts day before month before year, so it sorted by day of the month. And nil keys sorted before real values for some fields and after for others; unknown keys now sort last in both directions.
-- Random is seeded and the seed travels with each page request, so infinite scroll no longer duplicates and skips items.
-- Sort persists per library type, and the screen waits for the persisted value before querying. The sheet also used to default to "Recently Added" while the server defaulted to title, so it labelled title-sorted data as recently added.
-
-### Downloads
-
-A download could get stuck showing "Downloading" with a frozen progress bar, and the only way out was deleting it and adding it again (#380). On iOS this is not an edge case: the OS suspends the app shortly after backgrounding, the isolate stops, and nothing on the next launch picked the row back up.
-
-Three independent defects, each now covered by a regression test:
-
-- Orphaned tasks were never reaped. Liveness lived in an in-memory map that is empty after a relaunch, and only transcoding rows were resumed.
-- Nothing could restart a task in a non-terminal state. Retry required `failed` or `cancelled` and resume required exactly `paused`, so a task frozen in `downloading` matched neither and no API could move it.
-- Resume restarted from zero and corrupted the file. Both paths regenerated the filename with a fresh timestamp, so the resume check tested a path that had never existed, and the underlying download call truncates by default, so a ranged request wrote the tail of the file at offset zero.
-
-What is new: two non-terminal statuses, `interrupted` and `stalled`; a recovery pass that runs at launch, on service injection and on app resume, honouring your concurrency limit and giving up after three attempts; a watchdog that marks a download stalled after 90 seconds without byte movement; and Pause, Resume and Restart in the active download sheet. Transient failures retry three times with backoff instead of spinning forever, and a dropped server-side job now fails the task with a message saying so.
-
-Re-pointing the download tests at the real service also surfaced a live bug: pausing a download silently cancelled it, because the cancel handler overwrote the paused status unconditionally. Two smaller ones came with it. The concurrency setting in the storage sheet was written to storage and never reached the downloader, and the queue manager's `processQueue` set a task to `pending` and then called a function that returns early on `pending`.
-
-Series downloads are rebuilt around per-season horizontal card rails with readable queue rows, and episode thumbnails are warmed at download completion so artwork survives going offline (#375).
-
-### Detail pages and playback
-
-- Card taps are honest about what they do (#376). A card's body opens what it depicts; Continue Watching and Up Next still resume on tap, matching what Infuse and Plex both do. The play affordance on those cards was hover-only, which never fires on a phone, so identical-looking cards had opposite behaviour with nothing to tell them apart. Long press, and right click on desktop, opens a menu with Play, Go to show, and the details screen. The show page's episode rail now selects an episode and carries you back to the hero, which is what plays.
-- The play button is back on the title row on both the movie and TV show detail pages (#372). A hero rebuild had moved it into a centred row inside a stretched column, so at wide widths it floated in the middle of a 248px column with roughly 74px of dead space on each side, lining up with nothing.
-- Library grid posters show the TMDB rating (#371). The field was already selected by both queries and thrown away by the parsers, so cached entries carry it and ratings appear immediately rather than after a refetch. An unrated title renders no chip.
-- The quality menu says what each choice will actually do: Direct Play, lossless Original, or re-encoding required, with capped rungs labelled by their bitrate ceiling (#382).
-- Fullscreen works in the browser player on iPhone (#379). Tapping it flipped the icon to "exit fullscreen" while nothing else happened, because the state was optimistic and never asked the platform, and because iPhone Safari cannot fullscreen an arbitrary element below iOS 26. Fullscreen state is now written only from platform events, and on iPhone Safari the player hands off to Apple's native video player, which brings landscape rotation, AirPlay and system gestures with it, with subtitles preserved across the handoff. Touch browsers also get the centre play button and the enlarged seek target they were missing, since a phone browser was previously classified as neither mobile nor desktop.
-- The iOS minimum deployment target is raised to 15.0 (#367), following an App Store Connect advisory that no app may be uploaded below that from spring 2027.
-
-## Site and docs
-
-- mydia.dev has real per-platform download links at `/download/<platform>` for Android, macOS, Windows, Linux, iOS and Flatpak (#385). They resolve to the current release's asset, so nothing hardcodes a version. The README lists every platform, and two CI badges that pointed at workflow files which do not exist are repointed.
-- The Linux how-to link on that page needed the docs site's `/latest/` prefix and was 404ing (#387).
+- Per-platform download links at `mydia.dev/download/<platform>` for Android, macOS, Windows, Linux, iOS and Flatpak, resolving to the current release's asset. The README lists every platform (#385)
+- The Linux how-to link on that page was 404ing (#387)
 
 ## Technical
 
-- `TowerReporter`'s async task queries the settings table, and under PostgreSQL that task could hit a dead SQL sandbox owner. The database layer raises an EXIT rather than an exception there, which `rescue` does not catch, so the task died before it could enqueue anything. It now catches the exit and falls back to the environment variable (#388).
+- Crash reports are no longer dropped when the reporter's settings query hits a dead SQL sandbox owner under PostgreSQL (#388)
 
 ## Upgrade notes
 
-1. **One additive migration**, creating the custom format tables. Built-in formats start unassigned, so ranking behaves exactly as it did until you assign a score in a quality profile.
-2. **Custom formats apply at grab time only.** A file already in your library is never re-evaluated, so an existing release is not replaced by one matching a preferred format; that needs a delete and re-search.
-3. **The Missing filter now matches unmonitored items.** If you relied on the previous result set, Missing combined with the Monitored filter reproduces it exactly.
-4. **The player sidebar changes shape on first launch after upgrading.** Nobody has a stored layout yet, so everyone gets the new defaults: the two-level tree is gone, Home and Library no longer nest, and Continue Watching is new. The mobile bottom navigation is unchanged. Anything you reorder or hide from here on persists.
-5. **The iOS player now requires iOS 15.0.** Devices on iOS 13 or 14 can no longer install it.
-6. **GraphQL changes are additive**: seven new sort fields, a `seed` on `SortInput`, and `category` and `sort` arguments on `favorites` and `unwatched`. An older player build against this server keeps working.
-7. **Seedbox support is opt-in per download client** and does nothing until you enable it on one.
+- One additive migration, for the custom format tables. Built-ins start unassigned, so ranking behaves exactly as it did until you assign a score (#389)
+- The Missing filter now matches unmonitored items. Missing plus the Monitored filter reproduces the previous result set (#392)
+- The player sidebar changes shape on first launch, since nobody has a stored layout yet: the two-level tree is gone and Continue Watching is new. The mobile bottom navigation is unchanged, and anything you reorder or hide from here on persists (#386)
+- The iOS player now requires iOS 15.0, so devices on 13 or 14 can no longer install it (#367)
+- GraphQL changes are additive: seven new sort fields, `SortInput.seed`, and `category` and `sort` on `favorites` and `unwatched`. Older player builds keep working (#377, #386)
+- Seedbox support is opt-in per download client (#368)
 
 **Full Changelog**: https://github.com/getmydia/mydia/compare/v0.13.0...v0.13.1

--- a/priv/changelog/0.13.1.md
+++ b/priv/changelog/0.13.1.md
@@ -1,0 +1,125 @@
+A patch release on top of `v0.13.0`. Most of it is player fixes, but two additions are worth knowing about before you upgrade: Custom Formats, which adds one migration, and optional seedbox support. Neither changes behaviour until you configure it.
+
+## Server
+
+### Custom Formats
+
+Named, reusable sets of release-title regexes that a quality profile can score or reject (#389). This closes the gap where Mydia had no way to distinguish release variants that differ only by a title tag.
+
+The motivating case is French audio. A Quebec dub (`VFQ`) and a France dub (`VFF`) of the same film at the same resolution were identical to the ranker, so which one got grabbed came down to seeder count.
+
+- Built-in formats ship for the common French audio tags and are available immediately: VFF, VF2, VFI, VFQ, MULTI and VOSTFR. They start unassigned, so installing this changes nothing until you assign a score.
+- Admin → Custom Formats owns the definitions. Score assignment lives in the quality profile editor, since what a format is worth is a property of the profile.
+- Built-ins come from a compile-time manifest. Editing one writes an override row sharing its slug, and Reset deletes that row, so a later release can tighten a built-in regex and reach every operator who has not edited it.
+- Format score is its own sort tier rather than part of the composite score. Resolution preference stays primary, so a format score can never promote a 720p release over a 1080p one.
+- Matching runs through `:re` with a match limit rather than `Regex`, so an operator-authored pattern that backtracks catastrophically returns a miss instead of hanging an Oban job.
+- Rejected releases appear in Activity with the format that dropped them.
+
+### Seedbox support
+
+Optional SFTP pull from a remote torrent client (#368). When a torrent finishes on the seedbox, Mydia pulls the completed files down to local storage and hands off to the existing import pipeline unchanged.
+
+- Works with the existing `qbittorrent`, `transmission`, `rqbit` and `rtorrent` client types. Configuration lives in the download client edit modal, with password or SSH-key auth and a Test SFTP Connection action.
+- Transport is Erlang/OTP's built-in `:ssh` and `:ssh_sftp`, so there is no new dependency, and the config lives in the existing `connection_settings` column, so there is no migration.
+- Handles single-file and directory transfers, size verification, resume from partial files, retry with backoff, and best-effort remote cleanup after a verified transfer.
+- Status interception sits in the one place every download client adapter's status already flows through, so none of the four adapters changed.
+
+Building the admin UI surfaced a bug class worth naming. Several places read a value out of `connection_settings` and compared it as a native boolean or integer, when a real form submission always produces a string. Five instances were found and fixed. The worst was the seedbox `enabled` check itself, which matched only the literal boolean `true`, so the feature would never have engaged for any config saved through the admin UI while passing every test that used real Elixir booleans.
+
+### Missing status on unmonitored items
+
+An unmonitored movie never showed a Missing badge and never appeared under the library's Missing filter (#392). Anyone who adds titles as a reminder and downloads them by hand saw an empty Missing list, which is the workflow that needs it most.
+
+`get_media_status/1` treated monitoring and availability as one axis and returned `:not_monitored` without ever looking at the files. A new `AvailabilityStatus` struct splits them: state answers whether you have it, monitored answers whether Mydia is trying to get it. Three branches were collapsing into `:not_monitored` and all three are fixed, including a monitored show whose episodes are all unmonitored, which reported "Not Monitored" despite the show being monitored.
+
+Unmonitored items render their real availability at reduced weight, so Missing reads as missing without lighting up a library of deliberately ignored titles. Episode rows on the show detail page get the same treatment, so a show card and its own episode table cannot disagree.
+
+### Search
+
+Release rows link through to the tracker's own page for that release (#391). The indexer badge becomes a link on the manual search modal, the global search page's Source column, and the search detail modal. `SearchResult` has carried an `info_url` all along, populated by all four adapter paths; nothing ever rendered it.
+
+The link is guarded. `info_url` is indexer-supplied and Cardigann definitions are fetched from an external repo, and HEEx does not validate `href` schemes, so `javascript:` and `data:` URLs would otherwise pass straight through escaping into a live script URL. The guard requires an allowed scheme and a non-empty host, and it also suppresses the link when `info_url` is byte-identical to the download URL, since Prowlarr and Jackett fall back to the torznab guid, which on some indexers is the `.torrent` link.
+
+### Web UI
+
+- On the movie and TV grids, the quality badge rendered on top of the Continue and Watched badges. Any item with both playback progress and a known resolution showed two badges in the same pixels. A single `poster_badges/1` component now owns that corner, and the quality badge moves from primary to neutral so the playback state stays the element that draws the eye (#390).
+- Metadata refresh honours an injected relay configuration instead of always reaching for the default, and per-episode translation fetches are bounded at 15 seconds rather than running unbounded (#383).
+
+## Player
+
+### Settings
+
+The settings screen is rebuilt (#381) and then flattened (#384). It was 247 lines of stock `ListTile`s in a flat `ListView` that opted out of the app's own depth system and rendered edge to edge, so on a wide window a toggle's label sat a thousand pixels from its switch. Status and controls also wore identical clothes, so nothing signalled which rows did something and which merely reported.
+
+- Identity, connection state, sign out and version each landed somewhere that suits them: a flat identity band, a live subtitle with a tone dot on the Connection details row, a danger row in a new Account section, and a centred footer line.
+- Connection internals moved to a diagnostics screen one tap away.
+- One vocabulary for connection state, replacing three switch statements that named the same states three ways, so the sidebar dot and the settings row can no longer describe one connection differently at the same moment. `P2P (Mixed)` became `Partly relayed` and `P2P (Relay)` became `Connected through a relay`.
+- The Updates section is hidden on iOS, where its actions were no-ops. The platform gate moved inside the update card so the screen cannot forget it.
+- A preferences load failure used to replace the whole screen body, hiding sign out from someone quite likely there to sign out. Now it disables the Playback controls and leaves everything else reachable.
+
+### Sidebar and saved filters
+
+The hardcoded two-level navigation tree is replaced by one flat, reorderable list where built-in destinations and user-created saved filters are the same kind of thing (#386).
+
+`Home` both navigated and toggled its own expansion, so one tap did two things. `Library` only toggled and had no route. It also started collapsed, burying Movies and TV Shows one level deep on every cold start, and expansion state reset every launch.
+
+- Drag to reorder, overflow menu to hide, edit or delete. Search anchors to the top; Downloads and Settings anchor to the bottom and cannot be hidden, Downloads because it is the only destination that works offline and Settings because it is where you go to un-hide something.
+- A saved filter is a media type, an optional category, a watch scope and a sort, routing to `/filter/<id>`. Every combination maps to exactly one query.
+- Continue Watching becomes a real destination with its own route.
+- Layout and filter definitions persist locally and reconcile on load: unknown ids are dropped, absent built-ins are inserted at their default position rather than appended, orphaned filters are appended, and any parse failure falls through to the defaults. Bad stored state can produce the default sidebar, never an empty one.
+- On the server side, `favorites` and `unwatched` gain `category` and `sort` arguments.
+
+### Library sort
+
+The sort menu never sorted anything (#377). `LibraryController.setSort` ignored its argument, and the comment explaining why claimed the queries took no sort argument, which had stopped being true.
+
+- Sort fields go from four to eleven. Duration, popularity, content rating, release date, last played, watch state and random join title, year, date added and rating.
+- Three pre-existing ordering bugs are fixed. Descending was `Enum.reverse` of ascending, which also reverses tie groups. "Date added" compared two `DateTime` structs by term order, which puts day before month before year, so it sorted by day of the month. And nil keys sorted before real values for some fields and after for others; unknown keys now sort last in both directions.
+- Random is seeded and the seed travels with each page request, so infinite scroll no longer duplicates and skips items.
+- Sort persists per library type, and the screen waits for the persisted value before querying. The sheet also used to default to "Recently Added" while the server defaulted to title, so it labelled title-sorted data as recently added.
+
+### Downloads
+
+A download could get stuck showing "Downloading" with a frozen progress bar, and the only way out was deleting it and adding it again (#380). On iOS this is not an edge case: the OS suspends the app shortly after backgrounding, the isolate stops, and nothing on the next launch picked the row back up.
+
+Three independent defects, each now covered by a regression test:
+
+- Orphaned tasks were never reaped. Liveness lived in an in-memory map that is empty after a relaunch, and only transcoding rows were resumed.
+- Nothing could restart a task in a non-terminal state. Retry required `failed` or `cancelled` and resume required exactly `paused`, so a task frozen in `downloading` matched neither and no API could move it.
+- Resume restarted from zero and corrupted the file. Both paths regenerated the filename with a fresh timestamp, so the resume check tested a path that had never existed, and the underlying download call truncates by default, so a ranged request wrote the tail of the file at offset zero.
+
+What is new: two non-terminal statuses, `interrupted` and `stalled`; a recovery pass that runs at launch, on service injection and on app resume, honouring your concurrency limit and giving up after three attempts; a watchdog that marks a download stalled after 90 seconds without byte movement; and Pause, Resume and Restart in the active download sheet. Transient failures retry three times with backoff instead of spinning forever, and a dropped server-side job now fails the task with a message saying so.
+
+Re-pointing the download tests at the real service also surfaced a live bug: pausing a download silently cancelled it, because the cancel handler overwrote the paused status unconditionally. Two smaller ones came with it. The concurrency setting in the storage sheet was written to storage and never reached the downloader, and the queue manager's `processQueue` set a task to `pending` and then called a function that returns early on `pending`.
+
+Series downloads are rebuilt around per-season horizontal card rails with readable queue rows, and episode thumbnails are warmed at download completion so artwork survives going offline (#375).
+
+### Detail pages and playback
+
+- Card taps are honest about what they do (#376). A card's body opens what it depicts; Continue Watching and Up Next still resume on tap, matching what Infuse and Plex both do. The play affordance on those cards was hover-only, which never fires on a phone, so identical-looking cards had opposite behaviour with nothing to tell them apart. Long press, and right click on desktop, opens a menu with Play, Go to show, and the details screen. The show page's episode rail now selects an episode and carries you back to the hero, which is what plays.
+- The play button is back on the title row on both the movie and TV show detail pages (#372). A hero rebuild had moved it into a centred row inside a stretched column, so at wide widths it floated in the middle of a 248px column with roughly 74px of dead space on each side, lining up with nothing.
+- Library grid posters show the TMDB rating (#371). The field was already selected by both queries and thrown away by the parsers, so cached entries carry it and ratings appear immediately rather than after a refetch. An unrated title renders no chip.
+- The quality menu says what each choice will actually do: Direct Play, lossless Original, or re-encoding required, with capped rungs labelled by their bitrate ceiling (#382).
+- Fullscreen works in the browser player on iPhone (#379). Tapping it flipped the icon to "exit fullscreen" while nothing else happened, because the state was optimistic and never asked the platform, and because iPhone Safari cannot fullscreen an arbitrary element below iOS 26. Fullscreen state is now written only from platform events, and on iPhone Safari the player hands off to Apple's native video player, which brings landscape rotation, AirPlay and system gestures with it, with subtitles preserved across the handoff. Touch browsers also get the centre play button and the enlarged seek target they were missing, since a phone browser was previously classified as neither mobile nor desktop.
+- The iOS minimum deployment target is raised to 15.0 (#367), following an App Store Connect advisory that no app may be uploaded below that from spring 2027.
+
+## Site and docs
+
+- mydia.dev has real per-platform download links at `/download/<platform>` for Android, macOS, Windows, Linux, iOS and Flatpak (#385). They resolve to the current release's asset, so nothing hardcodes a version. The README lists every platform, and two CI badges that pointed at workflow files which do not exist are repointed.
+- The Linux how-to link on that page needed the docs site's `/latest/` prefix and was 404ing (#387).
+
+## Technical
+
+- `TowerReporter`'s async task queries the settings table, and under PostgreSQL that task could hit a dead SQL sandbox owner. The database layer raises an EXIT rather than an exception there, which `rescue` does not catch, so the task died before it could enqueue anything. It now catches the exit and falls back to the environment variable (#388).
+
+## Upgrade notes
+
+1. **One additive migration**, creating the custom format tables. Built-in formats start unassigned, so ranking behaves exactly as it did until you assign a score in a quality profile.
+2. **Custom formats apply at grab time only.** A file already in your library is never re-evaluated, so an existing release is not replaced by one matching a preferred format; that needs a delete and re-search.
+3. **The Missing filter now matches unmonitored items.** If you relied on the previous result set, Missing combined with the Monitored filter reproduces it exactly.
+4. **The player sidebar changes shape on first launch after upgrading.** Nobody has a stored layout yet, so everyone gets the new defaults: the two-level tree is gone, Home and Library no longer nest, and Continue Watching is new. The mobile bottom navigation is unchanged. Anything you reorder or hide from here on persists.
+5. **The iOS player now requires iOS 15.0.** Devices on iOS 13 or 14 can no longer install it.
+6. **GraphQL changes are additive**: seven new sort fields, a `seed` on `SortInput`, and `category` and `sort` arguments on `favorites` and `unwatched`. An older player build against this server keeps working.
+7. **Seedbox support is opt-in per download client** and does nothing until you enable it on one.
+
+**Full Changelog**: https://github.com/getmydia/mydia/compare/v0.13.0...v0.13.1


### PR DESCRIPTION
Adds `priv/changelog/0.13.1.md`, the bundled release notes for v0.13.1. Per `docs/contributing/releasing.md` this must be the last thing merged before the release draft is pinned to a commit, because the workflow refuses to build a stable release whose notes file is missing at the pinned SHA.

## Scope of the release

21 of the 25 PRs merged since v0.13.0. Two additions carry real behaviour: Custom Formats (#389), which brings the one migration in this release, and optional seedbox support (#368). The rest is player and web UI fixes.

## Deliberately excluded

Four PRs are left out of the notes because the work is not ready to be advertised:

- #373, #374, #378 (Mydia Server, the Rust workspace)
- #370 (the public web player at web.mydia.dev)

#379 is included, since its fullscreen and touch-input fixes reach the instance-hosted `/player` that ships today, and the notes describe it as the browser player without naming web.mydia.dev.

## Notes on the version number

Custom Formats and seedbox support are features, so v0.14.0 would be the more conventional number. v0.13.1 is a deliberate call. Since this is a patch release, the GitHub release notes will be `0.13.1.md` concatenated with `0.13.0.md` per the releasing guide, while the bundled file holds only this release's changes so the app never shows the same content twice.

## Verification

- `./dev mix test test/mydia/changelog_test.exs`: 12 tests, 0 failures. This compiles `Mydia.Changelog`, which parses the filename as bare semver and renders the markdown through Earmark at compile time, so a malformed file would be a build failure rather than a runtime surprise.
- No em dashes or en dashes in the file.
- Every PR number cited resolves to a PR merged after the v0.13.0 tag.
