### PR TITLE
feat(playback): merge Continue Watching and Up Next into one sorted On Deck rail

### DIFF
--- a/lib/mydia/playback.ex
+++ b/lib/mydia/playback.ex
@@ -457,6 +457,14 @@ defmodule Mydia.Playback do
   end
 
   @doc """
+  Returns the user's Continue Watching entries, most recent first.
+
+  See `Mydia.Playback.OnDeck.list/2` for the rule set and options.
+  """
+  @spec on_deck(binary(), keyword()) :: [Mydia.Playback.OnDeckEntry.t()]
+  defdelegate on_deck(user_id, opts \\ []), to: Mydia.Playback.OnDeck, as: :list
+
+  @doc """
   Clears recent watch history for all users.
   """
   def clear_recent_history do

--- a/lib/mydia/playback.ex
+++ b/lib/mydia/playback.ex
@@ -452,50 +452,7 @@ defmodule Mydia.Playback do
         |> Repo.all()
         |> Map.new()
 
-      # Find the next episode to watch
-      determine_next_episode(episodes_with_files, progress_map)
-    end
-  end
-
-  # Helper function to determine which episode to play next
-  defp determine_next_episode(episodes, progress_map) do
-    # First, check for in-progress episodes (< 90% completion)
-    in_progress_episode =
-      Enum.find(episodes, fn episode ->
-        case Map.get(progress_map, episode.id) do
-          %Progress{watched: false, completion_percentage: pct} when pct < 90.0 -> true
-          _ -> false
-        end
-      end)
-
-    if in_progress_episode do
-      {:continue, in_progress_episode}
-    else
-      # Find the first unwatched episode (no progress or not marked as watched)
-      unwatched_episode =
-        Enum.find(episodes, fn episode ->
-          case Map.get(progress_map, episode.id) do
-            nil -> true
-            %Progress{watched: false} -> true
-            _ -> false
-          end
-        end)
-
-      case unwatched_episode do
-        nil ->
-          # All episodes watched
-          :all_watched
-
-        episode ->
-          # Check if there's any progress at all
-          has_any_progress? = progress_map != %{}
-
-          if has_any_progress? do
-            {:next, episode}
-          else
-            {:start, episode}
-          end
-      end
+      Mydia.Playback.NextEpisode.determine(episodes_with_files, progress_map)
     end
   end
 

--- a/lib/mydia/playback/next_episode.ex
+++ b/lib/mydia/playback/next_episode.ex
@@ -1,0 +1,62 @@
+defmodule Mydia.Playback.NextEpisode do
+  @moduledoc """
+  The in-memory decision for "which episode of this show comes next".
+
+  Extracted so the single-show path (`Playback.get_next_episode/2`, which loads
+  one show) and the batched On Deck path (which loads many shows at once) run
+  the same logic instead of two copies that can drift apart.
+
+  Callers are responsible for passing `episodes` already ordered by season then
+  episode number, and already filtered to episodes with an untrashed file.
+  """
+
+  alias Mydia.Playback.Progress
+
+  @watched_threshold 90.0
+
+  @doc """
+  Returns the next episode to play and why.
+
+  - `{:continue, episode}` an episode is partially watched
+  - `{:next, episode}` the first unwatched episode, with history present
+  - `{:start, episode}` the first episode, with no history at all
+  - `:all_watched` nothing is left
+  """
+  def determine(episodes, progress_map) do
+    in_progress_episode =
+      Enum.find(episodes, fn episode ->
+        case Map.get(progress_map, episode.id) do
+          %Progress{watched: false, completion_percentage: pct} when pct < @watched_threshold ->
+            true
+
+          _ ->
+            false
+        end
+      end)
+
+    if in_progress_episode do
+      {:continue, in_progress_episode}
+    else
+      unwatched_episode =
+        Enum.find(episodes, fn episode ->
+          case Map.get(progress_map, episode.id) do
+            nil -> true
+            %Progress{watched: false} -> true
+            _ -> false
+          end
+        end)
+
+      case unwatched_episode do
+        nil ->
+          :all_watched
+
+        episode ->
+          if progress_map == %{} do
+            {:start, episode}
+          else
+            {:next, episode}
+          end
+      end
+    end
+  end
+end

