### PR TITLE
fix(library): let users choose a movie's download library, stop new libraries capturing imports

### DIFF
--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -512,6 +512,16 @@ defmodule Mydia.Config.Loader do
         System.get_env("#{prefix}CATEGORY_PATHS"),
         &parse_json/1
       )
+      |> put_if_present(
+        :default_for_movies,
+        System.get_env("#{prefix}DEFAULT_FOR_MOVIES"),
+        &parse_boolean/1
+      )
+      |> put_if_present(
+        :default_for_series,
+        System.get_env("#{prefix}DEFAULT_FOR_SERIES"),
+        &parse_boolean/1
+      )
     end)
     |> Enum.reject(&(&1 == %{}))
   end

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -219,6 +219,8 @@ defmodule Mydia.Config.Schema do
       field :type, Ecto.Enum, values: [:movies, :series, :mixed, :music, :books, :adult]
       field :monitored, :boolean, default: true
       field :scan_interval, :integer
+      field :default_for_movies, :boolean, default: false
+      field :default_for_series, :boolean, default: false
     end
 
     # Env/YAML-sourced installed plugins (PLUGIN_<N>_*). DB-sourced installs
@@ -562,7 +564,9 @@ defmodule Mydia.Config.Schema do
       :path,
       :type,
       :monitored,
-      :scan_interval
+      :scan_interval,
+      :default_for_movies,
+      :default_for_series
     ])
     |> validate_required([:path, :type])
     |> validate_inclusion(:type, [:movies, :series, :mixed, :music, :books, :adult])

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -741,20 +741,13 @@ defmodule Mydia.Downloads.Queue do
   end
 
   defp resolve_rematch_destination(media_item, episode) do
-    # Build a probe reflecting the NEW target so determine_library_path resolves
-    # the correct destination (the download row still holds the old target here).
-    probe = %Download{
-      media_item_id: media_item && media_item.id,
-      media_item: media_item,
-      episode_id: episode && episode.id,
-      episode: episode,
-      library_path: nil,
-      library_path_id: nil
-    }
+    # Resolves against the NEW target: the download row still holds the old one
+    # here, so no download is passed and step 1 is skipped by design.
+    _ = episode
 
-    case Mydia.Jobs.MediaImport.determine_library_path(probe) do
-      nil -> {:error, :no_library_path}
-      library_path -> {:ok, library_path}
+    case media_item && Mydia.Library.TargetResolver.resolve(media_item) do
+      {:ok, library_path, _reason} -> {:ok, library_path}
+      _ -> {:error, :no_library_path}
     end
   end
 

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -38,6 +38,7 @@ defmodule Mydia.Jobs.MediaImport do
   alias Mydia.Downloads.ImportCandidates
   alias Mydia.Library.{FileNamer, FileOrganizer, SampleDetector}
   alias Mydia.Library.ReleaseParser
+  alias Mydia.Library.TargetResolver
   alias Mydia.Library.ReleaseParser.TargetContext
   alias Mydia.Media.Episode
   alias Mydia.Indexers.QualityParser
@@ -831,53 +832,47 @@ defmodule Mydia.Jobs.MediaImport do
 
   @doc false
   def determine_library_path(download) do
-    # If download has a direct library_path association (specialized libraries),
-    # use that directly
-    if download.library_path do
-      download.library_path
-    else
-      # Get library paths from settings
-      library_paths = Settings.list_library_paths()
+    cond do
+      download.library_path ->
+        download.library_path
 
-      {media_type, required_types} =
-        cond do
-          # TV episode
-          download.episode && download.media_item ->
-            {"TV show", [:series, :mixed]}
+      is_nil(download.media_item) ->
+        # A download with no media item has no kind to resolve against. This
+        # branch preserves the historical :mixed-only lookup verbatim; nothing
+        # in the targeting design changes what should happen to an
+        # unattributed download.
+        resolve_unattributed(download)
 
-          # Movie
-          download.media_item && download.media_item.type == "movie" ->
-            {"movie", [:movies, :mixed]}
+      true ->
+        case TargetResolver.resolve(download.media_item, download: download) do
+          {:ok, library_path, _reason} ->
+            library_path
 
-          # TV show (no specific episode)
-          download.media_item && download.media_item.type == "tv_show" ->
-            {"TV show", [:series, :mixed]}
-
-          true ->
-            {"unknown", [:mixed]}
+          {:error, :no_compatible_library} ->
+            warn_no_library(download, download.media_item.type)
+            nil
         end
-
-      # Find compatible library path
-      library_path =
-        Enum.find(library_paths, fn lp ->
-          lp.type in required_types && lp.monitored
-        end)
-
-      # Log warning if no compatible library found
-      if is_nil(library_path) do
-        Logger.warning("No compatible library path found for import",
-          download_id: download.id,
-          media_type: media_type,
-          required_library_types: required_types,
-          available_libraries:
-            Enum.map(library_paths, fn lp ->
-              %{path: lp.path, type: lp.type, monitored: lp.monitored}
-            end)
-        )
-      end
-
-      library_path
     end
+  end
+
+  defp resolve_unattributed(download) do
+    library_paths = Settings.list_library_paths()
+    library_path = Enum.find(library_paths, &(&1.type == :mixed and &1.monitored))
+
+    if is_nil(library_path), do: warn_no_library(download, "unknown")
+
+    library_path
+  end
+
+  defp warn_no_library(download, media_type) do
+    Logger.warning("No compatible library path found for import",
+      download_id: download.id,
+      media_type: media_type,
+      available_libraries:
+        Enum.map(Settings.list_library_paths(), fn lp ->
+          %{path: lp.path, type: lp.type, monitored: lp.monitored}
+        end)
+    )
   end
 
   defp organize_and_import_files(download, files, library_path, args) do

--- a/lib/mydia/library/target_resolver.ex
+++ b/lib/mydia/library/target_resolver.ex
@@ -1,0 +1,146 @@
+defmodule Mydia.Library.TargetResolver do
+  @moduledoc """
+  Decides which library a media item's content belongs in.
+
+  This is the single authority for that question. Import, rematch and the
+  detail page all route through `resolve/2` so they cannot disagree.
+
+  Resolution order, first match wins:
+
+    1. `:download_override`  - the download row's own `library_path_id`
+    2. `:explicit`           - the media item's `library_path_id`
+    3. `:existing_files`     - where this item's non-trashed files already live
+    4. `:type_default`       - the operator-set default for the item's kind
+    5. `:first_compatible`   - the historical rule: first compatible library by
+                               `Settings.list_library_paths/1` ordering
+
+  Step 5 is deliberately the pre-existing behaviour, so an install that never
+  configures a default resolves exactly as it did before this module existed.
+
+  ## Candidate validation
+
+  Each step produces a candidate that must pass a check before being accepted;
+  a failing candidate falls through rather than aborting, because a library can
+  be deleted, disabled or retyped long after an item started pointing at it.
+
+  The check differs by step on purpose. An **explicit** choice requires only
+  that the library exists, is not disabled, and is type-compatible. It does not
+  require `monitored`: unmonitoring means "stop scanning", usually because a
+  drive is offline, and silently rerouting an explicit choice to a different
+  disk is how one movie ends up in two places. Inferred steps additionally
+  require `monitored`, matching the historical behaviour.
+  """
+
+  import Ecto.Query
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.MediaItem
+  alias Mydia.Repo
+  alias Mydia.Settings
+  alias Mydia.Settings.LibraryPath
+
+  @type reason ::
+          :download_override | :explicit | :existing_files | :type_default | :first_compatible
+
+  @movie_types [:movies, :mixed]
+  @series_types [:series, :mixed]
+
+  @doc """
+  Resolves the target library for `media_item`.
+
+  ## Options
+
+    * `:download` - the `%Mydia.Downloads.Download{}` being imported, if any.
+      Its `library_path` association supplies step 1.
+    * `:library_paths` - candidate list, defaulting to
+      `Settings.list_library_paths/0`. Injectable so tests need no global state.
+  """
+  @spec resolve(MediaItem.t(), keyword()) ::
+          {:ok, LibraryPath.t(), reason()} | {:error, :no_compatible_library}
+  def resolve(%MediaItem{} = media_item, opts \\ []) do
+    library_paths = Keyword.get_lazy(opts, :library_paths, &Settings.list_library_paths/0)
+    kind = kind_for(media_item)
+    allowed = allowed_types(kind)
+
+    steps = [
+      {:download_override, fn -> download_target(opts[:download]) end, :no_validation},
+      {:explicit, fn -> explicit_target(media_item, library_paths) end, :explicit_rules},
+      {:existing_files, fn -> files_target(media_item, library_paths) end, :inferred_rules},
+      {:type_default, fn -> default_target(kind) end, :inferred_rules},
+      {:first_compatible, fn -> first_compatible(library_paths, allowed) end, :inferred_rules}
+    ]
+
+    Enum.find_value(steps, {:error, :no_compatible_library}, fn {reason, produce, rules} ->
+      case produce.() do
+        nil -> nil
+        candidate -> if acceptable?(candidate, allowed, rules), do: {:ok, candidate, reason}
+      end
+    end)
+  end
+
+  @doc """
+  The library types that can hold content of `kind`.
+  """
+  @spec allowed_types(:movies | :series) :: [atom()]
+  def allowed_types(:movies), do: @movie_types
+  def allowed_types(:series), do: @series_types
+
+  @doc """
+  Maps a media item to the kind of library it belongs in.
+  """
+  @spec kind_for(MediaItem.t()) :: :movies | :series
+  def kind_for(%MediaItem{type: "movie"}), do: :movies
+  def kind_for(%MediaItem{}), do: :series
+
+  ## Candidate producers
+
+  defp download_target(nil), do: nil
+  defp download_target(%{library_path: %LibraryPath{} = library_path}), do: library_path
+  defp download_target(_), do: nil
+
+  defp explicit_target(%MediaItem{library_path_id: nil}, _paths), do: nil
+
+  defp explicit_target(%MediaItem{library_path_id: id}, paths) do
+    Enum.find(paths, &(to_string(&1.id) == to_string(id))) || Repo.get(LibraryPath, id)
+  end
+
+  defp files_target(%MediaItem{id: id}, paths) do
+    MediaFile
+    |> where([f], f.media_item_id == ^id)
+    |> where([f], is_nil(f.trashed_at))
+    |> where([f], not is_nil(f.library_path_id))
+    |> group_by([f], f.library_path_id)
+    |> order_by([f], desc: count(f.id), desc: max(f.inserted_at))
+    |> limit(1)
+    |> select([f], f.library_path_id)
+    |> Repo.one()
+    |> case do
+      nil -> nil
+      library_path_id -> Enum.find(paths, &(to_string(&1.id) == to_string(library_path_id)))
+    end
+  end
+
+  defp default_target(kind), do: Settings.default_library_for(kind)
+
+  defp first_compatible(paths, allowed) do
+    Enum.find(paths, &(&1.type in allowed and &1.monitored))
+  end
+
+  ## Candidate validation
+
+  # A download-level override is honoured as-is. It is the pre-existing
+  # specialized-library escape hatch (music, books, adult) whose type would
+  # never satisfy a movie's or show's allow-list, and the design leaves that
+  # step unchanged.
+  defp acceptable?(%LibraryPath{}, _allowed, :no_validation), do: true
+
+  defp acceptable?(%LibraryPath{} = candidate, allowed, rules) do
+    candidate.type in allowed and not disabled?(candidate) and
+      (rules == :explicit_rules or candidate.monitored)
+  end
+
+  defp acceptable?(_, _, _), do: false
+
+  defp disabled?(%LibraryPath{disabled: true}), do: true
+  defp disabled?(_), do: false
+end

--- a/lib/mydia/library/target_resolver.ex
+++ b/lib/mydia/library/target_resolver.ex
@@ -96,6 +96,13 @@ defmodule Mydia.Library.TargetResolver do
 
   defp download_target(nil), do: nil
   defp download_target(%{library_path: %LibraryPath{} = library_path}), do: library_path
+
+  # Fall back to the id when the association is not preloaded. Without this a
+  # caller passing a Download whose `library_path_id` is set but whose
+  # `library_path` was never loaded would silently skip the override and
+  # resolve somewhere else.
+  defp download_target(%{library_path_id: id}) when not is_nil(id), do: Repo.get(LibraryPath, id)
+
   defp download_target(_), do: nil
 
   defp explicit_target(%MediaItem{library_path_id: nil}, _paths), do: nil
@@ -110,7 +117,9 @@ defmodule Mydia.Library.TargetResolver do
     |> where([f], is_nil(f.trashed_at))
     |> where([f], not is_nil(f.library_path_id))
     |> group_by([f], f.library_path_id)
-    |> order_by([f], desc: count(f.id), desc: max(f.inserted_at))
+    # library_path_id is the tertiary key so an exact tie on both count and
+    # recency still resolves the same way on every run.
+    |> order_by([f], desc: count(f.id), desc: max(f.inserted_at), asc: f.library_path_id)
     |> limit(1)
     |> select([f], f.library_path_id)
     |> Repo.one()

