### PR TITLE
fix(player): redesign the Media Info panel

### DIFF
--- a/player/lib/presentation/widgets/media_info/media_info_content.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_content.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/media_stream.dart';
+import '../../../domain/models/subtitle_track.dart';
 import 'stream_formatters.dart';
 
 /// Shown when the server has not captured detailed streams for a file yet.
@@ -22,11 +23,20 @@ class MediaInfoContent extends StatelessWidget {
   final int selectedIndex;
   final ValueChanged<int> onSelectVersion;
 
+  /// Whether the host sizes itself to this content.
+  ///
+  /// The side panel has a bounded height and leaves this false, so rows build
+  /// lazily. The bottom sheet sizes to its content and must pass true, which
+  /// forces every row to be measured. A definite sheet height would avoid that
+  /// but would leave a one-stream file 78% of the screen tall.
+  final bool shrinkWrap;
+
   const MediaInfoContent({
     super.key,
     required this.files,
     required this.selectedIndex,
     required this.onSelectVersion,
+    this.shrinkWrap = false,
   });
 
   @override
@@ -44,17 +54,86 @@ class MediaInfoContent extends StatelessWidget {
     final index = selectedIndex.clamp(0, files.length - 1);
     final file = files[index];
 
-    return ListView(
-      shrinkWrap: true,
-      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
-      children: [
-        if (files.length > 1) _versionSwitcher(index),
-        _fileSection(file),
-        ..._streamSections(file),
-        if (!file.hasDetailedStreams) _pendingNote(),
+    final video = file.ofType(MediaStreamType.video);
+    final audio = file.ofType(MediaStreamType.audio);
+    final subtitle = file.ofType(MediaStreamType.subtitle);
+    final external = file.externalSubtitles;
+
+    return CustomScrollView(
+      shrinkWrap: shrinkWrap,
+      slivers: [
+        if (files.length > 1)
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(18, 12, 18, 0),
+            sliver: SliverToBoxAdapter(child: _versionSwitcher(index)),
+          ),
+        _header('File', 1),
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 18),
+          sliver: SliverToBoxAdapter(child: _fileBlock(file)),
+        ),
+        if (video.isNotEmpty) ...[
+          _header('Video', video.length),
+          _streams(
+            video.length,
+            (i) => _StreamTile(
+              key: Key('media-info-stream-${video[i].index}'),
+              stream: video[i],
+            ),
+          ),
+        ],
+        if (audio.isNotEmpty) ...[
+          _header('Audio', audio.length),
+          _streams(
+            audio.length,
+            (i) => _StreamTile(
+              key: Key('media-info-stream-${audio[i].index}'),
+              stream: audio[i],
+            ),
+          ),
+        ],
+        if (subtitle.isNotEmpty || external.isNotEmpty) ...[
+          _header('Subtitles', subtitle.length + external.length),
+          _streams(
+            subtitle.length + external.length,
+            (i) => i < subtitle.length
+                ? _StreamTile(
+                    key: Key('media-info-stream-${subtitle[i].index}'),
+                    stream: subtitle[i],
+                  )
+                : _externalTile(external[i - subtitle.length]),
+          ),
+        ],
+        if (!file.hasDetailedStreams)
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(18, 16, 18, 0),
+            sliver: SliverToBoxAdapter(child: _pendingNote()),
+          ),
+        const SliverToBoxAdapter(child: SizedBox(height: 24)),
       ],
     );
   }
