### PR TITLE
style(custom-formats): conform the admin page to the config UI standard

### DIFF
--- a/lib/mydia_web/live/admin_custom_formats_live/components.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/components.ex
@@ -21,56 +21,79 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
       </div>
 
       <div class="bg-base-200 rounded-box divide-y divide-base-300">
-        <div
-          :for={format <- @formats}
-          id={"custom-format-row-#{format.slug}"}
-          class="flex items-center gap-3 p-3 sm:p-4"
-        >
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-2">
-              <span class="font-medium">{format.name}</span>
-              <span :if={format.builtin?} class="badge badge-sm badge-ghost">Built-in</span>
-              <span :if={format.overridden?} class="badge badge-sm badge-warning">Edited</span>
-            </div>
-            <div class="text-xs opacity-60 truncate font-mono">
-              {Enum.join(format.patterns, "  ")}
-            </div>
+        <.custom_format_row :for={format <- @formats} format={format} />
+      </div>
+    </div>
+    """
+  end
+
+  attr :format, :map, required: true
+
+  defp custom_format_row(assigns) do
+    ~H"""
+    <div id={"custom-format-row-#{@format.slug}"} class="p-3 sm:p-4">
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+        <div class="flex-1 min-w-0">
+          <div class="font-semibold">{@format.name}</div>
+          <div class="text-xs opacity-60 font-mono truncate mt-0.5">{row_descriptor(@format)}</div>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2">
+          <span :if={@format.builtin?} class="badge badge-sm badge-outline">Built-in</span>
+          <span :if={@format.overridden?} class="badge badge-sm badge-warning">Edited</span>
+
+          <div class="join ml-auto sm:ml-2">
+            <button
+              id={"custom-format-edit-#{@format.slug}"}
+              class="btn btn-sm btn-ghost join-item"
+              phx-click="edit_custom_format"
+              phx-value-slug={@format.slug}
+              title="Edit"
+            >
+              <.icon name="hero-pencil" class="w-4 h-4" />
+            </button>
+            <%= if @format.builtin? do %>
+              <button
+                id={"custom-format-reset-#{@format.slug}"}
+                class="btn btn-sm btn-ghost join-item"
+                phx-click="reset_custom_format"
+                phx-value-slug={@format.slug}
+                disabled={not @format.overridden?}
+                title={
+                  if(@format.overridden?,
+                    do: "Reset to the shipped definition",
+                    else: "Not modified"
+                  )
+                }
+              >
+                <.icon
+                  name="hero-arrow-uturn-left"
+                  class={["w-4 h-4", not @format.overridden? && "opacity-30"]}
+                />
+              </button>
+            <% else %>
+              <button
+                id={"custom-format-delete-#{@format.slug}"}
+                class="btn btn-sm btn-ghost join-item text-error"
+                phx-click="delete_custom_format"
+                phx-value-slug={@format.slug}
+                data-confirm={"Delete #{@format.name}?"}
+                title="Delete"
+              >
+                <.icon name="hero-trash" class="w-4 h-4" />
+              </button>
+            <% end %>
           </div>
-
-          <.button
-            id={"custom-format-edit-#{format.slug}"}
-            phx-click="edit_custom_format"
-            phx-value-slug={format.slug}
-            class="btn-sm btn-ghost"
-          >
-            Edit
-          </.button>
-
-          <.button
-            :if={format.overridden?}
-            id={"custom-format-reset-#{format.slug}"}
-            phx-click="reset_custom_format"
-            phx-value-slug={format.slug}
-            class="btn-sm btn-ghost"
-          >
-            Reset
-          </.button>
-
-          <.button
-            :if={not format.builtin?}
-            id={"custom-format-delete-#{format.slug}"}
-            phx-click="delete_custom_format"
-            phx-value-slug={format.slug}
-            data-confirm={"Delete #{format.name}?"}
-            class="btn-sm btn-ghost text-error"
-          >
-            Delete
-          </.button>
         </div>
       </div>
     </div>
     """
   end
+
+  # Formats normally show their patterns. A format with none would otherwise
+  # render a blank second line, so fall back to the description.
+  defp row_descriptor(%{patterns: []} = format), do: format.description || "No patterns"
+  defp row_descriptor(format), do: Enum.join(format.patterns, "  ")
 
   @doc """
   Renders the Custom Format modal.

--- a/lib/mydia_web/live/admin_custom_formats_live/components.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/components.ex
@@ -68,7 +68,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
               >
                 <.icon
                   name="hero-arrow-uturn-left"
-                  class={["w-4 h-4", not @format.overridden? && "opacity-30"]}
+                  class={if(@format.overridden?, do: "w-4 h-4", else: "w-4 h-4 opacity-30")}
                 />
               </button>
             <% else %>
