### PR TITLE
feat(relay): GitHub SSO for the maintainer dashboards, and file issues from feedback

### DIFF
--- a/infra/config.yaml.example
+++ b/infra/config.yaml.example
@@ -29,6 +29,18 @@ relay_tmdb_api_key: "your-tmdb-api-key"
 # Key from: https://subdl.com/panel/api
 relay_subdl_api_key: ""
 
+# Maintainer dashboard GitHub sign-in (optional)
+# Only used when DASHBOARD_GITHUB_USERS is set in the metadata-relay ConfigMap.
+# Leave blank and the dashboards stay on basic auth.
+# The session key is the Phoenix one, unrelated to relay_secret_key_base above,
+# which is written as RELAY_TOKEN_SECRET. Generate with:
+#   head -c 48 /dev/urandom | base64
+# Credentials come from the "Mydia Relay" GitHub App:
+#   https://github.com/organizations/getmydia/settings/apps
+relay_dashboard_secret_key_base: ""
+relay_github_app_client_id: ""
+relay_github_app_client_secret: ""
+
 # Feedback email notifications (optional)
 # All six fields below must be set together for the relay to send feedback emails.
 # Leave blank to disable. Stored locally only — never committed to git.

--- a/infra/config.yaml.example
+++ b/infra/config.yaml.example
@@ -30,7 +30,7 @@ relay_tmdb_api_key: "your-tmdb-api-key"
 relay_subdl_api_key: ""
 
 # Maintainer dashboard GitHub sign-in (optional)
-# Only used when DASHBOARD_GITHUB_USERS is set in the metadata-relay ConfigMap.
+# Only used when DASHBOARD_GITHUB_ORG is set in the metadata-relay ConfigMap.
 # Leave blank and the dashboards stay on basic auth.
 # The session key is the Phoenix one, unrelated to relay_secret_key_base above,
 # which is written as RELAY_TOKEN_SECRET. Generate with:

--- a/infra/deploy
+++ b/infra/deploy
@@ -100,6 +100,13 @@ class Config:
     # relay answers /api/v1/subtitles/* with 503 not-configured)
     relay_subdl_api_key: str = ""
 
+    # Maintainer dashboard sign-in (optional; leave blank and the dashboards
+    # stay on basic auth). Note this is the Phoenix session key, unrelated to
+    # relay_secret_key_base above, which is written as RELAY_TOKEN_SECRET.
+    relay_dashboard_secret_key_base: str = ""
+    relay_github_app_client_id: str = ""
+    relay_github_app_client_secret: str = ""
+
     # Feedback email notifications (optional; leave blank to disable)
     relay_smtp_host: str = ""
     relay_smtp_port: str = ""
@@ -193,6 +200,9 @@ class Config:
             "relay_tmdb_api_key": self.relay_tmdb_api_key,
             "relay_smtp_password": self.relay_smtp_password,
             "relay_subdl_api_key": self.relay_subdl_api_key,
+            "relay_dashboard_secret_key_base": self.relay_dashboard_secret_key_base,
+            "relay_github_app_client_id": self.relay_github_app_client_id,
+            "relay_github_app_client_secret": self.relay_github_app_client_secret,
             "relay_smtp_host": self.relay_smtp_host,
             "relay_smtp_port": self.relay_smtp_port,
             "relay_smtp_username": self.relay_smtp_username,
@@ -1036,6 +1046,15 @@ def metadata_relay_secret_data(config: Config) -> dict[str, str]:
 
     if config.relay_subdl_api_key:
         data["SUBDL_API_KEY"] = config.relay_subdl_api_key
+
+    if config.relay_dashboard_secret_key_base:
+        data["SECRET_KEY_BASE"] = config.relay_dashboard_secret_key_base
+
+    if config.relay_github_app_client_id:
+        data["GITHUB_APP_CLIENT_ID"] = config.relay_github_app_client_id
+
+    if config.relay_github_app_client_secret:
+        data["GITHUB_APP_CLIENT_SECRET"] = config.relay_github_app_client_secret
 
     return data
 

--- a/infra/kubernetes/apps/metadata-relay/README.md
+++ b/infra/kubernetes/apps/metadata-relay/README.md
@@ -75,7 +75,7 @@ curl https://relay.mydia.dev/health
 - `MIX_ENV`: Environment (prod)
 - `SQLITE_DB_PATH`: Path to SQLite database file
 - `FEEDBACK_DASHBOARD_URL`: Base URL used in feedback notification links
-- `DASHBOARD_GITHUB_USERS`: Comma-separated GitHub logins allowed into `/feedback` and `/errors`. Setting this switches the dashboards from basic auth to GitHub sign-in. Leave empty to keep basic auth.
+- `DASHBOARD_GITHUB_ORG`: GitHub organization whose active members may reach `/feedback` and `/errors`. Setting this switches the dashboards from basic auth to GitHub sign-in. Leave empty to keep basic auth.
 - `FEEDBACK_GITHUB_REPO`: Repository that issues filed from the feedback dashboard land in (default `getmydia/mydia`)
 
 ### Secrets (secret.yaml)
@@ -98,17 +98,19 @@ Optional secrets:
 
 The `/feedback` and `/errors` dashboards support two mutually exclusive access modes.
 
-**Basic auth** (default): leave `DASHBOARD_GITHUB_USERS` empty and set `DASHBOARD_USERNAME` / `DASHBOARD_PASSWORD`. The issue-filing button is hidden.
+**Basic auth** (default): leave `DASHBOARD_GITHUB_ORG` empty and set `DASHBOARD_USERNAME` / `DASHBOARD_PASSWORD`. The issue-filing button is hidden.
 
-**GitHub App sign-in**: set `DASHBOARD_GITHUB_USERS` to an allowlist of GitHub logins. Basic auth is disabled. Maintainers sign in through the "Mydia Relay" GitHub App, and the feedback dashboard can file issues as the signed-in maintainer.
+**GitHub App sign-in**: set `DASHBOARD_GITHUB_ORG` to a GitHub organization. Basic auth is disabled. Active members of that organization sign in through the "Mydia Relay" GitHub App, and the feedback dashboard can file issues as the signed-in maintainer.
+
+Membership is read with `GET /user/memberships/orgs/{org}` using the signed-in maintainer's own token, so private membership works and the App needs no permission to read the org's member list. Only `active` counts; a pending invitation is refused. The check runs at sign-in and again at most every five minutes, so removing someone from the organization ends their session within that window. If GitHub is unreachable an already-verified session is kept rather than dropped.
 
 To enable GitHub sign-in:
 
 1. Create a GitHub App named "Mydia Relay" owned by the `getmydia` organization. Repository permissions: Issues, read and write. Callback URL: `https://relay.mydia.dev/auth/github/callback`. Leave "Expire user authorization tokens" unchecked. Disable webhooks.
 2. Install the App on `getmydia/mydia`.
-3. Add `SECRET_KEY_BASE`, `GITHUB_APP_CLIENT_ID`, and `GITHUB_APP_CLIENT_SECRET` to the cluster secret, and `DASHBOARD_GITHUB_USERS` plus `FEEDBACK_GITHUB_REPO` to the ConfigMap.
+3. Add `SECRET_KEY_BASE`, `GITHUB_APP_CLIENT_ID`, and `GITHUB_APP_CLIENT_SECRET` to the cluster secret **first**, then `DASHBOARD_GITHUB_ORG` plus `FEEDBACK_GITHUB_REPO` to the ConfigMap.
 
-Without the App credentials and allowlist the relay stays in basic-auth mode, so there is no window in which the dashboards are unprotected.
+Order matters in one direction only. A non-empty `DASHBOARD_GITHUB_ORG` turns basic auth off, so applying the ConfigMap before the App credentials are in the secret leaves `/feedback` and `/errors` unreachable until the secret lands: sign-in cannot complete and basic auth is gone. The relay keeps serving the proxy throughout, so this is a locked door rather than an outage, and there is never a window in which the dashboards are unprotected. Apply the secret first.
 
 ### Storage
 

--- a/infra/kubernetes/apps/metadata-relay/README.md
+++ b/infra/kubernetes/apps/metadata-relay/README.md
@@ -74,6 +74,9 @@ curl https://relay.mydia.dev/health
 - `PHX_HOST`: Hostname for Phoenix (relay.mydia.dev)
 - `MIX_ENV`: Environment (prod)
 - `SQLITE_DB_PATH`: Path to SQLite database file
+- `FEEDBACK_DASHBOARD_URL`: Base URL used in feedback notification links
+- `DASHBOARD_GITHUB_USERS`: Comma-separated GitHub logins allowed into `/feedback` and `/errors`. Setting this switches the dashboards from basic auth to GitHub sign-in. Leave empty to keep basic auth.
+- `FEEDBACK_GITHUB_REPO`: Repository that issues filed from the feedback dashboard land in (default `getmydia/mydia`)
 
 ### Secrets (secret.yaml)
 
@@ -87,6 +90,25 @@ Optional secrets:
   `/api/v1/subtitles/*` endpoint returns 503 until it is set, so it is
   required for subtitle functionality specifically, not for the service to
   boot.
+- `SECRET_KEY_BASE`: Phoenix session signing and encryption key (generate with `head -c 48 /dev/urandom | base64`). A random key is generated per boot if unset, but dashboard sessions will not survive a restart.
+- `GITHUB_APP_CLIENT_ID`: Client ID of the "Mydia Relay" GitHub App
+- `GITHUB_APP_CLIENT_SECRET`: Client secret of the "Mydia Relay" GitHub App
+
+### Maintainer access
+
+The `/feedback` and `/errors` dashboards support two mutually exclusive access modes.
+
+**Basic auth** (default): leave `DASHBOARD_GITHUB_USERS` empty and set `DASHBOARD_USERNAME` / `DASHBOARD_PASSWORD`. The issue-filing button is hidden.
+
+**GitHub App sign-in**: set `DASHBOARD_GITHUB_USERS` to an allowlist of GitHub logins. Basic auth is disabled. Maintainers sign in through the "Mydia Relay" GitHub App, and the feedback dashboard can file issues as the signed-in maintainer.
+
+To enable GitHub sign-in:
+
+1. Create a GitHub App named "Mydia Relay" owned by the `getmydia` organization. Repository permissions: Issues, read and write. Callback URL: `https://relay.mydia.dev/auth/github/callback`. Leave "Expire user authorization tokens" unchecked. Disable webhooks.
+2. Install the App on `getmydia/mydia`.
+3. Add `SECRET_KEY_BASE`, `GITHUB_APP_CLIENT_ID`, and `GITHUB_APP_CLIENT_SECRET` to the cluster secret, and `DASHBOARD_GITHUB_USERS` plus `FEEDBACK_GITHUB_REPO` to the ConfigMap.
+
+Without the App credentials and allowlist the relay stays in basic-auth mode, so there is no window in which the dashboards are unprotected.
 
 ### Storage
 

--- a/infra/kubernetes/apps/metadata-relay/configmap.yaml
+++ b/infra/kubernetes/apps/metadata-relay/configmap.yaml
@@ -23,6 +23,12 @@ data:
   FEEDBACK_EMAIL_TO: "feedback@mydia.dev"
   FEEDBACK_EMAIL_FROM: "feedback@mydia.dev"
   FEEDBACK_DASHBOARD_URL: "https://relay.mydia.dev"
+  # Comma-separated GitHub logins allowed into /feedback and /errors.
+  # Setting this switches the dashboards from basic auth to GitHub sign-in.
+  # Leave empty to keep basic auth.
+  DASHBOARD_GITHUB_USERS: "arsfeld"
+  # Repository that issues filed from the feedback dashboard land in.
+  FEEDBACK_GITHUB_REPO: "getmydia/mydia"
   SMTP_HOST: "smtp.resend.com"
   SMTP_PORT: "587"
   SMTP_USERNAME: "resend"

--- a/infra/kubernetes/apps/metadata-relay/configmap.yaml
+++ b/infra/kubernetes/apps/metadata-relay/configmap.yaml
@@ -23,10 +23,11 @@ data:
   FEEDBACK_EMAIL_TO: "feedback@mydia.dev"
   FEEDBACK_EMAIL_FROM: "feedback@mydia.dev"
   FEEDBACK_DASHBOARD_URL: "https://relay.mydia.dev"
-  # Comma-separated GitHub logins allowed into /feedback and /errors.
-  # Setting this switches the dashboards from basic auth to GitHub sign-in.
-  # Leave empty to keep basic auth.
-  DASHBOARD_GITHUB_USERS: "arsfeld"
+  # GitHub organization whose active members may reach /feedback and /errors.
+  # Setting this switches the dashboards from basic auth to GitHub sign-in, so
+  # apply GITHUB_APP_CLIENT_ID/SECRET to the secret before applying this, or the
+  # dashboards are unreachable until it lands. Leave empty to keep basic auth.
+  DASHBOARD_GITHUB_ORG: "getmydia"
   # Repository that issues filed from the feedback dashboard land in.
   FEEDBACK_GITHUB_REPO: "getmydia/mydia"
   SMTP_HOST: "smtp.resend.com"

--- a/infra/kubernetes/apps/metadata-relay/secret.yaml.example
+++ b/infra/kubernetes/apps/metadata-relay/secret.yaml.example
@@ -32,6 +32,20 @@ stringData:
   # functionality specifically, not for the service to boot.
   SUBDL_API_KEY: "your-subdl-api-key"
 
+  # Phoenix session signing and encryption key.
+  # Generate with: head -c 48 /dev/urandom | base64
+  # Optional: a random key is generated per boot if unset, but dashboard
+  # sessions will not survive a restart.
+  SECRET_KEY_BASE: "generate-a-64-byte-or-longer-value"
+
+  # GitHub App "Mydia Relay" credentials.
+  # Create at: https://github.com/organizations/getmydia/settings/apps
+  # Repository permissions: Issues read and write.
+  # Callback URL: https://relay.mydia.dev/auth/github/callback
+  # Leave "Expire user authorization tokens" unchecked.
+  GITHUB_APP_CLIENT_ID: "your-github-app-client-id"
+  GITHUB_APP_CLIENT_SECRET: "your-github-app-client-secret"
+
 ---
 # Instructions:
 # 1. Copy this file to secret.yaml

--- a/metadata-relay/CLAUDE.md
+++ b/metadata-relay/CLAUDE.md
@@ -26,9 +26,11 @@ mix test
 mix format
 ```
 
-Environment variables: `PORT` (default 4001), `SECRET_KEY_BASE` (optional; a random key is generated per boot if unset, so sessions do not survive a restart), `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` (required in production unless `DASHBOARD_GITHUB_USERS` is set), `DASHBOARD_GITHUB_USERS` (comma-separated GitHub logins; setting this switches `/errors` and `/feedback` from basic auth to GitHub App sign-in and disables basic auth), `GITHUB_APP_CLIENT_ID` and `GITHUB_APP_CLIENT_SECRET` (the "Mydia Relay" GitHub App), `FEEDBACK_GITHUB_REPO` (default `getmydia/mydia`), `TMDB_API_KEY`, `TVDB_API_KEY`, `SUBDL_API_KEY`, `REDIS_URL` (optional).
+Environment variables: `PORT` (default 4001), `SECRET_KEY_BASE` (optional; a random key is generated per boot if unset, so sessions do not survive a restart), `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` (required in production unless `DASHBOARD_GITHUB_ORG` is set), `DASHBOARD_GITHUB_ORG` (a GitHub organization login; setting this switches `/errors` and `/feedback` from basic auth to GitHub App sign-in by active members of that org, and disables basic auth), `GITHUB_APP_CLIENT_ID` and `GITHUB_APP_CLIENT_SECRET` (the "Mydia Relay" GitHub App), `FEEDBACK_GITHUB_REPO` (default `getmydia/mydia`), `TMDB_API_KEY`, `TVDB_API_KEY`, `SUBDL_API_KEY`, `REDIS_URL` (optional).
 
-The two dashboard access modes are mutually exclusive. With `DASHBOARD_GITHUB_USERS` set, GitHub sign-in is the only way in and the feedback dashboard can file issues as the signed-in maintainer. With it empty, basic auth applies and the issue-filing button is hidden.
+The two dashboard access modes are mutually exclusive. With `DASHBOARD_GITHUB_ORG` set, GitHub sign-in is the only way in and the feedback dashboard can file issues as the signed-in maintainer. With it empty, basic auth applies and the issue-filing button is hidden.
+
+Access follows organization membership, so there is no list of logins to maintain: adding someone to the org grants the dashboards, removing them takes it away. Only an `active` membership counts, since a pending invitation would otherwise be enough to get in. Membership is a remote lookup rather than config, so it is checked at sign-in and re-checked at most every five minutes; a removed member keeps a live session until that window passes. When GitHub cannot be reached the existing session is left alone rather than signed out, so an outage at GitHub does not lock a maintainer out of the dashboards.
 
 ## Deploying a New Version
 

--- a/metadata-relay/CLAUDE.md
+++ b/metadata-relay/CLAUDE.md
@@ -26,7 +26,9 @@ mix test
 mix format
 ```
 
-Environment variables: `PORT` (default 4001), `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` (required in production for `/errors` and `/feedback` dashboards), `TMDB_API_KEY`, `TVDB_API_KEY`, `SUBDL_API_KEY`, `REDIS_URL` (optional).
+Environment variables: `PORT` (default 4001), `SECRET_KEY_BASE` (optional; a random key is generated per boot if unset, so sessions do not survive a restart), `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` (required in production unless `DASHBOARD_GITHUB_USERS` is set), `DASHBOARD_GITHUB_USERS` (comma-separated GitHub logins; setting this switches `/errors` and `/feedback` from basic auth to GitHub App sign-in and disables basic auth), `GITHUB_APP_CLIENT_ID` and `GITHUB_APP_CLIENT_SECRET` (the "Mydia Relay" GitHub App), `FEEDBACK_GITHUB_REPO` (default `getmydia/mydia`), `TMDB_API_KEY`, `TVDB_API_KEY`, `SUBDL_API_KEY`, `REDIS_URL` (optional).
+
+The two dashboard access modes are mutually exclusive. With `DASHBOARD_GITHUB_USERS` set, GitHub sign-in is the only way in and the feedback dashboard can file issues as the signed-in maintainer. With it empty, basic auth applies and the issue-filing button is hidden.
 
 ## Deploying a New Version
 

--- a/metadata-relay/config/runtime.exs
+++ b/metadata-relay/config/runtime.exs
@@ -16,6 +16,24 @@ if config_env() != :test do
     end
   end
 
+  secret_key_base =
+    case normalize_env.("SECRET_KEY_BASE") do
+      nil ->
+        IO.puts(
+          :stderr,
+          "[metadata_relay] SECRET_KEY_BASE is not set. Generating a random key for this boot. " <>
+            "Dashboard sessions will not survive a restart."
+        )
+
+        48 |> :crypto.strong_rand_bytes() |> Base.encode64()
+
+      value when byte_size(value) < 64 ->
+        raise("SECRET_KEY_BASE must be at least 64 bytes")
+
+      value ->
+        value
+    end
+
   dashboard_username =
     System.get_env("DASHBOARD_USERNAME") ||
       if config_env() == :prod do
@@ -47,7 +65,8 @@ if config_env() != :test do
 
   config :metadata_relay, MetadataRelayWeb.Endpoint,
     http: [port: port],
-    server: true
+    server: true,
+    secret_key_base: secret_key_base
 
   feedback_email_to = normalize_env.("FEEDBACK_EMAIL_TO")
   feedback_email_from = normalize_env.("FEEDBACK_EMAIL_FROM") || "metadata-relay@localhost"

--- a/metadata-relay/config/runtime.exs
+++ b/metadata-relay/config/runtime.exs
@@ -34,22 +34,6 @@ if config_env() != :test do
         value
     end
 
