### PR TITLE
feat(config): make automatic-search min_seeders operator-configurable

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -177,6 +177,24 @@ downloads:
   # How often to monitor downloads for completion (in minutes)
   monitor_interval_minutes: 2
 
+  # Minimum seeders an automatic (background) search result must report.
+  # Environment variable: AUTO_SEARCH_MIN_SEEDERS
+  #
+  # This is a hard filter applied before ranking, so a torrent below the
+  # threshold is removed from the results, not merely demoted. It applies only
+  # to automatic searches; manual searches have their own control in the search
+  # interface. Usenet results report no seeder count at all and are exempt.
+  #
+  # The default of 0 filters nothing. Raising it to 3-5 on a torrent-only setup
+  # keeps automatic searches from grabbing a release that can never complete.
+  #
+  # Read this before raising it: some torrent indexers report 0 when they mean
+  # "unknown" rather than "dead". Cardigann reports 0 when its seeders selector
+  # does not match the site, and Jackett reports 0 for an empty field. Any
+  # nonzero floor discards everything those indexers return without a parsed
+  # seeder count, which looks a lot like an indexer that stopped working.
+  min_seeders: 0
+
 # FlareSolverr Configuration
 # ---------------------------
 # FlareSolverr is a proxy server to bypass Cloudflare and DDoS-GUARD protection.

--- a/config/config.exs
+++ b/config/config.exs
@@ -383,14 +383,14 @@ config :mydia, :episode_monitor,
   # With 200 items × 3s delay = ~10 min per run, well within the 30-min interval
   search_delay_ms: 3000
 
-# Auto-search seeder requirements
-# Controls the minimum seeder count for automatic searches
+# Auto-search release filtering
+#
+# NOTE: the minimum seeder count for automatic searches moved out of this
+# compile-time block and into the layered runtime config as
+# `downloads.min_seeders` (config.yml), settable at runtime from the admin
+# settings UI or with the AUTO_SEARCH_MIN_SEEDERS environment variable. It
+# still defaults to 0. See Mydia.Config.Schema.
 config :mydia, :auto_search,
-  # Minimum seeders required for auto-search results (movies and TV shows)
-  # Set to 0 for Usenet compatibility (Usenet indexers report 0 seeders)
-  # Set to 3-5 for torrent-only setups to filter out dead torrents
-  # This setting only affects automatic background searches, not manual searches
-  min_seeders: 0,
   # Case-insensitive substring tokens that disqualify a release title.
   # Default is empty — opt in by overriding in runtime.exs or releases.exs.
   # Examples for English-only libraries:

--- a/docs/using/explanation/quality-decisions.md
+++ b/docs/using/explanation/quality-decisions.md
@@ -98,6 +98,28 @@ nothing, and it only applies to automatic background searches unless you set it
 yourself in the manual search interface. And Usenet results, which report no
 seeder count at all, are exempt rather than being filtered out wholesale.
 
+#### Setting it
+
+The floor for automatic searches lives in the layered configuration as
+`downloads.min_seeders`, so you can set it three ways, in increasing order of
+precedence:
+
+- **Settings > Configuration > Downloads** in the web UI, as *Minimum Seeders
+  (automatic search)*. This is the usual way and takes effect without a restart.
+- `downloads.min_seeders` in `config.yml`.
+- The `AUTO_SEARCH_MIN_SEEDERS` environment variable, which wins over both.
+
+The manual search interface keeps its own separate control, which is only ever
+applied to the search you are running at the time.
+
+Something to know before you raise it above zero: a few torrent indexers report
+zero seeders when they mean "I could not read the seeder count", not "this
+torrent is dead". Cardigann definitions do this when their seeders selector does
+not match the site's markup, and Jackett does it for an empty field. Any nonzero
+floor discards every result from those indexers that has no parsed seeder count,
+which looks a lot like an indexer that quietly stopped working. If you set a
+floor, check that your indexers still return results.
+
 The practical warning: this is the one setting that can genuinely empty a result
 list. If you raised it to filter out dead torrents and searches stopped finding
 anything, lower it before investigating anything else.