@@ -107,67 +107,104 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
     ~H"""
     <div class="modal modal-open">
       <div class="modal-box max-w-2xl">
-        <h3 class="font-bold text-lg mb-4">
-          {if(@custom_format_mode == :new,
-            do: "New format",
-            else: "Edit #{@editing_custom_format.name}"
-          )}
-        </h3>
-
         <.form
           for={@custom_format_form}
           id="custom-format-form"
           phx-change="validate_custom_format"
           phx-submit="save_custom_format"
         >
-          <.input
-            field={@custom_format_form[:name]}
-            type="text"
-            label="Name"
-            disabled={@editing_custom_format.builtin?}
-          />
-          <.input field={@custom_format_form[:description]} type="text" label="Description" />
-          <.input
-            field={@custom_format_form[:patterns_text]}
-            type="textarea"
-            label="Patterns (one per line)"
-            rows="6"
-          />
+          <%!-- Header --%>
+          <div class="flex items-center gap-3 mb-5">
+            <div class="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center">
+              <.icon
+                name={
+                  if(@custom_format_mode == :new,
+                    do: "hero-plus-circle",
+                    else: "hero-pencil-square"
+                  )
+                }
+                class="w-5 h-5 text-primary"
+              />
+            </div>
+            <div>
+              <h3 class="font-bold text-lg">
+                {if(@custom_format_mode == :new,
+                  do: "New Format",
+                  else: "Edit #{@editing_custom_format.name}"
+                )}
+              </h3>
+              <p class="text-sm text-base-content/60">
+                {if(@custom_format_mode == :new,
+                  do: "Match release titles by regex. Scores are set per quality profile.",
+                  else: "Update its patterns. Scores are set per quality profile."
+                )}
+              </p>
+            </div>
+          </div>
 
-          <div class="divider">Test</div>
+          <div class="space-y-5">
+            <div>
+              <.input
+                field={@custom_format_form[:name]}
+                type="text"
+                label="Name"
+                disabled={@editing_custom_format.builtin?}
+              />
+              <p :if={@editing_custom_format.builtin?} class="text-xs text-base-content/60 mt-1">
+                Built-in names are fixed. Saving stores a local override of the shipped definition.
+              </p>
+            </div>
 
-          <.input
-            field={@custom_format_form[:test_title]}
-            id="custom-format-test-input"
-            type="text"
-            label="Paste a release title"
-            placeholder="Film.2024.VFF.1080p.WEB-DL.x264-GROUP"
-          />
+            <.input field={@custom_format_form[:description]} type="text" label="Description" />
 
-          <ul :if={@test_results != []} class="mt-2 space-y-1 text-sm">
-            <li :for={r <- @test_results} class="flex items-center gap-2 font-mono">
-              <span :if={r.status == :match} class="custom-format-test-match text-success">
-                <.icon name="hero-check-circle" class="w-4 h-4" />
-              </span>
-              <span :if={r.status == :miss} class="opacity-40">
-                <.icon name="hero-x-circle" class="w-4 h-4" />
-              </span>
-              <span :if={match?({:error, _}, r.status)} class="text-error">
-                <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
-              </span>
-              <span>{r.pattern}</span>
-            </li>
-          </ul>
+            <.input
+              field={@custom_format_form[:patterns_text]}
+              type="textarea"
+              label="Patterns (one per line)"
+              rows="6"
+            />
 
-          <div class="modal-action">
-            <.button type="button" phx-click="close_custom_format_modal" class="btn-ghost">
+            <div class="divider text-xs text-base-content/40 my-2">
+              Test against a release title
+            </div>
+
+            <.input
+              field={@custom_format_form[:test_title]}
+              id="custom-format-test-input"
+              type="text"
+              label="Paste a release title"
+              placeholder="Film.2024.VFF.1080p.WEB-DL.x264-GROUP"
+            />
+
+            <ul :if={@test_results != []} class="space-y-1 text-sm">
+              <li :for={r <- @test_results} class="flex items-center gap-2 font-mono">
+                <span :if={r.status == :match} class="custom-format-test-match text-success">
+                  <.icon name="hero-check-circle" class="w-4 h-4" />
+                </span>
+                <span :if={r.status == :miss} class="opacity-40">
+                  <.icon name="hero-x-circle" class="w-4 h-4" />
+                </span>
+                <span :if={match?({:error, _}, r.status)} class="text-error">
+                  <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
+                </span>
+                <span>{r.pattern}</span>
+              </li>
+            </ul>
+          </div>
+
+          <%!-- Modal Actions --%>
+          <div class="modal-action mt-6 pt-4 border-t border-base-300">
+            <button type="button" class="btn btn-ghost" phx-click="close_custom_format_modal">
               Cancel
-            </.button>
-            <.button type="submit" class="btn-primary">Save</.button>
+            </button>
+            <button type="submit" class="btn btn-primary gap-2">
+              <.icon name="hero-check" class="w-4 h-4" />
+              {if(@custom_format_mode == :new, do: "Add Format", else: "Save Changes")}
+            </button>
           </div>
         </.form>
       </div>
-      <div class="modal-backdrop" phx-click="close_custom_format_modal"></div>
+      <div class="modal-backdrop bg-black/50" phx-click="close_custom_format_modal"></div>
     </div>
     """
   end

