### PR TITLE
fix(media-servers): unblock saving a Plex server after auto-connect

### DIFF
--- a/lib/mydia/media_server/plex/selection.ex
+++ b/lib/mydia/media_server/plex/selection.ex
@@ -66,4 +66,38 @@ defmodule Mydia.MediaServer.Plex.Selection do
       enabled: true
     }
   end
+
+  @doc """
+  Re-applies discovery-owned attrs onto form params.
+
+  The wizard's discovered fields are deliberately absent from the modal's form:
+  `connections` is a list rather than an input, the two tokens are secrets that
+  should not be rendered into the page, and none of them are operator-editable.
+  Without this merge the LiveView's change and submit handlers rebuild the
+  changeset from browser params alone and silently drop every one of them,
+  leaving a config with no `url` and no discovery data, which
+  `MediaServerConfig.changeset/2` then rejects.
+
+  `params` arrive string-keyed from the browser and `cast/3` rejects a map that
+  mixes atom and string keys, so the atom keys from `config_attrs/3` are
+  converted here. The `connections` value itself stays as-is: `JsonListType`
+  passes lists through untouched and Jason stringifies their keys on dump.
+  """
+  @spec merge_discovery(map(), map() | nil) :: map()
+  def merge_discovery(params, nil), do: params
+
+  def merge_discovery(%{"type" => "plex"} = params, discovery) when is_map(discovery) do
+    Map.merge(params, %{
+      "machine_identifier" => discovery[:machine_identifier],
+      "connections" => discovery[:connections],
+      "server_access_token" => discovery[:server_access_token],
+      "connections_refreshed_at" => discovery[:connections_refreshed_at],
+      "token" => discovery[:token]
+    })
+  end
+
+  # Any other type means the operator moved the Type select off Plex. Discovery
+  # no longer describes what is being saved, so it is dropped rather than
+  # smuggled into a Jellyfin config.
+  def merge_discovery(params, _discovery), do: params
 end

--- a/lib/mydia/settings/media_server_config.ex
+++ b/lib/mydia/settings/media_server_config.ex
@@ -98,7 +98,15 @@ defmodule Mydia.Settings.MediaServerConfig do
     end
   end
 
-  defp addressable_by_discovery?(changeset) do
+  @doc """
+  Returns true when a Plex config can address itself through discovery.
+
+  Public because the media server modal needs exactly this rule to decide
+  whether the Server URL field is a requirement or an optional manual override.
+  Two copies of the rule would drift.
+  """
+  @spec addressable_by_discovery?(Ecto.Changeset.t()) :: boolean()
+  def addressable_by_discovery?(changeset) do
     present?(get_field(changeset, :machine_identifier)) or
       get_field(changeset, :connections) not in [nil, []]
   end

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -3,6 +3,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   use MydiaWeb, :html
 
   alias Mydia.Settings
+  alias Mydia.Settings.MediaServerConfig
 
   @doc """
   Renders the Media Servers tab content.
@@ -230,6 +231,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   attr :plex_oauth_servers, :list, default: []
   attr :plex_manual_entry, :boolean, default: false
   attr :plex_reachability, :any, default: :checking
+  attr :plex_discovery, :map, default: nil
 
   def media_server_modal(assigns) do
     # Get the current type from the form
@@ -241,7 +243,13 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
         type when is_binary(type) -> String.to_existing_atom(type)
       end
 
-    assigns = assign(assigns, :current_type, current_type)
+    assigns =
+      assigns
+      |> assign(:current_type, current_type)
+      |> assign(
+        :plex_addressable,
+        MediaServerConfig.addressable_by_discovery?(assigns.media_server_form.source)
+      )
 
     ~H"""
     <div
@@ -493,8 +501,10 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
               </div>
             <% end %>
 
-            <%!-- Manual entry fields - shown for Jellyfin, or Plex in manual mode, or after OAuth complete --%>
-            <%= if @current_type != :plex or @plex_manual_entry or @plex_oauth_state == :complete do %>
+            <%!-- Manual entry fields - shown for Jellyfin, or Plex in manual mode.
+                  The discovery path renders its own read-only review panel instead,
+                  because it has no url to collect and its token is not operator-editable. --%>
+            <%= if @current_type != :plex or @plex_manual_entry do %>
               <div class="card bg-base-200/50 border border-base-300">
                 <div class="card-body p-4 gap-4">
                   <div class="flex items-center gap-2 text-sm font-medium text-base-content/70">
@@ -512,13 +522,16 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                             do: "http://192.168.1.100:32400",
                             else: "http://192.168.1.100:8096"
                         }
-                        required
+                        required={@current_type != :plex or not @plex_addressable}
                       />
                       <p class="text-xs text-base-content/50 mt-1 ml-1">
-                        <%= if @current_type == :plex do %>
-                          Full URL including port (default: 32400)
-                        <% else %>
-                          Full URL including port (default: 8096)
+                        <%= cond do %>
+                          <% @current_type == :plex and @plex_addressable -> %>
+                            Optional manual override. Leave blank to use the addresses discovered from your Plex account.
+                          <% @current_type == :plex -> %>
+                            Full URL including port (default: 32400)
+                          <% true -> %>
+                            Full URL including port (default: 8096)
                         <% end %>
                       </p>
                     </div>

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -712,10 +712,15 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
             </button>
             <button
               type="submit"
