### PR TITLE
fix(downloads): honour the Cardigann download block when grabbing

### DIFF
--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -14,6 +14,7 @@ defmodule Mydia.Downloads.Queue do
   alias Mydia.Downloads.Structs.DownloadMetadata
   alias Mydia.Downloads.Structs.ExternalTorrent
   alias Mydia.Downloads.TorrentHash
+  alias Mydia.Indexers
   alias Mydia.Indexers.SearchResult
   alias Mydia.Indexers.Structs.SearchResultMetadata
   alias Mydia.Settings
@@ -1294,7 +1295,7 @@ defmodule Mydia.Downloads.Queue do
         # For HTTP(S) URLs, download the torrent file content
         # This avoids redirect issues that download clients can't handle
         String.starts_with?(url, "http://") or String.starts_with?(url, "https://") ->
-          download_torrent_file(url, indexer_name)
+          resolve_through_indexer_definition(url, indexer_name)
 
         # Unknown format, try as URL
         true ->
@@ -1309,6 +1310,38 @@ defmodule Mydia.Downloads.Queue do
     case result do
       {:ok, {:magnet, magnet}} -> {:ok, {:magnet, TorrentHash.ensure_trackers(magnet)}}
       other -> other
+    end
+  end
+
+  # A Cardigann definition can describe how to *derive* a download rather than
+  # serve one. Public DHT crawlers in particular hand out a landing page as the
+  # row's link and assemble the magnet in client-side JavaScript, so fetching
+  # that link returns HTML with no magnet in it to scrape. Consulting the
+  # definition's `download:` block first is the only way to grab such an
+  # indexer at all.
+  #
+  # A definition that has no block, or whose block fails, falls back to fetching
+  # the link directly, which is what every other indexer needs.
+  defp resolve_through_indexer_definition(url, indexer_name) do
+    case Indexers.resolve_cardigann_download(indexer_name, url) do
+      {:ok, {:magnet, magnet}} ->
+        Logger.info("Resolved magnet via #{indexer_name} download block")
+        {:ok, {:magnet, magnet}}
+
+      {:ok, {:link, link}} ->
+        Logger.info("Resolved download link via #{indexer_name} download block")
+        download_torrent_file(link, indexer_name)
+
+      :not_applicable ->
+        download_torrent_file(url, indexer_name)
+
+      {:error, reason} ->
+        Logger.warning(
+          "Download block for #{indexer_name} failed (#{inspect(reason)}), " <>
+            "falling back to fetching the link directly"
+        )
+
+        download_torrent_file(url, indexer_name)
     end
   end
 

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -29,6 +29,8 @@ defmodule Mydia.Indexers do
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Indexers.CardigannDefinition
   alias Mydia.Indexers.CardigannAuth
+  alias Mydia.Indexers.CardigannDownload
+  alias Mydia.Indexers.CardigannParser
   alias Mydia.Settings
   alias Mydia.Repo
   import Ecto.Query
@@ -710,6 +712,51 @@ defmodule Mydia.Indexers do
         }
     end
   end