--- a/lib/mydia_web/live/admin_custom_formats_live/components.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/components.ex
@@ -53,24 +53,30 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
               <.icon name="hero-pencil" class="w-4 h-4" />
             </button>
             <%= if @format.builtin? do %>
-              <button
-                id={"custom-format-reset-#{@format.slug}"}
-                class="btn btn-sm btn-ghost join-item"
-                phx-click="reset_custom_format"
-                phx-value-slug={@format.slug}
-                disabled={not @format.overridden?}
-                title={
-                  if(@format.overridden?,
-                    do: "Reset to the shipped definition",
-                    else: "Not modified"
-                  )
-                }
-              >
-                <.icon
-                  name="hero-arrow-uturn-left"
-                  class={if(@format.overridden?, do: "w-4 h-4", else: "w-4 h-4 opacity-30")}
-                />
-              </button>
+              <%!-- A disabled <button> does not fire hover, so the native title
+                   attribute is unreliable there. Wrap it the way the other
+                   config pages do and let DaisyUI's .tooltip carry the text. --%>
+              <%= if @format.overridden? do %>
+                <button
+                  id={"custom-format-reset-#{@format.slug}"}
+                  class="btn btn-sm btn-ghost join-item"
+                  phx-click="reset_custom_format"
+                  phx-value-slug={@format.slug}
+                  title="Reset to the shipped definition"
+                >
+                  <.icon name="hero-arrow-uturn-left" class="w-4 h-4" />
+                </button>
+              <% else %>
+                <div class="tooltip" data-tip="Not modified">
+                  <button
+                    id={"custom-format-reset-#{@format.slug}"}
+                    class="btn btn-sm btn-ghost join-item"
+                    disabled
+                  >
+                    <.icon name="hero-arrow-uturn-left" class="w-4 h-4 opacity-30" />
+                  </button>
+                </div>
+              <% end %>
             <% else %>
               <button
                 id={"custom-format-delete-#{@format.slug}"}

--- a/lib/mydia_web/live/admin_custom_formats_live/components.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/components.ex
@@ -1,0 +1,139 @@
+defmodule MydiaWeb.AdminCustomFormatsLive.Components do
+  @moduledoc false
+  use MydiaWeb, :html
+
+  @doc """
+  Renders the Custom Formats tab content.
+  """
+  attr :formats, :list, required: true
+
+  def custom_formats_tab(assigns) do
+    ~H"""
+    <div class="space-y-4">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-2xl font-bold">Custom Formats</h1>
+          <p class="text-sm opacity-70">
+            Match release titles by regex. Assign scores per quality profile.
+          </p>
+        </div>
+        <.button id="custom-format-new" phx-click="new" class="btn-primary">
+          <.icon name="hero-plus" class="w-4 h-4" /> New format
+        </.button>
+      </div>
+
+      <div class="card bg-base-100 shadow">
+        <div class="card-body p-0 divide-y divide-base-200">
+          <div
+            :for={format <- @formats}
+            id={"custom-format-row-#{format.slug}"}
+            class="flex items-center gap-3 p-4"
+          >
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="font-medium">{format.name}</span>
+                <span :if={format.builtin?} class="badge badge-sm badge-ghost">Built-in</span>
+                <span :if={format.overridden?} class="badge badge-sm badge-warning">Edited</span>
+              </div>
+              <div class="text-xs opacity-60 truncate font-mono">
+                {Enum.join(format.patterns, "  ")}
+              </div>
+            </div>
+
+            <.button
+              id={"custom-format-edit-#{format.slug}"}
+              phx-click="edit"
+              phx-value-slug={format.slug}
+              class="btn-sm btn-ghost"
+            >
+              Edit
+            </.button>
+
+            <.button
+              :if={format.overridden?}
+              id={"custom-format-reset-#{format.slug}"}
+              phx-click="reset"
+              phx-value-slug={format.slug}
+              class="btn-sm btn-ghost"
+            >
+              Reset
+            </.button>
+
+            <.button
+              :if={not format.builtin?}
+              id={"custom-format-delete-#{format.slug}"}
+              phx-click="delete"
+              phx-value-slug={format.slug}
+              data-confirm={"Delete #{format.name}?"}
+              class="btn-sm btn-ghost text-error"
+            >
+              Delete
+            </.button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders the Custom Format modal.
+  """
+  attr :editing, :any, required: true
+  attr :form, :any, required: true
+  attr :test_results, :list, default: []
+
+  def custom_format_modal(assigns) do
+    ~H"""
+    <div class="modal modal-open">
+      <div class="modal-box max-w-2xl">
+        <h3 class="font-bold text-lg mb-4">
+          {if(@editing.slug, do: "Edit #{@editing.name}", else: "New format")}
+        </h3>
+
+        <.form for={@form} id="custom-format-form" phx-change="validate" phx-submit="save">
+          <.input field={@form[:name]} type="text" label="Name" disabled={@editing.builtin?} />
+          <.input field={@form[:description]} type="text" label="Description" />
+          <.input
+            field={@form[:patterns_text]}
+            type="textarea"
+            label="Patterns (one per line)"
+            rows="6"
+          />
+
+          <div class="divider">Test</div>
+
+          <.input
+            field={@form[:test_title]}
+            id="custom-format-test-input"
+            type="text"
+            label="Paste a release title"
+            placeholder="Film.2024.VFF.1080p.WEB-DL.x264-GROUP"
+          />
+
+          <ul :if={@test_results != []} class="mt-2 space-y-1 text-sm">
+            <li :for={r <- @test_results} class="flex items-center gap-2 font-mono">
+              <span :if={r.status == :match} class="custom-format-test-match text-success">
+                <.icon name="hero-check-circle" class="w-4 h-4" />
+              </span>
+              <span :if={r.status == :miss} class="opacity-40">
+                <.icon name="hero-x-circle" class="w-4 h-4" />
+              </span>
+              <span :if={match?({:error, _}, r.status)} class="text-error">
+                <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
+              </span>
+              <span>{r.pattern}</span>
+            </li>
+          </ul>
+
+          <div class="modal-action">
+            <.button type="button" phx-click="cancel" class="btn-ghost">Cancel</.button>
+            <.button type="submit" class="btn-primary">Save</.button>
+          </div>
+        </.form>
+      </div>
+      <div class="modal-backdrop" phx-click="cancel"></div>
+    </div>
+    """
+  end
+end