+              id="media-server-submit"
               class={[
                 "btn btn-primary gap-2 col-span-2 order-first sm:order-none",
                 modal_action_btn()
               ]}
+              disabled={
+                @media_server_mode == :new and @current_type == :plex and
+                  not @plex_manual_entry and @plex_oauth_state != :complete
+              }
             >
               <.icon name="hero-check" class="w-4 h-4" />
               {if @media_server_mode == :new, do: "Add Server", else: "Save Changes"}

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -450,33 +450,82 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                         </button>
                       </div>
                     <% :complete -> %>
-                      <div class="text-center py-2">
-                        <div class="bg-success/10 inline-flex p-3 rounded-full mb-3">
-                          <.icon name="hero-check-circle" class="w-8 h-8 text-success" />
+                      <div class="space-y-3">
+                        <div class="text-center py-2">
+                          <div class="bg-success/10 inline-flex p-3 rounded-full mb-3">
+                            <.icon name="hero-check-circle" class="w-8 h-8 text-success" />
+                          </div>
+                          <p class="font-medium text-success">Configuration complete!</p>
+                          <p class="text-sm text-base-content/60">
+                            Review the details below and save.
+                          </p>
+                          <div class="mt-3 text-xs">
+                            <%= case @plex_reachability do %>
+                              <% :checking -> %>
+                                <span class="inline-flex items-center gap-2 text-base-content/60">
+                                  <span class="loading loading-spinner loading-xs"></span>
+                                  Checking connectivity...
+                                </span>
+                              <% {:ok, uri} -> %>
+                                <span class="inline-flex items-center gap-1 text-success">
+                                  <.icon name="hero-check-circle" class="w-3 h-3" /> Reachable at
+                                  <span class="font-mono">{simplify_plex_url(uri)}</span>
+                                </span>
+                              <% {:error, _error} -> %>
+                                <span class="inline-flex items-center gap-1 text-warning">
+                                  <.icon name="hero-exclamation-triangle" class="w-3 h-3" />
+                                  No address responded yet. You can still save; Mydia will keep looking.
+                                </span>
+                            <% end %>
+                          </div>
                         </div>
-                        <p class="font-medium text-success">Configuration complete!</p>
-                        <p class="text-sm text-base-content/60">
-                          Review the details below and save.
-                        </p>
-                        <div class="mt-3 text-xs">
-                          <%= case @plex_reachability do %>
-                            <% :checking -> %>
-                              <span class="inline-flex items-center gap-2 text-base-content/60">
-                                <span class="loading loading-spinner loading-xs"></span>
-                                Checking connectivity...
-                              </span>
-                            <% {:ok, uri} -> %>
-                              <span class="inline-flex items-center gap-1 text-success">
-                                <.icon name="hero-check-circle" class="w-3 h-3" /> Reachable at
-                                <span class="font-mono">{simplify_plex_url(uri)}</span>
-                              </span>
-                            <% {:error, _error} -> %>
-                              <span class="inline-flex items-center gap-1 text-warning">
-                                <.icon name="hero-exclamation-triangle" class="w-3 h-3" />
-                                No address responded yet. You can still save; Mydia will keep looking.
-                              </span>
-                          <% end %>
-                        </div>
+
+                        <%= if @plex_discovery do %>
+                          <div
+                            class="bg-base-100 rounded-lg p-3 space-y-2"
+                            data-test="plex-discovery-summary"
+                          >
+                            <div class="flex items-center gap-2">
+                              <div class="bg-primary/10 p-2 rounded-lg">
+                                <.icon name="hero-server" class="w-5 h-5 text-primary" />
+                              </div>
+                              <div class="min-w-0">
+                                <p class="font-medium truncate">{@plex_discovery[:name]}</p>
+                                <p class="font-mono text-xs text-base-content/50 truncate">
+                                  {@plex_discovery[:machine_identifier]}
+                                </p>
+                              </div>
+                            </div>
+
+                            <div class="space-y-1">
+                              <%= for conn <- @plex_discovery[:connections] || [] do %>
+                                <div class="flex items-center gap-2 text-xs">
+                                  <span class="font-mono truncate flex-1">
+                                    {simplify_plex_url(conn[:uri] || conn["uri"])}
+                                  </span>
+                                  <%= if conn[:local] || conn["local"] do %>
+                                    <span class="badge badge-xs badge-info gap-1">
+                                      <.icon name="hero-home" class="w-3 h-3" /> local
+                                    </span>
+                                  <% end %>
+                                  <%= if conn[:relay] || conn["relay"] do %>
+                                    <span class="badge badge-xs badge-warning gap-1">
+                                      <.icon name="hero-cloud" class="w-3 h-3" /> relay
+                                    </span>
+                                  <% end %>
+                                </div>
+                              <% end %>
+                            </div>
+                          </div>
+                        <% end %>
+
+                        <button
+                          type="button"
+                          class="btn btn-ghost btn-sm gap-1"
+                          phx-click="cancel_plex_oauth"
+                        >
+                          <.icon name="hero-arrow-left" class="w-4 h-4" /> Start over
+                        </button>
                       </div>
                     <% :error -> %>
                       <div class="text-center space-y-4 py-2">
