### PR TITLE
fix(media-server): make scheduled Plex watched sync actually run

### DIFF
--- a/lib/mydia/jobs/media_server_watched_sync.ex
+++ b/lib/mydia/jobs/media_server_watched_sync.ex
@@ -81,6 +81,11 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
     end
 
     :ok
+  rescue
+    # Deleting a media server while its jobs are still queued is ordinary
+    # operator behaviour, and a deleted config is a terminal state rather than a
+    # failure worth three retries. Mirrors Mydia.Jobs.PlexLinkSeed.
+    Ecto.NoResultsError -> :ok
   end
 
   def perform(%Oban.Job{args: raw_args}) do
@@ -93,6 +98,9 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
       {:ok, config} -> run_sync(config, user_id)
       {:error, reason} -> skip(config, reason, user_id)
     end
+  rescue
+    # Same window, reached more often now that server mode fans these out.
+    Ecto.NoResultsError -> :ok
   end
 
   defp run_sync(config, user_id) do

--- a/lib/mydia/jobs/media_server_watched_sync.ex
+++ b/lib/mydia/jobs/media_server_watched_sync.ex
@@ -2,11 +2,17 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
   @moduledoc """
   Oban worker for syncing watched status between Mydia and media servers.
 
-  Two modes:
+  Three modes:
   - **Individual**: Sync a specific server for a specific user.
-    Args: `%{"config_id" => id, "user_id" => uid, "link_id" => lid}`
-  - **Scheduler**: Find all enabled servers with watched sync enabled
-    and enqueue individual jobs for each linked user.
+    Args: `%{"config_id" => id, "user_id" => uid, "link_id" => lid}` (`link_id`
+    is optional; without it the config's own token is used).
+  - **Server**: Fan out to an individual job for every enabled link on one
+    server, seeding Plex Home links first when none exist yet. This is what
+    the "Sync Now" button triggers, and what `Mydia.Jobs.PlexLinkSeed`
+    enqueues after a successful seed.
+    Args: `%{"mode" => "server", "config_id" => id}`
+  - **Scheduler**: Find every enabled server with watched sync enabled and
+    fan out the same way, one server at a time.
     Args: `%{"mode" => "all_enabled"}`
   """
 
@@ -166,12 +172,20 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
     cond do
       not watched_sync_enabled?(config) -> :sync_disabled
       match?({:error, _}, provider_for(config)) -> :unsupported_provider
+      not has_token?(config) -> :no_token
       true -> nil
     end
   end
 
   defp provider_for(%{type: :plex}), do: {:ok, Plex}
   defp provider_for(_), do: {:error, :unsupported_provider}