--- a/lib/mydia/playback/on_deck.ex
+++ b/lib/mydia/playback/on_deck.ex
@@ -1,0 +1,207 @@
+defmodule Mydia.Playback.OnDeck do
+  @moduledoc """
+  Builds the Continue Watching rail: the things a user is genuinely in the
+  middle of, most recent first.
+
+  The rail merges two kinds of card that used to live on separate rows. A
+  `:continue` entry is a resume point, a movie or episode left partway. A
+  `:next` entry is the successor of an episode just finished, which has no
+  progress row of its own and so could never appear on a resume-only rail.
+
+  Membership hangs on one idea: a progress row only counts as real viewing if
+  it is either marked watched or has at least two minutes on the clock, and it
+  happened inside the last ninety days. The watched branch matters because
+  media-server sync writes synthetic rows shaped `position 0 / duration 1`, and
+  a seconds-only floor would read those as "never watched" and suppress the
+  next-episode card for an entire synced library.
+
+  The exact thresholds are the `@default_min_position_seconds` and
+  `@default_max_age_days` attributes below, overridable per call.
+  """
+
+  import Ecto.Query
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.{Episode, MediaItem}
+  alias Mydia.Playback.{NextEpisode, OnDeckEntry, Progress}
+  alias Mydia.Repo
+
+  @default_min_position_seconds 120
+  @default_max_age_days 90
+  @default_limit 20
+  @watched_threshold 90.0
+
+  @doc """
+  Returns the user's On Deck entries, most recently watched first.
+
+  ## Options
+
+    * `:limit` - how many entries to return (default #{@default_limit})
+    * `:min_position_seconds` - the viewing floor (default #{@default_min_position_seconds})
+    * `:max_age_days` - the recency window (default #{@default_max_age_days})
+    * `:now` - the clock, injectable so tests need not manipulate real time
+  """
+  @spec list(binary(), keyword()) :: [OnDeckEntry.t()]
+  def list(user_id, opts \\ []) do
+    limit = Keyword.get(opts, :limit, @default_limit)
+    min_position = Keyword.get(opts, :min_position_seconds, @default_min_position_seconds)
+    max_age_days = Keyword.get(opts, :max_age_days, @default_max_age_days)
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+    cutoff = DateTime.add(now, -max_age_days, :day)
+
+    counting =
+      from(p in Progress, where: p.user_id == ^user_id)
+      |> Repo.all()
+      |> Enum.filter(&counting_row?(&1, min_position, cutoff))
+
+    (movie_entries(counting) ++ show_entries(counting, user_id))
+    |> Enum.sort_by(&sort_key/1, :desc)
+    |> Enum.take(limit)
+  end
+
+  # Sorted on a tuple so entries sharing a timestamp, which a bulk watched
+  # import makes common, still come back in a stable order across requests.
+  defp sort_key(entry) do
+    {DateTime.to_unix(entry.sort_at, :microsecond), OnDeckEntry.id(entry)}
+  end
+
+  defp counting_row?(%Progress{last_watched_at: nil}, _min_position, _cutoff), do: false
+
+  defp counting_row?(%Progress{} = progress, min_position, cutoff) do
+    real_viewing? =
+      progress.watched == true or (progress.position_seconds || 0) >= min_position
+
+    real_viewing? and DateTime.compare(progress.last_watched_at, cutoff) != :lt
+  end
+
+  defp movie_entries(counting) do
+    candidates =
+      Enum.filter(counting, fn progress ->
+        not is_nil(progress.media_item_id) and progress.watched == false and
+          (progress.completion_percentage || 0.0) < @watched_threshold
+      end)
+
+    ids = Enum.map(candidates, & &1.media_item_id)
+    movies = ids |> load_media_items() |> Map.new(&{&1.id, &1})
+    files = load_movie_files(ids)
+
+    for progress <- candidates,
+        movie = Map.get(movies, progress.media_item_id),
+        not is_nil(movie),
+        movie_files = Map.get(files, progress.media_item_id, []),
+        movie_files != [] do
+      %OnDeckEntry{
+        kind: :movie,
+        state: :continue,
+        media_item: movie,
+        progress: progress,
+        files: movie_files,
+        sort_at: progress.last_watched_at
+      }
+    end
+  end
+
+  defp show_entries(counting, user_id) do
+    episode_rows = Enum.filter(counting, &(not is_nil(&1.episode_id)))
+    episode_ids = Enum.map(episode_rows, & &1.episode_id)
+    episode_to_show = load_episode_show_ids(episode_ids)
+
+    sort_at_by_show =
+      episode_rows
+      |> Enum.group_by(&Map.get(episode_to_show, &1.episode_id))
+      |> Map.delete(nil)
+      |> Map.new(fn {show_id, rows} ->
+        {show_id, rows |> Enum.map(& &1.last_watched_at) |> Enum.max(DateTime)}
+      end)
+
+    show_ids = Map.keys(sort_at_by_show)
+    shows = show_ids |> load_media_items() |> Map.new(&{&1.id, &1})
+
+    for show_id <- show_ids,
+        show = Map.get(shows, show_id),
+        not is_nil(show),
+        entry = build_show_entry(show, user_id, sort_at_by_show[show_id]),
+        not is_nil(entry) do
+      entry
+    end
+  end
+
+  defp build_show_entry(show, user_id, sort_at) do
+    episodes = load_episodes_with_files(show.id)
+    progress_map = load_progress_for_episodes(user_id, Enum.map(episodes, & &1.id))
+
+    case NextEpisode.determine(episodes, progress_map) do
+      {:continue, episode} ->
+        episode_entry(show, episode, :continue, Map.get(progress_map, episode.id), sort_at)
+
+      {state, episode} when state in [:next, :start] ->
+        # `:start` means the progress map was empty, which normally means a
+        # never-started show. Engagement was already established from the
+        # show's full row set, so this is the trashed-file case: the watched
+        # episode lost its file and dropped out of the map. It is a `:next`.
+        episode_entry(show, episode, :next, Map.get(progress_map, episode.id), sort_at)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp episode_entry(show, episode, state, progress, sort_at) do
+    %OnDeckEntry{
+      kind: :episode,
+      state: state,
+      episode: episode,
+      show: show,
+      progress: progress,
+      files: episode.media_files,
+      sort_at: sort_at
+    }
+  end
+
+  defp load_media_items([]), do: []
+
+  defp load_media_items(ids) do
+    Repo.all(from(m in MediaItem, where: m.id in ^ids))
+  end
+
+  defp load_movie_files([]), do: %{}
+
+  defp load_movie_files(ids) do
+    from(mf in MediaFile,
+      where: mf.media_item_id in ^ids and is_nil(mf.trashed_at)
+    )
+    |> Repo.all()
+    |> Enum.group_by(& &1.media_item_id)
+  end
+
+  defp load_episode_show_ids([]), do: %{}
+
+  defp load_episode_show_ids(ids) do
+    from(e in Episode, where: e.id in ^ids, select: {e.id, e.media_item_id})
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  defp load_episodes_with_files(show_id) do
+    active_files = from(mf in MediaFile, where: is_nil(mf.trashed_at))
+
+    from(e in Episode,
+      where: e.media_item_id == ^show_id,
+      order_by: [asc: e.season_number, asc: e.episode_number],
+      preload: [media_files: ^active_files]
+    )
+    |> Repo.all()
+    |> Enum.filter(&(&1.media_files != []))
+  end
+
+  defp load_progress_for_episodes(_user_id, []), do: %{}
+
+  defp load_progress_for_episodes(user_id, episode_ids) do
+    from(p in Progress,
+      where: p.user_id == ^user_id and p.episode_id in ^episode_ids,
+      select: {p.episode_id, p}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+end

--- a/lib/mydia/playback/on_deck.ex
+++ b/lib/mydia/playback/on_deck.ex
@@ -116,19 +116,36 @@ defmodule Mydia.Playback.OnDeck do
 
     show_ids = Map.keys(sort_at_by_show)
     shows = show_ids |> load_media_items() |> Map.new(&{&1.id, &1})
+    episodes_by_show = load_episodes_with_files(show_ids)
+
+    all_episode_ids =
+      episodes_by_show |> Map.values() |> List.flatten() |> Enum.map(& &1.id)
+
+    progress_by_episode = load_progress_for_episodes(user_id, all_episode_ids)
 
     for show_id <- show_ids,
         show = Map.get(shows, show_id),
         not is_nil(show),
-        entry = build_show_entry(show, user_id, sort_at_by_show[show_id]),
+        entry =
+          build_show_entry(
+            show,
+            Map.get(episodes_by_show, show_id, []),
+            progress_by_episode,
+            sort_at_by_show[show_id]
+          ),
         not is_nil(entry) do
       entry
     end
   end
 
-  defp build_show_entry(show, user_id, sort_at) do
-    episodes = load_episodes_with_files(show.id)
-    progress_map = load_progress_for_episodes(user_id, Enum.map(episodes, & &1.id))
+  defp build_show_entry(show, episodes, progress_by_episode, sort_at) do
+    progress_map =
+      Enum.reduce(episodes, %{}, fn episode, acc ->
+        case Map.get(progress_by_episode, episode.id) do
+          nil -> acc
+          progress -> Map.put(acc, episode.id, progress)
+        end
+      end)
 
     case NextEpisode.determine(episodes, progress_map) do
       {:continue, episode} ->
@@ -182,16 +199,19 @@ defmodule Mydia.Playback.OnDeck do
     |> Map.new()
   end
 
-  defp load_episodes_with_files(show_id) do
+  defp load_episodes_with_files([]), do: %{}
+
+  defp load_episodes_with_files(show_ids) do
     active_files = from(mf in MediaFile, where: is_nil(mf.trashed_at))
 
     from(e in Episode,
-      where: e.media_item_id == ^show_id,
+      where: e.media_item_id in ^show_ids,
       order_by: [asc: e.season_number, asc: e.episode_number],
       preload: [media_files: ^active_files]
     )
     |> Repo.all()
     |> Enum.filter(&(&1.media_files != []))
+    |> Enum.group_by(& &1.media_item_id)
   end
 
   defp load_progress_for_episodes(_user_id, []), do: %{}

--- a/lib/mydia/playback/on_deck_entry.ex
+++ b/lib/mydia/playback/on_deck_entry.ex
@@ -1,0 +1,40 @@
+defmodule Mydia.Playback.OnDeckEntry do
+  @moduledoc """
+  One card on the Continue Watching rail.
+
+  A movie entry carries `media_item`; an episode entry carries `episode` plus
+  its `show`. `progress` is nil for a `:next` entry, which by definition has
+  never been played. `files` is carried here rather than re-fetched per card so
+  building the GraphQL response adds no queries.
+  """
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.{Episode, MediaItem}
+  alias Mydia.Playback.Progress
+
+  @type kind :: :movie | :episode
+  @type state :: :continue | :next
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          state: state(),
+          media_item: MediaItem.t() | nil,
+          episode: Episode.t() | nil,
+          show: MediaItem.t() | nil,
+          progress: Progress.t() | nil,
+          files: [MediaFile.t()],
+          sort_at: DateTime.t()
+        }
+
+  defstruct [:kind, :state, :media_item, :episode, :show, :progress, :sort_at, files: []]
+
+  @doc """
+  The rail identity for an entry: the movie id or the episode id.
+
+  Used as the sort tiebreak so ordering is deterministic when two entries share
+  a timestamp, which a bulk watched-import makes common.
+  """
+  @spec id(t()) :: binary()
+  def id(%__MODULE__{kind: :movie, media_item: %{id: id}}), do: id
+  def id(%__MODULE__{kind: :episode, episode: %{id: id}}), do: id
+end

--- a/lib/mydia_web/schema/query_types.ex
+++ b/lib/mydia_web/schema/query_types.ex
@@ -206,6 +206,9 @@ defmodule MydiaWeb.Schema.QueryTypes do
     field :title, non_null(:string)
     field :artwork, :artwork
     field :progress, non_null(:progress)
+
+    @desc "Why this item is on the rail: continue for a resume point, next for the successor of a finished episode"
+    field :state, :string
     @desc "Playable files for this item, used to start playback straight from the rail"
     field :files, list_of(:media_file)
 

--- a/lib/mydia_web/schema/query_types.ex
+++ b/lib/mydia_web/schema/query_types.ex
@@ -145,6 +145,7 @@ defmodule MydiaWeb.Schema.QueryTypes do
 
     @desc "Get next episodes to watch across all TV shows"
     field :up_next, list_of(:up_next_item) do
+      deprecate("Merged into continueWatching, which now carries next episodes as well")
       arg(:first, :integer, default_value: 10)
       arg(:after, :string)
       resolve(&DiscoveryResolver.up_next/3)