-  dashboard_username =
-    System.get_env("DASHBOARD_USERNAME") ||
-      if config_env() == :prod do
-        raise("DASHBOARD_USERNAME not set")
-      else
-        "admin"
-      end
-
-  dashboard_password =
-    System.get_env("DASHBOARD_PASSWORD") ||
-      if config_env() == :prod do
-        raise("DASHBOARD_PASSWORD not set")
-      else
-        "admin"
-      end
-
   dashboard_github_users =
     case normalize_env.("DASHBOARD_GITHUB_USERS") do
       nil ->
@@ -61,6 +45,25 @@ if config_env() != :test do
         |> Enum.map(&String.trim/1)
         |> Enum.reject(&(&1 == ""))
     end
+
+  # Basic auth credentials are only required when GitHub sign-in is not
+  # configured. The two modes are mutually exclusive, so demanding unused
+  # basic-auth credentials from a GitHub-only deployment would be busywork.
+  github_dashboard? = dashboard_github_users != []
+
+  require_dashboard_credential = fn name ->
+    cond do
+      github_dashboard? -> nil
+      config_env() == :prod -> raise("#{name} not set, and DASHBOARD_GITHUB_USERS is empty")
+      true -> "admin"
+    end
+  end
+
+  dashboard_username =
+    System.get_env("DASHBOARD_USERNAME") || require_dashboard_credential.("DASHBOARD_USERNAME")
+
+  dashboard_password =
+    System.get_env("DASHBOARD_PASSWORD") || require_dashboard_credential.("DASHBOARD_PASSWORD")
 
   config :metadata_relay,
     dashboard_auth: [username: dashboard_username, password: dashboard_password],

--- a/metadata-relay/config/runtime.exs
+++ b/metadata-relay/config/runtime.exs
@@ -111,6 +111,11 @@ if config_env() != :test do
     end
   end
 
+  config :metadata_relay, MetadataRelay.GitHub,
+    client_id: normalize_env.("GITHUB_APP_CLIENT_ID"),
+    client_secret: normalize_env.("GITHUB_APP_CLIENT_SECRET"),
+    repo: normalize_env.("FEEDBACK_GITHUB_REPO") || "getmydia/mydia"
+
   if config_env() == :prod do
     # API keys from environment
     tmdb_api_key = System.get_env("TMDB_API_KEY")

--- a/metadata-relay/config/runtime.exs
+++ b/metadata-relay/config/runtime.exs
@@ -49,11 +49,15 @@ if config_env() != :test do
     end
   end
 
+  # normalize_env, not System.get_env: an empty variable is truthy in Elixir, so
+  # `System.get_env("X") || raise(...)` happily yields "". Plug.BasicAuth then
+  # accepts an empty username and password, which opens the dashboards to
+  # anyone sending `Authorization: Basic <base64(":")>`.
   dashboard_username =
-    System.get_env("DASHBOARD_USERNAME") || require_dashboard_credential.("DASHBOARD_USERNAME")
+    normalize_env.("DASHBOARD_USERNAME") || require_dashboard_credential.("DASHBOARD_USERNAME")
 
   dashboard_password =
-    System.get_env("DASHBOARD_PASSWORD") || require_dashboard_credential.("DASHBOARD_PASSWORD")
+    normalize_env.("DASHBOARD_PASSWORD") || require_dashboard_credential.("DASHBOARD_PASSWORD")
 
   config :metadata_relay,
     dashboard_auth: [username: dashboard_username, password: dashboard_password],
@@ -117,10 +121,27 @@ if config_env() != :test do
     end
   end
 
+  github_client_id = normalize_env.("GITHUB_APP_CLIENT_ID")
+  github_client_secret = normalize_env.("GITHUB_APP_CLIENT_SECRET")
+
   config :metadata_relay, MetadataRelay.GitHub,
-    client_id: normalize_env.("GITHUB_APP_CLIENT_ID"),
-    client_secret: normalize_env.("GITHUB_APP_CLIENT_SECRET"),
+    client_id: github_client_id,
+    client_secret: github_client_secret,
     repo: normalize_env.("FEEDBACK_GITHUB_REPO") || "getmydia/mydia"
+
+  # GitHub mode with no App credentials leaves the dashboards unreachable: basic
+  # auth is off and sign-in cannot complete. Say so loudly rather than raising,
+  # because raising would crashloop the relay and take the TMDB/TVDB proxy down
+  # for every install over a maintainer-only feature. Failing this way is closed,
+  # not open, so the dashboards are shut rather than exposed.
+  if github_dashboard? and (is_nil(github_client_id) or is_nil(github_client_secret)) do
+    IO.puts(
+      :stderr,
+      "[metadata_relay] DASHBOARD_GITHUB_ORG is set but GITHUB_APP_CLIENT_ID/GITHUB_APP_CLIENT_SECRET " <>
+        "are not. Basic auth is disabled and GitHub sign-in cannot complete, so /feedback and /errors " <>
+        "are unreachable until both are set."
+    )
+  end
 
   if config_env() == :prod do
     # API keys from environment

--- a/metadata-relay/config/runtime.exs
+++ b/metadata-relay/config/runtime.exs
@@ -34,27 +34,17 @@ if config_env() != :test do
         value
     end
 
-  dashboard_github_users =
-    case normalize_env.("DASHBOARD_GITHUB_USERS") do
-      nil ->
-        []
-
-      value ->
-        value
-        |> String.split(",")
-        |> Enum.map(&String.trim/1)
-        |> Enum.reject(&(&1 == ""))
-    end
+  dashboard_github_org = normalize_env.("DASHBOARD_GITHUB_ORG")
 
   # Basic auth credentials are only required when GitHub sign-in is not
   # configured. The two modes are mutually exclusive, so demanding unused
   # basic-auth credentials from a GitHub-only deployment would be busywork.
-  github_dashboard? = dashboard_github_users != []
+  github_dashboard? = dashboard_github_org != nil
 
   require_dashboard_credential = fn name ->
     cond do
       github_dashboard? -> nil
-      config_env() == :prod -> raise("#{name} not set, and DASHBOARD_GITHUB_USERS is empty")
+      config_env() == :prod -> raise("#{name} not set, and DASHBOARD_GITHUB_ORG is empty")
       true -> "admin"
     end
   end
@@ -67,7 +57,7 @@ if config_env() != :test do
 
   config :metadata_relay,
     dashboard_auth: [username: dashboard_username, password: dashboard_password],
-    dashboard_github_users: dashboard_github_users
+    dashboard_github_org: dashboard_github_org
 
   # Database configuration (all environments except test)
   db_path = System.get_env("SQLITE_DB_PATH") || "./metadata_relay.db"

--- a/metadata-relay/config/runtime.exs
+++ b/metadata-relay/config/runtime.exs
@@ -50,8 +50,21 @@ if config_env() != :test do
         "admin"
       end
 
+  dashboard_github_users =
+    case normalize_env.("DASHBOARD_GITHUB_USERS") do
+      nil ->
+        []
+
+      value ->
+        value
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> Enum.reject(&(&1 == ""))
+    end
+
   config :metadata_relay,
-    dashboard_auth: [username: dashboard_username, password: dashboard_password]
+    dashboard_auth: [username: dashboard_username, password: dashboard_password],
+    dashboard_github_users: dashboard_github_users
 
   # Database configuration (all environments except test)
   db_path = System.get_env("SQLITE_DB_PATH") || "./metadata_relay.db"

--- a/metadata-relay/lib/metadata_relay/feedback.ex
+++ b/metadata-relay/lib/metadata_relay/feedback.ex
@@ -6,6 +6,7 @@ defmodule MetadataRelay.Feedback do
   import Ecto.Query
 
   alias MetadataRelay.Feedback.Submission
+  alias MetadataRelay.GitHub.Client
   alias MetadataRelay.Repo
 
   def create_submission(attrs) when is_map(attrs) do
@@ -87,6 +88,21 @@ defmodule MetadataRelay.Feedback do
     submission
     |> Submission.github_ref_changeset(github_ref)
     |> Repo.update()
