### PR TITLE
fix(dashboard): count TV streams and source recent activity from real plays

### DIFF
--- a/lib/mydia/playback.ex
+++ b/lib/mydia/playback.ex
@@ -468,6 +468,12 @@ defmodule Mydia.Playback do
 
   @doc """
   Lists recent watch history for all users.
+
+  This is progress rows ordered by `last_watched_at`, which is not the same as
+  "recently watched here": a media-server sync writes progress for watches that
+  happened on somebody else's box, and stamps that column with the sync time
+  whenever the remote carries no timestamp. For plays that happened on this
+  server, use `Mydia.Playback.Stats.recent_plays/1`.
   """
   def list_recent_history(opts \\ []) do
     limit = Keyword.get(opts, :limit, 20)

--- a/lib/mydia/playback/stats.ex
+++ b/lib/mydia/playback/stats.ex
@@ -9,8 +9,18 @@ defmodule Mydia.Playback.Stats do
 
   import Ecto.Query
 
+  alias Mydia.Accounts.User
   alias Mydia.Events.Event
+  alias Mydia.Media.Episode
+  alias Mydia.Media.MediaItem
+  alias Mydia.Playback.Progress
   alias Mydia.Repo
+
+  # Filtering and de-duplication both shrink the scanned set, so read more rows
+  # than asked for. Bounded so a server with a long history does not load its
+  # whole play log to render twenty lines.
+  @scan_factor 5
+  @scan_ceiling 200
 
   @doc """
   Plays per local day, split into movies and episodes.
@@ -113,5 +123,113 @@ defmodule Mydia.Playback.Stats do
 
   defp within?(date, first_day, today) do
     Date.compare(date, first_day) != :lt and Date.compare(date, today) != :gt
+  end
+
+  @doc """
+  Recent plays that happened on this server, newest first.
+
+  Sourced from `playback.started` events, which only a real streaming session
+  emits, rather than from playback progress rows. A media-server sync writes
+  progress for watches that happened on somebody else's box, and stamps
+  `last_watched_at` with the sync time whenever the remote carries no timestamp
+  (`Mydia.WatchSync.Engine.apply_local/5`), so ordering progress by that column
+  buried every local play under a wall of imported history. This is the same
+  rule `Mydia.Streaming.emit_playback_started/2` already documents for the
+  plays-per-day chart.
+
+  Returns unsaved `Progress` structs used purely as a view model: they carry the
+  viewer and the resolved episode or media item, so `progress_title/1` and
+  `progress_poster_path/1` render a play exactly as they render a history row.
+  `last_watched_at` is the moment playback started.
+
+  Plays whose content has since been deleted are dropped rather than rendered
+  as "Unknown Media".
+  """
+  @spec recent_plays(pos_integer()) :: [Progress.t()]
+  def recent_plays(limit \\ 20) when is_integer(limit) and limit > 0 do
+    limit
+    |> fetch_recent_starts()
+    |> Enum.uniq_by(&{&1.actor_id, &1.resource_type, &1.resource_id})
+    |> Enum.take(limit)
+    |> resolve_plays()
+  end
+
+  defp fetch_recent_starts(limit) do
+    scan = min(limit * @scan_factor, @scan_ceiling)
+
+    Event
+    |> where([e], e.type == "playback.started")
+    # `inserted_at` is second-granularity, so a stable tiebreak is needed or two
+    # plays in the same second could swap places between renders.
+    |> order_by([e], desc: e.inserted_at, desc: e.id)
+    |> limit(^scan)
+    |> Repo.all()
+  end
+
+  defp resolve_plays([]), do: []
+
+  defp resolve_plays(events) do
+    episodes = load_by_id(Episode, events, "episode", preload: :media_item)
+    items = load_by_id(MediaItem, events, "media_item")
+    users = load_users(events)
+
+    Enum.flat_map(events, fn event ->
+      case play_content(event, episodes, items) do
+        nil ->
+          []
+
+        content ->
+          play = %Progress{
+            user: Map.get(users, event.actor_id),
+            last_watched_at: event.inserted_at
+          }
+
+          [struct(play, content)]
+      end
+    end)
+  end
+
+  defp play_content(%{resource_type: "episode", resource_id: id}, episodes, _items) do
+    case Map.fetch(episodes, id) do
+      {:ok, episode} -> %{episode: episode, episode_id: id}
+      :error -> nil
+    end
+  end
+
+  defp play_content(%{resource_type: "media_item", resource_id: id}, _episodes, items) do
+    case Map.fetch(items, id) do
+      {:ok, item} -> %{media_item: item, media_item_id: id}
+      :error -> nil
+    end
+  end
+
+  defp play_content(_event, _episodes, _items), do: nil
+
+  defp load_by_id(schema, events, resource_type, opts \\ []) do
+    ids =
+      for event <- events, event.resource_type == resource_type, do: event.resource_id
+
+    case Enum.uniq(ids) do
+      [] ->
+        %{}
+
+      ids ->
+        schema
+        |> where([r], r.id in ^ids)
+        |> preload(^Keyword.get(opts, :preload, []))
+        |> Repo.all()
+        |> Map.new(&{&1.id, &1})
+    end
+  end
+
+  # `actor_id` is a string column, since system actors are not UUIDs. Anything
+  # that is not a user id simply finds no row and renders without a name.
+  defp load_users(events) do
+    ids = events |> Enum.map(& &1.actor_id) |> Enum.uniq() |> Enum.reject(&is_nil/1)
+
+    case ids do
+      [] -> %{}
+      ids -> User |> where([u], u.id in ^ids) |> Repo.all() |> Map.new(&{&1.id, &1})
+    end
   end
 end

--- a/lib/mydia/streaming.ex
+++ b/lib/mydia/streaming.ex
@@ -69,40 +69,37 @@ defmodule Mydia.Streaming do
       # Fetch User
       user = Repo.get(User, user_id)
 
-      # Fetch Media Info - use non-raising query to handle deleted files gracefully
-      media_file = Library.get_media_file(media_file_id, preload: [:media_item, :episode])
+      # Fetch Media Info - use non-raising query to handle deleted files gracefully.
+      # A TV file's show hangs off `episode.media_item`, so that association has
+      # to come along or every episode session renders without a title.
+      media_file =
+        Library.get_media_file(media_file_id, preload: [:media_item, episode: :media_item])
 
-      # Return nil if media file or media_item doesn't exist (will be filtered out below)
-      if media_file && media_file.media_item do
-        # Derive title/type
-        {title, type, episode_info} =
-          case media_file do
-            %{episode: %{season_number: s, episode_number: e, title: ep_title}, media_item: show} ->
-              {show.title, :tv_show, "S#{pad(s)}E#{pad(e)} - #{ep_title}"}
+      # Return nil when the file has been deleted, or carries neither an episode
+      # nor a media item (filtered out below)
+      case session_media(media_file) do
+        nil ->
+          nil
 
-            %{media_item: movie} ->
-              {movie.title, :movie, nil}
-          end
+        {title, type, episode_info, artwork_item} ->
+          progress =
+            user && Mydia.Playback.get_progress(user.id, progress_content_id(media_file))
 
-        progress = user && Mydia.Playback.get_progress(user.id, progress_content_id(media_file))
-
-        %ActiveSession{
-          session_id: session_id,
-          user: user,
-          media_title: title,
-          media_type: type,
-          episode_info: episode_info,
-          mode: mode,
-          started_at: started_at,
-          ready: ready,
-          media_file_id: media_file_id,
-          bitrate_bps: media_file.bitrate,
-          position_seconds: progress && progress.position_seconds,
-          duration_seconds: progress && progress.duration_seconds,
-          poster_path: poster_path(media_file.media_item)
-        }
-      else
-        nil
+          %ActiveSession{
+            session_id: session_id,
+            user: user,
+            media_title: title,
+            media_type: type,
+            episode_info: episode_info,
+            mode: mode,
+            started_at: started_at,
+            ready: ready,
+            media_file_id: media_file_id,
+            bitrate_bps: media_file.bitrate,
+            position_seconds: progress && progress.position_seconds,
+            duration_seconds: progress && progress.duration_seconds,
+            poster_path: poster_path(artwork_item)
+          }
       end
     end)
     # Filter out sessions where user or media might be missing (deleted)
@@ -167,6 +164,31 @@ defmodule Mydia.Streaming do
   # An episode's media_file carries its show as media_item, so a TV session gets
   # the show poster rather than an episode still, which is what the now-playing
   # card wants.
+  # Title, type, episode line, and the item artwork comes from, or nil when the
+  # session has nothing left to render.
+  #
+  # A TV file carries `episode_id` with `media_item_id` NULL, so its show hangs
+  # off `episode.media_item` and reading the show from `media_item` always finds
+  # nil. Gating this on `media_item` therefore dropped every episode session,
+  # which on a TV library is nearly all of them, and left the dashboard
+  # reporting nobody watching while a stream was running. The episode clause has
+  # to come first: a movie file has no episode, but nothing stops a future TV
+  # file from carrying both keys.
+  defp session_media(%{episode: %{season_number: s, episode_number: e, title: ep_title}} = file) do
+    episode_info = "S#{pad(s)}E#{pad(e)} - #{ep_title}"
+
+    case file.episode do
+      %{media_item: %{title: show_title} = show} -> {show_title, :tv_show, episode_info, show}
+      # An episode whose show has been deleted still names itself. Rendering the
+      # episode beats vanishing from the dashboard mid-stream.
+      _ -> {ep_title, :tv_show, episode_info, nil}
+    end
+  end
+
+  defp session_media(%{media_item: %{title: title} = movie}), do: {title, :movie, nil, movie}
+
+  defp session_media(_), do: nil
+
   defp poster_path(%{metadata: %{poster_path: path}}), do: path
   defp poster_path(_), do: nil
 

--- a/lib/mydia_web/live/admin_dashboard_live/components.ex
+++ b/lib/mydia_web/live/admin_dashboard_live/components.ex
@@ -34,7 +34,9 @@ defmodule MydiaWeb.AdminDashboardLive.Components do
       </div>
       <div id="kpi-bandwidth" class="stat bg-base-200 rounded-box shadow-sm">
         <div class="stat-title">Bandwidth</div>
-        <div class="stat-value text-2xl">{format_mbps(@total_mbps)}</div>
+        <div class="stat-value text-2xl">
+          {format_mbps(@total_mbps)}<span class="text-sm font-normal opacity-60 ml-1">Mbps</span>
+        </div>
         <div class="stat-desc">
           Estimated{if @unmeasured_count > 0, do: ", #{@unmeasured_count} unmeasured", else: ""}
         </div>
@@ -229,7 +231,10 @@ defmodule MydiaWeb.AdminDashboardLive.Components do
       )
 
     ~H"""
