### PR TITLE
fix(watch-sync): map Plex TV episodes and re-crawl mappings on an interval

### DIFF
--- a/lib/mydia/jobs/media_server_watched_sync.ex
+++ b/lib/mydia/jobs/media_server_watched_sync.ex
@@ -150,6 +150,10 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
         # rather than the feature.
         run = start_run(config, scope.user_id, direction)
         refresh = refresh_mode(config)
+        # Captured before the claim overwrites it, so a failed sync can put it
+        # back. See restore_mapping_refresh/3.
+        previous_mapping_refresh_at =
+          get_in_connection_settings(config, "last_mapping_refresh_at")
 
         # Rebound deliberately: the claim writes connection_settings, and the
         # later update_last_sync_timestamp/1 merges into whatever config it is
@@ -174,11 +178,21 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
           # the UI could say why. Recorded as a skip it reads like every other
           # credential problem on the page, and the operator gets told which
           # mapping to fix.
+          #
+          # Deliberately does NOT restore the mapping-refresh stamp (contrast
+          # the general clause below). These reasons surface only from
+          # list_changes/3, which runs after maybe_refresh/5 -- the crawl --
+          # already completed, so the crawl this claim was for did happen. A
+          # misconfigured link also persists across ticks rather than clearing
+          # itself, so restoring here would force a full library re-crawl on
+          # every 30-minute tick for as long as the credential stays broken,
+          # exactly the cost the 24h interval exists to avoid.
           {:error, reason} when reason in @misconfigured ->
             skip(config, reason, scope.user_id, run)
 
           {:error, reason} ->
             finish_run(run, :error, %{}, describe_error(reason))
+            restore_mapping_refresh(config, refresh, previous_mapping_refresh_at)
             {:error, reason}
         end
       end
@@ -385,12 +399,18 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
   end
 
   # `:force` when no crawl has ever been recorded, when the stamp cannot be
-  # read, or when it has aged past the interval.
+  # read, when it has aged past the interval, or when it is in the future.
+  # A future stamp only happens from clock skew or a hand-edited
+  # connection_settings value, but left alone it would make the diff negative
+  # and pin the mode at :auto until the wall clock caught up to it, silently
+  # withholding the crawl for however long that takes.
   defp refresh_mode(config) do
     with value when is_binary(value) <-
            get_in_connection_settings(config, "last_mapping_refresh_at"),
          {:ok, at, _offset} <- DateTime.from_iso8601(value) do
-      if DateTime.diff(DateTime.utc_now(), at, :second) >= @mapping_refresh_interval_seconds,
+      age_seconds = DateTime.diff(DateTime.utc_now(), at, :second)
+
+      if age_seconds < 0 or age_seconds >= @mapping_refresh_interval_seconds,
         do: :force,
         else: :auto
     else
@@ -400,8 +420,12 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
 
   # Stamped before the sync runs, not after it succeeds. A server with several
   # linked users fans out one job per user on the same tick, and stamping on
-  # success would have every one of them crawl the whole library. Claiming it up
-  # front means the first job crawls and the rest read a fresh stamp.
+  # success would have every one of them crawl the whole library. Claiming it
+  # up front cuts that down, though not to exactly one: the `integrations`
+  # queue runs with concurrency 2, so up to two same-tick workers for one
+  # config can both read the stale stamp before either writes theirs, and both
+  # crawl. What claiming guarantees is at most one crawl per concurrent
+  # worker; any job beyond that reads the fresh stamp and skips it.
   #
   # The cost is that a run failing after a forced crawl waits for the next
   # interval instead of retrying immediately. That is acceptable: the crawl is
@@ -416,6 +440,41 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
       {:error, reason} ->
         Logger.warning("Could not claim mapping refresh for #{config.name}: #{inspect(reason)}")
         config
+    end
+  end
+
+  # Undoes claim_mapping_refresh/2's stamp on a general sync failure.
+  # WatchSync.sync/4 (Engine.sync/4) crawls before it does anything else --
+  # maybe_refresh/5 runs first -- so a failure reaching this branch most
+  # likely happened during or before the crawl, not after it. Left standing,
+  # the stamp would claim a crawl that never finished, and the next tick's
+  # refresh_mode/1 would read it as fresh and silently stay on :auto. Putting
+  # the previous value back (or clearing the key when there was none) makes
+  # refresh_mode/1 force again on the next attempt.
+  #
+  # A no-op when refresh was :auto: claim_mapping_refresh/2 never wrote
+  # anything in that case, so there is nothing to restore.
+  defp restore_mapping_refresh(_config, :auto, _previous_value), do: :ok
+
+  defp restore_mapping_refresh(config, :force, nil) do
+    settings = Map.delete(config.connection_settings || %{}, "last_mapping_refresh_at")
+
+    case Settings.update_media_server_config(config, %{connection_settings: settings}) do
+      {:ok, _updated} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Could not restore mapping refresh for #{config.name}: #{inspect(reason)}")
+    end
+  end
+
+  defp restore_mapping_refresh(config, :force, previous_value) do
+    case put_connection_setting(config, "last_mapping_refresh_at", previous_value) do
+      {:ok, _updated} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Could not restore mapping refresh for #{config.name}: #{inspect(reason)}")
     end
   end
 

--- a/lib/mydia/jobs/media_server_watched_sync.ex
+++ b/lib/mydia/jobs/media_server_watched_sync.ex
@@ -29,6 +29,13 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
   # wants an account GUID.
   @misconfigured [:missing_user_token, :missing_remote_user_id]
 
+  # A mapping crawl is the expensive call, so it does not run on every tick. But
+  # the engine only crawls an instance that has no mappings at all, which means
+  # it runs exactly once in an instance's life: media added later is never
+  # mapped, and a fix to id matching is never picked up. Re-crawling on an
+  # interval is what makes both self-healing.
+  @mapping_refresh_interval_seconds 24 * 60 * 60
+
   alias Mydia.MediaServer.Error
   alias Mydia.Repo
   alias Mydia.Settings
@@ -142,10 +149,17 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
         # there to explain what happened, so losing it degrades observability
         # rather than the feature.
         run = start_run(config, scope.user_id, direction)
