### PR TITLE
fix(requests): one-click guest requests and posters on approved items

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -300,6 +300,8 @@ config :mydia, Oban,
        {"*/5 * * * *", Mydia.Jobs.SegmentDetectionScheduler},
        # Refresh metadata for all monitored items weekly on Sunday at 5 AM
        {"0 5 * * 0", Mydia.Jobs.MetadataRefresh, args: %{"refresh_all" => true}},
+       # Repair media items stored with no metadata (blank posters) daily at 5:15 AM
+       {"15 5 * * *", Mydia.Jobs.MetadataBackfill},
        # Permanently delete trashed media files past retention period daily at 5 AM
        {"0 5 * * *", Mydia.Jobs.TrashCleanup},
        # Sync runs accrue per server per user per tick, so they need pruning

--- a/lib/mydia/jobs/metadata_backfill.ex
+++ b/lib/mydia/jobs/metadata_backfill.ex
@@ -1,0 +1,86 @@
+defmodule Mydia.Jobs.MetadataBackfill do
+  @moduledoc """
+  Enqueues a metadata refresh for every media item stored without metadata.
+
+  Approving a media request used to create a bare row with no `metadata`, which
+  renders as an empty poster placeholder forever. That is fixed at the source in
+  `Mydia.MediaRequests.approve_request/3`, but libraries already carry the
+  damaged rows, and a self-hosted operator should not have to find and repair
+  them by hand.
+
+  Runs daily. Once a library is repaired the query returns nothing and the job
+  costs one empty read, so it also self-heals if nil-metadata items appear again
+  from any other cause. Idempotent and safe to re-run.
+  """
+
+  use Oban.Worker,
+    queue: :media,
+    max_attempts: 3,
+    unique: [
+      period: 86_400,
+      states: [:suspended, :available, :scheduled, :executing, :retryable]
+    ]
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Mydia.Jobs.MetadataRefresh
+  alias Mydia.Media.MediaItem
+  alias Mydia.Repo
+
+  # Delay between batches to avoid hammering the relay once the refreshes run.
+  @batch_delay_ms 2_000
+  @batch_size 10
+
+  @spec perform(Oban.Job.t()) :: :ok
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    ids =
+      from(m in MediaItem, where: is_nil(m.metadata), select: m.id, order_by: [asc: m.title])
+      |> Repo.all()
+
+    total = length(ids)
+
+    if total == 0 do
+      :ok
+    else
+      Logger.info("[MetadataBackfill] Found #{total} media items without metadata")
+
+      ids
+      |> Enum.chunk_every(@batch_size)
+      |> Enum.with_index()
+      |> Enum.each(fn {batch, batch_index} ->
+        if batch_index > 0 do
+          Process.sleep(@batch_delay_ms)
+        end
+
+        Enum.each(batch, &enqueue_refresh/1)
+      end)
+
+      Logger.info("[MetadataBackfill] Enqueued #{total} metadata refreshes")
+
+      :ok
+    end
+  end
+
+  defp enqueue_refresh(media_item_id) do
+    # Singular Oban.insert/1, never insert_all/1: uniqueness on Basic and Lite
+    # is only applied by the singular path, so insert_all would queue duplicate
+    # refreshes on every daily run.
+    %{media_item_id: media_item_id}
+    |> MetadataRefresh.new()
+    |> Oban.insert()
+    |> case do
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "[MetadataBackfill] Could not enqueue refresh for #{media_item_id}: #{inspect(reason)}"
+        )
+
+        :ok
+    end
+  end
+end

--- a/lib/mydia/media/add.ex
+++ b/lib/mydia/media/add.ex
@@ -245,11 +245,13 @@ defmodule Mydia.Media.Add do
   end
 
   defp resolve_tv_show_attrs_from_tmdb(provider_id, provider_id_int, config, opts) do
-    # Derive the provider from the configured libraries. `derived` may be nil
-    # (libraries disagree); the fetch still needs a provider, so fall back to
-    # TVDB for content while leaving provenance unstamped.
+    # The initial fetch below is always TMDB, because that is the id we hold.
+    # `primary_provider` selects which provider's metadata ends up as the
+    # item's primary content, not which one is fetched first. `derived` may be
+    # nil when the configured libraries disagree; TVDB is the richer source, so
+    # it wins the content while provenance stays unstamped.
     derived = Settings.derive_tv_metadata_source()
-    fetch_provider = derived || :tvdb
+    primary_provider = derived || :tvdb
 
     case Metadata.fetch_by_id(config, provider_id, media_type: :tv_show, provider: :tmdb) do
       {:ok, tmdb_metadata} ->
@@ -258,7 +260,7 @@ defmodule Mydia.Media.Add do
            tmdb_metadata,
            provider_id_int,
            derived,
-           fetch_provider,
+           primary_provider,
            config,
            opts
          )}

