### PR TITLE
fix(downloads): stop auto-rejecting healthy qBittorrent downloads in a loop

### DIFF
--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -97,6 +97,11 @@ defmodule Mydia.Config.Schema do
       # inserted without an explicit `expires_at`. See `Mydia.Downloads.Blacklists`
       # (#123).
       field :release_blacklist_default_ttl_days, :integer, default: 30
+      # How many consecutive system auto-rejections (see
+      # Mydia.Jobs.DownloadMonitor) one media item may accrue before Mydia
+      # stops auto-rejecting it. Bounds a systematic false positive to this
+      # many releases instead of the item's entire search result set.
+      field :auto_reject_limit, :integer, default: 3
     end
 
     embeds_one :upgrades, Upgrades, on_replace: :update, primary_key: false do
@@ -350,9 +355,14 @@ defmodule Mydia.Config.Schema do
 
   defp downloads_changeset(schema, attrs) do
     schema
-    |> cast(attrs, [:monitor_interval_minutes, :release_blacklist_default_ttl_days])
+    |> cast(attrs, [
+      :monitor_interval_minutes,
+      :release_blacklist_default_ttl_days,
+      :auto_reject_limit
+    ])
     |> validate_number(:monitor_interval_minutes, greater_than: 0)
     |> validate_number(:release_blacklist_default_ttl_days, greater_than: 0)
+    |> validate_number(:auto_reject_limit, greater_than: 0)
   end
 
   defp upgrades_changeset(schema, attrs) do

--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -129,6 +129,8 @@ defmodule Mydia.Downloads do
   @spec update_download(Download.t(), map()) :: {:ok, Download.t()} | {:error, Ecto.Changeset.t()}
   defdelegate update_download(download, attrs), to: Mydia.Downloads.History
 
+  defdelegate mark_content_checked(ids), to: Mydia.Downloads.History
+
   @doc """
   Lists failed path-mapping-mismatch downloads whose reported path is at or under
   the given remote prefix (the apply-mapping fan-out set).

--- a/lib/mydia/downloads/client.ex
+++ b/lib/mydia/downloads/client.ex
@@ -302,6 +302,25 @@ defmodule Mydia.Downloads.Client do
   """
   @callback supported_protocols() :: [protocol(), ...]
 
+  @doc """
+  Lists the individual files belonging to a torrent.
+
+  Unlike `DownloadStatus.files`, which is a *scoping* path that may be a
+  single directory (qBittorrent and rtorrent both report one), this returns a
+  complete leaf-level enumeration: one entry per real file. Entries are
+  absolute paths.
+
+  Optional. Adapters that cannot enumerate a torrent's contents simply do not
+  implement it, and the facade reports `{:error, :unsupported}` on their
+  behalf. Callers MUST treat `:unsupported` and `{:ok, []}` as "unknown" and
+  never as "this torrent has no files": an empty list from a torrent client
+  normally means metadata has not resolved yet.
+  """
+  @callback list_files(config(), client_id :: String.t()) ::
+              {:ok, [String.t()]} | {:error, :unsupported | Error.t() | term()}
+
+  @optional_callbacks list_files: 2
+
   ## Convenience Functions
 
   # Adapter resolution flows through Client.Registry.lookup/1, which returns nil
@@ -383,5 +402,23 @@ defmodule Mydia.Downloads.Client do
 
   def resume_torrent(adapter, config, client_id) when is_atom(adapter) do
     adapter.resume_torrent(config, client_id)
+  end
+
+  @doc """
+  Lists a torrent's individual files using the specified adapter.
+
+  Returns `{:error, :unsupported}` for adapters that do not implement the
+  optional `c:list_files/2` callback, so a caller never has to know which
+  adapters can enumerate. See the `no_adapter_error/0` comment above for why
+  the nil clause exists.
+  """
+  def list_files(nil, _config, _client_id), do: no_adapter_error()
+
+  def list_files(adapter, config, client_id) when is_atom(adapter) do
+    if Code.ensure_loaded?(adapter) and function_exported?(adapter, :list_files, 2) do
+      adapter.list_files(config, client_id)
+    else
+      {:error, :unsupported}
+    end
   end
 end

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -168,6 +168,18 @@ defmodule Mydia.Downloads.Client.QBittorrent do
   end
 
   @impl true
+  def list_files(config, client_id) do
+    with_authenticated_session(config, fn req ->
+      with {:ok, info_response} <- get_info(req, hashes: client_id),
+           {:ok, save_path} <- save_path_from_info(info_response.body),
+           {:ok, files_response} <-
+             authed_request(req, :get, "/api/v2/torrents/files", params: [hash: client_id]) do
+        parse_file_entries(save_path, files_response.body)
+      end
+    end)
+  end
+
+  @impl true
   def remove_torrent(config, client_id, opts \\ []) do
     delete_files = Keyword.get(opts, :delete_files, false)
     body = %{hashes: client_id, deleteFiles: to_string(delete_files)}
@@ -580,6 +592,26 @@ defmodule Mydia.Downloads.Client.QBittorrent do
   end
 
   defp content_files(_save_path, _content_path), do: nil
+
+  # /torrents/info is hit first purely for `save_path`: /torrents/files reports
+  # each `name` relative to it, and the callback contract promises absolute
+  # paths. Both requests share one authenticated session.
+  defp save_path_from_info([torrent | _]), do: {:ok, torrent["save_path"] || ""}
+  defp save_path_from_info([]), do: {:error, Error.not_found("Torrent not found")}
+  defp save_path_from_info(_other), do: {:error, Error.parse_error("Unexpected response body")}
+
+  defp parse_file_entries(save_path, entries) when is_list(entries) do
+    paths =
+      entries
+      |> Enum.map(& &1["name"])
+      |> Enum.filter(&(is_binary(&1) and &1 != ""))
+      |> Enum.map(&Path.join(save_path, &1))
+
+    {:ok, paths}
+  end
+
+  defp parse_file_entries(_save_path, _other),
+    do: {:error, Error.parse_error("Unexpected /torrents/files response body")}
 
   # State mappings. Unknown / unrecognised states deliberately fall through to
   # :checking (transient) rather than :error, because DownloadMonitor deletes

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -596,7 +596,20 @@ defmodule Mydia.Downloads.Client.QBittorrent do
   # /torrents/info is hit first purely for `save_path`: /torrents/files reports
   # each `name` relative to it, and the callback contract promises absolute
   # paths. Both requests share one authenticated session.
-  defp save_path_from_info([torrent | _]), do: {:ok, torrent["save_path"] || ""}
+  # A blank save_path is an error rather than a "" default: `Path.join("", name)`
+  # yields a RELATIVE path, and the callback contract promises absolute ones.
+  # Erroring makes the caller treat the torrent as unevaluated, which is the
+  # safe direction, instead of silently handing back paths of the wrong kind.
+  defp save_path_from_info([torrent | _]) do
+    case torrent["save_path"] do
+      path when is_binary(path) and path != "" ->
+        {:ok, path}
+
+      _blank ->
+        {:error, Error.parse_error("Torrent reported no save_path")}
+    end
+  end
+
   defp save_path_from_info([]), do: {:error, Error.not_found("Torrent not found")}
   defp save_path_from_info(_other), do: {:error, Error.parse_error("Unexpected response body")}
 

--- a/lib/mydia/downloads/client/rqbit.ex
+++ b/lib/mydia/downloads/client/rqbit.ex
@@ -149,10 +149,11 @@ defmodule Mydia.Downloads.Client.Rqbit do
   @impl true
   def list_files(config, client_id) do
     # `resolve_torrent_files/2` already produces a genuine leaf enumeration
-    # from torrent-get's `files` array, so `get_status/2` is the single source
-    # of truth here. `files` is nil when the client reported none yet, which
-    # the callback contract represents as an empty list ("unknown"), never as
-    # "this torrent is empty".
+    # from the torrent details endpoint's `files` array (joining each entry's
+    # `name`/`components` onto `output_folder` and skipping `included: false`
+    # entries), so `get_status/2` is the single source of truth here. `files`
+    # is nil when the client reported none yet, which the callback contract
+    # represents as an empty list ("unknown"), never as "this torrent is empty".
     case get_status(config, client_id) do
       {:ok, %DownloadStatus{files: files}} when is_list(files) -> {:ok, files}
       {:ok, %DownloadStatus{}} -> {:ok, []}