-    <div class="card bg-base-100 shadow-sm border border-base-300">
+    <div
+      id={"now-playing-#{@session.media_file_id}"}
+      class="card bg-base-100 shadow-sm border border-base-300"
+    >
       <div class="card-body p-3 gap-2">
         <div class="flex items-center gap-3">
           <%= if @session.poster_path do %>

--- a/lib/mydia_web/live/admin_dashboard_live/index.ex
+++ b/lib/mydia_web/live/admin_dashboard_live/index.ex
@@ -92,13 +92,16 @@ defmodule MydiaWeb.AdminDashboardLive.Index do
     completed_jobs =
       Downloads.list_transcode_jobs(status: ["ready", "failed"], limit: 15, preload: job_preloads)
 
-    watch_history = Playback.list_recent_history(limit: 15)
+    # Plays, not progress rows: a media-server sync writes progress for watches
+    # that happened elsewhere and stamps it with the sync time, which flooded
+    # this list with imported Plex history the moment a sync ran.
+    plays = Playback.Stats.recent_plays(15)
 
     job_items =
       Enum.map(completed_jobs, &%{type: :transcode_job, data: &1, timestamp: &1.updated_at})
 
     history_items =
-      Enum.map(watch_history, &%{type: :watch_history, data: &1, timestamp: &1.last_watched_at})
+      Enum.map(plays, &%{type: :watch_history, data: &1, timestamp: &1.last_watched_at})
 
     (job_items ++ history_items)
     |> Enum.sort_by(& &1.timestamp, {:desc, DateTime})

