### PR TITLE
fix(downloads): give up on a stalled download instead of mislabelling it as a failed import

### DIFF
--- a/docs/using/reference/download-clients.md
+++ b/docs/using/reference/download-clients.md
@@ -45,3 +45,37 @@ These fields appear when adding or editing a client in the Admin UI. Not every f
 | Category | Default category | `mydia` |
 | Priority | Client priority | `1` |
 | Download Directory | Output directory | `/downloads` |
+| Stalled Timeout | Minutes without progress before a download is flagged as stalled | `60` |
+
+## Stalled Downloads
+
+Mydia watches byte progress on every active download and acts in two stages.
+
+**Stage 1: flagged as stalled.** A download that makes no byte progress for the client's **Stalled Timeout** (default 60 minutes) is flagged with a yellow "Stalled" badge on the Downloads screen. This is a warning, not a verdict. The download keeps its place in the queue, and if bytes start moving again the flag clears itself.
+
+**Stage 2: given up on.** If the download stays stalled for three times the timeout after that (180 minutes on the default, so **4 hours without progress in total**), Mydia gives up on the release. It:
+
+- removes the torrent from your download client
+- blocklists that release for **1 day**, so the replacement search does not immediately grab the same dead copy back
+- deletes the download from the queue
+- queues a fresh search straight away
+
+The blocklist is deliberately short. A torrent with no seeds today may have seeds tomorrow, so a stall earns a cooldown rather than the near-permanent block a corrupt release gets. You will find the give-up recorded in the activity feed and on the media item's history.
+
+While a download is in stage 1, the row tells you exactly when stage 2 will fire and offers two buttons: **Remove and find another** does it immediately, and **Keep waiting** resets the clock and buys another full window.
+
+### Restarts, outages, and paused torrents do not count
+
+Stall time only accrues while Mydia is actually watching a download run. If it goes unobserved for more than 6 minutes, for any reason, the clock resets instead of accruing.
+
+That covers a Mydia restart, a download client that goes unreachable, and a torrent you paused or that sat queued behind others. It is why a torrent can look frozen at the same byte count for a day and never be touched: Mydia only counts the stretches where it watched the download fail to progress, not wall-clock time.
+
+### When Mydia stops giving up
+
+Giving up is capped per media item. After a few automatic rejections for the same movie or episode (3 by default, configurable via `auto_reject_limit`), Mydia stops rejecting and leaves further stalled downloads alone.
+
+The reasoning: if Mydia has already thrown away several releases for one item, the likeliest explanation is that the detection is wrong rather than that every release is bad. Leaving the download alone gives it the chance to finish.
+
+### Debrid clients
+
+Debrid clients default to a 1440-minute (24 hour) timeout instead of 60, because an uncached release legitimately sits waiting on the provider for hours. That makes the give-up deadline **4 days** of no progress. This is intentional: a debrid wait is not a stall.

--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -406,17 +406,23 @@ defmodule Mydia.Downloads do
   defdelegate resolve_file_mappings(download, mappings), to: Mydia.Downloads.Queue
 
   @doc """
-  Rejects a release the operator has judged unusable: blacklists
-  `(indexer, guid)`, removes it from the download client (best effort),
-  deletes the download row, and queues a fresh search. See
-  `Mydia.Downloads.Queue.reject_release/2` for details.
+  Rejects a release judged unusable: blacklists `(indexer, guid)`, removes it
+  from the download client (best effort), deletes the download row, and queues
+  a fresh search. See `Mydia.Downloads.Queue.reject_release/2` for details.
+
+  A download with no blacklist key, or whose blacklist write fails, is still
+  cleared — it is simply not recorded. The torrent is dead either way.
 
   ## Options
     - `:actor_type` - The type of actor (:user, :system, :job) - defaults to :user
     - `:actor_id` - The ID of the actor (user_id, job name, etc.)
+    - `:failure_reason` - Blacklist reason slug - defaults to "rejected_by_user"
+    - `:ttl_days` - Days until the blacklist entry expires - defaults to the
+      configured `release_blacklist_default_ttl_days` (30)
+    - `:event` - `:cancelled` (default) emits `download.cancelled`; `:none`
+      emits nothing, for callers that emit their own more specific event
   """
-  @spec reject_release(Download.t(), keyword()) ::
-          {:ok, :rejected} | {:error, :no_indexer | :no_guid | term()}
+  @spec reject_release(Download.t(), keyword()) :: {:ok, :rejected} | {:error, term()}
   defdelegate reject_release(download, opts \\ []), to: Mydia.Downloads.Queue
 
   @doc """

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -156,28 +156,55 @@ defmodule Mydia.Downloads.Queue do
              indexer,
              guid,
              download.title || "Unknown release",
-             Keyword.get(opts, :failure_reason, "rejected_by_user")
+             Keyword.get(opts, :failure_reason, "rejected_by_user"),
+             blacklist_opts(opts)
            ) do
-      # Computed before deletion: it reads through the media_item association.
-      search = replacement_search(download)
+      finish_reject(download, opts)
+    end
+  end
 
-      remove_from_client(download)
+  # Only forward :ttl_days when the caller set it, so Blacklists.add/5 keeps
+  # applying its own configured default for every existing caller.
+  defp blacklist_opts(opts) do
+    case Keyword.get(opts, :ttl_days) do
+      nil -> []
+      days -> [ttl_days: days]
+    end
+  end
 
-      case History.delete_download(download) do
-        {:ok, _deleted} ->
-          enqueue_search(search)
+  # Everything after the blacklist decision: clear the torrent, drop the row,
+  # queue a replacement, and (optionally) announce it.
+  defp finish_reject(%Download{} = download, opts) do
+    # Computed before deletion: it reads through the media_item association.
+    search = replacement_search(download)
 
-          Events.download_cancelled(
-            download,
-            Keyword.get(opts, :actor_type, :user),
-            Keyword.get(opts, :actor_id, "unknown")
-          )
+    remove_from_client(download)
 
-          {:ok, :rejected}
+    case History.delete_download(download) do
+      {:ok, _deleted} ->
+        enqueue_search(search)
+        emit_reject_event(download, opts)
 
-        {:error, reason} ->
-          {:error, reason}
-      end
+        {:ok, :rejected}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # A caller that emits its own, more specific event passes `event: :none` so
+  # one give-up does not produce two entries in the activity feed.
+  defp emit_reject_event(download, opts) do
+    case Keyword.get(opts, :event, :cancelled) do
+      :none ->
+        :ok
+
+      :cancelled ->
+        Events.download_cancelled(
+          download,
+          Keyword.get(opts, :actor_type, :user),
+          Keyword.get(opts, :actor_id, "unknown")
+        )
     end
   end
 

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -175,8 +175,21 @@ defmodule Mydia.Downloads.Queue do
            ) do
       :ok
     else
+      # Having no release key is an ordinary shape, not a problem: externally
+      # adopted torrents and manual grabs never had one. Logging it at warning
+      # would make routine operator rejections look like faults.
+      {:error, reason} when reason in [:no_indexer, :no_guid] ->
+        Logger.debug("Rejecting a release with no blacklist key",
+          download_id: download.id,
+          reason: inspect(reason)
+        )
+
+        :ok
+
+      # A write that actually failed is worth surfacing: the release will not be
+      # filtered out of the next search.
       {:error, reason} ->
-        Logger.warning("Rejecting release without a blacklist entry",
+        Logger.warning("Rejecting release but the blacklist write failed",
           download_id: download.id,
           reason: inspect(reason)
         )

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -136,16 +136,21 @@ defmodule Mydia.Downloads.Queue do
   @doc """
   Rejects a release the operator has judged unusable.
 
-  Blacklists `(indexer, guid)` so future searches filter it out, removes the
-  torrent and its data from the client, deletes the download row, and queues a
-  fresh search for the bound episode or movie.
+  Best-effort blacklists `(indexer, guid)` when a key can be extracted, removes
+  the torrent and its data from the client (best effort), deletes the download
+  row, and queues a fresh search for the bound episode or movie.
 