--- a/lib/mydia/media/media_item.ex
+++ b/lib/mydia/media/media_item.ex
@@ -26,6 +26,8 @@ defmodule Mydia.Media.MediaItem do
           seasons_refreshed_at: DateTime.t() | nil,
           last_upgrade_check_at: DateTime.t() | nil,
           quality_profile: Mydia.Settings.QualityProfile.t() | Ecto.Association.NotLoaded.t(),
+          library_path: Mydia.Settings.LibraryPath.t() | nil | Ecto.Association.NotLoaded.t(),
+          library_path_id: binary() | nil,
           episodes: [Mydia.Media.Episode.t()] | Ecto.Association.NotLoaded.t(),
           media_files: [Mydia.Library.MediaFile.t()] | Ecto.Association.NotLoaded.t(),
           downloads: [Mydia.Downloads.Download.t()] | Ecto.Association.NotLoaded.t(),
@@ -63,6 +65,7 @@ defmodule Mydia.Media.MediaItem do
     field :last_upgrade_check_at, :utc_datetime
 
     belongs_to :quality_profile, Mydia.Settings.QualityProfile
+    belongs_to :library_path, Mydia.Settings.LibraryPath
     has_many :episodes, Mydia.Media.Episode
     has_many :media_files, Mydia.Library.MediaFile
     has_many :downloads, Mydia.Downloads.Download
@@ -89,7 +92,8 @@ defmodule Mydia.Media.MediaItem do
       :metadata,
       :monitored,
       :monitoring_preset,
-      :quality_profile_id
+      :quality_profile_id,
+      :library_path_id
     ])
     |> validate_required([:type, :title])
     |> validate_inclusion(:type, @type_values)
@@ -98,6 +102,7 @@ defmodule Mydia.Media.MediaItem do
     |> unique_constraint(:tmdb_id)
     |> unique_constraint(:tvdb_id)
     |> foreign_key_constraint(:quality_profile_id)
+    |> foreign_key_constraint(:library_path_id)
   end
 
   # Custom validation to ensure movies have year data

--- a/lib/mydia/settings.ex
+++ b/lib/mydia/settings.ex
@@ -673,6 +673,19 @@ defmodule Mydia.Settings do
           {:ok, LibraryPath.t()} | {:error, Ecto.Changeset.t()}
   defdelegate delete_library_path(library_path), to: Mydia.Settings.LibraryPaths
 
+  @doc """
+  Makes a library the default download target for `:movies` or `:series`.
+  """
+  @spec set_default_library(LibraryPath.t(), :movies | :series) ::
+          {:ok, LibraryPath.t()} | {:error, Ecto.Changeset.t() | :incompatible_type}
+  defdelegate set_default_library(library_path, kind), to: Mydia.Settings.LibraryPaths
+
+  @doc """
+  Returns the default target library for `:movies` or `:series`, or nil.
+  """
+  @spec default_library_for(:movies | :series) :: LibraryPath.t() | nil
+  defdelegate default_library_for(kind), to: Mydia.Settings.LibraryPaths
+
   # ── Runtime Configuration ────────────────────────────────────────────
 
   @doc """

--- a/lib/mydia/settings/library_path.ex
+++ b/lib/mydia/settings/library_path.ex
@@ -27,6 +27,8 @@ defmodule Mydia.Settings.LibraryPath do
           write_nfo: boolean(),
           auto_rename: boolean(),
           tv_metadata_source: atom() | nil,
+          default_for_movies: boolean(),
+          default_for_series: boolean(),
           quality_profile:
             Mydia.Settings.QualityProfile.t() | nil | Ecto.Association.NotLoaded.t(),
           quality_profile_id: binary() | nil,
@@ -37,8 +39,14 @@ defmodule Mydia.Settings.LibraryPath do
         }
 
   @path_types [:movies, :series, :mixed, :music, :books, :adult]
+  @movie_library_types [:movies, :mixed]
+  @series_library_types [:series, :mixed]
   @scan_statuses [:success, :failed, :in_progress]
   @tv_metadata_sources [:tvdb, :tmdb]
+
+  @doc "Library types that can serve as the default target for each media kind."
+  def movie_library_types, do: @movie_library_types
+  def series_library_types, do: @series_library_types
 
   @doc "Valid TV metadata source providers for series/mixed libraries."
   def tv_metadata_sources, do: @tv_metadata_sources
@@ -67,6 +75,9 @@ defmodule Mydia.Settings.LibraryPath do
     field :auto_rename, :boolean, default: true
     # Metadata provider for TV shows in this library (series/mixed only)
     field :tv_metadata_source, Ecto.Enum, values: @tv_metadata_sources, default: :tvdb
+    # At most one library per media kind may be the default download target.
+    field :default_for_movies, :boolean, default: false
+    field :default_for_series, :boolean, default: false
 
     belongs_to :quality_profile, Mydia.Settings.QualityProfile
     belongs_to :updated_by, Mydia.Accounts.User
@@ -96,13 +107,24 @@ defmodule Mydia.Settings.LibraryPath do
       :auto_import,
       :write_nfo,
       :auto_rename,
-      :tv_metadata_source
+      :tv_metadata_source,
+      :default_for_movies,
+      :default_for_series
     ])
     |> validate_required([:path, :type])
     |> validate_inclusion(:type, @path_types)
     |> validate_inclusion(:tv_metadata_source, @tv_metadata_sources)
     |> validate_number(:scan_interval, greater_than_or_equal_to: 900)
     |> validate_category_paths()
+    |> validate_default_flag_types()
+    |> unique_constraint(:default_for_movies,
+      name: :library_paths_single_default_for_movies,
+      message: "another library is already the default for movies"
+    )
+    |> unique_constraint(:default_for_series,
+      name: :library_paths_single_default_for_series,
+      message: "another library is already the default for series"
+    )
     |> unique_constraint(:path)
   end
 
@@ -144,6 +166,32 @@ defmodule Mydia.Settings.LibraryPath do
 
   defp valid_category_key?(key) when is_atom(key), do: MediaCategory.valid?(key)
   defp valid_category_key?(_), do: false
+
+  @doc """
+  Rejects a default flag the library's own `type` cannot serve.
+
+  A :movies library cannot be the series default, and vice versa. A :mixed
+  library may hold both.
+  """
+  def validate_default_flag_types(changeset) do
+    type = get_field(changeset, :type)
+
+    changeset
+    |> validate_flag_for_type(:default_for_movies, type, @movie_library_types, "movies")
+    |> validate_flag_for_type(:default_for_series, type, @series_library_types, "series")
+  end
+
+  defp validate_flag_for_type(changeset, field, type, allowed_types, kind_label) do
+    if get_field(changeset, field) && type not in allowed_types do
+      add_error(
+        changeset,
+        field,
+        "cannot be the default #{kind_label} library for a #{type} library"
+      )
+    else
+      changeset
+    end
+  end
 
   @doc """
   Resolves the full destination path for a media item based on its category.

--- a/lib/mydia/settings/library_paths.ex
+++ b/lib/mydia/settings/library_paths.ex
@@ -22,6 +22,59 @@ defmodule Mydia.Settings.LibraryPaths do
     RC.merge_with_runtime_config(db_paths, &RC.get_runtime_library_paths/0, :path)
   end
 
+  @kind_types %{movies: [:movies, :mixed], series: [:series, :mixed]}
+  @kind_fields %{movies: :default_for_movies, series: :default_for_series}
+
+  @doc """
+  Makes `library_path` the default download target for `kind`.
+
+  Clears the flag from whichever row currently holds it, in one transaction, so
+  the partial unique index is a backstop rather than the thing that surfaces a
+  conflict to the user.
+
+  Returns `{:error, :incompatible_type}` when the library's `type` cannot serve
+  the kind.
+  """
+  @spec set_default_library(LibraryPath.t(), :movies | :series) ::
+          {:ok, LibraryPath.t()} | {:error, Ecto.Changeset.t() | :incompatible_type}
+  def set_default_library(%LibraryPath{} = library_path, kind) when kind in [:movies, :series] do
+    field = Map.fetch!(@kind_fields, kind)
+
+    if library_path.type in Map.fetch!(@kind_types, kind) do
+      Repo.transaction(fn ->
+        LibraryPath
+        |> where([l], field(l, ^field) == true)
+        |> where([l], l.id != ^library_path.id)
+        |> Repo.update_all(set: [{field, false}])
+
+        library_path
+        |> LibraryPath.changeset(%{field => true})
+        |> Repo.update()
+        |> case do
+          {:ok, updated} -> updated
+          {:error, changeset} -> Repo.rollback(changeset)
+        end
+      end)
+    else
+      {:error, :incompatible_type}
+    end
+  end
+
+  @doc """
+  Returns the library flagged as the default target for `kind`, or nil.
+
+  Disabled libraries are excluded, matching `list_library_paths/1`.
+  """
+  @spec default_library_for(:movies | :series) :: LibraryPath.t() | nil
+  def default_library_for(kind) when kind in [:movies, :series] do
+    field = Map.fetch!(@kind_fields, kind)
+
+    LibraryPath
+    |> where([l], field(l, ^field) == true)
+    |> where([l], l.disabled == false or is_nil(l.disabled))
+    |> Repo.one()
+  end
+
   @tv_library_types [:series, :mixed]
 
   @doc """

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -8,6 +8,7 @@ defmodule MydiaWeb.DiscoverComponents do
   import MydiaWeb.CoreComponents, only: [icon: 1]
 
   alias Mydia.Metadata.ImageUrl
+  alias MydiaWeb.LibraryComponents
 
   use Phoenix.VerifiedRoutes,
     endpoint: MydiaWeb.Endpoint,
@@ -30,6 +31,7 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :media_type, :atom, required: true
   attr :current_user, :map, required: true
   attr :adding_item_id, :string, default: nil
+  attr :libraries, :list, default: []
 
   def trending_card(assigns) do
     ~H"""
@@ -88,6 +90,7 @@ defmodule MydiaWeb.DiscoverComponents do
           media_type={@media_type}
           current_user={@current_user}
           adding_item_id={@adding_item_id}
+          libraries={@libraries}
         />
       </div>
     </div>
@@ -98,6 +101,7 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :media_type, :atom, required: true
   attr :current_user, :map, required: true
   attr :adding_item_id, :string, default: nil
+  attr :libraries, :list, default: []
 
   defp trending_card_action(assigns) do
     ~H"""
@@ -110,19 +114,26 @@ defmodule MydiaWeb.DiscoverComponents do
           <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
         </.link>
       <% else %>
-        <button
-          phx-click="add_to_library"
-          phx-value-tmdb_id={@item.provider_id}
-          phx-value-media_type={@media_type}
-          disabled={@adding_item_id == to_string(@item.provider_id)}
-          class="btn btn-primary btn-sm mt-2 w-full"
-        >
-          <%= if @adding_item_id == to_string(@item.provider_id) do %>
-            <span class="loading loading-spinner loading-xs"></span> Adding...
-          <% else %>
-            <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
-          <% end %>
-        </button>
+        <div class="join w-full mt-2">
+          <button
+            phx-click="add_to_library"
+            phx-value-tmdb_id={@item.provider_id}
+            phx-value-media_type={@media_type}
+            disabled={@adding_item_id == to_string(@item.provider_id)}
+            class="btn btn-primary btn-sm join-item flex-1"
+          >
+            <%= if @adding_item_id == to_string(@item.provider_id) do %>
+              <span class="loading loading-spinner loading-xs"></span> Adding...
+            <% else %>
+              <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
+            <% end %>
+          </button>
+          <LibraryComponents.library_picker_menu
+            libraries={@libraries}
+            event="add_to_library"
+            extra_values={%{tmdb_id: @item.provider_id, media_type: @media_type}}
+          />
+        </div>
       <% end %>
     <% else %>
       <.link navigate={library_path(@media_type, @item.id)} class="btn btn-ghost btn-sm mt-2 w-full">

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -131,7 +131,8 @@ defmodule MydiaWeb.DiscoverComponents do
           <LibraryComponents.library_picker_menu
             libraries={@libraries}
             event="add_to_library"
-            extra_values={%{tmdb_id: @item.provider_id, media_type: @media_type}}
+            tmdb_id={@item.provider_id}
+            media_type={@media_type}
           />
         </div>
       <% end %>

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -526,4 +526,56 @@ defmodule MydiaWeb.LibraryComponents do
     </.modal>
     """
   end
