### PR TITLE
test: load modules before asserting exports, fixing an order-dependent flake

### DIFF
--- a/test/mydia/indexers/adapter/jackett_test.exs
+++ b/test/mydia/indexers/adapter/jackett_test.exs
@@ -161,6 +161,12 @@ defmodule Mydia.Indexers.Adapter.JackettTest do
   describe "adapter structure" do
     test "implements required callbacks" do
       # Verify the adapter is properly structured
+      #
+      # function_exported?/3 answers false for a module that has not been
+      # loaded yet, so without this the assertion races on whether some
+      # earlier test in the run happened to reference Jackett first.
+      Code.ensure_loaded!(Jackett)
+
       assert function_exported?(Jackett, :search, 3)
       assert function_exported?(Jackett, :test_connection, 1)
       assert function_exported?(Jackett, :get_capabilities, 1)

--- a/test/mydia/indexers/adapter/prowlarr_test.exs
+++ b/test/mydia/indexers/adapter/prowlarr_test.exs
@@ -193,6 +193,12 @@ defmodule Mydia.Indexers.Adapter.ProwlarrTest do
       # Mock response with quality indicators in title
       # This test would need to be expanded with actual response mocking
       # For now, we verify the adapter is properly structured
+      #
+      # function_exported?/3 answers false for a module that has not been
+      # loaded yet, so without this the assertion races on whether some
+      # earlier test in the run happened to reference Prowlarr first.
+      Code.ensure_loaded!(Prowlarr)
+
       assert function_exported?(Prowlarr, :search, 3)
       assert function_exported?(Prowlarr, :test_connection, 1)
       assert function_exported?(Prowlarr, :get_capabilities, 1)

--- a/test/mydia/settings/db_runtime_test.exs
+++ b/test/mydia/settings/db_runtime_test.exs
@@ -222,6 +222,15 @@ defmodule Mydia.DBRuntimeTest do
   describe "runtime functions - verify compile includes both branches" do
     test "module exports all runtime functions" do
       # Verify all runtime functions are exported
+      #
+      # Defensive, unlike the same guard in the indexer adapter tests:
+      # function_exported?/3 answers false for an unloaded module, and this
+      # assertion only escapes that today because `use Mydia.DataCase` drags
+      # in the Repo stack and loads Mydia.DB as a side effect. Pinning it here
+      # means the test keeps testing exports rather than load order if that
+      # incidental dependency ever goes away.
+      Code.ensure_loaded!(Mydia.DB)
+
       assert function_exported?(Mydia.DB, :json_equals, 3)
       assert function_exported?(Mydia.DB, :json_integer_equals, 3)
       assert function_exported?(Mydia.DB, :json_is_true, 2)


### PR DESCRIPTION
## The bug

`function_exported?/3` answers `false` for a module that has not been loaded yet. Several tests assert a module's exports without loading it first, so they were really testing whether some earlier test in the run happened to reference that module. Whether they pass depends on the ExUnit seed.

`Mydia.Indexers.Adapter.ProwlarrTest` "parses quality from title" failed a full-suite run on master this way while passing in isolation.

## Reproduction

Running each test alone, where nothing else in its file loads the adapter, fails deterministically:

```
mix test test/mydia/indexers/adapter/prowlarr_test.exs:182 \
         test/mydia/indexers/adapter/jackett_test.exs:162 --include external

3 tests, 2 failures (55 excluded)
```

Both failures are `Expected truthy, got false` on `assert function_exported?(<Adapter>, :search, 3)`, matching the CI failure exactly. With this change the same command is `3 tests, 0 failures`.

## The fix

`Code.ensure_loaded!/1` before the assertions, which is already the established pattern in this repo.

Six places use the `function_exported?` pattern in tests. Three were already guarded, one by an explicit comment describing this exact bug:

- `nzbhydra2_test.exs` — `assert Code.ensure_loaded?(NzbHydra2)`, commented "flakes under test orderings where no prior test has referenced NzbHydra2"
- `cardigann_test.exs` — `Code.ensure_loaded!/1`
- `provider_registry_test.exs` — `Code.ensure_loaded!/1`
- `queue_test.exs` — safe by construction; its `implements_client_behaviour?/1` calls `module_info/1` first

So this had been fixed reactively, one file at a time, as each one flaked. This PR covers the remaining three rather than only the one that happened to fail.

`db_runtime_test.exs` is the one defensive change here: it does not currently fail, because `use Mydia.DataCase` drags in the Repo stack and loads `Mydia.DB` as a side effect. The guard means the test keeps testing exports rather than load order if that incidental dependency ever goes away. Its comment says so.

## Not addressed

The Prowlarr test is named "parses quality from title" and sits under `describe "result parsing"`, but it asserts callback exports and tests no parsing at all. Its own comment admits it ("This test would need to be expanded with actual response mocking"). Renaming or replacing it is a separate question from the flake and is left alone here.

## Verification

- The three affected files in full: 58 tests, 0 failures, 12 skipped
- Before/after on the isolated reproduction above: 2 failures → 0
