### PR TITLE
feat(metadata-relay): reply to the submitter on feedback notifications

### DIFF
--- a/metadata-relay/lib/metadata_relay/feedback/notifier.ex
+++ b/metadata-relay/lib/metadata_relay/feedback/notifier.ex
@@ -10,6 +10,10 @@ defmodule MetadataRelay.Feedback.Notifier do
 
   @config_key __MODULE__
 
+  # Deliberately strict: \A..\z (not ^..$) so no trailing newline slips through,
+  # and the excluded characters keep a crafted contact from injecting headers.
+  @contact_address ~r/\A[^\s@,;:<>"]+@[^\s@,;:<>"]+\.[^\s@,;:<>"]+\z/
+
   def deliver_new_submission(%Submission{} = submission) do
     case recipient() do
       nil ->
@@ -30,6 +34,24 @@ defmodule MetadataRelay.Feedback.Notifier do
     |> from(from_address())
     |> subject(subject)
     |> text_body(text_body(submission))
+    |> maybe_reply_to(submission.contact)
+  end
+
+  # The contact field is free text, so it may be a GitHub handle, a Discord tag,
+  # or nothing at all. Only wire up Reply-To when it actually looks like an
+  # address, and keep From as the relay's own so SPF/DKIM alignment holds.
+  defp maybe_reply_to(email, contact) do
+    case contact_address(contact) do
+      nil -> email
+      address -> reply_to(email, address)
+    end
+  end
+
+  defp contact_address(contact) do
+    case normalize_optional_string(contact) do
+      nil -> nil
+      value -> if Regex.match?(@contact_address, value), do: value
+    end
   end
 
   defp text_body(submission) do

--- a/metadata-relay/mix.exs
+++ b/metadata-relay/mix.exs
@@ -4,7 +4,7 @@ defmodule MetadataRelay.MixProject do
   def project do
     [
       app: :metadata_relay,
-      version: "0.11.0",
+      version: "0.11.1",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/metadata-relay/test/metadata_relay/feedback_ingest_test.exs
+++ b/metadata-relay/test/metadata_relay/feedback_ingest_test.exs
@@ -78,6 +78,54 @@ defmodule MetadataRelay.FeedbackIngestTest do
       assert email.text_body =~ "Dashboard: https://relay.example.com/feedback#feedback-"
     end
 
+    test "sets reply-to to the contact when it is an email address" do
+      conn =
+        post_feedback(%{
+          "type" => "bug",
+          "message" => "Subtitles are offset",
+          "contact" => "  Reporter@Example.COM  "
+        })
+
+      assert conn.status == 201
+
+      email =
+        await_email(fn email ->
+          email.subject == "[Mydia feedback] bug: Subtitles are offset"
+        end)
+
+      assert email.reply_to == {"", "Reporter@Example.COM"}
+      assert email.from == {"", "metadata-relay@example.com"}
+    end
+
+    test "omits reply-to when the contact is not an email address" do
+      conn =
+        post_feedback(%{
+          "type" => "idea",
+          "message" => "Add a dark theme",
+          "contact" => "@some-github-handle"
+        })
+
+      assert conn.status == 201
+
+      email =
+        await_email(fn email -> email.subject == "[Mydia feedback] idea: Add a dark theme" end)
+
+      assert email.reply_to == nil
+    end
+
+    test "omits reply-to when no contact was given" do
+      conn = post_feedback(%{"type" => "question", "message" => "Where are logs stored?"})
+
+      assert conn.status == 201
+
+      email =
+        await_email(fn email ->
+          email.subject == "[Mydia feedback] question: Where are logs stored?"
+        end)
+
+      assert email.reply_to == nil
+    end
+
     test "returns 400 when type is missing" do
       conn = post_feedback(%{"message" => "Playback froze"})
 


### PR DESCRIPTION
## Problem

The feedback notification email set only `From` and `To`, and both were `feedback@mydia.dev`. Hitting Reply in a mail client sent back to the relay's own address rather than to the person who submitted the feedback. The submitter's contact was reachable only by hand-copying it out of the message body.

## Change

Set `Reply-To` to the submitter's contact when it parses as an email address.

- The contact field is free text (`type="text"`, placeholder "Email, GitHub handle, Discord, or anything you prefer") and is neither required nor format-checked, so it is matched against an anchored pattern before being used.
- The pattern uses `\A..\z` rather than `^..$` so a trailing newline cannot slip into a header, and excludes whitespace plus `@,;:<>"` so a crafted contact cannot inject headers.
- `From` stays the relay's own address, keeping SPF/DKIM alignment intact. Only `Reply-To` carries the submitter.

## Tests

Three tests in `feedback_ingest_test.exs`:

- contact that is an email address becomes `Reply-To` (trimmed, casing preserved), `From` unchanged
- non-email contact (`@some-github-handle`) leaves `Reply-To` unset
- absent contact leaves `Reply-To` unset

Verified the first fails before the change. The two negative tests were mutation-checked: dropping the pattern match puts `@some-github-handle` into `Reply-To` and the test fails, so they are not vacuous.

Local run of the CI gates: `mix compile --warnings-as-errors` clean, `mix format --check-formatted` clean, `mix test --warnings-as-errors` 178 tests / 0 failures.

## Related, done outside this PR

`mydia.dev` had no DMARC record. Added `_dmarc.mydia.dev TXT "v=DMARC1; p=none; rua=mailto:dmarc@mydia.dev"` in Cloudflare (monitoring only, no enforcement). Reports land in the existing Email Routing catch-all.

## Deploy note

This does not reach production until metadata-relay is tagged and released (`metadata-relay-vX.Y.Z`).