+  end
+
+  @doc """
+  Creates a GitHub issue for a submission using the caller's token.
+
+  On success the reference, URL, and state are written in one update. On
+  failure the row is left untouched, so a failed call never leaves a
+  half-filed submission behind.
+  """
+  def file_issue(%Submission{} = submission, attrs, token) do
+    with {:ok, %{number: number, html_url: html_url}} <- Client.create_issue(attrs, token) do
+      submission
+      |> Submission.filed_changeset("##{number}", html_url)
+      |> Repo.update()
+    end
   end
 
   @doc """

--- a/metadata-relay/lib/metadata_relay/feedback.ex
+++ b/metadata-relay/lib/metadata_relay/feedback.ex
@@ -37,6 +37,11 @@ defmodule MetadataRelay.Feedback do
               "coalesce(sum(case when ? = 'read' then 1 else 0 end), 0)",
               submission.state
             ),
+          filed:
+            fragment(
+              "coalesce(sum(case when ? = 'filed' then 1 else 0 end), 0)",
+              submission.state
+            ),
           archived:
             fragment(
               "coalesce(sum(case when ? = 'archived' then 1 else 0 end), 0)",

--- a/metadata-relay/lib/metadata_relay/feedback.ex
+++ b/metadata-relay/lib/metadata_relay/feedback.ex
@@ -84,6 +84,43 @@ defmodule MetadataRelay.Feedback do
     |> Repo.update()
   end
 
+  @doc """
+  Base URL of the maintainer dashboard, with any trailing slash removed.
+
+  Shared by the email notifier and the GitHub issue body so both derive their
+  backlink from one place.
+  """
+  def dashboard_url do
+    :metadata_relay
+    |> Application.get_env(MetadataRelay.Feedback.Notifier, [])
+    |> Keyword.get(:dashboard_url)
+    |> case do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> nil
+          trimmed -> String.trim_trailing(trimmed, "/")
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  @doc """
+  Dashboard link for a submission, focusing and anchoring it.
+
+  The two-argument form takes the base URL so pure callers such as
+  `MetadataRelay.Feedback.IssueDraft` can build the same link without reading
+  configuration. This is the single definition of the link format.
+  """
+  def submission_url(submission), do: submission_url(submission, dashboard_url())
+
+  def submission_url(_submission, nil), do: nil
+
+  def submission_url(%Submission{id: id}, base) when is_binary(base) do
+    "#{base}/feedback?focus=#{id}#feedback-#{id}"
+  end
+
   defp maybe_filter(query, _field, nil), do: query
   defp maybe_filter(query, _field, "all"), do: query
   defp maybe_filter(query, _field, :all), do: query

--- a/metadata-relay/lib/metadata_relay/feedback/issue_draft.ex
+++ b/metadata-relay/lib/metadata_relay/feedback/issue_draft.ex
@@ -1,0 +1,84 @@
+defmodule MetadataRelay.Feedback.IssueDraft do
+  @moduledoc """
+  Turns a feedback submission into a GitHub issue draft.
+
+  Pure. Issues on the target repository are public, so the draft deliberately
+  omits `contact`, `source_ip`, and `instance_id`. `mydia_version` is included
+  because it is the one field that consistently earns its place in a bug report.
+  """
+
+  alias MetadataRelay.Feedback.Submission
+
+  @title_limit 72
+
+  @labels %{
+    "bug" => ["bug"],
+    "idea" => ["enhancement"],
+    "question" => ["question"]
+  }
+
+  defstruct [:title, :body, :labels]
+
+  @type t :: %__MODULE__{
+          title: String.t(),
+          body: String.t(),
+          labels: [String.t()]
+        }
+
+  @spec from_submission(Submission.t(), String.t() | nil) :: t()
+  def from_submission(%Submission{} = submission, dashboard_url) do
+    %__MODULE__{
+      title: title(submission),
+      body: body(submission, dashboard_url),
+      labels: Map.get(@labels, submission.type, [])
+    }
+  end
+
+  defp title(%Submission{message: message, type: type}) do
+    message
+    |> to_string()
+    |> String.split("\n")
+    |> Enum.map(&(&1 |> String.replace(~r/\s+/, " ") |> String.trim()))
+    |> Enum.find(&(&1 != ""))
+    |> case do
+      nil -> "Feedback: #{type}"
+      line -> truncate(line)
+    end
+  end
+
+  defp truncate(line) do
+    if String.length(line) > @title_limit do
+      String.slice(line, 0, @title_limit) <> "…"
+    else
+      line
+    end
+  end
+
+  defp body(submission, dashboard_url) do
+    [
+      submission.message,
+      "",
+      "---",
+      provenance(submission),
+      backlink(submission, dashboard_url)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp provenance(%Submission{mydia_version: nil}), do: "Reported via in-app feedback."
+
+  defp provenance(%Submission{mydia_version: version}) do
+    case String.trim(to_string(version)) do
+      "" -> "Reported via in-app feedback."
+      trimmed -> "Reported via in-app feedback from Mydia #{trimmed}."
+    end
+  end
+
+  defp backlink(submission, dashboard_url) do
+    case MetadataRelay.Feedback.submission_url(submission, dashboard_url) do
+      nil -> nil
+      url -> "Feedback: " <> url
+    end
+  end
+end

--- a/metadata-relay/lib/metadata_relay/feedback/issue_draft.ex
+++ b/metadata-relay/lib/metadata_relay/feedback/issue_draft.ex
@@ -56,7 +56,7 @@ defmodule MetadataRelay.Feedback.IssueDraft do
 
   defp body(submission, dashboard_url) do
     [
-      submission.message,
+      defang(submission.message),
       "",
       "---",
       provenance(submission),
@@ -64,6 +64,21 @@ defmodule MetadataRelay.Feedback.IssueDraft do
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join("\n")
+  end
+
+  @doc false
+  # Feedback is submitted anonymously and the issue is public, so a reporter
+  # could otherwise make a maintainer's account ping arbitrary people with
+  # `@someone` or backlink an unrelated issue with `#123`. GitHub's own escape
+  # is an empty HTML comment: it renders as the original text but stops the
+  # mention and the autolink.
+  def defang(nil), do: nil
+
+  def defang(message) do
+    message
+    |> to_string()
+    |> String.replace(~r/(?<![\w`])@(?=[A-Za-z0-9])/, "@<!---->")
+    |> String.replace(~r/(?<![\w`&])#(?=\d)/, "#<!---->")
   end
 
   defp provenance(%Submission{mydia_version: nil}), do: "Reported via in-app feedback."

--- a/metadata-relay/lib/metadata_relay/feedback/issue_draft.ex
+++ b/metadata-relay/lib/metadata_relay/feedback/issue_draft.ex
@@ -78,6 +78,10 @@ defmodule MetadataRelay.Feedback.IssueDraft do
     message
     |> to_string()
     |> String.replace(~r/(?<![\w`])@(?=[A-Za-z0-9])/, "@<!---->")
+    # owner/repo#123 cross-references another repository and backlinks it there.
+    # It has to come first: the bare rule below refuses to touch a `#` that
+    # follows a word character, which is exactly what this form looks like.
+    |> String.replace(~r"([\w.\-]+/[\w.\-]+)#(?=\d)", "\\1#<!---->")
     |> String.replace(~r/(?<![\w`&])#(?=\d)/, "#<!---->")
   end
 

--- a/metadata-relay/lib/metadata_relay/feedback/notifier.ex
+++ b/metadata-relay/lib/metadata_relay/feedback/notifier.ex
@@ -86,20 +86,9 @@ defmodule MetadataRelay.Feedback.Notifier do
   end
 
   defp dashboard_line(submission) do
-    case dashboard_url() do
+    case MetadataRelay.Feedback.submission_url(submission) do
       nil -> ""
-      dashboard_url -> "\n\nDashboard: #{dashboard_url}/feedback#feedback-#{submission.id}"
-    end
-  end
-
-  defp dashboard_url do
-    @config_key
-    |> config()
-    |> Keyword.get(:dashboard_url)
-    |> normalize_optional_string()
-    |> case do
-      nil -> nil
-      url -> String.trim_trailing(url, "/")
+      url -> "\n\nDashboard: #{url}"
     end
   end
 

--- a/metadata-relay/lib/metadata_relay/feedback/submission.ex
+++ b/metadata-relay/lib/metadata_relay/feedback/submission.ex
@@ -11,7 +11,8 @@ defmodule MetadataRelay.Feedback.Submission do
   @foreign_key_type :binary_id
 
   @types ["bug", "idea", "question"]
-  @states ["unread", "read", "archived"]
+  @states ["unread", "read", "filed", "archived"]
+  @promotable_states ["unread", "read"]
 
   schema "feedback_submissions" do
     field(:type, :string)
@@ -22,6 +23,7 @@ defmodule MetadataRelay.Feedback.Submission do
     field(:source_ip, :string)
     field(:state, :string, default: "unread")
     field(:github_ref, :string)
+    field(:github_issue_url, :string)
 
     timestamps(type: :utc_datetime)
   end
@@ -36,7 +38,8 @@ defmodule MetadataRelay.Feedback.Submission do
       :mydia_version,
       :source_ip,
       :state,
-      :github_ref
+      :github_ref,
+      :github_issue_url
     ])
     |> validate_required([:type, :message])
     |> validate_inclusion(:type, @types)
@@ -51,6 +54,35 @@ defmodule MetadataRelay.Feedback.Submission do
   end
 
   def github_ref_changeset(submission, github_ref) do
-    cast(submission, %{github_ref: github_ref}, [:github_ref])
+    submission
+    |> cast(%{github_ref: github_ref}, [:github_ref])
+    |> maybe_promote_state()
+    |> validate_inclusion(:state, @states)
   end
+
+  def filed_changeset(submission, github_ref, github_issue_url) do
+    state = if submission.state == "archived", do: "archived", else: "filed"
+
+    submission
+    |> cast(
+      %{github_ref: github_ref, github_issue_url: github_issue_url, state: state},
+      [:github_ref, :github_issue_url, :state]
+    )
+    |> validate_required([:github_ref, :state])
+    |> validate_inclusion(:state, @states)
+  end
+
+  defp maybe_promote_state(changeset) do
+    ref = get_field(changeset, :github_ref)
+    state = changeset.data.state
+
+    if present?(ref) and state in @promotable_states do
+      put_change(changeset, :state, "filed")
+    else
+      changeset
+    end
+  end
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(_), do: false
 end

--- a/metadata-relay/lib/metadata_relay/github/client.ex
+++ b/metadata-relay/lib/metadata_relay/github/client.ex
@@ -1,0 +1,90 @@
+defmodule MetadataRelay.GitHub.Client do
+  @moduledoc """
+  Authenticated GitHub REST calls made on behalf of the signed-in maintainer.
+
+  The token is always supplied by the caller. The relay holds no long-lived
+  GitHub credential of its own.
+  """
+
+  alias MetadataRelay.Feedback.IssueDraft
+
+  @config_key MetadataRelay.GitHub
+  @api_url "https://api.github.com"
+  @default_repo "getmydia/mydia"
+
+  @doc "Target repository in `owner/repo` form."
+  def repo do
+    :metadata_relay
+    |> Application.get_env(@config_key, [])
+    |> Keyword.get(:repo)
+    |> case do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> @default_repo
+          trimmed -> trimmed
+        end
+
+      _ ->
+        @default_repo
+    end
+  end
+
+  @doc """
+  Creates an issue from a draft or an equivalent map of `:title`, `:body` and
+  `:labels`.
+  """
+  def create_issue(%IssueDraft{} = draft, token) do
+    create_issue(%{title: draft.title, body: draft.body, labels: draft.labels}, token)
+  end
+
+  def create_issue(%{title: title, body: body} = attrs, token) when is_binary(token) do
+    payload = %{
+      title: title,
+      body: body,
+      labels: Map.get(attrs, :labels, [])
+    }
+
+    request =
+      req_new(
+        url: @api_url <> "/repos/" <> repo() <> "/issues",
+        method: :post,
+        headers: [
+          {"accept", "application/vnd.github+json"},
+          {"authorization", "Bearer " <> token},
+          {"x-github-api-version", "2022-11-28"}
+        ],
+        json: payload
+      )
+
+    case Req.request(request) do
+      {:ok, %{status: 201, body: %{"number" => number, "html_url" => html_url}}} ->
+        {:ok, %{number: number, html_url: html_url}}
+
+      {:ok, %{status: status}} when status in [401, 403] ->
+        {:error, {:unauthorized, "GitHub rejected your sign-in. Sign in again and retry."}}
+
+      {:ok, %{status: 404}} ->
+        {:error,
+         {:not_found, "Repository #{repo()} not found, or your account lacks Issues access."}}
+
+      {:ok, %{status: 422, body: body}} ->
+        {:error, {:unprocessable, message(body, "GitHub rejected the issue.")}}
+
+      {:ok, %{status: _status}} ->
+        {:error, {:server_error, "GitHub is unreachable. Your draft is preserved, try again."}}
+
+      {:error, _reason} ->
+        {:error, {:transport, "GitHub is unreachable. Your draft is preserved, try again."}}
+    end
+  end
+
+  defp message(%{"message" => message}, _default) when is_binary(message), do: message
+  defp message(_body, default), do: default
+
+  defp req_new(opts) do
+    adapter = Application.get_env(:metadata_relay, :github_http_adapter)
+    opts = if adapter, do: Keyword.put(opts, :adapter, adapter), else: opts
+
+    Req.new(opts)
+  end
+end

--- a/metadata-relay/lib/metadata_relay/github/oauth.ex
+++ b/metadata-relay/lib/metadata_relay/github/oauth.ex
@@ -119,6 +119,16 @@ defmodule MetadataRelay.GitHub.OAuth do
       {:ok, %{status: 404}} ->
         {:error, :not_a_member}
 
+      # GitHub answers 403 for rate limiting as well as for refusal, so the
+      # status alone cannot tell "you may not" from "not right now". Callers
+      # sign a session out on a refusal, and doing that to a rate-limited
+      # maintainer would be both wrong and confusing.
+      {:ok, %{status: 429}} ->
+        {:error, :rate_limited}
+
+      {:ok, %{status: 403} = response} ->
+        if rate_limited?(response), do: {:error, :rate_limited}, else: {:error, {:http, 403}}
+
       {:ok, %{status: status}} ->
         {:error, {:http, status}}
 
@@ -126,6 +136,16 @@ defmodule MetadataRelay.GitHub.OAuth do
         {:error, {:transport, reason}}
     end
   end
+
+  defp rate_limited?(%{headers: headers}) do
+    not is_nil(header(headers, "retry-after")) or header(headers, "x-ratelimit-remaining") == "0"
+  end
+
+  defp header(headers, name) when is_map(headers) do
+    headers |> Map.get(name, []) |> List.wrap() |> List.first()
+  end
+
+  defp header(_headers, _name), do: nil
 
   defp req_new(opts) do
     adapter = Application.get_env(:metadata_relay, :github_http_adapter)

--- a/metadata-relay/lib/metadata_relay/github/oauth.ex
+++ b/metadata-relay/lib/metadata_relay/github/oauth.ex
@@ -1,0 +1,110 @@
+defmodule MetadataRelay.GitHub.OAuth do
+  @moduledoc """
+  User-to-server authorization against the Mydia Relay GitHub App.
+
+  The App's registered callback URL is used, so no `redirect_uri` is sent.
+  GitHub Apps take their permissions from the App declaration, so no `scope`
+  parameter is sent either.
+
+  ## Testing
+
+  Inject a Req adapter through application config:
+
+      config :metadata_relay, :github_http_adapter, fn request ->
+        {request, Req.Response.new(status: 200, body: %{})}
+      end
+  """
+
+  @config_key MetadataRelay.GitHub
+
+  @authorize_url "https://github.com/login/oauth/authorize"
+  @token_url "https://github.com/login/oauth/access_token"
+  @api_url "https://api.github.com"
+
+  @doc "True when both App credentials are present."
+  def configured?, do: not is_nil(client_id()) and not is_nil(client_secret())
+
+  @doc "URL to send the browser to, carrying an anti-forgery state value."
+  def authorize_url(state) when is_binary(state) do
+    query = URI.encode_query(%{"client_id" => client_id(), "state" => state})
+    @authorize_url <> "?" <> query
+  end
+
+  @doc "Trades an authorization code for a user access token."
+  def exchange_code(code) when is_binary(code) do
+    request =
+      req_new(
+        url: @token_url,
+        method: :post,
+        headers: [{"accept", "application/json"}],
+        json: %{
+          client_id: client_id(),
+          client_secret: client_secret(),
+          code: code
+        }
+      )
+
+    case Req.request(request) do
+      {:ok, %{status: 200, body: %{"access_token" => token}}} when is_binary(token) ->
+        {:ok, token}
+
+      {:ok, %{status: 200, body: %{"error" => error} = body}} ->
+        {:error, {:oauth, Map.get(body, "error_description", error)}}
+
+      {:ok, %{status: status}} ->
+        {:error, {:http, status}}
+
+      {:error, reason} ->
+        {:error, {:transport, reason}}
+    end
+  end
+
+  @doc "Looks up the authenticated user for a token."
+  def fetch_user(token) when is_binary(token) do
+    request =
+      req_new(
+        url: @api_url <> "/user",
+        method: :get,
+        headers: [
+          {"accept", "application/vnd.github+json"},
+          {"authorization", "Bearer " <> token},
+          {"x-github-api-version", "2022-11-28"}
+        ]
+      )
+
+    case Req.request(request) do
+      {:ok, %{status: 200, body: %{"login" => login}}} when is_binary(login) ->
+        {:ok, %{login: login}}
+
+      {:ok, %{status: status}} ->
+        {:error, {:http, status}}
+
+      {:error, reason} ->
+        {:error, {:transport, reason}}
+    end
+  end
+
+  defp req_new(opts) do
+    adapter = Application.get_env(:metadata_relay, :github_http_adapter)
+    opts = if adapter, do: Keyword.put(opts, :adapter, adapter), else: opts
+
+    Req.new(opts)
+  end
+
+  defp client_id, do: config(:client_id)
+  defp client_secret, do: config(:client_secret)
+
+  defp config(key) do
+    :metadata_relay
+    |> Application.get_env(@config_key, [])
+    |> Keyword.get(key)
+    |> normalize()
+  end
+
+  defp normalize(value) when is_binary(value) do
+    trimmed = String.trim(value)
+    if trimmed == "", do: nil, else: trimmed
+  end
+
+  defp normalize(_), do: nil
+end

--- a/metadata-relay/lib/metadata_relay/github/oauth.ex
+++ b/metadata-relay/lib/metadata_relay/github/oauth.ex
@@ -84,6 +84,49 @@ defmodule MetadataRelay.GitHub.OAuth do
     end
   end
 
+  @doc """
+  Checks the authenticated user's membership of `org`.
+
+  The endpoint is scoped to the caller's own membership, so it sees private
+  membership without the App needing to read the org's member list.
+
+  A pending invitation also answers 200, with `state` set to `"pending"`. Only
+  `"active"` counts, otherwise merely inviting someone would hand them the
+  dashboard.
+  """
+  def fetch_org_membership(token, org) when is_binary(token) and is_binary(org) do
+    request =
+      req_new(
+        url: @api_url <> "/user/memberships/orgs/" <> URI.encode(org),
+        method: :get,
+        headers: [
+          {"accept", "application/vnd.github+json"},
+          {"authorization", "Bearer " <> token},
+          {"x-github-api-version", "2022-11-28"}
+        ]
+      )
+
+    case Req.request(request) do
+      {:ok, %{status: 200, body: %{"state" => "active"}}} ->
+        {:ok, :active}
+
+      {:ok, %{status: 200, body: %{"state" => state}}} ->
+        {:error, {:membership, state}}
+
+      {:ok, %{status: 200}} ->
+        {:error, {:membership, "unknown"}}
+
+      {:ok, %{status: 404}} ->
+        {:error, :not_a_member}
+
+      {:ok, %{status: status}} ->
+        {:error, {:http, status}}
+
+      {:error, reason} ->
+        {:error, {:transport, reason}}
+    end
+  end
+
   defp req_new(opts) do
     adapter = Application.get_env(:metadata_relay, :github_http_adapter)
     opts = if adapter, do: Keyword.put(opts, :adapter, adapter), else: opts

--- a/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
+++ b/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
@@ -59,6 +59,10 @@ defmodule MetadataRelayWeb.AuthController do
 
     conn
     |> configure_session(renew: true)
+    # The state has served its purpose. Dropping it makes it single-use, so a
+    # replayed callback URL cannot be validated against a stale value.
+    |> delete_session(:oauth_state)
+    |> delete_session(:return_to)
     |> put_session(:github_login, login)
     |> put_session(:github_token, token)
     |> redirect(to: return_to)

--- a/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
+++ b/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
@@ -1,0 +1,75 @@
+defmodule MetadataRelayWeb.AuthController do
+  @moduledoc """
+  GitHub App sign-in for the maintainer dashboards.
+  """
+
+  use Phoenix.Controller, formats: [:html]
+
+  import Plug.Conn
+
+  alias MetadataRelay.GitHub.OAuth
+  alias MetadataRelayWeb.DashboardAuth
+
+  @generic_failure "GitHub sign-in failed. Try again."
+  @not_authorized "That GitHub account is not authorized for this dashboard."
+
+  def login(conn, params) do
+    render(conn, :login, error: error_message(params["error"]))
+  end
+
+  def request(conn, _params) do
+    if OAuth.configured?() do
+      state = 24 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+
+      conn
+      |> put_session(:oauth_state, state)
+      |> redirect(external: OAuth.authorize_url(state))
+    else
+      redirect(conn, to: "/auth/login?error=failed")
+    end
+  end
+
+  def callback(conn, %{"code" => code, "state" => state}) do
+    expected = get_session(conn, :oauth_state)
+
+    with true <- is_binary(expected) and Plug.Crypto.secure_compare(state, expected),
+         {:ok, token} <- OAuth.exchange_code(code),
+         {:ok, %{login: login}} <- OAuth.fetch_user(token) do
+      if DashboardAuth.allowed?(login) do
+        sign_in(conn, login, token)
+      else
+        deny(conn, "denied")
+      end
+    else
+      _ -> deny(conn, "failed")
+    end
+  end
+
+  def callback(conn, _params), do: deny(conn, "failed")
+
+  def logout(conn, _params) do
+    conn
+    |> configure_session(drop: true)
+    |> redirect(to: "/auth/login")
+  end
+
+  defp sign_in(conn, login, token) do
+    return_to = DashboardAuth.safe_return_to(get_session(conn, :return_to))
+
+    conn
+    |> configure_session(renew: true)
+    |> put_session(:github_login, login)
+    |> put_session(:github_token, token)
+    |> redirect(to: return_to)
+  end
+
+  defp deny(conn, reason) do
+    conn
+    |> configure_session(drop: true)
+    |> redirect(to: "/auth/login?error=" <> reason)
+  end
+
+  defp error_message("denied"), do: @not_authorized
+  defp error_message("failed"), do: @generic_failure
+  defp error_message(_), do: nil
+end

--- a/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
+++ b/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
@@ -49,6 +49,7 @@ defmodule MetadataRelayWeb.AuthController do
 
   def logout(conn, _params) do
     conn
+    |> clear_session()
     |> configure_session(drop: true)
     |> redirect(to: "/auth/login")
   end
@@ -65,6 +66,7 @@ defmodule MetadataRelayWeb.AuthController do
 
   defp deny(conn, reason) do
     conn
+    |> clear_session()
     |> configure_session(drop: true)
     |> redirect(to: "/auth/login?error=" <> reason)
   end

--- a/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
+++ b/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
@@ -29,7 +29,11 @@ defmodule MetadataRelayWeb.AuthController do
     end
   end
 
-  def callback(conn, %{"code" => code, "state" => state}) do
+  # Nested query params (`?state[]=x`) arrive as lists, and both
+  # `secure_compare/2` and `exchange_code/1` only accept binaries. Guarding here
+  # sends malformed callbacks to the catch-all clause below instead of raising.
+  def callback(conn, %{"code" => code, "state" => state})
+      when is_binary(code) and is_binary(state) do
     expected = get_session(conn, :oauth_state)
 
     with true <- is_binary(expected) and Plug.Crypto.secure_compare(state, expected),

--- a/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
+++ b/metadata-relay/lib/metadata_relay_web/controllers/auth_controller.ex
@@ -11,7 +11,8 @@ defmodule MetadataRelayWeb.AuthController do
   alias MetadataRelayWeb.DashboardAuth
 
   @generic_failure "GitHub sign-in failed. Try again."
-  @not_authorized "That GitHub account is not authorized for this dashboard."
+  @not_authorized "That GitHub account is not an active member of the organization."
+  @unavailable "GitHub could not confirm your membership right now. Try again."
 
   def login(conn, params) do
     render(conn, :login, error: error_message(params["error"]))
@@ -39,10 +40,10 @@ defmodule MetadataRelayWeb.AuthController do
     with true <- is_binary(expected) and Plug.Crypto.secure_compare(state, expected),
          {:ok, token} <- OAuth.exchange_code(code),
          {:ok, %{login: login}} <- OAuth.fetch_user(token) do
-      if DashboardAuth.allowed?(login) do
-        sign_in(conn, login, token)
-      else
-        deny(conn, "denied")
+      case DashboardAuth.verify_membership(token) do
+        :ok -> sign_in(conn, login, token)
+        {:error, :denied} -> deny(conn, "denied")
+        {:error, :unavailable} -> deny(conn, "unavailable")
       end
     else
       _ -> deny(conn, "failed")
@@ -69,6 +70,7 @@ defmodule MetadataRelayWeb.AuthController do
     |> delete_session(:return_to)
     |> put_session(:github_login, login)
     |> put_session(:github_token, token)
+    |> put_session(:github_verified_at, DashboardAuth.verified_now())
     |> redirect(to: return_to)
   end
 
@@ -80,6 +82,7 @@ defmodule MetadataRelayWeb.AuthController do
   end
 
   defp error_message("denied"), do: @not_authorized
+  defp error_message("unavailable"), do: @unavailable
   defp error_message("failed"), do: @generic_failure
   defp error_message(_), do: nil
 end

--- a/metadata-relay/lib/metadata_relay_web/controllers/auth_html.ex
+++ b/metadata-relay/lib/metadata_relay_web/controllers/auth_html.ex
@@ -1,0 +1,39 @@
+defmodule MetadataRelayWeb.AuthHTML do
+  @moduledoc """
+  Markup for the maintainer sign-in page.
+  """
+
+  use Phoenix.Component
+
+  attr(:flash, :map, default: %{})
+  attr(:error, :string, default: nil)
+
+  def login(assigns) do
+    ~H"""
+    <MetadataRelayWeb.Layouts.app flash={@flash}>
+      <section id="sign-in" class="mx-auto w-full max-w-md py-16">
+        <div class="card border border-base-300 bg-base-100 shadow-xl">
+          <div class="card-body items-center gap-6 text-center">
+            <div class="badge badge-primary badge-lg">Maintainer dashboard</div>
+
+            <div class="space-y-2">
+              <h1 class="text-3xl font-semibold tracking-tight">Metadata Relay</h1>
+              <p class="text-base-content/70">
+                Sign in with GitHub to review feedback and error reports.
+              </p>
+            </div>
+
+            <div :if={@error} id="sign-in-error" class="alert alert-error">
+              <span>{@error}</span>
+            </div>
+
+            <a id="sign-in-github" href="/auth/github" class="btn btn-primary btn-wide">
+              Sign in with GitHub
+            </a>
+          </div>
+        </div>
+      </section>
+    </MetadataRelayWeb.Layouts.app>
+    """
+  end
+end

--- a/metadata-relay/lib/metadata_relay_web/dashboard_auth.ex
+++ b/metadata-relay/lib/metadata_relay_web/dashboard_auth.ex
@@ -65,6 +65,8 @@ defmodule MetadataRelayWeb.DashboardAuth do
   defp classify({:ok, :active}), do: :ok
   defp classify({:error, :not_a_member}), do: {:error, :denied}
   defp classify({:error, {:membership, _state}}), do: {:error, :denied}
+  # Being throttled is not a refusal, so it must not end a verified session.
+  defp classify({:error, :rate_limited}), do: {:error, :unavailable}
   defp classify({:error, {:http, status}}) when status in 401..403, do: {:error, :denied}
   defp classify({:error, _reason}), do: {:error, :unavailable}
 

--- a/metadata-relay/lib/metadata_relay_web/dashboard_auth.ex
+++ b/metadata-relay/lib/metadata_relay_web/dashboard_auth.ex
@@ -2,36 +2,81 @@ defmodule MetadataRelayWeb.DashboardAuth do
   @moduledoc """
   Access control for the maintainer dashboards.
 
-  Two mutually exclusive modes. When `:dashboard_github_users` is non-empty the
-  dashboards require GitHub sign-in and basic auth is off. When it is empty the
-  relay keeps the original HTTP Basic Auth, which is what self-hosted relays,
-  local development, and the test suite use.
+  Two mutually exclusive modes. When `:dashboard_github_org` is set the
+  dashboards require GitHub sign-in by an active member of that organization,
+  and basic auth is off. When it is unset the relay keeps the original HTTP
+  Basic Auth, which is what self-hosted relays, local development, and the test
+  suite use.
+
+  Membership is a remote lookup, not a config value, so it is checked once at
+  sign-in and then re-checked at most every `#{div(300, 60)}` minutes. That
+  bounds how long someone removed from the organization keeps a live session,
+  without an API call on every request.
   """
 
   import Plug.Conn
   import Phoenix.Controller, only: [redirect: 2]
 
+  alias MetadataRelay.GitHub.OAuth
   alias Phoenix.Component
   alias Phoenix.LiveView
 
   @default_return_to "/feedback"
 
+  # How long a verified membership is trusted before it is checked again.
+  @revalidate_after_seconds 300
+
   @doc "Which access-control mode is active."
   def mode do
-    case allowlist() do
-      [] -> :basic
+    case org() do
+      nil -> :basic
       _ -> :github
     end
   end
 
-  @doc "Whether a GitHub login may reach the dashboards."
-  def allowed?(login) when is_binary(login) do
-    normalized = login |> String.trim() |> String.downcase()
-
-    normalized != "" and normalized in allowlist()
+  @doc "The organization whose members may reach the dashboards, or nil."
+  def org do
+    :metadata_relay
+    |> Application.get_env(:dashboard_github_org)
+    |> normalize()
   end
 
-  def allowed?(_), do: false
+  @doc """
+  Confirms the token's owner is an active member of the configured org.
+
+  Returns `:ok`, or `{:error, :denied}` when GitHub answered definitively that
+  this account may not enter, or `{:error, :unavailable}` when GitHub could not
+  be reached. Callers distinguish the two: a denial ends the session, an
+  outage leaves an already-verified session alone.
+  """
+  def verify_membership(token) do
+    case org() do
+      nil ->
+        {:error, :denied}
+
+      org when is_binary(token) ->
+        classify(OAuth.fetch_org_membership(token, org))
+
+      _org ->
+        {:error, :denied}
+    end
+  end
+
+  defp classify({:ok, :active}), do: :ok
+  defp classify({:error, :not_a_member}), do: {:error, :denied}
+  defp classify({:error, {:membership, _state}}), do: {:error, :denied}
+  defp classify({:error, {:http, status}}) when status in 401..403, do: {:error, :denied}
+  defp classify({:error, _reason}), do: {:error, :unavailable}
+
+  @doc "Seconds-since-epoch stamp recorded when membership was last confirmed."
+  def verified_now, do: System.system_time(:second)
+
+  @doc "Whether a stored verification stamp is still inside the revalidation window."
+  def verification_fresh?(verified_at) when is_integer(verified_at) do
+    verified_now() - verified_at < @revalidate_after_seconds
+  end
+
+  def verification_fresh?(_), do: false
 
   @doc """
   Constrains a stored return path to a local absolute path.
