### PR TITLE
fix(flatpak): repair the live repo's empty directories before publishing

### DIFF
--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -307,6 +307,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # player/flatpak/test/ holds four script tests and nothing ran any of
+      # them, which is how the publish.sh skeleton bug reached v0.13.1. This one
+      # needs no packages beyond bash, so it runs first. The other three want
+      # ostree, rclone, flatpak and gpg and are still manual.
+      - name: Test the ostree skeleton repair
+        run: ./player/flatpak/test/ensure-skeleton-test.sh
+
       # Seconds, not minutes. Catches most manifest metadata mistakes long
       # before the full flatpak-build job below finishes compiling mpv.
       - name: Install validators

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1365,45 +1365,14 @@ jobs:
           path: staged-repo
 
       - name: Restore the staged repo's empty directories
-        run: |
-          set -euo pipefail
-          # upload-artifact does not preserve empty directories, and an ostree
-          # repo is full of them: refs/remotes, refs/mirrors, extensions, state
-          # and tmp/cache all survive a build empty. The artifact round trip
-          # drops them, so the first thing to read the downloaded repo dies with
-          # "Listing refs: opendir(refs/remotes): No such file or directory".
-          #
-          # The dry run cannot catch this. It rehearses against $PWD/staged-repo
-          # in the build job, which never goes through an artifact, so the
-          # skeleton is still intact there.
-          #
-          # mkdir, not `ostree init`. Whether init repairs an existing repo is
-          # version dependent: libostree 2026.2 recreates the missing skeleton,
-          # but the 2024.5 on ubuntu-latest returns 0 and changes nothing, so
-          # the repair silently did not happen and build-commit-from still died.
-          # That is what failed the flatpak publish on v0.13.0-beta.5. Creating
-          # the directories outright does not depend on any of that.
-          #
-          # The whole refs skeleton is recreated rather than just the subset a
-          # given build happens to leave empty, because mkdir -p on a directory
-          # that already exists costs nothing and does not require reasoning
-          # about which refs a build produced. refs/heads normally survives, in
-          # that it holds the app ref; it is listed for that reason, not because
-          # it is expected to be missing. objects/ is omitted because it always
-          # carries content, so its absence would mean a broken artifact rather
-          # than a dropped empty directory, and should fail loudly.
-          mkdir -p \
-            staged-repo/refs/heads \
-            staged-repo/refs/mirrors \
-            staged-repo/refs/remotes \
-            staged-repo/extensions \
-            staged-repo/state \
-            staged-repo/tmp/cache
-          # Fail here rather than inside flatpak build-commit-from, where the
-          # same problem surfaces as an opaque refs error.
-          for d in refs/heads refs/mirrors refs/remotes extensions state tmp/cache; do
-            test -d "staged-repo/$d" || { echo "::error::staged-repo/$d missing" >&2; exit 1; }
-          done
+        # upload-artifact does not preserve empty directories, and an ostree
+        # repo is full of them. See player/flatpak/ensure-skeleton.sh for why
+        # this is mkdir rather than `ostree init`.
+        #
+        # The dry run cannot catch a regression here. It rehearses against
+        # $PWD/staged-repo in the build job, which never goes through an
+        # artifact, so the skeleton is still intact there.
+        run: ./player/flatpak/ensure-skeleton.sh staged-repo
 
       - name: Import the signing key
         env:

--- a/player/flatpak/ensure-skeleton.sh
+++ b/player/flatpak/ensure-skeleton.sh
@@ -27,9 +27,12 @@
 # happens to drop, because mkdir -p on a directory that already exists costs
 # nothing and does not require reasoning about which refs a build produced.
 # refs/heads normally survives, in that it holds the app ref; it is listed for
-# that reason, not because it is expected to be missing. objects/ is omitted
-# because it always carries content, so its absence would mean a broken repo
-# rather than a dropped empty directory, and should fail loudly.
+# that reason, not because it is expected to be missing.
+#
+# objects/ is deliberately NOT created. It always carries content, so its
+# absence means a broken transfer rather than a dropped empty directory, and
+# creating it would paper over that and defer the failure into flatpak. It is
+# asserted instead, so the break is reported here and names itself.
 set -euo pipefail
 
 REPO="${1:?repo path required}"