+
+  @doc """
+  Resolves a download URL through a Cardigann indexer's `download:` block.
+
+  Definitions for sites that do not serve a `.torrent` at the row's link
+  describe how to derive the real download instead - a metadata request, an
+  infohash to build a magnet from, or a selector pointing at the true link.
+  Grabbing such an indexer without this step fetches a landing page and fails.
+
+  Returns `:not_applicable` when the indexer is unknown, is not a Cardigann
+  definition, or has no `download:` block to act on, in which case the caller
+  should fetch the URL directly as before.
+
+  ## Examples
+
+      iex> resolve_cardigann_download("MagnetDownload", "https://site/info/123")
+      {:ok, {:magnet, "magnet:?xt=urn:btih:..."}}
+
+      iex> resolve_cardigann_download("SomeTorrentSite", "https://site/dl/123")
+      :not_applicable
+  """
+  @spec resolve_cardigann_download(binary() | nil, binary()) ::
+          {:ok, {:magnet, binary()} | {:link, binary()}} | {:error, term()} | :not_applicable
+  def resolve_cardigann_download(nil, _download_url), do: :not_applicable
+
+  def resolve_cardigann_download(indexer_name, download_url) when is_binary(indexer_name) do
+    with %CardigannDefinition{} = definition <- get_cardigann_definition_by_name(indexer_name),
+         {:ok, parsed} <- CardigannParser.parse_definition(definition.definition) do
+      CardigannDownload.resolve(parsed, download_url, %{
+        cookies: get_cardigann_auth_cookies(indexer_name)
+      })
+    else
+      nil ->
+        :not_applicable
+
+      {:error, reason} ->
+        Logger.warning(
+          "Could not parse Cardigann definition for #{indexer_name}: #{inspect(reason)}"
+        )
+
+        :not_applicable
+    end
+  end
+
+  def resolve_cardigann_download(_indexer_name, _download_url), do: :not_applicable
 
   @doc """
   Enables a Cardigann indexer definition.

--- a/lib/mydia/indexers/cardigann_download.ex
+++ b/lib/mydia/indexers/cardigann_download.ex
@@ -179,8 +179,17 @@ defmodule Mydia.Indexers.CardigannDownload do
         end
       end)
       |> case do
-        nil -> {:error, {:cardigann_download, "no download selector matched the response"}}
-        link -> {:ok, {:link, absolute_link(definition, download_url, link)}}
+        nil ->
+          {:error, {:cardigann_download, "no download selector matched the response"}}
+
+        link ->
+          # Many definitions point their download selector straight at a magnet.
+          # Handing that back as a link would send the grab path off to fetch a
+          # `magnet:` URL over HTTP, which it cannot do.
+          case absolute_link(definition, download_url, link) do
+            "magnet:" <> _ = magnet -> {:ok, {:magnet, magnet}}
+            resolved -> {:ok, {:link, resolved}}
+          end
       end
     end
   end

--- a/lib/mydia/indexers/cardigann_download.ex
+++ b/lib/mydia/indexers/cardigann_download.ex
@@ -1,0 +1,338 @@
+defmodule Mydia.Indexers.CardigannDownload do
+  @moduledoc """
+  Resolves a Cardigann `download:` block into a concrete torrent input.
+
+  Public DHT crawlers rarely serve a `.torrent` at the link a search row
+  carries. The row points at a human-facing landing page, and the definition
+  describes how to derive the real download from it:
+
+    * `before` - a preliminary request, usually to a JSON metadata API, whose
+      response carries the data the selectors below need.
+    * `infohash` - `hash` and `title` selectors that pull a 40-hex infohash and
+      a name out of a response, from which a magnet is built. When
+      `usebeforeresponse` is set the selectors read the `before` response
+      rather than a fresh fetch of the landing page.
+
+  Without this step the grab path fetches the landing page directly and gets
+  HTML back, which is neither a torrent nor a magnet. Sites that build their
+  magnet in client-side JavaScript cannot be rescued by scraping the HTML,
+  because the link is never in the markup to begin with.
+  """
+
+  require Logger
+
+  alias Mydia.Downloads.TorrentHash
+  alias Mydia.Indexers.CardigannDefinition.Parsed
+  alias Mydia.Indexers.CardigannResultParser
+  alias Mydia.Indexers.CardigannSearchEngine
+  alias Mydia.Indexers.CardigannTemplate
+
+  @typedoc """
+  A resolved download. `:magnet` is ready to hand to a client as-is;
+  `:link` still needs to be fetched by the caller.
+  """
+  @type resolved :: {:magnet, String.t()} | {:link, String.t()}
+
+  # Cardigann definitions use `:root` to mean "the whole response". Jackett gets
+  # this for free by parsing every body as HTML and reading the document's text,
+  # which for a JSON body is the JSON itself. Matching that explicitly keeps
+  # JSON responses working without pretending they are markup.
+  @whole_document_selectors [":root", "", nil]
+
+  @doc """
+  Resolves `download_url` through the definition's `download:` block.
+
+  `user_config` is passed through to the HTTP layer for cookies, and matches
+  the shape `Mydia.Indexers.CardigannSearchEngine.execute_http_request/4`
+  expects.
+
+  Returns `:not_applicable` when the definition has no `download:` block, or has
+  one carrying neither a usable `infohash` nor any `selectors`, which lets the
+  caller fall back to fetching the link directly.
+  """
+  @spec resolve(Parsed.t(), String.t(), map()) ::
+          {:ok, resolved()} | {:error, term()} | :not_applicable
+  def resolve(definition, download_url, user_config \\ %{})
+
+  def resolve(%Parsed{download: download} = definition, download_url, user_config)
+      when is_map(download) do
+    variables = template_variables(download_url)
+    infohash = Map.get(download, :infohash)
+    selectors = Map.get(download, :selectors) || []
+
+    cond do
+      usable_infohash?(infohash) ->
+        with {:ok, before_response} <-
+               run_before(definition, Map.get(download, :before), variables, user_config) do
+          resolve_infohash(
+            definition,
+            infohash,
+            download_url,
+            before_response,
+            variables,
+            user_config
+          )
+        end
+
+      selectors != [] ->
+        with {:ok, before_response} <-
+               run_before(definition, Map.get(download, :before), variables, user_config) do
+          resolve_selectors(
+            definition,
+            selectors,
+            download_url,
+            before_response,
+            variables,
+            user_config
+          )
+        end
+
+      true ->
+        :not_applicable
+    end
+  end
+
+  def resolve(_definition, _download_url, _user_config), do: :not_applicable
+
+  defp usable_infohash?(%{hash: hash}) when is_map(hash), do: true
+  defp usable_infohash?(_), do: false
+
+  # -- before request ---------------------------------------------------------
+
+  defp run_before(_definition, nil, _variables, _user_config), do: {:ok, nil}
+
+  defp run_before(definition, before, variables, user_config) when is_map(before) do
+    with {:ok, base_url} <- base_url(definition),
+         {:ok, path} <- render(Map.get(before, :path, ""), variables),
+         {:ok, inputs} <- render_inputs(Map.get(before, :inputs) || %{}, variables) do
+      url = join_url(base_url, path)
+
+      params = %{
+        query_params: inputs,
+        headers: [],
+        method: http_method(Map.get(before, :method, "get")),
+        decode_body: false
+      }
+
+      Logger.debug("Cardigann download before-request: #{url} #{inspect(inputs)}")
+
+      CardigannSearchEngine.execute_http_request(definition, url, params, user_config)
+    end
+  end
+
+  # -- infohash ---------------------------------------------------------------
+
+  defp resolve_infohash(
+         definition,
+         infohash,
+         download_url,
+         before_response,
+         variables,
+         user_config
+       ) do
+    with {:ok, response} <-
+           infohash_source(definition, infohash, download_url, before_response, user_config),
+         {:ok, hash} <- match_selector(response, Map.get(infohash, :hash), variables, "hash"),
+         {:ok, title} <- match_title(response, Map.get(infohash, :title), variables) do
+      case TorrentHash.build_magnet(hash, title) do
+        nil ->
+          {:error, {:cardigann_download, "infohash #{inspect(hash)} did not form a valid magnet"}}
+
+        magnet ->
+          {:ok, {:magnet, magnet}}
+      end
+    end
+  end
+
+  # `usebeforeresponse` reuses the body already fetched by the before-request
+  # instead of spending a second round trip on the landing page.
+  defp infohash_source(_definition, %{usebeforeresponse: true}, _url, before_response, _config)
+       when is_map(before_response) do
+    {:ok, before_response}
+  end
+
+  defp infohash_source(definition, _infohash, download_url, _before_response, user_config) do
+    fetch(definition, download_url, user_config)
+  end
+
+  # A magnet without a display name is still valid, so a title that fails to
+  # match costs us nothing but a cosmetic label. Losing the hash is fatal;
+  # losing the name is not.
+  defp match_title(_response, nil, _variables), do: {:ok, nil}
+
+  defp match_title(response, selector, variables) do
+    case match_selector(response, selector, variables, "title") do
+      {:ok, title} -> {:ok, title}
+      {:error, _reason} -> {:ok, nil}
+    end
+  end
+
+  # -- selectors --------------------------------------------------------------
+
+  defp resolve_selectors(definition, selectors, download_url, before_response, variables, config) do
+    with {:ok, response} <- selector_source(definition, download_url, before_response, config) do
+      selectors
+      |> Enum.find_value(fn selector ->
+        case match_selector(response, selector, variables, "download link") do
+          {:ok, link} when is_binary(link) and link != "" -> link
+          _ -> nil
+        end
+      end)
+      |> case do
+        nil -> {:error, {:cardigann_download, "no download selector matched the response"}}
+        link -> {:ok, {:link, absolute_link(definition, download_url, link)}}
+      end
+    end
+  end
+
+  defp selector_source(_definition, _url, before_response, _config) when is_map(before_response),
+    do: {:ok, before_response}
+
+  defp selector_source(definition, download_url, _before_response, user_config),
+    do: fetch(definition, download_url, user_config)
+
+  # -- selector matching ------------------------------------------------------
+
+  defp match_selector(_response, nil, _variables, label) do
+    {:error, {:cardigann_download, "no #{label} selector configured"}}
+  end
+
+  defp match_selector(response, selector, variables, label) do
+    body = to_body(response)
+    filters = Map.get(selector, :filters) || []
+
+    with {:ok, selector_text} <- render(Map.get(selector, :selector), variables),
+         {:ok, raw} <- extract(body, selector_text, Map.get(selector, :attribute), label),
+         {:ok, value} <- CardigannResultParser.apply_filters(raw, filters, variables) do
+      case String.trim(value) do
+        "" -> {:error, {:cardigann_download, "#{label} selector matched an empty value"}}
+        trimmed -> {:ok, trimmed}
+      end
+    end
+  end
+
+  defp extract(body, selector_text, _attribute, _label)
+       when selector_text in @whole_document_selectors do
+    {:ok, body}
+  end
+
+  defp extract(body, selector_text, attribute, label) do
+    with {:ok, document} <- parse_document(body, label) do
+      case Floki.find(document, selector_text) do
+        [] ->
+          {:error, {:cardigann_download, "#{label} selector #{selector_text} matched nothing"}}
+
+        elements ->
+          {:ok, element_value(elements, attribute)}
+      end
+    end
+  end
+
+  defp element_value(elements, nil), do: elements |> Floki.text() |> String.trim()
+
+  defp element_value(elements, attribute) do
+    case Floki.attribute(elements, attribute) do
+      [value | _] -> String.trim(value)
+      [] -> ""
+    end
+  end
+
+  defp parse_document(body, label) do
+    case Floki.parse_document(body) do
+      {:ok, document} ->
+        {:ok, document}
+
+      {:error, reason} ->
+        {:error, {:cardigann_download, "could not parse #{label} response: #{inspect(reason)}"}}
+    end
+  end
+
+  # -- http -------------------------------------------------------------------
+
+  defp fetch(definition, url, user_config) do
+    params = %{query_params: %{}, headers: [], method: :get, decode_body: false}
+    CardigannSearchEngine.execute_http_request(definition, url, params, user_config)
+  end
+
+  defp to_body(%{body: body}), do: to_body(body)
+  defp to_body(body) when is_binary(body), do: body
+
+  # Belt and braces: we ask Req not to decode, but a decoded body must still
+  # yield text rather than silently matching nothing.
+  defp to_body(body) when is_map(body) or is_list(body) do
+    case Jason.encode(body) do
+      {:ok, json} -> json
+      {:error, _} -> ""
+    end
+  end
+
+  defp to_body(_), do: ""
+
+  defp http_method(method) when is_binary(method) do
+    if String.downcase(method) == "post", do: :post, else: :get
+  end
+
+  defp http_method(_), do: :get
+
+  # -- urls and templates -----------------------------------------------------
+
+  defp base_url(%Parsed{links: [link | _]}) when is_binary(link), do: {:ok, link}
+
+  defp base_url(%Parsed{id: id}),
+    do: {:error, {:cardigann_download, "definition #{id} has no site link"}}
+
+  defp join_url(base, path), do: base |> URI.merge(path) |> URI.to_string()
+
+  defp absolute_link(_definition, _download_url, "magnet:" <> _ = magnet), do: magnet
+
+  defp absolute_link(definition, download_url, link) do
+    base =
+      case base_url(definition) do
+        {:ok, site} -> site
+        {:error, _} -> download_url
+      end
+
+    base |> URI.merge(link) |> URI.to_string()
+  end
+
+  # Cardigann exposes the row's link to templates as `.DownloadUri`, which is
+  # how a `before` block derives its inputs from the landing page URL.
+  defp template_variables(download_url) do
+    uri = URI.parse(download_url)
+
+    %{
+      "DownloadUri" => %{
+        "AbsoluteUri" => download_url,
+        "AbsolutePath" => uri.path || "/",
+        "Scheme" => uri.scheme,
+        "Host" => uri.host,
+        "Query" => uri.query || "",
+        "PathAndQuery" => path_and_query(uri)
+      }
+    }
+  end
+
+  defp path_and_query(%URI{path: path, query: nil}), do: path || "/"
+  defp path_and_query(%URI{path: path, query: query}), do: "#{path || "/"}?#{query}"
+
+  defp render(nil, _variables), do: {:ok, ""}
+
+  defp render(template, variables) when is_binary(template) do
+    # Values land in query params and selectors, both of which are escaped
+    # downstream; encoding here would double-escape them.
+    CardigannTemplate.render(template, variables, url_encode: false)
+  end
+
+  defp render(value, _variables), do: {:ok, to_string(value)}
+
+  defp render_inputs(inputs, variables) when is_map(inputs) do
+    Enum.reduce_while(inputs, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+      case render(value, variables) do
+        {:ok, rendered} -> {:cont, {:ok, Map.put(acc, to_string(key), rendered)}}
+        {:error, reason} -> {:halt, {:error, {:cardigann_download, reason}}}
+      end
+    end)
+  end
+
+  defp render_inputs(_inputs, _variables), do: {:ok, %{}}
+end

--- a/lib/mydia/indexers/cardigann_parser.ex
+++ b/lib/mydia/indexers/cardigann_parser.ex
@@ -301,12 +301,46 @@ defmodule Mydia.Indexers.CardigannParser do
       download ->
         %{
           selectors: parse_download_selectors(download),
-          before: Map.get(download, "before"),
+          before: parse_download_before(download),
           method: Map.get(download, "method", "get"),
-          infohash: normalize_selector(Map.get(download, "infohash", ""))
+          infohash: parse_download_infohash(download)
         }
     end
   end
+
+  # `infohash` holds two nested selectors rather than being one itself, so
+  # running it through normalize_selector/1 silently drops `hash` and `title` -
+  # exactly the fields the grab path needs to build a magnet.
+  defp parse_download_infohash(download) do
+    case Map.get(download, "infohash") do
+      infohash when is_map(infohash) ->
+        %{
+          usebeforeresponse: Map.get(infohash, "usebeforeresponse", false) == true,
+          hash: parse_optional_selector(Map.get(infohash, "hash")),
+          title: parse_optional_selector(Map.get(infohash, "title"))
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_download_before(download) do
+    case Map.get(download, "before") do
+      before when is_map(before) ->
+        %{
+          path: Map.get(before, "path", ""),
+          method: Map.get(before, "method", "get"),
+          inputs: Map.get(before, "inputs", %{})
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_optional_selector(nil), do: nil
+  defp parse_optional_selector(selector), do: normalize_selector(selector)
 
   defp parse_download_selectors(download) do
     case Map.get(download, "selectors") do

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -672,6 +672,16 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
       retry: false
     ]
 
+    # Cardigann selectors run against the response *text*, so a caller working
+    # with raw selectors (the `download:` block) has to opt out of Req's
+    # automatic JSON decoding - otherwise a JSON content-type silently turns the
+    # body into a map and every selector matches nothing.
+    base_opts =
+      case Map.get(request_params, :decode_body) do
+        false -> Keyword.put(base_opts, :decode_body, false)
+        _ -> base_opts
+      end
+
     # Add query params for GET, body for POST
     opts_with_params =
       case request_params.method do

--- a/test/fixtures/cardigann/magnetdownload.yml
+++ b/test/fixtures/cardigann/magnetdownload.yml
@@ -1,0 +1,97 @@
+---
+id: magnetdownload
+name: MagnetDownload
+description: "MagnetDownload is a Public DHT Crawler"
+language: en-US
+type: public
+encoding: UTF-8
+links:
+  - https://www.magnetdownload.com/
+
+caps:
+  categorymappings:
+    - {id: Other, cat: Other, desc: Other}
+
+  modes:
+    search: [q]
+    tv-search: [q, season, ep]
+    movie-search: [q]
+    music-search: [q]
+    book-search: [q]
+
+settings:
+  - name: info_category_8000
+    type: info_category_8000
+
+download:
+  before:
+    path: api/json_info
+    inputs:
+      # /info/14152933
+      hashes: "{{ re_replace .DownloadUri.AbsolutePath \"/info/\" \"\" }}"
+  infohash:
+    usebeforeresponse: true
+    hash:
+      selector: :root
+      filters:
+        - name: regexp
+          args: ([A-F|a-f|0-9]{40})
+    title:
+      selector: :root
+      filters:
+        - name: regexp
+          args: name\". \"(.+?)\"
+        - name: validfilename
+
+search:
+  paths:
+    # https://www.magnetdownload.com/search/2025/
+    - path: "search/{{ if .Keywords }}{{ .Keywords }}{{ else }}{{ .Today.Year }}{{ end }}/"
+
+  rows:
+    selector: tr > td.x-item
+#    filters:
+#      - name: andmatch
+
+  fields:
+    category:
+      text: Other
+    title:
+      selector: a
+      attribute: title
+    details:
+      selector: a
+      attribute: href
+    download:
+      selector: a
+      attribute: href
+    date:
+      # 2 days, 5 hours
+      selector: span.ctime
+      filters:
+        - name: timeago
+    files:
+      selector: div.tail
+      filters:
+        - name: regexp
+          args: Files. (\d+)
+    size:
+      selector: div.tail
+      filters:
+        - name: regexp
+          args: size. (.+?)  T
+    grabs:
+      selector: div.tail
+      filters:
+        - name: regexp
+          args: requests. (\d+)
+    seeders:
+      text: 1
+    leechers:
+      text: 1
+    downloadvolumefactor:
+      text: 0
+    uploadvolumefactor:
+      text: 1
+# engine n/a
+

--- a/test/mydia/downloads/cardigann_download_grab_test.exs
+++ b/test/mydia/downloads/cardigann_download_grab_test.exs
@@ -1,0 +1,87 @@
+defmodule Mydia.Downloads.CardigannDownloadGrabTest do
+  @moduledoc """
+  The grab path must honour a Cardigann `download:` block.
+
+  Indexers like MagnetDownload publish a landing page as the row's download
+  link and build the magnet in client-side JavaScript, so fetching that link
+  yields HTML with no magnet anywhere in it. The definition says how to derive
+  the magnet instead; the grab path has to follow it.
+  """
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Downloads.Queue
+  alias Mydia.Indexers.CardigannDefinition
+  alias Mydia.Indexers.SearchResult
+  alias Mydia.Repo
+
+  @info_hash "d2e202a5d71ea60b26203f2a9003a1e569382096"
+  @title "Ted.Lasso.S04E02.1080p.10bit.WEBRip.6CH.x265.HEVC-PSA.mkv"
+
+  @json_info ~s({"result": [{"name": "#{@title}", "info_hash": "#{@info_hash}"}], "ret": 0})
+
+  # What the real site serves at /info/<id>: the magnet is assembled in JS from
+  # an XHR, so the markup contains no magnet link and no infohash.
+  @landing_page """
+  <html><head><title>#{@title}</title></head><body>
+  <script>var link1 = 'magnet:' + '?xt=urn' + ':btih:' + info.info_hash;</script>
+  </body></html>
+  """
+
+  defp store_definition!(port) do
+    yaml =
+      "test/fixtures/cardigann/magnetdownload.yml"
+      |> File.read!()
+      |> String.replace("https://www.magnetdownload.com/", "http://localhost:#{port}/")
+
+    %CardigannDefinition{}
+    |> CardigannDefinition.changeset(%{
+      indexer_id: "magnetdownload",
+      name: "MagnetDownload",
+      type: "public",
+      links: %{"main" => "http://localhost:#{port}/"},
+      capabilities: %{},
+      definition: yaml,
+      schema_version: "1",
+      enabled: true
+    })
+    |> Repo.insert!()
+  end
+
+  test "derives the magnet from the definition instead of fetching the landing page" do
+    test_pid = self()
+    bypass = Bypass.open()
+
+    Bypass.stub(bypass, "GET", "/api/json_info", fn conn ->
+      params = Plug.Conn.fetch_query_params(conn).query_params
+      send(test_pid, {:metadata_api_called, params})
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, @json_info)
+    end)
+
+    Bypass.stub(bypass, "GET", "/info/24845983", fn conn ->
+      send(test_pid, :landing_page_fetched)
+      Plug.Conn.resp(conn, 200, @landing_page)
+    end)
+
+    store_definition!(bypass.port)
+
+    search_result = %SearchResult{
+      title: @title,
+      indexer: "MagnetDownload",
+      download_url: "http://localhost:#{bypass.port}/info/24845983",
+      size: 576_012_298,
+      seeders: 1,
+      leechers: 1,
+      download_protocol: :torrent
+    }
+
+    # No download client is configured, so this fails at client selection - but
+    # only after the torrent input has been prepared, which is the step at test.
+    Queue.select_and_add_to_client(search_result, [])
+
+    assert_receive {:metadata_api_called, %{"hashes" => "24845983"}}, 2_000
+    refute_received :landing_page_fetched
+  end
+end

--- a/test/mydia/indexers/cardigann_download_resolution_test.exs
+++ b/test/mydia/indexers/cardigann_download_resolution_test.exs
@@ -1,0 +1,63 @@
+defmodule Mydia.Indexers.CardigannDownloadResolutionTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Indexers
+  alias Mydia.Indexers.CardigannDefinition
+  alias Mydia.Repo
+
+  @info_hash "d2e202a5d71ea60b26203f2a9003a1e569382096"
+  @title "Ted.Lasso.S04E02.1080p.10bit.WEBRip.6CH.x265.HEVC-PSA.mkv"
+
+  @json_info ~s({"result": [{"name": "#{@title}", "info_hash": "#{@info_hash}"}], "ret": 0})
+
+  defp store_definition!(port) do
+    yaml =
+      "test/fixtures/cardigann/magnetdownload.yml"
+      |> File.read!()
+      |> String.replace("https://www.magnetdownload.com/", "http://localhost:#{port}/")
+
+    %CardigannDefinition{}
+    |> CardigannDefinition.changeset(%{
+      indexer_id: "magnetdownload",
+      name: "MagnetDownload",
+      type: "public",
+      links: %{"main" => "http://localhost:#{port}/"},
+      capabilities: %{},
+      definition: yaml,
+      schema_version: "1",
+      enabled: true
+    })
+    |> Repo.insert!()
+  end
+
+  describe "resolve_cardigann_download/2" do
+    test "turns a stored definition's download block into a magnet" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/api/json_info", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, @json_info)
+      end)
+
+      store_definition!(bypass.port)
+
+      assert {:ok, {:magnet, magnet}} =
+               Indexers.resolve_cardigann_download(
+                 "MagnetDownload",
+                 "http://localhost:#{bypass.port}/info/24845983"
+               )
+
+      assert magnet =~ "xt=urn:btih:#{@info_hash}"
+    end
+
+    test "returns :not_applicable for an indexer with no stored definition" do
+      assert :not_applicable =
+               Indexers.resolve_cardigann_download("Nonexistent", "https://example.test/info/1")
+    end
+
+    test "returns :not_applicable when the indexer name is nil" do
+      assert :not_applicable = Indexers.resolve_cardigann_download(nil, "https://example.test/x")
+    end
+  end
+end

--- a/test/mydia/indexers/cardigann_download_test.exs
+++ b/test/mydia/indexers/cardigann_download_test.exs
@@ -46,11 +46,55 @@ defmodule Mydia.Indexers.CardigannDownloadTest do
         selector: td.seeds
   """
 
