### PR TITLE
fix(ci): pin the browser Wallaby drives, not just the driver

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -119,11 +119,33 @@ config :tower,
 wallaby_headless = System.get_env("WALLABY_HEADLESS", "true") == "true"
 is_ci = System.get_env("CI") == "true" || System.get_env("GITHUB_ACTIONS") == "true"
 
+# `binary` pins the *browser* the way `path` pins the driver, and it matters as
+# much. Wallaby resolves Chrome itself in `Wallaby.Chrome.find_chrome_executable/0`,
+# which searches `[chromedriver_config[:binary] | default_paths]` and falls
+# through to whatever `google-chrome` is on PATH. On a GitHub runner that is the
+# system Chrome, which tracks stable and moves independently of nixpkgs, so
+# Wallaby compared it against devenv's pinned chromedriver and aborted every
+# session with "invalid session id" once the runner image reached Chrome 151
+# while nixpkgs pinned chromedriver 149.
+#
+# `scripts/run-feature-tests.sh` already prefers CHROME_PATH for exactly this
+# reason (see `get_chrome_version`), so its preflight reported a clean 149/149
+# match and Wallaby then failed its own independent check. Setting `binary` here
+# is what makes the two agree.
 wallaby_chromedriver_opts =
-  case System.get_env("CHROMEDRIVER_PATH") do
-    nil -> [headless: wallaby_headless]
-    path -> [path: path, headless: wallaby_headless]
-  end
+  [headless: wallaby_headless]
+  |> then(fn opts ->
+    case System.get_env("CHROMEDRIVER_PATH") do
+      nil -> opts
+      path -> Keyword.put(opts, :path, path)
+    end
+  end)
+  |> then(fn opts ->
+    case System.get_env("CHROME_PATH") do
+      nil -> opts
+      binary -> Keyword.put(opts, :binary, binary)
+    end
+  end)
 
 # Chrome capabilities for headless mode
 # These are especially important for CI environments


### PR DESCRIPTION
## The break

Every `Test / E2E Browser` job has been failing since roughly 18:30 UTC today, on master and on unrelated PRs alike (#400's merge and #402 both, with every other job green). Every single feature test fails with:

```
** (RuntimeError) invalid session id
```

The cause is in the job log:

```
warning: Looks like you're trying to run Wallaby with a mismatched version of
Chrome: 151.0.7922 and chromedriver: 149.0.7827.
Chrome and chromedriver must match to a major, minor, and build version.
```

GitHub's runner image has rolled out Chrome 151. nixpkgs pins chromedriver 149. ChromeDriver cannot drive that browser, so no session is ever valid.

## Why the existing guard did not catch it

`config/test.exs` told Wallaby where **chromedriver** lives but never where **Chrome** lives:

```elixir
case System.get_env("CHROMEDRIVER_PATH") do
  nil -> [headless: wallaby_headless]
  path -> [path: path, headless: wallaby_headless]
end
```

Wallaby resolves the browser itself, in `Wallaby.Chrome.find_chrome_executable/0`:

```elixir
chrome_path =
  :wallaby |> Application.get_env(:chromedriver, []) |> Keyword.get(:binary, [])

[Path.expand(chrome_path) | default_chrome_paths]
|> Enum.find_value(&System.find_executable/1)
```

With `:binary` unset that first entry is empty, so Wallaby falls through to `google-chrome` on PATH, which on a runner is the system Chrome rather than devenv's pinned chromium.

`scripts/run-feature-tests.sh` already anticipated this precise failure and prefers `CHROME_PATH` in `get_chrome_version`, with a comment saying so. That is why the preflight reported a clean `Versions match: Chrome 149.0.7827, ChromeDriver 149.0.7827` and Wallaby then failed its own independent check moments later. The hardening existed in the shell script but never made it into the Elixir config.

## The fix

Pass `binary: CHROME_PATH` into the `:chromedriver` config alongside `path: CHROMEDRIVER_PATH`, so the browser is pinned the same way the driver already was. Both env vars are set by `devenv.nix`, so this needs no workflow change and no separate Chrome action.

Neither key is set when its env var is absent, so local darwin runs (where devenv deliberately does not provide chromium) keep their existing auto-detection behaviour.

## Verification

Resolved config inside devenv now reports a matched pair:

```
binary: ".../chromium-149.0.7827.114/bin/chromium"
path:   ".../chromedriver-unwrapped-149.0.7827.114/bin/chromedriver"
```

Feature suite locally: 52 tests, 0 failures, 1 skipped.

Local cannot reproduce the CI break itself, since it depends on a system Chrome 151 being present for Wallaby to find. The real proof is this PR's own `Test / E2E Browser` job going green.