--- a/lib/mydia/downloads/client/rqbit.ex
+++ b/lib/mydia/downloads/client/rqbit.ex
@@ -147,6 +147,20 @@ defmodule Mydia.Downloads.Client.Rqbit do
   end
 
   @impl true
+  def list_files(config, client_id) do
+    # `resolve_torrent_files/2` already produces a genuine leaf enumeration
+    # from torrent-get's `files` array, so `get_status/2` is the single source
+    # of truth here. `files` is nil when the client reported none yet, which
+    # the callback contract represents as an empty list ("unknown"), never as
+    # "this torrent is empty".
+    case get_status(config, client_id) do
+      {:ok, %DownloadStatus{files: files}} when is_list(files) -> {:ok, files}
+      {:ok, %DownloadStatus{}} -> {:ok, []}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
   def remove_torrent(config, client_id, opts \\ []) do
     req = HTTP.new_request(config)
     action = if Keyword.get(opts, :delete_files, false), do: "delete", else: "forget"

--- a/lib/mydia/downloads/client/transmission.ex
+++ b/lib/mydia/downloads/client/transmission.ex
@@ -223,6 +223,20 @@ defmodule Mydia.Downloads.Client.Transmission do
   end
 
   @impl true
+  def list_files(config, client_id) do
+    # `resolve_torrent_files/2` already produces a genuine leaf enumeration
+    # from torrent-get's `files` array, so `get_status/2` is the single source
+    # of truth here. `files` is nil when the client reported none yet, which
+    # the callback contract represents as an empty list ("unknown"), never as
+    # "this torrent is empty".
+    case get_status(config, client_id) do
+      {:ok, %DownloadStatus{files: files}} when is_list(files) -> {:ok, files}
+      {:ok, %DownloadStatus{}} -> {:ok, []}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
   def remove_torrent(config, client_id, opts \\ []) do
     # client_id is the torrent hash string
     torrent_id = parse_torrent_id(client_id)

--- a/lib/mydia/downloads/download.ex
+++ b/lib/mydia/downloads/download.ex
@@ -32,6 +32,7 @@ defmodule Mydia.Downloads.Download do
           last_observed_at: DateTime.t() | nil,
           stalled_since: DateTime.t() | nil,
           bytes_pulled: integer() | nil,
+          content_checked_at: DateTime.t() | nil,
           media_item: Mydia.Media.MediaItem.t() | Ecto.Association.NotLoaded.t(),
           episode: Mydia.Media.Episode.t() | nil | Ecto.Association.NotLoaded.t(),
           library_path: Mydia.Settings.LibraryPath.t() | nil | Ecto.Association.NotLoaded.t(),
@@ -85,6 +86,12 @@ defmodule Mydia.Downloads.Download do
     # in `Fetcher.init/1` knows where to resume after a crash. Nil for adapters
     # that don't perform a local pull.
     field :bytes_pulled, :integer
+
+    # Set once DownloadMonitor has successfully enumerated this torrent's
+    # files for the pre-completion content check. Nil means "not yet
+    # evaluated"; once set, the enumeration is never repeated. See
+    # Mydia.Jobs.DownloadMonitor.evaluate_content/1.
+    field :content_checked_at, :utc_datetime
 
     belongs_to :media_item, Mydia.Media.MediaItem
     belongs_to :episode, Mydia.Media.Episode
@@ -153,7 +160,8 @@ defmodule Mydia.Downloads.Download do
       :last_known_bytes,
       :last_observed_at,
       :stalled_since,
-      :bytes_pulled
+      :bytes_pulled,
+      :content_checked_at
     ])
     |> validate_required([:title])
     |> validate_inclusion(:match_status, ["unresolved_files", "partial_pack"])

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -236,6 +236,24 @@ defmodule Mydia.Downloads.History do
   end
 
   @doc """
+  Stamps `content_checked_at` on the given downloads.
+
+  Called by `Mydia.Jobs.DownloadMonitor` once a torrent's file list has been
+  successfully enumerated, so the enumeration is never repeated for that
+  download. A no-op for an empty list.
+  """
+  @spec mark_content_checked([binary()]) :: {integer(), nil}
+  def mark_content_checked([]), do: {0, nil}
+
+  def mark_content_checked(ids) when is_list(ids) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Download
+    |> where([d], d.id in ^ids)
+    |> Repo.update_all(set: [content_checked_at: now])
+  end
+
+  @doc """
   Lists failed downloads classified as a path-mapping mismatch whose reported
   path is at or under `remote_prefix`. Used to fan out an applied mapping to
   every affected download.
@@ -567,6 +585,7 @@ defmodule Mydia.Downloads.History do
       import_reported_path: download.import_reported_path,
       import_next_retry_at: download.import_next_retry_at,
       import_failed_at: download.import_failed_at,
+      content_checked_at: download.content_checked_at,
       last_progress_at: download.last_progress_at,
       last_known_bytes: download.last_known_bytes,
       last_observed_at: download.last_observed_at,
@@ -615,6 +634,7 @@ defmodule Mydia.Downloads.History do
       import_reported_path: download.import_reported_path,
       import_next_retry_at: download.import_next_retry_at,
       import_failed_at: download.import_failed_at,
+      content_checked_at: download.content_checked_at,
       last_progress_at: download.last_progress_at,
       last_known_bytes: download.last_known_bytes,
       # Carry the persisted stall state through an outage. The soft-stall badge
@@ -687,6 +707,7 @@ defmodule Mydia.Downloads.History do
       import_reported_path: download.import_reported_path,
       import_next_retry_at: download.import_next_retry_at,
       import_failed_at: download.import_failed_at,
+      content_checked_at: download.content_checked_at,
       last_progress_at: download.last_progress_at,
       last_known_bytes: download.last_known_bytes,
       last_observed_at: download.last_observed_at,

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -911,6 +911,21 @@ defmodule Mydia.Downloads.Queue do
     end
   end
 
+  @doc false
+  # Resolves a client name to {adapter, config_map}. Public so callers outside
+  # this module (Mydia.Jobs.DownloadMonitor) can talk to a download client
+  # without duplicating the config lookup, adapter lookup and config_to_map
+  # conversion for a sixth time.
+  @spec resolve_adapter(String.t() | nil) :: {:ok, module(), map()} | {:error, term()}
+  def resolve_adapter(nil), do: {:error, :no_client}
+
+  def resolve_adapter(client_name) do
+    with {:ok, client_config} <- find_client_config(client_name),
+         {:ok, adapter} <- get_adapter_for_client(client_config) do
+      {:ok, adapter, config_to_map(client_config)}
+    end
+  end
+
   # Selects appropriate client and adds the download, with smart fallback if type is detected
   @doc false
   # Public so Mydia.Downloads.Grabber can reuse the fetch/select/add pipeline.

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -142,13 +142,21 @@ defmodule Mydia.Downloads.Queue do
   The blacklist write happens first: if a later step fails, the release must
   still not be re-grabbed. Client removal is best effort, since the torrent may
   already be gone.
+
+  Accepts `:failure_reason` (default `"rejected_by_user"`) so a system-initiated
+  rejection is distinguishable from an operator's in `release_blacklist`.
   """
   @spec reject_release(Download.t(), keyword()) ::
           {:ok, :rejected} | {:error, :no_indexer | :no_guid | term()}
   def reject_release(%Download{} = download, opts \\ []) do
     with {:ok, indexer, guid} <- Blacklists.extract_key(download),
          {:ok, _row} <-
-           Blacklists.add(indexer, guid, download.title || "Unknown release", "rejected_by_user") do
+           Blacklists.add(
+             indexer,
+             guid,
+             download.title || "Unknown release",
+             Keyword.get(opts, :failure_reason, "rejected_by_user")
+           ) do
       # Computed before deletion: it reads through the media_item association.
       search = replacement_search(download)
 

--- a/lib/mydia/downloads/structs/download_status.ex
+++ b/lib/mydia/downloads/structs/download_status.ex
@@ -52,11 +52,16 @@ defmodule Mydia.Downloads.Structs.DownloadStatus do
     # classify their failures. See `Mydia.Downloads.Client.FailureCategory`.
     :failure_category,
     :failure_detail,