@@ -639,12 +688,17 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
           <div class="modal-action mt-6 grid grid-cols-2 gap-2 sticky bottom-0 bg-base-100 -mx-6 px-6 -mb-6 pb-6 pt-4 border-t border-base-300 sm:flex sm:gap-2">
             <button
               type="button"
-              class={["btn btn-ghost", modal_action_btn()]}
+              class={[
+                "btn btn-ghost",
+                @plex_oauth_state == :complete && "col-span-2 sm:col-span-1",
+                modal_action_btn()
+              ]}
               phx-click="close_media_server_modal"
             >
               Cancel
             </button>
             <button
+              :if={@plex_oauth_state != :complete}
               type="button"
               class={["btn btn-outline btn-secondary gap-2", modal_action_btn()]}
               phx-click="test_media_server_connection"

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -504,17 +504,21 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                             </div>
 
                             <div class="space-y-1">
+                              <%!-- These connections come straight from PlexOAuth.parse_connections/1
+                                    and are always atom-keyed. A future change that feeds this panel
+                                    from a persisted MediaServerConfig (string-keyed after a DB round
+                                    trip through JsonListType) would need to normalize first. --%>
                               <%= for conn <- @plex_discovery[:connections] || [] do %>
                                 <div class="flex items-center gap-2 text-xs">
                                   <span class="font-mono truncate flex-1">
-                                    {simplify_plex_url(conn[:uri] || conn["uri"])}
+                                    {simplify_plex_url(conn[:uri])}
                                   </span>
-                                  <%= if conn[:local] || conn["local"] do %>
+                                  <%= if conn[:local] do %>
                                     <span class="badge badge-xs badge-info gap-1">
                                       <.icon name="hero-home" class="w-3 h-3" /> local
                                     </span>
                                   <% end %>
-                                  <%= if conn[:relay] || conn["relay"] do %>
+                                  <%= if conn[:relay] do %>
                                     <span class="badge badge-xs badge-warning gap-1">
                                       <.icon name="hero-cloud" class="w-3 h-3" /> relay
                                     </span>

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -287,13 +287,19 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
           </div>
           <label class="label cursor-pointer gap-2 w-full justify-between sm:w-auto sm:justify-end">
             <span class="label-text text-sm">Enabled</span>
-            <input type="hidden" name={@media_server_form[:enabled].name} value="false" />
+            <input
+              type="hidden"
+              name={@media_server_form[:enabled].name}
+              value="false"
+              form="media-server-form"
+            />
             <input
               type="checkbox"
               name={@media_server_form[:enabled].name}
               value="true"
               checked={Phoenix.HTML.Form.input_value(@media_server_form, :enabled) in [true, "true"]}
               class="toggle toggle-success toggle-sm"
+              form="media-server-form"
             />
           </label>
         </div>

--- a/lib/mydia_web/live/admin_media_servers_live/index.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.ex
@@ -56,7 +56,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
      |> assign(:plex_oauth_token, nil)
      |> assign(:plex_reachability, :checking)
      |> assign(:plex_manual_entry, false)
-     |> assign(:plex_discovery, nil)}
+     |> assign(:plex_discovery, nil)
+     |> assign(:plex_discovery_summary, nil)}
   end
 
   @impl true
@@ -86,7 +87,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
        |> assign(:plex_oauth_token, nil)
        |> assign(:plex_reachability, :checking)
        |> assign(:plex_manual_entry, true)
-       |> assign(:plex_discovery, nil)}
+       |> assign(:plex_discovery, nil)
+       |> assign(:plex_discovery_summary, nil)}
     end
   end
 
@@ -118,7 +120,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
        |> assign(:plex_oauth_servers, [])
        |> assign(:plex_oauth_token, nil)
        |> assign(:plex_manual_entry, false)
-       |> assign(:plex_discovery, nil)}
+       |> assign(:plex_discovery, nil)
+       |> assign(:plex_discovery_summary, nil)}
     end
   end
 
@@ -306,6 +309,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
      |> assign(:plex_oauth_token, nil)
      |> assign(:plex_reachability, :checking)
      |> assign(:plex_discovery, nil)
+     |> assign(:plex_discovery_summary, nil)
      |> push_event("plex_auth_cancelled", %{})}
   end
 
@@ -319,7 +323,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
      |> assign(:plex_oauth_servers, [])
      |> assign(:plex_oauth_token, nil)
      |> assign(:plex_reachability, :checking)
-     |> assign(:plex_discovery, nil)}
+     |> assign(:plex_discovery, nil)
+     |> assign(:plex_discovery_summary, nil)}
   end
 
   @impl true
@@ -466,7 +471,16 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
         socket
         |> assign(:plex_oauth_state, :complete)
         |> assign(:plex_reachability, :checking)