--- a/lib/mydia_web/live/admin_custom_formats_live/components.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/components.ex
@@ -17,7 +17,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
             Match release titles by regex. Assign scores per quality profile.
           </p>
         </div>
-        <.button id="custom-format-new" phx-click="new" class="btn-primary">
+        <.button id="custom-format-new" phx-click="new_custom_format" class="btn-primary">
           <.icon name="hero-plus" class="w-4 h-4" /> New format
         </.button>
       </div>
@@ -42,7 +42,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
 
             <.button
               id={"custom-format-edit-#{format.slug}"}
-              phx-click="edit"
+              phx-click="edit_custom_format"
               phx-value-slug={format.slug}
               class="btn-sm btn-ghost"
             >
@@ -52,7 +52,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
             <.button
               :if={format.overridden?}
               id={"custom-format-reset-#{format.slug}"}
-              phx-click="reset"
+              phx-click="reset_custom_format"
               phx-value-slug={format.slug}
               class="btn-sm btn-ghost"
             >
@@ -62,7 +62,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
             <.button
               :if={not format.builtin?}
               id={"custom-format-delete-#{format.slug}"}
-              phx-click="delete"
+              phx-click="delete_custom_format"
               phx-value-slug={format.slug}
               data-confirm={"Delete #{format.name}?"}
               class="btn-sm btn-ghost text-error"
@@ -79,8 +79,9 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
   @doc """
   Renders the Custom Format modal.
   """
-  attr :editing, :any, required: true
-  attr :form, :any, required: true
+  attr :custom_format_form, :any, required: true
+  attr :custom_format_mode, :atom, required: true
+  attr :editing_custom_format, :any, required: true
   attr :test_results, :list, default: []
 
   def custom_format_modal(assigns) do
@@ -88,14 +89,27 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
     <div class="modal modal-open">
       <div class="modal-box max-w-2xl">
         <h3 class="font-bold text-lg mb-4">
-          {if(@editing.slug, do: "Edit #{@editing.name}", else: "New format")}
+          {if(@custom_format_mode == :new,
+            do: "New format",
+            else: "Edit #{@editing_custom_format.name}"
+          )}
         </h3>
 
-        <.form for={@form} id="custom-format-form" phx-change="validate" phx-submit="save">
-          <.input field={@form[:name]} type="text" label="Name" disabled={@editing.builtin?} />
-          <.input field={@form[:description]} type="text" label="Description" />
+        <.form
+          for={@custom_format_form}
+          id="custom-format-form"
+          phx-change="validate_custom_format"
+          phx-submit="save_custom_format"
+        >
           <.input
-            field={@form[:patterns_text]}
+            field={@custom_format_form[:name]}
+            type="text"
+            label="Name"
+            disabled={@editing_custom_format.builtin?}
+          />
+          <.input field={@custom_format_form[:description]} type="text" label="Description" />
+          <.input
+            field={@custom_format_form[:patterns_text]}
             type="textarea"
             label="Patterns (one per line)"
             rows="6"
@@ -104,7 +118,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
           <div class="divider">Test</div>
 
           <.input
-            field={@form[:test_title]}
+            field={@custom_format_form[:test_title]}
             id="custom-format-test-input"
             type="text"
             label="Paste a release title"
@@ -127,12 +141,14 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
           </ul>
 
           <div class="modal-action">