+  # Plenty of definitions (torrentgalaxyclone, 1337x, eztv, nyaasi) point their
+  # download selector straight at a magnet on the details page.
+  @magnet_selector_definition """
+  ---
+  id: magnetselectortest
+  name: Magnet Selector Test
+  description: "Points its download selector straight at a magnet"
+  language: en-US
+  type: public
+  encoding: UTF-8
+  links:
+    - https://magnetselector.example/
+
+  caps:
+    modes:
+      search: [q]
+
+  download:
+    selectors:
+      - selector: a[href^="magnet:?xt="]
+        attribute: href
+
+  search:
+    paths:
+      - path: search
+    rows:
+      selector: tr
+    fields:
+      title:
+        selector: a
+      size:
+        selector: td.size
+      seeders:
+        selector: td.seeds
+  """
+
   @landing_page """
   <html><body>
     <h1>#{@title}</h1>
     <a class="other" href="/info/1">details</a>
     <a class="download-link" href="/get/24845983.torrent">download</a>
+  </body></html>
+  """
+
+  @magnet_landing_page """
+  <html><body>
+    <h1>#{@title}</h1>
+    <a class="other" href="/info/1">details</a>
+    <a href="magnet:?xt=urn:btih:#{@info_hash}&amp;dn=Ted.Lasso">magnet</a>
   </body></html>
   """
 