-    # Absolute paths of files that belong to THIS torrent/NZB only.
-    # When present and non-empty, MediaImport must import these paths
-    # instead of recursively listing `save_path` — clients like rqbit
-    # often share one output folder across many torrents, and a recursive
-    # listing would cross-contaminate series libraries.
+    # A path that scopes THIS torrent/NZB's data, so MediaImport can import it
+    # instead of recursively listing `save_path` (clients like rqbit share one
+    # output folder across many torrents, and a recursive listing would
+    # cross-contaminate libraries).
+    #
+    # NOT a reliable file listing. Transmission and rqbit populate it with
+    # real leaf paths, but qBittorrent reports a single `content_path` and
+    # rtorrent a single `base_path`, either of which is usually the torrent's
+    # root DIRECTORY. Anything that needs to know what is actually inside a
+    # torrent must use `Mydia.Downloads.Client.list_files/3` instead.
     files: nil
   ]
 

--- a/lib/mydia/downloads/structs/enriched_download.ex
+++ b/lib/mydia/downloads/structs/enriched_download.ex
@@ -66,6 +66,9 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
     :import_reported_path,
     :import_next_retry_at,
     :import_failed_at,
+    # Set once DownloadMonitor has enumerated this torrent's files for the
+    # pre-completion content check. Nil means not yet evaluated.
+    :content_checked_at,
     # Issues-tab path-mapping enrichment (computed in the LiveView; nil otherwise)
     :path_mapping_suggestion,
     :path_mapping_affected_count,
@@ -144,6 +147,7 @@ defmodule Mydia.Downloads.Structs.EnrichedDownload do
           import_reported_path: String.t() | nil,
           import_next_retry_at: DateTime.t() | nil,
           import_failed_at: DateTime.t() | nil,
