### PR TITLE
fix(player): offer tap-to-play when the browser blocks the start

### DIFF
--- a/player/lib/core/player/playback_error.dart
+++ b/player/lib/core/player/playback_error.dart
@@ -44,8 +44,10 @@ const List<String> _autoplayRefusals = [
 /// it like every other error is what put a "Failed to load video" screen in
 /// front of a video that was already sitting there ready to play.
 ///
-/// Always false off the web, where playback never passes through an autoplay
-/// policy; the phrases below are browser strings that mpv does not produce.
+/// Matches on wording alone and knows nothing about the platform. These are
+/// browser strings that mpv has no reason to produce, but the caller gates on
+/// `kIsWeb` anyway rather than leave a native build's error text to be judged
+/// against a browser's vocabulary.
 bool autoplayBlocked(String raw) {
   final lower = raw.toLowerCase();
   return _autoplayRefusals.any(lower.contains);

--- a/player/lib/core/player/playback_error.dart
+++ b/player/lib/core/player/playback_error.dart
@@ -15,6 +15,42 @@ library;
 /// reaped.
 const String _openFailure = 'failed to open';
 
+/// How each engine words a `play()` the browser refused to start.
+///
+/// On web `Player.play()` is `HTMLVideoElement.play()`, and a browser will
+/// reject that promise with a `NotAllowedError` whenever the page has no live
+/// user activation to spend. media_kit hands us only the `DOMException`'s
+/// `message` — never its `name` — so the wording is all there is to match on.
+///
+/// Matched on the stable middle of each sentence rather than the whole of it:
+/// Chromium appends a help URL that has changed before, and matching
+/// `interact with the document` rather than `didn't interact` sidesteps
+/// whether the apostrophe arrives straight or curly.
+const List<String> _autoplayRefusals = [
+  // WebKit's generic NotAllowedError description, and Firefox's near-identical
+  // wording ("The play method is not allowed by the user agent...").
+  'not allowed by the user agent',
+  // Chromium: "play() failed because the user didn't interact with the
+  // document first. https://goo.gl/xX8pDD"
+  'interact with the document',
+];
+
+/// Whether [raw] is a browser refusing to *start* playback, not a failure to
+/// load it.
+///
+/// This is the one media_kit error that is not a failure at all: the media is
+/// open, the manifest is attached and the element is ready — the browser is
+/// simply declining to begin without a user gesture to charge it to. Treating
+/// it like every other error is what put a "Failed to load video" screen in
+/// front of a video that was already sitting there ready to play.
+///
+/// Always false off the web, where playback never passes through an autoplay
+/// policy; the phrases below are browser strings that mpv does not produce.
+bool autoplayBlocked(String raw) {
+  final lower = raw.toLowerCase();
+  return _autoplayRefusals.any(lower.contains);
+}
+
 /// A viewer-facing sentence for a raw media_kit error string.
 ///
 /// Falls through to the raw text for anything unrecognised. Showing an ugly

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -249,8 +249,11 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// play affordance over it rather than torn down for an error screen. See
   /// [_onPlaybackError].
   ///
-  /// Only ever true on web. Every browser requires a live user activation to
-  /// start an unmuted video, and on a cold start nothing here can promise one:
+  /// Only ever true on web, and [_onPlaybackError] gates on `kIsWeb` to keep
+  /// that true by construction rather than by trusting mpv never to phrase an
+  /// error the way a browser does. Every browser requires a live user
+  /// activation to start an unmuted video, and on a cold start nothing here
+  /// can promise one:
   /// the tap that asked for playback is separated from [Player.play] by a
   /// route change, the candidates and progress queries, `StartStreamingSession`
   /// and the open itself. Over a remote server that routinely outlasts the
@@ -1987,10 +1990,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       return;
     }
 
-    if (autoplayBlocked(message)) {
+    if (kIsWeb && autoplayBlocked(message)) {
       setState(() {
         _autoplayBlocked = true;
         _isLoading = false;
+        // These are two mutually exclusive views of one screen and
+        // `_buildBody` reads `_error` first, so a stale one left set here
+        // would draw the error page over a video that only wants a tap.
+        // `_initializePlayer`'s catch can set it after `play()` has already
+        // been called — a throw while wiring up progress tracking, say — and
+        // the refusal then arrives behind it on the error stream. The refusal
+        // is the newer and better news of the two: a stream broken badly
+        // enough to fail never gets as far as being declined a start. If it
+        // is broken anyway, the tap raises a fresh error and the error screen
+        // comes straight back.
+        _error = null;
       });
       return;
     }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -43,6 +43,7 @@ import '../../widgets/cast_device_picker.dart';
 import '../../widgets/video_controls/cast_chrome_icon.dart';
 import '../../widgets/video_controls/custom_video_controls.dart';
 import '../../widgets/video_controls/skip_segment_button.dart';
+import '../../widgets/tap_to_play_overlay.dart';
 import '../../widgets/up_next_overlay.dart';
 import '../../../domain/models/audio_track.dart' as app_models_audio;
 import '../../../domain/models/media_segment.dart';
@@ -240,6 +241,23 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   bool _playbackAdvanced = false;
   bool _isLoading = true;
   String? _error;
+
+  /// Whether the browser refused to start playback for want of a user gesture.
+  ///
+  /// Deliberately not an [_error]. By the time this is set the media is open
+  /// and ready and only the *start* was declined, so the video is shown with a
+  /// play affordance over it rather than torn down for an error screen. See
+  /// [_onPlaybackError].
+  ///
+  /// Only ever true on web. Every browser requires a live user activation to
+  /// start an unmuted video, and on a cold start nothing here can promise one:
+  /// the tap that asked for playback is separated from [Player.play] by a
+  /// route change, the candidates and progress queries, `StartStreamingSession`
+  /// and the open itself. Over a remote server that routinely outlasts the
+  /// activation window, which is why this is a state to recover from rather
+  /// than a race to try to win.
+  bool _autoplayBlocked = false;
+
   String? _loadingMessage;
   int? _savedPositionSeconds;
   int? _savedDurationSeconds;
@@ -614,6 +632,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       setState(() {
         _isLoading = true;
         _error = null;
+        _autoplayBlocked = false;
       });
 
       // Check if we're in offline mode
@@ -1951,6 +1970,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// during `open` leaves the screen still loading, and `_buildBody` checks
   /// the loading state first, so an error set on its own would never be
   /// reached.
+  ///
+  /// A browser's autoplay refusal is routed to [_autoplayBlocked] instead of
+  /// [_error], because it is the one message on this stream that does not mean
+  /// the video failed. Checked after the [_playbackAdvanced] gate, not before:
+  /// once playback is under way the ordinary transport controls are on screen
+  /// and can start it again, and throwing a full-bleed overlay over a running
+  /// video would be the worse answer.
   void _onPlaybackError(String message) {
     debugPrint('[PlayerScreen] Playback error: $message');
     if (!mounted) return;
@@ -1961,9 +1987,35 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       return;
     }
 
+    if (autoplayBlocked(message)) {
+      setState(() {
+        _autoplayBlocked = true;
+        _isLoading = false;
+      });
+      return;
+    }
+
     setState(() {
       _error = playbackErrorMessage(message);
       _isLoading = false;
+    });
+  }
+
+  /// Start the playback the browser declined to start on its own.
+  ///
+  /// The [Player.play] call has to happen inside the tap handler itself. That
+  /// is the entire point: the gesture is what the browser was missing, and
+  /// awaiting anything first would spend it. For the same reason this does not
+  /// re-run [_initializePlayer] the way the error screen's Retry does — the
+  /// media is already open, and re-initialising would abandon a perfectly good
+  /// HLS session and make the server transcode the opening of the file twice.
+  void _playAfterAutoplayBlock() {
+    final player = _player;
+    if (player == null) return;
+
+    unawaited(player.play());
+    setState(() {
+      _autoplayBlocked = false;
     });
   }
 
@@ -2967,6 +3019,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         _videoController = null;
         _isLoading = true;
         _error = null;
+        _autoplayBlocked = false;
       });
     } else {
       _videoController = null;
@@ -3128,6 +3181,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
             onPlayNow: _playNextEpisode,
             onCancel: _cancelAutoPlay,
           ),
