### PR TITLE
fix(player): give browse screens one shared page chrome

### DIFF
--- a/player/lib/core/layout/breakpoints.dart
+++ b/player/lib/core/layout/breakpoints.dart
@@ -135,3 +135,19 @@ class CardSize {
 
   double get aspectRatio => width / height;
 }
+
+/// Columns for a poster grid of [width] logical pixels.
+///
+/// Lived in `library_grid_body.dart` until `BrowseGrid` needed it: a widget in
+/// `presentation/widgets/` importing from a sibling screen folder inverts the
+/// layering, and `ContinueWatchingScreen` was already reaching across for it.
+/// The table is unchanged.
+int libraryCrossAxisCount(double width) {
+  if (width > 1400) return 8;
+  if (width > 1200) return 7;
+  if (width > 1000) return 6;
+  if (width > 800) return 5;
+  if (width > 600) return 4;
+  if (width > 400) return 3;
+  return 2;
+}

--- a/player/lib/presentation/screens/collections/collections_screen.dart
+++ b/player/lib/presentation/screens/collections/collections_screen.dart
@@ -2,16 +2,14 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'collections_controller.dart';
-import '../../../domain/models/collection.dart';
-import '../../widgets/ambient_backdrop_provider.dart';
-import '../../widgets/app_shell.dart';
-import '../../widgets/freshness_header.dart';
-import '../../widgets/glass_surface.dart';
+
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
 import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
+import '../../../domain/models/collection.dart';
+import '../../widgets/browse_scaffold.dart';
+import 'collections_controller.dart';
 
 class CollectionsScreen extends ConsumerWidget {
   const CollectionsScreen({super.key});
@@ -19,102 +17,38 @@ class CollectionsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final collectionsData = ref.watch(collectionsControllerProvider);
-    final isDesktop = Breakpoints.isDesktop(context);
 
-    // Grid screens use the calm static backdrop (no per-title artwork).
-    publishBackdropSource(ref, BackdropSource.none);
-
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      extendBodyBehindAppBar: true,
-      appBar: _buildAppBar(context, isDesktop),
-      body: Column(
-        children: [
-          FreshnessHeader(
-            queryKeys: [QueryKeys.collections],
-            topInset: freshnessTopInset(
-              context,
-              appBarHeight: isDesktop ? null : kToolbarHeight,
+    return BrowseScaffold(
+      icon: Icons.collections_bookmark_rounded,
+      title: 'Collections',
+      queryKeys: [QueryKeys.collections],
+      actions: [
+        if (!Breakpoints.isDesktop(context))
+          IconButton(
+            icon: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Icon(Icons.search_rounded, size: 20),
             ),
+            onPressed: () => context.push('/search'),
+            tooltip: 'Search',
           ),
-          Expanded(
-            child: RefreshIndicator(
-              onRefresh: () async {
-                await ref
-                    .read(collectionsControllerProvider.notifier)
-                    .refresh();
-              },
-              child: collectionsData.when(
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, _) => _buildErrorView(context, error, ref),
-                data: (collections) {
-                  if (collections.isEmpty) {
-                    return _buildEmptyState(context);
-                  }
-                  return _buildGridView(context, collections);
-                },
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  PreferredSizeWidget _buildAppBar(BuildContext context, bool isDesktop) {
-    if (isDesktop) {
-      return const PreferredSize(
-          preferredSize: Size.fromHeight(0), child: SizedBox.shrink());
-    }
-    return PreferredSize(
-      preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: GlassSurface.appBar(
-        child: AppBar(
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-          leading: IconButton(
-            icon: const Icon(Icons.menu_rounded),
-            onPressed: () {
-              AppShell.scaffoldKey.currentState?.openDrawer();
-            },
-            tooltip: 'Menu',
-          ),
-          title: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.collections_bookmark_rounded,
-                color: AppColors.primary,
-                size: 22,
-              ),
-              SizedBox(width: 10),
-              Text(
-                'Collections',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: -0.5,
-                ),
-              ),
-            ],
-          ),
-          actions: [
-            IconButton(
-              icon: Container(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: AppColors.surfaceVariant.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: const Icon(Icons.search_rounded, size: 20),
-              ),
-              onPressed: () {
-                context.push('/search');
-              },
-              tooltip: 'Search',
-            ),
-            const SizedBox(width: 8),
-          ],
-        ),
+      ],
+      onRefresh: () async {
+        await ref.read(collectionsControllerProvider.notifier).refresh();
+      },
+      body: (context, scrollTopPadding) => collectionsData.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => _buildErrorView(context, error, ref),
+        data: (collections) {
+          if (collections.isEmpty) {
+            return _buildEmptyState(context);
+          }
+          return _buildGridView(context, collections, scrollTopPadding);
+        },
       ),
     );
   }
@@ -213,7 +147,11 @@ class CollectionsScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildGridView(BuildContext context, List<Collection> collections) {
+  Widget _buildGridView(
+    BuildContext context,
+    List<Collection> collections,
+    double scrollTopPadding,
+  ) {
     final horizontalPadding = Breakpoints.getHorizontalPadding(context);
     final cardSpacing = Breakpoints.getCardSpacing(context);
     final bottomPadding = DockInsets.bottomOf(context);
@@ -224,7 +162,11 @@ class CollectionsScreen extends ConsumerWidget {
 
         return GridView.builder(
           padding: EdgeInsets.fromLTRB(
-              horizontalPadding, 100, horizontalPadding, bottomPadding),
+            horizontalPadding,
+            scrollTopPadding,
+            horizontalPadding,
+            bottomPadding,
+          ),
           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: crossAxisCount,
             childAspectRatio: 0.85,
@@ -382,7 +324,6 @@ class _CollectionCardState extends State<_CollectionCard> {
       );
     }
 
-    // 2x2 grid collage for 2-4 posters
     return GridView.count(
       crossAxisCount: 2,
       physics: const NeverScrollableScrollPhysics(),

--- a/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
@@ -12,7 +12,6 @@ import '../../widgets/app_shell.dart';
 import '../../widgets/freshness_header.dart';
 import '../../widgets/glass_surface.dart';
 import '../../widgets/media_poster.dart';
-import '../library/library_grid_body.dart';
 import 'continue_watching_controller.dart';
 
 class ContinueWatchingScreen extends ConsumerStatefulWidget {

--- a/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
@@ -4,13 +4,10 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
-import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/continue_watching_item.dart';
-import '../../widgets/ambient_backdrop_provider.dart';
-import '../../widgets/app_shell.dart';
-import '../../widgets/freshness_header.dart';
-import '../../widgets/glass_surface.dart';
+import '../../widgets/browse_grid.dart';
+import '../../widgets/browse_scaffold.dart';
 import '../../widgets/media_poster.dart';
 import 'continue_watching_controller.dart';
 
@@ -59,110 +56,51 @@ class _ContinueWatchingScreenState
   @override
   Widget build(BuildContext context) {
     final data = ref.watch(continueWatchingControllerProvider);
-    final isDesktop = Breakpoints.isDesktop(context);
-    final chromeTop = freshnessTopInset(
-      context,
-      appBarHeight: isDesktop ? null : kToolbarHeight,
-    );
-    final scrollTopPadding = chromeTop + 8;
 
-    publishBackdropSource(ref, BackdropSource.none);
-
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      extendBodyBehindAppBar: true,
-      appBar: _buildAppBar(context, isDesktop),
-      body: Stack(
-        children: [
-          RefreshIndicator(
-            edgeOffset: chromeTop,
-            onRefresh: () async {
-              await ref
-                  .read(continueWatchingControllerProvider.notifier)
-                  .refresh();
+    return BrowseScaffold(
+      icon: Icons.play_circle_outline_rounded,
+      title: 'Continue Watching',
+      queryKeys: [QueryKeys.continueWatchingList],
+      actions: [
+        if (!Breakpoints.isDesktop(context))
+          IconButton(
+            icon: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Icon(Icons.search_rounded, size: 20),
+            ),
+            onPressed: () => context.push('/search'),
+            tooltip: 'Search',
+          ),
+      ],
+      onRefresh: () async {
+        await ref.read(continueWatchingControllerProvider.notifier).refresh();
+      },
+      body: (context, scrollTopPadding) => data.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => _buildErrorView(context, error, ref),
+        data: (page) {
+          if (page.isEmpty) return _buildEmptyState(context);
+          return BrowseGrid(
+            controller: _scrollController,
+            itemCount: page.items.length,
+            scrollTopPadding: scrollTopPadding,
+            itemBuilder: (context, index) {
+              final item = page.items[index];
+              return MediaPoster(
+                key: ValueKey(item.id),
+                posterUrl: item.posterUrl,
+                title: item.title,
+                subtitle: item.showTitle,
+                progressPercentage: item.progress?.percentage,
+                onTap: () => _handleItemTap(context, item),
+              );
             },
-            child: data.when(
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) => _buildErrorView(context, error, ref),
-              data: (page) {
-                if (page.isEmpty) {
-                  return _buildEmptyState(context);
-                }
-                return _buildGridView(context, page.items, scrollTopPadding);
-              },
-            ),
-          ),
-          Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            child: FreshnessHeader(
-              queryKeys: [QueryKeys.continueWatchingList],
-              topInset: chromeTop,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  PreferredSizeWidget _buildAppBar(BuildContext context, bool isDesktop) {
-    if (isDesktop) {
-      return const PreferredSize(
-        preferredSize: Size.fromHeight(0),
-        child: SizedBox.shrink(),
-      );
-    }
-
-    return PreferredSize(
-      preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: GlassSurface.appBar(
-        child: AppBar(
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-          leading: IconButton(
-            icon: const Icon(Icons.menu_rounded),
-            onPressed: () {
-              AppShell.scaffoldKey.currentState?.openDrawer();
-            },
-            tooltip: 'Menu',
-          ),
-          title: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.play_circle_outline_rounded,
-                color: AppColors.primary,
-                size: 22,
-              ),
-              SizedBox(width: 10),
-              Text(
-                'Continue Watching',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: -0.5,
-                ),
-              ),
-            ],
-          ),
-          actions: [
-            IconButton(
-              icon: Container(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: AppColors.surfaceVariant.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: const Icon(Icons.search_rounded, size: 20),
-              ),
-              onPressed: () {
-                context.push('/search');
-              },
-              tooltip: 'Search',
-            ),
-            const SizedBox(width: 8),
-          ],
-        ),
+          );
+        },
       ),
     );
   }
@@ -232,48 +170,6 @@ class _ContinueWatchingScreenState
           textAlign: TextAlign.center,
         ),
       ),
-    );
-  }
-
-  Widget _buildGridView(
-    BuildContext context,
-    List<ContinueWatchingItem> items,
-    double scrollTopPadding,
-  ) {
-    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
-    final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = DockInsets.bottomOf(context);
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return GridView.builder(
-          controller: _scrollController,
-          padding: EdgeInsets.fromLTRB(
-            horizontalPadding,
-            scrollTopPadding,
-            horizontalPadding,
-            bottomPadding,
-          ),
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: libraryCrossAxisCount(constraints.maxWidth),
-            childAspectRatio: 0.58,
-            crossAxisSpacing: cardSpacing,
-            mainAxisSpacing: cardSpacing + 4,
-          ),
-          itemCount: items.length,
-          itemBuilder: (context, index) {
-            final item = items[index];
-            return MediaPoster(
-              key: ValueKey(item.id),
-              posterUrl: item.posterUrl,
-              title: item.title,
-              subtitle: item.showTitle,
-              progressPercentage: item.progress?.percentage,
-              onTap: () => _handleItemTap(context, item),
-            );
-          },
-        );
-      },
     );
   }
 }