+          content_checked_at: DateTime.t() | nil,
           path_mapping_suggestion: map() | nil,
           path_mapping_affected_count: integer() | nil,
           last_progress_at: DateTime.t() | nil,

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -863,6 +863,43 @@ defmodule Mydia.Events do
   end
 
   @doc """
+  Records that Mydia declined to auto-reject a download because the media item
+  had already hit `downloads.auto_reject_limit`.
+
+  When the cap trips, the likely truth is that our own content detection is
+  wrong and the torrent is fine, so the download is left alone to finish and
+  import. This event is the operator's record that the detector misfired.
+  """
+  def download_auto_reject_suppressed(download, opts \\ []) do
+    media_item = opts[:media_item]
+
+    {resource_type, resource_id} =
+      if media_item do
+        {"media_item", media_item.id}
+      else
+        {"download", download.id}
+      end
+
+    metadata =
+      %{
+        "title" => download.title,
+        "download_client" => download.download_client,
+        "download_id" => download.id
+      }
+      |> maybe_add_media_context(media_item)
+
+    create_event_async(%{
+      category: "downloads",
+      type: "download.auto_reject_suppressed",
+      actor_type: :system,
+      actor_id: "download_monitor",
+      resource_type: resource_type,
+      resource_id: resource_id,
+      metadata: metadata
+    })
+  end
+
+  @doc """
   Records a download.cleared event.
 
   This event is recorded when a user explicitly clears a completed download

--- a/lib/mydia/events/presentation.ex
+++ b/lib/mydia/events/presentation.ex
@@ -146,6 +146,12 @@ defmodule Mydia.Events.Presentation do
       title: "Download recovered"
     },
     %{
+      type: "download.auto_reject_suppressed",
+      icon: "hero-shield-exclamation",
+      color: "text-warning",
+      title: "Auto-reject suppressed"
+    },
+    %{
       type: "download.cleared",
       icon: "hero-archive-box-x-mark",
       color: "text-base-content/60",
@@ -359,6 +365,7 @@ defmodule Mydia.Events.Presentation do
   @plain_download_types ~w(
     download.initiated download.completed download.cancelled
     download.paused download.resumed download.unstalled
+    download.auto_reject_suppressed
   )
 
   def detail(%Event{type: type, metadata: metadata}) when type in @plain_download_types,

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -53,6 +53,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   require Logger
   alias Mydia.Downloads
   alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.Client
   alias Mydia.Downloads.ClientAdoption
   alias Mydia.Downloads.Client.FailureCategory
   alias Mydia.Downloads.ImportCandidates
@@ -174,9 +175,8 @@ defmodule Mydia.Jobs.DownloadMonitor do
     # torrent (a single disguised .exe with no video file at all) from
     # pulling its full multi-hundred-MB-to-multi-GB payload just to be
     # thrown away by the post-completion importer.
-    bad_content =
-      Enum.filter(active_for_stall_check, fn d -> is_list(d.files) and d.files != [] end)
-      |> Enum.reject(&any_importable_file?/1)
+    {bad_content, content_checked_ids} = evaluate_content(active_for_stall_check)
+    Downloads.mark_content_checked(content_checked_ids)
 
     active_for_stall_check = active_for_stall_check -- bad_content
 
@@ -369,15 +369,54 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
   # --- Pre-completion content check --------------------------------------
 
-  # `downloads.media_item_id` only ever points at a `movie` or `tv_show`
-  # media item (the only two `MediaItem.valid_types/0`), so every download
-  # reaching this check wants a video file regardless of which of the two it
-  # is — `ImportCandidates.importable?/2` treats `:movies`/`:series`/`:mixed`
-  # identically. Passing `:series` unconditionally is exact, not a guess.
-  defp any_importable_file?(%{files: files}) do
-    Enum.any?(files, fn path ->
-      ImportCandidates.importable?(%{name: Path.basename(path)}, :series)
+  # Decides which active downloads hold nothing importable, and which ones we
+  # managed to evaluate at all.
+  #
+  # This deliberately does NOT read `DownloadStatus.files`. That field is an
+  # import-*scoping* path and qBittorrent and rtorrent both report a single
+  # entry that is the torrent's root DIRECTORY, whose extension
+  # (`.x264-YTS`, or none at all) is never a video extension. Judging content
+  # from it rejected every multi-file qBittorrent torrent mid-download,
+  # blacklisted the release, deleted the data and grabbed a replacement that
+  # met the same fate. `Client.list_files/3` is the enumeration contract:
+  # adapters that cannot enumerate report `:unsupported` and are skipped.
+  #
+  # `{:error, _}` and `{:ok, []}` both mean "we do not know". An empty list
+  # from a torrent client means metadata has not resolved yet, never that the
+  # torrent is empty, so neither is stamped and both are retried next poll.
+  defp evaluate_content(candidates) do
+    Enum.reduce(candidates, {[], []}, fn download_map, {bad, checked} ->
+      if download_map.content_checked_at do
+        {bad, checked}
+      else
+        case enumerate_files(download_map) do
+          {:ok, [_ | _] = files} ->
+            if Enum.any?(files, &importable_path?/1) do
+              {bad, [download_map.id | checked]}
+            else
+              {[download_map | bad], [download_map.id | checked]}
+            end
+
+          _unknown ->
+            {bad, checked}
+        end
+      end
     end)
+  end
+
+  defp enumerate_files(download_map) do
+    with {:ok, adapter, config} <- Queue.resolve_adapter(download_map.download_client) do
+      Client.list_files(adapter, config, download_map.download_client_id)
+    end
+  end
+
+  # `downloads.media_item_id` only ever points at a `movie` or `tv_show` media
+  # item (the only two `MediaItem.valid_types/0`), so every download reaching
+  # this check wants a video file regardless of which of the two it is:
+  # `ImportCandidates.importable?/2` treats `:movies`/`:series`/`:mixed`
+  # identically. Passing `:series` unconditionally is exact, not a guess.
+  defp importable_path?(path) do
+    ImportCandidates.importable?(%{name: Path.basename(path)}, :series)
   end
 
   # Rejects a still-downloading torrent whose already-known file list

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -402,7 +402,11 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
     download = Downloads.get_download!(download_map.id)
 
-    case Queue.reject_release(download, actor_type: :system, actor_id: "download_monitor") do
+    case Queue.reject_release(download,
+           actor_type: :system,
+           actor_id: "download_monitor",
+           failure_reason: "no_importable_files"
+         ) do
       {:ok, :rejected} ->
         :ok
 

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -430,16 +430,63 @@ defmodule Mydia.Jobs.DownloadMonitor do
   @bad_content_log_sample 10
 
   defp reject_bad_content(download_map) do
+    download = Downloads.get_download!(download_map.id, preload: [:media_item])
+
+    if auto_reject_exhausted?(download.media_item_id) do
+      suppress_auto_reject(download, download_map)
+    else
+      do_reject_bad_content(download, download_map)
+    end
+  rescue
+    Ecto.NoResultsError -> :ok
+  end
+
+  # A media item with no id (an unbound download) has no counter to consult,
+  # so it is never capped.
+  defp auto_reject_exhausted?(nil), do: false
+
+  defp auto_reject_exhausted?(media_item_id) do
+    case Mydia.Search.get_backoff_info("auto_reject", media_item_id) do
+      %{failure_count: count} -> count >= auto_reject_limit()
+      _ -> false
+    end
+  end
+
+  # The torrent is left completely untouched. Writing `import_failure_reason`
+  # here would be the obvious way to surface it, but the Issues filter
+  # (Mydia.Downloads.History, the `:failed` branch) needs `import_failed_at`
+  # or a failed/missing status, and setting either would present a healthy,
+  # still-progressing download as terminally failed. When the cap trips the
+  # likely truth is that our detector is wrong, so the right outcome is that
+  # this download finishes and imports.
+  defp suppress_auto_reject(download, download_map) do
+    Logger.warning(
+      "Auto-reject limit reached, leaving download alone",
+      download_id: download_map.id,
+      title: download_map.title,
+      media_item_id: download.media_item_id,
+      limit: auto_reject_limit()
+    )
+
+    Events.download_auto_reject_suppressed(download, media_item: download.media_item)
+    :ok
+  end
+
+  defp do_reject_bad_content(download, download_map) do
     Logger.warning(
       "Rejecting download before completion — no importable files in torrent",
       download_id: download_map.id,
       title: download_map.title,
-      file_count: length(download_map.files),
+      file_count: length(download_map.files || []),
       files_sample:
-        download_map.files |> Enum.take(@bad_content_log_sample) |> Enum.map(&Path.basename/1)
+        (download_map.files || [])
+        |> Enum.take(@bad_content_log_sample)
+        |> Enum.map(&Path.basename/1)
     )
 
-    download = Downloads.get_download!(download_map.id)
+    if download.media_item_id do
+      Mydia.Search.record_failure("auto_reject", download.media_item_id, "no_importable_files")
+    end
 
     case Queue.reject_release(download,
            actor_type: :system,
@@ -457,8 +504,17 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
         :ok
     end
-  rescue
-    Ecto.NoResultsError -> :ok
+  end
+
+  # See UpgradeSweep.enabled?/0 for why this reads through the layered runtime
+  # config rather than a flat Application.get_env key: nothing explodes the
+  # resolved Config.Schema struct back out to flat top-level keys, so a flat
+  # read would silently ignore both the env var and the settings UI.
+  defp auto_reject_limit do
+    case Mydia.Config.get() do
+      %{downloads: %{auto_reject_limit: limit}} when is_integer(limit) and limit > 0 -> limit
+      _ -> 3
+    end
   end
 
   # --- Release blacklist (#123) ------------------------------------------

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -484,16 +484,25 @@ defmodule Mydia.Jobs.DownloadMonitor do
         |> Enum.map(&Path.basename/1)
     )
 
-    if download.media_item_id do
-      Mydia.Search.record_failure("auto_reject", download.media_item_id, "no_importable_files")
-    end
-
     case Queue.reject_release(download,
            actor_type: :system,
            actor_id: "download_monitor",
            failure_reason: "no_importable_files"
          ) do
       {:ok, :rejected} ->
+        # Counted only once the rejection actually happened. Counting it up
+        # front would let a release that can never be rejected (no indexer or
+        # guid, so `Blacklists.extract_key/1` fails) burn through the cap and
+        # suppress future *real* auto-rejections for this item, having never
+        # rejected anything.
+        if download.media_item_id do
+          Mydia.Search.record_failure(
+            "auto_reject",
+            download.media_item_id,
+            "no_importable_files"
+          )
+        end
+
         :ok
 
       {:error, reason} ->

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -537,6 +537,15 @@ defmodule Mydia.Jobs.MediaImport do
 
         case Downloads.update_download(updated_download, import_update) do
           {:ok, _updated} ->
+            # A successful import means whatever this item grabbed was real,
+            # so the consecutive-auto-rejection counter that
+            # Mydia.Jobs.DownloadMonitor keeps must not carry over. Without
+            # this, three genuine malware rejections would permanently
+            # disable auto-rejection for the item.
+            if download.media_item_id do
+              Mydia.Search.reset_backoff("auto_reject", download.media_item_id)
+            end
+
             Logger.info("Download marked as imported",
               download_id: download.id,
               has_unresolved: has_unresolved

--- a/lib/mydia/search/search_backoff.ex
+++ b/lib/mydia/search/search_backoff.ex
@@ -83,7 +83,10 @@ defmodule Mydia.Search.SearchBackoff do
       "episode",
       "movie_upgrade",
       "episode_upgrade",
-      "season_upgrade"
+      "season_upgrade",
+      # Consecutive DownloadMonitor auto-rejections for one media item
+      # (see Mydia.Jobs.DownloadMonitor).
+      "auto_reject"
     ])
   end
 end

--- a/priv/repo/migrations/20260811120000_add_content_checked_at_to_downloads.exs
+++ b/priv/repo/migrations/20260811120000_add_content_checked_at_to_downloads.exs
@@ -1,0 +1,15 @@
+defmodule Mydia.Repo.Migrations.AddContentCheckedAtToDownloads do
+  use Ecto.Migration
+
+  # Purely additive: one new column. No ALTER COLUMN, so this needs no
+  # SQLite/Postgres branching.
+  #
+  # Stamped once DownloadMonitor has successfully enumerated a torrent's
+  # files, so the pre-completion content check costs at most one client
+  # request per download for its entire lifetime rather than one per poll.
+  def change do
+    alter table(:downloads) do
+      add :content_checked_at, :utc_datetime
+    end
+  end
+end

--- a/priv/repo/migrations/20260811120100_purge_false_auto_reject_blacklist.exs
+++ b/priv/repo/migrations/20260811120100_purge_false_auto_reject_blacklist.exs
@@ -16,8 +16,12 @@ defmodule Mydia.Repo.Migrations.PurgeFalseAutoRejectBlacklist do
   #
   # Rows written after the fix carry `no_importable_files` and are untouched.
   #
-  # Plain DELETE with an ISO-8601 literal, identical on SQLite (lexicographic
-  # text comparison) and PostgreSQL (timestamp cast), so no adapter branching.
+  # Plain DELETE. The cutoff is written as a `YYYY-MM-DD HH:MM:SS.ffffff`
+  # timestamp literal, matching the stored format exactly rather than the
+  # `T`-separated ISO-8601 form: SQLite compares it lexicographically as text,
+  # so a format that differs from what is stored would compare wrong, while
+  # PostgreSQL casts it to a timestamp. One literal is correct on both, so no
+  # adapter branching is needed.
   def up do
     execute("""
     DELETE FROM release_blacklist

--- a/priv/repo/migrations/20260811120100_purge_false_auto_reject_blacklist.exs
+++ b/priv/repo/migrations/20260811120100_purge_false_auto_reject_blacklist.exs
@@ -1,0 +1,32 @@
+defmodule Mydia.Repo.Migrations.PurgeFalseAutoRejectBlacklist do
+  use Ecto.Migration
+
+  # v0.13.0 (tagged 2026-08-07) shipped a pre-completion content check that
+  # judged a torrent's contents from `DownloadStatus.files`. For qBittorrent
+  # and rtorrent that field holds a single path which is usually the
+  # torrent's root DIRECTORY, so healthy multi-file releases were rejected
+  # mid-download, blacklisted, and replaced by another release that met the
+  # same fate. Those rows were written as `rejected_by_user` (reject_release/2
+  # hardcoded the reason regardless of actor) with a 30-day TTL, so without
+  # this purge they keep suppressing good releases for a month.
+  #
+  # Genuine operator rejections made in the same window are also dropped.
+  # That is the accepted trade: they are cheap to redo, and every affected
+  # install self-heals on upgrade with no operator action.
+  #
+  # Rows written after the fix carry `no_importable_files` and are untouched.
+  #
+  # Plain DELETE with an ISO-8601 literal, identical on SQLite (lexicographic
+  # text comparison) and PostgreSQL (timestamp cast), so no adapter branching.
+  def up do
+    execute("""
+    DELETE FROM release_blacklist
+    WHERE failure_reason = 'rejected_by_user'
+      AND inserted_at >= '2026-08-07 00:00:00.000000'
+    """)
+  end
+
+  # Deleted rows cannot be reconstructed, and re-adding them would re-suppress
+  # the releases this migration exists to free.
+  def down, do: :ok
+end