--- a/test/mydia/playback/recent_plays_test.exs
+++ b/test/mydia/playback/recent_plays_test.exs
@@ -1,0 +1,138 @@
+defmodule Mydia.Playback.RecentPlaysTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
+  alias Mydia.Playback
+  alias Mydia.Playback.Stats
+  alias Mydia.Streaming
+
+  defp episode_file(attrs \\ %{}) do
+    show = MediaFixtures.media_item_fixture(Map.merge(%{type: "tv_show"}, attrs))
+    episode = MediaFixtures.episode_fixture(%{media_item_id: show.id})
+    media_file = MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+
+    {show, episode, media_file}
+  end
+
+  # Ordering needs timestamps the emitter cannot produce on demand, so those
+  # cases write the event row the emitter would have written.
+  defp insert_start(user_id, episode_id, at) do
+    Repo.insert!(%Mydia.Events.Event{
+      category: "playback",
+      type: "playback.started",
+      actor_type: :user,
+      actor_id: user_id,
+      resource_type: "episode",
+      resource_id: episode_id,
+      metadata: %{"episode_id" => episode_id, "origin" => "player"},
+      inserted_at: at
+    })
+  end
+
+  describe "recent_plays/1" do
+    test "a play started on this server is listed" do
+      {show, _episode, media_file} = episode_file(%{title: "House of the Dragon"})
+      user = AccountsFixtures.user_fixture()
+
+      :ok = Streaming.emit_playback_started(media_file.id, user.id)
+
+      assert [play] = Stats.recent_plays(10)
+      assert Playback.progress_title(play) =~ show.title
+      assert play.user.id == user.id
+      assert play.last_watched_at
+    end
+
+    test "a movie play is listed" do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "Arrival"})
+      media_file = MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+      user = AccountsFixtures.user_fixture()
+
+      :ok = Streaming.emit_playback_started(media_file.id, user.id)
+
+      assert [play] = Stats.recent_plays(10)
+      assert Playback.progress_title(play) == "Arrival"
+    end
+
+    # The bug this function exists to fix. A media-server sync writes progress
+    # for watches that happened on somebody else's box, and stamps
+    # `last_watched_at` with the sync time whenever the remote carries no
+    # timestamp, so an import buried every real play under a wall of history
+    # that was never watched here.
+    test "a media-server sync is not a play" do
+      {_show, episode, _media_file} = episode_file()
+      user = AccountsFixtures.user_fixture()
+
+      Playback.ensure_watched(user.id, [episode_id: episode.id], origin: "sync:plex")
+
+      assert Stats.recent_plays(10) == []
+    end
+
+    test "sync writes never outrank a real play" do
+      {_show, watched_episode, _} = episode_file()
+      {show, _episode, media_file} = episode_file(%{title: "The Expanse"})
+      user = AccountsFixtures.user_fixture()
+
+      :ok = Streaming.emit_playback_started(media_file.id, user.id)
+      Playback.ensure_watched(user.id, [episode_id: watched_episode.id], origin: "sync:plex")
+
+      assert [play] = Stats.recent_plays(10)
+      assert Playback.progress_title(play) =~ show.title
+    end
+
+    # `events.inserted_at` is second-granularity, so ordering is asserted on
+    # plays a minute apart. Two plays inside the same second fall back to a
+    # tiebreak that is stable between renders but not chronological, which for
+    # an activity feed is immaterial.
+    test "newest first" do
+      {_show, older_episode, _} = episode_file(%{title: "Older"})
+      {_show, newer_episode, _} = episode_file(%{title: "Newer"})
+      user = AccountsFixtures.user_fixture()
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      insert_start(user.id, older_episode.id, DateTime.add(now, -60, :second))
+      insert_start(user.id, newer_episode.id, now)
+
+      titles = Stats.recent_plays(10) |> Enum.map(&Playback.progress_title/1)
+
+      assert length(titles) == 2
+      assert hd(titles) =~ "Newer"
+    end
+
+    # A session that restarts mid-stream, which the offset-mismatch path does,
+    # emits a second start for the same content. One viewer watching one thing
+    # is one row in the activity feed.
+    test "a repeated start on the same content is listed once" do
+      {_show, _episode, media_file} = episode_file()
+      user = AccountsFixtures.user_fixture()
+
+      :ok = Streaming.emit_playback_started(media_file.id, user.id)
+      :ok = Streaming.emit_playback_started(media_file.id, user.id)
+
+      assert [_single] = Stats.recent_plays(10)
+    end
+
+    test "honours the limit" do
+      user = AccountsFixtures.user_fixture()
+
+      for _ <- 1..3 do
+        {_show, _episode, media_file} = episode_file()
+        :ok = Streaming.emit_playback_started(media_file.id, user.id)
+      end
+
+      assert length(Stats.recent_plays(2)) == 2
+    end
+
+    # Deleting a show must not take the dashboard down with it.
+    test "a play whose content has been deleted is skipped" do
+      {_show, episode, media_file} = episode_file()
+      user = AccountsFixtures.user_fixture()
+
+      :ok = Streaming.emit_playback_started(media_file.id, user.id)
+      Repo.delete!(episode)
+
+      assert Stats.recent_plays(10) == []
+    end
+  end
+end