--- a/player/lib/presentation/screens/favorites/favorites_screen.dart
+++ b/player/lib/presentation/screens/favorites/favorites_screen.dart
@@ -1,16 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'favorites_controller.dart';
-import '../../widgets/media_poster.dart';
-import '../../widgets/ambient_backdrop_provider.dart';
-import '../../widgets/app_shell.dart';
-import '../../widgets/freshness_header.dart';
-import '../../widgets/glass_surface.dart';
+
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
-import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
+import '../../widgets/browse_grid.dart';
+import '../../widgets/browse_scaffold.dart';
+import '../../widgets/media_poster.dart';
+import 'favorites_controller.dart';
 
 class FavoritesScreen extends ConsumerWidget {
   const FavoritesScreen({super.key});
@@ -27,99 +25,48 @@ class FavoritesScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final favoritesData = ref.watch(favoritesControllerProvider);
-    final isDesktop = Breakpoints.isDesktop(context);
 
-    // Grid screens use the calm static backdrop (no per-title artwork).
-    publishBackdropSource(ref, BackdropSource.none);
-
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      extendBodyBehindAppBar: true,
-      appBar: _buildAppBar(context, isDesktop),
-      body: Column(
-        children: [
-          FreshnessHeader(
-            queryKeys: [QueryKeys.favorites],
-            topInset: freshnessTopInset(
-              context,
-              appBarHeight: isDesktop ? null : kToolbarHeight,
-            ),
-          ),
-          Expanded(
-            child: RefreshIndicator(
-              onRefresh: () async {
-                await ref.read(favoritesControllerProvider.notifier).refresh();
-              },
-              child: favoritesData.when(
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, _) => _buildErrorView(context, error, ref),
-                data: (items) {
-                  if (items.isEmpty) {
-                    return _buildEmptyState(context);
-                  }
-                  return _buildGridView(context, items);
-                },
+    return BrowseScaffold(
+      icon: Icons.favorite_rounded,
+      title: 'Favorites',
+      queryKeys: [QueryKeys.favorites],
+      actions: [
+        if (!Breakpoints.isDesktop(context))
+          IconButton(
+            icon: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(10),
               ),
+              child: const Icon(Icons.search_rounded, size: 20),
             ),
+            onPressed: () => context.push('/search'),
+            tooltip: 'Search',
           ),
-        ],
-      ),
-    );
-  }
-
-  PreferredSizeWidget _buildAppBar(BuildContext context, bool isDesktop) {
-    if (isDesktop)
-      return const PreferredSize(
-          preferredSize: Size.fromHeight(0), child: SizedBox.shrink());
-    return PreferredSize(
-      preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: GlassSurface.appBar(
-        child: AppBar(
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-          leading: IconButton(
-            icon: const Icon(Icons.menu_rounded),
-            onPressed: () {
-              AppShell.scaffoldKey.currentState?.openDrawer();
+      ],
+      onRefresh: () async {
+        await ref.read(favoritesControllerProvider.notifier).refresh();
+      },
+      body: (context, scrollTopPadding) => favoritesData.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => _buildErrorView(context, error, ref),
+        data: (items) {
+          if (items.isEmpty) return _buildEmptyState(context);
+          return BrowseGrid(
+            itemCount: items.length,
+            scrollTopPadding: scrollTopPadding,
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return MediaPoster(
+                key: ValueKey(item.id),
+                posterUrl: item.posterUrl,
+                title: item.title,
+                onTap: () => _handleItemTap(context, item.id, item.type),
+              );
             },
-            tooltip: 'Menu',
-          ),
-          title: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.favorite_rounded,
-                color: AppColors.primary,
-                size: 22,
-              ),
-              SizedBox(width: 10),
-              Text(
-                'Favorites',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: -0.5,
-                ),
-              ),
-            ],
-          ),
-          actions: [
-            IconButton(
-              icon: Container(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: AppColors.surfaceVariant.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: const Icon(Icons.search_rounded, size: 20),
-              ),
-              onPressed: () {
-                context.push('/search');
-              },
-              tooltip: 'Search',
-            ),
-            const SizedBox(width: 8),
-          ],
-        ),
+          );
+        },
       ),
     );
   }
@@ -216,48 +163,5 @@ class FavoritesScreen extends ConsumerWidget {
         ),
       ),
     );
-  }
-
-  Widget _buildGridView(BuildContext context, List items) {
-    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
-    final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = DockInsets.bottomOf(context);
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final crossAxisCount = _calculateCrossAxisCount(constraints.maxWidth);
-
-        return GridView.builder(
-          padding: EdgeInsets.fromLTRB(
-              horizontalPadding, 100, horizontalPadding, bottomPadding),
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: crossAxisCount,
-            childAspectRatio: 0.58,
-            crossAxisSpacing: cardSpacing,
-            mainAxisSpacing: cardSpacing + 4,
-          ),
-          itemCount: items.length,
-          itemBuilder: (context, index) {
-            final item = items[index];
-            return MediaPoster(
-              key: ValueKey(item.id),
-              posterUrl: item.posterUrl,
-              title: item.title,
-              onTap: () => _handleItemTap(context, item.id, item.type),
-            );
-          },
-        );
-      },
-    );
-  }
-
-  int _calculateCrossAxisCount(double width) {
-    if (width > 1400) return 8;
-    if (width > 1200) return 7;
-    if (width > 1000) return 6;
-    if (width > 800) return 5;
-    if (width > 600) return 4;
-    if (width > 400) return 3;
-    return 2;
   }
 }

--- a/player/lib/presentation/screens/library/library_grid_body.dart
+++ b/player/lib/presentation/screens/library/library_grid_body.dart
@@ -339,16 +339,6 @@ class _LibraryMediaBodyState extends ConsumerState<LibraryMediaBody> {
   }
 }
 
-int libraryCrossAxisCount(double width) {
-  if (width > 1400) return 8;
-  if (width > 1200) return 7;
-  if (width > 1000) return 6;
-  if (width > 800) return 5;
-  if (width > 600) return 4;
-  if (width > 400) return 3;
-  return 2;
-}
-
 class LibraryListItem extends StatelessWidget {
   final LibraryItem item;
   final VoidCallback onTap;

--- a/player/lib/presentation/screens/recently_added/recently_added_screen.dart
+++ b/player/lib/presentation/screens/recently_added/recently_added_screen.dart
@@ -1,16 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'recently_added_controller.dart';
-import '../../widgets/media_poster.dart';
-import '../../widgets/ambient_backdrop_provider.dart';
-import '../../widgets/app_shell.dart';
-import '../../widgets/freshness_header.dart';
-import '../../widgets/glass_surface.dart';
+
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
-import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
+import '../../widgets/browse_grid.dart';
+import '../../widgets/browse_scaffold.dart';
+import '../../widgets/media_poster.dart';
+import 'recently_added_controller.dart';
 
 class RecentlyAddedScreen extends ConsumerWidget {
   const RecentlyAddedScreen({super.key});
@@ -27,101 +25,49 @@ class RecentlyAddedScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final data = ref.watch(recentlyAddedControllerProvider);
-    final isDesktop = Breakpoints.isDesktop(context);
 
-    // Grid screens use the calm static backdrop (no per-title artwork).
-    publishBackdropSource(ref, BackdropSource.none);
-
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      extendBodyBehindAppBar: true,
-      appBar: _buildAppBar(context, isDesktop),
-      body: Column(
-        children: [
-          FreshnessHeader(
-            queryKeys: [QueryKeys.recentlyAdded],
-            topInset: freshnessTopInset(
-              context,
-              appBarHeight: isDesktop ? null : kToolbarHeight,
-            ),
-          ),
-          Expanded(
-            child: RefreshIndicator(
-              onRefresh: () async {
-                await ref
-                    .read(recentlyAddedControllerProvider.notifier)
-                    .refresh();
-              },
-              child: data.when(
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, _) => _buildErrorView(context, error, ref),
-                data: (items) {
-                  if (items.isEmpty) {
-                    return _buildEmptyState(context);
-                  }
-                  return _buildGridView(context, items);
-                },
+    return BrowseScaffold(
+      icon: Icons.fiber_new_rounded,
+      title: 'Recently Added',
+      queryKeys: [QueryKeys.recentlyAdded],
+      actions: [
+        if (!Breakpoints.isDesktop(context))
+          IconButton(
+            icon: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(10),
               ),
+              child: const Icon(Icons.search_rounded, size: 20),
             ),
+            onPressed: () => context.push('/search'),
+            tooltip: 'Search',
           ),
-        ],
-      ),
-    );
-  }
-
-  PreferredSizeWidget _buildAppBar(BuildContext context, bool isDesktop) {
-    if (isDesktop)
-      return const PreferredSize(
-          preferredSize: Size.fromHeight(0), child: SizedBox.shrink());
-    return PreferredSize(
-      preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: GlassSurface.appBar(
-        child: AppBar(
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-          leading: IconButton(
-            icon: const Icon(Icons.menu_rounded),
-            onPressed: () {
-              AppShell.scaffoldKey.currentState?.openDrawer();
+      ],
+      onRefresh: () async {
+        await ref.read(recentlyAddedControllerProvider.notifier).refresh();
+      },
+      body: (context, scrollTopPadding) => data.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => _buildErrorView(context, error, ref),
+        data: (items) {
+          if (items.isEmpty) return _buildEmptyState(context);
+          return BrowseGrid(
+            itemCount: items.length,
+            scrollTopPadding: scrollTopPadding,
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return MediaPoster(
+                key: ValueKey(item.id),
+                posterUrl: item.posterUrl,
+                title: item.title,
+                subtitle: item.newContentLabel,
+                onTap: () => _handleItemTap(context, item.id, item.type),
+              );
             },
-            tooltip: 'Menu',
-          ),
-          title: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.fiber_new_rounded,
-                color: AppColors.primary,
-                size: 22,
-              ),
-              SizedBox(width: 10),
-              Text(
-                'Recently Added',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: -0.5,
-                ),
-              ),
-            ],
-          ),
-          actions: [
-            IconButton(
-              icon: Container(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: AppColors.surfaceVariant.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: const Icon(Icons.search_rounded, size: 20),
-              ),
-              onPressed: () {
-                context.push('/search');
-              },
-              tooltip: 'Search',
-            ),
-            const SizedBox(width: 8),
-          ],
-        ),
+          );
+        },
       ),
     );
   }