+        # `plex_discovery` keeps the full attrs (including `token` and
+        # `server_access_token`) so `Selection.merge_discovery/2` still has
+        # what it needs on submit. `plex_discovery_summary` is the
+        # template-facing view: only the fields the review panel actually
+        # renders, so the two secrets never reach template scope.
         |> assign(:plex_discovery, attrs)
+        |> assign(
+          :plex_discovery_summary,
+          Map.take(attrs, [:name, :machine_identifier, :connections])
+        )
         |> start_reachability_probe(server)
         |> assign(:media_server_form, to_form(changeset))
     end
@@ -496,6 +510,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
     if socket.assigns[:plex_discovery] do
       socket
       |> assign(:plex_discovery, nil)
+      |> assign(:plex_discovery_summary, nil)
       |> assign(:plex_oauth_state, :idle)
       |> assign(:plex_reachability, :checking)
     else
@@ -522,6 +537,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
     |> assign(:plex_oauth_servers, [])
     |> assign(:plex_reachability, :checking)
     |> assign(:plex_manual_entry, false)
+    |> assign(:plex_discovery, nil)
+    |> assign(:plex_discovery_summary, nil)
   end
 
   defp get_media_server_health_status(media_servers) do

--- a/lib/mydia_web/live/admin_media_servers_live/index.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.ex
@@ -55,7 +55,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
      |> assign(:plex_oauth_servers, [])
      |> assign(:plex_oauth_token, nil)
      |> assign(:plex_reachability, :checking)
-     |> assign(:plex_manual_entry, false)}
+     |> assign(:plex_manual_entry, false)
+     |> assign(:plex_discovery, nil)}
   end
 
   @impl true
@@ -84,7 +85,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
        |> assign(:plex_oauth_servers, [])
        |> assign(:plex_oauth_token, nil)
        |> assign(:plex_reachability, :checking)
-       |> assign(:plex_manual_entry, true)}
+       |> assign(:plex_manual_entry, true)
+       |> assign(:plex_discovery, nil)}
     end
   end
 
@@ -115,12 +117,15 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
        |> assign(:plex_oauth_pin_id, nil)
        |> assign(:plex_oauth_servers, [])
        |> assign(:plex_oauth_token, nil)
-       |> assign(:plex_manual_entry, false)}
+       |> assign(:plex_manual_entry, false)
+       |> assign(:plex_discovery, nil)}
     end
   end
 
   @impl true
   def handle_event("validate_media_server", %{"media_server_config" => params}, socket) do
+    params = Selection.merge_discovery(params, socket.assigns[:plex_discovery])
+
     server =
       case socket.assigns.media_server_mode do
         :new -> %MediaServerConfig{}
@@ -132,11 +137,16 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
       |> Settings.change_media_server_config(params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign(socket, :media_server_form, to_form(changeset))}
+    {:noreply,
+     socket
+     |> assign(:media_server_form, to_form(changeset))
+     |> reset_wizard_if_type_changed(params)}
   end
 
   @impl true
   def handle_event("save_media_server", %{"media_server_config" => params}, socket) do
+    params = Selection.merge_discovery(params, socket.assigns[:plex_discovery])
+
     params =
       case socket.assigns.media_server_mode do
         :edit ->
@@ -295,6 +305,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
      |> assign(:plex_oauth_servers, [])
      |> assign(:plex_oauth_token, nil)
      |> assign(:plex_reachability, :checking)
+     |> assign(:plex_discovery, nil)
      |> push_event("plex_auth_cancelled", %{})}
   end
 
@@ -307,7 +318,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
      |> assign(:plex_oauth_pin_id, nil)
      |> assign(:plex_oauth_servers, [])
      |> assign(:plex_oauth_token, nil)
-     |> assign(:plex_reachability, :checking)}
+     |> assign(:plex_reachability, :checking)
+     |> assign(:plex_discovery, nil)}
   end
 
   @impl true
@@ -454,6 +466,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
         socket
         |> assign(:plex_oauth_state, :complete)
         |> assign(:plex_reachability, :checking)
+        |> assign(:plex_discovery, attrs)
         |> start_reachability_probe(server)
         |> assign(:media_server_form, to_form(changeset))
     end
@@ -472,6 +485,22 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
     end)
 
     socket
+  end
+
+  # Moving the Type select off Plex makes the discovered data describe something
+  # other than what is being saved. Resetting the wizard is what stops a stale
+  # "Configuration complete!" panel from sitting above a Jellyfin form.
+  defp reset_wizard_if_type_changed(socket, %{"type" => "plex"}), do: socket
+
+  defp reset_wizard_if_type_changed(socket, _params) do
+    if socket.assigns[:plex_discovery] do
+      socket
+      |> assign(:plex_discovery, nil)
+      |> assign(:plex_oauth_state, :idle)
+      |> assign(:plex_reachability, :checking)
+    else
+      socket
+    end
   end
 
   defp load_data(socket) do

