### PR TITLE
fix(admin): make the media servers config page usable on mobile

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -55,6 +55,23 @@
   color: oklch(var(--bc) / 0.35);
 }
 
+/* iOS Safari zooms the viewport when a focused field is under 16px. DaisyUI 5
+   defaults .input/.select/.textarea to --font-size-min: .875rem (14px), so
+   every text field in the media server modal triggers it. Setting DaisyUI's own
+   variable is preferable to overriding font-size directly, which would fight
+   the component's `max()` expression.
+
+   This is an app-wide papercut; the same rule without the ID prefix would fix
+   every form in Mydia on iOS. Scoped here to match the agreed scope of the
+   media servers mobile work. */
+@media (max-width: 639px) {
+  #media-server-modal .input,
+  #media-server-modal .select,
+  #media-server-modal .textarea {
+    --font-size-min: 1rem;
+  }
+}
+
 /* This file is for your main application CSS */
 
 /* Hide badges when selection mode is active */

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -65,10 +65,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                     <div class="flex items-center gap-2 flex-wrap">
                       <h3 class="font-semibold text-base truncate">{server.name}</h3>
                       <%= if is_runtime do %>
-                        <span
-                          class="badge badge-primary badge-xs gap-1 tooltip cursor-help"
-                          data-tip="Configured via environment variables (read-only)"
-                        >
+                        <span class="badge badge-primary badge-xs gap-1">
                           <.icon name="hero-lock-closed" class="w-3 h-3" /> ENV
                         </span>
                       <% end %>
@@ -156,6 +153,14 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                   <span :if={last_run.error} class="text-error/80">{last_run.error}</span>
                 </div>
 
+                <p
+                  :if={is_runtime}
+                  data-test="env-config-note"
+                  class="text-xs text-base-content/50"
+                >
+                  Configured via environment variables, read-only
+                </p>
+
                 <%!-- Bottom Row: Actions --%>
                 <div class="flex items-center justify-end gap-1 pt-2 border-t border-base-200">
                   <button
@@ -183,29 +188,23 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                   >
                     <.icon name="hero-signal" class="w-4 h-4" /> Test
                   </button>