@@ -218,49 +164,5 @@ class RecentlyAddedScreen extends ConsumerWidget {
         ),
       ),
     );
-  }
-
-  Widget _buildGridView(BuildContext context, List items) {
-    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
-    final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = DockInsets.bottomOf(context);
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final crossAxisCount = _calculateCrossAxisCount(constraints.maxWidth);
-
-        return GridView.builder(
-          padding: EdgeInsets.fromLTRB(
-              horizontalPadding, 100, horizontalPadding, bottomPadding),
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: crossAxisCount,
-            childAspectRatio: 0.58,
-            crossAxisSpacing: cardSpacing,
-            mainAxisSpacing: cardSpacing + 4,
-          ),
-          itemCount: items.length,
-          itemBuilder: (context, index) {
-            final item = items[index];
-            return MediaPoster(
-              key: ValueKey(item.id),
-              posterUrl: item.posterUrl,
-              title: item.title,
-              subtitle: item.newContentLabel,
-              onTap: () => _handleItemTap(context, item.id, item.type),
-            );
-          },
-        );
-      },
-    );
-  }
-
-  int _calculateCrossAxisCount(double width) {
-    if (width > 1400) return 8;
-    if (width > 1200) return 7;
-    if (width > 1000) return 6;
-    if (width > 800) return 5;
-    if (width > 600) return 4;
-    if (width > 400) return 3;
-    return 2;
   }
 }

--- a/player/lib/presentation/screens/search/search_screen.dart
+++ b/player/lib/presentation/screens/search/search_screen.dart
@@ -4,12 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/layout/breakpoints.dart';
 import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/search_result.dart';
-import '../../widgets/ambient_backdrop_provider.dart';
-import '../../widgets/cast_actions.dart';
-import '../../widgets/cast_button.dart';
+import '../../widgets/browse_scaffold.dart';
 import 'search_controller.dart';
 import 'widgets/episode_result_row.dart';
 import 'widgets/search_filter_chip.dart';
@@ -132,47 +131,22 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   Widget build(BuildContext context) {
     final searchState = ref.watch(searchControllerProvider);
 
-    // Search is a grid surface, so it uses the calm static backdrop rather than
-    // inheriting whatever artwork the previous screen published. Individual
-    // result posters still tint it on hover via PosterFrame.
-    publishBackdropSource(ref, BackdropSource.none);
-
-    return Scaffold(
-      // Transparent so the shell's ambient backdrop shows through, matching
-      // every other in-shell destination.
-      backgroundColor: Colors.transparent,
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        surfaceTintColor: Colors.transparent,
-        // Navigator, not go_router's context.canPop(): inside the shell route
-        // this resolves the shell navigator, which is exactly what a pushed
-        // search screen sits on, and it does not require a GoRouter ancestor,
-        // so the screen stays pumpable in a plain widget test.
-        leading: Navigator.of(context).canPop()
-            ? IconButton(
-                icon: const Icon(Icons.arrow_back_rounded),
-                onPressed: () => Navigator.of(context).maybePop(),
-              )
-            : null,
-        automaticallyImplyLeading: false,
-        title: _buildSearchField(searchState),
-        titleSpacing: 0,
-        actions: [
-          if (_searchController.text.isNotEmpty)
-            IconButton(
-              icon: const Icon(Icons.close_rounded),
-              onPressed: _onClear,
-              tooltip: 'Clear',
-            ),
-          // SearchScreen's app bar is always visible (no desktop
-          // suppression), so it carries its own cast affordance instead of
-          // the shell's overlay — see AppShell._hasOwnCastButton.
-          CastButton(onPressed: () => pickCastDevice(context, ref)),
-          const SizedBox(width: 8),
-        ],
-      ),
-      body: Column(
+    return BrowseScaffold(
+      icon: Icons.search_rounded,
+      title: 'Search',
+      queryKeys: const [],
+      actions: [
+        if (_searchController.text.isNotEmpty)
+          IconButton(
+            icon: const Icon(Icons.close_rounded),
+            onPressed: _onClear,
+            tooltip: 'Clear',
+          ),
+      ],
+      secondRow: _buildSearchField(searchState),
+      body: (context, scrollTopPadding) => Column(
         children: [
+          SizedBox(height: scrollTopPadding),
           _buildFilterChips(searchState),
           Expanded(child: _buildBody(searchState)),
         ],
@@ -181,25 +155,35 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   }
 
   Widget _buildSearchField(SearchState searchState) {
-    return TextField(
-      controller: _searchController,
-      focusNode: _focusNode,
-      onChanged: _onSearchChanged,
-      onSubmitted: (_) {
-        _debounceTimer?.cancel();
-        ref.read(searchControllerProvider.notifier).search();
-      },
-      style: const TextStyle(fontSize: 18),
-      decoration: InputDecoration(
-        hintText: 'Search your library...',
-        hintStyle: TextStyle(
-          color: AppColors.textSecondary.withValues(alpha: 0.6),
-          fontSize: 18,
+    return Center(
+      child: TextField(
+        controller: _searchController,
+        focusNode: _focusNode,
+        onChanged: _onSearchChanged,
+        onSubmitted: (_) {
+          _debounceTimer?.cancel();
+          ref.read(searchControllerProvider.notifier).search();
+        },
+        style: const TextStyle(fontSize: 18),
+        decoration: InputDecoration(
+          hintText: 'Search your library...',
+          hintStyle: TextStyle(
+            color: AppColors.textSecondary.withValues(alpha: 0.6),
+            fontSize: 18,
+          ),
+          // The app theme sets `filled: true` with a rounded fill.
+          // `InputBorder.none` alone suppresses the stroke but not the fill,
+          // which left this field rendering as a pill nobody designed, flush
+          // against the chrome. Both have to be off.
+          filled: false,
+          border: InputBorder.none,
+          isDense: true,
+          contentPadding: const EdgeInsets.symmetric(vertical: 8),
+          prefixIcon: const Icon(Icons.search_rounded, size: 20),
+          prefixIconConstraints: const BoxConstraints(minWidth: 32),
         ),
-        border: InputBorder.none,
-        contentPadding: const EdgeInsets.symmetric(vertical: 12),
+        textInputAction: TextInputAction.search,
       ),
-      textInputAction: TextInputAction.search,
     );
   }
 
@@ -444,13 +428,17 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
             )
           else
             SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
+              padding: EdgeInsets.symmetric(
+                horizontal: Breakpoints.getHorizontalPadding(context),
+              ),
               sliver: SliverGrid.builder(
-                gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-                  maxCrossAxisExtent: 180,
-                  mainAxisSpacing: 16,
-                  crossAxisSpacing: 12,
-                  childAspectRatio: 0.55,
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: libraryCrossAxisCount(
+                    MediaQuery.sizeOf(context).width,
+                  ),
+                  childAspectRatio: 0.58,
+                  crossAxisSpacing: Breakpoints.getCardSpacing(context),
+                  mainAxisSpacing: Breakpoints.getCardSpacing(context) + 4,
                 ),
                 itemCount: section.results.length,
                 itemBuilder: (context, index) {

--- a/player/lib/presentation/screens/search/search_screen.dart
+++ b/player/lib/presentation/screens/search/search_screen.dart
@@ -427,28 +427,37 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
               },
             )
           else
-            SliverPadding(
-              padding: EdgeInsets.symmetric(
-                horizontal: Breakpoints.getHorizontalPadding(context),
-              ),
-              sliver: SliverGrid.builder(
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: libraryCrossAxisCount(
-                    MediaQuery.sizeOf(context).width,
-                  ),
-                  childAspectRatio: 0.58,
-                  crossAxisSpacing: Breakpoints.getCardSpacing(context),
-                  mainAxisSpacing: Breakpoints.getCardSpacing(context) + 4,
+            // `SliverLayoutBuilder`, not `MediaQuery`: on desktop `AppShell`
+            // puts a fixed 260px `DesktopSidebar` beside this screen, so the
+            // window is wider than the content area. Counting columns from
+            // the window overestimates the space and cramps every card.
+            // `crossAxisExtent` here is the viewport's, measured outside the
+            // padding below, which matches how `BrowseGrid` reads
+            // `constraints.maxWidth` so both grids bucket identically.
+            SliverLayoutBuilder(
+              builder: (context, sliverConstraints) => SliverPadding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: Breakpoints.getHorizontalPadding(context),
                 ),
-                itemCount: section.results.length,
-                itemBuilder: (context, index) {
-                  final result = section.results[index];
-                  return SearchResultCard(
-                    key: ValueKey(result.id),
-                    result: result,
-                    onTap: () => context.push(result.routePath),
-                  );
-                },
+                sliver: SliverGrid.builder(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: libraryCrossAxisCount(
+                      sliverConstraints.crossAxisExtent,
+                    ),
+                    childAspectRatio: 0.58,
+                    crossAxisSpacing: Breakpoints.getCardSpacing(context),
+                    mainAxisSpacing: Breakpoints.getCardSpacing(context) + 4,
+                  ),
+                  itemCount: section.results.length,
+                  itemBuilder: (context, index) {
+                    final result = section.results[index];
+                    return SearchResultCard(
+                      key: ValueKey(result.id),
+                      result: result,
+                      onTap: () => context.push(result.routePath),
+                    );
+                  },
+                ),
               ),
             ),
         ],

--- a/player/lib/presentation/screens/unwatched/unwatched_screen.dart
+++ b/player/lib/presentation/screens/unwatched/unwatched_screen.dart
@@ -1,16 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'unwatched_controller.dart';
-import '../../widgets/media_poster.dart';
-import '../../widgets/ambient_backdrop_provider.dart';
-import '../../widgets/app_shell.dart';
-import '../../widgets/freshness_header.dart';
-import '../../widgets/glass_surface.dart';
+
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
-import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
+import '../../widgets/browse_grid.dart';
+import '../../widgets/browse_scaffold.dart';
+import '../../widgets/media_poster.dart';
+import 'unwatched_controller.dart';
 
 class UnwatchedScreen extends ConsumerWidget {
   const UnwatchedScreen({super.key});
@@ -27,99 +25,48 @@ class UnwatchedScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final data = ref.watch(unwatchedControllerProvider);
-    final isDesktop = Breakpoints.isDesktop(context);
 
-    // Grid screens use the calm static backdrop (no per-title artwork).
-    publishBackdropSource(ref, BackdropSource.none);
-
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      extendBodyBehindAppBar: true,
-      appBar: _buildAppBar(context, isDesktop),
-      body: Column(
-        children: [
-          FreshnessHeader(
-            queryKeys: [QueryKeys.unwatched],
-            topInset: freshnessTopInset(
-              context,
-              appBarHeight: isDesktop ? null : kToolbarHeight,
-            ),
-          ),
-          Expanded(
-            child: RefreshIndicator(
-              onRefresh: () async {
-                await ref.read(unwatchedControllerProvider.notifier).refresh();
-              },
-              child: data.when(
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, _) => _buildErrorView(context, error, ref),
-                data: (items) {
-                  if (items.isEmpty) {
-                    return _buildEmptyState(context);
-                  }
-                  return _buildGridView(context, items);
-                },
+    return BrowseScaffold(
+      icon: Icons.visibility_off_rounded,
+      title: 'Unwatched',
+      queryKeys: [QueryKeys.unwatched],
+      actions: [
+        if (!Breakpoints.isDesktop(context))
+          IconButton(
+            icon: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(10),
               ),
+              child: const Icon(Icons.search_rounded, size: 20),
             ),
+            onPressed: () => context.push('/search'),
+            tooltip: 'Search',
           ),
-        ],
-      ),
-    );
-  }
-
-  PreferredSizeWidget _buildAppBar(BuildContext context, bool isDesktop) {
-    if (isDesktop)
-      return const PreferredSize(
-          preferredSize: Size.fromHeight(0), child: SizedBox.shrink());
-    return PreferredSize(
-      preferredSize: const Size.fromHeight(kToolbarHeight),
-      child: GlassSurface.appBar(
-        child: AppBar(
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-          leading: IconButton(
-            icon: const Icon(Icons.menu_rounded),
-            onPressed: () {
-              AppShell.scaffoldKey.currentState?.openDrawer();
+      ],
+      onRefresh: () async {
+        await ref.read(unwatchedControllerProvider.notifier).refresh();
+      },
+      body: (context, scrollTopPadding) => data.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => _buildErrorView(context, error, ref),
+        data: (items) {
+          if (items.isEmpty) return _buildEmptyState(context);
+          return BrowseGrid(
+            itemCount: items.length,
+            scrollTopPadding: scrollTopPadding,
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return MediaPoster(
+                key: ValueKey(item.id),
+                posterUrl: item.posterUrl,
+                title: item.title,
+                onTap: () => _handleItemTap(context, item.id, item.type),
+              );
             },
-            tooltip: 'Menu',
-          ),
-          title: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.visibility_off_rounded,
-                color: AppColors.primary,
-                size: 22,
-              ),
-              SizedBox(width: 10),
-              Text(
-                'Unwatched',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: -0.5,
-                ),
-              ),
-            ],
-          ),
-          actions: [
-            IconButton(
-              icon: Container(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: AppColors.surfaceVariant.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: const Icon(Icons.search_rounded, size: 20),
-              ),
-              onPressed: () {
-                context.push('/search');
-              },
-              tooltip: 'Search',
-            ),
-            const SizedBox(width: 8),
-          ],
-        ),
+          );
+        },
       ),
     );
   }