--- a/lib/mydia_web/live/admin_media_servers_live/index.html.heex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.html.heex
@@ -16,7 +16,7 @@
         plex_oauth_servers={assigns[:plex_oauth_servers] || []}
         plex_manual_entry={assigns[:plex_manual_entry] || false}
         plex_reachability={assigns[:plex_reachability] || :checking}
-        plex_discovery={assigns[:plex_discovery]}
+        plex_discovery={assigns[:plex_discovery_summary]}
       />
     <% end %>
   </.admin_page>

--- a/lib/mydia_web/live/admin_media_servers_live/index.html.heex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.html.heex
@@ -16,6 +16,7 @@
         plex_oauth_servers={assigns[:plex_oauth_servers] || []}
         plex_manual_entry={assigns[:plex_manual_entry] || false}
         plex_reachability={assigns[:plex_reachability] || :checking}
+        plex_discovery={assigns[:plex_discovery]}
       />
     <% end %>
   </.admin_page>

--- a/test/mydia/media_server/plex/selection_test.exs
+++ b/test/mydia/media_server/plex/selection_test.exs
@@ -2,6 +2,7 @@ defmodule Mydia.MediaServer.Plex.SelectionTest do
   use ExUnit.Case, async: true
 
   alias Mydia.MediaServer.Plex.Selection