+        refresh = refresh_mode(config)
+
+        # Rebound deliberately: the claim writes connection_settings, and the
+        # later update_last_sync_timestamp/1 merges into whatever config it is
+        # handed. Passing the stale struct would drop the stamp we just wrote.
+        config = claim_mapping_refresh(config, refresh)
 
         case WatchSync.sync(provider, config, scope,
                provider: to_string(config.type),
-               direction: direction
+               direction: direction,
+               refresh_mappings: refresh
              ) do
           {:ok, stats} ->
             finish_run(run, :ok, stats, nil)
@@ -370,12 +384,47 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
     end
   end
 
+  # `:force` when no crawl has ever been recorded, when the stamp cannot be
+  # read, or when it has aged past the interval.
+  defp refresh_mode(config) do
+    with value when is_binary(value) <-
+           get_in_connection_settings(config, "last_mapping_refresh_at"),
+         {:ok, at, _offset} <- DateTime.from_iso8601(value) do
+      if DateTime.diff(DateTime.utc_now(), at, :second) >= @mapping_refresh_interval_seconds,
+        do: :force,
+        else: :auto
+    else
+      _ -> :force
+    end
+  end
+
+  # Stamped before the sync runs, not after it succeeds. A server with several
+  # linked users fans out one job per user on the same tick, and stamping on
+  # success would have every one of them crawl the whole library. Claiming it up
+  # front means the first job crawls and the rest read a fresh stamp.
+  #
+  # The cost is that a run failing after a forced crawl waits for the next
+  # interval instead of retrying immediately. That is acceptable: the crawl is
+  # idempotent upserts, so whatever it wrote persists.
+  defp claim_mapping_refresh(config, :auto), do: config
+
+  defp claim_mapping_refresh(config, :force) do
+    case put_connection_setting(config, "last_mapping_refresh_at", iso_now()) do
+      {:ok, updated} -> updated
+      {:error, _reason} -> config
+    end
+  end
+
   defp update_last_sync_timestamp(config) do
-    current_settings = config.connection_settings || %{}
-    now = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+    put_connection_setting(config, "last_watched_sync_at", iso_now())
+  end
 
-    updated_settings = Map.put(current_settings, "last_watched_sync_at", now)
+  defp put_connection_setting(config, key, value) do
+    settings = Map.put(config.connection_settings || %{}, key, value)
+    Settings.update_media_server_config(config, %{connection_settings: settings})
+  end
 
-    Settings.update_media_server_config(config, %{connection_settings: updated_settings})
+  defp iso_now do
+    DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
   end
 end

--- a/lib/mydia/jobs/media_server_watched_sync.ex
+++ b/lib/mydia/jobs/media_server_watched_sync.ex
@@ -410,8 +410,12 @@ defmodule Mydia.Jobs.MediaServerWatchedSync do
 
   defp claim_mapping_refresh(config, :force) do
     case put_connection_setting(config, "last_mapping_refresh_at", iso_now()) do
-      {:ok, updated} -> updated
-      {:error, _reason} -> config
+      {:ok, updated} ->
+        updated
+
+      {:error, reason} ->
+        Logger.warning("Could not claim mapping refresh for #{config.name}: #{inspect(reason)}")
+        config
     end
   end
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -184,10 +184,28 @@ defmodule Mydia.Media do
   @spec find_by_external_ids(map(), keyword()) :: MediaItem.t() | nil
   def find_by_external_ids(ids, opts \\ []) when is_map(ids) do
     type = Keyword.get(opts, :type)
+    validate_external_id_type!(type)
 
     find_by_imdb(Map.get(ids, :imdb), type) ||
       find_by_tvdb(Map.get(ids, :tvdb), type) ||
       find_by_tmdb(Map.get(ids, :tmdb), type)
+  end
+
+  # `nil` means "no filter" and is always valid. Anything else must be one of
+  # MediaItem's own valid types. An unrecognised value such as `"tvshow"`
+  # (missing the underscore) would otherwise silently make every lookup
+  # return nil via a `where` clause that matches nothing, which reads exactly
+  # like a total mapping failure rather than the typo it is.
+  defp validate_external_id_type!(nil), do: :ok
+
+  defp validate_external_id_type!(type) do
+    if type in MediaItem.valid_types() do
+      :ok
+    else
+      raise ArgumentError,
+            "invalid :type #{inspect(type)} for find_by_external_ids/2, " <>
+              "expected nil or one of #{inspect(MediaItem.valid_types())}"
+    end
   end
 
   defp find_by_imdb(nil, _type), do: nil
@@ -199,22 +217,63 @@ defmodule Mydia.Media do
   defp find_by_tvdb(nil, _type), do: nil
 
   defp find_by_tvdb(tvdb, type) do
-    MediaItem |> where([m], m.tvdb_id == ^tvdb) |> external_id_match(type)
+    case parse_external_id(tvdb) do
+      nil -> nil
+      id -> MediaItem |> where([m], m.tvdb_id == ^id) |> external_id_match(type)
+    end
   end
 
   defp find_by_tmdb(nil, _type), do: nil
 
   defp find_by_tmdb(tmdb, type) do
-    MediaItem |> where([m], m.tmdb_id == ^tmdb) |> external_id_match(type)
+    case parse_external_id(tmdb) do
+      nil -> nil
+      id -> MediaItem |> where([m], m.tmdb_id == ^id) |> external_id_match(type)
+    end
   end
+
+  # tvdb_id and tmdb_id are :integer columns, so Ecto's query planner raises
+  # Ecto.Query.CastError when an interpolated param cannot be cast, rather
+  # than returning nil. The crawl feeds these columns raw provider strings --
+  # whatever follows `tvdb://` in a Plex GUID, or a Jellyfin `ProviderIds`
+  # value, passed through untouched -- so a malformed id must fail closed
+  # here (returning nil so the cascade continues to the next id) instead of
+  # raising inside Engine.do_refresh/4's bare Enum.each and aborting every
+  # remaining item in the crawl.
+  #
+  # Integer.parse/1 is used deliberately over String.to_integer/1, which
+  # raises on non-numeric input rather than returning an error value.
+  # Trailing garbage is rejected outright: Integer.parse/1 returns
+  # `{123, "abc"}` for "123abc", and that partial parse is not the same id as
+  # 123, so anything left over after the digits is treated as a non-match.
+  defp parse_external_id(id) when is_integer(id), do: id
+
+  defp parse_external_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {value, ""} -> value
+      _ -> nil
+    end
+  end
+
+  defp parse_external_id(_id), do: nil
 
   # `limit(1)` rather than a bare `Repo.one/1`: imdb_id carries no unique index,
   # so a duplicate would raise Ecto.MultipleResultsError partway through a crawl