@@ -206,7 +153,7 @@ class UnwatchedScreen extends ConsumerWidget {
             ),
             const SizedBox(height: 8),
             Text(
-              'You\'ve watched everything in your library',
+              "You've watched everything in your library",
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     color: AppColors.textSecondary,
                   ),
@@ -216,48 +163,5 @@ class UnwatchedScreen extends ConsumerWidget {
         ),
       ),
     );
-  }
-
-  Widget _buildGridView(BuildContext context, List items) {
-    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
-    final cardSpacing = Breakpoints.getCardSpacing(context);
-    final bottomPadding = DockInsets.bottomOf(context);
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final crossAxisCount = _calculateCrossAxisCount(constraints.maxWidth);
-
-        return GridView.builder(
-          padding: EdgeInsets.fromLTRB(
-              horizontalPadding, 100, horizontalPadding, bottomPadding),
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: crossAxisCount,
-            childAspectRatio: 0.58,
-            crossAxisSpacing: cardSpacing,
-            mainAxisSpacing: cardSpacing + 4,
-          ),
-          itemCount: items.length,
-          itemBuilder: (context, index) {
-            final item = items[index];
-            return MediaPoster(
-              key: ValueKey(item.id),
-              posterUrl: item.posterUrl,
-              title: item.title,
-              onTap: () => _handleItemTap(context, item.id, item.type),
-            );
-          },
-        );
-      },
-    );
-  }
-
-  int _calculateCrossAxisCount(double width) {
-    if (width > 1400) return 8;
-    if (width > 1200) return 7;
-    if (width > 1000) return 6;
-    if (width > 800) return 5;
-    if (width > 600) return 4;
-    if (width > 400) return 3;
-    return 2;
   }
 }

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -55,7 +55,12 @@ class AppShell extends ConsumerStatefulWidget {
       location.startsWith('/shows') ||
       location.startsWith('/downloads') ||
       location.startsWith('/settings') ||
-      location.startsWith('/search');
+      location.startsWith('/search') ||
+      location.startsWith('/unwatched') ||
+      location.startsWith('/continue-watching') ||
+      location.startsWith('/favorites') ||
+      location.startsWith('/recently-added') ||
+      location.startsWith('/collections');
 
   /// Builds the shell's cast overlay for the desktop or mobile branch.
   ///

--- a/player/lib/presentation/widgets/browse_grid.dart
+++ b/player/lib/presentation/widgets/browse_grid.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import '../../core/layout/breakpoints.dart';
+import '../../core/layout/dock_insets.dart';
+
+/// The poster grid shared by every browse screen that shows media.
+///
+/// Exists because five screens hand-rolled the same delegate and three of the
+/// copies had drifted: one duplicated `libraryCrossAxisCount` verbatim as a
+/// private helper, and four hardcoded a 100px top padding that was tuned for
+/// a mobile toolbar and became dead space on desktop.
+///
+/// Collections deliberately does not use this. `_CollectionCard` is a
+/// different shape (aspect 0.85, its own column table), which is a real
+/// design difference rather than drift, so that screen takes `BrowseScaffold`
+/// alone and keeps its own grid.
+class BrowseGrid extends StatelessWidget {
+  const BrowseGrid({
+    super.key,
+    required this.itemCount,
+    required this.itemBuilder,
+    required this.scrollTopPadding,
+    this.controller,
+  });
+
+  final int itemCount;
+  final Widget? Function(BuildContext context, int index) itemBuilder;
+
+  /// Top padding that clears the glass bar, from `BrowseScaffold`'s body
+  /// builder. Never computed here: only the scaffold knows the bar's height.
+  final double scrollTopPadding;
+
+  /// Supplied by screens that paginate on scroll.
+  final ScrollController? controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
+    final cardSpacing = Breakpoints.getCardSpacing(context);
+    final bottomPadding = DockInsets.bottomOf(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return GridView.builder(
+          controller: controller,
+          padding: EdgeInsets.fromLTRB(
+            horizontalPadding,
+            scrollTopPadding,
+            horizontalPadding,
+            bottomPadding,
+          ),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: libraryCrossAxisCount(constraints.maxWidth),
+            childAspectRatio: 0.58,
+            crossAxisSpacing: cardSpacing,
+            mainAxisSpacing: cardSpacing + 4,
+          ),
+          itemCount: itemCount,
+          itemBuilder: itemBuilder,
+        );
+      },
+    );
+  }
+}