+
+  # token isn't validate_required on MediaServerConfig. Without this, a Plex
+  # config saved with sync on but a blank token would pass skip_reason/1,
+  # record :seeding_links on every tick, and enqueue a seed job that can never
+  # produce a link (PlexLinkSeed.seedable?/1 also requires a token) — a job
+  # reporting healthy while doing nothing forever.
+  defp has_token?(%{token: token}), do: is_binary(token) and token != ""
 
   defp record_skip(config, reason, user_id \\ nil) do
     Mydia.Sync.record_skip(

--- a/lib/mydia/jobs/media_server_watched_sync.ex
+++ b/lib/mydia/jobs/media_server_watched_sync.ex
@@ -36,6 +36,10 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
       %__MODULE__{mode: "all_enabled"}
     end
 
+    def parse(%{"mode" => "server", "config_id" => config_id}) do
+      %__MODULE__{mode: "server", config_id: config_id}
+    end
+
     def parse(%{"config_id" => config_id, "user_id" => user_id} = args) do
       %__MODULE__{
         config_id: config_id,
@@ -55,6 +59,20 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
         reason -> record_skip(config, reason)
       end
     end)
+
+    :ok
+  end
+
+  # Syncs one server across every linked user. This is what the "Sync Now"
+  # button and a successful link seed both trigger, so manual and scheduled
+  # runs share one fan-out rather than drifting apart.
+  def perform(%Oban.Job{args: %{"mode" => "server", "config_id" => config_id}}) do
+    config = Settings.get_media_server_config!(config_id)
+
+    case skip_reason(config) do
+      nil -> enqueue_linked_users(config)
+      reason -> record_skip(config, reason)
+    end
 
     :ok
   end

--- a/lib/mydia/jobs/media_server_watched_sync.ex
+++ b/lib/mydia/jobs/media_server_watched_sync.ex
@@ -186,12 +186,23 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
 
   defp enqueue_linked_users(config) do
     case Settings.list_media_server_user_links(config.id) |> Enum.filter(& &1.enabled) do
+      # Links are created by Mydia.Jobs.PlexLinkSeed and nothing else. Recording
+      # :no_user_mapping and stopping is exactly what made this job report
+      # healthy while doing nothing: seed first, and the seed job re-enters sync
+      # once it has produced links.
       [] ->
-        record_skip(config, :no_user_mapping)
+        enqueue_seed(config)
+        record_skip(config, :seeding_links)
 
       links ->
         Enum.each(links, fn link -> enqueue(config, link) end)
     end
+  end
+
+  defp enqueue_seed(config) do
+    %{"config_id" => config.id}
+    |> Mydia.Jobs.PlexLinkSeed.new()
+    |> safe_insert()
   end
 
   defp enqueue(config, link) do

--- a/lib/mydia/jobs/plex_link_seed.ex
+++ b/lib/mydia/jobs/plex_link_seed.ex
@@ -45,11 +45,28 @@ defmodule Mydia.Jobs.PlexLinkSeed do
   # A non-Plex or unconfigured server is a no-op rather than an error. The
   # scheduler enqueues this for any config missing links, and a Jellyfin server
   # with no Plex links is the expected state.
-  defp seedable?(%{type: :plex, enabled: true, token: token})
-       when is_binary(token) and token != "",
-       do: true
+  #
+  # Also requires watched sync itself to be on. `maybe_seed_plex_links/1` fires
+  # on every Plex config save, including one that only wants library refresh
+  # and never opted into watched-status sync. Without this check, seeding
+  # would enumerate Plex Home and mint a long-lived per-profile token for
+  # every household member for a feature the operator never asked for.
+  # Nothing is lost: the scheduler path only enqueues a seed once sync is on,
+  # and turning sync on later is itself a config save that re-triggers
+  # `maybe_seed_plex_links/1`.
+  defp seedable?(%{type: :plex, enabled: true, token: token} = config)
+       when is_binary(token) and token != "" do
+    watched_sync_enabled?(config)
+  end
 
   defp seedable?(_), do: false
+
+  defp watched_sync_enabled?(config) do
+    case config.connection_settings do
+      %{} = settings -> Map.get(settings, "sync_watched") in [true, "true"]
+      _ -> false
+    end
+  end
 
   defp seed(config, opts) do
     case Home.seed_links(config, opts) do

--- a/lib/mydia/jobs/plex_link_seed.ex
+++ b/lib/mydia/jobs/plex_link_seed.ex
@@ -1,0 +1,107 @@
+defmodule Mydia.Jobs.PlexLinkSeed do
+  @moduledoc """
+  Seeds `media_server_user_links` for a Plex config from its Plex Home profiles.
+
+  `Mydia.MediaServer.Plex.Home.seed_links/2` is the only code that creates those
+  links, and it had no caller at all. Without links the watched-sync scheduler
+  skipped every config with `:no_user_mapping` on every tick, forever, so
+  scheduled sync had never run for anyone. This worker is the missing caller.
+
+  Seeding makes 1 + N plex.tv round trips (list Home users, then one profile
+  switch per matched user), which is why it is a job rather than an inline call
+  on the save path.
+  """
+
+  use Oban.Worker,
+    queue: :integrations,
+    max_attempts: 3,
+    unique: [period: 120, keys: [:config_id]]
+
+  require Logger
+
+  alias Mydia.Jobs.MediaServerWatchedSync
+  alias Mydia.MediaServer.Error
+  alias Mydia.MediaServer.Plex.Home
+  alias Mydia.Repo
+  alias Mydia.Settings
+  alias Mydia.Sync
+
+  @spec perform(Oban.Job.t()) :: :ok | {:error, term()}
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"config_id" => config_id} = args}) do
+    config = Settings.get_media_server_config!(config_id)
+
+    if seedable?(config) do
+      seed(config, seed_opts(args))
+    else
+      :ok
+    end
+  rescue
+    # The config was deleted between enqueue and execution. That is a terminal
+    # state, not a failure worth three retries.
+    Ecto.NoResultsError -> :ok
+  end
+
+  # A non-Plex or unconfigured server is a no-op rather than an error. The
+  # scheduler enqueues this for any config missing links, and a Jellyfin server
+  # with no Plex links is the expected state.
+  defp seedable?(%{type: :plex, enabled: true, token: token})
+       when is_binary(token) and token != "",
+       do: true
+
+  defp seedable?(_), do: false
+
+  defp seed(config, opts) do
+    case Home.seed_links(config, opts) do
+      {:ok, [_ | _] = links} ->
+        Logger.info("Seeded #{length(links)} Plex user link(s) for #{config.name}")
+        enqueue_sync(config)
+        :ok
+
+      # Deliberately enqueues nothing. Server mode with no links enqueues this
+      # worker, and this worker enqueues server mode, so only a run that
+      # actually produced links may re-enter that cycle.
+      {:ok, []} ->
+        record_skip(config, :no_matching_users)
+        :ok
+
+      {:error, reason} ->
+        record_skip(config, :link_seeding_failed)
+        {:error, describe(reason)}
+    end
+  end
+
+  defp enqueue_sync(config) do
+    %{"mode" => "server", "config_id" => config.id}
+    |> MediaServerWatchedSync.new()
+    |> safe_insert()
+  end
+
+  # Oban is not started under `testing: :manual` (config/test.exs), so
+  # Oban.insert/1 raises a RuntimeError when a job's own perform/1 tries to
+  # enqueue another job during tests. `MediaServerWatchedSync.safe_insert/1`
+  # establishes this fallback; mirrored here for the same reason.
+  defp safe_insert(changeset) do
+    try do
+      Oban.insert(changeset)
+    rescue
+      RuntimeError -> Repo.insert(changeset)
+    end
+  end
+
+  defp record_skip(config, reason) do
+    Sync.record_skip(
+      %{provider: to_string(config.type), provider_instance_id: config.id, user_id: nil},
+      reason
+    )
+  end
+
+  # A test seam so Bypass can stand in for plex.tv. Production jobs never carry
+  # it, and it is deliberately not read from application env, which would leak
+  # across concurrent tests.
+  defp seed_opts(%{"plex_tv_base" => base}) when is_binary(base), do: [plex_tv_base: base]
+  defp seed_opts(_), do: []
+
+  defp describe(%Error{} = error), do: Error.message(error)
+  defp describe(reason), do: inspect(reason)
+end

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -20,6 +20,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
           <span class="badge badge-ghost">{length(@media_servers)}</span>
         </h2>
         <button