--- a/docs/using/reference/environment-variables.md
+++ b/docs/using/reference/environment-variables.md
@@ -248,6 +248,16 @@ INDEXER_3_BASE_URL=http://nzbhydra2:5076
 INDEXER_3_API_KEY=your-nzbhydra2-api-key
 ```
 
+## Automatic Search
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AUTO_SEARCH_MIN_SEEDERS` | Minimum seeders a result must report for an automatic search to consider it. A hard filter applied before ranking, so a torrent below it is removed rather than demoted. Manual searches have their own control, and Usenet results report no seeders and are exempt | `0` (filters nothing) |
+
+Some indexers report zero seeders when they could not read the count rather than when a torrent is dead, so any nonzero floor can silently empty their
+results. See [How Mydia decides which release to grab](../explanation/quality-decisions.md#minimum-seeders-is-a-filter-and-the-only-one-you-are-likely-to-set)
+before raising it. Also settable under **Admin > Configuration > Settings > Downloads**.
+
 ## PostgreSQL Configuration
 
 For PostgreSQL deployments (using `latest-pg` image):

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -255,6 +255,11 @@ defmodule Mydia.Config.Loader do
       System.get_env("DOWNLOAD_MONITOR_INTERVAL_MINUTES"),
       &parse_integer/1
     )
+    |> put_if_present(
+      :min_seeders,
+      System.get_env("AUTO_SEARCH_MIN_SEEDERS"),
+      &parse_integer/1
+    )
   end
 
   defp load_upgrades_env do

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -102,6 +102,23 @@ defmodule Mydia.Config.Schema do
       # stops auto-rejecting it. Bounds a systematic false positive to this
       # many releases instead of the item's entire search result set.
       field :auto_reject_limit, :integer, default: 3
+      # Minimum seeder count an automatic (background) search result must
+      # report before Mydia will consider it. `Mydia.Indexers.search_all/2`
+      # applies it as a hard filter, before deduplication and ranking, so a
+      # release below the floor is dropped rather than demoted. Manual search
+      # has its own control in the search UI and does not read this.
+      #
+      # The default of 0 filters nothing, which is also what Usenet needs:
+      # NZB results carry no seeder count and are exempt from the filter.
+      #
+      # Read this before raising it. Some torrent adapters report 0 to mean
+      # "unknown" rather than "dead": Cardigann coerces a missing seeders
+      # selector to 0 (`Mydia.Indexers.CardigannResultParser`) and Jackett
+      # maps an empty field to 0 (`Mydia.Indexers.Adapter.Jackett`). Any
+      # nonzero floor therefore discards every result those indexers return
+      # without a parsed seeder count, which can look like an indexer that
+      # stopped working.
+      field :min_seeders, :integer, default: 0
     end
 
     embeds_one :upgrades, Upgrades, on_replace: :update, primary_key: false do
@@ -371,11 +388,16 @@ defmodule Mydia.Config.Schema do
     |> cast(attrs, [
       :monitor_interval_minutes,
       :release_blacklist_default_ttl_days,
-      :auto_reject_limit
+      :auto_reject_limit,
+      :min_seeders
     ])
     |> validate_number(:monitor_interval_minutes, greater_than: 0)
     |> validate_number(:release_blacklist_default_ttl_days, greater_than: 0)
     |> validate_number(:auto_reject_limit, greater_than: 0)
+    # Not greater_than: 0 — 0 is the default and means "filter nothing".
+    # A negative floor is meaningless, so it is rejected at config time
+    # rather than silently behaving like 0.
+    |> validate_number(:min_seeders, greater_than_or_equal_to: 0)
   end
 
   defp upgrades_changeset(schema, attrs) do

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -108,9 +108,24 @@ defmodule Mydia.Jobs.MovieSearch do
     end
   end
 