+  alias Mydia.Settings.MediaServerConfig
 
   defp server(name, opts \\ []) do
     %{
@@ -102,6 +103,72 @@ defmodule Mydia.MediaServer.Plex.SelectionTest do
       attrs = Selection.config_attrs(server("Storage"), "tok", now)
 
       assert attrs.connections_refreshed_at == ~U[2026-08-11 12:00:00Z]
+    end
+  end
+
+  describe "merge_discovery/2" do
+    defp discovery do
+      Selection.config_attrs(
+        server("Storage", owned: true),
+        "acct-token",
+        ~U[2026-08-12 00:00:00Z]
+      )
+    end
+
+    defp form_params(overrides \\ %{}) do
+      Map.merge(%{"name" => "Storage", "type" => "plex", "url" => ""}, overrides)
+    end
+
+    test "nil discovery leaves params untouched" do
+      params = form_params()
+      assert Selection.merge_discovery(params, nil) == params
+    end
+
+    test "discovery-owned fields are restored onto form params" do
+      merged = Selection.merge_discovery(form_params(), discovery())
+
+      assert merged["machine_identifier"] == "Storage"
+      assert merged["server_access_token"] == "srv-Storage"
+      assert merged["token"] == "acct-token"
+      assert merged["connections_refreshed_at"] == ~U[2026-08-12 00:00:00Z]
+      assert [%{uri: "http://127.0.0.1:32400"}] = merged["connections"]
+    end
+
+    test "operator edits to form fields win over discovery" do
+      merged = Selection.merge_discovery(form_params(%{"name" => "Renamed"}), discovery())
+
+      assert merged["name"] == "Renamed"
+    end
+
+    test "the merged map stays entirely string-keyed, because cast/3 rejects mixed keys" do
+      merged = Selection.merge_discovery(form_params(), discovery())
+
+      assert Enum.all?(Map.keys(merged), &is_binary/1)
+    end
+
+    test "switching the type away from Plex drops discovery entirely" do
+      params = form_params(%{"type" => "jellyfin", "url" => "http://box:8096"})
+
+      assert Selection.merge_discovery(params, discovery()) == params
+    end
+
+    # The regression this whole change exists to prevent: the wizard leaves url
+    # nil on purpose, so without the merge there is nothing left to address the
+    # server by and the changeset rejects a config the operator just authorised.
+    test "merged params build a valid changeset even with a blank url" do
+      merged = Selection.merge_discovery(form_params(), discovery())
+      changeset = MediaServerConfig.changeset(%MediaServerConfig{}, merged)
+
+      assert changeset.valid?
+    end
+
+    test "the same params without the merge are rejected" do
+      changeset = MediaServerConfig.changeset(%MediaServerConfig{}, form_params())
+
+      refute changeset.valid?
+
+      assert {"is required until a Plex server is discovered", _} =
+               changeset.errors[:url]
     end
   end
 end

--- a/test/mydia_web/live/admin_media_servers_live/components_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live/components_test.exs
@@ -217,6 +217,30 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
     end
   end
 
+  describe "media server modal, Enabled toggle form association" do
+    # The Enabled toggle sits in the modal header, above where <.form> opens,
+    # so it is not a descendant of the form element. Without an explicit
+    # `form="media-server-form"` attribute the browser never submits it: the
+    # hidden false-sentinel is dropped and the checkbox is dropped, so
+    # `enabled` never reaches phx-change or phx-submit at all.
+    defp enabled_inputs(html) do
+      html
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query(~s([name="media_server_config[enabled]"]))
+    end
+
+    test "both the hidden sentinel and the checkbox are associated with the form by id" do
+      html = render_modal(mode: :edit)
+
+      form_attrs =
+        html
+        |> enabled_inputs()
+        |> LazyHTML.attribute("form")
+
+      assert form_attrs == ["media-server-form", "media-server-form"]
+    end
+  end
+
   describe "media server modal, discovery review panel" do
     defp discovery_map do
       %{

--- a/test/mydia_web/live/admin_media_servers_live/components_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live/components_test.exs
@@ -4,9 +4,46 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
   # Only `render_component/2` is needed here, and importing `render/1` alongside
   # the local helpers below is noise. Matches franchise_components_test.exs.
   import Phoenix.LiveViewTest, except: [render: 1]
+  import Phoenix.Component, only: [to_form: 1]
 
   alias Mydia.Settings.MediaServerConfig
   alias MydiaWeb.AdminMediaServersLive.Components
+
+  defp render_modal(opts) do
+    config = Keyword.get(opts, :config, %MediaServerConfig{type: :plex})
+
+    render_component(&Components.media_server_modal/1, %{
+      media_server_form: to_form(MediaServerConfig.changeset(config, %{})),
+      media_server_mode: Keyword.get(opts, :mode, :new),
+      plex_oauth_state: Keyword.get(opts, :oauth_state, :idle),
+      plex_manual_entry: Keyword.get(opts, :manual_entry, false),
+      plex_reachability: Keyword.get(opts, :reachability, :checking),
+      plex_discovery: Keyword.get(opts, :discovery)
+    })
+  end
+
+  defp url_input_required?(html) do
+    required =
+      html
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query("#media_server_config_url")
+      |> LazyHTML.attribute("required")
+
+    required != []
+  end
+
+  defp discovered_plex_config do
+    %MediaServerConfig{
+      id: "22222222-2222-2222-2222-222222222222",
+      name: "Storage",
+      type: :plex,
+      enabled: true,
+      url: nil,
+      token: "acct-token",
+      machine_identifier: "machine-abc",
+      connections: [%{"uri" => "http://127.0.0.1:32400", "local" => true}]
+    }
+  end
 
   defp server(attrs \\ %{}) do
     struct!(
@@ -89,6 +126,45 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
       assert html =~ "edit_media_server"
       assert html =~ "delete_media_server"
       refute html =~ ~s(data-test="env-config-note")
+    end
+  end
+
+  describe "media server modal, Server URL requirement" do
+    # Editing a server that was added through the wizard is what regressed:
+    # its url is nil by design, so a hard `required` made the modal unsavable
+    # and there was no way to rename it or change its sync settings.
+    test "a discovered Plex config offers the URL as an optional override" do
+      html = render_modal(config: discovered_plex_config(), mode: :edit, manual_entry: true)
+
+      assert html =~ ~s(id="media_server_config_url")
+      refute url_input_required?(html)
+      assert html =~ "Optional manual override"
+    end
+
+    test "a Plex config with no discovery data still requires the URL" do
+      html = render_modal(manual_entry: true)
+
+      assert url_input_required?(html)
+      assert html =~ "default: 32400"
+    end
+
+    test "a Jellyfin config still requires the URL" do
+      html = render_modal(config: %MediaServerConfig{type: :jellyfin})
+
+      assert url_input_required?(html)
+      assert html =~ "default: 8096"
+    end
+
+    test "the discovery path renders no URL or token inputs at all" do
+      html =
+        render_modal(
+          config: discovered_plex_config(),
+          oauth_state: :complete,
+          discovery: %{name: "Storage", machine_identifier: "machine-abc", connections: []}
+        )
+
+      refute html =~ ~s(id="media_server_config_url")
+      refute html =~ ~s(id="media_server_config_token")
     end
   end
 end

--- a/test/mydia_web/live/admin_media_servers_live/components_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live/components_test.exs
@@ -167,4 +167,54 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
       refute html =~ ~s(id="media_server_config_token")
     end
   end
+
+  describe "media server modal, discovery review panel" do
+    defp discovery_map do
+      %{
+        name: "Storage",
+        machine_identifier: "machine-abc",
+        connections: [
+          %{uri: "https://10-0-0-4.abc.plex.direct:32400", local: true, relay: false},
+          %{uri: "https://relay.plex.direct:443", local: false, relay: true}
+        ]
+      }
+    end
+
+    test "the review panel names the server and its machine identifier" do
+      html = render_modal(oauth_state: :complete, discovery: discovery_map())
+
+      assert html =~ ~s(data-test="plex-discovery-summary")
+      assert html =~ "Storage"
+      assert html =~ "machine-abc"
+    end
+
+    test "the review panel lists the discovered addresses with their badges" do
+      html = render_modal(oauth_state: :complete, discovery: discovery_map())
+
+      assert html =~ "local"
+      assert html =~ "relay"
+    end
+
+    test "the review panel offers a way back but collects no input" do
+      html = render_modal(oauth_state: :complete, discovery: discovery_map())
+
+      assert html =~ "cancel_plex_oauth"
+      refute html =~ ~s(id="media_server_config_url")
+    end
+
+    # Test Connection builds its probe config from url and token alone, with no
+    # connections, so on the discovery path it always fails. The reachability
+    # line already on this screen reports the same thing honestly.
+    test "Test Connection is hidden on the review step" do
+      html = render_modal(oauth_state: :complete, discovery: discovery_map())
+
+      refute html =~ "test_media_server_connection"
+    end
+
+    test "Test Connection is still offered everywhere else" do
+      html = render_modal(manual_entry: true)
+
+      assert html =~ "test_media_server_connection"
+    end
+  end
 end

--- a/test/mydia_web/live/admin_media_servers_live/components_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live/components_test.exs
@@ -168,6 +168,55 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
     end
   end
 
+  describe "media server modal, submit button availability" do
+    defp submit_disabled?(html) do
+      disabled =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query("#media-server-submit")
+        |> LazyHTML.attribute("disabled")
+
+      disabled != []
+    end
+
+    # New + Plex + no manual entry + not yet complete means there is no url
+    # input on screen at all: submitting would fail on a changeset error
+    # pinned to :url, which nothing on the page shows. Disable Add Server
+    # rather than let that happen silently.
+    test "Add Server is disabled for a new Plex server before the wizard completes" do
+      html = render_modal(mode: :new, oauth_state: :idle, manual_entry: false)
+
+      assert submit_disabled?(html)
+    end
+
+    test "Add Server is enabled once the Plex wizard reaches the review step" do
+      html =
+        render_modal(
+          mode: :new,
+          oauth_state: :complete,
+          manual_entry: false,
+          discovery: %{name: "Storage", machine_identifier: "machine-abc", connections: []}
+        )
+
+      refute submit_disabled?(html)
+    end
+
+    test "Save Changes stays enabled in edit mode even before the wizard completes" do
+      # In edit/reconnect mode the base struct already carries the discovery
+      # data, so the same visual state that blocks a new save can save
+      # successfully here.
+      html =
+        render_modal(
+          config: discovered_plex_config(),
+          mode: :edit,
+          oauth_state: :idle,
+          manual_entry: false
+        )
+
+      refute submit_disabled?(html)
+    end
+  end
+
   describe "media server modal, discovery review panel" do
     defp discovery_map do
       %{
@@ -191,8 +240,14 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
     test "the review panel lists the discovered addresses with their badges" do
       html = render_modal(oauth_state: :complete, discovery: discovery_map())
 
-      assert html =~ "local"
-      assert html =~ "relay"
+      # `simplify_plex_url("https://relay.plex.direct:443")` renders as
+      # "relay:443" in the connection line itself, so a loose `html =~
+      # "relay"` passes even with the relay badge deleted. Assert on the
+      # DaisyUI badge classes the markup actually uses instead.
+      document = LazyHTML.from_fragment(html)
+
+      refute Enum.empty?(LazyHTML.query(document, ".badge-info"))
+      refute Enum.empty?(LazyHTML.query(document, ".badge-warning"))
     end
 
     test "the review panel offers a way back but collects no input" do

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -139,7 +139,14 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
     end
   end
 
-  describe "Editing a server added through the Plex wizard" do
+  # Characterization test, not a regression test: pre-branch, edit-mode save
+  # already used `editing_media_server` as the changeset base, so
+  # `machine_identifier` and `connections` already survived a form-params-only
+  # save. What actually blocked editing a wizard-created server was the
+  # browser-level `required` attribute on the URL input, which `render_submit/1`
+  # does not enforce; that blockage is pinned separately in
+  # `components_test.exs` ("media server modal, Server URL requirement").
+  describe "discovery data on a Plex wizard config survives a form-params-only save" do
     setup %{conn: conn, token: token} do
       start_supervised!(Mydia.Indexers.Health)
 
@@ -163,7 +170,8 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
       %{conn: conn, config: config}
     end
 
-    test "the server can be renamed without supplying a url", %{conn: conn, config: config} do
+    test "renaming via form params alone preserves machine_identifier and connections",
+         %{conn: conn, config: config} do
       {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
 
       view |> element("[phx-click='edit_media_server']") |> render_click()

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -195,4 +195,16 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
       assert [%{"uri" => "http://127.0.0.1:32400"}] = updated.connections
     end
   end
+
+  # A LiveView integration test for the Enabled toggle fix (form="media-server-form"
+  # on components.ex:290-298) was attempted here and deleted. Phoenix.LiveViewTest's
+  # form/3 collects inputs by walking descendants of the located <form> node; it does
+  # not implement HTML5 form-attribute association the way a real browser does, so a
+  # submit driven through form/3 never picks up the hidden sentinel or checkbox at all
+  # regardless of whether the form="media-server-form" attribute is present. Confirmed
+  # empirically: submitting via form/3 against a seeded enabled: true config left
+  # updated.enabled == true even with the fix in place, because no "enabled" key ever
+  # reached the params. That is a limitation of the test helper, not the fix. The
+  # honest pin for this fix lives in components_test.exs ("media server modal, Enabled
+  # toggle form association"), which asserts the form= attribute on the rendered markup.
 end

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -138,4 +138,53 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
       assert has_element?(view, "li.step", "Server")
     end
   end
+
+  describe "Editing a server added through the Plex wizard" do
+    setup %{conn: conn, token: token} do
+      start_supervised!(Mydia.Indexers.Health)
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      # A wizard-created config: no url, addressable only through discovery.
+      {:ok, config} =
+        Mydia.Settings.create_media_server_config(%{
+          name: "Storage",
+          type: :plex,
+          url: nil,
+          token: "acct-token",
+          machine_identifier: "machine-abc",
+          connections: [%{"uri" => "http://127.0.0.1:32400", "local" => true}]
+        })
+
+      %{conn: conn, config: config}
+    end
+
+    test "the server can be renamed without supplying a url", %{conn: conn, config: config} do
+      {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
+
+      view |> element("[phx-click='edit_media_server']") |> render_click()
+
+      view
+      |> form("#media-server-form", %{
+        "media_server_config" => %{
+          "name" => "Renamed",
+          "type" => "plex",
+          "url" => "",
+          "token" => "acct-token"
+        }
+      })
+      |> render_submit()
+
+      updated = Mydia.Settings.get_media_server_config!(config.id)
+
+      assert updated.name == "Renamed"
+      # Discovery data must survive a save driven purely by form params.
+      assert updated.machine_identifier == "machine-abc"
+      assert [%{"uri" => "http://127.0.0.1:32400"}] = updated.connections
+    end
+  end
 end


### PR DESCRIPTION
Signing in with Plex, picking a server, and clicking "Add Server" did nothing. The connection-picker rework was sound; the blockage was entirely downstream of it, and it turned out to be four stacked defects rather than one.

## What was broken

**1. An empty URL field marked `required`.** The wizard's `:complete` state still rendered the "Connection Details" card, whose Server URL input carried an unconditional `required`. `Selection.config_attrs/3` leaves `url` nil on purpose, because `Plex.Endpoint.resolve/1` discovers a working address at call time. The browser refused to submit and nothing reached the server.

**2. The save dropped every discovery field.** `save_media_server` built its changeset from DOM params alone. The form has no inputs for `connections`, `machine_identifier`, `server_access_token`, `token`, or `connections_refreshed_at`, so all of them were discarded on submit and `validate_addressable/1` then rejected the config. Removing `required` alone would have turned a silent block into a confusing error.

**3. Typing destroyed the discovery data.** `validate_media_server` rebuilt from a bare `%MediaServerConfig{}` on every `phx-change`, so editing the Name after OAuth completed stripped discovery from the form while the panel kept reporting success.

**4. Edit was blocked identically.** `edit_media_server` sets `plex_manual_entry: true`, rendering the same required-URL card. A wizard-created config has `url: nil`, so an existing Plex server could not be renamed or have its watched-sync settings changed.

## What changed

- **`Selection.merge_discovery/2`** (new, pure): re-applies the discovery-owned attrs onto form params. It lives in `Selection` rather than the LiveView because that module already owns wizard policy that cannot be exercised without a socket, which makes this directly unit-testable.
- **`MediaServerConfig.addressable_by_discovery?/1`** promoted to public so the modal reuses the schema's own rule instead of keeping a second copy that would drift.
- **Conditional `required`** on Server URL: still hard-required for Jellyfin and for Plex manual entry from scratch, optional when a config can already address itself through discovery. Help text there reframes it as a manual override.
- **`:plex_discovery` socket assign**, merged into params on both form events, cleared on all five wizard reset paths, and dropped when the Type select moves off Plex. Discovery data never round-trips through the browser, so the account token and the connections list stay out of the page.
- **Read-only review panel** at `:complete` showing server name, machine identifier, and the discovered addresses with their local/relay badges, which is what the existing "Review the details below and save" copy had been promising. "Test Connection" is hidden there, since it builds its probe from url and token with no `connections` and could only ever fail on that path.

`url` deliberately stays nil on the discovery path. Pinning a chosen address would be a regression: `Endpoint.resolve/1` probes an explicit `url` with no fallback to discovery, so it would trade away self-healing when a Plex server moves networks.

## Incidental fix

This removes a pre-existing secret leak. The old `:complete` condition rendered the Plex account token into a populated `type="password"` input, because `Phoenix.HTML.Form.normalize_value/2` has no password clause and emits the value.

## Testing

`mix precommit` green: 7 steps including Credo and format, 7129 tests, 0 failures.

New coverage: 7 unit tests on `merge_discovery/2` (including that merged params build a valid changeset with a blank url, and that unmerged params do not), and component tests pinning the URL requirement across all four render paths, the review panel contents, the submit guard, and the absence of URL/token inputs on the discovery path.

**Known gap.** The wiring from `select_plex_server` to `:complete` to the `:plex_discovery` assign has no automated test. Reaching that state in a test would require stubbing `PlexOAuth.check_pin/1`, which hardcodes its API base with no override, and adding one would be a production change made purely for testability. Verified by hand instead: complete a real Plex sign-in, confirm the review panel names the server and no URL or token field appears, confirm typing in Name does not break the save, confirm flipping Type to Jellyfin at `:complete` clears the panel and leaves the revealed token field empty, and confirm the saved row carries `machine_identifier` and `connections`.

## Out of scope

The "Enabled" toggle is rendered outside `<.form>` with no `form=` attribute, so `enabled` is never submitted and toggling it is a no-op on both create and edit. That predates this branch and is left for a separate change.
