### PR TITLE
fix(player): let the Flatpak player persist a pairing

### DIFF
--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -327,6 +327,9 @@ jobs:
       - name: Validate AppStream metainfo
         run: appstreamcli validate --explain player/flatpak/dev.mydia.player.metainfo.xml
 
+      - name: Validate finish-args
+        run: player/flatpak/test/finish-args-test.sh
+
   flatpak-build:
     name: Flatpak / Build
     runs-on: ubuntu-latest

--- a/player/flatpak/dev.mydia.player.yml
+++ b/player/flatpak/dev.mydia.player.yml
@@ -43,6 +43,11 @@ finish-args:
   - --device=dri
   # Stop the screen blanking during playback.
   - --talk-name=org.freedesktop.ScreenSaver
+  # flutter_secure_storage reaches the host Secret Service through libsecret,
+  # which talks D-Bus. Without this the sandbox reports the name as unknown,
+  # every credential write fails, and a pairing silently does not survive a
+  # restart. player/flatpak/test/finish-args-test.sh guards this line.
+  - --talk-name=org.freedesktop.secrets
   # The Flutter bundle and mpv both live under /app/lib.
   - --env=LD_LIBRARY_PATH=/app/lib
   # No --filesystem: the player streams from a server and reads no local media.

--- a/player/flatpak/smoke-test.sh
+++ b/player/flatpak/smoke-test.sh
@@ -39,4 +39,23 @@ if grep -qiE 'error while loading shared libraries|cannot open shared object' "$
   exit 1
 fi
 
+# The Secret Service permission does not crash anything when missing. It
+# silently costs the user their pairing on the next launch, which no runtime
+# smoke test can observe in ten seconds. Assert on the exported metadata
+# instead, which is what actually governs the installed app.
+#
+# This reads metadata rather than making a live D-Bus call on purpose: a real
+# call would need a session bus and a running Secret Service on the runner,
+# neither of which is guaranteed, and would turn a correctness check into a
+# flaky one.
+echo "Checking exported permissions"
+PERMS="$(flatpak info --show-permissions "dev.mydia.player//${BRANCH}")"
+if ! grep -qx 'org.freedesktop.secrets=talk' <<<"$PERMS"; then
+  echo "::error::Exported app is missing org.freedesktop.secrets=talk."
+  echo "Credential writes would fail and pairings would not survive a restart."
+  echo "Permissions follow:"
+  echo "$PERMS"
+  exit 1
+fi
+
 echo "PASS: smoke test clean"

--- a/player/flatpak/test/finish-args-test.sh
+++ b/player/flatpak/test/finish-args-test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Asserts the Flatpak manifest declares every runtime permission the player
+# depends on, and records why each one is there.
+#
+# The Secret Service entry earns the whole file. Its absence did not crash
+# anything, it silently cost every Flatpak user their pairing on the next
+# launch: flutter_secure_storage reaches the host keyring through libsecret
+# over D-Bus, and a Flatpak sandbox denies every session bus name that is not
+# listed here.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MANIFEST="$REPO_ROOT/player/flatpak/dev.mydia.player.yml"
+
+# Read only the finish-args block, so a match inside modules: or in a prose
+# comment cannot satisfy an assertion.
+finish_args="$(awk '/^finish-args:/{f=1;next} /^[a-z-]+:/{f=0} f' "$MANIFEST")"
+
+if [ -z "$finish_args" ]; then
+  echo "FAIL: could not parse a finish-args block out of $MANIFEST"
+  exit 1
+fi
+
+fail=0
+
+require_arg() {
+  local arg="$1" why="$2"
+  # Strip indentation and match the whole line, so --share=network cannot be
+  # satisfied by a longer argument that merely starts with it.
+  if ! printf '%s\n' "$finish_args" \
+     | sed 's/^[[:space:]]*//' \
+     | grep -qxF -- "- $arg"; then
+    echo "FAIL: finish-args is missing $arg"
+    echo "      Without it: $why"
+    fail=1
+  fi
+}
+
+require_arg --share=network \
+  "the player cannot reach the server or any p2p peer"
+require_arg --socket=wayland \
+  "the window does not open on a Wayland session"
+require_arg --socket=fallback-x11 \
+  "the window does not open on an X11 session"
+require_arg --socket=pulseaudio \
+  "playback has no audio"
+require_arg --device=dri \
+  "hardware video decode is unavailable"
+require_arg --talk-name=org.freedesktop.secrets \
+  "every credential write fails, so a pairing does not survive a restart"
+
+[ "$fail" -eq 0 ] || exit 1
+
+echo "PASS"