-  # Get min_seeders from config (defaults to 0 for Usenet compatibility)
+  # Minimum seeders an automatic search result must report, resolved through
+  # the layered runtime config (schema default < YAML < settings UI/DB <
+  # AUTO_SEARCH_MIN_SEEDERS).
+  #
+  # See DownloadMonitor.auto_reject_limit/0 for why this reads
+  # `Mydia.Config.get()` rather than a flat
+  # `Application.get_env(:mydia, :auto_search)[:min_seeders]` key: nothing
+  # explodes the resolved Config.Schema struct back out to flat top-level
+  # keys, so a flat read would silently ignore both the env var and the
+  # settings UI.
+  #
+  # Defaults to 0, which filters nothing — Usenet results carry no seeder
+  # count at all.
   defp get_min_seeders do
-    Application.get_env(:mydia, :auto_search, [])[:min_seeders] || 0
+    case Mydia.Config.get() do
+      %{downloads: %{min_seeders: min}} when is_integer(min) and min >= 0 -> min
+      _ -> 0
+    end
   end
 
   # Merge user-supplied job-arg blocked_tags with the globally configured

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -186,9 +186,24 @@ defmodule Mydia.Jobs.TVShowSearch do
     end
   end
 
-  # Get min_seeders from config (defaults to 0 for Usenet compatibility)
+  # Minimum seeders an automatic search result must report, resolved through
+  # the layered runtime config (schema default < YAML < settings UI/DB <
+  # AUTO_SEARCH_MIN_SEEDERS).
+  #
+  # See DownloadMonitor.auto_reject_limit/0 for why this reads
+  # `Mydia.Config.get()` rather than a flat
+  # `Application.get_env(:mydia, :auto_search)[:min_seeders]` key: nothing
+  # explodes the resolved Config.Schema struct back out to flat top-level
+  # keys, so a flat read would silently ignore both the env var and the
+  # settings UI.
+  #
+  # Defaults to 0, which filters nothing — Usenet results carry no seeder
+  # count at all.
   defp get_min_seeders do
-    Application.get_env(:mydia, :auto_search, [])[:min_seeders] || 0
+    case Mydia.Config.get() do
+      %{downloads: %{min_seeders: min}} when is_integer(min) and min >= 0 -> min
+      _ -> 0
+    end
   end
 
   # Merge user-supplied job-arg blocked_tags with the globally configured

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -423,6 +423,26 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
               "downloads.monitor_interval_minutes",
               all_db_settings
             )
+        },
+        %{
+          key: "downloads.min_seeders",
+          label: "Minimum Seeders (automatic search)",
+          description:
+            "Minimum seeders a result must report for automatic searches to consider it. " <>
+              "This is a hard filter applied before ranking, so a torrent below it is " <>
+              "removed rather than demoted. Manual searches have their own control, and " <>
+              "Usenet results report no seeders at all and are exempt. 0, the default, " <>
+              "filters nothing. Careful above 0: some indexers report 0 when they mean " <>
+              "\"unknown\" rather than \"dead\", so a floor can silently empty their results.",
+          type: :integer,
+          value: config.downloads.min_seeders,
+          placeholder: "0",
+          source:
+            Settings.config_source(
+              "AUTO_SEARCH_MIN_SEEDERS",
+              "downloads.min_seeders",
+              all_db_settings
+            )
         }
       ],
       "Streaming" => [

--- a/test/mydia/config/loader_test.exs
+++ b/test/mydia/config/loader_test.exs
@@ -43,7 +43,8 @@ defmodule Mydia.Config.LoaderTest do
         "METADATA_LANGUAGE",
         "LOG_LEVEL",
         "OBAN_POLL_INTERVAL",
-        "MAX_TRANSCODE_HEIGHT"
+        "MAX_TRANSCODE_HEIGHT",
+        "AUTO_SEARCH_MIN_SEEDERS"
       ] ++ download_client_vars ++ library_path_vars
 
     # Store original values
@@ -659,6 +660,84 @@ defmodule Mydia.Config.LoaderTest do
       {:ok, config} = Loader.load(config_file: "nonexistent.yml")
 
       assert config.streaming.max_transcode_height == nil