+        // Last in the stack, so the tap that starts playback reaches this and
+        // not the seek gestures underneath. Nothing below it can do anything
+        // useful while the browser is still refusing to start.
+        if (_autoplayBlocked) TapToPlayOverlay(onPlay: _playAfterAutoplayBlock),
       ],
     );
   }

--- a/player/lib/presentation/widgets/tap_to_play_overlay.dart
+++ b/player/lib/presentation/widgets/tap_to_play_overlay.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+/// The affordance shown when a browser declines to start playback on its own.
+///
+/// Every browser refuses to start an unmuted video without a live user
+/// activation, and a cold start cannot promise one: the tap that asked for
+/// playback is separated from the `play()` call by a route change, several
+/// round trips to the server and the media open itself. Over a remote server
+/// that gap routinely outlasts the activation window, and the browser rejects
+/// the play with a `NotAllowedError`.
+///
+/// Nothing has actually failed at that point. The media is open, the manifest
+/// is attached and the first frames are buffered, so this covers the video it
+/// is waiting on rather than replacing it, and the whole surface is the
+/// target: on a phone, hunting for a glyph is a worse ask than tapping the
+/// picture already under your thumb.
+class TapToPlayOverlay extends StatelessWidget {
+  /// Starts playback. Must call `play()` synchronously — the tap *is* the
+  /// activation, and awaiting anything before spending it hands back exactly
+  /// the failure this overlay exists to recover from.
+  final VoidCallback onPlay;
+
+  const TapToPlayOverlay({
+    super.key,
+    required this.onPlay,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: Semantics(
+        button: true,
+        label: 'Play',
+        child: GestureDetector(
+          onTap: onPlay,
+          // Without this the scrim's transparent regions would pass taps
+          // through to the gesture controls underneath, so the half of the
+          // screen that is not the glyph would seek instead of play.
+          behavior: HitTestBehavior.opaque,
+          child: ColoredBox(
+            color: Colors.black.withValues(alpha: 0.45),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: 88,
+                  height: 88,
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.55),
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: Colors.white.withValues(alpha: 0.15),
+                    ),
+                  ),
+                  child: const Icon(
+                    Icons.play_arrow_rounded,
+                    size: 56,
+                    color: Colors.white,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  'Tap to play',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 32),
+                  child: Text(
+                    'Your browser needs a tap before it will start the video.',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.white70,
+                        ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/player/test/core/player/playback_error_test.dart
+++ b/player/test/core/player/playback_error_test.dart
@@ -40,4 +40,64 @@ void main() {
       expect(playbackErrorMessage(''), contains('unknown reason'));
     });
   });
+
+  group('autoplayBlocked', () {
+    // The exact strings each engine rejects `HTMLVideoElement.play()` with.
+    // They are transcribed rather than paraphrased on purpose: this function
+    // has nothing but the wording to go on, so a test that reworded them
+    // would stop defending anything.
+    test('recognises WebKit, which is what iOS Safari reports', () {
+      expect(
+        autoplayBlocked(
+          'The request is not allowed by the user agent or the platform in '
+          'the current context, possibly because the user denied permission.',
+        ),
+        isTrue,
+      );
+    });
+
+    test('recognises Firefox, which words it slightly differently', () {
+      expect(
+        autoplayBlocked(
+          'The play method is not allowed by the user agent or the platform '
+          'in the current context, possibly because the user denied '
+          'permission.',
+        ),
+        isTrue,
+      );
+    });
+
+    test('recognises Chromium, help URL and all', () {
+      expect(
+        autoplayBlocked(
+          "play() failed because the user didn't interact with the document "
+          'first. https://goo.gl/xX8pDD',
+        ),
+        isTrue,
+      );
+    });
+
+    test('survives Chromium changing its help URL or its apostrophe', () {
+      expect(
+        autoplayBlocked(
+          'play() failed because the user did not interact with the document '
+          'first.',
+        ),
+        isTrue,
+      );
+    });
+
+    test('leaves genuine load failures to the error screen', () {
+      expect(
+        autoplayBlocked(
+          'Failed to open http://127.0.0.1:12345/direct/file-old/stream.',
+        ),
+        isFalse,
+        reason: 'a dead source is fatal — offering a play button for it would '
+            'strand the viewer tapping at a stream that will never start',
+      );
+      expect(autoplayBlocked('Audio device init failed'), isFalse);
+      expect(autoplayBlocked(''), isFalse);
+    });
+  });
 }

