### PR TITLE
fix(plex): test through discovery and let operators map Home profiles

### DIFF
--- a/lib/mydia/jobs/media_server_watched_sync.ex
+++ b/lib/mydia/jobs/media_server_watched_sync.ex
@@ -213,11 +213,34 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
       # healthy while doing nothing: seed first, and the seed job re-enters sync
       # once it has produced links.
       [] ->
-        enqueue_seed(config)
-        record_skip(config, :seeding_links)
+        report_no_links(config)
 
       links ->
         Enum.each(links, fn link -> enqueue(config, link) end)
+    end
+  end
+
+  # Seeding is only worth announcing while it can still produce something. Once
+  # PlexLinkSeed reports :no_matching_users — no Plex profile shares a name with
+  # a Mydia user — that verdict does not change on its own, and re-recording
+  # :seeding_links on the next tick buried it under a newer row. The UI then read
+  # "Linking Plex Home profiles" indefinitely for a state that was already dead,
+  # hiding the one message that tells the operator to map the profiles by hand.
+  defp report_no_links(config) do
+    if seeding_exhausted?(config) do
+      record_skip(config, :no_matching_users)
+    else
+      enqueue_seed(config)
+      record_skip(config, :seeding_links)
+    end
+  end
+
+  # Only :no_matching_users is terminal. :link_seeding_failed means plex.tv was
+  # unreachable, which is worth another attempt.
+  defp seeding_exhausted?(config) do
+    case Mydia.Sync.last_run(to_string(config.type), config.id) do
+      %{status: :skipped, skip_reason: "no_matching_users"} -> true
+      _ -> false
     end
   end
 

--- a/lib/mydia/media_server/client/plex.ex
+++ b/lib/mydia/media_server/client/plex.ex
@@ -11,21 +11,42 @@ defmodule Mydia.MediaServer.Client.Plex do
   require Logger
 
   @impl true
-  def test_connection(%{url: nil}), do: {:error, Error.unexpected("URL is required")}
-  def test_connection(%{url: ""}), do: {:error, Error.unexpected("URL is required")}
   def test_connection(%{token: nil}), do: {:error, Error.auth("Token is required")}
   def test_connection(%{token: ""}), do: {:error, Error.auth("Token is required")}
 
-  def test_connection(config) do
-    # `/library/sections` requires a valid token. `/identity` does NOT: it
-    # answers 200 with a garbage token or with no token header at all, which is
-    # why it must never be used to validate credentials.
-    # Probe directly; do not recurse through Endpoint.resolve/1.
+  # An explicit `url` is a manual operator override and is probed exactly as
+  # typed, matching the precedence Endpoint.resolve/1 already applies. The two
+  # have to agree, or the test button checks a different address than the one
+  # every other call goes to.
+  #
+  # `/library/sections` requires a valid token. `/identity` does NOT: it
+  # answers 200 with a garbage token or with no token header at all, which is
+  # why it must never be used to validate credentials.
+  def test_connection(%{url: url} = config) when is_binary(url) and url != "" do
     config
     |> build_url("/library/sections")
     |> Req.get(headers: headers(config), retry: false)
     |> classify()
   end
+
+  # A Plex server connected through OAuth stores no `url` at all: it addresses
+  # itself through the connections plex.tv advertises, which is why
+  # MediaServerConfig.validate_addressable/1 stopped requiring one. Rejecting
+  # that config as "URL is required" failed the test button for every
+  # OAuth-connected server while the server itself answered fine.
+  #
+  # probe_connections/2 rather than Endpoint.resolve/1 on purpose: resolve
+  # caches its winner for ten minutes, so a test click could report success for
+  # a server that died right after the previous one. A test has to be live.
+  def test_connection(%{connections: [_ | _] = connections, token: token}) do
+    case Endpoint.probe_connections(connections, token) do
+      {:ok, _uri} -> :ok
+      {:error, _} = error -> error
+    end
+  end
+
+  # No url and nothing discovered: there is genuinely no address to test.
+  def test_connection(_config), do: {:error, Error.unexpected("URL is required")}
 
   @impl true
   def update_library(config, opts \\ []) do

--- a/lib/mydia/media_server/plex/home.ex
+++ b/lib/mydia/media_server/plex/home.ex
@@ -104,21 +104,32 @@ defmodule Mydia.MediaServer.Plex.Home do
 
   Links whose profile is unmapped, or whose profile has disappeared from Plex
   Home, are removed, so this unlinks as well as links.