-  # and abort every remaining item.
-  defp external_id_match(query, nil), do: query |> limit(1) |> Repo.one()
+  # and abort every remaining item. `order_by` makes the pick among duplicates
+  # deterministic (oldest first) rather than left to whatever order the
+  # database happens to return, which on PostgreSQL is not guaranteed to be
+  # insertion order -- and the crawl now repeats daily, so a nondeterministic
+  # pick could flip the stored mapping between runs.
+  defp external_id_match(query, nil),
+    do: query |> order_by([m], asc: m.inserted_at) |> limit(1) |> Repo.one()
 
-  defp external_id_match(query, type),
-    do: query |> where([m], m.type == ^type) |> limit(1) |> Repo.one()
+  defp external_id_match(query, type) do
+    query
+    |> where([m], m.type == ^type)
+    |> order_by([m], asc: m.inserted_at)
+    |> limit(1)
+    |> Repo.one()
+  end
 
   @doc """
   Finds an episode by show ID, season number, and episode number.

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -166,21 +166,55 @@ defmodule Mydia.Media do
   Finds a media item by external IDs using cascading lookup: IMDB → TVDB → TMDB.
 
   Accepts a map with atom keys: `%{imdb: id, tvdb: id, tmdb: id}`.
+
+  The cascade advances on a lookup *miss*, not on a missing id. Branching on
+  mere presence is what left every Plex episode unmapped: Plex supplies an imdb
+  id for every show, while Mydia stores tvdb and tmdb for shows and no imdb at
+  all, so the imdb branch was always taken and always missed.
+
+  ## Options
+
+    * `:type` - `"movie"` or `"tv_show"`. When set, a row of a different type is
+      not a match and the cascade continues to the next id. Callers that address
+      a movie or a show specifically should pass it. Callers that legitimately
+      accept either, such as `Mydia.Plugins.Matcher.match_item/1`, should not.
+
   Returns nil if no match is found.
   """
-  @spec find_by_external_ids(map()) :: MediaItem.t() | nil
-  def find_by_external_ids(ids) when is_map(ids) do
-    imdb = Map.get(ids, :imdb)
-    tvdb = Map.get(ids, :tvdb)
-    tmdb = Map.get(ids, :tmdb)
+  @spec find_by_external_ids(map(), keyword()) :: MediaItem.t() | nil
+  def find_by_external_ids(ids, opts \\ []) when is_map(ids) do
+    type = Keyword.get(opts, :type)
 
-    cond do
-      imdb -> Repo.get_by(MediaItem, imdb_id: imdb)
-      tvdb -> Repo.get_by(MediaItem, tvdb_id: tvdb)
-      tmdb -> Repo.get_by(MediaItem, tmdb_id: tmdb)
-      true -> nil
-    end
+    find_by_imdb(Map.get(ids, :imdb), type) ||
+      find_by_tvdb(Map.get(ids, :tvdb), type) ||
+      find_by_tmdb(Map.get(ids, :tmdb), type)
   end
+
+  defp find_by_imdb(nil, _type), do: nil
+
+  defp find_by_imdb(imdb, type) do
+    MediaItem |> where([m], m.imdb_id == ^imdb) |> external_id_match(type)
+  end
+
+  defp find_by_tvdb(nil, _type), do: nil
+
+  defp find_by_tvdb(tvdb, type) do
+    MediaItem |> where([m], m.tvdb_id == ^tvdb) |> external_id_match(type)
+  end
+
+  defp find_by_tmdb(nil, _type), do: nil
+
+  defp find_by_tmdb(tmdb, type) do
+    MediaItem |> where([m], m.tmdb_id == ^tmdb) |> external_id_match(type)
+  end
+
+  # `limit(1)` rather than a bare `Repo.one/1`: imdb_id carries no unique index,
+  # so a duplicate would raise Ecto.MultipleResultsError partway through a crawl
+  # and abort every remaining item.
+  defp external_id_match(query, nil), do: query |> limit(1) |> Repo.one()
+
+  defp external_id_match(query, type),
+    do: query |> where([m], m.type == ^type) |> limit(1) |> Repo.one()
 
   @doc """
   Finds an episode by show ID, season number, and episode number.

--- a/lib/mydia/plugins/matcher.ex
+++ b/lib/mydia/plugins/matcher.ex
@@ -17,8 +17,10 @@ defmodule Mydia.Plugins.Matcher do
       anti-pattern).
     * No coordinates → the external ids identify a movie.
 
-  External ids are resolved through `Mydia.Media.find_by_external_ids/1`, which
-  cascades imdb → tvdb → tmdb.
+  External ids are resolved through `Mydia.Media.find_by_external_ids/2`, which
+  cascades imdb → tvdb → tmdb, advancing on a lookup miss rather than a missing
+  id. `match/1` pins the expected type so a movie id cannot resolve to a show,
+  while `match_item/1` deliberately accepts either.
   """
 
   alias Mydia.Media
@@ -63,14 +65,14 @@ defmodule Mydia.Plugins.Matcher do
   end
 
   defp match_movie(ids) do
-    case Media.find_by_external_ids(ids) do
+    case Media.find_by_external_ids(ids, type: "movie") do
       %{id: id} -> {:movie, id}
       _ -> :not_found
     end
   end
 
   defp match_episode(ids, season, number) do
-    with %{id: show_id} <- Media.find_by_external_ids(ids),
+    with %{id: show_id} <- Media.find_by_external_ids(ids, type: "tv_show"),
          %{id: episode_id} <- Media.find_episode(show_id, season, number) do
       {:episode, episode_id}
     else

