### PR TITLE
feat(player): Plex-style Media Info panel with per-stream detail

### DIFF
--- a/lib/mydia/jobs/file_analysis.ex
+++ b/lib/mydia/jobs/file_analysis.ex
@@ -2,7 +2,8 @@ defmodule Mydia.Jobs.FileAnalysis do
   @moduledoc """
   Recurring worker that fills in tech metadata for `MediaFile` rows the
   import path leaves at `analyzed_at IS NULL`, then uses spare capacity to
-  repair legacy analyzed rows that are missing persisted dimensions.
+  repair legacy analyzed rows that are missing persisted dimensions or
+  per-stream detail.
 
   Selection is by row state, so the worker is naturally idempotent: every
   tick pulls a bounded batch of un-analyzed rows whose `analysis_attempts`
@@ -78,6 +79,12 @@ defmodule Mydia.Jobs.FileAnalysis do
     end
   end
 
+  @doc false
+  # Test seam for the repair lane's row selection. Not part of the public API.
+  def repair_rows_for_test(limit, max_attempts, exclude_ids) do
+    fetch_repair_rows(limit, max_attempts, exclude_ids)
+  end
+
   defp fetch_unanalyzed_rows(batch_size, max_attempts) do
     from(mf in MediaFile,
       where: is_nil(mf.analyzed_at) and mf.analysis_attempts < ^max_attempts,
@@ -99,7 +106,8 @@ defmodule Mydia.Jobs.FileAnalysis do
           mf.analysis_attempts < ^max_attempts and
           not is_nil(mf.codec) and not is_nil(mf.resolution) and
           (is_nil(json_extract(mf.metadata, "$.width")) or
-             is_nil(json_extract(mf.metadata, "$.height"))) and
+             is_nil(json_extract(mf.metadata, "$.height")) or
+             is_nil(json_extract(mf.metadata, "$.streams"))) and
           mf.id not in ^exclude_ids,
       order_by: [asc: mf.updated_at, asc: mf.id],
       limit: ^overscan_limit,
@@ -111,7 +119,7 @@ defmodule Mydia.Jobs.FileAnalysis do
   end
 
   defp repair_candidate?(%MediaFile{metadata: %FileMetadata{} = metadata}) do
-    is_nil(metadata.width) or is_nil(metadata.height)
+    is_nil(metadata.width) or is_nil(metadata.height) or is_nil(metadata.streams)
   end
 
   defp repair_candidate?(_), do: false

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -375,6 +375,7 @@ defmodule Mydia.Library do
         |> maybe_put_struct_field(:container, result.container)
         |> maybe_put_struct_field(:width, result.width)
         |> maybe_put_struct_field(:height, result.height)
+        |> maybe_put_struct_field(:streams, result.streams)
         # The `audio_codec` column below is normalized for streaming
         # compatibility, which collapses "DD+ 5.1" to "ac3" and "TrueHD Atmos"
         # to "truehd" — losing the channel layout and the Atmos/E-AC3
@@ -533,16 +534,21 @@ defmodule Mydia.Library do
           |> maybe_put_struct_field(:container, result.container)
           |> maybe_put_struct_field(:width, result.width)
           |> maybe_put_struct_field(:height, result.height)
+          |> maybe_put_struct_field(:streams, result.streams)
 
         set = build_analysis_success_set(result, metadata, now)
 
+        # This guard must stay in lockstep with FileAnalysis.fetch_repair_rows/3
+        # and repair_candidate?/1. If it is narrower than the selection, the
+        # lane re-probes the same rows on every tick and writes nothing.
         query =
           from(mf in MediaFile,
             where:
               mf.id == ^media_file.id and mf.updated_at == ^current.updated_at and
                 mf.analyzed_at == ^current.analyzed_at and
                 (is_nil(json_extract(mf.metadata, "$.width")) or
-                   is_nil(json_extract(mf.metadata, "$.height")))
+                   is_nil(json_extract(mf.metadata, "$.height")) or
+                   is_nil(json_extract(mf.metadata, "$.streams")))
           )
 
         case Repo.update_all(query, set: set) do
@@ -2325,6 +2331,13 @@ defmodule Mydia.Library do
           {:error, :file_not_found}
         end
     end
+  end
+
+  @doc false
+  # Test seam for the repair write path, which is otherwise only reachable
+  # through repair_file_metadata/1 and therefore through a real ffprobe run.
+  def apply_repair_analysis_for_test(%MediaFile{} = media_file, result) do
+    apply_repair_analysis(media_file, result)
   end
 
   @doc """

--- a/lib/mydia/library/file_analyzer.ex
+++ b/lib/mydia/library/file_analyzer.ex
@@ -14,6 +14,7 @@ defmodule Mydia.Library.FileAnalyzer do
   require Logger
 
   alias Mydia.Library.Structs.FileAnalysisResult
+  alias Mydia.Library.Structs.StreamInfo
 
   @type analysis_result :: FileAnalysisResult.t()
 
@@ -254,11 +255,22 @@ defmodule Mydia.Library.FileAnalyzer do
         hdr_format: extract_hdr_format(video_stream),
         duration: extract_duration(format),
         container: extract_container(format),
-        size: nil
+        size: nil,
+        streams: extract_streams(streams)
       })
 
     {:ok, metadata}
   end