+
+  Every plex.tv round trip happens before the database is touched, and the
+  writes then land in one transaction. Minting is one profile switch per newly
+  linked profile, so a transaction held open across them would lock the whole
+  SQLite database for the length of a network call; doing the network first also
+  means a mint that fails leaves the existing mapping exactly as it was.
   """
   @spec apply_mapping(map(), %{optional(String.t()) => binary() | nil}, keyword()) ::
           {:ok, [MediaServerUserLink.t()]} | {:error, term()}
   def apply_mapping(config, mapping, opts \\ []) do
     with :ok <- validate_mapping(mapping),
          {:ok, home_users} <- list_users(config, opts) do
+      by_account =
+        config.id
+        |> Settings.list_media_server_user_links()
+        |> Map.new(&{&1.plex_account_id, &1})
+
       desired =
         for home_user <- home_users,
             user_id = Map.get(mapping, home_user.plex_account_id),
             not is_nil(user_id),
             do: {home_user, user_id}
 
-      existing = Settings.list_media_server_user_links(config.id)
-      drop_unmapped(existing, desired)
-      upsert_mapped(config, desired, Map.new(existing, &{&1.plex_account_id, &1}), opts)
+      with {:ok, entries} <- resolve_entries(config, desired, by_account, opts) do
+        Settings.replace_media_server_user_links(config.id, entries)
+      end
     end
   end
 
@@ -133,53 +144,55 @@ defmodule Mydia.MediaServer.Plex.Home do
       else: {:error, :duplicate_user}
   end
 
-  defp drop_unmapped(existing, desired) do
-    keep = MapSet.new(desired, fn {_home_user, user_id} -> user_id end)
-
-    Enum.each(existing, fn link ->
-      unless MapSet.member?(keep, link.user_id) do
-        Settings.delete_media_server_user_link(link)
-      end
-    end)
-  end
-
-  defp upsert_mapped(config, desired, by_account, opts) do
+  # Resolves the whole mapping to plain attrs, doing every token mint up front.
+  # Nothing is written here, so an error means the stored links are untouched.
+  defp resolve_entries(config, desired, by_account, opts) do
     desired
     |> Enum.reduce_while({:ok, []}, fn {home_user, user_id}, {:ok, acc} ->
-      case Map.get(by_account, home_user.plex_account_id) do
-        # Already pointing at this user with a usable token. Re-minting would
-        # cost a plex.tv profile switch per profile on every save of a form the
-        # operator may not have changed at all.
-        %{user_id: ^user_id, access_token: token} = link
-        when is_binary(token) and token != "" ->
-          {:cont, {:ok, [link | acc]}}
+      case token_for_mapping(config, home_user, user_id, by_account, opts) do
+        {:ok, token} ->
+          {:cont, {:ok, [link_attrs(config, home_user, user_id, token) | acc]}}
 
-        _ ->
-          case link_user(config, home_user, user_id, opts) do
-            {:ok, link} -> {:cont, {:ok, [link | acc]}}
-            {:error, _} = error -> {:halt, error}
-          end
+        {:error, _} = error ->
+          {:halt, error}
       end
     end)
     |> case do
-      {:ok, links} -> {:ok, Enum.reverse(links)}
+      {:ok, entries} -> {:ok, Enum.reverse(entries)}
       other -> other
     end
   end
 
-  # The one place a link is written. Both the auto-matcher and the manual
-  # mapping go through here so a link means the same thing however it was made:
-  # a Mydia user bound to a Plex profile by that profile's own token.
+  # Reuses the token already on a link that points at this same user. Re-minting
+  # would cost a plex.tv profile switch per profile on every save of a form the
+  # operator may not have changed at all.
+  defp token_for_mapping(config, home_user, user_id, by_account, opts) do
+    case Map.get(by_account, home_user.plex_account_id) do
+      %{user_id: ^user_id, access_token: token} when is_binary(token) and token != "" ->
+        {:ok, token}
+
+      _ ->
+        token_for(config, home_user.plex_account_id, opts)
+    end
+  end
+
+  # The one shape a link is ever written in. Both the auto-matcher and the
+  # manual mapping build it here so a link means the same thing however it was
+  # made: a Mydia user bound to a Plex profile by that profile's own token.
+  defp link_attrs(config, home_user, user_id, token) do
+    %{
+      media_server_config_id: config.id,
+      user_id: user_id,
+      plex_account_id: home_user.plex_account_id,
+      plex_username: home_user.username,
+      access_token: token,
+      enabled: true
+    }
+  end
+
   defp link_user(config, home_user, user_id, opts) do
     with {:ok, token} <- token_for(config, home_user.plex_account_id, opts) do
-      Settings.upsert_media_server_user_link(%{
-        media_server_config_id: config.id,
-        user_id: user_id,
-        plex_account_id: home_user.plex_account_id,
-        plex_username: home_user.username,
-        access_token: token,
-        enabled: true
-      })
+      Settings.upsert_media_server_user_link(link_attrs(config, home_user, user_id, token))
     end
   end
 

--- a/lib/mydia/media_server/plex/home.ex
+++ b/lib/mydia/media_server/plex/home.ex
@@ -90,6 +90,99 @@ defmodule Mydia.MediaServer.Plex.Home do
     end
   end
 
+  @doc """
+  Applies an operator-chosen profile-to-user mapping.
+
+  `mapping` maps a Plex Home `plex_account_id` to a Mydia user id, or to `nil`
+  for "do not sync this profile".
+
+  `seed_links/2` can only ever link a profile whose name equals a Mydia
+  username. Self-hosters name Plex profiles after people and their Mydia
+  account `admin`, so on most installs that matches nothing, leaves zero links,
+  and watched sync sits skipped forever with no operator recourse. This is the
+  recourse.
+
+  Links whose profile is unmapped, or whose profile has disappeared from Plex
+  Home, are removed, so this unlinks as well as links.
+  """
+  @spec apply_mapping(map(), %{optional(String.t()) => binary() | nil}, keyword()) ::
+          {:ok, [MediaServerUserLink.t()]} | {:error, term()}
+  def apply_mapping(config, mapping, opts \\ []) do
+    with :ok <- validate_mapping(mapping),
+         {:ok, home_users} <- list_users(config, opts) do
+      desired =
+        for home_user <- home_users,
+            user_id = Map.get(mapping, home_user.plex_account_id),
+            not is_nil(user_id),
+            do: {home_user, user_id}
+
+      existing = Settings.list_media_server_user_links(config.id)
+      drop_unmapped(existing, desired)
+      upsert_mapped(config, desired, Map.new(existing, &{&1.plex_account_id, &1}), opts)
+    end
+  end
+
+  # Two profiles aimed at one Mydia user would not fail: media_server_user_links
+  # is unique on (config, user), so the second would quietly replace the first
+  # and leave a profile displaying as linked while syncing nothing.
+  defp validate_mapping(mapping) do
+    user_ids = mapping |> Map.values() |> Enum.reject(&is_nil/1)
+
+    if length(user_ids) == length(Enum.uniq(user_ids)),
+      do: :ok,
+      else: {:error, :duplicate_user}
+  end
+
+  defp drop_unmapped(existing, desired) do
+    keep = MapSet.new(desired, fn {_home_user, user_id} -> user_id end)
+
+    Enum.each(existing, fn link ->
+      unless MapSet.member?(keep, link.user_id) do
+        Settings.delete_media_server_user_link(link)
+      end
+    end)
+  end
+
+  defp upsert_mapped(config, desired, by_account, opts) do
+    desired
+    |> Enum.reduce_while({:ok, []}, fn {home_user, user_id}, {:ok, acc} ->
+      case Map.get(by_account, home_user.plex_account_id) do
+        # Already pointing at this user with a usable token. Re-minting would
+        # cost a plex.tv profile switch per profile on every save of a form the
+        # operator may not have changed at all.
+        %{user_id: ^user_id, access_token: token} = link
+        when is_binary(token) and token != "" ->
+          {:cont, {:ok, [link | acc]}}
+
+        _ ->
+          case link_user(config, home_user, user_id, opts) do
+            {:ok, link} -> {:cont, {:ok, [link | acc]}}
+            {:error, _} = error -> {:halt, error}
+          end
+      end
+    end)
+    |> case do
+      {:ok, links} -> {:ok, Enum.reverse(links)}
+      other -> other
+    end
+  end
+
+  # The one place a link is written. Both the auto-matcher and the manual
+  # mapping go through here so a link means the same thing however it was made:
+  # a Mydia user bound to a Plex profile by that profile's own token.
+  defp link_user(config, home_user, user_id, opts) do
+    with {:ok, token} <- token_for(config, home_user.plex_account_id, opts) do
+      Settings.upsert_media_server_user_link(%{
+        media_server_config_id: config.id,
+        user_id: user_id,
+        plex_account_id: home_user.plex_account_id,
+        plex_username: home_user.username,
+        access_token: token,
+        enabled: true
+      })
+    end
+  end
+
   defp seed_matched_links(config, home_users, opts) do
     by_username =
       Map.new(Accounts.list_users(), fn user ->
@@ -108,29 +201,20 @@ defmodule Mydia.MediaServer.Plex.Home do
           # Skip rather than fall back to the admin token. A link carrying the
           # wrong account's token silently merges two people's watch history,
           # which is precisely what per-user mapping is meant to prevent.
-          case token_for(config, home_user.plex_account_id, opts) do
-            {:ok, token} ->
-              attrs = %{
-                media_server_config_id: config.id,
-                user_id: user.id,
-                plex_account_id: home_user.plex_account_id,
-                plex_username: home_user.username,
-                access_token: token,
-                enabled: true
-              }
+          case link_user(config, home_user, user.id, opts) do
+            {:ok, link} ->
+              {:cont, {:ok, [link | acc]}}
 
-              case Settings.upsert_media_server_user_link(attrs) do
-                {:ok, link} -> {:cont, {:ok, [link | acc]}}
-                {:error, _} = err -> {:halt, err}
-              end
-
-            {:error, reason} ->
+            {:error, %Error{} = reason} ->
               Logger.warning(
                 "Skipping Plex Home link for #{home_user.username}: " <>
                   "could not mint a per-user token (#{inspect(reason)})"
               )
 
               {:cont, {:ok, acc}}
+
+            {:error, _} = err ->
+              {:halt, err}
           end
       end
     end)

--- a/lib/mydia/settings.ex
+++ b/lib/mydia/settings.ex
@@ -573,6 +573,16 @@ defmodule Mydia.Settings do
           {:ok, MediaServerUserLink.t()} | {:error, Ecto.Changeset.t()}
   defdelegate delete_media_server_user_link(link), to: Mydia.Settings.ServiceConfigs
 
+  @doc """
+  Replaces a config's user links with `entries` in one transaction, deleting any
+  link whose user is not named by `entries`. Callers must do all network work
+  first; see `Mydia.Settings.ServiceConfigs.replace_media_server_user_links/2`.
+  """
+  @spec replace_media_server_user_links(binary(), [map()]) ::
+          {:ok, [MediaServerUserLink.t()]} | {:error, Ecto.Changeset.t()}
+  defdelegate replace_media_server_user_links(media_server_config_id, entries),
+    to: Mydia.Settings.ServiceConfigs
+
   # ── Plugin Configs ───────────────────────────────────────────────────
 
   @doc """