--- a/lib/mydia/watch_sync/engine.ex
+++ b/lib/mydia/watch_sync/engine.ex
@@ -88,14 +88,14 @@ defmodule Mydia.WatchSync.Engine do
   end
 
   defp resolve_local(%{type: :movie} = mapping) do
-    case Media.find_by_external_ids(mapping.external_ids) do
+    case Media.find_by_external_ids(mapping.external_ids, type: "movie") do
       nil -> nil
       item -> [media_item_id: item.id]
     end
   end
 
   defp resolve_local(%{type: :episode} = mapping) do
-    with %{id: show_id} <- Media.find_by_external_ids(mapping.external_ids),
+    with %{id: show_id} <- Media.find_by_external_ids(mapping.external_ids, type: "tv_show"),
          %{id: ep_id} <-
            Media.find_episode(show_id, mapping.season_number, mapping.episode_number) do
       [episode_id: ep_id]

--- a/test/mydia/jobs/media_server_watched_sync_test.exs
+++ b/test/mydia/jobs/media_server_watched_sync_test.exs
@@ -812,12 +812,27 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
     end
 
     test "a fresh stamp is left alone on the next run", ctx do
-      first = run(ctx.config, ctx.user, ctx.link)
-      stamp = first.connection_settings["last_mapping_refresh_at"]
+      # A stamp within the last second would pass this assertion even if
+      # every run re-claimed unconditionally, since both timestamps would
+      # print identically at second precision. Seeding one an hour old (well
+      # inside the 24h window, so refresh_mode/1 reads :auto) and asserting
+      # byte-identity against the seeded string is what actually exercises
+      # "an :auto run must leave the stamp untouched".
+      fresh =
+        DateTime.utc_now()
+        |> DateTime.add(-1 * 60 * 60, :second)
+        |> DateTime.truncate(:second)
+        |> DateTime.to_iso8601()
 
-      second = run(first, ctx.user, ctx.link)
+      {:ok, config} =
+        Settings.update_media_server_config(ctx.config, %{
+          connection_settings:
+            Map.put(ctx.config.connection_settings, "last_mapping_refresh_at", fresh)
+        })
 
-      assert second.connection_settings["last_mapping_refresh_at"] == stamp
+      config = run(config, ctx.user, ctx.link)
+
+      assert config.connection_settings["last_mapping_refresh_at"] == fresh
     end
 
     test "a stamp older than the interval is refreshed", ctx do
@@ -855,6 +870,79 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
 
       assert is_binary(config.connection_settings["last_mapping_refresh_at"])
       assert is_binary(config.connection_settings["last_watched_sync_at"])