-  The blacklist write happens first: if a later step fails, the release must
-  still not be re-grabbed. Client removal is best effort, since the torrent may
-  already be gone.
+  A download with no blacklist key, or whose blacklist write fails, is still
+  cleared — it is simply not recorded. The torrent is dead either way.
 
-  Accepts `:failure_reason` (default `"rejected_by_user"`) so a system-initiated
-  rejection is distinguishable from an operator's in `release_blacklist`.
+  ## Options
+    - `:actor_type` - The type of actor (:user, :system, :job) - defaults to :user
+    - `:actor_id` - The ID of the actor (user_id, job name, etc.)
+    - `:failure_reason` - Blacklist reason slug - defaults to "rejected_by_user"
+    - `:ttl_days` - Days until the blacklist entry expires - defaults to the
+      configured `release_blacklist_default_ttl_days` (30)
+    - `:event` - `:cancelled` (default) emits `download.cancelled`; `:none`
+      emits nothing, for callers that emit their own more specific event
   """
   @spec reject_release(Download.t(), keyword()) :: {:ok, :rejected} | {:error, term()}
   def reject_release(%Download{} = download, opts \\ []) do

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -147,9 +147,18 @@ defmodule Mydia.Downloads.Queue do
   Accepts `:failure_reason` (default `"rejected_by_user"`) so a system-initiated
   rejection is distinguishable from an operator's in `release_blacklist`.
   """
-  @spec reject_release(Download.t(), keyword()) ::
-          {:ok, :rejected} | {:error, :no_indexer | :no_guid | term()}
+  @spec reject_release(Download.t(), keyword()) :: {:ok, :rejected} | {:error, term()}
   def reject_release(%Download{} = download, opts \\ []) do
+    blacklist_release(download, opts)
+    finish_reject(download, opts)
+  end
+
+  # Best effort, and deliberately so. A release we cannot key (no indexer or
+  # guid — externally-adopted torrents, manual grabs) or whose blacklist write
+  # fails is still a dead download: clearing it matters more than recording
+  # why. Leaving the torrent running because the bookkeeping failed is the
+  # exact bug this path exists to fix.
+  defp blacklist_release(%Download{} = download, opts) do
     with {:ok, indexer, guid} <- Blacklists.extract_key(download),
          {:ok, _row} <-
            Blacklists.add(
@@ -159,7 +168,15 @@ defmodule Mydia.Downloads.Queue do
              Keyword.get(opts, :failure_reason, "rejected_by_user"),
              blacklist_opts(opts)
            ) do
-      finish_reject(download, opts)
+      :ok
+    else
+      {:error, reason} ->
+        Logger.warning("Rejecting release without a blacklist entry",
+          download_id: download.id,
+          reason: inspect(reason)
+        )
+
+        :ok
     end
   end
 

--- a/lib/mydia/downloads/stall_detector.ex
+++ b/lib/mydia/downloads/stall_detector.ex
@@ -24,8 +24,9 @@ defmodule Mydia.Downloads.StallDetector do
       NOT a terminal `import_failed_at` failure — and auto-clears on resumed
       progress or a gap reset.
     * **Escalate.** A download that stays continuously soft-stalled past a
-      separate, longer escalation threshold escalates to a terminal failure
-      (the monitor sets `import_failed_at`, releasing the episode for re-search).
+      separate, longer escalation threshold is one we give up on: the monitor
+      rejects the release outright (blocklists it briefly, removes the torrent
+      from the client, deletes the row, and queues a replacement search).
     * **Initialize.** First time we see a download (`last_progress_at` nil) we
       set the baseline and never flag stalled on first sight.
 
@@ -35,6 +36,10 @@ defmodule Mydia.Downloads.StallDetector do
   """
 
   alias Mydia.Downloads.StallDetector.Thresholds
+
+  # A soft-stall escalates to a give-up after grace × this. A dedicated
+  # per-client knob is deliberately deferred (see the stall give-up spec).
+  @escalation_multiplier 3
 
   @type decision ::
           :no_change
@@ -79,7 +84,8 @@ defmodule Mydia.Downloads.StallDetector do
     * `{:soft_stall, message, now}` — bytes unchanged past the grace window. Set
       `stalled_since = now`; leave `import_failed_at` nil (episode retained).
     * `{:escalate, message, now}` — soft-stalled past the escalation threshold.
-      Set `import_failed_at = now` + `import_last_error = message` (terminal).
+      The monitor rejects the release; `message` is recorded on the emitted
+      `download.failed` event.
 
   Boundary semantics: a download whose baseline is EXACTLY `grace_minutes` old is
   *not yet* soft-stalled, and one stalled EXACTLY `escalation_minutes` is *not
@@ -134,7 +140,7 @@ defmodule Mydia.Downloads.StallDetector do
       # the longer threshold) or hold the soft-stall.
       not is_nil(stalled_since) ->
         if DateTime.diff(now, stalled_since, :second) > escalation_minutes * 60 do
-          {:escalate, escalation_message(escalation_minutes), now}
+          {:escalate, escalation_message(grace_minutes, escalation_minutes), now}
         else
           :no_change
         end
@@ -158,13 +164,42 @@ defmodule Mydia.Downloads.StallDetector do
   end
 
   @doc """
-  Build the terminal-escalation error message. Kept with a leading `"stalled"`
-  prefix so `stalled?/1` and the LiveView badge continue to recognise it.
+  How long a soft-stall may persist before we give up, derived from the
+  per-client grace window.
+
+  Single-sourced here rather than in `DownloadMonitor` so the Downloads
+  LiveView can show the operator the same deadline the monitor will act on,
+  with no chance of the two drifting apart.
   """
-  @spec escalation_message(pos_integer()) :: String.t()
-  def escalation_message(escalation_minutes)
-      when is_integer(escalation_minutes) and escalation_minutes > 0 do
-    "stalled after #{escalation_minutes}m without progress — escalated to failure"
+  @spec escalation_minutes(pos_integer()) :: pos_integer()
+  def escalation_minutes(grace_minutes)
+      when is_integer(grace_minutes) and grace_minutes > 0 do
+    grace_minutes * @escalation_multiplier
+  end
+
+  @doc """
+  Build the give-up message recorded on the `download.failed` event.
+
+  Reports the *total* time without progress (grace + escalation). The previous
+  message reported only the escalation window, understating the stall by the
+  whole grace window, and asserted "escalated to failure" while leaving the
+  torrent running. The consequence now lives on the event's `failure_category`
+  and in what actually happens to the download.
+  """
+  @spec escalation_message(pos_integer(), pos_integer()) :: String.t()
+  def escalation_message(grace_minutes, escalation_minutes)
+      when is_integer(grace_minutes) and grace_minutes > 0 and
+             is_integer(escalation_minutes) and escalation_minutes > 0 do
+    "no progress for #{format_window(grace_minutes + escalation_minutes)}"
+  end
+
+  defp format_window(minutes) when minutes < 60, do: "#{minutes}m"
+
+  defp format_window(minutes) do
+    case {div(minutes, 60), rem(minutes, 60)} do
+      {hours, 0} -> "#{hours}h"
+      {hours, rest} -> "#{hours}h #{rest}m"
+    end
   end
 
   @doc """

--- a/lib/mydia/downloads/stall_detector.ex
+++ b/lib/mydia/downloads/stall_detector.ex
@@ -201,14 +201,4 @@ defmodule Mydia.Downloads.StallDetector do
       {hours, rest} -> "#{hours}h #{rest}m"
     end
   end
-
-  @doc """
-  Test whether a download's `import_last_error` indicates a stalled state.
-  Used by the LiveView badge helper.
-  """
-  @spec stalled?(String.t() | nil) :: boolean()
-  def stalled?(nil), do: false
-
-  def stalled?(error_message) when is_binary(error_message),
-    do: String.starts_with?(error_message, "stalled")
 end

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -64,10 +64,6 @@ defmodule Mydia.Jobs.DownloadMonitor do
   alias Mydia.Events
   alias Mydia.Settings
 