+    end
+
+    test "the automatic-search seeder floor is reachable from every layer" do
+      # Like the transcode ceiling above, this shipped as a bare compile-time
+      # key (config :mydia, :auto_search, min_seeders: ...) that no operator
+      # could reach without rebuilding the image, while the docs described it
+      # as the one filter you are likely to set.
+      File.mkdir_p!("test/fixtures")
+
+      File.write!(@test_yaml_path, """
+      downloads:
+        min_seeders: 3
+      """)
+
+      {:ok, from_yaml} = Loader.load(config_file: @test_yaml_path)
+      assert from_yaml.downloads.min_seeders == 3
+
+      {:ok, _} =
+        Repo.insert(%ConfigSetting{
+          key: "downloads.min_seeders",
+          value: "5",
+          category: :downloads
+        })
+
+      {:ok, from_db} = Loader.load(config_file: @test_yaml_path)
+      assert from_db.downloads.min_seeders == 5
+
+      System.put_env("AUTO_SEARCH_MIN_SEEDERS", "10")
+
+      {:ok, from_env} = Loader.load(config_file: @test_yaml_path)
+      assert from_env.downloads.min_seeders == 10
+    end
+
+    test "the automatic-search seeder floor defaults to 0, filtering nothing" do
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert config.downloads.min_seeders == 0
+    end
+
+    test "AUTO_SEARCH_MIN_SEEDERS=0 is honoured rather than treated as unset" do
+      File.mkdir_p!("test/fixtures")
+
+      File.write!(@test_yaml_path, """
+      downloads:
+        min_seeders: 7
+      """)
+
+      System.put_env("AUTO_SEARCH_MIN_SEEDERS", "0")
+
+      {:ok, config} = Loader.load(config_file: @test_yaml_path)
+
+      assert config.downloads.min_seeders == 0
+    end
+
+    test "an unparseable AUTO_SEARCH_MIN_SEEDERS is ignored, not applied" do
+      File.mkdir_p!("test/fixtures")
+
+      File.write!(@test_yaml_path, """
+      downloads:
+        min_seeders: 3
+      """)
+
+      System.put_env("AUTO_SEARCH_MIN_SEEDERS", "lots")
+
+      {:ok, config} = Loader.load(config_file: @test_yaml_path)
+
+      # The lower layer stands rather than the whole config failing to load,
+      # which would take the app down over one bad variable.
+      assert config.downloads.min_seeders == 3
+    end
+
+    test "a negative AUTO_SEARCH_MIN_SEEDERS fails validation" do
+      System.put_env("AUTO_SEARCH_MIN_SEEDERS", "-1")
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Loader.load(config_file: "nonexistent.yml")
+
+      refute changeset.valid?
     end
 
     test "environment variables override database settings" do

--- a/test/mydia/config/schema_test.exs
+++ b/test/mydia/config/schema_test.exs
@@ -446,6 +446,36 @@ defmodule Mydia.Config.SchemaTest do
     end
   end
 
+  describe "downloads min_seeders (AUTO_SEARCH_MIN_SEEDERS)" do
+    test "round-trips a configured seeder floor" do
+      changeset = Schema.changeset(%Schema{}, %{downloads: %{min_seeders: 5}})
+      assert changeset.valid?
+
+      config = Ecto.Changeset.apply_changes(changeset)
+      assert config.downloads.min_seeders == 5
+    end
+
+    test "defaults to 0, which filters nothing" do
+      assert Schema.defaults().downloads.min_seeders == 0
+    end
+
+    test "accepts 0 explicitly rather than treating it as unset" do
+      changeset = Schema.changeset(%Schema{}, %{downloads: %{min_seeders: 0}})
+
+      assert changeset.valid?
+      assert Ecto.Changeset.apply_changes(changeset).downloads.min_seeders == 0
+    end
+
+    test "rejects a negative floor" do
+      changeset = Schema.changeset(%Schema{}, %{downloads: %{min_seeders: -1}})
+
+      refute changeset.valid?
+
+      errors = errors_on(changeset).downloads.min_seeders
+      assert "must be greater than or equal to 0" in errors
+    end
+  end
+
   describe "plugins override_dir (PLUGINS_OVERRIDE_DIR)" do
     test "round-trips a configured override directory" do
       changeset = Schema.changeset(%Schema{}, %{plugins: %{override_dir: "/data/plugins"}})