+    end
+  end
+
+  describe "mapping refresh forces a crawl" do
+    # No block-level setup here, deliberately: the block above's `setup`
+    # creates its own Bypass server before every test regardless of arity,
+    # and this test needs to control its Bypass instance precisely (to count
+    # hits), so it stays self-contained instead.
+    test "an auto run skips the crawl a forced run performs, per the /Items hit count" do
+      # Every test in the block above only asserts on the connection_settings
+      # stamp, which claim_mapping_refresh/2 writes independently of the
+      # `refresh_mappings: refresh` option threaded to WatchSync.sync/4. That
+      # leaves nothing distinguishing :auto from :force: this test does, by
+      # counting real Jellyfin /Items calls. A seeded mapping makes engine.ex's
+      # mapped_any?/2 true, so an :auto run calls /Items once (list_changes
+      # only); a :force run calls it twice (refresh_mappings's crawl, then
+      # list_changes).
+      bypass = Bypass.open()
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      Bypass.expect(bypass, "GET", "/Items", fn conn ->
+        Agent.update(counter, &(&1 + 1))
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"Items" => [], "TotalRecordCount" => 0}))
+      end)
+
+      user = user_fixture()
+      media_item = insert(:media_item)
+
+      {:ok, config} =
+        Settings.create_media_server_config(%{
+          name: "Jellyfin",
+          type: :jellyfin,
+          url: "http://localhost:#{bypass.port}",
+          token: "api-key",
+          enabled: true,
+          connection_settings: %{
+            "sync_watched" => true,
+            "last_mapping_refresh_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+          }
+        })
+
+      link = link_fixture(config, user)
+
+      {:ok, _mapping} =
+        %Mapping{}
+        |> Mapping.changeset(%{
+          provider: "jellyfin",
+          provider_instance_id: config.id,
+          media_item_id: media_item.id,
+          remote_id: "jf1"
+        })
+        |> Repo.insert()
+
+      auto_config = run(config, user, link)
+      assert Agent.get(counter, & &1) == 1
+
+      stale =
+        DateTime.utc_now()
+        |> DateTime.add(-25 * 60 * 60, :second)
+        |> DateTime.truncate(:second)
+        |> DateTime.to_iso8601()
+
+      {:ok, forced_config} =
+        Settings.update_media_server_config(auto_config, %{
+          connection_settings:
+            Map.put(auto_config.connection_settings, "last_mapping_refresh_at", stale)
+        })
+
+      run(forced_config, user, link)
+      assert Agent.get(counter, & &1) == 3
     end
   end
 

--- a/test/mydia/jobs/media_server_watched_sync_test.exs
+++ b/test/mydia/jobs/media_server_watched_sync_test.exs
@@ -850,7 +850,11 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
 
       config = run(config, ctx.user, ctx.link)
 
-      assert config.connection_settings["last_mapping_refresh_at"] != stale
+      stamp = config.connection_settings["last_mapping_refresh_at"]
+      assert stamp != stale
+      # A bug writing a garbage string would still change the value and pass
+      # the inequality check above; this proves the new value actually parses.
+      assert {:ok, _, _} = DateTime.from_iso8601(stamp)
     end
 
     test "an unreadable stamp is treated as never crawled", ctx do
@@ -862,7 +866,31 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
 
       config = run(config, ctx.user, ctx.link)
 
-      assert config.connection_settings["last_mapping_refresh_at"] != "not-a-timestamp"
+      stamp = config.connection_settings["last_mapping_refresh_at"]
+      assert stamp != "not-a-timestamp"
+      # A bug writing a garbage string would still change the value and pass
+      # the inequality check above; this proves the new value actually parses.
+      assert {:ok, _, _} = DateTime.from_iso8601(stamp)
+    end
+
+    test "a future stamp (clock skew) forces a crawl instead of pinning to auto", ctx do
+      future =
+        DateTime.utc_now()
+        |> DateTime.add(60 * 60, :second)
+        |> DateTime.truncate(:second)
+        |> DateTime.to_iso8601()
+
+      {:ok, config} =
+        Settings.update_media_server_config(ctx.config, %{
+          connection_settings:
+            Map.put(ctx.config.connection_settings, "last_mapping_refresh_at", future)
+        })
+
+      config = run(config, ctx.user, ctx.link)
+
+      stamp = config.connection_settings["last_mapping_refresh_at"]
+      assert stamp != future
+      assert {:ok, _, _} = DateTime.from_iso8601(stamp)
     end
 
     test "claiming a refresh does not clobber the last sync timestamp", ctx do
@@ -943,6 +971,148 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
 
       run(forced_config, user, link)
       assert Agent.get(counter, & &1) == 3
+    end
+  end
+
+  describe "mapping refresh claim is undone on a general failure" do
+    test "a crawl failure restores the pre-claim stamp instead of burning the 24h window" do
+      # No last_mapping_refresh_at at all, so refresh_mode/1 returns :force and
+      # claim_mapping_refresh/2 stamps it before WatchSync.sync/4 runs. The
+      # crawl (Engine.maybe_refresh/5, the first thing sync/4 does) then fails
+      # against a 500, landing in run_sync/2's general {:error, reason} clause.
+      # Without the fix, the claimed stamp would stay written, and the next
+      # tick's refresh_mode/1 would read it as fresh and silently skip the
+      # crawl it still owes.
+      bypass = Bypass.open()
+
+      Bypass.expect(bypass, "GET", "/Items", fn conn ->
+        Plug.Conn.resp(conn, 500, "boom")
+      end)
+
+      user = user_fixture()
+
+      {:ok, config} =
+        Settings.create_media_server_config(%{
+          name: "Jellyfin",
+          type: :jellyfin,
+          url: "http://localhost:#{bypass.port}",
+          token: "api-key",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      link = link_fixture(config, user)
+
+      refute Map.has_key?(config.connection_settings, "last_mapping_refresh_at")
+
+      assert {:error, _reason} =
+               perform_job(MediaServerWatchedSync, %{
+                 "config_id" => config.id,
+                 "user_id" => user.id,
+                 "link_id" => link.id
+               })
+
+      reloaded = Settings.get_media_server_config!(config.id)
+
+      refute Map.has_key?(reloaded.connection_settings, "last_mapping_refresh_at")
+
+      # The run itself is still recorded as a failure, same as before the fix.
+      run = Sync.last_run("jellyfin", config.id)
+      assert run.status == :error
+    end
+
+    test "a stale stamp is restored to its previous value, not merely cleared" do
+      stale =
+        DateTime.utc_now()
+        |> DateTime.add(-25 * 60 * 60, :second)
+        |> DateTime.truncate(:second)
+        |> DateTime.to_iso8601()
+
+      bypass = Bypass.open()
+
+      Bypass.expect(bypass, "GET", "/Items", fn conn ->
+        Plug.Conn.resp(conn, 500, "boom")
+      end)
+
+      user = user_fixture()
+
+      {:ok, config} =
+        Settings.create_media_server_config(%{
+          name: "Jellyfin",
+          type: :jellyfin,
+          url: "http://localhost:#{bypass.port}",
+          token: "api-key",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true, "last_mapping_refresh_at" => stale}
+        })
+
+      link = link_fixture(config, user)
+
+      assert {:error, _reason} =
+               perform_job(MediaServerWatchedSync, %{
+                 "config_id" => config.id,
+                 "user_id" => user.id,
+                 "link_id" => link.id
+               })
+
+      reloaded = Settings.get_media_server_config!(config.id)
+
+      assert reloaded.connection_settings["last_mapping_refresh_at"] == stale
+    end
+
+    test "a @misconfigured error keeps the claimed stamp, since the crawl already succeeded" do
+      # missing_remote_user_id surfaces from list_changes/3, which only runs
+      # after maybe_refresh/5 (the crawl) already completed. Restoring the
+      # stamp here would force a full re-crawl on every 30-minute tick for as
+      # long as the link stays unmapped, which is exactly the cost the 24h
+      # interval exists to avoid.
+      bypass = Bypass.open()
+
+      Bypass.expect(bypass, "GET", "/Items", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"Items" => [], "TotalRecordCount" => 0}))
+      end)
+
+      user = user_fixture()
+
+      {:ok, config} =
+        Settings.create_media_server_config(%{
+          name: "Jellyfin",
+          type: :jellyfin,
+          url: "http://localhost:#{bypass.port}",
+          token: "api-key",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      # No remote_user_id: list_changes/3 fails with :missing_remote_user_id,
+      # but only after the crawl (forced because no stamp exists yet) runs.
+      {:ok, link} =
+        Settings.upsert_media_server_user_link(%{
+          media_server_config_id: config.id,
+          user_id: user.id,
+          remote_user_id: nil,
+          access_token: "leftover-token",
+          enabled: true
+        })
+
+      refute Map.has_key?(config.connection_settings, "last_mapping_refresh_at")
+
+      assert {:ok, :skipped} =
+               perform_job(MediaServerWatchedSync, %{
+                 "config_id" => config.id,
+                 "user_id" => user.id,
+                 "link_id" => link.id
+               })
+
+      reloaded = Settings.get_media_server_config!(config.id)
+
+      assert is_binary(reloaded.connection_settings["last_mapping_refresh_at"])
+
+      run = Sync.last_run("jellyfin", config.id)
+      assert run.status == :skipped
+      assert run.skip_reason == "missing_remote_user_id"
     end
   end
 

--- a/test/mydia/jobs/media_server_watched_sync_test.exs
+++ b/test/mydia/jobs/media_server_watched_sync_test.exs
@@ -369,11 +369,12 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
       # credential. That silent fallback is exactly the merge bug per-user
       # links exist to prevent.
       #
-      # A mapping row is seeded so the sync skips its (legitimately
+      # A mapping row is seeded, and the config carries a fresh
+      # last_mapping_refresh_at, so the sync skips its (legitimately
       # admin-token-scoped) refresh crawl and calls straight into
-      # `list_changes/3`, which is the call this test is guarding. Without it,
-      # the assertion below could not tell a correct refusal apart from an
-      # unrelated connection failure against a URL with no real server.
+      # `list_changes/3`, which is the call this test is guarding. Without
+      # both, the assertion below could not tell a correct refusal apart from
+      # an unrelated connection failure against a URL with no real server.
       user = user_fixture()
       media_item = insert(:media_item)
 
@@ -384,7 +385,10 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
           url: "http://localhost:32400",
           token: "admin-token",
           enabled: true,
-          connection_settings: %{"sync_watched" => "true"}
+          connection_settings: %{
+            "sync_watched" => "true",
+            "last_mapping_refresh_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+          }
         })
 
       {:ok, link} =
@@ -442,7 +446,10 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
           url: "http://localhost:#{bypass.port}",
           token: "api-key",
           enabled: true,
-          connection_settings: %{"sync_watched" => "true"}
+          connection_settings: %{
+            "sync_watched" => "true",
+            "last_mapping_refresh_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+          }
         })
 
       # A token with no GUID is a valid-looking link that Jellyfin cannot use.