--- a/test/mydia/streaming/list_active_sessions_test.exs
+++ b/test/mydia/streaming/list_active_sessions_test.exs
@@ -1,0 +1,80 @@
+defmodule Mydia.Streaming.ListActiveSessionsTest do
+  # Drives the real session registry and a real DirectPlaySession, so the
+  # sandbox has to be shared with those processes.
+  use Mydia.DataCase, async: false
+
+  alias Mydia.MediaFixtures
+  alias Mydia.Streaming
+  alias Mydia.Streaming.HlsSessionSupervisor
+
+  defp start_direct_play(media_file, user) do
+    {:ok, _pid, :started} = HlsSessionSupervisor.start_direct_session(media_file.id, user.id)
+
+    on_exit(fn -> HlsSessionSupervisor.stop_direct_session(media_file.id, user.id) end)
+
+    Enum.find(Streaming.list_active_sessions(), &(&1.media_file_id == media_file.id))
+  end
+
+  describe "list_active_sessions/0" do
+    # A TV file carries episode_id with media_item_id NULL: the show hangs off
+    # episode.media_item. Requiring media_file.media_item therefore dropped
+    # every episode session, which on a TV-heavy library is nearly all of them,
+    # and left the dashboard reporting zero viewers while a stream was running.
+    test "an episode session reports the show and the episode" do
+      show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "House of the Dragon"})
+
+      episode =
+        MediaFixtures.episode_fixture(%{
+          media_item_id: show.id,
+          season_number: 3,
+          episode_number: 3,
+          title: "The Burning Mill"
+        })
+
+      media_file = MediaFixtures.media_file_fixture(%{episode_id: episode.id, bitrate: 7_857_251})
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      session = start_direct_play(media_file, user)
+
+      assert session, "an active episode session must appear in the now-playing list"
+      assert session.media_title == "House of the Dragon"
+      assert session.media_type == :tv_show
+      assert session.episode_info == "S03E03 - The Burning Mill"
+      assert session.bitrate_bps == 7_857_251
+      assert session.user.id == user.id
+    end
+
+    test "a movie session still reports the movie" do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "Arrival"})
+      media_file = MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      session = start_direct_play(media_file, user)
+
+      assert session
+      assert session.media_title == "Arrival"
+      assert session.media_type == :movie
+      assert session.episode_info == nil
+    end
+
+    # The session's scrubber comes from the viewer's progress row, which for a
+    # TV file is keyed by episode rather than by show.
+    test "an episode session carries the viewer's saved position" do
+      show = MediaFixtures.media_item_fixture(%{type: "tv_show"})
+      episode = MediaFixtures.episode_fixture(%{media_item_id: show.id})
+      media_file = MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      {:ok, _} =
+        Mydia.Playback.save_progress(user.id, [episode_id: episode.id], %{
+          position_seconds: 62,
+          duration_seconds: 3389
+        })
+
+      session = start_direct_play(media_file, user)
+
+      assert session.position_seconds == 62
+      assert session.duration_seconds == 3389
+    end
+  end
+end