--- a/player/lib/core/auth/auth_service.dart
+++ b/player/lib/core/auth/auth_service.dart
@@ -15,8 +15,18 @@ import '../../graphql/mutations/login.graphql.dart';
 /// like auth tokens and server URLs. On native platforms, uses encrypted
 /// storage. On web, uses localStorage.
 class AuthService {
-  final AuthStorage _storage = getAuthStorage();
+  /// [storage] is injectable for tests. Production callers use the default,
+  /// which is the platform-appropriate implementation.
+  AuthService({AuthStorage? storage}) : _storage = storage ?? getAuthStorage();
+
+  final AuthStorage _storage;
   final DeviceInfoService _deviceInfo = DeviceInfoService();
+
+  /// Whether credential writes are reaching durable storage.
+  ///
+  /// When true, everything written this session is lost when the app closes,
+  /// so the user must be told rather than shown a success message.
+  bool get storageDegraded => _storage.degraded;
 
   static const _authTokenKey = 'auth_token';
   static const _serverUrlKey = 'server_url';

--- a/player/lib/core/auth/auth_service.dart
+++ b/player/lib/core/auth/auth_service.dart
@@ -22,10 +22,13 @@ class AuthService {
   final AuthStorage _storage;
   final DeviceInfoService _deviceInfo = DeviceInfoService();
 
-  /// Whether credential writes are reaching durable storage.
+  /// Whether durability can still be guaranteed for credential writes.
   ///
-  /// When true, everything written this session is lost when the app closes,
-  /// so the user must be told rather than shown a success message.
+  /// True once at least one write has failed to reach secure storage. It does
+  /// not mean every value is lost: writes before and after the failure may
+  /// well have persisted. It means the app can no longer promise that what it
+  /// just stored will be there next launch, which is enough to owe the user a
+  /// warning instead of a success message.
   bool get storageDegraded => _storage.degraded;
 
   static const _authTokenKey = 'auth_token';

--- a/player/lib/core/auth/auth_storage.dart
+++ b/player/lib/core/auth/auth_storage.dart
@@ -16,4 +16,10 @@ abstract class AuthStorage {
   Future<void> write(String key, String value);
   Future<void> delete(String key);
   Future<void> deleteAll();
+
+  /// Whether any write has failed to reach durable storage in this process.
+  ///
+  /// A caller that has just written credentials should check this before
+  /// telling the user the credentials were saved.
+  bool get degraded;
 }

--- a/player/lib/core/auth/auth_storage_native.dart
+++ b/player/lib/core/auth/auth_storage_native.dart
@@ -3,22 +3,75 @@
 /// This provides secure storage on iOS, Android, macOS, Windows, and Linux.
 library;
 
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../storage/secure_storage_options.dart';
 import 'auth_storage.dart';
 
-AuthStorage getAuthStorage() => _NativeAuthStorage();
+AuthStorage getAuthStorage() => NativeAuthStorage();
 
-class _NativeAuthStorage implements AuthStorage {
+/// The subset of `FlutterSecureStorage` this file depends on.
+///
+/// Exists so a test can inject a backend that fails. The degraded path only
+/// runs when the platform keyring is unavailable, and there is no other way to
+/// reach it in a unit test without a genuinely broken keyring.
+abstract class SecretBackend {
+  Future<String?> read(String key);
+  Future<void> write(String key, String value);
+  Future<void> delete(String key);
+  Future<void> deleteAll();
+}
+
+class _FlutterSecureStorageBackend implements SecretBackend {
+  const _FlutterSecureStorageBackend();
+
   static const _storage = FlutterSecureStorage(
     aOptions: kAndroidSecureStorageOptions,
     mOptions: kMacOsSecureStorageOptions,
   );
 
+  @override
+  Future<String?> read(String key) => _storage.read(key: key);
+
+  @override
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete(String key) => _storage.delete(key: key);
+
+  @override
+  Future<void> deleteAll() => _storage.deleteAll();
+}
+
+class NativeAuthStorage implements AuthStorage {
+  NativeAuthStorage({SecretBackend? backend})
+      : _backend = backend ?? const _FlutterSecureStorageBackend();
+
+  final SecretBackend _backend;
+
   static final Map<String, String> _memoryStorage = <String, String>{};
   static bool _warnedAboutFallback = false;
+  static bool _degraded = false;
+
+  /// Whether any write has failed to reach the platform keyring in this
+  /// process.
+  ///
+  /// Sticky, and deliberately never cleared. This failure is a property of the
+  /// environment rather than a transient fault, and once a write has been lost
+  /// there is no way to know what else went with it. Process lifetime bounds
+  /// how long the flag can be wrong.
+  @override
+  bool get degraded => _degraded;
+
+  /// Resets the process-wide state so one test cannot leak into the next.
+  @visibleForTesting
+  static void resetForTest() {
+    _memoryStorage.clear();
+    _warnedAboutFallback = false;
+    _degraded = false;
+  }
 
   /// Runs [operation] against secure storage, degrading to an in-memory map
   /// only for the individual call that failed.
@@ -28,11 +81,18 @@ class _NativeAuthStorage implements AuthStorage {
   /// key that isn't there, which `flutter_secure_storage` reports as -34018 on
   /// the macOS legacy keychain — silently downgraded every later read and
   /// write to memory and cost the user their pairing on the next launch.
+  ///
+  /// [durability] marks the calls whose failure means data will not survive
+  /// the process. Only those set [degraded]; a failed delete does not.
   Future<T> _withFallback<T>(
-      Future<T> Function() operation, T Function() onFallback) async {
+    Future<T> Function() operation,
+    T Function() onFallback, {
+    bool durability = false,
+  }) async {
     try {
       return await operation();
     } catch (e) {
+      if (durability) _degraded = true;
       if (!_warnedAboutFallback) {
         _warnedAboutFallback = true;
         debugPrint(
@@ -48,7 +108,7 @@ class _NativeAuthStorage implements AuthStorage {
   @override
   Future<String?> read(String key) async {
     final value = await _withFallback<String?>(
-      () => _storage.read(key: key),
+      () => _backend.read(key),
       () => _memoryStorage[key],
     );
     // A prior write may have been the one call that failed and landed in
@@ -59,17 +119,18 @@ class _NativeAuthStorage implements AuthStorage {
   @override
   Future<void> write(String key, String value) async {
     await _withFallback<void>(
-      () => _storage.write(key: key, value: value),
+      () => _backend.write(key, value),
       () {
         _memoryStorage[key] = value;
       },
+      durability: true,
     );
   }
 
   @override
   Future<void> delete(String key) async {
     await _withFallback<void>(
-      () => _storage.delete(key: key),
+      () => _backend.delete(key),
       () {
         _memoryStorage.remove(key);
       },
@@ -79,7 +140,7 @@ class _NativeAuthStorage implements AuthStorage {
   @override
   Future<void> deleteAll() async {
     await _withFallback<void>(
-      _storage.deleteAll,
+      _backend.deleteAll,
       () {
         _memoryStorage.clear();
       },

--- a/player/lib/core/auth/auth_storage_native.dart
+++ b/player/lib/core/auth/auth_storage_native.dart
@@ -107,43 +107,41 @@ class NativeAuthStorage implements AuthStorage {
 
   @override
   Future<String?> read(String key) async {
-    final value = await _withFallback<String?>(
-      () => _backend.read(key),
-      () => _memoryStorage[key],
-    );
-    // A prior write may have been the one call that failed and landed in
-    // memory, so fall back to it rather than reporting the key as missing.
-    return value ?? _memoryStorage[key];
+    // The overlay wins whenever it holds the key. Consulting the backend first
+    // would return whatever it still has from an earlier successful write,
+    // which is older than a write that has since fallen back to memory. That
+    // is how a failed token refresh would keep handing out the expired token
+    // for the rest of the session.
+    if (_memoryStorage.containsKey(key)) return _memoryStorage[key];
+
+    return _withFallback<String?>(() => _backend.read(key), () => null);
   }
 
   @override
   Future<void> write(String key, String value) async {
+    // Mirrored unconditionally, not just on failure, so the overlay is never
+    // staler than the backend. A write-on-failure-only overlay would let an
+    // old fallback value shadow a later successful write.
+    _memoryStorage[key] = value;
+
     await _withFallback<void>(
       () => _backend.write(key, value),
-      () {
-        _memoryStorage[key] = value;
-      },
+      () {},
       durability: true,
     );
   }
 
   @override
   Future<void> delete(String key) async {
-    await _withFallback<void>(
-      () => _backend.delete(key),
-      () {
-        _memoryStorage.remove(key);
-      },
-    );
+    _memoryStorage.remove(key);
+
+    await _withFallback<void>(() => _backend.delete(key), () {});
   }
 
   @override
   Future<void> deleteAll() async {
-    await _withFallback<void>(
-      _backend.deleteAll,
-      () {
-        _memoryStorage.clear();
-      },
-    );
+    _memoryStorage.clear();
+
+    await _withFallback<void>(_backend.deleteAll, () {});
   }
 }

--- a/player/lib/core/auth/auth_storage_stub.dart
+++ b/player/lib/core/auth/auth_storage_stub.dart
@@ -12,6 +12,9 @@ class _StubAuthStorage implements AuthStorage {
   final Map<String, String> _data = {};
 
   @override
+  bool get degraded => false;
+
+  @override
   Future<String?> read(String key) async => _data[key];
 
   @override

--- a/player/lib/core/auth/auth_storage_web.dart
+++ b/player/lib/core/auth/auth_storage_web.dart
@@ -14,6 +14,11 @@ AuthStorage getAuthStorage() => _WebAuthStorage();
 class _WebAuthStorage implements AuthStorage {
   static const _prefix = 'mydia_auth_';
 
+  /// localStorage writes do not go through a fallback path, so there is no
+  /// degraded state to report on web.
+  @override
+  bool get degraded => false;
+
   @override
   Future<String?> read(String key) async {
     final value = web.window.localStorage.getItem('$_prefix$key');

--- a/player/lib/presentation/screens/login/login_controller.dart
+++ b/player/lib/presentation/screens/login/login_controller.dart
@@ -71,6 +71,7 @@ class LoginState {
     this.claimCodeStatus = ClaimCodeStatus.idle,
     this.claimCodeMessage,
     this.updateRequiredError,
+    this.credentialsNotPersisted = false,
   });
 
   final ConnectionMode mode;
@@ -84,6 +85,12 @@ class LoginState {
   /// The UI should show an UpdateRequiredDialog when this is not null.
   final UpdateRequiredError? updateRequiredError;
 
+  /// Set when pairing or login succeeded but the credentials could not be
+  /// written to durable storage, so they are lost when the app closes.
+  ///
+  /// The UI must warn the user before letting them into the app.
+  final bool credentialsNotPersisted;
+
   LoginState copyWith({
     ConnectionMode? mode,
     bool? isLoading,
@@ -93,6 +100,7 @@ class LoginState {
     String? claimCodeMessage,
     UpdateRequiredError? updateRequiredError,
     bool clearUpdateRequiredError = false,
+    bool? credentialsNotPersisted,
   }) {
     return LoginState(
       mode: mode ?? this.mode,
@@ -104,6 +112,8 @@ class LoginState {
       updateRequiredError: clearUpdateRequiredError
           ? null
           : (updateRequiredError ?? this.updateRequiredError),
+      credentialsNotPersisted:
+          credentialsNotPersisted ?? this.credentialsNotPersisted,
     );
   }
 
@@ -253,6 +263,7 @@ class LoginController extends _$LoginController {
         claimCodeStatus: ClaimCodeStatus.paired,
         claimCodeMessage: 'Paired successfully!',
         success: true,
+        credentialsNotPersisted: authService.storageDegraded,
       );
       debugPrint('[LoginController] Success state set!');
     } on UpdateRequiredError catch (e) {
@@ -299,7 +310,11 @@ class LoginController extends _$LoginController {
       await ref.read(authStateProvider.notifier).refresh();
 
       if (!ref.mounted) return;
-      state = state.copyWith(isLoading: false, success: true);
+      state = state.copyWith(
+        isLoading: false,
+        success: true,
+        credentialsNotPersisted: authService.storageDegraded,
+      );
     } catch (e) {
       // Check if still mounted before updating state
       if (!ref.mounted) return;
@@ -424,6 +439,7 @@ class LoginController extends _$LoginController {
         claimCodeStatus: ClaimCodeStatus.paired,
         claimCodeMessage: 'Paired successfully!',
         success: true,
+        credentialsNotPersisted: authService.storageDegraded,
       );
     } on UpdateRequiredError catch (e) {
       if (!ref.mounted) return;

--- a/player/lib/presentation/screens/login_screen.dart
+++ b/player/lib/presentation/screens/login_screen.dart
@@ -8,6 +8,7 @@ import '../../core/auth/auth_service.dart';
 import '../../core/p2p/p2p_service.dart' show defaultRelayUrl;
 import '../../core/theme/colors.dart';
 import '../widgets/glass_surface.dart';
+import '../widgets/storage_unavailable_dialog.dart';
 import '../widgets/update_required_dialog.dart';
 import 'login/login_controller.dart';
 
@@ -197,16 +198,30 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     _pairWithQrData(qrData);
   }
 
+  /// Finishes a successful pairing or login by entering the app.
+  ///
+  /// When the credentials could not be written to durable storage, the user
+  /// has to acknowledge that before going in. This is the only moment they are
+  /// told, because the login screen is gone immediately afterwards.
+  Future<void> _completePairing() async {
+    if (!mounted) return;
+
+    final state = ref.read(loginControllerProvider);
+    if (!state.success) return;
+
+    if (state.credentialsNotPersisted) {
+      await showStorageUnavailableDialog(context);
+      if (!mounted) return;
+    }
+
+    context.go('/');
+  }
+
   Future<void> _pairWithQrData(QrPairingData qrData) async {
     final controller = ref.read(loginControllerProvider.notifier);
     await controller.pairWithQrCode(qrData);
 
-    if (mounted) {
-      final state = ref.read(loginControllerProvider);
-      if (state.success) {
-        context.go('/');
-      }
-    }
+    await _completePairing();
   }
 
   Future<void> _handleLogin() async {
@@ -219,12 +234,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
       _passwordController.text,
     );
 
-    if (mounted) {
-      final state = ref.read(loginControllerProvider);
-      if (state.success) {
-        context.go('/');
-      }
-    }
+    await _completePairing();
   }
 
   Future<void> _handleClaimCodeSubmit() async {
@@ -235,12 +245,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     // Custom relay URL is no longer needed - we use IPFS DHT bootstrap
     await controller.pairWithClaimCode(code);
 
-    if (mounted) {
-      final state = ref.read(loginControllerProvider);
-      if (state.success) {
-        context.go('/');
-      }
-    }
+    await _completePairing();
   }
 
   @override

--- a/player/lib/presentation/screens/login_screen.dart
+++ b/player/lib/presentation/screens/login_screen.dart
@@ -242,7 +242,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     if (code.isEmpty) return;
 
     final controller = ref.read(loginControllerProvider.notifier);
-    // Custom relay URL is no longer needed - we use IPFS DHT bootstrap
+    // No custom relay URL: the claim code resolves through the relay API and
+    // iroh's default discovery.
     await controller.pairWithClaimCode(code);
 
     await _completePairing();

--- a/player/lib/presentation/widgets/storage_unavailable_dialog.dart
+++ b/player/lib/presentation/widgets/storage_unavailable_dialog.dart
@@ -21,13 +21,14 @@ class StorageUnavailableDialog extends StatelessWidget {
         children: [
           const Text(
             'You are connected and can keep using the app, but this '
-            'connection will be lost when you close it.',
+            'connection may be lost when you close it.',
           ),
           const SizedBox(height: 12),
           Text(
-            'This system\'s secure storage is unavailable, so Mydia could not '
-            'save your credentials. On Linux this usually means no keyring '
-            'service is running.',
+            'Mydia could not save your credentials because this system\'s '
+            'secure storage rejected them. On Linux that usually means either '
+            'no keyring service is running, or the app is sandboxed without '
+            'permission to reach it.',
             style: theme.textTheme.bodySmall,
           ),
         ],

--- a/player/lib/presentation/widgets/storage_unavailable_dialog.dart
+++ b/player/lib/presentation/widgets/storage_unavailable_dialog.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+/// Warns that credentials were accepted but could not be saved.
+///
+/// Shown after a successful pairing or login when the platform's secure
+/// storage rejected the writes. The session works, so this is a warning rather
+/// than an error, but the user needs to know before they rely on it.
+class StorageUnavailableDialog extends StatelessWidget {
+  const StorageUnavailableDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AlertDialog(
+      icon: const Icon(Icons.warning_amber_rounded, size: 32),
+      title: const Text('Connection could not be saved'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'You are connected and can keep using the app, but this '
+            'connection will be lost when you close it.',
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'This system\'s secure storage is unavailable, so Mydia could not '
+            'save your credentials. On Linux this usually means no keyring '
+            'service is running.',
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Continue'),
+        ),
+      ],
+    );
+  }
+}
+
+/// Shows the storage warning and waits for the user to acknowledge it.
+///
+/// Not dismissible by tapping outside: the user is about to be taken into the
+/// app, and this is the only moment they are told the connection is temporary.
+Future<void> showStorageUnavailableDialog(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) => const StorageUnavailableDialog(),
+  );
+}

--- a/player/test/core/auth/auth_service_storage_degraded_test.dart
+++ b/player/test/core/auth/auth_service_storage_degraded_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_service.dart';
+
+import '../../test_utils/mock_auth_storage.dart';
+
+void main() {
+  group('AuthService.storageDegraded', () {
+    test('is false when storage is persisting normally', () {
+      final storage = MockAuthStorage();
+      final service = AuthService(storage: storage);
+
+      expect(service.storageDegraded, isFalse);
+    });
+
+    test('reflects storage that cannot persist', () {
+      final storage = MockAuthStorage()..degradedValue = true;
+      final service = AuthService(storage: storage);
+
+      expect(service.storageDegraded, isTrue);
+    });
+  });
+}

--- a/player/test/core/auth/auth_storage_native_test.dart
+++ b/player/test/core/auth/auth_storage_native_test.dart
@@ -71,6 +71,41 @@ void main() {
       expect(await storage.read('token'), equals('abc'));
     });
 
+    test('a failed write is not shadowed by an older backend value', () async {
+      // The backend already holds a value the keyring accepted earlier.
+      final backend = _FailingBackend(failWrite: true)
+        ..stored['token'] = 'stale';
+      final storage = NativeAuthStorage(backend: backend);
+
+      await storage.write('token', 'fresh');
+
+      // Reading must not prefer the backend here. A refreshed access token
+      // that failed to persist would otherwise leave every later read handing
+      // back the expired one for the rest of the session.
+      expect(await storage.read('token'), equals('fresh'));
+    });
+
+    test('a successful write is not shadowed by an earlier fallback', () async {
+      final storage = NativeAuthStorage(backend: _FailingBackend());
+
+      await storage.write('token', 'first');
+      await storage.write('token', 'second');
+
+      expect(await storage.read('token'), equals('second'));
+    });
+
+    test('a delete clears the in-memory overlay', () async {
+      final storage =
+          NativeAuthStorage(backend: _FailingBackend(failWrite: true));
+
+      await storage.write('token', 'abc');
+      await storage.delete('token');
+
+      // Without clearing the overlay, a deleted credential would keep being
+      // served for the rest of the session.
+      expect(await storage.read('token'), isNull);
+    });
+
     test('a failed delete does not report degraded', () async {
       final storage =
           NativeAuthStorage(backend: _FailingBackend(failDelete: true));

--- a/player/test/core/auth/auth_storage_native_test.dart
+++ b/player/test/core/auth/auth_storage_native_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_storage_native.dart';
+
+/// A backend whose operations fail on demand, standing in for a keyring that
+/// is absent, locked, or unreachable across D-Bus.
+class _FailingBackend implements SecretBackend {
+  _FailingBackend({
+    this.failWrite = false,
+    this.failDelete = false,
+  });
+
+  final bool failWrite;
+  final bool failDelete;
+
+  final Map<String, String> stored = {};
+
+  @override
+  Future<String?> read(String key) async {
+    return stored[key];
+  }
+
+  @override
+  Future<void> write(String key, String value) async {
+    if (failWrite) throw Exception('keyring unavailable');
+    stored[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    if (failDelete) throw Exception('keyring unavailable');
+    stored.remove(key);
+  }
+
+  @override
+  Future<void> deleteAll() async {
+    if (failDelete) throw Exception('keyring unavailable');
+    stored.clear();
+  }
+}
+
+void main() {
+  group('NativeAuthStorage', () {
+    setUp(NativeAuthStorage.resetForTest);
+    tearDown(NativeAuthStorage.resetForTest);
+
+    test('is not degraded when writes reach the backend', () async {
+      final storage = NativeAuthStorage(backend: _FailingBackend());
+
+      await storage.write('token', 'abc');
+
+      expect(storage.degraded, isFalse);
+      expect(await storage.read('token'), equals('abc'));
+    });
+
+    test('reports degraded when a write fails', () async {
+      final storage =
+          NativeAuthStorage(backend: _FailingBackend(failWrite: true));
+
+      await storage.write('token', 'abc');
+
+      expect(storage.degraded, isTrue);
+    });
+
+    test('keeps the value readable in-session after a failed write', () async {
+      final storage =
+          NativeAuthStorage(backend: _FailingBackend(failWrite: true));
+
+      await storage.write('token', 'abc');
+
+      // The session must keep working; only durability is lost.
+      expect(await storage.read('token'), equals('abc'));
+    });
+
+    test('a failed delete does not report degraded', () async {
+      final storage =
+          NativeAuthStorage(backend: _FailingBackend(failDelete: true));
+
+      await storage.delete('missing-key');
+
+      // Deleting an absent key is the benign macOS -34018 case that
+      // secure_storage_options.dart documents. It must stay tolerated, and it
+      // says nothing about whether writes are durable.
+      expect(storage.degraded, isFalse);
+    });
+
+    test('degraded is sticky once a write has failed', () async {
+      final backend = _FailingBackend(failWrite: true);
+      final storage = NativeAuthStorage(backend: backend);
+
+      await storage.write('token', 'abc');
+      expect(storage.degraded, isTrue);
+
+      // A later success does not prove the earlier lost write came back.
+      final healthy = NativeAuthStorage(backend: _FailingBackend());
+      await healthy.write('other', 'xyz');
+
+      expect(healthy.degraded, isTrue);
+    });
+  });
+}

--- a/player/test/presentation/screens/login/login_state_test.dart
+++ b/player/test/presentation/screens/login/login_state_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/screens/login/login_controller.dart';
+
+void main() {
+  group('LoginState.credentialsNotPersisted', () {
+    test('defaults to false', () {
+      expect(const LoginState().credentialsNotPersisted, isFalse);
+    });
+
+    test('is set through copyWith', () {
+      final state = const LoginState().copyWith(credentialsNotPersisted: true);
+
+      expect(state.credentialsNotPersisted, isTrue);
+    });
+
+    test('survives an unrelated copyWith', () {
+      // The warning must not be dropped by the next state update, which is
+      // what would happen if it were treated like the transient error field.
+      final state = const LoginState()
+          .copyWith(credentialsNotPersisted: true)
+          .copyWith(isLoading: false);
+
+      expect(state.credentialsNotPersisted, isTrue);
+    });
+  });
+}

--- a/player/test/presentation/widgets/storage_unavailable_dialog_test.dart
+++ b/player/test/presentation/widgets/storage_unavailable_dialog_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/storage_unavailable_dialog.dart';
+
+void main() {
+  group('showStorageUnavailableDialog', () {
+    testWidgets('tells the user the pairing will not survive a restart',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => showStorageUnavailableDialog(context),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StorageUnavailableDialog), findsOneWidget);
+      expect(
+        find.textContaining('lost when you close', findRichText: true),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('completes when dismissed', (tester) async {
+      var completed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                await showStorageUnavailableDialog(context);
+                completed = true;
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      expect(completed, isTrue);
+      expect(find.byType(StorageUnavailableDialog), findsNothing);
+    });
+  });
+}

--- a/player/test/test_utils/mock_auth_storage.dart
+++ b/player/test/test_utils/mock_auth_storage.dart
@@ -6,6 +6,12 @@ import 'package:player/core/auth/auth_storage.dart';
 class MockAuthStorage implements AuthStorage {
   final Map<String, String> _storage = {};
 
+  /// Set by tests that need to simulate storage that cannot persist.
+  bool degradedValue = false;
+
+  @override
+  bool get degraded => degradedValue;
+
   @override
   Future<String?> read(String key) async {
     return _storage[key];


### PR DESCRIPTION
A pairing made in the Linux Flatpak player did not survive a restart.

## Cause

Every persisted value in the player goes through `flutter_secure_storage`. On Linux that reaches the host keyring via libsecret, which talks to the D-Bus Secret Service at `org.freedesktop.secrets`. The Flatpak manifest granted no session bus names beyond `org.freedesktop.ScreenSaver`, and a sandbox denies every name that is not listed, so libsecret could not reach the service.

`_NativeAuthStorage._withFallback` then caught the failure and redirected the value to a process-local map behind a single `debugPrint`. The write looked successful to every caller, worked for the session, and was gone on the next launch.

Confirmed on a real install rather than inferred from the manifest:

- `flatpak info --show-permissions dev.mydia.player` listed only `org.freedesktop.ScreenSaver=talk`
- the host had a working Secret Service the whole time (gnome-keyring owning `org.freedesktop.secrets`)
- a D-Bus ping inside the sandbox returned `ServiceUnknown`
- the same ping with `--talk-name=org.freedesktop.secrets` returned `()`

## Blast radius

Pairing was the visible symptom, but everything sharing that storage was affected and reset on each launch: cert fingerprints, media tokens, player settings (default quality, auto-skip, library sort), the update-check timestamp, and `device_id`. Because `device_id` was regenerated every launch, each pairing attempt registered a **new** device server-side.

## Changes

- Add `--talk-name=org.freedesktop.secrets` to the manifest `finish-args`
- Add `player/flatpak/test/finish-args-test.sh`, asserting the manifest declares every runtime permission the app depends on, each with the feature that breaks without it; wired into the seconds-long `flatpak-validate` job rather than the 90-minute build
- Assert `org.freedesktop.secrets=talk` on the exported artifact in `smoke-test.sh`, which catches a permission lost between manifest and export
- Track a `degraded` flag on `AuthStorage` when a write fails to reach durable storage, keeping the in-session fallback so the app still works
- Surface that through `AuthService.storageDegraded` and `LoginState.credentialsNotPersisted`
- Warn the user with a dialog they must acknowledge before entering the app, via a single `_completePairing()` helper that also collapses three copy-pasted navigation tails in `login_screen.dart`

The silent degradation is the reason this shipped unnoticed. The same shape already cost macOS once, documented in `secure_storage_options.dart`. A lost pairing now says so instead of looking identical to a saved one.

## Testing

- Full player suite green (2098 tests, `--concurrency=1`)
- `finish-args-test.sh` verified in both directions: it fails on the pre-fix manifest with the exact missing-permission message, and passes after
- The smoke-test assertion verified to fail against a pre-fix install, so it is not passing vacuously
- New unit tests cover degraded-on-write, not-degraded-on-failed-delete (guarding the macOS -34018 tolerance), stickiness, and the in-session fallback

Not covered here: pairing against a live server and confirming the restart survives end to end needs a human and a running instance.