@@ -455,7 +462,8 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
           enabled: true
         })
 
-      # Seeded so the run skips its refresh crawl and calls straight into
+      # Seeded so the run skips its refresh crawl (the config above also
+      # carries a fresh last_mapping_refresh_at) and calls straight into
       # list_changes/3, the call under test.
       {:ok, _mapping} =
         %Mapping{}
@@ -768,6 +776,88 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
     end
   end
 
+  describe "mapping refresh staleness" do
+    setup do
+      bypass = Bypass.open()
+
+      Bypass.expect(bypass, "GET", "/Items", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"Items" => [], "TotalRecordCount" => 0}))
+      end)
+
+      user = user_fixture()
+
+      {:ok, config} =
+        Settings.create_media_server_config(%{
+          name: "Jellyfin",
+          type: :jellyfin,
+          url: "http://localhost:#{bypass.port}",
+          token: "api-key",
+          enabled: true,
+          connection_settings: %{"sync_watched" => true}
+        })
+
+      link = link_fixture(config, user)
+
+      {:ok, config: config, user: user, link: link}
+    end
+
+    test "a server that has never crawled claims a refresh", ctx do
+      refute Map.has_key?(ctx.config.connection_settings, "last_mapping_refresh_at")
+
+      config = run(ctx.config, ctx.user, ctx.link)
+
+      assert is_binary(config.connection_settings["last_mapping_refresh_at"])
+    end
+
+    test "a fresh stamp is left alone on the next run", ctx do
+      first = run(ctx.config, ctx.user, ctx.link)
+      stamp = first.connection_settings["last_mapping_refresh_at"]
+
+      second = run(first, ctx.user, ctx.link)
+
+      assert second.connection_settings["last_mapping_refresh_at"] == stamp
+    end
+
+    test "a stamp older than the interval is refreshed", ctx do
+      stale =
+        DateTime.utc_now()
+        |> DateTime.add(-25 * 60 * 60, :second)
+        |> DateTime.truncate(:second)
+        |> DateTime.to_iso8601()
+
+      {:ok, config} =
+        Settings.update_media_server_config(ctx.config, %{
+          connection_settings:
+            Map.put(ctx.config.connection_settings, "last_mapping_refresh_at", stale)
+        })
+
+      config = run(config, ctx.user, ctx.link)
+
+      assert config.connection_settings["last_mapping_refresh_at"] != stale
+    end
+
+    test "an unreadable stamp is treated as never crawled", ctx do
+      {:ok, config} =
+        Settings.update_media_server_config(ctx.config, %{
+          connection_settings:
+            Map.put(ctx.config.connection_settings, "last_mapping_refresh_at", "not-a-timestamp")
+        })
+
+      config = run(config, ctx.user, ctx.link)
+
+      assert config.connection_settings["last_mapping_refresh_at"] != "not-a-timestamp"
+    end
+
+    test "claiming a refresh does not clobber the last sync timestamp", ctx do
+      config = run(ctx.config, ctx.user, ctx.link)
+
+      assert is_binary(config.connection_settings["last_mapping_refresh_at"])
+      assert is_binary(config.connection_settings["last_watched_sync_at"])
+    end
+  end
+
   defp link_fixture(config, user, attrs \\ %{}) do
     {:ok, link} =
       Settings.upsert_media_server_user_link(
@@ -785,5 +875,16 @@ defmodule Mydia.Jobs.MediaServerWatchedSyncTest do
       )
 
     link
+  end
+
+  defp run(config, user, link) do
+    assert :ok =
+             perform_job(MediaServerWatchedSync, %{
+               "config_id" => config.id,
+               "user_id" => user.id,
+               "link_id" => link.id
+             })
+
+    Settings.get_media_server_config!(config.id)
   end
 end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -2310,5 +2310,95 @@ defmodule Mydia.MediaTest do
       assert %{id: id} = Media.find_by_external_ids(%{imdb: "tt999"})
       assert id == movie.id
     end