@@ -65,6 +109,11 @@ defmodule Mydia.Indexers.CardigannDownloadTest do
 
   defp selector_definition(port) do
     {:ok, parsed} = CardigannParser.parse_definition(@selector_definition)
+    %{parsed | links: ["http://localhost:#{port}/"]}
+  end
+
+  defp magnet_selector_definition(port) do
+    {:ok, parsed} = CardigannParser.parse_definition(@magnet_selector_definition)
     %{parsed | links: ["http://localhost:#{port}/"]}
   end
 
@@ -184,6 +233,22 @@ defmodule Mydia.Indexers.CardigannDownloadTest do
 
       assert {:ok, {:link, link}} = CardigannDownload.resolve(definition, url)
       assert link == "http://localhost:#{bypass.port}/get/24845983.torrent"
+    end
+
+    # A magnet handed back as {:link, ...} would be fetched over HTTP by the
+    # grab path, which cannot speak the magnet scheme.
+    test "returns a magnet, not a link, when the selector points at one" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/info/24845983", fn conn ->
+        Plug.Conn.resp(conn, 200, @magnet_landing_page)
+      end)
+
+      definition = magnet_selector_definition(bypass.port)
+      url = "http://localhost:#{bypass.port}/info/24845983"
+
+      assert {:ok, {:magnet, magnet}} = CardigannDownload.resolve(definition, url)
+      assert magnet =~ "xt=urn:btih:#{@info_hash}"
     end
   end
 