@@ -62,6 +107,10 @@ defmodule MetadataRelayWeb.DashboardAuth do
   @doc """
   LiveView hook. The connected mount is a separate request, so the plug alone
   is not enough.
+
+  The hook cannot write back to the session, so a stale stamp is re-checked on
+  every mount until an ordinary request refreshes it. Mounts are infrequent
+  enough for that to be cheap.
   """
   def on_mount(:require_github_login, _params, session, socket) do
     case mode() do
@@ -70,9 +119,10 @@ defmodule MetadataRelayWeb.DashboardAuth do
 
       :github ->
         login = session["github_login"]
+        token = session["github_token"]
 
-        if allowed?(login) do
-          {:cont, assign_identity(socket, login, session["github_token"])}
+        if signed_in?(login, token) and mount_membership_ok?(token, session["github_verified_at"]) do
+          {:cont, assign_identity(socket, login, token)}
         else
           {:halt, LiveView.redirect(socket, to: "/auth/login")}
         end
@@ -85,8 +135,20 @@ defmodule MetadataRelayWeb.DashboardAuth do
   def live_session_data(conn) do
     %{
       "github_login" => get_session(conn, :github_login),
-      "github_token" => get_session(conn, :github_token)
+      "github_token" => get_session(conn, :github_token),
+      "github_verified_at" => get_session(conn, :github_verified_at)
     }
+  end
+
+  defp signed_in?(login, token), do: is_binary(login) and login != "" and is_binary(token)
+
+  defp mount_membership_ok?(token, verified_at) do
+    if verification_fresh?(verified_at) do
+      true
+    else
+      # An outage must not sign a verified maintainer out mid-session.
+      verify_membership(token) != {:error, :denied}
+    end
   end
 
   defp assign_identity(socket, login, token) do
@@ -106,24 +168,54 @@ defmodule MetadataRelayWeb.DashboardAuth do
   end
 
   defp github_auth(conn) do
-    if allowed?(get_session(conn, :github_login)) do
+    login = get_session(conn, :github_login)
+    token = get_session(conn, :github_token)
+
+    if signed_in?(login, token) do
+      revalidate(conn, token)
+    else
+      send_to_login(conn)
+    end
+  end
+
+  defp revalidate(conn, token) do
+    if verification_fresh?(get_session(conn, :github_verified_at)) do
       conn
     else
-      conn
-      |> put_session(:return_to, current_path(conn))
-      |> redirect(to: "/auth/login")
-      |> halt()
+      case verify_membership(token) do
+        :ok ->
+          put_session(conn, :github_verified_at, verified_now())
+
+        {:error, :denied} ->
+          conn
+          |> clear_session()
+          |> configure_session(drop: true)
+          |> redirect(to: "/auth/login?error=denied")
+          |> halt()
+
+        # GitHub is unreachable. The session was verified at some point, so
+        # keep it and try again on the next request rather than locking the
+        # maintainer out of the dashboards during someone else's outage.
+        {:error, :unavailable} ->
+          conn
+      end
     end
+  end
+
+  defp send_to_login(conn) do
+    conn
+    |> put_session(:return_to, current_path(conn))
+    |> redirect(to: "/auth/login")
+    |> halt()
   end
 
   defp current_path(%Plug.Conn{request_path: path, query_string: ""}), do: path
   defp current_path(%Plug.Conn{request_path: path, query_string: query}), do: path <> "?" <> query
 
-  defp allowlist do
-    :metadata_relay
-    |> Application.get_env(:dashboard_github_users, [])
-    |> List.wrap()
-    |> Enum.map(&(&1 |> to_string() |> String.trim() |> String.downcase()))
-    |> Enum.reject(&(&1 == ""))
+  defp normalize(value) when is_binary(value) do
+    trimmed = String.trim(value)
+    if trimmed == "", do: nil, else: trimmed
   end
+
+  defp normalize(_), do: nil
 end

--- a/metadata-relay/lib/metadata_relay_web/dashboard_auth.ex
+++ b/metadata-relay/lib/metadata_relay_web/dashboard_auth.ex
@@ -1,0 +1,129 @@
+defmodule MetadataRelayWeb.DashboardAuth do
+  @moduledoc """
+  Access control for the maintainer dashboards.
+
+  Two mutually exclusive modes. When `:dashboard_github_users` is non-empty the
+  dashboards require GitHub sign-in and basic auth is off. When it is empty the
+  relay keeps the original HTTP Basic Auth, which is what self-hosted relays,
+  local development, and the test suite use.
+  """
+
+  import Plug.Conn
+  import Phoenix.Controller, only: [redirect: 2]
+
+  alias Phoenix.Component
+  alias Phoenix.LiveView
+
+  @default_return_to "/feedback"
+
+  @doc "Which access-control mode is active."
+  def mode do
+    case allowlist() do
+      [] -> :basic
+      _ -> :github
+    end
+  end
+
+  @doc "Whether a GitHub login may reach the dashboards."
+  def allowed?(login) when is_binary(login) do
+    normalized = login |> String.trim() |> String.downcase()
+
+    normalized != "" and normalized in allowlist()
+  end
+
+  def allowed?(_), do: false
+
+  @doc """
+  Constrains a stored return path to a local absolute path.
+
+  Anything that could send the browser to another origin falls back to the
+  dashboard root.
+  """
+  def safe_return_to("/" <> rest = path) do
+    cond do
+      String.starts_with?(rest, "/") -> @default_return_to
+      String.starts_with?(rest, "\\") -> @default_return_to
+      true -> path
+    end
+  end
+
+  def safe_return_to(_), do: @default_return_to
+
+  @doc """
+  Router plug. Enforces whichever mode is active.
+  """
+  def require_dashboard_auth(conn, _opts) do
+    case mode() do
+      :basic -> basic_auth(conn)
+      :github -> github_auth(conn)
+    end
+  end
+
+  @doc """
+  LiveView hook. The connected mount is a separate request, so the plug alone
+  is not enough.
+  """
+  def on_mount(:require_github_login, _params, session, socket) do
+    case mode() do
+      :basic ->
+        {:cont, assign_identity(socket, nil, nil)}
+
+      :github ->
+        login = session["github_login"]
+
+        if allowed?(login) do
+          {:cont, assign_identity(socket, login, session["github_token"])}
+        else
+          {:halt, LiveView.redirect(socket, to: "/auth/login")}
+        end
+    end
+  end
+
+  @doc """
+  Values handed from the connection session to the LiveView session.
+  """
+  def live_session_data(conn) do
+    %{
+      "github_login" => get_session(conn, :github_login),
+      "github_token" => get_session(conn, :github_token)
+    }
+  end
+
+  defp assign_identity(socket, login, token) do
+    socket
+    |> Component.assign(:github_login, login)
+    |> Component.assign(:github_token, token)
+  end
+
+  defp basic_auth(conn) do
+    Plug.BasicAuth.basic_auth(
+      conn,
+      Keyword.merge(
+        [realm: "Metadata Relay Dashboard"],
+        Application.fetch_env!(:metadata_relay, :dashboard_auth)
+      )
+    )
+  end
+
+  defp github_auth(conn) do
+    if allowed?(get_session(conn, :github_login)) do
+      conn
+    else
+      conn
+      |> put_session(:return_to, current_path(conn))
+      |> redirect(to: "/auth/login")
+      |> halt()
+    end
+  end
+
+  defp current_path(%Plug.Conn{request_path: path, query_string: ""}), do: path
+  defp current_path(%Plug.Conn{request_path: path, query_string: query}), do: path <> "?" <> query
+
+  defp allowlist do
+    :metadata_relay
+    |> Application.get_env(:dashboard_github_users, [])
+    |> List.wrap()
+    |> Enum.map(&(&1 |> to_string() |> String.trim() |> String.downcase()))
+    |> Enum.reject(&(&1 == ""))
+  end
+end

--- a/metadata-relay/lib/metadata_relay_web/endpoint.ex
+++ b/metadata-relay/lib/metadata_relay_web/endpoint.ex
@@ -1,15 +1,20 @@
 defmodule MetadataRelayWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :metadata_relay
 
-  # The session will be stored in the cookie and signed,
-  # this means its contents can be read but not tampered with.
-  # Set :encryption_salt if you would also like to encrypt it.
   @session_options [
     store: :cookie,
     key: "_metadata_relay_key",
     signing_salt: "error_tracker_salt",
+    encryption_salt: "metadata_relay_session_encryption",
     same_site: "Lax"
   ]
+
+  @doc """
+  Session options shared by the plug pipeline and the LiveView socket.
+
+  Exposed so tests can assert on the cookie configuration.
+  """
+  def session_options, do: @session_options
 
   socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]])
 

--- a/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.ex
+++ b/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.ex
@@ -8,7 +8,7 @@ defmodule MetadataRelayWeb.FeedbackLive.Index do
   alias MetadataRelay.Feedback
 
   @message_preview_limit 220
-  @valid_state_filters ~w(unread read archived all)
+  @valid_state_filters ~w(unread read filed archived all)
   @valid_type_filters ~w(bug idea question all)
 
   @impl true
@@ -125,6 +125,7 @@ defmodule MetadataRelayWeb.FeedbackLive.Index do
 
   def state_label("unread"), do: "Unread"
   def state_label("read"), do: "Read"
+  def state_label("filed"), do: "Filed"
   def state_label("archived"), do: "Archived"
 
   def type_badge_class("bug"), do: "badge-error"
@@ -133,6 +134,7 @@ defmodule MetadataRelayWeb.FeedbackLive.Index do
 
   def state_badge_class("unread"), do: "badge-primary"
   def state_badge_class("read"), do: "badge-ghost"
+  def state_badge_class("filed"), do: "badge-success"
   def state_badge_class("archived"), do: "badge-neutral"
 
   def expandable_message?(message), do: byte_size(message) > @message_preview_limit
@@ -143,6 +145,7 @@ defmodule MetadataRelayWeb.FeedbackLive.Index do
   defp label_for_state_filter("all"), do: "all states"
   defp label_for_state_filter("unread"), do: "unread"
   defp label_for_state_filter("read"), do: "read"
+  defp label_for_state_filter("filed"), do: "filed"
   defp label_for_state_filter("archived"), do: "archived"
   defp label_for_state_filter(_), do: "all states"
 

--- a/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.ex
+++ b/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.ex
@@ -100,23 +100,36 @@ defmodule MetadataRelayWeb.FeedbackLive.Index do
   end
 
   def handle_event("submit_issue", %{"title" => title, "body" => body}, socket) do
-    draft = socket.assigns.issue_draft
-    token = socket.assigns.github_token
+    # The modal only renders with a draft and a token, but a client can push
+    # this event regardless. Handle both gaps explicitly: a nil draft would
+    # raise here, and a nil token would fail inside the async task and surface
+    # as a misleading "GitHub is unreachable".
+    case {socket.assigns.issue_draft, socket.assigns.github_token} do
+      {nil, _token} ->
+        {:noreply, put_flash(socket, :error, "No issue draft is open.")}
 
-    attrs = %{title: title, body: body, labels: draft.labels}
-    submission_id = draft.submission_id
+      {_draft, token} when not is_binary(token) ->
+        {:noreply,
+         socket
+         |> assign(:issue_error, "Your GitHub sign-in is missing. Sign in again and retry.")
+         |> assign(:issue_submitting?, false)}
 
-    {:noreply,
-     socket
-     |> assign(:issue_draft, %{draft | title: title, body: body})
-     |> assign(:issue_error, nil)
-     |> assign(:issue_submitting?, true)
-     |> start_async(:file_issue, fn ->
-       case Feedback.get_submission(submission_id) do
-         nil -> {:error, {:missing, "Feedback no longer exists."}}
-         submission -> Feedback.file_issue(submission, attrs, token)
-       end
-     end)}
+      {draft, token} ->
+        attrs = %{title: title, body: body, labels: draft.labels}
+        submission_id = draft.submission_id
+
+        {:noreply,
+         socket
+         |> assign(:issue_draft, %{draft | title: title, body: body})
+         |> assign(:issue_error, nil)
+         |> assign(:issue_submitting?, true)
+         |> start_async(:file_issue, fn ->
+           case Feedback.get_submission(submission_id) do
+             nil -> {:error, {:missing, "Feedback no longer exists."}}
+             submission -> Feedback.file_issue(submission, attrs, token)
+           end
+         end)}
+    end
   end
 
   @impl true

--- a/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.ex
+++ b/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.ex
@@ -6,6 +6,8 @@ defmodule MetadataRelayWeb.FeedbackLive.Index do
   use Phoenix.LiveView
 
   alias MetadataRelay.Feedback
+  alias MetadataRelay.Feedback.IssueDraft
+  alias MetadataRelay.GitHub.Client
 
   @message_preview_limit 220
   @valid_state_filters ~w(unread read filed archived all)
@@ -19,6 +21,10 @@ defmodule MetadataRelayWeb.FeedbackLive.Index do
      |> assign(:type_filter, "all")
      |> assign(:expanded_ids, focused_ids(params))
      |> assign(:page_title, "Feedback Dashboard")
+     |> assign(:issue_draft, nil)
+     |> assign(:issue_error, nil)
+     |> assign(:issue_submitting?, false)
+     |> assign(:github_repo, Client.repo())
      |> load_dashboard()}
   end
 
@@ -59,6 +65,93 @@ defmodule MetadataRelayWeb.FeedbackLive.Index do
     update_submission(socket, id, fn submission ->
       Feedback.set_github_ref(submission, github_ref)
     end)
+  end
+
+  def handle_event("open_issue", %{"id" => id}, socket) do
+    case Feedback.get_submission(id) do
+      nil ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Feedback no longer exists.")
+         |> load_dashboard()}
+
+      submission ->
+        draft = IssueDraft.from_submission(submission, Feedback.dashboard_url())
+
+        {:noreply,
+         socket
+         |> assign(:issue_draft, %{
+           submission_id: submission.id,
+           title: draft.title,
+           body: draft.body,
+           labels: draft.labels
+         })
+         |> assign(:issue_error, nil)
+         |> assign(:issue_submitting?, false)}
+    end
+  end
+
+  def handle_event("close_issue", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:issue_draft, nil)
+     |> assign(:issue_error, nil)
+     |> assign(:issue_submitting?, false)}
+  end
+
+  def handle_event("submit_issue", %{"title" => title, "body" => body}, socket) do
+    draft = socket.assigns.issue_draft
+    token = socket.assigns.github_token
+
+    attrs = %{title: title, body: body, labels: draft.labels}
+    submission_id = draft.submission_id
+
+    {:noreply,
+     socket
+     |> assign(:issue_draft, %{draft | title: title, body: body})
+     |> assign(:issue_error, nil)
+     |> assign(:issue_submitting?, true)
+     |> start_async(:file_issue, fn ->
+       case Feedback.get_submission(submission_id) do
+         nil -> {:error, {:missing, "Feedback no longer exists."}}
+         submission -> Feedback.file_issue(submission, attrs, token)
+       end
+     end)}
+  end
+
+  @impl true
+  def handle_async(:file_issue, {:ok, {:ok, submission}}, socket) do
+    {:noreply,
+     socket
+     |> assign(:issue_draft, nil)
+     |> assign(:issue_error, nil)
+     |> assign(:issue_submitting?, false)
+     |> put_flash(:info, "Filed as #{submission.github_ref}")
+     |> load_dashboard()}
+  end
+
+  def handle_async(:file_issue, {:ok, {:error, {_reason, message}}}, socket) do
+    {:noreply,
+     socket
+     |> assign(:issue_error, message)
+     |> assign(:issue_submitting?, false)}
+  end
+
+  def handle_async(:file_issue, {:ok, {:error, _changeset}}, socket) do
+    {:noreply,
+     socket
+     |> assign(
+       :issue_error,
+       "The issue was created but could not be recorded. Reload and check GitHub."
+     )
+     |> assign(:issue_submitting?, false)}
+  end
+
+  def handle_async(:file_issue, {:exit, _reason}, socket) do
+    {:noreply,
+     socket
+     |> assign(:issue_error, "GitHub is unreachable. Your draft is preserved, try again.")
+     |> assign(:issue_submitting?, false)}
   end
 
   defp update_submission(socket, id, updater) do

--- a/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.ex
+++ b/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.ex
@@ -12,15 +12,18 @@ defmodule MetadataRelayWeb.FeedbackLive.Index do
   @valid_type_filters ~w(bug idea question all)
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     {:ok,
      socket
      |> assign(:state_filter, "unread")
      |> assign(:type_filter, "all")
-     |> assign(:expanded_ids, MapSet.new())
+     |> assign(:expanded_ids, focused_ids(params))
      |> assign(:page_title, "Feedback Dashboard")
      |> load_dashboard()}
   end
+
+  defp focused_ids(%{"focus" => focus}) when is_binary(focus), do: MapSet.new([focus])
+  defp focused_ids(_params), do: MapSet.new()
 
   @impl true
   def handle_event("filter", %{"filters" => filters}, socket) do

--- a/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.html.heex
+++ b/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.html.heex
@@ -41,6 +41,11 @@
             <div class="stat-value text-3xl text-info">{@summary.read}</div>
             <div class="stat-desc">Acknowledged</div>
           </div>
+          <div id="feedback-stat-filed" class="stat">
+            <div class="stat-title">Filed</div>
+            <div class="stat-value text-3xl text-success">{@summary.filed}</div>
+            <div class="stat-desc">On GitHub</div>
+          </div>
           <div id="feedback-stat-archived" class="stat">
             <div class="stat-title">Archived</div>
             <div class="stat-value text-3xl text-neutral">{@summary.archived}</div>
@@ -71,6 +76,7 @@
             <select id="feedback-filter-state" name="filters[state]" class="select select-bordered w-full">
               <option value="unread" selected={@state_filter == "unread"}>Unread</option>
               <option value="read" selected={@state_filter == "read"}>Read</option>
+              <option value="filed" selected={@state_filter == "filed"}>Filed</option>
               <option value="archived" selected={@state_filter == "archived"}>Archived</option>
               <option value="all" selected={@state_filter == "all"}>All</option>
             </select>
@@ -120,7 +126,20 @@
                 <span class={["badge badge-outline font-medium", state_badge_class(submission.state)]}>
                   {state_label(submission.state)}
                 </span>
-                <span :if={submission.github_ref} class="badge badge-outline badge-info">
+                <a
+                  :if={submission.github_ref && submission.github_issue_url}
+                  id={"github-link-#{submission.id}"}
+                  href={submission.github_issue_url}
+                  target="_blank"
+                  rel="noopener"
+                  class="badge badge-outline badge-info"
+                >
+                  Filed as {submission.github_ref}
+                </a>
+                <span
+                  :if={submission.github_ref && is_nil(submission.github_issue_url)}
+                  class="badge badge-outline badge-info"
+                >
                   Filed as {submission.github_ref}
                 </span>
               </div>
@@ -151,6 +170,16 @@
             </div>
 
             <div class="flex shrink-0 flex-wrap gap-2 xl:justify-end">
+              <button
+                :if={@github_token && is_nil(submission.github_ref)}
+                id={"file-issue-#{submission.id}"}
+                type="button"
+                phx-click="open_issue"
+                phx-value-id={submission.id}
+                class="btn btn-primary btn-sm"
+              >
+                File GitHub issue
+              </button>
               <button
                 :if={submission.state == "unread"}
                 id={"mark-read-#{submission.id}"}
@@ -222,5 +251,62 @@
         </div>
       </article>
     </section>