--- a/lib/mydia/media/add.ex
+++ b/lib/mydia/media/add.ex
@@ -1,0 +1,338 @@
+defmodule Mydia.Media.Add do
+  @moduledoc """
+  Turns a provider ID into a library media item.
+
+  This is the single path from "the user picked something on TMDB or TVDB" to a
+  row in `media_items` carrying full metadata. The admin "Add to Library" flow
+  reaches it through `MydiaWeb.Live.Helpers.MediaAddHelpers`, and request
+  approval reaches it through `Mydia.MediaRequests.approve_request/3`, so an
+  approved request lands with the same poster, overview and provenance an
+  admin-added item gets.
+
+  `resolve_attrs/4` and `from_attrs/3` are separate so a caller can do the
+  network work outside a database transaction and the insert inside one.
+  """
+
+  require Logger
+
+  alias Mydia.Media
+  alias Mydia.Metadata
+  alias Mydia.Settings
+
+  # Options consumed by `Media.create_media_item/2` rather than by attrs building.
+  @create_opt_keys [:actor_type, :actor_id, :skip_episode_refresh, :season_monitoring]
+
+  @type error :: {:metadata, term()} | {:changeset, Ecto.Changeset.t()}
+
+  @doc """
+  Fetches provider metadata and builds the attrs for `Media.create_media_item/2`.
+
+  Performs every network call this module makes, so callers that need to keep
+  HTTP out of a database transaction can run this first.
+
+  ## Options
+
+    * `:provider` - `:tmdb` (default) or `:tvdb`. `:tvdb` is only meaningful for
+      TV shows and fetches the TVDB series directly rather than starting from a
+      TMDB lookup.
+    * Everything `build_media_item_attrs/3` accepts.
+  """
+  @spec resolve_attrs(String.t() | integer(), :movie | :tv_show, map() | nil, keyword()) ::
+          {:ok, map()} | {:error, {:metadata, term()}}
+  def resolve_attrs(provider_id, media_type, config \\ nil, opts \\ [])
+
+  def resolve_attrs(nil, _media_type, _config, _opts), do: {:error, {:metadata, :no_provider_id}}
+
+  def resolve_attrs(provider_id, media_type, config, opts) do
+    config = config || Metadata.default_relay_config()
+    provider_id_int = parse_provider_id(provider_id)
+    provider_id = to_string(provider_id_int)
+
+    if media_type == :tv_show do
+      resolve_tv_show_attrs(provider_id, provider_id_int, config, opts)
+    else
+      resolve_movie_attrs(provider_id, provider_id_int, config, opts)
+    end
+  end
+
+  @doc """
+  Inserts a media item from attrs produced by `resolve_attrs/4`.
+
+  Makes no provider calls of its own. Note that `Media.create_media_item/2`
+  still fetches episodes for TV shows, which is a network call; that is
+  pre-existing behaviour and is deliberately left where it is.
+  """
+  @spec from_attrs(map(), map() | nil, keyword()) ::
+          {:ok, Media.MediaItem.t()} | {:error, {:changeset, Ecto.Changeset.t()}}
+  def from_attrs(attrs, config \\ nil, opts \\ []) do
+    config = config || Metadata.default_relay_config()
+
+    create_opts =
+      opts
+      |> Keyword.take(@create_opt_keys)
+      |> Keyword.put(:config, config)
+
+    case Media.create_media_item(attrs, create_opts) do
+      {:ok, media_item} -> {:ok, media_item}
+      {:error, changeset} -> {:error, {:changeset, changeset}}
+    end
+  end
+
+  @doc """
+  Fetches metadata and creates the media item in one call.
+
+  For TV shows the metadata provider is derived from the configured
+  `:series`/`:mixed` libraries (see `Settings.derive_tv_metadata_source/0`) and
+  stamped as `metadata_source` so content, episodes and provenance agree. When
+  the libraries conflict the item is added with `metadata_source: nil` and the
+  scan path establishes provenance later. Movies use TMDB and leave
+  `metadata_source` nil.
+  """
+  @spec from_provider(String.t() | integer(), :movie | :tv_show, map() | nil, keyword()) ::
+          {:ok, Media.MediaItem.t()} | {:error, error()}
+  def from_provider(provider_id, media_type, config \\ nil, opts \\ []) do
+    config = config || Metadata.default_relay_config()
+
+    with {:ok, attrs} <- resolve_attrs(provider_id, media_type, config, opts) do
+      from_attrs(attrs, config, opts)
+    end
+  end
+
+  @doc """
+  Builds media item attrs from metadata.
+
+  ## Options
+    * `:tmdb_id` - Explicit TMDB ID to use
+    * `:tvdb_id` - Explicit TVDB ID to use
+    * `:metadata_source` - Provenance to stamp (`:tvdb` | `:tmdb` | `nil`).
+      Recorded for TV shows only; movies always leave it nil.
+    * `:monitored` - Monitored flag for the new item (default: `true`)
+    * `:quality_profile_id` - Quality profile to assign. Omitted from the attrs
+      entirely when nil.
+    * `:library_path_id` - Explicit target library. Omitted from the attrs
+      entirely when nil, leaving the item on dynamic resolution.
+
+  If neither id is given, falls back to parsing `metadata.provider_id` as tmdb_id.
+  """
+  def build_media_item_attrs(metadata, media_type, opts \\ []) do
+    type_string = if media_type == :movie, do: "movie", else: "tv_show"
+    tmdb_id = opts[:tmdb_id]
+    tvdb_id = opts[:tvdb_id]
+
+    {tmdb_id, tvdb_id} =
+      case {tmdb_id, tvdb_id} do
+        {nil, nil} -> {parse_provider_id(metadata.provider_id), nil}
+        other -> other
+      end
+
+    attrs = %{
+      type: type_string,
+      title: metadata.title,
+      original_title: metadata.original_title,
+      year: extract_year(metadata),
+      tmdb_id: tmdb_id,
+      tvdb_id: tvdb_id,
+      imdb_id: metadata.imdb_id,
+      metadata: metadata,
+      monitored: Keyword.get(opts, :monitored, true)
+    }
+
+    attrs = maybe_put_quality_profile(attrs, opts[:quality_profile_id])
+    attrs = maybe_put_library_path(attrs, opts[:library_path_id])
+
+    # Record provenance for TV shows only; movies leave metadata_source nil.
+    if media_type == :movie do
+      attrs
+    else
+      Map.put(attrs, :metadata_source, opts[:metadata_source])
+    end
+  end
+
+  @doc """
+  Looks up a TVDB ID for a TV show by searching TVDB by title and year.
+  """
+  def lookup_and_add_tvdb_id(attrs, config) do
+    search_opts =
+      if attrs[:year] do
+        [media_type: :tv_show, provider: :tvdb, year: attrs[:year]]
+      else
+        [media_type: :tv_show, provider: :tvdb]
+      end
+
+    case Metadata.search(config, attrs.title, search_opts) do
+      {:ok, [first | _]} ->
+        case Integer.parse(first.provider_id) do
+          {tvdb_id, ""} -> Map.put(attrs, :tvdb_id, tvdb_id)
+          _ -> attrs
+        end
+
+      _ ->
+        attrs
+    end
+  end
+
+  @doc """
+  Resolves richer TVDB metadata for a show discovered on TMDB.
+  """
+  def resolve_tvdb_metadata(tmdb_metadata, config) do
+    year = extract_year(tmdb_metadata)
+
+    search_opts =
+      if year do
+        [media_type: :tv_show, provider: :tvdb, year: year]
+      else
+        [media_type: :tv_show, provider: :tvdb]
+      end
+
+    with {:ok, [first | _]} <- Metadata.search(config, tmdb_metadata.title, search_opts),
+         {tvdb_id, ""} <- Integer.parse(first.provider_id),
+         {:ok, tvdb_metadata} <-
+           Metadata.fetch_by_id(config, to_string(tvdb_id),
+             media_type: :tv_show,
+             provider: :tvdb
+           ) do
+      {:ok, tvdb_metadata, tvdb_id}
+    else
+      _ -> {:error, :tvdb_not_found}
+    end
+  end
+
+  @doc """
+  Normalises a provider ID to an integer.
+  """
+  def parse_provider_id(nil), do: nil
+  def parse_provider_id(id) when is_integer(id), do: id
+  def parse_provider_id(id) when is_binary(id), do: String.to_integer(id)
+
+  # Private helpers
+
+  defp resolve_movie_attrs(provider_id, provider_id_int, config, opts) do
+    case Metadata.fetch_by_id(config, provider_id, media_type: :movie, provider: :tmdb) do
+      {:ok, metadata} ->
+        {:ok,
+         build_media_item_attrs(metadata, :movie, Keyword.put(opts, :tmdb_id, provider_id_int))}
+
+      {:error, reason} ->
+        {:error, {:metadata, reason}}
+    end
+  end
+
+  defp resolve_tv_show_attrs(provider_id, provider_id_int, config, opts) do
+    case Keyword.get(opts, :provider, :tmdb) do
+      :tvdb -> resolve_tv_show_attrs_from_tvdb(provider_id, provider_id_int, config, opts)
+      _ -> resolve_tv_show_attrs_from_tmdb(provider_id, provider_id_int, config, opts)
+    end
+  end
+
+  # The request flow can hold a TVDB ID with no TMDB counterpart. Starting from
+  # a TMDB lookup would send the TVDB id to the wrong provider.
+  defp resolve_tv_show_attrs_from_tvdb(provider_id, provider_id_int, config, opts) do
+    case Metadata.fetch_by_id(config, to_string(provider_id),
+           media_type: :tv_show,
+           provider: :tvdb
+         ) do
+      {:ok, tvdb_metadata} ->
+        {:ok,
+         build_media_item_attrs(
+           tvdb_metadata,
+           :tv_show,
+           Keyword.merge(opts, tvdb_id: provider_id_int, metadata_source: :tvdb)
+         )}
+
+      {:error, reason} ->
+        {:error, {:metadata, reason}}
+    end
+  end
+
+  defp resolve_tv_show_attrs_from_tmdb(provider_id, provider_id_int, config, opts) do
+    # Derive the provider from the configured libraries. `derived` may be nil
+    # (libraries disagree); the fetch still needs a provider, so fall back to
+    # TVDB for content while leaving provenance unstamped.
+    derived = Settings.derive_tv_metadata_source()
+    fetch_provider = derived || :tvdb
+
+    case Metadata.fetch_by_id(config, provider_id, media_type: :tv_show, provider: :tmdb) do
+      {:ok, tmdb_metadata} ->
+        {:ok,
+         build_tv_show_attrs(
+           tmdb_metadata,
+           provider_id_int,
+           derived,
+           fetch_provider,
+           config,
+           opts
+         )}
+
+      {:error, reason} ->
+        {:error, {:metadata, reason}}
+    end
+  end
+
+  # Derived source is TMDB: keep the TMDB metadata as primary, resolve a
+  # secondary tvdb_id for dedup/future matching, and stamp :tmdb.
+  defp build_tv_show_attrs(tmdb_metadata, provider_id_int, derived, :tmdb, config, opts) do
+    build_media_item_attrs(
+      tmdb_metadata,
+      :tv_show,
+      Keyword.merge(opts, tmdb_id: provider_id_int, metadata_source: derived)
+    )
+    |> lookup_and_add_tvdb_id(config)
+  end
+
+  # Derived source is TVDB (or nil/conflict): use richer TVDB metadata as
+  # primary when resolvable, else TMDB content with a tvdb_id from search.
+  # Provenance is stamped as `derived` (:tvdb, or nil on conflict).
+  defp build_tv_show_attrs(tmdb_metadata, provider_id_int, derived, :tvdb, config, opts) do
+    case resolve_tvdb_metadata(tmdb_metadata, config) do
+      {:ok, tvdb_metadata, tvdb_id} ->
+        build_media_item_attrs(
+          tvdb_metadata,
+          :tv_show,
+          Keyword.merge(opts,
+            tmdb_id: provider_id_int,
+            tvdb_id: tvdb_id,
+            metadata_source: derived
+          )
+        )
+
+      {:error, _} ->
+        build_media_item_attrs(
+          tmdb_metadata,
+          :tv_show,
+          Keyword.merge(opts, tmdb_id: provider_id_int, metadata_source: derived)
+        )
+        |> lookup_and_add_tvdb_id(config)
+    end
+  end
+
+  defp maybe_put_quality_profile(attrs, nil), do: attrs
+  defp maybe_put_quality_profile(attrs, id), do: Map.put(attrs, :quality_profile_id, id)
+
+  defp maybe_put_library_path(attrs, nil), do: attrs
+  defp maybe_put_library_path(attrs, id), do: Map.put(attrs, :library_path_id, id)
+
+  defp extract_year(metadata) do
+    cond do
+      metadata.year ->
+        metadata.year
+
+      metadata.release_date || metadata.first_air_date ->
+        date_value = metadata.release_date || metadata.first_air_date
+        extract_year_from_date(date_value)
+
+      true ->
+        nil
+    end
+  end
+
+  defp extract_year_from_date(%Date{} = date), do: date.year
+
+  defp extract_year_from_date(date_str) when is_binary(date_str) do
+    case Date.from_iso8601(date_str) do
+      {:ok, date} -> date.year
+      _ -> nil
+    end
+  end
+
+  defp extract_year_from_date(_), do: nil
+end

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -16,6 +16,7 @@ defmodule Mydia.MediaRequests do
 
   alias Mydia.Repo
   alias Mydia.Media
+  alias Mydia.Media.Add
   alias Mydia.Media.MediaRequest
   alias Ecto.Multi
 
@@ -72,20 +73,72 @@ defmodule Mydia.MediaRequests do
   @doc """
   Approves a media request and creates the corresponding media item.
 
-  This operation is atomic - if media creation fails, the approval is rolled back.
+  Provider metadata is fetched before the transaction opens, so the media item
+  lands with the same poster, overview and provenance an admin-added item gets,
+  and no HTTP call is made while a write transaction is held. If the metadata
+  relay cannot be reached the request is left untouched and pending, so the
+  admin can retry rather than ending up with an artwork-less library entry.
+
+  The insert and the request update remain atomic: if either fails, both roll
+  back.
 
   ## Attributes
     - `approved_by_id` - Required, ID of the admin approving the request
     - `admin_notes` - Optional notes from the admin
+
+  ## Options
+    - `:config` - Relay config to fetch with. Defaults to
+      `Metadata.default_relay_config/0`. Inject a Bypass config in tests.
   """