--- a/test/mydia/downloads/client/list_files_test.exs
+++ b/test/mydia/downloads/client/list_files_test.exs
@@ -1,0 +1,38 @@
+defmodule Mydia.Downloads.Client.ListFilesStubWithout do
+  @moduledoc false
+  # Deliberately does NOT implement list_files/2.
+  def get_status(_config, _client_id), do: {:ok, %{}}
+end
+
+defmodule Mydia.Downloads.Client.ListFilesStubWith do
+  @moduledoc false
+  def list_files(_config, "known"), do: {:ok, ["/downloads/Movie/movie.mkv"]}
+  def list_files(_config, _other), do: {:error, :nope}
+end
+
+defmodule Mydia.Downloads.ClientListFilesTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.Client
+  alias Mydia.Downloads.Client.ListFilesStubWith
+  alias Mydia.Downloads.Client.ListFilesStubWithout
+
+  describe "list_files/3" do
+    test "returns :unsupported for an adapter that does not implement the callback" do
+      assert {:error, :unsupported} = Client.list_files(ListFilesStubWithout, %{}, "abc")
+    end
+
+    test "dispatches to an adapter that does implement the callback" do
+      assert {:ok, ["/downloads/Movie/movie.mkv"]} =
+               Client.list_files(ListFilesStubWith, %{}, "known")
+    end
+
+    test "passes an adapter error straight through" do
+      assert {:error, :nope} = Client.list_files(ListFilesStubWith, %{}, "other")
+    end
+
+    test "returns a descriptive error for a nil adapter" do
+      assert {:error, %Mydia.Downloads.Client.Error{}} = Client.list_files(nil, %{}, "abc")
+    end
+  end
+end

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -1,7 +1,7 @@
 defmodule Mydia.Downloads.Client.QBittorrentTest do
   use ExUnit.Case, async: true
 
-  alias Mydia.Downloads.Client.QBittorrent
+  alias Mydia.Downloads.Client.{Error, QBittorrent}
 
   @config %{
     type: :qbittorrent,
@@ -919,6 +919,96 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
                  priority: :high,
                  title: "Test"
                )
+    end
+  end
+
+  describe "list_files/2" do
+    test "returns absolute leaf paths for a multi-file torrent" do
+      bypass = Bypass.open()
+      config = bypass_config(bypass)
+
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=abc; path=/")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [%{"hash" => "abc", "save_path" => "/downloads"}])
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/files", fn conn ->
+        json_resp(conn, 200, [
+          %{"name" => "Minions.Monsters.2026.720p.WEBRip.x264-YTS/movie.mkv", "size" => 1},
+          %{"name" => "Minions.Monsters.2026.720p.WEBRip.x264-YTS/subs.srt", "size" => 2}
+        ])
+      end)
+
+      assert {:ok, files} = QBittorrent.list_files(config, "abc")
+
+      assert files == [
+               "/downloads/Minions.Monsters.2026.720p.WEBRip.x264-YTS/movie.mkv",
+               "/downloads/Minions.Monsters.2026.720p.WEBRip.x264-YTS/subs.srt"
+             ]
+    end
+
+    test "reports names without the .!qB incomplete suffix" do
+      bypass = Bypass.open()
+      config = bypass_config(bypass)
+
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=abc; path=/")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [%{"hash" => "abc", "save_path" => "/downloads"}])
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/files", fn conn ->
+        json_resp(conn, 200, [%{"name" => "movie.mkv", "size" => 1}])
+      end)
+
+      assert {:ok, ["/downloads/movie.mkv"]} = QBittorrent.list_files(config, "abc")
+    end
+
+    test "returns not_found when the torrent is absent" do
+      bypass = Bypass.open()
+      config = bypass_config(bypass)
+
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=abc; path=/")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [])
+      end)
+
+      assert {:error, %Error{type: :not_found}} = QBittorrent.list_files(config, "abc")
+    end
+
+    test "returns an error rather than crashing on a malformed files body" do
+      bypass = Bypass.open()
+      config = bypass_config(bypass)
+
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=abc; path=/")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [%{"hash" => "abc", "save_path" => "/downloads"}])
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/files", fn conn ->
+        json_resp(conn, 200, %{"unexpected" => true})
+      end)
+
+      assert {:error, %Error{}} = QBittorrent.list_files(config, "abc")
     end
   end
 

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -923,6 +923,25 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
   end
 
   describe "list_files/2" do
+    test "errors rather than returning relative paths when save_path is blank" do
+      bypass = Bypass.open()
+      config = bypass_config(bypass)
+
+      Bypass.expect(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=abc; path=/")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [%{"hash" => "abc", "save_path" => ""}])
+      end)
+
+      # The callback contract promises absolute paths. Joining onto "" would
+      # hand back relative ones, so this must fail closed instead.
+      assert {:error, %Error{}} = QBittorrent.list_files(config, "abc")
+    end
+
     test "returns absolute leaf paths for a multi-file torrent" do
       bypass = Bypass.open()
       config = bypass_config(bypass)

--- a/test/mydia/downloads/client/rqbit_test.exs
+++ b/test/mydia/downloads/client/rqbit_test.exs
@@ -416,6 +416,72 @@ defmodule Mydia.Downloads.Client.RqbitTest do
     end
   end
 
+  describe "list_files/2" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "returns the torrent's absolute file paths", %{bypass: bypass, config: config} do
+      Bypass.expect(bypass, "GET", "/torrents/#{@hash}", fn conn ->
+        json_resp(conn, 200, %{
+          "id" => 0,
+          "info_hash" => @hash,
+          "name" => "Some.Movie.2026.720p",
+          "output_folder" => "/downloads",
+          "files" => [
+            %{
+              "name" => "Some.Movie.2026.720p/movie.mkv",
+              "components" => ["Some.Movie.2026.720p", "movie.mkv"],
+              "length" => 1,
+              "included" => true
+            },
+            %{
+              "name" => "Some.Movie.2026.720p/sub.srt",
+              "components" => ["Some.Movie.2026.720p", "sub.srt"],
+              "length" => 2,
+              "included" => true
+            }
+          ]
+        })
+      end)
+
+      stub_stats(
+        bypass,
+        stats(state: "live", finished: false, progress_bytes: 1, total_bytes: 3)
+      )
+
+      assert {:ok, files} = Rqbit.list_files(config, @hash)
+
+      assert files == [
+               "/downloads/Some.Movie.2026.720p/movie.mkv",
+               "/downloads/Some.Movie.2026.720p/sub.srt"
+             ]
+    end
+
+    test "returns an empty list when the client reports no files yet", %{
+      bypass: bypass,
+      config: config
+    } do
+      Bypass.expect(bypass, "GET", "/torrents/#{@hash}", fn conn ->
+        json_resp(conn, 200, %{
+          "id" => 0,
+          "info_hash" => @hash,
+          "name" => "Some.Movie.2026.720p",
+          "output_folder" => "/downloads",
+          "files" => []
+        })
+      end)
+
+      stub_stats(
+        bypass,
+        stats(state: "live", finished: false, progress_bytes: 0, total_bytes: 0)
+      )
+
+      assert {:ok, []} = Rqbit.list_files(config, @hash)
+    end
+  end
+
   ## Helpers
 
   defp bypass_config(bypass) do

--- a/test/mydia/downloads/client/transmission_test.exs
+++ b/test/mydia/downloads/client/transmission_test.exs
@@ -331,36 +331,7 @@ defmodule Mydia.Downloads.Client.TransmissionTest do
   describe "get_status/2 file list (Bypass)" do
     setup do
       bypass = Bypass.open()