-            <.button type="button" phx-click="cancel" class="btn-ghost">Cancel</.button>
+            <.button type="button" phx-click="close_custom_format_modal" class="btn-ghost">
+              Cancel
+            </.button>
             <.button type="submit" class="btn-primary">Save</.button>
           </div>
         </.form>
       </div>
-      <div class="modal-backdrop" phx-click="cancel"></div>
+      <div class="modal-backdrop" phx-click="close_custom_format_modal"></div>
     </div>
     """
   end

--- a/lib/mydia_web/live/admin_custom_formats_live/components.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/components.ex
@@ -9,67 +9,63 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Components do
 
   def custom_formats_tab(assigns) do
     ~H"""
-    <div class="space-y-4">
-      <div class="flex items-center justify-between">
-        <div>
-          <h1 class="text-2xl font-bold">Custom Formats</h1>
-          <p class="text-sm opacity-70">
-            Match release titles by regex. Assign scores per quality profile.
-          </p>
-        </div>
-        <.button id="custom-format-new" phx-click="new_custom_format" class="btn-primary">
-          <.icon name="hero-plus" class="w-4 h-4" /> New format
-        </.button>
+    <div class="p-4 sm:p-6 space-y-4">
+      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <.icon name="hero-language" class="w-5 h-5 opacity-60" /> Custom Formats
+          <span class="badge badge-ghost">{length(@formats)}</span>
+        </h2>
+        <button id="custom-format-new" class="btn btn-sm btn-primary" phx-click="new_custom_format">
+          <.icon name="hero-plus" class="w-4 h-4" /> New
+        </button>
       </div>
 
-      <div class="card bg-base-100 shadow">
-        <div class="card-body p-0 divide-y divide-base-200">
-          <div
-            :for={format <- @formats}
-            id={"custom-format-row-#{format.slug}"}
-            class="flex items-center gap-3 p-4"
-          >
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2">
-                <span class="font-medium">{format.name}</span>
-                <span :if={format.builtin?} class="badge badge-sm badge-ghost">Built-in</span>
-                <span :if={format.overridden?} class="badge badge-sm badge-warning">Edited</span>
-              </div>
-              <div class="text-xs opacity-60 truncate font-mono">
-                {Enum.join(format.patterns, "  ")}
-              </div>
+      <div class="bg-base-200 rounded-box divide-y divide-base-300">
+        <div
+          :for={format <- @formats}
+          id={"custom-format-row-#{format.slug}"}
+          class="flex items-center gap-3 p-3 sm:p-4"
+        >
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="font-medium">{format.name}</span>
+              <span :if={format.builtin?} class="badge badge-sm badge-ghost">Built-in</span>
+              <span :if={format.overridden?} class="badge badge-sm badge-warning">Edited</span>
             </div>
-
-            <.button
-              id={"custom-format-edit-#{format.slug}"}
-              phx-click="edit_custom_format"
-              phx-value-slug={format.slug}
-              class="btn-sm btn-ghost"
-            >
-              Edit
-            </.button>
-
-            <.button
-              :if={format.overridden?}
-              id={"custom-format-reset-#{format.slug}"}
-              phx-click="reset_custom_format"
-              phx-value-slug={format.slug}
-              class="btn-sm btn-ghost"
-            >
-              Reset
-            </.button>
-
-            <.button
-              :if={not format.builtin?}
-              id={"custom-format-delete-#{format.slug}"}
-              phx-click="delete_custom_format"
-              phx-value-slug={format.slug}
-              data-confirm={"Delete #{format.name}?"}
-              class="btn-sm btn-ghost text-error"
-            >
-              Delete
-            </.button>
+            <div class="text-xs opacity-60 truncate font-mono">
+              {Enum.join(format.patterns, "  ")}
+            </div>
           </div>
+
+          <.button
+            id={"custom-format-edit-#{format.slug}"}
+            phx-click="edit_custom_format"
+            phx-value-slug={format.slug}
+            class="btn-sm btn-ghost"
+          >
+            Edit
+          </.button>
+
+          <.button
+            :if={format.overridden?}
+            id={"custom-format-reset-#{format.slug}"}
+            phx-click="reset_custom_format"
+            phx-value-slug={format.slug}
+            class="btn-sm btn-ghost"
+          >
+            Reset
+          </.button>
+
+          <.button
+            :if={not format.builtin?}
+            id={"custom-format-delete-#{format.slug}"}
+            phx-click="delete_custom_format"
+            phx-value-slug={format.slug}
+            data-confirm={"Delete #{format.name}?"}
+            class="btn-sm btn-ghost text-error"
+          >
+            Delete
+          </.button>
         </div>
       </div>
     </div>

--- a/lib/mydia_web/live/admin_custom_formats_live/index.ex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.ex
@@ -10,78 +10,80 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
   alias Mydia.Settings.CustomFormats
   alias Mydia.Settings.CustomFormats.Matcher
 
+  # Stand-in for the record being edited while creating a new format, so the
+  # modal can read `builtin?` and `slug` without a nil check.
+  @blank_format %{slug: nil, name: "", description: "", patterns: [], builtin?: false}
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,
      socket
      |> assign(:page_title, "Custom Formats")
      |> assign(:active_tab, :custom_formats)