--- a/test/mydia/indexers/cardigann_download_test.exs
+++ b/test/mydia/indexers/cardigann_download_test.exs
@@ -1,0 +1,206 @@
+defmodule Mydia.Indexers.CardigannDownloadTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Indexers.CardigannDefinition.Parsed
+  alias Mydia.Indexers.CardigannDownload
+  alias Mydia.Indexers.CardigannParser
+
+  @info_hash "d2e202a5d71ea60b26203f2a9003a1e569382096"
+  @title "Ted.Lasso.S04E02.1080p.10bit.WEBRip.6CH.x265.HEVC-PSA.mkv"
+
+  # Trimmed copy of a real www.magnetdownload.com /api/json_info response.
+  @json_info ~s({"result": [{"category": "video", "name": "#{@title}", ) <>
+               ~s("info_hash": "#{@info_hash}", "length": 576012298, "id": 24845983}], "ret": 0})
+
+  @selector_definition """
+  ---
+  id: selectortest
+  name: Selector Test
+  description: "Resolves its download link out of the landing page"
+  language: en-US
+  type: public
+  encoding: UTF-8
+  links:
+    - https://selector.example/
+
+  caps:
+    modes:
+      search: [q]
+
+  download:
+    selectors:
+      - selector: a.download-link
+        attribute: href
+
+  search:
+    paths:
+      - path: search
+    rows:
+      selector: tr
+    fields:
+      title:
+        selector: a
+      size:
+        selector: td.size
+      seeders:
+        selector: td.seeds
+  """
+
+  @landing_page """
+  <html><body>
+    <h1>#{@title}</h1>
+    <a class="other" href="/info/1">details</a>
+    <a class="download-link" href="/get/24845983.torrent">download</a>
+  </body></html>
+  """
+
+  defp magnetdownload_definition(port) do
+    {:ok, parsed} =
+      "test/fixtures/cardigann/magnetdownload.yml"
+      |> File.read!()
+      |> CardigannParser.parse_definition()
+
+    %{parsed | links: ["http://localhost:#{port}/"]}
+  end
+
+  defp selector_definition(port) do
+    {:ok, parsed} = CardigannParser.parse_definition(@selector_definition)
+    %{parsed | links: ["http://localhost:#{port}/"]}
+  end
+
+  # A definition whose infohash block reads the landing page directly rather
+  # than a before-response.
+  defp direct_infohash_definition(port) do
+    %Parsed{
+      id: "directhash",
+      name: "Direct Hash",
+      type: "public",
+      encoding: "UTF-8",
+      links: ["http://localhost:#{port}/"],
+      capabilities: %{modes: %{}},
+      search: %{paths: [%{path: "/search"}], rows: %{selector: "tr"}, fields: %{}},
+      download: %{
+        selectors: [],
+        before: nil,
+        method: "get",
+        infohash: %{
+          usebeforeresponse: false,
+          hash: %{selector: ":root", filters: [%{"name" => "regexp", "args" => "([a-f0-9]{40})"}]},
+          title: %{
+            selector: ":root",
+            filters: [%{"name" => "regexp", "args" => "<h1>(.+?)</h1>"}]
+          }
+        }
+      }
+    }
+  end
+
+  describe "resolve/3 with a before-request and an infohash block" do
+    test "builds a magnet from the hash in the before-response" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/api/json_info", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["hashes"] == "24845983"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, @json_info)
+      end)
+
+      definition = magnetdownload_definition(bypass.port)
+      url = "http://localhost:#{bypass.port}/info/24845983"
+
+      assert {:ok, {:magnet, magnet}} = CardigannDownload.resolve(definition, url)
+      assert magnet =~ "xt=urn:btih:#{@info_hash}"
+      assert magnet =~ "Ted.Lasso.S04E02"
+    end
+
+    test "returns an error when the hash selector matches nothing" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/api/json_info", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, ~s({"result": [], "ret": 1}))
+      end)
+
+      definition = magnetdownload_definition(bypass.port)
+      url = "http://localhost:#{bypass.port}/info/24845983"
+
+      assert {:error, {:cardigann_download, message}} =
+               CardigannDownload.resolve(definition, url)
+
+      assert message =~ "hash"
+    end
+
+    test "still builds a magnet when only the title selector fails to match" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/api/json_info", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, ~s({"info_hash": "#{@info_hash}", "ret": 0}))
+      end)
+
+      definition = magnetdownload_definition(bypass.port)
+      url = "http://localhost:#{bypass.port}/info/24845983"
+
+      assert {:ok, {:magnet, magnet}} = CardigannDownload.resolve(definition, url)
+      assert magnet =~ "xt=urn:btih:#{@info_hash}"
+    end
+  end
+
+  describe "resolve/3 with an infohash block that reads the landing page" do
+    test "fetches the download url when usebeforeresponse is not set" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/info/24845983", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          "<html><body><h1>#{@title}</h1><p>#{@info_hash}</p></body></html>"
+        )
+      end)
+
+      definition = direct_infohash_definition(bypass.port)
+      url = "http://localhost:#{bypass.port}/info/24845983"
+
+      assert {:ok, {:magnet, magnet}} = CardigannDownload.resolve(definition, url)
+      assert magnet =~ "xt=urn:btih:#{@info_hash}"
+    end
+  end
+
+  describe "resolve/3 with a selectors block" do
+    test "returns the link the selector points at, made absolute" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/info/24845983", fn conn ->
+        Plug.Conn.resp(conn, 200, @landing_page)
+      end)
+
+      definition = selector_definition(bypass.port)
+      url = "http://localhost:#{bypass.port}/info/24845983"
+
+      assert {:ok, {:link, link}} = CardigannDownload.resolve(definition, url)
+      assert link == "http://localhost:#{bypass.port}/get/24845983.torrent"
+    end
+  end
+
+  describe "resolve/3 when there is nothing to resolve" do
+    test "returns :not_applicable for a definition with no download block" do
+      definition = %Parsed{
+        id: "plain",
+        name: "Plain",
+        type: "public",
+        links: ["https://plain.example/"],
+        capabilities: %{modes: %{}},
+        search: %{paths: [%{path: "/search"}], rows: %{selector: "tr"}, fields: %{}},
+        download: nil
+      }
+
+      assert :not_applicable =
+               CardigannDownload.resolve(definition, "https://plain.example/info/1")
+    end
+  end
+end