+
+    test "raises ArgumentError on an unrecognised :type" do
+      assert_raise ArgumentError, fn ->
+        Media.find_by_external_ids(%{imdb: "tt1"}, type: "tvshow")
+      end
+    end
+
+    test "type: nil applies no filter" do
+      {:ok, movie} =
+        Media.create_media_item(%{
+          title: "Untyped Filter",
+          type: "movie",
+          year: 2024,
+          imdb_id: "tt-untyped"
+        })
+
+      assert %{id: id} = Media.find_by_external_ids(%{imdb: "tt-untyped"}, type: nil)
+      assert id == movie.id
+    end
+
+    test "a duplicate match deterministically picks the earliest inserted row" do
+      # imdb_id carries no unique index (unlike tvdb_id/tmdb_id), so this is
+      # the id that can actually collide. Without an order_by, PostgreSQL does
+      # not guarantee LIMIT 1 returns insertion order, and since the crawl now
+      # repeats daily a nondeterministic pick could flip the stored mapping
+      # between runs.
+      {:ok, older} =
+        Media.create_media_item(%{
+          title: "Older Duplicate",
+          type: "tv_show",
+          imdb_id: "tt-dup-order"
+        })
+
+      {:ok, _newer} =
+        Media.create_media_item(%{
+          title: "Newer Duplicate",
+          type: "tv_show",
+          imdb_id: "tt-dup-order"
+        })
+
+      assert %{id: id} = Media.find_by_external_ids(%{imdb: "tt-dup-order"})
+      assert id == older.id
+    end
+
+    test "a non-numeric tvdb id falls through to tmdb instead of raising" do
+      {:ok, show} =
+        Media.create_media_item(
+          %{title: "Tmdb Fallback Show", type: "tv_show", tmdb_id: 555_555},
+          skip_episode_refresh: true
+        )
+
+      assert %{id: id} = Media.find_by_external_ids(%{tvdb: "not-a-number", tmdb: "555555"})
+      assert id == show.id
+    end
+
+    test "a non-numeric tmdb id does not raise and returns nil" do
+      assert Media.find_by_external_ids(%{tmdb: "not-a-number"}) == nil
+    end
+
+    test "a tvdb id with trailing garbage does not match" do
+      {:ok, _show} =
+        Media.create_media_item(
+          %{title: "Trailing Garbage Show", type: "tv_show", tvdb_id: 123},
+          skip_episode_refresh: true
+        )
+
+      assert Media.find_by_external_ids(%{tvdb: "123abc"}) == nil
+    end
+
+    test "a numeric tvdb string still matches" do
+      {:ok, show} =
+        Media.create_media_item(
+          %{title: "Numeric String Show", type: "tv_show", tvdb_id: 42},
+          skip_episode_refresh: true
+        )
+
+      assert %{id: id} = Media.find_by_external_ids(%{tvdb: "42"})
+      assert id == show.id
+    end
+
+    test "an integer tvdb id still matches" do
+      {:ok, show} =
+        Media.create_media_item(
+          %{title: "Integer Id Show", type: "tv_show", tvdb_id: 43},
+          skip_episode_refresh: true
+        )
+
+      assert %{id: id} = Media.find_by_external_ids(%{tvdb: 43})
+      assert id == show.id
+    end
   end
 end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -2224,4 +2224,91 @@ defmodule Mydia.MediaTest do
       assert is_binary(row.id)
     end
   end
+
+  describe "find_by_external_ids/2" do
+    test "falls through to tvdb when the imdb id matches nothing" do
+      {:ok, show} =
+        Media.create_media_item(
+          %{title: "Cascade Show", type: "tv_show", tvdb_id: 378_982},
+          skip_episode_refresh: true
+        )
+
+      # A Plex episode carries all three ids on its show; only tvdb is local.
+      # Strings are what Plex GUIDs parse to, and Ecto casts them for the
+      # integer column.
+      assert %{id: id} = Media.find_by_external_ids(%{imdb: "tt-absent", tvdb: "378982"})
+      assert id == show.id
+    end
+
+    test "falls through to tmdb when imdb and tvdb both miss" do
+      {:ok, show} =
+        Media.create_media_item(
+          %{title: "Tmdb Show", type: "tv_show", tmdb_id: 108_255},
+          skip_episode_refresh: true
+        )
+
+      assert %{id: id} =
+               Media.find_by_external_ids(%{
+                 imdb: "tt-absent",
+                 tvdb: "999999",
+                 tmdb: "108255"
+               })
+
+      assert id == show.id
+    end
+
+    test "returns nil when no ids are given" do
+      assert Media.find_by_external_ids(%{}) == nil
+    end
+
+    test "returns nil when nothing matches" do
+      assert Media.find_by_external_ids(%{imdb: "tt-nope", tvdb: "424242", tmdb: "424243"}) == nil
+    end
+
+    test "a wrong-type match does not short-circuit the cascade" do
+      {:ok, _decoy} =
+        Media.create_media_item(%{
+          title: "Decoy Movie",
+          type: "movie",
+          year: 2024,
+          imdb_id: "tt777"
+        })
+
+      {:ok, show} =
+        Media.create_media_item(
+          %{title: "Real Show", type: "tv_show", tvdb_id: 777},
+          skip_episode_refresh: true
+        )
+
+      assert %{id: id} =
+               Media.find_by_external_ids(%{imdb: "tt777", tvdb: "777"}, type: "tv_show")
+
+      assert id == show.id
+    end
+
+    test "returns nil when the only match is the wrong type" do
+      {:ok, _movie} =
+        Media.create_media_item(%{
+          title: "Only Movie",
+          type: "movie",
+          year: 2024,
+          imdb_id: "tt888"
+        })
+
+      assert Media.find_by_external_ids(%{imdb: "tt888"}, type: "tv_show") == nil
+    end
+
+    test "arity-1 calls still resolve" do
+      {:ok, movie} =
+        Media.create_media_item(%{
+          title: "Legacy Caller",
+          type: "movie",
+          year: 2024,
+          imdb_id: "tt999"
+        })
+
+      assert %{id: id} = Media.find_by_external_ids(%{imdb: "tt999"})
+      assert id == movie.id
+    end
+  end
 end

--- a/test/mydia/plugins/matcher_test.exs
+++ b/test/mydia/plugins/matcher_test.exs
@@ -91,4 +91,22 @@ defmodule Mydia.Plugins.MatcherTest do
       assert :not_found = Matcher.match_item(%{tvdb: 999_999_999})
     end
   end