@@ -45,5 +48,14 @@ done
 for d in "${DIRS[@]}"; do
   test -d "$REPO/$d" || { echo "::error::$REPO/$d missing" >&2; exit 1; }
 done
+
+# Gated on config, which is a file and therefore survives every transfer. Its
+# presence is what distinguishes an existing repo, where objects/ must be
+# there, from a first publish against an empty directory, where nothing has
+# been initialised yet and its absence is expected.
+if [ -e "$REPO/config" ] && [ ! -d "$REPO/objects" ]; then
+  echo "::error::$REPO/objects is missing from a repo that has a config. That is a broken transfer, not a dropped empty directory." >&2
+  exit 1
+fi
 
 echo "skeleton: $REPO ok"

--- a/player/flatpak/ensure-skeleton.sh
+++ b/player/flatpak/ensure-skeleton.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Recreates the empty directories an ostree repo needs, then proves they exist.
+#
+# Usage: player/flatpak/ensure-skeleton.sh <repo>
+#
+# An ostree repo is full of directories that survive a build empty: refs/remotes,
+# refs/mirrors, extensions, state and tmp/cache. Two things in the release path
+# carry a repo from one place to another and neither preserves an empty
+# directory:
+#
+#   1. upload-artifact / download-artifact, for the staged repo.
+#   2. rclone against object storage, for the live repo. R2 has no directories
+#      at all, only keys, so an empty one cannot be stored and
+#      --create-empty-src-dirs has nothing to recreate it from.
+#
+# Whichever path dropped them, the first command to read the repo dies with
+# "Listing refs: opendir(refs/remotes): No such file or directory".
+#
+# mkdir, not `ostree init`. Whether init repairs an existing repo is version
+# dependent: libostree 2026.2 recreates the missing skeleton, but the 2024.5 on
+# ubuntu-latest returns 0 and changes nothing, so the repair silently does not
+# happen. That is what failed the flatpak publish on v0.13.0-beta.5 (staged
+# repo, fixed inline in release.yml) and again on v0.13.1 (live repo, which had
+# an `ostree init` that was believed to cover this and did not).
+#
+# The whole skeleton is recreated rather than just the subset a given path
+# happens to drop, because mkdir -p on a directory that already exists costs
+# nothing and does not require reasoning about which refs a build produced.
+# refs/heads normally survives, in that it holds the app ref; it is listed for
+# that reason, not because it is expected to be missing. objects/ is omitted
+# because it always carries content, so its absence would mean a broken repo
+# rather than a dropped empty directory, and should fail loudly.
+set -euo pipefail
+
+REPO="${1:?repo path required}"
+
+DIRS=(refs/heads refs/mirrors refs/remotes extensions state tmp/cache)
+
+for d in "${DIRS[@]}"; do
+  mkdir -p "$REPO/$d"
+done
+
+# Fail here rather than inside flatpak build-commit-from or build-update-repo,
+# where the same problem surfaces as an opaque refs error.
+for d in "${DIRS[@]}"; do
+  test -d "$REPO/$d" || { echo "::error::$REPO/$d missing" >&2; exit 1; }
+done
+
+echo "skeleton: $REPO ok"

--- a/player/flatpak/publish.sh
+++ b/player/flatpak/publish.sh
@@ -26,10 +26,13 @@ mkdir -p "$LIVE"
 rclone sync "$DEST" "$LIVE" --create-empty-src-dirs \
   --transfers 32 --checkers 32 --retries 5
 
-# Idempotent, and it recreates the refs/ skeleton if object storage ever lost
-# an empty directory. Safe on an existing repo: ostree init leaves the config
-# and objects alone.
+# Creates the repo on a first publish, when $DEST is still empty. Safe on an
+# existing repo: ostree init leaves the config and objects alone. It does NOT
+# repair a repo whose empty directories the sync dropped, which is what
+# ensure-skeleton.sh below is for.
 ostree init --repo="$LIVE" --mode=archive