--- a/test/mydia_web/live/admin_dashboard_live_test.exs
+++ b/test/mydia_web/live/admin_dashboard_live_test.exs
@@ -150,4 +150,35 @@ defmodule MydiaWeb.AdminDashboardLiveTest do
     refute fresh_fill == MydiaWeb.AdminDashboardLive.Components.series_fill("old")
     assert html =~ fresh_fill
   end
+
+  # Regression: on a TV library the dashboard reported nobody watching while a
+  # stream was running, because an episode's media file carries `episode_id`
+  # with `media_item_id` NULL and the session list required the latter.
+  test "an episode stream appears in now playing", %{conn: conn, token: token} do
+    show =
+      Mydia.MediaFixtures.media_item_fixture(%{type: "tv_show", title: "House of the Dragon"})
+
+    episode = Mydia.MediaFixtures.episode_fixture(%{media_item_id: show.id})
+    media_file = Mydia.MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+    viewer = Mydia.AccountsFixtures.user_fixture()
+
+    {:ok, _pid, :started} =
+      Mydia.Streaming.HlsSessionSupervisor.start_direct_session(media_file.id, viewer.id)
+
+    on_exit(fn ->
+      Mydia.Streaming.HlsSessionSupervisor.stop_direct_session(media_file.id, viewer.id)
+    end)
+
+    {:ok, view, _html} = live(authed(conn, token), ~p"/admin/dashboard")
+
+    refute has_element?(view, "#now-playing-empty")
+    assert has_element?(view, "#now-playing-#{media_file.id}")
+    assert render(view) =~ "House of the Dragon"
+  end
+
+  test "the bandwidth KPI carries its unit", %{conn: conn, token: token} do
+    {:ok, view, _html} = live(authed(conn, token), ~p"/admin/dashboard")
+
+    assert view |> element("#kpi-bandwidth") |> render() =~ "Mbps"
+  end
 end