--- a/test/mydia/jobs/movie_search_test.exs
+++ b/test/mydia/jobs/movie_search_test.exs
@@ -637,4 +637,86 @@ defmodule Mydia.Jobs.MovieSearchTest do
       assert backoff.failure_count == 1
     end
   end
+
+  # The seeder floor for automatic searches is a layered runtime setting
+  # (downloads.min_seeders / AUTO_SEARCH_MIN_SEEDERS / the admin settings UI),
+  # not the flat compile-time `config :mydia, :auto_search` key it used to be.
+  # Nothing explodes the resolved Config.Schema struct back out into flat
+  # top-level keys, so a flat read would silently ignore both the env var and
+  # the settings UI. See get_min_seeders/0 in lib/mydia/jobs/movie_search.ex.
+  describe "minimum seeders for automatic search" do
+    setup do
+      original = Application.get_env(:mydia, :runtime_config)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:mydia, :runtime_config, original)
+        else
+          Application.delete_env(:mydia, :runtime_config)
+        end
+      end)
+
+      :ok
+    end
+
+    test "considers every mocked result at the default floor of 0" do
+      assert Mydia.Config.Schema.defaults().downloads.min_seeders == 0
+
+      movie = media_item_fixture(%{type: "movie", title: "The Matrix", year: 1999})
+      put_min_seeders(0)
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "downloads")
+
+      assert :ok =
+               perform_job(MovieSearch, %{"mode" => "specific", "media_item_id" => movie.id})
+
+      assert_receive {:search_completed, _id, %{results_found: found}}
+      assert found > 0
+    end
+
+    test "drops every result below a configured floor" do
+      # The mocked indexer's best result reports 100 seeders.
+      movie = media_item_fixture(%{type: "movie", title: "The Matrix", year: 1999})
+      put_min_seeders(500)
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "downloads")
+
+      assert :ok =
+               perform_job(MovieSearch, %{"mode" => "specific", "media_item_id" => movie.id})
+
+      assert_receive {:search_completed, _id, %{results_found: 0}}
+      assert Mydia.Downloads.list_downloads() == []
+    end
+
+    test "reads the layered config, not the flat :auto_search app env key" do
+      movie = media_item_fixture(%{type: "movie", title: "The Matrix", year: 1999})
+
+      # A floor high enough to empty the result set, set the old way. It must
+      # have no effect now.
+      original_auto_search = Application.get_env(:mydia, :auto_search, [])
+      on_exit(fn -> Application.put_env(:mydia, :auto_search, original_auto_search) end)
+
+      Application.put_env(
+        :mydia,
+        :auto_search,
+        Keyword.put(original_auto_search, :min_seeders, 500)
+      )
+
+      put_min_seeders(0)
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "downloads")
+
+      assert :ok =
+               perform_job(MovieSearch, %{"mode" => "specific", "media_item_id" => movie.id})
+
+      assert_receive {:search_completed, _id, %{results_found: found}}
+      assert found > 0
+    end
+  end
+
+  # Overrides only the :downloads embed of the layered runtime config
+  # (Mydia.Config.get().downloads), leaving the rest of the resolved config
+  # (indexers, media, and so on) exactly as this suite's setup left it.
+  defp put_min_seeders(min) do
+    config = Mydia.Config.get()
+    downloads = struct(config.downloads, min_seeders: min)
+    Application.put_env(:mydia, :runtime_config, %{config | downloads: downloads})
+  end
 end

--- a/test/mydia/jobs/tv_show_search_test.exs
+++ b/test/mydia/jobs/tv_show_search_test.exs
@@ -1770,4 +1770,89 @@ defmodule Mydia.Jobs.TVShowSearchTest do
       assert Mydia.Downloads.list_downloads() == []
     end
   end
