### PR TITLE
fix(subtitles): rebuild the subtitle search modal on daisyUI 5 and an honest state machine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ git commit -m "message"
 
 - **Always use and maintain this import syntax** in the app.css file for projects generated with `phx.new`
 - **Never** use `@apply` when writing raw css
-- **Use DaisyUI 4.x components** for consistent, accessible UI elements:
+- **Use DaisyUI 5.x components** for consistent, accessible UI elements:
   - DaisyUI provides semantic component classes (btn, card, modal, etc.)
   - Combine DaisyUI components with custom Tailwind classes for specific styling
   - Use DaisyUI's built-in theming system for dark/light modes
@@ -307,6 +307,10 @@ git commit -m "message"
   - Configure custom theme in tailwind config if needed
   - Use semantic color names (`primary`, `secondary`, `accent`, `base-100`, etc.)
 - **Reference DaisyUI documentation** for complete component APIs and variants
+- **Prefer real form inputs styled as components** where daisyUI supports it. A
+  multi-select chip row is `<div class="filter">` holding
+  `<input type="checkbox" class="btn">` elements, which daisyUI renders as
+  primary-filled chips when checked. Do not hand-roll chips out of raw Tailwind.
 
 ### Component Organization
 

--- a/lib/mydia/subtitles.ex
+++ b/lib/mydia/subtitles.ex
@@ -8,7 +8,8 @@ defmodule Mydia.Subtitles do
   ## Usage
 
       # Search for subtitles
-      {:ok, results} = Subtitles.search_subtitles(media_file_id, languages: "en,es")
+      {:ok, %{results: results, providers: providers}} =
+        Subtitles.search_candidates(media_file_id, "en,es")
 
       # Download a specific subtitle
       {:ok, subtitle} = Subtitles.download_subtitle(subtitle_info, media_file_id)
@@ -100,8 +101,9 @@ defmodule Mydia.Subtitles do
   Searches providers for a media file and returns scored candidates plus
   per-provider status.
 
