### PR TITLE
ci: cut a backend PR from 13 jobs to 6 and the merge gate from 7 checks to 3

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,9 +1,12 @@
 name: CI / Docker
 
 on:
+  # Push only. PR runs already set `push: false` on the build-push action, so
+  # they only ever proved the image builds, at 25 minutes per PR. release.yml
+  # rebuilds from ./Dockerfile across its db and arch matrix rather than
+  # retagging :master, so release is an independent second net.
   push:
     branches: [master, main]
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -10,26 +10,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    name: Build / Packages
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-
-      - name: Build SQLite package
-        run: nix build .#checks.x86_64-linux.package -L
-
-      - name: Build PostgreSQL package
-        run: nix build .#checks.x86_64-linux.package-postgres -L
-
   flutter-pin:
     name: Check / Flutter Pin
     runs-on: ubuntu-latest
@@ -113,17 +93,19 @@ jobs:
       - name: Assert every Apple deployment target agrees
         run: ./scripts/check-apple-deployment-targets.sh
 
-  # No `needs: build`, intentionally. Nix builds are content-addressed and
-  # reproducible, so `nix build .#checks...nixos-module` below transitively
-  # rebuilds the same package on its own -- there is no correctness reason to
-  # wait for the `build` job. A `needs: build` dependency was tried so this
-  # job could reuse the build job's cache instead of rebuilding (~7 min), but
-  # the build job's own cache-upload step costs ~12 min on its own, more than
-  # the rebuild it was meant to avoid. Running in parallel instead cuts the
-  # workflow's wall-clock critical path roughly in half.
+  # Both NixOS VM tests run on push only. They are the slowest and least
+  # reliable jobs in CI, combining a QEMU boot with a full Nix build on top of
+  # the FlakeHub cache 503s that can hit any Nix job, and breaking the NixOS
+  # module is rare enough that catching it on master costs less than paying for
+  # it on every PR.
+  #
+  # They also build packages.default and packages.postgres as inputs, via
+  # nix/checks/flake-module.nix, which is why the former `Build / Packages` job
+  # was deleted as redundant rather than kept alongside them.
   test-sqlite-module:
     name: Test / NixOS Module (SQLite)
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Checkout
@@ -147,6 +129,7 @@ jobs:
   test-postgres-module:
     name: Test / NixOS Module (PostgreSQL)
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-player-e2e.yml
+++ b/.github/workflows/ci-player-e2e.yml
@@ -1,9 +1,16 @@
 name: CI / Player E2E
 
 on:
+  # Push only. This job's internal dorny/paths-filter treats lib/**, config/**,
+  # priv/**, mix.exs and Dockerfile as relevant on purpose, so backend PRs pulled
+  # the full 20-minute run. Narrowing that list was rejected: the filter block
+  # documents an invariant that `relevant` must be a superset of `server`,
+  # `toolbox` and `relay`, and records two past bugs from violating it. Dropping
+  # the PR trigger sidesteps the filter entirely. The filter itself is guarded
+  # on `github.event_name == 'pull_request'`, so it goes inert on its own and is
+  # left in place to keep a revert to a one-line change.
   push:
     branches: [master, main]
-  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -12,11 +12,18 @@ on:
       # player/. Without this, a change breaking the Android target lands green
       # (ci.yml only builds the NIF for the host) and surfaces at release time.
       - "native/**"
+      # test-player's build_runner step runs graphql_codegen, which validates
+      # the ~29 .graphql query files under player/lib/graphql/ against this
+      # schema. player/lib/graphql/schema.graphql is a symlink to this file,
+      # so filtering on the symlink's own path would never fire when only the
+      # target changes.
+      - "priv/graphql/schema.graphql"
       - ".github/workflows/ci-player.yml"
   pull_request:
     paths:
       - "player/**"
       - "native/**"
+      - "priv/graphql/schema.graphql"
       - ".github/workflows/ci-player.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -28,6 +28,62 @@ env:
   PLAYER_PATH: 'player'
 
 jobs:
+  # Moved here from ci.yml, which has no path filter and therefore ran the
+  # whole Flutter suite on every Elixir-only PR. This workflow already filters
+  # on player/** and native/**, which is the correct trigger surface for it.
+  # The job name is unchanged so the check context stays `Test / Player`.
+  test-player:
+    name: Test / Player
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: player
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version-file: player/.fvmrc
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run code generation
+        run: flutter pub run build_runner build
+
+      - name: Run tests
+        # --concurrency=1: the default concurrency silently drops 2-4 test
+        # files while still exiting 0, so this is load-bearing, not cosmetic.
+        run: flutter test --concurrency=1
+
+      - name: Run browser tests
+        # The run above is a VM run, which skips every @TestOn('browser') file.
+        # Without this step the IndexedDB keystore has no coverage in CI at all.
+        #
+        # The files are enumerated rather than passing a bare `--platform
+        # chrome`, because that would try to run the whole suite in a browser
+        # and most of it needs dart:io. Empty means the naming convention broke,
+        # which must fail rather than silently cover nothing.
+        #
+        # No --concurrency here, unlike the VM run above: flutter parses it and
+        # then ignores it for web runs, printing a warning that reads like a
+        # mistake.
+        run: |
+          set -euo pipefail
+          files=$(git ls-files 'test/**/*_web_test.dart')
+          if [ -z "$files" ]; then
+            echo "No test/**/*_web_test.dart files matched; expected at least one." >&2
+            exit 1
+          fi
+          echo "Browser tests: $files"
+          flutter test --platform chrome $files
+
   build:
     name: Build / ${{ matrix.platform }}
     strategy:

--- a/.github/workflows/ci-relay.yml
+++ b/.github/workflows/ci-relay.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   test:
-    name: Test
+    name: Relay / Test
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -5,12 +5,18 @@ on:
     branches: [master]
     paths:
       - "server/**"
+      # player/lib/graphql/schema.graphql is a symlink to priv/graphql/schema.graphql,
+      # so it never fires on its own: GitHub Actions path filters match the
+      # recorded path of the changed file, and editing the target leaves the
+      # symlink's blob untouched. The priv/ entry below is the one doing the work.
       - "player/lib/graphql/schema.graphql"
       - "priv/graphql/schema.graphql"
       - ".github/workflows/ci-server.yml"
   pull_request:
     paths:
       - "server/**"
+      # See the push.paths comment above: this entry is inert for the same
+      # symlink reason, and priv/graphql/schema.graphql is what actually triggers.
       - "player/lib/graphql/schema.graphql"
       - "priv/graphql/schema.graphql"
       - ".github/workflows/ci-server.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,58 +345,6 @@ jobs:
           mix test --cover
           DEVENV
 
-  test-player:
-    name: Test / Player
-    runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: player
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version-file: player/.fvmrc
-          channel: stable
-          cache: true
-
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Run code generation
-        run: flutter pub run build_runner build
-
-      - name: Run tests
-        # --concurrency=1: the default concurrency silently drops 2-4 test
-        # files while still exiting 0, so this is load-bearing, not cosmetic.
-        run: flutter test --concurrency=1
-
-      - name: Run browser tests
-        # The run above is a VM run, which skips every @TestOn('browser') file.
-        # Without this step the IndexedDB keystore has no coverage in CI at all.
-        #
-        # The files are enumerated rather than passing a bare `--platform
-        # chrome`, because that would try to run the whole suite in a browser
-        # and most of it needs dart:io. Empty means the naming convention broke,
-        # which must fail rather than silently cover nothing.
-        #
-        # No --concurrency here, unlike the VM run above: flutter parses it and
-        # then ignores it for web runs, printing a warning that reads like a
-        # mistake.
-        run: |
-          set -euo pipefail
-          files=$(git ls-files 'test/**/*_web_test.dart')
-          if [ -z "$files" ]; then
-            echo "No test/**/*_web_test.dart files matched; expected at least one." >&2
-            exit 1
-          fi
-          echo "Browser tests: $files"
-          flutter test --platform chrome $files
-
   test-e2e:
     name: Test / E2E Browser
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backend-only PRs ran 13 jobs and about 121 runner-minutes, and the slowest jobs were also the flakiest, so time to green frequently doubled on re-runs. Minutes are free on a public repo; this is about latency and reliability.

Changes:

- Move `Test / Player` from `ci.yml`, which has no path filter, into `ci-player.yml`, which already filters on `player/**` and `native/**`.
- Delete `Build / Packages`. `nix/checks/flake-module.nix` passes `packages.default` and `packages.postgres` into the two NixOS module tests, so its signal was a strict subset of theirs.
- Run both NixOS VM tests on push only. `Check / Flutter Pin` and `Check / Apple Deployment Targets` still run on PRs, which is why `ci-nix.yml` keeps its `pull_request` trigger and gates those two jobs with `if:` instead.
- Run Docker builds on push only. PR runs already set `push: false`, and `release.yml` rebuilds from `./Dockerfile` independently.
- Run Player E2E on push only. Its internal `dorny/paths-filter` treats `lib/**`, `config/**`, `priv/**`, `mix.exs` and `Dockerfile` as relevant by design, so backend PRs paid the full 20 minutes. The filter is left in place and goes inert on its own, keeping a revert to a one-line change.
- Rename the relay workflow's `Test` job to `Relay / Test`, which frees a required check context that `ci.yml` and `ci-relay.yml` were both emitting under integration id 15368.

The required check list was reduced from 7 contexts to 3 (`Test`, `Test / PostgreSQL`, `Test / E2E Browser`) before this PR was opened, because four of the seven stop reporting on PRs as of this change and would otherwise have deadlocked it.

Expected effect on a backend-only PR: 6 jobs and roughly 37 runner-minutes, down from 13 jobs and 121 minutes, with wall clock going from about 20 minutes to about 14.

Accepted tradeoff: the NixOS module, the Docker image, the nix package, and the player suites can now break on master. All surface on push within about 25 minutes, and release rebuilds Docker independently.

Note that this PR itself edits `.github/workflows/ci-player.yml`, so `CI / Player Desktop` runs here and exercises the moved `Test / Player` job.
