### PR TITLE
feat(media-server): auto-connect Plex without picking from a list

### DIFF
--- a/lib/mydia/media_server/plex/endpoint.ex
+++ b/lib/mydia/media_server/plex/endpoint.ex
@@ -95,9 +95,14 @@ defmodule Mydia.MediaServer.Plex.Endpoint do
 
   # ── Private ────────────────────────────────────────────────────────
 
-  defp probe_all(config), do: probe_all(config, false)
+  @doc """
+  Races every candidate address and returns the first that answers.
 
-  defp probe_all(%MediaServerConfig{connections: connections, token: token} = config, retried?) do
+  Public and cache-free because the add-server wizard needs this for a config
+  that has not been saved yet, so there is no id to key the cache on.
+  """
+  @spec probe_connections([map()], String.t() | nil) :: {:ok, String.t()} | {:error, Error.t()}
+  def probe_connections(connections, token) do
     uris = connections |> Enum.map(&candidate_uri/1) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
     # `ordered: false` plus a lazy scan lets the first working candidate win
@@ -116,16 +121,21 @@ defmodule Mydia.MediaServer.Plex.Endpoint do
         {:exit, _} -> []
       end)
 
-    {winner, results} = first_success(stream)
+    case first_success(stream) do
+      {{uri, :ok}, _results} -> {:ok, uri}
+      {nil, results} -> {:error, worst_error(results)}
+    end
+  end
 
-    case winner do
-      {uri, :ok} ->
+  defp probe_all(config), do: probe_all(config, false)
+
+  defp probe_all(%MediaServerConfig{connections: connections, token: token} = config, retried?) do
+    case probe_connections(connections, token) do
+      {:ok, uri} ->
         put_cache(config, uri)
         {:ok, uri}
 
-      nil ->
-        error = worst_error(results)
-
+      {:error, error} ->
         if not retried? and error.kind == :unreachable and
              is_binary(config.machine_identifier) do
           case rediscover(config) do

--- a/lib/mydia/media_server/plex/endpoint.ex
+++ b/lib/mydia/media_server/plex/endpoint.ex
@@ -18,6 +18,8 @@ defmodule Mydia.MediaServer.Plex.Endpoint do
   @probe_path "/library/sections"
   @probe_timeout_ms 3_000
   @cache_ttl_ms :timer.minutes(10)
+  @refresh_after_ms :timer.hours(6)
+  @refresh_claim_ttl_ms :timer.minutes(2)
 
   @doc """
   Returns a working base URL for the config.
@@ -25,20 +27,36 @@ defmodule Mydia.MediaServer.Plex.Endpoint do
   An explicit `url` on the config is a manual operator override and wins over
   discovery. Otherwise the cached winner is reused when fresh, and failing that
   every candidate is probed concurrently.
+
+  Options:
+    * `:plex_tv_base` - override the plex.tv base URL (tests only)
   """
-  @spec resolve(MediaServerConfig.t()) :: {:ok, String.t()} | {:error, Error.t()}
-  def resolve(%MediaServerConfig{url: url} = config) when is_binary(url) and url != "" do
+  @spec resolve(MediaServerConfig.t(), keyword()) :: {:ok, String.t()} | {:error, Error.t()}
+  # Multiple clauses with a default argument require an explicit function head.
+  def resolve(config, opts \\ [])
+
+  def resolve(%MediaServerConfig{url: url} = config, _opts) when is_binary(url) and url != "" do
     case probe(url, config.token) do
       :ok -> {:ok, url}
       {:error, _} = err -> err
     end
   end
 
-  def resolve(%MediaServerConfig{} = config) do
-    case cached(config) do
-      {:ok, url} -> {:ok, url}
-      :miss -> probe_all(config)
+  def resolve(%MediaServerConfig{} = config, opts) do
+    result =
+      case cached(config) do
+        {:ok, url} -> {:ok, url}
+        :miss -> probe_all(config)
+      end
+
+    # Only on success. A failure has already been through probe_all's own
+    # rediscover retry, so a second refresh would be pure duplication.
+    case result do
+      {:ok, _} -> maybe_refresh_stale(config, opts)
+      {:error, _} -> :ok
     end