-     |> assign(:editing, nil)
-     |> assign(:test_title, "")
+     |> assign(:show_custom_format_modal, false)
      |> assign(:test_results, [])
      |> load_formats()}
   end
 
   @impl true
-  def handle_event("new", _params, socket) do
+  def handle_event("new_custom_format", _params, socket) do
     {:noreply,
      socket
-     |> assign(:editing, %{slug: nil, name: "", description: "", patterns: [], builtin?: false})
+     |> open_modal(:new, @blank_format)
      |> assign(
-       :form,
-       to_form(%{"name" => "", "description" => "", "patterns_text" => ""},
+       :custom_format_form,
+       to_form(
+         %{"name" => "", "description" => "", "patterns_text" => "", "test_title" => ""},
          as: :custom_format
        )
-     )
-     |> assign(:test_title, "")
-     |> assign(:test_results, [])}
+     )}
   end
 
-  def handle_event("edit", %{"slug" => slug}, socket) do
+  def handle_event("edit_custom_format", %{"slug" => slug}, socket) do
     format = CustomFormats.get(slug)
 
     {:noreply,
      socket
-     |> assign(:editing, format)
+     |> open_modal(:edit, format)
      |> assign(
-       :form,
+       :custom_format_form,
        to_form(
          %{
            "name" => format.name,
            "description" => format.description || "",
-           "patterns_text" => Enum.join(format.patterns, "\n")
+           "patterns_text" => Enum.join(format.patterns, "\n"),
+           "test_title" => ""
          },
          as: :custom_format
        )
-     )
-     |> assign(:test_title, "")
-     |> assign(:test_results, [])}
+     )}
   end
 
-  def handle_event("cancel", _params, socket) do
-    {:noreply, assign(socket, :editing, nil)}
+  def handle_event("close_custom_format_modal", _params, socket) do
+    {:noreply, assign(socket, :show_custom_format_modal, false)}
   end
 
-  def handle_event("validate", %{"custom_format" => params}, socket) do
+  def handle_event("validate_custom_format", %{"custom_format" => params}, socket) do
     title = Map.get(params, "test_title", "")
     patterns = split_patterns(Map.get(params, "patterns_text", ""))
 
     {:noreply,
      socket
-     |> assign(:form, to_form(params, as: :custom_format))
-     |> assign(:test_title, title)
+     |> assign(:custom_format_form, to_form(params, as: :custom_format))
      |> assign(:test_results, test_patterns(patterns, title))}
   end
 
-  def handle_event("save", %{"custom_format" => params}, socket) do
+  def handle_event("save_custom_format", %{"custom_format" => params}, socket) do
+    editing = socket.assigns.editing_custom_format
+
     attrs = %{
-      name: save_name(socket.assigns.editing, params),
+      name: save_name(editing, params),
       description: Map.get(params, "description"),
       patterns: split_patterns(Map.get(params, "patterns_text", ""))
     }
 
     result =
-      case socket.assigns.editing do
+      case editing do
         %{slug: nil} -> CustomFormats.create_format(attrs)
         %{builtin?: true, slug: slug} -> CustomFormats.override_builtin(slug, attrs)
         %{slug: slug} -> CustomFormats.update_format(slug, attrs)
@@ -92,13 +94,13 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
         {:noreply,
          socket
          |> put_flash(:info, "Format saved")
-         |> assign(:editing, nil)
+         |> assign(:show_custom_format_modal, false)
          |> load_formats()}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply,
          socket
-         |> assign(:form, save_error_form(changeset, params, socket.assigns.editing))
+         |> assign(:custom_format_form, save_error_form(changeset, params, editing))
          |> put_flash(:error, changeset_message(changeset))}
 
       # The format disappeared between opening the modal and submitting it:
@@ -109,12 +111,12 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
         {:noreply,
          socket
          |> put_flash(:error, "That format no longer exists. The list has been refreshed.")
-         |> assign(:editing, nil)
+         |> assign(:show_custom_format_modal, false)
          |> load_formats()}
     end
   end
 
-  def handle_event("reset", %{"slug" => slug}, socket) do
+  def handle_event("reset_custom_format", %{"slug" => slug}, socket) do
     :ok = CustomFormats.reset_builtin(slug)
 
     {:noreply,
@@ -123,7 +125,7 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
      |> load_formats()}
   end
 
-  def handle_event("delete", %{"slug" => slug}, socket) do
+  def handle_event("delete_custom_format", %{"slug" => slug}, socket) do
     case CustomFormats.delete_format(slug) do
       :ok ->
         {:noreply, socket |> put_flash(:info, "Format deleted") |> load_formats()}
@@ -132,6 +134,14 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
         {:noreply,
          put_flash(socket, :error, "Built-in formats cannot be deleted. Reset instead.")}
     end
