### PR TITLE
fix(metadata-relay): answer 503 when Trakt credentials are absent

### DIFF
--- a/infra/kubernetes/apps/metadata-relay/secret.yaml.example
+++ b/infra/kubernetes/apps/metadata-relay/secret.yaml.example
@@ -16,6 +16,14 @@ stringData:
   TMDB_API_KEY: "your-tmdb-api-key"
   TVDB_API_KEY: "your-tvdb-api-key"
 
+  # REQUIRED for the Trakt.tv integration (scrobbling and sync).
+  # Create an application at https://trakt.tv/oauth/applications with the
+  # redirect URI urn:ietf:wg:oauth:2.0:oob (device flow).
+  # Without these, every /trakt/* endpoint answers 503 trakt_not_configured
+  # and Mydia clients cannot connect a Trakt account.
+  TRAKT_CLIENT_ID: "your-trakt-client-id"
+  TRAKT_CLIENT_SECRET: "your-trakt-client-secret"
+
   # REQUIRED: Master pepper for rendezvous namespace derivation
   # Generate with: openssl rand -hex 32
   RENDEZVOUS_MASTER_PEPPER: "your-secure-random-pepper-here"

--- a/lib/mydia_web/live/integrations_live/index.ex
+++ b/lib/mydia_web/live/integrations_live/index.ex
@@ -9,6 +9,10 @@ defmodule MydiaWeb.IntegrationsLive.Index do
 
   require Logger
 
+  @trakt_not_configured_message "Trakt is unavailable because the metadata relay this server " <>
+                                  "uses has no Trakt credentials configured. If you run your own " <>
+                                  "relay, set TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET on it."
+
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns.current_user
@@ -63,8 +67,10 @@ defmodule MydiaWeb.IntegrationsLive.Index do
       {:error, reason} ->
         Logger.error("Failed to generate Trakt device code: #{inspect(reason)}")
 
-        {:noreply,
-         assign(socket, :trakt_error, "Failed to start Trakt authorization. Please try again.")}
+        message =
+          trakt_error_message(reason, "Failed to start Trakt authorization. Please try again.")
+
+        {:noreply, assign(socket, :trakt_error, message)}
     end
   end
 
@@ -231,7 +237,10 @@ defmodule MydiaWeb.IntegrationsLive.Index do
           {:noreply,
            socket
            |> assign(:trakt_polling, false)
-           |> assign(:trakt_error, "An error occurred. Please try again.")}
+           |> assign(
+             :trakt_error,
+             trakt_error_message(reason, "An error occurred. Please try again.")
+           )}
       end
     else
       {:noreply, socket}
@@ -329,6 +338,13 @@ defmodule MydiaWeb.IntegrationsLive.Index do
   end
 
   ## Private Helpers
+
+  # The relay answers 503 with this code when it carries no Trakt credentials.
+  # Retrying never clears it, so say what actually needs to happen.
+  defp trakt_error_message({:http_error, 503, %{"error" => "trakt_not_configured"}}, _fallback),
+    do: @trakt_not_configured_message
+
+  defp trakt_error_message(_reason, fallback), do: fallback
 
   defp compute_trakt_expiry(nil), do: nil
 