--- a/player/lib/presentation/widgets/browse_scaffold.dart
+++ b/player/lib/presentation/widgets/browse_scaffold.dart
@@ -157,7 +157,26 @@ class BrowseScaffold extends ConsumerWidget {
                   ),
                   child: Row(
                     children: [
-                      if (!isDesktop)
+                      // A pushed screen gets back; a shell destination gets
+                      // the drawer. Search is the case that forces this: every
+                      // other browse screen reaches it with
+                      // `context.push('/search')`, so it sits on top of the
+                      // shell navigator, and a hamburger there goes sideways
+                      // rather than back. Desktop had no leading control at
+                      // all, which made the push a one-way trip.
+                      //
+                      // `Navigator`, not go_router's `context.canPop()`:
+                      // inside the shell route this resolves the shell
+                      // navigator, which is exactly what a pushed screen sits
+                      // on, and it does not require a GoRouter ancestor, so
+                      // this widget stays pumpable in a plain widget test.
+                      if (Navigator.of(context).canPop())
+                        IconButton(
+                          icon: const Icon(Icons.arrow_back_rounded),
+                          onPressed: () => Navigator.of(context).maybePop(),
+                          tooltip: 'Back',
+                        )
+                      else if (!isDesktop)
                         IconButton(
                           icon: const Icon(Icons.menu_rounded),
                           onPressed: () {

--- a/player/lib/presentation/widgets/browse_scaffold.dart
+++ b/player/lib/presentation/widgets/browse_scaffold.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/graphql/watch/query_key.dart';
+import '../../core/layout/breakpoints.dart';
+import '../../core/theme/colors.dart';
+import 'ambient_backdrop_provider.dart';
+import 'app_shell.dart';
+import 'cast_actions.dart';
+import 'cast_button.dart';
+import 'freshness_header.dart';
+import 'glass_surface.dart';
+
+/// Builds a screen's scrollable body, given the top padding it must reserve
+/// so its first item lands below the glass bar rather than behind it.
+typedef BrowseBodyBuilder = Widget Function(
+  BuildContext context,
+  double scrollTopPadding,
+);
+
+/// The single owner of the browse-screen page-chrome contract.
+///
+/// Before this widget, the contract lived only in `LibraryScreen` and six
+/// other screens copied fragments of it three different ways. Two of those
+/// fragments were load-bearing and routinely went missing:
+///
+///  * the glass bar was suppressed entirely on desktop, which left those
+///    screens with no title anywhere and made `freshnessTopInset` return 0,
+///    so their grids either sat 8px from the top edge or cleared a bar that
+///    was not there with a hardcoded 100px of dead space;
+///  * `FreshnessHeader` was mounted as a `Column` sibling, so it was charged
+///    as layout height and every background refetch shoved the whole grid
+///    down by about 58px. `LibraryScreen` fixed this by overlaying the header
+///    in a `Stack`; the copies never received the fix. That is why the header
+///    here is a `Positioned` child and must stay one.
+///
+/// What it owns: the bar and its height, the derived `chromeTop` and
+/// `scrollTopPadding`, the freshness overlay, the pull-to-refresh edge
+/// offset, and resetting the ambient backdrop to the calm static fallback
+/// (every browse screen wants `BackdropSource.none`; only detail screens
+/// publish artwork).
+///
+/// What it does not own: the grid or list, controllers, data loading, or
+/// empty and error states. Those stay with each screen.
+class BrowseScaffold extends ConsumerWidget {
+  const BrowseScaffold({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.queryKeys,
+    required this.body,
+    this.actions = const <Widget>[],
+    this.secondRow,
+    this.onRefresh,
+  });
+
+  /// Leading glyph beside [title], tinted with the primary colour.
+  final IconData icon;
+
+  /// The screen's name. This is the only place it appears on desktop.
+  final String title;
+
+  /// Keys whose combined freshness the overlay header describes.
+  final List<QueryKey> queryKeys;
+
+  /// Builds the scrollable body.
+  final BrowseBodyBuilder body;
+
+  /// Rendered between [title] and the trailing [CastButton].
+  ///
+  /// Actions that belong to one breakpoint only (the mobile search shortcut)
+  /// are filtered by the calling screen behind its own
+  /// [Breakpoints.isDesktop] check. This widget renders whatever it is given.
+  final List<Widget> actions;
+
+  /// An optional second bar row, [secondRowHeight] tall, padded to the same
+  /// gutters as the content below it. Search is the only user.
+  final Widget? secondRow;
+
+  /// Enables pull-to-refresh when supplied.
+  final Future<void> Function()? onRefresh;
+
+  /// Height of [secondRow]. Matches `LibraryScreen`'s own search row so the
+  /// two bars line up when a user moves between them.
+  static const double secondRowHeight = 56;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Read MediaQuery here, above the `Scaffold`. Inside the body of a
+    // `Scaffold(extendBodyBehindAppBar: true)` Flutter rewrites `padding.top`
+    // to the app bar's own bottom edge (see `_BodyBuilder` in
+    // material/scaffold.dart), so a descendant that reads it and adds the bar
+    // height again counts the bar twice. That was `LibraryScreen`'s original
+    // bug and the reason this math lives at the top of the build method.
+    final barHeight =
+        kToolbarHeight + (secondRow == null ? 0.0 : secondRowHeight);
+    final chromeTop = freshnessTopInset(context, appBarHeight: barHeight);
+    final scrollTopPadding = chromeTop + 8;
+
+    publishBackdropSource(ref, BackdropSource.none);
+
+    final content = body(context, scrollTopPadding);
+    final refresh = onRefresh;
+
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      extendBodyBehindAppBar: true,
+      appBar: _buildAppBar(context, ref, barHeight),
+      body: Stack(
+        children: [
+          if (refresh == null)
+            content
+          else
+            RefreshIndicator(
+              edgeOffset: chromeTop,
+              onRefresh: refresh,
+              child: content,
+            ),
+          // Overlaid, never a `Column` sibling. See the class doc.
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: FreshnessHeader(
+              queryKeys: queryKeys,
+              topInset: chromeTop,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  PreferredSizeWidget _buildAppBar(
+    BuildContext context,
+    WidgetRef ref,
+    double barHeight,
+  ) {
+    final isDesktop = Breakpoints.isDesktop(context);
+    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
+    final row = secondRow;
+
+    return PreferredSize(
+      preferredSize: Size.fromHeight(barHeight),
+      child: GlassSurface.appBar(
+        opacity: 0.85,
+        child: SafeArea(
+          bottom: false,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                height: kToolbarHeight,
+                child: Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: isDesktop ? horizontalPadding - 8 : 8,
+                  ),
+                  child: Row(
+                    children: [
+                      if (!isDesktop)
+                        IconButton(
+                          icon: const Icon(Icons.menu_rounded),
+                          onPressed: () {
+                            AppShell.scaffoldKey.currentState?.openDrawer();
+                          },
+                          tooltip: 'Menu',
+                        ),
+                      // Flexible, and the label ellipsises: this bar uses
+                      // `headlineSmall` to match LibraryScreen, which is
+                      // larger than the `titleLarge` the old mobile bars
+                      // used. "Continue Watching" at that size overflows a
+                      // narrow phone bar once the drawer and cast buttons
+                      // take their share.
+                      Flexible(
+                        child: Padding(
+                          padding: EdgeInsets.only(left: isDesktop ? 8 : 0),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(icon, color: AppColors.primary, size: 22),
+                              const SizedBox(width: 10),
+                              Flexible(
+                                child: Text(
+                                  title,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .headlineSmall
+                                      ?.copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        letterSpacing: -0.3,
+                                      ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const Spacer(),
+                      ...actions,
+                      CastButton(
+                        onPressed: () => pickCastDevice(context, ref),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              if (row != null)
+                SizedBox(
+                  height: secondRowHeight,
+                  child: Padding(
+                    padding: EdgeInsets.fromLTRB(
+                      horizontalPadding,
+                      0,
+                      horizontalPadding,
+                      12,
+                    ),
+                    child: row,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/player/test/presentation/screens/collections/collections_screen_test.dart
+++ b/player/test/presentation/screens/collections/collections_screen_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/presentation/screens/collections/collections_screen.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+import '../../../test_utils/stub_graphql_client.dart';
+
+class _StubAuthState extends AuthStateNotifier {
+  @override
+  AsyncValue<AuthStatus> build() =>
+      const AsyncValue.data(AuthStatus.authenticated);
+}
+
+Map<String, dynamic> _collectionsResponse(List<Map<String, dynamic>> items) => {
+      '__typename': 'Query',
+      'collections': items,
+    };
+
+Map<String, dynamic> _collection({
+  required String id,
+  required String name,
+  String type = 'manual',
+  String visibility = 'private',
+  int itemCount = 3,
+  List<String> posterPaths = const [],
+}) =>
+    {
+      '__typename': 'Collection',
+      'id': id,
+      'name': name,
+      'description': null,
+      'type': type,
+      'visibility': visibility,
+      'itemCount': itemCount,
+      'posterPaths': posterPaths,
+    };
+
+Future<void> pumpCollectionsScreen(
+  WidgetTester tester, {
+  required StubLink link,
+  Size size = const Size(1200, 900),
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          asyncGraphqlClientProvider.overrideWith(
+            (ref) async => stubClient(link),
+          ),
+          castCapabilitiesProvider
+              .overrideWithValue(const CastCapabilities.full()),
+          authStateProvider.overrideWith(_StubAuthState.new),
+        ],
+        child: const MaterialApp(home: CollectionsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+}
+
+void main() {
+  testWidgets('shows its title on desktop, where it previously had none',
+      (tester) async {
+    await pumpCollectionsScreen(
+      tester,
+      link: StubLink.responses([
+        _collectionsResponse([_collection(id: 'c-1', name: 'Marvel')]),
+      ]),
+    );
+
+    expect(find.text('Collections'), findsOneWidget);
+    expect(find.byIcon(Icons.collections_bookmark_rounded), findsOneWidget);
+  });
+
+  testWidgets('keeps its own card geometry, not the shared poster grid',
+      (tester) async {
+    await pumpCollectionsScreen(
+      tester,
+      link: StubLink.responses([
+        _collectionsResponse([_collection(id: 'c-1', name: 'Marvel')]),
+      ]),
+    );
+
+    final grid = tester.widget<GridView>(find.byType(GridView));
+    final delegate =
+        grid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+
+    expect(delegate.childAspectRatio, 0.85);
+    expect(find.text('Marvel'), findsOneWidget);
+  });
+
+  testWidgets('keeps its empty state', (tester) async {
+    await pumpCollectionsScreen(
+      tester,
+      link: StubLink.responses([_collectionsResponse([])]),
+    );
+
+    expect(find.text('No collections yet'), findsOneWidget);
+    expect(
+      find.text('Create collections in Mydia to organize your media'),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Icons.collections_bookmark_outlined), findsOneWidget);
+  });
+}

--- a/player/test/presentation/screens/continue_watching/continue_watching_screen_test.dart
+++ b/player/test/presentation/screens/continue_watching/continue_watching_screen_test.dart
@@ -1,14 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/cast/cast_capabilities.dart';
 import 'package:player/core/cast/cast_providers.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/presentation/screens/continue_watching/continue_watching_screen.dart';
+import 'package:player/presentation/widgets/browse_grid.dart';
 import 'package:player/presentation/widgets/media_poster.dart';
 
 import '../../../test_utils/mock_network_images.dart';
 import '../../../test_utils/stub_graphql_client.dart';
+
+class _StubAuthState extends AuthStateNotifier {
+  @override
+  AsyncValue<AuthStatus> build() =>
+      const AsyncValue.data(AuthStatus.authenticated);
+}
 
 Map<String, dynamic> _continueWatchingResponse(
         List<Map<String, dynamic>> items) =>
@@ -68,6 +76,7 @@ Future<void> pumpContinueWatchingScreen(
           ),
           castCapabilitiesProvider
               .overrideWithValue(const CastCapabilities.full()),
+          authStateProvider.overrideWith(_StubAuthState.new),
         ],
         child: const MaterialApp(home: ContinueWatchingScreen()),
       ),
@@ -106,5 +115,32 @@ void main() {
     );
 
     expect(find.text('Nothing in progress.'), findsOneWidget);
+  });
+
+  testWidgets('shows its title on desktop, where it previously had none',
+      (tester) async {
+    await pumpContinueWatchingScreen(
+      tester,
+      link: StubLink.responses([
+        _continueWatchingResponse([
+          _continueWatchingItem(id: 'cw-1', title: 'In Progress Movie'),
+        ]),
+      ]),
+    );
+
+    expect(find.text('Continue Watching'), findsOneWidget);
+  });
+
+  testWidgets('renders items through the shared grid', (tester) async {
+    await pumpContinueWatchingScreen(
+      tester,
+      link: StubLink.responses([
+        _continueWatchingResponse([
+          _continueWatchingItem(id: 'cw-1', title: 'In Progress Movie'),
+        ]),
+      ]),
+    );
+
+    expect(find.byType(BrowseGrid), findsOneWidget);
   });
 }

--- a/player/test/presentation/screens/favorites/favorites_screen_test.dart
+++ b/player/test/presentation/screens/favorites/favorites_screen_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/presentation/screens/favorites/favorites_screen.dart';
+import 'package:player/presentation/widgets/browse_grid.dart';
+import 'package:player/presentation/widgets/media_poster.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+import '../../../test_utils/stub_graphql_client.dart';
+
+class _StubAuthState extends AuthStateNotifier {
+  @override
+  AsyncValue<AuthStatus> build() =>
+      const AsyncValue.data(AuthStatus.authenticated);
+}
+
+Map<String, dynamic> _favoritesResponse(List<Map<String, dynamic>> items) => {
+      '__typename': 'Query',
+      'favorites': items,
+    };
+
+Map<String, dynamic> _favoritesItem({
+  required String id,
+  required String title,
+  String type = 'movie',
+}) =>
+    {
+      '__typename': 'MediaItem',
+      'id': id,
+      'type': type,
+      'title': title,
+      'year': 2026,
+      'artwork': {
+        '__typename': 'Artwork',
+        'posterUrl': null,
+        'backdropUrl': null,
+        'thumbnailUrl': null,
+      },
+      'addedAt': '2026-07-01T00:00:00Z',
+    };
+
+Future<void> pumpFavoritesScreen(
+  WidgetTester tester, {
+  required StubLink link,
+  Size size = const Size(1200, 900),
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          asyncGraphqlClientProvider.overrideWith(
+            (ref) async => stubClient(link),
+          ),
+          castCapabilitiesProvider
+              .overrideWithValue(const CastCapabilities.full()),
+          authStateProvider.overrideWith(_StubAuthState.new),
+        ],
+        child: const MaterialApp(home: FavoritesScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+}
+
+void main() {
+  testWidgets('shows its title on desktop, where it previously had none',
+      (tester) async {
+    await pumpFavoritesScreen(
+      tester,
+      link: StubLink.responses([
+        _favoritesResponse([
+          _favoritesItem(id: 'f-1', title: 'Favorite Movie'),
+        ]),
+      ]),
+    );
+
+    expect(find.text('Favorites'), findsOneWidget);
+    expect(find.byIcon(Icons.favorite_rounded), findsOneWidget);
+  });
+
+  testWidgets('renders items through the shared grid', (tester) async {
+    await pumpFavoritesScreen(
+      tester,
+      link: StubLink.responses([
+        _favoritesResponse([
+          _favoritesItem(id: 'f-1', title: 'Favorite Movie'),
+        ]),
+      ]),
+    );
+
+    expect(find.byType(BrowseGrid), findsOneWidget);
+    expect(find.byType(MediaPoster), findsOneWidget);
+    expect(find.text('Favorite Movie'), findsOneWidget);
+  });
+
+  testWidgets('keeps its empty state', (tester) async {
+    await pumpFavoritesScreen(
+      tester,
+      link: StubLink.responses([_favoritesResponse([])]),
+    );
+
+    expect(find.text('No favorites yet'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/screens/recently_added/recently_added_screen_test.dart
+++ b/player/test/presentation/screens/recently_added/recently_added_screen_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/presentation/screens/recently_added/recently_added_screen.dart';
+import 'package:player/presentation/widgets/browse_grid.dart';
+import 'package:player/presentation/widgets/media_poster.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+import '../../../test_utils/stub_graphql_client.dart';
+
+class _StubAuthState extends AuthStateNotifier {
+  @override
+  AsyncValue<AuthStatus> build() =>
+      const AsyncValue.data(AuthStatus.authenticated);
+}
+
+Map<String, dynamic> _recentlyAddedResponse(List<Map<String, dynamic>> items) =>
+    {
+      '__typename': 'Query',
+      'recentlyAdded': items,
+    };
+
+Map<String, dynamic> _recentlyAddedItem({
+  required String id,
+  required String title,
+  String type = 'movie',
+}) =>
+    {
+      '__typename': 'MediaItem',
+      'id': id,
+      'type': type,
+      'title': title,
+      'year': 2026,
+      'artwork': {
+        '__typename': 'Artwork',
+        'posterUrl': null,
+        'backdropUrl': null,
+        'thumbnailUrl': null,
+      },
+      'addedAt': '2026-07-01T00:00:00Z',
+      'newEpisodeCount': null,
+      'latestSeasonNumber': null,
+      'latestEpisodeNumber': null,
+    };
+
+Future<void> pumpRecentlyAddedScreen(
+  WidgetTester tester, {
+  required StubLink link,
+  Size size = const Size(1200, 900),
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          asyncGraphqlClientProvider.overrideWith(
+            (ref) async => stubClient(link),
+          ),
+          castCapabilitiesProvider
+              .overrideWithValue(const CastCapabilities.full()),
+          authStateProvider.overrideWith(_StubAuthState.new),
+        ],
+        child: const MaterialApp(home: RecentlyAddedScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+}
+
+void main() {
+  testWidgets('shows its title on desktop, where it previously had none',
+      (tester) async {
+    await pumpRecentlyAddedScreen(
+      tester,
+      link: StubLink.responses([
+        _recentlyAddedResponse([
+          _recentlyAddedItem(id: 'r-1', title: 'New Movie'),
+        ]),
+      ]),
+    );
+
+    expect(find.text('Recently Added'), findsOneWidget);
+    expect(find.byIcon(Icons.fiber_new_rounded), findsOneWidget);
+  });
+
+  testWidgets('renders items through the shared grid', (tester) async {
+    await pumpRecentlyAddedScreen(
+      tester,
+      link: StubLink.responses([
+        _recentlyAddedResponse([
+          _recentlyAddedItem(id: 'r-1', title: 'New Movie'),
+        ]),
+      ]),
+    );
+
+    expect(find.byType(BrowseGrid), findsOneWidget);
+    expect(find.byType(MediaPoster), findsOneWidget);
+    expect(find.text('New Movie'), findsOneWidget);
+  });
+
+  testWidgets('keeps its empty state', (tester) async {
+    await pumpRecentlyAddedScreen(
+      tester,
+      link: StubLink.responses([_recentlyAddedResponse([])]),
+    );
+
+    expect(find.text('Nothing new'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/screens/search/search_screen_test.dart
+++ b/player/test/presentation/screens/search/search_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:mockito/mockito.dart';
 import 'package:player/core/cast/cast_capabilities.dart';
 import 'package:player/core/cast/cast_providers.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/core/layout/breakpoints.dart';
 import 'package:player/domain/models/search_result.dart';
 import 'package:player/presentation/screens/search/search_controller.dart';
 import 'package:player/presentation/screens/search/search_screen.dart';
@@ -51,7 +52,15 @@ const _twoSections = {
 void main() {
   late MockGraphQLClient client;
 
-  Widget host({String? initialQuery, SearchResultType? initialType}) {
+  /// [contentWidth] narrows the screen without narrowing the window, which is
+  /// what `AppShell`'s desktop layout does by putting a fixed 260px
+  /// `DesktopSidebar` beside it. Grid geometry must follow the content area,
+  /// not `MediaQuery`.
+  Widget host({
+    String? initialQuery,
+    SearchResultType? initialType,
+    double? contentWidth,
+  }) {
     client = MockGraphQLClient();
     when(client.query(any)).thenAnswer(
       (_) async => QueryResult(
@@ -59,6 +68,11 @@ void main() {
         source: QueryResultSource.network,
         data: const {'search': _twoSections},
       ),
+    );
+
+    final screen = SearchScreen(
+      initialQuery: initialQuery,
+      initialType: initialType,
     );
 
     return ProviderScope(
@@ -69,10 +83,12 @@ void main() {
         ),
       ],
       child: MaterialApp(
-        home: SearchScreen(
-          initialQuery: initialQuery,
-          initialType: initialType,
-        ),
+        home: contentWidth == null
+            ? screen
+            : Align(
+                alignment: Alignment.topLeft,
+                child: SizedBox(width: contentWidth, child: screen),
+              ),
       ),
     );
   }
@@ -428,5 +444,28 @@ void main() {
     // Was SliverGridDelegateWithMaxCrossAxisExtent(180) at aspect 0.55,
     // the only grid in the app that did not match the library.
     expect(delegate.childAspectRatio, 0.58);
+  });
+
+  testWidgets('counts columns from the content area, not the window',
+      (tester) async {
+    // A 1400px window whose content area is only 700px, which is the shape
+    // `AppShell` creates on desktop with its fixed 260px `DesktopSidebar`.
+    // Reading `MediaQuery` here would say 1400 and lay out 7 columns into
+    // space that fits 4, cramping every card.
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await mockNetworkImages(() async {
+      await tester.pumpWidget(host(initialQuery: 'alien', contentWidth: 700));
+      await tester.pumpAndSettle();
+    });
+
+    final grid = tester.widget<SliverGrid>(find.byType(SliverGrid));
+    final delegate =
+        grid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+
+    expect(delegate.crossAxisCount, libraryCrossAxisCount(700));
+    expect(delegate.crossAxisCount, isNot(libraryCrossAxisCount(1400)));
   });
 }

--- a/player/test/presentation/screens/search/search_screen_test.dart
+++ b/player/test/presentation/screens/search/search_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:player/presentation/screens/search/widgets/episode_result_row.da
 import 'package:player/presentation/screens/search/widgets/search_result_card.dart';
 import 'package:player/presentation/screens/search/widgets/search_section_header.dart';
 import 'package:player/presentation/widgets/ambient_backdrop_provider.dart';
+import 'package:player/presentation/widgets/browse_scaffold.dart';
 
 import '../../../test_utils/mock_network_images.dart';
 import 'search_screen_test.mocks.dart';
@@ -353,5 +354,79 @@ void main() {
       container.read(ambientBackdropControllerProvider.notifier).defaultSource,
       BackdropSource.none,
     );
+  });
+
+  testWidgets('gives the search field real gutters instead of sitting flush',
+      (tester) async {
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await mockNetworkImages(() async {
+      await tester.pumpWidget(host(initialQuery: 'alien'));
+      await tester.pumpAndSettle();
+    });
+
+    final fieldLeft = tester.getTopLeft(find.byType(TextField)).dx;
+
+    // Breakpoints.getHorizontalPadding returns 32 at or above 1200 wide. The
+    // old bar used `titleSpacing: 0`, which put the field flush against the
+    // leading icon with no margin at all.
+    expect(fieldLeft, greaterThanOrEqualTo(32.0));
+  });
+
+  testWidgets('does not inherit the theme filled pill', (tester) async {
+    await mockNetworkImages(() async {
+      await tester.pumpWidget(host(initialQuery: 'alien'));
+      await tester.pumpAndSettle();
+    });
+
+    final field = tester.widget<TextField>(find.byType(TextField));
+
+    // The app theme sets `filled: true` with a rounded fill.
+    // `InputBorder.none` suppresses the stroke but not the fill, which is how
+    // this field came to render as a pill nobody designed.
+    expect(field.decoration?.filled, isFalse);
+  });
+
+  testWidgets('shows the screen title in its bar', (tester) async {
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await mockNetworkImages(() async {
+      await tester.pumpWidget(host(initialQuery: 'alien'));
+      await tester.pumpAndSettle();
+    });
+
+    // Scoped to the bar: 'Search' would otherwise also match chip and section
+    // labels elsewhere on the screen.
+    expect(
+      find.descendant(
+        of: find.byType(BrowseScaffold),
+        matching: find.text('Search'),
+      ),
+      findsWidgets,
+    );
+  });
+
+  testWidgets('uses the app-wide poster geometry for result cards',
+      (tester) async {
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await mockNetworkImages(() async {
+      await tester.pumpWidget(host(initialQuery: 'alien'));
+      await tester.pumpAndSettle();
+    });
+
+    final grid = tester.widget<SliverGrid>(find.byType(SliverGrid));
+    final delegate =
+        grid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+
+    // Was SliverGridDelegateWithMaxCrossAxisExtent(180) at aspect 0.55,
+    // the only grid in the app that did not match the library.
+    expect(delegate.childAspectRatio, 0.58);
   });
 }

--- a/player/test/presentation/screens/unwatched/unwatched_screen_test.dart
+++ b/player/test/presentation/screens/unwatched/unwatched_screen_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/presentation/screens/unwatched/unwatched_screen.dart';
+import 'package:player/presentation/widgets/browse_grid.dart';
+import 'package:player/presentation/widgets/media_poster.dart';
+
+import '../../../test_utils/mock_network_images.dart';
+import '../../../test_utils/stub_graphql_client.dart';
+
+class _StubAuthState extends AuthStateNotifier {
+  @override
+  AsyncValue<AuthStatus> build() =>
+      const AsyncValue.data(AuthStatus.authenticated);
+}
+
+Map<String, dynamic> _unwatchedResponse(List<Map<String, dynamic>> items) => {
+      '__typename': 'Query',
+      'unwatched': items,
+    };
+
+Map<String, dynamic> _unwatchedItem({
+  required String id,
+  required String title,
+  String type = 'movie',
+}) =>
+    {
+      '__typename': 'MediaItem',
+      'id': id,
+      'type': type,
+      'title': title,
+      'year': 2026,
+      'artwork': {
+        '__typename': 'Artwork',
+        'posterUrl': null,
+        'backdropUrl': null,
+        'thumbnailUrl': null,
+      },
+      'addedAt': '2026-07-01T00:00:00Z',
+    };
+
+Future<void> pumpUnwatchedScreen(
+  WidgetTester tester, {
+  required StubLink link,
+  Size size = const Size(1200, 900),
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await mockNetworkImages(() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          asyncGraphqlClientProvider.overrideWith(
+            (ref) async => stubClient(link),
+          ),
+          castCapabilitiesProvider
+              .overrideWithValue(const CastCapabilities.full()),
+          authStateProvider.overrideWith(_StubAuthState.new),
+        ],
+        child: const MaterialApp(home: UnwatchedScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+}
+
+void main() {
+  testWidgets('shows its title on desktop, where it previously had none',
+      (tester) async {
+    await pumpUnwatchedScreen(
+      tester,
+      link: StubLink.responses([
+        _unwatchedResponse([_unwatchedItem(id: 'u-1', title: 'Unseen Movie')]),
+      ]),
+    );
+
+    expect(find.text('Unwatched'), findsOneWidget);
+  });
+
+  testWidgets('renders items through the shared grid', (tester) async {
+    await pumpUnwatchedScreen(
+      tester,
+      link: StubLink.responses([
+        _unwatchedResponse([_unwatchedItem(id: 'u-1', title: 'Unseen Movie')]),
+      ]),
+    );
+
+    expect(find.byType(BrowseGrid), findsOneWidget);
+    expect(find.byType(MediaPoster), findsOneWidget);
+    expect(find.text('Unseen Movie'), findsOneWidget);
+  });
+
+  testWidgets('keeps its empty state', (tester) async {
+    await pumpUnwatchedScreen(
+      tester,
+      link: StubLink.responses([_unwatchedResponse([])]),
+    );
+
+    expect(find.text('All caught up!'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/widgets/app_shell_cast_overlay_test.dart
+++ b/player/test/presentation/widgets/app_shell_cast_overlay_test.dart
@@ -1,11 +1,11 @@
 // The shell pins CastOverlayButton into its own Stack so casting is reachable
-// even on desktop screens that suppress their app bar entirely (Home,
-// Unwatched, Favorites, RecentlyAdded, Collections). But some in-shell
-// screens (Library, Downloads, Settings, Search) keep a real, always-visible
-// app bar with their own action buttons in the same top-right band the
-// overlay paints into — those screens carry their own CastButton instead, and
-// the shell must not also paint the overlay there, or the overlay sits on top
-// of and intercepts taps for the screen's own actions.
+// even on desktop screens that suppress their app bar entirely (Home). But some
+// in-shell screens (Library, Downloads, Settings, Search, Unwatched,
+// ContinueWatching, Favorites, RecentlyAdded, Collections) keep a real,
+// always-visible app bar with their own action buttons in the same top-right
+// band the overlay paints into — those screens carry their own CastButton
+// instead, and the shell must not also paint the overlay there, or the overlay
+// sits on top of and intercepts taps for the screen's own actions.
 //
 // `AppShell.hasOwnCastButton` is the single routing decision that keeps these
 // two mutually exclusive. It's asserted directly here (rather than by
@@ -35,6 +35,14 @@ void main() {
       '/downloads',
       '/settings',
       '/search',
+      // Gained an always-visible glass bar with its own CastButton when they
+      // moved onto `BrowseScaffold`. Before that they suppressed their bar
+      // entirely on desktop and the overlay was their only affordance.
+      '/unwatched',
+      '/continue-watching',
+      '/favorites',
+      '/recently-added',
+      '/collections',
       // Sub-paths under a route with its own button must also be excluded
       // from the overlay, matching how `_isHomeSection`/`_isLibrarySection`
       // already treat these as prefixes, not exact matches.
@@ -46,15 +54,10 @@ void main() {
       });
     }
 
-    // Home, Unwatched, Favorites, RecentlyAdded and Collections all suppress
-    // their app bar entirely on desktop — the overlay is the only cast
-    // affordance they ever get, so it must stay lit for these routes.
+    // Home is the last in-shell destination that still suppresses its app bar
+    // on desktop, so the overlay remains its only cast affordance.
     for (final location in [
       '/',
-      '/unwatched',
-      '/favorites',
-      '/recently-added',
-      '/collections',
     ]) {
       test('is false for $location (overlay is the only affordance)', () {
         expect(AppShell.hasOwnCastButton(location), isFalse);

--- a/player/test/presentation/widgets/browse_grid_test.dart
+++ b/player/test/presentation/widgets/browse_grid_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/breakpoints.dart';
+import 'package:player/presentation/widgets/browse_grid.dart';
+
+Future<void> pumpGrid(
+  WidgetTester tester, {
+  required Size size,
+  double scrollTopPadding = 120,
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: BrowseGrid(
+          itemCount: 24,
+          scrollTopPadding: scrollTopPadding,
+          itemBuilder: (context, index) => SizedBox(
+            key: ValueKey('item-$index'),
+            child: Text('Item $index'),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('libraryCrossAxisCount', () {
+    // The exact table the library grid has always used. Moving the function
+    // between files must not change a single boundary.
+    test('matches the established column table', () {
+      expect(libraryCrossAxisCount(1500), 8);
+      expect(libraryCrossAxisCount(1300), 7);
+      expect(libraryCrossAxisCount(1100), 6);
+      expect(libraryCrossAxisCount(900), 5);
+      expect(libraryCrossAxisCount(700), 4);
+      expect(libraryCrossAxisCount(500), 3);
+      expect(libraryCrossAxisCount(300), 2);
+    });
+  });
+
+  testWidgets('reserves the caller scrollTopPadding above the first item',
+      (tester) async {
+    await pumpGrid(tester, size: const Size(1200, 900));
+
+    final grid = tester.widget<GridView>(find.byType(GridView));
+    final padding = grid.padding! as EdgeInsets;
+
+    expect(padding.top, 120);
+  });
+
+  testWidgets('uses Breakpoints gutters rather than a hardcoded value',
+      (tester) async {
+    await pumpGrid(tester, size: const Size(1200, 900));
+
+    final grid = tester.widget<GridView>(find.byType(GridView));
+    final padding = grid.padding! as EdgeInsets;
+
+    // 1200 is at or above the desktop breakpoint, so 32.
+    expect(padding.left, 32);
+    expect(padding.right, 32);
+  });
+
+  testWidgets('lays out the app-wide column count for its width',
+      (tester) async {
+    await pumpGrid(tester, size: const Size(1200, 900));
+
+    final grid = tester.widget<GridView>(find.byType(GridView));
+    final delegate =
+        grid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+
+    // 1200 wide minus 32 gutters each side leaves 1136 for the grid itself.
+    expect(delegate.crossAxisCount, libraryCrossAxisCount(1136));
+    expect(delegate.childAspectRatio, 0.58);
+  });
+}

--- a/player/test/presentation/widgets/browse_scaffold_test.dart
+++ b/player/test/presentation/widgets/browse_scaffold_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/core/graphql/watch/freshness.dart';
+import 'package:player/core/graphql/watch/query_key.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/presentation/widgets/browse_scaffold.dart';
+
+/// Mirrors the stub in `freshness_header_test.dart`. The real
+/// `AuthStateNotifier` reaches for secure storage on build, which a widget
+/// test has no business doing.
+class _StubAuthState extends AuthStateNotifier {
+  @override
+  AsyncValue<AuthStatus> build() =>
+      const AsyncValue.data(AuthStatus.authenticated);
+}
+
+const _bodyKey = Key('browse-scaffold-test-body');
+
+Future<void> pumpScaffold(
+  WidgetTester tester, {
+  required Size size,
+  Widget? secondRow,
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authStateProvider.overrideWith(_StubAuthState.new),
+        castCapabilitiesProvider
+            .overrideWithValue(const CastCapabilities.full()),
+      ],
+      child: MaterialApp(
+        home: BrowseScaffold(
+          icon: Icons.visibility_off_rounded,
+          title: 'Unwatched',
+          queryKeys: [QueryKeys.unwatched],
+          secondRow: secondRow,
+          body: (context, scrollTopPadding) => ListView(
+            padding: EdgeInsets.only(top: scrollTopPadding),
+            children: const [
+              SizedBox(key: _bodyKey, height: 400, width: 400),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('renders the title on desktop, where the old bar was absent',
+      (tester) async {
+    await pumpScaffold(tester, size: const Size(1200, 900));
+
+    expect(find.text('Unwatched'), findsOneWidget);
+    expect(find.byIcon(Icons.visibility_off_rounded), findsOneWidget);
+  });
+
+  testWidgets('renders the title and a drawer button on mobile',
+      (tester) async {
+    await pumpScaffold(tester, size: const Size(400, 800));
+
+    expect(find.text('Unwatched'), findsOneWidget);
+    expect(find.byIcon(Icons.menu_rounded), findsOneWidget);
+  });
+
+  testWidgets('omits the drawer button on desktop', (tester) async {
+    await pumpScaffold(tester, size: const Size(1200, 900));
+
+    expect(find.byIcon(Icons.menu_rounded), findsNothing);
+  });
+
+  testWidgets('carries its own cast button', (tester) async {
+    await pumpScaffold(tester, size: const Size(1200, 900));
+
+    expect(find.byKey(const Key('cast-button')), findsOneWidget);
+  });
+
+  testWidgets('an in-flight refetch does not move the body', (tester) async {
+    await pumpScaffold(tester, size: const Size(1200, 900));
+
+    final before = tester.getTopLeft(find.byKey(_bodyKey));
+
+    // Drive the real registry the way a live watcher does. This is the
+    // regression: as a `Column` sibling the header was charged as layout
+    // height and shoved the whole grid down on every background refetch.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(BrowseScaffold)),
+    );
+    container.read(freshnessRegistryProvider.notifier).publish(
+          QueryKeys.unwatched,
+          const Freshness(isRefreshing: true, hasData: true),
+        );
+    await tester.pump();
+
+    expect(tester.getTopLeft(find.byKey(_bodyKey)), before);
+  });
+
+  testWidgets('a second row makes the bar taller and insets the body',
+      (tester) async {
+    await pumpScaffold(tester, size: const Size(1200, 900));
+    final withoutRow = tester.getTopLeft(find.byKey(_bodyKey)).dy;
+
+    await pumpScaffold(
+      tester,
+      size: const Size(1200, 900),
+      secondRow: const TextField(key: Key('second-row-field')),
+    );
+    final withRow = tester.getTopLeft(find.byKey(_bodyKey)).dy;
+
+    expect(find.byKey(const Key('second-row-field')), findsOneWidget);
+    expect(withRow - withoutRow, BrowseScaffold.secondRowHeight);
+  });
+}

--- a/player/test/presentation/widgets/browse_scaffold_test.dart
+++ b/player/test/presentation/widgets/browse_scaffold_test.dart
@@ -20,6 +20,18 @@ class _StubAuthState extends AuthStateNotifier {
 
 const _bodyKey = Key('browse-scaffold-test-body');
 
+/// The scaffold on its own, for tests that need to control how it is routed
+/// to rather than mounting it as `home`.
+final _scaffoldUnderTest = BrowseScaffold(
+  icon: Icons.search_rounded,
+  title: 'Search',
+  queryKeys: [QueryKeys.unwatched],
+  body: (context, scrollTopPadding) => ListView(
+    padding: EdgeInsets.only(top: scrollTopPadding),
+    children: const [SizedBox(key: _bodyKey, height: 400, width: 400)],
+  ),
+);
+
 Future<void> pumpScaffold(
   WidgetTester tester, {
   required Size size,
@@ -118,5 +130,68 @@ void main() {
 
     expect(find.byKey(const Key('second-row-field')), findsOneWidget);
     expect(withRow - withoutRow, BrowseScaffold.secondRowHeight);
+  });
+
+  group('when the screen was pushed rather than navigated to', () {
+    // Search is reached with `context.push('/search')` from every other
+    // browse screen, which puts it on top of the shell navigator. Without a
+    // back affordance that push is a one-way trip: the drawer hamburger goes
+    // sideways, not back, and desktop had no leading control at all.
+    Future<void> pumpPushed(WidgetTester tester, {required Size size}) async {
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authStateProvider.overrideWith(_StubAuthState.new),
+            castCapabilitiesProvider
+                .overrideWithValue(const CastCapabilities.full()),
+          ],
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: TextButton(
+                  key: const Key('push-trigger'),
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => _scaffoldUnderTest,
+                    ),
+                  ),
+                  child: const Text('push'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const Key('push-trigger')));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('offers back instead of the drawer on mobile', (tester) async {
+      await pumpPushed(tester, size: const Size(400, 800));
+
+      expect(find.byIcon(Icons.arrow_back_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.menu_rounded), findsNothing);
+    });
+
+    testWidgets(
+        'offers back on desktop, which otherwise has no leading '
+        'control at all', (tester) async {
+      await pumpPushed(tester, size: const Size(1200, 900));
+
+      expect(find.byIcon(Icons.arrow_back_rounded), findsOneWidget);
+    });
+
+    testWidgets('back actually pops the route', (tester) async {
+      await pumpPushed(tester, size: const Size(400, 800));
+
+      await tester.tap(find.byIcon(Icons.arrow_back_rounded));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('push-trigger')), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
Six browse screens had visibly wrong top spacing, each in a different way:

- **Search** rendered a filled, rounded text field flush against the chrome with no margin. The field passes `border: InputBorder.none`, which suppresses the theme's stroke but not its `filled: true` fill, so it looked like a pill nobody designed.
- **Continue Watching** started its grid 8px from the top edge on desktop, with content jammed against the chrome.
- **Unwatched**, **Favorites**, **Recently Added** and **Collections** reserved 100px of empty space on desktop with nothing in it. That value was tuned to clear a mobile toolbar.

## Root cause

`library_screen.dart` implements a page-chrome contract that no other browse screen fully copies: a glass bar whose height is computed, `extendBodyBehindAppBar`, `FreshnessHeader` as a `Stack` overlay, `chromeTop` from `freshnessTopInset`, `scrollTopPadding = chromeTop + 8`, and `Breakpoints` gutters.

Six screens implemented fragments of it three different ways. On desktop, five of them collapsed their app bar to a zero-height `SizedBox.shrink()`, which both removed the screen title entirely and made `freshnessTopInset` return 0.

## Also fixes a live bug

In Unwatched, Favorites, Recently Added and Collections, `FreshnessHeader` sat in a `Column`, so it was charged as layout height and **every background refetch shoved the whole grid down by ~58px**. `library_screen.dart:164` documents fixing exactly this by switching to a `Stack`; those four never received the fix. There is now a regression test for it.

## Approach

Two new widgets absorb the contract:

- `BrowseScaffold` owns the glass bar, the inset math, the freshness overlay, the pull-to-refresh edge offset, and the ambient backdrop reset.
- `BrowseGrid` owns the poster grid geometry.

Each screen keeps its own controller, empty state, and error state.

Collections deliberately keeps its own grid: `_CollectionCard` is aspect 0.85 with its own column table, a real design difference rather than drift. Search keeps slivers, since its grouped-section view is a `CustomScrollView`, but adopts the shared geometry values.

`libraryCrossAxisCount` moves from `library_grid_body.dart` to `core/layout/breakpoints.dart`. A widget in `presentation/widgets/` importing from a sibling screen folder inverts the layering, and `ContinueWatchingScreen` was already reaching across for it.

`AppShell.hasOwnCastButton` gains the five newly-barred routes. Its doc comment already warned that this predicate is what keeps the shell's floating cast overlay from colliding with a screen's own app bar, and those bars now carry their own `CastButton`.

## Notes

- `library_screen.dart` is not ported. Its bar owns sort, view-mode, saved-filter and search state, so it stays as-is.
- `collection_detail_screen.dart` keeps its hardcoded `100`. Detail screens are out of scope here, but it is the same defect class and worth a follow-up.
- The shared bar uses `headlineSmall` to match the library, which is larger than the `titleLarge` the old mobile bars used, so the title is `Flexible` with ellipsis to keep "Continue Watching" from overflowing a narrow phone bar.

## Testing

2068 tests pass (`flutter test --concurrency=1`, up from 2065). New coverage:

- `BrowseScaffold`: title renders at both breakpoints, drawer only on mobile, back instead of drawer when the screen was pushed, an in-flight refetch does not move the body, a second row inserts exactly 56px.
- `BrowseGrid`: column table unchanged by the move, `Breakpoints` gutters, caller's `scrollTopPadding` honoured.
- New screen tests for Unwatched, Favorites, Recently Added and Collections, which previously had controller tests only.

`flutter analyze` reports 55 issues, all pre-existing `info` lints in untouched files and all present on master. Zero errors, zero warnings, and none in the new files.