--- a/lib/mydia_web/schema/resolvers/discovery_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/discovery_resolver.ex
@@ -78,33 +78,19 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
         {:ok, []}
 
       user ->
-        # Get all TV shows with in-progress episodes
-        tv_shows = Media.list_media_items(type: "tv_show", has_files: true)
-
-        all_items =
-          tv_shows
-          |> Enum.map(fn show ->
-            case Playback.get_next_episode(show.id, user.id) do
-              nil ->
-                nil
-
-              :all_watched ->
-                nil
-
-              {state, episode} ->
-                %{
-                  episode: episode,
-                  show: Map.put(show, :added_at, show.inserted_at),
-                  progress_state: Atom.to_string(state)
-                }
-            end
+        items =
+          user.id
+          |> Playback.on_deck(limit: pagination_limit(first, after_cursor))
+          |> Enum.filter(&(&1.kind == :episode))
+          |> Enum.map(fn entry ->
+            %{
+              episode: entry.episode,
+              show: Map.put(entry.show, :added_at, entry.show.inserted_at),
+              progress_state: Atom.to_string(entry.state)
+            }
           end)
-          |> Enum.reject(&is_nil/1)
 
-        # Apply cursor pagination
-        items = paginate_simple(all_items, first, after_cursor)
-
-        {:ok, items}
+        {:ok, paginate_simple(items, first, after_cursor)}
     end
   end
 

--- a/lib/mydia_web/schema/resolvers/discovery_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/discovery_resolver.ex
@@ -3,11 +3,12 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
   Resolvers for discovery-related GraphQL queries (home screen rails).
   """
 
-  alias Mydia.{Library, Media, Playback}
+  alias Mydia.{Media, Playback}
 
   alias Mydia.Media.RecentlyAdded
   alias Mydia.Metadata.Access, as: MetadataAccess
   alias Mydia.Metadata.ImageUrl
+  alias Mydia.Playback.OnDeckEntry
   alias MydiaWeb.Schema.Resolvers.ItemBuilder
   alias MydiaWeb.Schema.Resolvers.MediaSort
 
@@ -22,20 +23,12 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
         {:ok, []}
 
       user ->
-        # Get in-progress items (watched = false, has position)
-        progress_list =
-          Playback.list_user_progress(user.id, watched: false, limit: first * 3)
-          |> Enum.filter(&(&1.position_seconds > 0 && (&1.completion_percentage || 0) < 90))
+        items =
+          user.id
+          |> Playback.on_deck(limit: pagination_limit(first, after_cursor))
+          |> Enum.map(&build_on_deck_item/1)
 
-        all_items =
-          progress_list
-          |> Enum.map(&build_continue_watching_item(&1, user.id))
-          |> Enum.reject(&is_nil/1)
-
-        # Apply cursor pagination
-        items = paginate_simple(all_items, first, after_cursor)
-
-        {:ok, items}
+        {:ok, paginate_simple(items, first, after_cursor)}
     end
   end
 
@@ -285,60 +278,37 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
   defp pagination_limit(first, nil), do: first
   defp pagination_limit(first, after_cursor), do: decode_cursor(after_cursor) + 1 + first
 
-  defp build_continue_watching_item(%{media_item_id: media_item_id} = progress, _user_id)
-       when not is_nil(media_item_id) do
-    media_item = Media.get_media_item!(media_item_id)
-
-    case Library.get_media_files_for_item(media_item_id) do
-      [] ->
-        nil
-
-      files ->
-        %{
-          id: media_item.id,
-          type: String.to_existing_atom(media_item.type),
-          title: media_item.title,
-          artwork: ItemBuilder.artwork(media_item),
-          progress: format_progress(progress),
-          files: files,
-          show_title: nil,
-          season_number: nil,
-          episode_number: nil
-        }
-    end
-  rescue
-    Ecto.NoResultsError -> nil
+  defp build_on_deck_item(%OnDeckEntry{kind: :movie} = entry) do
+    %{
+      id: entry.media_item.id,
+      type: String.to_existing_atom(entry.media_item.type),
+      title: entry.media_item.title,
+      artwork: ItemBuilder.artwork(entry.media_item),
+      progress: format_progress(entry.progress),
+      state: Atom.to_string(entry.state),
+      files: entry.files,
+      show_id: nil,
+      show_title: nil,
+      season_number: nil,
+      episode_number: nil
+    }
   end
 
-  defp build_continue_watching_item(%{episode_id: episode_id} = progress, _user_id)
-       when not is_nil(episode_id) do
-    episode = Media.get_episode!(episode_id)
-
-    case Library.get_media_files_for_episode(episode_id) do
-      [] ->
-        nil
-
-      files ->
-        show = Media.get_media_item!(episode.media_item_id)
-
-        %{
-          id: episode.id,
-          type: :episode,
-          title: episode.title || "Episode #{episode.episode_number}",
-          artwork: build_episode_artwork(episode, show),
-          progress: format_progress(progress),
-          files: files,
-          show_id: show.id,
-          show_title: show.title,
-          season_number: episode.season_number,
-          episode_number: episode.episode_number
-        }
-    end
-  rescue
-    Ecto.NoResultsError -> nil
+  defp build_on_deck_item(%OnDeckEntry{kind: :episode} = entry) do
+    %{
+      id: entry.episode.id,
+      type: :episode,
+      title: entry.episode.title || "Episode #{entry.episode.episode_number}",
+      artwork: build_episode_artwork(entry.episode, entry.show),
+      progress: format_progress(entry.progress),
+      state: Atom.to_string(entry.state),
+      files: entry.files,
+      show_id: entry.show.id,
+      show_title: entry.show.title,
+      season_number: entry.episode.season_number,
+      episode_number: entry.episode.episode_number
+    }
   end
-
-  defp build_continue_watching_item(_, _), do: nil
 
   defp build_episode_artwork(%{metadata: metadata} = episode, show) when not is_nil(metadata) do
     still_path = MetadataAccess.get(episode.metadata, :still_path)
@@ -352,6 +322,16 @@ defmodule MydiaWeb.Schema.Resolvers.DiscoveryResolver do
   end
 
   defp build_episode_artwork(_episode, show), do: ItemBuilder.artwork(show)
+
+  defp format_progress(nil) do
+    %{
+      position_seconds: 0,
+      duration_seconds: nil,
+      percentage: 0.0,
+      watched: false,
+      last_watched_at: nil
+    }
+  end
 
   defp format_progress(progress) do
     %{

--- a/player/lib/domain/models/continue_watching_item.dart
+++ b/player/lib/domain/models/continue_watching_item.dart
@@ -8,6 +8,7 @@ class ContinueWatchingItem {
   final String title;
   final Artwork? artwork;
   final Progress? progress;
+  final String? state;
   final String? showId;
   final String? showTitle;
   final int? seasonNumber;
@@ -20,6 +21,7 @@ class ContinueWatchingItem {
     required this.title,
     this.artwork,
     this.progress,
+    this.state,
     this.showId,
     this.showTitle,
     this.seasonNumber,
@@ -38,6 +40,7 @@ class ContinueWatchingItem {
       progress: json['progress'] != null
           ? Progress.fromJson(json['progress'] as Map<String, dynamic>)
           : null,
+      state: json['state'] as String?,
       showId: json['showId'] as String?,
       showTitle: json['showTitle'] as String?,
       seasonNumber: json['seasonNumber'] as int?,
@@ -67,6 +70,40 @@ class ContinueWatchingItem {
       return '$show - $code';
     }
     return title;
+  }
+
+  /// The zero-padded season and episode code, or null for a movie.
+  String? get episodeCode {
+    final season = seasonNumber;
+    final episode = episodeNumber;
+    if (!isEpisode || season == null || episode == null) return null;
+
+    return 'S${season.toString().padLeft(2, '0')}'
+        'E${episode.toString().padLeft(2, '0')}';
+  }
+
+  /// Whether this card is the next episode rather than a resume point.
+  ///
+  /// Falls back to inferring from a zero saved position because a server older
+  /// than the merged rail does not send `state` at all, and the player reaches
+  /// those through the legacy query document.
+  bool get isNext {
+    final state = this.state;
+    if (state != null) return state == 'next';
+
+    return (progress?.positionSeconds ?? 0) == 0;
+  }
+
+  /// The rail card's second line. Null for movies, which carry their title
+  /// alone.
+  String? get railSubtitle {
+    final code = episodeCode;
+    if (code == null) return null;
+
+    if (isNext) return 'Next up · $code';
+
+    final show = showTitle;
+    return show == null ? code : '$show · $code';
   }
 
   String? get posterUrl => artwork?.posterUrl;

--- a/player/lib/domain/models/home_data.dart
+++ b/player/lib/domain/models/home_data.dart
@@ -1,17 +1,14 @@
 import 'continue_watching_item.dart';
 import 'recently_added_item.dart';
-import 'up_next_item.dart';
 
 class HomeData {
   final List<ContinueWatchingItem> continueWatching;
   final List<RecentlyAddedItem> recentlyAdded;
-  final List<UpNextItem> upNext;
   final List<RecentlyAddedItem> favorites;
 
   const HomeData({
     required this.continueWatching,
     required this.recentlyAdded,
-    required this.upNext,
     required this.favorites,
   });
 
@@ -27,10 +24,6 @@ class HomeData {
                   (e) => RecentlyAddedItem.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [],
-      upNext: (json['upNext'] as List<dynamic>?)
-              ?.map((e) => UpNextItem.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          [],
       favorites: (json['favorites'] as List<dynamic>?)
               ?.map(
                   (e) => RecentlyAddedItem.fromJson(e as Map<String, dynamic>))
@@ -40,8 +33,5 @@ class HomeData {
   }
 
   bool get isEmpty =>
-      continueWatching.isEmpty &&
-      recentlyAdded.isEmpty &&
-      upNext.isEmpty &&
-      favorites.isEmpty;
+      continueWatching.isEmpty && recentlyAdded.isEmpty && favorites.isEmpty;
 }

--- a/player/lib/presentation/screens/continue_watching/continue_watching_controller.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_controller.dart
@@ -21,6 +21,46 @@ query ContinueWatchingList($first: Int, $after: String) {
     id
     type
     title
+    state
+    artwork {
+      posterUrl
+      backdropUrl
+      thumbnailUrl
+    }
+    progress {
+      positionSeconds
+      durationSeconds
+      percentage
+      watched
+      lastWatchedAt
+    }
+    showId
+    showTitle
+    seasonNumber
+    episodeNumber
+    files {
+      id
+      resolution
+      codec
+      audioCodec
+      hdrFormat
+      size
+      bitrate
+      directPlaySupported
+      streamUrl
+      directPlayUrl
+    }
+  }
+}
+''';
+
+/// The pre-merged-rail shape, for a server older than this build.
+const String continueWatchingListQueryLegacy = r'''
+query ContinueWatchingList($first: Int, $after: String) {
+  continueWatching(first: $first, after: $after) {
+    id
+    type
+    title
     artwork {
       posterUrl
       backdropUrl
@@ -134,6 +174,7 @@ class ContinueWatchingController extends _$ContinueWatchingController {
       ref,
       key: QueryKeys.continueWatchingList,
       document: gql(continueWatchingListQuery),
+      fallbackDocument: gql(continueWatchingListQueryLegacy),
       variables: _variables(),
       parse: _parseContinueWatching,
       canRefetch: () => !_hasPaginated,

--- a/player/lib/presentation/screens/home/home_controller.dart
+++ b/player/lib/presentation/screens/home/home_controller.dart
@@ -8,11 +8,12 @@ import '../../../domain/models/home_data.dart';
 part 'home_controller.g.dart';
 
 const String homeScreenQuery = r'''
-query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $upNextLimit: Int, $favoritesLimit: Int) {
+query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $favoritesLimit: Int) {
   continueWatching(first: $continueWatchingLimit) {
     id
     type
     title
+    state
     artwork {
       posterUrl
       backdropUrl
@@ -59,47 +60,6 @@ query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $upNextL
     latestEpisodeNumber
   }
 
-  upNext(first: $upNextLimit) {
-    progressState
-    episode {
-      id
-      seasonNumber
-      episodeNumber
-      title
-      airDate
-      thumbnailUrl
-      hasFile
-      files {
-        id
-        resolution
-        codec
-        audioCodec
-        hdrFormat
-        size
-        bitrate
-        directPlaySupported
-        streamUrl
-        directPlayUrl
-      }
-      progress {
-        positionSeconds
-        durationSeconds
-        percentage
-        watched
-        lastWatchedAt
-      }
-    }
-    show {
-      id
-      title
-      artwork {
-        posterUrl
-        backdropUrl
-        thumbnailUrl
-      }
-    }
-  }
-
   favorites(first: $favoritesLimit) {
     id
     type
@@ -117,7 +77,7 @@ query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $upNextL
 
 /// The pre-episode-context shape, for a server older than this build.
 const String homeScreenQueryLegacy = r'''
-query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $upNextLimit: Int, $favoritesLimit: Int) {
+query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $favoritesLimit: Int) {
   continueWatching(first: $continueWatchingLimit) {
     id
     type
@@ -165,47 +125,6 @@ query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $upNextL
     addedAt
   }
 
-  upNext(first: $upNextLimit) {
-    progressState
-    episode {
-      id
-      seasonNumber
-      episodeNumber
-      title
-      airDate
-      thumbnailUrl
-      hasFile
-      files {
-        id
-        resolution
-        codec
-        audioCodec
-        hdrFormat
-        size
-        bitrate
-        directPlaySupported
-        streamUrl
-        directPlayUrl
-      }
-      progress {
-        positionSeconds
-        durationSeconds
-        percentage
-        watched
-        lastWatchedAt
-      }
-    }
-    show {
-      id
-      title
-      artwork {
-        posterUrl
-        backdropUrl
-        thumbnailUrl
-      }
-    }
-  }
-
   favorites(first: $favoritesLimit) {
     id
     type
@@ -224,7 +143,6 @@ query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $upNextL
 const Map<String, dynamic> homeScreenVariables = {
   'continueWatchingLimit': 10,
   'recentlyAddedLimit': 20,
-  'upNextLimit': 10,
   'favoritesLimit': 10,
 };
 

--- a/player/lib/presentation/screens/home_screen.dart
+++ b/player/lib/presentation/screens/home_screen.dart
@@ -8,8 +8,6 @@ import '../../core/player/best_file.dart';
 import '../../core/player/resume_plan.dart';
 import '../../domain/models/continue_watching_item.dart';
 import '../../domain/models/media_file.dart';
-import '../../domain/models/show_next_up.dart';
-import '../../domain/models/up_next_item.dart';
 import '../widgets/ambient_backdrop_provider.dart';
 import '../widgets/content_rail.dart';
 import '../widgets/freshness_header.dart';
@@ -33,24 +31,6 @@ String _resumeSuffix({
     watched: watched,
   );
   return pass ? '&resume=$positionSeconds' : '';
-}
-
-/// Player route for an Up Next card.
-String playerRouteForUpNext(UpNextItem item, {required String fileId}) {
-  final episode = item.episode;
-  final progress = episode.progress;
-  final title = '${item.show.title} - ${episode.episodeCode}';
-
-  return '/player/episode/${episode.id}'
-      '?fileId=$fileId'
-      '&title=${Uri.encodeComponent(title)}'
-      '&showId=${item.show.id}'
-      '&seasonNumber=${episode.seasonNumber}'
-      '${_resumeSuffix(
-    isContinueState: item.state == NextUpState.continueWatching,
-    positionSeconds: progress?.positionSeconds,
-    watched: progress?.watched ?? false,
-  )}';
 }
 
 /// Player route for a Continue Watching card.
@@ -124,17 +104,6 @@ class HomeScreen extends ConsumerWidget {
   Future<void> _handlePlay(BuildContext context, Object item) async {
     final router = GoRouter.of(context);
     final screenWidth = MediaQuery.sizeOf(context).width;
-
-    if (item is UpNextItem) {
-      final file = await _bestFileOrNull(item.episode.files, screenWidth);
-      if (file == null) {
-        // Nothing playable: fall back to detail rather than a dead tap.
-        router.push('/episode/${item.episode.id}');
-        return;
-      }
-      router.push(playerRouteForUpNext(item, fileId: file.id));
-      return;
-    }
 
     if (item is ContinueWatchingItem) {
       final file = await _bestFileOrNull(item.files, screenWidth);
@@ -264,16 +233,6 @@ class HomeScreen extends ConsumerWidget {
                               onItemTap: (id, type) =>
                                   _handleItemTap(context, id, type),
                               onSeeAllTap: () => context.push('/favorites'),
-                            ),
-                          if (data.upNext.isNotEmpty)
-                            ContentRail(
-                              title: 'Up Next',
-                              items: data.upNext,
-                              showEpisodeInfo: true,
-                              onItemTap: (id, type) =>
-                                  _handleItemTap(context, id, type),
-                              onItemActivate: (item) =>
-                                  _handlePlay(context, item),
                             ),
                           SizedBox(height: bottomPadding),
                         ]),

--- a/player/lib/presentation/widgets/content_rail.dart
+++ b/player/lib/presentation/widgets/content_rail.dart
@@ -207,7 +207,7 @@ class _ContentRailState extends State<ContentRail> {
       return MediaCard(
         posterUrl: item.posterUrl,
         title: item.title,
-        subtitle: item.showTitle,
+        subtitle: item.railSubtitle,
         progressPercentage: item.progress?.percentage,
         width: cardSize.width,
         height: cardSize.height,

--- a/player/test/domain/models/continue_watching_item_state_test.dart
+++ b/player/test/domain/models/continue_watching_item_state_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/continue_watching_item.dart';
+
+Map<String, dynamic> episodeJson({
+  String? state,
+  int positionSeconds = 0,
+}) {
+  return {
+    'id': 'ep-1',
+    'type': 'episode',
+    'title': 'Rhaenyra Triumphant',
+    'state': state,
+    'showId': 'show-1',
+    'showTitle': 'House of the Dragon',
+    'seasonNumber': 3,
+    'episodeNumber': 3,
+    'progress': {
+      'positionSeconds': positionSeconds,
+      'durationSeconds': 3600,
+      'percentage': 0.0,
+      'watched': false,
+      'lastWatchedAt': null,
+    },
+    'files': <dynamic>[],
+  };
+}
+
+void main() {
+  group('ContinueWatchingItem.state', () {
+    test('parses the state field', () {
+      final item = ContinueWatchingItem.fromJson(episodeJson(state: 'next'));
+
+      expect(item.state, 'next');
+      expect(item.isNext, isTrue);
+    });
+
+    test('a continue item is not next', () {
+      final item = ContinueWatchingItem.fromJson(
+        episodeJson(state: 'continue', positionSeconds: 600),
+      );
+
+      expect(item.isNext, isFalse);
+    });
+
+    test('infers next from a zero position when state is absent', () {
+      // The legacy query path against an older server omits `state`.
+      final item = ContinueWatchingItem.fromJson(episodeJson());
+
+      expect(item.state, isNull);
+      expect(item.isNext, isTrue);
+    });
+
+    test('does not infer next when a saved position exists', () {
+      final item = ContinueWatchingItem.fromJson(
+        episodeJson(positionSeconds: 600),
+      );
+
+      expect(item.isNext, isFalse);
+    });
+  });
+
+  group('ContinueWatchingItem.railSubtitle', () {
+    test('a next episode is labelled', () {
+      final item = ContinueWatchingItem.fromJson(episodeJson(state: 'next'));
+
+      expect(item.railSubtitle, 'Next up · S03E03');
+    });
+
+    test('a continue episode shows the show and code', () {
+      final item = ContinueWatchingItem.fromJson(
+        episodeJson(state: 'continue', positionSeconds: 600),
+      );
+
+      expect(item.railSubtitle, 'House of the Dragon · S03E03');
+    });
+
+    test('a movie has no subtitle', () {
+      final item = ContinueWatchingItem.fromJson({
+        'id': 'movie-1',
+        'type': 'movie',
+        'title': 'Some Movie',
+        'state': 'continue',
+        'progress': {
+          'positionSeconds': 600,
+          'durationSeconds': 7200,
+          'percentage': 8.3,
+          'watched': false,
+          'lastWatchedAt': null,
+        },
+        'files': <dynamic>[],
+      });
+
+      expect(item.railSubtitle, isNull);
+    });
+  });
+}

--- a/player/test/presentation/screens/home_screen_navigation_test.dart
+++ b/player/test/presentation/screens/home_screen_navigation_test.dart
@@ -1,55 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/domain/models/continue_watching_item.dart';
-import 'package:player/domain/models/up_next_item.dart';
 import 'package:player/presentation/screens/home_screen.dart';
 
 void main() {
   group('playerRouteFor', () {
-    test('builds an episode route with resume for a continue item', () {
-      final item = UpNextItem.fromJson({
-        'progressState': 'continue',
-        'episode': {
-          'id': 'e1',
-          'seasonNumber': 2,
-          'episodeNumber': 5,
-          'title': 'Woe\'s Hollow',
-          'hasFile': true,
-          'progress': {
-            'positionSeconds': 600,
-            'durationSeconds': 2700,
-            'percentage': 22.2,
-            'watched': false,
-          },
-        },
-        'show': {'id': 's1', 'title': 'Severance'},
-      });
-
-      final route = playerRouteForUpNext(item, fileId: 'f1');
-
-      expect(route, startsWith('/player/episode/e1?'));
-      expect(route, contains('fileId=f1'));
-      expect(route, contains('showId=s1'));
-      expect(route, contains('seasonNumber=2'));
-      expect(route, contains('resume=600'));
-    });
-
-    test('omits resume for a start item', () {
-      final item = UpNextItem.fromJson({
-        'progressState': 'start',
-        'episode': {
-          'id': 'e1',
-          'seasonNumber': 1,
-          'episodeNumber': 1,
-          'title': 'Good News About Hell',
-          'hasFile': true,
-        },
-        'show': {'id': 's1', 'title': 'Severance'},
-      });
-
-      expect(
-          playerRouteForUpNext(item, fileId: 'f1'), isNot(contains('resume=')));
-    });
-
     test('routes a continue-watching movie to the movie player', () {
       final item = ContinueWatchingItem.fromJson({
         'id': 'm1',
@@ -93,6 +47,34 @@ void main() {
       expect(route, contains('showId=s1'));
       expect(route, contains('seasonNumber=2'));
       expect(route, contains('resume=120'));
+    });
+
+    testWidgets('a next-episode card starts from the beginning',
+        (tester) async {
+      final item = ContinueWatchingItem.fromJson({
+        'id': 'ep-1',
+        'type': 'episode',
+        'title': 'Rhaenyra Triumphant',
+        'state': 'next',
+        'showId': 'show-1',
+        'showTitle': 'House of the Dragon',
+        'seasonNumber': 3,
+        'episodeNumber': 3,
+        'progress': {
+          'positionSeconds': 0,
+          'durationSeconds': 3600,
+          'percentage': 0.0,
+          'watched': false,
+          'lastWatchedAt': null,
+        },
+        'files': <dynamic>[],
+      });
+
+      final route = playerRouteForContinueWatching(item, fileId: 'file-1');
+
+      expect(route, isNot(contains('resume=')));
+      expect(route, contains('/player/episode/ep-1'));
+      expect(route, contains('showId=show-1'));
     });
   });
 }

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -272,6 +272,9 @@ type ContinueWatchingItem {
 
   progress: Progress!
 
+  "Why this item is on the rail: continue for a resume point, next for the successor of a finished episode"
+  state: String
+
   "Playable files for this item, used to start playback straight from the rail"
   files: [MediaFile]
 

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -36,7 +36,7 @@ type RootQueryType {
   recentlyAdded(first: Int, after: String, types: [MediaType]): [RecentlyAddedItem]
 
   "Get next episodes to watch across all TV shows"
-  upNext(first: Int, after: String): [UpNextItem]
+  upNext(first: Int, after: String): [UpNextItem] @deprecated(reason: "Merged into continueWatching, which now carries next episodes as well")
 
   "Get the user's favorite items"
   favorites(first: Int, after: String, types: [MediaType], category: MediaCategory, sort: SortInput): [RecentlyAddedItem]

--- a/server/crates/api/src/query.rs
+++ b/server/crates/api/src/query.rs
@@ -357,6 +357,9 @@ impl RootQueryType {
     }
 
     /// Get next episodes to watch across all TV shows
+    #[graphql(
+        deprecation = "Merged into continueWatching, which now carries next episodes as well"
+    )]
     async fn up_next(
         &self,
         _ctx: &Context<'_>,

--- a/server/crates/api/src/types/discovery.rs
+++ b/server/crates/api/src/types/discovery.rs
@@ -24,6 +24,9 @@ pub struct ContinueWatchingItem {
     pub show_title: Option<String>,
     pub season_number: Option<i32>,
     pub episode_number: Option<i32>,
+    /// Why this item is on the rail: continue for a resume point, next for the
+    /// successor of a finished episode.
+    pub state: Option<String>,
 }
 
 #[derive(SimpleObject)]

--- a/test/mydia/playback/next_episode_test.exs
+++ b/test/mydia/playback/next_episode_test.exs
@@ -1,0 +1,63 @@
+defmodule Mydia.Playback.NextEpisodeTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Media.Episode
+  alias Mydia.Playback.NextEpisode
+  alias Mydia.Playback.Progress
+
+  defp ep(id, season, number) do
+    %Episode{id: id, season_number: season, episode_number: number}
+  end
+
+  defp watched(episode_id) do
+    %Progress{episode_id: episode_id, watched: true, completion_percentage: 100.0}
+  end
+
+  defp partial(episode_id, pct) do
+    %Progress{episode_id: episode_id, watched: false, completion_percentage: pct}
+  end
+
+  describe "determine/2" do
+    test "returns start when there is no progress at all" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2)]
+
+      assert {:start, %Episode{id: "a"}} = NextEpisode.determine(episodes, %{})
+    end
+
+    test "returns continue for an in-progress episode" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2)]
+      progress = %{"a" => partial("a", 25.0)}
+
+      assert {:continue, %Episode{id: "a"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "returns next for the episode after a watched one" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2)]
+      progress = %{"a" => watched("a")}
+
+      assert {:next, %Episode{id: "b"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "returns all_watched when every episode is watched" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2)]
+      progress = %{"a" => watched("a"), "b" => watched("b")}
+
+      assert :all_watched = NextEpisode.determine(episodes, progress)
+    end
+
+    test "an episode at or past 90 percent is not a continue entry" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2)]
+      progress = %{"a" => partial("a", 95.0)}
+
+      # Not `:continue`, because resuming at 95% would land on the credits.
+      # It is still the episode returned, though: only the `watched` flag marks
+      # completion here, so the episode comes back as the next thing to play
+      # and starts from the beginning.
+      #
+      # A row in this state is reachable in production. `Progress.changeset/3`
+      # auto-marks watched at 90%, but a sync passing `authoritative_watched:
+      # true` preserves the remote's own unwatched flag at any percentage.
+      assert {:next, %Episode{id: "a"}} = NextEpisode.determine(episodes, progress)
+    end
+  end
+end

--- a/test/mydia/playback/on_deck_test.exs
+++ b/test/mydia/playback/on_deck_test.exs
@@ -1,0 +1,323 @@
+defmodule Mydia.Playback.OnDeckTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
+  alias Mydia.Playback
+  alias Mydia.Playback.{OnDeck, OnDeckEntry}
+
+  setup do
+    %{user: AccountsFixtures.user_fixture()}
+  end
+
+  # A show with `count` episodes in season 1, each with an untrashed file.
+  defp show_with_episodes(count, title \\ nil) do
+    show =
+      MediaFixtures.media_item_fixture(%{
+        type: "tv_show",
+        title: title || "Show #{System.unique_integer([:positive])}"
+      })
+
+    episodes =
+      for n <- 1..count do
+        episode =
+          MediaFixtures.episode_fixture(%{
+            media_item_id: show.id,
+            season_number: 1,
+            episode_number: n
+          })
+
+        MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+        episode
+      end
+
+    {show, episodes}
+  end
+
+  defp watch(user, episode, at) do
+    {:ok, progress} =
+      Playback.save_progress(
+        user.id,
+        [episode_id: episode.id],
+        %{
+          position_seconds: 2400,
+          duration_seconds: 2400,
+          watched: true,
+          last_watched_at: at
+        }
+      )
+
+    progress
+  end
+
+  defp start_watching(user, episode, position, at) do
+    {:ok, progress} =
+      Playback.save_progress(
+        user.id,
+        [episode_id: episode.id],
+        %{position_seconds: position, duration_seconds: 2400, last_watched_at: at}
+      )
+
+    progress
+  end
+
+  defp now, do: ~U[2026-08-12 20:00:00Z]
+  defp ago(seconds), do: DateTime.add(now(), -seconds, :second)
+  defp days_ago(days), do: DateTime.add(now(), -days, :day)
+
+  describe "list/2 next episode" do
+    test "finishing an episode surfaces the next one", ctx do
+      {_show, [e1, e2, _e3]} = show_with_episodes(3)
+      watch(ctx.user, e1, ago(60))
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert entry.kind == :episode
+      assert entry.state == :next
+      assert entry.episode.id == e2.id
+      assert entry.progress == nil
+    end
+
+    test "a partially watched episode is a continue entry", ctx do
+      {_show, [e1, _e2, _e3]} = show_with_episodes(3)
+      start_watching(ctx.user, e1, 600, ago(60))
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert entry.state == :continue
+      assert entry.episode.id == e1.id
+      assert entry.progress.position_seconds == 600
+    end
+
+    test "a fully watched show produces no entry", ctx do
+      {_show, episodes} = show_with_episodes(2)
+      Enum.each(episodes, &watch(ctx.user, &1, ago(60)))
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "carries the episode's untrashed files on the entry", ctx do
+      {_show, [e1, e2, _e3]} = show_with_episodes(3)
+      watch(ctx.user, e1, ago(60))
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert entry.episode.id == e2.id
+      assert length(entry.files) == 1
+    end
+  end
+
+  describe "list/2 engagement" do
+    test "a never-started show produces no entry", ctx do
+      show_with_episodes(3)
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "a tap under the position floor does not create engagement", ctx do
+      {_show, [e1, _e2, _e3]} = show_with_episodes(3)
+      start_watching(ctx.user, e1, 73, ago(60))
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "a tap at or above the position floor does create engagement", ctx do
+      {_show, [e1, _e2, _e3]} = show_with_episodes(3)
+      start_watching(ctx.user, e1, 120, ago(60))
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert entry.episode.id == e1.id
+    end
+
+    test "a synced watched row with position 0 still creates engagement", ctx do
+      {_show, [e1, e2, _e3]} = show_with_episodes(3)
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [episode_id: e1.id],
+          %{
+            position_seconds: 0,
+            duration_seconds: 1,
+            watched: true,
+            last_watched_at: ago(60)
+          },
+          authoritative_watched: true
+        )
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert entry.state == :next
+      assert entry.episode.id == e2.id
+    end
+
+    test "the position floor is configurable", ctx do
+      {_show, [e1, _e2, _e3]} = show_with_episodes(3)
+      start_watching(ctx.user, e1, 73, ago(60))
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+      assert [_entry] = OnDeck.list(ctx.user.id, now: now(), min_position_seconds: 60)
+    end
+  end
+
+  describe "list/2 age cutoff" do
+    test "a row older than the cutoff drops out", ctx do
+      {_show, [e1, _e2, _e3]} = show_with_episodes(3)
+      watch(ctx.user, e1, days_ago(120))
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "the same row inside the window does not drop out", ctx do
+      {_show, [e1, _e2, _e3]} = show_with_episodes(3)
+      watch(ctx.user, e1, days_ago(30))
+
+      assert [_entry] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "history outside the cutoff still informs which episode is next", ctx do
+      {_show, [e1, e2, e3]} = show_with_episodes(3)
+      # Season watched long ago, then one episode watched recently.
+      watch(ctx.user, e1, days_ago(300))
+      watch(ctx.user, e2, ago(60))
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert entry.episode.id == e3.id
+      assert entry.state == :next
+    end
+  end
+
+  describe "list/2 one card per show" do
+    test "several in-progress episodes still yield exactly one entry", ctx do
+      {_show, [e1, e2, e3]} = show_with_episodes(3)
+      start_watching(ctx.user, e1, 600, ago(300))
+      start_watching(ctx.user, e2, 600, ago(200))
+      start_watching(ctx.user, e3, 600, ago(100))
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      # The earliest in series order is what you would actually play next.
+      assert entry.episode.id == e1.id
+    end
+  end
+
+  describe "list/2 movies" do
+    test "an in-progress movie appears", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+      MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: movie.id],
+          %{position_seconds: 900, duration_seconds: 7200, last_watched_at: ago(60)}
+        )
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert entry.kind == :movie
+      assert entry.state == :continue
+      assert entry.media_item.id == movie.id
+      assert length(entry.files) == 1
+    end
+
+    test "a movie with no file is skipped", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: movie.id],
+          %{position_seconds: 900, duration_seconds: 7200, last_watched_at: ago(60)}
+        )
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "a watched movie is skipped", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+      MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: movie.id],
+          %{
+            position_seconds: 7000,
+            duration_seconds: 7200,
+            last_watched_at: ago(60)
+          }
+        )
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+  end
+
+  describe "list/2 ordering" do
+    test "the most recently watched show sorts first", ctx do
+      {_a, [a1, _a2]} = show_with_episodes(2, "Alpha")
+      {_b, [b1, _b2]} = show_with_episodes(2, "Bravo")
+      {_c, [c1, _c2]} = show_with_episodes(2, "Charlie")
+
+      watch(ctx.user, a1, ago(3000))
+      watch(ctx.user, c1, ago(60))
+      watch(ctx.user, b1, ago(1500))
+
+      titles = ctx.user.id |> OnDeck.list(now: now()) |> Enum.map(& &1.show.title)
+
+      assert titles == ["Charlie", "Bravo", "Alpha"]
+    end
+
+    test "movies and episodes interleave by recency", ctx do
+      {_show, [e1, _e2]} = show_with_episodes(2, "Alpha")
+      movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "Some Movie"})
+      MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+
+      watch(ctx.user, e1, ago(3000))
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: movie.id],
+          %{position_seconds: 900, duration_seconds: 7200, last_watched_at: ago(60)}
+        )
+
+      assert [first, second] = OnDeck.list(ctx.user.id, now: now())
+      assert first.kind == :movie
+      assert second.kind == :episode
+    end
+
+    test "the limit applies after sorting, not before", ctx do
+      # The production bug: the show just watched was at index 37 of 43 in an
+      # unordered list and was truncated away by a limit of 10.
+      for n <- 1..12 do
+        {_show, [e1, _e2]} = show_with_episodes(2, "Filler #{n}")
+        watch(ctx.user, e1, ago(10_000 + n))
+      end
+
+      {_target, [t1, t2]} = show_with_episodes(2, "Just Watched")
+      watch(ctx.user, t1, ago(60))
+
+      entries = OnDeck.list(ctx.user.id, now: now(), limit: 10)
+
+      assert length(entries) == 10
+      assert hd(entries).episode.id == t2.id
+      assert hd(entries).show.title == "Just Watched"
+    end
+  end
+
+  describe "list/2 isolation" do
+    test "another user's progress does not leak in", ctx do
+      other = AccountsFixtures.user_fixture()
+      {_show, [e1, _e2]} = show_with_episodes(2)
+      watch(other, e1, ago(60))
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+      assert [_entry] = OnDeck.list(other.id, now: now())
+    end
+  end
+
+  describe "id/1" do
+    test "uses the episode id for an episode entry", ctx do
+      {_show, [e1, e2, _e3]} = show_with_episodes(3)
+      watch(ctx.user, e1, ago(60))
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert OnDeckEntry.id(entry) == e2.id
+    end
+  end
+end

--- a/test/mydia/playback/on_deck_test.exs
+++ b/test/mydia/playback/on_deck_test.exs
@@ -320,4 +320,27 @@ defmodule Mydia.Playback.OnDeckTest do
       assert OnDeckEntry.id(entry) == e2.id
     end
   end
+
+  describe "list/2 trashed files" do
+    test "an engaged show whose watched episode lost its file reports next", ctx do
+      {_show, [e1, e2]} = show_with_episodes(2)
+      watch(ctx.user, e1, ago(60))
+
+      # The watched episode's only file goes to the trash. `load_episodes_with_files`
+      # then drops e1 entirely, so the progress map handed to `NextEpisode` is
+      # empty and it answers `:start`, the same value it gives a show that was
+      # never touched. Engagement was already established from the full row set,
+      # so `OnDeck` has to normalize that back to `:next`.
+      #
+      # This is the only path that reaches the `:start` arm of build_show_entry.
+      Mydia.Repo.update_all(
+        from(mf in Mydia.Library.MediaFile, where: mf.episode_id == ^e1.id),
+        set: [trashed_at: DateTime.truncate(DateTime.utc_now(), :second)]
+      )
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert entry.state == :next
+      assert entry.episode.id == e2.id
+    end
+  end
 end

--- a/test/mydia/playback/on_deck_test.exs
+++ b/test/mydia/playback/on_deck_test.exs
@@ -343,4 +343,57 @@ defmodule Mydia.Playback.OnDeckTest do
       assert entry.episode.id == e2.id
     end
   end
+
+  describe "list/2 query count" do
+    test "the query count does not grow with the number of engaged shows", ctx do
+      count_queries = fn fun ->
+        ref = make_ref()
+        parent = self()
+
+        handler = fn _event, _measurements, _metadata, _config ->
+          send(parent, {ref, :query})
+        end
+
+        :telemetry.attach(
+          "on-deck-query-count-#{inspect(ref)}",
+          [:mydia, :repo, :query],
+          handler,
+          nil
+        )
+
+        fun.()
+
+        :telemetry.detach("on-deck-query-count-#{inspect(ref)}")
+
+        count_messages = fn count_messages ->
+          receive do
+            {^ref, :query} -> 1 + count_messages.(count_messages)
+          after
+            0 -> 0
+          end
+        end
+
+        count_messages.(count_messages)
+      end
+
+      for n <- 1..3 do
+        {_show, [e1, _e2]} = show_with_episodes(2, "Small #{n}")
+        watch(ctx.user, e1, ago(100 + n))
+      end
+
+      small = count_queries.(fn -> OnDeck.list(ctx.user.id, now: now()) end)
+
+      for n <- 4..15 do
+        {_show, [e1, _e2]} = show_with_episodes(2, "Large #{n}")
+        watch(ctx.user, e1, ago(100 + n))
+      end
+
+      large = count_queries.(fn -> OnDeck.list(ctx.user.id, now: now()) end)
+
+      assert small == large,
+             "expected a constant query count, got #{small} for 3 shows and #{large} for 15"
+
+      assert large <= 8, "expected at most 8 queries, got #{large}"
+    end
+  end
 end

--- a/test/mydia_web/schema/continue_watching_test.exs
+++ b/test/mydia_web/schema/continue_watching_test.exs
@@ -1,0 +1,109 @@
+defmodule MydiaWeb.Schema.ContinueWatchingTest do
+  use MydiaWeb.ConnCase
+
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
+  alias Mydia.Playback
+
+  @query """
+  query ContinueWatching($first: Int) {
+    continueWatching(first: $first) {
+      id
+      type
+      title
+      state
+      showId
+      showTitle
+      seasonNumber
+      episodeNumber
+      progress {
+        positionSeconds
+        percentage
+        watched
+      }
+      files {
+        id
+      }
+    }
+  }
+  """
+
+  setup do
+    user = AccountsFixtures.user_fixture()
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Test Show"})
+
+    episodes =
+      for n <- 1..3 do
+        episode =
+          MediaFixtures.episode_fixture(%{
+            media_item_id: show.id,
+            season_number: 1,
+            episode_number: n
+          })
+
+        MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+        episode
+      end
+
+    %{user: user, show: show, episodes: episodes}
+  end
+
+  test "a finished episode surfaces its successor as a next item", ctx do
+    [e1, e2, _e3] = ctx.episodes
+    :changed = Playback.ensure_watched(ctx.user.id, episode_id: e1.id)
+
+    assert {:ok, %{data: %{"continueWatching" => [item]}}} =
+             run_query(@query, %{"first" => 10}, ctx.user)
+
+    assert item["id"] == e2.id
+    assert item["type"] == "EPISODE"
+    assert item["state"] == "next"
+    assert item["showId"] == ctx.show.id
+    assert item["showTitle"] == "Test Show"
+    assert item["seasonNumber"] == 1
+    assert item["episodeNumber"] == 2
+    assert item["progress"]["positionSeconds"] == 0
+    assert item["progress"]["percentage"] == 0.0
+    assert item["progress"]["watched"] == false
+    assert length(item["files"]) == 1
+  end
+
+  test "an in-progress episode is a continue item carrying its real progress", ctx do
+    [e1, _e2, _e3] = ctx.episodes
+
+    {:ok, _} =
+      Playback.save_progress(
+        ctx.user.id,
+        [episode_id: e1.id],
+        %{position_seconds: 600, duration_seconds: 2400}
+      )
+
+    assert {:ok, %{data: %{"continueWatching" => [item]}}} =
+             run_query(@query, %{"first" => 10}, ctx.user)
+
+    assert item["id"] == e1.id
+    assert item["state"] == "continue"
+    assert item["progress"]["positionSeconds"] == 600
+  end
+
+  test "a never-started show returns nothing", ctx do
+    assert {:ok, %{data: %{"continueWatching" => []}}} =
+             run_query(@query, %{"first" => 10}, ctx.user)
+  end
+
+  test "an anonymous caller is denied by the fail-closed auth gate" do
+    # continueWatching requires authentication (MydiaWeb.Schema.middleware/3,
+    # MydiaWeb.Schema.Middleware.RequireAuth), so the nil-user branch in
+    # continue_watching/3 is defense in depth but not reachable through the
+    # schema. See auth_gating_test.exs.
+    assert {:ok, %{data: %{"continueWatching" => nil}, errors: errors}} =
+             run_query(@query, %{"first" => 10}, nil)
+
+    assert Enum.any?(errors, &(&1.message =~ "Authentication required"))
+  end
+
+  defp run_query(query, variables, user) do
+    context = if user, do: %{current_user: user}, else: %{}
+    Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: context)
+  end
+end

--- a/test/mydia_web/schema/continue_watching_test.exs
+++ b/test/mydia_web/schema/continue_watching_test.exs
@@ -102,6 +102,75 @@ defmodule MydiaWeb.Schema.ContinueWatchingTest do
     assert Enum.any?(errors, &(&1.message =~ "Authentication required"))
   end
 
+  describe "upNext" do
+    @up_next_query """
+    query UpNext($first: Int) {
+      upNext(first: $first) {
+        progressState
+        episode {
+          id
+          seasonNumber
+          episodeNumber
+        }
+        show {
+          id
+          title
+        }
+      }
+    }
+    """
+
+    test "returns the successor of a finished episode", ctx do
+      [e1, e2, _e3] = ctx.episodes
+      :changed = Playback.ensure_watched(ctx.user.id, episode_id: e1.id)
+
+      assert {:ok, %{data: %{"upNext" => [item]}}} =
+               run_query(@up_next_query, %{"first" => 10}, ctx.user)
+
+      assert item["progressState"] == "next"
+      assert item["episode"]["id"] == e2.id
+      assert item["show"]["id"] == ctx.show.id
+    end
+
+    test "excludes never-started shows", ctx do
+      other = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Untouched"})
+
+      episode =
+        MediaFixtures.episode_fixture(%{
+          media_item_id: other.id,
+          season_number: 1,
+          episode_number: 1
+        })
+
+      MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+
+      [e1, _e2, _e3] = ctx.episodes
+      :changed = Playback.ensure_watched(ctx.user.id, episode_id: e1.id)
+
+      assert {:ok, %{data: %{"upNext" => items}}} =
+               run_query(@up_next_query, %{"first" => 10}, ctx.user)
+
+      titles = Enum.map(items, & &1["show"]["title"])
+      assert titles == ["Test Show"]
+      refute "Untouched" in titles
+    end
+
+    test "excludes movies, which belong only on the merged rail", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "A Movie"})
+      MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: movie.id],
+          %{position_seconds: 900, duration_seconds: 7200}
+        )
+
+      assert {:ok, %{data: %{"upNext" => []}}} =
+               run_query(@up_next_query, %{"first" => 10}, ctx.user)
+    end
+  end
+
   defp run_query(query, variables, user) do
     context = if user, do: %{current_user: user}, else: %{}
     Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: context)

--- a/test/mydia_web/schema/continue_watching_test.exs
+++ b/test/mydia_web/schema/continue_watching_test.exs
@@ -91,6 +91,35 @@ defmodule MydiaWeb.Schema.ContinueWatchingTest do
              run_query(@query, %{"first" => 10}, ctx.user)
   end
 
+  test "an in-progress movie renders on the merged rail", ctx do
+    # The only test that reaches the `kind: :movie` clause of
+    # build_on_deck_item/1. The upNext movie test does not: that resolver
+    # filters to episodes, so it never builds a movie item. Without this, the
+    # movie clause and its String.to_existing_atom/1 call ship unexecuted.
+    movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "Some Movie"})
+    MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+
+    {:ok, _} =
+      Playback.save_progress(
+        ctx.user.id,
+        [media_item_id: movie.id],
+        %{position_seconds: 900, duration_seconds: 7200}
+      )
+
+    assert {:ok, %{data: %{"continueWatching" => [item]}}} =
+             run_query(@query, %{"first" => 10}, ctx.user)
+
+    assert item["id"] == movie.id
+    assert item["type"] == "MOVIE"
+    assert item["title"] == "Some Movie"
+    assert item["state"] == "continue"
+    assert item["showId"] == nil
+    assert item["seasonNumber"] == nil
+    assert item["episodeNumber"] == nil
+    assert item["progress"]["positionSeconds"] == 900
+    assert length(item["files"]) == 1
+  end
+
   test "an anonymous caller is denied by the fail-closed auth gate" do
     # continueWatching requires authentication (MydiaWeb.Schema.middleware/3,
     # MydiaWeb.Schema.Middleware.RequireAuth), so the nil-user branch in


### PR DESCRIPTION
Merges the Continue Watching and Up Next rails into a single recency-sorted On Deck rail, so finishing an episode surfaces the next one instead of losing it.

## The bug

Observed on production. User finished House of the Dragon S03E02 at 98.6%. S03E03 has a file and `get_next_episode/2` correctly returned `{:next, S03E03}`. It appeared on neither rail.

Two independent defects:

- **Continue Watching structurally excluded it.** The resolver read only `playback_progress` rows with `watched == false` and `position > 0`. An episode never started has no row at all, so it could never qualify. The rail was resume-points-only.
- **Up Next was unordered and truncated.** `up_next/3` listed every show via `list_media_items(type: "tv_show", has_files: true)` with no `order_by`, then took the first 10. That list had 43 entries with House of the Dragon at position 37, and 33 of the 43 were shows never played at all, sitting at S01E01 and consuming every slot.

The old resolver also cost roughly 94 queries per home load (47 shows times two).

## The change

- New `Mydia.Playback.OnDeck` owns the rule set and returns `OnDeckEntry` structs; the resolvers become thin mappers.
- A progress row counts as real viewing when it is marked watched **or** has at least 120 seconds on the clock, and falls inside a 90 day window. The watched branch matters because media-server sync writes synthetic `position 0 / duration 1` rows, and a seconds-only floor would suppress the next-episode card for an entire synced library.
- Shows contribute exactly one entry, so one-card-per-show needs no dedup pass.
- Never-started shows are excluded. Sorting is by recency, tie-broken by id for stable pagination, and the limit applies **after** sorting, which is the specific thing that was broken.
- Query count is now constant (about 5 to 7) rather than scaling with library size, with a test asserting it does not grow from 3 shows to 15.
- `continueWatching` gains a nullable `state` field (`continue` or `next`). `progress` stays `Progress!`; a next-episode entry gets a synthesized zero progress, so this is not a breaking schema change.
- `upNext` is rebuilt on the same engine and deprecated rather than removed, so older player builds keep working and receive the ordering fix too.
- Player drops the Up Next rail and renders the merged data.

## Cross-version behavior

Server and player update independently on self-hosted installs, so both directions work:

- **New server, older player**: receives merged sorted items. Next-episode cards arrive at position 0, and the existing `shouldPassResume` gate declines to resume at or below 30 seconds, so they start from the beginning with no player change.
- **Newer player, older server**: the unknown `state` field errors and `createWatcher` falls back to a legacy document without it, inferring `next` from a zero position.

## Result on real data

Running the new rules against the production database for the affected user:

```
1. [next    ] House of the Dragon S03E03 Rhaenyra Triumphant  (2026-08-12 19:42)
2. [continue] Ted Lasso S04E02 Curiouser and Curiouser        (2026-08-12 13:00)
3. [next    ] Fallout S02E01 The Innovator                    (2026-08-10 16:01)
4. [continue] Bluey S01E01 Weird Funeral                      (2026-08-04 14:14)
```

Ten slots of months-old sub-1% rows and a 43-entry unordered Up Next become the four things actually in flight.

## Testing

- `Mydia.Playback.OnDeck`: 23 tests covering engagement, the position floor, the age cutoff, one-card-per-show, movies, ordering, user isolation, and the trashed-file `:start` normalization.
- The anchor regression test rebuilds the production shape: with 40-plus engaged shows, the one just finished lands at position 1 under a limit of 10 rather than at index 37 where truncation discarded it.
- GraphQL tests cover the merged shape including `state`, the movie clause, the fail-closed auth gate, and that `upNext` stays sorted and excludes never-started shows.
- Full suites: 7203 Elixir tests and 2115 player tests, both green. No migration; this is a query-layer change.