+
+    <div :if={@issue_draft} id="issue-modal" class="modal modal-open">
+      <div class="modal-box max-w-2xl">
+        <h3 class="text-lg font-semibold">File a GitHub issue</h3>
+        <p class="mt-1 text-sm text-base-content/70">
+          This will be public on {@github_repo}. Review before creating.
+        </p>
+
+        <div :if={@issue_error} id="issue-modal-error" class="alert alert-error mt-4">
+          <span>{@issue_error}</span>
+        </div>
+
+        <form id="issue-form" phx-submit="submit_issue" class="mt-4 space-y-4">
+          <label class="form-control w-full">
+            <div class="label pb-2">
+              <span class="label-text font-medium">Title</span>
+            </div>
+            <input
+              id="issue-title"
+              type="text"
+              name="title"
+              value={@issue_draft.title}
+              class="input input-bordered w-full"
+              required
+            />
+          </label>
+
+          <label class="form-control w-full">
+            <div class="label pb-2">
+              <span class="label-text font-medium">Body</span>
+            </div>
+            <textarea
+              id="issue-body"
+              name="body"
+              rows="10"
+              class="textarea textarea-bordered w-full font-mono text-sm"
+            >{@issue_draft.body}</textarea>
+          </label>
+
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="text-sm text-base-content/60">Labels</span>
+            <span :for={label <- @issue_draft.labels} class="badge badge-outline">{label}</span>
+          </div>
+
+          <div class="modal-action">
+            <button id="issue-cancel" type="button" phx-click="close_issue" class="btn btn-ghost">
+              Cancel
+            </button>
+            <button id="issue-submit" type="submit" class="btn btn-primary" disabled={@issue_submitting?}>
+              <span :if={@issue_submitting?} class="loading loading-spinner loading-sm"></span>
+              Create issue
+            </button>
+          </div>
+        </form>
+      </div>
+      <div class="modal-backdrop" phx-click="close_issue"></div>
+    </div>
   </section>
 </MetadataRelayWeb.Layouts.app>

--- a/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.html.heex
+++ b/metadata-relay/lib/metadata_relay_web/live/feedback_live/index.html.heex
@@ -11,6 +11,18 @@
               Review product feedback from Mydia instances, focus on unread items first, and keep GitHub filing notes attached to each submission.
             </p>
           </div>
+
+          <form
+            :if={@github_login}
+            id="sign-out-form"
+            action="/auth/logout"
+            method="post"
+            class="flex items-center gap-3"
+          >
+            <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+            <span class="text-sm text-base-content/60">Signed in as {@github_login}</span>
+            <button id="sign-out" type="submit" class="btn btn-ghost btn-xs">Sign out</button>
+          </form>
         </div>
 
         <div class="stats stats-vertical rounded-box border border-base-300 bg-base-200/70 shadow-sm sm:stats-horizontal">

--- a/metadata-relay/lib/metadata_relay_web/router.ex
+++ b/metadata-relay/lib/metadata_relay_web/router.ex
@@ -5,6 +5,7 @@ defmodule MetadataRelayWeb.Router do
   import Plug.Conn
   import Phoenix.Controller
   import Phoenix.LiveView.Router
+  import MetadataRelayWeb.DashboardAuth
 
   pipeline :browser do
     plug(:accepts, ["html"])
@@ -16,7 +17,7 @@ defmodule MetadataRelayWeb.Router do
   end
 
   pipeline :authed_dashboard do
-    plug(:dashboard_basic_auth)
+    plug(:require_dashboard_auth)
   end
 
   scope "/auth", MetadataRelayWeb do
@@ -31,20 +32,18 @@ defmodule MetadataRelayWeb.Router do
   # Maintainer dashboards
   scope "/" do
     pipe_through([:browser, :authed_dashboard])
-    error_tracker_dashboard("/errors")
-    live("/feedback", MetadataRelayWeb.FeedbackLive.Index, :index)
+
+    error_tracker_dashboard("/errors",
+      on_mount: [{MetadataRelayWeb.DashboardAuth, :require_github_login}]
+    )
+
+    live_session :feedback,
+      on_mount: [{MetadataRelayWeb.DashboardAuth, :require_github_login}],
+      session: {MetadataRelayWeb.DashboardAuth, :live_session_data, []} do
+      live("/feedback", MetadataRelayWeb.FeedbackLive.Index, :index)
+    end
   end
 
   # Forward all other requests to the API router
   forward("/", MetadataRelay.Router)
-
-  defp dashboard_basic_auth(conn, _opts) do
-    Plug.BasicAuth.basic_auth(
-      conn,
-      Keyword.merge(
-        [realm: "Metadata Relay Dashboard"],
-        Application.fetch_env!(:metadata_relay, :dashboard_auth)
-      )
-    )
-  end
 end

--- a/metadata-relay/lib/metadata_relay_web/router.ex
+++ b/metadata-relay/lib/metadata_relay_web/router.ex
@@ -19,6 +19,15 @@ defmodule MetadataRelayWeb.Router do
     plug(:dashboard_basic_auth)
   end
 
+  scope "/auth", MetadataRelayWeb do
+    pipe_through(:browser)
+
+    get("/login", AuthController, :login)
+    get("/github", AuthController, :request)
+    get("/github/callback", AuthController, :callback)
+    post("/logout", AuthController, :logout)
+  end
+
   # Maintainer dashboards
   scope "/" do
     pipe_through([:browser, :authed_dashboard])

--- a/metadata-relay/priv/repo/migrations/20260810120000_add_github_issue_url_to_feedback.exs
+++ b/metadata-relay/priv/repo/migrations/20260810120000_add_github_issue_url_to_feedback.exs
@@ -1,0 +1,9 @@
+defmodule MetadataRelay.Repo.Migrations.AddGithubIssueUrlToFeedback do
+  use Ecto.Migration
+
+  def change do
+    alter table(:feedback_submissions) do
+      add(:github_issue_url, :string)
+    end
+  end
+end

--- a/metadata-relay/test/metadata_relay/feedback/issue_draft_test.exs
+++ b/metadata-relay/test/metadata_relay/feedback/issue_draft_test.exs
@@ -60,6 +60,32 @@ defmodule MetadataRelay.Feedback.IssueDraftTest do
     assert draft.body =~ "Reported via in-app feedback"
   end
 
+  test "mentions and issue references in the message cannot ping or backlink" do
+    draft =
+      draft_for(%{
+        message: "cc @getmydia/maintainers and @someuser, same as #123 and issue #4"
+      })
+
+    refute draft.body =~ "@getmydia"
+    refute draft.body =~ "@someuser"
+    refute draft.body =~ ~r/(?<!<!---->)#123/
+
+    # The text still reads the same to a human.
+    assert draft.body =~ "@<!---->getmydia/maintainers"
+    assert draft.body =~ "@<!---->someuser"
+    assert draft.body =~ "#<!---->123"
+    assert draft.body =~ "#<!---->4"
+  end
+
+  test "defanging leaves text that GitHub would not linkify alone" do
+    draft = draft_for(%{message: "Email me at a@b.com, C# code, 100% broken, issue ##"})
+
+    assert draft.body =~ "a@b.com"
+    assert draft.body =~ "C# code"
+    assert draft.body =~ "100% broken"
+    assert draft.body =~ "issue ##"
+  end
+
   test "identifying fields never reach the draft" do
     draft =
       draft_for(%{

--- a/metadata-relay/test/metadata_relay/feedback/issue_draft_test.exs
+++ b/metadata-relay/test/metadata_relay/feedback/issue_draft_test.exs
@@ -77,6 +77,17 @@ defmodule MetadataRelay.Feedback.IssueDraftTest do
     assert draft.body =~ "#<!---->4"
   end
 
+  test "cross-repository references cannot backlink another repo" do
+    draft =
+      draft_for(%{message: "same as getmydia/mydia#123 and elixir-lang/elixir#4567"})
+
+    refute draft.body =~ ~r"getmydia/mydia#\d"
+    refute draft.body =~ ~r"elixir-lang/elixir#\d"
+
+    assert draft.body =~ "getmydia/mydia#<!---->123"
+    assert draft.body =~ "elixir-lang/elixir#<!---->4567"
+  end
+
   test "defanging leaves text that GitHub would not linkify alone" do
     draft = draft_for(%{message: "Email me at a@b.com, C# code, 100% broken, issue ##"})
 

--- a/metadata-relay/test/metadata_relay/feedback/issue_draft_test.exs
+++ b/metadata-relay/test/metadata_relay/feedback/issue_draft_test.exs
@@ -1,0 +1,98 @@
+defmodule MetadataRelay.Feedback.IssueDraftTest do
+  use ExUnit.Case, async: true
+
+  alias MetadataRelay.Feedback.IssueDraft
+  alias MetadataRelay.Feedback.Submission
+
+  @id "11111111-2222-3333-4444-555555555555"
+
+  test "title uses the first non-empty line with whitespace collapsed" do
+    draft = draft_for(%{message: "\n\n  Playback   stalls  \nmore detail here"})
+
+    assert draft.title == "Playback stalls"
+  end
+
+  test "title truncates at 72 characters with an ellipsis" do
+    message = String.duplicate("a", 80)
+    draft = draft_for(%{message: message})
+
+    assert String.length(draft.title) == 73
+    assert String.ends_with?(draft.title, "…")
+    assert String.starts_with?(draft.title, String.duplicate("a", 72))
+  end
+
+  test "title keeps a message exactly at the limit intact" do
+    message = String.duplicate("a", 72)
+    draft = draft_for(%{message: message})
+
+    assert draft.title == message
+  end
+
+  test "title falls back to the type when no usable line exists" do
+    draft = draft_for(%{message: "   \n  \n", type: "idea"})
+
+    assert draft.title == "Feedback: idea"
+  end
+
+  test "body carries the message, the version, and the backlink" do
+    draft = draft_for(%{message: "It broke", mydia_version: "1.4.2"})
+
+    assert draft.body == """
+           It broke
+
+           ---
+           Reported via in-app feedback from Mydia 1.4.2.
+           Feedback: https://relay.example.com/feedback?focus=#{@id}#feedback-#{@id}\
+           """
+  end
+
+  test "body omits the version when it is unknown" do
+    draft = draft_for(%{message: "It broke", mydia_version: nil})
+
+    assert draft.body =~ "Reported via in-app feedback.\n"
+    refute draft.body =~ "from Mydia"
+  end
+
+  test "body omits the backlink when no dashboard URL is configured" do
+    draft = draft_for(%{message: "It broke"}, nil)
+
+    refute draft.body =~ "Feedback:"
+    assert draft.body =~ "Reported via in-app feedback"
+  end
+
+  test "identifying fields never reach the draft" do
+    draft =
+      draft_for(%{
+        message: "It broke",
+        contact: "reporter@example.com",
+        source_ip: "203.0.113.7",
+        instance_id: "instance-abcdef123456"
+      })
+
+    refute draft.title =~ "reporter@example.com"
+    refute draft.body =~ "reporter@example.com"
+    refute draft.body =~ "203.0.113.7"
+    refute draft.body =~ "instance-abcdef123456"
+  end
+
+  test "labels map from the feedback type" do
+    assert draft_for(%{type: "bug"}).labels == ["bug"]
+    assert draft_for(%{type: "idea"}).labels == ["enhancement"]
+    assert draft_for(%{type: "question"}).labels == ["question"]
+  end
+
+  defp draft_for(attrs, dashboard_url \\ "https://relay.example.com") do
+    submission =
+      struct(
+        %Submission{
+          id: @id,
+          type: "bug",
+          message: "Something",
+          state: "unread"
+        },
+        attrs
+      )
+
+    IssueDraft.from_submission(submission, dashboard_url)
+  end
+end

--- a/metadata-relay/test/metadata_relay/feedback_file_issue_test.exs
+++ b/metadata-relay/test/metadata_relay/feedback_file_issue_test.exs
@@ -1,0 +1,83 @@
+defmodule MetadataRelay.FeedbackFileIssueTest do
+  use ExUnit.Case, async: false
+
+  import MetadataRelay.Test.GitHubHelpers
+
+  alias MetadataRelay.Feedback
+  alias MetadataRelay.Feedback.Submission
+  alias MetadataRelay.Repo
+
+  @attrs %{title: "Playback stalls", body: "It broke", labels: ["bug"]}
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Repo.delete_all(Submission)
+
+    previous =
+      put_github_config(client_id: "cid", client_secret: "csecret", repo: "getmydia/mydia")
+
+    on_exit(fn ->
+      restore_github_config(previous)
+      clear_github_adapter()
+    end)
+
+    :ok
+  end
+
+  test "a successful call records the ref, the URL, and the filed state" do
+    stub_created(123)
+
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "It broke"})
+
+    assert {:ok, filed} = Feedback.file_issue(submission, @attrs, "gho_token")
+
+    assert filed.github_ref == "#123"
+    assert filed.github_issue_url == "https://github.com/getmydia/mydia/issues/123"
+    assert filed.state == "filed"
+
+    reloaded = Feedback.get_submission!(submission.id)
+    assert reloaded.github_ref == "#123"
+    assert reloaded.state == "filed"
+  end
+
+  test "an archived submission stays archived" do
+    stub_created(124)
+
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "It broke"})
+    {:ok, submission} = Feedback.update_state(submission, "archived")
+
+    assert {:ok, filed} = Feedback.file_issue(submission, @attrs, "gho_token")
+
+    assert filed.state == "archived"
+    assert filed.github_ref == "#124"
+  end
+
+  test "a failure leaves the row untouched" do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: 422, body: %{"message" => "Validation Failed"})}
+    end)
+
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "It broke"})
+
+    assert {:error, {:unprocessable, "Validation Failed"}} =
+             Feedback.file_issue(submission, @attrs, "gho_token")
+
+    reloaded = Feedback.get_submission!(submission.id)
+    assert reloaded.github_ref == nil
+    assert reloaded.github_issue_url == nil
+    assert reloaded.state == "unread"
+  end
+
+  defp stub_created(number) do
+    set_github_adapter(fn request ->
+      {request,
+       Req.Response.new(
+         status: 201,
+         body: %{
+           "number" => number,
+           "html_url" => "https://github.com/getmydia/mydia/issues/#{number}"
+         }
+       )}
+    end)
+  end
+end

--- a/metadata-relay/test/metadata_relay/feedback_ingest_test.exs
+++ b/metadata-relay/test/metadata_relay/feedback_ingest_test.exs
@@ -75,7 +75,7 @@ defmodule MetadataRelay.FeedbackIngestTest do
       assert email.text_body =~ "Instance: instance-1"
       assert email.text_body =~ "Mydia version: 1.2.3"
       assert email.text_body =~ "Message:\nAdd watch party mode"
-      assert email.text_body =~ "Dashboard: https://relay.example.com/feedback#feedback-"
+      assert email.text_body =~ "Dashboard: https://relay.example.com/feedback?focus="
     end
 
     test "sets reply-to to the contact when it is an email address" do

--- a/metadata-relay/test/metadata_relay/feedback_notifier_test.exs
+++ b/metadata-relay/test/metadata_relay/feedback_notifier_test.exs
@@ -1,0 +1,38 @@
+defmodule MetadataRelay.FeedbackNotifierTest do
+  use ExUnit.Case, async: false
+
+  import Swoosh.TestAssertions
+
+  alias MetadataRelay.Feedback
+  alias MetadataRelay.Feedback.Notifier
+  alias MetadataRelay.Feedback.Submission
+  alias MetadataRelay.Repo
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Repo.delete_all(Submission)
+    :ok
+  end
+
+  test "the dashboard link carries a focus parameter as well as the anchor" do
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Broken"})
+
+    :ok = deliver(submission)
+
+    assert_email_sent(fn email ->
+      assert email.text_body =~
+               "https://relay.example.com/feedback?focus=#{submission.id}#feedback-#{submission.id}"
+    end)
+  end
+
+  test "dashboard_url trims a trailing slash" do
+    assert Feedback.dashboard_url() == "https://relay.example.com"
+  end
+
+  defp deliver(submission) do
+    case Notifier.deliver_new_submission(submission) do
+      {:ok, _} -> :ok
+      :ok -> :ok
+    end
+  end
+end

--- a/metadata-relay/test/metadata_relay/feedback_test.exs
+++ b/metadata-relay/test/metadata_relay/feedback_test.exs
@@ -101,4 +101,48 @@ defmodule MetadataRelay.FeedbackTest do
     assert {:error, changeset} = Feedback.update_state(submission, "invalid")
     assert {"is invalid", _} = changeset.errors[:state]
   end
+
+  test "summary counts filed submissions" do
+    {:ok, filed} = Feedback.create_submission(%{type: "bug", message: "Filed"})
+    {:ok, _filed} = Feedback.update_state(filed, "filed")
+
+    assert %{filed: 1} = Feedback.submission_summary()
+  end
+
+  test "saving a github ref promotes unread to filed" do
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Unread"})
+
+    {:ok, updated} = Feedback.set_github_ref(submission, "#123")
+
+    assert updated.state == "filed"
+    assert updated.github_ref == "#123"
+  end
+
+  test "saving a github ref promotes read to filed" do
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Read"})
+    {:ok, submission} = Feedback.update_state(submission, "read")
+
+    {:ok, updated} = Feedback.set_github_ref(submission, "#123")
+
+    assert updated.state == "filed"
+  end
+
+  test "saving a github ref leaves an archived submission archived" do
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Archived"})
+    {:ok, submission} = Feedback.update_state(submission, "archived")
+
+    {:ok, updated} = Feedback.set_github_ref(submission, "#123")
+
+    assert updated.state == "archived"
+  end
+
+  test "clearing a github ref does not demote the state" do
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Filed"})
+    {:ok, submission} = Feedback.set_github_ref(submission, "#123")
+
+    {:ok, updated} = Feedback.set_github_ref(submission, nil)
+
+    assert updated.state == "filed"
+    assert updated.github_ref == nil
+  end
 end