+
+    result
   end
 
   @doc """
@@ -63,7 +81,10 @@ defmodule Mydia.MediaServer.Plex.Endpoint do
     with {:ok, servers} <- PlexOAuth.list_servers(config.token, opts),
          %{} = match <- find_by_identifier(servers, config.machine_identifier),
          {:ok, updated} <- persist(config, match) do
-      invalidate(config)
+      # A six-hourly refresh that always invalidated would throw away a healthy
+      # cached winner for nothing. Only a changed address set justifies it.
+      if updated.connections != config.connections, do: invalidate(config)
+
       {:ok, updated}
     else
       nil ->
@@ -148,6 +169,66 @@ defmodule Mydia.MediaServer.Plex.Endpoint do
     end
   end
 
+  # Fires a background rediscovery when the stored address list has aged out.
+  # The caller never waits: it already has a working URL, and a plex.tv round
+  # trip on the request path is exactly the latency this module avoids.
+  defp maybe_refresh_stale(%MediaServerConfig{machine_identifier: mi} = config, opts)
+       when is_binary(mi) do
+    if stale?(config) and claim_refresh(config) do
+      Task.Supervisor.start_child(Mydia.TaskSupervisor, fn ->
+        try do
+          rediscover(config, opts)
+        after
+          release_refresh(config)
+        end
+      end)
+    end
+
+    :ok
+  end
+
+  defp maybe_refresh_stale(_config, _opts), do: :ok
+
+  defp stale?(%MediaServerConfig{connections_refreshed_at: nil}), do: true
+
+  defp stale?(%MediaServerConfig{connections_refreshed_at: at}) do
+    DateTime.diff(DateTime.utc_now(), at, :millisecond) >= @refresh_after_ms
+  end
+
+  # Only one refresh per config at a time, so a burst of concurrent requests
+  # does not become a burst of plex.tv calls. A claim older than the TTL can be
+  # taken over, so a refresher that dies before releasing does not wedge the
+  # config forever. Two processes can in principle steal the same expired claim
+  # at once; the cost is one duplicate refresh, which is not worth a lock.
+  defp claim_refresh(%MediaServerConfig{id: id}) do
+    ensure_table()
+    key = {:refreshing, id}
+    now = System.monotonic_time(:millisecond)
+
+    if :ets.insert_new(@table, {key, now}) do
+      true
+    else
+      case :ets.lookup(@table, key) do
+        [{^key, claimed_at}] when now - claimed_at >= @refresh_claim_ttl_ms ->
+          :ets.insert(@table, {key, now})
+          true
+
+        _ ->
+          false
+      end
+    end
+  rescue
+    ArgumentError -> false
+  end
+
+  defp release_refresh(%MediaServerConfig{id: id}) do
+    ensure_table()
+    :ets.delete(@table, {:refreshing, id})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
   # Walks the stream only as far as the first success. Returns that result (or
   # nil) plus everything consumed, so error classification still sees the
   # failures observed along the way.
@@ -179,7 +260,8 @@ defmodule Mydia.MediaServer.Plex.Endpoint do
   defp persist(config, server) do
     Settings.update_media_server_config(config, %{
       connections: connections_for_storage(server.connections),
-      server_access_token: server.access_token
+      server_access_token: server.access_token,
+      connections_refreshed_at: DateTime.utc_now() |> DateTime.truncate(:second)
     })
   end
 

--- a/lib/mydia/media_server/plex/selection.ex
+++ b/lib/mydia/media_server/plex/selection.ex
@@ -1,0 +1,69 @@
+defmodule Mydia.MediaServer.Plex.Selection do
+  @moduledoc """
+  Decides which Plex server to attach, and turns that choice into config attrs.
+
+  This is policy, kept out of `PlexOAuth` (which is transport) and out of the
+  LiveView (which cannot be exercised without a socket). A Plex account often
+  carries several servers: the operator's own, plus any shared by friends. The
+  rule is to pick silently whenever the choice is not a real choice, and to ask
+  only when it genuinely is.
+  """
+
+  alias Mydia.MediaServer.PlexOAuth
+
+  @type server :: PlexOAuth.server()
+
+  @doc """
+  Picks the server to attach.
+
+  `PlexOAuth.list_servers/2` has already filtered to resources that provide
+  `server`, so no capability filtering happens here.
+  """
+  @spec auto_select([server()]) ::
+          {:ok, server()} | {:ambiguous, [server()]} | {:error, :no_servers}
+  def auto_select([]), do: {:error, :no_servers}
+  def auto_select([single]), do: {:ok, single}
+
+  def auto_select(servers) when is_list(servers) do
+    case Enum.filter(servers, & &1.owned) do
+      [single] -> {:ok, single}
+      _ -> {:ambiguous, rank(servers)}
+    end
+  end
+
+  @doc """
+  Orders servers owned-first, then online, then by name.
+
+  Only matters for the picker that renders when the choice is ambiguous, but a
+  ranked list makes that picker coherent instead of arbitrary.
+  """
+  @spec rank([server()]) :: [server()]
+  def rank(servers) when is_list(servers) do
+    # `not owned` sorts false before true, so owned servers come first.
+    Enum.sort_by(servers, fn s -> {not s.owned, not s.presence, s.name || ""} end)
+  end
+
+  @doc """
+  Builds `MediaServerConfig` attrs for a chosen server.
+
+  `url` stays nil deliberately: a non-nil `url` is a manual operator override
+  that bypasses discovery entirely, and this path is discovery.
+
+  `now` is an argument rather than a `DateTime.utc_now/0` call in the body so
+  the function stays testable without mocking the clock.
+  """
+  @spec config_attrs(server(), String.t(), DateTime.t()) :: map()
+  def config_attrs(server, account_token, now \\ DateTime.utc_now()) do
+    %{
+      name: server.name,
+      type: :plex,
+      url: nil,
+      token: account_token,
+      machine_identifier: server.machine_identifier,
+      connections: server.connections,
+      server_access_token: server.access_token,
+      connections_refreshed_at: DateTime.truncate(now, :second),
+      enabled: true
+    }
+  end
+end

--- a/lib/mydia/media_server/plex_oauth.ex
+++ b/lib/mydia/media_server/plex_oauth.ex
@@ -182,29 +182,6 @@ defmodule Mydia.MediaServer.PlexOAuth do
   end
 
   @doc """
