### PR TITLE
docs(changelog): add the v0.13.2 release notes

### DIFF
--- a/priv/changelog/0.13.2.md
+++ b/priv/changelog/0.13.2.md
@@ -1,0 +1,78 @@
+A bugfix release on top of `v0.13.1`. Most of it is repair work on features that shipped in earlier versions and never actually ran: watched-state sync with Plex, favoriting from the player, guest requests, and most Cardigann indexers. There are 18 migrations. One of them deletes blacklist entries a v0.13.0 bug wrote for healthy releases, so read the upgrade notes before pulling.
+
+## Server
+
+### Watched-state sync
+
+- Watched-state sync with Plex has never run once in production, on any install. Three separate blockers, each fatal on its own: sync was never enabled, the stored server address was frozen at setup time and had become unroutable, and the health check probed an endpoint that requires no authentication, so a revoked token still read as healthy. Configs now store every advertised address and resolve a working one at call time, auth failures report as auth failures with a reconnect prompt, and a `sync_runs` table records every attempt including skips and why they were skipped (#403)
+- Scheduled sync now runs. The job that creates the per-user links it depends on had no callers anywhere, so every scheduled run found no links and stopped. Installs that already have Plex configured self-heal without re-running OAuth (#420)
+- TV episodes sync. `find_by_external_ids/1` branched on whether an external id was present rather than on whether the lookup found anything, so Plex's imdb id was always tried and always missed against shows Mydia stores by tvdb. Measured on a live instance: 0 of 1386 Plex episodes were mapped. Mappings also re-crawl on an interval instead of exactly once, ever (#434)
+- Jellyfin gets watched-state sync too, and the health badge on the Media Servers page works for the first time. It returned a hardcoded Unknown for every server type, Plex included. Running a job by hand from the Jobs page also discarded the crontab's arguments, which crashed any worker with a strict args contract (#423)
+- Plex Home profiles map to Mydia users in the admin UI, and profile switching keys on the account uuid instead of the numeric id, which had 404'd every per-user token mint since the feature landed (#424, #427)
+- Testing a Plex connection resolves an address through discovery instead of answering "URL is required" for every OAuth-connected server (#424)
+
+### Downloads
+
+- Healthy qBittorrent and rtorrent downloads are no longer auto-rejected in a loop. The v0.13.0 content check read a field those clients populate with the torrent's root directory, so a folder named `Minions.Monsters.2026.720p.WEBRip.x264-YTS` yielded an extension of `.x264-YTS`, the release was judged content-free, blacklisted and replaced by another that met the same fate, until the result set ran out (#400)
+- A stalled download says it stalled instead of reporting "Import failed", names its deadline while there is still time to act, and offers Remove and find another alongside Keep waiting. Giving up now removes the torrent and searches again, where it previously wrote two timestamps and left the torrent running (#426)
+- Movies download into the library you pick. Adding a second movies library captured every subsequent import, including movies whose files already lived elsewhere, because the destination was re-derived on each import as the alphabetically first compatible library. Libraries now carry an explicit per-kind default, and the Add Movie dropdown is read instead of discarded (#402)
+
+### Indexers
+
+- Public Cardigann indexers work. Definitions ship up to 26 links and Mydia used only the first, so a rotated or blocked domain killed the indexer permanently. The health check now probes every candidate and stores the first that answers, and a search that hits a transport failure advances to the next. Selector normalization also discarded every key outside a list of seven, which is why `rows.after` and `rows.count` had working implementations that had never once received a value (#419)
+- Grabs honour the definition's download block, so a tracker whose download link needs a separate fetch stops handing back an HTML page (#416)
+
+### Requests and metadata
+
+- Discovery's Request button submits in one click. It built a URL carrying the TMDB id that the request page never read, so guests landed on an empty search form. Approving a request also now fetches metadata before creating the item, instead of leaving an empty poster placeholder forever, with a daily backfill for items already stored without it (#415)
+
+### Admin
+
+- New playback dashboard at `/admin/dashboard`: live per-session bandwidth, 30 days of plays, now-playing cards and background transcodes, drawn as server-rendered SVG with no new dependency. Two live bugs move with it. Every TV episode in Recent Activity rendered as "Unknown Media", and "Clear Recent Activity" was wired to a `delete_all` over playback progress, so a button labelled clear activity destroyed every user's resume positions and watched flags (#430)
+- Continue Watching and Up Next merge into one recency-sorted On Deck rail, so finishing an episode surfaces the next one. Continue Watching read only progress rows, which an episode you have never started does not have, and Up Next was unordered before being truncated to 10 of 43 shows. Home load also drops from roughly 94 queries to a constant 5 to 7 (#429)
+- Adding a Plex server no longer asks you to pick an address from a list, and saving one after OAuth works. The picker discarded the address you clicked, and the save then dropped every discovery field the form has no input for (#418, #421, #422)
+- The media servers config page is usable on a phone, and the custom formats page follows the same layout standard as the rest of `/admin/config` (#414, #397)
+
+### Integrations
+
+- The Trakt integration is removed. As of 22 July 2026 Trakt limits free accounts to one connected community app at a time, and Mydia's users typically already have Kodi, Stremio, Infuse or Plex connected, so adding Mydia would mean giving one up or paying for VIP. Connecting an account had never worked anyway: the relay carried no client id, and the failure surfaced as advice to try again, which could never succeed. Simkl is the migration path (#406)
+- The bundled Simkl plugin pushes owned-but-unwatched items as plan-to-watch and pulls plan-to-watch items Mydia does not own back as favorites (#409)
+
+### Subtitles
+
+- Subtitle search returns results on a default install for the first time. This work is not finished and continues in the next release. What landed here: the relay's backend moved from OpenSubtitles to SubDL, Gestdown was added as a keyless second provider so search survives one upstream going down, provider configuration joined the layered config model with a new page at `/admin/subtitle-providers`, and the search modal was rebuilt so it stops reporting "No subtitles found" before you have searched anything (#425, #432, #435, #436)
+
+## Player
+
+- Favoriting works. Both detail controllers called mutations the schema does not have, `toggleShowFavorite` and `toggleMovieFavorite`, against a server that only exposes `toggleFavorite`. Every tap filled the heart optimistically and reverted. It has been broken since the player shipped (#396)
+- Media Info panel with a full per-stream readout, opened from the movie and episode detail screens. `FileAnalyzer` already ran `ffprobe -show_streams` and kept only the first video and first audio stream; it now keeps them all, in the existing metadata JSON with no migration (#399, #407)
+- The web player offers tap-to-play when the browser blocks the start, instead of replacing the screen with "Failed to load video". That message was the browser's autoplay gate rather than a load failure. Retry appeared to fix it only by supplying the missing gesture, at the cost of re-running the whole pipeline and making the server transcode the opening a second time (#413)
+- The floating mobile dock stops painting over content and over the nav drawer, where a tap landing on "Home" navigated straight through the open drawer's scrim (#398)
+- Browse screens share one page chrome. Search rendered a filled pill nobody designed, Continue Watching started its grid 8px from the top on desktop, and four other screens reserved 100px of empty space tuned for a toolbar that is not there (#408)
+- The home backdrop and the boot screen drop the last of the old navy palette (#405)
+- The Linux Flatpak keeps a pairing across restarts. The sandbox granted no D-Bus access to the Secret Service, and the storage layer caught that failure and redirected the write to a process-local map, so a pairing worked for the session and was gone on the next launch (#417)
+
+## Technical
+
+- A backend PR runs 6 CI jobs instead of 13, and the merge gate is 3 required checks instead of 7. Wall clock to green goes from about 20 minutes to about 14 (#431)
+- Feedback notification emails set `Reply-To` to the submitter's contact when it parses as an address, so replying reaches the person instead of the relay's own inbox (#412)
+- Two migrations stamped `20260811130000` merged independently, which made Ecto refuse to run every migration in the tree. Caught and resolved on master (#410)
+- The Flatpak publish step recreates the OSTree repo's empty directories, which the artifact round trip does not preserve. This is why v0.13.1 published every platform except Flatpak (#394)
+- The E2E browser job pins the browser Wallaby drives, not just the driver (#404)
+- Several tests asserted a module's exports without loading it first, so what they really tested was whether an earlier test in the run happened to reference that module (#428)
+
+## Upgrade notes
+
+Back up first.
+
+1. **Blacklist entries written since 2026-08-07 with reason `rejected_by_user` are deleted.** The v0.13.0 content check wrote them for healthy releases with a 30-day TTL, so without this they keep suppressing good releases for a month. Genuine rejections you made in that window go with them; they are cheap to redo (#400)
+2. **Each kind of library gets a default flag**, backfilled to the oldest monitored library of that kind. That reproduces what most installs did before, but it is a guess. Check Settings if you run more than one movies or series library (#402)
+3. **Watched-state sync writes to your media server.** It is off by default and stays off unless you enable it. Once enabled, per-user profile links are seeded so each person syncs against their own account rather than the admin's (#403, #420)
+4. **Connecting a Trakt account is gone**, along with its relay routes and its crontab entry. No install ever had a working connection, so nothing regresses, but scrobbling, ratings, watchlist and collection sync have no Simkl equivalent. The `user_integrations` table and its generic CRUD are kept (#406)
+5. **Per-user subtitle provider rows are replaced by instance-scoped configs** resolved through the layered config model. Configure providers at `/admin/subtitle-providers` (#425)
+6. **18 migrations**, all additive except the two deletions named above. `subtitles.subtitle_hash` loses its global unique index in favour of one scoped per media file, so two rips of the same movie can each hold their own copy (#425)
+7. **The plugin ABI goes to `mydia:plugin@1.2.0`**, additive only. The host publishes `host@1.2.0` alongside `1.1.0` and `1.0.0`, so plugins compiled against the older versions keep linking and no deploy ordering is required (#403)
+8. **GraphQL changes are additive**: a nullable `state` on `continueWatching` entries, the subtitle search and content fields, and the media info stream types. Older player builds keep working (#429, #425, #399)
+9. **The relay's subtitle routes keep their exact paths and response shapes**, so installs that are never upgraded keep working against the new SubDL backend (#436)
+
+**Full Changelog**: https://github.com/getmydia/mydia/compare/v0.13.1...v0.13.2

--- a/priv/changelog/0.13.2.md
+++ b/priv/changelog/0.13.2.md
@@ -1,14 +1,14 @@
-A bugfix release on top of `v0.13.1`. Most of it is repair work on features that shipped in earlier versions and never actually ran: watched-state sync with Plex, favoriting from the player, guest requests, and most Cardigann indexers. There are 18 migrations. One of them deletes blacklist entries a v0.13.0 bug wrote for healthy releases, so read the upgrade notes before pulling.
+A bugfix release on top of `v0.13.1`. Most of it is repair work on features that shipped in earlier versions with bugs: watched-state sync with Plex, favoriting from the player, guest requests, and most Cardigann indexers. There are 18 migrations. One of them deletes blacklist entries a v0.13.0 bug wrote for healthy releases, so read the upgrade notes before pulling.
 
 ## Server
 
 ### Watched-state sync
 
-- Watched-state sync with Plex has never run once in production, on any install. Three separate blockers, each fatal on its own: sync was never enabled, the stored server address was frozen at setup time and had become unroutable, and the health check probed an endpoint that requires no authentication, so a revoked token still read as healthy. Configs now store every advertised address and resolve a working one at call time, auth failures report as auth failures with a reconnect prompt, and a `sync_runs` table records every attempt including skips and why they were skipped (#403)
-- Scheduled sync now runs. The job that creates the per-user links it depends on had no callers anywhere, so every scheduled run found no links and stopped. Installs that already have Plex configured self-heal without re-running OAuth (#420)
-- TV episodes sync. `find_by_external_ids/1` branched on whether an external id was present rather than on whether the lookup found anything, so Plex's imdb id was always tried and always missed against shows Mydia stores by tvdb. Measured on a live instance: 0 of 1386 Plex episodes were mapped. Mappings also re-crawl on an interval instead of exactly once, ever (#434)
-- Jellyfin gets watched-state sync too, and the health badge on the Media Servers page works for the first time. It returned a hardcoded Unknown for every server type, Plex included. Running a job by hand from the Jobs page also discarded the crontab's arguments, which crashed any worker with a strict args contract (#423)
-- Plex Home profiles map to Mydia users in the admin UI, and profile switching keys on the account uuid instead of the numeric id, which had 404'd every per-user token mint since the feature landed (#424, #427)
+- Watched-state sync with Plex had three separate bugs, each enough to stop it on its own: sync was never enabled, the stored server address was frozen at setup time and could become unroutable, and the health check probed an endpoint that requires no authentication, so a revoked token still read as healthy. Configs now store every advertised address and resolve a working one at call time, auth failures report as auth failures with a reconnect prompt, and a `sync_runs` table records every attempt including skips and why they were skipped (#403)
+- Scheduled sync now runs. The job that creates the per-user links it depends on was never called, so scheduled runs found no links and stopped. Installs that already have Plex configured self-heal without re-running OAuth (#420)
+- TV episodes sync. `find_by_external_ids/1` branched on whether an external id was present rather than on whether the lookup found anything, so Plex's imdb id was always tried and always missed against shows Mydia stores by tvdb. Measured on a live instance, 1386 Plex episodes went unmapped. Mappings also re-crawl on an interval, where the crawl previously ran only while an instance had no mappings at all (#434)
+- Jellyfin gets watched-state sync too, and the health badge on the Media Servers page reports real status. It returned a hardcoded Unknown for every server type, Plex included. Running a job by hand from the Jobs page also discarded the crontab's arguments, which crashed any worker with a strict args contract (#423)
+- Plex Home profiles map to Mydia users in the admin UI, and profile switching keys on the account uuid instead of the numeric id, which had been 404ing every per-user token mint (#424, #427)
 - Testing a Plex connection resolves an address through discovery instead of answering "URL is required" for every OAuth-connected server (#424)
 
 ### Downloads
@@ -19,7 +19,7 @@ A bugfix release on top of `v0.13.1`. Most of it is repair work on features that
 
 ### Indexers
 
-- Public Cardigann indexers work. Definitions ship up to 26 links and Mydia used only the first, so a rotated or blocked domain killed the indexer permanently. The health check now probes every candidate and stores the first that answers, and a search that hits a transport failure advances to the next. Selector normalization also discarded every key outside a list of seven, which is why `rows.after` and `rows.count` had working implementations that had never once received a value (#419)
+- Public Cardigann indexers survive a domain rotation. Definitions ship up to 26 links and Mydia used only the first, so a rotated or blocked domain took the indexer down for good. The health check now probes every candidate and stores the first that answers, and a search that hits a transport failure advances to the next. Selector normalization also discarded every key outside a list of seven, which is why the working `rows.after` and `rows.count` implementations never received a value (#419)
 - Grabs honour the definition's download block, so a tracker whose download link needs a separate fetch stops handing back an HTML page (#416)
 
 ### Requests and metadata
@@ -35,16 +35,19 @@ A bugfix release on top of `v0.13.1`. Most of it is repair work on features that
 
 ### Integrations
 
-- The Trakt integration is removed. As of 22 July 2026 Trakt limits free accounts to one connected community app at a time, and Mydia's users typically already have Kodi, Stremio, Infuse or Plex connected, so adding Mydia would mean giving one up or paying for VIP. Connecting an account had never worked anyway: the relay carried no client id, and the failure surfaced as advice to try again, which could never succeed. Simkl is the migration path (#406)
+- The Trakt integration is removed. As of 22 July 2026 Trakt limits free accounts to one connected community app at a time, and Mydia's users typically already have Kodi, Stremio, Infuse or Plex connected, so adding Mydia would mean giving one up or paying for VIP. Connecting an account was also broken, since the relay carried no client id and the failure surfaced as advice to try again. Simkl is the migration path (#406)
 - The bundled Simkl plugin pushes owned-but-unwatched items as plan-to-watch and pulls plan-to-watch items Mydia does not own back as favorites (#409)
 
 ### Subtitles
 
-- Subtitle search returns results on a default install for the first time. This work is not finished and continues in the next release. What landed here: the relay's backend moved from OpenSubtitles to SubDL, Gestdown was added as a keyless second provider so search survives one upstream going down, provider configuration joined the layered config model with a new page at `/admin/subtitle-providers`, and the search modal was rebuilt so it stops reporting "No subtitles found" before you have searched anything (#425, #432, #435, #436)
+- Subtitle search returns results on a default install. This work is not finished and continues in the next release. What landed here: the relay's backend moved from OpenSubtitles to SubDL, Gestdown was added as a keyless second provider so search survives one upstream going down, provider configuration joined the layered config model with a new page at `/admin/subtitle-providers`, and the search modal was rebuilt so it stops reporting "No subtitles found" before you have searched anything (#425, #432, #435, #436)
+- A targeted `subtitleContent` query resolves one track's body on demand. Extraction runs ffmpeg server-side, so folding it into the media file fragment would have run one extraction per embedded track on every season query (#433)
 
 ## Player
 
-- Favoriting works. Both detail controllers called mutations the schema does not have, `toggleShowFavorite` and `toggleMovieFavorite`, against a server that only exposes `toggleFavorite`. Every tap filled the heart optimistically and reverted. It has been broken since the player shipped (#396)
+- Favoriting works. Both detail controllers called mutations the schema does not have, `toggleShowFavorite` and `toggleMovieFavorite`, against a server that only exposes `toggleFavorite`. Every tap filled the heart optimistically and reverted (#396)
+- Subtitles play in every connection mode. Tracks were loaded by URL, which 404s over p2p and fails as mixed content on web, limiting them to a LAN. They now arrive as text over GraphQL, which is already tunnelled in every mode, so LAN, direct, p2p and web all work from one path. Image-based tracks (PGS, VobSub) stay selectable in direct play, where the engine renders them from the container, and are hidden when streaming instead of being offered as tracks that silently do nothing (#433)
+- The playback subtitle sheet can search and download online subtitles: language chips, results carrying the release name, exact-hash match, rating and which provider answered, and each provider's remaining quota or the reason it failed. Picking a result downloads and selects it in one step. Two selection bugs go with it: a track whose fetch failed left the pending target stuck on it, so re-tapping was silently swallowed, and a player restart left the sheet showing a track checked with nothing rendering (#433)
 - Media Info panel with a full per-stream readout, opened from the movie and episode detail screens. `FileAnalyzer` already ran `ffprobe -show_streams` and kept only the first video and first audio stream; it now keeps them all, in the existing metadata JSON with no migration (#399, #407)
 - The web player offers tap-to-play when the browser blocks the start, instead of replacing the screen with "Failed to load video". That message was the browser's autoplay gate rather than a load failure. Retry appeared to fix it only by supplying the missing gesture, at the cost of re-running the whole pipeline and making the server transcode the opening a second time (#413)
 - The floating mobile dock stops painting over content and over the nav drawer, where a tap landing on "Home" navigated straight through the open drawer's scrim (#398)
@@ -60,6 +63,7 @@ A bugfix release on top of `v0.13.1`. Most of it is repair work on features that
 - The Flatpak publish step recreates the OSTree repo's empty directories, which the artifact round trip does not preserve. This is why v0.13.1 published every platform except Flatpak (#394)
 - The E2E browser job pins the browser Wallaby drives, not just the driver (#404)
 - Several tests asserted a module's exports without loading it first, so what they really tested was whether an earlier test in the run happened to reference that module (#428)
+- A player widget test seeded Hive through a disk-backed box, leaving a real file write outstanding inside `testWidgets`' fake-async zone. It hung for the full ten minute timeout and took the two tests after it down with it, since a timed-out test never releases the binding. That suite goes from 20 minutes with 3 failures to 4 seconds with none (#433)
 
 ## Upgrade notes
 
@@ -68,11 +72,11 @@ Back up first.
 1. **Blacklist entries written since 2026-08-07 with reason `rejected_by_user` are deleted.** The v0.13.0 content check wrote them for healthy releases with a 30-day TTL, so without this they keep suppressing good releases for a month. Genuine rejections you made in that window go with them; they are cheap to redo (#400)
 2. **Each kind of library gets a default flag**, backfilled to the oldest monitored library of that kind. That reproduces what most installs did before, but it is a guess. Check Settings if you run more than one movies or series library (#402)
 3. **Watched-state sync writes to your media server.** It is off by default and stays off unless you enable it. Once enabled, per-user profile links are seeded so each person syncs against their own account rather than the admin's (#403, #420)
-4. **Connecting a Trakt account is gone**, along with its relay routes and its crontab entry. No install ever had a working connection, so nothing regresses, but scrobbling, ratings, watchlist and collection sync have no Simkl equivalent. The `user_integrations` table and its generic CRUD are kept (#406)
+4. **Connecting a Trakt account is gone**, along with its relay routes and its crontab entry. Connecting was broken, so little regresses in practice, but scrobbling, ratings, watchlist and collection sync have no Simkl equivalent. The `user_integrations` table and its generic CRUD are kept (#406)
 5. **Per-user subtitle provider rows are replaced by instance-scoped configs** resolved through the layered config model. Configure providers at `/admin/subtitle-providers` (#425)
 6. **18 migrations**, all additive except the two deletions named above. `subtitles.subtitle_hash` loses its global unique index in favour of one scoped per media file, so two rips of the same movie can each hold their own copy (#425)
 7. **The plugin ABI goes to `mydia:plugin@1.2.0`**, additive only. The host publishes `host@1.2.0` alongside `1.1.0` and `1.0.0`, so plugins compiled against the older versions keep linking and no deploy ordering is required (#403)
-8. **GraphQL changes are additive**: a nullable `state` on `continueWatching` entries, the subtitle search and content fields, and the media info stream types. Older player builds keep working (#429, #425, #399)
+8. **GraphQL changes are additive**: a nullable `state` on `continueWatching` entries, the subtitle search fields, a targeted `subtitleContent` query, and the media info stream types. Older player builds keep working (#429, #425, #399, #433)
 9. **The relay's subtitle routes keep their exact paths and response shapes**, so installs that are never upgraded keep working against the new SubDL backend (#436)
 
 **Full Changelog**: https://github.com/getmydia/mydia/compare/v0.13.1...v0.13.2


### PR DESCRIPTION
Bundled release notes for v0.13.2, per `docs/contributing/releasing.md` step 1. Must merge before the draft is pinned to a commit; the workflow refuses to build a stable release whose notes file is missing at the pinned SHA.

Covers the 39 PRs merged since v0.13.1 (#394 through #436). Framed as a bugfix release, since the bulk of it repairs features that shipped earlier and never actually ran: Plex watched-state sync, favoriting from the player, guest requests, and most Cardigann indexers.

Two framing calls worth flagging:

- **Subtitles are described as unfinished.** Search returns results on a default install for the first time, but the bullet says so plainly and points at the next release rather than presenting it as done.
- **Trakt removal leads with the terms change**, not with the fact that it never worked. The one-connected-community-app limit from 22 July 2026 is the reason it is not coming back; the broken relay credential is secondary.

Upgrade notes call out the two destructive migrations: the `rejected_by_user` blacklist purge from #400, and the removed Trakt Oban rows from #406. The library default-flag backfill is flagged as a guess that multi-library installs should check.

Verified: `mix test test/mydia/changelog_test.exs test/mydia_web/live/changelog_live_test.exs` green (17 tests, 0 failures). That compiles `Mydia.Changelog`, which parses and renders every bundled file at compile time, so a malformed notes file would fail the build.