-  def approve_request(%MediaRequest{} = request, attrs \\ %{}) do
+  def approve_request(%MediaRequest{} = request, attrs \\ %{}, opts \\ []) do
+    with {:ok, media_attrs} <- resolve_media_attrs(request, opts) do
+      insert_approval(request, media_attrs, attrs, opts)
+    end
+  end
+
+  defp resolve_media_attrs(request, opts) do
+    {provider_id, provider} = request_provider(request)
+    media_type = if request.media_type == "movie", do: :movie, else: :tv_show
+
+    case Add.resolve_attrs(provider_id, media_type, opts[:config],
+           provider: provider,
+           monitored: true
+         ) do
+      {:ok, media_attrs} ->
+        {:ok, media_attrs}
+
+      {:error, {:metadata, reason}} ->
+        Logger.warning(
+          "Cannot approve request #{request.id}: metadata fetch failed: #{inspect(reason)}"
+        )
+
+        {:error, {:metadata, reason}}
+    end
+  end
+
+  # A request may carry a TVDB id with no TMDB counterpart (the series search
+  # page stores whichever the provider returned). Sending a TVDB id down the
+  # TMDB path would fetch the wrong show.
+  defp request_provider(%MediaRequest{tmdb_id: tmdb_id}) when is_integer(tmdb_id),
+    do: {tmdb_id, :tmdb}
+
+  defp request_provider(%MediaRequest{tvdb_id: tvdb_id}) when is_integer(tvdb_id),
+    do: {tvdb_id, :tvdb}
+
+  defp request_provider(_request), do: {nil, :tmdb}
+
+  defp insert_approval(request, media_attrs, attrs, opts) do
     Multi.new()
     |> Multi.run(:media_item, fn _repo, _changes ->
-      # Create media item from request
-      create_media_from_request(request, attrs[:approved_by_id])
+      case Add.from_attrs(media_attrs, opts[:config],
+             actor_type: :user,
+             actor_id: attrs[:approved_by_id]
+           ) do
+        {:ok, media_item} -> {:ok, media_item}
+        {:error, {:changeset, changeset}} -> {:error, changeset}
+      end
     end)
     |> Multi.run(:request, fn _repo, %{media_item: media_item} ->
-      # Update request with approval
       request
       |> MediaRequest.approve_changeset(Map.put(attrs, :media_item_id, media_item.id))
       |> Repo.update()
@@ -173,22 +226,5 @@ defmodule Mydia.MediaRequests do
     else
       :ok
     end
-  end
-
-  defp create_media_from_request(request, approved_by_id) do
-    media_attrs = %{
-      type: request.media_type,
-      title: request.title,
-      original_title: request.original_title,
-      year: request.year,
-      tmdb_id: request.tmdb_id,
-      imdb_id: request.imdb_id,
-      monitored: true
-    }
-
-    Media.create_media_item(media_attrs,
-      actor_type: :user,
-      actor_id: approved_by_id
-    )
   end
 end

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -31,6 +31,7 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :media_type, :atom, required: true
   attr :current_user, :map, required: true
   attr :adding_item_id, :string, default: nil
+  attr :requesting_item_id, :string, default: nil
   attr :libraries, :list, default: []
 
   def trending_card(assigns) do
@@ -90,6 +91,7 @@ defmodule MydiaWeb.DiscoverComponents do
           media_type={@media_type}
           current_user={@current_user}
           adding_item_id={@adding_item_id}
+          requesting_item_id={@requesting_item_id}
           libraries={@libraries}
         />
       </div>
@@ -101,18 +103,29 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :media_type, :atom, required: true
   attr :current_user, :map, required: true
   attr :adding_item_id, :string, default: nil
+  attr :requesting_item_id, :string, default: nil
   attr :libraries, :list, default: []
 
   defp trending_card_action(assigns) do
     ~H"""
     <%= if not @item.in_library do %>
       <%= if @current_user && @current_user.role == "guest" do %>
-        <.link
-          navigate={request_path(@media_type, @item.provider_id)}
+        <button
+          phx-click="request_media"
+          phx-value-tmdb_id={@item.provider_id}
+          phx-value-media_type={@media_type}
+          disabled={requested?(@item) or requesting?(@item, @requesting_item_id)}
           class="btn btn-primary btn-sm mt-2 w-full"
         >
-          <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
-        </.link>
+          <%= cond do %>
+            <% requesting?(@item, @requesting_item_id) -> %>
+              <span class="loading loading-spinner loading-xs"></span> Requesting...
+            <% requested?(@item) -> %>
+              <.icon name="hero-check" class="w-4 h-4" /> Requested
+            <% true -> %>
+              <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
+          <% end %>
+        </button>
       <% else %>
         <div class="join w-full mt-2">
           <button
@@ -145,8 +158,10 @@ defmodule MydiaWeb.DiscoverComponents do
     """
   end
 
-  defp request_path(:movie, provider_id), do: ~p"/request/movie?tmdb_id=#{provider_id}"
-  defp request_path(:tv_show, provider_id), do: ~p"/request/series?tmdb_id=#{provider_id}"
+  defp requested?(item), do: Map.get(item, :request_status) != nil
+
+  defp requesting?(item, requesting_item_id),
+    do: requesting_item_id != nil and requesting_item_id == to_string(item.provider_id)
 
   defp library_path(:movie, id), do: "/movies/#{id}"
   defp library_path(:tv_show, id), do: "/tv/#{id}"

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -88,6 +88,18 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
          )
          |> load_requests()}
 
+      {:error, {:metadata, reason}} ->
+        Logger.warning("Approval blocked by metadata failure: #{inspect(reason)}")
+
+        {:noreply,
+         socket
+         |> assign(:show_approve_modal, false)
+         |> assign(:selected_request, nil)
+         |> put_flash(
+           :error,
+           "Could not reach the metadata service, so the request was not approved. Please try again."
+         )}
+
       {:error, changeset} ->
         {:noreply,
          socket

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -173,12 +173,19 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
             </button>
             <%= if not in_library?(@item) do %>
               <%= if @current_user && @current_user.role == "guest" do %>
-                <.link
-                  navigate={request_path(@item)}
+                <button
+                  phx-click="request_media"
+                  phx-value-tmdb_id={@item.provider_id}
+                  phx-value-media_type={media_type_string(@item)}
+                  disabled={Map.get(@item, :request_status) != nil}
                   class="btn btn-primary"
                 >
-                  <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
-                </.link>
+                  <%= if Map.get(@item, :request_status) do %>
+                    <.icon name="hero-check" class="w-4 h-4" /> Requested
+                  <% else %>
+                    <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
+                  <% end %>
+                </button>
               <% else %>
                 <div class="join">
                   <button
@@ -279,14 +286,6 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
       :movie -> "Movie"
       :tv_show -> "Show"
       _ -> "Movie"
-    end
-  end
-
-  defp request_path(item) do
-    case item.media_type do
-      :movie -> "/request/movie?tmdb_id=#{item.provider_id}"
-      :tv_show -> "/request/series?tmdb_id=#{item.provider_id}"
-      _ -> "/request/movie?tmdb_id=#{item.provider_id}"
     end
   end
 

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -12,6 +12,7 @@ defmodule MydiaWeb.DashboardLive.Index do
   alias Mydia.MediaRequests
   alias Mydia.Accounts.Authorization
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
+  alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
   @impl true
   def mount(_params, _session, socket) do
@@ -26,6 +27,8 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:trending_tv, [])
         |> assign(:library_status_map, %{})
         |> assign(:adding_item_id, nil)
+        |> assign(:requesting_item_id, nil)
+        |> assign(:request_status_map, %{})
         |> assign(:selected_item, nil)
         |> assign(:selected_metadata, nil)
         |> assign(:detail_loading, false)
@@ -46,6 +49,8 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:upcoming_episodes, [])
         |> assign(:library_status_map, %{})
         |> assign(:adding_item_id, nil)
+        |> assign(:requesting_item_id, nil)
+        |> assign(:request_status_map, %{})
         |> assign(:pending_requests_count, 0)
         |> assign(:selected_item, nil)
         |> assign(:selected_metadata, nil)
@@ -100,6 +105,7 @@ defmodule MydiaWeb.DashboardLive.Index do
     |> assign(:active_downloads_count, active_downloads_count)
     |> assign(:total_storage, total_storage)
     |> assign(:library_status_map, library_status_map)
+    |> assign(:request_status_map, MediaRequestHelpers.request_status_map())
     |> assign(:recent_episodes, Enum.take(recent_episodes, 10))
     |> assign(:upcoming_episodes, Enum.take(upcoming_episodes, 10))
     |> assign(:pending_requests_count, pending_requests_count)
@@ -119,6 +125,17 @@ defmodule MydiaWeb.DashboardLive.Index do
     # Start async task to add media
     send(self(), {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]})
 
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "request_media",
+        %{"tmdb_id" => provider_id, "media_type" => media_type},
+        socket
+      ) do
+    media_type_atom = String.to_existing_atom(media_type)
+    socket = assign(socket, :requesting_item_id, provider_id)
+    send(self(), {:request_media, provider_id, media_type_atom})
     {:noreply, socket}
   end
 