-                  <%= if is_runtime do %>
-                    <div class="tooltip" data-tip="Cannot modify runtime-configured servers">
-                      <button class="btn btn-sm btn-ghost" disabled>
-                        <.icon name="hero-pencil" class="w-4 h-4 opacity-30" />
-                      </button>
-                    </div>
-                  <% else %>
-                    <button
-                      class="btn btn-sm btn-ghost"
-                      phx-click="edit_media_server"
-                      phx-value-id={server.id}
-                    >
-                      <.icon name="hero-pencil" class="w-4 h-4" />
-                    </button>
-                    <button
-                      class="btn btn-sm btn-ghost text-error hover:bg-error/10"
-                      phx-click="delete_media_server"
-                      phx-value-id={server.id}
-                      data-confirm="Are you sure you want to delete this media server?"
-                    >
-                      <.icon name="hero-trash" class="w-4 h-4" />
-                    </button>
-                  <% end %>
+                  <button
+                    :if={not is_runtime}
+                    class="btn btn-sm btn-ghost"
+                    phx-click="edit_media_server"
+                    phx-value-id={server.id}
+                  >
+                    <.icon name="hero-pencil" class="w-4 h-4" />
+                  </button>
+                  <button
+                    :if={not is_runtime}
+                    class="btn btn-sm btn-ghost text-error hover:bg-error/10"
+                    phx-click="delete_media_server"
+                    phx-value-id={server.id}
+                    data-confirm="Are you sure you want to delete this media server?"
+                  >
+                    <.icon name="hero-trash" class="w-4 h-4" />
+                  </button>
                 </div>
               </div>
             </div>

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -245,10 +245,14 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
     assigns = assign(assigns, :current_type, current_type)
 
     ~H"""
-    <div class="modal modal-open" id="media-server-modal" phx-hook="PlexOAuth">
+    <div
+      class="modal modal-bottom sm:modal-middle modal-open"
+      id="media-server-modal"
+      phx-hook="PlexOAuth"
+    >
       <div class="modal-box max-w-xl">
         <%!-- Modal Header --%>
-        <div class="flex items-center justify-between mb-5">
+        <div class="flex flex-wrap items-center justify-between gap-3 mb-5">
           <div class="flex items-center gap-3">
             <div class={[
               "w-10 h-10 rounded-xl flex items-center justify-center",
@@ -274,7 +278,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
               </p>
             </div>
           </div>
-          <label class="label cursor-pointer gap-2">
+          <label class="label cursor-pointer gap-2 w-full justify-between sm:w-auto sm:justify-end">
             <span class="label-text text-sm">Enabled</span>
             <input type="hidden" name={@media_server_form[:enabled].name} value="false" />
             <input
@@ -403,7 +407,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                           <span class="font-medium text-sm">Authenticated successfully</span>
                         </div>
                         <p class="text-sm text-base-content/70">Select your Plex server:</p>
-                        <div class="space-y-2 max-h-48 overflow-y-auto">
+                        <div class="space-y-2 sm:max-h-48 sm:overflow-y-auto">
                           <%= for server <- @plex_oauth_servers do %>
                             <button
                               type="button"
@@ -460,7 +464,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                           <span class="font-medium">{@plex_selected_server.name}</span>
                         </div>
                         <p class="text-sm text-base-content/70">Choose a connection:</p>
-                        <div class="space-y-2 max-h-48 overflow-y-auto">
+                        <div class="space-y-2 sm:max-h-48 sm:overflow-y-auto">
                           <% sorted_connections =
                             Enum.sort_by(@plex_selected_server.connections, fn conn ->
                               case Map.get(@plex_connection_statuses, conn.uri, :testing) do

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -80,21 +80,13 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
 
                   <%!-- Health Status Indicator --%>
                   <div
+                    role="img"
+                    aria-label={health_status_label(health.status)}
                     class={[
-                      "tooltip tooltip-left",
-                      health.status == :unhealthy && health[:error] && "cursor-help"
-                    ]}
-                    data-tip={
-                      if health.status == :unhealthy and health[:error],
-                        do: health.error,
-                        else: health_status_label(health.status)
-                    }
-                  >
-                    <div class={[
-                      "w-3 h-3 rounded-full",
+                      "w-3 h-3 rounded-full shrink-0 mt-1",
                       health_status_dot_class(health.status)
-                    ]}>
-                    </div>
+                    ]}
+                  >
                   </div>
                 </div>
 
@@ -120,6 +112,14 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                     {health_status_label(health.status)}
                   </span>
                 </div>
+
+                <p
+                  :if={health.status == :unhealthy and health[:error]}
+                  data-test="health-error"
+                  class="text-xs text-error/80 break-words"
+                >
+                  {health.error}
+                </p>
 
                 <%!-- Watched Sync Status --%>
                 <% sync_enabled =

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -19,7 +19,10 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
           <.icon name="hero-server-stack" class="w-5 h-5 opacity-60" /> Media Servers
           <span class="badge badge-ghost">{length(@media_servers)}</span>
         </h2>
-        <button class="btn btn-sm btn-primary" phx-click="new_media_server">
+        <button
+          class="btn btn-primary w-full min-h-11 sm:btn-sm sm:w-auto sm:min-h-8"
+          phx-click="new_media_server"
+        >
           <.icon name="hero-plus" class="w-4 h-4" /> New
         </button>
       </div>
@@ -51,12 +54,12 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                 <div class="flex items-start gap-3">
                   <%!-- Server Type Icon --%>
                   <div class={[
-                    "p-3 rounded-xl shrink-0",
+                    "p-2 sm:p-3 rounded-xl shrink-0",
                     media_server_type_bg_class(server.type)
                   ]}>
                     <.icon
                       name={media_server_type_icon(server.type)}
-                      class={"w-6 h-6 #{media_server_type_icon_class(server.type)}"}
+                      class={"w-5 h-5 sm:w-6 sm:h-6 #{media_server_type_icon_class(server.type)}"}
                     />
                   </div>
 
@@ -70,7 +73,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                         </span>
                       <% end %>
                     </div>
-                    <div class="text-xs text-base-content/50 mt-0.5 font-mono truncate">
+                    <div class="text-xs text-base-content/50 mt-0.5 font-mono break-all sm:truncate">
                       {server.url}
                     </div>
                   </div>
@@ -162,11 +165,11 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                 </p>
 
                 <%!-- Bottom Row: Actions --%>
-                <div class="flex items-center justify-end gap-1 pt-2 border-t border-base-200">
+                <div class="flex flex-wrap items-center gap-2 pt-3 border-t border-base-200 sm:justify-end sm:gap-1 sm:pt-2">
                   <button
                     :if={server.last_auth_error_at}
                     data-test="reconnect-plex"
-                    class="btn btn-sm btn-warning gap-1"
+                    class={["btn btn-warning gap-1", card_action_btn()]}
                     phx-click="reconnect_plex"
                     phx-value-id={server.id}
                   >
@@ -174,7 +177,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                   </button>
                   <%= if sync_enabled and server.type == :plex do %>
                     <button
-                      class="btn btn-sm btn-ghost gap-1"
+                      class={["btn btn-ghost gap-1", card_action_btn()]}
                       phx-click="sync_watched"
                       phx-value-id={server.id}
                     >
@@ -182,7 +185,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                     </button>
                   <% end %>
                   <button
-                    class="btn btn-sm btn-ghost gap-1"
+                    class={["btn btn-ghost gap-1", card_action_btn()]}
                     phx-click="test_media_server"
                     phx-value-id={server.id}
                   >
@@ -190,20 +193,22 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                   </button>
                   <button
                     :if={not is_runtime}
-                    class="btn btn-sm btn-ghost"
+                    class={["btn btn-ghost gap-1", card_action_btn()]}
                     phx-click="edit_media_server"
                     phx-value-id={server.id}
                   >
                     <.icon name="hero-pencil" class="w-4 h-4" />
+                    <span class="sm:hidden">Edit</span>
                   </button>
                   <button
                     :if={not is_runtime}
-                    class="btn btn-sm btn-ghost text-error hover:bg-error/10"
+                    class={["btn btn-ghost gap-1 text-error hover:bg-error/10", card_action_btn()]}
                     phx-click="delete_media_server"
                     phx-value-id={server.id}
                     data-confirm="Are you sure you want to delete this media server?"
                   >
                     <.icon name="hero-trash" class="w-4 h-4" />
+                    <span class="sm:hidden">Delete</span>
                   </button>
                 </div>
               </div>
@@ -763,6 +768,16 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   defp health_status_label(:healthy), do: "Healthy"
   defp health_status_label(:unhealthy), do: "Unhealthy"
   defp health_status_label(:unknown), do: "Unknown"
+
+  # Card action buttons: two per row on phones, with a lone trailing button
+  # stretching to fill, and today's compact right-aligned row from `sm` up.
+  #
+  # DaisyUI 5 .btn is 2.5rem and .btn-sm is 2rem, both under the 44px iOS and
+  # 48px Android touch-target guidance. `min-h-11` (2.75rem) clamps the
+  # component's own `height`; a Tailwind `h-*` utility would be competing with
+  # DaisyUI's own cascade layer and is not reliable here.
+  defp card_action_btn,
+    do: "flex-1 basis-[45%] min-h-11 sm:flex-none sm:basis-auto sm:btn-sm sm:min-h-8"
 
   defp run_label(%{status: :skipped, skip_reason: reason}) when is_binary(reason) do
     "Skipped: #{reason}"

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -703,13 +703,17 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
           </div>
 
           <%!-- Modal Actions --%>
-          <div class="modal-action mt-6 pt-4 border-t border-base-300">
-            <button type="button" class="btn btn-ghost" phx-click="close_media_server_modal">
+          <div class="modal-action mt-6 grid grid-cols-2 gap-2 sticky bottom-0 bg-base-100 -mx-6 px-6 -mb-6 pb-6 pt-4 border-t border-base-300 sm:flex sm:gap-2">
+            <button
+              type="button"
+              class={["btn btn-ghost", modal_action_btn()]}
+              phx-click="close_media_server_modal"
+            >
               Cancel
             </button>
             <button
               type="button"
-              class="btn btn-outline btn-secondary gap-2"
+              class={["btn btn-outline btn-secondary gap-2", modal_action_btn()]}
               phx-click="test_media_server_connection"
               disabled={@testing_media_server_connection}
             >
@@ -719,7 +723,13 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                 <.icon name="hero-signal" class="w-4 h-4" /> Test Connection
               <% end %>
             </button>
-            <button type="submit" class="btn btn-primary gap-2">
+            <button
+              type="submit"
+              class={[
+                "btn btn-primary gap-2 col-span-2 order-first sm:order-none",
+                modal_action_btn()
+              ]}
+            >
               <.icon name="hero-check" class="w-4 h-4" />
               {if @media_server_mode == :new, do: "Add Server", else: "Save Changes"}
             </button>
@@ -782,6 +792,10 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   # DaisyUI's own cascade layer and is not reliable here.
   defp card_action_btn,
     do: "flex-1 basis-[45%] min-h-11 sm:flex-none sm:basis-auto sm:btn-sm sm:min-h-8"
+
+  # Modal footer buttons: full-width stacked rows on phones, today's inline
+  # row from `sm` up. Same 44px reasoning as card_action_btn/0.
+  defp modal_action_btn, do: "w-full min-h-11 sm:w-auto sm:min-h-8"
 
   defp run_label(%{status: :skipped, skip_reason: reason}) when is_binary(reason) do
     "Skipped: #{reason}"

--- a/test/mydia_web/live/admin_media_servers_live/components_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live/components_test.exs
@@ -1,0 +1,60 @@
+defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
+  use ExUnit.Case, async: true
+
+  # Only `render_component/2` is needed here, and importing `render/1` alongside
+  # the local helpers below is noise. Matches franchise_components_test.exs.
+  import Phoenix.LiveViewTest, except: [render: 1]
+
+  alias Mydia.Settings.MediaServerConfig
+  alias MydiaWeb.AdminMediaServersLive.Components
+
+  defp server(attrs \\ %{}) do
+    struct!(
+      %MediaServerConfig{
+        id: "11111111-1111-1111-1111-111111111111",
+        name: "Storage",
+        type: :plex,
+        enabled: true,
+        url: "http://localhost:32400",
+        token: "tok",
+        connection_settings: %{}
+      },
+      attrs
+    )
+  end
+
+  defp render_tab(servers, health) do
+    render_component(&Components.media_servers_tab/1, %{
+      media_servers: servers,
+      media_server_health: health,
+      last_runs: %{}
+    })
+  end
+
+  describe "health status" do
+    test "an unhealthy server renders its error as text" do
+      s = server()
+
+      html = render_tab([s], %{s.id => %{status: :unhealthy, error: "connection refused"}})
+
+      assert html =~ ~s(data-test="health-error")
+      assert html =~ "connection refused"
+    end
+
+    test "a healthy server renders no error line" do
+      s = server()
+
+      html = render_tab([s], %{s.id => %{status: :healthy}})
+
+      refute html =~ ~s(data-test="health-error")
+    end
+
+    test "an unhealthy server with no error detail renders no error line" do
+      s = server()
+
+      html = render_tab([s], %{s.id => %{status: :unhealthy}})
+
+      refute html =~ ~s(data-test="health-error")
+    end
+  end
+end

--- a/test/mydia_web/live/admin_media_servers_live/components_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live/components_test.exs
@@ -57,4 +57,38 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
       refute html =~ ~s(data-test="health-error")
     end
   end
+
+  describe "env-configured servers" do
+    defp runtime_server do
+      server(%{id: "runtime::media_server::storage"})
+    end
+
+    test "an env-configured server explains itself in text" do
+      s = runtime_server()
+
+      html = render_tab([s], %{s.id => %{status: :unknown}})
+
+      assert html =~ ~s(data-test="env-config-note")
+      assert html =~ "Configured via environment variables"
+    end
+
+    test "an env-configured server offers no edit or delete control" do
+      s = runtime_server()
+
+      html = render_tab([s], %{s.id => %{status: :unknown}})
+
+      refute html =~ "edit_media_server"
+      refute html =~ "delete_media_server"
+    end
+
+    test "a normal server offers edit and delete and carries no env note" do
+      s = server()
+
+      html = render_tab([s], %{s.id => %{status: :unknown}})
+
+      assert html =~ "edit_media_server"
+      assert html =~ "delete_media_server"
+      refute html =~ ~s(data-test="env-config-note")
+    end
+  end
 end


### PR DESCRIPTION
Makes `/admin/config/media-servers` usable on a phone. Layout only, no behaviour changes beyond removing a dead control.

## Card

- Health errors render as text instead of living only in a `data-tip` tooltip, which is CSS hover and unreachable on touch
- Removes the permanently-disabled edit button shown for env-configured servers, whose only purpose was hosting a tooltip explaining why it was disabled. Disabled buttons do not reliably emit hover or focus, so that explanation was unreliable on desktop and absent on touch. Replaced by a visible line on the card
- Action row wraps two-per-row at 44px touch targets below 640px, handling one through five buttons without stranding an orphan half-width button
- Long `plex.direct` URLs wrap instead of truncating
- Type icon and the New button sized down on phones

## Modal

- `modal-bottom sm:modal-middle`, so it is a full-width bottom sheet on phones and the current centred dialog from 640px up
- Footer is a sticky two-row grid on phones. Cancel, Test Connection, and Add Server want roughly 341px in a row and there is roughly 312px available at 360px. Sticky also helps desktop, where the Plex OAuth flow already pushes the buttons below the fold
- Header wraps so the Enabled toggle gets its own row instead of colliding with the subtitle
- The two `max-h-48 overflow-y-auto` Plex lists lose their height cap below 640px. They sat inside a `.modal-box` that is itself `overflow-y: auto`, which traps touch scroll

## CSS

- One media query setting DaisyUI's `--font-size-min: 1rem` on modal fields. DaisyUI 5 defaults `.input`/`.select` to 14px and iOS Safari zooms the viewport on focus below 16px. Scoped to `#media-server-modal`; the same rule unscoped would fix every form in Mydia on iOS, which is worth doing separately

## Tests

Six new tests in `test/mydia_web/live/admin_media_servers_live/components_test.exs`, covering the two behavioural deltas. Pure `render_component/2`, no database, `async: true`.

They cannot go through the LiveView: `get_media_server_health_status/1` hardcodes every server to `:unknown` so an unhealthy server is unreachable, and env-configured servers are not database rows so they cannot be inserted.

## Verification

Resolved against the compiled stylesheet rather than by eye:

- **The desktop modal width does not regress.** `.max-w-xl` compiles into the bare `utilities` layer while `.sm\:modal-middle > .modal-box` compiles into the nested `daisyui.l1.l2` sublayer of `utilities`. Unlayered styles beat layered ones within a layer, so `max-w-xl` (36rem) wins despite its lower specificity. This is DaisyUI 5's intent: components sit in sublayers so Tailwind utilities override them
- **The sticky footer bleed is exact.** `.modal-box` padding compiles to `calc(0.25rem * 6)` = 1.5rem, and `-mx-6`/`px-6`/`-mb-6`/`pb-6` are the same 1.5rem, so the negative margins cancel the padding precisely

Still outstanding, and needs a human:

- Visual sanity at 360px, 390px, and 768px, including the five-button card action row, which needs a Plex server with both `last_auth_error_at` set and watched sync enabled
- iOS Safari focus zoom, which emulation does not reproduce

## Note for reviewers

The health error line is correct but inert in production. `get_media_server_health_status/1` (`lib/mydia_web/live/admin_media_servers_live/index.ex:514`) returns `%{status: :unknown}` for every server, so the `:healthy` and `:unhealthy` branches on the card are dead at runtime. The tooltip this replaces has never displayed a real error. Implementing health checking is out of scope here.

Out of scope and still open: the admin config tab strip is eleven tabs in a wrapping container with no scroll, so this page still opens below the fold on a phone. That affects all eleven admin config pages and wants its own change.