--- a/player/test/presentation/widgets/tap_to_play_overlay_test.dart
+++ b/player/test/presentation/widgets/tap_to_play_overlay_test.dart
@@ -1,0 +1,100 @@
+// Coverage for the affordance that recovers a browser's autoplay refusal.
+//
+// The branch in `_onPlaybackError` that raises this overlay cannot be driven
+// from `player_screen_test_harness.dart`: reaching it needs a live media_kit
+// `Player` to emit on `stream.error`, and building one under `flutter test`
+// fails for want of `MediaKit.ensureInitialized` (see
+// `player_screen_cast_start_failure_test.dart`'s header). What *is* pinned
+// here is the half that matters at the point of contact — that a tap anywhere
+// on the video starts playback, and that the tap cannot fall through to the
+// seek gestures underneath.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/tap_to_play_overlay.dart';
+
+void main() {
+  /// Mounts the overlay over a stand-in for the gesture controls it covers,
+  /// so a tap that leaks through is observable rather than silently ignored.
+  Future<void> pumpOverlay(
+    WidgetTester tester, {
+    required VoidCallback onPlay,
+    required VoidCallback onUnderlayTap,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                onTap: onUnderlayTap,
+                behavior: HitTestBehavior.opaque,
+                child: const ColoredBox(color: Colors.black),
+              ),
+            ),
+            TapToPlayOverlay(onPlay: onPlay),
+          ],
+        ),
+      ),
+    );
+  }
+
+  testWidgets('a tap on the glyph starts playback', (tester) async {
+    var plays = 0;
+    var underlayTaps = 0;
+
+    await pumpOverlay(
+      tester,
+      onPlay: () => plays++,
+      onUnderlayTap: () => underlayTaps++,
+    );
+
+    await tester.tap(find.byIcon(Icons.play_arrow_rounded));
+    await tester.pump();
+
+    expect(plays, 1);
+    expect(underlayTaps, 0);
+  });
+
+  testWidgets('a tap anywhere on the video starts playback', (tester) async {
+    var plays = 0;
+    var underlayTaps = 0;
+
+    await pumpOverlay(
+      tester,
+      onPlay: () => plays++,
+      onUnderlayTap: () => underlayTaps++,
+    );
+
+    // The top-left corner: as far from the glyph as this surface goes, and
+    // squarely inside the left half, where `GestureControls` would otherwise
+    // read a tap as a seek.
+    await tester.tapAt(const Offset(20, 20));
+    await tester.pump();
+
+    expect(
+      plays,
+      1,
+      reason: 'the whole picture is the target — asking a viewer to find a '
+          'glyph is the friction this overlay exists to remove',
+    );
+    expect(
+      underlayTaps,
+      0,
+      reason: 'a tap that reaches the gesture controls underneath would seek '
+          'a video that has not started',
+    );
+  });
+
+  testWidgets('says what it is waiting for', (tester) async {
+    await pumpOverlay(tester, onPlay: () {}, onUnderlayTap: () {});
+
+    expect(find.text('Tap to play'), findsOneWidget);
+    expect(
+      find.textContaining('browser'),
+      findsOneWidget,
+      reason: 'naming the browser as the thing holding playback up is what '
+          'keeps this from reading as another failure',
+    );
+  });
+}