### PR DESCRIPTION
The admin dashboard reported nobody watching while a stream was running, and filled Recent Activity with Plex history that was never watched here. Traced against the live galactica instance.

## Active streams / Now Playing showed zero

`Streaming.list_active_sessions/0` gated every session on `media_file.media_item`. A TV file carries `episode_id` with `media_item_id` NULL, and its show hangs off `episode.media_item`, so every episode session was silently dropped. On galactica that is 1763 of 2268 media files.

The bandwidth sampler reads the registry key rather than the association, so it kept counting the same stream the session list had discarded, which is why Bandwidth showed a live figure next to zero viewers.

Confirmed from prod: `playback.started` with `"origin":"player"` fired at 13:59:53 for a House of the Dragon episode while the dashboard showed nothing.

Fixed by preloading `episode: :media_item` and deriving the title from the episode's show. An episode whose show has been deleted now names itself instead of vanishing mid-stream.

## Recent Activity showed synced Plex items

It listed progress rows ordered by `last_watched_at`. A media-server sync writes progress for watches that happened on somebody else's box, and `WatchSync.Engine.apply_local/5` stamps that column with the sync time whenever the remote carries no timestamp, so an import buries every local play. Eight such rows landed at one identical instant on galactica.

Now sourced from `playback.started` events, which only a real streaming session emits, via a new `Playback.Stats.recent_plays/1`. Same rule `Streaming.emit_playback_started/2` already documents for the plays-per-day chart. `list_recent_history/1` keeps its callers-free existence with a doc note pointing at the difference.

## Bandwidth KPI had no unit

It rendered a bare `9.4`. Now `9.4 Mbps`.

## Tests

Three new regression files, plus a LiveView test that drives a real direct-play session so an episode stream has to reach the page. The previous suite covered `list_active_sessions/0` only through an extracted helper, on the grounds that it "needs a live session registry to reach", which is exactly how this shipped.

`mix precommit`: 7591 tests, 0 failures, Credo strict clean.

## Noted, not fixed

Two identical `playback.started` events fired for one play on galactica, which double-counts "Plays today". `recent_plays/1` dedupes them for the activity feed, but the emission needs its own look.