-  Unlike `search_subtitles/2` this never downloads and always reports which
-  providers answered, which is what the player's results header shows.
+  This is what the subtitle search modal and the player's results header
+  call. Unlike `search_subtitles/2` it never downloads and always reports
+  which providers answered.
   """
   @spec search_candidates(binary(), String.t()) ::
           {:ok, %{results: [map()], providers: [map()]}} | {:error, term()}

--- a/lib/mydia/subtitles/provider_chain.ex
+++ b/lib/mydia/subtitles/provider_chain.ex
@@ -204,5 +204,13 @@ defmodule Mydia.Subtitles.ProviderChain do
   defp describe(:timeout), do: "The provider did not respond in time"
   defp describe({:crashed, _reason}), do: "The provider failed unexpectedly"
   defp describe({:transport, _reason}), do: "Could not reach the provider"
+
+  defp describe(:metadata_relay_not_configured),
+    do: "Subtitle search is not configured. Set a metadata relay URL or add a provider."
+
+  defp describe(:service_unavailable),
+    do:
+      "The subtitle provider is unavailable. A self-hosted relay needs OpenSubtitles credentials."
+
   defp describe(reason), do: "Search failed: #{inspect(reason)}"
 end

--- a/lib/mydia_web/languages.ex
+++ b/lib/mydia_web/languages.ex
@@ -1,0 +1,50 @@
+defmodule MydiaWeb.Languages do
+  @moduledoc """
+  Display names for the ISO 639-1 language codes the UI offers.
+
+  This is presentation data rather than domain data: providers and the metadata
+  relay all speak raw codes, and the only consumers of the names are web
+  surfaces (Discover's language filter and the subtitle search modal).
+  """
+
+  @all [
+    {"en", "English"},
+    {"ja", "Japanese"},
+    {"ko", "Korean"},
+    {"es", "Spanish"},
+    {"fr", "French"},
+    {"de", "German"},
+    {"it", "Italian"},
+    {"pt", "Portuguese"},
+    {"zh", "Chinese"},
+    {"hi", "Hindi"},
+    {"ru", "Russian"},
+    {"ar", "Arabic"},
+    {"th", "Thai"},
+    {"tr", "Turkish"},
+    {"pl", "Polish"},
+    {"nl", "Dutch"},
+    {"sv", "Swedish"},
+    {"da", "Danish"},
+    {"no", "Norwegian"},
+    {"fi", "Finnish"}
+  ]
+
+  # The languages that get a permanent chip in the subtitle search modal. The
+  # rest live behind its dropdown.
+  @common ~w(en es fr de it pt ja zh)
+
+  @names Map.new(@all)
+
+  @doc "Every offered language as `{code, display_name}`, in menu order."
+  @spec all() :: [{String.t(), String.t()}]
+  def all, do: @all
+
+  @doc "The subset shown as always-visible chips, in display order."
+  @spec common() :: [{String.t(), String.t()}]
+  def common, do: Enum.map(@common, fn code -> {code, name(code)} end)
+
+  @doc "Display name for a code, falling back to the code itself when unknown."
+  @spec name(String.t()) :: String.t()
+  def name(code), do: Map.get(@names, code, code)
+end

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -10,29 +10,6 @@ defmodule MydiaWeb.DiscoverLive.Index do
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
-  @languages [
-    {"en", "English"},
-    {"ja", "Japanese"},
-    {"ko", "Korean"},
-    {"es", "Spanish"},
-    {"fr", "French"},
-    {"de", "German"},
-    {"it", "Italian"},
-    {"pt", "Portuguese"},
-    {"zh", "Chinese"},
-    {"hi", "Hindi"},
-    {"ru", "Russian"},
-    {"ar", "Arabic"},
-    {"th", "Thai"},
-    {"tr", "Turkish"},
-    {"pl", "Polish"},
-    {"nl", "Dutch"},
-    {"sv", "Swedish"},
-    {"da", "Danish"},
-    {"no", "Norwegian"},
-    {"fi", "Finnish"}
-  ]
-
   @movie_categories [
     {:trending, "Trending"},
     {:popular, "Popular"},
@@ -61,7 +38,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
     socket =
       socket
       |> assign(:page_title, "Discover")
-      |> assign(:languages, @languages)
+      |> assign(:languages, MydiaWeb.Languages.all())
       |> assign(:sort_options, @sort_options)
       |> assign(:items, [])
       |> assign(:loading, true)

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -346,6 +346,9 @@ defmodule MydiaWeb.MediaLive.Show do
   def handle_event("update_subtitle_languages", params, socket),
     do: SubtitleEvents.update_subtitle_languages(params, socket)
 
+  def handle_event("clear_subtitle_languages", params, socket),
+    do: SubtitleEvents.clear_subtitle_languages(params, socket)
+
   def handle_event("perform_subtitle_search", params, socket),
     do: SubtitleEvents.perform_subtitle_search(params, socket)
 

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -137,9 +137,10 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:applying_monitoring_preset, false)
      # Subtitle state
      |> assign(:show_subtitle_search_modal, false)
-     |> assign(:searching_subtitles, false)
-     |> assign(:downloading_subtitle, false)
+     |> assign(:subtitle_search_state, :idle)
+     |> assign(:downloading_subtitle_id, nil)
      |> assign(:subtitle_search_results, [])
+     |> assign(:subtitle_providers, [])
      |> assign(:selected_media_file, nil)
      |> assign(:selected_languages, ["en"])
      |> assign(:media_file_subtitles, load_media_file_subtitles(media_item))

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -281,9 +281,10 @@
   <%= if @show_subtitle_search_modal && @selected_media_file do %>
     <Modals.subtitle_search_modal
       media_file={@selected_media_file}
-      searching={@searching_subtitles}
+      subtitle_search_state={@subtitle_search_state}
       subtitle_search_results={@subtitle_search_results}
-      downloading_subtitle={@downloading_subtitle}
+      subtitle_providers={@subtitle_providers}
+      downloading_subtitle_id={@downloading_subtitle_id}
       selected_languages={@selected_languages}
     />
   <% end %>

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -1165,9 +1165,10 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   Subtitle search modal for searching and downloading subtitles.
   """
   attr :media_file, :map, required: true
-  attr :searching, :boolean, required: true
+  attr :subtitle_search_state, :any, default: :idle
   attr :subtitle_search_results, :list, required: true
-  attr :downloading_subtitle, :boolean, default: false
+  attr :subtitle_providers, :list, default: []
+  attr :downloading_subtitle_id, :any, default: nil
   attr :selected_languages, :list, default: ["en"]
 
   def subtitle_search_modal(assigns) do
@@ -1268,9 +1269,9 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
               type="button"
               phx-click="perform_subtitle_search"
               class="btn btn-primary btn-sm"
-              disabled={@searching or @selected_languages == []}
+              disabled={@subtitle_search_state == :searching or @selected_languages == []}
             >
-              <%= if @searching do %>
+              <%= if @subtitle_search_state == :searching do %>
                 <span class="loading loading-spinner loading-sm"></span> Searching
               <% else %>
                 <.icon name="hero-magnifying-glass" class="w-4 h-4" /> Search
@@ -1279,99 +1280,99 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
           </form>
         </div>
         <div id="subtitle-search-body" class="flex-1 overflow-y-auto p-4 sm:p-6">
-          <%!-- Search results --%>
-          <%= if @searching do %>
-            <div class="flex items-center justify-center py-8">
-              <span class="loading loading-spinner loading-lg"></span>
-            </div>
-          <% else %>
-            <%= if length(@subtitle_search_results) > 0 do %>
-              <div class="overflow-x-auto">
-                <table class="table table-sm">
-                  <thead>
-                    <tr>
-                      <th>Language</th>
-                      <th>Format</th>
-                      <th>Rating</th>
-                      <th>Downloads</th>
-                      <th>HI</th>
-                      <th>Score</th>
-                      <th>Action</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <%= for result <- @subtitle_search_results do %>
-                      <tr>
-                        <td>{result.language}</td>
-                        <td>
-                          <span class="badge badge-ghost badge-sm">{result.format}</span>
-                        </td>
-                        <td>
-                          <%= if result[:rating] do %>
-                            <div class="flex items-center gap-1">
-                              <.icon name="hero-star-solid" class="w-3 h-3 text-warning" />
-                              <span class="text-xs">{result.rating}/10</span>
-                            </div>
-                          <% else %>
-                            <span class="text-base-content/50">—</span>
-                          <% end %>
-                        </td>
-                        <td>
-                          <%= if result[:download_count] do %>
-                            <span class="text-xs">{result.download_count}</span>
-                          <% else %>
-                            <span class="text-base-content/50">—</span>
-                          <% end %>
-                        </td>
-                        <td>
-                          <%= if result[:hearing_impaired] do %>
-                            <.icon name="hero-check-circle-solid" class="w-4 h-4 text-success" />
-                          <% else %>
-                            <span class="text-base-content/50">—</span>
-                          <% end %>
-                        </td>
-                        <td>
-                          <span class={[
-                            "badge badge-sm",
-                            result.score >= 150 && "badge-success",
-                            result.score >= 100 && result.score < 150 && "badge-warning",
-                            result.score < 100 && "badge-ghost"
-                          ]}>
-                            {result.score}
-                          </span>
-                        </td>
-                        <td>
-                          <button
-                            type="button"
-                            phx-click="download_subtitle_result"
-                            phx-value-file-id={result.file_id}
-                            phx-value-language={result.language}
-                            phx-value-format={result.format}
-                            phx-value-subtitle-hash={result.subtitle_hash}
-                            phx-value-rating={result[:rating]}
-                            phx-value-download-count={result[:download_count]}
-                            phx-value-hearing-impaired={result[:hearing_impaired] || false}
-                            class="btn btn-primary btn-xs"
-                            disabled={@downloading_subtitle}
-                          >
-                            <%= if @downloading_subtitle do %>
-                              <span class="loading loading-spinner loading-xs"></span>
-                            <% else %>
-                              <.icon name="hero-arrow-down-tray" class="w-3 h-3" /> Download
-                            <% end %>
-                          </button>
-                        </td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
+          <%= case @subtitle_search_state do %>
+            <% :idle -> %>
+              <div class="flex flex-col items-center justify-center py-16 text-center">
+                <.icon name="hero-language" class="w-16 h-16 text-base-content/20 mb-4" />
+                <h3 class="text-xl font-semibold text-base-content/70 mb-2">
+                  Choose one or more languages
+                </h3>
+                <p class="text-base-content/50 max-w-sm">
+                  Then run a search to see what your providers have for this file.
+                </p>
               </div>
-            <% else %>
-              <div class="alert alert-info">
-                <.icon name="hero-information-circle" class="w-5 h-5" />
-                <span>No subtitles found. Try searching with different languages.</span>
+            <% :searching -> %>
+              <div class="flex flex-col gap-3">
+                <div :for={_ <- 1..5} class="skeleton h-16 w-full"></div>
               </div>
-            <% end %>
+            <% {:error, reason} -> %>
+              <div class="alert alert-error">
+                <.icon name="hero-exclamation-circle" class="w-5 h-5 shrink-0" />
+                <div class="flex-1">
+                  <div class="font-medium">Search failed</div>
+                  <div class="text-sm opacity-80">{search_error_message(reason)}</div>
+                </div>
+                <button type="button" phx-click="perform_subtitle_search" class="btn btn-sm">
+                  Retry
+                </button>
+              </div>
+            <% :loaded -> %>
+              <%= cond do %>
+                <% @subtitle_providers == [] -> %>
+                  <div class="flex flex-col items-center justify-center py-16 text-center">
+                    <.icon name="hero-cog-6-tooth" class="w-16 h-16 text-base-content/20 mb-4" />
+                    <h3 class="text-xl font-semibold text-base-content/70 mb-2">
+                      No subtitle providers configured
+                    </h3>
+                    <p class="text-base-content/50 max-w-sm mb-4">
+                      Add a provider before searching. Nothing is enabled and healthy right now.
+                    </p>
+                    <.link navigate="/admin/subtitle-providers" class="btn btn-primary btn-sm">
+                      Configure providers
+                    </.link>
+                  </div>
+                <% @subtitle_search_results == [] and Enum.all?(@subtitle_providers, & &1.error) -> %>
+                  <div class="alert alert-error">
+                    <.icon name="hero-exclamation-circle" class="w-5 h-5 shrink-0" />
+                    <div class="flex-1">
+                      <div class="font-medium">Every provider failed</div>
+                      <ul class="text-sm opacity-80 mt-1">
+                        <li :for={provider <- @subtitle_providers}>
+                          {provider.name}: {provider.error}
+                        </li>
+                      </ul>
+                    </div>
+                    <button type="button" phx-click="perform_subtitle_search" class="btn btn-sm">
+                      Retry
+                    </button>
+                  </div>
+                <% @subtitle_search_results == [] -> %>
+                  <div class="flex flex-col items-center justify-center py-16 text-center">
+                    <.icon
+                      name="hero-magnifying-glass"
+                      class="w-16 h-16 text-base-content/20 mb-4"
+                    />
+                    <h3 class="text-xl font-semibold text-base-content/70 mb-2">
+                      No subtitles found
+                    </h3>
+                    <p class="text-base-content/50 max-w-sm">
+                      Your providers answered but had nothing for this file. Try more languages.
+                    </p>
+                  </div>
+                <% true -> %>
+                  <% failed = Enum.filter(@subtitle_providers, & &1.error) %>
+                  <div :if={failed != []} class="alert alert-warning mb-4">
+                    <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
+                    <div class="flex-1">
+                      <div class="text-sm font-medium">
+                        {length(failed)} of {length(@subtitle_providers)} providers failed
+                      </div>
+                      <ul class="text-xs opacity-80 mt-1">
+                        <li :for={provider <- failed}>{provider.name}: {provider.error}</li>
+                      </ul>
+                    </div>
+                  </div>
+                  <%!-- Result rows are replaced in Task 5. --%>
+                  <div class="overflow-x-auto">
+                    <table class="table table-sm">
+                      <tbody>
+                        <tr :for={result <- @subtitle_search_results}>
+                          <td>{result.file_name || MydiaWeb.Languages.name(result.language)}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+              <% end %>
           <% end %>
         </div>
       </div>
@@ -1475,4 +1476,22 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   defp score_color(score) when score >= 80, do: "text-success"
   defp score_color(score) when score >= 50, do: "text-warning"
   defp score_color(_score), do: "text-error"
+
+  # Provider-level failures arrive already humanized from ProviderChain. These
+  # are the top-level ones, which would otherwise reach the user as raw atoms.
+  defp search_error_message(:media_file_not_found),
+    do: "That file is no longer in the library."
+
+  defp search_error_message(:metadata_relay_not_configured),
+    do: "Subtitle search is not configured. Set a metadata relay URL or add a provider."
+
+  defp search_error_message(:service_unavailable),
+    do:
+      "The subtitle provider is unavailable. A self-hosted relay needs OpenSubtitles credentials."
+
+  defp search_error_message(:crashed),
+    do: "The search failed unexpectedly. Check the server logs for details."
+
+  defp search_error_message(_reason),
+    do: "The search could not be completed. Check the server logs for details."
 end

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -1172,175 +1172,179 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
 
   def subtitle_search_modal(assigns) do
     ~H"""
-    <div class="modal modal-open">
-      <div class="modal-box max-w-4xl">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="font-bold text-lg">Search Subtitles</h3>
+    <div class="modal modal-open" id="subtitle-search-modal">
+      <div class="modal-box max-w-3xl max-h-[85vh] flex flex-col p-0">
+        <%!-- Header --%>
+        <div class="sticky top-0 z-10 bg-base-100 border-b border-base-300 p-4 sm:p-6">
+          <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0">
+              <h3 class="text-xl sm:text-2xl font-bold">Search Subtitles</h3>
+              <p class="text-sm text-base-content/70 truncate mt-1" title={@media_file.path}>
+                {Path.basename(@media_file.path)}
+              </p>
+            </div>
+            <button
+              type="button"
+              phx-click="close_subtitle_search_modal"
+              class="btn btn-ghost btn-sm btn-circle shrink-0"
+              aria-label="Close"
+            >
+              <.icon name="hero-x-mark" class="w-6 h-6" />
+            </button>
+          </div>
+        </div>
+        <div id="subtitle-search-body" class="flex-1 overflow-y-auto p-4 sm:p-6">
+          <%!-- Language selection --%>
+          <div class="form-control mb-4">
+            <label class="label">
+              <span class="label-text">Select Languages</span>
+            </label>
+            <select
+              class="select select-bordered"
+              multiple
+              phx-change="update_subtitle_languages"
+              name="languages[]"
+            >
+              <option value="en" selected={Enum.member?(@selected_languages, "en")}>
+                English
+              </option>
+              <option value="es" selected={Enum.member?(@selected_languages, "es")}>
+                Spanish
+              </option>
+              <option value="fr" selected={Enum.member?(@selected_languages, "fr")}>
+                French
+              </option>
+              <option value="de" selected={Enum.member?(@selected_languages, "de")}>
+                German
+              </option>
+              <option value="it" selected={Enum.member?(@selected_languages, "it")}>
+                Italian
+              </option>
+              <option value="pt" selected={Enum.member?(@selected_languages, "pt")}>
+                Portuguese
+              </option>
+              <option value="ru" selected={Enum.member?(@selected_languages, "ru")}>
+                Russian
+              </option>
+              <option value="ja" selected={Enum.member?(@selected_languages, "ja")}>
+                Japanese
+              </option>
+              <option value="zh" selected={Enum.member?(@selected_languages, "zh")}>
+                Chinese
+              </option>
+              <option value="ar" selected={Enum.member?(@selected_languages, "ar")}>
+                Arabic
+              </option>
+            </select>
+          </div>
+
           <button
             type="button"
-            phx-click="close_subtitle_search_modal"
-            class="btn btn-ghost btn-sm btn-circle"
+            phx-click="perform_subtitle_search"
+            class="btn btn-primary btn-block mb-4"
+            disabled={@searching}
           >
-            <.icon name="hero-x-mark" class="w-5 h-5" />
+            <%= if @searching do %>
+              <span class="loading loading-spinner loading-sm"></span> Searching...
+            <% else %>
+              <.icon name="hero-magnifying-glass" class="w-5 h-5" /> Search Subtitles
+            <% end %>
           </button>
-        </div>
 
-        <%!-- Language selection --%>
-        <div class="form-control mb-4">
-          <label class="label">
-            <span class="label-text">Select Languages</span>
-          </label>
-          <select
-            class="select select-bordered"
-            multiple
-            phx-change="update_subtitle_languages"
-            name="languages[]"
-          >
-            <option value="en" selected={Enum.member?(@selected_languages, "en")}>
-              English
-            </option>
-            <option value="es" selected={Enum.member?(@selected_languages, "es")}>
-              Spanish
-            </option>
-            <option value="fr" selected={Enum.member?(@selected_languages, "fr")}>
-              French
-            </option>
-            <option value="de" selected={Enum.member?(@selected_languages, "de")}>
-              German
-            </option>
-            <option value="it" selected={Enum.member?(@selected_languages, "it")}>
-              Italian
-            </option>
-            <option value="pt" selected={Enum.member?(@selected_languages, "pt")}>
-              Portuguese
-            </option>
-            <option value="ru" selected={Enum.member?(@selected_languages, "ru")}>
-              Russian
-            </option>
-            <option value="ja" selected={Enum.member?(@selected_languages, "ja")}>
-              Japanese
-            </option>
-            <option value="zh" selected={Enum.member?(@selected_languages, "zh")}>
-              Chinese
-            </option>
-            <option value="ar" selected={Enum.member?(@selected_languages, "ar")}>
-              Arabic
-            </option>
-          </select>
-        </div>
-
-        <button
-          type="button"
-          phx-click="perform_subtitle_search"
-          class="btn btn-primary btn-block mb-4"
-          disabled={@searching}
-        >
+          <%!-- Search results --%>
           <%= if @searching do %>
-            <span class="loading loading-spinner loading-sm"></span> Searching...
+            <div class="flex items-center justify-center py-8">
+              <span class="loading loading-spinner loading-lg"></span>
+            </div>
           <% else %>
-            <.icon name="hero-magnifying-glass" class="w-5 h-5" /> Search Subtitles
-          <% end %>
-        </button>
-
-        <%!-- Search results --%>
-        <%= if @searching do %>
-          <div class="flex items-center justify-center py-8">
-            <span class="loading loading-spinner loading-lg"></span>
-          </div>
-        <% else %>
-          <%= if length(@subtitle_search_results) > 0 do %>
-            <div class="overflow-x-auto">
-              <table class="table table-sm">
-                <thead>
-                  <tr>
-                    <th>Language</th>
-                    <th>Format</th>
-                    <th>Rating</th>
-                    <th>Downloads</th>
-                    <th>HI</th>
-                    <th>Score</th>
-                    <th>Action</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <%= for result <- @subtitle_search_results do %>
+            <%= if length(@subtitle_search_results) > 0 do %>
+              <div class="overflow-x-auto">
+                <table class="table table-sm">
+                  <thead>
                     <tr>
-                      <td>{result.language}</td>
-                      <td>
-                        <span class="badge badge-ghost badge-sm">{result.format}</span>
-                      </td>
-                      <td>
-                        <%= if result[:rating] do %>
-                          <div class="flex items-center gap-1">
-                            <.icon name="hero-star-solid" class="w-3 h-3 text-warning" />
-                            <span class="text-xs">{result.rating}/10</span>
-                          </div>
-                        <% else %>
-                          <span class="text-base-content/50">—</span>
-                        <% end %>
-                      </td>
-                      <td>
-                        <%= if result[:download_count] do %>
-                          <span class="text-xs">{result.download_count}</span>
-                        <% else %>
-                          <span class="text-base-content/50">—</span>
-                        <% end %>
-                      </td>
-                      <td>
-                        <%= if result[:hearing_impaired] do %>
-                          <.icon name="hero-check-circle-solid" class="w-4 h-4 text-success" />
-                        <% else %>
-                          <span class="text-base-content/50">—</span>
-                        <% end %>
-                      </td>
-                      <td>
-                        <span class={[
-                          "badge badge-sm",
-                          result.score >= 150 && "badge-success",
-                          result.score >= 100 && result.score < 150 && "badge-warning",
-                          result.score < 100 && "badge-ghost"
-                        ]}>
-                          {result.score}
-                        </span>
-                      </td>
-                      <td>
-                        <button
-                          type="button"
-                          phx-click="download_subtitle_result"
-                          phx-value-file-id={result.file_id}
-                          phx-value-language={result.language}
-                          phx-value-format={result.format}
-                          phx-value-subtitle-hash={result.subtitle_hash}
-                          phx-value-rating={result[:rating]}
-                          phx-value-download-count={result[:download_count]}
-                          phx-value-hearing-impaired={result[:hearing_impaired] || false}
-                          class="btn btn-primary btn-xs"
-                          disabled={@downloading_subtitle}
-                        >
-                          <%= if @downloading_subtitle do %>
-                            <span class="loading loading-spinner loading-xs"></span>
-                          <% else %>
-                            <.icon name="hero-arrow-down-tray" class="w-3 h-3" /> Download
-                          <% end %>
-                        </button>
-                      </td>
+                      <th>Language</th>
+                      <th>Format</th>
+                      <th>Rating</th>
+                      <th>Downloads</th>
+                      <th>HI</th>
+                      <th>Score</th>
+                      <th>Action</th>
                     </tr>
-                  <% end %>
-                </tbody>
-              </table>
-            </div>
-          <% else %>
-            <div class="alert alert-info">
-              <.icon name="hero-information-circle" class="w-5 h-5" />
-              <span>No subtitles found. Try searching with different languages.</span>
-            </div>
+                  </thead>
+                  <tbody>
+                    <%= for result <- @subtitle_search_results do %>
+                      <tr>
+                        <td>{result.language}</td>
+                        <td>
+                          <span class="badge badge-ghost badge-sm">{result.format}</span>
+                        </td>
+                        <td>
+                          <%= if result[:rating] do %>
+                            <div class="flex items-center gap-1">
+                              <.icon name="hero-star-solid" class="w-3 h-3 text-warning" />
+                              <span class="text-xs">{result.rating}/10</span>
+                            </div>
+                          <% else %>
+                            <span class="text-base-content/50">—</span>
+                          <% end %>
+                        </td>
+                        <td>
+                          <%= if result[:download_count] do %>
+                            <span class="text-xs">{result.download_count}</span>
+                          <% else %>
+                            <span class="text-base-content/50">—</span>
+                          <% end %>
+                        </td>
+                        <td>
+                          <%= if result[:hearing_impaired] do %>
+                            <.icon name="hero-check-circle-solid" class="w-4 h-4 text-success" />
+                          <% else %>
+                            <span class="text-base-content/50">—</span>
+                          <% end %>
+                        </td>
+                        <td>
+                          <span class={[
+                            "badge badge-sm",
+                            result.score >= 150 && "badge-success",
+                            result.score >= 100 && result.score < 150 && "badge-warning",
+                            result.score < 100 && "badge-ghost"
+                          ]}>
+                            {result.score}
+                          </span>
+                        </td>
+                        <td>
+                          <button
+                            type="button"
+                            phx-click="download_subtitle_result"
+                            phx-value-file-id={result.file_id}
+                            phx-value-language={result.language}
+                            phx-value-format={result.format}
+                            phx-value-subtitle-hash={result.subtitle_hash}
+                            phx-value-rating={result[:rating]}
+                            phx-value-download-count={result[:download_count]}
+                            phx-value-hearing-impaired={result[:hearing_impaired] || false}
+                            class="btn btn-primary btn-xs"
+                            disabled={@downloading_subtitle}
+                          >
+                            <%= if @downloading_subtitle do %>
+                              <span class="loading loading-spinner loading-xs"></span>
+                            <% else %>
+                              <.icon name="hero-arrow-down-tray" class="w-3 h-3" /> Download
+                            <% end %>
+                          </button>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            <% else %>
+              <div class="alert alert-info">
+                <.icon name="hero-information-circle" class="w-5 h-5" />
+                <span>No subtitles found. Try searching with different languages.</span>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
-
-        <div class="modal-action">
-          <button type="button" phx-click="close_subtitle_search_modal" class="btn btn-ghost">
-            Close
-          </button>
         </div>
       </div>
       <div class="modal-backdrop" phx-click="close_subtitle_search_modal"></div>

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -1171,6 +1171,25 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   attr :selected_languages, :list, default: ["en"]
 
   def subtitle_search_modal(assigns) do
+    common = MydiaWeb.Languages.common()
+    common_codes = Enum.map(common, &elem(&1, 0))
+
+    # A selected language always gets a chip, even an uncommon one, so the
+    # current selection is never hidden behind the dropdown.
+    extra_chips =
+      assigns.selected_languages
+      |> Enum.reject(&(&1 in common_codes))
+      |> Enum.map(&{&1, MydiaWeb.Languages.name(&1)})
+
+    chips = common ++ extra_chips
+    chip_codes = Enum.map(chips, &elem(&1, 0))
+    more = Enum.reject(MydiaWeb.Languages.all(), fn {code, _} -> code in chip_codes end)
+
+    assigns =
+      assigns
+      |> assign(:language_chips, chips)
+      |> assign(:more_languages, more)
+
     ~H"""
     <div class="modal modal-open" id="subtitle-search-modal">
       <div class="modal-box max-w-3xl max-h-[85vh] flex flex-col p-0">
@@ -1193,64 +1212,73 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
             </button>
           </div>
         </div>
-        <div id="subtitle-search-body" class="flex-1 overflow-y-auto p-4 sm:p-6">
-          <%!-- Language selection --%>
-          <div class="form-control mb-4">
-            <label class="label">
-              <span class="label-text">Select Languages</span>
-            </label>
-            <select
-              class="select select-bordered"
-              multiple
-              phx-change="update_subtitle_languages"
-              name="languages[]"
-            >
-              <option value="en" selected={Enum.member?(@selected_languages, "en")}>
-                English
-              </option>
-              <option value="es" selected={Enum.member?(@selected_languages, "es")}>
-                Spanish
-              </option>
-              <option value="fr" selected={Enum.member?(@selected_languages, "fr")}>
-                French
-              </option>
-              <option value="de" selected={Enum.member?(@selected_languages, "de")}>
-                German
-              </option>
-              <option value="it" selected={Enum.member?(@selected_languages, "it")}>
-                Italian
-              </option>
-              <option value="pt" selected={Enum.member?(@selected_languages, "pt")}>
-                Portuguese
-              </option>
-              <option value="ru" selected={Enum.member?(@selected_languages, "ru")}>
-                Russian
-              </option>
-              <option value="ja" selected={Enum.member?(@selected_languages, "ja")}>
-                Japanese
-              </option>
-              <option value="zh" selected={Enum.member?(@selected_languages, "zh")}>
-                Chinese
-              </option>
-              <option value="ar" selected={Enum.member?(@selected_languages, "ar")}>
-                Arabic
-              </option>
-            </select>
-          </div>
-
-          <button
-            type="button"
-            phx-click="perform_subtitle_search"
-            class="btn btn-primary btn-block mb-4"
-            disabled={@searching}
+        <%!-- Control band --%>
+        <div class="bg-base-200/50 border-b border-base-300 px-4 py-3 sm:px-6">
+          <form
+            id="subtitle-language-form"
+            phx-change="update_subtitle_languages"
+            class="flex flex-wrap items-center gap-2"
           >
-            <%= if @searching do %>
-              <span class="loading loading-spinner loading-sm"></span> Searching...
-            <% else %>
-              <.icon name="hero-magnifying-glass" class="w-5 h-5" /> Search Subtitles
-            <% end %>
-          </button>
+            <div class="filter">
+              <button
+                type="button"
+                class="btn btn-sm btn-square filter-reset"
+                phx-click="clear_subtitle_languages"
+                aria-label="Clear selected languages"
+              >
+                ×
+              </button>
+              <input
+                :for={{code, label} <- @language_chips}
+                class="btn btn-sm"
+                type="checkbox"
+                name="languages[]"
+                value={code}
+                aria-label={label}
+                checked={code in @selected_languages}
+              />
+            </div>
 
+            <div class="dropdown dropdown-end">
+              <div tabindex="0" role="button" class="btn btn-sm btn-ghost">
+                +{length(@more_languages)} more <.icon name="hero-chevron-down" class="w-4 h-4" />
+              </div>
+              <ul
+                tabindex="0"
+                class="dropdown-content menu bg-base-100 rounded-box z-10 w-52 p-2 shadow-sm max-h-64 flex-nowrap overflow-y-auto"
+              >
+                <li :for={{code, label} <- @more_languages}>
+                  <label class="label cursor-pointer justify-start gap-2">
+                    <input
+                      type="checkbox"
+                      class="checkbox checkbox-sm"
+                      name="languages[]"
+                      value={code}
+                      checked={code in @selected_languages}
+                    />
+                    <span class="label-text">{label}</span>
+                  </label>
+                </li>
+              </ul>
+            </div>
+
+            <div class="flex-1"></div>
+
+            <button
+              type="button"
+              phx-click="perform_subtitle_search"
+              class="btn btn-primary btn-sm"
+              disabled={@searching or @selected_languages == []}
+            >
+              <%= if @searching do %>
+                <span class="loading loading-spinner loading-sm"></span> Searching
+              <% else %>
+                <.icon name="hero-magnifying-glass" class="w-4 h-4" /> Search
+              <% end %>
+            </button>
+          </form>
+        </div>
+        <div id="subtitle-search-body" class="flex-1 overflow-y-auto p-4 sm:p-6">
           <%!-- Search results --%>
           <%= if @searching do %>
             <div class="flex items-center justify-center py-8">

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -1359,16 +1359,69 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                     failed={failed}
                     total={length(@subtitle_providers)}
                   />
-                  <%!-- Result rows are replaced in Task 5. --%>
-                  <div class="overflow-x-auto">
-                    <table class="table table-sm">
-                      <tbody>
-                        <tr :for={result <- @subtitle_search_results}>
-                          <td>{result.file_name || MydiaWeb.Languages.name(result.language)}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
+                  <ul class="list bg-base-100 rounded-box">
+                    <li
+                      :for={result <- @subtitle_search_results}
+                      class="list-row hover:bg-base-200/50 transition-colors"
+                    >
+                      <div class="min-w-0">
+                        <div class="font-medium truncate">
+                          {result.file_name || MydiaWeb.Languages.name(result.language)}
+                        </div>
+                        <div class="flex flex-wrap items-center gap-1.5 mt-1">
+                          <span class="badge badge-sm">
+                            {MydiaWeb.Languages.name(result.language)}
+                          </span>
+                          <span class="badge badge-ghost badge-sm">{result.format}</span>
+                          <span :if={result.provider_name} class="badge badge-ghost badge-sm">
+                            {result.provider_name}
+                          </span>
+                          <span :if={result.moviehash_match} class="badge badge-success badge-sm">
+                            Exact match
+                          </span>
+                          <span
+                            :if={result.hearing_impaired}
+                            class="badge badge-outline badge-sm tooltip"
+                            data-tip="Includes hearing impaired captions"
+                          >
+                            HI
+                          </span>
+                          <span class={[
+                            "badge badge-sm",
+                            score_badge_class(result.score)
+                          ]}>
+                            Score {result.score}
+                          </span>
+                        </div>
+                        <div class="text-xs text-base-content/60 mt-1 flex gap-3">
+                          <span :if={result.rating}>★ {result.rating}/10</span>
+                          <span :if={result.download_count}>
+                            {result.download_count} downloads
+                          </span>
+                        </div>
+                      </div>
+
+                      <button
+                        type="button"
+                        phx-click="download_subtitle_result"
+                        phx-value-file-id={result.file_id}
+                        phx-value-language={result.language}
+                        phx-value-format={result.format}
+                        phx-value-subtitle-hash={result.subtitle_hash}
+                        phx-value-rating={result.rating}
+                        phx-value-download-count={result.download_count}
+                        phx-value-hearing-impaired={result.hearing_impaired}
+                        class="btn btn-primary btn-sm"
+                        disabled={@downloading_subtitle_id != nil}
+                      >
+                        <%= if @downloading_subtitle_id == result.file_id do %>
+                          <span class="loading loading-spinner loading-xs"></span>
+                        <% else %>
+                          <.icon name="hero-arrow-down-tray" class="w-4 h-4" /> Download
+                        <% end %>
+                      </button>
+                    </li>
+                  </ul>
               <% end %>
           <% end %>
         </div>
@@ -1510,4 +1563,9 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
 
   defp search_error_message(_reason),
     do: "The search could not be completed. Check the server logs for details."
+
+  # Thresholds carried over from the previous table so ranking reads the same.
+  defp score_badge_class(score) when score >= 150, do: "badge-success"
+  defp score_badge_class(score) when score >= 100, do: "badge-warning"
+  defp score_badge_class(_score), do: "badge-ghost"
 end

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -1220,7 +1220,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
             phx-change="update_subtitle_languages"
             class="flex flex-wrap items-center gap-2"
           >
-            <div class="filter">
+            <div class="filter" role="group" aria-label="Subtitle languages">
               <button
                 type="button"
                 class="btn btn-sm btn-square filter-reset"
@@ -1255,7 +1255,6 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                       class="checkbox checkbox-sm"
                       name="languages[]"
                       value={code}
-                      checked={code in @selected_languages}
                     />
                     <span class="label-text">{label}</span>
                   </label>
@@ -1302,7 +1301,12 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                   <div class="font-medium">Search failed</div>
                   <div class="text-sm opacity-80">{search_error_message(reason)}</div>
                 </div>
-                <button type="button" phx-click="perform_subtitle_search" class="btn btn-sm">
+                <button
+                  type="button"
+                  phx-click="perform_subtitle_search"
+                  class="btn btn-sm"
+                  disabled={@selected_languages == []}
+                >
                   Retry
                 </button>
               </div>
@@ -1333,7 +1337,12 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                         </li>
                       </ul>
                     </div>
-                    <button type="button" phx-click="perform_subtitle_search" class="btn btn-sm">
+                    <button
+                      type="button"
+                      phx-click="perform_subtitle_search"
+                      class="btn btn-sm"
+                      disabled={@selected_languages == []}
+                    >
                       Retry
                     </button>
                   </div>
@@ -1364,7 +1373,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                       :for={result <- @subtitle_search_results}
                       class="list-row hover:bg-base-200/50 transition-colors"
                     >
-                      <div class="min-w-0">
+                      <div class="list-col-grow min-w-0">
                         <div class="font-medium truncate">
                           {result.file_name || MydiaWeb.Languages.name(result.language)}
                         </div>
@@ -1379,13 +1388,13 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                           <span :if={result.moviehash_match} class="badge badge-success badge-sm">
                             Exact match
                           </span>
-                          <span
+                          <div
                             :if={result.hearing_impaired}
-                            class="badge badge-outline badge-sm tooltip"
+                            class="tooltip"
                             data-tip="Includes hearing impaired captions"
                           >
-                            HI
-                          </span>
+                            <span class="badge badge-outline badge-sm">HI</span>
+                          </div>
                           <span class={[
                             "badge badge-sm",
                             score_badge_class(result.score)

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -1307,6 +1307,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                 </button>
               </div>
             <% :loaded -> %>
+              <% failed = Enum.filter(@subtitle_providers, & &1.error) %>
               <%= cond do %>
                 <% @subtitle_providers == [] -> %>
                   <div class="flex flex-col items-center justify-center py-16 text-center">
@@ -1337,6 +1338,10 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                     </button>
                   </div>
                 <% @subtitle_search_results == [] -> %>
+                  <.subtitle_provider_failure_banner
+                    failed={failed}
+                    total={length(@subtitle_providers)}
+                  />
                   <div class="flex flex-col items-center justify-center py-16 text-center">
                     <.icon
                       name="hero-magnifying-glass"
@@ -1350,18 +1355,10 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                     </p>
                   </div>
                 <% true -> %>
-                  <% failed = Enum.filter(@subtitle_providers, & &1.error) %>
-                  <div :if={failed != []} class="alert alert-warning mb-4">
-                    <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
-                    <div class="flex-1">
-                      <div class="text-sm font-medium">
-                        {length(failed)} of {length(@subtitle_providers)} providers failed
-                      </div>
-                      <ul class="text-xs opacity-80 mt-1">
-                        <li :for={provider <- failed}>{provider.name}: {provider.error}</li>
-                      </ul>
-                    </div>
-                  </div>
+                  <.subtitle_provider_failure_banner
+                    failed={failed}
+                    total={length(@subtitle_providers)}
+                  />
                   <%!-- Result rows are replaced in Task 5. --%>
                   <div class="overflow-x-auto">
                     <table class="table table-sm">
@@ -1377,6 +1374,28 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
         </div>
       </div>
       <div class="modal-backdrop" phx-click="close_subtitle_search_modal"></div>
+    </div>
+    """
+  end
+
+  # Partial-failure warning banner shared by the "results found" and "healthy
+  # zero-hit" branches of the loaded subtitle search state, so a provider that
+  # failed alongside others that answered is never silently dropped.
+  attr :failed, :list, required: true
+  attr :total, :integer, required: true
+
+  defp subtitle_provider_failure_banner(assigns) do
+    ~H"""
+    <div :if={@failed != []} class="alert alert-warning mb-4">
+      <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
+      <div class="flex-1">
+        <div class="text-sm font-medium">
+          {length(@failed)} of {@total} providers failed
+        </div>
+        <ul class="text-xs opacity-80 mt-1">
+          <li :for={provider <- @failed}>{provider.name}: {provider.error}</li>
+        </ul>
+      </div>
     </div>
     """
   end
@@ -1478,16 +1497,13 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   defp score_color(_score), do: "text-error"
 
   # Provider-level failures arrive already humanized from ProviderChain. These
-  # are the top-level ones, which would otherwise reach the user as raw atoms.
+  # are the top-level ones search_candidates/2 can actually return, which
+  # would otherwise reach the user as raw atoms.
   defp search_error_message(:media_file_not_found),
     do: "That file is no longer in the library."
 
-  defp search_error_message(:metadata_relay_not_configured),
-    do: "Subtitle search is not configured. Set a metadata relay URL or add a provider."
-
-  defp search_error_message(:service_unavailable),
-    do:
-      "The subtitle provider is unavailable. A self-hosted relay needs OpenSubtitles credentials."
+  defp search_error_message(:insufficient_search_criteria),
+    do: "This file has no hash or metadata IDs to search with."
 
   defp search_error_message(:crashed),
     do: "The search failed unexpectedly. Check the server logs for details."

--- a/lib/mydia_web/live/media_live/show/subtitle_events.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_events.ex
@@ -16,7 +16,9 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
      socket
      |> assign(:show_subtitle_search_modal, true)
      |> assign(:selected_media_file, media_file)
-     |> assign(:subtitle_search_results, [])}
+     |> assign(:subtitle_search_state, :idle)
+     |> assign(:subtitle_search_results, [])
+     |> assign(:subtitle_providers, [])}
   end
 
   def close_subtitle_search_modal(_params, socket) do
@@ -24,8 +26,9 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
      socket
      |> assign(:show_subtitle_search_modal, false)
      |> assign(:selected_media_file, nil)
+     |> assign(:subtitle_search_state, :idle)
      |> assign(:subtitle_search_results, [])
-     |> assign(:searching_subtitles, false)}
+     |> assign(:subtitle_providers, [])}
   end
 
   def update_subtitle_languages(%{"languages" => languages}, socket) do
@@ -48,9 +51,9 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
 
     {:noreply,
      socket
-     |> assign(:searching_subtitles, true)
+     |> assign(:subtitle_search_state, :searching)
      |> start_async(:subtitle_search, fn ->
-       Mydia.Subtitles.search_subtitles(media_file.id, languages: languages)
+       Mydia.Subtitles.search_candidates(media_file.id, languages)
      end)}
   end
 
@@ -77,7 +80,7 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
 
     {:noreply,
      socket
-     |> assign(:downloading_subtitle, true)
+     |> assign(:downloading_subtitle_id, subtitle_info.file_id)
      |> start_async(:download_subtitle, fn ->
        Mydia.Subtitles.download_subtitle(subtitle_info, media_file.id)
      end)}
@@ -102,31 +105,32 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
 
   # handle_async dispatches
 
-  def handle_subtitle_search_async({:ok, {:ok, results}}, socket) do
-    Logger.info("Subtitle search completed", result_count: length(results))
+  def handle_subtitle_search_async(
+        {:ok, {:ok, %{results: results, providers: providers}}},
+        socket
+      ) do
+    Logger.info("Subtitle search completed",
+      result_count: length(results),
+      provider_count: length(providers)
+    )
 
     {:noreply,
      socket
-     |> assign(:searching_subtitles, false)
-     |> assign(:subtitle_search_results, results)}
+     |> assign(:subtitle_search_state, :loaded)
+     |> assign(:subtitle_search_results, results)
+     |> assign(:subtitle_providers, providers)}
   end
 
   def handle_subtitle_search_async({:ok, {:error, reason}}, socket) do
     Logger.error("Subtitle search failed: #{inspect(reason)}")
 
-    {:noreply,
-     socket
-     |> assign(:searching_subtitles, false)
-     |> put_flash(:error, "Subtitle search failed: #{inspect(reason)}")}
+    {:noreply, assign(socket, :subtitle_search_state, {:error, reason})}
   end
 
   def handle_subtitle_search_async({:exit, reason}, socket) do
     Logger.error("Subtitle search task crashed: #{inspect(reason)}")
 
-    {:noreply,
-     socket
-     |> assign(:searching_subtitles, false)
-     |> put_flash(:error, "Subtitle search failed unexpectedly")}
+    {:noreply, assign(socket, :subtitle_search_state, {:error, :crashed})}
   end
 
   def handle_download_subtitle_async({:ok, {:ok, _subtitle}}, socket) do
@@ -134,10 +138,12 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
 
     {:noreply,
      socket
-     |> assign(:downloading_subtitle, false)
+     |> assign(:downloading_subtitle_id, nil)
      |> assign(:show_subtitle_search_modal, false)
      |> assign(:selected_media_file, nil)
+     |> assign(:subtitle_search_state, :idle)
      |> assign(:subtitle_search_results, [])
+     |> assign(:subtitle_providers, [])
      |> assign(:media_file_subtitles, load_media_file_subtitles(socket.assigns.media_item))
      |> put_flash(:info, "Subtitle downloaded successfully")}
   end
@@ -147,7 +153,7 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
 
     {:noreply,
      socket
-     |> assign(:downloading_subtitle, false)
+     |> assign(:downloading_subtitle_id, nil)
      |> put_flash(:error, "Subtitle download failed: #{inspect(reason)}")}
   end
 
@@ -156,7 +162,7 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
 
     {:noreply,
      socket
-     |> assign(:downloading_subtitle, false)
+     |> assign(:downloading_subtitle_id, nil)
      |> put_flash(:error, "Subtitle download failed unexpectedly")}
   end
 end

--- a/lib/mydia_web/live/media_live/show/subtitle_events.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_events.ex
@@ -32,6 +32,16 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
     {:noreply, assign(socket, :selected_languages, languages)}
   end
 
+  # Unchecking every chip drops the key from the change payload rather than
+  # sending an empty list.
+  def update_subtitle_languages(_params, socket) do
+    {:noreply, assign(socket, :selected_languages, [])}
+  end
+
+  def clear_subtitle_languages(_params, socket) do
+    {:noreply, assign(socket, :selected_languages, [])}
+  end
+
   def perform_subtitle_search(_params, socket) do
     media_file = socket.assigns.selected_media_file
     languages = Enum.join(socket.assigns.selected_languages, ",")

--- a/lib/mydia_web/live/media_live/show/subtitle_events.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_events.ex
@@ -154,7 +154,7 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
     {:noreply,
      socket
      |> assign(:downloading_subtitle_id, nil)
-     |> put_flash(:error, "Subtitle download failed: #{inspect(reason)}")}
+     |> put_flash(:error, "Subtitle download failed: #{download_error_message(reason)}")}
   end
 
   def handle_download_subtitle_async({:exit, reason}, socket) do
@@ -163,6 +163,36 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
     {:noreply,
      socket
      |> assign(:downloading_subtitle_id, nil)
-     |> put_flash(:error, "Subtitle download failed unexpectedly")}
+     |> put_flash(:error, "Subtitle download failed: #{download_error_message(reason)}")}
   end
+
+  # Every clause here matches a class of failure `Mydia.Subtitles.download_subtitle/3`
+  # (or the provider it delegates to) can return. Anything unmatched still logs the
+  # raw reason above but never puts it in front of an operator.
+  defp download_error_message(:media_file_not_found),
+    do: "that file is no longer in the library."
+
+  defp download_error_message(:media_file_path_not_resolved),
+    do: "the file's location on disk could not be resolved."
+
+  defp download_error_message({:unsupported_format, _format}),
+    do: "that subtitle format is not supported."
+
+  defp download_error_message({:missing_required_fields, _fields}),
+    do: "the provider did not return everything needed to download it."
+
+  defp download_error_message(:not_found),
+    do: "that subtitle is no longer available from the provider."
+
+  defp download_error_message(:rate_limited),
+    do: "the provider rate limited the request. Try again shortly."
+
+  defp download_error_message(:service_unavailable),
+    do: "the subtitle provider is unavailable right now."
+
+  defp download_error_message(:unauthorized),
+    do: "the provider rejected the request. Check its credentials."
+
+  defp download_error_message(_reason),
+    do: "check the server logs for details."
 end

--- a/test/mydia/subtitles/provider_chain_test.exs
+++ b/test/mydia/subtitles/provider_chain_test.exs
@@ -24,6 +24,11 @@ defmodule Mydia.Subtitles.ProviderChainTest do
     def search(%{name: "exhausted"}, _params), do: {:error, :quota_exceeded}
     def search(%{name: "broken"}, _params), do: {:error, {:transport, :nxdomain}}
 
+    def search(%{name: "relay-unconfigured"}, _params),
+      do: {:error, :metadata_relay_not_configured}
+
+    def search(%{name: "relay-down"}, _params), do: {:error, :service_unavailable}
+
     def search(%{name: "slow"}, _params) do
       Process.sleep(5_000)
       {:ok, []}
@@ -172,5 +177,25 @@ defmodule Mydia.Subtitles.ProviderChainTest do
              ProviderChain.search(%{languages: "en", media_type: "movie"})
 
     assert broken.error != nil
+  end
+
+  test "humanizes a relay-not-configured error instead of leaking the raw atom" do
+    SubtitleProviderFixtures.config_fixture(%{name: "relay-unconfigured", adapter: StubAdapter})
+
+    assert {:ok, %{providers: [provider]}} =
+             ProviderChain.search(%{languages: "en", media_type: "movie"})
+
+    assert provider.error =~ "not configured"
+    refute provider.error =~ "metadata_relay_not_configured"
+  end
+
+  test "humanizes a service-unavailable error instead of leaking the raw atom" do
+    SubtitleProviderFixtures.config_fixture(%{name: "relay-down", adapter: StubAdapter})
+
+    assert {:ok, %{providers: [provider]}} =
+             ProviderChain.search(%{languages: "en", media_type: "movie"})
+
+    assert provider.error =~ "unavailable"
+    refute provider.error =~ "service_unavailable"
   end
 end

--- a/test/mydia_web/languages_test.exs
+++ b/test/mydia_web/languages_test.exs
@@ -1,0 +1,33 @@
+defmodule MydiaWeb.LanguagesTest do
+  use ExUnit.Case, async: true
+
+  alias MydiaWeb.Languages
+
+  test "name/1 returns the display name for a known code" do
+    assert Languages.name("pt") == "Portuguese"
+    assert Languages.name("en") == "English"
+  end
+
+  test "name/1 falls back to the raw code for an unknown one" do
+    assert Languages.name("xx") == "xx"
+  end
+
+  test "common/0 returns the eight chip languages in display order" do
+    assert Enum.map(Languages.common(), &elem(&1, 0)) == ~w(en es fr de it pt ja zh)
+  end
+
+  test "every common code also appears in all/0" do
+    all_codes = Enum.map(Languages.all(), &elem(&1, 0))
+
+    for {code, _name} <- Languages.common() do
+      assert code in all_codes
+    end
+  end
+
+  test "all/0 pairs every code with a non-empty display name" do
+    for {code, name} <- Languages.all() do
+      assert is_binary(code) and byte_size(code) == 2
+      assert is_binary(name) and name != ""
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -172,5 +172,31 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
       # The body is a dedicated scroll region.
       assert html =~ ~s(id="subtitle-search-body")
     end
+
+    test "renders language chips as daisyUI checkbox buttons with the selection checked" do
+      html = subtitle_modal_html(selected_languages: ["en", "fr"])
+
+      assert html =~ ~s(class="filter")
+      assert html =~ ~s(phx-click="clear_subtitle_languages")
+      # Real checkbox inputs, not a <select multiple>.
+      refute html =~ "select-bordered"
+      refute html =~ "multiple"
+      assert html =~ ~s(name="languages[]")
+      assert html =~ ~s(aria-label="English")
+      assert html =~ ~s(aria-label="Japanese")
+    end
+
+    test "promotes a selected uncommon language out of the dropdown into a chip" do
+      # Finnish is not one of the eight common chips, but selecting it must not
+      # bury it inside the dropdown.
+      assert subtitle_modal_html(selected_languages: ["fi"]) =~ ~s(aria-label="Finnish")
+    end
+
+    test "disables search when no language is selected" do
+      html = subtitle_modal_html(selected_languages: [])
+
+      assert html =~ ~s(phx-click="perform_subtitle_search")
+      assert html =~ "disabled"
+    end
   end
 end

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -16,6 +16,23 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
     }
   end
 
+  @subtitle_media_file %{
+    id: "mf-1",
+    path: "/media/movies/The Matrix (1999)/The.Matrix.1999.1080p.BluRay.mkv"
+  }
+
+  defp subtitle_modal_html(overrides \\ []) do
+    defaults = [
+      media_file: @subtitle_media_file,
+      searching: false,
+      subtitle_search_results: [],
+      downloading_subtitle: false,
+      selected_languages: ["en"]
+    ]
+
+    render_component(&Modals.subtitle_search_modal/1, Keyword.merge(defaults, overrides))
+  end
+
   describe "reidentify_modal/1" do
     test "renders candidates with selectable buttons wired to the select event" do
       html =
@@ -139,6 +156,21 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
       html = modal_html(%{downloading: true})
 
       assert html =~ "Grabbing…"
+    end
+  end
+
+  describe "subtitle_search_modal/1 shell" do
+    test "names the file being searched and has no redundant footer close button" do
+      html = subtitle_modal_html()
+
+      # The header tells you which file this is for.
+      assert html =~ "The.Matrix.1999.1080p.BluRay.mkv"
+      # The full path is not dumped into the header text.
+      refute html =~ ">/media/movies/"
+      # Header X only; the footer Close button is gone.
+      refute html =~ "modal-action"
+      # The body is a dedicated scroll region.
+      assert html =~ ~s(id="subtitle-search-body")
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -24,9 +24,10 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
   defp subtitle_modal_html(overrides \\ []) do
     defaults = [
       media_file: @subtitle_media_file,
-      searching: false,
+      subtitle_search_state: :idle,
       subtitle_search_results: [],
-      downloading_subtitle: false,
+      subtitle_providers: [],
+      downloading_subtitle_id: nil,
       selected_languages: ["en"]
     ]
 
@@ -197,6 +198,104 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
 
       assert html =~ ~s(phx-click="perform_subtitle_search")
       assert html =~ "disabled"
+    end
+  end
+
+  describe "subtitle_search_modal/1 states" do
+    test "idle never claims nothing was found" do
+      html = subtitle_modal_html(subtitle_search_state: :idle)
+
+      refute html =~ "No subtitles found"
+      assert html =~ "Choose one or more languages"
+    end
+
+    test "searching shows skeletons and no results" do
+      html = subtitle_modal_html(subtitle_search_state: :searching)
+
+      assert html =~ "skeleton"
+      refute html =~ "No subtitles found"
+    end
+
+    test "a failed search reports the failure instead of blaming the language choice" do
+      html = subtitle_modal_html(subtitle_search_state: {:error, :media_file_not_found})
+
+      assert html =~ "alert-error"
+      refute html =~ "No subtitles found"
+      refute html =~ "media_file_not_found"
+      assert html =~ ~s(phx-click="perform_subtitle_search")
+    end
+
+    test "with no providers configured it points at the admin page" do
+      html = subtitle_modal_html(subtitle_search_state: :loaded, subtitle_providers: [])
+
+      assert html =~ "/admin/subtitle-providers"
+      refute html =~ "No subtitles found"
+    end
+
+    test "when every provider errored it names them and their reasons" do
+      html =
+        subtitle_modal_html(
+          subtitle_search_state: :loaded,
+          subtitle_providers: [
+            %{
+              name: "OpenSubtitles",
+              quota_remaining: nil,
+              quota_total: nil,
+              error: "Daily quota exhausted"
+            }
+          ]
+        )
+
+      assert html =~ "OpenSubtitles"
+      assert html =~ "Daily quota exhausted"
+      refute html =~ "No subtitles found"
+    end
+
+    test "a healthy search with zero hits is the only case that says nothing was found" do
+      html =
+        subtitle_modal_html(
+          subtitle_search_state: :loaded,
+          subtitle_providers: [
+            %{name: "OpenSubtitles", quota_remaining: nil, quota_total: nil, error: nil}
+          ]
+        )
+
+      assert html =~ "No subtitles found"
+    end
+
+    test "a partial provider failure warns but still shows results" do
+      html =
+        subtitle_modal_html(
+          subtitle_search_state: :loaded,
+          subtitle_providers: [
+            %{name: "OpenSubtitles", quota_remaining: nil, quota_total: nil, error: nil},
+            %{
+              name: "Podnapisi",
+              quota_remaining: nil,
+              quota_total: nil,
+              error: "Rate limited, try again shortly"
+            }
+          ],
+          subtitle_search_results: [
+            %{
+              file_id: 1,
+              language: "en",
+              format: "srt",
+              subtitle_hash: "abc",
+              file_name: "The.Matrix.1999.1080p.BluRay.srt",
+              rating: 8.5,
+              download_count: 1200,
+              hearing_impaired: false,
+              moviehash_match: true,
+              provider_name: "OpenSubtitles",
+              score: 160
+            }
+          ]
+        )
+
+      assert html =~ "alert-warning"
+      assert html =~ "Podnapisi"
+      assert html =~ "The.Matrix.1999.1080p.BluRay.srt"
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -297,5 +297,33 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
       assert html =~ "Podnapisi"
       assert html =~ "The.Matrix.1999.1080p.BluRay.srt"
     end
+
+    test "a partial provider failure with zero results still warns about the failure" do
+      html =
+        subtitle_modal_html(
+          subtitle_search_state: :loaded,
+          subtitle_providers: [
+            %{name: "OpenSubtitles", quota_remaining: nil, quota_total: nil, error: nil},
+            %{
+              name: "Podnapisi",
+              quota_remaining: nil,
+              quota_total: nil,
+              error: "Rate limited, try again shortly"
+            }
+          ],
+          subtitle_search_results: []
+        )
+
+      assert html =~ "alert-warning"
+      assert html =~ "Podnapisi"
+      assert html =~ "No subtitles found"
+    end
+
+    test "an unidentified file's search failure names the missing criteria, not the atom" do
+      html = subtitle_modal_html(subtitle_search_state: {:error, :insufficient_search_criteria})
+
+      assert html =~ "no hash or metadata IDs"
+      refute html =~ "insufficient_search_criteria"
+    end
   end
 end

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -34,6 +34,40 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
     render_component(&Modals.subtitle_search_modal/1, Keyword.merge(defaults, overrides))
   end
 
+  defp result_fixture(overrides \\ %{}) do
+    Map.merge(
+      %{
+        file_id: 1,
+        language: "en",
+        format: "srt",
+        subtitle_hash: "abc",
+        file_name: "The.Matrix.1999.1080p.BluRay.srt",
+        rating: 8.5,
+        download_count: 1200,
+        hearing_impaired: false,
+        moviehash_match: true,
+        provider_name: "OpenSubtitles",
+        score: 160
+      },
+      overrides
+    )
+  end
+
+  defp loaded_html(results, overrides \\ []) do
+    subtitle_modal_html(
+      Keyword.merge(
+        [
+          subtitle_search_state: :loaded,
+          subtitle_providers: [
+            %{name: "OpenSubtitles", quota_remaining: nil, quota_total: nil, error: nil}
+          ],
+          subtitle_search_results: results
+        ],
+        overrides
+      )
+    )
+  end
+
   describe "reidentify_modal/1" do
     test "renders candidates with selectable buttons wired to the select event" do
       html =
@@ -324,6 +358,41 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
 
       assert html =~ "no hash or metadata IDs"
       refute html =~ "insufficient_search_criteria"
+    end
+
+    test "rows show the release name, a language name, and the exact-match signal" do
+      html = loaded_html([result_fixture()])
+
+      assert html =~ "list-row"
+      assert html =~ "The.Matrix.1999.1080p.BluRay.srt"
+      # Language name, not the raw code.
+      assert html =~ "English"
+      # moviehash_match is surfaced rather than discarded.
+      assert html =~ "Exact match"
+      assert html =~ "OpenSubtitles"
+    end
+
+    test "a row without a release name falls back to the language name" do
+      html = loaded_html([result_fixture(%{file_name: nil, moviehash_match: false})])
+
+      assert html =~ "English"
+      refute html =~ "Exact match"
+    end
+
+    test "only the downloading row spins" do
+      html =
+        loaded_html(
+          [result_fixture(%{file_id: 1}), result_fixture(%{file_id: 2, subtitle_hash: "def"})],
+          downloading_subtitle_id: 1
+        )
+
+      # One spinner, not one per row.
+      assert length(String.split(html, "loading-spinner")) - 1 == 1
+    end
+
+    test "hearing impaired is flagged only when true" do
+      assert loaded_html([result_fixture(%{hearing_impaired: true})]) =~ "hearing impaired"
+      refute loaded_html([result_fixture(%{hearing_impaired: false})]) =~ "hearing impaired"
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/subtitle_events_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitle_events_test.exs
@@ -89,18 +89,33 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEventsTest do
       assert socket.assigns.downloading_subtitle_id == nil
     end
 
-    test "a failed download clears the downloading id" do
+    test "a failed download clears the downloading id and humanizes a known reason" do
       {:noreply, socket} =
         SubtitleEvents.handle_download_subtitle_async({:ok, {:error, :not_found}}, socket())
 
       assert socket.assigns.downloading_subtitle_id == nil
+      assert flash(socket)["error"] =~ "no longer available from the provider"
+      refute flash(socket)["error"] =~ "not_found"
     end
 
-    test "a crashed download task clears the downloading id" do
+    test "a failed download with an unrecognized reason never flashes the raw term" do
+      {:noreply, socket} =
+        SubtitleEvents.handle_download_subtitle_async(
+          {:ok, {:error, {:database_insert_failed, %{}}}},
+          socket()
+        )
+
+      assert flash(socket)["error"] =~ "check the server logs"
+      refute flash(socket)["error"] =~ "database_insert_failed"
+    end
+
+    test "a crashed download task clears the downloading id and never flashes the raw reason" do
       {:noreply, socket} =
         SubtitleEvents.handle_download_subtitle_async({:exit, :boom}, socket())
 
       assert socket.assigns.downloading_subtitle_id == nil
+      assert flash(socket)["error"] =~ "check the server logs"
+      refute flash(socket)["error"] =~ "boom"
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/subtitle_events_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitle_events_test.exs
@@ -1,0 +1,37 @@
+defmodule MydiaWeb.MediaLive.Show.SubtitleEventsTest do
+  use MydiaWeb.ConnCase, async: true
+
+  alias MydiaWeb.MediaLive.Show.SubtitleEvents
+
+  defp socket(assigns \\ %{}) do
+    %Phoenix.LiveView.Socket{
+      assigns: Map.merge(%{__changed__: %{}, selected_languages: ["en"]}, assigns)
+    }
+  end
+
+  describe "update_subtitle_languages/2" do
+    test "stores the submitted selection" do
+      {:noreply, socket} =
+        SubtitleEvents.update_subtitle_languages(%{"languages" => ["en", "fr"]}, socket())
+
+      assert socket.assigns.selected_languages == ["en", "fr"]
+    end
+
+    test "treats a payload with no languages key as an empty selection" do
+      # Unchecking every daisyUI chip omits the key entirely rather than
+      # sending an empty list, which used to raise FunctionClauseError.
+      {:noreply, socket} = SubtitleEvents.update_subtitle_languages(%{}, socket())
+
+      assert socket.assigns.selected_languages == []
+    end
+  end
+
+  describe "clear_subtitle_languages/2" do
+    test "empties the selection" do
+      {:noreply, socket} =
+        SubtitleEvents.clear_subtitle_languages(%{}, socket(%{selected_languages: ["en", "fr"]}))
+
+      assert socket.assigns.selected_languages == []
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/subtitle_events_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitle_events_test.exs
@@ -3,11 +3,18 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEventsTest do
 
   alias MydiaWeb.MediaLive.Show.SubtitleEvents
 
+  # `flash: %{}` and `private.live_temp` satisfy `Phoenix.LiveView.put_flash/3`,
+  # which some of the async handlers still call on their remaining paths.
   defp socket(assigns \\ %{}) do
+    base = %{__changed__: %{}, flash: %{}, selected_languages: ["en"]}
+
     %Phoenix.LiveView.Socket{
-      assigns: Map.merge(%{__changed__: %{}, selected_languages: ["en"]}, assigns)
+      assigns: Map.merge(base, assigns),
+      private: %{live_temp: %{}}
     }
   end
+
+  defp flash(%Phoenix.LiveView.Socket{assigns: %{flash: f}}), do: f
 
   describe "update_subtitle_languages/2" do
     test "stores the submitted selection" do
@@ -32,6 +39,68 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEventsTest do
         SubtitleEvents.clear_subtitle_languages(%{}, socket(%{selected_languages: ["en", "fr"]}))
 
       assert socket.assigns.selected_languages == []
+    end
+  end
+
+  describe "handle_subtitle_search_async/2" do
+    test "a successful search transitions to :loaded with its results and providers" do
+      {:noreply, socket} =
+        SubtitleEvents.handle_subtitle_search_async(
+          {:ok, {:ok, %{results: [], providers: []}}},
+          socket()
+        )
+
+      assert socket.assigns.subtitle_search_state == :loaded
+      assert socket.assigns.subtitle_search_results == []
+      assert socket.assigns.subtitle_providers == []
+    end
+
+    test "a top-level search error carries the reason and sets no flash" do
+      {:noreply, socket} =
+        SubtitleEvents.handle_subtitle_search_async(
+          {:ok, {:error, :media_file_not_found}},
+          socket()
+        )
+
+      assert socket.assigns.subtitle_search_state == {:error, :media_file_not_found}
+      assert flash(socket) == %{}
+    end
+
+    test "a crashed search task becomes a reportable :crashed state" do
+      {:noreply, socket} =
+        SubtitleEvents.handle_subtitle_search_async({:exit, :boom}, socket())
+
+      assert socket.assigns.subtitle_search_state == {:error, :crashed}
+    end
+  end
+
+  describe "handle_download_subtitle_async/2" do
+    defp socket_with_media_item(assigns \\ %{}) do
+      socket(Map.merge(%{media_item: %{media_files: []}}, assigns))
+    end
+
+    test "a successful download clears the downloading id" do
+      {:noreply, socket} =
+        SubtitleEvents.handle_download_subtitle_async(
+          {:ok, {:ok, %{}}},
+          socket_with_media_item()
+        )
+
+      assert socket.assigns.downloading_subtitle_id == nil
+    end
+
+    test "a failed download clears the downloading id" do
+      {:noreply, socket} =
+        SubtitleEvents.handle_download_subtitle_async({:ok, {:error, :not_found}}, socket())
+
+      assert socket.assigns.downloading_subtitle_id == nil
+    end
+
+    test "a crashed download task clears the downloading id" do
+      {:noreply, socket} =
+        SubtitleEvents.handle_download_subtitle_async({:exit, :boom}, socket())
+
+      assert socket.assigns.downloading_subtitle_id == nil
     end
   end
 end


### PR DESCRIPTION
Rebuilds the "Search Subtitles" modal on stock DaisyUI 5 components and replaces its two-state rendering with an explicit state machine.

## Why

The modal had two render states, `searching` and everything-else. That produced three user-facing lies:

- Opening it showed "No subtitles found. Try searching with different languages." **before you had searched anything**.
- A total provider outage showed that same message, blaming your language choice for an outage.
- Errors went to a flash as `inspect(reason)`, so an operator saw `:service_unavailable` and had nothing to act on.

The language picker was a native `<select multiple>`, which needs ctrl/cmd-click to pick more than one language. Nobody discovers that.

## What changed

- **Language picker** is now a DaisyUI `filter` row of `<input type="checkbox" class="btn">` chips plus a dropdown for the less common languages. Checked chips fill primary through DaisyUI's own `input.btn:checked` rule, so there is no custom CSS. Real checkbox inputs also beat a `<select multiple>` for form semantics and screen readers.
- **Six distinct states** replace the two: idle, searching, search failed, no providers configured, providers answered with nothing, and results. Only the fifth says "No subtitles found".
- **Failures report inline** with humanized copy and a Retry, instead of flashing a raw atom. Provider-level reasons were already humanized by `ProviderChain.describe/1`; two missing clauses were added there so `:metadata_relay_not_configured` and `:service_unavailable` stop reaching the UI as raw atoms.
- **"No subtitle providers configured"** is its own state, since `ProviderChain.search/1` returns `providers: []` rather than an error. It links to `/admin/subtitle-providers`. This is the state a fresh install actually lands in.
- **Result rows** are DaisyUI `list`/`list-row` and now surface `file_name`, `provider_name`, and `moviehash_match` ("Exact match"), which the old table discarded. `moviehash_match` is the strongest relevance signal available: it means the subtitle is timed to this exact release. Language shows as "English", not `en`.
- **Per-row download state.** `downloading_subtitle` was one boolean shared by every row, so downloading one subtitle spun all of them. It is now keyed by `file_id`.
- **Shared `MydiaWeb.Languages`** replaces two divergent hardcoded language lists.
- **Sticky header naming the file being searched.** `@media_file` was passed in and never rendered.
- `AGENTS.md` said to target DaisyUI 4.x. The project is on 5.7.7.

## Testing

Component tests cover all six states via `render_component/2`, including the regression that motivated this (idle must not claim nothing was found). Event tests cover the async contract, the language-selection clauses, and the download resets. 256 tests in the touched areas, `compile --warnings-as-errors` and `credo --strict` clean.

## Known follow-ups, not fixed here

- `download_error_message/1` has four unreachable clauses. `Downloader.download/3` wraps every adapter error as `{:error, {:download_failed, reason}}` before it reaches the humanizer, so those clauses never fire and everything lands on the catch-all. No raw atom reaches a user either way, since the catch-all is safe, but the specific clauses are dead and the `:not_found` test exercises a shape production cannot produce.
- `subtitle_events.ex:72` does `String.to_integer(file_id)`. Gestdown is enabled by default and uses GUID file ids; SubDL uses URLs. A Download click on such a row crashes the LiveView. Pre-existing and unchanged here, but worth its own issue.
- `Mydia.Subtitles.search_subtitles/2` now has zero callers. Removing it also orphans `ensure_a_provider_answered/2`, `handle_search_results/3`, the `auto_download` option, and the `{:all_providers_failed, _}` tuple, so it belongs in its own change.
- `modals.ex` is about 1580 lines against the repo's ~500 guideline. It was already 1446 before this branch.

## Not verified

No manual browser walkthrough was performed. The two DaisyUI layout defects found in review were caught by reading DaisyUI's CSS, not by looking at the page. Chip fill and reset in motion, light and dark themes, and phone-width wrap and scroll behavior are still unverified visually.