@@ -167,6 +184,7 @@ defmodule MydiaWeb.DashboardLive.Index do
           movies
           |> Enum.take(10)
           |> MediaAddHelpers.enrich_with_library_status(socket.assigns.library_status_map)
+          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
         {:noreply,
          socket
@@ -188,6 +206,7 @@ defmodule MydiaWeb.DashboardLive.Index do
           shows
           |> Enum.take(10)
           |> MediaAddHelpers.enrich_with_library_status(socket.assigns.library_status_map)
+          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
         {:noreply,
          socket
@@ -242,13 +261,14 @@ defmodule MydiaWeb.DashboardLive.Index do
       {:ok, media_item, updated_map} ->
         # Re-enrich trending items with updated library status
         trending_movies =
-          MediaAddHelpers.enrich_with_library_status(
-            socket.assigns.trending_movies,
-            updated_map
-          )
+          socket.assigns.trending_movies
+          |> MediaAddHelpers.enrich_with_library_status(updated_map)
+          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
         trending_tv =
-          MediaAddHelpers.enrich_with_library_status(socket.assigns.trending_tv, updated_map)
+          socket.assigns.trending_tv
+          |> MediaAddHelpers.enrich_with_library_status(updated_map)
+          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
         {:noreply,
          socket
@@ -272,6 +292,18 @@ defmodule MydiaWeb.DashboardLive.Index do
          socket
          |> assign(:adding_item_id, nil)
          |> put_flash(:error, "Failed to fetch metadata: #{inspect(reason)}")}
+    end
+  end
+
+  def handle_info({:request_media, provider_id, media_type}, socket) do
+    trending = socket.assigns.trending_movies ++ socket.assigns.trending_tv
+
+    case Enum.find(trending, &(to_string(&1.provider_id) == provider_id)) do
+      nil ->
+        {:noreply, assign(socket, :requesting_item_id, nil)}
+
+      item ->
+        {:noreply, submit_request(socket, item, media_type)}
     end
   end
 
@@ -311,4 +343,47 @@ defmodule MydiaWeb.DashboardLive.Index do
     tb = bytes / (1024 * 1024 * 1024 * 1024)
     "#{Float.round(tb, 2)} TB"
   end
+
+  defp submit_request(socket, item, media_type) do
+    case MediaRequestHelpers.handle_request_media(
+           item,
+           media_type,
+           socket.assigns.current_user.id
+         ) do
+      {:ok, request, status_updates} ->
+        request_status_map = Map.merge(socket.assigns.request_status_map, status_updates)
+
+        socket
+        |> assign(:requesting_item_id, nil)
+        |> assign(:request_status_map, request_status_map)
+        |> assign(
+          :trending_movies,
+          MediaRequestHelpers.enrich_with_request_status(
+            socket.assigns.trending_movies,
+            request_status_map
+          )
+        )
+        |> assign(
+          :trending_tv,
+          MediaRequestHelpers.enrich_with_request_status(
+            socket.assigns.trending_tv,
+            request_status_map
+          )
+        )
+        |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")
+
+      {:error, reason} ->
+        socket
+        |> assign(:requesting_item_id, nil)
+        |> put_flash(:error, request_error_message(reason))
+    end
+  end
+
+  defp request_error_message(:duplicate_media), do: "That title is already in the library."
+  defp request_error_message(:duplicate_request), do: "Someone has already requested that title."
+
+  defp request_error_message(%Ecto.Changeset{} = changeset),
+    do: "Could not submit the request: #{MediaAddHelpers.format_changeset_errors(changeset)}"
+
+  defp request_error_message(_), do: "Could not submit the request. Please try again."
 end

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -14,6 +14,8 @@ defmodule MydiaWeb.DashboardLive.Index do
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
+  @unsupported_media_type "That media type is not supported."
+
   @impl true
   def mount(_params, _session, socket) do
     socket =
@@ -117,15 +119,22 @@ defmodule MydiaWeb.DashboardLive.Index do
         %{"tmdb_id" => provider_id, "media_type" => media_type} = params,
         socket
       ) do
-    media_type_atom = String.to_existing_atom(media_type)
+    case parse_event_media_type(media_type) do
+      {:ok, media_type_atom} ->
+        # Set the adding state
+        socket = assign(socket, :adding_item_id, provider_id)
 
-    # Set the adding state
-    socket = assign(socket, :adding_item_id, provider_id)
+        # Start async task to add media
+        send(
+          self(),
+          {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
+        )
 
-    # Start async task to add media
-    send(self(), {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]})
+        {:noreply, socket}
 
-    {:noreply, socket}
+      :error ->
+        {:noreply, put_flash(socket, :error, @unsupported_media_type)}
+    end
   end
 
   def handle_event(
@@ -133,38 +142,30 @@ defmodule MydiaWeb.DashboardLive.Index do
         %{"tmdb_id" => provider_id, "media_type" => media_type},
         socket
       ) do
-    media_type_atom = String.to_existing_atom(media_type)
-    socket = assign(socket, :requesting_item_id, provider_id)
-    send(self(), {:request_media, provider_id, media_type_atom})
-    {:noreply, socket}
+    case parse_event_media_type(media_type) do
+      {:ok, media_type_atom} ->
+        socket = assign(socket, :requesting_item_id, provider_id)
+        send(self(), {:request_media, provider_id, media_type_atom})
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, put_flash(socket, :error, @unsupported_media_type)}
+    end
   end
 
   def handle_event("show_details", %{"id" => id, "type" => type}, socket) do
-    # Find the item from trending lists
-    media_type = String.to_existing_atom(type)
+    with {:ok, media_type} <- parse_event_media_type(type),
+         item when not is_nil(item) <- find_trending_item(socket, id, media_type) do
+      # Show modal with loading state and trigger metadata fetch
+      send(self(), {:fetch_detail_metadata, id, media_type})
 
-    item =
-      case media_type do
-        :movie ->
-          Enum.find(socket.assigns.trending_movies, &(&1.provider_id == id))
-
-        :tv_show ->
-          Enum.find(socket.assigns.trending_tv, &(&1.provider_id == id))
-      end
-
-    case item do
-      nil ->
-        {:noreply, socket}
-
-      item ->
-        # Show modal with loading state and trigger metadata fetch
-        send(self(), {:fetch_detail_metadata, id, media_type})
-
-        {:noreply,
-         socket
-         |> assign(:selected_item, item)
-         |> assign(:selected_metadata, nil)
-         |> assign(:detail_loading, true)}
+      {:noreply,
+       socket
+       |> assign(:selected_item, item)
+       |> assign(:selected_metadata, nil)
+       |> assign(:detail_loading, true)}
+    else
+      _ -> {:noreply, socket}
     end
   end
 
@@ -386,4 +387,17 @@ defmodule MydiaWeb.DashboardLive.Index do
     do: "Could not submit the request: #{MediaAddHelpers.format_changeset_errors(changeset)}"
 
   defp request_error_message(_), do: "Could not submit the request. Please try again."
+
+  # phx-value payloads are client-controlled, and String.to_existing_atom/1
+  # would raise on anything unexpected and take the LiveView down with it.
+  # Match the two known types explicitly instead.
+  defp parse_event_media_type("movie"), do: {:ok, :movie}
+  defp parse_event_media_type("tv_show"), do: {:ok, :tv_show}
+  defp parse_event_media_type(_), do: :error
+
+  defp find_trending_item(socket, id, :movie),
+    do: Enum.find(socket.assigns.trending_movies, &(&1.provider_id == id))
+
+  defp find_trending_item(socket, id, :tv_show),
+    do: Enum.find(socket.assigns.trending_tv, &(&1.provider_id == id))
 end

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -223,6 +223,7 @@
               media_type={:movie}
               current_user={@current_user}
               adding_item_id={@adding_item_id}
+              requesting_item_id={@requesting_item_id}
               libraries={@movie_libraries}
             />
           <% end %>
@@ -257,6 +258,7 @@
               media_type={:tv_show}
               current_user={@current_user}
               adding_item_id={@adding_item_id}
+              requesting_item_id={@requesting_item_id}
               libraries={@show_libraries}
             />
           <% end %>

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -54,6 +54,8 @@ defmodule MydiaWeb.DiscoverLive.Index do
     {"primary_release_date.asc", "Oldest First"}
   ]
 
+  @unsupported_media_type "That media type is not supported."
+
   @impl true
   def mount(_params, _session, socket) do
     socket =
@@ -229,10 +231,20 @@ defmodule MydiaWeb.DiscoverLive.Index do
         %{"tmdb_id" => provider_id, "media_type" => media_type} = params,
         socket
       ) do
-    media_type_atom = String.to_existing_atom(media_type)
-    socket = assign(socket, :adding_item_id, provider_id)
-    send(self(), {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]})
-    {:noreply, socket}
+    case parse_event_media_type(media_type) do
+      {:ok, media_type_atom} ->
+        socket = assign(socket, :adding_item_id, provider_id)
+
+        send(
+          self(),
+          {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
+        )
+
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, put_flash(socket, :error, @unsupported_media_type)}
+    end
   end
 
   def handle_event(
@@ -240,28 +252,29 @@ defmodule MydiaWeb.DiscoverLive.Index do
         %{"tmdb_id" => provider_id, "media_type" => media_type},
         socket
       ) do