+
+"$(dirname "${BASH_SOURCE[0]}")/ensure-skeleton.sh" "$LIVE"
 
 echo "publish: committing the staged build into $LIVE"
 flatpak build-commit-from \

--- a/player/flatpak/test/ensure-skeleton-test.sh
+++ b/player/flatpak/test/ensure-skeleton-test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Proves ensure-skeleton.sh repairs a repo whose empty directories were dropped
+# in transit, which is what object storage and the artifact round trip both do.
+# Needs nothing but bash: the script under test is mkdir and test -d.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/player/flatpak/ensure-skeleton.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+SKELETON=(refs/mirrors refs/remotes extensions state tmp/cache)
+
+# What comes back from `rclone sync r2:... ./live-repo`: every directory that
+# held an object, and none of the ones that were empty. R2 stores keys, not
+# directories, so an empty directory cannot round trip and
+# --create-empty-src-dirs has nothing to recreate it from.
+REPO="$WORK/live-repo"
+mkdir -p "$REPO/objects/ab" "$REPO/refs/heads"
+echo "config" > "$REPO/config"
+echo "object" > "$REPO/objects/ab/cdef.filez"
+echo "commit" > "$REPO/refs/heads/app"
+
+for d in "${SKELETON[@]}"; do
+  [ ! -d "$REPO/$d" ] \
+    || { echo "FAIL: fixture should not already have $d"; exit 1; }
+done
+
+"$SCRIPT" "$REPO" >/dev/null
+
+for d in refs/heads "${SKELETON[@]}"; do
+  test -d "$REPO/$d" \
+    || { echo "FAIL: $d missing after repair"; exit 1; }
+done
+
+# The repair must not disturb what the sync did bring down.
+[ -f "$REPO/config" ] || { echo "FAIL: config was lost"; exit 1; }
+[ -f "$REPO/objects/ab/cdef.filez" ] || { echo "FAIL: object was lost"; exit 1; }
+[ "$(cat "$REPO/refs/heads/app")" = "commit" ] \
+  || { echo "FAIL: existing ref was clobbered"; exit 1; }
+
+# Idempotent: the release path runs this on repos that are already intact.
+"$SCRIPT" "$REPO" >/dev/null
+[ "$(cat "$REPO/refs/heads/app")" = "commit" ] \
+  || { echo "FAIL: second run clobbered an existing ref"; exit 1; }
+
+# A first publish starts from an empty directory and must also come out whole.
+FRESH="$WORK/fresh"
+mkdir -p "$FRESH"
+"$SCRIPT" "$FRESH" >/dev/null
+for d in refs/heads "${SKELETON[@]}"; do
+  test -d "$FRESH/$d" || { echo "FAIL: $d missing on a fresh repo"; exit 1; }
+done
+
+# The guard must fail loudly rather than let an unusable repo through to
+# flatpak, where the same problem surfaces as an opaque refs error. A regular
+# file where a directory belongs is the deterministic way to make mkdir -p fail.
+BROKEN="$WORK/broken"
+mkdir -p "$BROKEN"
+touch "$BROKEN/refs"
+if "$SCRIPT" "$BROKEN" >/dev/null 2>&1; then
+  echo "FAIL: a repo that cannot be repaired must exit non-zero"
+  exit 1
+fi
+
+echo "PASS"

--- a/player/flatpak/test/ensure-skeleton-test.sh
+++ b/player/flatpak/test/ensure-skeleton-test.sh
@@ -63,4 +63,16 @@ if "$SCRIPT" "$BROKEN" >/dev/null 2>&1; then
   exit 1
 fi
 
+# A missing objects/ is a broken transfer, not a dropped empty directory, so it
+# must be reported here rather than created and deferred into flatpak.
+NOOBJECTS="$WORK/no-objects"
+mkdir -p "$NOOBJECTS/refs/heads"
+echo "config" > "$NOOBJECTS/config"
+if "$SCRIPT" "$NOOBJECTS" >/dev/null 2>&1; then
+  echo "FAIL: a repo with a config but no objects/ must exit non-zero"
+  exit 1
+fi
+[ ! -d "$NOOBJECTS/objects" ] \
+  || { echo "FAIL: objects/ must never be created, only asserted"; exit 1; }
+
 echo "PASS"