--- a/lib/mydia/settings/service_configs.ex
+++ b/lib/mydia/settings/service_configs.ex
@@ -317,6 +317,37 @@ defmodule Mydia.Settings.ServiceConfigs do
     Repo.delete(link)
   end
 
+  @doc """
+  Replaces a config's user links with `entries` in one transaction.
+
+  Any existing link for the config whose user is not named by `entries` is
+  deleted. Applying a mapping as separate deletes and upserts left a partial
+  mapping behind whenever one of them failed, which can unlink people who were
+  syncing fine.
+
+  Callers must resolve everything an entry needs, per-user Plex tokens
+  included, before calling. Nothing in here may make a network call: on SQLite a
+  write transaction locks the entire database, so a plex.tv round trip inside
+  one stalls every other writer for its duration.
+  """
+  def replace_media_server_user_links(media_server_config_id, entries) do
+    keep = MapSet.new(entries, & &1.user_id)
+
+    Repo.transaction(fn ->
+      media_server_config_id
+      |> list_media_server_user_links()
+      |> Enum.reject(&MapSet.member?(keep, &1.user_id))
+      |> Enum.each(&delete_media_server_user_link/1)
+
+      Enum.map(entries, fn attrs ->
+        case upsert_media_server_user_link(attrs) do
+          {:ok, link} -> link
+          {:error, changeset} -> Repo.rollback(changeset)
+        end
+      end)
+    end)
+  end
+
   ## Plugin Configs
 
   def list_plugin_configs(opts \\ []) do

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -200,6 +200,14 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
                   </button>
                   <%= if sync_enabled and server.type == :plex do %>
                     <button
+                      data-test="plex-profiles"
+                      class={["btn btn-ghost gap-1", card_action_btn()]}
+                      phx-click="open_plex_profiles"
+                      phx-value-id={server.id}
+                    >
+                      <.icon name="hero-user-group" class="w-4 h-4" /> Profiles
+                    </button>
+                    <button
                       class={["btn btn-ghost gap-1", card_action_btn()]}
                       phx-click="sync_watched"
                       phx-value-id={server.id}