-    media_type_atom = String.to_existing_atom(media_type)
-    socket = assign(socket, :requesting_item_id, provider_id)
-    send(self(), {:request_media, provider_id, media_type_atom})
-    {:noreply, socket}
+    case parse_event_media_type(media_type) do
+      {:ok, media_type_atom} ->
+        socket = assign(socket, :requesting_item_id, provider_id)
+        send(self(), {:request_media, provider_id, media_type_atom})
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, put_flash(socket, :error, @unsupported_media_type)}
+    end
   end
 
   def handle_event("show_details", %{"id" => id, "type" => type}, socket) do
-    media_type = String.to_existing_atom(type)
-    item = Enum.find(socket.assigns.items, &(&1.provider_id == id))
+    with {:ok, media_type} <- parse_event_media_type(type),
+         item when not is_nil(item) <- Enum.find(socket.assigns.items, &(&1.provider_id == id)) do
+      send(self(), {:fetch_detail_metadata, id, media_type})
 
-    case item do
-      nil ->
-        {:noreply, socket}
-
-      item ->
-        send(self(), {:fetch_detail_metadata, id, media_type})
-
-        {:noreply,
-         socket
-         |> assign(:selected_item, item)
-         |> assign(:selected_metadata, nil)
-         |> assign(:detail_loading, true)}
+      {:noreply,
+       socket
+       |> assign(:selected_item, item)
+       |> assign(:selected_metadata, nil)
+       |> assign(:detail_loading, true)}
+    else
+      _ -> {:noreply, socket}
     end
   end
 
@@ -577,8 +590,17 @@ defmodule MydiaWeb.DiscoverLive.Index do
     params
   end
 
+  # Lenient: URL params are user-typed, so an unknown ?type= falls back to
+  # movies rather than erroring.
   defp parse_media_type("tv_show"), do: :tv_show
   defp parse_media_type(_), do: :movie
+
+  # Strict: phx-value payloads are client-controlled, and
+  # String.to_existing_atom/1 would raise on anything unexpected and take the
+  # LiveView down with it. Match the two known types explicitly instead.
+  defp parse_event_media_type("movie"), do: {:ok, :movie}
+  defp parse_event_media_type("tv_show"), do: {:ok, :tv_show}
+  defp parse_event_media_type(_), do: :error
 
   defp parse_category(nil, _), do: :trending
   defp parse_category("discover", _), do: :discover

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -8,6 +8,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
   alias Mydia.Media
   alias Mydia.Metadata
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
+  alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
   @languages [
     {"en", "English"},
@@ -69,6 +70,8 @@ defmodule MydiaWeb.DiscoverLive.Index do
       |> assign(:genres, [])
       |> assign(:library_status_map, %{})
       |> assign(:adding_item_id, nil)
+      |> assign(:requesting_item_id, nil)
+      |> assign(:request_status_map, %{})
       |> assign(:selected_item, nil)
       |> assign(:selected_metadata, nil)
       |> assign(:load_error, nil)
@@ -135,7 +138,11 @@ defmodule MydiaWeb.DiscoverLive.Index do
 
       # Load library status map
       library_status_map = Media.get_library_status_map()
-      socket = assign(socket, :library_status_map, library_status_map)
+
+      socket =
+        socket
+        |> assign(:library_status_map, library_status_map)
+        |> assign(:request_status_map, MediaRequestHelpers.request_status_map())
 
       send(self(), :load_data)
 
@@ -225,6 +232,17 @@ defmodule MydiaWeb.DiscoverLive.Index do
     media_type_atom = String.to_existing_atom(media_type)
     socket = assign(socket, :adding_item_id, provider_id)
     send(self(), {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]})
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "request_media",
+        %{"tmdb_id" => provider_id, "media_type" => media_type},
+        socket
+      ) do
+    media_type_atom = String.to_existing_atom(media_type)
+    socket = assign(socket, :requesting_item_id, provider_id)
+    send(self(), {:request_media, provider_id, media_type_atom})
     {:noreply, socket}
   end
 
@@ -354,7 +372,9 @@ defmodule MydiaWeb.DiscoverLive.Index do
          ) do
       {:ok, media_item, updated_map} ->
         items =
-          MediaAddHelpers.enrich_with_library_status(socket.assigns.items, updated_map)
+          socket.assigns.items
+          |> MediaAddHelpers.enrich_with_library_status(updated_map)
+          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
         {:noreply,
          socket
@@ -380,13 +400,58 @@ defmodule MydiaWeb.DiscoverLive.Index do
     end
   end
 
+  def handle_info({:request_media, provider_id, media_type}, socket) do
+    case Enum.find(socket.assigns.items, &(to_string(&1.provider_id) == provider_id)) do
+      nil ->
+        {:noreply, assign(socket, :requesting_item_id, nil)}
+
+      item ->
+        {:noreply, submit_request(socket, item, media_type)}
+    end
+  end
+
+  defp submit_request(socket, item, media_type) do
+    case MediaRequestHelpers.handle_request_media(
+           item,
+           media_type,
+           socket.assigns.current_user.id
+         ) do
+      {:ok, request, status_updates} ->
+        request_status_map = Map.merge(socket.assigns.request_status_map, status_updates)
+
+        items =
+          MediaRequestHelpers.enrich_with_request_status(socket.assigns.items, request_status_map)
+
+        socket
+        |> assign(:requesting_item_id, nil)
+        |> assign(:request_status_map, request_status_map)
+        |> assign(:items, items)
+        |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")
+
+      {:error, reason} ->
+        socket
+        |> assign(:requesting_item_id, nil)
+        |> put_flash(:error, request_error_message(reason))
+    end
+  end
+
+  defp request_error_message(:duplicate_media), do: "That title is already in the library."
+  defp request_error_message(:duplicate_request), do: "Someone has already requested that title."
+
+  defp request_error_message(%Ecto.Changeset{} = changeset),
+    do: "Could not submit the request: #{MediaAddHelpers.format_changeset_errors(changeset)}"
+
+  defp request_error_message(_), do: "Could not submit the request. Please try again."
+
   # Private helpers
 
   defp handle_load_result(socket, result, mode) do
     case result do
       {:ok, %{results: results, page: page, total_pages: total_pages}} ->
         enriched =
-          MediaAddHelpers.enrich_with_library_status(results, socket.assigns.library_status_map)
+          results
+          |> MediaAddHelpers.enrich_with_library_status(socket.assigns.library_status_map)
+          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
         items =
           if mode == :append do
@@ -406,7 +471,9 @@ defmodule MydiaWeb.DiscoverLive.Index do
       {:ok, results} when is_list(results) ->
         # Search returns a flat list
         enriched =
-          MediaAddHelpers.enrich_with_library_status(results, socket.assigns.library_status_map)
+          results
+          |> MediaAddHelpers.enrich_with_library_status(socket.assigns.library_status_map)
+          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
         items =
           if mode == :append do

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -164,6 +164,7 @@
               media_type={item.media_type || @media_type}
               current_user={@current_user}
               adding_item_id={@adding_item_id}
+              requesting_item_id={@requesting_item_id}
               libraries={@libraries}
             />
           <% end %>

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -1,11 +1,13 @@
 defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   @moduledoc """
-  Shared helpers for adding media items to the library from external metadata.
+  Shared LiveView helpers for the "Add to Library" flow.
 
-  Used by DashboardLive and DiscoverLive for the "Add to Library" flow.
+  Used by DashboardLive, DiscoverLive and the media detail franchise panel.
+  The actual provider-fetch-and-create work lives in `Mydia.Media.Add`, which
+  request approval shares.
   """
 
-  alias Mydia.Media
+  alias Mydia.Media.Add
   alias Mydia.Metadata
   alias Mydia.Settings
 
@@ -38,12 +40,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   """
   def enrich_with_library_status(items, library_status_map) do
     Enum.map(items, fn item ->
-      provider_id_int =
-        case item.provider_id do
-          id when is_integer(id) -> id
-          id when is_binary(id) -> String.to_integer(id)
-          nil -> nil
-        end
+      provider_id_int = Add.parse_provider_id(item.provider_id)
 
       library_status =
         Map.get(library_status_map, provider_id_int) ||
@@ -59,104 +56,20 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   end
 
   @doc """
-  Builds media item attrs from metadata for creating a media item.
-
-  ## Options
-    * `:tmdb_id` - Explicit TMDB ID to use
-    * `:tvdb_id` - Explicit TVDB ID to use
-    * `:metadata_source` - Provenance to stamp (`:tvdb` | `:tmdb` | `nil`).
-      Recorded for TV shows only; movies always leave it nil.
-    * `:monitored` - Monitored flag for the new item (default: `true`)
-    * `:quality_profile_id` - Quality profile to assign. Omitted from the attrs
-      entirely when nil.
-    * `:library_path_id` - Explicit target library. Omitted from the attrs
-      entirely when nil, leaving the item on dynamic resolution.
-
-  If neither id is given, falls back to parsing `metadata.provider_id` as tmdb_id.
+  Builds media item attrs from metadata. See `Mydia.Media.Add.build_media_item_attrs/3`.
   """
-  def build_media_item_attrs(metadata, media_type, opts \\ []) do
-    type_string = if media_type == :movie, do: "movie", else: "tv_show"
-    tmdb_id = opts[:tmdb_id]
-    tvdb_id = opts[:tvdb_id]
-
-    {tmdb_id, tvdb_id} =
-      case {tmdb_id, tvdb_id} do
-        {nil, nil} ->
-          {parse_provider_id(metadata.provider_id), nil}
-
-        other ->
-          other
-      end
-
-    attrs = %{
-      type: type_string,
-      title: metadata.title,
-      original_title: metadata.original_title,
-      year: extract_year(metadata),
-      tmdb_id: tmdb_id,
-      tvdb_id: tvdb_id,
-      imdb_id: metadata.imdb_id,
-      metadata: metadata,
-      monitored: Keyword.get(opts, :monitored, true)
-    }
-
-    attrs = maybe_put_quality_profile(attrs, opts[:quality_profile_id])
-    attrs = maybe_put_library_path(attrs, opts[:library_path_id])
-
-    # Record provenance for TV shows only; movies leave metadata_source nil.
-    if media_type == :movie do
-      attrs
-    else
-      Map.put(attrs, :metadata_source, opts[:metadata_source])
-    end
-  end
-
-  defp maybe_put_quality_profile(attrs, nil), do: attrs
-  defp maybe_put_quality_profile(attrs, id), do: Map.put(attrs, :quality_profile_id, id)
-
-  defp maybe_put_library_path(attrs, nil), do: attrs
-  defp maybe_put_library_path(attrs, id), do: Map.put(attrs, :library_path_id, id)
-
-  @doc """
-  Looks up TVDB ID for a TV show by searching TVDB by title+year.
-  """
-  def lookup_and_add_tvdb_id(attrs, config) do
-    search_opts =
-      if attrs[:year] do
-        [media_type: :tv_show, provider: :tvdb, year: attrs[:year]]
-      else
-        [media_type: :tv_show, provider: :tvdb]
-      end
-
-    case Metadata.search(config, attrs.title, search_opts) do
-      {:ok, [first | _]} ->
-        case Integer.parse(first.provider_id) do
-          {tvdb_id, ""} -> Map.put(attrs, :tvdb_id, tvdb_id)
-          _ -> attrs
-        end
-
-      _ ->
-        attrs
-    end
-  end
+  defdelegate build_media_item_attrs(metadata, media_type, opts \\ []), to: Add
 
   @doc """
   Handles the full add-media-to-library flow.
 
-  For TV shows, the metadata provider is derived from the configured
-  `:series`/`:mixed` libraries (see `Settings.derive_tv_metadata_source/0`) and
-  stamped as `metadata_source` so content, episodes, and provenance agree. When
-  the libraries conflict, the item is added with `metadata_source: nil` and the
-  scan path establishes provenance later.
-
-  For movies, uses TMDB as the primary source and leaves `metadata_source` nil.
-
-  Returns `{:ok, media_item, updated_library_status_map}` or `{:error, reason}`.
+  Returns `{:ok, media_item, updated_library_status_map}` or `{:error, reason}`,
+  where reason is `{:metadata, term()}` or `{:changeset, Ecto.Changeset.t()}`.
 
   An optional `config` (relay config map) can be injected for testing; it
   defaults to `Metadata.default_relay_config()`.
 
-  `opts` are forwarded to `build_media_item_attrs/3`; `:monitored`,
+  `opts` are forwarded to `Mydia.Media.Add`; `:monitored`,
   `:quality_profile_id` and `:library_path_id` let a caller inherit settings
   from an item the user is already looking at, or pin an explicit target
   library. TV shows ignore monitored and quality profile today.
@@ -168,17 +81,9 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
         config \\ nil,
         opts \\ []
       ) do