-  Returns the best connection URL for a server.
-
-  Preference order:
-  1. Local HTTPS connections
-  2. Local HTTP connections
-  3. Remote HTTPS connections
-  4. Remote HTTP connections
-  5. Relay connections (last resort)
-  """
-  @spec best_connection_url([connection()]) :: String.t() | nil
-  def best_connection_url(connections) when is_list(connections) do
-    connections
-    |> Enum.sort_by(&connection_priority/1)
-    |> List.first()
-    |> case do
-      nil -> nil
-      conn -> conn.uri
-    end
-  end
-
-  def best_connection_url(_), do: nil
-
-  @doc """
   Returns the client identifier used for OAuth requests.
   """
   @spec client_identifier() :: String.t()
@@ -253,11 +230,4 @@ defmodule Mydia.MediaServer.PlexOAuth do
   end
 
   defp parse_connections(_), do: []
-
-  # Lower number = higher priority
-  defp connection_priority(%{relay: true}), do: 5
-  defp connection_priority(%{local: true, protocol: "https"}), do: 1
-  defp connection_priority(%{local: true}), do: 2
-  defp connection_priority(%{protocol: "https"}), do: 3
-  defp connection_priority(_), do: 4
 end

--- a/lib/mydia/settings/media_server_config.ex
+++ b/lib/mydia/settings/media_server_config.ex
@@ -21,6 +21,7 @@ defmodule Mydia.Settings.MediaServerConfig do
           server_access_token: String.t() | nil,
           last_auth_error: String.t() | nil,
           last_auth_error_at: DateTime.t() | nil,
+          connections_refreshed_at: DateTime.t() | nil,
           updated_by: Mydia.Accounts.User.t() | nil | Ecto.Association.NotLoaded.t(),
           updated_by_id: binary() | nil,
           inserted_at: DateTime.t(),
@@ -41,6 +42,7 @@ defmodule Mydia.Settings.MediaServerConfig do
     field :server_access_token, :string, redact: true
     field :last_auth_error, :string
     field :last_auth_error_at, :utc_datetime
+    field :connections_refreshed_at, :utc_datetime
 
     belongs_to :updated_by, Mydia.Accounts.User
 
@@ -64,6 +66,7 @@ defmodule Mydia.Settings.MediaServerConfig do
       :server_access_token,
       :last_auth_error,
       :last_auth_error_at,
+      :connections_refreshed_at,
       :updated_by_id
     ])
     |> validate_required([:name, :type])

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -229,8 +229,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   attr :plex_oauth_state, :atom, default: :idle
   attr :plex_oauth_servers, :list, default: []
   attr :plex_manual_entry, :boolean, default: false
-  attr :plex_selected_server, :map, default: nil
-  attr :plex_connection_statuses, :map, default: %{}
+  attr :plex_reachability, :any, default: :checking
 
   def media_server_modal(assigns) do
     # Get the current type from the form
@@ -327,29 +326,16 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                   <ul class="steps steps-horizontal w-full text-xs mb-4">
                     <li class={[
                       "step",
-                      @plex_oauth_state in [
-                        :idle,
-                        :authorizing,
-                        :selecting_server,
-                        :selecting_connection,
-                        :complete,
-                        :error
-                      ] && "step-warning"
+                      @plex_oauth_state in [:idle, :authorizing, :selecting_server, :complete, :error] &&
+                        "step-warning"
                     ]}>
                       Sign In
                     </li>
                     <li class={[
                       "step",
-                      @plex_oauth_state in [:selecting_server, :selecting_connection, :complete] &&
-                        "step-warning"
+                      @plex_oauth_state in [:selecting_server, :complete] && "step-warning"
                     ]}>
                       Server
-                    </li>
-                    <li class={[
-                      "step",
-                      @plex_oauth_state in [:selecting_connection, :complete] && "step-warning"
-                    ]}>
-                      Connection
                     </li>
                     <li class={["step", @plex_oauth_state == :complete && "step-warning"]}>Done</li>
                   </ul>
@@ -455,91 +441,6 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                           <.icon name="hero-arrow-left" class="w-4 h-4" /> Start over
                         </button>
                       </div>
-                    <% :selecting_connection -> %>
-                      <div class="space-y-3">
-                        <div class="flex items-center gap-2 bg-base-100 rounded-lg p-2">
-                          <div class="bg-primary/10 p-2 rounded-lg">
-                            <.icon name="hero-server" class="w-5 h-5 text-primary" />
-                          </div>
-                          <span class="font-medium">{@plex_selected_server.name}</span>
-                        </div>
-                        <p class="text-sm text-base-content/70">Choose a connection:</p>
-                        <div class="space-y-2 sm:max-h-48 sm:overflow-y-auto">
-                          <% sorted_connections =
-                            Enum.sort_by(@plex_selected_server.connections, fn conn ->
-                              case Map.get(@plex_connection_statuses, conn.uri, :testing) do
-                                :ok -> 0
-                                :testing -> 1
-                                _ -> 2
-                              end
-                            end) %>
-                          <%= for conn <- sorted_connections do %>
-                            <% status = Map.get(@plex_connection_statuses, conn.uri, :testing) %>
-                            <button
-                              type="button"
-                              class={[
-                                "card card-compact bg-base-100 border w-full cursor-pointer transition-all",
-                                cond do
-                                  status == :ok ->
-                                    "border-success/50 hover:border-success hover:shadow-md"
-
-                                  status == :error ->
-                                    "border-error/30 opacity-50 cursor-not-allowed"
-
-                                  true ->
-                                    "border-base-300 hover:border-warning/50"
-                                end
-                              ]}
-                              phx-click="select_plex_connection"
-                              phx-value-url={conn.uri}
-                              disabled={status == :error}
-                            >
-                              <div class="card-body flex-row items-center gap-3 p-3">
-                                <%= case status do %>
-                                  <% :testing -> %>
-                                    <span class="loading loading-spinner loading-sm text-warning"></span>
-                                  <% :ok -> %>
-                                    <div class="bg-success/10 p-1.5 rounded-lg">
-                                      <.icon name="hero-check-circle" class="w-4 h-4 text-success" />
-                                    </div>
-                                  <% _ -> %>
-                                    <div class="bg-error/10 p-1.5 rounded-lg">
-                                      <.icon name="hero-x-circle" class="w-4 h-4 text-error" />
-                                    </div>
-                                <% end %>
-                                <div class="flex-1 text-left min-w-0">
-                                  <p class="font-mono text-xs truncate">
-                                    {simplify_plex_url(conn.uri)}
-                                  </p>
-                                  <div class="flex gap-1 mt-1">
-                                    <%= if conn.local do %>
-                                      <span class="badge badge-xs badge-info gap-1">
-                                        <.icon name="hero-home" class="w-3 h-3" /> local
-                                      </span>
-                                    <% end %>
-                                    <%= if conn.relay do %>
-                                      <span class="badge badge-xs badge-warning gap-1">
-                                        <.icon name="hero-cloud" class="w-3 h-3" /> relay
-                                      </span>
-                                    <% end %>
-                                  </div>
-                                </div>
-                              </div>
-                            </button>
-                          <% end %>
-                        </div>
-                        <p class="text-xs text-base-content/50">
-                          <.icon name="hero-check-circle" class="w-3 h-3 inline text-success" />
-                          connections are reachable. Choose "local" if on same network.
-                        </p>
-                        <button
-                          type="button"
-                          class="btn btn-ghost btn-sm gap-1"
-                          phx-click="cancel_plex_oauth"
-                        >
-                          <.icon name="hero-arrow-left" class="w-4 h-4" /> Back to servers
-                        </button>
-                      </div>
                     <% :complete -> %>
                       <div class="text-center py-2">
                         <div class="bg-success/10 inline-flex p-3 rounded-full mb-3">
@@ -549,6 +450,25 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                         <p class="text-sm text-base-content/60">
                           Review the details below and save.
                         </p>
+                        <div class="mt-3 text-xs">
+                          <%= case @plex_reachability do %>
+                            <% :checking -> %>
+                              <span class="inline-flex items-center gap-2 text-base-content/60">
+                                <span class="loading loading-spinner loading-xs"></span>
+                                Checking connectivity...
+                              </span>
+                            <% {:ok, uri} -> %>
+                              <span class="inline-flex items-center gap-1 text-success">
+                                <.icon name="hero-check-circle" class="w-3 h-3" /> Reachable at
+                                <span class="font-mono">{simplify_plex_url(uri)}</span>
+                              </span>
+                            <% {:error, _error} -> %>
+                              <span class="inline-flex items-center gap-1 text-warning">
+                                <.icon name="hero-exclamation-triangle" class="w-3 h-3" />
+                                No address responded yet. You can still save; Mydia will keep looking.
+                              </span>
+                          <% end %>
+                        </div>
                       </div>
                     <% :error -> %>
                       <div class="text-center space-y-4 py-2">

--- a/lib/mydia_web/live/admin_media_servers_live/index.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.ex
@@ -6,6 +6,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
   alias Mydia.MediaServer.Client, as: MediaServerClient
   alias Mydia.MediaServer.Error
   alias Mydia.MediaServer.PlexOAuth
+  alias Mydia.MediaServer.Plex.Endpoint, as: PlexEndpoint
+  alias Mydia.MediaServer.Plex.Selection
   alias Mydia.Sync
 
   require Logger
@@ -25,14 +27,12 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
     {:noreply, socket}
   end
 
-  ## Plex connection test result handler
+  ## Plex reachability probe result
 
   @impl true
-  def handle_info({:plex_connection_tested, uri, result}, socket) do
-    if socket.assigns[:plex_oauth_state] == :selecting_connection do
-      statuses = socket.assigns[:plex_connection_statuses] || %{}
-      updated_statuses = Map.put(statuses, uri, result)
-      {:noreply, assign(socket, :plex_connection_statuses, updated_statuses)}
+  def handle_info({:plex_reachability, result}, socket) do
+    if socket.assigns[:plex_oauth_state] == :complete do
+      {:noreply, assign(socket, :plex_reachability, result)}
     else
       {:noreply, socket}
     end
@@ -54,6 +54,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
      |> assign(:plex_oauth_pin_id, nil)
      |> assign(:plex_oauth_servers, [])
      |> assign(:plex_oauth_token, nil)
+     |> assign(:plex_reachability, :checking)
      |> assign(:plex_manual_entry, false)}
   end
 
@@ -82,6 +83,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
        |> assign(:plex_oauth_pin_id, nil)
        |> assign(:plex_oauth_servers, [])
        |> assign(:plex_oauth_token, nil)
+       |> assign(:plex_reachability, :checking)
        |> assign(:plex_manual_entry, true)}
     end
   end
@@ -231,14 +233,14 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
   def handle_event("check_plex_pin", %{"pin_id" => pin_id}, socket) do
     case PlexOAuth.check_pin(pin_id) do
       {:ok, %{auth_token: token}} ->
+        socket = assign(socket, :plex_oauth_token, token)
+
         case PlexOAuth.list_servers(token) do
           {:ok, servers} ->
             {:noreply,
              socket
-             |> assign(:plex_oauth_state, :selecting_server)
-             |> assign(:plex_oauth_token, token)
-             |> assign(:plex_oauth_servers, servers)
-             |> push_event("plex_auth_complete", %{})}
+             |> push_event("plex_auth_complete", %{})
+             |> apply_selection(servers)}
 
           {:error, reason} ->
             Logger.error("Failed to fetch Plex servers: #{inspect(reason)}")
@@ -278,110 +280,22 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
 
   @impl true
   def handle_event("select_plex_server", %{"server_id" => server_id}, socket) do
-    servers = socket.assigns.plex_oauth_servers
-    token = socket.assigns.plex_oauth_token
-
-    case Enum.find(servers, &(&1.client_identifier == server_id)) do
-      nil ->
-        {:noreply, put_flash(socket, :error, "Server not found")}
-
-      server ->
-        if server.connections == [] do
-          {:noreply, put_flash(socket, :error, "No available connections for this server")}
-        else
-          initial_statuses =
-            Map.new(server.connections, fn conn -> {conn.uri, :testing} end)
-
-          parent = self()
-
-          for conn <- server.connections do
-            Task.start(fn ->
-              result = test_plex_connection(conn, token)
-              send(parent, {:plex_connection_tested, conn.uri, result})
-            end)
-          end
-
-          {:noreply,
-           socket
-           |> assign(:plex_oauth_state, :selecting_connection)
-           |> assign(:plex_selected_server, server)
-           |> assign(:plex_connection_statuses, initial_statuses)}
-        end
-    end
-  end
-
-  @impl true
-  def handle_event("select_plex_connection", %{"url" => _url}, socket) do
-    server = socket.assigns.plex_selected_server
-    token = socket.assigns.plex_oauth_token
-
-    server_base =
-      case socket.assigns.media_server_mode do
-        :new -> %MediaServerConfig{}
-        :edit -> socket.assigns.editing_media_server
-      end
-
-    # url stays nil so it remains a pure manual override; discovery owns the
-    # candidate list and Endpoint.resolve/1 picks a working address at call time.
-    attrs = %{
-      name: server.name,
-      type: :plex,
-      url: nil,
-      token: token,
-      machine_identifier: server.machine_identifier,
-      connections: server.connections,
-      server_access_token: server.access_token,
-      enabled: true
-    }
-
-    case socket.assigns.media_server_mode do
-      :edit ->
-        # Reconnect (and edit-time re-auth) must update the existing row in
-        # place so user links and sync state are not orphaned.
-        attrs = Map.merge(attrs, %{last_auth_error: nil, last_auth_error_at: nil})
-
-        case Settings.update_media_server_config(server_base, attrs) do
-          {:ok, _updated} ->
-            {:noreply,
-             socket
-             |> put_flash(:info, "Plex reconnected successfully")
-             |> load_data()}
-
-          {:error, %Ecto.Changeset{} = changeset} ->
-            {:noreply,
-             socket
-             |> assign(:plex_oauth_state, :error)
-             |> assign(:media_server_form, to_form(changeset))
-             |> put_flash(:error, "Failed to update media server")}
-        end
-
-      :new ->
-        changeset = Settings.change_media_server_config(server_base, attrs)
-
-        {:noreply,
-         socket
-         |> assign(:plex_oauth_state, :complete)
-         |> assign(:media_server_form, to_form(changeset))}
+    case Enum.find(socket.assigns.plex_oauth_servers, &(&1.client_identifier == server_id)) do
+      nil -> {:noreply, put_flash(socket, :error, "Server not found")}
+      server -> {:noreply, attach_server(socket, server)}
     end
   end
 
   @impl true
   def handle_event("cancel_plex_oauth", _params, socket) do
-    if socket.assigns.plex_oauth_state == :selecting_connection do
-      {:noreply,
-       socket
-       |> assign(:plex_oauth_state, :selecting_server)
-       |> assign(:plex_selected_server, nil)}
-    else
-      {:noreply,
-       socket
-       |> assign(:plex_oauth_state, :idle)
-       |> assign(:plex_oauth_pin_id, nil)
-       |> assign(:plex_oauth_servers, [])
-       |> assign(:plex_oauth_token, nil)
-       |> assign(:plex_selected_server, nil)
-       |> push_event("plex_auth_cancelled", %{})}
-    end
+    {:noreply,
+     socket
+     |> assign(:plex_oauth_state, :idle)
+     |> assign(:plex_oauth_pin_id, nil)
+     |> assign(:plex_oauth_servers, [])
+     |> assign(:plex_oauth_token, nil)
+     |> assign(:plex_reachability, :checking)
+     |> push_event("plex_auth_cancelled", %{})}
   end
 
   @impl true
@@ -392,7 +306,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
      |> assign(:plex_oauth_state, :idle)
      |> assign(:plex_oauth_pin_id, nil)
      |> assign(:plex_oauth_servers, [])
-     |> assign(:plex_oauth_token, nil)}
+     |> assign(:plex_oauth_token, nil)
+     |> assign(:plex_reachability, :checking)}
   end
 
   @impl true
@@ -491,6 +406,74 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
 
   ## Private Helpers
 
+  # A Plex account often carries the operator's own server plus any shared by
+  # friends. Picking is only worth asking about when it is a real choice.
+  defp apply_selection(socket, servers) do
+    case Selection.auto_select(servers) do
+      {:ok, server} ->
+        attach_server(socket, server)
+
+      {:ambiguous, ranked} ->
+        socket
+        |> assign(:plex_oauth_state, :selecting_server)
+        |> assign(:plex_oauth_servers, ranked)
+
+      {:error, :no_servers} ->
+        socket
+        |> assign(:plex_oauth_state, :error)
+        |> assign(:plex_oauth_servers, [])
+        |> put_flash(:error, "No Plex servers found for this account")
+    end
+  end
+
+  defp attach_server(socket, server) do
+    attrs = Selection.config_attrs(server, socket.assigns.plex_oauth_token)
+
+    case socket.assigns.media_server_mode do
+      :edit ->
+        # Reconnect must update the existing row in place so user links and
+        # sync state are not orphaned.
+        attrs = Map.merge(attrs, %{last_auth_error: nil, last_auth_error_at: nil})
+
+        case Settings.update_media_server_config(socket.assigns.editing_media_server, attrs) do
+          {:ok, _updated} ->
+            socket
+            |> put_flash(:info, "Plex reconnected successfully")
+            |> load_data()
+
+          {:error, %Ecto.Changeset{} = changeset} ->
+            socket
+            |> assign(:plex_oauth_state, :error)
+            |> assign(:media_server_form, to_form(changeset))
+            |> put_flash(:error, "Failed to update media server")
+        end
+
+      :new ->
+        changeset = Settings.change_media_server_config(%MediaServerConfig{}, attrs)
+
+        socket
+        |> assign(:plex_oauth_state, :complete)
+        |> assign(:plex_reachability, :checking)
+        |> start_reachability_probe(server)
+        |> assign(:media_server_form, to_form(changeset))
+    end
+  end
+
+  # Advisory only. The review step never blocks Save on the result, because a
+  # server that is merely powered off is still worth saving: rediscovery finds
+  # it when it comes back.
+  defp start_reachability_probe(socket, server) do
+    parent = self()
+    token = socket.assigns.plex_oauth_token
+    connections = server.connections
+
+    Task.Supervisor.start_child(Mydia.TaskSupervisor, fn ->
+      send(parent, {:plex_reachability, PlexEndpoint.probe_connections(connections, token)})
+    end)
+
+    socket
+  end
+
   defp load_data(socket) do
     media_servers = Settings.list_media_server_configs()
     media_server_health = get_media_server_health_status(media_servers)
@@ -508,6 +491,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
     |> assign(:testing_media_server_connection, false)
     |> assign(:plex_oauth_state, :idle)
     |> assign(:plex_oauth_servers, [])
+    |> assign(:plex_reachability, :checking)
     |> assign(:plex_manual_entry, false)
   end
 
@@ -515,49 +499,5 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
     media_servers
     |> Enum.map(fn server -> {server.id, %{status: :unknown}} end)
     |> Map.new()
-  end
-
-  defp test_plex_connection(conn, token) do
-    protocol = conn.protocol || "https"
-    address = conn.address
-    port = conn.port
-
-    test_url = "#{protocol}://#{address}:#{port}/identity"
-
-    headers = [
-      {"X-Plex-Token", token},
-      {"Accept", "application/json"}
-    ]
-
-    Logger.info("Testing Plex connection: #{test_url}")
-
-    opts = [
-      headers: headers,
-      receive_timeout: 5_000,
-      pool_timeout: 5_000,
-      retry: false,
-      connect_options: [
-        timeout: 3_000,
-        transport_opts: [verify: :verify_none]
-      ]
-    ]
-
-    case Req.get(test_url, opts) do
-      {:ok, %{status: 200}} ->
-        Logger.info("Plex connection OK: #{conn.uri}")
-        :ok
-
-      {:ok, %{status: status}} ->
-        Logger.info("Plex connection failed HTTP #{status}: #{conn.uri}")
-        :error
-
-      {:error, error} ->
-        Logger.info("Plex connection error: #{conn.uri} - #{inspect(error)}")
-        :error
-    end
-  rescue
-    e ->
-      Logger.info("Plex connection exception: #{conn.uri} - #{inspect(e)}")
-      :error
   end
 end

--- a/lib/mydia_web/live/admin_media_servers_live/index.html.heex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.html.heex
@@ -15,8 +15,7 @@
         plex_oauth_state={assigns[:plex_oauth_state] || :idle}
         plex_oauth_servers={assigns[:plex_oauth_servers] || []}
         plex_manual_entry={assigns[:plex_manual_entry] || false}
-        plex_selected_server={assigns[:plex_selected_server]}
-        plex_connection_statuses={assigns[:plex_connection_statuses] || %{}}
+        plex_reachability={assigns[:plex_reachability] || :checking}
       />
     <% end %>
   </.admin_page>

--- a/priv/repo/migrations/20260811190000_add_connections_refreshed_at.exs
+++ b/priv/repo/migrations/20260811190000_add_connections_refreshed_at.exs
@@ -1,0 +1,12 @@
+defmodule Mydia.Repo.Migrations.AddConnectionsRefreshedAt do
+  use Ecto.Migration
+
+  # Purely additive and nullable, so neither adapter needs a table rebuild and
+  # no adapter branching is required. Existing rows read nil, which the
+  # staleness check treats as "refresh on first use".
+  def change do
+    alter table(:media_server_configs) do
+      add :connections_refreshed_at, :utc_datetime
+    end
+  end
+end

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -2273,11 +2273,20 @@ defmodule Mydia.Jobs.MediaImportTest do
 
       handler_id = {__MODULE__, :delete_download_before_snapshot_reload, download.id}
 
+      # Telemetry handlers are global and run inside whichever process emitted
+      # the event, so without this pid guard any *other* async test querying
+      # `library_paths` steals the handler. The delete then runs on that
+      # process's sandbox connection, where this row does not exist, and Ecto
+      # raises StaleEntryError; telemetry detaches the failed handler, so the
+      # row is never deleted and the assertion below fails. `perform_job/2` runs
+      # the worker inline in this process, so the intended trigger still fires.
+      test_pid = self()
+
       :telemetry.attach(
         handler_id,
         [:mydia, :repo, :query],
         fn _event, _measurements, metadata, _config ->
-          if metadata.source == "library_paths" do
+          if metadata.source == "library_paths" and self() == test_pid do
             :telemetry.detach(handler_id)
             {:ok, _} = Mydia.Downloads.delete_download(download)
           end

--- a/test/mydia/media_server/plex/endpoint_probe_connections_test.exs
+++ b/test/mydia/media_server/plex/endpoint_probe_connections_test.exs
@@ -1,0 +1,71 @@
+defmodule Mydia.MediaServer.Plex.EndpointProbeConnectionsTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.MediaServer.Error
+  alias Mydia.MediaServer.Plex.Endpoint
+
+  setup do
+    bypass = Bypass.open()
+    on_exit(fn -> Endpoint.invalidate_all() end)
+    {:ok, bypass: bypass}
+  end
+
+  test "returns the candidate that answers and ignores the dead one", %{bypass: bypass} do
+    Bypass.stub(bypass, "GET", "/library/sections", fn conn ->
+      Plug.Conn.resp(conn, 200, ~s({"MediaContainer":{}}))
+    end)
+
+    live = "http://127.0.0.1:#{bypass.port}"
+
+    assert {:ok, ^live} =
+             Endpoint.probe_connections(
+               [%{"uri" => "http://127.0.0.1:1"}, %{"uri" => live}],
+               "tok"
+             )
+  end
+
+  test "accepts atom-keyed connections, as parsed from plex.tv", %{bypass: bypass} do
+    Bypass.stub(bypass, "GET", "/library/sections", fn conn ->
+      Plug.Conn.resp(conn, 200, ~s({"MediaContainer":{}}))
+    end)
+
+    live = "http://127.0.0.1:#{bypass.port}"
+
+    assert {:ok, ^live} = Endpoint.probe_connections([%{uri: live}], "tok")
+  end
+
+  test "an empty candidate list is unreachable, not a crash" do
+    assert {:error, %Error{kind: :unreachable}} = Endpoint.probe_connections([], "tok")
+  end
+
+  test "prefers an auth failure over a transport failure", %{bypass: bypass} do
+    Bypass.stub(bypass, "GET", "/library/sections", fn conn ->
+      Plug.Conn.resp(conn, 401, "")
+    end)
+
+    rejecting = "http://127.0.0.1:#{bypass.port}"
+
+    assert {:error, %Error{kind: :auth}} =
+             Endpoint.probe_connections(
+               [%{"uri" => "http://127.0.0.1:1"}, %{"uri" => rejecting}],
+               "tok"
+             )
+  end
+
+  test "all candidates dead reports unreachable" do
+    assert {:error, %Error{kind: :unreachable}} =
+             Endpoint.probe_connections(
+               [%{"uri" => "http://127.0.0.1:1"}, %{"uri" => "http://127.0.0.1:2"}],
+               "tok"
+             )
+  end
+
+  test "does not populate the resolve cache" do
+    # probe_connections/2 is used for unsaved configs that have no id to key on,
+    # so it must stay cache-free.
+    assert {:error, %Error{}} =
+             Endpoint.probe_connections([%{"uri" => "http://127.0.0.1:1"}], "t")
+
+    assert :ets.tab2list(:plex_endpoint_cache) == []
+  end
+end

--- a/test/mydia/media_server/plex/endpoint_probe_connections_test.exs
+++ b/test/mydia/media_server/plex/endpoint_probe_connections_test.exs
@@ -1,11 +1,20 @@
 defmodule Mydia.MediaServer.Plex.EndpointProbeConnectionsTest do
-  use ExUnit.Case, async: true
+  # Synchronous on purpose. `:plex_endpoint_cache` is a single global ETS table
+  # shared with every other Plex endpoint test, so the "does not populate the
+  # cache" assertion below would otherwise read entries a concurrent test wrote,
+  # and this module's `invalidate_all/0` would wipe that test's cache mid-run.
+  # ExUnit runs sync modules only after the async ones finish, which makes both
+  # hazards impossible rather than merely unlikely.
+  use ExUnit.Case, async: false
 
   alias Mydia.MediaServer.Error
   alias Mydia.MediaServer.Plex.Endpoint
 
   setup do
     bypass = Bypass.open()
+    # Clear on the way in as well as out: entries left by an earlier module
+    # would otherwise be attributed to this one.
+    Endpoint.invalidate_all()
     on_exit(fn -> Endpoint.invalidate_all() end)
     {:ok, bypass: bypass}
   end

--- a/test/mydia/media_server/plex/endpoint_staleness_test.exs
+++ b/test/mydia/media_server/plex/endpoint_staleness_test.exs
@@ -1,0 +1,164 @@
+defmodule Mydia.MediaServer.Plex.EndpointStalenessTest do
+  use Mydia.DataCase, async: false
+
+  alias Mydia.MediaServer.Plex.Endpoint
+  alias Mydia.Settings
+
+  setup do
+    plex_tv = Bypass.open()
+    server = Bypass.open()
+    on_exit(fn -> Endpoint.invalidate_all() end)
+
+    Bypass.stub(server, "GET", "/library/sections", fn conn ->
+      Plug.Conn.resp(conn, 200, ~s({"MediaContainer":{}}))
+    end)
+
+    test_pid = self()
+
+    Bypass.stub(plex_tv, "GET", "/api/v2/resources", fn conn ->
+      send(test_pid, :refreshed)
+
+      body =
+        Jason.encode!([
+          %{
+            "name" => "Storage",
+            "clientIdentifier" => "machine-1",
+            "provides" => "server",
+            "owned" => true,
+            "accessToken" => "fresh-token",
+            "connections" => [
+              %{"uri" => "http://127.0.0.1:#{server.port}", "local" => true, "relay" => false}
+            ]
+          }
+        ])
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, body)
+    end)
+
+    {:ok, plex_tv: plex_tv, server: server}
+  end
+
+  defp create_config(server, opts) do
+    Settings.create_media_server_config(%{
+      name: "Storage #{System.unique_integer([:positive])}",
+      type: :plex,
+      token: "account-token",
+      machine_identifier: Keyword.get(opts, :machine_identifier, "machine-1"),
+      connections: [%{"uri" => "http://127.0.0.1:#{server.port}"}],
+      connections_refreshed_at: Keyword.get(opts, :refreshed_at)
+    })
+  end
+
+  defp opts(plex_tv), do: [plex_tv_base: "http://127.0.0.1:#{plex_tv.port}/api/v2"]
+
+  defp hours_ago(n),
+    do: DateTime.utc_now() |> DateTime.add(-n * 3600, :second) |> DateTime.truncate(:second)
+
+  test "a nil timestamp triggers a refresh", %{plex_tv: plex_tv, server: server} do
+    {:ok, config} = create_config(server, refreshed_at: nil)
+
+    assert {:ok, _url} = Endpoint.resolve(config, opts(plex_tv))
+    assert_receive :refreshed, 2_000
+  end
+
+  test "a timestamp older than six hours triggers a refresh",
+       %{plex_tv: plex_tv, server: server} do
+    {:ok, config} = create_config(server, refreshed_at: hours_ago(7))
+
+    assert {:ok, _url} = Endpoint.resolve(config, opts(plex_tv))
+    assert_receive :refreshed, 2_000
+  end
+
+  test "a fresh timestamp triggers nothing", %{plex_tv: plex_tv, server: server} do
+    {:ok, config} = create_config(server, refreshed_at: hours_ago(1))
+
+    assert {:ok, _url} = Endpoint.resolve(config, opts(plex_tv))
+    refute_receive :refreshed, 500
+  end
+
+  test "a config with no machine_identifier triggers nothing",
+       %{plex_tv: plex_tv, server: server} do
+    {:ok, config} = create_config(server, refreshed_at: nil, machine_identifier: nil)
+
+    assert {:ok, _url} = Endpoint.resolve(config, opts(plex_tv))
+    refute_receive :refreshed, 500
+  end
+
+  test "a manual url override never triggers a refresh", %{plex_tv: plex_tv, server: server} do
+    {:ok, config} = create_config(server, refreshed_at: nil)
+
+    {:ok, config} =
+      Settings.update_media_server_config(config, %{url: "http://127.0.0.1:#{server.port}"})
+
+    assert {:ok, _url} = Endpoint.resolve(config, opts(plex_tv))
+    refute_receive :refreshed, 500
+  end
+
+  test "concurrent resolves refresh only once", %{plex_tv: plex_tv, server: server} do
+    test_pid = self()
+
+    # Re-stub so the refresh holds its claim for the whole burst. Without this
+    # the first refresh can finish and release before the last resolve runs,
+    # which would let a second refresh start and make the test flaky.
+    Bypass.stub(plex_tv, "GET", "/api/v2/resources", fn conn ->
+      send(test_pid, :refreshed)
+      Process.sleep(300)
+
+      body =
+        Jason.encode!([
+          %{
+            "name" => "Storage",
+            "clientIdentifier" => "machine-1",
+            "provides" => "server",
+            "owned" => true,
+            "accessToken" => "fresh-token",
+            "connections" => [
+              %{"uri" => "http://127.0.0.1:#{server.port}", "local" => true, "relay" => false}
+            ]
+          }
+        ])
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, body)
+    end)
+
+    {:ok, config} = create_config(server, refreshed_at: nil)
+
+    1..5
+    |> Enum.map(fn _ -> Task.async(fn -> Endpoint.resolve(config, opts(plex_tv)) end) end)
+    |> Enum.each(&Task.await(&1, 5_000))
+
+    assert_receive :refreshed, 2_000
+    refute_receive :refreshed, 800
+  end
+
+  test "the refresh stamps connections_refreshed_at", %{plex_tv: plex_tv, server: server} do
+    {:ok, config} = create_config(server, refreshed_at: nil)
+
+    assert {:ok, _url} = Endpoint.resolve(config, opts(plex_tv))
+    assert_receive :refreshed, 2_000
+
+    # The HTTP handler fires before the background task writes, so poll rather
+    # than sleeping on a guessed duration.
+    assert eventually(fn ->
+             not is_nil(Settings.get_media_server_config!(config.id).connections_refreshed_at)
+           end)
+  end
+
+  defp eventually(fun, attempts \\ 40) do
+    cond do
+      fun.() ->
+        true
+
+      attempts <= 0 ->
+        false
+
+      true ->
+        Process.sleep(50)
+        eventually(fun, attempts - 1)
+    end
+  end
+end

--- a/test/mydia/media_server/plex/selection_test.exs
+++ b/test/mydia/media_server/plex/selection_test.exs
@@ -1,0 +1,107 @@
+defmodule Mydia.MediaServer.Plex.SelectionTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.MediaServer.Plex.Selection
+
+  defp server(name, opts \\ []) do
+    %{
+      name: name,
+      client_identifier: Keyword.get(opts, :id, name),
+      machine_identifier: Keyword.get(opts, :id, name),
+      access_token: Keyword.get(opts, :access_token, "srv-#{name}"),
+      provides: "server",
+      owned: Keyword.get(opts, :owned, false),
+      presence: Keyword.get(opts, :presence, true),
+      connections: Keyword.get(opts, :connections, [%{uri: "http://127.0.0.1:32400"}])
+    }
+  end
+
+  describe "auto_select/1" do
+    test "an empty account is an error, not an empty picker" do
+      assert {:error, :no_servers} = Selection.auto_select([])
+    end
+
+    test "a single owned server is chosen" do
+      s = server("Storage", owned: true)
+      assert {:ok, ^s} = Selection.auto_select([s])
+    end
+
+    test "a single shared server is chosen, because it is still unambiguous" do
+      s = server("Friend's Box", owned: false)
+      assert {:ok, ^s} = Selection.auto_select([s])
+    end
+
+    test "exactly one owned server wins over any number of shared ones" do
+      mine = server("Storage", owned: true)
+      theirs = [server("Alice"), server("Bob"), server("Carol")]
+
+      assert {:ok, ^mine} = Selection.auto_select(theirs ++ [mine])
+    end
+
+    test "several owned servers are ambiguous" do
+      a = server("Attic", owned: true)
+      b = server("Basement", owned: true)
+
+      assert {:ambiguous, ranked} = Selection.auto_select([a, b])
+      assert length(ranked) == 2
+    end
+
+    test "several shared servers with none owned are ambiguous" do
+      assert {:ambiguous, ranked} = Selection.auto_select([server("Alice"), server("Bob")])
+      assert length(ranked) == 2
+    end
+
+    test "the ambiguous list is returned ranked" do
+      offline_owned = server("Zeta", owned: true, presence: false)
+      online_owned = server("Alpha", owned: true)
+      shared = server("Aardvark", owned: false)
+
+      assert {:ambiguous, [first, second, third]} =
+               Selection.auto_select([shared, offline_owned, online_owned])
+
+      assert first.name == "Alpha"
+      assert second.name == "Zeta"
+      assert third.name == "Aardvark"
+    end
+  end
+
+  describe "rank/1" do
+    test "orders owned first, then online, then by name" do
+      servers = [
+        server("Yak", owned: false, presence: true),
+        server("Bison", owned: true, presence: false),
+        server("Antelope", owned: true, presence: true),
+        server("Zebra", owned: true, presence: true)
+      ]
+
+      assert ["Antelope", "Zebra", "Bison", "Yak"] = Enum.map(Selection.rank(servers), & &1.name)
+    end
+  end
+
+  describe "config_attrs/3" do
+    test "builds attrs that leave url nil so discovery stays in charge" do
+      now = ~U[2026-08-11 12:00:00Z]
+      s = server("Storage", owned: true, id: "machine-1", access_token: "server-token")
+
+      attrs = Selection.config_attrs(s, "account-token", now)
+
+      assert attrs.name == "Storage"
+      assert attrs.type == :plex
+      assert is_nil(attrs.url)
+      assert attrs.token == "account-token"
+      assert attrs.machine_identifier == "machine-1"
+      assert attrs.server_access_token == "server-token"
+      assert attrs.connections == s.connections
+      assert attrs.connections_refreshed_at == now
+      assert attrs.enabled == true
+    end
+
+    test "truncates the timestamp to seconds for :utc_datetime" do
+      now = DateTime.from_naive!(~N[2026-08-11 12:00:00.123456], "Etc/UTC")
+
+      attrs = Selection.config_attrs(server("Storage"), "tok", now)
+
+      assert attrs.connections_refreshed_at == ~U[2026-08-11 12:00:00Z]
+    end
+  end
+end

--- a/test/mydia/media_server/plex_oauth_test.exs
+++ b/test/mydia/media_server/plex_oauth_test.exs
@@ -36,8 +36,8 @@ defmodule Mydia.MediaServer.PlexOAuthTest do
 
       assert server.machine_identifier == "cf3ab3f4"
       assert server.access_token == "resource-token"
-      # The whole list survives. Previously only best_connection_url/1's single
-      # pick was kept, which froze an address that later became unroutable.
+      # The whole list survives. An earlier revision kept only one ranked pick,
+      # which froze an address that later became unroutable.
       assert length(server.connections) == 2
     end
   end

--- a/test/mydia/settings/media_server_config_test.exs
+++ b/test/mydia/settings/media_server_config_test.exs
@@ -85,4 +85,38 @@ defmodule Mydia.Settings.MediaServerConfigTest do
       refute changeset.valid?
     end
   end
+
+  describe "connections_refreshed_at" do
+    test "is cast and round-trips through the database" do
+      at = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      {:ok, config} =
+        Mydia.Settings.create_media_server_config(%{
+          name: "Refresh Stamp #{System.unique_integer([:positive])}",
+          type: :plex,
+          token: "tok",
+          machine_identifier: "abc123",
+          connections: [%{"uri" => "http://127.0.0.1:32400"}],
+          connections_refreshed_at: at
+        })
+
+      assert config.connections_refreshed_at == at
+
+      assert Mydia.Repo.get!(Mydia.Settings.MediaServerConfig, config.id).connections_refreshed_at ==
+               at
+    end
+
+    test "defaults to nil when not provided" do
+      {:ok, config} =
+        Mydia.Settings.create_media_server_config(%{
+          name: "No Stamp #{System.unique_integer([:positive])}",
+          type: :plex,
+          token: "tok",
+          machine_identifier: "def456",
+          connections: [%{"uri" => "http://127.0.0.1:32400"}]
+        })
+
+      assert is_nil(config.connections_refreshed_at)
+    end
+  end
 end

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -116,4 +116,26 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
       assert has_element?(view, "[data-test=reconnect-plex]")
     end
   end
+
+  describe "Plex wizard auto-connect" do
+    setup %{conn: conn, token: token} do
+      start_supervised!(Mydia.Indexers.Health)
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
+      %{view: view}
+    end
+
+    test "the modal no longer offers a Connection step", %{view: view} do
+      view |> element("[phx-click='new_media_server']") |> render_click()
+
+      refute has_element?(view, "li.step", "Connection")
+      assert has_element?(view, "li.step", "Server")
+    end
+  end
 end


### PR DESCRIPTION
Adding a Plex server no longer asks you to pick from a list, and the stored address list now refreshes itself before it goes stale.

## Why

The add-server wizard made you pick twice. The second pick did nothing: `select_plex_connection` discarded the URL you clicked and saved `url: nil`, leaving `Plex.Endpoint.resolve/1` to choose an address anyway. You studied a list of addresses, clicked one, and the click was thrown away.

Separately, addresses were only re-fetched from plex.tv after every stored address had already failed. A server that changed address while still partly reachable kept a stale list until it broke completely.

## What changed

- **No more picking.** The connection step is gone. The server step only renders when the account has genuinely ambiguous candidates; a single owned server attaches silently. Review-and-Save is unchanged.
- **New `Mydia.MediaServer.Plex.Selection`.** Pure policy: no servers is an error, one candidate is chosen, exactly one *owned* server wins over any number shared by friends, anything else is ambiguous and returned ranked owned-then-online-then-name.
- **`Endpoint.probe_connections/2`** extracted from `probe_all/2`, public and cache-free, so the wizard can race addresses for a server that has no id to key the cache on yet.
- **Lazy staleness refresh.** New nullable `connections_refreshed_at`. After `resolve/1` returns a URL, a config older than six hours starts a supervised background `rediscover/2`. The caller never waits. Concurrent resolves are deduplicated through an ETS claim with a two minute steal window, so a refresher that dies before releasing does not wedge the config.
- **`rediscover/2` now invalidates the winner cache only when the address set actually changed.** A six-hourly refresh that always invalidated would discard a healthy cached address for nothing.
- **Dead code removed:** the connection-selection handlers, `test_plex_connection/2`, and `PlexOAuth.best_connection_url/1` with its `connection_priority/1` helper, which nothing had called since discovery landed.

Parallel probing and full-connection-list storage already existed; this builds on them rather than replacing them.

## Notes

There is deliberately no cron entry. Refresh happens when needed: on total failure, as before, plus the six hour age check on the resolve path.

The manual `url` override never triggers a refresh, even when the config carries a `machine_identifier`. Pinning an address is opting out of discovery.

Out of scope: `resolve/1` on a manual `url` probes on every call and never caches, so those configs pay a round trip per request. Caching it would also cache failures, which is a separate behaviour decision.

## Compatibility

One nullable column, so no adapter branching and no SQLite table rebuild. Existing rows read `nil`, which counts as stale and refreshes once on first use. An older release ignores the column, so there is no upgrade ordering requirement.

## Testing

`./dev mix precommit` passes: format, Credo, and 7038 tests with 0 failures.

New coverage: selection policy across empty/single/one-owned-among-shared/multiple-owned/zero-owned cases; the probe race including first-responder-wins and auth-preferred-over-timeout error classification; and staleness triggering, covering nil and aged timestamps, a fresh timestamp, a missing `machine_identifier`, the manual-override opt-out, and concurrent resolves refreshing only once.