--- a/metadata-relay/test/metadata_relay/github/client_test.exs
+++ b/metadata-relay/test/metadata_relay/github/client_test.exs
@@ -1,0 +1,119 @@
+defmodule MetadataRelay.GitHub.ClientTest do
+  use ExUnit.Case, async: false
+
+  import MetadataRelay.Test.GitHubHelpers
+
+  alias MetadataRelay.GitHub.Client
+
+  @attrs %{title: "Playback stalls", body: "It broke", labels: ["bug"]}
+
+  setup do
+    previous =
+      put_github_config(client_id: "cid", client_secret: "csecret", repo: "getmydia/mydia")
+
+    on_exit(fn ->
+      restore_github_config(previous)
+      clear_github_adapter()
+    end)
+
+    :ok
+  end
+
+  test "create_issue posts the draft and returns the number and URL" do
+    set_github_adapter(fn request ->
+      assert URI.to_string(request.url) == "https://api.github.com/repos/getmydia/mydia/issues"
+      assert request.method == :post
+
+      body = request.body |> IO.iodata_to_binary() |> Jason.decode!()
+      assert body["title"] == "Playback stalls"
+      assert body["body"] == "It broke"
+      assert body["labels"] == ["bug"]
+
+      {request,
+       Req.Response.new(
+         status: 201,
+         body: %{"number" => 123, "html_url" => "https://github.com/getmydia/mydia/issues/123"}
+       )}
+    end)
+
+    assert {:ok, %{number: 123, html_url: "https://github.com/getmydia/mydia/issues/123"}} =
+             Client.create_issue(@attrs, "gho_token")
+  end
+
+  test "create_issue sends the caller's token" do
+    set_github_adapter(fn request ->
+      headers =
+        Enum.flat_map(request.headers, fn {name, values} ->
+          Enum.map(List.wrap(values), &{name, &1})
+        end)
+
+      assert {"authorization", "Bearer gho_token"} in headers
+      assert {"x-github-api-version", "2022-11-28"} in headers
+
+      {request, Req.Response.new(status: 201, body: %{"number" => 1, "html_url" => "u"})}
+    end)
+
+    assert {:ok, _} = Client.create_issue(@attrs, "gho_token")
+  end
+
+  test "create_issue maps a rejected token" do
+    stub_status(401, %{"message" => "Bad credentials"})
+
+    assert {:error, {:unauthorized, message}} = Client.create_issue(@attrs, "stale")
+    # Case-insensitive: the copy says "Sign in again", and pinning exact
+    # capitalisation would make this test churn every time the wording changes.
+    assert message =~ ~r/sign in/i
+  end
+
+  test "create_issue maps a forbidden response the same way" do
+    stub_status(403, %{"message" => "Forbidden"})
+
+    assert {:error, {:unauthorized, _}} = Client.create_issue(@attrs, "stale")
+  end
+
+  test "create_issue maps a missing repository" do
+    stub_status(404, %{"message" => "Not Found"})
+
+    assert {:error, {:not_found, message}} = Client.create_issue(@attrs, "gho_token")
+    assert message =~ "Repository"
+  end
+
+  test "create_issue surfaces a 422 message verbatim" do
+    stub_status(422, %{"message" => "Validation Failed: label does not exist"})
+
+    assert {:error, {:unprocessable, "Validation Failed: label does not exist"}} =
+             Client.create_issue(@attrs, "gho_token")
+  end
+
+  test "create_issue maps a server error" do
+    stub_status(500, %{"message" => "boom"})
+
+    assert {:error, {:server_error, message}} = Client.create_issue(@attrs, "gho_token")
+    assert message =~ "unreachable"
+  end
+
+  test "create_issue maps a transport failure" do
+    set_github_adapter(fn request ->
+      {request, %Req.TransportError{reason: :econnrefused}}
+    end)
+
+    assert {:error, {:transport, message}} = Client.create_issue(@attrs, "gho_token")
+    assert message =~ "unreachable"
+  end
+
+  test "create_issue accepts an IssueDraft struct" do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: 201, body: %{"number" => 7, "html_url" => "u"})}
+    end)
+
+    draft = %MetadataRelay.Feedback.IssueDraft{title: "T", body: "B", labels: ["bug"]}
+
+    assert {:ok, %{number: 7}} = Client.create_issue(draft, "gho_token")
+  end
+
+  defp stub_status(status, body) do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: status, body: body)}
+    end)
+  end
+end

--- a/metadata-relay/test/metadata_relay/github/oauth_test.exs
+++ b/metadata-relay/test/metadata_relay/github/oauth_test.exs
@@ -1,0 +1,103 @@
+defmodule MetadataRelay.GitHub.OAuthTest do
+  use ExUnit.Case, async: false
+
+  import MetadataRelay.Test.GitHubHelpers
+
+  alias MetadataRelay.GitHub.OAuth
+
+  setup do
+    previous =
+      put_github_config(client_id: "cid", client_secret: "csecret", repo: "getmydia/mydia")
+
+    on_exit(fn ->
+      restore_github_config(previous)
+      clear_github_adapter()
+    end)
+
+    :ok
+  end
+
+  test "configured? reflects whether both credentials are present" do
+    assert OAuth.configured?()
+
+    put_github_config(client_id: "cid", client_secret: nil)
+    refute OAuth.configured?()
+
+    put_github_config([])
+    refute OAuth.configured?()
+  end
+
+  test "authorize_url carries the client id and state" do
+    url = OAuth.authorize_url("random-state")
+    %URI{query: query} = URI.parse(url)
+    params = URI.decode_query(query)
+
+    assert String.starts_with?(url, "https://github.com/login/oauth/authorize?")
+    assert params["client_id"] == "cid"
+    assert params["state"] == "random-state"
+  end
+
+  test "exchange_code returns the access token" do
+    set_github_adapter(fn request ->
+      assert URI.to_string(request.url) == "https://github.com/login/oauth/access_token"
+      {request, Req.Response.new(status: 200, body: %{"access_token" => "gho_token"})}
+    end)
+
+    assert {:ok, "gho_token"} = OAuth.exchange_code("the-code")
+  end
+
+  test "exchange_code treats a 200 carrying an error field as a failure" do
+    set_github_adapter(fn request ->
+      {request,
+       Req.Response.new(
+         status: 200,
+         body: %{
+           "error" => "bad_verification_code",
+           "error_description" => "The code is expired."
+         }
+       )}
+    end)
+
+    assert {:error, {:oauth, "The code is expired."}} = OAuth.exchange_code("stale")
+  end
+
+  test "exchange_code reports a non-200 response" do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: 500, body: "boom")}
+    end)
+
+    assert {:error, {:http, 500}} = OAuth.exchange_code("the-code")
+  end
+
+  test "exchange_code reports a transport failure" do
+    set_github_adapter(fn request ->
+      {request, %Req.TransportError{reason: :econnrefused}}
+    end)
+
+    assert {:error, {:transport, _}} = OAuth.exchange_code("the-code")
+  end
+
+  test "fetch_user returns the login" do
+    set_github_adapter(fn request ->
+      assert URI.to_string(request.url) == "https://api.github.com/user"
+      assert {"authorization", "Bearer gho_token"} in flat_headers(request)
+      {request, Req.Response.new(status: 200, body: %{"login" => "arsfeld", "id" => 1})}
+    end)
+
+    assert {:ok, %{login: "arsfeld"}} = OAuth.fetch_user("gho_token")
+  end
+
+  test "fetch_user reports a rejected token" do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: 401, body: %{"message" => "Bad credentials"})}
+    end)
+
+    assert {:error, {:http, 401}} = OAuth.fetch_user("nope")
+  end
+
+  defp flat_headers(request) do
+    Enum.flat_map(request.headers, fn {name, values} ->
+      Enum.map(List.wrap(values), &{name, &1})
+    end)
+  end
+end

--- a/metadata-relay/test/metadata_relay/github/oauth_test.exs
+++ b/metadata-relay/test/metadata_relay/github/oauth_test.exs
@@ -95,6 +95,61 @@ defmodule MetadataRelay.GitHub.OAuthTest do
     assert {:error, {:http, 401}} = OAuth.fetch_user("nope")
   end
 
+  test "fetch_org_membership asks the caller-scoped endpoint and accepts an active member" do
+    set_github_adapter(fn request ->
+      assert URI.to_string(request.url) ==
+               "https://api.github.com/user/memberships/orgs/getmydia"
+
+      assert {"authorization", "Bearer gho_token"} in flat_headers(request)
+
+      {request, Req.Response.new(status: 200, body: %{"state" => "active", "role" => "admin"})}
+    end)
+
+    assert {:ok, :active} = OAuth.fetch_org_membership("gho_token", "getmydia")
+  end
+
+  test "fetch_org_membership reports a pending invitation as its own state" do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: 200, body: %{"state" => "pending"})}
+    end)
+
+    assert {:error, {:membership, "pending"}} =
+             OAuth.fetch_org_membership("gho_token", "getmydia")
+  end
+
+  test "fetch_org_membership reports a non-member" do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: 404, body: %{"message" => "Not Found"})}
+    end)
+
+    assert {:error, :not_a_member} = OAuth.fetch_org_membership("gho_token", "getmydia")
+  end
+
+  test "fetch_org_membership reports a blocked app and a transport failure separately" do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: 403, body: %{"message" => "Blocked"})}
+    end)
+
+    assert {:error, {:http, 403}} = OAuth.fetch_org_membership("gho_token", "getmydia")
+
+    set_github_adapter(fn request ->
+      {request, %Req.TransportError{reason: :econnrefused}}
+    end)
+
+    assert {:error, {:transport, _}} = OAuth.fetch_org_membership("gho_token", "getmydia")
+  end
+
+  test "fetch_org_membership escapes the organization in the path" do
+    set_github_adapter(fn request ->
+      assert URI.to_string(request.url) ==
+               "https://api.github.com/user/memberships/orgs/weird%20org"
+
+      {request, Req.Response.new(status: 404, body: %{})}
+    end)
+
+    assert {:error, :not_a_member} = OAuth.fetch_org_membership("gho_token", "weird org")
+  end
+
   defp flat_headers(request) do
     Enum.flat_map(request.headers, fn {name, values} ->
       Enum.map(List.wrap(values), &{name, &1})

--- a/metadata-relay/test/metadata_relay/github/oauth_test.exs
+++ b/metadata-relay/test/metadata_relay/github/oauth_test.exs
@@ -139,6 +139,36 @@ defmodule MetadataRelay.GitHub.OAuthTest do
     assert {:error, {:transport, _}} = OAuth.fetch_org_membership("gho_token", "getmydia")
   end
 
+  test "fetch_org_membership tells a rate-limited 403 from a refusal" do
+    # GitHub reuses 403 for throttling, so only the headers separate the two.
+    for headers <- [%{"retry-after" => ["60"]}, %{"x-ratelimit-remaining" => ["0"]}] do
+      set_github_adapter(fn request ->
+        {request, Req.Response.new(status: 403, body: %{}, headers: headers)}
+      end)
+
+      assert {:error, :rate_limited} = OAuth.fetch_org_membership("gho_token", "getmydia")
+    end
+
+    set_github_adapter(fn request ->
+      {request,
+       Req.Response.new(
+         status: 403,
+         body: %{"message" => "Blocked"},
+         headers: %{"x-ratelimit-remaining" => ["4999"]}
+       )}
+    end)
+
+    assert {:error, {:http, 403}} = OAuth.fetch_org_membership("gho_token", "getmydia")
+  end
+
+  test "fetch_org_membership treats 429 as rate limiting" do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: 429, body: %{})}
+    end)
+
+    assert {:error, :rate_limited} = OAuth.fetch_org_membership("gho_token", "getmydia")
+  end
+
   test "fetch_org_membership escapes the organization in the path" do
     set_github_adapter(fn request ->
       assert URI.to_string(request.url) ==

--- a/metadata-relay/test/metadata_relay_web/dashboard_auth_unit_test.exs
+++ b/metadata-relay/test/metadata_relay_web/dashboard_auth_unit_test.exs
@@ -1,0 +1,57 @@
+defmodule MetadataRelayWeb.DashboardAuthUnitTest do
+  use ExUnit.Case, async: false
+
+  alias MetadataRelayWeb.DashboardAuth
+
+  setup do
+    previous = Application.get_env(:metadata_relay, :dashboard_github_users)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:metadata_relay, :dashboard_github_users)
+        value -> Application.put_env(:metadata_relay, :dashboard_github_users, value)
+      end
+    end)
+
+    :ok
+  end
+
+  test "mode is basic when no logins are allowlisted" do
+    Application.delete_env(:metadata_relay, :dashboard_github_users)
+    assert DashboardAuth.mode() == :basic
+
+    Application.put_env(:metadata_relay, :dashboard_github_users, [])
+    assert DashboardAuth.mode() == :basic
+  end
+
+  test "mode is github once a login is allowlisted" do
+    Application.put_env(:metadata_relay, :dashboard_github_users, ["arsfeld"])
+    assert DashboardAuth.mode() == :github
+  end
+
+  test "allowed? compares logins case-insensitively" do
+    Application.put_env(:metadata_relay, :dashboard_github_users, ["ArsFeld"])
+
+    assert DashboardAuth.allowed?("arsfeld")
+    assert DashboardAuth.allowed?("ARSFELD")
+    refute DashboardAuth.allowed?("someone-else")
+    refute DashboardAuth.allowed?(nil)
+    refute DashboardAuth.allowed?("")
+  end
+
+  test "allowed? is false in basic mode" do
+    Application.delete_env(:metadata_relay, :dashboard_github_users)
+    refute DashboardAuth.allowed?("arsfeld")
+  end
+
+  test "safe_return_to keeps local paths and rejects everything else" do
+    assert DashboardAuth.safe_return_to("/feedback?focus=abc") == "/feedback?focus=abc"
+    assert DashboardAuth.safe_return_to("/errors") == "/errors"
+
+    assert DashboardAuth.safe_return_to("//evil.example.com") == "/feedback"
+    assert DashboardAuth.safe_return_to("https://evil.example.com") == "/feedback"
+    assert DashboardAuth.safe_return_to("/\\evil.example.com") == "/feedback"
+    assert DashboardAuth.safe_return_to("feedback") == "/feedback"
+    assert DashboardAuth.safe_return_to(nil) == "/feedback"
+  end
+end

--- a/metadata-relay/test/metadata_relay_web/dashboard_auth_unit_test.exs
+++ b/metadata-relay/test/metadata_relay_web/dashboard_auth_unit_test.exs
@@ -1,47 +1,77 @@
 defmodule MetadataRelayWeb.DashboardAuthUnitTest do
   use ExUnit.Case, async: false
 
+  import MetadataRelay.Test.GitHubHelpers
+
   alias MetadataRelayWeb.DashboardAuth
 
   setup do
-    previous = Application.get_env(:metadata_relay, :dashboard_github_users)
+    previous = put_dashboard_org(nil)
 
     on_exit(fn ->
-      case previous do
-        nil -> Application.delete_env(:metadata_relay, :dashboard_github_users)
-        value -> Application.put_env(:metadata_relay, :dashboard_github_users, value)
-      end
+      restore_dashboard_org(previous)
+      clear_github_adapter()
     end)
 
     :ok
   end
 
-  test "mode is basic when no logins are allowlisted" do
-    Application.delete_env(:metadata_relay, :dashboard_github_users)
+  test "mode is basic when no organization is configured" do
+    put_dashboard_org(nil)
     assert DashboardAuth.mode() == :basic
 
-    Application.put_env(:metadata_relay, :dashboard_github_users, [])
+    put_dashboard_org("")
+    assert DashboardAuth.mode() == :basic
+
+    put_dashboard_org("   ")
     assert DashboardAuth.mode() == :basic
   end
 
-  test "mode is github once a login is allowlisted" do
-    Application.put_env(:metadata_relay, :dashboard_github_users, ["arsfeld"])
+  test "mode is github once an organization is configured" do
+    put_dashboard_org("getmydia")
     assert DashboardAuth.mode() == :github
+    assert DashboardAuth.org() == "getmydia"
   end
 
-  test "allowed? compares logins case-insensitively" do
-    Application.put_env(:metadata_relay, :dashboard_github_users, ["ArsFeld"])
+  test "verify_membership accepts only an active membership" do
+    put_dashboard_org("getmydia")
 
-    assert DashboardAuth.allowed?("arsfeld")
-    assert DashboardAuth.allowed?("ARSFELD")
-    refute DashboardAuth.allowed?("someone-else")
-    refute DashboardAuth.allowed?(nil)
-    refute DashboardAuth.allowed?("")
+    stub_membership(Req.Response.new(status: 200, body: active_membership()))
+    assert DashboardAuth.verify_membership("gho_token") == :ok
+
+    stub_membership(Req.Response.new(status: 200, body: %{"state" => "pending"}))
+    assert DashboardAuth.verify_membership("gho_token") == {:error, :denied}
+
+    stub_membership(Req.Response.new(status: 404, body: %{}))
+    assert DashboardAuth.verify_membership("gho_token") == {:error, :denied}
   end
 
-  test "allowed? is false in basic mode" do
-    Application.delete_env(:metadata_relay, :dashboard_github_users)
-    refute DashboardAuth.allowed?("arsfeld")
+  test "verify_membership separates a refusal from an outage" do
+    put_dashboard_org("getmydia")
+
+    stub_membership(Req.Response.new(status: 403, body: %{}))
+    assert DashboardAuth.verify_membership("gho_token") == {:error, :denied}
+
+    stub_membership(Req.Response.new(status: 500, body: %{}))
+    assert DashboardAuth.verify_membership("gho_token") == {:error, :unavailable}
+
+    set_github_adapter(fn request -> {request, %Req.TransportError{reason: :econnrefused}} end)
+    assert DashboardAuth.verify_membership("gho_token") == {:error, :unavailable}
+  end
+
+  test "verify_membership refuses without an organization or a token" do
+    put_dashboard_org(nil)
+    assert DashboardAuth.verify_membership("gho_token") == {:error, :denied}
+
+    put_dashboard_org("getmydia")
+    assert DashboardAuth.verify_membership(nil) == {:error, :denied}
+  end
+
+  test "verification_fresh? tracks the revalidation window" do
+    assert DashboardAuth.verification_fresh?(DashboardAuth.verified_now())
+    refute DashboardAuth.verification_fresh?(DashboardAuth.verified_now() - 100_000)
+    refute DashboardAuth.verification_fresh?(nil)
+    refute DashboardAuth.verification_fresh?("not a timestamp")
   end
 
   test "safe_return_to keeps local paths and rejects everything else" do
@@ -53,5 +83,9 @@ defmodule MetadataRelayWeb.DashboardAuthUnitTest do
     assert DashboardAuth.safe_return_to("/\\evil.example.com") == "/feedback"
     assert DashboardAuth.safe_return_to("feedback") == "/feedback"
     assert DashboardAuth.safe_return_to(nil) == "/feedback"
+  end
+
+  defp stub_membership(response) do
+    set_github_adapter(fn request -> {request, response} end)
   end
 end

--- a/metadata-relay/test/metadata_relay_web/dashboard_auth_unit_test.exs
+++ b/metadata-relay/test/metadata_relay_web/dashboard_auth_unit_test.exs
@@ -59,6 +59,14 @@ defmodule MetadataRelayWeb.DashboardAuthUnitTest do
     assert DashboardAuth.verify_membership("gho_token") == {:error, :unavailable}
   end
 
+  test "a rate-limited 403 does not end a session the way a refusal does" do
+    put_dashboard_org("getmydia")
+
+    stub_membership(Req.Response.new(status: 403, body: %{}, headers: %{"retry-after" => ["60"]}))
+
+    assert DashboardAuth.verify_membership("gho_token") == {:error, :unavailable}
+  end
+
   test "verify_membership refuses without an organization or a token" do
     put_dashboard_org(nil)
     assert DashboardAuth.verify_membership("gho_token") == {:error, :denied}

--- a/metadata-relay/test/metadata_relay_web/dashboard_auth_unit_test.exs
+++ b/metadata-relay/test/metadata_relay_web/dashboard_auth_unit_test.exs
@@ -85,6 +85,68 @@ defmodule MetadataRelayWeb.DashboardAuthUnitTest do
     assert DashboardAuth.safe_return_to(nil) == "/feedback"
   end
 
+  describe "on_mount/4" do
+    test "basic mode mounts with no GitHub identity" do
+      put_dashboard_org(nil)
+
+      assert {:cont, socket} = mount_with(%{})
+      assert socket.assigns.github_login == nil
+      assert socket.assigns.github_token == nil
+    end
+
+    test "a fresh session mounts without calling GitHub" do
+      put_dashboard_org("getmydia")
+      set_github_adapter(fn _request -> raise "GitHub must not be called for a fresh session" end)
+
+      assert {:cont, socket} = mount_with(session())
+      assert socket.assigns.github_login == "arsfeld"
+      assert socket.assigns.github_token == "gho_token"
+    end
+
+    test "a session without a login or token is turned away" do
+      put_dashboard_org("getmydia")
+
+      assert {:halt, _} = mount_with(%{})
+      assert {:halt, _} = mount_with(session(login: nil))
+      assert {:halt, _} = mount_with(session(login: ""))
+      assert {:halt, _} = mount_with(session(token: nil))
+    end
+
+    test "a stale session is turned away once GitHub refuses" do
+      put_dashboard_org("getmydia")
+      stub_membership(Req.Response.new(status: 404, body: %{}))
+
+      assert {:halt, _} = mount_with(session(verified_at: stale()))
+    end
+
+    test "a stale session survives an unreachable GitHub" do
+      put_dashboard_org("getmydia")
+      stub_membership(Req.Response.new(status: 500, body: %{}))
+
+      assert {:cont, socket} = mount_with(session(verified_at: stale()))
+      assert socket.assigns.github_login == "arsfeld"
+    end
+
+    defp mount_with(session) do
+      DashboardAuth.on_mount(
+        :require_github_login,
+        %{},
+        session,
+        %Phoenix.LiveView.Socket{}
+      )
+    end
+
+    defp session(opts \\ []) do
+      %{
+        "github_login" => Keyword.get(opts, :login, "arsfeld"),
+        "github_token" => Keyword.get(opts, :token, "gho_token"),
+        "github_verified_at" => Keyword.get(opts, :verified_at, DashboardAuth.verified_now())
+      }
+    end
+
+    defp stale, do: DashboardAuth.verified_now() - 100_000
+  end
+
   defp stub_membership(response) do
     set_github_adapter(fn request -> {request, response} end)
   end