+
+  # The seeder floor for automatic searches is a layered runtime setting
+  # (downloads.min_seeders / AUTO_SEARCH_MIN_SEEDERS / the admin settings UI),
+  # not the flat compile-time `config :mydia, :auto_search` key it used to be.
+  # Nothing explodes the resolved Config.Schema struct back out into flat
+  # top-level keys, so a flat read would silently ignore both the env var and
+  # the settings UI. See get_min_seeders/0 in lib/mydia/jobs/tv_show_search.ex.
+  describe "minimum seeders for automatic search" do
+    setup do
+      original = Application.get_env(:mydia, :runtime_config)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:mydia, :runtime_config, original)
+        else
+          Application.delete_env(:mydia, :runtime_config)
+        end
+      end)
+
+      tv_show = media_item_fixture(%{type: "tv_show", title: "Breaking Bad"})
+
+      _episode =
+        episode_fixture(%{
+          media_item_id: tv_show.id,
+          season_number: 1,
+          episode_number: 1,
+          air_date: ~D[2020-01-01]
+        })
+
+      %{tv_show: tv_show}
+    end
+
+    test "considers every mocked result at the default floor of 0", %{tv_show: tv_show} do
+      assert Mydia.Config.Schema.defaults().downloads.min_seeders == 0
+
+      put_min_seeders(0)
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "downloads")
+
+      assert :ok = perform_job(TVShowSearch, %{"mode" => "show", "media_item_id" => tv_show.id})
+
+      assert_receive {:search_completed, _id, %{results_found: found}}
+      assert found > 0
+    end
+
+    test "drops every result below a configured floor", %{tv_show: tv_show} do
+      # The mocked indexer's best result reports 150 seeders.
+      put_min_seeders(500)
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "downloads")
+
+      assert :ok = perform_job(TVShowSearch, %{"mode" => "show", "media_item_id" => tv_show.id})
+
+      assert_receive {:search_completed, _id, %{results_found: 0}}
+      assert Mydia.Downloads.list_downloads() == []
+    end
+
+    test "reads the layered config, not the flat :auto_search app env key", %{tv_show: tv_show} do
+      # A floor high enough to empty the result set, set the old way. It must
+      # have no effect now.
+      original_auto_search = Application.get_env(:mydia, :auto_search, [])
+      on_exit(fn -> Application.put_env(:mydia, :auto_search, original_auto_search) end)
+
+      Application.put_env(
+        :mydia,
+        :auto_search,
+        Keyword.put(original_auto_search, :min_seeders, 500)
+      )
+
+      put_min_seeders(0)
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "downloads")
+
+      assert :ok = perform_job(TVShowSearch, %{"mode" => "show", "media_item_id" => tv_show.id})
+
+      assert_receive {:search_completed, _id, %{results_found: found}}
+      assert found > 0
+    end
+  end
+
+  # Overrides only the :downloads embed of the layered runtime config
+  # (Mydia.Config.get().downloads), leaving the rest of the resolved config
+  # (indexers, media, and so on) exactly as this suite's setup left it.
+  defp put_min_seeders(min) do
+    config = Mydia.Config.get()
+    downloads = struct(config.downloads, min_seeders: min)
+    Application.put_env(:mydia, :runtime_config, %{config | downloads: downloads})
+  end
 end


### PR DESCRIPTION
## Why

Follow-up to #440, from the same production investigation.

A show's automatic search found 10 season-pack candidates and **every one reported `seeders: 0`**. `ReleaseRanker` still picked one and Mydia grabbed it. Five of eight trackers announced successfully and confirmed the swarm was genuinely dead, so it could never complete.

The operator has no supported way to set a seeder floor for automatic search. `docs/using/explanation/quality-decisions.md` documents it as "a filter, and the only one you are likely to set", and manual search exposes it in the UI, but for automatic search it was defined only at `config/config.exs:388-393` and read via a flat `Application.get_env(:mydia, :auto_search)[:min_seeders]`. It was absent from `Config.Schema`, `Config.Loader`, `config.example.yml`, and the settings UI. Changing it meant editing a release config and rebuilding.