+
+  # Every video, audio and subtitle stream, in ffprobe's own order. Attachment
+  # and data streams return nil from from_ffprobe_stream/1 and are dropped.
+  defp extract_streams(streams) when is_list(streams) do
+    streams
+    |> Enum.map(&StreamInfo.from_ffprobe_stream/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp extract_streams(_streams), do: []
 
   defp extract_duration(format) do
     case format["duration"] do

--- a/lib/mydia/library/structs/file_analysis_result.ex
+++ b/lib/mydia/library/structs/file_analysis_result.ex
@@ -18,6 +18,7 @@ defmodule Mydia.Library.Structs.FileAnalysisResult do
   - `:size` - File size in bytes
   - `:duration` - Duration in seconds (floating point for precision)
   - `:container` - Container format (e.g., "mp4", "mkv", "webm")
+  - `:streams` - Every video, audio and subtitle stream (see `Mydia.Library.Structs.StreamInfo`)
 
   All fields are optional as FFprobe may not be able to extract all metadata.
   """
@@ -32,7 +33,8 @@ defmodule Mydia.Library.Structs.FileAnalysisResult do
     :hdr_format,
     :size,
     :duration,
-    :container
+    :container,
+    :streams
   ]
 
   @type t :: %__MODULE__{
@@ -45,7 +47,8 @@ defmodule Mydia.Library.Structs.FileAnalysisResult do
           hdr_format: String.t() | nil,
           size: integer() | nil,
           duration: float() | nil,
-          container: String.t() | nil
+          container: String.t() | nil,
+          streams: [Mydia.Library.Structs.StreamInfo.t()] | nil
         }
 
   @doc """

--- a/lib/mydia/library/structs/file_metadata.ex
+++ b/lib/mydia/library/structs/file_metadata.ex
@@ -16,9 +16,12 @@ defmodule Mydia.Library.Structs.FileMetadata do
   - **VP9 codec details**: vp9_profile, vp9_level
   - **AV1 codec details**: av1_profile, av1_level, av1_tier
   - **Shared codec detail**: bit_depth
+  - **Streams**: streams (per-stream detail, see `Mydia.Library.Structs.StreamInfo`)
   - **Quality evaluation**: quality_evaluation (written by QualityProfileEngine)
   - **Catch-all**: extra (captures unknown keys from legacy data or future ffprobe versions)
   """
+
+  alias Mydia.Library.Structs.StreamInfo
 
   defstruct [
     # Core technical
@@ -60,6 +63,12 @@ defmodule Mydia.Library.Structs.FileMetadata do
     # Shared codec detail
     :bit_depth,
 
+    # Every video, audio and subtitle stream. nil means capture has never run
+    # for this file; [] means it ran and found nothing usable. The repair lane
+    # in Mydia.Jobs.FileAnalysis keys off nil, so writing [] is what stops a
+    # pathological file being re-probed on every tick forever.
+    :streams,
+
     # Quality evaluation (written by QualityProfileEngine)
     :quality_evaluation,
 
@@ -87,6 +96,7 @@ defmodule Mydia.Library.Structs.FileMetadata do
           av1_level: integer() | nil,
           av1_tier: integer() | nil,
           bit_depth: integer() | nil,
+          streams: [StreamInfo.t()] | nil,
           quality_evaluation: map() | nil,
           extra: map()
         }
@@ -112,6 +122,7 @@ defmodule Mydia.Library.Structs.FileMetadata do
     "av1_level" => :av1_level,
     "av1_tier" => :av1_tier,
     "bit_depth" => :bit_depth,
+    "streams" => :streams,
     "quality_evaluation" => :quality_evaluation
   }
 
@@ -127,6 +138,9 @@ defmodule Mydia.Library.Structs.FileMetadata do
     {known, extra} =
       Enum.reduce(map, {%{}, %{}}, fn {key, value}, {known_acc, extra_acc} ->
         case resolve_key(key) do
+          {:known, :streams} ->
+            {Map.put(known_acc, :streams, normalize_streams(value)), extra_acc}
+
           {:known, atom_key} ->
             {Map.put(known_acc, atom_key, value), extra_acc}
 
@@ -137,6 +151,17 @@ defmodule Mydia.Library.Structs.FileMetadata do
 
     struct(__MODULE__, Map.put(known, :extra, extra))
   end
+
+  # `streams` arrives either as StreamInfo structs (from the analyzer, via
+  # Ecto.Type.cast/1) or as plain maps (from stored JSON, via load/1).
+  defp normalize_streams(streams) when is_list(streams) do
+    Enum.map(streams, fn
+      %StreamInfo{} = stream -> stream
+      map when is_map(map) -> StreamInfo.from_map(map)
+    end)
+  end
+
+  defp normalize_streams(_streams), do: nil
 
   @doc """
   Creates an empty FileMetadata with all fields set to nil.
@@ -153,7 +178,10 @@ defmodule Mydia.Library.Structs.FileMetadata do
     |> Map.from_struct()
     |> Map.delete(:extra)
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-    |> Enum.map(fn {k, v} -> {to_string(k), v} end)
+    |> Enum.map(fn
+      {:streams, streams} -> {"streams", Enum.map(streams, &StreamInfo.to_map/1)}
+      {k, v} -> {to_string(k), v}
+    end)
     |> Map.new()
     |> Map.merge(metadata.extra || %{})
   end

--- a/lib/mydia/library/structs/file_metadata.ex
+++ b/lib/mydia/library/structs/file_metadata.ex
@@ -154,10 +154,16 @@ defmodule Mydia.Library.Structs.FileMetadata do
 
   # `streams` arrives either as StreamInfo structs (from the analyzer, via
   # Ecto.Type.cast/1) or as plain maps (from stored JSON, via load/1).
+  #
+  # Anything else in the list is dropped rather than raised on. This runs on
+  # every metadata load, so a single malformed entry in a hand-edited or legacy
+  # JSON column would otherwise crash reads and repairs for that file instead of
+  # costing it one stream.
   defp normalize_streams(streams) when is_list(streams) do
-    Enum.map(streams, fn
-      %StreamInfo{} = stream -> stream
-      map when is_map(map) -> StreamInfo.from_map(map)
+    Enum.flat_map(streams, fn
+      %StreamInfo{} = stream -> [stream]
+      map when is_map(map) -> [StreamInfo.from_map(map)]
+      _other -> []
     end)
   end
 

--- a/lib/mydia/library/structs/stream_info.ex
+++ b/lib/mydia/library/structs/stream_info.ex
@@ -1,0 +1,266 @@
+defmodule Mydia.Library.Structs.StreamInfo do
+  @moduledoc """
+  One elementary stream of a media file, as reported by `ffprobe -show_streams`.
+
+  `Mydia.Library.FileAnalyzer` historically kept only the first video and first
+  audio stream, collapsing them into the flat columns on `media_files`. This
+  struct preserves every video, audio and subtitle stream so the player can show
+  a full per-file readout.
+
+  Values are stored as ffprobe reports them. Composing display strings
+  ("HEVC Main 10", "7.1 (8 ch)", "23.976 fps") is the client's job, so the same
+  data can be formatted differently by a future consumer without a server change.
+
+  Attachment and data streams (embedded fonts, timecode tracks) are dropped: they
+  are noise in a readout and would inflate the stored JSON.
+
+  The disposition fields are named `is_default` / `is_forced` rather than
+  `default` / `forced` because `default` is a reserved word in Dart, and these
+  names reach the Flutter player verbatim through GraphQL codegen.
+  """
+
+  defstruct [
+    # common
+    :index,
+    :type,
+    :codec,
+    :codec_long,
+    :profile,
+    :level,
+    :language,
+    :title,
+    :bitrate,
+    :is_default,
+    :is_forced,
+    :is_hearing_impaired,
+    :is_commentary,
+    # video
+    :width,
+    :height,
+    :frame_rate,
+    :pixel_format,
+    :bit_depth,
+    :color_space,
+    :color_transfer,
+    :color_primaries,
+    :dolby_vision_profile,
+    :aspect_ratio,
+    # audio
+    :channels,
+    :channel_layout,
+    :sample_rate
+  ]
+
+  @type stream_type :: :video | :audio | :subtitle
+
+  @type t :: %__MODULE__{
+          index: integer() | nil,
+          type: stream_type() | nil,
+          codec: String.t() | nil,
+          codec_long: String.t() | nil,
+          profile: String.t() | nil,
+          level: integer() | nil,
+          language: String.t() | nil,
+          title: String.t() | nil,
+          bitrate: integer() | nil,
+          is_default: boolean() | nil,
+          is_forced: boolean() | nil,
+          is_hearing_impaired: boolean() | nil,
+          is_commentary: boolean() | nil,
+          width: integer() | nil,
+          height: integer() | nil,
+          frame_rate: float() | nil,
+          pixel_format: String.t() | nil,
+          bit_depth: integer() | nil,
+          color_space: String.t() | nil,
+          color_transfer: String.t() | nil,
+          color_primaries: String.t() | nil,
+          dolby_vision_profile: integer() | nil,
+          aspect_ratio: String.t() | nil,
+          channels: integer() | nil,
+          channel_layout: String.t() | nil,
+          sample_rate: integer() | nil
+        }
+
+  @known_keys ~w(
+    index type codec codec_long profile level language title bitrate
+    is_default is_forced is_hearing_impaired is_commentary
+    width height frame_rate pixel_format bit_depth
+    color_space color_transfer color_primaries dolby_vision_profile aspect_ratio
+    channels channel_layout sample_rate
+  )
+
+  @doc """
+  Builds a `StreamInfo` from one entry of ffprobe's `streams` array.
+
+  Returns `nil` for stream kinds that do not belong in a readout (attachment,
+  data) and for anything that is not a recognisable stream map.
+  """
+  @spec from_ffprobe_stream(map()) :: t() | nil
+  def from_ffprobe_stream(%{"codec_type" => "video"} = stream), do: build(:video, stream)
+  def from_ffprobe_stream(%{"codec_type" => "audio"} = stream), do: build(:audio, stream)
+  def from_ffprobe_stream(%{"codec_type" => "subtitle"} = stream), do: build(:subtitle, stream)
+  def from_ffprobe_stream(_stream), do: nil
+
+  defp build(type, stream) do
+    tags = normalize_tags(Map.get(stream, "tags"))
+    disposition = Map.get(stream, "disposition")
+
+    %__MODULE__{
+      index: to_int(stream["index"]),
+      type: type,
+      codec: scrub_utf8(stream["codec_name"]),
+      codec_long: scrub_utf8(stream["codec_long_name"]),
+      profile: scrub_utf8(stream["profile"]),
+      level: to_int(stream["level"]),
+      language: scrub_utf8(tags["language"]),
+      title: scrub_utf8(tags["title"]),
+      bitrate: to_int(stream["bit_rate"]),
+      is_default: flag(disposition, "default"),
+      is_forced: flag(disposition, "forced"),
+      is_hearing_impaired: flag(disposition, "hearing_impaired"),
+      is_commentary: flag(disposition, "comment"),
+      width: to_int(stream["width"]),
+      height: to_int(stream["height"]),
+      frame_rate: parse_rational(stream["avg_frame_rate"] || stream["r_frame_rate"]),
+      pixel_format: stream["pix_fmt"],
+      bit_depth: bit_depth(stream),
+      color_space: stream["color_space"],
+      color_transfer: stream["color_transfer"],
+      color_primaries: stream["color_primaries"],
+      dolby_vision_profile: dolby_vision_profile(stream),
+      aspect_ratio: stream["display_aspect_ratio"],
+      channels: to_int(stream["channels"]),
+      channel_layout: stream["channel_layout"],
+      sample_rate: to_int(stream["sample_rate"])
+    }
+  end
+
+  @doc """
+  Converts to a plain string-keyed map for JSON storage.
+
+  Nil fields are dropped so a subtitle stream does not serialise twenty null
+  video fields. `false` is kept, since it is a meaningful disposition value.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = stream) do
+    stream
+    |> Map.from_struct()
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new(fn {key, value} -> {Atom.to_string(key), encode(value)} end)
+  end
+
+  @doc """
+  Rebuilds a `StreamInfo` from a stored string-keyed map. Unknown keys are
+  ignored rather than raising, so data written by a future version loads.
+  """
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map) do
+    attrs =
+      Enum.reduce(@known_keys, %{}, fn key, acc ->
+        case fetch_either(map, key) do
+          {:ok, value} -> Map.put(acc, String.to_existing_atom(key), decode(key, value))
+          :error -> acc
+        end
+      end)
+
+    struct(__MODULE__, attrs)
+  end
+
+  defp fetch_either(map, key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> Map.fetch(map, String.to_existing_atom(key))
+    end
+  end
+
+  defp encode(value) when is_boolean(value), do: value
+  defp encode(value) when is_atom(value) and not is_nil(value), do: Atom.to_string(value)
+  defp encode(value), do: value
+
+  defp decode("type", "video"), do: :video
+  defp decode("type", "audio"), do: :audio
+  defp decode("type", "subtitle"), do: :subtitle
+  defp decode("type", value) when is_atom(value), do: value
+  defp decode("type", _value), do: nil
+  defp decode(_key, value), do: value
+
+  defp normalize_tags(tags) when is_map(tags) do
+    # Matroska commonly writes tag names in upper case (LANGUAGE, TITLE).
+    Map.new(tags, fn {key, value} -> {String.downcase(to_string(key)), value} end)
+  end
+
+  defp normalize_tags(_tags), do: %{}
+
+  defp flag(disposition, key) when is_map(disposition), do: Map.get(disposition, key) == 1
+  defp flag(_disposition, _key), do: false
+
+  # ffprobe reports frame rates as a rational string such as "24000/1001".
+  defp parse_rational(value) when is_binary(value) do
+    with [numerator, denominator] <- String.split(value, "/"),
+         {num, ""} <- Integer.parse(numerator),
+         {den, ""} <- Integer.parse(denominator),
+         true <- den != 0 do
+      Float.round(num / den, 3)
+    else
+      _ -> nil
+    end
+  end
+
+  defp parse_rational(_value), do: nil
+
+  defp bit_depth(stream) do
+    case to_int(stream["bits_per_raw_sample"]) do
+      nil -> bit_depth_from_pixel_format(stream["pix_fmt"])
+      depth -> depth
+    end
+  end
+
+  defp bit_depth_from_pixel_format(pix_fmt) when is_binary(pix_fmt) do
+    case Regex.run(~r/p(\d+)(?:le|be)?$/, pix_fmt) do
+      [_full, depth] -> String.to_integer(depth)
+      nil -> if String.starts_with?(pix_fmt, "yuv"), do: 8, else: nil
+    end
+  end
+
+  defp bit_depth_from_pixel_format(_pix_fmt), do: nil
+
+  # Dolby Vision is signalled by a DOVI configuration record in side data.
+  # Matching on the presence of dv_profile is more robust than the type string.
+  defp dolby_vision_profile(stream) do
+    stream
+    |> Map.get("side_data_list")
+    |> List.wrap()
+    |> Enum.find_value(fn
+      %{"dv_profile" => profile} -> to_int(profile)
+      _other -> nil
+    end)
+  end
+
+  defp to_int(value) when is_integer(value), do: value
+
+  defp to_int(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, _rest} -> int
+      :error -> nil
+    end
+  end
+
+  defp to_int(_value), do: nil
+
+  # Container tags carry arbitrary bytes. Raw non-UTF-8 passes silently on
+  # SQLite and raises on PostgreSQL in the `:string` metadata column, so
+  # anything invalid is reinterpreted as latin1, which always yields valid UTF-8.
+  defp scrub_utf8(value) when is_binary(value) do
+    if String.valid?(value) do
+      value
+    else
+      case :unicode.characters_to_binary(value, :latin1, :utf8) do
+        converted when is_binary(converted) -> converted
+        _error -> nil
+      end
+    end
+  end
+
+  defp scrub_utf8(_value), do: nil
+end

--- a/lib/mydia/subtitles/extractor.ex
+++ b/lib/mydia/subtitles/extractor.ex
@@ -187,8 +187,13 @@ defmodule Mydia.Subtitles.Extractor do
   defp normalize_subtitle_format("hdmv_pgs_subtitle"), do: "pgs"
   defp normalize_subtitle_format(codec), do: codec || "unknown"
 
-  # Get external subtitles from database
-  defp get_external_subtitles(media_file_id) do
+  @doc """
+  Subtitle tracks stored as sidecar files for a media file.
+
+  Reads only the database. Unlike `list_subtitle_tracks/2` this never runs
+  ffprobe, which makes it safe to resolve on a hot GraphQL path.
+  """
+  def list_external_subtitle_tracks(media_file_id) do
     Mydia.Subtitles.list_subtitles(media_file_id)
     |> Enum.map(fn subtitle ->
       %{
@@ -200,6 +205,8 @@ defmodule Mydia.Subtitles.Extractor do
       }
     end)
   end
+
+  defp get_external_subtitles(media_file_id), do: list_external_subtitle_tracks(media_file_id)
 
   # Format external subtitle title
   defp format_external_title(subtitle) do

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -12,6 +12,56 @@ defmodule MydiaWeb.Schema.CommonTypes do
     field :thumbnail_url, :string, description: "Thumbnail image URL"
   end
 
+  @desc "What kind of elementary stream this is"
+  enum :media_stream_type do
+    value(:video, description: "Video stream")
+    value(:audio, description: "Audio stream")
+    value(:subtitle, description: "Subtitle stream")
+  end
+
+  @desc """
+  One elementary stream of a media file, as reported by ffprobe.
+
+  Values are raw. Composing display strings ("HEVC Main 10", "7.1 (8 ch)") is
+  the client's job, so the same data can be formatted differently without a
+  server change. Type-specific fields are null on streams of other types.
+
+  The disposition fields are `isDefault` / `isForced` rather than `default` /
+  `forced` because `default` is a reserved word in Dart and would make the
+  player's GraphQL codegen emit invalid source.
+  """
+  object :media_stream do
+    field :index, :integer, description: "Stream index within the container"
+    field :type, non_null(:media_stream_type)
+    field :codec, :string, description: "Short codec name (e.g. hevc, truehd, subrip)"
+    field :codec_long, :string, description: "Descriptive codec name"
+    field :profile, :string, description: "Codec profile (e.g. Main 10)"
+    field :level, :integer, description: "Codec level, as ffprobe's integer"
+    field :language, :string, description: "ISO 639-2 language code from container tags"
+    field :title, :string, description: "Track title from container tags"
+    field :bitrate, :integer, description: "Stream bitrate in bits per second"
+
+    field :is_default, :boolean
+    field :is_forced, :boolean
+    field :is_hearing_impaired, :boolean
+    field :is_commentary, :boolean
+
+    field :width, :integer
+    field :height, :integer
+    field :frame_rate, :float, description: "Average frame rate in frames per second"
+    field :pixel_format, :string
+    field :bit_depth, :integer
+    field :color_space, :string
+    field :color_transfer, :string
+    field :color_primaries, :string
+    field :dolby_vision_profile, :integer, description: "Dolby Vision profile, when present"
+    field :aspect_ratio, :string, description: "Display aspect ratio (e.g. 16:9)"
+
+    field :channels, :integer
+    field :channel_layout, :string, description: "Channel layout (e.g. 5.1, 7.1)"
+    field :sample_rate, :integer, description: "Sample rate in Hz"
+  end
+
   @desc "A playable video file"
   object :media_file do
     field :id, non_null(:id), description: "File ID"
@@ -21,6 +71,54 @@ defmodule MydiaWeb.Schema.CommonTypes do
     field :hdr_format, :string, description: "HDR format if applicable (e.g., dolby_vision)"
     field :size, :integer, description: "File size in bytes"
     field :bitrate, :integer, description: "Bitrate in bits per second"
+
+    @desc "Every video, audio and subtitle stream. Null when detailed capture has not run for this file yet."
+    field :streams, list_of(:media_stream) do
+      resolve(fn file, _args, _info ->
+        case file.metadata do
+          %Mydia.Library.Structs.FileMetadata{streams: streams} when is_list(streams) ->
+            {:ok, streams}
+
+          _ ->
+            {:ok, nil}
+        end
+      end)
+    end
+
+    @desc "File name without its directory"
+    field :file_name, :string do
+      resolve(fn file, _args, _info ->
+        # relative_path is on the row itself, so this needs no library_path preload.
+        {:ok, file.relative_path && Path.basename(file.relative_path)}
+      end)
+    end
+
+    @desc "Absolute directory containing the file"
+    field :directory, :string do
+      resolve(fn file, _args, _info ->
+        case MydiaWeb.Schema.Resolvers.MediaResolver.absolute_path(file) do
+          nil -> {:ok, nil}
+          path -> {:ok, Path.dirname(path)}
+        end
+      end)
+    end
+
+    @desc "Container format (e.g. mkv, mp4)"
+    field :container, :string do
+      resolve(fn file, _args, _info -> {:ok, metadata_field(file, :container)} end)
+    end
+
+    @desc "Duration in seconds"
+    field :duration, :float do
+      resolve(fn file, _args, _info -> {:ok, metadata_field(file, :duration)} end)
+    end
+
+    @desc "Subtitle files stored alongside the media file. Unlike `subtitles`, this never probes the file."
+    field :external_subtitles, list_of(:subtitle_track) do
+      resolve(fn file, _args, _info ->
+        {:ok, Mydia.Subtitles.Extractor.list_external_subtitle_tracks(file.id)}
+      end)
+    end
 
     @desc "Whether this file can be direct played (no transcoding needed)"
     field :direct_play_supported, :boolean do
@@ -410,4 +508,9 @@ defmodule MydiaWeb.Schema.CommonTypes do
       end)
     end
   end
+
+  defp metadata_field(%{metadata: %Mydia.Library.Structs.FileMetadata{} = metadata}, key),
+    do: Map.get(metadata, key)
+
+  defp metadata_field(_file, _key), do: nil
 end

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -433,11 +433,12 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
       if Ecto.assoc_loaded?(media_file.library_path) do
         media_file
       else
-        Mydia.Library.get_media_file!(media_file.id, preload: [:library_path])
+        # Preload the one association rather than refetching the whole row:
+        # the struct is already in hand, and this cannot raise the way
+        # get_media_file!/2 does when the row is deleted mid-request.
+        Mydia.Repo.preload(media_file, :library_path)
       end
 
     Mydia.Library.MediaFile.absolute_path(media_file)
-  rescue
-    Ecto.NoResultsError -> nil
   end
 end

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -420,4 +420,24 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
   end
 
   def visible_segments(_media_file), do: []
+
+  @doc """
+  Absolute path of a media file, preloading `library_path` if the caller did not.
+
+  Kept here rather than inline in the schema so the preload fallback lives in
+  one place. Callers resolve a small `files` list per item, so the extra query
+  is bounded.
+  """
+  def absolute_path(%Mydia.Library.MediaFile{} = media_file) do
+    media_file =
+      if Ecto.assoc_loaded?(media_file.library_path) do
+        media_file
+      else
+        Mydia.Library.get_media_file!(media_file.id, preload: [:library_path])
+      end
+
+    Mydia.Library.MediaFile.absolute_path(media_file)
+  rescue
+    Ecto.NoResultsError -> nil
+  end
 end

--- a/player/lib/domain/models/media_stream.dart
+++ b/player/lib/domain/models/media_stream.dart
@@ -1,0 +1,188 @@
+import '../../graphql/fragments/media_info_fragment.graphql.dart';
+import 'subtitle_track.dart';
+
+/// What kind of elementary stream this is.
+enum MediaStreamType { video, audio, subtitle }
+
+/// One elementary stream of a media file, as reported by ffprobe.
+///
+/// Values are raw; `stream_formatters.dart` turns them into display strings.
+class MediaStream {
+  final int? index;
+  final MediaStreamType type;
+  final String? codec;
+  final String? codecLong;
+  final String? profile;
+  final int? level;
+  final String? language;
+  final String? title;
+  final int? bitrate;
+
+  final bool isDefault;
+  final bool isForced;
+  final bool isHearingImpaired;
+  final bool isCommentary;
+
+  final int? width;
+  final int? height;
+  final double? frameRate;
+  final String? pixelFormat;
+  final int? bitDepth;
+  final String? colorSpace;
+  final String? colorTransfer;
+  final String? colorPrimaries;
+  final int? dolbyVisionProfile;
+  final String? aspectRatio;
+
+  final int? channels;
+  final String? channelLayout;
+  final int? sampleRate;
+
+  const MediaStream({
+    this.index,
+    required this.type,
+    this.codec,
+    this.codecLong,
+    this.profile,
+    this.level,
+    this.language,
+    this.title,
+    this.bitrate,
+    this.isDefault = false,
+    this.isForced = false,
+    this.isHearingImpaired = false,
+    this.isCommentary = false,
+    this.width,
+    this.height,
+    this.frameRate,
+    this.pixelFormat,
+    this.bitDepth,
+    this.colorSpace,
+    this.colorTransfer,
+    this.colorPrimaries,
+    this.dolbyVisionProfile,
+    this.aspectRatio,
+    this.channels,
+    this.channelLayout,
+    this.sampleRate,
+  });
+
+  factory MediaStream.fromGraphQL(Fragment$MediaInfoFragment$streams s) {
+    return MediaStream(
+      index: s.index,
+      type: _typeFrom(s.type),
+      codec: s.codec,
+      codecLong: s.codecLong,
+      profile: s.profile,
+      level: s.level,
+      language: s.language,
+      title: s.title,
+      bitrate: s.bitrate,
+      isDefault: s.isDefault ?? false,
+      isForced: s.isForced ?? false,
+      isHearingImpaired: s.isHearingImpaired ?? false,
+      isCommentary: s.isCommentary ?? false,
+      width: s.width,
+      height: s.height,
+      frameRate: s.frameRate,
+      pixelFormat: s.pixelFormat,
+      bitDepth: s.bitDepth,
+      colorSpace: s.colorSpace,
+      colorTransfer: s.colorTransfer,
+      colorPrimaries: s.colorPrimaries,
+      dolbyVisionProfile: s.dolbyVisionProfile,
+      aspectRatio: s.aspectRatio,
+      channels: s.channels,
+      channelLayout: s.channelLayout,
+      sampleRate: s.sampleRate,
+    );
+  }
+
+  static MediaStreamType _typeFrom(dynamic value) {
+    final name = value.toString().split('.').last.toLowerCase();
+    switch (name) {
+      case 'audio':
+        return MediaStreamType.audio;
+      case 'subtitle':
+        return MediaStreamType.subtitle;
+      default:
+        return MediaStreamType.video;
+    }
+  }
+}
+
+/// One media file, with everything the Media Info panel shows about it.
+class MediaFileInfo {
+  final String id;
+  final String? fileName;
+  final String? directory;
+  final String? container;
+  final double? durationSeconds;
+  final int? sizeBytes;
+  final int? bitrate;
+  final String? resolution;
+  final String? codec;
+
+  /// Null when the server has not captured detailed streams for this file yet,
+  /// which is the normal state until the backfill reaches it. Distinct from an
+  /// empty list, which means capture ran and found nothing.
+  final List<MediaStream>? streams;
+
+  final List<SubtitleTrack> externalSubtitles;
+
+  const MediaFileInfo({
+    required this.id,
+    this.fileName,
+    this.directory,
+    this.container,
+    this.durationSeconds,
+    this.sizeBytes,
+    this.bitrate,
+    this.resolution,
+    this.codec,
+    this.streams,
+    this.externalSubtitles = const [],
+  });
+
+  bool get hasDetailedStreams => streams != null && streams!.isNotEmpty;
+
+  List<MediaStream> ofType(MediaStreamType type) =>
+      (streams ?? const []).where((s) => s.type == type).toList();
+
+  /// Short label for the version switcher, e.g. "2160p HEVC · 54.2 GB".
+  String get versionLabel {
+    final parts = <String>[
+      if (resolution != null) resolution!,
+      if (codec != null) codec!.toUpperCase(),
+    ];
+    return parts.isEmpty ? 'Version' : parts.join(' ');
+  }
+
+  factory MediaFileInfo.fromGraphQL(Fragment$MediaInfoFragment f) {
+    return MediaFileInfo(
+      id: f.id,
+      fileName: f.fileName,
+      directory: f.directory,
+      container: f.container,
+      durationSeconds: f.duration,
+      sizeBytes: f.size,
+      bitrate: f.bitrate,
+      resolution: f.resolution,
+      codec: f.codec,
+      streams: f.streams
+          ?.whereType<Fragment$MediaInfoFragment$streams>()
+          .map(MediaStream.fromGraphQL)
+          .toList(),
+      externalSubtitles: (f.externalSubtitles ?? [])
+          .whereType<Fragment$MediaInfoFragment$externalSubtitles>()
+          .map((s) => SubtitleTrack(
+                id: s.trackId,
+                language: s.language,
+                title: s.title,
+                format: s.format,
+                embedded: s.embedded,
+              ))
+          .toList(),
+    );
+  }
+}

--- a/player/lib/graphql/fragments/media_info_fragment.graphql
+++ b/player/lib/graphql/fragments/media_info_fragment.graphql
@@ -1,0 +1,46 @@
+fragment MediaInfoFragment on MediaFile {
+  id
+  fileName
+  directory
+  container
+  duration
+  size
+  bitrate
+  resolution
+  codec
+  streams {
+    index
+    type
+    codec
+    codecLong
+    profile
+    level
+    language
+    title
+    bitrate
+    isDefault
+    isForced
+    isHearingImpaired
+    isCommentary
+    width
+    height
+    frameRate
+    pixelFormat
+    bitDepth
+    colorSpace
+    colorTransfer
+    colorPrimaries
+    dolbyVisionProfile
+    aspectRatio
+    channels
+    channelLayout
+    sampleRate
+  }
+  externalSubtitles {
+    trackId
+    language
+    title
+    format
+    embedded
+  }
+}

--- a/player/lib/graphql/queries/media_info.graphql
+++ b/player/lib/graphql/queries/media_info.graphql
@@ -1,0 +1,53 @@
+#import '../fragments/media_info_fragment.graphql'
+
+query MovieMediaInfo($id: ID!) {
+  movie(id: $id) {
+    id
+    title
+    files {
+      ...MediaInfoFragment
+    }
+  }
+}
+
+query EpisodeMediaInfo($id: ID!) {
+  episode(id: $id) {
+    id
+    title
+    files {
+      ...MediaInfoFragment
+    }
+  }
+}
+
+query MovieMediaInfoLegacy($id: ID!) {
+  movie(id: $id) {
+    id
+    title
+    files {
+      id
+      size
+      bitrate
+      resolution
+      codec
+      audioCodec
+      hdrFormat
+    }
+  }
+}
+
+query EpisodeMediaInfoLegacy($id: ID!) {
+  episode(id: $id) {
+    id
+    title
+    files {
+      id
+      size
+      bitrate
+      resolution
+      codec
+      audioCodec
+      hdrFormat
+    }
+  }
+}

--- a/player/lib/presentation/screens/episode/episode_detail_screen.dart
+++ b/player/lib/presentation/screens/episode/episode_detail_screen.dart
@@ -15,6 +15,7 @@ import '../../../domain/models/download.dart';
 import '../../../core/theme/colors.dart';
 import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
+import '../../widgets/media_info/media_info_sheet.dart';
 import '../../widgets/smart_play_button.dart';
 
 class EpisodeDetailScreen extends ConsumerWidget {
@@ -212,8 +213,8 @@ class EpisodeDetailScreen extends ConsumerWidget {
                 ),
               ),
               const SizedBox(height: 20),
-              if (isDownloadSupported) ...[
-                _buildDownloadRow(context, ref, episode),
+              if (isDownloadSupported || episode.files.isNotEmpty) ...[
+                _buildActionRow(context, ref, episode),
                 const SizedBox(height: 20),
               ],
               _buildMetadata(context, episode),
@@ -416,14 +417,37 @@ class EpisodeDetailScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildDownloadRow(
+  Widget _buildActionRow(
       BuildContext context, WidgetRef ref, EpisodeDetail episode) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
       child: Row(
         children: [
-          _buildDownloadButton(context, ref, episode),
+          if (isDownloadSupported) _buildDownloadButton(context, ref, episode),
+          if (episode.files.isNotEmpty) ...[
+            if (isDownloadSupported) const SizedBox(width: 8),
+            _buildMediaInfoButton(context, episode),
+          ],
         ],
+      ),
+    );
+  }
+
+  Widget _buildMediaInfoButton(BuildContext context, EpisodeDetail episode) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: IconButton(
+        key: const Key('episode-media-info'),
+        onPressed: () => showMediaInfo(
+          context: context,
+          id: episode.id,
+          target: MediaInfoTarget.episode,
+        ),
+        icon: const Icon(Icons.info_outline_rounded, color: Colors.white),
+        tooltip: 'Media Info',
       ),
     );
   }

--- a/player/lib/presentation/screens/movie/movie_detail_screen.dart
+++ b/player/lib/presentation/screens/movie/movie_detail_screen.dart
@@ -18,6 +18,7 @@ import '../../widgets/cast_button.dart';
 import '../../widgets/cast_rail.dart';
 import '../../widgets/content_rail.dart';
 import '../../widgets/detail_action_row.dart';
+import '../../widgets/media_info/media_info_sheet.dart';
 import '../../widgets/movie_watched_controls.dart';
 import '../../widgets/hero_play_control.dart';
 
@@ -273,6 +274,13 @@ class MovieDetailScreen extends ConsumerWidget {
       showDownload: isDownloadSupported && movie.files.isNotEmpty,
       isDownloaded:
           ref.watch(isMediaDownloadedProvider(movie.id)).value ?? false,
+      onShowMediaInfo: movie.files.isEmpty
+          ? null
+          : () => showMediaInfo(
+                context: context,
+                id: movie.id,
+                target: MediaInfoTarget.movie,
+              ),
     );
   }
 

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -25,6 +25,7 @@ import '../../widgets/cast_rail.dart';
 import '../../widgets/content_rail.dart';
 import '../../widgets/detail_action_row.dart';
 import '../../widgets/hero_play_control.dart';
+import '../../widgets/media_info/media_info_sheet.dart';
 
 /// Below this width the hero's action column and tag column stack instead
 /// of sitting side by side. Matches the movie detail hero's breakpoint — see
@@ -589,6 +590,13 @@ class ShowDetailScreen extends ConsumerWidget {
       // the selected episode.
       isDownloaded:
           ref.watch(isMediaDownloadedProvider(episode.id)).value ?? false,
+      onShowMediaInfo: episode.files.isEmpty
+          ? null
+          : () => showMediaInfo(
+                context: context,
+                id: episode.id,
+                target: MediaInfoTarget.episode,
+              ),
     );
   }
 

--- a/player/lib/presentation/widgets/detail_action_row.dart
+++ b/player/lib/presentation/widgets/detail_action_row.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../core/theme/colors.dart';
 
-/// Four-button action row in the detail body, below the hero: mark
-/// watched/unwatched, favorite, download, and (when a trailer exists) open it
-/// on YouTube in a new tab. Shared between the movie and TV show detail
-/// screens, since both need the identical row.
+/// Action row in the detail body, below the hero: mark watched/unwatched,
+/// favorite, download, open the trailer on YouTube when one exists, and open
+/// the Media Info panel when the title has files. Shared between the movie and
+/// TV show detail screens, since both need the identical row.
 class DetailActionRow extends StatelessWidget {
   final bool watched;
   final VoidCallback onToggleWatched;
@@ -27,6 +27,10 @@ class DetailActionRow extends StatelessWidget {
   /// pre-redesign app-bar download button used to show.
   final bool isDownloaded;
 
+  /// Opens the Media Info panel. Null hides the action, which is what callers
+  /// pass when the title has no files to describe.
+  final VoidCallback? onShowMediaInfo;
+
   const DetailActionRow({
     super.key,
     required this.watched,
@@ -37,6 +41,7 @@ class DetailActionRow extends StatelessWidget {
     required this.trailerUrl,
     this.showDownload = true,
     this.isDownloaded = false,
+    this.onShowMediaInfo,
   });
 
   @override
@@ -80,6 +85,14 @@ class DetailActionRow extends StatelessWidget {
             highlighted: false,
             highlightColor: AppColors.primary,
             onTap: () => _openTrailer(context, trailerUrl),
+          ),
+        if (onShowMediaInfo != null)
+          _ActionButton(
+            icon: Icons.info_outline_rounded,
+            label: 'Info',
+            highlighted: false,
+            highlightColor: AppColors.textPrimary,
+            onTap: onShowMediaInfo!,
           ),
       ],
     );

--- a/player/lib/presentation/widgets/media_info/media_info_content.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_content.dart
@@ -1,0 +1,444 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/theme/colors.dart';
+import '../../../domain/models/media_stream.dart';
+import 'stream_formatters.dart';
+
+/// Shown when the server has not captured detailed streams for a file yet.
+/// This is the normal state for every file in an existing library until the
+/// analysis worker's repair lane reaches it, so it reads as information rather
+/// than as an error.
+const String kStreamsPendingMessage =
+    'Detailed stream information has not been captured for this file yet.';
+
+/// The Media Info readout.
+///
+/// Deliberately knows nothing about the container holding it, so the same
+/// widget serves the bottom sheet, the wide-screen side panel, and later the
+/// live playback overlay.
+class MediaInfoContent extends StatelessWidget {
+  final List<MediaFileInfo> files;
+  final int selectedIndex;
+  final ValueChanged<int> onSelectVersion;
+
+  const MediaInfoContent({
+    super.key,
+    required this.files,
+    required this.selectedIndex,
+    required this.onSelectVersion,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (files.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.all(24),
+        child: Text(
+          'No files for this title.',
+          style: TextStyle(color: AppColors.textSecondary),
+        ),
+      );
+    }
+
+    final index = selectedIndex.clamp(0, files.length - 1);
+    final file = files[index];
+
+    return ListView(
+      shrinkWrap: true,
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+      children: [
+        if (files.length > 1) _versionSwitcher(index),
+        _fileSection(file),
+        ..._streamSections(file),
+        if (!file.hasDetailedStreams) _pendingNote(),
+      ],
+    );
+  }
+
+  Widget _versionSwitcher(int index) {
+    return Padding(
+      key: const Key('media-info-versions'),
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        children: [
+          for (var i = 0; i < files.length; i++)
+            _VersionChip(
+              key: Key('media-info-version-$i'),
+              label: _versionChipLabel(files[i]),
+              selected: i == index,
+              onTap: () => onSelectVersion(i),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _versionChipLabel(MediaFileInfo file) {
+    final size = formatBytes(file.sizeBytes);
+    return size == null ? file.versionLabel : '${file.versionLabel} · $size';
+  }
+
+  Widget _fileSection(MediaFileInfo file) {
+    final size = formatBytes(file.sizeBytes);
+    final duration = formatDuration(file.durationSeconds);
+    final bitrate = formatBitrate(file.bitrate);
+    final summary = <String>[
+      if (file.container != null) file.container!.toUpperCase(),
+      if (size != null) size,
+      if (duration != null) duration,
+      if (bitrate != null) bitrate,
+    ];
+
+    return _Section(
+      label: 'File',
+      children: [
+        if (file.fileName != null)
+          Text(
+            file.fileName!,
+            style: const TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 13,
+              fontFamily: 'monospace',
+            ),
+          ),
+        if (file.directory != null)
+          Text(
+            file.directory!,
+            style: const TextStyle(
+              color: AppColors.textDisabled,
+              fontSize: 12,
+              fontFamily: 'monospace',
+            ),
+          ),
+        if (summary.isNotEmpty) _DetailLine(summary.join(' · ')),
+      ],
+    );
+  }
+
+  List<Widget> _streamSections(MediaFileInfo file) {
+    final video = file.ofType(MediaStreamType.video);
+    final audio = file.ofType(MediaStreamType.audio);
+    final subtitle = file.ofType(MediaStreamType.subtitle);
+
+    return [
+      if (video.isNotEmpty)
+        _Section(
+          label: 'Video',
+          children: [for (final s in video) _StreamTile(stream: s)],
+        ),
+      if (audio.isNotEmpty)
+        _Section(
+          label:
+              'Audio · ${audio.length} ${audio.length == 1 ? 'track' : 'tracks'}',
+          children: [for (final s in audio) _StreamTile(stream: s)],
+        ),
+      if (subtitle.isNotEmpty || file.externalSubtitles.isNotEmpty)
+        _Section(
+          label: 'Subtitles',
+          children: [
+            for (final s in subtitle) _StreamTile(stream: s),
+            for (final s in file.externalSubtitles)
+              _ExternalSubtitleTile(
+                language: languageName(s.language) ?? s.language,
+                format: s.format,
+              ),
+          ],
+        ),
+    ];
+  }
+
+  Widget _pendingNote() {
+    return const Padding(
+      padding: EdgeInsets.only(top: 16),
+      child: Text(
+        kStreamsPendingMessage,
+        style:
+            TextStyle(color: AppColors.textDisabled, fontSize: 12, height: 1.5),
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  final String label;
+  final List<Widget> children;
+
+  const _Section({required this.label, required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 18),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label.toUpperCase(),
+            style: const TextStyle(
+              color: AppColors.textDisabled,
+              fontSize: 10,
+              letterSpacing: 1.6,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...children,
+        ],
+      ),
+    );
+  }
+}
+
+class _StreamTile extends StatelessWidget {
+  final MediaStream stream;
+
+  const _StreamTile({required this.stream});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              if (stream.index != null) _IndexChip(index: stream.index!),
+              Text(
+                (stream.codec ?? 'Unknown').toUpperCase(),
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              ..._flags().map((f) => _FlagChip(label: f)),
+            ],
+          ),
+          const SizedBox(height: 2),
+          for (final line in _lines()) _DetailLine(line),
+        ],
+      ),
+    );
+  }
+
+  List<String> _flags() {
+    final language = languageName(stream.language);
+    return [
+      if (language != null) language,
+      if (stream.isDefault) 'Default',
+      if (stream.isForced) 'Forced',
+      if (stream.isHearingImpaired) 'SDH',
+      if (stream.isCommentary) 'Commentary',
+    ];
+  }
+
+  List<String> _lines() {
+    switch (stream.type) {
+      case MediaStreamType.video:
+        return _videoLines();
+      case MediaStreamType.audio:
+        return _audioLines();
+      case MediaStreamType.subtitle:
+        return _subtitleLines();
+    }
+  }
+
+  List<String> _videoLines() {
+    final frameRate = formatFrameRate(stream.frameRate);
+    final geometry = <String>[
+      if (stream.width != null && stream.height != null)
+        '${stream.width} × ${stream.height}',
+      if (frameRate != null) frameRate,
+      if (stream.bitDepth != null) '${stream.bitDepth}-bit',
+    ];
+
+    final colour = <String>[
+      if (stream.colorPrimaries != null) stream.colorPrimaries!,
+      if (stream.colorTransfer != null) stream.colorTransfer!,
+      if (stream.pixelFormat != null) stream.pixelFormat!,
+    ];
+
+    final bitrate = formatBitrate(stream.bitrate);
+    return [
+      if (stream.profile != null) stream.profile!,
+      if (geometry.isNotEmpty) geometry.join(' · '),
+      if (stream.dolbyVisionProfile != null)
+        'Dolby Vision (Profile ${stream.dolbyVisionProfile})',
+      if (colour.isNotEmpty) colour.join(' · '),
+      if (bitrate != null) bitrate,
+    ];
+  }
+
+  List<String> _audioLines() {
+    final channels = formatChannels(stream.channels, stream.channelLayout);
+    final sampleRate = formatSampleRate(stream.sampleRate);
+    final bitrate = formatBitrate(stream.bitrate);
+    final parts = <String>[
+      if (channels != null) channels,
+      if (sampleRate != null) sampleRate,
+      if (stream.bitDepth != null) '${stream.bitDepth}-bit',
+      if (bitrate != null) bitrate,
+    ];
+
+    return [
+      if (stream.title != null) stream.title!,
+      if (parts.isNotEmpty) parts.join(' · '),
+    ];
+  }
+
+  List<String> _subtitleLines() {
+    const imageCodecs = {
+      'hdmv_pgs_subtitle',
+      'dvd_subtitle',
+      'dvb_subtitle',
+      'xsub'
+    };
+    final isImage = imageCodecs.contains(stream.codec?.toLowerCase());
+    return [
+      if (stream.title != null) stream.title!,
+      isImage ? 'Image based' : 'Text based',
+    ];
+  }
+}
+
+class _ExternalSubtitleTile extends StatelessWidget {
+  final String language;
+  final String format;
+
+  const _ExternalSubtitleTile({required this.language, required this.format});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 6,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Text(
+                format.toUpperCase(),
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              _FlagChip(label: language),
+              const _FlagChip(label: 'External'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DetailLine extends StatelessWidget {
+  final String text;
+
+  const _DetailLine(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        color: AppColors.textSecondary,
+        fontSize: 12,
+        height: 1.6,
+        fontFamily: 'monospace',
+      ),
+    );
+  }
+}
+
+class _IndexChip extends StatelessWidget {
+  final int index;
+
+  const _IndexChip({required this.index});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceVariant,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        '$index',
+        style: const TextStyle(color: AppColors.textDisabled, fontSize: 10),
+      ),
+    );
+  }
+}
+
+class _FlagChip extends StatelessWidget {
+  final String label;
+
+  const _FlagChip({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+      decoration: BoxDecoration(
+        border: Border.all(color: AppColors.border),
+        borderRadius: BorderRadius.circular(3),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(color: AppColors.textSecondary, fontSize: 10),
+      ),
+    );
+  }
+}
+
+class _VersionChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _VersionChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(AppTheme.radiusBadge),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primary : Colors.transparent,
+          border: Border.all(
+            color: selected ? AppColors.primary : AppColors.border,
+          ),
+          borderRadius: BorderRadius.circular(AppTheme.radiusBadge),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: selected ? AppColors.onPrimary : AppColors.textSecondary,
+            fontSize: 11,
+            fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/media_info/media_info_controller.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import '../../../core/graphql/graphql_provider.dart';
+import '../../../core/graphql/watch/schema_downgrade.dart';
 import '../../../domain/models/media_stream.dart';
 import '../../../graphql/queries/media_info.graphql.dart';
 import 'media_info_sheet.dart';
@@ -41,7 +42,12 @@ final mediaInfoProvider =
   }
 
   var result = await run(document);
-  if (result.hasException) {
+
+  // Only an unknown-field rejection means the server predates these fields.
+  // Retrying on any exception would mask a network, auth or server error by
+  // re-running the narrower query and returning partial data as if it were
+  // whole. Same gate QueryWatcher uses for its own schema downgrade.
+  if (result.hasException && isUnknownFieldError(result.exception!)) {
     result = await run(fallback);
   }
   if (result.hasException) {

--- a/player/lib/presentation/widgets/media_info/media_info_controller.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_controller.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+import '../../../core/graphql/graphql_provider.dart';
+import '../../../domain/models/media_stream.dart';
+import '../../../graphql/queries/media_info.graphql.dart';
+import 'media_info_sheet.dart';
+
+typedef MediaInfoArgs = ({String id, MediaInfoTarget target});
+
+/// Fetches the files and per-stream detail for one movie or episode.
+///
+/// A new player can meet an older self-hosted server that does not define the
+/// stream fields, so a rejected query retries once with the legacy document.
+/// The panel then shows the same "not captured yet" state it shows for a file
+/// the server-side backfill has not reached.
+final mediaInfoProvider =
+    FutureProvider.family<List<MediaFileInfo>, MediaInfoArgs>(
+        (ref, args) async {
+  final client = ref.watch(graphqlClientProvider);
+  if (client == null) {
+    throw Exception('GraphQL client not available');
+  }
+
+  final document = args.target == MediaInfoTarget.movie
+      ? documentNodeQueryMovieMediaInfo
+      : documentNodeQueryEpisodeMediaInfo;
+
+  final fallback = args.target == MediaInfoTarget.movie
+      ? documentNodeQueryMovieMediaInfoLegacy
+      : documentNodeQueryEpisodeMediaInfoLegacy;
+
+  Future<QueryResult<Object?>> run(doc) {
+    return client.query(
+      QueryOptions(
+        document: doc,
+        variables: {'id': args.id},
+        fetchPolicy: FetchPolicy.networkOnly,
+      ),
+    );
+  }
+
+  var result = await run(document);
+  if (result.hasException) {
+    result = await run(fallback);
+  }
+  if (result.hasException) {
+    throw result.exception!;
+  }
+
+  final root = args.target == MediaInfoTarget.movie ? 'movie' : 'episode';
+  final data = result.data?[root] as Map<String, dynamic>?;
+  final files = (data?['files'] as List<dynamic>? ?? const []);
+
+  return files
+      .cast<Map<String, dynamic>>()
+      .map(_fileFromJson)
+      .toList(growable: false);
+});
+
+MediaFileInfo _fileFromJson(Map<String, dynamic> json) {
+  final streams = json['streams'] as List<dynamic>?;
+
+  return MediaFileInfo(
+    id: json['id'].toString(),
+    fileName: json['fileName'] as String?,
+    directory: json['directory'] as String?,
+    container: json['container'] as String?,
+    durationSeconds: (json['duration'] as num?)?.toDouble(),
+    sizeBytes: json['size'] as int?,
+    bitrate: json['bitrate'] as int?,
+    resolution: json['resolution'] as String?,
+    codec: json['codec'] as String?,
+    streams:
+        streams?.cast<Map<String, dynamic>>().map(_streamFromJson).toList(),
+  );
+}
+
+MediaStream _streamFromJson(Map<String, dynamic> json) {
+  return MediaStream(
+    index: json['index'] as int?,
+    type: _typeFromName(json['type'] as String?),
+    codec: json['codec'] as String?,
+    codecLong: json['codecLong'] as String?,
+    profile: json['profile'] as String?,
+    level: json['level'] as int?,
+    language: json['language'] as String?,
+    title: json['title'] as String?,
+    bitrate: json['bitrate'] as int?,
+    isDefault: json['isDefault'] as bool? ?? false,
+    isForced: json['isForced'] as bool? ?? false,
+    isHearingImpaired: json['isHearingImpaired'] as bool? ?? false,
+    isCommentary: json['isCommentary'] as bool? ?? false,
+    width: json['width'] as int?,
+    height: json['height'] as int?,
+    frameRate: (json['frameRate'] as num?)?.toDouble(),
+    pixelFormat: json['pixelFormat'] as String?,
+    bitDepth: json['bitDepth'] as int?,
+    colorSpace: json['colorSpace'] as String?,
+    colorTransfer: json['colorTransfer'] as String?,
+    colorPrimaries: json['colorPrimaries'] as String?,
+    dolbyVisionProfile: json['dolbyVisionProfile'] as int?,
+    aspectRatio: json['aspectRatio'] as String?,
+    channels: json['channels'] as int?,
+    channelLayout: json['channelLayout'] as String?,
+    sampleRate: json['sampleRate'] as int?,
+  );
+}
+
+MediaStreamType _typeFromName(String? name) {
+  switch (name?.toUpperCase()) {
+    case 'AUDIO':
+      return MediaStreamType.audio;
+    case 'SUBTITLE':
+      return MediaStreamType.subtitle;
+    default:
+      return MediaStreamType.video;
+  }
+}

--- a/player/lib/presentation/widgets/media_info/media_info_sheet.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_sheet.dart
@@ -1,0 +1,266 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/layout/breakpoints.dart';
+import '../../../core/theme/colors.dart';
+import '../../../domain/models/media_stream.dart';
+import 'media_info_content.dart';
+import 'media_info_controller.dart';
+
+/// Which detail screen the panel was opened from.
+enum MediaInfoTarget { movie, episode }
+
+/// The panel body: version state plus the readout.
+///
+/// Separate from the sheet so widget tests can pump it without a navigator or
+/// a GraphQL client.
+class MediaInfoPanel extends StatefulWidget {
+  final List<MediaFileInfo> files;
+
+  const MediaInfoPanel({super.key, required this.files});
+
+  @override
+  State<MediaInfoPanel> createState() => _MediaInfoPanelState();
+}
+
+class _MediaInfoPanelState extends State<MediaInfoPanel> {
+  int _selected = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final content = MediaInfoContent(
+      files: widget.files,
+      selectedIndex: _selected,
+      onSelectVersion: (index) => setState(() => _selected = index),
+    );
+
+    // Below the desktop breakpoint the panel is a bottom sheet; at or above it
+    // is a right-hand side panel, so the backdrop and poster stay visible.
+    return Breakpoints.isDesktop(context)
+        ? _SidePanel(key: const Key('media-info-side'), child: content)
+        : _BottomPanel(key: const Key('media-info-bottom'), child: content);
+  }
+}
+
+class _BottomPanel extends StatelessWidget {
+  final Widget child;
+
+  const _BottomPanel({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.sizeOf(context).height * 0.78,
+      ),
+      decoration: const BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const _Grabber(),
+          const _PanelHeader(),
+          Flexible(child: child),
+        ],
+      ),
+    );
+  }
+}
+
+class _SidePanel extends StatelessWidget {
+  final Widget child;
+
+  const _SidePanel({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerRight,
+      child: Container(
+        width: 420,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          color: AppColors.surface,
+          border: Border(left: BorderSide(color: AppColors.border)),
+        ),
+        child: Column(
+          children: [
+            const SizedBox(height: 12),
+            const _PanelHeader(),
+            Expanded(child: child),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Grabber extends StatelessWidget {
+  const _Grabber();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 4,
+      margin: const EdgeInsets.only(top: 10, bottom: 4),
+      decoration: BoxDecoration(
+        color: AppColors.border,
+        borderRadius: BorderRadius.circular(2),
+      ),
+    );
+  }
+}
+
+class _PanelHeader extends StatelessWidget {
+  const _PanelHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(18, 6, 10, 6),
+      child: Row(
+        children: [
+          const Expanded(
+            child: Text(
+              'Media Info',
+              style: TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          IconButton(
+            key: const Key('media-info-close'),
+            icon:
+                const Icon(Icons.close_rounded, color: AppColors.textSecondary),
+            onPressed: () => Navigator.of(context).maybePop(),
+            tooltip: 'Close',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Opens the Media Info panel for a movie or episode.
+///
+/// Focus is trapped inside the panel in both layouts so TV remote navigation
+/// cannot walk out of it into the detail screen underneath.
+Future<void> showMediaInfo({
+  required BuildContext context,
+  required String id,
+  required MediaInfoTarget target,
+}) {
+  final isWide = Breakpoints.isDesktop(context);
+
+  return showGeneralDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    barrierLabel: 'Media Info',
+    barrierColor: isWide ? Colors.black26 : Colors.black54,
+    transitionDuration: const Duration(milliseconds: 220),
+    pageBuilder: (dialogContext, _, __) {
+      return FocusScope(
+        autofocus: true,
+        child: Align(
+          alignment: isWide ? Alignment.centerRight : Alignment.bottomCenter,
+          child: Consumer(
+            builder: (consumerContext, ref, _) {
+              final async =
+                  ref.watch(mediaInfoProvider((id: id, target: target)));
+
+              return async.when(
+                loading: () => const _PanelShell(
+                  child: Padding(
+                    padding: EdgeInsets.all(32),
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                ),
+                error: (_, __) => _PanelShell(
+                  child: _ErrorBody(
+                    onRetry: () => ref.invalidate(
+                      mediaInfoProvider((id: id, target: target)),
+                    ),
+                  ),
+                ),
+                data: (files) => MediaInfoPanel(files: files),
+              );
+            },
+          ),
+        ),
+      );
+    },
+    transitionBuilder: (_, animation, __, child) {
+      final begin = isWide ? const Offset(1, 0) : const Offset(0, 1);
+      return SlideTransition(
+        position: Tween<Offset>(begin: begin, end: Offset.zero).animate(
+          CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
+        ),
+        child: child,
+      );
+    },
+  );
+}
+
+class _PanelShell extends StatelessWidget {
+  final Widget child;
+
+  const _PanelShell({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final isWide = Breakpoints.isDesktop(context);
+
+    return Container(
+      width: isWide ? 420 : double.infinity,
+      height: isWide ? double.infinity : null,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: isWide
+            ? null
+            : const BorderRadius.vertical(top: Radius.circular(16)),
+        border: isWide
+            ? const Border(left: BorderSide(color: AppColors.border))
+            : null,
+      ),
+      child: Column(mainAxisSize: MainAxisSize.min, children: [
+        const _PanelHeader(),
+        child,
+      ]),
+    );
+  }
+}
+
+class _ErrorBody extends StatelessWidget {
+  final VoidCallback onRetry;
+
+  const _ErrorBody({required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(18, 8, 18, 28),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Media info could not be loaded. Check your connection to the server.',
+            style: TextStyle(
+                color: AppColors.textSecondary, fontSize: 13, height: 1.5),
+          ),
+          const SizedBox(height: 14),
+          TextButton(
+            key: const Key('media-info-retry'),
+            onPressed: onRetry,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/media_info/stream_formatters.dart
+++ b/player/lib/presentation/widgets/media_info/stream_formatters.dart
@@ -1,0 +1,119 @@
+// Formatting helpers for the Media Info panel.
+//
+// The server sends raw ffprobe values; composing them into display strings
+// happens here. Deliberately free of Flutter imports so every function is
+// unit-testable without pumping a widget.
+
+/// Human readable file size, e.g. "54.2 GB".
+String? formatBytes(int? bytes) {
+  if (bytes == null) return null;
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  var value = bytes.toDouble();
+  var unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  final decimals = unit == 0 ? 0 : 1;
+  return '${value.toStringAsFixed(decimals)} ${units[unit]}';
+}
+
+/// Human readable bitrate, e.g. "38.1 Mbps" or "768 kbps".
+String? formatBitrate(int? bitsPerSecond) {
+  if (bitsPerSecond == null) return null;
+  if (bitsPerSecond >= 1000000) {
+    return '${(bitsPerSecond / 1000000).toStringAsFixed(1)} Mbps';
+  }
+  return '${(bitsPerSecond / 1000).round()} kbps';
+}
+
+/// Duration as "2h 43m", or "42m" when under an hour.
+String? formatDuration(double? seconds) {
+  if (seconds == null) return null;
+  final total = seconds.round();
+  final hours = total ~/ 3600;
+  final minutes = (total % 3600) ~/ 60;
+  if (hours == 0) return '${minutes}m';
+  return '${hours}h ${minutes}m';
+}
+
+/// Frame rate with trailing zeros trimmed, e.g. "23.976 fps" or "24 fps".
+String? formatFrameRate(double? fps) {
+  if (fps == null) return null;
+  var text = fps.toStringAsFixed(3);
+  if (text.contains('.')) {
+    text = text.replaceAll(RegExp(r'0+$'), '').replaceAll(RegExp(r'\.$'), '');
+  }
+  return '$text fps';
+}
+
+/// Sample rate in kilohertz, e.g. "48 kHz".
+String? formatSampleRate(int? hertz) {
+  if (hertz == null) return null;
+  final khz = hertz / 1000;
+  final text = khz == khz.roundToDouble()
+      ? khz.round().toString()
+      : khz.toStringAsFixed(1);
+  return '$text kHz';
+}
+
+/// Channel layout with its count, e.g. "7.1 (8 ch)".
+String? formatChannels(int? channels, String? layout) {
+  if (layout != null && layout.isNotEmpty && channels != null) {
+    return '$layout ($channels ch)';
+  }
+  if (layout != null && layout.isNotEmpty) return layout;
+  if (channels != null) return '$channels ch';
+  return null;
+}
+
+const Map<String, String> _languageNames = {
+  'eng': 'English',
+  'en': 'English',
+  'spa': 'Spanish',
+  'es': 'Spanish',
+  'fre': 'French',
+  'fra': 'French',
+  'fr': 'French',
+  'ger': 'German',
+  'deu': 'German',
+  'de': 'German',
+  'ita': 'Italian',
+  'it': 'Italian',
+  'por': 'Portuguese',
+  'pt': 'Portuguese',
+  'rus': 'Russian',
+  'ru': 'Russian',
+  'jpn': 'Japanese',
+  'ja': 'Japanese',
+  'kor': 'Korean',
+  'ko': 'Korean',
+  'chi': 'Chinese',
+  'zho': 'Chinese',
+  'zh': 'Chinese',
+  'ara': 'Arabic',
+  'ar': 'Arabic',
+  'hin': 'Hindi',
+  'hi': 'Hindi',
+  'nld': 'Dutch',
+  'dut': 'Dutch',
+  'nl': 'Dutch',
+  'swe': 'Swedish',
+  'sv': 'Swedish',
+  'nor': 'Norwegian',
+  'no': 'Norwegian',
+  'dan': 'Danish',
+  'da': 'Danish',
+  'fin': 'Finnish',
+  'fi': 'Finnish',
+  'pol': 'Polish',
+  'pl': 'Polish',
+  'tur': 'Turkish',
+  'tr': 'Turkish',
+};
+
+/// Display name for an ISO 639 code, falling back to the upper cased code.
+String? languageName(String? code) {
+  if (code == null || code.isEmpty) return null;
+  return _languageNames[code.toLowerCase()] ?? code.toUpperCase();
+}

--- a/player/test/presentation/widgets/media_info/media_info_content_test.dart
+++ b/player/test/presentation/widgets/media_info/media_info_content_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/media_stream.dart';
+import 'package:player/presentation/widgets/media_info/media_info_content.dart';
+
+MediaFileInfo _richFile() => MediaFileInfo(
+      id: 'f1',
+      fileName: 'Blade.Runner.2049.2160p.mkv',
+      directory: '/media/movies/Blade Runner 2049 (2017)',
+      container: 'mkv',
+      durationSeconds: 9780,
+      sizeBytes: 58200000000,
+      bitrate: 47300000,
+      resolution: '2160p',
+      codec: 'hevc',
+      streams: const [
+        MediaStream(
+          index: 0,
+          type: MediaStreamType.video,
+          codec: 'hevc',
+          profile: 'Main 10',
+          width: 3840,
+          height: 2160,
+          frameRate: 23.976,
+          bitDepth: 10,
+        ),
+        MediaStream(
+          index: 1,
+          type: MediaStreamType.audio,
+          codec: 'truehd',
+          channels: 8,
+          channelLayout: '7.1',
+          language: 'eng',
+          isDefault: true,
+        ),
+        MediaStream(
+          index: 2,
+          type: MediaStreamType.subtitle,
+          codec: 'subrip',
+          language: 'spa',
+          isForced: true,
+        ),
+      ],
+    );
+
+MediaFileInfo _bareFile() => const MediaFileInfo(
+      id: 'f2',
+      fileName: 'Old.Movie.1080p.mkv',
+      resolution: '1080p',
+      codec: 'h264',
+      sizeBytes: 8400000,
+      streams: null,
+    );
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  testWidgets('renders file, video, audio and subtitle sections',
+      (tester) async {
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: [_richFile()],
+      selectedIndex: 0,
+      onSelectVersion: (_) {},
+    )));
+
+    expect(find.text('Blade.Runner.2049.2160p.mkv'), findsOneWidget);
+    expect(find.textContaining('54.2 GB'), findsOneWidget);
+    expect(find.textContaining('2h 43m'), findsOneWidget);
+    expect(find.textContaining('3840'), findsOneWidget);
+    expect(find.textContaining('23.976 fps'), findsOneWidget);
+    expect(find.textContaining('7.1 (8 ch)'), findsOneWidget);
+    expect(find.textContaining('English'), findsOneWidget);
+    expect(find.textContaining('Spanish'), findsOneWidget);
+  });
+
+  testWidgets('shows the not-yet-captured note when streams are null',
+      (tester) async {
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: [_bareFile()],
+      selectedIndex: 0,
+      onSelectVersion: (_) {},
+    )));
+
+    expect(find.text(kStreamsPendingMessage), findsOneWidget);
+    expect(find.textContaining('1080p'), findsWidgets);
+  });
+
+  testWidgets('hides the version switcher for a single file', (tester) async {
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: [_richFile()],
+      selectedIndex: 0,
+      onSelectVersion: (_) {},
+    )));
+
+    expect(find.byKey(const Key('media-info-versions')), findsNothing);
+  });
+
+  testWidgets('reports the tapped version', (tester) async {
+    var selected = -1;
+
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: [_richFile(), _bareFile()],
+      selectedIndex: 0,
+      onSelectVersion: (index) => selected = index,
+    )));
+
+    expect(find.byKey(const Key('media-info-versions')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('media-info-version-1')));
+    await tester.pumpAndSettle();
+
+    expect(selected, 1);
+  });
+}

--- a/player/test/presentation/widgets/media_info/media_info_sheet_test.dart
+++ b/player/test/presentation/widgets/media_info/media_info_sheet_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/media_stream.dart';
+import 'package:player/presentation/widgets/media_info/media_info_sheet.dart';
+
+const _file = MediaFileInfo(
+  id: 'f1',
+  fileName: 'Movie.2160p.mkv',
+  resolution: '2160p',
+  codec: 'hevc',
+  streams: [
+    MediaStream(index: 0, type: MediaStreamType.video, codec: 'hevc'),
+  ],
+);
+
+Widget _harness(Size size) {
+  return MediaQuery(
+    data: MediaQueryData(size: size),
+    child: const MaterialApp(
+      home: Scaffold(
+        body: MediaInfoPanel(files: [_file]),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('lays out as a bottom sheet below the desktop breakpoint',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_harness(const Size(390, 844)));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('media-info-bottom')), findsOneWidget);
+    expect(find.byKey(const Key('media-info-side')), findsNothing);
+  });
+
+  testWidgets('lays out as a side panel at or above the desktop breakpoint',
+      (tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_harness(const Size(1280, 800)));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('media-info-side')), findsOneWidget);
+    expect(find.byKey(const Key('media-info-bottom')), findsNothing);
+  });
+
+  testWidgets('keeps the selected version across a rebuild', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_harness(const Size(390, 844)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Movie.2160p.mkv'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/widgets/media_info/stream_formatters_test.dart
+++ b/player/test/presentation/widgets/media_info/stream_formatters_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/media_info/stream_formatters.dart';
+
+void main() {
+  group('formatBytes', () {
+    test(
+        'formats gigabytes', () => expect(formatBytes(58200000000), '54.2 GB'));
+    test('formats megabytes', () => expect(formatBytes(8400000), '8.0 MB'));
+    test('returns null for null', () => expect(formatBytes(null), isNull));
+  });
+
+  group('formatBitrate', () {
+    test(
+        'formats megabits', () => expect(formatBitrate(38100000), '38.1 Mbps'));
+    test('formats kilobits', () => expect(formatBitrate(768000), '768 kbps'));
+    test('returns null for null', () => expect(formatBitrate(null), isNull));
+  });
+
+  group('formatDuration', () {
+    test('formats hours and minutes',
+        () => expect(formatDuration(9780), '2h 43m'));
+    test('formats minutes only', () => expect(formatDuration(2520), '42m'));
+    test('returns null for null', () => expect(formatDuration(null), isNull));
+  });
+
+  group('formatFrameRate', () {
+    test('trims trailing zeros', () => expect(formatFrameRate(24.0), '24 fps'));
+    test('keeps fractional rates',
+        () => expect(formatFrameRate(23.976), '23.976 fps'));
+    test('returns null for null', () => expect(formatFrameRate(null), isNull));
+  });
+
+  group('formatSampleRate', () {
+    test('formats kilohertz', () => expect(formatSampleRate(48000), '48 kHz'));
+    test('returns null for null', () => expect(formatSampleRate(null), isNull));
+  });
+
+  group('formatChannels', () {
+    test('combines layout and count',
+        () => expect(formatChannels(8, '7.1'), '7.1 (8 ch)'));
+    test('falls back to count alone',
+        () => expect(formatChannels(2, null), '2 ch'));
+    test('returns null when both are null',
+        () => expect(formatChannels(null, null), isNull));
+  });
+
+  group('languageName', () {
+    test('maps three letter codes',
+        () => expect(languageName('eng'), 'English'));
+    test('maps two letter codes', () => expect(languageName('es'), 'Spanish'));
+    test('upper cases unknown codes', () => expect(languageName('zzz'), 'ZZZ'));
+    test('returns null for null', () => expect(languageName(null), isNull));
+  });
+}

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -598,6 +598,96 @@ type Artwork {
   thumbnailUrl: String
 }
 
+"What kind of elementary stream this is"
+enum MediaStreamType {
+  "Video stream"
+  VIDEO
+
+  "Audio stream"
+  AUDIO
+
+  "Subtitle stream"
+  SUBTITLE
+}
+
+"""
+One elementary stream of a media file, as reported by ffprobe.
+
+Values are raw. Composing display strings ("HEVC Main 10", "7.1 (8 ch)") is
+the client's job, so the same data can be formatted differently without a
+server change. Type-specific fields are null on streams of other types.
+
+The disposition fields are `isDefault` / `isForced` rather than `default` /
+`forced` because `default` is a reserved word in Dart and would make the
+player's GraphQL codegen emit invalid source.
+"""
+type MediaStream {
+  "Stream index within the container"
+  index: Int
+
+  type: MediaStreamType!
+
+  "Short codec name (e.g. hevc, truehd, subrip)"
+  codec: String
+
+  "Descriptive codec name"
+  codecLong: String
+
+  "Codec profile (e.g. Main 10)"
+  profile: String
+
+  "Codec level, as ffprobe's integer"
+  level: Int
+
+  "ISO 639-2 language code from container tags"
+  language: String
+
+  "Track title from container tags"
+  title: String
+
+  "Stream bitrate in bits per second"
+  bitrate: Int
+
+  isDefault: Boolean
+
+  isForced: Boolean
+
+  isHearingImpaired: Boolean
+
+  isCommentary: Boolean
+
+  width: Int
+
+  height: Int
+
+  "Average frame rate in frames per second"
+  frameRate: Float
+
+  pixelFormat: String
+
+  bitDepth: Int
+
+  colorSpace: String
+
+  colorTransfer: String
+
+  colorPrimaries: String
+
+  "Dolby Vision profile, when present"
+  dolbyVisionProfile: Int
+
+  "Display aspect ratio (e.g. 16:9)"
+  aspectRatio: String
+
+  channels: Int
+
+  "Channel layout (e.g. 5.1, 7.1)"
+  channelLayout: String
+
+  "Sample rate in Hz"
+  sampleRate: Int
+}
+
 "A playable video file"
 type MediaFile {
   "File ID"
@@ -620,6 +710,24 @@ type MediaFile {
 
   "Bitrate in bits per second"
   bitrate: Int
+
+  "Every video, audio and subtitle stream. Null when detailed capture has not run for this file yet."
+  streams: [MediaStream]
+
+  "File name without its directory"
+  fileName: String
+
+  "Absolute directory containing the file"
+  directory: String
+
+  "Container format (e.g. mkv, mp4)"
+  container: String
+
+  "Duration in seconds"
+  duration: Float
+
+  "Subtitle files stored alongside the media file. Unlike `subtitles`, this never probes the file."
+  externalSubtitles: [SubtitleTrack]
 
   "Whether this file can be direct played (no transcoding needed)"
   directPlaySupported: Boolean

--- a/server/crates/api/src/mapping.rs
+++ b/server/crates/api/src/mapping.rs
@@ -7,6 +7,7 @@
 //! false, because they are absent from the product rather than unfinished.
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use async_graphql::ID;
 use chrono::{DateTime, TimeZone, Utc};
@@ -122,17 +123,24 @@ pub fn media_file_from(row: &MediaFileRow, external: &[ExternalSubtitleRow]) -> 
         })
         .unwrap_or_default();
 
+    let external_tracks = || -> Vec<Option<SubtitleTrack>> {
+        external
+            .iter()
+            .map(|sub| {
+                Some(SubtitleTrack {
+                    track_id: sub.id.clone(),
+                    language: sub.language.clone(),
+                    title: external_title(&sub.language),
+                    format: sub.format.clone(),
+                    embedded: false,
+                    media_file_id: row.id.clone(),
+                })
+            })
+            .collect()
+    };
+
     // Embedded first, then external, matching extractor.ex:59.
-    tracks.extend(external.iter().map(|sub| {
-        Some(SubtitleTrack {
-            track_id: sub.id.clone(),
-            language: sub.language.clone(),
-            title: external_title(&sub.language),
-            format: sub.format.clone(),
-            embedded: false,
-            media_file_id: row.id.clone(),
-        })
-    }));
+    tracks.extend(external_tracks());
 
     MediaFile {
         id: ID(row.id.clone()),
@@ -140,6 +148,20 @@ pub fn media_file_from(row: &MediaFileRow, external: &[ExternalSubtitleRow]) -> 
         codec: row.codec.clone(),
         audio_codec: row.audio_codec.clone(),
         hdr_format: row.hdr_format.clone(),
+        file_name: Path::new(&row.path)
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned()),
+        directory: Path::new(&row.path)
+            .parent()
+            .map(|dir| dir.to_string_lossy().into_owned()),
+        container: row.container.clone(),
+        duration: row.duration_seconds,
+        // Null, not empty: the contract distinguishes "capture has not run"
+        // from "ran and found nothing", and this scanner does not persist
+        // per-stream detail yet. The player renders null as "not captured
+        // yet" and degrades cleanly, the same way `segments` does below.
+        streams: None,
+        external_subtitles: Some(external_tracks()),
         size: row.size,
         bitrate: row.bitrate.and_then(|v| i32::try_from(v).ok()),
         // Elixir hardcodes true behind a "TODO: Implement based on client

--- a/server/crates/api/src/types/common.rs
+++ b/server/crates/api/src/types/common.rs
@@ -1,11 +1,12 @@
 //! Enums, the Node interface, pagination machinery, and the shared sort
 //! input.
 //!
-//! The 16 types owned by this module (keep in sync with
+//! The 17 types owned by this module (keep in sync with
 //! tests/types_common.rs): Node, NodeEdge, NodeConnection, PageInfo,
 //! SortInput, and the enums DeviceEventType, MediaType, SearchResultType,
 //! LibraryType, SortField, SortDirection, MediaCategory, SubtitleFormat,
-//! StreamingStrategy, StreamingCandidateStrategy, SegmentType.
+//! StreamingStrategy, StreamingCandidateStrategy, SegmentType,
+//! MediaStreamType.
 
 use async_graphql::{Enum, InputObject, Interface, Object, SimpleObject, ID};
 
@@ -160,6 +161,14 @@ pub enum StreamingCandidateStrategy {
 pub enum SegmentType {
     Intro,
     Credits,
+}
+
+/// What kind of elementary stream a `MediaStream` describes.
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub enum MediaStreamType {
+    Video,
+    Audio,
+    Subtitle,
 }
 
 /// Renders just this group's types as SDL, so the group can be compared

--- a/server/crates/api/src/types/media.rs
+++ b/server/crates/api/src/types/media.rs
@@ -1,9 +1,9 @@
 //! Media-shaped types.
 //!
-//! The 17 types owned by this module (keep in sync with
+//! The 18 types owned by this module (keep in sync with
 //! tests/types_media.rs): Movie, TvShow, Season, Episode, ShowNextUp,
 //! MovieEdge, MovieConnection, TvShowEdge, TvShowConnection, Artwork,
-//! CastMember, MediaFile, MediaSegment, Progress, LibraryPath,
+//! CastMember, MediaFile, MediaStream, MediaSegment, Progress, LibraryPath,
 //! RecentlyAddedItem, SubtitleTrack.
 
 use async_graphql::{
@@ -12,8 +12,8 @@ use async_graphql::{
 use chrono::{DateTime, NaiveDate, Utc};
 
 use crate::types::common::{
-    LibraryType, MediaCategory, MediaType, Node, NodeConnection, PageInfo, SegmentType,
-    SubtitleFormat,
+    LibraryType, MediaCategory, MediaStreamType, MediaType, Node, NodeConnection, PageInfo,
+    SegmentType, SubtitleFormat,
 };
 
 #[derive(Clone)]
@@ -102,6 +102,45 @@ impl SubtitleTrack {
     }
 }
 
+/// One elementary stream of a media file, as reported by ffprobe.
+///
+/// Values are raw. Composing display strings ("HEVC Main 10", "7.1 (8 ch)") is
+/// the client's job, which keeps this type a straight mirror of the contract.
+///
+/// The disposition fields are `isDefault` / `isForced` rather than `default` /
+/// `forced`: `default` is a reserved word in Dart, and these names reach the
+/// Flutter player verbatim through GraphQL codegen.
+#[derive(SimpleObject)]
+pub struct MediaStream {
+    pub index: Option<i32>,
+    #[graphql(name = "type")]
+    pub stream_type: MediaStreamType,
+    pub codec: Option<String>,
+    pub codec_long: Option<String>,
+    pub profile: Option<String>,
+    pub level: Option<i32>,
+    pub language: Option<String>,
+    pub title: Option<String>,
+    pub bitrate: Option<i32>,
+    pub is_default: Option<bool>,
+    pub is_forced: Option<bool>,
+    pub is_hearing_impaired: Option<bool>,
+    pub is_commentary: Option<bool>,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+    pub frame_rate: Option<f64>,
+    pub pixel_format: Option<String>,
+    pub bit_depth: Option<i32>,
+    pub color_space: Option<String>,
+    pub color_transfer: Option<String>,
+    pub color_primaries: Option<String>,
+    pub dolby_vision_profile: Option<i32>,
+    pub aspect_ratio: Option<String>,
+    pub channels: Option<i32>,
+    pub channel_layout: Option<String>,
+    pub sample_rate: Option<i32>,
+}
+
 #[derive(SimpleObject)]
 pub struct MediaFile {
     pub id: ID,
@@ -109,6 +148,17 @@ pub struct MediaFile {
     pub codec: Option<String>,
     pub audio_codec: Option<String>,
     pub hdr_format: Option<String>,
+    pub file_name: Option<String>,
+    pub directory: Option<String>,
+    pub container: Option<String>,
+    pub duration: Option<f64>,
+    /// Null means detailed per-stream capture has not run for this file, which
+    /// is what the player's Media Info panel renders as "not captured yet".
+    pub streams: Option<Vec<Option<MediaStream>>>,
+    /// Sidecar subtitle files only. `subtitles` carries these too, after the
+    /// embedded tracks; this field lets a client ask for just the external ones
+    /// without the embedded half.
+    pub external_subtitles: Option<Vec<Option<SubtitleTrack>>>,
     /// Bytes. i64 rather than i32: a 4 GB film overflows 32 bits, and the
     /// contract's `Int` is Absinthe's non-spec-compliant 2^53 Int, so the
     /// Elixir server already emits real byte counts. async-graphql renders

--- a/server/crates/api/tests/types_common.rs
+++ b/server/crates/api/tests/types_common.rs
@@ -4,8 +4,8 @@
 
 use mydia_api::sdl::canonicalize;
 
-/// The 16 types owned by this group: the Node interface, the pagination
-/// machinery, the one shared input, and all 11 enums. Keep in sync with the
+/// The 17 types owned by this group: the Node interface, the pagination
+/// machinery, the one shared input, and all 12 enums. Keep in sync with the
 /// comment in src/types/common.rs.
 const OWNED: &[&str] = &[
     "Node",
@@ -24,6 +24,7 @@ const OWNED: &[&str] = &[
     "StreamingStrategy",
     "StreamingCandidateStrategy",
     "SegmentType",
+    "MediaStreamType",
 ];
 
 fn reference_sdl() -> String {

--- a/server/crates/api/tests/types_media.rs
+++ b/server/crates/api/tests/types_media.rs
@@ -2,7 +2,7 @@
 
 use mydia_api::sdl::canonicalize;
 
-/// The 17 types owned by this group. Keep in sync with the comment in
+/// The 18 types owned by this group. Keep in sync with the comment in
 /// src/types/media.rs.
 const OWNED: &[&str] = &[
     "Movie",
@@ -17,6 +17,7 @@ const OWNED: &[&str] = &[
     "Artwork",
     "CastMember",
     "MediaFile",
+    "MediaStream",
     "MediaSegment",
     "Progress",
     "LibraryPath",

--- a/test/mydia/jobs/file_analysis_test.exs
+++ b/test/mydia/jobs/file_analysis_test.exs
@@ -5,6 +5,7 @@ defmodule Mydia.Jobs.FileAnalysisTest do
   use Oban.Testing, repo: Mydia.Repo
 
   import Ecto.Query
+  import Mydia.MediaFixtures
   import Mydia.SettingsFixtures
 
   alias Mydia.Jobs.FileAnalysis
@@ -170,6 +171,71 @@ defmodule Mydia.Jobs.FileAnalysisTest do
         File.rm(shim)
         File.rm(path)
       end
+    end
+  end
+
+  describe "repair lane backfills streams" do
+    test "selects an analyzed row that has dimensions but no streams" do
+      media_file =
+        media_file_fixture(%{
+          analyzed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          codec: "h264",
+          resolution: "1080p",
+          metadata: %Mydia.Library.Structs.FileMetadata{
+            width: 1920,
+            height: 1080,
+            streams: nil
+          }
+        })
+
+      rows = FileAnalysis.repair_rows_for_test(50, 3, [])
+
+      assert Enum.any?(rows, &(&1.id == media_file.id))
+    end
+
+    test "does not select a row that already has streams" do
+      media_file =
+        media_file_fixture(%{
+          analyzed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          codec: "h264",
+          resolution: "1080p",
+          metadata: %Mydia.Library.Structs.FileMetadata{
+            width: 1920,
+            height: 1080,
+            streams: [%Mydia.Library.Structs.StreamInfo{index: 0, type: :video, codec: "h264"}]
+          }
+        })
+
+      rows = FileAnalysis.repair_rows_for_test(50, 3, [])
+
+      refute Enum.any?(rows, &(&1.id == media_file.id))
+    end
+
+    test "the repair write matches a row that has dimensions but no streams" do
+      media_file =
+        media_file_fixture(%{
+          analyzed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          codec: "h264",
+          resolution: "1080p",
+          metadata: %Mydia.Library.Structs.FileMetadata{
+            width: 1920,
+            height: 1080,
+            streams: nil
+          }
+        })
+
+      result = %Mydia.Library.Structs.FileAnalysisResult{
+        resolution: "1080p",
+        codec: "H.264",
+        width: 1920,
+        height: 1080,
+        streams: [%Mydia.Library.Structs.StreamInfo{index: 0, type: :video, codec: "h264"}]
+      }
+
+      assert :ok = Mydia.Library.apply_repair_analysis_for_test(media_file, result)
+
+      reloaded = Mydia.Library.get_media_file!(media_file.id)
+      assert [%Mydia.Library.Structs.StreamInfo{codec: "h264"}] = reloaded.metadata.streams
     end
   end
 

--- a/test/mydia/library/file_analyzer_test.exs
+++ b/test/mydia/library/file_analyzer_test.exs
@@ -255,6 +255,93 @@ defmodule Mydia.Library.FileAnalyzerTest do
     end
   end
 
+  describe "stream capture" do
+    setup do
+      target_file = write_temp_file("fake video content")
+
+      on_exit(fn ->
+        Application.delete_env(:mydia, :ffprobe_path)
+        File.rm(target_file)
+      end)
+
+      %{target_file: target_file}
+    end
+
+    test "captures every video, audio and subtitle stream", %{target_file: target_file} do
+      shim =
+        write_json_shim(~s({"streams":[
+          {"index":0,"codec_type":"video","codec_name":"hevc","width":3840,"height":2160,"avg_frame_rate":"24000/1001"},
+          {"index":1,"codec_type":"audio","codec_name":"truehd","channels":8,"tags":{"language":"eng"}},
+          {"index":2,"codec_type":"audio","codec_name":"eac3","channels":6,"tags":{"language":"eng"}},
+          {"index":3,"codec_type":"subtitle","codec_name":"subrip","tags":{"language":"spa"}}
+        ],"format":{"duration":"9780.0","format_name":"matroska"}}))
+
+      try do
+        Application.put_env(:mydia, :ffprobe_path, shim)
+
+        assert {:ok, result} = FileAnalyzer.analyze(target_file)
+        assert length(result.streams) == 4
+        assert Enum.map(result.streams, & &1.type) == [:video, :audio, :audio, :subtitle]
+        assert Enum.at(result.streams, 1).channels == 8
+        assert Enum.at(result.streams, 3).language == "spa"
+      after
+        File.rm(shim)
+      end
+    end
+
+    test "drops attachment streams", %{target_file: target_file} do
+      shim =
+        write_json_shim(~s({"streams":[
+          {"index":0,"codec_type":"video","codec_name":"h264","width":1920,"height":1080},
+          {"index":1,"codec_type":"attachment","codec_name":"ttf"}
+        ],"format":{"duration":"60.0","format_name":"matroska"}}))
+
+      try do
+        Application.put_env(:mydia, :ffprobe_path, shim)
+
+        assert {:ok, result} = FileAnalyzer.analyze(target_file)
+        assert length(result.streams) == 1
+        assert hd(result.streams).type == :video
+      after
+        File.rm(shim)
+      end
+    end
+
+    test "returns an empty list when there are no usable streams", %{target_file: target_file} do
+      shim =
+        write_json_shim(~s({"streams":[],"format":{"duration":"60.0","format_name":"matroska"}}))
+
+      try do
+        Application.put_env(:mydia, :ffprobe_path, shim)
+
+        assert {:ok, result} = FileAnalyzer.analyze(target_file)
+        assert result.streams == []
+      after
+        File.rm(shim)
+      end
+    end
+
+    test "leaves the derived flat fields unchanged", %{target_file: target_file} do
+      shim =
+        write_json_shim(~s({"streams":[
+          {"index":0,"codec_type":"video","codec_name":"h264","width":1920,"height":1080},
+          {"index":1,"codec_type":"audio","codec_name":"aac","channels":6}
+        ],"format":{"duration":"60.0","format_name":"matroska"}}))
+
+      try do
+        Application.put_env(:mydia, :ffprobe_path, shim)
+
+        assert {:ok, result} = FileAnalyzer.analyze(target_file)
+        assert result.resolution == "1080p"
+        assert result.width == 1920
+        assert result.height == 1080
+        assert result.container == "mkv"
+      after
+        File.rm(shim)
+      end
+    end
+  end
+
   defp write_temp_file(content) do
     path = Path.join(System.tmp_dir!(), "ffprobe_test_#{:rand.uniform(10_000_000)}.mkv")
     File.write!(path, content)

--- a/test/mydia/library/structs/file_metadata_test.exs
+++ b/test/mydia/library/structs/file_metadata_test.exs
@@ -1,0 +1,59 @@
+defmodule Mydia.Library.Structs.FileMetadataTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.Structs.{FileMetadata, StreamInfo}
+
+  describe "streams round trip" do
+    test "survives to_map then from_map" do
+      metadata = %FileMetadata{
+        duration: 9780.0,
+        container: "mkv",
+        streams: [
+          %StreamInfo{index: 0, type: :video, codec: "hevc", width: 3840, height: 2160},
+          %StreamInfo{index: 1, type: :audio, codec: "truehd", channels: 8, is_default: true}
+        ]
+      }
+
+      restored = metadata |> FileMetadata.to_map() |> FileMetadata.from_map()
+
+      assert restored.duration == 9780.0
+      assert restored.container == "mkv"
+      assert length(restored.streams) == 2
+      assert Enum.at(restored.streams, 0).type == :video
+      assert Enum.at(restored.streams, 0).width == 3840
+      assert Enum.at(restored.streams, 1).codec == "truehd"
+      assert Enum.at(restored.streams, 1).is_default == true
+    end
+
+    test "survives a JSON encode and decode cycle" do
+      metadata = %FileMetadata{
+        streams: [%StreamInfo{index: 0, type: :subtitle, codec: "subrip", language: "eng"}]
+      }
+
+      restored =
+        metadata
+        |> FileMetadata.to_map()
+        |> Jason.encode!()
+        |> Jason.decode!()
+        |> FileMetadata.from_map()
+
+      assert [%StreamInfo{type: :subtitle, codec: "subrip", language: "eng"}] = restored.streams
+    end
+
+    test "keeps nil distinct from an empty list" do
+      assert FileMetadata.from_map(FileMetadata.to_map(%FileMetadata{streams: nil})).streams ==
+               nil
+
+      assert FileMetadata.from_map(FileMetadata.to_map(%FileMetadata{streams: []})).streams == []
+    end
+
+    test "accepts a list of structs directly, as the analyzer supplies them" do
+      restored = FileMetadata.from_map(%{"streams" => [%StreamInfo{index: 0, type: :video}]})
+      assert [%StreamInfo{index: 0, type: :video}] = restored.streams
+    end
+
+    test "an empty metadata map still has nil streams" do
+      assert FileMetadata.empty().streams == nil
+    end
+  end
+end

--- a/test/mydia/library/structs/file_metadata_test.exs
+++ b/test/mydia/library/structs/file_metadata_test.exs
@@ -55,5 +55,26 @@ defmodule Mydia.Library.Structs.FileMetadataTest do
     test "an empty metadata map still has nil streams" do
       assert FileMetadata.empty().streams == nil
     end
+
+    test "drops malformed stream entries instead of raising" do
+      # This runs on every metadata load, so one bad entry in a hand-edited or
+      # legacy JSON column must cost that stream, not crash reads and repairs
+      # for the whole file.
+      restored =
+        FileMetadata.from_map(%{
+          "streams" => [
+            %{"type" => "video", "codec" => "h264"},
+            nil,
+            "not a stream",
+            42,
+            %{"type" => "audio", "codec" => "aac"}
+          ]
+        })
+
+      assert [
+               %StreamInfo{type: :video, codec: "h264"},
+               %StreamInfo{type: :audio, codec: "aac"}
+             ] = restored.streams
+    end
   end
 end

--- a/test/mydia/library/structs/stream_info_test.exs
+++ b/test/mydia/library/structs/stream_info_test.exs
@@ -1,0 +1,156 @@
+defmodule Mydia.Library.Structs.StreamInfoTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.Structs.StreamInfo
+
+  describe "from_ffprobe_stream/1" do
+    test "parses a video stream" do
+      stream = %{
+        "index" => 0,
+        "codec_type" => "video",
+        "codec_name" => "hevc",
+        "codec_long_name" => "H.265 / HEVC",
+        "profile" => "Main 10",
+        "level" => 153,
+        "width" => 3840,
+        "height" => 2160,
+        "avg_frame_rate" => "24000/1001",
+        "pix_fmt" => "yuv420p10le",
+        "color_space" => "bt2020nc",
+        "color_transfer" => "smpte2084",
+        "color_primaries" => "bt2020",
+        "display_aspect_ratio" => "16:9",
+        "bit_rate" => "38100000"
+      }
+
+      assert %StreamInfo{} = info = StreamInfo.from_ffprobe_stream(stream)
+      assert info.type == :video
+      assert info.index == 0
+      assert info.codec == "hevc"
+      assert info.profile == "Main 10"
+      assert info.level == 153
+      assert info.width == 3840
+      assert info.height == 2160
+      assert info.frame_rate == 23.976
+      assert info.bit_depth == 10
+      assert info.color_transfer == "smpte2084"
+      assert info.bitrate == 38_100_000
+    end
+
+    test "parses an audio stream with tags and disposition" do
+      stream = %{
+        "index" => 1,
+        "codec_type" => "audio",
+        "codec_name" => "truehd",
+        "channels" => 8,
+        "channel_layout" => "7.1",
+        "sample_rate" => "48000",
+        "bit_rate" => "6200000",
+        "tags" => %{"language" => "eng", "title" => "Atmos"},
+        "disposition" => %{"default" => 1, "comment" => 0}
+      }
+
+      assert %StreamInfo{} = info = StreamInfo.from_ffprobe_stream(stream)
+      assert info.type == :audio
+      assert info.channels == 8
+      assert info.channel_layout == "7.1"
+      assert info.sample_rate == 48_000
+      assert info.language == "eng"
+      assert info.title == "Atmos"
+      assert info.is_default == true
+      assert info.is_commentary == false
+    end
+
+    test "reads uppercase Matroska tag keys" do
+      stream = %{
+        "index" => 2,
+        "codec_type" => "subtitle",
+        "codec_name" => "subrip",
+        "tags" => %{"LANGUAGE" => "spa", "TITLE" => "Spanish"}
+      }
+
+      info = StreamInfo.from_ffprobe_stream(stream)
+      assert info.language == "spa"
+      assert info.title == "Spanish"
+    end
+
+    test "extracts the Dolby Vision profile from side data" do
+      stream = %{
+        "index" => 0,
+        "codec_type" => "video",
+        "codec_name" => "hevc",
+        "side_data_list" => [
+          %{"side_data_type" => "DOVI configuration record", "dv_profile" => 7}
+        ]
+      }
+
+      assert StreamInfo.from_ffprobe_stream(stream).dolby_vision_profile == 7
+    end
+
+    test "scrubs invalid UTF-8 out of titles" do
+      stream = %{
+        "index" => 1,
+        "codec_type" => "audio",
+        "codec_name" => "aac",
+        "tags" => %{"title" => <<"Commentary ", 0xFF, 0xFE>>}
+      }
+
+      title = StreamInfo.from_ffprobe_stream(stream).title
+      assert String.valid?(title)
+      assert String.starts_with?(title, "Commentary ")
+    end
+
+    test "returns nil for a malformed frame rate rather than raising" do
+      stream = %{
+        "index" => 0,
+        "codec_type" => "video",
+        "codec_name" => "h264",
+        "avg_frame_rate" => "0/0"
+      }
+
+      assert StreamInfo.from_ffprobe_stream(stream).frame_rate == nil
+    end
+
+    test "falls back to 8-bit depth for an 8-bit pixel format" do
+      stream = %{"index" => 0, "codec_type" => "video", "pix_fmt" => "yuv420p"}
+      assert StreamInfo.from_ffprobe_stream(stream).bit_depth == 8
+    end
+
+    test "drops attachment and data streams" do
+      assert StreamInfo.from_ffprobe_stream(%{"codec_type" => "attachment"}) == nil
+      assert StreamInfo.from_ffprobe_stream(%{"codec_type" => "data"}) == nil
+      assert StreamInfo.from_ffprobe_stream(%{}) == nil
+    end
+  end
+
+  describe "to_map/1 and from_map/1" do
+    test "round-trips through string-keyed maps" do
+      original = %StreamInfo{
+        index: 1,
+        type: :audio,
+        codec: "eac3",
+        channels: 6,
+        channel_layout: "5.1",
+        is_default: false,
+        is_forced: false
+      }
+
+      assert original |> StreamInfo.to_map() |> StreamInfo.from_map() == original
+    end
+
+    test "to_map drops nil fields but keeps false booleans" do
+      map = StreamInfo.to_map(%StreamInfo{index: 0, type: :video, is_default: false})
+
+      refute Map.has_key?(map, "width")
+      refute Map.has_key?(map, "language")
+      assert map["type"] == "video"
+      assert map["is_default"] == false
+    end
+
+    test "from_map ignores unknown keys" do
+      info = StreamInfo.from_map(%{"type" => "video", "codec" => "av1", "bogus" => 1})
+      assert info.type == :video
+      assert info.codec == "av1"
+    end
+  end
+end

--- a/test/mydia_web/schema/media_stream_test.exs
+++ b/test/mydia_web/schema/media_stream_test.exs
@@ -1,0 +1,106 @@
+defmodule MydiaWeb.Schema.MediaStreamTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Library.Structs.{FileMetadata, StreamInfo}
+
+  @query """
+  query ($id: ID!) {
+    movie(id: $id) {
+      files {
+        fileName
+        container
+        duration
+        streams {
+          index
+          type
+          codec
+          width
+          height
+          frameRate
+          channels
+          channelLayout
+          isDefault
+          language
+        }
+      }
+    }
+  }
+  """
+
+  setup %{conn: conn} do
+    {user, token} = create_user_and_token()
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> put_req_header("content-type", "application/json")
+
+    %{conn: conn, user: user}
+  end
+
+  test "resolves streams from persisted metadata", %{conn: conn} do
+    movie = media_item_fixture(%{type: "movie"})
+
+    media_file_fixture(%{
+      media_item_id: movie.id,
+      relative_path: "Blade Runner 2049.mkv",
+      metadata: %FileMetadata{
+        container: "mkv",
+        duration: 9780.0,
+        streams: [
+          %StreamInfo{
+            index: 0,
+            type: :video,
+            codec: "hevc",
+            width: 3840,
+            height: 2160,
+            frame_rate: 23.976
+          },
+          %StreamInfo{
+            index: 1,
+            type: :audio,
+            codec: "truehd",
+            channels: 8,
+            channel_layout: "7.1",
+            is_default: true,
+            language: "eng"
+          }
+        ]
+      }
+    })
+
+    conn = post(conn, "/api/graphql", %{query: @query, variables: %{"id" => movie.id}})
+    %{"data" => %{"movie" => %{"files" => [file]}}} = json_response(conn, 200)
+
+    assert file["fileName"] == "Blade Runner 2049.mkv"
+    assert file["container"] == "mkv"
+    assert file["duration"] == 9780.0
+
+    [video, audio] = file["streams"]
+    assert video["type"] == "VIDEO"
+    assert video["codec"] == "hevc"
+    assert video["width"] == 3840
+    assert video["frameRate"] == 23.976
+    assert audio["type"] == "AUDIO"
+    assert audio["channelLayout"] == "7.1"
+    assert audio["isDefault"] == true
+    assert audio["language"] == "eng"
+  end
+
+  test "returns null streams when capture has never run", %{conn: conn} do
+    movie = media_item_fixture(%{type: "movie"})
+
+    media_file_fixture(%{
+      media_item_id: movie.id,
+      relative_path: "Old Movie.mkv",
+      metadata: %FileMetadata{width: 1920, height: 1080, streams: nil}
+    })
+
+    conn = post(conn, "/api/graphql", %{query: @query, variables: %{"id" => movie.id}})
+    %{"data" => %{"movie" => %{"files" => [file]}}} = json_response(conn, 200)
+
+    assert file["streams"] == nil
+  end
+end


### PR DESCRIPTION
Adds a Plex-style Media Info panel to the Flutter player: a full per-stream readout of a media file, opened from movie and episode detail screens.

Most of the work is backend data capture. `FileAnalyzer` already ran `ffprobe -show_format -show_streams` and kept only the first video and first audio stream, discarding the rest. This captures all of them.

## What changed

**Capture and persistence**

- New `Mydia.Library.Structs.StreamInfo`: one elementary stream as ffprobe reports it. Attachment and data streams (embedded fonts, timecode tracks) are dropped.
- `FileAnalyzer` maps every video, audio, and subtitle stream. The ffprobe invocation is unchanged: `-show_streams` already returned `tags`, `disposition`, and `side_data_list`, so Dolby Vision profile detection needed parsing, not a new flag.
- Streams persist as a nested list in the existing `media_files.metadata` JSON. No migration.
- The derived flat fields (`resolution`, `codec`, `audio_codec`, `hdr_format`, `bitrate`, `width`, `height`) are untouched, so quality profiles, `Mydia.Upgrades.Attrs`, and streaming compatibility checks see no behavior change.

**Backfill**

Existing libraries fill in through `Mydia.Jobs.FileAnalysis`'s existing repair lane, which uses spare batch capacity to re-probe already-analyzed rows missing newer metadata. No new job, no operator action.

Three gates had to widen together: the SQL prefilter in `fetch_repair_rows/3`, `repair_candidate?/1`, and the optimistic-concurrency `WHERE` in `apply_repair_analysis/3`. If the last one had been missed, the lane would select rows, run ffprobe, write nothing, and repeat forever with no error surfaced. A test asserts the write matches a row, not just that selection picks it up.

`streams` is `nil` when capture has never run and `[]` when it ran and found nothing, which is what stops a pathological file being re-probed on every tick.

**GraphQL**

- `MediaStream` type and `MediaStreamType` enum. `MediaFile.streams` resolves straight from persisted metadata with no filesystem access.
- New `MediaFile` fields the panel needs: `fileName`, `directory`, `container`, `duration`.
- `MediaFile.externalSubtitles` reads the database only, so the panel never triggers the live ffprobe that the existing `subtitles` field performs. `subtitles` is unchanged, since playback needs live track indices to extract by.
- Disposition fields are `isDefault` / `isForced` rather than `default` / `forced`: `default` is a reserved word in Dart and would make the player's codegen emit invalid source.

**Player**

- `MediaInfoContent` is container-agnostic, so the same widget serves the bottom sheet, the wide-screen side panel, and a future live playback overlay.
- Bottom sheet below 900px, right-side panel at or above, using the existing `Breakpoints.isDesktop` threshold.
- Version switcher for items with more than one file.
- `stream_formatters.dart` has no Flutter imports, so byte sizes, bitrates, frame rates, channel layouts, sample rates, and language names are unit-tested as plain functions.
- The queries ship legacy fallback documents. The player updates independently of the self-hosted server, so a new player can meet a server without these fields; it then degrades into the same "not captured yet" state rather than erroring.

## Behavior on upgrade

Every file in every existing library starts with no captured streams. That is a normal state, not an error: the panel shows what it has and notes that detailed information has not been captured yet, then fills in on its own as the repair lane works through the library.

## Testing

- `mix precommit`: 6858 tests, 0 failures, plus format, Credo, unused deps.
- `flutter test --concurrency=1`: 2015 tests, all passing.
- The repair-lane changes were verified on PostgreSQL as well as SQLite, since `Mydia.DB.json_extract/2` compiles to different SQL per adapter and three queries using it changed.

## Still needs a human

- Opening the panel on a real multi-track MKV with both text and image subtitles.
- Watching a pre-existing library backfill, confirming the worker does not keep re-probing files it has already filled in.