--- a/metadata-relay/test/metadata_relay_web/endpoint_session_test.exs
+++ b/metadata-relay/test/metadata_relay_web/endpoint_session_test.exs
@@ -1,0 +1,11 @@
+defmodule MetadataRelayWeb.EndpointSessionTest do
+  use ExUnit.Case, async: true
+
+  test "session cookies are encrypted, not merely signed" do
+    opts = MetadataRelayWeb.Endpoint.session_options()
+
+    assert Keyword.fetch!(opts, :store) == :cookie
+    assert is_binary(Keyword.get(opts, :encryption_salt))
+    assert Keyword.get(opts, :encryption_salt) != Keyword.get(opts, :signing_salt)
+  end
+end

--- a/metadata-relay/test/metadata_relay_web/feedback_issue_live_test.exs
+++ b/metadata-relay/test/metadata_relay_web/feedback_issue_live_test.exs
@@ -172,6 +172,29 @@ defmodule MetadataRelayWeb.FeedbackIssueLiveTest do
     assert has_element?(view, "#feedback-#{submission.id}")
   end
 
+  test "submitting with no draft open reports it instead of crashing" do
+    {:ok, view, _html} = live(signed_in_conn(), "/feedback")
+
+    html = render_hook(view, "submit_issue", %{"title" => "T", "body" => "B"})
+
+    assert html =~ "No issue draft is open."
+    assert has_element?(view, "#dashboard-flash-error", "No issue draft is open.")
+  end
+
+  test "submitting without a GitHub token reports a sign-in error, not a transport error" do
+    Application.delete_env(:metadata_relay, :dashboard_github_users)
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Playback stalls"})
+
+    {:ok, view, _html} = live(basic_conn(), "/feedback")
+
+    render_hook(view, "open_issue", %{"id" => submission.id})
+    html = render_hook(view, "submit_issue", %{"title" => "T", "body" => "B"})
+
+    assert html =~ "GitHub sign-in is missing"
+    refute html =~ "unreachable"
+    assert Feedback.get_submission!(submission.id).github_ref == nil
+  end
+
   defp signed_in_conn do
     build_conn()
     |> init_test_session(github_login: "arsfeld", github_token: "gho_token")

--- a/metadata-relay/test/metadata_relay_web/feedback_issue_live_test.exs
+++ b/metadata-relay/test/metadata_relay_web/feedback_issue_live_test.exs
@@ -1,0 +1,184 @@
+defmodule MetadataRelayWeb.FeedbackIssueLiveTest do
+  use ExUnit.Case, async: false
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+  import Plug.Conn
+  import MetadataRelay.Test.GitHubHelpers
+
+  alias MetadataRelay.Feedback
+  alias MetadataRelay.Feedback.Submission
+  alias MetadataRelay.Repo
+
+  @endpoint MetadataRelayWeb.Endpoint
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    # start_async runs Feedback.file_issue/3 in a Task, which needs to share
+    # this test's database connection.
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+    Repo.delete_all(Submission)
+
+    previous_users = Application.get_env(:metadata_relay, :dashboard_github_users)
+
+    previous_github =
+      put_github_config(client_id: "cid", client_secret: "csecret", repo: "getmydia/mydia")
+
+    Application.put_env(:metadata_relay, :dashboard_github_users, ["arsfeld"])
+
+    on_exit(fn ->
+      Ecto.Adapters.SQL.Sandbox.mode(Repo, :manual)
+
+      case previous_users do
+        nil -> Application.delete_env(:metadata_relay, :dashboard_github_users)
+        value -> Application.put_env(:metadata_relay, :dashboard_github_users, value)
+      end
+
+      restore_github_config(previous_github)
+      clear_github_adapter()
+    end)
+
+    :ok
+  end
+
+  test "the file issue button is absent without a GitHub token" do
+    Application.delete_env(:metadata_relay, :dashboard_github_users)
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "It broke"})
+
+    {:ok, view, _html} = live(basic_conn(), "/feedback")
+
+    refute has_element?(view, "#file-issue-#{submission.id}")
+  end
+
+  test "the modal opens prefilled from the submission" do
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Playback stalls"})
+
+    {:ok, view, _html} = live(signed_in_conn(), "/feedback")
+
+    html =
+      view
+      |> element("#file-issue-#{submission.id}")
+      |> render_click()
+
+    assert has_element?(view, "#issue-modal")
+    assert has_element?(view, "#issue-title[value='Playback stalls']")
+    assert html =~ "Playback stalls"
+  end
+
+  test "creating an issue records the ref and closes the modal" do
+    set_github_adapter(fn request ->
+      {request,
+       Req.Response.new(
+         status: 201,
+         body: %{
+           "number" => 123,
+           "html_url" => "https://github.com/getmydia/mydia/issues/123"
+         }
+       )}
+    end)
+
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Playback stalls"})
+
+    {:ok, view, _html} = live(signed_in_conn(), "/feedback")
+
+    view |> element("#file-issue-#{submission.id}") |> render_click()
+
+    view
+    |> form("#issue-form", %{"title" => "Playback stalls", "body" => "Edited body"})
+    |> render_submit()
+
+    render_async(view)
+
+    reloaded = Feedback.get_submission!(submission.id)
+    assert reloaded.github_ref == "#123"
+    assert reloaded.github_issue_url == "https://github.com/getmydia/mydia/issues/123"
+    assert reloaded.state == "filed"
+
+    refute has_element?(view, "#issue-modal")
+  end
+
+  test "a failure keeps the modal open with the edited body" do
+    set_github_adapter(fn request ->
+      {request, Req.Response.new(status: 422, body: %{"message" => "Validation Failed"})}
+    end)
+
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Playback stalls"})
+
+    {:ok, view, _html} = live(signed_in_conn(), "/feedback")
+
+    view |> element("#file-issue-#{submission.id}") |> render_click()
+
+    view
+    |> form("#issue-form", %{"title" => "Retitled", "body" => "Edited body"})
+    |> render_submit()
+
+    html = render_async(view)
+
+    assert has_element?(view, "#issue-modal")
+    assert has_element?(view, "#issue-modal-error", "Validation Failed")
+    assert html =~ "Edited body"
+    assert has_element?(view, "#issue-title[value='Retitled']")
+
+    assert Feedback.get_submission!(submission.id).github_ref == nil
+  end
+
+  test "cancelling closes the modal without filing" do
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Playback stalls"})
+
+    {:ok, view, _html} = live(signed_in_conn(), "/feedback")
+
+    view |> element("#file-issue-#{submission.id}") |> render_click()
+    view |> element("#issue-cancel") |> render_click()
+
+    refute has_element?(view, "#issue-modal")
+    assert Feedback.get_submission!(submission.id).github_ref == nil
+  end
+
+  test "a filed submission links to its issue instead of offering the button" do
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Playback stalls"})
+
+    {:ok, _filed} =
+      submission
+      |> Submission.filed_changeset("#123", "https://github.com/getmydia/mydia/issues/123")
+      |> Repo.update()
+
+    {:ok, view, _html} = live(signed_in_conn(), "/feedback")
+
+    view
+    |> form("#feedback-filters", %{"filters" => %{"state" => "all", "type" => "all"}})
+    |> render_change()
+
+    refute has_element?(view, "#file-issue-#{submission.id}")
+
+    assert has_element?(
+             view,
+             "a[href='https://github.com/getmydia/mydia/issues/123']",
+             "Filed as #123"
+           )
+  end
+
+  test "the filed filter and stat tile are present" do
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Playback stalls"})
+    {:ok, _filed} = Feedback.update_state(submission, "filed")
+
+    {:ok, view, _html} = live(signed_in_conn(), "/feedback")
+
+    assert has_element?(view, "#feedback-stat-filed")
+
+    view
+    |> form("#feedback-filters", %{"filters" => %{"state" => "filed", "type" => "all"}})
+    |> render_change()
+
+    assert has_element?(view, "#feedback-#{submission.id}")
+  end
+
+  defp signed_in_conn do
+    build_conn()
+    |> init_test_session(github_login: "arsfeld", github_token: "gho_token")
+  end
+
+  defp basic_conn do
+    build_conn()
+    |> put_req_header("authorization", "Basic " <> Base.encode64("admin:admin"))
+  end
+end

--- a/metadata-relay/test/metadata_relay_web/feedback_issue_live_test.exs
+++ b/metadata-relay/test/metadata_relay_web/feedback_issue_live_test.exs
@@ -19,21 +19,15 @@ defmodule MetadataRelayWeb.FeedbackIssueLiveTest do
     Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
     Repo.delete_all(Submission)
 
-    previous_users = Application.get_env(:metadata_relay, :dashboard_github_users)
+    previous_org = put_dashboard_org("getmydia")
 
     previous_github =
       put_github_config(client_id: "cid", client_secret: "csecret", repo: "getmydia/mydia")
 
-    Application.put_env(:metadata_relay, :dashboard_github_users, ["arsfeld"])
-
     on_exit(fn ->
       Ecto.Adapters.SQL.Sandbox.mode(Repo, :manual)
 
-      case previous_users do
-        nil -> Application.delete_env(:metadata_relay, :dashboard_github_users)
-        value -> Application.put_env(:metadata_relay, :dashboard_github_users, value)
-      end
-
+      restore_dashboard_org(previous_org)
       restore_github_config(previous_github)
       clear_github_adapter()
     end)
@@ -42,7 +36,7 @@ defmodule MetadataRelayWeb.FeedbackIssueLiveTest do
   end
 
   test "the file issue button is absent without a GitHub token" do
-    Application.delete_env(:metadata_relay, :dashboard_github_users)
+    put_dashboard_org(nil)
     {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "It broke"})
 
     {:ok, view, _html} = live(basic_conn(), "/feedback")
@@ -182,7 +176,7 @@ defmodule MetadataRelayWeb.FeedbackIssueLiveTest do
   end
 
   test "submitting without a GitHub token reports a sign-in error, not a transport error" do
-    Application.delete_env(:metadata_relay, :dashboard_github_users)
+    put_dashboard_org(nil)
     {:ok, submission} = Feedback.create_submission(%{type: "bug", message: "Playback stalls"})
 
     {:ok, view, _html} = live(basic_conn(), "/feedback")
@@ -197,7 +191,11 @@ defmodule MetadataRelayWeb.FeedbackIssueLiveTest do
 
   defp signed_in_conn do
     build_conn()
-    |> init_test_session(github_login: "arsfeld", github_token: "gho_token")
+    |> init_test_session(
+      github_login: "arsfeld",
+      github_token: "gho_token",
+      github_verified_at: MetadataRelayWeb.DashboardAuth.verified_now()
+    )
   end
 
   defp basic_conn do

--- a/metadata-relay/test/metadata_relay_web/feedback_live_test.exs
+++ b/metadata-relay/test/metadata_relay_web/feedback_live_test.exs
@@ -156,6 +156,26 @@ defmodule MetadataRelayWeb.FeedbackLiveTest do
     assert has_element?(view, "#dashboard-flash-error", "Feedback no longer exists.")
   end
 
+  test "a focus parameter expands the targeted submission" do
+    long_message = String.duplicate("This message is long enough to be truncated. ", 12)
+    {:ok, focused} = Feedback.create_submission(%{type: "bug", message: long_message})
+    {:ok, other} = Feedback.create_submission(%{type: "bug", message: long_message})
+
+    {:ok, view, _html} = live(authed_conn(), "/feedback?focus=#{focused.id}")
+
+    assert has_element?(view, "#toggle-expand-#{focused.id}", "Collapse message")
+    assert has_element?(view, "#toggle-expand-#{other.id}", "Expand message")
+  end
+
+  test "an unknown focus parameter expands nothing" do
+    long_message = String.duplicate("This message is long enough to be truncated. ", 12)
+    {:ok, submission} = Feedback.create_submission(%{type: "bug", message: long_message})
+
+    {:ok, view, _html} = live(authed_conn(), "/feedback?focus=#{Ecto.UUID.generate()}")
+
+    assert has_element?(view, "#toggle-expand-#{submission.id}", "Expand message")
+  end
+
   defp authed_conn do
     build_conn()
     |> put_req_header("authorization", "Basic " <> Base.encode64("admin:admin"))

--- a/metadata-relay/test/metadata_relay_web/feedback_live_test.exs
+++ b/metadata-relay/test/metadata_relay_web/feedback_live_test.exs
@@ -118,7 +118,7 @@ defmodule MetadataRelayWeb.FeedbackLiveTest do
 
     {:ok, view, _html} = live(authed_conn(), "/feedback")
 