+
+  @doc """
+  A caret button opening a menu of target libraries.
+
+  Renders nothing when there are fewer than two candidates, so a single-library
+  install sees the plain add button exactly as before.
+
+  Libraries have no `name` column, only `path`, so each entry shows the
+  basename with the full path as secondary text.
+  """
+  attr :libraries, :list, required: true
+  attr :event, :string, required: true
+  attr :extra_values, :map, default: %{}
+  attr :selected_id, :string, default: nil
+
+  def library_picker_menu(assigns) do
+    ~H"""
+    <div :if={length(@libraries) > 1} class="dropdown dropdown-end">
+      <div
+        tabindex="0"
+        role="button"
+        data-test="library-picker-caret"
+        class="btn btn-primary btn-sm join-item px-2"
+        title="Choose a library"
+      >
+        <.icon name="hero-chevron-down" class="w-3 h-3" />
+      </div>
+      <ul
+        tabindex="0"
+        class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-60 border border-base-300"
+      >
+        <li class="menu-title text-xs">Add to library</li>
+        <li :for={library <- @libraries}>
+          <button
+            type="button"
+            phx-click={@event}
+            phx-value-library_path_id={library.id}
+            {phx_values(@extra_values)}
+            class="flex-col items-start gap-0"
+          >
+            <span class="font-medium">{Path.basename(library.path)}</span>
+            <span class="text-xs text-base-content/50 truncate w-full">{library.path}</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+    """
+  end
+
+  defp phx_values(values) do
+    Map.new(values, fn {key, value} -> {:"phx-value-#{key}", value} end)
+  end
 end

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -538,7 +538,8 @@ defmodule MydiaWeb.LibraryComponents do
   """
   attr :libraries, :list, required: true
   attr :event, :string, required: true
-  attr :extra_values, :map, default: %{}
+  attr :tmdb_id, :any, default: nil
+  attr :media_type, :any, default: nil
   attr :selected_id, :string, default: nil
 
   def library_picker_menu(assigns) do
@@ -563,7 +564,8 @@ defmodule MydiaWeb.LibraryComponents do
             type="button"
             phx-click={@event}
             phx-value-library_path_id={library.id}
-            {phx_values(@extra_values)}
+            phx-value-tmdb_id={@tmdb_id}
+            phx-value-media_type={@media_type}
             class="flex-col items-start gap-0"
           >
             <span class="font-medium">{Path.basename(library.path)}</span>
@@ -573,9 +575,5 @@ defmodule MydiaWeb.LibraryComponents do
       </ul>
     </div>
     """
-  end
-
-  defp phx_values(values) do
-    Map.new(values, fn {key, value} -> {:"phx-value-#{key}", value} end)
   end
 end

--- a/lib/mydia_web/live/add_media_live/index.ex
+++ b/lib/mydia_web/live/add_media_live/index.ex
@@ -230,8 +230,8 @@ defmodule MydiaWeb.AddMediaLive.Index do
 
         case Media.create_media_item(attrs, season_monitoring: season_monitoring) do
           {:ok, media_item} ->
-            # Stay on page with success message
-            # Use provider_id as key (integer) for tracking added items
+            maybe_queue_search(media_item, config)
+
             id_key = String.to_integer(selected.provider_id)
 
             {:noreply,
@@ -404,6 +404,24 @@ defmodule MydiaWeb.AddMediaLive.Index do
 
   defp path_exists?(paths, id) do
     Enum.any?(paths, &(&1.id == id))
+  end
+
+  # Uses the shared auto-search path rather than enqueuing directly: it is
+  # already Oban-dedupe-safe (singular insert/1, not insert_all/1) and is what
+  # the media detail page uses.
+  defp maybe_queue_search(media_item, config) do
+    if Map.get(config, :search_on_add) do
+      case Mydia.Search.queue_auto_searches([media_item]) do
+        {:ok, _count} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("Failed to queue search on add",
+            media_item_id: media_item.id,
+            reason: inspect(reason)
+          )
+      end
+    end
   end
 
   defp build_media_item_attrs(metadata, config, media_type) do

--- a/lib/mydia_web/live/add_media_live/index.ex
+++ b/lib/mydia_web/live/add_media_live/index.ex
@@ -61,7 +61,10 @@ defmodule MydiaWeb.AddMediaLive.Index do
   defp load_library_paths(socket, type) do
     paths =
       Settings.list_library_paths()
-      |> Enum.filter(&((&1.type == type or &1.type == :mixed) and &1.monitored))
+      |> Enum.filter(fn lp ->
+        (lp.type == type or lp.type == :mixed) and lp.monitored and
+          not String.starts_with?(to_string(lp.id), "runtime::")
+      end)
 
     assign(socket, :library_paths, paths)
   end
@@ -414,7 +417,8 @@ defmodule MydiaWeb.AddMediaLive.Index do
       imdb_id: metadata.imdb_id,
       metadata: metadata,
       monitored: config.monitored,
-      quality_profile_id: config.quality_profile_id
+      quality_profile_id: config.quality_profile_id,
+      library_path_id: config.library_path_id
     }
 
     # For TV shows fetched via TVDB, store tvdb_id; for movies, store tmdb_id

--- a/lib/mydia_web/live/add_media_live/index.ex
+++ b/lib/mydia_web/live/add_media_live/index.ex
@@ -307,16 +307,8 @@ defmodule MydiaWeb.AddMediaLive.Index do
   end
 
   defp assign_config_form(socket) do
-    # Build changeset from current toolbar settings for the modal
     changeset =
-      {%{},
-       %{
-         quality_profile_id: :string,
-         library_path_id: :string,
-         monitored: :boolean,
-         search_on_add: :boolean,
-         season_monitoring: :string
-       }}
+      {config_defaults(), config_types()}
       |> Ecto.Changeset.cast(
         %{
           quality_profile_id: socket.assigns.toolbar_quality_profile_id,
@@ -325,22 +317,42 @@ defmodule MydiaWeb.AddMediaLive.Index do
           search_on_add: socket.assigns.toolbar_search_on_add,
           season_monitoring: socket.assigns.toolbar_season_monitoring
         },
-        [:quality_profile_id, :library_path_id, :monitored, :search_on_add, :season_monitoring]
+        Map.keys(config_types())
       )
 
     assign(socket, :config_form, to_form(changeset, as: :config))
   end
 
-  defp validate_config(params, assigns) do
-    types = %{
+  # The changeset is schemaless, so `apply_changes/1` returns
+  # `Map.merge(data, changes)`. Seeding `data` with every key means a field
+  # submitted as nil or "" (blank quality profile, unticked checkbox) is still
+  # present in the result. With `%{}` as data it would be absent, and the dot
+  # access in build_media_item_attrs/3 would raise KeyError. Seeding is
+  # structural: it immunises any field added later, not just today's two.
+  defp config_defaults do
+    %{
+      quality_profile_id: nil,
+      library_path_id: nil,
+      monitored: true,
+      search_on_add: false,
+      season_monitoring: "all"
+    }
+  end
+
+  defp config_types do
+    %{
       quality_profile_id: :string,
       library_path_id: :string,
       monitored: :boolean,
       search_on_add: :boolean,
       season_monitoring: :string
     }
+  end
 
-    {%{}, types}
+  defp validate_config(params, assigns) do
+    types = config_types()
+
+    {config_defaults(), types}
     |> Ecto.Changeset.cast(params, Map.keys(types))
     |> Ecto.Changeset.validate_required([:library_path_id])
     |> validate_profile_exists(assigns.quality_profiles)

--- a/lib/mydia_web/live/add_media_live/index.ex
+++ b/lib/mydia_web/live/add_media_live/index.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.AddMediaLive.Index do
 
   alias Mydia.{Media, Metadata, Settings}
   alias MydiaWeb.Live.Authorization
+  alias MydiaWeb.Live.Helpers.MediaAddHelpers
 
   @impl true
   def mount(_params, session, socket) do
@@ -59,14 +60,8 @@ defmodule MydiaWeb.AddMediaLive.Index do
   defp maybe_trigger_search(socket, _params), do: socket
 
   defp load_library_paths(socket, type) do
-    paths =
-      Settings.list_library_paths()
-      |> Enum.filter(fn lp ->
-        (lp.type == type or lp.type == :mixed) and lp.monitored and
-          not String.starts_with?(to_string(lp.id), "runtime::")
-      end)
-
-    assign(socket, :library_paths, paths)
+    media_type = if type == :movies, do: :movie, else: :tv_show
+    assign(socket, :library_paths, MediaAddHelpers.candidate_libraries(media_type))
   end
 
   ## Event Handlers

--- a/lib/mydia_web/live/add_media_live/index.html.heex
+++ b/lib/mydia_web/live/add_media_live/index.html.heex
@@ -327,9 +327,11 @@
             <%!-- Monitoring --%>
             <div class="form-control mb-4">
               <label class="label cursor-pointer justify-start gap-4">
+                <input type="hidden" name="config[monitored]" value="false" />
                 <input
                   type="checkbox"
                   name="config[monitored]"
+                  value="true"
                   class="toggle toggle-primary"
                   checked={@config_form[:monitored].value}
                 />

--- a/lib/mydia_web/live/admin_library_paths_live/components.ex
+++ b/lib/mydia_web/live/admin_library_paths_live/components.ex
@@ -247,6 +247,19 @@ defmodule MydiaWeb.AdminLibraryPathsLive.Components do
                   />
                 </div>
 
+                <.input
+                  :if={@library_path_form[:type].value in ["movies", "mixed", :movies, :mixed]}
+                  field={@library_path_form[:default_for_movies]}
+                  type="checkbox"
+                  label="Default library for movies"
+                />
+                <.input
+                  :if={@library_path_form[:type].value in ["series", "mixed", :series, :mixed]}
+                  field={@library_path_form[:default_for_series]}
+                  type="checkbox"
+                  label="Default library for series"
+                />
+
                 <%!-- Write NFO Toggle (only for movies/series/mixed) --%>
                 <%= if to_string(@library_path_form[:type].value) in ["movies", "series", "mixed"] do %>
                   <div class="flex items-center justify-between bg-base-200 rounded-lg px-4 py-3">
@@ -377,6 +390,12 @@ defmodule MydiaWeb.AdminLibraryPathsLive.Components do
           <span class={["badge badge-sm", library_type_badge_class(@library_path.type)]}>
             <.icon name={library_type_icon(@library_path.type)} class="w-3 h-3 mr-1" />
             {library_type_display(@library_path.type)}
+          </span>
+          <span
+            :if={@library_path.default_for_movies or @library_path.default_for_series}
+            class="badge badge-sm badge-outline"
+          >
+            Default
           </span>
           <span class={[
             "badge badge-sm",

--- a/lib/mydia_web/live/admin_library_paths_live/index.ex
+++ b/lib/mydia_web/live/admin_library_paths_live/index.ex
@@ -151,10 +151,23 @@ defmodule MydiaWeb.AdminLibraryPathsLive.Index do
 
       case validate_directory(validated_data.path) do
         :ok ->
+          save_params = strip_new_default_flags(params, library_path)
+
           result =
             case socket.assigns.library_path_mode do
-              :new -> Settings.create_library_path(params)
-              :edit -> Settings.update_library_path(socket.assigns.editing_library_path, params)
+              :new ->
+                with {:ok, path} <- Settings.create_library_path(save_params) do
+                  apply_default_flags(path, params)
+                end
+
+              :edit ->
+                with {:ok, path} <-
+                       Settings.update_library_path(
+                         socket.assigns.editing_library_path,
+                         save_params
+                       ) do
+                  apply_default_flags(path, params)
+                end
             end
 
           case result do
@@ -167,6 +180,10 @@ defmodule MydiaWeb.AdminLibraryPathsLive.Index do
 
             {:error, %Ecto.Changeset{} = changeset} ->
               {:noreply, assign(socket, :library_path_form, to_form(changeset))}
+
+            {:error, :incompatible_type} ->
+              {:noreply,
+               put_flash(socket, :error, "Library type cannot serve as default for that kind")}
           end
 
         {:error, reason} ->
@@ -266,6 +283,38 @@ defmodule MydiaWeb.AdminLibraryPathsLive.Index do
   end
 
   ## Private Helpers
+
+  defp strip_new_default_flags(params, library_path) do
+    Enum.reduce(["default_for_movies", "default_for_series"], params, fn key, acc ->
+      field = String.to_existing_atom(key)
+      already? = Map.fetch!(library_path, field) == true
+
+      if acc[key] in ["true", true] and not already? do
+        Map.delete(acc, key)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp apply_default_flags(library_path, params) do
+    Enum.reduce_while(
+      [{:movies, "default_for_movies"}, {:series, "default_for_series"}],
+      {:ok, library_path},
+      fn
+        {kind, param_key}, {:ok, acc} ->
+          if params[param_key] in ["true", true] and
+               not Map.fetch!(acc, String.to_existing_atom(param_key)) do
+            case Settings.set_default_library(acc, kind) do
+              {:ok, updated} -> {:cont, {:ok, updated}}
+              error -> {:halt, error}
+            end
+          else
+            {:cont, {:ok, acc}}
+          end
+      end
+    )
+  end
 
   defp load_data(socket) do
     socket

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -180,14 +180,26 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
                   <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
                 </.link>
               <% else %>
-                <button
-                  phx-click="add_to_library"
-                  phx-value-tmdb_id={@item.provider_id}
-                  phx-value-media_type={media_type_string(@item)}
-                  class="btn btn-primary"
-                >
-                  <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
-                </button>
+                <div class="join">
+                  <button
+                    phx-click="add_to_library"
+                    phx-value-tmdb_id={@item.provider_id}
+                    phx-value-media_type={media_type_string(@item)}
+                    class="btn btn-primary join-item"
+                  >
+                    <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
+                  </button>
+                  <.library_picker_menu
+                    libraries={@libraries}
+                    event="add_to_library"
+                    extra_values={
+                      %{
+                        tmdb_id: @item.provider_id,
+                        media_type: media_type_string(@item)
+                      }
+                    }
+                  />
+                </div>
               <% end %>
             <% else %>
               <.link navigate={library_path(@item)} class="btn btn-ghost">
@@ -213,7 +225,8 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
      |> assign(assigns)
      |> assign_new(:open, fn -> false end)
      |> assign_new(:loading, fn -> false end)
-     |> assign_new(:metadata, fn -> nil end)}
+     |> assign_new(:metadata, fn -> nil end)
+     |> assign_new(:libraries, fn -> [] end)}
   end
 
   # Helper functions for accessing data from either SearchResult (item) or MediaMetadata

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -192,12 +192,8 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
                   <.library_picker_menu
                     libraries={@libraries}
                     event="add_to_library"
-                    extra_values={
-                      %{
-                        tmdb_id: @item.provider_id,
-                        media_type: media_type_string(@item)
-                      }
-                    }
+                    tmdb_id={@item.provider_id}
+                    media_type={media_type_string(@item)}
                   />
                 </div>
               <% end %>

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -223,7 +223,14 @@ defmodule MydiaWeb.DashboardLive.Index do
   end
 
   def handle_info({:add_media_to_library, provider_id, media_type, library_path_id}, socket) do
-    opts = if library_path_id, do: [library_path_id: library_path_id], else: []
+    # Comes from client params, so a blank string is possible. "" is truthy in
+    # Elixir and would reach the changeset as library_path_id: "", failing the
+    # foreign key instead of falling back to normal resolution.
+    opts =
+      case library_path_id do
+        id when is_binary(id) and id != "" -> [library_path_id: id]
+        _ -> []
+      end
 
     case MediaAddHelpers.handle_add_media_to_library(
            provider_id,

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -29,6 +29,8 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:selected_item, nil)
         |> assign(:selected_metadata, nil)
         |> assign(:detail_loading, false)
+        |> assign(:movie_libraries, MediaAddHelpers.candidate_libraries(:movie))
+        |> assign(:show_libraries, MediaAddHelpers.candidate_libraries(:tv_show))
         |> load_dashboard_data()
       else
         socket
@@ -48,6 +50,8 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:selected_item, nil)
         |> assign(:selected_metadata, nil)
         |> assign(:detail_loading, false)
+        |> assign(:movie_libraries, [])
+        |> assign(:show_libraries, [])
       end
 
     {:ok, socket}
@@ -104,7 +108,7 @@ defmodule MydiaWeb.DashboardLive.Index do
   @impl true
   def handle_event(
         "add_to_library",
-        %{"tmdb_id" => provider_id, "media_type" => media_type},
+        %{"tmdb_id" => provider_id, "media_type" => media_type} = params,
         socket
       ) do
     media_type_atom = String.to_existing_atom(media_type)
@@ -113,7 +117,7 @@ defmodule MydiaWeb.DashboardLive.Index do
     socket = assign(socket, :adding_item_id, provider_id)
 
     # Start async task to add media
-    send(self(), {:add_media_to_library, provider_id, media_type_atom})
+    send(self(), {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]})
 
     {:noreply, socket}
   end
