### PR TITLE
fix(media-servers): submit the Enabled toggle and drop dead key-shape fallbacks

### DIFF
--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -504,17 +504,21 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                             </div>
 
                             <div class="space-y-1">
+                              <%!-- These connections come straight from PlexOAuth.parse_connections/1
+                                    and are always atom-keyed. A future change that feeds this panel
+                                    from a persisted MediaServerConfig (string-keyed after a DB round
+                                    trip through JsonListType) would need to normalize first. --%>
                               <%= for conn <- @plex_discovery[:connections] || [] do %>
                                 <div class="flex items-center gap-2 text-xs">
                                   <span class="font-mono truncate flex-1">
-                                    {simplify_plex_url(conn[:uri] || conn["uri"])}
+                                    {simplify_plex_url(conn[:uri])}
                                   </span>
-                                  <%= if conn[:local] || conn["local"] do %>
+                                  <%= if conn[:local] do %>
                                     <span class="badge badge-xs badge-info gap-1">
                                       <.icon name="hero-home" class="w-3 h-3" /> local
                                     </span>
                                   <% end %>
-                                  <%= if conn[:relay] || conn["relay"] do %>
+                                  <%= if conn[:relay] do %>
                                     <span class="badge badge-xs badge-warning gap-1">
                                       <.icon name="hero-cloud" class="w-3 h-3" /> relay
                                     </span>

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -287,13 +287,19 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
           </div>
           <label class="label cursor-pointer gap-2 w-full justify-between sm:w-auto sm:justify-end">
             <span class="label-text text-sm">Enabled</span>
-            <input type="hidden" name={@media_server_form[:enabled].name} value="false" />
+            <input
+              type="hidden"
+              name={@media_server_form[:enabled].name}
+              value="false"
+              form="media-server-form"
+            />
             <input
               type="checkbox"
               name={@media_server_form[:enabled].name}
               value="true"
               checked={Phoenix.HTML.Form.input_value(@media_server_form, :enabled) in [true, "true"]}
               class="toggle toggle-success toggle-sm"
+              form="media-server-form"
             />
           </label>
         </div>

--- a/test/mydia_web/live/admin_media_servers_live/components_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live/components_test.exs
@@ -217,6 +217,30 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
     end
   end
 
+  describe "media server modal, Enabled toggle form association" do
+    # The Enabled toggle sits in the modal header, above where <.form> opens,
+    # so it is not a descendant of the form element. Without an explicit
+    # `form="media-server-form"` attribute the browser never submits it: the
+    # hidden false-sentinel is dropped and the checkbox is dropped, so
+    # `enabled` never reaches phx-change or phx-submit at all.
+    defp enabled_inputs(html) do
+      html
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query(~s([name="media_server_config[enabled]"]))
+    end
+
+    test "both the hidden sentinel and the checkbox are associated with the form by id" do
+      html = render_modal(mode: :edit)
+
+      form_attrs =
+        html
+        |> enabled_inputs()
+        |> LazyHTML.attribute("form")
+
+      assert form_attrs == ["media-server-form", "media-server-form"]
+    end
+  end
+
   describe "media server modal, discovery review panel" do
     defp discovery_map do
       %{

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -195,4 +195,16 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
       assert [%{"uri" => "http://127.0.0.1:32400"}] = updated.connections
     end
   end
+
+  # A LiveView integration test for the Enabled toggle fix (form="media-server-form"
+  # on components.ex:290-298) was attempted here and deleted. Phoenix.LiveViewTest's
+  # form/3 collects inputs by walking descendants of the located <form> node; it does
+  # not implement HTML5 form-attribute association the way a real browser does, so a
+  # submit driven through form/3 never picks up the hidden sentinel or checkbox at all
+  # regardless of whether the form="media-server-form" attribute is present. Confirmed
+  # empirically: submitting via form/3 against a seeded enabled: true config left
+  # updated.enabled == true even with the fix in place, because no "enabled" key ever
+  # reached the params. That is a limitation of the test helper, not the fix. The
+  # honest pin for this fix lives in components_test.exs ("media server modal, Enabled
+  # toggle form association"), which asserts the form= attribute on the rendered markup.
 end


### PR DESCRIPTION
Two cleanups deferred from #421, both in the media server modal. Independent of each other, one commit each.

Stacked on #421 and targeting its branch so the diff here stays clean. GitHub will retarget this to `master` automatically once #421 merges.

## 1. The "Enabled" toggle was never submitted

The toggle sits in the modal header at `components.ex:288-298`, but `<.form id="media-server-form">` does not open until line 301, so neither the hidden false-sentinel nor the checkbox is a descendant of the form. The browser never serialized either one, and `enabled` never reached `phx-change` or `phx-submit`.

The visible effect: toggling Enabled in edit mode did nothing at all, and an operator who toggled it off while *adding* a server was silently ignored too. Create only looked correct because the schema defaults `enabled` to `true`.

Fixed with HTML5 form-attribute association, `form="media-server-form"` on both inputs. The markup does not move, since the toggle's position in the header is a deliberate layout choice.

This predates #421. It appears to have been introduced in dd42289a and survived the mobile restyle in 729513b1.

**On test coverage.** A LiveView integration test was attempted and removed. `Phoenix.LiveViewTest`'s `form/3` collects inputs by walking descendants of the located `<form>` node and does not implement form-attribute association the way a browser does, so a submit driven through it never picks up these inputs whether or not the fix is present. Confirmed empirically: with the fix in place, submitting via `form/3` against a seeded `enabled: true` config still left `enabled` unchanged, because no `enabled` key ever reached the params. That is a limitation of the helper rather than of the fix. The pin is a component test asserting the `form` attribute on both rendered inputs, and the reasoning is left as a comment where the integration test would have gone.

## 2. Dead key-shape fallbacks in the discovery review panel

The panel read each connection field against two key shapes (`conn[:uri] || conn["uri"]`, and the same for `local` and `relay`). The string-key branches are unreachable: `@plex_discovery` is populated only from `Selection.config_attrs/3`, whose connections come from `PlexOAuth.parse_connections/1` and are always atom-keyed.

The dual-shape concern is real elsewhere, for connections reloaded from the database through `JsonListType`, which Jason stringifies on dump. That path just never reaches this component. Every assignment site was traced to confirm it, in both source and tests.

Removed the fallbacks and left a comment recording the atom-keyed guarantee, so a future change that feeds this panel from a persisted config knows it needs to normalize first.

## Testing

`mix precommit` green. The new component test asserts both Enabled inputs carry `form="media-server-form"` by querying them with LazyHTML and comparing the full attribute list, rather than substring-matching the markup, which would pass vacuously against the form's own `id`.
