### PR TITLE
fix(player): stop the floating dock covering content and the nav drawer

### DIFF
--- a/player/lib/core/layout/dock_insets.dart
+++ b/player/lib/core/layout/dock_insets.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+import 'breakpoints.dart';
+
+/// Bottom clearance for content that scrolls under the floating mobile dock.
+///
+/// `AppShell`'s mobile branch uses `Scaffold(extendBody: true)`, which makes
+/// body content flow under the dock on purpose so the frosted pill reads as
+/// real glass over the ambient backdrop. Flutter compensates by rewriting the
+/// body's `MediaQuery.padding.bottom` to the dock's measured height (see
+/// `_BodyBuilder` in material/scaffold.dart, which takes
+/// `max(metrics.padding.bottom, bodyConstraints.bottomWidgetsHeight)`), with
+/// the system safe-area inset already folded in because `BottomNav` wraps
+/// itself in a `SafeArea`.
+///
+/// That value survives `AppShell.contentGutter` (which insets top only) and
+/// each screen's own nested `Scaffold` (which has no `bottomNavigationBar`, so
+/// it passes the padding through untouched). Reading it here is therefore
+/// exact by construction, and self-correcting if the dock is ever restyled.
+///
+/// Measured: the dock is 83.0 tall with no system inset and 117.0 with a 34px
+/// home indicator. The literal `100.0` this replaced was short on every
+/// home-indicator phone.
+abstract final class DockInsets {
+  /// Breathing room between the last item and the floating dock.
+  static const double dockGap = 16;
+
+  /// Bottom breathing room on desktop, which has no dock because the sidebar
+  /// is on the left. Preserves the pre-existing spacing exactly.
+  static const double desktopGap = 32;
+
+  /// Bottom padding a scrollable must reserve for its last item to clear the
+  /// dock.
+  ///
+  /// Branches on [Breakpoints.isDesktop] rather than on whether the inset is
+  /// non-zero, for two reasons. The arms encode different intents: clearing a
+  /// floating dock versus leaving window-edge breathing room. And it is the
+  /// same predicate `AppShell` uses to pick its own desktop or mobile branch,
+  /// read off the window-sized ambient `MediaQuery`, so a screen can never
+  /// disagree with the shell about which layout it is in.
+  static double bottomOf(BuildContext context) => Breakpoints.isDesktop(context)
+      ? desktopGap
+      : MediaQuery.paddingOf(context).bottom + dockGap;
+}
+
+/// A box-shaped gap reserving [DockInsets.bottomOf].
+///
+/// Use at the tail of a `Column` or `SingleChildScrollView`. The gap must sit
+/// INSIDE the scrollable, never as a `SafeArea` wrapped around it: wrapping
+/// would shrink the viewport so it ends above the dock, leaving nothing
+/// visible under the glass and losing the blur the design depends on.
+class DockGap extends StatelessWidget {
+  const DockGap({super.key});
+
+  @override
+  Widget build(BuildContext context) =>
+      SizedBox(height: DockInsets.bottomOf(context));
+}
+
+/// The sliver form of [DockGap]. Always the LAST sliver in a
+/// `CustomScrollView`.
+///
+/// `CustomScrollView` is not a `BoxScrollView`, so unlike `ListView` and
+/// `GridView` it never auto-pads from `MediaQuery` even when no explicit
+/// padding is given. A sliver list gets nothing unless someone writes it,
+/// which is why the worst-reserved screens were all sliver-based.
+class SliverDockGap extends StatelessWidget {
+  const SliverDockGap({super.key});
+
+  @override
+  Widget build(BuildContext context) =>
+      const SliverToBoxAdapter(child: DockGap());
+}

--- a/player/lib/presentation/screens/collections/collection_detail_screen.dart
+++ b/player/lib/presentation/screens/collections/collection_detail_screen.dart
@@ -12,6 +12,7 @@ import '../../../core/downloads/collection_sync_service.dart';
 import '../../../core/downloads/download_service.dart' show isDownloadSupported;
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/recently_added_item.dart';
 
@@ -203,10 +204,9 @@ class CollectionDetailScreen extends ConsumerWidget {
   }
 
   Widget _buildGridView(BuildContext context, List items) {
-    final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = isDesktop ? 32.0 : 100.0;
+    final bottomPadding = DockInsets.bottomOf(context);
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/player/lib/presentation/screens/collections/collections_screen.dart
+++ b/player/lib/presentation/screens/collections/collections_screen.dart
@@ -10,6 +10,7 @@ import '../../widgets/freshness_header.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 
 class CollectionsScreen extends ConsumerWidget {
@@ -213,10 +214,9 @@ class CollectionsScreen extends ConsumerWidget {
   }
 
   Widget _buildGridView(BuildContext context, List<Collection> collections) {
-    final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = isDesktop ? 32.0 : 100.0;
+    final bottomPadding = DockInsets.bottomOf(context);
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/continue_watching_item.dart';
 import '../../widgets/ambient_backdrop_provider.dart';
@@ -240,10 +241,9 @@ class _ContinueWatchingScreenState
     List<ContinueWatchingItem> items,
     double scrollTopPadding,
   ) {
-    final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = isDesktop ? 32.0 : 100.0;
+    final bottomPadding = DockInsets.bottomOf(context);
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/player/lib/presentation/screens/downloads/downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/downloads_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/cache/poster_cache_manager.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
@@ -207,8 +208,7 @@ class DownloadsScreen extends ConsumerWidget {
               },
             ),
 
-          // Bottom padding
-          const SliverToBoxAdapter(child: SizedBox(height: 100)),
+          const SliverDockGap(),
         ],
       ),
     );