+          id="new-media-server"
           class="btn btn-primary w-full min-h-11 sm:btn-sm sm:w-auto sm:min-h-8"
           phx-click="new_media_server"
         >
@@ -28,11 +29,32 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
       </div>
 
       <%= if @media_servers == [] do %>
-        <div class="alert alert-info">
-          <.icon name="hero-information-circle" class="w-5 h-5" />
-          <span>
-            No media servers configured yet. Add Plex or Jellyfin to enable automatic library updates.
-          </span>
+        <div
+          id="media-servers-empty"
+          class="card bg-base-100 border border-base-300"
+        >
+          <div class="card-body items-center text-center gap-3 py-10">
+            <div class="bg-primary/10 p-4 rounded-full">
+              <.icon name="hero-server-stack" class="w-8 h-8 text-primary" />
+            </div>
+            <h3 class="font-semibold text-lg">No media servers connected</h3>
+            <p class="text-sm text-base-content/70 max-w-md">
+              Connect Plex or Jellyfin and Mydia refreshes its library as soon as an import
+              finishes, so new episodes show up without waiting for the server's next
+              scheduled scan.
+            </p>
+            <p class="text-sm text-base-content/70 max-w-md">
+              Plex also syncs watched status in both directions, mapped separately for each
+              Plex Home profile.
+            </p>
+            <button
+              id="media-servers-empty-cta"
+              class="btn btn-primary mt-2 min-h-11 sm:min-h-8"
+              phx-click="new_media_server"
+            >
+              <.icon name="hero-plus" class="w-4 h-4" /> Connect a server
+            </button>
+          </div>
         </div>
       <% else %>
         <%!-- Server Cards Grid --%>
@@ -718,7 +740,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   defp modal_action_btn, do: "w-full min-h-11 sm:w-auto sm:min-h-8"
 
   defp run_label(%{status: :skipped, skip_reason: reason}) when is_binary(reason) do
-    "Skipped: #{reason}"
+    skip_reason_label(reason)
   end
 
   defp run_label(%{status: :ok, counts: counts}) when is_map(counts) do
@@ -729,6 +751,17 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
 
   defp run_label(%{status: :error}), do: "Failed"
   defp run_label(_), do: "Failed"
+
+  # sync_runs rows outlive the code that wrote them, so every reason ever
+  # recorded needs a label, including :no_user_mapping which nothing writes now.
+  defp skip_reason_label("server_disabled"), do: "Server is disabled"
+  defp skip_reason_label("sync_disabled"), do: "Watched sync is off"
+  defp skip_reason_label("unsupported_provider"), do: "Watched sync is Plex only"
+  defp skip_reason_label("no_user_mapping"), do: "No Plex users linked yet"
+  defp skip_reason_label("seeding_links"), do: "Linking Plex Home profiles"
+  defp skip_reason_label("no_matching_users"), do: "No Plex profile matched a Mydia user"
+  defp skip_reason_label("link_seeding_failed"), do: "Could not reach plex.tv to link users"
+  defp skip_reason_label(other), do: "Skipped: #{other}"
 
   # Simplify plex.direct URLs to show just the IP/host and port
   # e.g., "https://10-1-1-5.abc123.plex.direct:32400" -> "(ssl) 10.1.1.5:32400"

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -761,6 +761,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   defp skip_reason_label("seeding_links"), do: "Linking Plex Home profiles"
   defp skip_reason_label("no_matching_users"), do: "No Plex profile matched a Mydia user"
   defp skip_reason_label("link_seeding_failed"), do: "Could not reach plex.tv to link users"