-
-      config = %{
-        @config
-        | host: "localhost",
-          port: bypass.port
-      }
-
-      {:ok, bypass: bypass, config: config}
-    end
-
-    defp respond_torrent_get(conn, session_id, arguments_assertion, torrents) do
-      case Plug.Conn.get_req_header(conn, "x-transmission-session-id") do
-        [] ->
-          conn
-          |> Plug.Conn.put_resp_header("x-transmission-session-id", session_id)
-          |> Plug.Conn.resp(409, "")
-
-        [^session_id] ->
-          {:ok, body, conn} = Plug.Conn.read_body(conn, length: 1_000_000)
-          decoded = Jason.decode!(body)
-          assert decoded["method"] == "torrent-get"
-          arguments_assertion.(decoded["arguments"])
-
-          conn
-          |> Plug.Conn.put_resp_content_type("application/json")
-          |> Plug.Conn.resp(
-            200,
-            Jason.encode!(%{"result" => "success", "arguments" => %{"torrents" => torrents}})
-          )
-      end
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
     end
 
     test "requests the files field and resolves it to absolute paths",
@@ -465,6 +436,95 @@ defmodule Mydia.Downloads.Client.TransmissionTest do
 
       assert {:ok, status} = Transmission.get_status(config, "jkl012")
       assert status.files == nil
+    end
+  end
+
+  describe "list_files/2" do
+    test "returns the torrent's absolute file paths" do
+      bypass = Bypass.open()
+      config = bypass_config(bypass)
+
+      mock_torrent_get(bypass, [
+        %{
+          "hashString" => "abc",
+          "name" => "Some.Movie.2026.720p",
+          "status" => 4,
+          "percentDone" => 0.1,
+          "downloadDir" => "/downloads",
+          "files" => [
+            %{"name" => "Some.Movie.2026.720p/movie.mkv", "length" => 1},
+            %{"name" => "Some.Movie.2026.720p/sub.srt", "length" => 2}
+          ]
+        }
+      ])
+
+      assert {:ok, files} = Transmission.list_files(config, "abc")
+
+      assert files == [
+               "/downloads/Some.Movie.2026.720p/movie.mkv",
+               "/downloads/Some.Movie.2026.720p/sub.srt"
+             ]
+    end
+
+    test "returns an empty list when the client reports no files yet" do
+      bypass = Bypass.open()
+      config = bypass_config(bypass)
+
+      mock_torrent_get(bypass, [
+        %{
+          "hashString" => "abc",
+          "name" => "Some.Movie.2026.720p",
+          "status" => 4,
+          "percentDone" => 0.0,
+          "downloadDir" => "/downloads",
+          "files" => []
+        }
+      ])
+
+      assert {:ok, []} = Transmission.list_files(config, "abc")
+    end
+  end
+
+  ## Helpers
+
+  defp bypass_config(bypass) do
+    %{
+      @config
+      | host: "localhost",
+        port: bypass.port
+    }
+  end
+
+  defp mock_torrent_get(bypass, torrents) do
+    Bypass.expect(bypass, "POST", "/transmission/rpc", fn conn ->
+      respond_torrent_get(
+        conn,
+        "session-list-files",
+        fn args -> assert "files" in args["fields"] end,
+        torrents
+      )
+    end)
+  end
+
+  defp respond_torrent_get(conn, session_id, arguments_assertion, torrents) do
+    case Plug.Conn.get_req_header(conn, "x-transmission-session-id") do
+      [] ->
+        conn
+        |> Plug.Conn.put_resp_header("x-transmission-session-id", session_id)
+        |> Plug.Conn.resp(409, "")
+
+      [^session_id] ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn, length: 1_000_000)
+        decoded = Jason.decode!(body)
+        assert decoded["method"] == "torrent-get"
+        arguments_assertion.(decoded["arguments"])
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{"result" => "success", "arguments" => %{"torrents" => torrents}})
+        )
     end
   end
 

--- a/test/mydia/downloads/queue_test.exs
+++ b/test/mydia/downloads/queue_test.exs
@@ -12,6 +12,7 @@ defmodule Mydia.Downloads.QueueTest do
   alias Mydia.Downloads.Queue
   alias Mydia.Downloads.Client.Registry
   alias Mydia.Downloads.Download
+  alias Mydia.Downloads.ReleaseBlacklist
   alias Mydia.Repo
   alias Mydia.Settings.DownloadClientConfig
 
@@ -626,6 +627,45 @@ defmodule Mydia.Downloads.QueueTest do
                Queue.check_for_active_download(search_result, movie.id, nil,
                  exclude_download_id: existing.id
                )
+    end
+  end
+
+  describe "reject_release/2 failure_reason" do
+    test "defaults to rejected_by_user" do
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          indexer: "1337x",
+          metadata: %{"indexer" => "1337x", "guid" => "guid-default"}
+        })
+
+      assert {:ok, :rejected} = Queue.reject_release(download)
+
+      row = Repo.get_by(ReleaseBlacklist, indexer: "1337x", guid: "guid-default")
+      assert row.failure_reason == "rejected_by_user"
+    end
+
+    test "records the caller's reason when given" do
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          indexer: "1337x",
+          metadata: %{"indexer" => "1337x", "guid" => "guid-custom"}
+        })
+
+      assert {:ok, :rejected} =
+               Queue.reject_release(download,
+                 actor_type: :system,
+                 actor_id: "download_monitor",
+                 failure_reason: "no_importable_files"
+               )
+
+      row = Repo.get_by(ReleaseBlacklist, indexer: "1337x", guid: "guid-custom")
+      assert row.failure_reason == "no_importable_files"
     end
   end
 end

--- a/test/mydia/jobs/download_monitor_adoption_bypass_test.exs
+++ b/test/mydia/jobs/download_monitor_adoption_bypass_test.exs
@@ -40,6 +40,18 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionBypassTest do
       |> Plug.Conn.resp(200, Jason.encode!([torrent_payload(@hash)]))
     end)
 
+    # DownloadMonitor's pre-completion content check calls list_files/2, which
+    # hits /torrents/files after /torrents/info. Stub it so healthy torrents
+    # are not treated as unknown and so Bypass does not see an unexpected route.
+    Bypass.stub(bypass, "GET", "/api/v2/torrents/files", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!([%{"name" => "Movie.2024.1080p.mkv", "size" => 1}])
+      )
+    end)
+
     {:ok, bypass: bypass}
   end
 
@@ -174,6 +186,15 @@ defmodule Mydia.Jobs.DownloadMonitorAdoptionBypassTest do
       conn
       |> Plug.Conn.put_resp_content_type("application/json")
       |> Plug.Conn.resp(200, Jason.encode!([torrent_payload(@hash)]))
+    end)
+
+    Bypass.stub(bypass, "GET", "/api/v2/torrents/files", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!([%{"name" => "Movie.2024.1080p.mkv", "size" => 1}])
+      )
     end)
 
     setup_runtime_config([reachable_client("qbit-new", bypass.port)])

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1241,6 +1241,110 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       refute Mydia.Downloads.Blacklists.blacklisted?("1337x", "guid-pending")
       assert Mydia.Downloads.get_download!(download.id)
     end