A compile-time-only knob is a gap against Mydia's layered-config design, and the docs described a setting that could not actually be reached.

## What changed

`downloads.min_seeders` now resolves through the normal layering: schema default → `config.yml` → settings UI/DB → `AUTO_SEARCH_MIN_SEEDERS`.

Both search jobs read it via `Mydia.Config.get()` instead of a flat app-env key. That matters: nothing explodes the resolved `Config.Schema` struct back out to flat top-level keys, so a flat read silently ignores **both** the env var and the settings UI. This follows the idiom `DownloadMonitor.auto_reject_limit/0` already uses and documents.

Chose the `downloads` section because `:downloads` is already a valid `ConfigSetting` category with admin-UI plumbing, and its nearest sibling in meaning (`auto_reject_limit`) already lives there. A new `search` section would have needed a new DB enum value and new admin plumbing for one field.

Validation is `greater_than_or_equal_to: 0`, not `greater_than: 0`, since 0 is the default and means "filter nothing". A negative floor is rejected at config time rather than silently behaving like 0.

## No behavior change by default

The default stays 0 in the schema, in both job fallbacks, and in the example YAML. Nothing filters differently unless an operator opts in.

## The caveat, documented where operators will read it

Raising this is a judgment call, not a free win, and the schema comment plus both doc pages say so:

- `Cardigann` coerces a missing seeders selector to `0` (`cardigann_result_parser.ex:1655`) and defaults protocol to `:torrent`
- `Jackett` maps an empty seeders field to `0` (`jackett.ex:301-305`) and never sets `download_protocol`

So for those adapters `0` can mean "unknown", not "dead". Any nonzero floor discards every result they return without a parsed seeder count, which presents as an indexer that quietly stopped working. NZB results carry no seeder count and are exempt (`is_nil(result.seeders) or result.seeders >= min_seeders`).

That hazard is exactly why this PR does **not** raise the default or add a hard 0-seeder floor. Making one safe by default would first require Jackett to set `download_protocol` and Cardigann to distinguish "selector absent" from "selector returned 0" — separate work.

## Breaking-ish note for review

`min_seeders: 0` is removed from the `config :mydia, :auto_search` block rather than left in place, since nothing reads it now and a live-looking dead knob is worse than none. Anyone who overrode it in a custom `releases.exs` must move to `AUTO_SEARCH_MIN_SEEDERS` or the settings UI. In practice that was a rebuild-only path the docs already described as unreachable.

## Tests

- **Schema**: round-trip, default is 0, explicit 0 accepted (not treated as unset), negative rejected.
- **Loader**: reachable from every layer (YAML 3 → DB 5 → env 10), `AUTO_SEARCH_MIN_SEEDERS=0` honoured over a YAML 7, unparseable value ignored so the lower layer stands, negative fails validation. The var was also added to the setup's env-cleanup list so it cannot leak into the rest of the suite.
- **Both search jobs**: default floor 0 finds results; a floor of 500 (above the mocks' best) empties the result set and creates no download; and a flat `:auto_search` `min_seeders: 500` app-env key has **no** effect while the layered value is 0.

**Mutation-checked.** Reverting `movie_search.ex` to the old flat read and re-running the new describe block produced 2 failures exactly where predicted, confirming the tests discriminate rather than passing vacuously.

## Verification

```
mix compile --warnings-as-errors + config/admin tests   → 90 tests, 0 failures
search job tests                                        → 80 tests, 0 failures
new describe blocks isolated                            → 6 tests, 0 failures
mix test --warnings-as-errors (all 5 touched files)     → 170 tests, 0 failures  (= 90 + 80, no path silently dropped)
mix precommit                                           → 7606 tests, 0 failures, 34 skipped
```

Not verified: the settings UI was not exercised in a browser, only that the field renders in the config map and `admin_settings_live_test.exs` still passes. The save path is the generic one `downloads.monitor_interval_minutes` already uses.