+  defp skip_reason_label("no_token"), do: "No API token configured"
   defp skip_reason_label(other), do: "Skipped: #{other}"
 
   # Simplify plex.direct URLs to show just the IP/host and port

--- a/lib/mydia_web/live/admin_media_servers_live/index.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.ex
@@ -156,7 +156,9 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
       end
 
     case result do
-      {:ok, _server} ->
+      {:ok, server} ->
+        maybe_seed_plex_links(server)
+
         {:noreply,
          socket
          |> assign(:show_media_server_modal, false)
@@ -341,19 +343,21 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
   @impl true
   def handle_event("sync_watched", %{"id" => id}, socket) do
     server = Settings.get_media_server_config!(id)
-    user_id = socket.assigns.current_user.id
 
+    # Server mode rather than a job for the clicking user. With per-user links in
+    # play, a job carrying no link_id falls back to the config token, which reads
+    # the admin's Plex watch state and writes it onto whoever clicked.
     changeset =
       Mydia.Jobs.MediaServerWatchedSync.new(%{
-        "config_id" => server.id,
-        "user_id" => user_id
+        "mode" => "server",
+        "config_id" => server.id
       })
 
-    case Oban.insert(changeset) do
+    case safe_insert(changeset) do
       {:ok, _job} ->
         {:noreply,
          socket
-         |> put_flash(:info, "Watched sync started for #{server.name}")
+         |> put_flash(:info, "Watched sync queued for #{server.name}")
          |> load_data()}
 
       {:error, _reason} ->
@@ -436,7 +440,9 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
         attrs = Map.merge(attrs, %{last_auth_error: nil, last_auth_error_at: nil})
 
         case Settings.update_media_server_config(socket.assigns.editing_media_server, attrs) do
-          {:ok, _updated} ->
+          {:ok, updated} ->
+            maybe_seed_plex_links(updated)
+
             socket
             |> put_flash(:info, "Plex reconnected successfully")
             |> load_data()
@@ -472,6 +478,31 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
     end)
 
     socket
+  end
+
+  # Seeds per-user Plex links after any Plex config is persisted. Fires on every
+  # Plex save, including one that only flips a sync direction: the job is cheap
+  # to enqueue, its 120-second uniqueness window collapses bursts, and the
+  # alternative is dirty-field tracking that would silently miss a changed token.
+  defp maybe_seed_plex_links(%MediaServerConfig{type: :plex, id: id}) when is_binary(id) do
+    %{"config_id" => id}
+    |> Mydia.Jobs.PlexLinkSeed.new()
+    |> safe_insert()
+
+    :ok
+  end
+
+  defp maybe_seed_plex_links(_config), do: :ok
+
+  # Oban's supervisor isn't started under `testing: :manual` (see
+  # `Mydia.Application.oban_children/0`), so a bare `Oban.insert/1` raises a
+  # RuntimeError there. Falling back to a plain repo insert keeps this working
+  # both in that mode and in production, matching the pattern already used by
+  # `Mydia.Jobs.MediaServerWatchedSync.safe_insert/1`.
+  defp safe_insert(changeset) do
+    Oban.insert(changeset)
+  rescue
+    RuntimeError -> Mydia.Repo.insert(changeset)
   end
 
   defp load_data(socket) do

--- a/test/mydia/jobs/media_server_watched_sync_test.exs
+++ b/test/mydia/jobs/media_server_watched_sync_test.exs
@@ -354,4 +354,52 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
       assert [] = all_enqueued(worker: MediaServerWatchedSync) |> Enum.reject(& &1.args["mode"])
     end
   end