-  # Fallback grace window (minutes) when a download has no resolvable client
-  # config. The DB schema's default is also 60; this just guards against a nil.
-  @default_grace_minutes 60
-
   # How long a give-up blocklists the release. Deliberately far shorter than
   # the 30-day default: a torrent with no seeds today may have seeds tomorrow,
   # so a stall earns a cooldown, not the near-permanent ban a corrupt release
@@ -203,7 +199,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
     # Track progress / flag stalled downloads. Grace minutes are read from each
     # download's configured client (DB or runtime config) — cached per poll.
-    grace_map = build_grace_map()
+    grace_map = Settings.download_client_grace_map()
     stalled_count = check_progress(active_for_stall_check, grace_map, now)
 
     # Find and match untracked torrents (manually added to clients)
@@ -843,18 +839,8 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
   # --- Stall detection ----------------------------------------------------
 
-  # Build a `%{client_name => grace_minutes}` map once per poll. Both DB-backed
-  # and runtime-config clients flow through `Settings.list_download_client_configs/0`,
-  # so a single source is enough.
-  defp build_grace_map do
-    Settings.list_download_client_configs()
-    |> Enum.into(%{}, fn config ->
-      {config.name, config.incomplete_grace_minutes || @default_grace_minutes}
-    end)
-  end
-
   defp grace_minutes_for(client_name, grace_map) do
-    Map.get(grace_map, client_name, @default_grace_minutes)
+    Map.get(grace_map, client_name, Settings.default_grace_minutes())
   end
 
   # Iterate active downloads and apply the StallDetector decision. Returns the

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -68,10 +68,11 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # config. The DB schema's default is also 60; this just guards against a nil.
   @default_grace_minutes 60
 
-  # A soft-stall escalates to a terminal failure only after it has persisted for
-  # `grace_minutes × @stall_escalation_multiplier` (default 60 × 3 = 180 min).
-  # A dedicated per-client knob is deferred.
-  @stall_escalation_multiplier 3
+  # How long a give-up blocklists the release. Deliberately far shorter than
+  # the 30-day default: a torrent with no seeds today may have seeds tomorrow,
+  # so a stall earns a cooldown, not the near-permanent ban a corrupt release
+  # gets.
+  @stall_blacklist_ttl_days 1
 
   # An observation gap larger than this resets the stall clock instead of
   # accruing stall time — covers client outages, Mydia restarts, and torrents