@@ -764,6 +772,142 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
     </div>
     """
   end
+
+  @doc """
+  Renders the Plex Home profile mapping modal.
+
+  Auto-matching links a profile only when its name equals a Mydia username.
+  People name Plex profiles after people and their Mydia account `admin`, so on
+  most installs nothing matches and watched sync sits skipped with no way out.
+  This is the way out.
+  """
+  attr :config, :map, required: true
+  attr :state, :any, required: true
+  attr :profiles, :list, default: []
+  attr :users, :list, default: []
+  attr :mapping, :map, default: %{}
+  attr :saving, :boolean, default: false
+
+  def plex_profiles_modal(assigns) do
+    ~H"""
+    <div class="modal modal-open" id="plex-profiles-modal">
+      <div class="modal-box max-w-2xl">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <h3 class="font-bold text-lg">Plex profiles</h3>
+            <p class="text-sm text-base-content/60 mt-1">
+              Choose which Mydia user each Plex Home profile syncs watched status with.
+              Each profile syncs through its own Plex token, so histories stay separate.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-sm btn-circle btn-ghost"
+            phx-click="close_plex_profiles"
+            aria-label="Close"
+          >
+            <.icon name="hero-x-mark" class="w-4 h-4" />
+          </button>
+        </div>
+
+        <div class="mt-5">
+          <%= case @state do %>
+            <% :loading -> %>
+              <div
+                id="plex-profiles-loading"
+                class="flex items-center justify-center gap-3 py-10 text-sm text-base-content/70"
+              >
+                <span class="loading loading-spinner loading-sm"></span>
+                Asking plex.tv for this account's Home profiles...
+              </div>
+            <% {:error, message} -> %>
+              <div id="plex-profiles-error" class="alert alert-error">
+                <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
+                <span>{message}</span>
+              </div>
+            <% :ready -> %>
+              <%= if @profiles == [] do %>
+                <div id="plex-profiles-empty" class="text-center py-10">
+                  <p class="text-sm text-base-content/70">
+                    This Plex account has no Home profiles, so there is nothing to map.
+                    Watched sync uses the account owner directly.
+                  </p>
+                </div>
+              <% else %>
+                <form id="plex-profiles-form" phx-submit="save_plex_profiles">
+                  <div class="flex items-center justify-between mb-2">
+                    <span class="text-sm font-medium">
+                      {length(@profiles)} {ngettext_profiles(@profiles)}
+                    </span>
+                    <span class="text-xs text-base-content/50">Mydia user</span>
+                  </div>
+
+                  <div class="flex flex-col gap-2">
+                    <div
+                      :for={profile <- @profiles}
+                      id={"plex-profile-#{profile.plex_account_id}"}
+                      class="flex flex-col gap-2 rounded-lg bg-base-200 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div class="flex items-center gap-2 min-w-0">
+                        <.icon name="hero-user-circle" class="w-4 h-4 text-base-content/50" />
+                        <span class="truncate text-sm font-medium">
+                          {profile.username || "Unnamed profile"}
+                        </span>
+                        <span :if={profile.admin?} class="badge badge-xs badge-warning">owner</span>
+                      </div>
+                      <div class="sm:w-56">
+                        <.input
+                          type="select"
+                          id={"plex-profile-select-#{profile.plex_account_id}"}
+                          name={"mapping[#{profile.plex_account_id}]"}
+                          value={Map.get(@mapping, profile.plex_account_id)}
+                          options={user_options(@users)}
+                          class="select select-sm select-bordered w-full"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="modal-action mt-6">
+                    <button
+                      type="button"
+                      class={["btn btn-ghost", modal_action_btn()]}
+                      phx-click="close_plex_profiles"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      id="plex-profiles-save"
+                      class={["btn btn-primary gap-2", modal_action_btn()]}
+                      disabled={@saving}
+                    >
+                      <%= if @saving do %>
+                        <span class="loading loading-spinner loading-sm"></span> Saving...
+                      <% else %>
+                        <.icon name="hero-check" class="w-4 h-4" /> Save links
+                      <% end %>
+                    </button>
+                  </div>
+                </form>
+              <% end %>
+          <% end %>
+        </div>
+      </div>
+      <div class="modal-backdrop bg-black/50" phx-click="close_plex_profiles"></div>
+    </div>
+    """
+  end
+
+  # "Don't sync" carries the empty string so an unmapped profile round-trips as
+  # a present-but-blank param rather than vanishing from the form payload, which
+  # is what lets the save path tell "unlink this" apart from "never asked".
+  defp user_options(users) do
+    [{"Don't sync", ""} | Enum.map(users, &{&1.username, &1.id})]
+  end
+
+  defp ngettext_profiles([_]), do: "profile found"
+  defp ngettext_profiles(_), do: "profiles found"
 
   # Media server type helpers
   defp media_server_type_icon(:plex), do: "hero-play-circle"

--- a/lib/mydia_web/live/admin_media_servers_live/index.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.ex
@@ -1,12 +1,14 @@
 defmodule MydiaWeb.AdminMediaServersLive.Index do
   use MydiaWeb, :live_view
 
+  alias Mydia.Accounts
   alias Mydia.Settings
   alias Mydia.Settings.MediaServerConfig
   alias Mydia.MediaServer.Client, as: MediaServerClient
   alias Mydia.MediaServer.Error
   alias Mydia.MediaServer.PlexOAuth
   alias Mydia.MediaServer.Plex.Endpoint, as: PlexEndpoint
+  alias Mydia.MediaServer.Plex.Home, as: PlexHome
   alias Mydia.MediaServer.Plex.Selection
   alias Mydia.Sync
 
@@ -19,6 +21,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
      socket
      |> assign(:page_title, "Configuration - Media Servers")
      |> assign(:active_tab, :media_servers)
+     |> clear_plex_profiles()
      |> load_data()}
   end
 
@@ -38,7 +41,63 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
     end
   end
 
+  ## Plex Home profile mapping
+
+  @impl true
+  def handle_info({:plex_profiles, config_id, result}, socket) do
+    # Guarded on the id so a slow plex.tv answer for a server the operator has
+    # already closed cannot repopulate the modal for a different one.
+    case socket.assigns[:plex_profiles_config] do
+      %{id: ^config_id} = config -> {:noreply, apply_profile_load(socket, config, result)}
+      _ -> {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_info({:plex_profiles_saved, config_id, result}, socket) do
+    case socket.assigns[:plex_profiles_config] do
+      %{id: ^config_id} = config -> {:noreply, apply_profile_save(socket, config, result)}
+      _ -> {:noreply, socket}
+    end
+  end
+
   ## Media Server Events
+
+  @impl true
+  def handle_event("open_plex_profiles", %{"id" => id}, socket) do
+    config = Settings.get_media_server_config!(id)
+
+    {:noreply,
+     socket
+     |> assign(:plex_profiles_config, config)
+     |> assign(:plex_profiles_state, :loading)
+     |> assign(:plex_profiles, [])
+     |> assign(:plex_profiles_users, Accounts.list_users())
+     |> assign(:plex_profiles_mapping, %{})
+     |> assign(:plex_profiles_saving, false)
+     |> start_profile_load(config)}
+  end
+
+  @impl true
+  def handle_event("close_plex_profiles", _params, socket) do
+    {:noreply, clear_plex_profiles(socket)}
+  end
+
+  @impl true
+  def handle_event("save_plex_profiles", params, socket) do
+    config = socket.assigns.plex_profiles_config
+    mapping = normalize_mapping(params["mapping"] || %{})
+    parent = self()
+
+    # Off the LiveView process: applying a mapping is one plex.tv profile switch
+    # per newly linked profile, and blocking here would freeze every other event
+    # on the page while they run.
+    Task.Supervisor.start_child(Mydia.TaskSupervisor, fn ->
+      send(parent, {:plex_profiles_saved, config.id, PlexHome.apply_mapping(config, mapping)})
+    end)
+
+    {:noreply, assign(socket, :plex_profiles_saving, true)}
+  end
 
   @impl true
   def handle_event("new_media_server", _params, socket) do
@@ -394,11 +453,17 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
         _ -> :plex
       end
 
+    # `connections` and `machine_identifier` have to ride along. A server just
+    # picked through the OAuth wizard has no url yet and addresses itself purely
+    # through its advertised connections, so dropping them here made the test
+    # button report "URL is required" for a server it had only just discovered.
     test_config = %MediaServerConfig{
       type: type,
       url: params.url,
       token: params.token,
-      name: params.name || "Test"
+      name: params.name || "Test",
+      connections: params.connections || [],
+      machine_identifier: params.machine_identifier
     }
 
     adapter = MediaServerClient.adapter_for(test_config)
@@ -490,6 +555,140 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
         |> start_reachability_probe(server)
         |> assign(:media_server_form, to_form(changeset))
     end
+  end
+
+  defp start_profile_load(socket, config) do
+    parent = self()
+
+    Task.Supervisor.start_child(Mydia.TaskSupervisor, fn ->
+      send(parent, {:plex_profiles, config.id, PlexHome.list_users(config)})
+    end)
+
+    socket
+  end
+
+  defp apply_profile_load(socket, config, {:ok, profiles}) do
+    links = Settings.list_media_server_user_links(config.id)
+
+    socket
+    |> assign(:plex_profiles, profiles)
+    |> assign(
+      :plex_profiles_mapping,
+      initial_mapping(profiles, links, socket.assigns.plex_profiles_users)
+    )
+    |> assign(:plex_profiles_state, :ready)
+  end
+
+  defp apply_profile_load(socket, _config, {:error, %Error{} = error}) do
+    assign(
+      socket,
+      :plex_profiles_state,
+      {:error, "Could not load Plex Home profiles: #{Error.message(error)}"}
+    )
+  end
+
+  defp apply_profile_save(socket, config, {:ok, links}) do
+    # A fresh mapping is worth acting on immediately: the operator opened this
+    # because sync had been sitting idle, and making them wait for the next
+    # half-hourly tick to see whether it worked is the wrong answer.
+    if links != [], do: enqueue_server_sync(config)
+
+    socket
+    |> clear_plex_profiles()
+    |> put_flash(:info, link_flash(links, config))
+    |> load_data()
+  end
+
+  defp apply_profile_save(socket, _config, {:error, :duplicate_user}) do
+    socket
+    |> assign(:plex_profiles_saving, false)
+    |> put_flash(:error, "Each Mydia user can be linked to only one Plex profile.")
+  end
+
+  defp apply_profile_save(socket, _config, {:error, %Error{} = error}) do
+    socket
+    |> assign(:plex_profiles_saving, false)
+    |> put_flash(:error, "Could not save Plex profile links: #{Error.message(error)}")
+  end
+
+  defp apply_profile_save(socket, _config, {:error, reason}) do
+    MydiaLogger.log_warning(:liveview, "Saving Plex profile links failed",
+      operation: :save_plex_profiles,
+      error: inspect(reason)
+    )
+
+    socket
+    |> assign(:plex_profiles_saving, false)
+    |> put_flash(:error, "Could not save Plex profile links.")
+  end
+
+  defp link_flash([], config), do: "No Plex profiles are linked to #{config.name}."
+
+  defp link_flash(links, config) do
+    "Linked #{length(links)} Plex #{if length(links) == 1, do: "profile", else: "profiles"} " <>
+      "on #{config.name}. Watched sync queued."
+  end
+
+  defp enqueue_server_sync(config) do
+    %{"mode" => "server", "config_id" => config.id}
+    |> Mydia.Jobs.MediaServerWatchedSync.new()
+    |> safe_insert()
+
+    :ok
+  end
+
+  # A blank select is "do not sync this profile", which has to survive as an
+  # explicit nil: it is the difference between unlinking a profile and never
+  # having been asked about it.
+  defp normalize_mapping(mapping) do
+    Map.new(mapping, fn
+      {account_id, ""} -> {account_id, nil}
+      {account_id, user_id} -> {account_id, user_id}
+    end)
+  end
+
+  # A saved link is the operator's own decision and always wins. A username
+  # match is only a suggestion for a profile nobody has mapped yet, and it must
+  # never propose a user another profile already holds: two profiles on one user
+  # is refused on save, and offering that as the default would hand the operator
+  # a form that cannot be submitted without them working out why.
+  defp initial_mapping(profiles, links, users) do
+    by_account = Map.new(links, &{&1.plex_account_id, &1.user_id})
+    by_username = Map.new(users, &{String.downcase(&1.username), &1.id})
+
+    {mapping, _taken} =
+      Enum.reduce(profiles, {%{}, MapSet.new(Map.values(by_account))}, fn profile, {acc, taken} ->
+        case Map.get(by_account, profile.plex_account_id) do
+          nil ->
+            case Map.get(by_username, String.downcase(profile.username || "")) do
+              suggestion when is_binary(suggestion) ->
+                if MapSet.member?(taken, suggestion) do
+                  {Map.put(acc, profile.plex_account_id, nil), taken}
+                else
+                  {Map.put(acc, profile.plex_account_id, suggestion),
+                   MapSet.put(taken, suggestion)}
+                end
+
+              _ ->
+                {Map.put(acc, profile.plex_account_id, nil), taken}
+            end
+
+          user_id ->
+            {Map.put(acc, profile.plex_account_id, user_id), taken}
+        end
+      end)
+
+    mapping
+  end
+
+  defp clear_plex_profiles(socket) do
+    socket
+    |> assign(:plex_profiles_config, nil)
+    |> assign(:plex_profiles_state, :loading)
+    |> assign(:plex_profiles, [])
+    |> assign(:plex_profiles_users, [])
+    |> assign(:plex_profiles_mapping, %{})
+    |> assign(:plex_profiles_saving, false)
   end
 
   # Advisory only. The review step never blocks Save on the result, because a

--- a/lib/mydia_web/live/admin_media_servers_live/index.html.heex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.html.heex
@@ -19,5 +19,17 @@
         plex_discovery={assigns[:plex_discovery_summary]}
       />
     <% end %>
+
+    <%!-- Plex Home Profile Mapping Modal --%>
+    <%= if assigns[:plex_profiles_config] do %>
+      <MydiaWeb.AdminMediaServersLive.Components.plex_profiles_modal
+        config={@plex_profiles_config}
+        state={@plex_profiles_state}
+        profiles={assigns[:plex_profiles] || []}
+        users={assigns[:plex_profiles_users] || []}
+        mapping={assigns[:plex_profiles_mapping] || %{}}
+        saving={assigns[:plex_profiles_saving] || false}
+      />
+    <% end %>
   </.admin_page>
 </Layouts.app>

--- a/test/mydia/jobs/media_server_watched_sync_test.exs
+++ b/test/mydia/jobs/media_server_watched_sync_test.exs
@@ -353,6 +353,62 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
       # test has always guarded, and seeding must not reintroduce it.
       assert [] = all_enqueued(worker: MediaServerWatchedSync) |> Enum.reject(& &1.args["mode"])
     end
+
+    test "stops announcing seeding once seeding has reported nothing to link" do
+      # :no_matching_users is terminal: no Plex profile shares a name with a
+      # Mydia user, and that does not change on its own. Re-recording
+      # :seeding_links every tick buried that verdict under a newer row, so the
+      # UI read "Linking Plex Home profiles" indefinitely while nothing was
+      # being linked and nothing ever would be.
+      {:ok, config} =
+        Settings.create_media_server_config(%{
+          name: "Storage",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "tok",
+          enabled: true,
+          connection_settings: %{"sync_watched" => "true"}
+        })
+
+      Sync.record_skip(
+        %{provider: "plex", provider_instance_id: config.id, user_id: nil},
+        :no_matching_users
+      )
+
+      assert :ok = perform_job(MediaServerWatchedSync, %{"mode" => "all_enabled"})
+
+      runs = Mydia.Repo.all(Mydia.Sync.Run)
+      refute Enum.any?(runs, &(&1.skip_reason == "seeding_links"))
+      assert Enum.count(runs, &(&1.skip_reason == "no_matching_users")) == 2
+
+      # Re-seeding would only reach the same verdict; the operator has to map
+      # the profiles by hand from here.
+      assert [] = all_enqueued(worker: Mydia.Jobs.PlexLinkSeed)
+    end
+
+    test "a transient seeding failure is retried rather than treated as terminal" do
+      # link_seeding_failed means plex.tv was unreachable, which is exactly the
+      # kind of thing that fixes itself. Only :no_matching_users is terminal.
+      {:ok, config} =
+        Settings.create_media_server_config(%{
+          name: "Storage",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "tok",
+          enabled: true,
+          connection_settings: %{"sync_watched" => "true"}
+        })
+
+      Sync.record_skip(
+        %{provider: "plex", provider_instance_id: config.id, user_id: nil},
+        :link_seeding_failed
+      )
+
+      assert :ok = perform_job(MediaServerWatchedSync, %{"mode" => "all_enabled"})
+
+      assert Sync.last_run("plex", config.id).skip_reason == "seeding_links"
+      assert_enqueued(worker: Mydia.Jobs.PlexLinkSeed, args: %{"config_id" => config.id})
+    end
   end
 
   describe "a config deleted between enqueue and execution" do

--- a/test/mydia/media_server/client/plex_connection_test.exs
+++ b/test/mydia/media_server/client/plex_connection_test.exs
@@ -69,4 +69,74 @@ defmodule Mydia.MediaServer.Client.PlexConnectionTest do
 
     assert {:error, %Error{kind: :unexpected}} = Plex.test_connection(config)
   end
+
+  describe "a server addressed by discovery rather than by url" do
+    setup %{bypass: bypass, config: config} do
+      discovered = %{
+        config
+        | url: nil,
+          machine_identifier: "abc",
+          connections: [%{"uri" => "http://127.0.0.1:#{bypass.port}"}]
+      }
+
+      {:ok, discovered: discovered}
+    end
+
+    test "is tested against its advertised connections", %{
+      bypass: bypass,
+      discovered: discovered
+    } do
+      # A Plex server connected through OAuth stores no url at all, so testing
+      # `config.url` reported "URL is required" for a server that was reachable
+      # the whole time.
+      Bypass.stub(bypass, "GET", "/library/sections", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, ~s({"MediaContainer":{"Directory":[]}}))
+      end)
+
+      assert :ok = Plex.test_connection(discovered)
+    end
+
+    test "reports a rejected token as an auth error", %{
+      bypass: bypass,
+      discovered: discovered
+    } do
+      Bypass.stub(bypass, "GET", "/library/sections", fn conn ->
+        Plug.Conn.resp(conn, 401, "")
+      end)
+
+      assert {:error, %Error{kind: :auth}} = Plex.test_connection(discovered)
+    end
+
+    test "reports an unreachable advertised address as unreachable", %{discovered: discovered} do
+      dead = %{discovered | connections: [%{"uri" => "http://127.0.0.1:1"}]}
+
+      assert {:error, %Error{kind: :unreachable}} = Plex.test_connection(dead)
+    end
+
+    test "an explicit url still wins over the advertised connections", %{
+      bypass: bypass,
+      discovered: discovered
+    } do
+      # Endpoint.resolve/1 treats a stored url as a manual operator override;
+      # the test button has to agree with it or the two disagree about which
+      # address was actually checked.
+      Bypass.stub(bypass, "GET", "/library/sections", fn conn ->
+        Plug.Conn.resp(conn, 500, "")
+      end)
+
+      overridden = %{discovered | url: "http://127.0.0.1:#{bypass.port}"}
+
+      assert {:error, %Error{kind: :unexpected}} = Plex.test_connection(overridden)
+    end
+  end
+
+  test "a config with neither a url nor a connection still reports a missing url",
+       %{config: config} do
+    unaddressable = %{config | url: nil, connections: []}
+
+    assert {:error, %Error{kind: :unexpected, detail: "URL is required"}} =
+             Plex.test_connection(unaddressable)
+  end
 end

--- a/test/mydia/media_server/plex/home_test.exs
+++ b/test/mydia/media_server/plex/home_test.exs
@@ -103,6 +103,95 @@ defmodule Mydia.MediaServer.Plex.HomeTest do
     end
   end
 
+  describe "apply_mapping/3" do
+    setup %{bypass: bypass, config: config} do
+      Bypass.stub(bypass, "GET", "/api/v2/home/users", fn conn ->
+        body =
+          Jason.encode!(%{
+            "users" => [
+              %{"id" => 1, "username" => "arsfeld", "admin" => true},
+              %{"id" => 2, "username" => "Camille", "admin" => false}
+            ]
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      {:ok, saved} = Mydia.Settings.create_media_server_config(persistable(config))
+
+      {:ok, saved: saved}
+    end
+
+    test "links a profile whose name matches no Mydia user at all",
+         %{bypass: bypass, base: base, saved: saved} do
+      # Auto-matching only fires when Plex and Mydia agree on a name. People
+      # name Plex profiles after people and their Mydia account "admin", so on
+      # most installs it matches nothing and there was no other way to link.
+      Bypass.expect(bypass, "POST", "/api/v2/home/users/2/switch", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"authToken" => "camille-token"}))
+      end)
+
+      user = Mydia.AccountsFixtures.user_fixture(%{username: "alex"})
+
+      assert {:ok, [link]} = Home.apply_mapping(saved, %{"2" => user.id}, plex_tv_base: base)
+
+      assert link.user_id == user.id
+      assert link.plex_account_id == "2"
+      assert link.plex_username == "Camille"
+      assert link.access_token == "camille-token"
+    end
+
+    test "removes the link for a profile the operator unmapped",
+         %{bypass: bypass, base: base, saved: saved} do
+      Bypass.stub(bypass, "POST", "/api/v2/home/users/2/switch", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"authToken" => "camille-token"}))
+      end)
+
+      user = Mydia.AccountsFixtures.user_fixture(%{username: "alex"})
+
+      assert {:ok, [_link]} = Home.apply_mapping(saved, %{"2" => user.id}, plex_tv_base: base)
+      assert {:ok, []} = Home.apply_mapping(saved, %{"2" => nil}, plex_tv_base: base)
+      assert Mydia.Settings.list_media_server_user_links(saved.id) == []
+    end
+
+    test "refuses to point two profiles at one Mydia user",
+         %{base: base, saved: saved} do
+      # The links table is unique on (config, user), so this would not fail
+      # loudly: the second profile would overwrite the first and one of them
+      # would sit in the UI looking linked while syncing nothing.
+      user = Mydia.AccountsFixtures.user_fixture(%{username: "alex"})
+
+      assert {:error, :duplicate_user} =
+               Home.apply_mapping(saved, %{"1" => user.id, "2" => user.id}, plex_tv_base: base)
+    end
+
+    test "re-saving an unchanged mapping does not mint a fresh token",
+         %{bypass: bypass, base: base, saved: saved} do
+      {:ok, switches} = Agent.start_link(fn -> 0 end)
+
+      Bypass.stub(bypass, "POST", "/api/v2/home/users/2/switch", fn conn ->
+        Agent.update(switches, &(&1 + 1))
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"authToken" => "camille-token"}))
+      end)
+
+      user = Mydia.AccountsFixtures.user_fixture(%{username: "alex"})
+
+      assert {:ok, [_]} = Home.apply_mapping(saved, %{"2" => user.id}, plex_tv_base: base)
+      assert {:ok, [_]} = Home.apply_mapping(saved, %{"2" => user.id}, plex_tv_base: base)
+
+      assert Agent.get(switches, & &1) == 1
+    end
+  end
+
   defp persistable(config) do
     %{
       name: "Storage #{System.unique_integer([:positive])}",

--- a/test/mydia/media_server/plex/home_test.exs
+++ b/test/mydia/media_server/plex/home_test.exs
@@ -171,6 +171,35 @@ defmodule Mydia.MediaServer.Plex.HomeTest do
                Home.apply_mapping(saved, %{"1" => user.id, "2" => user.id}, plex_tv_base: base)
     end
 
+    test "a failed token mint leaves the existing mapping untouched",
+         %{bypass: bypass, base: base, saved: saved} do
+      # Deleting before minting meant a mint that failed had already unlinked
+      # somebody who was syncing fine, and the operator saw only an error.
+      Bypass.stub(bypass, "POST", "/api/v2/home/users/2/switch", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"authToken" => "camille-token"}))
+      end)
+
+      Bypass.stub(bypass, "POST", "/api/v2/home/users/1/switch", fn conn ->
+        Plug.Conn.resp(conn, 500, "")
+      end)
+
+      camille = Mydia.AccountsFixtures.user_fixture(%{username: "alex"})
+      owner = Mydia.AccountsFixtures.user_fixture(%{username: "arsfeld"})
+
+      assert {:ok, [_]} = Home.apply_mapping(saved, %{"2" => camille.id}, plex_tv_base: base)
+
+      # Unmap Camille and map the owner in one save. The owner's mint fails, so
+      # the save must not have unlinked Camille on its way there.
+      assert {:error, _} =
+               Home.apply_mapping(saved, %{"1" => owner.id, "2" => nil}, plex_tv_base: base)
+
+      assert [link] = Mydia.Settings.list_media_server_user_links(saved.id)
+      assert link.user_id == camille.id
+      assert link.plex_account_id == "2"
+    end
+
     test "re-saving an unchanged mapping does not mint a fresh token",
          %{bypass: bypass, base: base, saved: saved} do
       {:ok, switches} = Agent.start_link(fn -> 0 end)

--- a/test/mydia_web/live/admin_media_servers_live/components_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live/components_test.exs
@@ -281,9 +281,11 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
       refute html =~ ~s(id="media_server_config_url")
     end
 
-    # Test Connection builds its probe config from url and token alone, with no
-    # connections, so on the discovery path it always fails. The reachability
-    # line already on this screen reports the same thing honestly.
+    # The review step already reports reachability on its own, so a second
+    # button asking the same question is noise. (It used to be worse than noise:
+    # the probe config was built from url and token alone, so on the discovery
+    # path it answered "URL is required" every time. It now carries the
+    # discovered connections, but the panel still says it better.)
     test "Test Connection is hidden on the review step" do
       html = render_modal(oauth_state: :complete, discovery: discovery_map())
 
@@ -294,6 +296,112 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
       html = render_modal(manual_entry: true)
 
       assert html =~ "test_media_server_connection"
+    end
+  end
+
+  describe "Plex Home profile mapping modal" do
+    defp render_profiles(opts) do
+      render_component(&Components.plex_profiles_modal/1, %{
+        config: Keyword.get(opts, :config, %MediaServerConfig{name: "Galactica", type: :plex}),
+        state: Keyword.get(opts, :state, :ready),
+        profiles: Keyword.get(opts, :profiles, []),
+        users: Keyword.get(opts, :users, []),
+        mapping: Keyword.get(opts, :mapping, %{}),
+        saving: Keyword.get(opts, :saving, false)
+      })
+    end
+
+    defp profile(id, username, admin? \\ false) do
+      %{plex_account_id: id, username: username, admin?: admin?}
+    end
+
+    defp users, do: [%{id: "u-admin", username: "admin"}, %{id: "u-alex", username: "alex"}]
+
+    defp selected_option(html, account_id) do
+      html
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query(~s(select[name="mapping[#{account_id}]"] option[selected]))
+      |> LazyHTML.attribute("value")
+      |> List.first()
+    end
+
+    test "shows a row and a user select for every Plex Home profile" do
+      html =
+        render_profiles(
+          profiles: [profile("1", "arsfeld", true), profile("2", "Camille")],
+          users: users()
+        )
+
+      assert html =~ ~s(id="plex-profile-1")
+      assert html =~ ~s(id="plex-profile-2")
+      assert html =~ "arsfeld"
+      assert html =~ "Camille"
+      assert html =~ ~s(name="mapping[1]")
+      assert html =~ ~s(name="mapping[2]")
+    end
+
+    test "every select offers Don't sync plus each Mydia user" do
+      html = render_profiles(profiles: [profile("2", "Camille")], users: users())
+
+      assert html =~ "Don&#39;t sync"
+      assert html =~ ~s(value="u-admin")
+      assert html =~ ~s(value="u-alex")
+    end
+
+    test "preselects the user the mapping names" do
+      # Without this the operator's saved links would render as unmapped and a
+      # blind re-save would silently unlink everyone.
+      html =
+        render_profiles(
+          profiles: [profile("1", "arsfeld"), profile("2", "Camille")],
+          users: users(),
+          mapping: %{"1" => "u-alex", "2" => nil}
+        )
+
+      assert selected_option(html, "1") == "u-alex"
+      assert selected_option(html, "2") in [nil, ""]
+    end
+
+    test "marks the Plex account owner" do
+      html = render_profiles(profiles: [profile("1", "arsfeld", true)], users: users())
+
+      assert html =~ "owner"
+    end
+
+    test "reports that plex.tv is still being asked" do
+      html = render_profiles(state: :loading)
+
+      assert html =~ ~s(id="plex-profiles-loading")
+      refute html =~ ~s(id="plex-profiles-form")
+    end
+
+    test "surfaces a load failure instead of an empty list" do
+      # An empty list and a failed request look identical on screen otherwise,
+      # and "this account has no profiles" is the wrong thing to tell someone
+      # whose token just expired.
+      html = render_profiles(state: {:error, "Could not load Plex Home profiles: HTTP 401"})
+
+      assert html =~ ~s(id="plex-profiles-error")
+      assert html =~ "HTTP 401"
+      refute html =~ ~s(id="plex-profiles-form")
+    end
+
+    test "explains an account with no Home profiles" do
+      html = render_profiles(state: :ready, profiles: [])
+
+      assert html =~ ~s(id="plex-profiles-empty")
+      refute html =~ ~s(id="plex-profiles-form")
+    end
+
+    test "disables the save button while a save is in flight" do
+      html = render_profiles(profiles: [profile("2", "Camille")], users: users(), saving: true)
+
+      assert html =~ "Saving..."
+
+      assert html
+             |> LazyHTML.from_fragment()
+             |> LazyHTML.query("#plex-profiles-save")
+             |> LazyHTML.attribute("disabled") != []
     end
   end
 end

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -347,5 +347,49 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
         args: %{"mode" => "server", "config_id" => config.id}
       )
     end
+
+    test "a Plex server syncing watched status offers profile mapping", %{conn: conn} do
+      # Auto-matching links a profile only when its name equals a Mydia
+      # username, which on most installs is never, and until this button there
+      # was no way for the operator to make the mapping themselves.
+      {:ok, config} =
+        Mydia.Settings.create_media_server_config(%{
+          name: "Map Me",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "tok",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
+
+      assert has_element?(
+               view,
+               "button[phx-click='open_plex_profiles'][phx-value-id='#{config.id}']"
+             )
+    end
+
+    test "a Plex server not syncing watched status does not offer profile mapping",
+         %{conn: conn} do
+      # Links exist only to keep per-user watch history apart. With sync off
+      # there is nothing to keep apart, and offering the mapping would imply a
+      # feature the operator never turned on.
+      {:ok, config} =
+        Mydia.Settings.create_media_server_config(%{
+          name: "No Sync",
+          type: :plex,
+          url: "http://localhost:32400",
+          token: "tok",
+          enabled: true
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/media-servers")
+
+      refute has_element?(
+               view,
+               "button[phx-click='open_plex_profiles'][phx-value-id='#{config.id}']"
+             )
+    end
   end
 end


### PR DESCRIPTION
Two defects that made a healthy Plex server look broken in the admin UI. Both were confirmed against a live instance before any code changed.

## Test reported "URL is required" for every OAuth-connected server

A Plex config addressed by discovery stores no `url` at all and resolves one from its advertised `connections` at call time. `MediaServerConfig.validate_addressable/1` has permitted that since endpoint discovery landed, but `Client.Plex.test_connection/1` still carried the nil-url guard from the commit before it and built its probe straight off `config.url`. It was the one function in the module not going through the resolver.

Observed on a live config, same struct, same moment:

```
Client.Plex.test_connection(config)  #=> {:error, "URL is required"}
Endpoint.resolve(config)             #=> {:ok, "https://10-88-0-1.….plex.direct:32400"}
```

`test_connection/1` now probes the advertised connections. It calls `probe_connections/2` rather than `resolve/1` on purpose: `resolve/1` caches its winner for ten minutes, so a test click could report success for a server that died right after the previous one. An explicit `url` still wins as the manual operator override, matching the precedence `resolve/1` already applies.

The modal's Test Connection had the same hole from the other side. It dropped `connections` and `machine_identifier` when building its probe config, so editing a discovered server and testing it failed identically. Fixed here too.

## Watched sync sat on "Linking Plex Home profiles" forever

Links are only ever created by matching a Plex Home profile name to a Mydia username. Self-hosters name profiles after people and their Mydia account `admin`, so on most installs nothing matches. On the instance I looked at: profiles `arsfeld`, `Camille`, `Guest`, `Sueli` against users `admin`, `alex`, `admin-oidc`.

`PlexLinkSeed` recorded the terminal `:no_matching_users` and stopped. The next sync tick re-recorded `:seeding_links` on top of it, and the card reads the newest run. An unrecoverable state rendered as in progress, and the one message that would have told the operator what to do was buried under it. The `sync_runs` rows show the thrash directly:

```
19:05:41  skipped  no_matching_users   <- seeding gave up here
19:05:45  skipped  seeding_links
19:06:03  skipped  seeding_links
```

There was no manual mapping UI anywhere in the app, so there was also no way out.

Two changes. The scheduler stops announcing seeding once seeding has reported nothing to link, and surfaces `no_matching_users` instead. Only that reason is terminal; `link_seeding_failed` means plex.tv was unreachable and is still retried.

And the server card gains a **Profiles** button, on Plex servers with watched sync enabled, opening a modal with one row per Home profile and a Mydia user to bind it to:

- A saved link is the operator's decision and beats the username suggestion.
- A suggestion never claims a user another profile already holds, so an untouched form is always submittable.
- Unmapping a profile deletes its link, so this unlinks as well as links.
- Two profiles on one Mydia user is refused. The links table is unique on `(config, user)`, so it would otherwise overwrite silently and leave a profile displaying as linked while syncing nothing.
- Re-saving an unchanged mapping mints no new token, avoiding a plex.tv profile switch per profile on every save.
- Saving queues a server-mode sync so the result is visible without waiting for the next half-hourly tick.

Both linking paths now write through one function, so a link means the same thing however it was made.

## Testing

`mix precommit` green: 7167 tests, 0 failures, Credo strict clean, format clean.

New coverage:

- `plex_connection_test.exs`: discovery-addressed configs test against their connections, auth and unreachable classify correctly, explicit url still wins, and a config with neither a url nor a connection still reports a missing url.
- `home_test.exs`: `apply_mapping/3` links a profile matching no username, unmaps, refuses duplicate users, and skips re-minting on an unchanged save.
- `media_server_watched_sync_test.exs`: seeding stops being announced once terminal, and a transient seeding failure is still retried.
- `components_test.exs`: modal rows, options, preselection, owner badge, loading, error, empty, and saving states.
- `admin_media_servers_live_test.exs`: the Profiles button appears with watched sync on and not without it.

One coverage limit worth stating. The plex.tv base is an opts-only test seam with no channel from a LiveView, so the open and save handlers cannot be stubbed end to end without a real network call. The modal's states are covered via `render_component`, the mapping behaviour via Bypass against `Home.apply_mapping/3` directly, and the LiveView tests assert only that the button wiring exists.