+
+  describe "a config deleted between enqueue and execution" do
+    setup do
+      user = user_fixture()
+
+      {:ok, config} =
+        Settings.create_media_server_config(%{
+          name: "Doomed",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "tok",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      {:ok, link} =
+        Settings.upsert_media_server_user_link(%{
+          media_server_config_id: config.id,
+          user_id: user.id,
+          access_token: "user-token",
+          enabled: true
+        })
+
+      # Capture the ids, then delete. The jobs are already queued at this point
+      # in the real failure, so they still carry ids that no longer resolve.
+      ids = %{config_id: config.id, user_id: user.id, link_id: link.id}
+      {:ok, _} = Settings.delete_media_server_config(config)
+
+      ids
+    end
+
+    test "server mode is a no-op rather than three failed retries", ids do
+      assert :ok =
+               perform_job(MediaServerWatchedSync, %{
+                 "mode" => "server",
+                 "config_id" => ids.config_id
+               })
+    end
+
+    test "per-user mode is a no-op rather than three failed retries", ids do
+      assert :ok =
+               perform_job(MediaServerWatchedSync, %{
+                 "config_id" => ids.config_id,
+                 "user_id" => ids.user_id,
+                 "link_id" => ids.link_id
+               })
+    end
+  end
 end

--- a/test/mydia/jobs/media_server_watched_sync_test.exs
+++ b/test/mydia/jobs/media_server_watched_sync_test.exs
@@ -55,6 +55,74 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
     end
   end
 
+  describe "perform/1 with mode server" do
+    test "fans out one job per enabled link" do
+      user = user_fixture()
+
+      {:ok, server} =
+        Settings.create_media_server_config(%{
+          name: "Server Mode Plex",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "test-token",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      {:ok, link} =
+        Settings.upsert_media_server_user_link(%{
+          media_server_config_id: server.id,
+          user_id: user.id,
+          plex_account_id: "1",
+          plex_username: user.username,
+          access_token: "user-token",
+          enabled: true
+        })
+
+      assert :ok =
+               perform_job(MediaServerWatchedSync, %{
+                 "mode" => "server",
+                 "config_id" => server.id
+               })
+
+      assert_enqueued(
+        worker: MediaServerWatchedSync,
+        args: %{"config_id" => server.id, "user_id" => user.id, "link_id" => link.id}
+      )
+    end
+
+    test "records a skip and enqueues nothing when the server is disabled" do
+      user = user_fixture()
+
+      {:ok, server} =
+        Settings.create_media_server_config(%{
+          name: "Disabled Plex",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "test-token",
+          enabled: false,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      {:ok, _link} =
+        Settings.upsert_media_server_user_link(%{
+          media_server_config_id: server.id,
+          user_id: user.id,
+          access_token: "user-token",
+          enabled: true
+        })
+
+      assert :ok =
+               perform_job(MediaServerWatchedSync, %{
+                 "mode" => "server",
+                 "config_id" => server.id
+               })
+
+      assert Sync.last_run("plex", server.id).skip_reason == "server_disabled"
+      assert [] = all_enqueued(worker: MediaServerWatchedSync) |> Enum.reject(& &1.args["mode"])
+    end
+  end
+
   describe "perform/1 with individual config" do
     test "skips when server is disabled" do
       user = user_fixture()

--- a/test/mydia/jobs/media_server_watched_sync_test.exs
+++ b/test/mydia/jobs/media_server_watched_sync_test.exs
@@ -303,7 +303,7 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
       assert Sync.last_run("plex", config.id).skip_reason == "link_user_mismatch"
     end
 
-    test "a user with no link is skipped with a reason rather than defaulted" do
+    test "a config with no links seeds them instead of skipping forever" do
       {:ok, config} =
         Settings.create_media_server_config(%{
           name: "Storage",
@@ -316,12 +316,18 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
 
       # Three users exist, none linked. Previously all three would sync against
       # the single admin token, merging their histories into one Plex account.
+      # Now the run seeds links rather than recording :no_user_mapping and
+      # stopping, which is what made this job do nothing on every install.
       _u1 = user_fixture()
       _u2 = user_fixture()
 
       assert :ok = perform_job(MediaServerWatchedSync, %{"mode" => "all_enabled"})
 
-      assert Sync.last_run("plex", config.id).skip_reason == "no_user_mapping"
+      assert Sync.last_run("plex", config.id).skip_reason == "seeding_links"
+      assert_enqueued(worker: Mydia.Jobs.PlexLinkSeed, args: %{"config_id" => config.id})
+
+      # Still no per-user job: defaulting to the admin token is the bug this
+      # test has always guarded, and seeding must not reintroduce it.
       assert [] = all_enqueued(worker: MediaServerWatchedSync) |> Enum.reject(& &1.args["mode"])
     end
   end

--- a/test/mydia/jobs/media_server_watched_sync_test.exs
+++ b/test/mydia/jobs/media_server_watched_sync_test.exs
@@ -303,6 +303,29 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
       assert Sync.last_run("plex", config.id).skip_reason == "link_user_mismatch"
     end
 
+    test "a Plex config with watched sync on and a blank token records no_token and enqueues nothing" do
+      # token isn't validate_required on MediaServerConfig, so a Plex config
+      # saved with sync on but no token would otherwise reach enqueue_linked_users,
+      # record :seeding_links every tick, and enqueue a seed job that can never
+      # produce a link (PlexLinkSeed.seedable?/1 also requires a token). That is
+      # a job reporting healthy while doing nothing forever.
+      {:ok, config} =
+        Settings.create_media_server_config(%{
+          name: "Tokenless Plex",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      assert :ok = perform_job(MediaServerWatchedSync, %{"mode" => "all_enabled"})
+
+      assert Sync.last_run("plex", config.id).skip_reason == "no_token"
+      assert [] = all_enqueued(worker: MediaServerWatchedSync) |> Enum.reject(& &1.args["mode"])
+      assert [] = all_enqueued(worker: Mydia.Jobs.PlexLinkSeed)
+    end
+
     test "a config with no links seeds them instead of skipping forever" do
       {:ok, config} =
         Settings.create_media_server_config(%{

--- a/test/mydia/jobs/plex_link_seed_test.exs
+++ b/test/mydia/jobs/plex_link_seed_test.exs
@@ -1,0 +1,133 @@
+defmodule Mydia.Jobs.PlexLinkSeedTest do
+  use Mydia.DataCase
+  use Oban.Testing, repo: Mydia.Repo
+
+  alias Mydia.Jobs.MediaServerWatchedSync
+  alias Mydia.Jobs.PlexLinkSeed
+  alias Mydia.Settings
+  alias Mydia.Sync
+
+  import Mydia.AccountsFixtures
+
+  setup do
+    bypass = Bypass.open()
+    # plex_tv_base is the /api/v2 root, the same shape as @plex_api_base in Home.
+    {:ok, bypass: bypass, base: "http://127.0.0.1:#{bypass.port}/api/v2"}
+  end
+
+  defp plex_config(attrs \\ %{}) do
+    defaults = %{
+      name: "Storage",
+      type: :plex,
+      url: "http://localhost:32400",
+      token: "account-token",
+      enabled: true,
+      connection_settings: %{"sync_watched" => true}
+    }
+
+    {:ok, config} = Settings.create_media_server_config(Map.merge(defaults, attrs))
+    config
+  end
+
+  test "seeds links from Plex Home and enqueues a server-mode sync",
+       %{bypass: bypass, base: base} do
+    user = user_fixture()
+    config = plex_config()
+
+    Bypass.stub(bypass, "GET", "/api/v2/home/users", fn conn ->
+      body = Jason.encode!(%{"users" => [%{"id" => 7, "username" => user.username}]})
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, body)
+    end)
+
+    Bypass.stub(bypass, "POST", "/api/v2/home/users/7/switch", fn conn ->
+      body = Jason.encode!(%{"authToken" => "per-user-token"})
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, body)
+    end)
+
+    assert :ok =
+             perform_job(PlexLinkSeed, %{
+               "config_id" => config.id,
+               "plex_tv_base" => base
+             })
+
+    assert [link] = Settings.list_media_server_user_links(config.id)
+    assert link.user_id == user.id
+    assert link.access_token == "per-user-token"
+
+    assert_enqueued(
+      worker: MediaServerWatchedSync,
+      args: %{"mode" => "server", "config_id" => config.id}
+    )
+  end
+
+  test "records no_matching_users and enqueues nothing when no profile matches",
+       %{bypass: bypass, base: base} do
+    config = plex_config()
+
+    # A Plex Home profile whose username matches no Mydia user. Enqueueing a
+    # sync here would loop: server mode with no links enqueues this worker.
+    Bypass.stub(bypass, "GET", "/api/v2/home/users", fn conn ->
+      body = Jason.encode!(%{"users" => [%{"id" => 9, "username" => "nobody-here"}]})
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, body)
+    end)
+
+    assert :ok =
+             perform_job(PlexLinkSeed, %{
+               "config_id" => config.id,
+               "plex_tv_base" => base
+             })
+
+    assert [] = Settings.list_media_server_user_links(config.id)
+    assert Sync.last_run("plex", config.id).skip_reason == "no_matching_users"
+    assert [] = all_enqueued(worker: MediaServerWatchedSync)
+  end
+
+  test "records link_seeding_failed and returns an error when plex.tv rejects the token",
+       %{bypass: bypass, base: base} do
+    config = plex_config()
+
+    Bypass.stub(bypass, "GET", "/api/v2/home/users", fn conn ->
+      Plug.Conn.resp(conn, 401, "")
+    end)
+
+    assert {:error, _reason} =
+             perform_job(PlexLinkSeed, %{
+               "config_id" => config.id,
+               "plex_tv_base" => base
+             })
+
+    assert Sync.last_run("plex", config.id).skip_reason == "link_seeding_failed"
+    assert [] = all_enqueued(worker: MediaServerWatchedSync)
+  end
+
+  test "is a no-op for a Jellyfin config" do
+    {:ok, config} =
+      Settings.create_media_server_config(%{
+        name: "Jelly",
+        type: :jellyfin,
+        url: "http://localhost:8096",
+        token: "tok",
+        enabled: true
+      })
+
+    assert :ok = perform_job(PlexLinkSeed, %{"config_id" => config.id})
+    assert [] = Settings.list_media_server_user_links(config.id)
+    assert [] = all_enqueued(worker: MediaServerWatchedSync)
+  end
+
+  test "is a no-op when the config was deleted between enqueue and execution" do
+    config = plex_config()
+    {:ok, _} = Settings.delete_media_server_config(config)
+
+    assert :ok = perform_job(PlexLinkSeed, %{"config_id" => config.id})
+  end
+end

--- a/test/mydia/jobs/plex_link_seed_test.exs
+++ b/test/mydia/jobs/plex_link_seed_test.exs
@@ -109,6 +109,24 @@ defmodule Mydia.Jobs.PlexLinkSeedTest do
     assert [] = all_enqueued(worker: MediaServerWatchedSync)
   end
 
+  test "does nothing when watched sync is disabled", %{base: base} do
+    # maybe_seed_plex_links/1 fires on every Plex config save, including one
+    # where the operator only wants library refresh and never opted into
+    # watched-status sync. Seeding here would enumerate Plex Home and mint a
+    # long-lived per-profile token for every household member for a feature
+    # they never asked for.
+    config = plex_config(%{connection_settings: %{"sync_watched" => false}})
+
+    assert :ok =
+             perform_job(PlexLinkSeed, %{
+               "config_id" => config.id,
+               "plex_tv_base" => base
+             })
+
+    assert [] = Settings.list_media_server_user_links(config.id)
+    assert [] = all_enqueued(worker: MediaServerWatchedSync)
+  end
+
   test "is a no-op for a Jellyfin config" do
     {:ok, config} =
       Settings.create_media_server_config(%{

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -1,5 +1,6 @@
 defmodule MydiaWeb.AdminMediaServersLiveTest do
   use MydiaWeb.ConnCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
 
   import Phoenix.LiveViewTest
   alias Mydia.Accounts
@@ -132,10 +133,54 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
     end
 
     test "the modal no longer offers a Connection step", %{view: view} do
-      view |> element("[phx-click='new_media_server']") |> render_click()
+      view |> element("#new-media-server") |> render_click()
 
       refute has_element?(view, "li.step", "Connection")
       assert has_element?(view, "li.step", "Server")
+    end
+  end
+
+  describe "Empty state and skip reasons" do
+    setup %{conn: conn, token: token} do
+      start_supervised!(Mydia.Indexers.Health)
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      %{conn: conn}
+    end
+
+    test "renders the empty state with a connect action when nothing is configured",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
+
+      assert has_element?(view, "#media-servers-empty")
+      assert has_element?(view, "#media-servers-empty-cta")
+    end
+
+    test "renders a humanized skip reason rather than a raw atom", %{conn: conn} do
+      {:ok, config} =
+        Mydia.Settings.create_media_server_config(%{
+          name: "Skipped Plex",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "tok",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      Mydia.Sync.record_skip(
+        %{provider: "plex", provider_instance_id: config.id},
+        :seeding_links
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
+
+      assert has_element?(view, "[data-test='last-sync-run']")
+      refute render(view) =~ "seeding_links"
     end
   end
 end

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -183,4 +183,100 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
       refute render(view) =~ "seeding_links"
     end
   end
+
+  describe "Plex link seeding and Sync Now" do
+    setup %{conn: conn, token: token} do
+      start_supervised!(Mydia.Indexers.Health)
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      %{conn: conn}
+    end
+
+    test "saving a Plex config enqueues a link seed", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
+
+      view
+      |> element("#media-servers-empty-cta")
+      |> render_click()
+
+      # The Plex wizard defaults to the OAuth flow, which renders no url/token
+      # inputs. Switch to manual entry (a real, existing escape hatch in the
+      # wizard) so the form actually has fields to submit.
+      view
+      |> element("button[phx-click='toggle_plex_manual_entry']")
+      |> render_click()
+
+      view
+      |> form("#media-server-form", %{
+        "media_server_config" => %{
+          "name" => "Seeded Plex",
+          "type" => "plex",
+          "url" => "http://localhost:32400",
+          "token" => "tok"
+        }
+      })
+      |> render_submit()
+
+      config = Mydia.Settings.list_media_server_configs() |> List.first()
+
+      assert_enqueued(worker: Mydia.Jobs.PlexLinkSeed, args: %{"config_id" => config.id})
+    end
+
+    test "saving a Jellyfin config does not enqueue a link seed", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
+
+      view
+      |> element("#media-servers-empty-cta")
+      |> render_click()
+
+      # The modal defaults to type "plex", which renders the OAuth wizard
+      # instead of url/token inputs. Switch the type to jellyfin first so the
+      # form re-renders with the plain url/token fields jellyfin uses.
+      view
+      |> form("#media-server-form", %{"media_server_config" => %{"type" => "jellyfin"}})
+      |> render_change()
+
+      view
+      |> form("#media-server-form", %{
+        "media_server_config" => %{
+          "name" => "Jelly",
+          "type" => "jellyfin",
+          "url" => "http://localhost:8096",
+          "token" => "tok"
+        }
+      })
+      |> render_submit()
+
+      assert [] = all_enqueued(worker: Mydia.Jobs.PlexLinkSeed)
+      assert Mydia.Settings.list_media_server_configs() |> List.first()
+    end
+
+    test "Sync Now enqueues the server-mode job, not a per-user job", %{conn: conn} do
+      {:ok, config} =
+        Mydia.Settings.create_media_server_config(%{
+          name: "Sync Me",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "tok",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
+
+      view
+      |> element("button[phx-click='sync_watched'][phx-value-id='#{config.id}']")
+      |> render_click()
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MediaServerWatchedSync,
+        args: %{"mode" => "server", "config_id" => config.id}
+      )
+    end
+  end
 end


### PR DESCRIPTION
## What

The Media Servers page advertised "automatic library updates" and nothing else, which described about a third of the integration. Investigating the copy turned up why the omitted part was missing: it never worked.

`Mydia.MediaServer.Plex.Home.seed_links/2` is the only code that creates the per-user Plex links that watched-status sync depends on, and it had **zero callers in `lib/`**. So every 30 minutes the scheduler ran, found no links, recorded `:no_user_mapping`, and stopped. Scheduled watched sync has never run for anyone, on any install. Only the manual "Sync Now" button worked, and only because it fell back to the config token.

## Changes

- Add `Mydia.Jobs.PlexLinkSeed`, the missing caller for `seed_links/2`. Seeding is a job because it makes 1 + N plex.tv round trips (list Plex Home users, then one profile switch per matched user), which is too slow to hang a form submit on.
- Add a server-mode clause to `MediaServerWatchedSync` so one job syncs a whole server across every linked user. "Sync Now" and the scheduler now share one fan-out path.
- Make the scheduler self-heal: a config with no links enqueues a seed instead of skipping forever. This is what unbreaks installs that already saved a Plex config, with no need to re-run OAuth.
- Repoint "Sync Now" at the server fan-out. It previously enqueued a job with no `link_id`, which fell through to the config token and wrote the admin's Plex watch state onto whoever clicked. Harmless while no links existed, a cross-account history merge once they do.
- Rewrite the empty state to describe library refresh, Plex-only two-way watched sync, and per-Plex-Home-profile mapping.
- Render humanized skip reasons instead of raw atoms like `Skipped: no_user_mapping`.
- Gate seeding on watched sync being enabled. Without this, connecting Plex purely for library refresh would enumerate Plex Home and store a long-lived per-profile token for every household member, for a feature the operator never opted into.
- Add a `:no_token` skip reason. A Plex config with sync on but a blank token previously recorded `:seeding_links` every tick for work that could never happen, repeating the exact "reports healthy while doing nothing" failure this PR exists to remove.

## Termination

There is a deliberate cycle: server mode with no links enqueues `PlexLinkSeed`, and `PlexLinkSeed` enqueues server mode on a successful seed. It terminates only because `PlexLinkSeed` enqueues nothing when a seed produces zero links. Reviewed against disabled links, mid-cycle deletion, Oban's 120s uniqueness window, error paths, and retries. Worst case is one extra hop. Runtime and env-configured Plex configs cannot enter the cycle at all, because their embed carries no `connection_settings`, so `watched_sync_enabled?/1` is always false for them.

## Verification

- Full suite: 7123 tests, 0 failures, 34 skipped. `mix precommit` exit 0.
- New tests cover the loop guard's empty-seed branch, per-link fan-out, the self-heal path, the sync-disabled and blank-token gates, and the empty state by DOM id.
- No migrations.

## Not in scope

The modal's "Enabled" toggle sits outside `<.form id="media-server-form">`, so it is never submitted and is inert for real users on both create and edit. Pre-existing, predates this branch, left alone rather than buried in an unrelated commit. Worth its own fix.