-    provider_id_int = parse_provider_id(provider_id)
-    config = config || Metadata.default_relay_config()
+    provider_id_int = Add.parse_provider_id(provider_id)
 
-    result =
-      if media_type == :tv_show do
-        add_tv_show_to_library(provider_id, provider_id_int, config, opts)
-      else
-        add_movie_to_library(provider_id, provider_id_int, config, opts)
-      end
-
-    case result do
+    case Add.from_provider(provider_id, media_type, config, opts) do
       {:ok, media_item} ->
         updated_map = update_library_status_map(library_status_map, media_item, provider_id_int)
         {:ok, media_item, updated_map}
@@ -210,7 +115,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
           if Settings.derive_tv_metadata_source() == :tmdb do
             {:ok, tmdb_metadata}
           else
-            case resolve_tvdb_metadata(tmdb_metadata, config) do
+            case Add.resolve_tvdb_metadata(tmdb_metadata, config) do
               {:ok, tvdb_metadata, _tvdb_id} -> {:ok, tvdb_metadata}
               {:error, _} -> {:ok, tmdb_metadata}
             end
@@ -238,112 +143,6 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
   # Private helpers
 
-  defp add_movie_to_library(provider_id, provider_id_int, config, opts) do
-    case Metadata.fetch_by_id(config, provider_id, media_type: :movie, provider: :tmdb) do
-      {:ok, metadata} ->
-        attrs =
-          build_media_item_attrs(
-            metadata,
-            :movie,
-            Keyword.put(opts, :tmdb_id, provider_id_int)
-          )
-
-        case Media.create_media_item(attrs) do
-          {:ok, media_item} -> {:ok, media_item}
-          {:error, changeset} -> {:error, {:changeset, changeset}}
-        end
-
-      {:error, reason} ->
-        {:error, {:metadata, reason}}
-    end
-  end
-
-  defp add_tv_show_to_library(provider_id, provider_id_int, config, opts) do
-    # Derive the provider from the configured libraries. `derived` may be nil
-    # (libraries disagree); the fetch still needs a provider, so fall back to
-    # TVDB for content while leaving provenance unstamped.
-    derived = Settings.derive_tv_metadata_source()
-    fetch_provider = derived || :tvdb
-
-    # Fetch TMDB metadata first (we have the TMDB ID from curated lists)
-    case Metadata.fetch_by_id(config, provider_id, media_type: :tv_show, provider: :tmdb) do
-      {:ok, tmdb_metadata} ->
-        tmdb_metadata
-        |> build_tv_show_attrs(provider_id_int, derived, fetch_provider, config, opts)
-        |> create_media_item_result(config)
-
-      {:error, reason} ->
-        {:error, {:metadata, reason}}
-    end
-  end
-
-  # Derived source is TMDB: keep the TMDB metadata as primary, resolve a
-  # secondary tvdb_id for dedup/future matching, and stamp :tmdb.
-  defp build_tv_show_attrs(tmdb_metadata, provider_id_int, derived, :tmdb, config, opts) do
-    build_media_item_attrs(
-      tmdb_metadata,
-      :tv_show,
-      Keyword.merge(opts, tmdb_id: provider_id_int, metadata_source: derived)
-    )
-    |> lookup_and_add_tvdb_id(config)
-  end
-
-  # Derived source is TVDB (or nil/conflict): use richer TVDB metadata as
-  # primary when resolvable, else TMDB content with a tvdb_id from search.
-  # Provenance is stamped as `derived` (:tvdb, or nil on conflict).
-  defp build_tv_show_attrs(tmdb_metadata, provider_id_int, derived, :tvdb, config, opts) do
-    case resolve_tvdb_metadata(tmdb_metadata, config) do
-      {:ok, tvdb_metadata, tvdb_id} ->
-        build_media_item_attrs(
-          tvdb_metadata,
-          :tv_show,
-          Keyword.merge(opts,
-            tmdb_id: provider_id_int,
-            tvdb_id: tvdb_id,
-            metadata_source: derived
-          )
-        )
-
-      {:error, _} ->
-        build_media_item_attrs(
-          tmdb_metadata,
-          :tv_show,
-          Keyword.merge(opts, tmdb_id: provider_id_int, metadata_source: derived)
-        )
-        |> lookup_and_add_tvdb_id(config)
-    end
-  end
-
-  defp create_media_item_result(attrs, config) do
-    case Media.create_media_item(attrs, config: config) do
-      {:ok, media_item} -> {:ok, media_item}
-      {:error, changeset} -> {:error, {:changeset, changeset}}
-    end
-  end
-
-  defp resolve_tvdb_metadata(tmdb_metadata, config) do
-    year = extract_year(tmdb_metadata)
-
-    search_opts =
-      if year do
-        [media_type: :tv_show, provider: :tvdb, year: year]
-      else
-        [media_type: :tv_show, provider: :tvdb]
-      end
-
-    with {:ok, [first | _]} <- Metadata.search(config, tmdb_metadata.title, search_opts),
-         {tvdb_id, ""} <- Integer.parse(first.provider_id),
-         {:ok, tvdb_metadata} <-
-           Metadata.fetch_by_id(config, to_string(tvdb_id),
-             media_type: :tv_show,
-             provider: :tvdb
-           ) do
-      {:ok, tvdb_metadata, tvdb_id}
-    else
-      _ -> {:error, :tvdb_not_found}
-    end
-  end
-
   defp update_library_status_map(library_status_map, media_item, tmdb_id_int) do
     entry = %{
       in_library: true,
@@ -360,33 +159,4 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       map
     end
   end
-
-  defp extract_year(metadata) do
-    cond do
-      metadata.year ->
-        metadata.year
-
-      metadata.release_date || metadata.first_air_date ->
-        date_value = metadata.release_date || metadata.first_air_date
-        extract_year_from_date(date_value)
-
-      true ->
-        nil
-    end
-  end
-
-  defp extract_year_from_date(%Date{} = date), do: date.year
-
-  defp extract_year_from_date(date_str) when is_binary(date_str) do
-    case Date.from_iso8601(date_str) do
-      {:ok, date} -> date.year
-      _ -> nil
-    end
-  end
-
-  defp extract_year_from_date(_), do: nil
-
-  defp parse_provider_id(nil), do: nil
-  defp parse_provider_id(id) when is_integer(id), do: id
-  defp parse_provider_id(id) when is_binary(id), do: String.to_integer(id)
 end

--- a/lib/mydia_web/live/helpers/media_request_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_request_helpers.ex
@@ -1,0 +1,74 @@
+defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
+  @moduledoc """
+  Shared LiveView helpers for the guest "Request" flow.
+
+  Mirrors `MydiaWeb.Live.Helpers.MediaAddHelpers`: a status map, an enrichment
+  pass over trending items, and a submit function. Used by DashboardLive and
+  DiscoverLive so the request button behaves identically on both.
+  """
+
+  alias Mydia.Media.Add
+  alias Mydia.MediaRequests
+
+  # Statuses that should keep the request button disabled. A rejected request
+  # leaves the button enabled so a guest can ask again.
+  @outstanding ~w(pending approved)
+
+  @doc """
+  Maps `tmdb_id` to request status for every outstanding request.
+
+  Deliberately not scoped to a requester. `MediaRequests.create_request/1`
+  rejects duplicates globally via `pending_request_exists?/1`, so a per-user map
+  would show a second guest an enabled button that errors on click.
+  """
+  @spec request_status_map() :: %{integer() => String.t()}
+  def request_status_map do
+    @outstanding
+    |> Enum.flat_map(&MediaRequests.list_requests(status: &1))
+    |> Enum.reduce(%{}, fn request, acc ->
+      case request.tmdb_id do
+        nil -> acc
+        tmdb_id -> Map.put_new(acc, tmdb_id, request.status)
+      end
+    end)
+  end
+
+  @doc """
+  Adds a `:request_status` field to each item, or nil when it has no request.
+  """
+  def enrich_with_request_status(items, request_status_map) do
+    Enum.map(items, fn item ->
+      status = Map.get(request_status_map, Add.parse_provider_id(item.provider_id))
+      Map.put(item, :request_status, status)
+    end)
+  end
+
+  @doc """
+  Submits a request for a trending card item.
+
+  Returns `{:ok, request, updated_status_map}` or `{:error, reason}` where
+  reason is `:duplicate_media`, `:duplicate_request`, or a changeset.
+
+  The card carries no `imdb_id` or `original_title`; approval re-fetches from
+  the provider and resolves both, so nothing is lost by not fetching here. That
+  keeps the button instant.
+  """
+  @spec handle_request_media(map(), :movie | :tv_show, String.t()) ::
+          {:ok, Mydia.Media.MediaRequest.t(), map()} | {:error, term()}
+  def handle_request_media(item, media_type, requester_id) do
+    tmdb_id = Add.parse_provider_id(item.provider_id)
+
+    attrs = %{
+      media_type: if(media_type == :movie, do: "movie", else: "tv_show"),
+      title: item.title,
+      year: Map.get(item, :year),
+      tmdb_id: tmdb_id,
+      requester_id: requester_id
+    }
+
+    case MediaRequests.create_request(attrs) do
+      {:ok, request} -> {:ok, request, %{tmdb_id => request.status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/test/mydia/jobs/metadata_backfill_test.exs
+++ b/test/mydia/jobs/metadata_backfill_test.exs
@@ -1,0 +1,48 @@
+defmodule Mydia.Jobs.MetadataBackfillTest do
+  use Mydia.DataCase, async: false
+
+  use Oban.Testing, repo: Mydia.Repo
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Jobs.MetadataBackfill
+  alias Mydia.Jobs.MetadataRefresh
+  alias Mydia.Metadata.Structs.MediaMetadata
+
+  setup do
+    # The app skips Oban in test (engine: false), so Oban.insert cannot be
+    # resolved from inside the job. Start an isolated, manual-mode instance so
+    # enqueues land somewhere assert_enqueued can see them.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+    :ok
+  end
+
+  test "enqueues a refresh for each media item with no metadata" do
+    shell = media_item_fixture(%{type: "movie", title: "No Metadata", year: 2024})
+
+    assert :ok = perform_job(MetadataBackfill, %{})
+
+    assert_enqueued(worker: MetadataRefresh, args: %{"media_item_id" => shell.id})
+  end
+
+  test "leaves items that already have metadata alone" do
+    populated =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Has Metadata",
+        year: 2024,
+        metadata: %MediaMetadata{
+          provider_id: "1",
+          provider: :tmdb,
+          media_type: :movie,
+          title: "Has Metadata",
+          poster_path: "/p.jpg"
+        }
+      })
+
+    assert :ok = perform_job(MetadataBackfill, %{})
+
+    refute_enqueued(worker: MetadataRefresh, args: %{"media_item_id" => populated.id})
+  end
+end

--- a/test/mydia/media/add_test.exs
+++ b/test/mydia/media/add_test.exs
@@ -1,0 +1,77 @@
+defmodule Mydia.Media.AddTest do
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Media.Add
+
+  defp relay_config(bypass) do
+    %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false}
+    }
+  end
+
+  defp stub_tmdb_movie(bypass, id, title, poster_path) do
+    body = %{
+      "id" => id,
+      "title" => title,
+      "release_date" => "2021-03-04",
+      "poster_path" => poster_path,
+      "overview" => "x",
+      "credits" => %{"cast" => [], "crew" => []},
+      "genres" => []
+    }
+
+    Bypass.stub(bypass, "GET", "/tmdb/movies/#{id}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+  end
+
+  describe "resolve_attrs/4" do
+    test "returns movie attrs carrying the poster path" do
+      bypass = Bypass.open()
+      id = System.unique_integer([:positive])
+      stub_tmdb_movie(bypass, id, "Poster Movie", "/poster.jpg")
+
+      assert {:ok, attrs} = Add.resolve_attrs(id, :movie, relay_config(bypass))
+
+      assert attrs.type == "movie"
+      assert attrs.title == "Poster Movie"
+      assert attrs.tmdb_id == id
+      assert attrs.metadata.poster_path == "/poster.jpg"
+    end
+
+    test "returns {:error, {:metadata, reason}} when the relay is unreachable" do
+      bypass = Bypass.open()
+      id = System.unique_integer([:positive])
+      Bypass.down(bypass)
+
+      assert {:error, {:metadata, _reason}} = Add.resolve_attrs(id, :movie, relay_config(bypass))
+    end
+  end
+
+  describe "from_provider/4" do
+    test "creates a movie media item with metadata attached" do
+      bypass = Bypass.open()
+      id = System.unique_integer([:positive])
+      stub_tmdb_movie(bypass, id, "Created Movie", "/created.jpg")
+
+      assert {:ok, item} = Add.from_provider(id, :movie, relay_config(bypass))
+
+      assert item.title == "Created Movie"
+      assert item.tmdb_id == id
+      assert item.metadata.poster_path == "/created.jpg"
+    end
+
+    test "creates nothing and reports the metadata error when the relay is down" do
+      bypass = Bypass.open()
+      id = System.unique_integer([:positive])
+      Bypass.down(bypass)
+
+      assert {:error, {:metadata, _reason}} = Add.from_provider(id, :movie, relay_config(bypass))
+      refute Mydia.Media.get_media_item_by_tmdb(id)
+    end
+  end
+end

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -1,5 +1,5 @@
 defmodule Mydia.MediaRequestsTest do
-  use Mydia.DataCase, async: true
+  use Mydia.DataCase, async: false
 
   alias Mydia.MediaRequests
   alias Mydia.{Accounts, Media, Repo}
@@ -26,9 +26,13 @@ defmodule Mydia.MediaRequestsTest do
       approved = create_request(user, %{title: "Approved Movie"})
 
       admin = create_user(%{role: "admin"})
+      bypass = Bypass.open()
+      stub_tmdb_movie(bypass, approved.tmdb_id, "Approved Movie", "/x.jpg")
 
       {:ok, _} =
-        MediaRequests.approve_request(approved, %{approved_by_id: admin.id})
+        MediaRequests.approve_request(approved, %{approved_by_id: admin.id},
+          config: relay_config(bypass)
+        )
 
       pending_requests = MediaRequests.list_requests(status: "pending")
       assert length(pending_requests) == 1
@@ -163,17 +167,23 @@ defmodule Mydia.MediaRequestsTest do
       user = create_user()
       admin = create_user(%{role: "admin"})
       request = create_request(user)
-      %{user: user, admin: admin, request: request}
+      bypass = Bypass.open()
+      stub_tmdb_movie(bypass, request.tmdb_id, request.title, "/stub.jpg")
+      %{user: user, admin: admin, request: request, config: relay_config(bypass)}
     end
 
-    test "approves request and creates media item", %{request: request, admin: admin} do
+    test "approves request and creates media item", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
       attrs = %{
         approved_by_id: admin.id,
         admin_notes: "Looks good"
       }
 
       assert {:ok, %{request: updated_request, media_item: media_item}} =
-               MediaRequests.approve_request(request, attrs)
+               MediaRequests.approve_request(request, attrs, config: config)
 
       assert updated_request.status == "approved"
       assert updated_request.approved_by_id == admin.id
@@ -186,7 +196,11 @@ defmodule Mydia.MediaRequestsTest do
       assert media_item.type == request.media_type
     end
 
-    test "rolls back if media creation fails", %{request: request, admin: admin} do
+    test "rolls back if media creation fails", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
       # Create a media item with the same TMDB ID to cause a conflict
       {:ok, _existing} =
         Media.create_media_item(%{
@@ -198,7 +212,7 @@ defmodule Mydia.MediaRequestsTest do
 
       attrs = %{approved_by_id: admin.id}
 
-      assert {:error, _changeset} = MediaRequests.approve_request(request, attrs)
+      assert {:error, _changeset} = MediaRequests.approve_request(request, attrs, config: config)
 
       # Verify request was not updated
       reloaded = Repo.get!(MediaRequest, request.id)
@@ -206,9 +220,74 @@ defmodule Mydia.MediaRequestsTest do
       assert reloaded.approved_at == nil
     end
 
-    test "requires approved_by_id", %{request: request} do
-      assert {:error, changeset} = MediaRequests.approve_request(request, %{})
+    test "requires approved_by_id", %{request: request, config: config} do
+      assert {:error, changeset} = MediaRequests.approve_request(request, %{}, config: config)
       assert %{approved_by_id: ["can't be blank"]} = errors_on(changeset)
+    end
+  end
+
+  describe "approve_request/3 metadata" do
+    setup do
+      user = create_user()
+      admin = create_user(%{role: "admin"})
+      %{user: user, admin: admin}
+    end
+
+    test "populates the media item metadata with the provider poster", %{
+      user: user,
+      admin: admin
+    } do
+      bypass = Bypass.open()
+      request = create_request(user, %{title: "Stale Request Title"})
+      stub_tmdb_movie(bypass, request.tmdb_id, "Fresh Provider Title", "/approved.jpg")
+
+      assert {:ok, %{media_item: media_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: relay_config(bypass)
+               )
+
+      assert media_item.metadata.poster_path == "/approved.jpg"
+      assert media_item.title == "Fresh Provider Title"
+      assert media_item.tmdb_id == request.tmdb_id
+    end
+
+    test "leaves the request pending and creates nothing when the relay is unreachable", %{
+      user: user,
+      admin: admin
+    } do
+      bypass = Bypass.open()
+      request = create_request(user)
+      Bypass.down(bypass)
+
+      assert {:error, {:metadata, _reason}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: relay_config(bypass)
+               )
+
+      assert Repo.get!(MediaRequest, request.id).status == "pending"
+      refute Media.get_media_item_by_tmdb(request.tmdb_id)
+    end
+
+    test "reports a request with no TMDB or TVDB id rather than creating a shell", %{
+      user: user,
+      admin: admin
+    } do
+      bypass = Bypass.open()
+
+      {:ok, request} =
+        MediaRequests.create_request(%{
+          media_type: "movie",
+          title: "IMDB Only",
+          imdb_id: "tt0000001",
+          requester_id: user.id
+        })
+
+      assert {:error, {:metadata, :no_provider_id}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: relay_config(bypass)
+               )
+
+      assert Repo.get!(MediaRequest, request.id).status == "pending"
     end
   end
 
@@ -267,7 +346,13 @@ defmodule Mydia.MediaRequestsTest do
 
       # Approve one
       request3 = create_request(user, %{title: "Third Movie"})
-      MediaRequests.approve_request(request3, %{approved_by_id: admin.id})
+      bypass = Bypass.open()
+      stub_tmdb_movie(bypass, request3.tmdb_id, "Third Movie", "/x.jpg")
+
+      MediaRequests.approve_request(request3, %{approved_by_id: admin.id},
+        config: relay_config(bypass)
+      )
+
       assert MediaRequests.count_pending_requests() == 2
     end
   end
@@ -292,6 +377,32 @@ defmodule Mydia.MediaRequestsTest do
   end
 
   # Test helpers
+
+  defp relay_config(bypass) do
+    %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false}
+    }
+  end
+
+  defp stub_tmdb_movie(bypass, id, title, poster_path) do
+    body = %{
+      "id" => id,
+      "title" => title,
+      "release_date" => "2021-03-04",
+      "poster_path" => poster_path,
+      "overview" => "x",
+      "credits" => %{"cast" => [], "crew" => []},
+      "genres" => []
+    }
+
+    Bypass.stub(bypass, "GET", "/tmdb/movies/#{id}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+  end
 
   defp create_user(attrs \\ %{}) do
     unique_id = System.unique_integer([:positive])

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -1,0 +1,73 @@
+defmodule MydiaWeb.DiscoverComponentsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias MydiaWeb.DiscoverComponents
+
+  defp guest, do: %{role: "guest", id: "guest-1"}
+
+  defp card(assigns_overrides) do
+    item =
+      Map.merge(
+        %{
+          provider_id: "693134",
+          title: "Dune: Part Two",
+          year: 2024,
+          poster_path: "/dune.jpg",
+          in_library: false,
+          monitored: false,
+          id: nil,
+          request_status: nil
+        },
+        Map.get(assigns_overrides, :item, %{})
+      )
+
+    assigns =
+      %{
+        item: item,
+        media_type: :movie,
+        current_user: guest(),
+        adding_item_id: nil,
+        requesting_item_id: nil,
+        libraries: []
+      }
+      |> Map.merge(Map.delete(assigns_overrides, :item))
+
+    render_component(&DiscoverComponents.trending_card/1, assigns)
+  end
+
+  describe "guest request button" do
+    test "renders a request_media button rather than a link to the search page" do
+      html = card(%{})
+
+      assert html =~ ~s(phx-click="request_media")
+      assert html =~ ~s(phx-value-tmdb_id="693134")
+      assert html =~ "Request"
+      refute html =~ "/request/movie?tmdb_id="
+    end
+
+    test "shows the in-flight state while the request is being submitted" do
+      html = card(%{requesting_item_id: "693134"})
+
+      assert html =~ "Requesting..."
+      assert html =~ "loading-spinner"
+      assert html =~ "disabled"
+    end
+
+    test "shows a disabled Requested button once a request is outstanding" do
+      html = card(%{item: %{request_status: "pending"}})
+
+      assert html =~ "Requested"
+      assert html =~ "disabled"
+      refute html =~ "Requesting..."
+    end
+
+    test "keeps Add to Library for non-guest users" do
+      html = card(%{current_user: %{role: "admin", id: "admin-1"}})
+
+      assert html =~ "Add to Library"
+      refute html =~ ~s(phx-click="request_media")
+    end
+  end
+end

--- a/test/mydia_web/live/helpers/media_request_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_request_helpers_test.exs
@@ -1,0 +1,88 @@
+defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.{Accounts, MediaRequests}
+  alias MydiaWeb.Live.Helpers.MediaRequestHelpers
+
+  defp guest do
+    id = System.unique_integer([:positive])
+
+    {:ok, user} =
+      Accounts.create_user(%{
+        username: "guest#{id}",
+        email: "guest#{id}@example.com",
+        password: "passwordpassword",
+        role: "guest"
+      })
+
+    user
+  end
+
+  defp item(tmdb_id, title \\ "Card Movie") do
+    %{provider_id: to_string(tmdb_id), title: title, year: 2024}
+  end
+
+  describe "handle_request_media/3" do
+    test "creates a pending request and returns it in the updated map" do
+      user = guest()
+      tmdb_id = System.unique_integer([:positive])
+
+      assert {:ok, request, map} =
+               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
+
+      assert request.tmdb_id == tmdb_id
+      assert request.status == "pending"
+      assert request.requester_id == user.id
+      assert map[tmdb_id] == "pending"
+    end
+
+    test "reports a duplicate when a pending request already exists" do
+      user = guest()
+      tmdb_id = System.unique_integer([:positive])
+
+      assert {:ok, _request, _map} =
+               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
+
+      assert {:error, :duplicate_request} =
+               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
+    end
+  end
+
+  describe "request_status_map/0" do
+    test "includes pending requests from any requester" do
+      first = guest()
+      second = guest()
+      tmdb_id = System.unique_integer([:positive])
+
+      {:ok, _request} =
+        MediaRequests.create_request(%{
+          media_type: "movie",
+          title: "Someone Else's Pick",
+          tmdb_id: tmdb_id,
+          requester_id: first.id
+        })
+
+      # The second guest must see it as already requested: create_request/1
+      # rejects duplicates globally, so an enabled button would only error.
+      assert MediaRequestHelpers.request_status_map()[tmdb_id] == "pending"
+      assert second.id != first.id
+    end
+  end
+
+  describe "enrich_with_request_status/2" do
+    test "stamps the status onto matching items and nil onto the rest" do
+      requested = System.unique_integer([:positive])
+      untouched = System.unique_integer([:positive])
+      map = %{requested => "pending"}
+
+      [a, b] =
+        MediaRequestHelpers.enrich_with_request_status(
+          [item(requested), item(untouched)],
+          map
+        )
+
+      assert a.request_status == "pending"
+      assert b.request_status == nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes two defects in the guest request path.

- Discovery's Request button navigated guests to an empty search form. It built `/request/movie?tmdb_id=<id>`, but `RequestMediaLive` only reads `?q=`, so the id was silently dropped. It now submits the request in one click, mirroring the admin Add to Library button
- Approving a request created a media item with no `metadata`, so it rendered an empty poster placeholder forever. Approval now fetches provider metadata before opening the transaction, through the same `Mydia.Media.Add` path the admin add flow uses
- Extracted `Mydia.Media.Add` from `MediaAddHelpers` so there is one path from a provider ID to a library row, shared by the add flow and request approval
- Added `Mydia.Jobs.MetadataBackfill` to repair items already stored without metadata, daily at 5:15 AM

If the metadata relay is unreachable at approval time the request stays pending and the admin sees an error, rather than a metadata-less item being created.

Verified on SQLite (7005 tests, 0 failures) and PostgreSQL (53 affected tests, 0 failures), `credo --strict` clean.