+
+    test "does not reject a torrent whose file list is a single directory path" do
+      # Reproduces the qBittorrent shape: `files` holds one entry, and that
+      # entry is the torrent's root FOLDER, not a leaf file. Transmission is
+      # used as the transport here only because this describe block already
+      # has a Bypass harness for it; the point is the shape of the data.
+      {bypass, client_config} = start_transmission_bypass()
+
+      torrent = %{
+        "hashString" => "folder-hash",
+        "name" => "Minions.Monsters.2026.720p.WEBRip.x264-YTS",
+        "status" => 4,
+        "percentDone" => 0.42,
+        "downloadDir" => "/downloads",
+        "files" => [
+          %{"name" => "Minions.Monsters.2026.720p.WEBRip.x264-YTS/movie.mkv", "length" => 1}
+        ]
+      }
+
+      mock_transmission_torrent_get(bypass, [torrent])
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Minions.Monsters.2026.720p.WEBRip.x264-YTS",
+          indexer: "1337x",
+          download_client: client_config.name,
+          download_client_id: "folder-hash",
+          metadata: %{indexer: "1337x", guid: "guid-folder"}
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      # Still there, still ours, not blacklisted.
+      assert Mydia.Downloads.get_download!(download.id)
+      refute Mydia.Downloads.Blacklists.blacklisted?("1337x", "guid-folder")
+    end
+
+    test "stamps content_checked_at so the enumeration runs only once" do
+      {bypass, client_config} = start_transmission_bypass()
+
+      torrent = %{
+        "hashString" => "once-hash",
+        "name" => "Some.Movie.2026.720p",
+        "status" => 4,
+        "percentDone" => 0.42,
+        "downloadDir" => "/downloads",
+        "files" => [%{"name" => "Some.Movie.2026.720p/movie.mkv", "length" => 1}]
+      }
+
+      mock_transmission_torrent_get(bypass, [torrent])
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Some.Movie.2026.720p",
+          indexer: "1337x",
+          download_client: client_config.name,
+          download_client_id: "once-hash",
+          metadata: %{indexer: "1337x", guid: "guid-once"}
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+      assert Mydia.Downloads.get_download!(download.id).content_checked_at
+    end
+
+    test "does not reject when the client reports no files yet" do
+      {bypass, client_config} = start_transmission_bypass()
+
+      torrent = %{
+        "hashString" => "empty-hash",
+        "name" => "Some.Movie.2026.720p",
+        "status" => 4,
+        "percentDone" => 0.0,
+        "downloadDir" => "/downloads",
+        "files" => []
+      }
+
+      mock_transmission_torrent_get(bypass, [torrent])
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Some.Movie.2026.720p",
+          indexer: "1337x",
+          download_client: client_config.name,
+          download_client_id: "empty-hash",
+          metadata: %{indexer: "1337x", guid: "guid-empty"}
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      assert Mydia.Downloads.get_download!(download.id)
+      refute Mydia.Downloads.Blacklists.blacklisted?("1337x", "guid-empty")
+      # An empty enumeration means "metadata not resolved yet", so we must be
+      # willing to look again on the next poll.
+      refute Mydia.Downloads.get_download!(download.id).content_checked_at
+    end
   end
 
   describe "handle_failure/1 with a classified debrid failure" do

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1345,6 +1345,77 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       # willing to look again on the next poll.
       refute Mydia.Downloads.get_download!(download.id).content_checked_at
     end
+
+    test "stops auto-rejecting a media item after the configured limit" do
+      {bypass, client_config} = start_transmission_bypass()
+      media_item = media_item_fixture()
+
+      # Pre-load the counter to the default limit of 3.
+      for _ <- 1..3 do
+        Mydia.Search.record_failure("auto_reject", media_item.id, "no_importable_files")
+      end
+
+      torrent = %{
+        "hashString" => "capped-hash",
+        "name" => "Some.Movie.2026.720p",
+        "status" => 4,
+        "percentDone" => 0.42,
+        "downloadDir" => "/downloads",
+        "files" => [%{"name" => "Some.Movie.2026.720p/payload.exe", "length" => 1}]
+      }
+
+      mock_transmission_torrent_get(bypass, [torrent])
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Some.Movie.2026.720p",
+          indexer: "1337x",
+          download_client: client_config.name,
+          download_client_id: "capped-hash",
+          metadata: %{indexer: "1337x", guid: "guid-capped"}
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      # Suppressed: torrent untouched, release not blacklisted.
+      reloaded = Mydia.Downloads.get_download!(download.id)
+      refute Mydia.Downloads.Blacklists.blacklisted?("1337x", "guid-capped")
+
+      # Left non-terminal so it can still complete and import normally.
+      refute reloaded.import_failed_at
+      refute reloaded.import_failure_reason
+    end
+
+    test "still rejects while under the limit, and counts the rejection" do
+      {bypass, client_config} = start_transmission_bypass()
+      media_item = media_item_fixture()
+
+      torrent = %{
+        "hashString" => "under-hash",
+        "name" => "Some.Movie.2026.720p",
+        "status" => 4,
+        "percentDone" => 0.42,
+        "downloadDir" => "/downloads",
+        "files" => [%{"name" => "Some.Movie.2026.720p/payload.exe", "length" => 1}]
+      }
+
+      mock_transmission_torrent_get(bypass, [torrent])
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        title: "Some.Movie.2026.720p",
+        indexer: "1337x",
+        download_client: client_config.name,
+        download_client_id: "under-hash",
+        metadata: %{indexer: "1337x", guid: "guid-under"}
+      })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      assert Mydia.Downloads.Blacklists.blacklisted?("1337x", "guid-under")
+      assert %{failure_count: 1} = Mydia.Search.get_backoff_info("auto_reject", media_item.id)
+    end
   end
 
   describe "handle_failure/1 with a classified debrid failure" do

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1242,32 +1242,78 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       assert Mydia.Downloads.get_download!(download.id)
     end
 
-    test "does not reject a torrent whose file list is a single directory path" do
-      # Reproduces the qBittorrent shape: `files` holds one entry, and that
-      # entry is the torrent's root FOLDER, not a leaf file. Transmission is
-      # used as the transport here only because this describe block already
-      # has a Bypass harness for it; the point is the shape of the data.
-      {bypass, client_config} = start_transmission_bypass()
+    # The regression tests below drive a real qBittorrent adapter rather than
+    # Transmission, because the bug lived entirely in qBittorrent's shape:
+    # `parse_torrent_status/1` reports `files: [content_path]`, and
+    # `content_path` is the torrent's root DIRECTORY for a multi-file torrent.
+    # A Transmission fixture cannot express that, so a Transmission-based test
+    # here would pass both before and after the fix and prove nothing.
+    defp start_qbittorrent_bypass(overrides \\ %{}) do
+      bypass = Bypass.open()
 
-      torrent = %{
-        "hashString" => "folder-hash",
-        "name" => "Minions.Monsters.2026.720p.WEBRip.x264-YTS",
-        "status" => 4,
-        "percentDone" => 0.42,
-        "downloadDir" => "/downloads",
-        "files" => [
-          %{"name" => "Minions.Monsters.2026.720p.WEBRip.x264-YTS/movie.mkv", "length" => 1}
-        ]
+      client_config =
+        download_client_config_fixture(
+          Map.merge(%{type: "qbittorrent", host: "localhost", port: bypass.port}, overrides)
+        )
+
+      Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=test-sid; HttpOnly")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      # reject_release/2 removes the torrent from the client; stub it so the
+      # rejection path can complete instead of erroring on an unknown route.
+      Bypass.stub(bypass, "POST", "/api/v2/torrents/delete", fn conn ->
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      {bypass, client_config}
+    end
+
+    defp mock_qbittorrent(bypass, torrents, files) do
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, torrents)
+      end)
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/files", fn conn ->
+        json_resp(conn, 200, files)
+      end)
+    end
+
+    defp qbittorrent_torrent(hash, name) do
+      %{
+        "hash" => hash,
+        "name" => name,
+        "state" => "downloading",
+        "progress" => 0.42,
+        "save_path" => "/downloads",
+        # The whole bug in one field: the root folder, not a file.
+        "content_path" => "/downloads/#{name}"
       }
+    end
 