@@ -864,7 +865,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   defp check_progress(active_downloads, grace_map, now) do
     Enum.reduce(active_downloads, 0, fn download, stalled_acc ->
       grace = grace_minutes_for(download.download_client, grace_map)
-      escalation = grace * @stall_escalation_multiplier
+      escalation = StallDetector.escalation_minutes(grace)
 
       decision =
         StallDetector.evaluate(
@@ -981,40 +982,76 @@ defmodule Mydia.Jobs.DownloadMonitor do
     end
   end
 
-  # Escalation — a soft-stall that outlasted the longer threshold becomes a
-  # terminal failure, releasing the episode for re-search (today's terminal
-  # behaviour, now reached only after escalation).
-  #
-  # IMPORTANT: do NOT cast `:status` here — `Download.changeset/2` silently
-  # drops it (known bug, tracked separately). Use `import_failed_at` +
-  # `import_last_error` as the terminal signal.
-  defp apply_progress_decision(download, {:escalate, error_message, now}, _now) do
-    Logger.warning("Download stall escalated to terminal failure",
+  # A soft-stall that outlasted the escalation window is a release we give up
+  # on. Reuse the same reject path bad content uses rather than inventing a
+  # third terminal shape: blocklist briefly, pull the torrent from the client,
+  # delete the row, queue a replacement. The old behaviour wrote two import
+  # fields and left the torrent running, which read to operators as "Mydia
+  # says this failed but it is still downloading".
+  defp apply_progress_decision(download, {:escalate, error_message, _at}, _now) do
+    db_download = Downloads.get_download!(download.id, preload: [:media_item])
+
+    if auto_reject_exhausted?(db_download.media_item_id) do
+      suppress_stall_reject(db_download, error_message)
+    else
+      do_reject_stalled(db_download, error_message)
+    end
+  end
+
+  defp do_reject_stalled(download, error_message) do
+    Logger.warning("Giving up on stalled download",
       download_id: download.id,
       download_client: download.download_client,
       stalled_since: download.stalled_since,
       error: error_message
     )
 
-    db_download = Downloads.get_download!(download.id, preload: [:media_item])
+    # Emitted before the reject deletes the row: this event is the operator's
+    # only lasting record, same as the client-failure path at the top of this
+    # module.
+    Events.download_failed(download, error_message,
+      media_item: download.media_item,
+      failure_category: "stalled",
+      failure_detail: download.download_client
+    )
 
-    case Downloads.update_download(db_download, %{
-           import_failed_at: now,
-           import_last_error: error_message,
-           last_observed_at: now
-         }) do
-      {:ok, updated} ->
-        Events.download_failed(updated, error_message, media_item: updated.media_item)
-        1
+    case Queue.reject_release(download,
+           actor_type: :system,
+           actor_id: "download_monitor",
+           failure_reason: "stalled",
+           ttl_days: @stall_blacklist_ttl_days,
+           event: :none
+         ) do
+      {:ok, :rejected} ->
+        if download.media_item_id do
+          Mydia.Search.record_failure("auto_reject", download.media_item_id, "stalled")
+        end
 
-      {:error, changeset} ->
-        Logger.error("Failed to escalate stalled download",
+      {:error, reason} ->
+        Logger.warning("Could not clear stalled download",
           download_id: download.id,
-          errors: inspect(changeset.errors)
+          reason: inspect(reason)
         )
-
-        0
     end
+
+    1
+  end
+
+  # Same reasoning as suppress_auto_reject/2: when the cap trips, the likeliest
+  # truth is that our detector is wrong, so the right outcome is that this
+  # download finishes and imports. Touch nothing.
+  defp suppress_stall_reject(download, error_message) do
+    Logger.warning("Auto-reject limit reached, leaving stalled download alone",
+      download_id: download.id,
+      title: download.title,
+      media_item_id: download.media_item_id,
+      limit: auto_reject_limit(),
+      error: error_message
+    )
+
+    Events.download_auto_reject_suppressed(download, media_item: download.media_item)
+
+    1
   end
 
   # Persist a progress/reset decision that clears any in-flight soft-stall,

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -992,15 +992,6 @@ defmodule Mydia.Jobs.DownloadMonitor do
       error: error_message
     )
 
-    # Emitted before the reject deletes the row: this event is the operator's
-    # only lasting record, same as the client-failure path at the top of this
-    # module.
-    Events.download_failed(download, error_message,
-      media_item: download.media_item,
-      failure_category: "stalled",
-      failure_detail: download.download_client
-    )
-
     case Queue.reject_release(download,
            actor_type: :system,
            actor_id: "download_monitor",
@@ -1009,23 +1000,45 @@ defmodule Mydia.Jobs.DownloadMonitor do
            event: :none
          ) do
       {:ok, :rejected} ->
+        # Emitted only once the reject actually happened. The in-memory struct
+        # outlives the deleted row, so the event loses nothing by waiting, and
+        # a reject that failed must not leave a terminal "failed" record behind
+        # for a download still sitting in the queue — the next poll would
+        # re-enter this branch and emit a second one.
+        Events.download_failed(download, error_message,
+          media_item: download.media_item,
+          failure_category: "stalled",
+          failure_detail: download.download_client
+        )
+
         if download.media_item_id do
           Mydia.Search.record_failure("auto_reject", download.media_item_id, "stalled")
         end
+
+        1
 
       {:error, reason} ->
         Logger.warning("Could not clear stalled download",
           download_id: download.id,
           reason: inspect(reason)
         )
-    end
 
-    1
+        # Nothing changed, so nothing newly stalled.
+        0
+    end
   end
 
   # Same reasoning as suppress_auto_reject/2: when the cap trips, the likeliest
   # truth is that our detector is wrong, so the right outcome is that this
-  # download finishes and imports. Touch nothing.
+  # download finishes and imports.
+  #
+  # Unlike that one, this resets the stall clock rather than touching nothing.
+  # A suppressed download stays past the escalation threshold, so every poll
+  # re-enters this branch and re-emits the event — a burst every 15s while the
+  # fast-followup chain is running, until the observation-gap reset happens to
+  # clear `stalled_since` as a side effect. Leaning on that accident is fragile;
+  # resetting the clock explicitly gives one event per full grace+escalation
+  # cycle. This is the same reset the operator's "Keep waiting" performs.
   defp suppress_stall_reject(download, error_message) do
     Logger.warning("Auto-reject limit reached, leaving stalled download alone",
       download_id: download.id,
@@ -1037,7 +1050,24 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
     Events.download_auto_reject_suppressed(download, media_item: download.media_item)
 
-    1
+    now = DateTime.utc_now()
+
+    case Downloads.update_download(download, %{
+           stalled_since: nil,
+           last_progress_at: now,
+           last_observed_at: now
+         }) do
+      {:ok, _updated} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.error("Failed to reset the stall clock on a suppressed download",
+          download_id: download.id,
+          errors: inspect(changeset.errors)
+        )
+    end
+
+    0
   end
 
   # Persist a progress/reset decision that clears any in-flight soft-stall,

--- a/lib/mydia/settings.ex
+++ b/lib/mydia/settings.ex
@@ -339,6 +339,31 @@ defmodule Mydia.Settings do
   @spec list_download_client_configs(keyword()) :: [DownloadClientConfig.t()]
   defdelegate list_download_client_configs(opts \\ []), to: Mydia.Settings.ServiceConfigs
 
+  @default_grace_minutes 60
+
+  @doc """
+  The fallback stall grace window (minutes) for a client with no resolvable
+  config. Matches the `incomplete_grace_minutes` column default.
+  """
+  @spec default_grace_minutes() :: pos_integer()
+  def default_grace_minutes, do: @default_grace_minutes
+
+  @doc """
+  Builds a `%{client_name => grace_minutes}` map for stall detection.
+
+  Both DB-backed and runtime-config clients flow through
+  `list_download_client_configs/0`, so a single source is enough. Shared by
+  `Mydia.Jobs.DownloadMonitor` (which acts on the deadline) and the Downloads
+  LiveView (which shows it), so the two can never disagree.
+  """
+  @spec download_client_grace_map() :: %{String.t() => pos_integer()}
+  def download_client_grace_map do
+    list_download_client_configs()
+    |> Enum.into(%{}, fn config ->
+      {config.name, config.incomplete_grace_minutes || @default_grace_minutes}
+    end)
+  end
+
   @doc """
   Gets a download client configuration by ID.
 

--- a/lib/mydia_web/live/admin_download_clients_live/components.ex
+++ b/lib/mydia_web/live/admin_download_clients_live/components.ex
@@ -2,6 +2,7 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
   @moduledoc false
   use MydiaWeb, :html
 
+  alias Mydia.Downloads.StallDetector
   alias Mydia.Settings
 
   # Client types that surface category configuration in the admin form.
@@ -606,7 +607,9 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
               </div>
             <% end %>
 
-            <%!-- Stalled timeout. Visible for every client type. --%>
+            <%!-- Stalled timeout. Visible for every client type. The entered
+                 value is only the FIRST threshold; the give-up deadline is
+                 derived from it and was previously invisible everywhere. --%>
             <div class="space-y-2">
               <.input
                 field={@download_client_form[:incomplete_grace_minutes]}
@@ -616,8 +619,13 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
                 placeholder="60"
                 min="1"
               />
+              <% grace = grace_minutes_value(@download_client_form[:incomplete_grace_minutes].value) %>
+              <% escalation = StallDetector.escalation_minutes(grace) %>
               <p class="text-xs text-base-content/50">
-                A download with no byte progress for this many minutes is flagged as stalled.
+                Flagged as stalled after {format_duration(grace * 60)} without progress.
+                If it still hasn't moved {format_duration(escalation * 60)} later
+                ({format_duration((grace + escalation) * 60)} total), Mydia removes it
+                and searches for a different release.
               </p>
             </div>
 
@@ -960,6 +968,25 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
     case get_in(client.connection_settings || %{}, ["remote_fetch", "enabled"]) do
       enabled when enabled in [true, "true"] -> true
       _ -> false
+    end
+  end
+
+  # The form value arrives as a string while the operator types, as an integer
+  # from a loaded config, and as nil for a fresh form. Anything unusable falls
+  # back to the schema default so the help text never renders a broken number.
+  defp grace_minutes_value(value) do
+    case value do
+      n when is_integer(n) and n > 0 ->
+        n
+
+      s when is_binary(s) ->
+        case Integer.parse(s) do
+          {n, ""} when n > 0 -> n
+          _ -> Settings.default_grace_minutes()
+        end
+
+      _ ->
+        Settings.default_grace_minutes()
     end
   end
 end

--- a/lib/mydia_web/live/downloads_live/components.ex
+++ b/lib/mydia_web/live/downloads_live/components.ex
@@ -125,7 +125,6 @@ defmodule MydiaWeb.DownloadsLive.Components do
           class="btn btn-warning btn-sm"
           phx-click="reject_release"
           phx-value-id={@modal.download.id}
-          disabled={not rejectable?(@modal.download)}
           title={reject_hint(@modal.download)}
           data-confirm="Blacklist this release, remove the download and its data from the download client, and search again. Files already imported to the library are kept."
         >
@@ -194,15 +193,11 @@ defmodule MydiaWeb.DownloadsLive.Components do
   defp probe_label(%{"detail" => detail}), do: "Unknown (#{detail})"
   defp probe_label(_probe), do: nil
 
-  defp rejectable?(download) do
-    match?({:ok, _indexer, _guid}, Blacklists.extract_key(download))
-  end
-
   defp reject_hint(download) do
     case Blacklists.extract_key(download) do
       {:ok, _indexer, _guid} -> "Blacklist this release and search again"
-      {:error, :no_indexer} -> "No indexer recorded, so this release cannot be blacklisted"
-      {:error, :no_guid} -> "No release id recorded, so this release cannot be blacklisted"
+      {:error, :no_indexer} -> "Remove this download and search again (no indexer to blacklist)"
+      {:error, :no_guid} -> "Remove this download and search again (no release id to blacklist)"
     end
   end
 

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -882,14 +882,6 @@ defmodule MydiaWeb.DownloadsLive.Index do
            |> put_flash(:info, "Release blacklisted and a new search was queued")
            |> load_downloads()}
 
-        {:error, reason} when reason in [:no_indexer, :no_guid] ->
-          {:noreply,
-           assign(
-             socket,
-             :match_files_error,
-             "This download has no indexer or release id recorded, so it cannot be blacklisted."
-           )}
-
         {:error, _reason} ->
           {:noreply, assign(socket, :match_files_error, "Failed to reject the release.")}
       end

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -1,6 +1,7 @@
 defmodule MydiaWeb.DownloadsLive.Index do
   use MydiaWeb, :live_view
   alias Mydia.Downloads
+  alias Mydia.Downloads.Blacklists
   alias Mydia.Downloads.ExternalTorrents
   alias Mydia.Downloads.ImportCandidates
   alias Mydia.Downloads.StallDetector
@@ -878,11 +879,20 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
       case Downloads.reject_release(download) do
         {:ok, :rejected} ->
+          flash =
+            case Blacklists.extract_key(download) do
+              {:ok, _indexer, _guid} ->
+                "Release blacklisted and a new search was queued"
+
+              {:error, _} ->
+                "Download removed and a new search was queued"
+            end
+
           {:noreply,
            socket
            |> assign(:match_files_modal, nil)
            |> assign(:match_files_error, nil)
-           |> put_flash(:info, "Release blacklisted and a new search was queued")
+           |> put_flash(:info, flash)
            |> load_downloads()}
 
         {:error, _reason} ->
@@ -1443,9 +1453,10 @@ defmodule MydiaWeb.DownloadsLive.Index do
   defp status_rank(download) do
     # Stall state overrides the client status for sorting: a soft-stall groups
     # with warnings.
-    cond do
-      soft_stalled?(download) -> Map.fetch!(@status_rank, "stalled")
-      true -> Map.get(@status_rank, download.status, 99)
+    if soft_stalled?(download) do
+      Map.fetch!(@status_rank, "stalled")
+    else
+      Map.get(@status_rank, download.status, 99)
     end
   end
 
@@ -1608,12 +1619,10 @@ defmodule MydiaWeb.DownloadsLive.Index do
   # its episode and may auto-clear. There is no terminal stall badge — an
   # escalated stall is rejected outright and the row no longer exists.
   def status_badge(download) do
-    cond do
-      soft_stalled?(download) ->
-        {status_badge_class("stalled"), "Stalled"}
-
-      true ->
-        {status_badge_class(download.status), String.capitalize(download.status)}
+    if soft_stalled?(download) do
+      {status_badge_class("stalled"), "Stalled"}
+    else
+      {status_badge_class(download.status), String.capitalize(download.status)}
     end
   end
 

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -3,10 +3,12 @@ defmodule MydiaWeb.DownloadsLive.Index do
   alias Mydia.Downloads
   alias Mydia.Downloads.ExternalTorrents
   alias Mydia.Downloads.ImportCandidates
+  alias Mydia.Downloads.StallDetector
   alias Mydia.Downloads.Structs.DownloadMetadata
   alias Mydia.Library.Structs.Quality
   alias Mydia.Library
   alias Mydia.Media
+  alias Mydia.Settings
   alias Phoenix.PubSub
   alias MydiaWeb.Live.Authorization
   alias MydiaWeb.DownloadsLive.Components
@@ -108,6 +110,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
      |> assign(:library_search_results, [])
      # Match / re-match modal state (in-flight correction + post-import re-match)
      |> assign(:match_modal, nil)
+     |> assign(:stall_grace_map, Settings.download_client_grace_map())
      # Initialize all streams
      |> stream(:downloads, [])
      |> stream(:needs_matching, [])
@@ -890,6 +893,31 @@ defmodule MydiaWeb.DownloadsLive.Index do
     end
   end
 
+  # Snooze, not opt-out: clearing stalled_since and advancing last_progress_at
+  # buys a full fresh grace-then-escalation window. If it stalls again the
+  # operator gets warned again.
+  def handle_event("keep_waiting", %{"id" => id}, socket) do
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      download = Downloads.get_download!(id)
+
+      case Downloads.update_download(download, %{
+             stalled_since: nil,
+             last_progress_at: DateTime.utc_now()
+           }) do
+        {:ok, _updated} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Stall timer reset. Mydia will keep waiting on this download.")
+           |> load_downloads()}
+
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, "Could not reset the stall timer")}
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
   def handle_event("dismiss_download", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
       download = Downloads.get_download!(id)
@@ -1598,6 +1626,25 @@ defmodule MydiaWeb.DownloadsLive.Index do
   defp soft_stalled?(download) do
     download.status == "downloading" and
       not is_nil(download.stalled_since) and is_nil(download.import_failed_at)
+  end
+
+  # Seconds since this download last moved a byte. Falls back to stalled_since
+  # for a row whose last_progress_at predates stall tracking.
+  defp stall_elapsed_seconds(download) do
+    reference = download.last_progress_at || download.stalled_since
+    DateTime.diff(DateTime.utc_now(), reference, :second)
+  end
+
+  # Seconds left before DownloadMonitor gives up on this download. Derived from
+  # the same StallDetector rule the monitor applies, so the number the operator
+  # reads is the number that will actually fire.
+  defp stall_remaining_seconds(download, grace_map) do
+    grace = Map.get(grace_map, download.download_client, Settings.default_grace_minutes())
+
+    deadline =
+      DateTime.add(download.stalled_since, StallDetector.escalation_minutes(grace) * 60, :second)
+
+    max(DateTime.diff(deadline, DateTime.utc_now(), :second), 0)
   end
 
   defp format_ratio(nil), do: "0.00"

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -1414,10 +1414,9 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   defp status_rank(download) do
     # Stall state overrides the client status for sorting: a soft-stall groups
-    # with warnings, a terminal stall failure groups with errors.
+    # with warnings.
     cond do
       soft_stalled?(download) -> Map.fetch!(@status_rank, "stalled")
-      stalled?(download) -> Map.fetch!(@status_rank, "failed")
       true -> Map.get(@status_rank, download.status, 99)
     end
   end
@@ -1524,7 +1523,6 @@ defmodule MydiaWeb.DownloadsLive.Index do
       "queued" -> "badge-info"
       "paused" -> "badge-warning"
       "stalled" -> "badge-warning"
-      "stall_failed" -> "badge-error"
       _ -> "badge-ghost"
     end
   end
@@ -1577,20 +1575,14 @@ defmodule MydiaWeb.DownloadsLive.Index do
   defp import_issue_label(:retrying), do: "Import retrying"
 
   @doc false
-  # Returns `{class, label}` for the download's status badge. A stall has two
-  # distinct states (see DownloadMonitor stall-resilience rework):
-  #
-  #   * soft-stall — recoverable warning; progress has stopped but the download
-  #     still occupies its episode and may auto-clear. Yellow "Stalled" badge.
-  #   * terminal stall failure — escalated past the longer threshold; the
-  #     episode has been released for re-search. Red "Stall failed" badge.
+  # Returns `{class, label}` for the download's status badge. A soft-stall is a
+  # recoverable warning: progress has stopped but the download still occupies
+  # its episode and may auto-clear. There is no terminal stall badge — an
+  # escalated stall is rejected outright and the row no longer exists.
   def status_badge(download) do
     cond do
       soft_stalled?(download) ->
         {status_badge_class("stalled"), "Stalled"}
-
-      stalled?(download) ->
-        {status_badge_class("stall_failed"), "Stall failed"}
 
       true ->
         {status_badge_class(download.status), String.capitalize(download.status)}
@@ -1606,13 +1598,6 @@ defmodule MydiaWeb.DownloadsLive.Index do
   defp soft_stalled?(download) do
     download.status == "downloading" and
       not is_nil(download.stalled_since) and is_nil(download.import_failed_at)
-  end
-
-  # A terminal stall failure: escalated to `import_failed_at` with a stalled
-  # message.
-  defp stalled?(download) do
-    not is_nil(download.import_failed_at) and
-      Mydia.Downloads.StallDetector.stalled?(download.import_last_error)
   end
 
   defp format_ratio(nil), do: "0.00"

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -240,6 +240,39 @@
                 <% end %>
               </div>
             <% end %>
+            <%!-- Soft-stall: a recoverable warning. import_issue is nil here
+                 (a soft-stall never sets import_failed_at), so this is a
+                 sibling of the block above, not an alternative to it. This is
+                 the only place the give-up rule is visible while the operator
+                 can still change the outcome. --%>
+            <%= if soft_stalled?(download) do %>
+              <div class="text-xs text-warning flex flex-wrap items-center gap-1.5 mt-0.5">
+                <.icon name="hero-clock" class="size-3 shrink-0" />
+                <span>
+                  No progress for {format_duration(stall_elapsed_seconds(download))}. If nothing changes in the next {format_duration(
+                    stall_remaining_seconds(download, @stall_grace_map)
+                  )}, Mydia will remove it and search for a different release.
+                </span>
+                <button
+                  type="button"
+                  id={"stall-reject-#{download.id}"}
+                  class="btn btn-xs btn-warning btn-outline shrink-0"
+                  phx-click="reject_release"
+                  phx-value-id={download.id}
+                >
+                  Remove and find another
+                </button>
+                <button
+                  type="button"
+                  id={"stall-keep-waiting-#{download.id}"}
+                  class="btn btn-xs btn-ghost shrink-0"
+                  phx-click="keep_waiting"
+                  phx-value-id={download.id}
+                >
+                  Keep waiting
+                </button>
+              </div>
+            <% end %>
             <%!-- Line 3: compact metadata cluster (every metric carries an icon) --%>
             <div class="flex items-center gap-x-3 gap-y-1 flex-wrap mt-1 text-xs text-base-content/60">
               <% quality_str = Quality.format(get_metadata_value(download, "quality")) %>

--- a/test/mydia/downloads/reject_release_test.exs
+++ b/test/mydia/downloads/reject_release_test.exs
@@ -4,6 +4,7 @@ defmodule Mydia.Downloads.RejectReleaseTest do
 
   alias Mydia.Downloads
   alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.ReleaseBlacklist
   alias Mydia.Repo
 
   import Mydia.DownloadsFixtures
@@ -105,6 +106,35 @@ defmodule Mydia.Downloads.RejectReleaseTest do
       refute Repo.get(Mydia.Downloads.Download, download.id)
       refute_enqueued(worker: Mydia.Jobs.TVShowSearch)
       refute_enqueued(worker: Mydia.Jobs.MovieSearch)
+    end
+
+    test "honours an explicit :ttl_days on the blacklist entry" do
+      download =
+        download_fixture(%{
+          indexer: "1337x",
+          metadata: %{"guid" => "ttl-guid"}
+        })
+
+      assert {:ok, :rejected} = Downloads.reject_release(download, ttl_days: 1)
+
+      row = Repo.get_by!(ReleaseBlacklist, indexer: "1337x", guid: "ttl-guid")
+
+      # 1 day out, not the 30-day default. Allow a minute of slack for clock drift.
+      expected = DateTime.add(DateTime.utc_now(), 1 * 24 * 60 * 60, :second)
+      assert abs(DateTime.diff(row.expires_at, expected, :second)) < 60
+    end
+
+    test "emits no event when :event is :none" do
+      download =
+        download_fixture(%{
+          indexer: "1337x",
+          metadata: %{"guid" => "quiet-guid"}
+        })
+
+      assert {:ok, :rejected} = Downloads.reject_release(download, event: :none)
+
+      Process.sleep(100)
+      assert Mydia.Events.list_events(type: "download.cancelled") == []
     end
   end
 end

--- a/test/mydia/downloads/reject_release_test.exs
+++ b/test/mydia/downloads/reject_release_test.exs
@@ -70,18 +70,37 @@ defmodule Mydia.Downloads.RejectReleaseTest do
       )
     end
 
-    test "refuses and changes nothing when the guid is missing" do
-      download = download_fixture(%{indexer: "1337x", metadata: %{}})
+    # There is nothing to blacklist without a key, but the download is still
+    # dead and must not be left running in the client. Externally-adopted
+    # torrents and manual grabs land here.
+    test "clears the download without a blacklist entry when the guid is missing" do
+      media_item = media_item_fixture(%{type: "movie"})
 
-      assert {:error, :no_guid} = Downloads.reject_release(download)
-      assert Repo.get(Mydia.Downloads.Download, download.id)
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          indexer: "1337x",
+          metadata: %{}
+        })
+
+      assert {:ok, :rejected} = Downloads.reject_release(download)
+
+      refute Repo.get(Mydia.Downloads.Download, download.id)
+      assert Repo.aggregate(ReleaseBlacklist, :count) == 0
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MovieSearch,
+        args: %{"mode" => "specific", "media_item_id" => media_item.id}
+      )
     end
 
-    test "refuses and changes nothing when the indexer is missing" do
+    test "clears the download without a blacklist entry when the indexer is missing" do
       download = download_fixture(%{indexer: nil, metadata: %{"guid" => "abc"}})
 
-      assert {:error, :no_indexer} = Downloads.reject_release(download)
-      assert Repo.get(Mydia.Downloads.Download, download.id)
+      assert {:ok, :rejected} = Downloads.reject_release(download)
+
+      refute Repo.get(Mydia.Downloads.Download, download.id)
+      assert Repo.aggregate(ReleaseBlacklist, :count) == 0
     end
 
     # Ordering-adjacent coverage: extract_key/1 and Blacklists.add/4 are the

--- a/test/mydia/downloads/stall_detector_test.exs
+++ b/test/mydia/downloads/stall_detector_test.exs
@@ -225,25 +225,6 @@ defmodule Mydia.Downloads.StallDetectorTest do
     end
   end
 
-  describe "stalled?/1" do
-    test "true for the canonical soft-stall message" do
-      assert StallDetector.stalled?("stalled after 60m without progress")
-    end
-
-    test "false for the escalation message" do
-      refute StallDetector.stalled?(StallDetector.escalation_message(60, 180))
-    end
-
-    test "false for unrelated error messages" do
-      refute StallDetector.stalled?("Import failed: bad path")
-      refute StallDetector.stalled?("Removed from download client 'qBit'")
-    end
-
-    test "false for nil" do
-      refute StallDetector.stalled?(nil)
-    end
-  end
-
   describe "stalled_message/1" do
     test "interpolates the grace minutes" do
       assert StallDetector.stalled_message(60) == "stalled after 60m without progress"

--- a/test/mydia/downloads/stall_detector_test.exs
+++ b/test/mydia/downloads/stall_detector_test.exs
@@ -221,7 +221,7 @@ defmodule Mydia.Downloads.StallDetectorTest do
                  now: past
                )
 
-      assert StallDetector.stalled?(msg)
+      assert msg == "no progress for 4h"
     end
   end
 
@@ -230,8 +230,8 @@ defmodule Mydia.Downloads.StallDetectorTest do
       assert StallDetector.stalled?("stalled after 60m without progress")
     end
 
-    test "true for the escalation message" do
-      assert StallDetector.stalled?(StallDetector.escalation_message(180))
+    test "false for the escalation message" do
+      refute StallDetector.stalled?(StallDetector.escalation_message(60, 180))
     end
 
     test "false for unrelated error messages" do
@@ -244,16 +244,38 @@ defmodule Mydia.Downloads.StallDetectorTest do
     end
   end
 
-  describe "stalled_message/1 and escalation_message/1" do
-    test "stalled_message interpolates the grace minutes" do
+  describe "stalled_message/1" do
+    test "interpolates the grace minutes" do
       assert StallDetector.stalled_message(60) == "stalled after 60m without progress"
       assert StallDetector.stalled_message(5) == "stalled after 5m without progress"
     end
+  end
 
-    test "escalation_message interpolates and is recognised as stalled" do
-      msg = StallDetector.escalation_message(180)
-      assert String.contains?(msg, "180m")
-      assert StallDetector.stalled?(msg)
+  describe "escalation_message/2" do
+    # The old message reported only the escalation window, understating the
+    # stall by the entire grace window: a default-config download reaching
+    # escalation last moved bytes 240 minutes ago, not 180.
+    test "reports the total time without progress, not just the escalation window" do
+      assert StallDetector.escalation_message(60, 180) == "no progress for 4h"
+    end
+
+    test "renders a sub-hour total in minutes" do
+      assert StallDetector.escalation_message(10, 20) == "no progress for 30m"
+    end
+
+    test "renders a ragged total with both units" do
+      assert StallDetector.escalation_message(45, 90) == "no progress for 2h 15m"
+    end
+
+    test "no longer claims to have escalated to a failure" do
+      refute StallDetector.escalation_message(60, 180) =~ "escalated"
+    end
+  end
+
+  describe "escalation_minutes/1" do
+    test "is three times the grace window" do
+      assert StallDetector.escalation_minutes(60) == 180
+      assert StallDetector.escalation_minutes(1440) == 4320
     end
   end
 end

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -4,6 +4,8 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
   import Ecto.Query
 
+  alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.ReleaseBlacklist
   alias Mydia.Jobs.DownloadMonitor
   alias Mydia.Downloads
   alias Mydia.Downloads.Download
@@ -1906,7 +1908,7 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       assert updated.last_observed_at == stale_observed
     end
 
-    test "AE6: a soft-stall past the escalation threshold becomes terminal; episode released" do
+    test "AE6: a soft-stall past the escalation threshold is given up on entirely" do
       {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
       same_bytes = round(50.0 * 1024 * 1024)
 
@@ -1914,7 +1916,7 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
         sabnzbd_queue_item("nzo-ae6", "show.nzb", size_mb: 100.0, mb_left: 50.0)
       ])
 
-      media_item = media_item_fixture()
+      media_item = media_item_fixture(%{type: "movie"})
 
       # Escalation threshold = grace × 3 = 180 min. stalled_since is 182 min old,
       # observed continuously (recent last_observed_at), bytes unchanged.
@@ -1923,6 +1925,8 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
           media_item_id: media_item.id,
           download_client: client_config.name,
           download_client_id: "nzo-ae6",
+          indexer: "1337x",
+          metadata: %{"guid" => "ae6-guid"},
           last_progress_at: ~U[2026-06-16 00:00:00.000000Z],
           last_known_bytes: same_bytes,
           last_observed_at: ~U[2026-06-16 03:58:00.000000Z],
@@ -1932,14 +1936,102 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       now = ~U[2026-06-16 04:00:00.000000Z]
       assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
 
-      updated = Downloads.get_download!(download.id)
-      refute is_nil(updated.import_failed_at)
-      assert updated.import_last_error =~ "stalled"
-      # Terminal failure releases the episode for re-search.
+      # The row is gone, not annotated. That is the whole point: a give-up that
+      # leaves the download sitting in the queue is what confused operators.
+      refute Repo.get(Download, download.id)
       refute download.id in occupying_ids()
 
+      # Blacklisted briefly, so the replacement search cannot re-grab the same
+      # dead release, but a swarm that recovers overnight becomes available again.
+      assert Blacklists.blacklisted?("1337x", "ae6-guid")
+      row = Repo.get_by!(ReleaseBlacklist, indexer: "1337x", guid: "ae6-guid")
+      assert row.failure_reason == "stalled"
+      expected_expiry = DateTime.add(DateTime.utc_now(), 24 * 60 * 60, :second)
+      assert abs(DateTime.diff(row.expires_at, expected_expiry, :second)) < 60
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MovieSearch,
+        args: %{"mode" => "specific", "media_item_id" => media_item.id}
+      )
+
       Process.sleep(100)
-      assert Events.list_events(type: "download.failed") != []
+      # One event, not two: the stall path owns its own download.failed and
+      # suppresses reject_release/2's download.cancelled.
+      assert [event] = Events.list_events(type: "download.failed")
+      assert event.metadata["failure_category"] == "stalled"
+      assert event.metadata["error_message"] =~ "no progress for 4h"
+      assert Events.list_events(type: "download.cancelled") == []
+    end
+
+    test "AE6b: an exhausted auto-reject cap leaves the stalled download alone" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+      same_bytes = round(50.0 * 1024 * 1024)
+
+      mock_sabnzbd_queue(bypass, [
+        sabnzbd_queue_item("nzo-ae6b", "show.nzb", size_mb: 100.0, mb_left: 50.0)
+      ])
+
+      media_item = media_item_fixture(%{type: "movie"})
+
+      # Burn the cap (default limit is 3) before the poll runs.
+      for _ <- 1..3 do
+        Mydia.Search.record_failure("auto_reject", media_item.id, "stalled")
+      end
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-ae6b",
+          indexer: "1337x",
+          metadata: %{"guid" => "ae6b-guid"},
+          last_progress_at: ~U[2026-06-16 00:00:00.000000Z],
+          last_known_bytes: same_bytes,
+          last_observed_at: ~U[2026-06-16 03:58:00.000000Z],
+          stalled_since: ~U[2026-06-16 00:58:00.000000Z]
+        })
+
+      now = ~U[2026-06-16 04:00:00.000000Z]
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
+
+      # When the cap trips, the likeliest truth is that our detector is wrong,
+      # so the download is left to finish rather than destroyed.
+      assert Repo.get(Download, download.id)
+      refute Blacklists.blacklisted?("1337x", "ae6b-guid")
+
+      Process.sleep(100)
+      assert Events.list_events(type: "download.failed") == []
+      assert Events.list_events(type: "download.auto_reject_suppressed") != []
+    end
+
+    test "AE6c: a stalled download with no blacklist key is still cleared" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+      same_bytes = round(50.0 * 1024 * 1024)
+
+      mock_sabnzbd_queue(bypass, [
+        sabnzbd_queue_item("nzo-ae6c", "show.nzb", size_mb: 100.0, mb_left: 50.0)
+      ])
+
+      media_item = media_item_fixture(%{type: "movie"})
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-ae6c",
+          indexer: nil,
+          metadata: %{},
+          last_progress_at: ~U[2026-06-16 00:00:00.000000Z],
+          last_known_bytes: same_bytes,
+          last_observed_at: ~U[2026-06-16 03:58:00.000000Z],
+          stalled_since: ~U[2026-06-16 00:58:00.000000Z]
+        })
+
+      now = ~U[2026-06-16 04:00:00.000000Z]
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(now)})
+
+      refute Repo.get(Download, download.id)
+      assert Repo.aggregate(ReleaseBlacklist, :count) == 0
     end
   end
 

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1996,12 +1996,59 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
 
       # When the cap trips, the likeliest truth is that our detector is wrong,
       # so the download is left to finish rather than destroyed.
-      assert Repo.get(Download, download.id)
+      suppressed = Repo.get(Download, download.id)
+      assert suppressed
       refute Blacklists.blacklisted?("1337x", "ae6b-guid")
+
+      # The stall clock is reset so the decision is not re-announced on every
+      # poll. Without this the download stays past the escalation threshold and
+      # each poll re-emits the suppression event.
+      assert is_nil(suppressed.stalled_since)
+      assert suppressed.last_progress_at
 
       Process.sleep(100)
       assert Events.list_events(type: "download.failed") == []
-      assert Events.list_events(type: "download.auto_reject_suppressed") != []
+      assert length(Events.list_events(type: "download.auto_reject_suppressed")) == 1
+    end
+
+    test "AE6d: a suppressed stall is not re-announced on the next poll" do
+      {bypass, client_config} = start_sabnzbd_bypass(incomplete_grace_minutes: 60)
+      same_bytes = round(50.0 * 1024 * 1024)
+
+      mock_sabnzbd_queue(bypass, [
+        sabnzbd_queue_item("nzo-ae6d", "show.nzb", size_mb: 100.0, mb_left: 50.0)
+      ])
+
+      media_item = media_item_fixture(%{type: "movie"})
+
+      for _ <- 1..3 do
+        Mydia.Search.record_failure("auto_reject", media_item.id, "stalled")
+      end
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          download_client: client_config.name,
+          download_client_id: "nzo-ae6d",
+          indexer: "1337x",
+          metadata: %{"guid" => "ae6d-guid"},
+          last_progress_at: ~U[2026-06-16 00:00:00.000000Z],
+          last_known_bytes: same_bytes,
+          last_observed_at: ~U[2026-06-16 03:58:00.000000Z],
+          stalled_since: ~U[2026-06-16 00:58:00.000000Z]
+        })
+
+      first = ~U[2026-06-16 04:00:00.000000Z]
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(first)})
+
+      # One poll later, well inside the fresh grace window the reset bought.
+      second = DateTime.add(first, 120, :second)
+      assert :ok = perform_job(DownloadMonitor, %{"now" => DateTime.to_iso8601(second)})
+
+      assert Repo.get(Download, download.id)
+
+      Process.sleep(100)
+      assert length(Events.list_events(type: "download.auto_reject_suppressed")) == 1
     end
 
     test "AE6c: a stalled download with no blacklist key is still cleared" do

--- a/test/mydia_web/live/admin_download_clients_live_test.exs
+++ b/test/mydia_web/live/admin_download_clients_live_test.exs
@@ -301,6 +301,20 @@ defmodule MydiaWeb.AdminDownloadClientsLiveTest do
       refute Map.has_key?(saved.categories, "music")
     end
 
+    test "the stalled timeout field spells out both thresholds", %{view: view} do
+      view
+      |> element(~s{button[phx-click="new_download_client"]})
+      |> render_click()
+
+      html = render(view)
+
+      # The default of 60 means flagged at 1h and given up on at 4h total. The
+      # second number is the one that destroys something, and it was previously
+      # invisible everywhere in the UI.
+      assert html =~ "Flagged as stalled after 1h"
+      assert html =~ "4h total"
+    end
+
     test "blackhole client does not render category inputs", %{view: view} do
       view
       |> element(~s{button[phx-click="new_download_client"]})

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -505,4 +505,103 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
                })
     end
   end
+
+  describe "soft-stall row" do
+    setup do
+      bypass = Bypass.open()
+
+      client_config = ensure_test_client_bypass(bypass)
+
+      Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "SID=test-sid; HttpOnly")
+        |> Plug.Conn.resp(200, "Ok.")
+      end)
+
+      Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        torrents =
+          Downloads.list_downloads()
+          |> Enum.filter(
+            &(&1.download_client == "test-client" and not is_nil(&1.download_client_id))
+          )
+          |> Enum.map(fn d ->
+            %{
+              "hash" => d.download_client_id,
+              "name" => d.title,
+              "state" => "downloading",
+              "progress" => 0.42,
+              "save_path" => "/downloads",
+              "content_path" => "/downloads/#{d.title}"
+            }
+          end)
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(torrents))
+      end)
+
+      %{bypass: bypass, client_config: client_config}
+    end
+
+    test "names the deadline and offers both ways out", %{conn: conn} do
+      media_item = media_item_fixture(%{title: "Stalling Show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Stalling.S01E01",
+          status: "downloading",
+          last_progress_at: DateTime.add(DateTime.utc_now(), -90 * 60, :second),
+          stalled_since: DateTime.add(DateTime.utc_now(), -30 * 60, :second)
+        })
+
+      {:ok, view, html} = live(conn, ~p"/downloads")
+
+      assert html =~ "No progress for"
+      assert html =~ "search for a different release"
+      assert has_element?(view, "#stall-keep-waiting-#{download.id}")
+      assert has_element?(view, "#stall-reject-#{download.id}")
+    end
+
+    test "keep waiting resets the stall clock", %{conn: conn} do
+      media_item = media_item_fixture(%{title: "Patient Show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "downloading",
+          last_progress_at: DateTime.add(DateTime.utc_now(), -90 * 60, :second),
+          stalled_since: DateTime.add(DateTime.utc_now(), -30 * 60, :second)
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      view
+      |> element("#stall-keep-waiting-#{download.id}")
+      |> render_click()
+
+      updated = Mydia.Downloads.get_download!(download.id)
+      assert is_nil(updated.stalled_since)
+      assert DateTime.diff(DateTime.utc_now(), updated.last_progress_at, :second) < 60
+    end
+  end
+
+  defp ensure_test_client_bypass(bypass) do
+    attrs = %{
+      name: "test-client",
+      type: "qbittorrent",
+      host: "localhost",
+      port: bypass.port,
+      enabled: true
+    }
+
+    case Enum.find(Mydia.Settings.list_download_client_configs(), &(&1.name == "test-client")) do
+      nil ->
+        download_client_config_fixture(attrs)
+
+      cfg ->
+        {:ok, updated} = Mydia.Settings.update_download_client_config(cfg, attrs)
+        updated
+    end
+  end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -480,18 +480,6 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
                })
     end
 
-    test "a terminal stall failure renders an error 'Stall failed' badge" do
-      now = DateTime.utc_now()
-
-      assert {"badge-error", "Stall failed"} =
-               Index.status_badge(%{
-                 status: "downloading",
-                 stalled_since: now,
-                 import_failed_at: now,
-                 import_last_error: "stalled after 180m without progress — escalated to failure"
-               })
-    end
-
     test "a normal download falls through to its client-status badge" do
       assert {_class, "Downloading"} =
                Index.status_badge(%{

--- a/test/mydia_web/live/downloads_live/match_files_test.exs
+++ b/test/mydia_web/live/downloads_live/match_files_test.exs
@@ -364,7 +364,10 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
     refute Mydia.Repo.get(Mydia.Downloads.Download, download.id)
   end
 
-  test "the reject button is disabled without a guid", %{conn: conn, tmp_dir: tmp_dir} do
+  test "rejecting without a guid still removes the download but does not blacklist", %{
+    conn: conn,
+    tmp_dir: tmp_dir
+  } do
     dir = Path.join(tmp_dir, "noguid")
     File.mkdir_p!(dir)
     File.write!(Path.join(dir, "payload.exe"), "x")
@@ -404,8 +407,12 @@ defmodule MydiaWeb.DownloadsLive.MatchFilesTest do
     render_click(view, "switch_tab", %{"tab" => "issues"})
 
     view |> element("#match-files-#{download.id}") |> render_click()
+    refute has_element?(view, "#match-files-reject[disabled]")
 
-    assert has_element?(view, "#match-files-reject[disabled]")
+    view |> element("#match-files-reject") |> render_click()
+
+    refute Mydia.Downloads.Blacklists.blacklisted?("1337x", "missing-guid")
+    refute Mydia.Repo.get(Mydia.Downloads.Download, download.id)
   end
 
   test "unresolved-file downloads open the same modal", %{conn: conn, tmp_dir: tmp_dir} do


### PR DESCRIPTION
## The problem

A stalled download surfaced this on the Downloads screen:

> Import failed: stalled after 180m without progress — escalated to failure

Four things wrong with it:

1. **It is a download problem labelled as an import problem.** The stall detector had no download-side terminal field, so it reused `import_failed_at` / `import_last_error`, and the row template prefixes any non-nil `import_last_error` with `Import failed:`.
2. **The rule was documented nowhere.** The only user-facing mention was the "Stalled timeout (minutes)" field, whose help text described one of the two thresholds.
3. **"Escalated to failure" was not true.** Escalation wrote two timestamps and stopped. The torrent kept running in the client and the row stayed in the queue. Its only real effect was freeing the episode for re-search.
4. **The number was wrong.** Soft-stall fires at 60m, escalation 180m *after that*, so a download reaching that message had made no progress for 240 minutes.

## What changed

Stall escalation stops being a bespoke third terminal path and calls `Queue.reject_release/2`, the same primitive the bad-content path already uses. Giving up now means: blocklist the release for **1 day** (short, because a dead swarm may recover overnight, unlike a corrupt release), remove the torrent from the client, delete the row, and queue a replacement search immediately. Guarded by the existing per-item `auto_reject` cap, so a media item whose detector is misfiring is left alone rather than churned.

The explanation moves earlier, to where it can still change the outcome. The soft-stall row now names the deadline and offers both ways out:

> **Stalled** · No progress for 1h 12m. If nothing changes in the next 2h 48m, Mydia will remove it and search for a different release.
> `[Remove and find another]` `[Keep waiting]`

"Keep waiting" is a snooze, not an opt-out: it buys one full fresh window.

The client config field now derives and shows both thresholds instead of only the first, which makes the debrid default legible for the first time (flagged after 24h, given up on after 4 days).

`docs/using/reference/download-clients.md` gains a "Stalled Downloads" section covering both stages, the auto-reject cap, and the observation-gap reset. That last one is the least discoverable behaviour in the system: stall time only accrues while Mydia is actually watching, so a restart, a client outage, or a paused torrent resets the clock rather than accruing toward a give-up.

## Along the way

`reject_release/2` gains `:ttl_days` and `:event` (both defaulting to today's behaviour), and stops refusing outright when a download has no `(indexer, guid)` key. Previously it returned `{:error, :no_guid}` and changed nothing, leaving the torrent running. There is nothing to blocklist without a key, but there is still a dead download to clear. This also unblocks the reject button in the match-files modal, which was disabled for exactly those downloads.

The escalation message now reports the true total and drops the false claim: `"no progress for 4h"`.

Removed as unreachable: `StallDetector.stalled?/1`, the LiveView's `stalled?/1`, the `stall_failed` badge class, and the "Stall failed" badge branch.

## Verification

- Full suite: 7152 tests, 1 failure
- `credo --strict`: 13608 mods/funs, no issues
- `format --check-formatted` and `compile`: clean

The single failure is `Mydia.Indexers.Adapter.ProwlarrTest` "parses quality from title", which is **pre-existing and unrelated**. This PR touches no indexer file; the test passes in isolation; and it is a placeholder asserting `function_exported?(Prowlarr, :search, 3)` without ensuring the module is loaded, which returns false for an unloaded module and so races in a parallel run. Worth a separate one-line `Code.ensure_loaded?/1` fix.