@@ -218,11 +222,15 @@ defmodule MydiaWeb.DashboardLive.Index do
     end
   end
 
-  def handle_info({:add_media_to_library, provider_id, media_type}, socket) do
+  def handle_info({:add_media_to_library, provider_id, media_type, library_path_id}, socket) do
+    opts = if library_path_id, do: [library_path_id: library_path_id], else: []
+
     case MediaAddHelpers.handle_add_media_to_library(
            provider_id,
            media_type,
-           socket.assigns.library_status_map
+           socket.assigns.library_status_map,
+           nil,
+           opts
          ) do
       {:ok, media_item, updated_map} ->
         # Re-enrich trending items with updated library status

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -223,6 +223,7 @@
               media_type={:movie}
               current_user={@current_user}
               adding_item_id={@adding_item_id}
+              libraries={@movie_libraries}
             />
           <% end %>
         </div>
@@ -256,6 +257,7 @@
               media_type={:tv_show}
               current_user={@current_user}
               adding_item_id={@adding_item_id}
+              libraries={@show_libraries}
             />
           <% end %>
         </div>
@@ -361,5 +363,11 @@
     loading={@detail_loading}
     current_user={@current_user}
     open={@selected_item != nil}
+    libraries={
+      if(@selected_item && @selected_item.media_type == :tv_show,
+        do: @show_libraries,
+        else: @movie_libraries
+      )
+    }
   />
 </Layouts.app>

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -336,7 +336,14 @@ defmodule MydiaWeb.DiscoverLive.Index do
   end
 
   def handle_info({:add_media_to_library, provider_id, media_type, library_path_id}, socket) do
-    opts = if library_path_id, do: [library_path_id: library_path_id], else: []
+    # Comes from client params, so a blank string is possible. "" is truthy in
+    # Elixir and would reach the changeset as library_path_id: "", failing the
+    # foreign key instead of falling back to normal resolution.
+    opts =
+      case library_path_id do
+        id when is_binary(id) and id != "" -> [library_path_id: id]
+        _ -> []
+      end
 
     case MediaAddHelpers.handle_add_media_to_library(
            provider_id,

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -73,6 +73,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
       |> assign(:selected_metadata, nil)
       |> assign(:load_error, nil)
       |> assign(:detail_loading, false)
+      |> assign(:libraries, [])
 
     {:ok, socket}
   end
@@ -121,6 +122,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
         |> assign(:loading, true)
         |> assign(:load_error, nil)
         |> assign(:has_more, false)
+        |> assign(:libraries, MediaAddHelpers.candidate_libraries(media_type))
 
       # Load genres if not loaded yet or media type changed
       socket =
@@ -151,7 +153,8 @@ defmodule MydiaWeb.DiscoverLive.Index do
        |> assign(:selected_language, nil)
        |> assign(:selected_year, nil)
        |> assign(:min_rating, nil)
-       |> assign(:sort_by, "popularity.desc")}
+       |> assign(:sort_by, "popularity.desc")
+       |> assign(:libraries, MediaAddHelpers.candidate_libraries(:movie))}
     end
   end
 
@@ -216,12 +219,12 @@ defmodule MydiaWeb.DiscoverLive.Index do
 
   def handle_event(
         "add_to_library",
-        %{"tmdb_id" => provider_id, "media_type" => media_type},
+        %{"tmdb_id" => provider_id, "media_type" => media_type} = params,
         socket
       ) do
     media_type_atom = String.to_existing_atom(media_type)
     socket = assign(socket, :adding_item_id, provider_id)
-    send(self(), {:add_media_to_library, provider_id, media_type_atom})
+    send(self(), {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]})
     {:noreply, socket}
   end
 
@@ -332,11 +335,15 @@ defmodule MydiaWeb.DiscoverLive.Index do
     end
   end
 
-  def handle_info({:add_media_to_library, provider_id, media_type}, socket) do
+  def handle_info({:add_media_to_library, provider_id, media_type, library_path_id}, socket) do
+    opts = if library_path_id, do: [library_path_id: library_path_id], else: []
+
     case MediaAddHelpers.handle_add_media_to_library(
            provider_id,
            media_type,
-           socket.assigns.library_status_map
+           socket.assigns.library_status_map,
+           nil,
+           opts
          ) do
       {:ok, media_item, updated_map} ->
         items =

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -164,6 +164,7 @@
               media_type={item.media_type || @media_type}
               current_user={@current_user}
               adding_item_id={@adding_item_id}
+              libraries={@libraries}
             />
           <% end %>
         </div>
@@ -196,5 +197,6 @@
     loading={@detail_loading}
     current_user={@current_user}
     open={@selected_item != nil}
+    libraries={@libraries}
   />
 </Layouts.app>

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -10,6 +10,27 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   alias Mydia.Settings
 
   @doc """
+  Libraries a caller may pick as the add-time target for `media_type`.
+
+  Filters to monitored, type-compatible libraries and drops unmaterialised
+  runtime entries: those carry synthetic "runtime::" ids and have no
+  `library_paths` row for a foreign key to reference. `LibraryPathSync` upserts
+  env-configured paths into real rows at startup, so this list is complete in
+  practice.
+  """
+  @spec candidate_libraries(:movie | :tv_show) :: [Mydia.Settings.LibraryPath.t()]
+  def candidate_libraries(media_type) do
+    kind = if media_type == :movie, do: :movies, else: :series
+    allowed = Mydia.Library.TargetResolver.allowed_types(kind)
+
+    Settings.list_library_paths()
+    |> Enum.filter(fn lp ->
+      lp.type in allowed and lp.monitored and
+        not String.starts_with?(to_string(lp.id), "runtime::")
+    end)
+  end
+
+  @doc """
   Enriches a list of search result items with library status information.
 
   For each item, adds `:in_library`, `:monitored`, and `:id` fields
@@ -48,6 +69,8 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
     * `:monitored` - Monitored flag for the new item (default: `true`)
     * `:quality_profile_id` - Quality profile to assign. Omitted from the attrs
       entirely when nil.
+    * `:library_path_id` - Explicit target library. Omitted from the attrs
+      entirely when nil, leaving the item on dynamic resolution.
 
   If neither id is given, falls back to parsing `metadata.provider_id` as tmdb_id.
   """
@@ -78,6 +101,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
     }
 
     attrs = maybe_put_quality_profile(attrs, opts[:quality_profile_id])
+    attrs = maybe_put_library_path(attrs, opts[:library_path_id])
 
     # Record provenance for TV shows only; movies leave metadata_source nil.
     if media_type == :movie do
@@ -89,6 +113,9 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
   defp maybe_put_quality_profile(attrs, nil), do: attrs
   defp maybe_put_quality_profile(attrs, id), do: Map.put(attrs, :quality_profile_id, id)