+
+  Widget _header(String label, int count) => SliverPersistentHeader(
+        pinned: true,
+        delegate: _SectionHeaderDelegate(label: label, count: count),
+      );
+
+  Widget _streams(int count, Widget Function(int index) builder) {
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(horizontal: 18),
+      sliver: SliverList.builder(
+        itemCount: count,
+        itemBuilder: (_, index) => builder(index),
+      ),
+    );
+  }
+
+  Widget _externalTile(SubtitleTrack track) => _ExternalSubtitleTile(
+        key: Key('media-info-external-${track.id}'),
+        language: languageName(track.language) ?? track.language,
+        format: track.format,
+      );
 
   Widget _versionSwitcher(int index) {
     return Padding(
@@ -81,7 +160,7 @@ class MediaInfoContent extends StatelessWidget {
     return size == null ? file.versionLabel : '${file.versionLabel} · $size';
   }
 
-  Widget _fileSection(MediaFileInfo file) {
+  Widget _fileBlock(MediaFileInfo file) {
     final size = formatBytes(file.sizeBytes);
     final duration = formatDuration(file.durationSeconds);
     final bitrate = formatBitrate(file.bitrate);
@@ -92,8 +171,8 @@ class MediaInfoContent extends StatelessWidget {
       if (bitrate != null) bitrate,
     ];
 
-    return _Section(
-      label: 'File',
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (file.fileName != null)
           Text(
@@ -118,38 +197,6 @@ class MediaInfoContent extends StatelessWidget {
     );
   }
 
-  List<Widget> _streamSections(MediaFileInfo file) {
-    final video = file.ofType(MediaStreamType.video);
-    final audio = file.ofType(MediaStreamType.audio);
-    final subtitle = file.ofType(MediaStreamType.subtitle);
-
-    return [
-      if (video.isNotEmpty)
-        _Section(
-          label: 'Video',
-          children: [for (final s in video) _StreamTile(stream: s)],
-        ),
-      if (audio.isNotEmpty)
-        _Section(
-          label:
-              'Audio · ${audio.length} ${audio.length == 1 ? 'track' : 'tracks'}',
-          children: [for (final s in audio) _StreamTile(stream: s)],
-        ),
-      if (subtitle.isNotEmpty || file.externalSubtitles.isNotEmpty)
-        _Section(
-          label: 'Subtitles',
-          children: [
-            for (final s in subtitle) _StreamTile(stream: s),
-            for (final s in file.externalSubtitles)
-              _ExternalSubtitleTile(
-                language: languageName(s.language) ?? s.language,
-                format: s.format,
-              ),
-          ],
-        ),
-    ];
-  }
-
   Widget _pendingNote() {
     return const Padding(
       padding: EdgeInsets.only(top: 16),
@@ -162,40 +209,10 @@ class MediaInfoContent extends StatelessWidget {
   }
 }
 
-class _Section extends StatelessWidget {
-  final String label;
-  final List<Widget> children;
-
-  const _Section({required this.label, required this.children});
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 18),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label.toUpperCase(),
-            style: const TextStyle(
-              color: AppColors.textDisabled,
-              fontSize: 10,
-              letterSpacing: 1.6,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: 8),
-          ...children,
-        ],
-      ),
-    );
-  }
-}
-
 class _StreamTile extends StatelessWidget {
   final MediaStream stream;
 
-  const _StreamTile({required this.stream});
+  const _StreamTile({super.key, required this.stream});
 
   @override
   Widget build(BuildContext context) {
@@ -312,7 +329,11 @@ class _ExternalSubtitleTile extends StatelessWidget {
   final String language;
   final String format;
 
-  const _ExternalSubtitleTile({required this.language, required this.format});
+  const _ExternalSubtitleTile({
+    super.key,
+    required this.language,
+    required this.format,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -441,4 +462,53 @@ class _VersionChip extends StatelessWidget {
       ),
     );
   }
+}
+
+/// A section label that stays put while its rows scroll under it.
+///
+/// It paints [AppColors.surface] rather than sitting transparent so rows do not
+/// show through it once pinned.
+class _SectionHeaderDelegate extends SliverPersistentHeaderDelegate {
+  final String label;
+  final int count;
+
+  const _SectionHeaderDelegate({required this.label, required this.count});
+
+  static const double _height = 30;
+
+  @override
+  double get minExtent => _height;
+
+  @override
+  double get maxExtent => _height;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    final text = count > 1 ? '$label · $count' : label;
+
+    return Container(
+      key: Key('media-info-header-${label.toLowerCase()}'),
+      height: _height,
+      color: AppColors.surface,
+      alignment: Alignment.bottomLeft,
+      padding: const EdgeInsets.fromLTRB(18, 0, 18, 8),
+      child: Text(
+        text.toUpperCase(),
+        style: const TextStyle(
+          color: AppColors.textDisabled,
+          fontSize: 10,
+          letterSpacing: 1.6,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  @override
+  bool shouldRebuild(_SectionHeaderDelegate oldDelegate) =>
+      oldDelegate.label != label || oldDelegate.count != count;
 }

--- a/player/lib/presentation/widgets/media_info/media_info_content.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_content.dart
@@ -76,7 +76,7 @@ class MediaInfoContent extends StatelessWidget {
           _header('Video', video.length),
           _streams(
             video.length,
-            (i) => _StreamTile(
+            (i) => _VideoStreamTile(
               key: Key('media-info-stream-${video[i].index}'),
               stream: video[i],
             ),
@@ -84,24 +84,15 @@ class MediaInfoContent extends StatelessWidget {
         ],
         if (audio.isNotEmpty) ...[
           _header('Audio', audio.length),
-          _streams(
-            audio.length,
-            (i) => _StreamTile(
-              key: Key('media-info-stream-${audio[i].index}'),
-              stream: audio[i],
-            ),
-          ),
+          _streams(audio.length, (i) => _audioRow(audio[i])),
         ],
         if (subtitle.isNotEmpty || external.isNotEmpty) ...[
           _header('Subtitles', subtitle.length + external.length),
           _streams(
             subtitle.length + external.length,
             (i) => i < subtitle.length
-                ? _StreamTile(
-                    key: Key('media-info-stream-${subtitle[i].index}'),
-                    stream: subtitle[i],
-                  )
-                : _externalTile(external[i - subtitle.length]),
+                ? _subtitleRow(subtitle[i])
+                : _externalSubtitleRow(external[i - subtitle.length]),
           ),
         ],
         if (!file.hasDetailedStreams)
@@ -128,12 +119,6 @@ class MediaInfoContent extends StatelessWidget {
       ),
     );
   }
-
-  Widget _externalTile(SubtitleTrack track) => _ExternalSubtitleTile(
-        key: Key('media-info-external-${track.id}'),
-        language: languageName(track.language) ?? track.language,
-        format: track.format,
-      );
 
   Widget _versionSwitcher(int index) {
     return Padding(
@@ -209,10 +194,14 @@ class MediaInfoContent extends StatelessWidget {
   }
 }
 
-class _StreamTile extends StatelessWidget {
+/// A video stream, kept as a multi-line block.
+///
+/// There is rarely more than one, and profile, geometry, Dolby Vision profile,
+/// colour primaries, colour transfer and pixel format do not fit a single row.
+class _VideoStreamTile extends StatelessWidget {
   final MediaStream stream;
 
-  const _StreamTile({super.key, required this.stream});
+  const _VideoStreamTile({super.key, required this.stream});
 
   @override
   Widget build(BuildContext context) {
@@ -239,7 +228,7 @@ class _StreamTile extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 2),
-          for (final line in _lines()) _DetailLine(line),
+          for (final line in _videoLines()) _DetailLine(line),
         ],
       ),
     );
@@ -251,20 +240,7 @@ class _StreamTile extends StatelessWidget {
       if (language != null) language,
       if (stream.isDefault) 'Default',
       if (stream.isForced) 'Forced',
-      if (stream.isHearingImpaired) 'SDH',
-      if (stream.isCommentary) 'Commentary',
     ];
-  }
-
-  List<String> _lines() {
-    switch (stream.type) {
-      case MediaStreamType.video:
-        return _videoLines();
-      case MediaStreamType.audio:
-        return _audioLines();
-      case MediaStreamType.subtitle:
-        return _subtitleLines();
-    }
   }
 
   List<String> _videoLines() {
@@ -292,76 +268,190 @@ class _StreamTile extends StatelessWidget {
       if (bitrate != null) bitrate,
     ];
   }
-
-  List<String> _audioLines() {
-    final channels = formatChannels(stream.channels, stream.channelLayout);
-    final sampleRate = formatSampleRate(stream.sampleRate);
-    final bitrate = formatBitrate(stream.bitrate);
-    final parts = <String>[
-      if (channels != null) channels,
-      if (sampleRate != null) sampleRate,
-      if (stream.bitDepth != null) '${stream.bitDepth}-bit',
-      if (bitrate != null) bitrate,
-    ];
-
-    return [
-      if (stream.title != null) stream.title!,
-      if (parts.isNotEmpty) parts.join(' · '),
-    ];
-  }
-
-  List<String> _subtitleLines() {
-    const imageCodecs = {
-      'hdmv_pgs_subtitle',
-      'dvd_subtitle',
-      'dvb_subtitle',
-      'xsub'
-    };
-    final isImage = imageCodecs.contains(stream.codec?.toLowerCase());
-    return [
-      if (stream.title != null) stream.title!,
-      isImage ? 'Image based' : 'Text based',
-    ];
-  }
 }
 
-class _ExternalSubtitleTile extends StatelessWidget {
-  final String language;
-  final String format;
+/// One audio or subtitle stream, as a single aligned line.
+///
+/// Fixed leading column widths are what make values line up down the list; the
+/// monospace face keeps numbers aligned within a column. A second muted line
+/// renders only when the stream carries data the columns cannot hold, so in a
+/// 34-track remux most subtitle rows stay exactly one line tall.
+class _StreamRow extends StatelessWidget {
+  final String? index;
+  final String codec;
+  final String? language;
+  final String detail;
+  final List<String> flags;
+  final List<String> extra;
 
-  const _ExternalSubtitleTile({
+  const _StreamRow({
     super.key,
+    required this.index,
+    required this.codec,
     required this.language,
-    required this.format,
+    required this.detail,
+    required this.flags,
+    required this.extra,
   });
+
+  static const double _indexWidth = 22;
+  static const double _codecWidth = 66;
+  static const double _languageWidth = 88;
+  static const double _gap = 8;
+
+  static const TextStyle _codecStyle = TextStyle(
+    color: AppColors.textPrimary,
+    fontSize: 11,
+    height: 1.5,
+    fontWeight: FontWeight.w600,
+    fontFamily: 'monospace',
+  );
+
+  static const TextStyle _valueStyle = TextStyle(
+    color: AppColors.textSecondary,
+    fontSize: 11,
+    height: 1.5,
+    fontFamily: 'monospace',
+  );
+
+  static const TextStyle _mutedStyle = TextStyle(
+    color: AppColors.textDisabled,
+    fontSize: 11,
+    height: 1.5,
+    fontFamily: 'monospace',
+  );
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.symmetric(vertical: 3),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Wrap(
-            spacing: 6,
-            crossAxisAlignment: WrapCrossAlignment.center,
+          Row(
             children: [
-              Text(
-                format.toUpperCase(),
-                style: const TextStyle(
-                  color: AppColors.textPrimary,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
+              SizedBox(
+                width: _indexWidth,
+                child: Text(
+                  index ?? '',
+                  textAlign: TextAlign.right,
+                  style: _mutedStyle,
                 ),
               ),
-              _FlagChip(label: language),
-              const _FlagChip(label: 'External'),
+              const SizedBox(width: _gap),
+              SizedBox(
+                width: _codecWidth,
+                child: Text(
+                  codec.toUpperCase(),
+                  overflow: TextOverflow.ellipsis,
+                  style: _codecStyle,
+                ),
+              ),
+              const SizedBox(width: _gap),
+              SizedBox(
+                width: _languageWidth,
+                child: Text(
+                  language ?? '',
+                  overflow: TextOverflow.ellipsis,
+                  style: _valueStyle,
+                ),
+              ),
+              const SizedBox(width: _gap),
+              Expanded(
+                child: Text(
+                  detail,
+                  overflow: TextOverflow.ellipsis,
+                  style: _valueStyle,
+                ),
+              ),
+              if (flags.isNotEmpty) ...[
+                const SizedBox(width: _gap),
+                Text(flags.join(' · '), style: _mutedStyle),
+              ],
             ],
           ),
+          if (extra.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(
+                left: _indexWidth + _codecWidth + _gap * 2,
+              ),
+              child: Text(
+                extra.join(' · '),
+                overflow: TextOverflow.ellipsis,
+                style: _mutedStyle,
+              ),
+            ),
         ],
       ),
     );
   }
+}
+
+/// Subtitle codecs that carry bitmaps rather than text.
+const Set<String> _imageSubtitleCodecs = {
+  'hdmv_pgs_subtitle',
+  'dvd_subtitle',
+  'dvb_subtitle',
+  'xsub',
+};
+
+bool _isImageSubtitle(String? codec) =>
+    _imageSubtitleCodecs.contains(codec?.toLowerCase());
+
+/// Playback-affecting flags. Language is deliberately absent: it has its own
+/// column in [_StreamRow], unlike the video tile where it stays a chip.
+List<String> _rowFlags(MediaStream stream) => [
+      if (stream.isDefault) 'Default',
+      if (stream.isForced) 'Forced',
+      if (stream.isHearingImpaired) 'SDH',
+      if (stream.isCommentary) 'Commentary',
+    ];
+
+_StreamRow _audioRow(MediaStream stream) {
+  final channels = formatChannels(stream.channels, stream.channelLayout);
+  final sampleRate = formatSampleRate(stream.sampleRate);
+  final bitrate = formatBitrate(stream.bitrate);
+
+  return _StreamRow(
+    key: Key('media-info-stream-${stream.index}'),
+    index: stream.index?.toString(),
+    codec: stream.codec ?? 'Unknown',
+    language: languageName(stream.language),
+    detail: [
+      if (channels != null) channels,
+      if (sampleRate != null) sampleRate,
+    ].join(' · '),
+    flags: _rowFlags(stream),
+    extra: [
+      if (stream.title != null) stream.title!,
+      if (bitrate != null) bitrate,
+      if (stream.bitDepth != null) '${stream.bitDepth}-bit',
+    ],
+  );
+}
+
+_StreamRow _subtitleRow(MediaStream stream) {
+  return _StreamRow(
+    key: Key('media-info-stream-${stream.index}'),
+    index: stream.index?.toString(),
+    codec: stream.codec ?? 'Unknown',
+    language: languageName(stream.language),
+    detail: _isImageSubtitle(stream.codec) ? 'Image' : 'Text',
+    flags: _rowFlags(stream),
+    extra: [if (stream.title != null) stream.title!],
+  );
+}
+
+_StreamRow _externalSubtitleRow(SubtitleTrack track) {
+  return _StreamRow(
+    key: Key('media-info-external-${track.id}'),
+    index: null,
+    codec: track.format,
+    language: languageName(track.language),
+    detail: _isImageSubtitle(track.format) ? 'Image' : 'Text',
+    flags: const ['External'],
+    extra: [if (track.title != null) track.title!],
+  );
 }
 
 class _DetailLine extends StatelessWidget {

--- a/player/lib/presentation/widgets/media_info/media_info_controller.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_controller.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import '../../../core/graphql/graphql_provider.dart';
 import '../../../core/graphql/watch/schema_downgrade.dart';
 import '../../../domain/models/media_stream.dart';
+import '../../../domain/models/subtitle_track.dart';
 import '../../../graphql/queries/media_info.graphql.dart';
 import 'media_info_sheet.dart';
 
@@ -60,12 +62,17 @@ final mediaInfoProvider =
 
   return files
       .cast<Map<String, dynamic>>()
-      .map(_fileFromJson)
+      .map(mediaFileInfoFromJson)
       .toList(growable: false);
 });
 
-MediaFileInfo _fileFromJson(Map<String, dynamic> json) {
+/// Maps one `MediaInfoFragment` payload onto [MediaFileInfo].
+///
+/// Public only so it can be unit tested without a GraphQL client.
+@visibleForTesting
+MediaFileInfo mediaFileInfoFromJson(Map<String, dynamic> json) {
   final streams = json['streams'] as List<dynamic>?;
+  final external = json['externalSubtitles'] as List<dynamic>?;
 
   return MediaFileInfo(
     id: json['id'].toString(),
@@ -79,6 +86,20 @@ MediaFileInfo _fileFromJson(Map<String, dynamic> json) {
     codec: json['codec'] as String?,
     streams:
         streams?.cast<Map<String, dynamic>>().map(_streamFromJson).toList(),
+    externalSubtitles: (external ?? const [])
+        .cast<Map<String, dynamic>>()
+        .map(_externalSubtitleFromJson)
+        .toList(growable: false),
+  );
+}
+
+SubtitleTrack _externalSubtitleFromJson(Map<String, dynamic> json) {
+  return SubtitleTrack(
+    id: json['trackId'].toString(),
+    language: json['language'] as String? ?? 'und',
+    title: json['title'] as String?,
+    format: json['format'] as String? ?? 'srt',
+    embedded: json['embedded'] as bool? ?? false,
   );
 }
 

--- a/player/lib/presentation/widgets/media_info/media_info_sheet.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_sheet.dart
@@ -28,70 +28,77 @@ class _MediaInfoPanelState extends State<MediaInfoPanel> {
 
   @override
   Widget build(BuildContext context) {
-    final content = MediaInfoContent(
-      files: widget.files,
-      selectedIndex: _selected,
-      onSelectVersion: (index) => setState(() => _selected = index),
-    );
-
     // Below the desktop breakpoint the panel is a bottom sheet; at or above it
     // is a right-hand side panel, so the backdrop and poster stay visible.
-    return Breakpoints.isDesktop(context)
-        ? _SidePanel(key: const Key('media-info-side'), child: content)
-        : _BottomPanel(key: const Key('media-info-bottom'), child: content);
-  }
-}
+    final isWide = Breakpoints.isDesktop(context);
 
-class _BottomPanel extends StatelessWidget {
-  final Widget child;
-
-  const _BottomPanel({super.key, required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      constraints: BoxConstraints(
-        maxHeight: MediaQuery.sizeOf(context).height * 0.78,
-      ),
-      decoration: const BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
+    return _PanelSurface(
+      key: isWide
+          ? const Key('media-info-side')
+          : const Key('media-info-bottom'),
       child: Column(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisSize: isWide ? MainAxisSize.max : MainAxisSize.min,
         children: [
-          const _Grabber(),
+          if (isWide) const SizedBox(height: 12) else const _Grabber(),
           const _PanelHeader(),
-          Flexible(child: child),
+          Flexible(
+            fit: isWide ? FlexFit.tight : FlexFit.loose,
+            child: MediaInfoContent(
+              files: widget.files,
+              selectedIndex: _selected,
+              onSelectVersion: (index) => setState(() => _selected = index),
+            ),
+          ),
         ],
       ),
     );
   }
 }
 
-class _SidePanel extends StatelessWidget {
+/// The panel's background, border, radius and width, for every state.
+///
+/// A [Material] rather than a decorated [Container]: `showGeneralDialog`'s page
+/// has no Material ancestor, and without one every [Text] inherits Flutter's
+/// fallback debug style (a yellow double underline) and every [InkWell] fails
+/// `debugCheckHasMaterial`. Owning the width here also means the loading, error
+/// and loaded states cannot disagree about it and make the panel jump.
+class _PanelSurface extends StatelessWidget {
   final Widget child;
 
-  const _SidePanel({super.key, required this.child});
+  const _PanelSurface({super.key, required this.child});
+
+  /// Side-panel width.
+  ///
+  /// `Breakpoints.isDesktop` is `width >= 900` despite its name, so a flat
+  /// fraction would make the panel *narrower* than the 420 it shipped with on
+  /// small laptops. The floor keeps every viewport at least as wide as before;
+  /// the ceiling stops it sprawling on an ultrawide.
+  static double sideWidth(BuildContext context) =>
+      (MediaQuery.sizeOf(context).width * 0.4).clamp(420.0, 520.0);
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.centerRight,
+    final isWide = Breakpoints.isDesktop(context);
+
+    return Material(
+      color: AppColors.surface,
+      borderRadius:
+          isWide ? null : const BorderRadius.vertical(top: Radius.circular(16)),
+      clipBehavior: Clip.antiAlias,
       child: Container(
-        width: 420,
-        height: double.infinity,
-        decoration: const BoxDecoration(
-          color: AppColors.surface,
-          border: Border(left: BorderSide(color: AppColors.border)),
-        ),
-        child: Column(
-          children: [
-            const SizedBox(height: 12),
-            const _PanelHeader(),
-            Expanded(child: child),
-          ],
-        ),
+        width: isWide ? sideWidth(context) : double.infinity,
+        height: isWide ? double.infinity : null,
+        constraints: isWide
+            ? null
+            : BoxConstraints(
+                maxHeight: MediaQuery.sizeOf(context).height * 0.78,
+              ),
+        decoration: isWide
+            ? const BoxDecoration(
+                border: Border(left: BorderSide(color: AppColors.border)),
+              )
+            : null,
+        child: child,
       ),
     );
   }
@@ -213,24 +220,11 @@ class _PanelShell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isWide = Breakpoints.isDesktop(context);
-
-    return Container(
-      width: isWide ? 420 : double.infinity,
-      height: isWide ? double.infinity : null,
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: isWide
-            ? null
-            : const BorderRadius.vertical(top: Radius.circular(16)),
-        border: isWide
-            ? const Border(left: BorderSide(color: AppColors.border))
-            : null,
+    return _PanelSurface(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [const _PanelHeader(), child],
       ),
-      child: Column(mainAxisSize: MainAxisSize.min, children: [
-        const _PanelHeader(),
-        child,
-      ]),
     );
   }
 }

--- a/player/lib/presentation/widgets/media_info/media_info_sheet.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_sheet.dart
@@ -46,6 +46,7 @@ class _MediaInfoPanelState extends State<MediaInfoPanel> {
             child: MediaInfoContent(
               files: widget.files,
               selectedIndex: _selected,
+              shrinkWrap: !isWide,
               onSelectVersion: (index) => setState(() => _selected = index),
             ),
           ),

--- a/player/lib/presentation/widgets/media_info/media_info_sheet.dart
+++ b/player/lib/presentation/widgets/media_info/media_info_sheet.dart
@@ -85,7 +85,9 @@ class _PanelSurface extends StatelessWidget {
       color: AppColors.surface,
       borderRadius:
           isWide ? null : const BorderRadius.vertical(top: Radius.circular(16)),
-      clipBehavior: Clip.antiAlias,
+      // Only the bottom sheet has corners to clip. The side panel is a plain
+      // rectangle, so clipping there is pure rasterization cost.
+      clipBehavior: isWide ? Clip.none : Clip.antiAlias,
       child: Container(
         width: isWide ? sideWidth(context) : double.infinity,
         height: isWide ? double.infinity : null,

--- a/player/test/presentation/widgets/media_info/media_info_content_test.dart
+++ b/player/test/presentation/widgets/media_info/media_info_content_test.dart
@@ -4,7 +4,7 @@ import 'package:player/domain/models/media_stream.dart';
 import 'package:player/domain/models/subtitle_track.dart';
 import 'package:player/presentation/widgets/media_info/media_info_content.dart';
 
-MediaFileInfo _richFile() => MediaFileInfo(
+MediaFileInfo _richFile() => const MediaFileInfo(
       id: 'f1',
       fileName: 'Blade.Runner.2049.2160p.mkv',
       directory: '/media/movies/Blade Runner 2049 (2017)',
@@ -14,7 +14,7 @@ MediaFileInfo _richFile() => MediaFileInfo(
       bitrate: 47300000,
       resolution: '2160p',
       codec: 'hevc',
-      streams: const [
+      streams: [
         MediaStream(
           index: 0,
           type: MediaStreamType.video,
@@ -195,8 +195,8 @@ void main() {
   testWidgets('shows external subtitles under the subtitles header',
       (tester) async {
     await tester.pumpWidget(_wrap(MediaInfoContent(
-      files: [
-        const MediaFileInfo(
+      files: const [
+        MediaFileInfo(
           id: 'f4',
           fileName: 'Movie.mkv',
           streams: [
@@ -221,5 +221,107 @@ void main() {
       findsOneWidget,
     );
     expect(find.byKey(const Key('media-info-external-ext-1')), findsOneWidget);
+  });
+
+  testWidgets('renders an audio stream as one aligned line', (tester) async {
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: const [
+        MediaFileInfo(
+          id: 'f5',
+          fileName: 'Movie.mkv',
+          streams: [
+            MediaStream(
+              index: 1,
+              type: MediaStreamType.audio,
+              codec: 'truehd',
+              language: 'eng',
+              channels: 8,
+              channelLayout: '7.1',
+              sampleRate: 48000,
+              isDefault: true,
+            ),
+          ],
+        ),
+      ],
+      selectedIndex: 0,
+      onSelectVersion: (_) {},
+    )));
+
+    expect(find.text('TRUEHD'), findsOneWidget);
+    expect(find.text('English'), findsOneWidget);
+    expect(find.text('7.1 (8 ch) · 48 kHz'), findsOneWidget);
+    expect(find.text('Default'), findsOneWidget);
+  });
+
+  testWidgets('a titleless subtitle row is one line, a titled one is taller',
+      (tester) async {
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: const [
+        MediaFileInfo(
+          id: 'f6',
+          fileName: 'Movie.mkv',
+          streams: [
+            MediaStream(
+              index: 2,
+              type: MediaStreamType.subtitle,
+              codec: 'subrip',
+              language: 'eng',
+            ),
+            MediaStream(
+              index: 3,
+              type: MediaStreamType.subtitle,
+              codec: 'hdmv_pgs_subtitle',
+              language: 'fre',
+              title: 'Forced narrative only',
+            ),
+          ],
+        ),
+      ],
+      selectedIndex: 0,
+      onSelectVersion: (_) {},
+    )));
+
+    // getSize throws unless exactly one widget carries each key, so these two
+    // calls also assert one row per stream.
+    final plain =
+        tester.getSize(find.byKey(const Key('media-info-stream-2'))).height;
+    final titled =
+        tester.getSize(find.byKey(const Key('media-info-stream-3'))).height;
+
+    expect(plain, lessThan(28));
+    expect(titled, greaterThan(plain));
+    expect(find.text('Text'), findsOneWidget);
+    expect(find.text('Image'), findsOneWidget);
+    expect(find.text('Forced narrative only'), findsOneWidget);
+  });
+
+  testWidgets('an external subtitle row shows its title and External flag',
+      (tester) async {
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: const [
+        MediaFileInfo(
+          id: 'f7',
+          fileName: 'Movie.mkv',
+          streams: [
+            MediaStream(index: 0, type: MediaStreamType.video, codec: 'h264'),
+          ],
+          externalSubtitles: [
+            SubtitleTrack(
+              id: 'ext-1',
+              language: 'por',
+              title: 'Portugues do Brasil',
+              format: 'srt',
+            ),
+          ],
+        ),
+      ],
+      selectedIndex: 0,
+      onSelectVersion: (_) {},
+    )));
+
+    expect(find.text('SRT'), findsOneWidget);
+    expect(find.text('Portuguese'), findsOneWidget);
+    expect(find.text('External'), findsOneWidget);
+    expect(find.text('Portugues do Brasil'), findsOneWidget);
   });
 }

--- a/player/test/presentation/widgets/media_info/media_info_content_test.dart
+++ b/player/test/presentation/widgets/media_info/media_info_content_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/domain/models/media_stream.dart';
+import 'package:player/domain/models/subtitle_track.dart';
 import 'package:player/presentation/widgets/media_info/media_info_content.dart';
 
 MediaFileInfo _richFile() => MediaFileInfo(
@@ -109,5 +110,116 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(selected, 1);
+  });
+
+  MediaFileInfo manySubtitlesFile() => MediaFileInfo(
+        id: 'f3',
+        fileName: 'Remux.2160p.mkv',
+        container: 'mkv',
+        resolution: '2160p',
+        codec: 'hevc',
+        streams: [
+          const MediaStream(
+            index: 0,
+            type: MediaStreamType.video,
+            codec: 'hevc',
+            width: 3840,
+            height: 2160,
+          ),
+          const MediaStream(
+            index: 1,
+            type: MediaStreamType.audio,
+            codec: 'truehd',
+            language: 'eng',
+            channels: 8,
+            channelLayout: '7.1',
+          ),
+          for (var i = 2; i < 36; i++)
+            MediaStream(
+              index: i,
+              type: MediaStreamType.subtitle,
+              codec: 'subrip',
+              language: 'eng',
+            ),
+        ],
+      );
+
+  testWidgets('labels each section with its stream count', (tester) async {
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: [manySubtitlesFile()],
+      selectedIndex: 0,
+      onSelectVersion: (_) {},
+    )));
+
+    expect(find.byKey(const Key('media-info-header-file')), findsOneWidget);
+    expect(find.byKey(const Key('media-info-header-video')), findsOneWidget);
+    expect(find.byKey(const Key('media-info-header-audio')), findsOneWidget);
+    expect(
+      find.byKey(const Key('media-info-header-subtitles')),
+      findsOneWidget,
+    );
+    expect(find.text('SUBTITLES · 34'), findsOneWidget);
+  });
+
+  testWidgets('keeps the subtitles header pinned while scrolling',
+      (tester) async {
+    tester.view.physicalSize = const Size(520, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: [manySubtitlesFile()],
+      selectedIndex: 0,
+      onSelectVersion: (_) {},
+    )));
+
+    // scrollUntilVisible rather than a fixed drag distance: rows build lazily,
+    // so a hardcoded offset would depend on per-row heights that Task 4 then
+    // changes underneath this test.
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('media-info-stream-30')),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+
+    // Scrolled deep enough that an unpinned header would have left the
+    // viewport, yet the header is still on screen above its rows.
+    expect(find.byKey(const Key('media-info-stream-30')), findsOneWidget);
+    expect(
+      find.byKey(const Key('media-info-header-subtitles')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shows external subtitles under the subtitles header',
+      (tester) async {
+    await tester.pumpWidget(_wrap(MediaInfoContent(
+      files: [
+        const MediaFileInfo(
+          id: 'f4',
+          fileName: 'Movie.mkv',
+          streams: [
+            MediaStream(index: 0, type: MediaStreamType.video, codec: 'h264'),
+          ],
+          externalSubtitles: [
+            SubtitleTrack(
+              id: 'ext-1',
+              language: 'por',
+              title: 'Portugues',
+              format: 'srt',
+            ),
+          ],
+        ),
+      ],
+      selectedIndex: 0,
+      onSelectVersion: (_) {},
+    )));
+
+    expect(
+      find.byKey(const Key('media-info-header-subtitles')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('media-info-external-ext-1')), findsOneWidget);
   });
 }

--- a/player/test/presentation/widgets/media_info/media_info_controller_test.dart
+++ b/player/test/presentation/widgets/media_info/media_info_controller_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/media_info/media_info_controller.dart';
+
+void main() {
+  test('maps external subtitles from the query payload', () {
+    final file = mediaFileInfoFromJson({
+      'id': 7,
+      'fileName': 'Movie.mkv',
+      'externalSubtitles': [
+        {
+          'trackId': 'ext-1',
+          'language': 'por',
+          'title': 'Portugues (Brasil)',
+          'format': 'srt',
+          'embedded': false,
+        },
+      ],
+    });
+
+    expect(file.externalSubtitles, hasLength(1));
+
+    final track = file.externalSubtitles.single;
+    expect(track.id, 'ext-1');
+    expect(track.language, 'por');
+    expect(track.title, 'Portugues (Brasil)');
+    expect(track.format, 'srt');
+    expect(track.embedded, isFalse);
+  });
+
+  test('defaults external subtitles to empty when the field is absent', () {
+    // The legacy fallback query does not select externalSubtitles, so an older
+    // server yields a payload without the key at all.
+    final file = mediaFileInfoFromJson({'id': 7, 'fileName': 'Movie.mkv'});
+
+    expect(file.externalSubtitles, isEmpty);
+  });
+
+  test('still maps the scalar file fields', () {
+    final file = mediaFileInfoFromJson({
+      'id': 7,
+      'fileName': 'Movie.mkv',
+      'container': 'mkv',
+      'size': 8400000,
+      'duration': 5400.0,
+      'resolution': '1080p',
+      'codec': 'h264',
+    });
+
+    expect(file.id, '7');
+    expect(file.container, 'mkv');
+    expect(file.sizeBytes, 8400000);
+    expect(file.durationSeconds, 5400.0);
+    expect(file.resolution, '1080p');
+  });
+}

--- a/player/test/presentation/widgets/media_info/media_info_dialog_test.dart
+++ b/player/test/presentation/widgets/media_info/media_info_dialog_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/media_stream.dart';
+import 'package:player/presentation/widgets/media_info/media_info_sheet.dart';
+
+import '../../../test_utils/text_decoration.dart';
+
+const _file = MediaFileInfo(
+  id: 'f1',
+  fileName: 'Movie.2160p.mkv',
+  directory: '/media/movies/Movie (2024)',
+  container: 'mkv',
+  sizeBytes: 58200000000,
+  resolution: '2160p',
+  codec: 'hevc',
+  streams: [
+    MediaStream(index: 0, type: MediaStreamType.video, codec: 'hevc'),
+    MediaStream(
+      index: 1,
+      type: MediaStreamType.audio,
+      codec: 'eac3',
+      language: 'eng',
+      channels: 6,
+      channelLayout: '5.1',
+      isDefault: true,
+    ),
+    MediaStream(
+      index: 2,
+      type: MediaStreamType.subtitle,
+      codec: 'subrip',
+      language: 'spa',
+    ),
+  ],
+);
+
+const _secondFile = MediaFileInfo(
+  id: 'f2',
+  fileName: 'Movie.1080p.mkv',
+  resolution: '1080p',
+  codec: 'h264',
+  streams: [MediaStream(index: 0, type: MediaStreamType.video, codec: 'h264')],
+);
+
+/// Pushes the panel the way production does: through [showGeneralDialog],
+/// whose page has no [Material] ancestor of its own.
+///
+/// The sibling media-info tests pump the panel inside a [Scaffold], which
+/// supplies a Material the real app never provides. That is precisely why they
+/// cannot see this class of bug, so this harness must not add one.
+Future<void> _openDialog(WidgetTester tester, List<MediaFileInfo> files) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) => TextButton(
+          onPressed: () => showGeneralDialog<void>(
+            context: context,
+            barrierDismissible: true,
+            barrierLabel: 'Media Info',
+            pageBuilder: (_, __, ___) => Align(
+              alignment: Alignment.centerRight,
+              child: MediaInfoPanel(files: files),
+            ),
+          ),
+          child: const Text('open'),
+        ),
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+void _setViewport(WidgetTester tester, Size size) {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+void main() {
+  testWidgets('renders no debug text decorations outside a Scaffold',
+      (tester) async {
+    _setViewport(tester, const Size(1280, 900));
+
+    await _openDialog(tester, const [_file]);
+
+    expect(find.text('Media Info'), findsOneWidget);
+    expectNoDebugTextDecorations(tester);
+  });
+
+  testWidgets('opens with multiple versions without a Material assert',
+      (tester) async {
+    _setViewport(tester, const Size(1280, 900));
+
+    await _openDialog(tester, const [_file, _secondFile]);
+
+    expect(find.byKey(const Key('media-info-version-1')), findsOneWidget);
+    expectNoDebugTextDecorations(tester);
+  });
+
+  testWidgets('side panel width scales with the viewport', (tester) async {
+    _setViewport(tester, const Size(1280, 900));
+
+    await _openDialog(tester, const [_file]);
+
+    expect(
+      tester.getSize(find.byKey(const Key('media-info-side'))).width,
+      512,
+    );
+  });
+
+  testWidgets('side panel never drops below the 420 it shipped with',
+      (tester) async {
+    _setViewport(tester, const Size(900, 800));
+
+    await _openDialog(tester, const [_file]);
+
+    expect(
+      tester.getSize(find.byKey(const Key('media-info-side'))).width,
+      420,
+    );
+  });
+}

--- a/player/test/test_utils/text_decoration.dart
+++ b/player/test/test_utils/text_decoration.dart
@@ -12,14 +12,35 @@ import 'package:flutter_test/flutter_test.dart';
 /// This asserts on [RichText] rather than [Text] deliberately: [RichText] is
 /// what [Text] builds into once the styles are merged, so it holds the
 /// effective style rather than the declared one.
+///
+/// The whole [InlineSpan] tree is walked, not just the root span. A plain
+/// [Text] puts its merged style on the root, but a `Text.rich` can carry a
+/// decoration on a descendant span, and a root-only check would wave it
+/// through.
 void expectNoDebugTextDecorations(WidgetTester tester) {
   final offenders = <String>[];
 
-  for (final richText in tester.widgetList<RichText>(find.byType(RichText))) {
-    final decoration = richText.text.style?.decoration;
+  void inspect(InlineSpan span) {
+    final decoration = span.style?.decoration;
     if (decoration != null && decoration != TextDecoration.none) {
-      offenders.add('"${richText.text.toPlainText()}" has $decoration');
+      offenders.add('"${span.toPlainText()}" has $decoration');
     }
+  }
+
+  // Hand-rolled rather than InlineSpan.visitChildren: that skips a TextSpan
+  // whose own `text` is null, which is exactly the shape a styled wrapper span
+  // around children takes.
+  void walk(InlineSpan span) {
+    inspect(span);
+    if (span is TextSpan) {
+      for (final child in span.children ?? const <InlineSpan>[]) {
+        walk(child);
+      }
+    }
+  }
+
+  for (final richText in tester.widgetList<RichText>(find.byType(RichText))) {
+    walk(richText.text);
   }
 
   expect(

--- a/player/test/test_utils/text_decoration.dart
+++ b/player/test/test_utils/text_decoration.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fails if any rendered text carries a [TextDecoration].
+///
+/// Flutter's fallback text style, the one a [Text] inherits when no [Material]
+/// or [DefaultTextStyle] ancestor supplies one, is red with a yellow double
+/// underline. A [Text] with an explicit style *merges* over that default rather
+/// than replacing it, so colour, size and weight look correct while
+/// `decoration` survives untouched.
+///
+/// This asserts on [RichText] rather than [Text] deliberately: [RichText] is
+/// what [Text] builds into once the styles are merged, so it holds the
+/// effective style rather than the declared one.
+void expectNoDebugTextDecorations(WidgetTester tester) {
+  final offenders = <String>[];
+
+  for (final richText in tester.widgetList<RichText>(find.byType(RichText))) {
+    final decoration = richText.text.style?.decoration;
+    if (decoration != null && decoration != TextDecoration.none) {
+      offenders.add('"${richText.text.toPlainText()}" has $decoration');
+    }
+  }
+
+  expect(
+    offenders,
+    isEmpty,
+    reason: 'Text rendered with a decoration. This usually means the subtree '
+        'has no Material ancestor and is inheriting Flutter\'s fallback debug '
+        'style:\n${offenders.join('\n')}',
+  );
+}

--- a/player/test/test_utils/text_decoration_test.dart
+++ b/player/test/test_utils/text_decoration_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'text_decoration.dart';
+
+void main() {
+  testWidgets('passes when nothing carries a decoration', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: Text('plain'))),
+    );
+
+    expectNoDebugTextDecorations(tester);
+  });
+
+  testWidgets('catches a decoration on the root span', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Text(
+            'underlined',
+            style: TextStyle(decoration: TextDecoration.underline),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      () => expectNoDebugTextDecorations(tester),
+      throwsA(isA<TestFailure>()),
+    );
+  });
+
+  testWidgets('catches a decoration on a descendant span', (tester) async {
+    // The root span holds no text and no style, so a root-only check waves this
+    // through. This is the shape `Text.rich` produces and the reason the helper
+    // walks the whole tree.
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Text.rich(
+            TextSpan(
+              children: [
+                TextSpan(text: 'clean '),
+                TextSpan(
+                  text: 'underlined',
+                  style: TextStyle(decoration: TextDecoration.underline),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      () => expectNoDebugTextDecorations(tester),
+      throwsA(isA<TestFailure>()),
+    );
+  });
+}


### PR DESCRIPTION
## Why

Two complaints about the player's Media Info panel: every string in it was underlined, and it scrolled forever on files with many subtitle tracks.

**The underlines were a bug, not styling.** `showMediaInfo` pushes the panel with `showGeneralDialog`, whose `pageBuilder` returned `FocusScope → Align → Container` with no `Material` anywhere. Without one, every `Text` inherits Flutter's fallback debug style, which is red with a yellow double underline. Each `Text` supplied an explicit `TextStyle`, and `Text` *merges* that over the inherited default rather than replacing it, so colour and size were corrected while `decoration` survived.

The same gap made `_VersionChip`'s `InkWell` fail `debugCheckHasMaterial`, so any file with more than one version threw in a debug build. It stayed quiet because the version switcher only renders when `files.length > 1`.

Both existing test files pump the panel inside `MaterialApp(home: Scaffold(body: ...))`, supplying the exact `Material` production never provides, so the suite was structurally unable to see either bug. Same class of blind spot as 4bf1a6f1, where every widget test pumped a 1400px column and only the E2E job caught the overflow.

**The scroll was structural.** `MediaInfoContent` built one flat `ListView` with a tile per stream, each subtitle stacking three rows: an index chip with bordered flag chips, an optional title, then a near-identical "Text based" / "Image based" line. A remux with 34 subtitle tracks produced roughly 2400px of almost-repeating content in a 420px-wide panel.

## What changed

- **One `_PanelSurface` backed by `Material`.** `_SidePanel`, `_BottomPanel` and `_PanelShell` each hand-rolled the same surface; they are now one widget that also owns the width, so the loading, error and loaded states cannot disagree and make the panel jump.
- **Width scales**: `clamp(viewportWidth * 0.4, 420, 520)`. `Breakpoints.isDesktop` is `>= 900` despite its name, so a flat fraction would have made the panel *narrower* than the 420 it shipped with on small laptops. The floor means no viewport gets worse.
- **Pinned section headers** via `SliverPersistentHeader`, carrying stream counts (`SUBTITLES · 34`). Rows build lazily in the side panel; the bottom sheet sizes to content so it passes `shrinkWrap`.
- **Audio and subtitle streams are one aligned line each**, with fixed column widths. Flags dropped their chip borders, which were most of the bulk, and language moved out of the flag list into its own column. A second muted line renders only for streams carrying a title, a bitrate or a bit depth, so most subtitle rows stay exactly one line. Video keeps its multi-line block; profile, geometry, Dolby Vision and colour metadata do not fit a row.
- **External subtitles now render at all.** `MediaInfoFragment` selects `externalSubtitles` and `MediaFileInfo.fromGraphQL` maps them, but that factory has **zero call sites**: the live path is `mediaInfoProvider → _fileFromJson`, which never read the field. The rows were fetched over the wire and dropped, making `_ExternalSubtitleTile` dead code. The mapper is now `mediaFileInfoFromJson`, visible for testing, and reads the field. Their titles render too, which the old tile never did.

Net effect on a 34-track remux: roughly 2400px of subtitles down to roughly 800px, with no field dropped.

## Testing

New `expectNoDebugTextDecorations` helper in `test_utils` walks every `RichText` and asserts its merged style carries no decoration. `RichText` rather than `Text` is deliberate: it holds the effective style, so it sees what the user sees. Reusable anywhere a surface is pushed through `showGeneralDialog`.

`media_info_dialog_test.dart` pushes a real dialog route rather than a `Scaffold`, and deliberately does not supply a `Material`. It covers the decoration assertion, the multi-version `InkWell` path, and both width cases (512px at 1280, 420px at 900).

Also added: a 34-subtitle fixture asserting per-section counts and that the subtitles header stays pinned after scrolling deep into the list; row-height assertions proving a titleless subtitle row is a single line and a titled one is taller; and unit tests for the external-subtitle JSON mapping including the legacy-query case where the field is absent.

Full player suite green: 2049 tests. `flutter analyze` clean for these files.

## Not in scope

No changes to the GraphQL documents, `MediaStream`, `MediaFileInfo`, or the entry points in `detail_action_row.dart`. Streams keep ffprobe index order rather than being sorted or grouped, because index order is what a troubleshooting readout needs. The live playback overlay that `MediaInfoContent`'s doc comment anticipates is still not wired up.