+  end
+
+  defp open_modal(socket, mode, format) do
+    socket
+    |> assign(:show_custom_format_modal, true)
+    |> assign(:custom_format_mode, mode)
+    |> assign(:editing_custom_format, format)
+    |> assign(:test_results, [])
   end
 
   defp load_formats(socket), do: assign(socket, :formats, CustomFormats.list_all())
@@ -180,7 +190,10 @@ defmodule MydiaWeb.AdminCustomFormatsLive.Index do
       "name" => save_name(editing, params),
       "description" =>
         Map.get(params, "description", Ecto.Changeset.get_field(changeset, :description) || ""),
-      "patterns_text" => patterns_text
+      "patterns_text" => patterns_text,
+      # Carried through so a failed save does not wipe what the user typed into
+      # the pattern tester while `@test_results` stays on screen.
+      "test_title" => Map.get(params, "test_title", "")
     }
 
     errors =

--- a/lib/mydia_web/live/admin_custom_formats_live/index.html.heex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.html.heex
@@ -3,10 +3,11 @@
     <MydiaWeb.AdminCustomFormatsLive.Components.custom_formats_tab formats={@formats} />
 
     <%!-- Custom Format Modal --%>
-    <%= if @editing do %>
+    <%= if assigns[:show_custom_format_modal] do %>
       <MydiaWeb.AdminCustomFormatsLive.Components.custom_format_modal
-        editing={@editing}
-        form={@form}
+        custom_format_form={@custom_format_form}
+        custom_format_mode={@custom_format_mode}
+        editing_custom_format={@editing_custom_format}
         test_results={@test_results}
       />
     <% end %>

--- a/lib/mydia_web/live/admin_custom_formats_live/index.html.heex
+++ b/lib/mydia_web/live/admin_custom_formats_live/index.html.heex
@@ -1,118 +1,14 @@
 <Layouts.app {assigns}>
   <.admin_page active_tab={@active_tab}>
-    <div class="space-y-4">
-      <div class="flex items-center justify-between">
-        <div>
-          <h1 class="text-2xl font-bold">Custom Formats</h1>
-          <p class="text-sm opacity-70">
-            Match release titles by regex. Assign scores per quality profile.
-          </p>
-        </div>
-        <.button id="custom-format-new" phx-click="new" class="btn-primary">
-          <.icon name="hero-plus" class="w-4 h-4" /> New format
-        </.button>
-      </div>
+    <MydiaWeb.AdminCustomFormatsLive.Components.custom_formats_tab formats={@formats} />
 
-      <div class="card bg-base-100 shadow">
-        <div class="card-body p-0 divide-y divide-base-200">
-          <div
-            :for={format <- @formats}
-            id={"custom-format-row-#{format.slug}"}
-            class="flex items-center gap-3 p-4"
-          >
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2">
-                <span class="font-medium">{format.name}</span>
-                <span :if={format.builtin?} class="badge badge-sm badge-ghost">Built-in</span>
-                <span :if={format.overridden?} class="badge badge-sm badge-warning">Edited</span>
-              </div>
-              <div class="text-xs opacity-60 truncate font-mono">
-                {Enum.join(format.patterns, "  ")}
-              </div>
-            </div>
-
-            <.button
-              id={"custom-format-edit-#{format.slug}"}
-              phx-click="edit"
-              phx-value-slug={format.slug}
-              class="btn-sm btn-ghost"
-            >
-              Edit
-            </.button>
-
-            <.button
-              :if={format.overridden?}
-              id={"custom-format-reset-#{format.slug}"}
-              phx-click="reset"
-              phx-value-slug={format.slug}
-              class="btn-sm btn-ghost"
-            >
-              Reset
-            </.button>
-
-            <.button
-              :if={not format.builtin?}
-              id={"custom-format-delete-#{format.slug}"}
-              phx-click="delete"
-              phx-value-slug={format.slug}
-              data-confirm={"Delete #{format.name}?"}
-              class="btn-sm btn-ghost text-error"
-            >
-              Delete
-            </.button>
-          </div>
-        </div>
-      </div>
-
-      <div :if={@editing} class="modal modal-open">
-        <div class="modal-box max-w-2xl">
-          <h3 class="font-bold text-lg mb-4">
-            {if @editing.slug, do: "Edit #{@editing.name}", else: "New format"}
-          </h3>
-
-          <.form for={@form} id="custom-format-form" phx-change="validate" phx-submit="save">
-            <.input field={@form[:name]} type="text" label="Name" disabled={@editing.builtin?} />
-            <.input field={@form[:description]} type="text" label="Description" />
-            <.input
-              field={@form[:patterns_text]}
-              type="textarea"
-              label="Patterns (one per line)"
-              rows="6"
-            />
-
-            <div class="divider">Test</div>
-
-            <.input
-              field={@form[:test_title]}
-              id="custom-format-test-input"
-              type="text"
-              label="Paste a release title"
-              placeholder="Film.2024.VFF.1080p.WEB-DL.x264-GROUP"
-            />
-
-            <ul :if={@test_results != []} class="mt-2 space-y-1 text-sm">
-              <li :for={r <- @test_results} class="flex items-center gap-2 font-mono">
-                <span :if={r.status == :match} class="custom-format-test-match text-success">
-                  <.icon name="hero-check-circle" class="w-4 h-4" />
-                </span>
-                <span :if={r.status == :miss} class="opacity-40">
-                  <.icon name="hero-x-circle" class="w-4 h-4" />
-                </span>
-                <span :if={match?({:error, _}, r.status)} class="text-error">
-                  <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
-                </span>
-                <span>{r.pattern}</span>
-              </li>
-            </ul>
-
-            <div class="modal-action">
-              <.button type="button" phx-click="cancel" class="btn-ghost">Cancel</.button>
-              <.button type="submit" class="btn-primary">Save</.button>
-            </div>
-          </.form>
-        </div>
-        <div class="modal-backdrop" phx-click="cancel"></div>
-      </div>
-    </div>
+    <%!-- Custom Format Modal --%>
+    <%= if @editing do %>
+      <MydiaWeb.AdminCustomFormatsLive.Components.custom_format_modal
+        editing={@editing}
+        form={@form}
+        test_results={@test_results}
+      />
+    <% end %>
   </.admin_page>
 </Layouts.app>

