### PR TITLE
fix(subtitles): give the relay client a default URL, and ship the relay's OpenSubtitles credentials

### DIFF
--- a/infra/config.yaml.example
+++ b/infra/config.yaml.example
@@ -23,6 +23,16 @@ relay_tvdb_api_key: "your-tvdb-api-key"
 # TMDB API key from: https://www.themoviedb.org/settings/api
 relay_tmdb_api_key: "your-tmdb-api-key"
 
+# OpenSubtitles account backing the relay's subtitle endpoints.
+# All three must be set together, or the relay disables subtitle support and
+# answers /api/v1/subtitles/* with 503. Mydia enables its "Mydia Relay" subtitle
+# provider by default, so leaving these blank means every install that has not
+# configured its own provider gets no subtitle results.
+# API key from: https://www.opensubtitles.com/en/consumers
+relay_opensubtitles_api_key: ""
+relay_opensubtitles_username: ""
+relay_opensubtitles_password: ""
+
 # Feedback email notifications (optional)
 # All six fields below must be set together for the relay to send feedback emails.
 # Leave blank to disable. Stored locally only — never committed to git.

--- a/infra/deploy
+++ b/infra/deploy
@@ -96,6 +96,12 @@ class Config:
     relay_tmdb_api_key: str = ""
     relay_smtp_password: str = ""
 
+    # OpenSubtitles, which backs the relay's subtitle endpoints (optional; leave
+    # blank and the relay answers /api/v1/subtitles/* with 503 not-configured)
+    relay_opensubtitles_api_key: str = ""
+    relay_opensubtitles_username: str = ""
+    relay_opensubtitles_password: str = ""
+
     # Feedback email notifications (optional; leave blank to disable)
     relay_smtp_host: str = ""
     relay_smtp_port: str = ""
@@ -182,6 +188,9 @@ class Config:
             "relay_tvdb_api_key": self.relay_tvdb_api_key,
             "relay_tmdb_api_key": self.relay_tmdb_api_key,
             "relay_smtp_password": self.relay_smtp_password,
+            "relay_opensubtitles_api_key": self.relay_opensubtitles_api_key,
+            "relay_opensubtitles_username": self.relay_opensubtitles_username,
+            "relay_opensubtitles_password": self.relay_opensubtitles_password,
             "relay_smtp_host": self.relay_smtp_host,
             "relay_smtp_port": self.relay_smtp_port,
             "relay_smtp_username": self.relay_smtp_username,
@@ -1022,6 +1031,18 @@ def metadata_relay_secret_data(config: Config) -> dict[str, str]:
 
     if config.relay_smtp_password:
         data["SMTP_PASSWORD"] = config.relay_smtp_password
+
+    # All three are required together: MetadataRelay.Application treats a partial
+    # set as unconfigured, so shipping one or two would leave the subtitle
+    # endpoints answering 503 while looking configured from here.
+    opensubtitles = {
+        "OPENSUBTITLES_API_KEY": config.relay_opensubtitles_api_key,
+        "OPENSUBTITLES_USERNAME": config.relay_opensubtitles_username,
+        "OPENSUBTITLES_PASSWORD": config.relay_opensubtitles_password,
+    }
+
+    if all(opensubtitles.values()):
+        data.update(opensubtitles)
 
     return data
 

--- a/infra/kubernetes/apps/metadata-relay/secret.yaml.example
+++ b/infra/kubernetes/apps/metadata-relay/secret.yaml.example
@@ -25,10 +25,15 @@ stringData:
   # Resend API key (re_...). For any other SMTP provider, use its password.
   SMTP_PASSWORD: "your-smtp-password-or-resend-api-key"
 
-  # OPTIONAL: OpenSubtitles credentials (if subtitle support is needed)
-  # OPENSUBTITLES_API_KEY: "your-opensubtitles-api-key"
-  # OPENSUBTITLES_USERNAME: "your-opensubtitles-username"
-  # OPENSUBTITLES_PASSWORD: "your-opensubtitles-password"
+  # REQUIRED for subtitle search. Mydia enables its "Mydia Relay" subtitle
+  # provider by default, so without these the relay answers
+  # /api/v1/subtitles/* with 503 and every install that has not configured its
+  # own provider gets no subtitle results. All three are needed together --
+  # a partial set disables subtitle support just as completely as none.
+  # API key from: https://www.opensubtitles.com/en/consumers
+  OPENSUBTITLES_API_KEY: "your-opensubtitles-api-key"
+  OPENSUBTITLES_USERNAME: "your-opensubtitles-username"
+  OPENSUBTITLES_PASSWORD: "your-opensubtitles-password"
 
 ---
 # Instructions:

--- a/lib/mydia/subtitles/client/metadata_relay.ex
+++ b/lib/mydia/subtitles/client/metadata_relay.ex
@@ -23,7 +23,10 @@ defmodule Mydia.Subtitles.Client.MetadataRelay do
         base_url: "http://localhost:4001",
         timeout: 10_000
 
-  The base URL can also be configured via the `METADATA_RELAY_URL` environment variable.
+  The base URL can also be configured via the `METADATA_RELAY_URL` environment
+  variable. When nothing is configured the client uses the shared default from
+  `Mydia.Metadata.metadata_relay_url/0`, so the relay provider works on an
+  install that sets none of this. See `base_url/0` for the full precedence.
 
   ## Caching
 
@@ -85,7 +88,7 @@ defmodule Mydia.Subtitles.Client.MetadataRelay do
       {:ok, %{"subtitles" => [%{"id" => 12345, "language" => "en", ...}]}}
 
       iex> search(%{file_hash: "abc123", file_size: 123456})
-      {:error, :metadata_relay_not_configured}
+      {:ok, %{"subtitles" => []}}
 
   """
   @spec search(map(), keyword()) :: {:ok, map()} | {:error, term()}
@@ -124,13 +127,13 @@ defmodule Mydia.Subtitles.Client.MetadataRelay do
   """
   @spec get_download_url(integer() | String.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def get_download_url(file_id, opts \\ []) do
-    base_url = get_base_url()
+    base = base_url()
     timeout = Keyword.get(opts, :timeout, @timeout)
 
-    if base_url == "" do
+    if base == "" do
       {:error, :metadata_relay_not_configured}
     else
-      url = "#{base_url}/api/v1/subtitles/download-url/#{file_id}"
+      url = "#{base}/api/v1/subtitles/download-url/#{file_id}"
 
       Logger.debug("Fetching subtitle download URL",
         file_id: file_id,
@@ -144,13 +147,13 @@ defmodule Mydia.Subtitles.Client.MetadataRelay do
   ## Private Functions
 
   defp perform_search(params, opts) do
-    base_url = get_base_url()
+    base = base_url()
     timeout = Keyword.get(opts, :timeout, @timeout)
 
-    if base_url == "" do
+    if base == "" do
       {:error, :metadata_relay_not_configured}
     else
-      url = "#{base_url}/api/v1/subtitles/search"
+      url = "#{base}/api/v1/subtitles/search"
 
       Logger.debug("Searching metadata-relay for subtitles",
         params: inspect(params),
@@ -423,13 +426,31 @@ defmodule Mydia.Subtitles.Client.MetadataRelay do
     (@initial_backoff * :math.pow(2, retry_count)) |> round()
   end
 
-  # Configuration helpers
-  defp get_base_url do
-    # Try subtitle-specific URL first, then fall back to general metadata relay URL
+  @doc """
+  Returns the metadata-relay base URL this client talks to.
+
+  Subtitle-specific configuration wins, then general relay configuration, then
+  the environment. When none of those are set the shared default from
+  `Mydia.Metadata.metadata_relay_url/0` applies, which is what makes the relay
+  provider work on an install that configures nothing.
+  """
+  @spec base_url() :: String.t()
+  def base_url do
+    # The final clause is the same resolver every other relay consumer uses, and
+    # it carries the https://relay.mydia.dev default. This chain used to end in
+    # "" instead, so an install that never sets METADATA_RELAY_URL -- the normal
+    # self-hosted case -- failed every subtitle search with
+    # :metadata_relay_not_configured while metadata lookups on that same install
+    # worked, because they went through the shared resolver and got the default.
+    #
+    # METADATA_RELAY_URL stays listed explicitly rather than being left to the
+    # final clause: it has always outranked SUBTITLE_RELAY_URL here, and folding
+    # it into the fallback would silently invert that for an operator setting
+    # both.
     Application.get_env(:mydia, :subtitle_relay_url) ||
       Application.get_env(:mydia, :metadata_relay_url) ||
       System.get_env("METADATA_RELAY_URL") ||
       System.get_env("SUBTITLE_RELAY_URL") ||
-      ""
+      Mydia.Metadata.metadata_relay_url()
   end
 end

--- a/test/mydia/subtitles/client/metadata_relay_test.exs
+++ b/test/mydia/subtitles/client/metadata_relay_test.exs
@@ -1,0 +1,105 @@
+defmodule Mydia.Subtitles.Client.MetadataRelayTest do
+  # Not async: these tests clear and restore the global application and system
+  # environment that production relay configuration is read from. ExUnit runs
+  # sync modules serially after every async module has finished, so no
+  # concurrent test can observe the cleared window.
+  use ExUnit.Case, async: false
+
+  alias Mydia.Subtitles.Client.MetadataRelay
+
+  setup do
+    original = %{
+      subtitle_app: Application.get_env(:mydia, :subtitle_relay_url),
+      metadata_app: Application.get_env(:mydia, :metadata_relay_url),
+      metadata_env: System.get_env("METADATA_RELAY_URL"),
+      subtitle_env: System.get_env("SUBTITLE_RELAY_URL")
+    }
+
+    Application.delete_env(:mydia, :subtitle_relay_url)
+    Application.delete_env(:mydia, :metadata_relay_url)
+    System.delete_env("METADATA_RELAY_URL")
+    System.delete_env("SUBTITLE_RELAY_URL")
+
+    on_exit(fn ->
+      restore_app_env(:subtitle_relay_url, original.subtitle_app)
+      restore_app_env(:metadata_relay_url, original.metadata_app)
+      restore_system_env("METADATA_RELAY_URL", original.metadata_env)
+      restore_system_env("SUBTITLE_RELAY_URL", original.subtitle_env)
+    end)
+
+    :ok
+  end
+
+  describe "base_url/0" do
+    # The registry enables the relay provider by default (default_enabled: true)
+    # on the stated promise that it needs no setup, and every other relay
+    # consumer reaches the service through Mydia.Metadata.metadata_relay_url/0,
+    # which carries the https://relay.mydia.dev default. This client resolved
+    # its own URL and ended the chain with "", so a default install -- one that
+    # never sets METADATA_RELAY_URL, which is the normal self-hosted case --
+    # failed every subtitle search with :metadata_relay_not_configured while
+    # metadata lookups on the same install worked fine.
+    test "falls back to the shared relay default when nothing is configured" do
+      assert MetadataRelay.base_url() == Mydia.Metadata.metadata_relay_url()
+      refute MetadataRelay.base_url() == ""
+    end
+
+    test "prefers the subtitle-specific application config over everything else" do
+      Application.put_env(:mydia, :subtitle_relay_url, "http://subtitle-app.test")
+      Application.put_env(:mydia, :metadata_relay_url, "http://metadata-app.test")
+      System.put_env("METADATA_RELAY_URL", "http://metadata-env.test")
+      System.put_env("SUBTITLE_RELAY_URL", "http://subtitle-env.test")
+
+      assert MetadataRelay.base_url() == "http://subtitle-app.test"
+    end
+
+    test "prefers the general application config over the environment" do
+      Application.put_env(:mydia, :metadata_relay_url, "http://metadata-app.test")
+      System.put_env("METADATA_RELAY_URL", "http://metadata-env.test")
+
+      assert MetadataRelay.base_url() == "http://metadata-app.test"
+    end
+
+    # Guards the existing precedence: METADATA_RELAY_URL has always outranked
+    # SUBTITLE_RELAY_URL here, and adding the default must not quietly reorder
+    # the two for an operator who sets both.
+    test "prefers METADATA_RELAY_URL over SUBTITLE_RELAY_URL" do
+      System.put_env("METADATA_RELAY_URL", "http://metadata-env.test")
+      System.put_env("SUBTITLE_RELAY_URL", "http://subtitle-env.test")
+
+      assert MetadataRelay.base_url() == "http://metadata-env.test"
+    end
+
+    test "uses SUBTITLE_RELAY_URL when it is the only thing set" do
+      System.put_env("SUBTITLE_RELAY_URL", "http://subtitle-env.test")
+
+      assert MetadataRelay.base_url() == "http://subtitle-env.test"
+    end
+  end
+
+  describe "search/2 on an unconfigured install" do
+    # The production symptom this fix targets: the search short-circuited
+    # before any request was made, and the provider chain surfaced it as
+    # {:all_providers_failed, [{"Mydia Relay", "Search failed:
+    # :metadata_relay_not_configured"}]}.
+    test "reaches the default relay instead of reporting itself unconfigured" do
+      bypass = Bypass.open()
+      System.put_env("METADATA_RELAY_URL", "http://localhost:#{bypass.port}")
+
+      Bypass.expect_once(bypass, "POST", "/api/v1/subtitles/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"subtitles" => []}))
+      end)
+
+      assert {:ok, %{"subtitles" => []}} =
+               MetadataRelay.search(%{imdb_id: "0133093", languages: "en"})
+    end
+  end
+
+  defp restore_app_env(key, nil), do: Application.delete_env(:mydia, key)
+  defp restore_app_env(key, value), do: Application.put_env(:mydia, key, value)
+
+  defp restore_system_env(key, nil), do: System.delete_env(key)
+  defp restore_system_env(key, value), do: System.put_env(key, value)
+end


### PR DESCRIPTION
Subtitle search fails on a default install with:

```
{:all_providers_failed,
 [{"Mydia Relay", "Search failed: :metadata_relay_not_configured"}]}
```

Two independent defects produce it. Both are needed for subtitle search to work.

## 1. The client never had a default relay URL

`Mydia.Subtitles.Client.MetadataRelay` resolved its own base URL and ended the chain with `""`. Every other relay consumer goes through `Mydia.Metadata.metadata_relay_url/0`, which carries the `https://relay.mydia.dev` default, and nothing in `config/*.exs` sets either key. So on any install that does not set `METADATA_RELAY_URL` (the normal self-hosted case) subtitle search failed instantly while metadata lookups on that same install worked.

The provider registry enables this provider by default on the stated promise that it needs no setup, so that promise was never true.

Confirmed on the production instance: all four configuration sources are `nil`, and the shared resolver returns the default.

Fixed by ending the chain at the shared resolver. `METADATA_RELAY_URL` stays listed explicitly so it keeps outranking `SUBTITLE_RELAY_URL` for anyone setting both. Resolution is exposed as `base_url/0` so the precedence is testable without reaching the network for the no-configuration case.

Gestdown is `media_types: [:episode], search_keys: [:tvdb_id]`, which is why it was filtered out before the search ran and the relay was the only provider in the error.

## 2. The deployed relay has no OpenSubtitles credentials

`POST https://relay.mydia.dev/api/v1/subtitles/search` currently answers:

```
503 {"error":"Service not configured",
     "message":"OpenSubtitles integration is not configured. ..."}
```

`metadata_relay_secret_data()` in `infra/deploy` built `metadata-relay-secrets` from the TMDB and TVDB keys only, and the `OPENSUBTITLES_*` keys were commented out in the secret template. The secret is recreated on each deploy, so adding them to the live secret by hand would not survive either.

This PR adds the three fields and ships them in the secret. They travel together or not at all: `MetadataRelay.Application` requires all three before starting the OpenSubtitles auth process, so a partial set would look configured in the deploy tool while leaving subtitle support off. No values are committed, only field names and placeholders.

## What still has to happen after merge

Defect 2 needs real credentials. Until an OpenSubtitles account is filled into `infra/config.yaml` and the relay redeployed, the client fix alone changes the failure mode without fixing it. Measured against the live relay:

```
base_url   => https://relay.mydia.dev
elapsed_ms => 7280
result     => {:error, :service_unavailable}
```

The 503 is retried three times with 1s/2s/4s backoff, so the user waits ~7.3s instead of failing instantly, and it lands close enough to `ProviderChain`'s 8s deadline that a slightly slower relay reports a timeout instead.

## Follow-up worth considering separately

`handle_service_unavailable/5` retries a 503 as if it were transient, but the relay uses 503 for permanent misconfiguration too. Distinguishing "not configured" from "temporarily down" would avoid burning 7s per search on a condition that cannot resolve on its own. Left out of this PR to keep it to the root cause.

## Verification

- New `test/mydia/subtitles/client/metadata_relay_test.exs` covers the default fallback plus all four override precedence rules; the default-fallback test fails on `master`.
- `mix precommit`: 7509 tests, 0 failures, Credo clean, formatted.
- `infra/deploy` exercised directly: unset and partial credential sets are omitted from the secret, a full set is carried, and `save()` persists the new keys.