--- a/player/lib/presentation/screens/downloads/series_downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/series_downloads_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/cache/poster_cache_manager.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/downloads/download_providers.dart';
 import '../../../domain/models/download.dart';
 import '../../../core/theme/colors.dart';
@@ -83,6 +84,7 @@ class SeriesDownloadsScreen extends ConsumerWidget {
               ]),
             ),
           ),
+          const SliverDockGap(),
         ],
       ),
     );

--- a/player/lib/presentation/screens/episode/episode_detail_screen.dart
+++ b/player/lib/presentation/screens/episode/episode_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import '../../../core/cache/poster_cache_manager.dart';
+import '../../../core/layout/dock_insets.dart';
 import 'episode_detail_controller.dart';
 import '../../../domain/models/episode_detail.dart';
 import '../../widgets/freshness_header.dart';
@@ -221,7 +222,7 @@ class EpisodeDetailScreen extends ConsumerWidget {
                 const SizedBox(height: 24),
                 _buildOverview(context, episode),
               ],
-              const SizedBox(height: 32),
+              const DockGap(),
             ],
           ),
         ),

--- a/player/lib/presentation/screens/favorites/favorites_screen.dart
+++ b/player/lib/presentation/screens/favorites/favorites_screen.dart
@@ -9,6 +9,7 @@ import '../../widgets/freshness_header.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 
 class FavoritesScreen extends ConsumerWidget {
@@ -218,10 +219,9 @@ class FavoritesScreen extends ConsumerWidget {
   }
 
   Widget _buildGridView(BuildContext context, List items) {
-    final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = isDesktop ? 32.0 : 100.0;
+    final bottomPadding = DockInsets.bottomOf(context);
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/player/lib/presentation/screens/home_screen.dart
+++ b/player/lib/presentation/screens/home_screen.dart
@@ -16,6 +16,7 @@ import '../widgets/freshness_header.dart';
 import '../widgets/glass_surface.dart';
 import '../widgets/shimmer_card.dart';
 import '../../core/layout/breakpoints.dart';
+import '../../core/layout/dock_insets.dart';
 import '../../core/theme/colors.dart';
 import '../widgets/app_shell.dart';
 import '../widgets/mydia_logo.dart';
@@ -150,7 +151,7 @@ class HomeScreen extends ConsumerWidget {
     final homeData = ref.watch(homeControllerProvider);
     final isDesktop = Breakpoints.isDesktop(context);
     // On desktop, no bottom nav so less padding needed
-    final bottomPadding = isDesktop ? 32.0 : 100.0;
+    final bottomPadding = DockInsets.bottomOf(context);
 
     return Scaffold(
       backgroundColor: Colors.transparent,

--- a/player/lib/presentation/screens/library/library_grid_body.dart
+++ b/player/lib/presentation/screens/library/library_grid_body.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/navigation/media_filter.dart';
 import '../../models/library_data.dart';
@@ -284,10 +285,9 @@ class _LibraryMediaBodyState extends ConsumerState<LibraryMediaBody> {
   }
 
   Widget _buildGridView(BuildContext context, List<LibraryItem> items) {
-    final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = isDesktop ? 32.0 : 100.0;
+    final bottomPadding = DockInsets.bottomOf(context);
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -320,9 +320,8 @@ class _LibraryMediaBodyState extends ConsumerState<LibraryMediaBody> {
   }
 
   Widget _buildListView(BuildContext context, List<LibraryItem> items) {
-    final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
-    final bottomPadding = isDesktop ? 32.0 : 100.0;
+    final bottomPadding = DockInsets.bottomOf(context);
 
     return ListView.builder(
       controller: widget.scrollController,

--- a/player/lib/presentation/screens/movie/movie_detail_screen.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import '../../../core/cache/poster_cache_manager.dart';
+import '../../../core/layout/dock_insets.dart';
 import 'movie_detail_controller.dart';
 import '../../widgets/freshness_header.dart';
 import '../../widgets/quality_download_dialog.dart';
@@ -255,7 +256,7 @@ class MovieDetailScreen extends ConsumerWidget {
               },
             ),
           ),
-        const SliverToBoxAdapter(child: SizedBox(height: 32)),
+        const SliverDockGap(),
       ],
     );
   }

--- a/player/lib/presentation/screens/recently_added/recently_added_screen.dart
+++ b/player/lib/presentation/screens/recently_added/recently_added_screen.dart
@@ -9,6 +9,7 @@ import '../../widgets/freshness_header.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 
 class RecentlyAddedScreen extends ConsumerWidget {
@@ -220,10 +221,9 @@ class RecentlyAddedScreen extends ConsumerWidget {
   }
 
   Widget _buildGridView(BuildContext context, List items) {
-    final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = isDesktop ? 32.0 : 100.0;
+    final bottomPadding = DockInsets.bottomOf(context);
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/player/lib/presentation/screens/search/search_screen.dart
+++ b/player/lib/presentation/screens/search/search_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/search_result.dart';
 import '../../widgets/ambient_backdrop_provider.dart';
@@ -463,8 +464,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
               ),
             ),
         ],
-        // Clears the floating mobile bottom nav.
-        const SliverToBoxAdapter(child: SizedBox(height: 120)),
+        const SliverDockGap(),
       ],
     );
   }

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import '../../../core/cache/poster_cache_manager.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/downloads/bulk_download_helper.dart';
 import '../../../core/downloads/download_job_providers.dart';
 import '../../../core/downloads/download_providers.dart';