-    html =
+    _html =
       view
       |> form("#feedback-github-ref-#{submission.id}", %{
         "github_ref" => "gh#123"
@@ -126,6 +126,15 @@ defmodule MetadataRelayWeb.FeedbackLiveTest do
       |> render_submit()
 
     assert Feedback.get_submission!(submission.id).github_ref == "gh#123"
+    assert Feedback.get_submission!(submission.id).state == "filed"
+
+    # Saving a ref promotes the submission out of the unread inbox, so switch to
+    # the all filter before asserting on the rendered card.
+    html =
+      view
+      |> form("#feedback-filters", %{"filters" => %{"state" => "all", "type" => "all"}})
+      |> render_change()
+
     assert html =~ "Filed as gh#123"
     assert has_element?(view, "#github-ref-input-#{submission.id}[value='gh#123']")
   end

--- a/metadata-relay/test/metadata_relay_web/github_auth_test.exs
+++ b/metadata-relay/test/metadata_relay_web/github_auth_test.exs
@@ -6,25 +6,22 @@ defmodule MetadataRelayWeb.GitHubAuthTest do
   import MetadataRelay.Test.GitHubHelpers
 
   alias MetadataRelay.Repo
+  alias MetadataRelayWeb.DashboardAuth
 
   @endpoint MetadataRelayWeb.Endpoint
+
+  @membership_url "https://api.github.com/user/memberships/orgs/getmydia"
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
 
-    previous_users = Application.get_env(:metadata_relay, :dashboard_github_users)
+    previous_org = put_dashboard_org("getmydia")
 
     previous_github =
       put_github_config(client_id: "cid", client_secret: "csecret", repo: "getmydia/mydia")
 
-    Application.put_env(:metadata_relay, :dashboard_github_users, ["arsfeld"])
-
     on_exit(fn ->
-      case previous_users do
-        nil -> Application.delete_env(:metadata_relay, :dashboard_github_users)
-        value -> Application.put_env(:metadata_relay, :dashboard_github_users, value)
-      end
-
+      restore_dashboard_org(previous_org)
       restore_github_config(previous_github)
       clear_github_adapter()
     end)
@@ -56,7 +53,7 @@ defmodule MetadataRelayWeb.GitHubAuthTest do
     assert params["state"] == get_session(conn, :oauth_state)
   end
 
-  test "callback signs in an allowlisted user and honors return_to" do
+  test "callback signs in an active org member and honors return_to" do
     stub_successful_github("arsfeld")
 
     conn =
@@ -67,6 +64,7 @@ defmodule MetadataRelayWeb.GitHubAuthTest do
     assert redirected_to(conn) == "/feedback?focus=abc"
     assert get_session(conn, :github_login) == "arsfeld"
     assert get_session(conn, :github_token) == "gho_token"
+    assert is_integer(get_session(conn, :github_verified_at))
   end
 
   test "callback rewrites an off-site return_to" do
@@ -122,8 +120,8 @@ defmodule MetadataRelayWeb.GitHubAuthTest do
     end
   end
 
-  test "callback refuses a login outside the allowlist" do
-    stub_successful_github("stranger")
+  test "callback refuses a login that is not an org member" do
+    stub_github(membership: Req.Response.new(status: 404, body: %{"message" => "Not Found"}))
 
     conn =
       build_conn()
@@ -134,30 +132,83 @@ defmodule MetadataRelayWeb.GitHubAuthTest do
     assert get_session(conn, :github_login) == nil
   end
 
-  test "a signed-in session reaches the dashboard" do
+  test "callback refuses a pending invitation, which is not yet membership" do
+    stub_github(
+      membership: Req.Response.new(status: 200, body: %{"state" => "pending", "role" => "member"})
+    )
+
     conn =
       build_conn()
-      |> init_test_session(github_login: "arsfeld", github_token: "gho_token")
+      |> init_test_session(oauth_state: "st4te")
+      |> get("/auth/github/callback", %{"code" => "ok", "state" => "st4te"})
+
+    assert redirected_to(conn) == "/auth/login?error=denied"
+    assert get_session(conn, :github_login) == nil
+  end
+
+  test "callback reports an unreachable GitHub separately from a refusal" do
+    stub_github(membership: Req.Response.new(status: 500, body: %{}))
+
+    conn =
+      build_conn()
+      |> init_test_session(oauth_state: "st4te")
+      |> get("/auth/github/callback", %{"code" => "ok", "state" => "st4te"})
+
+    assert redirected_to(conn) == "/auth/login?error=unavailable"
+    assert get_session(conn, :github_login) == nil
+  end
+
+  test "a signed-in session with a fresh check reaches the dashboard without calling GitHub" do
+    set_github_adapter(fn _request -> raise "GitHub must not be called for a fresh session" end)
+
+    conn =
+      build_conn()
+      |> init_test_session(signed_in_session())
       |> get("/feedback")
 
     assert html_response(conn, 200) =~ "feedback-dashboard"
   end
 
-  test "a session whose login left the allowlist is turned away" do
-    Application.put_env(:metadata_relay, :dashboard_github_users, ["someone-else"])
+  test "a stale session is revalidated and refreshed when still a member" do
+    stub_github(membership: Req.Response.new(status: 200, body: active_membership()))
 
     conn =
       build_conn()
-      |> init_test_session(github_login: "arsfeld", github_token: "gho_token")
+      |> init_test_session(signed_in_session(verified_at: stale()))
       |> get("/feedback")
 
-    assert redirected_to(conn) == "/auth/login"
+    assert html_response(conn, 200) =~ "feedback-dashboard"
+    assert DashboardAuth.verification_fresh?(get_session(conn, :github_verified_at))
+  end
+
+  test "a session whose member left the org is turned away once the check goes stale" do
+    stub_github(membership: Req.Response.new(status: 404, body: %{"message" => "Not Found"}))
+
+    conn =
+      build_conn()
+      |> init_test_session(signed_in_session(verified_at: stale()))
+      |> get("/feedback")
+
+    assert redirected_to(conn) == "/auth/login?error=denied"
+    assert get_session(conn, :github_login) == nil
+  end
+
+  test "an unreachable GitHub does not sign out an already verified session" do
+    stub_github(membership: Req.Response.new(status: 500, body: %{}))
+
+    conn =
+      build_conn()
+      |> init_test_session(signed_in_session(verified_at: stale()))
+      |> get("/feedback")
+
+    assert html_response(conn, 200) =~ "feedback-dashboard"
+    assert get_session(conn, :github_login) == "arsfeld"
   end
 
   test "sign-out clears the session" do
     conn =
       build_conn()
-      |> init_test_session(github_login: "arsfeld", github_token: "gho_token")
+      |> init_test_session(signed_in_session())
       |> post("/auth/logout")
 
     assert redirected_to(conn) == "/auth/login"
@@ -177,7 +228,28 @@ defmodule MetadataRelayWeb.GitHubAuthTest do
     assert get_session(conn, :return_to) == nil
   end
 
+  defp signed_in_session(opts \\ []) do
+    [
+      github_login: "arsfeld",
+      github_token: "gho_token",
+      github_verified_at: Keyword.get(opts, :verified_at, DashboardAuth.verified_now())
+    ]
+  end
+
+  # Old enough that the revalidation window has passed.
+  defp stale, do: DashboardAuth.verified_now() - 100_000
+
   defp stub_successful_github(login) do
+    stub_github(
+      login: login,
+      membership: Req.Response.new(status: 200, body: active_membership(login))
+    )
+  end
+
+  defp stub_github(opts) do
+    login = Keyword.get(opts, :login, "arsfeld")
+    membership = Keyword.fetch!(opts, :membership)
+
     set_github_adapter(fn request ->
       case URI.to_string(request.url) do
         "https://github.com/login/oauth/access_token" ->
@@ -185,6 +257,9 @@ defmodule MetadataRelayWeb.GitHubAuthTest do
 
         "https://api.github.com/user" ->
           {request, Req.Response.new(status: 200, body: %{"login" => login})}
+
+        @membership_url ->
+          {request, membership}
       end
     end)
   end

--- a/metadata-relay/test/metadata_relay_web/github_auth_test.exs
+++ b/metadata-relay/test/metadata_relay_web/github_auth_test.exs
@@ -104,6 +104,24 @@ defmodule MetadataRelayWeb.GitHubAuthTest do
     assert get_session(conn, :github_login) == nil
   end
 
+  test "callback rejects non-binary code and state params without raising" do
+    stub_successful_github("arsfeld")
+
+    for params <- [
+          %{"code" => "ok", "state" => ["st4te"]},
+          %{"code" => ["ok"], "state" => "st4te"},
+          %{"code" => %{"a" => "b"}, "state" => %{"a" => "b"}}
+        ] do
+      conn =
+        build_conn()
+        |> init_test_session(oauth_state: "st4te")
+        |> get("/auth/github/callback", params)
+
+      assert redirected_to(conn) == "/auth/login?error=failed"
+      assert get_session(conn, :github_login) == nil
+    end
+  end
+
   test "callback refuses a login outside the allowlist" do
     stub_successful_github("stranger")
 

--- a/metadata-relay/test/metadata_relay_web/github_auth_test.exs
+++ b/metadata-relay/test/metadata_relay_web/github_auth_test.exs
@@ -146,6 +146,19 @@ defmodule MetadataRelayWeb.GitHubAuthTest do
     assert get_session(conn, :github_login) == nil
   end
 
+  test "a successful callback consumes the one-time oauth state" do
+    stub_successful_github("arsfeld")
+
+    conn =
+      build_conn()
+      |> init_test_session(oauth_state: "st4te", return_to: "/feedback")
+      |> get("/auth/github/callback", %{"code" => "ok", "state" => "st4te"})
+
+    assert get_session(conn, :github_login) == "arsfeld"
+    assert get_session(conn, :oauth_state) == nil
+    assert get_session(conn, :return_to) == nil
+  end
+
   defp stub_successful_github(login) do
     set_github_adapter(fn request ->
       case URI.to_string(request.url) do

--- a/metadata-relay/test/metadata_relay_web/github_auth_test.exs
+++ b/metadata-relay/test/metadata_relay_web/github_auth_test.exs
@@ -1,0 +1,160 @@
+defmodule MetadataRelayWeb.GitHubAuthTest do
+  use ExUnit.Case, async: false
+
+  import Phoenix.ConnTest
+  import Plug.Conn
+  import MetadataRelay.Test.GitHubHelpers
+
+  alias MetadataRelay.Repo
+
+  @endpoint MetadataRelayWeb.Endpoint
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    previous_users = Application.get_env(:metadata_relay, :dashboard_github_users)
+
+    previous_github =
+      put_github_config(client_id: "cid", client_secret: "csecret", repo: "getmydia/mydia")
+
+    Application.put_env(:metadata_relay, :dashboard_github_users, ["arsfeld"])
+
+    on_exit(fn ->
+      case previous_users do
+        nil -> Application.delete_env(:metadata_relay, :dashboard_github_users)
+        value -> Application.put_env(:metadata_relay, :dashboard_github_users, value)
+      end
+
+      restore_github_config(previous_github)
+      clear_github_adapter()
+    end)
+
+    :ok
+  end
+
+  test "GET /feedback redirects to sign-in instead of prompting for basic auth" do
+    conn = get(build_conn(), "/feedback")
+
+    assert redirected_to(conn) == "/auth/login"
+    assert get_resp_header(conn, "www-authenticate") == []
+  end
+
+  test "GET /errors redirects to sign-in" do
+    conn = get(build_conn(), "/errors")
+
+    assert redirected_to(conn) == "/auth/login"
+  end
+
+  test "GET /auth/github redirects to GitHub and stores the state" do
+    conn = get(build_conn(), "/auth/github")
+
+    location = redirected_to(conn, 302)
+    assert String.starts_with?(location, "https://github.com/login/oauth/authorize?")
+
+    params = location |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+    assert params["client_id"] == "cid"
+    assert params["state"] == get_session(conn, :oauth_state)
+  end
+
+  test "callback signs in an allowlisted user and honors return_to" do
+    stub_successful_github("arsfeld")
+
+    conn =
+      build_conn()
+      |> init_test_session(oauth_state: "st4te", return_to: "/feedback?focus=abc")
+      |> get("/auth/github/callback", %{"code" => "ok", "state" => "st4te"})
+
+    assert redirected_to(conn) == "/feedback?focus=abc"
+    assert get_session(conn, :github_login) == "arsfeld"
+    assert get_session(conn, :github_token) == "gho_token"
+  end
+
+  test "callback rewrites an off-site return_to" do
+    stub_successful_github("arsfeld")
+
+    conn =
+      build_conn()
+      |> init_test_session(oauth_state: "st4te", return_to: "//evil.example.com")
+      |> get("/auth/github/callback", %{"code" => "ok", "state" => "st4te"})
+
+    assert redirected_to(conn) == "/feedback"
+  end
+
+  test "callback rejects a mismatched state without signing in" do
+    stub_successful_github("arsfeld")
+
+    conn =
+      build_conn()
+      |> init_test_session(oauth_state: "expected")
+      |> get("/auth/github/callback", %{"code" => "ok", "state" => "attacker"})
+
+    assert redirected_to(conn) == "/auth/login?error=failed"
+    assert get_session(conn, :github_login) == nil
+  end
+
+  test "callback rejects a missing state without signing in" do
+    stub_successful_github("arsfeld")
+
+    conn =
+      build_conn()
+      |> init_test_session(%{})
+      |> get("/auth/github/callback", %{"code" => "ok", "state" => "anything"})
+
+    assert redirected_to(conn) == "/auth/login?error=failed"
+    assert get_session(conn, :github_login) == nil
+  end
+
+  test "callback refuses a login outside the allowlist" do
+    stub_successful_github("stranger")
+
+    conn =
+      build_conn()
+      |> init_test_session(oauth_state: "st4te")
+      |> get("/auth/github/callback", %{"code" => "ok", "state" => "st4te"})
+
+    assert redirected_to(conn) == "/auth/login?error=denied"
+    assert get_session(conn, :github_login) == nil
+  end
+
+  test "a signed-in session reaches the dashboard" do
+    conn =
+      build_conn()
+      |> init_test_session(github_login: "arsfeld", github_token: "gho_token")
+      |> get("/feedback")
+
+    assert html_response(conn, 200) =~ "feedback-dashboard"
+  end
+
+  test "a session whose login left the allowlist is turned away" do
+    Application.put_env(:metadata_relay, :dashboard_github_users, ["someone-else"])
+
+    conn =
+      build_conn()
+      |> init_test_session(github_login: "arsfeld", github_token: "gho_token")
+      |> get("/feedback")
+
+    assert redirected_to(conn) == "/auth/login"
+  end
+
+  test "sign-out clears the session" do
+    conn =
+      build_conn()
+      |> init_test_session(github_login: "arsfeld", github_token: "gho_token")
+      |> post("/auth/logout")
+
+    assert redirected_to(conn) == "/auth/login"
+    assert get_session(conn, :github_login) == nil
+  end
+
+  defp stub_successful_github(login) do
+    set_github_adapter(fn request ->
+      case URI.to_string(request.url) do
+        "https://github.com/login/oauth/access_token" ->
+          {request, Req.Response.new(status: 200, body: %{"access_token" => "gho_token"})}
+
+        "https://api.github.com/user" ->
+          {request, Req.Response.new(status: 200, body: %{"login" => login})}
+      end
+    end)
+  end
+end

--- a/metadata-relay/test/support/github_helpers.ex
+++ b/metadata-relay/test/support/github_helpers.ex
@@ -34,4 +34,37 @@ defmodule MetadataRelay.Test.GitHubHelpers do
 
   def restore_github_config(previous),
     do: Application.put_env(:metadata_relay, @config_key, previous)
+
+  @doc """
+  Sets the organization whose members may reach the dashboards, returning the
+  previous value so `on_exit` can restore it.
+  """
+  def put_dashboard_org(org) do
+    previous = Application.get_env(:metadata_relay, :dashboard_github_org)
+
+    case org do
+      nil -> Application.delete_env(:metadata_relay, :dashboard_github_org)
+      value -> Application.put_env(:metadata_relay, :dashboard_github_org, value)
+    end
+
+    previous
+  end
+
+  def restore_dashboard_org(nil),
+    do: Application.delete_env(:metadata_relay, :dashboard_github_org)
+
+  def restore_dashboard_org(previous),
+    do: Application.put_env(:metadata_relay, :dashboard_github_org, previous)
+
+  @doc """
+  Body for an active org membership, as `/user/memberships/orgs/:org` returns it.
+  """
+  def active_membership(login \\ "arsfeld", org \\ "getmydia") do
+    %{
+      "state" => "active",
+      "role" => "admin",
+      "user" => %{"login" => login},
+      "organization" => %{"login" => org}
+    }
+  end
 end

--- a/metadata-relay/test/support/github_helpers.ex
+++ b/metadata-relay/test/support/github_helpers.ex
@@ -1,0 +1,37 @@
+defmodule MetadataRelay.Test.GitHubHelpers do
+  @moduledoc """
+  Test helpers for the GitHub OAuth and REST clients.
+  """
+
+  @config_key MetadataRelay.GitHub
+
+  @doc """
+  Installs a Req adapter for GitHub calls, with retries disabled for speed.
+  """
+  def set_github_adapter(adapter) do
+    wrapped = fn request ->
+      request = %{request | options: Map.put(request.options, :retry, false)}
+      adapter.(request)
+    end
+
+    Application.put_env(:metadata_relay, :github_http_adapter, wrapped)
+  end
+
+  def clear_github_adapter do
+    Application.delete_env(:metadata_relay, :github_http_adapter)
+  end
+
+  @doc """
+  Sets GitHub config and returns the previous value so `on_exit` can restore it.
+  """
+  def put_github_config(opts) do
+    previous = Application.get_env(:metadata_relay, @config_key)
+    Application.put_env(:metadata_relay, @config_key, opts)
+    previous
+  end
+
+  def restore_github_config(nil), do: Application.delete_env(:metadata_relay, @config_key)
+
+  def restore_github_config(previous),
+    do: Application.put_env(:metadata_relay, @config_key, previous)
+end

--- a/metadata-relay/test/test_helper.exs
+++ b/metadata-relay/test/test_helper.exs
@@ -1,6 +1,7 @@
 # Load test support modules
 Code.require_file("support/tvdb_helpers.ex", __DIR__)
 Code.require_file("support/tmdb_helpers.ex", __DIR__)
+Code.require_file("support/github_helpers.ex", __DIR__)
 
 # Ensure the Repo is started and run migrations for in-memory database
 case MetadataRelay.Repo.start_link() do


### PR DESCRIPTION
Puts the metadata-relay maintainer dashboards behind GitHub App sign-in, and lets you file a GitHub issue straight from a feedback submission as yourself.

Following the deep link in a feedback notification email currently means an HTTP Basic Auth prompt, which is miserable on a phone. More importantly, basic auth carries no identity, so there was no way to act on GitHub from the dashboard without parking a long-lived write token in the relay's environment.

## What changed

`/feedback` and `/errors` authenticate against a GitHub App ("Mydia Relay") using user-to-server authorization, gated on membership of the `getmydia` organization. The same token files the issue, so there is one credential pair and no permanent write token on the server. A GitHub App rather than a classic OAuth app keeps the token narrow: it can only touch Issues on repos the App is installed on, instead of every public repo the account owns.

The feedback dashboard gains a "File GitHub issue" button that opens a modal with an editable title and body, then records the issue number and URL back onto the submission and moves it to a new `filed` state.

## Two modes, mutually exclusive

Setting `DASHBOARD_GITHUB_ORG` switches the dashboards to GitHub sign-in and turns basic auth off. Leaving it empty keeps today's behaviour exactly, which is what self-hosted relays and the test suite use. `test/metadata_relay_web/dashboard_auth_test.exs` is byte-identical to master after this branch, as the proof of that.

The issue-filing button only appears for a signed-in maintainer, so a relay in basic-auth mode simply does not show it.

## Security fix worth calling out separately

`config/config.exs` shipped a hardcoded placeholder `secret_key_base` with no runtime override. Harmless while the session carried nothing, but forgeable by anyone reading the repo once a login session exists. `SECRET_KEY_BASE` is now read from the environment, and the session cookie is encrypted rather than only signed.

When the variable is absent the relay generates a random key at boot and warns, rather than refusing to start. Raising would have broken every existing self-hosted relay on upgrade for a variable that did not previously exist.

## Compatibility

No public API surface moves. `lib/metadata_relay/router.ex` is unchanged, so the TMDB, TVDB and subtitle proxy paths, feedback ingest, pairing claims, and the p2p access endpoints all behave exactly as before. No Mydia instance is affected by this deploy.

Merging deploys nothing on its own: the relay ships only on a `metadata-relay-v*` tag, so this needs `metadata-relay-v0.12.0` cut against master afterwards.

Order does matter for the cluster config, and the ordering constraint is one way only. The ConfigMap in this branch sets `DASHBOARD_GITHUB_USERS: "arsfeld"`, and a non-empty allowlist turns basic auth off. Applying that ConfigMap before `GITHUB_APP_CLIENT_ID` and `GITHUB_APP_CLIENT_SECRET` are in the secret leaves `/feedback` and `/errors` unreachable: basic auth is disabled and sign-in cannot complete. The relay itself is unaffected and keeps serving the proxy, and adding the secret restores access, so the failure is a locked door rather than an outage. There is no window in which the dashboards are exposed, only one in which they are shut. Apply the secret first, or ship the ConfigMap with the allowlist empty and fill it in once the App exists.

## Operator steps before this does anything

1. Create a GitHub App named "Mydia Relay" owned by `getmydia`. Repository permissions: Issues, read and write. Callback URL `https://relay.mydia.dev/auth/github/callback`. Leave "Expire user authorization tokens" unchecked, since there is deliberately no refresh flow. Disable webhooks.
2. Install it on `getmydia/mydia`.
3. Add `SECRET_KEY_BASE`, `GITHUB_APP_CLIENT_ID` and `GITHUB_APP_CLIENT_SECRET` to the cluster secret, and `DASHBOARD_GITHUB_USERS` plus `FEEDBACK_GITHUB_REPO` to the ConfigMap.

## Testing

315 tests, 0 failures under `mix test --warnings-as-errors`. New coverage includes forged and missing OAuth `state`, off-site `return_to` rewriting, logins outside the allowlist, a login removed from the allowlist after signing in, the full GitHub client error surface, and an explicit assertion that `contact`, `source_ip` and `instance_id` never reach an issue body headed for a public repo.

Issues are public, so the draft omits the reporter's contact address, source IP, and instance ID by default, and the modal exists as a review step before anything is published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub sign-in with active organization membership checks for dashboard access; basic authentication remains available as a fallback.
  * Added tools to draft and file feedback as GitHub issues directly from the dashboard.
  * Added filed-status tracking, issue links, filtering, focused submission links, and improved issue review controls.
  * Enhanced encrypted session handling and access verification during GitHub outages.

* **Documentation**
  * Documented dashboard authentication modes, GitHub setup, repository configuration, and required secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Rebased onto master on 19 August 2026, picking up the SubDL subtitle work and the Trakt removal that landed in the meantime. Three files needed hand resolution, all documentation: the relay `CLAUDE.md` env var list, the infra README, and `secret.yaml.example`, each of which had gained `SUBDL_API_KEY` on master and lost the OpenSubtitles keys. `config/runtime.exs` and the feedback notifier merged cleanly, and `dashboard_auth_test.exs` is still byte-identical to master.

One bug surfaced while re-reviewing after the rebase, fixed in `fix(relay): deny malformed OAuth callback params instead of raising`. Nested query params arrive as lists, and both `Plug.Crypto.secure_compare/2` and `OAuth.exchange_code/1` only accept binaries, so `/auth/github/callback?code=x&state[]=y` raised `FunctionClauseError`. Not an auth bypass, since the request was refused either way, but an unauthenticated caller could turn every such request into a 500 and an ErrorTracker entry. The callback head now guards on binary `code` and `state`, so malformed params fall through to the existing catch-all and redirect to the login page like any other failed sign-in.

`infra/deploy` rebuilds `metadata-relay-secrets` from `metadata_relay_secret_data` on every run, and it did not know about the new keys, so credentials added by hand with `kubectl` would have been dropped on its next run. `chore(infra): provision the dashboard sign-in secrets from infra/deploy` adds them as optional config fields written only when set, matching how `SUBDL_API_KEY` and `SMTP_PASSWORD` already work. The Phoenix session key gets its own field rather than reusing `relay_secret_key_base`, which despite the name is written as `RELAY_TOKEN_SECRET`.

Worth knowing separately, and not something this branch changes: `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` appear nowhere in `infra/deploy`, so they are only in the live secret by hand. A run of `infra/deploy` drops them, and in basic-auth mode `runtime.exs` raises on a missing username in prod, which would crashloop the relay. That is why this branch does not make GitHub mode fall back to basic auth when the App credentials are absent: the fallback could take the proxy down instead of just the dashboards.

## Access follows org membership, not a list

Updated after review: `DASHBOARD_GITHUB_USERS` is gone, replaced by `DASHBOARD_GITHUB_ORG=getmydia`. Anyone with an active membership of that organization gets in, so adding a maintainer to the org grants the dashboards and removing them takes it away, with no list of logins to keep in step in the ConfigMap.

Membership is read with `GET /user/memberships/orgs/{org}` using the signed-in maintainer's own token. That endpoint is scoped to the caller, so it sees private membership and the App needs no permission to read the org's member list. Only `active` counts. A pending invitation also answers 200, and accepting that would mean merely inviting someone handed them the dashboard, so there is an explicit test for it.

The real cost of this over an allowlist is revocation latency, and it is worth being honest about. The allowlist was config, so it could be consulted on every request and a removal took effect immediately. Membership is a remote lookup, so it is checked at sign-in and re-checked at most every five minutes. Someone removed from the organization keeps a live session until that window passes.

The other direction matters too: an unreachable GitHub leaves an already-verified session alone rather than signing it out. Only a definitive refusal, a 404 or a non-active state or a 401/403, ends the session. Otherwise a GitHub outage would lock maintainers out of the dashboards they need precisely when something is going wrong.

`dashboard_auth_test.exs` is still byte-identical to master, so basic-auth mode remains provably untouched.

326 tests, 0 failures. `runtime.exs` has no test coverage, so the mode switch was exercised directly: unset, empty string, and whitespace all fall back to basic auth, and a set value produces GitHub mode with basic-auth credentials left nil.