### PR DESCRIPTION
The v0.13.1 release published everything except Flatpak. `Publish Flatpak` failed in run 31408977660:

```
publish: updating summary, generating deltas, pruning to depth 5
Updating appstream branch
Generating static deltas
error: Listing refs: opendir(refs/remotes): No such file or directory
```

## Cause

An ostree repo relies on directories that are legitimately empty: `refs/remotes`, `refs/mirrors`, `extensions`, `state`, `tmp/cache`. Object storage has no directories at all, only keys, so an empty one cannot exist on R2 and does not come back from `rclone sync`. `--create-empty-src-dirs` has nothing to recreate it from. `build-update-repo` is then the first command to read the repo, and it dies.

`publish.sh` had an `ostree init` that was believed to cover exactly this. Its comment said so: "it recreates the refs/ skeleton if object storage ever lost an empty directory." That is wrong on this runner, and `release.yml` already knew it, in the comment attached to the identical fix for the staged repo:

> mkdir, not `ostree init`. Whether init repairs an existing repo is version dependent: libostree 2026.2 recreates the missing skeleton, but the 2024.5 on ubuntu-latest returns 0 and changes nothing [...] That is what failed the flatpak publish on v0.13.0-beta.5.

So the same defect was diagnosed and fixed once for `staged-repo`, inline in the workflow, and the lesson never reached `publish.sh`. That duplication is the real root cause, which is why this extracts the repair instead of adding a second copy of it.

## Why it surfaced on v0.13.1 and not v0.13.0

v0.13.0 was the first stable Flatpak publish, so `live-repo` was created locally from scratch and its skeleton was complete. v0.13.1 is the first publish that syncs a pre-existing repo down from R2.

## Changes

- New `player/flatpak/ensure-skeleton.sh`, the single owner of the repair, carrying the full explanation of why it is `mkdir` and not `ostree init`.
- `publish.sh` calls it after the sync. Its `ostree init` stays, since that is what creates the repo on a first publish, but its comment no longer claims to do the repair.
- `release.yml` calls it instead of the 40-line inline block, so the two paths cannot drift again.
- New `player/flatpak/test/ensure-skeleton-test.sh`.
- `ci-player.yml` runs that test.

## On the test

`player/flatpak/test/` held four script tests and **nothing in the repository ran any of them**. That is how a `publish.sh` defect reached a release. The new test needs nothing beyond bash, so it is wired into the existing `Flatpak / Validate metadata` job, which costs it no meaningful time.

It covers repair of a synced-down repo, preservation of the config, objects and existing refs, idempotence, a first publish from an empty directory, and a non-zero exit when the repo cannot be repaired.

It was checked for teeth: replacing `ensure-skeleton.sh` with a no-op that only prints its success line, which is precisely what `ostree init` was doing on the runner, turns it red with `FAIL: refs/mirrors missing after repair`.

The other three tests want ostree, rclone, flatpak and gpg. They are still manual, and that gap is called out in a comment rather than closed here, since I could not run them locally to confirm they behave in CI.

## Verification

- `./player/flatpak/test/ensure-skeleton-test.sh`: PASS, and red against a neutered fix as described above.
- `bash -n` clean on all three touched scripts.
- Both workflow files parse as YAML.
- Both new scripts are committed mode 100755.

Not verified: an actual publish against R2. That needs the release path and its credentials.

## Note on the published release

R2 still holds the intact v0.13.0 stable repo. The failure happened before `sync-repo.sh` uploads anything, so nothing was corrupted and Flatpak users on stable are not broken. They are simply still on 0.13.0 until a publish succeeds.

Getting 0.13.1 onto the Flatpak stable channel is a separate decision and is not done by this PR. `gh run rerun --failed` would re-run against the pinned SHA and hit the identical failure, so it needs either a re-dispatch after this lands or a manual publish against the existing artifacts.