-      mock_transmission_torrent_get(bypass, [torrent])
+    test "keeps a qBittorrent torrent whose content_path is the release folder" do
+      {bypass, client_config} = start_qbittorrent_bypass()
+
+      # `Path.extname("Minions.Monsters.2026.720p.WEBRip.x264-YTS")` is
+      # ".x264-YTS", which is not a video extension, so judging the torrent
+      # from `content_path` destroyed it mid-download. The real enumeration
+      # below holds an .mkv, so it must survive.
+      name = "Minions.Monsters.2026.720p.WEBRip.x264-YTS"
+
+      mock_qbittorrent(
+        bypass,
+        [qbittorrent_torrent("folder-hash", name)],
+        [%{"name" => "#{name}/movie.mkv", "size" => 1}]
+      )
 
       media_item = media_item_fixture()
 
       download =
         download_fixture(%{
           media_item_id: media_item.id,
-          title: "Minions.Monsters.2026.720p.WEBRip.x264-YTS",
+          title: name,
           indexer: "1337x",
           download_client: client_config.name,
           download_client_id: "folder-hash",
@@ -1279,6 +1325,36 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       # Still there, still ours, not blacklisted.
       assert Mydia.Downloads.get_download!(download.id)
       refute Mydia.Downloads.Blacklists.blacklisted?("1337x", "guid-folder")
+    end
+
+    test "still rejects a qBittorrent torrent whose enumeration holds no video" do
+      # The other half of the regression: gating on a real enumeration must
+      # not cost qBittorrent users the malware protection this check exists
+      # for. Same directory-shaped content_path, genuinely bad contents.
+      {bypass, client_config} = start_qbittorrent_bypass()
+
+      name = "Some.Movie.2026.720p.WEBRip"
+
+      mock_qbittorrent(
+        bypass,
+        [qbittorrent_torrent("exe-hash", name)],
+        [%{"name" => "#{name}/payload.exe", "size" => 1}]
+      )
+
+      media_item = media_item_fixture()
+
+      download_fixture(%{
+        media_item_id: media_item.id,
+        title: name,
+        indexer: "1337x",
+        download_client: client_config.name,
+        download_client_id: "exe-hash",
+        metadata: %{indexer: "1337x", guid: "guid-exe"}
+      })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      assert Mydia.Downloads.Blacklists.blacklisted?("1337x", "guid-exe")
     end
 
     test "stamps content_checked_at so the enumeration runs only once" do

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -2296,4 +2296,54 @@ defmodule Mydia.Jobs.MediaImportTest do
       assert_raise Ecto.NoResultsError, fn -> Mydia.Downloads.get_download!(download.id) end
     end
   end
+
+  describe "auto_reject counter" do
+    @tag :tmp_dir
+    test "a successful import clears the media item's auto_reject counter", %{tmp_dir: tmp_dir} do
+      # Staging copied from "falls back to save_path when client query fails"
+      # — a completed download with a real video on disk and an unreachable
+      # client, importing via the save_path job arg.
+      _library_path = create_test_library_path(tmp_dir, :movies)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+      video_file = Path.join(download_dir, "AutoReject.Reset.2024.1080p.mkv")
+      File.write!(video_file, "fake video content")
+
+      media_item =
+        media_item_fixture(%{type: "movie", title: "AutoReject Reset Movie", year: 2024})
+
+      Mydia.Search.record_failure("auto_reject", media_item.id, "no_importable_files")
+      assert Mydia.Search.get_backoff_info("auto_reject", media_item.id)
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "AutoRejectResetClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "AutoRejectResetClient",
+          download_client_id: "auto-reject-reset"
+        })
+
+      assert {:ok, :imported} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      refute Mydia.Search.get_backoff_info("auto_reject", media_item.id)
+    end
+  end
 end

--- a/test/mydia/repo/migrations/purge_false_auto_reject_blacklist_test.exs
+++ b/test/mydia/repo/migrations/purge_false_auto_reject_blacklist_test.exs
@@ -1,0 +1,53 @@
+defmodule Mydia.Repo.Migrations.PurgeFalseAutoRejectBlacklistTest do
+  use Mydia.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Mydia.Downloads.ReleaseBlacklist
+  alias Mydia.Repo
+
+  @cutoff ~U[2026-08-07 00:00:00.000000Z]
+
+  # Mirrors the migration's DELETE predicate exactly.
+  defp purge do
+    {count, _} =
+      Repo.delete_all(
+        from b in ReleaseBlacklist,
+          where: b.failure_reason == "rejected_by_user" and b.inserted_at >= ^@cutoff
+      )
+
+    count
+  end
+
+  defp insert_row(reason, inserted_at) do
+    Repo.insert!(%ReleaseBlacklist{
+      indexer: "1337x",
+      guid: "guid-#{System.unique_integer([:positive])}",
+      title: "Some Release",
+      failure_reason: reason,
+      inserted_at: inserted_at,
+      expires_at: DateTime.add(inserted_at, 30, :day)
+    })
+  end
+
+  test "deletes rejected_by_user rows written on or after the cutoff" do
+    row = insert_row("rejected_by_user", ~U[2026-08-09 12:00:00.000000Z])
+
+    assert purge() == 1
+    refute Repo.get(ReleaseBlacklist, row.id)
+  end
+
+  test "keeps rejected_by_user rows written before the cutoff" do
+    row = insert_row("rejected_by_user", ~U[2026-08-01 12:00:00.000000Z])
+
+    assert purge() == 0
+    assert Repo.get(ReleaseBlacklist, row.id)
+  end
+
+  test "keeps rows with any other failure reason regardless of date" do
+    row = insert_row("stalled", ~U[2026-08-09 12:00:00.000000Z])
+
+    assert purge() == 0
+    assert Repo.get(ReleaseBlacklist, row.id)
+  end
+end


### PR DESCRIPTION
## The bug

Manually grabbing a 720p or 1080p release starts the download, then Mydia cancels it a minute or two later, blacklists the release, and grabs a different one. That replacement meets the same fate, and so on until the result set is exhausted. With the quality profile on "Any" the replacement is a 4K release; with the profile locked to HD-720 it walks the 720p list and then stops with nothing downloaded.

Reported against "Minions & Monsters (2026) [720p] [WEBRip]", which cycled through the WEBRip, the LAMA release, and the YTS release.

## Root cause

The pre-completion content check added in 81881830 and shipped in v0.13.0 reads `DownloadStatus.files` and assumes it is a list of leaf files. For qBittorrent it is not: `qbittorrent.ex` populates it with a single `content_path`, which the qBittorrent API defines as *"root path for multifile torrents, absolute file path for singlefile torrents"*.

Nearly every release is packaged as a folder, so the check ran `Path.extname/1` over a directory name:

- `Minions.Monsters.2026.720p.WEBRip.x264-YTS` yields `.x264-YTS`
- `Minions & Monsters (2026) [720p] [WEBRip]` yields `""`

Neither is a video extension, so a healthy torrent was judged content-free and handed to `Queue.reject_release/2`, which blacklists the release, removes the torrent with `delete_files: true`, and queues a replacement search.

rtorrent had the identical bug via `base_path`. Transmission and rqbit were unaffected: both build `files` from genuine per-file listings.

## The fix

- **`Client.list_files/3`**, a new optional adapter callback. Adapters that cannot enumerate a torrent's contents simply do not implement it and report `:unsupported` via `@optional_callbacks` plus a `function_exported?/3` probe, so they are safe by construction rather than by review.
- **qBittorrent enumerates for real** via `/api/v2/torrents/files`. That endpoint also reports names without the `.!qB` suffix, which fixes a second false positive for anyone running "Append .!qB extension to incomplete files".
- **Transmission and rqbit** implement the callback by delegating to the leaf listings they already build.
- **The check is gated on a real enumeration.** `{:error, _}` and `{:ok, []}` both mean "unknown" and never reject; an empty list from a torrent client means metadata has not resolved yet.
- **`content_checked_at`** bounds the cost to one client request per download for its lifetime, rather than one per poll.
- **A cap of 3 consecutive auto-rejections per media item**, reusing `search_backoffs`, bounds any future false positive to three releases instead of the entire result set. When it trips the download is left completely alone to finish and import, since the likely truth is that the detector is wrong.
- **Honest failure reasons.** `reject_release/2` no longer hardcodes `rejected_by_user` for system rejections.
- **A migration purges the damage**: `rejected_by_user` rows written on or after the v0.13.0 tag date. Genuine operator rejections from that four-day window go too, which is the accepted trade so every affected install self-heals without the operator having to find an admin page.

Malware protection is preserved throughout. The existing regression test for the disguised `.exe` in a House of the Dragon torrent still passes, and qBittorrent now gets that protection for the first time.

rtorrent keeps no pre-completion protection until `f.multicall` is wired up, but it is now safe rather than destructive.

## Verification

- Full SQLite suite: 6857 tests, 0 failures, 34 skipped
- PostgreSQL feature suites green. The 4 failures in the full Postgres run are the known deep-worktree-path flake: they die in `create_test_library_path/3` at fixture setup with a 256-character `:tmp_dir` against a `varchar(255)` column, before any changed code runs.
- `mix credo --strict`: no issues
- `mix format --check-formatted`: clean