### PR DESCRIPTION
Starting a movie in the web player frequently failed with "Failed to load video / Playback failed: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission." Tapping Retry usually worked.

## Root cause

That message is WebKit's `NotAllowedError`, the browser's autoplay gate, not a load failure.

On web `Player.play()` is `HTMLVideoElement.play()`. media_kit catches the rejected promise and pushes the raw `DOMException.message` onto `stream.error` (`media_kit/src/player/web/player/real.dart:555-567`), forwarding the `message` only and never the `name`. `_onPlaybackError` then treated it like every other failure and replaced the screen with an error page.

Nothing had failed. The media was open, the manifest attached and the first frames buffered. The browser was only declining to *start* an unmuted video with no live user activation to charge it to. The tap that asked for playback is separated from `play()` by a route change, the progress and candidates queries, `StartStreamingSession`, `player.open()` and a fixed 500ms settle, which against a remote server reliably outlasts the activation window.

Retry "worked" because a button tap supplies the missing gesture. It was not fixing anything, and it paid for the gesture by re-running the whole pipeline, abandoning a live HLS session and making the server transcode the opening of the file a second time. That is also why it was "usually" rather than "always": a slow warm path can still miss the window.

Ruled out along the way: missing `playsinline` (media_kit sets it, `real.dart:63`, and its absence forces fullscreen rather than throwing), and a server-side fault (the stream was serving fine throughout).

## Fix

- `autoplayBlocked()` in `playback_error.dart` classifies that one message apart from real failures, matching the WebKit, Firefox and Chromium wordings.
- `_onPlaybackError` routes it to a new `_autoplayBlocked` state instead of `_error`, so the ready video stays on screen.
- `TapToPlayOverlay` covers the video with a play affordance. The tap calls `play()` inside the handler, so no re-initialisation and no second transcode. It sits last in the stack so the tap cannot fall through to the seek gestures underneath.

## Testing

- 9 classifier cases against the verbatim strings each engine rejects `play()` with.
- 3 widget cases: a tap on the glyph plays, a tap anywhere on the picture plays, and neither reaches the gesture controls below.
- Full player suite green (2094 tests, `--concurrency=1`). `flutter analyze` reports no new issues.

## Known gaps

- The `_onPlaybackError` to overlay wiring has no end-to-end test. `player_screen_test_harness.dart` cannot build a real media_kit `Player` under `flutter test` (it needs `MediaKit.ensureInitialized`), so driving `stream.error` would have required adding a player-injection seam. The classification and the affordance are each covered; the few lines joining them are not.
- Diagnosed by tracing rather than by reproducing on an iOS device, so it is worth one confirmation on a phone after deploy.
- The fixed 500ms delay before `play()` is untouched. Shortening it would improve the odds without changing the failure mode, and it is load-bearing for `_detectTracks`.