--- a/test/mydia/indexers/cardigann_parser_test.exs
+++ b/test/mydia/indexers/cardigann_parser_test.exs
@@ -255,6 +255,28 @@ defmodule Mydia.Indexers.CardigannParserTest do
       assert is_map(parsed.download.infohash)
     end
 
+    test "preserves the nested selectors of an infohash block" do
+      assert {:ok, %Parsed{} = parsed} =
+               "test/fixtures/cardigann/magnetdownload.yml"
+               |> File.read!()
+               |> CardigannParser.parse_definition()
+
+      assert parsed.download.infohash.usebeforeresponse == true
+      assert parsed.download.infohash.hash.selector == ":root"
+      assert parsed.download.infohash.title.selector == ":root"
+      assert [%{"name" => "regexp"} | _] = parsed.download.infohash.hash.filters
+    end
+
+    test "parses the before-request of a download block" do
+      assert {:ok, %Parsed{} = parsed} =
+               "test/fixtures/cardigann/magnetdownload.yml"
+               |> File.read!()
+               |> CardigannParser.parse_definition()
+
+      assert parsed.download.before.path == "api/json_info"
+      assert parsed.download.before.inputs["hashes"] =~ "re_replace"
+    end
+
     test "parses indexer with settings" do
       assert {:ok, %Parsed{} = parsed} =
                CardigannParser.parse_definition(@indexer_with_settings)