--- a/metadata-relay/CLAUDE.md
+++ b/metadata-relay/CLAUDE.md
@@ -26,7 +26,9 @@ mix test
 mix format
 ```
 
-Environment variables: `PORT` (default 4001), `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` (required in production for `/errors` and `/feedback` dashboards), `TMDB_API_KEY`, `TVDB_API_KEY`, `REDIS_URL` (optional).
+Environment variables: `PORT` (default 4001), `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` (required in production for `/errors` and `/feedback` dashboards), `TMDB_API_KEY`, `TVDB_API_KEY`, `TRAKT_CLIENT_ID` and `TRAKT_CLIENT_SECRET` (required for the Trakt integration; without them every `/trakt/*` endpoint answers 503 `trakt_not_configured`), `REDIS_URL` (optional).
+
+When adding a proxy for a new upstream that needs its own credentials, add them in the same change to `README.md`'s env table, `docker-compose.yml`, and `infra/kubernetes/apps/metadata-relay/secret.yaml.example`. Trakt shipped without those entries and stayed dead in production until someone reported it.
 
 ## Deploying a New Version
 

--- a/metadata-relay/README.md
+++ b/metadata-relay/README.md
@@ -135,6 +135,8 @@ The service is configured entirely via environment variables for maximum flexibi
 | `PORT`            | No       | `4001`             | HTTP port the server listens on                                                                                         |
 | `TMDB_API_KEY`    | Yes      | -                  | API key for The Movie Database. Get one at https://www.themoviedb.org/settings/api                                      |
 | `TVDB_API_KEY`    | Yes      | -                  | API key for TheTVDB. Get one at https://thetvdb.com/api-information                                                     |
+| `TRAKT_CLIENT_ID` | Required for Trakt | -        | Trakt application client ID. Create an app at https://trakt.tv/oauth/applications. Without it, every `/trakt/*` endpoint answers 503 `trakt_not_configured` |
+| `TRAKT_CLIENT_SECRET` | Required for Trakt | -    | Trakt application client secret, held only by the relay so Mydia instances never see it                                  |
 | `REDIS_URL`       | No       | -                  | Redis connection URL for persistent caching. Format: `redis://[password@]host:port`. If not set, uses in-memory caching |
 | `FEEDBACK_EMAIL_TO` | No     | -                  | Email address that receives a notification for each new feedback submission. Notifications are disabled when unset       |
 | `FEEDBACK_EMAIL_FROM` | No   | `metadata-relay@localhost` | Sender address for feedback notification emails                                                                   |

--- a/metadata-relay/docker-compose.yml
+++ b/metadata-relay/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       - MIX_ENV=dev
       - TMDB_API_KEY=${TMDB_API_KEY:-your_api_key_here}
       - TVDB_API_KEY=${TVDB_API_KEY:-your_tvdb_key_here}
+      # Trakt is optional - /trakt/* answers 503 trakt_not_configured when unset
+      - TRAKT_CLIENT_ID=${TRAKT_CLIENT_ID:-}
+      - TRAKT_CLIENT_SECRET=${TRAKT_CLIENT_SECRET:-}
       # Redis is optional - comment out to use in-memory caching
       - REDIS_URL=redis://redis:6379
       # SQLite database path

--- a/metadata-relay/lib/metadata_relay/router.ex
+++ b/metadata-relay/lib/metadata_relay/router.ex
@@ -12,6 +12,7 @@ defmodule MetadataRelay.Router do
   alias MetadataRelay.OpenLibrary.Handler, as: OpenLibraryHandler
   alias MetadataRelay.OpenSubtitles.Handler, as: SubtitlesHandler
   alias MetadataRelay.Pairing.Handler, as: PairingHandler
+  alias MetadataRelay.Trakt.Client, as: TraktClient
   alias MetadataRelay.Trakt.Handler, as: TraktHandler
 
   @feedback_param_atoms %{
@@ -1228,6 +1229,12 @@ defmodule MetadataRelay.Router do
   # Trakt device poll handler — passes Trakt's HTTP status codes through transparently
   # so the client can distinguish pending (400), expired (410), denied (418), slow down (429)
   defp handle_trakt_device_poll(conn, handler_fn) do
+    with_trakt_configured(conn, fn ->
+      do_handle_trakt_device_poll(conn, handler_fn)
+    end)
+  end
+
+  defp do_handle_trakt_device_poll(conn, handler_fn) do
     case handler_fn.() do
       {:ok, body} ->
         MetadataRelay.Metrics.inc("metadata_relay_requests_total",
@@ -1268,6 +1275,37 @@ defmodule MetadataRelay.Router do
 
   # Trakt request handler
   defp handle_trakt_request(conn, handler_fn) do
+    with_trakt_configured(conn, fn ->
+      do_handle_trakt_request(conn, handler_fn)
+    end)
+  end
+
+  # Trakt credentials are optional: a relay without them still serves TMDB and
+  # TVDB. Reply with a machine-readable 503 so clients can tell "this relay has
+  # no Trakt" apart from a transient outage, instead of raising into a 500.
+  defp with_trakt_configured(conn, fun) do
+    if TraktClient.configured?() do
+      fun.()
+    else
+      MetadataRelay.Metrics.inc("metadata_relay_requests_total",
+        service: "trakt",
+        status: "not_configured"
+      )
+
+      body = %{
+        error: "trakt_not_configured",
+        message:
+          "This metadata relay has no Trakt credentials configured. " <>
+            "Set TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET on the relay to enable Trakt."
+      }
+
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(503, Jason.encode!(body))
+    end
+  end
+
+  defp do_handle_trakt_request(conn, handler_fn) do
     case handler_fn.() do
       {:ok, body} ->
         MetadataRelay.Metrics.inc("metadata_relay_requests_total",

--- a/metadata-relay/lib/metadata_relay/trakt/client.ex
+++ b/metadata-relay/lib/metadata_relay/trakt/client.ex
@@ -78,11 +78,21 @@ defmodule MetadataRelay.Trakt.Client do
   end
 
   @doc """
+  Returns true when both Trakt credentials are present.
+
+  Relays that do not carry Trakt credentials still serve TMDB and TVDB
+  normally, so callers check this and reply with a clear error rather than
+  letting `client_id/0` raise into a generic 500.
+  """
+  def configured? do
+    not is_nil(fetch_client_id()) and not is_nil(fetch_client_secret())
+  end
+
+  @doc """
   Returns the client_id (public, safe to expose to Mydia instances for building authorize URLs).
   """
   def client_id do
-    Application.get_env(:metadata_relay, :trakt_client_id) ||
-      System.get_env("TRAKT_CLIENT_ID") ||
+    fetch_client_id() ||
       raise(RuntimeError, "TRAKT_CLIENT_ID environment variable is not set.")
   end
 
@@ -90,10 +100,29 @@ defmodule MetadataRelay.Trakt.Client do
   Returns the client_secret (private, never exposed outside the relay).
   """
   def client_secret do
-    Application.get_env(:metadata_relay, :trakt_client_secret) ||
-      System.get_env("TRAKT_CLIENT_SECRET") ||
+    fetch_client_secret() ||
       raise(RuntimeError, "TRAKT_CLIENT_SECRET environment variable is not set.")
   end
+
+  defp fetch_client_id do
+    presence(
+      Application.get_env(:metadata_relay, :trakt_client_id) || System.get_env("TRAKT_CLIENT_ID")
+    )
+  end
+
+  defp fetch_client_secret do
+    presence(
+      Application.get_env(:metadata_relay, :trakt_client_secret) ||
+        System.get_env("TRAKT_CLIENT_SECRET")
+    )
+  end
+
+  defp presence(nil), do: nil
+
+  defp presence(value) when is_binary(value),
+    do: if(String.trim(value) == "", do: nil, else: value)
+
+  defp presence(value), do: value
 
   defp auth_header(nil), do: []
   defp auth_header(token), do: [{"authorization", "Bearer #{token}"}]

--- a/metadata-relay/test/metadata_relay/trakt/router_test.exs
+++ b/metadata-relay/test/metadata_relay/trakt/router_test.exs
@@ -1,0 +1,143 @@
+defmodule MetadataRelay.Trakt.RouterTest do
+  @moduledoc """
+  Covers the relay's behaviour when Trakt credentials are absent.
+
+  This is the production failure this suite was written for: the live relay
+  carried no TRAKT_CLIENT_ID, `Client.client_id/0` raised, and the raise
+  escaped as a generic HTML 500. Mydia could not tell that apart from an
+  outage and told users to "try again", which could never succeed.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  alias MetadataRelay.Router
+  alias MetadataRelay.Trakt.Client
+
+  setup do
+    previous = %{
+      id: Application.get_env(:metadata_relay, :trakt_client_id),
+      secret: Application.get_env(:metadata_relay, :trakt_client_secret),
+      env_id: System.get_env("TRAKT_CLIENT_ID"),
+      env_secret: System.get_env("TRAKT_CLIENT_SECRET")
+    }
+
+    # The lookup falls back to the OS environment, so a developer with real
+    # credentials exported would otherwise see these tests pass for the wrong
+    # reason. async: false, and everything is put back in on_exit.
+    System.delete_env("TRAKT_CLIENT_ID")
+    System.delete_env("TRAKT_CLIENT_SECRET")
+
+    on_exit(fn ->
+      restore(:trakt_client_id, previous.id)
+      restore(:trakt_client_secret, previous.secret)
+      restore_env("TRAKT_CLIENT_ID", previous.env_id)
+      restore_env("TRAKT_CLIENT_SECRET", previous.env_secret)
+    end)
+
+    :ok
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:metadata_relay, key)
+  defp restore(key, value), do: Application.put_env(:metadata_relay, key, value)
+
+  defp restore_env(key, nil), do: System.delete_env(key)
+  defp restore_env(key, value), do: System.put_env(key, value)
+
+  defp unconfigure do
+    Application.put_env(:metadata_relay, :trakt_client_id, nil)
+    Application.put_env(:metadata_relay, :trakt_client_secret, nil)
+  end
+
+  defp post_json(path, body) do
+    :post
+    |> Plug.Test.conn(path, Jason.encode!(body))
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Router.call([])
+  end
+
+  describe "Client.configured?/0" do
+    test "is false when both credentials are missing" do
+      unconfigure()
+      refute Client.configured?()
+    end
+
+    test "is false when only the client id is set" do
+      unconfigure()
+      Application.put_env(:metadata_relay, :trakt_client_id, "some-id")
+      refute Client.configured?()
+    end
+
+    test "is false when a credential is set but blank" do
+      Application.put_env(:metadata_relay, :trakt_client_id, "   ")
+      Application.put_env(:metadata_relay, :trakt_client_secret, "some-secret")
+
+      refute Client.configured?(),
+             "a blank credential must not count as configured, otherwise the relay " <>
+               "sends an empty trakt-api-key and Trakt answers 403"
+    end
+
+    test "is true when both credentials are present" do
+      Application.put_env(:metadata_relay, :trakt_client_id, "some-id")
+      Application.put_env(:metadata_relay, :trakt_client_secret, "some-secret")
+
+      assert Client.configured?()
+    end
+  end
+
+  describe "POST /trakt/oauth/device/code without credentials" do
+    setup do
+      unconfigure()
+      :ok
+    end
+
+    test "answers 503 instead of raising into a 500" do
+      conn = post_json("/trakt/oauth/device/code", %{})
+
+      assert conn.status == 503
+    end
+
+    test "answers JSON, not the generic HTML error page" do
+      conn = post_json("/trakt/oauth/device/code", %{})
+
+      assert ["application/json" <> _] = Plug.Conn.get_resp_header(conn, "content-type")
+    end
+
+    test "carries a machine-readable error code the client can match on" do
+      conn = post_json("/trakt/oauth/device/code", %{})
+
+      assert %{"error" => "trakt_not_configured", "message" => message} =
+               Jason.decode!(conn.resp_body)
+
+      assert message =~ "TRAKT_CLIENT_ID"
+    end
+  end
+
+  describe "other Trakt endpoints without credentials" do
+    setup do
+      unconfigure()
+      :ok
+    end
+
+    test "the device token poll answers 503 rather than a poll status code" do
+      conn = post_json("/trakt/oauth/device/token", %{"device_code" => "abc"})
+
+      assert conn.status == 503
+      assert %{"error" => "trakt_not_configured"} = Jason.decode!(conn.resp_body)
+    end
+
+    test "token refresh answers 503" do
+      conn = post_json("/trakt/oauth/refresh", %{"refresh_token" => "abc"})
+
+      assert conn.status == 503
+      assert %{"error" => "trakt_not_configured"} = Jason.decode!(conn.resp_body)
+    end
+
+    test "token revoke answers 503" do
+      conn = post_json("/trakt/oauth/revoke", %{"token" => "abc"})
+
+      assert conn.status == 503
+      assert %{"error" => "trakt_not_configured"} = Jason.decode!(conn.resp_body)
+    end
+  end
+end


### PR DESCRIPTION
## What was broken

Connecting a Trakt account fails on every Mydia instance with:

> Failed to start Trakt authorization. Please try again.

Reported against the galactica deployment, but it is not deployment-specific. `user_integrations` there has zero rows: Trakt has never successfully connected for anyone since it shipped in f47d58c9 (2026-02-22).

## Root cause

Traced through each boundary:

| Layer | Result |
| --- | --- |
| LiveView `trakt_connect` → `TraktClient.generate_device_code/0` | ok |
| `POST relay.mydia.dev/trakt/oauth/device/code` | request arrives |
| relay router → `TraktHandler.generate_device_code/0` | dispatches |
| `MetadataRelay.Trakt.Client.client_id/0` | **raises** |

From the live relay pod:

```
** (RuntimeError) TRAKT_CLIENT_ID environment variable is not set.
    lib/metadata_relay/trakt/client.ex:86: MetadataRelay.Trakt.Client.client_id/0
    lib/metadata_relay/trakt/handler.ex:20: MetadataRelay.Trakt.Handler.generate_device_code/0
    lib/metadata_relay/router.ex:1251: MetadataRelay.Router.handle_trakt_request/2
```

`handle_trakt_request/2` only handles `{:error, _}` tuples, so the raise escaped to Plug's generic HTML 500. Mydia could not distinguish that from a transient outage and told users to retry something that can never succeed.

The credentials were never recorded anywhere either: not in `secret.yaml.example`, `configmap.yaml`, the README env table, `docker-compose.yml`, or the live cluster secret. There were also no tests covering any Trakt route.

## What this changes

- `Client.configured?/0`, with both Trakt router helpers guarded by it. An unconfigured relay answers `503 {"error": "trakt_not_configured"}` rather than raising. A relay without Trakt credentials still serves TMDB and TVDB normally.
- Blank credentials count as missing. Only `nil` and `false` are falsy in Elixir, so an empty `TRAKT_CLIENT_ID` previously flowed through as an empty `trakt-api-key` header and drew a 403 from Trakt. Second latent bug in the same path.
- The integrations LiveView matches the relay's error code and names what actually has to change instead of saying "try again".
- `TRAKT_CLIENT_ID` / `TRAKT_CLIENT_SECRET` documented alongside the other provider credentials.
- 10 tests over the unconfigured path, where there were none.

## Verification

- Reproduced the 500 by curling `relay.mydia.dev` directly, with Mydia out of the picture.
- The new tests were confirmed to fail against pre-fix code with the exact production stack trace (`client.ex:86`), then pass after.
- metadata-relay: 185 tests, 0 failures. Mydia integrations LiveView: 5 tests, 0 failures. Both projects format-clean.

## Still needed to actually enable Trakt

This makes the misconfiguration diagnosable; it does not provision credentials. To turn Trakt on, register an app at https://trakt.tv/oauth/applications (redirect URI `urn:ietf:wg:oauth:2.0:oob` for the device flow) and add both keys to the `metadata-relay-secrets` secret on k3s-can1.

No mydia-side Bypass test: `METADATA_RELAY_URL` is read from global env, and the repo already documents that mutating it races async tests (`test/mydia/media/refresh_test.exs:144`). The relay tests carry the contract instead.

## Cross-version compatibility

Both directions degrade to the existing generic message, so relay and app can roll independently: an old Mydia against the new relay gets a 503 it does not specially match; a new Mydia against an old relay gets the HTML 500 it does not match either.