@@ -311,9 +312,7 @@ class ShowDetailScreen extends ConsumerWidget {
           ),
         ),
         _buildEpisodeList(context, ref),
-        const SliverToBoxAdapter(
-          child: SizedBox(height: 32),
-        ),
+        const SliverDockGap(),
       ],
     );
   }

--- a/player/lib/presentation/screens/unwatched/unwatched_screen.dart
+++ b/player/lib/presentation/screens/unwatched/unwatched_screen.dart
@@ -9,6 +9,7 @@ import '../../widgets/freshness_header.dart';
 import '../../widgets/glass_surface.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
+import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 
 class UnwatchedScreen extends ConsumerWidget {
@@ -218,10 +219,9 @@ class UnwatchedScreen extends ConsumerWidget {
   }
 
   Widget _buildGridView(BuildContext context, List items) {
-    final isDesktop = Breakpoints.isDesktop(context);
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = isDesktop ? 32.0 : 100.0;
+    final bottomPadding = DockInsets.bottomOf(context);
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -97,11 +97,14 @@ class AppShell extends ConsumerStatefulWidget {
 
   /// Wraps the bottom dock so it disappears while the nav drawer is open.
   ///
-  /// Flutter's `Scaffold` adds its drawer slot before `bottomNavigationBar`
-  /// (see `Scaffold.build`: `drawer` at 2983, `bottomNavigationBar` at 3167)
-  /// and paints in that order, so the floating dock would otherwise sit on top
-  /// of the drawer AND its scrim, and keep intercepting taps: tapping where
-  /// "Home" sits navigates while the drawer is open.
+  /// In `Scaffold.build`, the drawer slot is added to the child list before
+  /// `bottomNavigationBar`, and the layout paints in that order. So a floating
+  /// dock would otherwise sit on top of the drawer AND its scrim, and keep
+  /// intercepting taps: tapping where "Home" sits navigates while the drawer
+  /// is open.
+  ///
+  /// `app_shell_drawer_dock_test.dart` pins this behaviour, so a Flutter
+  /// upgrade that reorders those slots surfaces there rather than here.
   ///
   /// [child] stays MOUNTED rather than being swapped for `null`. Removing the
   /// bar would drop `MediaQuery.padding.bottom` to zero, which is the exact

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -95,6 +95,41 @@ class AppShell extends ConsumerStatefulWidget {
         child: child,
       );
 
+  /// Wraps the bottom dock so it disappears while the nav drawer is open.
+  ///
+  /// Flutter's `Scaffold` adds its drawer slot before `bottomNavigationBar`
+  /// (see `Scaffold.build`: `drawer` at 2983, `bottomNavigationBar` at 3167)
+  /// and paints in that order, so the floating dock would otherwise sit on top
+  /// of the drawer AND its scrim, and keep intercepting taps: tapping where
+  /// "Home" sits navigates while the drawer is open.
+  ///
+  /// [child] stays MOUNTED rather than being swapped for `null`. Removing the
+  /// bar would drop `MediaQuery.padding.bottom` to zero, which is the exact
+  /// value every screen's `DockInsets.bottomOf` reads, so all content would
+  /// reflow behind the open drawer and reflow back on close. Fading in place
+  /// holds the measured height stable.
+  ///
+  /// 200ms sits just inside Flutter's drawer settle duration (246ms), so the
+  /// dock is gone before the drawer finishes arriving.
+  ///
+  /// Public and `@visibleForTesting` for the reason [castOverlay] and
+  /// [contentGutter] are: a test can exercise the exact widget the shell
+  /// builds, instead of a mirror that silently drifts from the real call site
+  /// and would stay green if this wrapper were deleted.
+  @visibleForTesting
+  static Widget dockChrome({
+    required bool drawerOpen,
+    required Widget child,
+  }) =>
+      IgnorePointer(
+        ignoring: drawerOpen,
+        child: AnimatedOpacity(
+          opacity: drawerOpen ? 0 : 1,
+          duration: const Duration(milliseconds: 200),
+          child: child,
+        ),
+      );
+
   @override
   ConsumerState<AppShell> createState() => _AppShellState();
 }
@@ -102,6 +137,9 @@ class AppShell extends ConsumerStatefulWidget {
 class _AppShellState extends ConsumerState<AppShell> {
   GoRouter? _router;
   CollectionAutoSync? _collectionAutoSync;
+
+  /// Whether the nav drawer is open. Drives [AppShell.dockChrome].
+  bool _drawerOpen = false;
 
   @override
   void initState() {
@@ -252,6 +290,9 @@ class _AppShellState extends ConsumerState<AppShell> {
       key: AppShell.scaffoldKey,
       backgroundColor: Colors.transparent,
       extendBody: true,
+      onDrawerChanged: (isOpen) {
+        if (mounted) setState(() => _drawerOpen = isOpen);
+      },
       drawer: MobileDrawer(
         location: location,
         onNavigate: (route) {
@@ -275,11 +316,14 @@ class _AppShellState extends ConsumerState<AppShell> {
           if (showCastOverlay) AppShell.castOverlay(isDesktop: false),
         ],
       ),
-      bottomNavigationBar: BottomNav(
-        location: location,
-        onNavigate: _navigateTo,
-        isOffline: isOffline,
-        showBackToMydia: showBackToMydia,
+      bottomNavigationBar: AppShell.dockChrome(
+        drawerOpen: _drawerOpen,
+        child: BottomNav(
+          location: location,
+          onNavigate: _navigateTo,
+          isOffline: isOffline,
+          showBackToMydia: showBackToMydia,
+        ),
       ),
     );
   }

--- a/player/test/core/layout/dock_insets_test.dart
+++ b/player/test/core/layout/dock_insets_test.dart
@@ -1,0 +1,131 @@
+// Unit coverage for the dock-clearance reader. The real 83/117 dock heights
+// are NOT asserted here; they belong to the widget under test and are covered
+// by app_shell_dock_inset_test.dart. This file pins the arithmetic only.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/dock_insets.dart';
+
+/// A mobile width: below Breakpoints.tablet (900).
+const Size kMobileSize = Size(400, 800);
+
+/// A desktop width: at or above Breakpoints.tablet (900).
+const Size kDesktopSize = Size(1200, 900);
+
+/// Reads `DockInsets.bottomOf` under a synthetic ambient MediaQuery.
+Future<double> readBottomOf(
+  WidgetTester tester, {
+  required Size size,
+  required double inset,
+}) async {
+  late double value;
+  await tester.pumpWidget(
+    MediaQuery(
+      data: MediaQueryData(
+        size: size,
+        padding: EdgeInsets.only(bottom: inset),
+      ),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: Builder(
+          builder: (context) {
+            value = DockInsets.bottomOf(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    ),
+  );
+  return value;
+}
+
+void main() {
+  group('DockInsets.bottomOf', () {
+    testWidgets('on mobile returns the ambient bottom inset plus the gap',
+        (tester) async {
+      expect(
+        await readBottomOf(tester, size: kMobileSize, inset: 117),
+        117 + DockInsets.dockGap,
+      );
+    });
+
+    testWidgets('on mobile with no inset returns just the gap', (tester) async {
+      expect(
+        await readBottomOf(tester, size: kMobileSize, inset: 0),
+        DockInsets.dockGap,
+      );
+    });
+
+    testWidgets('on desktop returns the desktop gap and ignores the inset',
+        (tester) async {
+      expect(
+        await readBottomOf(tester, size: kDesktopSize, inset: 34),
+        DockInsets.desktopGap,
+      );
+    });
+
+    testWidgets('preserves the pre-existing desktop spacing of 32',
+        (tester) async {
+      // The eight screens this replaces all used `isDesktop ? 32.0 : 100.0`.
+      // Desktop must not shift by a single pixel.
+      expect(DockInsets.desktopGap, 32);
+    });
+  });
+
+  group('DockGap', () {
+    testWidgets('sizes itself to the dock clearance', (tester) async {
+      await tester.pumpWidget(
+        const MediaQuery(
+          data: MediaQueryData(
+            size: kMobileSize,
+            padding: EdgeInsets.only(bottom: 117),
+          ),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            // Align, so DockGap is measured under LOOSE constraints. The test
+            // binding's root is a tight 800x600; a bare SizedBox under it is
+            // forced to the full 600 by BoxConstraints.enforce, and getSize
+            // would report the viewport height rather than the gap.
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: DockGap(),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSize(find.byType(DockGap)).height,
+        117 + DockInsets.dockGap,
+      );
+    });
+  });
+
+  group('SliverDockGap', () {
+    testWidgets('reserves the dock clearance at the end of a sliver list',
+        (tester) async {
+      await tester.pumpWidget(
+        const MediaQuery(
+          data: MediaQueryData(
+            size: kMobileSize,
+            padding: EdgeInsets.only(bottom: 117),
+          ),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: CustomScrollView(
+              slivers: [
+                SliverToBoxAdapter(child: SizedBox(height: 200)),
+                SliverDockGap(),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSize(find.byType(DockGap)).height,
+        117 + DockInsets.dockGap,
+      );
+    });
+  });
+}

--- a/player/test/presentation/dock_clearance_test.dart
+++ b/player/test/presentation/dock_clearance_test.dart
@@ -1,0 +1,82 @@
+// End-to-end proof that content clears the dock, measured against a real
+// BottomNav inside a real shell rather than against a hardcoded guess.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/dock_insets.dart';
+import 'package:player/presentation/widgets/media_poster.dart';
+
+import '../test_utils/dock_harness.dart';
+import 'screens/library/library_screen_layout_test.dart' show pumpLibrary;
+
+void main() {
+  // LibraryScreen awaits LibrarySortController before it queries, and that
+  // controller reads flutter_secure_storage. Without the mock the read never
+  // completes, the sort spinner spins forever, and pumpAndSettle times out.
+  //
+  // `show pumpLibrary` imports the function but NOT the library test file's
+  // own setUp, which is where this mock normally lives (see the comment at
+  // library_screen_layout_test.dart:238). Borrowing a pump helper across test
+  // files means borrowing its fixtures explicitly.
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  group('DockInsets under a real BottomNav', () {
+    testWidgets('reserves more than the 100.0 screens used to hardcode',
+        (tester) async {
+      // 600 wide, not 400. Setting `view.physicalSize` really constrains
+      // layout (unlike Task 2, which only wraps a MediaQueryData and leaves
+      // the default ~800 view), and BottomNav's Row overflows by 152px at
+      // 400. That is a pre-existing responsive limit of the dock, unrelated
+      // to clearance; see the note at the end of this plan. Still below
+      // Breakpoints.tablet (900), so this is the mobile branch with a dock.
+      tester.view.physicalSize = const Size(600, 800);
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.padding = const FakeViewPadding(bottom: 34);
+      addTearDown(tester.view.reset);
+
+      late double reserved;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: shellHarness(
+            child: Builder(
+              builder: (context) {
+                reserved = DockInsets.bottomOf(context);
+                return const SizedBox.expand();
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The dock measures 117 at this inset; the old hardcoded value was 100.
+      expect(reserved, dockHeightOf(tester) + DockInsets.dockGap);
+      expect(reserved, greaterThan(100));
+    });
+  });
+
+  group('library grid', () {
+    testWidgets('scrolls its last poster clear of the dock', (tester) async {
+      await pumpLibrary(
+        tester,
+        // 600 wide, not 400: at 400 the library app bar's Row overflows on a
+        // pre-existing responsive bug unrelated to this change, and the test
+        // would fail for the wrong reason. Still below Breakpoints.tablet
+        // (900), so this is the mobile branch with a dock.
+        size: const Size(600, 900),
+        bottomInset: 34,
+        wrap: (child) => shellHarness(child: child),
+      );
+
+      // Scroll past the end; the grid clamps at its own extent.
+      await tester.drag(find.byType(GridView), const Offset(0, -5000));
+      await tester.pumpAndSettle();
+
+      expectClearsDock(tester, find.byType(MediaPoster).last);
+    });
+  });
+}

--- a/player/test/presentation/dock_clearance_test.dart
+++ b/player/test/presentation/dock_clearance_test.dart
@@ -27,12 +27,19 @@ void main() {
   group('DockInsets under a real BottomNav', () {
     testWidgets('reserves more than the 100.0 screens used to hardcode',
         (tester) async {
-      // 600 wide, not 400. Setting `view.physicalSize` really constrains
-      // layout (unlike Task 2, which only wraps a MediaQueryData and leaves
-      // the default ~800 view), and BottomNav's Row overflows by 152px at
-      // 400. That is a pre-existing responsive limit of the dock, unrelated
-      // to clearance; see the note at the end of this plan. Still below
-      // Breakpoints.tablet (900), so this is the mobile branch with a dock.
+      // 600 wide, not 400. Setting `view.physicalSize` genuinely constrains
+      // layout, unlike `app_shell_dock_inset_test.dart`, which only wraps a
+      // `MediaQueryData` and so leaves the default ~800 view in place. At 400
+      // BottomNav's Row overflows by 152px.
+      //
+      // That overflow is a pre-existing responsive limit of the dock, not a
+      // clearance problem, and it is NOT evidence of a bug on real 400px
+      // phones: widget tests render text in a placeholder font whose every
+      // glyph is a full em square, so labels measure far wider here than on a
+      // device. `library_screen_layout_test.dart` carries the same caveat.
+      //
+      // 600 is still below Breakpoints.tablet (900), so this is the mobile
+      // branch and the dock is present.
       tester.view.physicalSize = const Size(600, 800);
       tester.view.devicePixelRatio = 1.0;
       tester.view.padding = const FakeViewPadding(bottom: 34);

--- a/player/test/presentation/no_magic_dock_padding_test.dart
+++ b/player/test/presentation/no_magic_dock_padding_test.dart
@@ -1,0 +1,74 @@
+// The bug this guards against spread by copy-paste: eight screens carried the
+// identical line `final bottomPadding = isDesktop ? 32.0 : 100.0;`, and the
+// dock is 83 to 117 tall depending on the device's home indicator.
+//
+// Six screens cannot be mounted in a widget test without building their whole
+// provider graph, so a render assertion cannot cover them. This can.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Vector 1: the copy-paste that created this bug.
+///
+/// Deliberately requires the assigned variable's name to contain "bottom".
+/// A bare `isDesktop ? N : M` is far too broad: the codebase has nine
+/// legitimate ones for title padding, section gaps and rail headers
+/// (`filter_screen.dart`, `library_screen.dart`, `home_screen.dart`,
+/// `content_rail.dart`). A guard that cries wolf on those is a guard someone
+/// deletes.
+final RegExp _hardcodedBottomTernary = RegExp(
+  r'bottom\w*\s*=\s*isDesktop\s*\?\s*[\d.]+\s*:\s*[\d.]+',
+  caseSensitive: false,
+);
+
+/// Vector 2: a screen declaring its own dock clearance in prose.
+///
+/// `search_screen.dart` carried exactly this: a comment reading "Clears the
+/// floating mobile bottom nav" above a hardcoded `SizedBox(height: 120)`. The
+/// trailing-spacer shape itself cannot be matched reliably (a leading app-bar
+/// spacer in `downloads_screen.dart` is written identically), but a file that
+/// *says* it clears the nav should be using the shared widget.
+final RegExp _selfDeclaredClearance = RegExp(
+  r'clear[s]?.{0,30}(bottom nav|floating.*nav|dock)',
+  caseSensitive: false,
+);
+
+void main() {
+  test('no screen hardcodes its own dock clearance', () {
+    final offenders = <String>[];
+
+    final dir = Directory('lib/presentation');
+    expect(
+      dir.existsSync(),
+      isTrue,
+      reason: 'flutter test runs with the package root as cwd; '
+          'lib/presentation should resolve. cwd is ${Directory.current.path}',
+    );
+
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is! File) continue;
+      if (!entity.path.endsWith('.dart')) continue;
+      if (entity.path.endsWith('.g.dart')) continue;
+
+      final source = entity.readAsStringSync();
+
+      for (final match in _hardcodedBottomTernary.allMatches(source)) {
+        offenders.add('${entity.path}: ${match.group(0)}');
+      }
+      for (final match in _selfDeclaredClearance.allMatches(source)) {
+        offenders.add('${entity.path}: ${match.group(0)}');
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'Use DockInsets.bottomOf(context), or the DockGap / '
+          'SliverDockGap widgets, instead of hardcoding dock clearance. The '
+          'dock measures 83 with no system inset and 117 with a 34px home '
+          'indicator, so any literal is wrong on some device. '
+          'Offenders:\n${offenders.join('\n')}',
+    );
+  });
+}

--- a/player/test/presentation/screens/library/library_screen_layout_test.dart
+++ b/player/test/presentation/screens/library/library_screen_layout_test.dart
@@ -139,10 +139,13 @@ Future<void> pumpLibrary(
   double? rating,
   List<Override> extraOverrides = const [],
   bool settle = true,
+  double bottomInset = 0,
+  Widget Function(Widget child)? wrap,
 }) async {
   tester.view.physicalSize = size;
   tester.view.devicePixelRatio = 1.0;
-  tester.view.padding = const FakeViewPadding(top: kStatusBarTop);
+  tester.view.padding =
+      FakeViewPadding(top: kStatusBarTop, bottom: bottomInset);
   addTearDown(tester.view.reset);
 
   final ids = List.generate(itemCount, (i) => '$i');
@@ -161,9 +164,9 @@ Future<void> pumpLibrary(
               .overrideWithValue(const CastCapabilities.full()),
           ...extraOverrides,
         ],
-        child: MaterialApp(
-          home: LibraryScreen(libraryType: libraryType),
-        ),
+        child: wrap == null
+            ? MaterialApp(home: LibraryScreen(libraryType: libraryType))
+            : wrap(LibraryScreen(libraryType: libraryType)),
       ),
     );
 

--- a/player/test/presentation/widgets/app_shell_dock_inset_test.dart
+++ b/player/test/presentation/widgets/app_shell_dock_inset_test.dart
@@ -1,0 +1,166 @@
+// Regression guard for the mechanism every screen's dock clearance depends on.
+//
+// `AppShell`'s mobile branch uses `Scaffold(extendBody: true)` so content
+// scrolls under the frosted dock. Flutter compensates by rewriting the body's
+// `MediaQuery.padding.bottom` to the dock's measured height. `DockInsets`
+// reads that value rather than measuring anything itself, so if Flutter ever
+// changes this behaviour every screen regresses at once and silently. These
+// tests fail instead.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/app_shell.dart';
+import 'package:player/presentation/widgets/nav/bottom_nav.dart';
+
+/// An iPhone-style home indicator inset.
+const double kHomeIndicator = 34;
+
+void main() {
+  testWidgets('extendBody publishes the dock height as padding.bottom',
+      (tester) async {
+    const dockContentHeight = 60.0;
+    double? observedBottom;
+    final navKey = GlobalKey();
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          size: Size(400, 800),
+          padding: EdgeInsets.only(bottom: kHomeIndicator),
+          viewPadding: EdgeInsets.only(bottom: kHomeIndicator),
+        ),
+        child: MaterialApp(
+          home: Scaffold(
+            extendBody: true,
+            bottomNavigationBar: SafeArea(
+              key: navKey,
+              child: const SizedBox(height: dockContentHeight),
+            ),
+            body: Builder(
+              builder: (context) {
+                observedBottom = MediaQuery.paddingOf(context).bottom;
+                return const SizedBox.expand();
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final navHeight = tester.getSize(find.byKey(navKey)).height;
+    // The nav's own SafeArea absorbs the home indicator, so its measured
+    // height already includes it.
+    expect(navHeight, dockContentHeight + kHomeIndicator);
+    // ...and the body sees exactly that, which is what DockInsets reads.
+    expect(observedBottom, navHeight);
+  });
+
+  testWidgets('the inset survives the nested Scaffold every screen uses',
+      (tester) async {
+    const dockContentHeight = 60.0;
+    double? innerBottom;
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          size: Size(400, 800),
+          padding: EdgeInsets.only(bottom: kHomeIndicator),
+          viewPadding: EdgeInsets.only(bottom: kHomeIndicator),
+        ),
+        child: MaterialApp(
+          // Outer: AppShell's mobile Scaffold.
+          home: Scaffold(
+            extendBody: true,
+            bottomNavigationBar: const SafeArea(
+              child: SizedBox(height: dockContentHeight),
+            ),
+            body: AppShell.contentGutter(
+              child: Column(
+                children: [
+                  Expanded(
+                    // Inner: the per-screen Scaffold, as library and downloads
+                    // build it.
+                    child: Scaffold(
+                      backgroundColor: Colors.transparent,
+                      extendBodyBehindAppBar: true,
+                      appBar: AppBar(title: const Text('screen')),
+                      body: Builder(
+                        builder: (context) {
+                          innerBottom = MediaQuery.paddingOf(context).bottom;
+                          return const SizedBox.expand();
+                        },
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(innerBottom, dockContentHeight + kHomeIndicator);
+  });
+
+  group('the real BottomNav', () {
+    testWidgets('is taller than the 100.0 the screens used to hardcode',
+        (tester) async {
+      final navKey = GlobalKey();
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(
+            size: Size(400, 800),
+            padding: EdgeInsets.only(bottom: kHomeIndicator),
+            viewPadding: EdgeInsets.only(bottom: kHomeIndicator),
+          ),
+          child: ProviderScope(
+            child: MaterialApp(
+              home: Scaffold(
+                extendBody: true,
+                bottomNavigationBar: KeyedSubtree(
+                  key: navKey,
+                  child: BottomNav(location: '/', onNavigate: (_) {}),
+                ),
+                body: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Measured 117.0. This is the number the old hardcoded 100.0 was short
+      // of, and the reason content sat behind the dock on any phone with a
+      // home indicator.
+      expect(tester.getSize(find.byKey(navKey)).height, greaterThan(100));
+    });
+
+    testWidgets('still needs clearance with no system inset', (tester) async {
+      final navKey = GlobalKey();
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(size: Size(400, 800)),
+          child: ProviderScope(
+            child: MaterialApp(
+              home: Scaffold(
+                extendBody: true,
+                bottomNavigationBar: KeyedSubtree(
+                  key: navKey,
+                  child: BottomNav(location: '/', onNavigate: (_) {}),
+                ),
+                body: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Measured 83.0. Screens reserving 0, 16 or 32 were behind the dock on
+      // every device, not only phones with a home indicator.
+      expect(tester.getSize(find.byKey(navKey)).height, greaterThan(80));
+    });
+  });
+}

--- a/player/test/presentation/widgets/app_shell_drawer_dock_test.dart
+++ b/player/test/presentation/widgets/app_shell_drawer_dock_test.dart
@@ -1,0 +1,122 @@
+// The dock must not float over an open nav drawer.
+//
+// Flutter's Scaffold adds its drawer slot BEFORE bottomNavigationBar, and
+// paint order follows that list, so a floating dock paints on top of both the
+// drawer and its scrim and keeps intercepting taps. Rather than re-parenting
+// the drawer (which would mean owning the drag gesture, scrim and animation),
+// the shell fades the dock out while the drawer is open.
+//
+// These tests call the REAL `AppShell.dockChrome` seam, the same
+// `@visibleForTesting` pattern `AppShell.castOverlay` and
+// `AppShell.contentGutter` use. A hand-rolled mirror of the shell's shape
+// would stay green if the shell dropped the fade entirely.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/app_shell.dart';
+
+/// Marks the dock stand-in, so its mounted state and height can be measured.
+const Key _dockKey = Key('dock');
+
+/// Wraps the seam so finders can be scoped to it. `MaterialApp` and `Scaffold`
+/// both plant `IgnorePointer`s of their own, so an unscoped
+/// `find.byType(IgnorePointer)` matches several and `tester.widget` throws
+/// `Bad state: Too many elements`.
+const Key _rootKey = Key('dock-chrome-root');
+
+Future<void> pumpChrome(
+  WidgetTester tester, {
+  required bool drawerOpen,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Align(
+        alignment: Alignment.bottomCenter,
+        child: KeyedSubtree(
+          key: _rootKey,
+          child: AppShell.dockChrome(
+            drawerOpen: drawerOpen,
+            child: const SizedBox(key: _dockKey, height: 83),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+double dockOpacity(WidgetTester tester) => tester
+    .widget<AnimatedOpacity>(find.descendant(
+      of: find.byKey(_rootKey),
+      matching: find.byType(AnimatedOpacity),
+    ))
+    .opacity;
+
+bool dockIgnoring(WidgetTester tester) => tester
+    .widget<IgnorePointer>(find.descendant(
+      of: find.byKey(_rootKey),
+      matching: find.byType(IgnorePointer),
+    ))
+    .ignoring;
+
+void main() {
+  group('AppShell.dockChrome', () {
+    testWidgets('is opaque and interactive with the drawer closed',
+        (tester) async {
+      await pumpChrome(tester, drawerOpen: false);
+
+      expect(dockOpacity(tester), 1);
+      expect(dockIgnoring(tester), isFalse);
+    });
+
+    testWidgets('is transparent and inert with the drawer open',
+        (tester) async {
+      await pumpChrome(tester, drawerOpen: true);
+
+      expect(dockOpacity(tester), 0);
+      // Without this the user can tap "Home" straight through an open drawer.
+      expect(dockIgnoring(tester), isTrue);
+    });
+
+    testWidgets('keeps the dock mounted at full height while faded',
+        (tester) async {
+      await pumpChrome(tester, drawerOpen: false);
+      final closedHeight = tester.getSize(find.byKey(_dockKey)).height;
+
+      await pumpChrome(tester, drawerOpen: true);
+
+      // Mounted and unchanged: `MediaQuery.padding.bottom` stays put, so no
+      // screen's content reflows behind the open drawer. Swapping the bar for
+      // null would reflow every screen twice per drawer interaction.
+      expect(find.byKey(_dockKey), findsOneWidget);
+      expect(tester.getSize(find.byKey(_dockKey)).height, closedHeight);
+    });
+  });
+
+  group('Scaffold.onDrawerChanged', () {
+    testWidgets('reports open then closed, which is what drives the fade',
+        (tester) async {
+      final events = <bool>[];
+      final scaffoldKey = GlobalKey<ScaffoldState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            key: scaffoldKey,
+            onDrawerChanged: events.add,
+            drawer: const Drawer(child: SizedBox.expand()),
+            body: const SizedBox.expand(),
+          ),
+        ),
+      );
+
+      scaffoldKey.currentState!.openDrawer();
+      await tester.pumpAndSettle();
+      expect(events, [true]);
+
+      scaffoldKey.currentState!.closeDrawer();
+      await tester.pumpAndSettle();
+      expect(events, [true, false]);
+    });
+  });
+}

--- a/player/test/test_utils/dock_harness.dart
+++ b/player/test/test_utils/dock_harness.dart
@@ -1,0 +1,55 @@
+// Mounts a screen the way AppShell actually mounts it, so dock clearance can
+// be asserted against the REAL BottomNav height rather than a guess.
+//
+// This matters: the existing screen tests mount screens directly under
+// MaterialApp, where `MediaQuery.padding.bottom` is the raw view inset. Only
+// inside a `Scaffold(extendBody: true)` carrying a real bottomNavigationBar
+// does that value become the dock height, which is what DockInsets reads.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/app_shell.dart';
+import 'package:player/presentation/widgets/nav/bottom_nav.dart';
+
+/// Key on the harness's dock, so tests can measure it.
+const Key kDockKey = Key('dock-harness-nav');
+
+/// Wraps [child] in the same shape `AppShell`'s mobile branch builds:
+/// `Scaffold(extendBody: true)` with a real `BottomNav`, and the shell's
+/// content gutter around the body.
+///
+/// Callers must supply their own `ProviderScope`; `BottomNav` needs one
+/// because `SettingsNavItem` reads a provider for its badge.
+Widget shellHarness({required Widget child}) => MaterialApp(
+      home: Scaffold(
+        backgroundColor: Colors.transparent,
+        extendBody: true,
+        bottomNavigationBar: KeyedSubtree(
+          key: kDockKey,
+          child: BottomNav(location: '/', onNavigate: (_) {}),
+        ),
+        body: AppShell.contentGutter(child: child),
+      ),
+    );
+
+/// The measured height of the harness's dock, safe-area inset included.
+double dockHeightOf(WidgetTester tester) =>
+    tester.getSize(find.byKey(kDockKey)).height;
+
+/// Asserts [lastItem]'s bottom edge sits clear of the dock.
+///
+/// "Clear" means above the dock's top edge, which is where the last item must
+/// land once the user has scrolled all the way down. If content can never be
+/// brought past the dock, this fails.
+void expectClearsDock(WidgetTester tester, Finder lastItem) {
+  final viewportBottom = tester.getSize(find.byType(MaterialApp)).height;
+  final dockTop = viewportBottom - dockHeightOf(tester);
+  final itemBottom = tester.getRect(lastItem).bottom;
+
+  expect(
+    itemBottom,
+    lessThanOrEqualTo(dockTop),
+    reason: 'last item bottom ($itemBottom) is under the dock, whose top edge '
+        'is at $dockTop. The screen is not reserving DockInsets.bottomOf.',
+  );
+}


### PR DESCRIPTION
The mobile dock painted over content and over the nav drawer.

## What was wrong

Two independent causes.

**The drawer.** Flutter's `Scaffold` adds its `drawer` slot (line 2983) before `bottomNavigationBar` (line 3167) and paints in that order, so the floating dock sat on top of the drawer *and* its scrim, and stayed tappable through it: a tap where "Home" sits navigated while the drawer was open.

**Clearance.** `AppShell` uses `Scaffold(extendBody: true)` so content scrolls under the frosted pill by design. Flutter compensates by rewriting the body's `MediaQuery.padding.bottom` to the dock's measured height, and that value survives `AppShell.contentGutter` and each screen's own nested `Scaffold`. Nothing read it. Every screen hardcoded a number instead, and every number was too small:

| Reserved | Sites |
|---|---|
| 16 | `series_downloads_screen` |
| 32 | `show_detail_screen`, `movie_detail_screen`, `episode_detail_screen` |
| 100 | `downloads_screen` plus eight screens carrying the identical `final bottomPadding = isDesktop ? 32.0 : 100.0;` |
| 120 | `search_screen` (the one site already adequate) |

Measured, the dock is **83.0** tall with no system inset and **117.0** with a 34px home indicator. That explains the severity difference: the 32px sites were short on every device (show detail read as fully behind), while the 100px sites were fine on web and short by only 17px on a home-indicator phone (the library grid read as slightly behind).

## What changed

- New `DockInsets.bottomOf(context)` in `core/layout/`, reading the dock's real measured height rather than a literal, plus `DockGap` and `SliverDockGap` widgets. Self-correcting if the dock is ever restyled.
- All 15 call sites across 14 files converted.
- `AppShell.dockChrome` fades the dock out and wraps it in `IgnorePointer` while the drawer is open. It stays mounted on purpose: swapping it for `null` would drop `padding.bottom` to zero and reflow every screen's content behind the open drawer, then reflow back on close.
- Desktop spacing is unchanged at 32.

## Tests

- `dock_insets_test.dart`: the reader's arithmetic on mobile and desktop.
- `app_shell_dock_inset_test.dart`: pins the Flutter `extendBody` mechanism the whole design depends on, so a Flutter upgrade that changes it fails here instead of regressing every screen silently.
- `app_shell_drawer_dock_test.dart`: exercises the real `AppShell.dockChrome` seam, following the `castOverlay` / `contentGutter` pattern already in that file, so deleting the wrapper turns the tests red.
- `dock_clearance_test.dart`: scrolls a real `LibraryScreen` to its end inside a real shell with a real `BottomNav` and asserts the last poster clears the dock. Verified to fail by exactly 17px against the old hardcoded 100.
- `no_magic_dock_padding_test.dart`: static guard covering the six screens that cannot be mounted without their full provider graph. Scoped to two vectors (a `bottom*` variable from an `isDesktop` ternary, and a comment declaring its own nav clearance) so it does not flag the nine legitimate `isDesktop ? N : M` ternaries elsewhere. Verified to fail on both vectors before landing.

## Not addressed

`BottomNav`'s `Row` overflows at a 400px-wide test viewport. Widget tests render text in a placeholder font where every glyph is a full em square, so that threshold is systematically pessimistic and this may not reproduce on a real 375-430px phone. Unrelated to clearance, needs a real device to settle, so it is left out of scope and noted rather than guessed at.