+
+  defp maybe_put_library_path(attrs, nil), do: attrs
+  defp maybe_put_library_path(attrs, id), do: Map.put(attrs, :library_path_id, id)
 
   @doc """
   Looks up TVDB ID for a TV show by searching TVDB by title+year.
@@ -129,9 +156,10 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   An optional `config` (relay config map) can be injected for testing; it
   defaults to `Metadata.default_relay_config()`.
 
-  `opts` are forwarded to `build_media_item_attrs/3`; `:monitored` and
-  `:quality_profile_id` let a caller inherit settings from an item the user is
-  already looking at. TV shows ignore them today.
+  `opts` are forwarded to `build_media_item_attrs/3`; `:monitored`,
+  `:quality_profile_id` and `:library_path_id` let a caller inherit settings
+  from an item the user is already looking at, or pin an explicit target
+  library. TV shows ignore monitored and quality profile today.
   """
   def handle_add_media_to_library(
         provider_id,
@@ -145,7 +173,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
     result =
       if media_type == :tv_show do
-        add_tv_show_to_library(provider_id, provider_id_int, config)
+        add_tv_show_to_library(provider_id, provider_id_int, config, opts)
       else
         add_movie_to_library(provider_id, provider_id_int, config, opts)
       end
@@ -230,7 +258,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
     end
   end
 
-  defp add_tv_show_to_library(provider_id, provider_id_int, config) do
+  defp add_tv_show_to_library(provider_id, provider_id_int, config, opts) do
     # Derive the provider from the configured libraries. `derived` may be nil
     # (libraries disagree); the fetch still needs a provider, so fall back to
     # TVDB for content while leaving provenance unstamped.
@@ -241,7 +269,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
     case Metadata.fetch_by_id(config, provider_id, media_type: :tv_show, provider: :tmdb) do
       {:ok, tmdb_metadata} ->
         tmdb_metadata
-        |> build_tv_show_attrs(provider_id_int, derived, fetch_provider, config)
+        |> build_tv_show_attrs(provider_id_int, derived, fetch_provider, config, opts)
         |> create_media_item_result(config)
 
       {:error, reason} ->
@@ -251,10 +279,11 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
   # Derived source is TMDB: keep the TMDB metadata as primary, resolve a
   # secondary tvdb_id for dedup/future matching, and stamp :tmdb.
-  defp build_tv_show_attrs(tmdb_metadata, provider_id_int, derived, :tmdb, config) do
-    build_media_item_attrs(tmdb_metadata, :tv_show,
-      tmdb_id: provider_id_int,
-      metadata_source: derived
+  defp build_tv_show_attrs(tmdb_metadata, provider_id_int, derived, :tmdb, config, opts) do
+    build_media_item_attrs(
+      tmdb_metadata,
+      :tv_show,
+      Keyword.merge(opts, tmdb_id: provider_id_int, metadata_source: derived)
     )
     |> lookup_and_add_tvdb_id(config)
   end
@@ -262,19 +291,24 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   # Derived source is TVDB (or nil/conflict): use richer TVDB metadata as
   # primary when resolvable, else TMDB content with a tvdb_id from search.
   # Provenance is stamped as `derived` (:tvdb, or nil on conflict).
-  defp build_tv_show_attrs(tmdb_metadata, provider_id_int, derived, :tvdb, config) do
+  defp build_tv_show_attrs(tmdb_metadata, provider_id_int, derived, :tvdb, config, opts) do
     case resolve_tvdb_metadata(tmdb_metadata, config) do
       {:ok, tvdb_metadata, tvdb_id} ->
-        build_media_item_attrs(tvdb_metadata, :tv_show,
-          tmdb_id: provider_id_int,
-          tvdb_id: tvdb_id,
-          metadata_source: derived
+        build_media_item_attrs(
+          tvdb_metadata,
+          :tv_show,
+          Keyword.merge(opts,
+            tmdb_id: provider_id_int,
+            tvdb_id: tvdb_id,
+            metadata_source: derived
+          )
         )
 
       {:error, _} ->
-        build_media_item_attrs(tmdb_metadata, :tv_show,
-          tmdb_id: provider_id_int,
-          metadata_source: derived
+        build_media_item_attrs(
+          tmdb_metadata,
+          :tv_show,
+          Keyword.merge(opts, tmdb_id: provider_id_int, metadata_source: derived)
         )
         |> lookup_and_add_tvdb_id(config)
     end

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -8,6 +8,7 @@ defmodule MydiaWeb.MediaLive.Show do
   alias MydiaWeb.MediaLive.Show.EpisodeEvents
   alias MydiaWeb.MediaLive.Show.DownloadEvents
   alias MydiaWeb.MediaLive.Show.MediaItemEvents
+  alias MydiaWeb.MediaLive.Show.LibraryEvents
   alias MydiaWeb.MediaLive.Show.CategoryEvents
   alias MydiaWeb.MediaLive.Show.CollectionEvents
   alias MydiaWeb.MediaLive.Show.SubtitleEvents
@@ -164,6 +165,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> CollectionEvents.load_collection_data(media_item)
      |> SegmentEvents.assign_segment_status(media_item)
      |> FranchiseEvents.maybe_load()
+     |> assign_target_library(media_item)
      |> stream_configure(:search_results, dom_id: &generate_positioned_id/1)
      |> stream(:search_results, [])}
   end
@@ -379,6 +381,9 @@ defmodule MydiaWeb.MediaLive.Show do
 
   def handle_event("update_quality_profile", params, socket),
     do: CategoryEvents.update_quality_profile(params, socket)
+
+  def handle_event("update_target_library", params, socket),
+    do: LibraryEvents.update_target_library(params, socket)
 
   # Collection events
 

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -30,6 +30,9 @@
           is_favorite={@is_favorite}
           item_collections={@item_collections}
           user_collections={@user_collections}
+          target_library={@target_library}
+          target_reason={@target_reason}
+          target_library_candidates={@target_library_candidates}
         />
         <%!-- Right Column: Main Content --%>
         <div class="flex-1 min-w-0">

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -6,6 +6,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   import MydiaWeb.MediaLive.Show.Formatters
   import MydiaWeb.MediaLive.Show.Helpers
 
+  alias MydiaWeb.MediaLive.Show.LibraryComponents
   alias MydiaWeb.MediaLive.Show.SegmentComponents
 
   @doc """
@@ -19,6 +20,9 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :downloads_with_status, :list, required: true
   attr :quality_profiles, :list, required: true
   attr :default_quality_profile_name, :string, default: nil
+  attr :target_library, :map, default: nil
+  attr :target_reason, :atom, default: nil
+  attr :target_library_candidates, :list, default: []
   attr :applying_monitoring_preset, :boolean, default: false
   attr :is_favorite, :boolean, default: false
   attr :item_collections, :list, default: []
@@ -330,6 +334,13 @@ defmodule MydiaWeb.MediaLive.Show.Components do
               </li>
             </ul>
           </div>
+
+          <LibraryComponents.target_library_row
+            media_item={@media_item}
+            target_library={@target_library}
+            target_reason={@target_reason}
+            libraries={@target_library_candidates}
+          />
 
           <%!-- Category --%>
           <button

--- a/lib/mydia_web/live/media_live/show/library_components.ex
+++ b/lib/mydia_web/live/media_live/show/library_components.ex
@@ -1,0 +1,102 @@
+defmodule MydiaWeb.MediaLive.Show.LibraryComponents do
+  @moduledoc """
+  The target-library row in the media detail hero.
+
+  Shows where this item's next download will land and why. The reason is what
+  makes a surprising destination debuggable rather than merely surprising.
+  """
+
+  use MydiaWeb, :html
+
+  @doc """
+  Renders the resolved target library.
+
+  With two or more candidates this is a dropdown writing
+  `media_items.library_path_id`; with one it is static text. Selecting
+  "Automatic" clears the column and returns the item to dynamic resolution.
+  """
+  attr :media_item, :map, required: true
+  attr :target_library, :map, default: nil
+  attr :target_reason, :atom, default: nil
+  attr :libraries, :list, default: []
+
+  def target_library_row(assigns) do
+    ~H"""
+    <div class="dropdown dropdown-end w-full" data-test="target-library">
+      <div
+        tabindex="0"
+        role={if length(@libraries) > 1, do: "button", else: nil}
+        class={[
+          "flex items-center gap-2.5 px-2 py-1.5 rounded-lg w-full group transition-colors",
+          length(@libraries) > 1 && "cursor-pointer hover:bg-base-300/50"
+        ]}
+        title={if length(@libraries) > 1, do: "Click to change the download library", else: nil}
+      >
+        <div class="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center flex-shrink-0">
+          <.icon name="hero-folder" class="w-4 h-4 text-accent" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="text-xs text-base-content/50">Library</div>
+          <div class="text-sm font-medium truncate">
+            <%= if @target_library do %>
+              {Path.basename(@target_library.path)}
+              <span class="text-xs font-normal text-base-content/50">
+                {reason_label(@target_reason)}
+              </span>
+            <% else %>
+              <span class="text-base-content/40">No compatible library</span>
+            <% end %>
+          </div>
+        </div>
+        <.icon
+          :if={length(@libraries) > 1}
+          name="hero-chevron-right"
+          class="w-4 h-4 text-base-content/30 group-hover:text-base-content/60 transition-colors flex-shrink-0"
+        />
+      </div>
+      <ul
+        :if={length(@libraries) > 1}
+        tabindex="0"
+        class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-64 border border-base-300"
+      >
+        <li>
+          <button
+            type="button"
+            phx-click="update_target_library"
+            phx-value-library-path-id=""
+            class={["justify-between", is_nil(@media_item.library_path_id) && "active"]}
+          >
+            Automatic
+            <.icon :if={is_nil(@media_item.library_path_id)} name="hero-check" class="w-4 h-4" />
+          </button>
+        </li>
+        <li :for={library <- @libraries}>
+          <button
+            type="button"
+            phx-click="update_target_library"
+            phx-value-library-path-id={library.id}
+            class={["justify-between", @media_item.library_path_id == library.id && "active"]}
+          >
+            {Path.basename(library.path)}
+            <.icon
+              :if={@media_item.library_path_id == library.id}
+              name="hero-check"
+              class="w-4 h-4"
+            />
+          </button>
+        </li>
+        <li class="menu-title text-xs pt-2">
+          Changing this affects future downloads. Files already on disk stay where they are.
+        </li>
+      </ul>
+    </div>
+    """
+  end
+
+  defp reason_label(:download_override), do: "set on the download"
+  defp reason_label(:explicit), do: "chosen"
+  defp reason_label(:existing_files), do: "matches existing files"
+  defp reason_label(:type_default), do: "library default"
+  defp reason_label(:first_compatible), do: "first compatible library"
+  defp reason_label(_), do: ""
+end

--- a/lib/mydia_web/live/media_live/show/library_events.ex
+++ b/lib/mydia_web/live/media_live/show/library_events.ex
@@ -1,0 +1,43 @@
+defmodule MydiaWeb.MediaLive.Show.LibraryEvents do
+  @moduledoc false
+
+  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.LiveView, only: [put_flash: 3]
+
+  import MydiaWeb.MediaLive.Show.Loaders, only: [assign_target_library: 2]
+
+  alias Mydia.Media
+  alias MydiaWeb.Live.Authorization
+
+  def update_target_library(%{"library-path-id" => raw_id}, socket) do
+    with :ok <- Authorization.authorize_update_media(socket) do
+      media_item = socket.assigns.media_item
+      library_path_id = if raw_id == "", do: nil, else: raw_id
+
+      case Media.update_media_item(
+             media_item,
+             %{library_path_id: library_path_id},
+             reason: "Target library updated"
+           ) do
+        {:ok, updated} ->
+          message =
+            if library_path_id,
+              do: "Future downloads will go to the selected library",
+              else: "Library is now chosen automatically"
+
+          media_item = %{media_item | library_path_id: updated.library_path_id}
+
+          {:noreply,
+           socket
+           |> assign(:media_item, media_item)
+           |> assign_target_library(media_item)
+           |> put_flash(:info, message)}
+
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, "Failed to update the library")}
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+end

--- a/lib/mydia_web/live/media_live/show/loaders.ex
+++ b/lib/mydia_web/live/media_live/show/loaders.ex
@@ -106,4 +106,25 @@ defmodule MydiaWeb.MediaLive.Show.Loaders do
     end)
     |> Map.new()
   end
+
+  @doc """
+  Assigns the resolved target library, the reason, and the candidate list.
+  """
+  def assign_target_library(socket, media_item) do
+    {library, reason} =
+      case Mydia.Library.TargetResolver.resolve(media_item) do
+        {:ok, library, reason} -> {library, reason}
+        {:error, :no_compatible_library} -> {nil, nil}
+      end
+
+    media_type = if media_item.type == "movie", do: :movie, else: :tv_show
+
+    socket
+    |> Phoenix.Component.assign(:target_library, library)
+    |> Phoenix.Component.assign(:target_reason, reason)
+    |> Phoenix.Component.assign(
+      :target_library_candidates,
+      MydiaWeb.Live.Helpers.MediaAddHelpers.candidate_libraries(media_type)
+    )
+  end
 end

--- a/priv/repo/migrations/20260811172639_add_library_path_to_media_items.exs
+++ b/priv/repo/migrations/20260811172639_add_library_path_to_media_items.exs
@@ -1,0 +1,20 @@
+defmodule Mydia.Repo.Migrations.AddLibraryPathToMediaItems do
+  use Ecto.Migration
+
+  @moduledoc """
+  Adds an explicit download-target library to media items.
+
+  Nullable: NULL means "no explicit preference, resolve dynamically".
+  on_delete: :nilify_all so removing a library returns its items to inferred
+  resolution rather than blocking the delete.
+  """
+
+  def change do
+    alter table(:media_items) do
+      add :library_path_id,
+          references(:library_paths, type: :binary_id, on_delete: :nilify_all)
+    end
+
+    create index(:media_items, [:library_path_id])
+  end
+end

--- a/priv/repo/migrations/20260811172941_add_default_flags_to_library_paths.exs
+++ b/priv/repo/migrations/20260811172941_add_default_flags_to_library_paths.exs
@@ -1,0 +1,33 @@
+defmodule Mydia.Repo.Migrations.AddDefaultFlagsToLibraryPaths do
+  use Ecto.Migration
+
+  @moduledoc """
+  Marks one library per media kind as the default download target.
+
+  Two flags rather than one because a :mixed library serves both kinds. With a
+  single flag, a flagged :movies library and a flagged :mixed library would
+  both be "the default" for a movie and the tie would be arbitrary.
+
+  The column is not named `default`: it is a reserved word requiring quoting on
+  both adapters.
+
+  Partial unique indexes are supported by both SQLite (3.8+) and PostgreSQL.
+  """
+
+  def change do
+    alter table(:library_paths) do
+      add :default_for_movies, :boolean, default: false, null: false
+      add :default_for_series, :boolean, default: false, null: false
+    end
+
+    create unique_index(:library_paths, [:default_for_movies],
+             where: "default_for_movies = true",
+             name: :library_paths_single_default_for_movies
+           )
+
+    create unique_index(:library_paths, [:default_for_series],
+             where: "default_for_series = true",
+             name: :library_paths_single_default_for_series
+           )
+  end
+end

--- a/priv/repo/migrations/20260811173217_backfill_default_library_flags.exs
+++ b/priv/repo/migrations/20260811173217_backfill_default_library_flags.exs
@@ -1,0 +1,83 @@
+defmodule Mydia.Repo.Migrations.BackfillDefaultLibraryFlags do
+  use Ecto.Migration
+  import Ecto.Query
+
+  @moduledoc """
+  Flags the oldest monitored library of each kind as that kind's default.
+
+  Oldest-wins reproduces most installs' behaviour before the default flags
+  existed: destination was previously the alphabetically-first compatible
+  library, and for a single-library install that is the first one created.
+  It is a guess, but a visible one, correctable in the settings UI.
+
+  Written with Ecto queries rather than raw SQL so boolean rendering stays
+  adapter-agnostic (SQLite stores 1/0, PostgreSQL true/false).
+  """
+
+  @kinds [
+    {:default_for_movies, ["movies", "mixed"]},
+    {:default_for_series, ["series", "mixed"]}
+  ]
+
+  def up, do: backfill()
+
+  # Irreversible by design: down/0 would have to guess which flags were
+  # operator-set after the fact. Clearing all of them would silently change
+  # behaviour on rollback.
+  def down, do: :ok
+
+  @doc false
+  def backfill do
+    Enum.each(@kinds, fn {field, types} -> backfill_kind(field, types) end)
+    :ok
+  end
+
+  defp backfill_kind(field, types) do
+    unless already_flagged?(field) do
+      case oldest_candidate(field, types) do
+        nil ->
+          :ok
+
+        id ->
+          query_repo().update_all(
+            from(l in "library_paths", where: l.id == type(^id, :binary_id)),
+            set: [{field, boolean_true()}]
+          )
+      end
+    end
+  end
+
+  defp already_flagged?(field) do
+    query_repo().exists?(from(l in "library_paths", where: field(l, ^field) == true))
+  end
+
+  defp oldest_candidate(_field, types) do
+    from(l in "library_paths",
+      where: l.type in ^types,
+      where: l.monitored == true,
+      where: l.disabled == false or is_nil(l.disabled),
+      order_by: [asc: l.inserted_at, asc: l.id],
+      limit: 1,
+      select: type(l.id, :binary_id)
+    )
+    |> query_repo().one()
+  end
+
+  # Schemaless update_all has no column type, so Elixir `true` is dumped as the
+  # string "true" on SQLite. Match what Ecto.Adapters.SQLite3 stores for booleans.
+  defp boolean_true do
+    case query_repo().__adapter__() do
+      Ecto.Adapters.SQLite3 -> 1
+      _ -> true
+    end
+  end
+
+  # `repo/0` from Ecto.Migration only works inside a migration runner. Tests
+  # call `backfill/0` directly, so fall back to Mydia.Repo outside that context.
+  defp query_repo do
+    case Process.get(:ecto_migration) do
+      %{runner: _} -> repo()
+      _ -> Mydia.Repo
+    end
+  end
+end

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -2296,4 +2296,71 @@ defmodule Mydia.Jobs.MediaImportTest do
       assert_raise Ecto.NoResultsError, fn -> Mydia.Downloads.get_download!(download.id) end
     end
   end
+
+  describe "determine_library_path/1 destination stability" do
+    test "a newly added alphabetically-first library does not capture an item with existing files" do
+      # Reproduces the reported bug: "Cartoons" sorts before "Movies", and
+      # before this change Enum.find over path-ascending order picked it for
+      # every movie, including ones whose files already lived in Movies.
+      movies = library_path_fixture(%{type: "movies", path: "/tmp/zzz-Movies"})
+      _cartoons = library_path_fixture(%{type: "movies", path: "/tmp/aaa-Cartoons"})
+
+      item = media_item_fixture(%{type: "movie", title: "Old Movie", year: 2001})
+
+      {:ok, _file} =
+        Mydia.Library.create_media_file(%{
+          media_item_id: item.id,
+          library_path_id: movies.id,
+          relative_path: "Old Movie (2001)/old.mkv",
+          path: Path.join(movies.path, "Old Movie (2001)/old.mkv")
+        })
+
+      download = %Mydia.Downloads.Download{
+        media_item_id: item.id,
+        media_item: item,
+        episode: nil,
+        library_path: nil,
+        library_path_id: nil
+      }
+
+      assert Mydia.Jobs.MediaImport.determine_library_path(download).id == movies.id
+    end
+
+    test "an explicit target on the media item wins" do
+      _movies = library_path_fixture(%{type: "movies", path: "/tmp/aaa-Movies"})
+      cartoons = library_path_fixture(%{type: "movies", path: "/tmp/zzz-Cartoons"})
+
+      item =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Chosen Movie",
+          year: 2024,
+          library_path_id: cartoons.id
+        })
+
+      download = %Mydia.Downloads.Download{
+        media_item_id: item.id,
+        media_item: item,
+        episode: nil,
+        library_path: nil,
+        library_path_id: nil
+      }
+
+      assert Mydia.Jobs.MediaImport.determine_library_path(download).id == cartoons.id
+    end
+
+    test "a download with no media item still resolves to a mixed library" do
+      mixed = library_path_fixture(%{type: "mixed"})
+
+      download = %Mydia.Downloads.Download{
+        media_item_id: nil,
+        media_item: nil,
+        episode: nil,
+        library_path: nil,
+        library_path_id: nil
+      }
+
+      assert Mydia.Jobs.MediaImport.determine_library_path(download).id == mixed.id
+    end
+  end
 end

--- a/test/mydia/library/target_resolver_test.exs
+++ b/test/mydia/library/target_resolver_test.exs
@@ -1,0 +1,186 @@
+defmodule Mydia.Library.TargetResolverTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.SettingsFixtures
+  import Mydia.MediaFixtures
+
+  alias Mydia.Library.TargetResolver
+  alias Mydia.Settings
+
+  defp movie(attrs \\ %{}) do
+    media_item_fixture(Map.merge(%{type: "movie", title: "A Movie", year: 2024}, attrs))
+  end
+
+  defp file_in(media_item, library_path, relative_path) do
+    {:ok, file} =
+      Mydia.Library.create_media_file(%{
+        media_item_id: media_item.id,
+        library_path_id: library_path.id,
+        relative_path: relative_path,
+        path: Path.join(library_path.path, relative_path)
+      })
+
+    file
+  end
+
+  describe "resolve/2 step order" do
+    test "a download override wins over everything" do
+      chosen = library_path_fixture(%{type: "movies"})
+      override = library_path_fixture(%{type: "movies"})
+      item = movie(%{library_path_id: chosen.id})
+
+      download = %Mydia.Downloads.Download{
+        library_path_id: override.id,
+        library_path: override
+      }
+
+      assert {:ok, resolved, :download_override} =
+               TargetResolver.resolve(item, download: download)
+
+      assert resolved.id == override.id
+    end
+
+    test "an explicit target wins over existing files" do
+      chosen = library_path_fixture(%{type: "movies"})
+      elsewhere = library_path_fixture(%{type: "movies"})
+      item = movie(%{library_path_id: chosen.id})
+      file_in(item, elsewhere, "A Movie (2024)/a.mkv")
+
+      assert {:ok, resolved, :explicit} = TargetResolver.resolve(item)
+      assert resolved.id == chosen.id
+    end
+
+    test "existing files win over the type default" do
+      with_files = library_path_fixture(%{type: "movies"})
+      default = library_path_fixture(%{type: "movies"})
+      {:ok, _} = Settings.set_default_library(default, :movies)
+
+      item = movie()
+      file_in(item, with_files, "A Movie (2024)/a.mkv")
+
+      assert {:ok, resolved, :existing_files} = TargetResolver.resolve(item)
+      assert resolved.id == with_files.id
+    end
+
+    test "the type default wins over the alphabetical fallback" do
+      # "aaa" sorts first, so the fallback would pick it.
+      _alphabetically_first = library_path_fixture(%{type: "movies", path: "/tmp/aaa-movies"})
+      default = library_path_fixture(%{type: "movies", path: "/tmp/zzz-movies"})
+      {:ok, _} = Settings.set_default_library(default, :movies)
+
+      assert {:ok, resolved, :type_default} = TargetResolver.resolve(movie())
+      assert resolved.id == default.id
+    end
+
+    test "falls back to the alphabetically first compatible library" do
+      first = library_path_fixture(%{type: "movies", path: "/tmp/aaa-movies"})
+      _second = library_path_fixture(%{type: "movies", path: "/tmp/zzz-movies"})
+
+      assert {:ok, resolved, :first_compatible} = TargetResolver.resolve(movie())
+      assert resolved.id == first.id
+    end
+  end
+
+  describe "resolve/2 candidate validation" do
+    test "falls through a disabled explicit target" do
+      disabled = library_path_fixture(%{type: "movies", path: "/tmp/zzz-disabled"})
+      fallback = library_path_fixture(%{type: "movies", path: "/tmp/aaa-fallback"})
+      item = movie(%{library_path_id: disabled.id})
+      {:ok, _} = Settings.update_library_path(disabled, %{disabled: true})
+
+      assert {:ok, resolved, :first_compatible} = TargetResolver.resolve(item)
+      assert resolved.id == fallback.id
+    end
+
+    test "falls through an explicit target of the wrong type" do
+      wrong_type = library_path_fixture(%{type: "series", path: "/tmp/zzz-series"})
+      fallback = library_path_fixture(%{type: "movies", path: "/tmp/aaa-movies"})
+      item = movie(%{library_path_id: wrong_type.id})
+
+      assert {:ok, resolved, :first_compatible} = TargetResolver.resolve(item)
+      assert resolved.id == fallback.id
+    end
+
+    test "honours an explicit target that is unmonitored" do
+      unmonitored = library_path_fixture(%{type: "movies", path: "/tmp/zzz-unmonitored"})
+      _fallback = library_path_fixture(%{type: "movies", path: "/tmp/aaa-movies"})
+      item = movie(%{library_path_id: unmonitored.id})
+      {:ok, unmonitored} = Settings.update_library_path(unmonitored, %{monitored: false})
+
+      assert {:ok, resolved, :explicit} = TargetResolver.resolve(item)
+      assert resolved.id == unmonitored.id
+    end
+
+    test "does not infer an unmonitored library from existing files" do
+      unmonitored = library_path_fixture(%{type: "movies", path: "/tmp/zzz-unmonitored"})
+      fallback = library_path_fixture(%{type: "movies", path: "/tmp/aaa-movies"})
+      item = movie()
+      file_in(item, unmonitored, "A Movie (2024)/a.mkv")
+      {:ok, _} = Settings.update_library_path(unmonitored, %{monitored: false})
+
+      assert {:ok, resolved, :first_compatible} = TargetResolver.resolve(item)
+      assert resolved.id == fallback.id
+    end
+
+    test "returns an error when no compatible library exists" do
+      _series_only = library_path_fixture(%{type: "series"})
+
+      assert {:error, :no_compatible_library} = TargetResolver.resolve(movie())
+    end
+  end
+
+  describe "resolve/2 existing-files tie-breaking" do
+    test "picks the library holding the most files" do
+      majority = library_path_fixture(%{type: "movies", path: "/tmp/zzz-majority"})
+      minority = library_path_fixture(%{type: "movies", path: "/tmp/aaa-minority"})
+      item = movie()
+
+      file_in(item, majority, "A Movie (2024)/a.mkv")
+      file_in(item, majority, "A Movie (2024)/b.mkv")
+      file_in(item, minority, "A Movie (2024)/c.mkv")
+
+      assert {:ok, resolved, :existing_files} = TargetResolver.resolve(item)
+      assert resolved.id == majority.id
+    end
+
+    test "ignores trashed files" do
+      trashed_lib = library_path_fixture(%{type: "movies", path: "/tmp/zzz-trashed"})
+      live_lib = library_path_fixture(%{type: "movies", path: "/tmp/aaa-live"})
+      item = movie()
+
+      trashed = file_in(item, trashed_lib, "A Movie (2024)/old.mkv")
+      file_in(item, live_lib, "A Movie (2024)/new.mkv")
+
+      {:ok, _} =
+        trashed
+        |> Ecto.Changeset.change(trashed_at: DateTime.utc_now() |> DateTime.truncate(:second))
+        |> Mydia.Repo.update()
+
+      assert {:ok, resolved, :existing_files} = TargetResolver.resolve(item)
+      assert resolved.id == live_lib.id
+    end
+  end
+
+  describe "resolve/2 for TV" do
+    test "resolves a show into a series library" do
+      _movies = library_path_fixture(%{type: "movies", path: "/tmp/aaa-movies"})
+      series = library_path_fixture(%{type: "series", path: "/tmp/zzz-series"})
+
+      show = media_item_fixture(%{type: "tv_show", title: "A Show"})
+
+      assert {:ok, resolved, :first_compatible} = TargetResolver.resolve(show)
+      assert resolved.id == series.id
+    end
+
+    test "a mixed library serves both kinds" do
+      mixed = library_path_fixture(%{type: "mixed"})
+
+      assert {:ok, m, :first_compatible} = TargetResolver.resolve(movie())
+      assert m.id == mixed.id
+
+      show = media_item_fixture(%{type: "tv_show", title: "A Show"})
+      assert {:ok, s, :first_compatible} = TargetResolver.resolve(show)
+      assert s.id == mixed.id
+    end
+  end
+end

--- a/test/mydia/library/target_resolver_test.exs
+++ b/test/mydia/library/target_resolver_test.exs
@@ -40,6 +40,26 @@ defmodule Mydia.Library.TargetResolverTest do
       assert resolved.id == override.id
     end
 
+    test "a download override still applies when the association is not preloaded" do
+      chosen = library_path_fixture(%{type: "movies"})
+      override = library_path_fixture(%{type: "movies"})
+      item = movie(%{library_path_id: chosen.id})
+
+      download = %Mydia.Downloads.Download{
+        library_path_id: override.id,
+        library_path: %Ecto.Association.NotLoaded{
+          __field__: :library_path,
+          __owner__: Mydia.Downloads.Download,
+          __cardinality__: :one
+        }
+      }
+
+      assert {:ok, resolved, :download_override} =
+               TargetResolver.resolve(item, download: download)
+
+      assert resolved.id == override.id
+    end
+
     test "an explicit target wins over existing files" do
       chosen = library_path_fixture(%{type: "movies"})
       elsewhere = library_path_fixture(%{type: "movies"})

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -7,8 +7,39 @@ defmodule Mydia.MediaTest do
     alias Mydia.Media.MediaItem
 
     import Mydia.MediaFixtures
+    import Mydia.SettingsFixtures
 
     @invalid_attrs %{type: nil, title: nil}
+
+    test "create_media_item/2 accepts an explicit library_path_id" do
+      library = library_path_fixture(%{type: "movies"})
+
+      {:ok, item} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: "Targeted Movie",
+          year: 2024,
+          library_path_id: library.id
+        })
+
+      assert item.library_path_id == library.id
+    end
+
+    test "deleting a library path nils the media item's target instead of failing" do
+      library = library_path_fixture(%{type: "movies"})
+
+      {:ok, item} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: "Orphaned Target",
+          year: 2024,
+          library_path_id: library.id
+        })
+
+      {:ok, _} = Mydia.Settings.delete_library_path(library)
+
+      assert Mydia.Repo.get!(Mydia.Media.MediaItem, item.id).library_path_id == nil
+    end
 
     test "list_media_items/0 returns all media items" do
       media_item = media_item_fixture()

--- a/test/mydia/settings/library_path_defaults_test.exs
+++ b/test/mydia/settings/library_path_defaults_test.exs
@@ -1,0 +1,99 @@
+defmodule Mydia.Settings.LibraryPathDefaultsTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Settings
+  alias Mydia.Settings.LibraryPath
+
+  describe "changeset type compatibility" do
+    test "rejects default_for_series on a movies library" do
+      changeset =
+        LibraryPath.changeset(%LibraryPath{}, %{
+          path: "/tmp/only-movies",
+          type: "movies",
+          default_for_series: true
+        })
+
+      refute changeset.valid?
+      assert %{default_for_series: [_ | _]} = errors_on(changeset)
+    end
+
+    test "rejects default_for_movies on a series library" do
+      changeset =
+        LibraryPath.changeset(%LibraryPath{}, %{
+          path: "/tmp/only-series",
+          type: "series",
+          default_for_movies: true
+        })
+
+      refute changeset.valid?
+      assert %{default_for_movies: [_ | _]} = errors_on(changeset)
+    end
+
+    test "allows both flags on a mixed library" do
+      changeset =
+        LibraryPath.changeset(%LibraryPath{}, %{
+          path: "/tmp/mixed",
+          type: "mixed",
+          default_for_movies: true,
+          default_for_series: true
+        })
+
+      assert changeset.valid?
+    end
+  end
+
+  describe "set_default_library/2" do
+    test "moves the flag off whatever row held it" do
+      first = library_path_fixture(%{type: "movies"})
+      second = library_path_fixture(%{type: "movies"})
+
+      {:ok, _} = Settings.set_default_library(first, :movies)
+      {:ok, _} = Settings.set_default_library(second, :movies)
+
+      refute Mydia.Repo.get!(LibraryPath, first.id).default_for_movies
+      assert Mydia.Repo.get!(LibraryPath, second.id).default_for_movies
+    end
+
+    test "refuses a kind the library type cannot serve" do
+      series = library_path_fixture(%{type: "series"})
+
+      assert {:error, :incompatible_type} = Settings.set_default_library(series, :movies)
+    end
+
+    test "setting the movies default leaves the series default alone" do
+      movies = library_path_fixture(%{type: "movies"})
+      series = library_path_fixture(%{type: "series"})
+
+      {:ok, _} = Settings.set_default_library(series, :series)
+      {:ok, _} = Settings.set_default_library(movies, :movies)
+
+      assert Mydia.Repo.get!(LibraryPath, series.id).default_for_series
+      assert Mydia.Repo.get!(LibraryPath, movies.id).default_for_movies
+    end
+  end
+
+  describe "default_library_for/1" do
+    test "returns nil when nothing is flagged" do
+      library_path_fixture(%{type: "movies"})
+
+      assert Settings.default_library_for(:movies) == nil
+    end
+
+    test "returns the flagged library" do
+      library = library_path_fixture(%{type: "movies"})
+      {:ok, _} = Settings.set_default_library(library, :movies)
+
+      assert Settings.default_library_for(:movies).id == library.id
+    end
+
+    test "ignores a disabled flagged library" do
+      library = library_path_fixture(%{type: "movies"})
+      {:ok, library} = Settings.set_default_library(library, :movies)
+      {:ok, _} = Settings.update_library_path(library, %{disabled: true})
+
+      assert Settings.default_library_for(:movies) == nil
+    end
+  end
+end

--- a/test/mydia/settings/library_path_defaults_test.exs
+++ b/test/mydia/settings/library_path_defaults_test.exs
@@ -1,5 +1,7 @@
 defmodule Mydia.Settings.LibraryPathDefaultsTest do
-  use Mydia.DataCase, async: true
+  # async: false — the env configuration describe mutates System env
+  # (same hazard as test/mydia/config/loader_test.exs).
+  use Mydia.DataCase, async: false
 
   import Mydia.SettingsFixtures
 
@@ -160,6 +162,27 @@ defmodule Mydia.Settings.LibraryPathDefaultsTest do
         from(l in LibraryPath, where: l.id == ^library_path.id),
         set: [inserted_at: at]
       )
+    end
+  end
+
+  describe "env configuration" do
+    # Matches loader_test isolation: put_env + on_exit cleanup, assert on the
+    # validated config struct (not the raw env map).
+    test "LIBRARY_PATH_<N>_DEFAULT_FOR_MOVIES is parsed" do
+      System.put_env("LIBRARY_PATH_1_PATH", "/tmp/env-movies")
+      System.put_env("LIBRARY_PATH_1_TYPE", "movies")
+      System.put_env("LIBRARY_PATH_1_DEFAULT_FOR_MOVIES", "true")
+
+      on_exit(fn ->
+        System.delete_env("LIBRARY_PATH_1_PATH")
+        System.delete_env("LIBRARY_PATH_1_TYPE")
+        System.delete_env("LIBRARY_PATH_1_DEFAULT_FOR_MOVIES")
+      end)
+
+      {:ok, config} = Mydia.Config.Loader.load(config_file: "nonexistent.yml")
+      entry = Enum.find(config.library_paths, &(&1.path == "/tmp/env-movies"))
+
+      assert entry.default_for_movies == true
     end
   end
 end

--- a/test/mydia/settings/library_path_defaults_test.exs
+++ b/test/mydia/settings/library_path_defaults_test.exs
@@ -96,4 +96,70 @@ defmodule Mydia.Settings.LibraryPathDefaultsTest do
       assert Settings.default_library_for(:movies) == nil
     end
   end
+
+  describe "backfill" do
+    # Migration modules are not compiled into the app, so load the file explicitly.
+    Code.require_file("priv/repo/migrations/20260811173217_backfill_default_library_flags.exs")
+
+    alias Mydia.Repo.Migrations.BackfillDefaultLibraryFlags, as: Backfill
+
+    test "flags the oldest monitored library of each kind" do
+      older = library_path_fixture(%{type: "movies"})
+      newer = library_path_fixture(%{type: "movies"})
+      series = library_path_fixture(%{type: "series"})
+
+      # library_path_fixture inserts in call order, so `older` has the earlier
+      # inserted_at. Force a gap so the ordering is unambiguous under a
+      # second-resolution timestamp column.
+      backdate(older, ~U[2020-01-01 00:00:00Z])
+      backdate(newer, ~U[2021-01-01 00:00:00Z])
+      backdate(series, ~U[2020-01-01 00:00:00Z])
+
+      Backfill.backfill()
+
+      assert Mydia.Repo.get!(LibraryPath, older.id).default_for_movies
+      refute Mydia.Repo.get!(LibraryPath, newer.id).default_for_movies
+      assert Mydia.Repo.get!(LibraryPath, series.id).default_for_series
+    end
+
+    test "does not overwrite an existing flag" do
+      older = library_path_fixture(%{type: "movies"})
+      newer = library_path_fixture(%{type: "movies"})
+      backdate(older, ~U[2020-01-01 00:00:00Z])
+      backdate(newer, ~U[2021-01-01 00:00:00Z])
+
+      {:ok, _} = Settings.set_default_library(newer, :movies)
+
+      Backfill.backfill()
+
+      assert Mydia.Repo.get!(LibraryPath, newer.id).default_for_movies
+      refute Mydia.Repo.get!(LibraryPath, older.id).default_for_movies
+    end
+
+    test "skips unmonitored libraries" do
+      unmonitored = library_path_fixture(%{type: "movies", monitored: false})
+      monitored = library_path_fixture(%{type: "movies"})
+      backdate(unmonitored, ~U[2020-01-01 00:00:00Z])
+      backdate(monitored, ~U[2021-01-01 00:00:00Z])
+
+      Backfill.backfill()
+
+      assert Mydia.Repo.get!(LibraryPath, monitored.id).default_for_movies
+      refute Mydia.Repo.get!(LibraryPath, unmonitored.id).default_for_movies
+    end
+
+    test "is a no-op when there are no libraries" do
+      assert Backfill.backfill() == :ok
+      assert Settings.default_library_for(:movies) == nil
+    end
+
+    defp backdate(library_path, at) do
+      import Ecto.Query
+
+      Mydia.Repo.update_all(
+        from(l in LibraryPath, where: l.id == ^library_path.id),
+        set: [inserted_at: at]
+      )
+    end
+  end
 end

--- a/test/mydia_web/live/add_media_live/config_modal_test.exs
+++ b/test/mydia_web/live/add_media_live/config_modal_test.exs
@@ -135,6 +135,54 @@ defmodule MydiaWeb.AddMediaLive.ConfigModalTest do
     end
   end
 
+  describe "search on add" do
+    test "queues a search job when search_on_add is set", %{conn: conn, library: library} do
+      {:ok, view, _html} = live(conn, ~p"/add/movie?q=matrix")
+
+      assert render(view) =~ "The Matrix"
+
+      view
+      |> element(~s(button[phx-click="open_config_modal"][phx-value-index="0"]))
+      |> render_click()
+
+      params = %{
+        "config" => %{
+          "library_path_id" => to_string(library.id),
+          "quality_profile_id" => "",
+          "season_monitoring" => "all",
+          "search_on_add" => "true"
+        }
+      }
+
+      render_hook(view, "submit_config_modal", params)
+
+      assert eventually(fn -> Mydia.Repo.aggregate(Oban.Job, :count) > 0 end)
+    end
+
+    test "queues nothing when search_on_add is absent", %{conn: conn, library: library} do
+      {:ok, view, _html} = live(conn, ~p"/add/movie?q=matrix")
+
+      assert render(view) =~ "The Matrix"
+
+      view
+      |> element(~s(button[phx-click="open_config_modal"][phx-value-index="0"]))
+      |> render_click()
+
+      params = %{
+        "config" => %{
+          "library_path_id" => to_string(library.id),
+          "quality_profile_id" => "",
+          "season_monitoring" => "all"
+        }
+      }
+
+      render_hook(view, "submit_config_modal", params)
+
+      assert eventually(fn -> Media.list_media_items() != [] end)
+      assert Mydia.Repo.aggregate(Oban.Job, :count) == 0
+    end
+  end
+
   defp assert_no_crash(view) do
     # A LiveView that died mid-handle_info raises here; a live one renders.
     assert render(view) =~ "add"

--- a/test/mydia_web/live/add_media_live/config_modal_test.exs
+++ b/test/mydia_web/live/add_media_live/config_modal_test.exs
@@ -8,6 +8,7 @@ defmodule MydiaWeb.AddMediaLive.ConfigModalTest do
   import Mydia.SettingsFixtures
   import Mydia.AccountsFixtures
 
+  alias Mydia.Media
   alias Mydia.Metadata.Provider
   alias Mydia.Metadata.Structs.{ImagesResponse, MediaMetadata, SearchResult}
 
@@ -104,10 +105,52 @@ defmodule MydiaWeb.AddMediaLive.ConfigModalTest do
 
       assert_no_crash(view)
     end
+
+    test "stores the selected library on the created item", %{conn: conn, library: library} do
+      {:ok, view, _html} = live(conn, ~p"/add/movie?q=matrix")
+
+      assert render(view) =~ "The Matrix"
+
+      view
+      |> element(~s(button[phx-click="open_config_modal"][phx-value-index="0"]))
+      |> render_click()
+
+      params = %{
+        "config" => %{
+          "library_path_id" => to_string(library.id),
+          "quality_profile_id" => "",
+          "season_monitoring" => "all"
+        }
+      }
+
+      render_hook(view, "submit_config_modal", params)
+
+      # Poll briefly: creation happens in handle_info after a metadata fetch.
+      assert eventually(fn ->
+               case Media.list_media_items() do
+                 [item | _] -> item.library_path_id == library.id
+                 [] -> false
+               end
+             end)
+    end
   end
 
   defp assert_no_crash(view) do
     # A LiveView that died mid-handle_info raises here; a live one renders.
     assert render(view) =~ "add"
+  end
+
+  defp eventually(fun, retries \\ 20) do
+    cond do
+      fun.() ->
+        true
+
+      retries == 0 ->
+        false
+
+      true ->
+        Process.sleep(50)
+        eventually(fun, retries - 1)
+    end
   end
 end

--- a/test/mydia_web/live/add_media_live/config_modal_test.exs
+++ b/test/mydia_web/live/add_media_live/config_modal_test.exs
@@ -1,0 +1,113 @@
+defmodule MydiaWeb.AddMediaLive.ConfigModalTest do
+  # async: false — connected LiveView tests cannot use the Postgres
+  # non-shared sandbox, which hides test rows from the mount process.
+  # Also: Provider.Registry is global process state.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.SettingsFixtures
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Metadata.Provider
+  alias Mydia.Metadata.Structs.{ImagesResponse, MediaMetadata, SearchResult}
+
+  # Real-UI path: search + open gear + submit. Direct `submit_config_modal`
+  # needs `config_modal_index` / `config_modal_result`, which only exist after
+  # `open_config_modal`. Auth helper is `log_in_user` (no `log_in_admin`).
+  defmodule ResultProvider do
+    @behaviour Mydia.Metadata.Provider
+
+    @impl true
+    def test_connection(_config), do: {:ok, %{status: "ok"}}
+
+    @impl true
+    def search(_config, _query, _opts) do
+      {:ok,
+       [
+         %SearchResult{
+           provider_id: "603",
+           provider: :metadata_relay,
+           media_type: :movie,
+           id: 603,
+           title: "The Matrix",
+           release_date: "1999-03-30",
+           overview: "A computer hacker learns about the true nature of reality.",
+           poster_path: "/matrix-poster.jpg",
+           vote_average: 8.2
+         }
+       ]}
+    end
+
+    @impl true
+    def fetch_by_id(_config, _id, _opts) do
+      {:ok,
+       %MediaMetadata{
+         provider_id: "603",
+         provider: :metadata_relay,
+         media_type: :movie,
+         id: 603,
+         title: "The Matrix",
+         original_title: "The Matrix",
+         year: 1999,
+         release_date: ~D[1999-03-30],
+         overview: "A computer hacker learns about the true nature of reality.",
+         imdb_id: "tt0133093"
+       }}
+    end
+
+    @impl true
+    def fetch_images(_config, _id, _opts),
+      do: {:ok, ImagesResponse.new(%{posters: [], backdrops: [], logos: []})}
+
+    @impl true
+    def fetch_season(_config, _id, _season, _opts), do: {:ok, %{}}
+
+    @impl true
+    def fetch_trending(_config, _opts), do: {:ok, []}
+  end
+
+  setup %{conn: conn} do
+    Provider.Registry.register(:metadata_relay, ResultProvider)
+    on_exit(fn -> Mydia.Metadata.register_providers() end)
+
+    library = library_path_fixture(%{type: "movies"})
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin), library: library}
+  end
+
+  describe "submit_config_modal" do
+    test "creates the item with a blank quality profile and monitoring off",
+         %{conn: conn, library: library} do
+      {:ok, view, _html} = live(conn, ~p"/add/movie?q=matrix")
+
+      # Wait for async search results to render.
+      assert render(view) =~ "The Matrix"
+
+      view
+      |> element(~s(button[phx-click="open_config_modal"][phx-value-index="0"]))
+      |> render_click()
+
+      # Blank quality profile and an absent `monitored` key are exactly the two
+      # shapes that used to raise KeyError in build_media_item_attrs/3.
+      # Drive submit via hook (not form/2): the movie modal has no
+      # season_monitoring field, and a checked DOM checkbox would re-inject
+      # monitored=true — neither matches the crash shapes.
+      params = %{
+        "config" => %{
+          "library_path_id" => to_string(library.id),
+          "quality_profile_id" => "",
+          "season_monitoring" => "all"
+        }
+      }
+
+      render_hook(view, "submit_config_modal", params)
+
+      assert_no_crash(view)
+    end
+  end
+
+  defp assert_no_crash(view) do
+    # A LiveView that died mid-handle_info raises here; a live one renders.
+    assert render(view) =~ "add"
+  end
+end

--- a/test/mydia_web/live/discover_live/library_picker_test.exs
+++ b/test/mydia_web/live/discover_live/library_picker_test.exs
@@ -1,0 +1,35 @@
+defmodule MydiaWeb.DiscoverLive.LibraryPickerTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Mydia.SettingsFixtures
+
+  alias MydiaWeb.Live.Helpers.MediaAddHelpers
+
+  # Rendering tests omitted: there are no existing Discover LiveView tests, no
+  # `log_in_admin` helper, and Discover cards need a live metadata relay.
+  # Plan says drop rendering tests and keep candidate_libraries/1 unit tests.
+
+  describe "candidate_libraries/1" do
+    test "returns only monitored, type-compatible libraries" do
+      movies = library_path_fixture(%{type: "movies"})
+      mixed = library_path_fixture(%{type: "mixed"})
+      _series = library_path_fixture(%{type: "series"})
+      unmonitored = library_path_fixture(%{type: "movies", monitored: false})
+
+      ids = MediaAddHelpers.candidate_libraries(:movie) |> Enum.map(& &1.id)
+
+      assert movies.id in ids
+      assert mixed.id in ids
+      refute unmonitored.id in ids
+    end
+
+    test "excludes unmaterialised runtime entries" do
+      library_path_fixture(%{type: "movies"})
+
+      # Runtime entries carry synthetic "runtime::" ids and have no DB row to
+      # point a foreign key at, so they must never appear in a picker.
+      refute MediaAddHelpers.candidate_libraries(:movie)
+             |> Enum.any?(&String.starts_with?(to_string(&1.id), "runtime::"))
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show_library_test.exs
+++ b/test/mydia_web/live/media_live/show_library_test.exs
@@ -1,0 +1,55 @@
+defmodule MydiaWeb.MediaLive.ShowLibraryTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.SettingsFixtures
+  import Mydia.MediaFixtures
+
+  setup %{conn: conn} do
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  test "shows the resolved library and its reason", %{conn: conn} do
+    library = library_path_fixture(%{type: "movies"})
+    {:ok, library} = Mydia.Settings.set_default_library(library, :movies)
+    item = media_item_fixture(%{type: "movie", title: "Shown Movie", year: 2024})
+
+    {:ok, view, _html} = live(conn, ~p"/movies/#{item.id}")
+
+    assert has_element?(view, "[data-test='target-library']")
+    assert render(view) =~ Path.basename(library.path)
+    assert render(view) =~ "library default"
+  end
+
+  test "changing the library writes library_path_id", %{conn: conn} do
+    _first = library_path_fixture(%{type: "movies", path: "/tmp/aaa-first"})
+    second = library_path_fixture(%{type: "movies", path: "/tmp/zzz-second"})
+    item = media_item_fixture(%{type: "movie", title: "Retargeted", year: 2024})
+
+    {:ok, view, _html} = live(conn, ~p"/movies/#{item.id}")
+
+    render_click(view, "update_target_library", %{"library-path-id" => to_string(second.id)})
+
+    assert Mydia.Repo.get!(Mydia.Media.MediaItem, item.id).library_path_id == second.id
+  end
+
+  test "clearing the library returns the item to automatic resolution", %{conn: conn} do
+    library = library_path_fixture(%{type: "movies"})
+    _other = library_path_fixture(%{type: "movies"})
+
+    item =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Cleared",
+        year: 2024,
+        library_path_id: library.id
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/movies/#{item.id}")
+
+    render_click(view, "update_target_library", %{"library-path-id" => ""})
+
+    assert Mydia.Repo.get!(Mydia.Media.MediaItem, item.id).library_path_id == nil
+  end
+end


### PR DESCRIPTION
Adding a second movies library captured every subsequent movie import, including movies whose files already lived elsewhere. Reported by a user who added a "Cartoons" library alongside "Movies" and found pre-existing movies downloading into Cartoons.

## Root cause

`MediaImport.determine_library_path/1` re-derived the destination on every import with `Enum.find` over `Settings.list_library_paths/1`, which orders `monitored DESC, path ASC`. The effective rule was "the monitored, type-compatible library whose path sorts alphabetically first", so `/media/Cartoons` beat `/media/Movies` for everything.

Two further defects surfaced while fixing it:

- The Add Movie library dropdown was write-only on **both** paths. `build_media_item_attrs/3` never read `config.library_path_id`, and `media_items` had no column to store it in.
- "Configure Before Adding" crashed. `validate_config/2` built a schemaless changeset seeded with `%{}`, so `apply_changes/1` dropped any field submitted blank. A blank quality profile or an unticked Monitor raised `KeyError` and killed the LiveView mid-add.

## Approach

New `Mydia.Library.TargetResolver` is the single authority for "which library does this item's content go into", resolving in order:

1. `:download_override` - the download row's own `library_path_id` (existing specialized-library escape hatch, unchanged)
2. `:explicit` - the media item's new `library_path_id`
3. `:existing_files` - where this item's non-trashed files already live
4. `:type_default` - the operator-set default for the item's kind
5. `:first_compatible` - the historical alphabetical rule

Step 5 is deliberately the pre-existing behaviour, so an install that never configures a default resolves exactly as it did before.

Each candidate is re-validated before acceptance and falls through if stale, since a library can be deleted, disabled or retyped long after an item started pointing at it. The check differs by step on purpose: an explicit choice does not require `monitored`, because unmonitoring usually means a drive is offline and silently rerouting an explicit choice to a different disk is how one movie ends up in two places.

## Data model

- `media_items.library_path_id`, nullable, `on_delete: :nilify_all`. NULL means "no preference, resolve dynamically".
- `library_paths.default_for_movies` / `default_for_series`. Two flags rather than one because a `:mixed` library serves both kinds; with a single flag a flagged `:movies` library and a flagged `:mixed` library would both be "the default" and the tie would be arbitrary. Enforced by changeset validation plus a partial unique index each.
- Backfill flags the oldest monitored library per kind, reproducing most installs' behaviour before the change. Configurable via `LIBRARY_PATH_<N>_DEFAULT_FOR_MOVIES` / `_DEFAULT_FOR_SERIES` and in Admin, Library Paths.

## UI

- Discover, dashboard and trending modal: the add button becomes a split button. Plain click uses the default, the caret picks a library. The caret is hidden when fewer than two candidates exist, so single-library installs are unchanged.
- Media detail page: a Library row showing the destination and why it resolved that way ("matches existing files", "library default", "chosen"), editable. Changing it redirects future grabs only; files already on disk never move.

## Also fixed

- **Add + Search never searched.** `search_on_add` was collected on both paths and threaded into `config`, then never read. Now calls `Search.queue_auto_searches/1`, the same Oban-dedupe-safe path the detail page uses.
- **The library picker would have been a no-op for TV shows.** `add_tv_show_to_library/3` did not accept opts, so a caret pick could not reach `build_media_item_attrs/3` for series.

## Compatibility

All three migrations are additive, no `ALTER COLUMN`, so no SQLite table rebuild. Nothing is required of the operator: an install that never opens the new settings keeps working via step 5. No GraphQL schema or player changes, so there is no cross-version window to manage.

## Testing

- `TargetResolver`: 14 tests covering each resolution step, fall-through on disabled/retyped/unmonitored candidates, the explicit-but-unmonitored case, most-files-wins tie-breaking, and trashed-file exclusion.
- Regression test reproducing the reported bug directly: two movies libraries where the alphabetically-first is not the one holding the files.
- Backfill, changeset invariants, the gear-modal `KeyError` repro, the Discover picker, the detail-page row, and Add + Search.
- Full suite green on SQLite (6876 tests). Schema and migration tasks verified on PostgreSQL.

## Out of scope

`GET /api/v1/media/:id` and `POST /api/v1/media/:id/match` return 500 today: both preload `:library_path` on `MediaItem`, and `serialize_media_item/1` reads six fields that live inside `metadata` rather than on the struct. This PR adds `belongs_to :library_path`, which incidentally fixes the preload, but the serializer still raises. Broken before and after, unchanged in severity, and nothing in the repo calls those endpoints. Left for a separate change.