--- a/test/mydia_web/live/admin_custom_formats_live_test.exs
+++ b/test/mydia_web/live/admin_custom_formats_live_test.exs
@@ -136,4 +136,23 @@ defmodule MydiaWeb.AdminCustomFormatsLiveTest do
     assert Mydia.Settings.CustomFormats.get("lang-vff").patterns ==
              ["\\bVFF\\b", "\\bTRUEFRENCH\\b"]
   end
+
+  # An unmodified built-in has nothing to reset. The button still renders so the
+  # action column keeps a fixed width, but it must not be clickable.
+  test "reset is disabled on an unmodified built-in and enabled once overridden", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    assert has_element?(view, "#custom-format-reset-lang-vff[disabled]")
+
+    {:ok, _} =
+      Mydia.Settings.CustomFormats.override_builtin("lang-vff", %{
+        name: "VFF",
+        patterns: ["\\bONLYVFF\\b"]
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/custom-formats")
+
+    assert has_element?(view, "#custom-format-reset-lang-vff")
+    refute has_element?(view, "#custom-format-reset-lang-vff[disabled]")
+  end
 end


### PR DESCRIPTION
The custom formats admin page (`/admin/config/custom-formats`) shipped in #389 without the scaffolding that every other page under `/admin/config` uses. It worked, but it read as a different application from the five pages sitting beside it in the same tab bar. This conforms it.

## The standard it now follows

Verified identical across download clients, indexers, media servers, library paths, and quality profiles, down to the class strings:

- `index.html.heex` is a thin `Layouts.app` > `admin_page` shell. All markup moves to a sibling `components.ex`.
- No page `<h1>`. `admin_page` already renders the Configuration heading and the tab bar, so content opens with an `<h2>` carrying a leading icon and a `badge badge-ghost` count, with `New` on the right.
- Rows live in `bg-base-200 rounded-box divide-y divide-base-300`, not a `card` / `card-body`.
- Row actions are an icon-only `join` group with `title` tooltips, not labelled text buttons.
- The modal gains the icon-tile header with a subtitle, `modal-action mt-6 pt-4 border-t border-base-300`, and `modal-backdrop bg-black/50`.
- Events and assigns are namespaced: `new_custom_format`, `save_custom_format`, `show_custom_format_modal`, `custom_format_mode`, and so on, replacing bare `new` / `save` / `cancel` and a single `:editing` assign.

## Row actions

A built-in format can be edited and reset but never deleted. A user format can be edited and deleted but never reset. So each row is Edit plus one contextual second slot, rather than three slots with a dead button on every row. On an unmodified built-in, Reset renders disabled with a "Not modified" tooltip so the action column keeps a fixed width.

## Two fixes folded in

Both found while verifying the existing code, neither user-visible enough to have been reported:

- `:test_title` was assigned four times and never read. The template reads the value from `@form[:test_title]`. Removed.
- `save_error_form/3` rebuilt the form params from name, description, and patterns only, so a failed save wiped whatever the user had typed into the pattern tester while leaving the stale results on screen. It now carries `test_title` through.

## Testing

The existing 10 tests drive the page entirely by DOM id, and every id is preserved, so they pass unchanged. Treat a failure there as a regression in this PR rather than a test that needs updating.

One test added: Reset is disabled on an unmodified built-in and enabled once it has been overridden.

`mix test test/mydia_web/live/admin_custom_formats_live_test.exs` reports 11 tests, 0 failures. Full `mix precommit` is green.

## Not in scope

Those five reference pages duplicate this header, list, row, and modal scaffolding verbatim. Extracting shared `admin_section` / `admin_row` / `admin_modal` components is worth doing, but it would touch the whole config surface and risk visual regressions on five working pages, so it belongs in its own change.