### PR DESCRIPTION
## What broke

Grabbing from MagnetDownload fails in production. From the live instance on galactica:

```
22:25:46 queue.ex   Downloading file from URL: https://www.magnetdownload.com/info/24845983
22:25:49 queue.ex   Content preview: "<!DOCTYPE html>..."
22:25:49 queue.ex   [error] Downloaded body was not a recognised torrent/NZB/magnet, and no magnet link was found inside it
22:25:49 grabber.ex [warning] Grab failed for Ted.Lasso.S04E02.1080p...: {:download_failed, ...}
```

Search worked fine (3 rows parsed into 3 results). The grab is what failed.

## Root cause

The row's download link is a landing page, and the site builds its magnet in client-side JavaScript, splitting the scheme so no magnet literal ever appears in the served markup:

```js
if(navigator.userAgent.indexOf('bot')>-1) return; //prevent crawling apis
var url = '/api/json_info?hashes=' + '24845983';
$.getJSON(url, function(j){
    var link1 = 'magnet:' + '?xt=urn' + ':btih:' + info.info_hash;
```

So all three strategies in `extract_magnet_from_html/1` fail by construction: no `a[href^='magnet:']`, no `data-href`, and the regex finds nothing because the string does not exist in the source. There is no infohash on the page either.

The definition already describes how to derive the magnet:

```yaml
download:
  before:
    path: api/json_info
    inputs:
      hashes: "{{ re_replace .DownloadUri.AbsolutePath \"/info/\" \"\" }}"
  infohash:
    usebeforeresponse: true
    hash:  {selector: ':root', filters: [{name: regexp, args: '([A-F|a-f|0-9]{40})'}]}
    title: {selector: ':root', filters: [{name: regexp, args: 'name\". \"(.+?)\"'}]}
```

Nothing read it. `Parsed.download` was written by the parser and never consulted by any grab code, so `prepare_torrent_input/2` just fetched the row's link and choked on the HTML.

## Changes

- **Parse `download.infohash` as the container it is.** It was run through `normalize_selector/1`, which silently discarded its `hash` and `title` sub-selectors, so the fields the grab path needs never survived parsing.
- **Add `Mydia.Indexers.CardigannDownload`** to resolve a `download:` block into a magnet or a real link, covering `before`, `infohash` (including `usebeforeresponse`) and `selectors`.
- **Consult it from the grab path** via `Indexers.resolve_cardigann_download/2`. A definition with no block, or whose block fails, falls back to the direct fetch, so every other indexer behaves exactly as before.
- **Let a caller opt out of Req's JSON decoding.** Cardigann selectors run against response *text*; a JSON content-type otherwise turns the body into a map where every selector matches nothing. This one only showed up when validating against the live site, since a Bypass stub without a content-type returns a raw string and hides it.

## Verification

Resolved against the live site, using the same release that failed in production:

```
magnet:?xt=urn:btih:d2e202a5d71ea60b26203f2a9003a1e569382096&dn=Ted.Lasso.S04E02.1080p.10bit.WEBRip.6CH.x265.HEVC-PSA.mkv&tr=udp%3A%2F%2Ftracker.opentrackr.org%...
```

Full suite: 7018 tests, 0 failures. `mix format --check-formatted`, `mix credo --strict` and `mix compile --warnings-as-errors` all clean.

New coverage: the before+infohash path against the real definition, a landing-page infohash read, the selectors path, hash-miss and title-miss handling, the parser's nested infohash block, and an end-to-end grab test asserting the metadata API is consulted and the useless landing page is never fetched.

## Scope

92 definitions in the catalogue carry a `download:` block; all were ungrabbable to the extent they relied on it. Two are enabled on the galactica instance: `magnetdownload` and `bitsearch`.