+
+  test "match_item resolves a show as well as a movie" do
+    s = show(%{tvdb_id: 4242})
+
+    assert {:media_item, id} = Matcher.match_item(%{tvdb: 4242})
+    assert id == s.id
+  end
+
+  test "an episode target does not resolve to a like-numbered movie" do
+    # The movie owns the imdb id the show's target also carries. Without a type
+    # filter the cascade stops on the movie and the episode is never found.
+    _decoy = movie(%{imdb_id: "tt5150"})
+    s = show(%{tvdb_id: 5150})
+    ep = episode(s, 2, 3)
+
+    assert {:episode, id} = Matcher.match(%{imdb: "tt5150", tvdb: 5150, season: 2, episode: 3})
+    assert id == ep.id
+  end
 end

--- a/test/mydia/watch_sync/engine_test.exs
+++ b/test/mydia/watch_sync/engine_test.exs
@@ -175,4 +175,48 @@ defmodule Mydia.WatchSync.EngineTest do
       refute_received {:applied, _, _}
     end
   end
+
+  test "an episode maps when its show carries no local imdb id" do
+    user = user_fixture()
+
+    {:ok, show} =
+      Mydia.Media.create_media_item(
+        %{title: "Tvdb Only Show", type: "tv_show", tvdb_id: 378_982},
+        skip_episode_refresh: true
+      )
+
+    {:ok, episode} =
+      Mydia.Media.create_episode(%{
+        media_item_id: show.id,
+        season_number: 1,
+        episode_number: 1,
+        title: "Pilot"
+      })
+
+    instance = %{
+      id: "inst-ep",
+      test_pid: self(),
+      mappings: [
+        %{
+          remote_id: "ep1",
+          type: :episode,
+          # Exactly what Plex returns: all three ids on the show, none of them
+          # imdb-resolvable locally.
+          external_ids: %{imdb: "tt10590066", tmdb: "108255", tvdb: "378982"},
+          season_number: 1,
+          episode_number: 1
+        }
+      ],
+      changes: [%{remote_id: "ep1", watched: true, position_seconds: 0, at: DateTime.utc_now()}]
+    }
+
+    assert {:ok, counts} =
+             WatchSync.sync(StubProvider, instance, %{user_id: user.id, access_token: nil},
+               provider: "stub"
+             )
+
+    assert counts.not_found == 0
+    assert counts.imported == 1
+    assert %{watched: true} = Playback.get_progress(user.id, episode_id: episode.id)
+  end
 end


### PR DESCRIPTION
Watched-state sync with Plex was silently doing nothing for all TV content. Measured against the production instance before this change: 0 of 1386 Plex episodes were mapped, and across the two successful sync runs on record exactly 1 item had ever been exported to Plex.

## Two root causes

**The cascade never cascaded.** `Mydia.Media.find_by_external_ids/1` branched on whether an external id was *present*, not on whether the lookup *succeeded*:

```elixir
cond do
  imdb -> Repo.get_by(MediaItem, imdb_id: imdb)
  tvdb -> Repo.get_by(MediaItem, tvdb_id: tvdb)
  ...
```

Plex supplies an imdb id for every show. Mydia stores `imdb_id` on 0 of 53 local shows, keeping tvdb on 39 and tmdb on 38. So the imdb branch was always taken and always missed, and the cascade the docstring promised never happened. Movies were unaffected only because all 168 of them do carry an imdb id.

**The crawl ran exactly once, ever.** `WatchSync.Engine.maybe_refresh/5` only crawls when an instance has no mappings at all, so after the first sync nothing was ever mapped again. Media added later stayed invisible, and fixing the cascade alone would have changed nothing on an existing install, whose stale mappings suppress the re-crawl.

## Changes

- `find_by_external_ids/2` advances on a lookup miss rather than a missing id, and takes an optional `:type` so a movie id cannot resolve to a show. TMDB namespaces movie and TV ids separately while `tmdb_id` is one unique column across both, so an unpinned lookup could cross them.
- `WatchSync.Engine` and `Plugins.Matcher` pin the expected type at their call sites. `Matcher.match_item/1` stays untyped, since it legitimately addresses either.
- `MediaServerWatchedSync` re-crawls on a 24 hour interval, tracked by a new `last_mapping_refresh_at` key in `connection_settings` alongside the existing `last_watched_sync_at`. The staleness decision lives in the job so the provider-generic engine stays untouched, and the stamp is claimed before the run so a fan-out across several linked users does not crawl the library once per user.
- The claim is reverted when a sync fails, so a failed crawl retries on the next tick instead of burning the window. It is deliberately not reverted on the misconfiguration path, where the error comes from `list_changes/3` after the crawl already succeeded and would otherwise re-crawl every tick for as long as the config stays broken.
- `tvdb_id` and `tmdb_id` lookups parse defensively. Those are integer columns and Ecto raises on a param it cannot cast, so a single malformed GUID would abort an entire crawl. Numeric strings, which is what every Plex GUID parses to, still match.

No schema change and no migration. The new settings key is additive, and its absence means "crawl once", so existing configs self-heal on the first tick after deploy.

## Verification

`mix precommit` clean: Credo strict plus 7466 tests, 0 failures. Branch suites 193/193.

The two behavioural fixes were confirmed to fail without their change by reverting each production file and rerunning the new tests: the integer guard reproduced `Ecto.Query.CastError`, and the claim revert left the stamp written after a failed sync. The staleness tests discriminate by counting Jellyfin `/Items` hits, so removing `refresh_mappings:` from the sync call fails them rather than passing incidentally.

Expected effect on the measured instance: episode mappings 0 to roughly 1257, and `not_found` per sync 1466 to roughly 209. The residual is genuine: 70 Plex movies carry no GUIDs at all, 10 more are absent locally, 23 shows are not in Mydia, and 106 episodes belong to a local show that has no row for that episode.

## Known follow-ups, not fixed here

- A revoked user token 401s after a successful crawl, lands in the general error branch, and so re-crawls every tick until it is fixed. Bounded, but worth a narrower error shape from `Engine.sync/4`.
- The duplicate tie-break orders by `inserted_at`, which is second-precision and therefore ties in exactly the case that produces duplicates. Adding `asc: m.id` would make it genuinely stable.
- Jellyfin TV episodes remain unmapped for an unrelated reason: `to_mapping/1` passes the episode's own `ProviderIds` rather than the series ids the episode resolution path needs. The new type filter makes a wrong match unlikely, but this branch does not fix it.
