### PR TITLE
feat(player): Infuse-style watched indicators

### DIFF
--- a/lib/mydia/playback/watch_status.ex
+++ b/lib/mydia/playback/watch_status.ex
@@ -15,8 +15,12 @@ defmodule Mydia.Playback.WatchStatus do
   a badge count and a next-up selection cannot disagree with each other.
   """
 
+  import Ecto.Query
+
+  alias Mydia.Library.MediaFile
   alias Mydia.Media.Episode
   alias Mydia.Playback.Progress
+  alias Mydia.Repo
 
   defstruct [:watched, :percentage, :unwatched_episode_count]
 
@@ -77,5 +81,98 @@ defmodule Mydia.Playback.WatchStatus do
       percentage: nil,
       unwatched_episode_count: unwatched_count
     }
+  end
+
+  @doc """
+  Loads everything the watch rollups need for a set of shows, in a fixed
+  number of queries.
+
+  Shaped for `Absinthe.Resolution.Helpers.batch/3`: the extra context comes
+  first, the collected keys second, and the return is keyed by those keys.
+
+  Three queries, regardless of how many shows are on screen. Resolving this
+  per show is what made `season_count` and `episode_count` an N+1 in the first
+  place, and a 50-show library grid was issuing about 100 episode queries
+  before this existed.
+
+  `user_id` may be nil, in which case no progress is applied and every
+  playable episode counts as unwatched. The counts stay correct for the
+  unauthenticated caller that still asks for `season_count`.
+  """
+  @spec load_shows(term() | nil, [term()]) :: %{term() => map()}
+  def load_shows(user_id, show_ids) do
+    show_ids = Enum.uniq(show_ids)
+
+    episodes =
+      Episode
+      |> where([e], e.media_item_id in ^show_ids)
+      |> order_by([e], asc: e.season_number, asc: e.episode_number)
+      |> Repo.all()
+
+    episode_ids = Enum.map(episodes, & &1.id)
+
+    # Gate on `episode_id`, never on `media_item_id`.
+    #
+    # A TV media_file carries a NULL `media_item_id`; only the episode link is
+    # populated. Filtering these rows by `media_item_id` silently returns
+    # nothing for every show, which makes every episode look file-less and
+    # every badge read 0. That exact mistake has shipped twice in this
+    # codebase, and it fails silently rather than raising.
+    #
+    # `is_nil(trashed_at)` mirrors the default in
+    # `Mydia.Library.list_media_files/1`, which is what `resolve_has_file/3`
+    # goes through. Without it a trashed file would keep an episode countable
+    # here while `hasFile` reported false on the same screen.
+    file_ids =
+      MediaFile
+      |> where([f], f.episode_id in ^episode_ids and is_nil(f.trashed_at))
+      |> select([f], f.episode_id)
+      |> distinct(true)
+      |> Repo.all()
+      |> MapSet.new()
+
+    progress = load_progress(user_id, episode_ids)
+    episodes_by_show = Enum.group_by(episodes, & &1.media_item_id)
+
+    Map.new(show_ids, fn show_id ->
+      {show_id,
+       %{
+         episodes: Map.get(episodes_by_show, show_id, []),
+         file_ids: file_ids,
+         progress: progress
+       }}
+    end)
+  end
+
+  defp load_progress(nil, _episode_ids), do: %{}
+
+  defp load_progress(user_id, episode_ids) do
+    Progress
+    |> where([p], p.user_id == ^user_id and p.episode_id in ^episode_ids)
+    |> Repo.all()
+    |> Map.new(&{&1.episode_id, &1})
+  end
+
+  @doc "Every episode in a bundle, in season and episode order."
+  @spec episodes(map() | nil) :: [Episode.t()]
+  def episodes(nil), do: []
+  def episodes(bundle), do: bundle.episodes
+
+  @doc "Rolls a whole show up from its bundle."
+  @spec for_show(map() | nil) :: t()
+  def for_show(nil), do: from_episodes([], MapSet.new(), %{})
+
+  def for_show(bundle) do
+    from_episodes(bundle.episodes, bundle.file_ids, bundle.progress)
+  end
+
+  @doc "Rolls a single season up from its show's bundle."
+  @spec for_season(map() | nil, integer()) :: t()
+  def for_season(nil, _season_number), do: from_episodes([], MapSet.new(), %{})
+
+  def for_season(bundle, season_number) do
+    bundle.episodes
+    |> Enum.filter(&(&1.season_number == season_number))
+    |> from_episodes(bundle.file_ids, bundle.progress)
   end
 end

--- a/lib/mydia/playback/watch_status.ex
+++ b/lib/mydia/playback/watch_status.ex
@@ -1,0 +1,81 @@
+defmodule Mydia.Playback.WatchStatus do
+  @moduledoc """
+  The browse-surface rollup of watch state.
+
+  `Mydia.Playback.Progress` is the per-user playback row used to resume a
+  movie or an episode. It cannot describe a show or a season, because neither
+  has a row of its own. This struct is the projection the browse surfaces
+  actually render, and it covers all four.
+
+  The counting rule lives here and only here. An episode counts as unwatched
+  when it has at least one non-trashed file, its season number is not 0, and
+  it has either no progress row or a row whose `watched` flag is not true.
+  That last clause is the same predicate
+  `Mydia.Playback.NextEpisode.determine/2` uses to pick the next episode, so
+  a badge count and a next-up selection cannot disagree with each other.
+  """
+
+  alias Mydia.Media.Episode
+  alias Mydia.Playback.Progress
+
+  defstruct [:watched, :percentage, :unwatched_episode_count]
+
+  @type t :: %__MODULE__{
+          watched: boolean(),
+          percentage: float() | nil,
+          unwatched_episode_count: non_neg_integer() | nil
+        }
+
+  @doc """
+  Rolls a single movie's or episode's progress row up into a status.
+
+  `unwatched_episode_count` is nil, which is what tells the client this is a
+  leaf rather than a container.
+  """
+  @spec from_progress(Progress.t() | nil) :: t()
+  def from_progress(nil) do
+    %__MODULE__{watched: false, percentage: nil, unwatched_episode_count: nil}
+  end
+
+  def from_progress(%Progress{} = progress) do
+    %__MODULE__{
+      watched: progress.watched || false,
+      percentage: progress.completion_percentage,
+      unwatched_episode_count: nil
+    }
+  end
+
+  @doc """
+  Rolls a show's or a season's episodes up into a status.
+
+  `episode_ids_with_files` is a `MapSet` of episode ids holding at least one
+  non-trashed file. `progress_by_episode_id` maps an episode id to its
+  `Progress` row; absent keys mean the user has never played that episode.
+
+  `percentage` is nil, because a container has no resume point.
+  """
+  @spec from_episodes([Episode.t()], MapSet.t(), %{term() => Progress.t()}) :: t()
+  def from_episodes(episodes, episode_ids_with_files, progress_by_episode_id) do
+    countable =
+      Enum.filter(episodes, fn episode ->
+        episode.season_number != 0 and MapSet.member?(episode_ids_with_files, episode.id)
+      end)
+
+    unwatched_count =
+      Enum.count(countable, fn episode ->
+        case Map.get(progress_by_episode_id, episode.id) do
+          nil -> true
+          %Progress{watched: watched} -> watched != true
+        end
+      end)
+
+    %__MODULE__{
+      # A show with nothing playable is not "watched", it is empty. Reporting
+      # true here would draw a finished badge on a show the user has never
+      # been able to start.
+      watched: countable != [] and unwatched_count == 0,
+      percentage: nil,
+      unwatched_episode_count: unwatched_count
+    }
+  end
+end

--- a/lib/mydia_web/schema/media_types.ex
+++ b/lib/mydia_web/schema/media_types.ex
@@ -7,6 +7,18 @@ defmodule MydiaWeb.Schema.MediaTypes do
 
   alias MydiaWeb.Schema.Resolvers.MediaResolver
 
+  @desc "Rolled-up watch state for a browsable item"
+  object :watch_status do
+    @desc "Movie or episode watched, or every has-file non-special episode watched"
+    field :watched, non_null(:boolean)
+
+    @desc "Resume point, 0-100. Null for shows and seasons."
+    field :percentage, :float
+
+    @desc "Unwatched episodes that have a file, excluding season 0. Null for movies."
+    field :unwatched_episode_count, :integer
+  end
+
   @desc "A cast member (actor) on a movie or TV show"
   object :cast_member do
     field :name, non_null(:string)
@@ -106,6 +118,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
     @desc "User playback progress"
     field :progress, :progress do
       resolve(&MediaResolver.resolve_progress/3)
+    end
+
+    @desc "Rolled-up watch state"
+    field :watch_status, :watch_status do
+      resolve(&MediaResolver.resolve_movie_watch_status/3)
     end
 
     @desc "Whether this item is in user favorites"
@@ -221,6 +238,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
       resolve(&MediaResolver.resolve_episode_count/3)
     end
 
+    @desc "Rolled-up watch state"
+    field :watch_status, :watch_status do
+      resolve(&MediaResolver.resolve_show_watch_status/3)
+    end
+
     @desc "Next episode to watch for the current user"
     field :next_episode, :episode do
       resolve(&MediaResolver.resolve_next_episode/3)
@@ -283,6 +305,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
     field :aired_episode_count, :integer
     field :has_files, non_null(:boolean)
 
+    @desc "Rolled-up watch state"
+    field :watch_status, :watch_status do
+      resolve(&MediaResolver.resolve_season_watch_status/3)
+    end
+
     @desc "Episodes in this season"
     field :episodes, list_of(:episode) do
       resolve(&MediaResolver.resolve_season_episodes/3)
@@ -343,6 +370,11 @@ defmodule MydiaWeb.Schema.MediaTypes do
     @desc "User playback progress"
     field :progress, :progress do
       resolve(&MediaResolver.resolve_episode_progress/3)
+    end
+
+    @desc "Rolled-up watch state"
+    field :watch_status, :watch_status do
+      resolve(&MediaResolver.resolve_episode_watch_status/3)
     end
 
     @desc "Whether this episode has at least one file"

--- a/lib/mydia_web/schema/query_types.ex
+++ b/lib/mydia_web/schema/query_types.ex
@@ -239,6 +239,11 @@ defmodule MydiaWeb.Schema.QueryTypes do
 
     @desc "Number of the newest arrived episode. Null for movies and for unmatched files."
     field :latest_episode_number, :integer
+
+    @desc "Rolled-up watch state"
+    field :watch_status, :watch_status do
+      resolve(&MydiaWeb.Schema.Resolvers.MediaResolver.resolve_recently_added_watch_status/3)
+    end
   end
 
   @desc "An item in the up next rail (next episode to watch)"

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -3,7 +3,10 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
   Resolvers for media-related GraphQL fields.
   """
 
+  import Absinthe.Resolution.Helpers, only: [batch: 3]
+
   alias Mydia.{Media, Library, Playback}
+  alias Mydia.Playback.WatchStatus
 
   alias Mydia.Metadata.Access, as: MetadataAccess
   alias Mydia.Metadata.ImageUrl
@@ -162,6 +165,89 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
     end
   end
 
+  # Watch status resolvers
+  #
+  # All five go through one batch key, `{WatchStatus, :load_shows, user_id}`,
+  # so a grid of shows resolves in a fixed number of queries no matter how many
+  # cards are on screen. `resolve_season_count/3` and `resolve_episode_count/3`
+  # were rewritten onto the same key, which is what removes the pre-existing
+  # N+1 rather than adding a third one beside it.
+
+  @spec resolve_movie_watch_status(map(), map(), Absinthe.Resolution.t()) ::
+          {:ok, term()} | {:error, term()}
+  def resolve_movie_watch_status(%{id: media_item_id}, _args, %{context: context}) do
+    case context[:current_user] do
+      nil ->
+        {:ok, nil}
+
+      user ->
+        progress = Playback.get_progress(user.id, media_item_id: media_item_id)
+        {:ok, WatchStatus.from_progress(progress)}
+    end
+  end
+
+  @spec resolve_episode_watch_status(map(), map(), Absinthe.Resolution.t()) ::
+          {:ok, term()} | {:error, term()}
+  def resolve_episode_watch_status(%{id: episode_id}, _args, %{context: context}) do
+    case context[:current_user] do
+      nil ->
+        {:ok, nil}
+
+      user ->
+        progress = Playback.get_progress(user.id, episode_id: episode_id)
+        {:ok, WatchStatus.from_progress(progress)}
+    end
+  end
+
+  @spec resolve_show_watch_status(map(), map(), Absinthe.Resolution.t()) ::
+          {:ok, term()} | {:error, term()}
+  def resolve_show_watch_status(%{id: show_id}, _args, %{context: context}) do
+    case context[:current_user] do
+      nil ->
+        {:ok, nil}
+
+      user ->
+        batch({WatchStatus, :load_shows, user.id}, show_id, fn bundles ->
+          {:ok, WatchStatus.for_show(Map.get(bundles, show_id))}
+        end)
+    end
+  end
+
+  @spec resolve_season_watch_status(map(), map(), Absinthe.Resolution.t()) ::
+          {:ok, term()} | {:error, term()}
+  def resolve_season_watch_status(season, _args, %{context: context}) do
+    show_id = season[:_media_item_id]
+    season_number = season.season_number
+
+    case context[:current_user] do
+      nil ->
+        {:ok, nil}
+
+      user ->
+        batch({WatchStatus, :load_shows, user.id}, show_id, fn bundles ->
+          {:ok, WatchStatus.for_season(Map.get(bundles, show_id), season_number)}
+        end)
+    end
+  end
+
+  @spec resolve_recently_added_watch_status(map(), map(), Absinthe.Resolution.t()) ::
+          {:ok, term()} | {:error, term()}
+  def resolve_recently_added_watch_status(%{id: id, type: type}, _args, %{context: context}) do
+    case context[:current_user] do
+      nil ->
+        {:ok, nil}
+
+      user ->
+        if type in [:tv_show, "tv_show"] do
+          batch({WatchStatus, :load_shows, user.id}, id, fn bundles ->
+            {:ok, WatchStatus.for_show(Map.get(bundles, id))}
+          end)
+        else
+          {:ok, WatchStatus.from_progress(Playback.get_progress(user.id, media_item_id: id))}
+        end
+    end
+  end
+
   # TV Show-specific resolvers
 
   @spec resolve_seasons(map(), map(), Absinthe.Resolution.t()) :: {:ok, term()} | {:error, term()}
@@ -205,23 +291,36 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
 
   @spec resolve_season_count(map(), map(), Absinthe.Resolution.t()) ::
           {:ok, term()} | {:error, term()}
-  def resolve_season_count(%{id: media_item_id}, _args, _info) do
-    episodes = Media.list_episodes(media_item_id)
+  def resolve_season_count(%{id: media_item_id}, _args, %{context: context}) do
+    user_id = context[:current_user] && context[:current_user].id
 
-    season_count =
-      episodes
-      |> Enum.map(& &1.season_number)
-      |> Enum.uniq()
-      |> length()
+    batch({WatchStatus, :load_shows, user_id}, media_item_id, fn bundles ->
+      count =
+        bundles
+        |> Map.get(media_item_id)
+        |> WatchStatus.episodes()
+        |> Enum.map(& &1.season_number)
+        |> Enum.uniq()
+        |> length()
 
-    {:ok, season_count}
+      {:ok, count}
+    end)
   end
 
   @spec resolve_episode_count(map(), map(), Absinthe.Resolution.t()) ::
           {:ok, term()} | {:error, term()}
-  def resolve_episode_count(%{id: media_item_id}, _args, _info) do
-    episodes = Media.list_episodes(media_item_id)
-    {:ok, length(episodes)}
+  def resolve_episode_count(%{id: media_item_id}, _args, %{context: context}) do
+    user_id = context[:current_user] && context[:current_user].id
+
+    batch({WatchStatus, :load_shows, user_id}, media_item_id, fn bundles ->
+      count =
+        bundles
+        |> Map.get(media_item_id)
+        |> WatchStatus.episodes()
+        |> length()
+
+      {:ok, count}
+    end)
   end
 
   @spec resolve_next_episode(map(), map(), Absinthe.Resolution.t()) ::

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -167,11 +167,17 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
 
   # Watch status resolvers
   #
-  # All five go through one batch key, `{WatchStatus, :load_shows, user_id}`,
+  # The container resolvers (show, season, and the tv_show branch of
+  # recently-added) share one batch key, `{WatchStatus, :load_shows, user_id}`,
   # so a grid of shows resolves in a fixed number of queries no matter how many
   # cards are on screen. `resolve_season_count/3` and `resolve_episode_count/3`
-  # were rewritten onto the same key, which is what removes the pre-existing
+  # were rewritten onto that same key, which is what removes the pre-existing
   # N+1 rather than adding a third one beside it.
+  #
+  # The leaf resolvers (movie, episode, and the movie branch of
+  # recently-added) do not batch. They read a single `Progress` row through
+  # `Playback.get_progress/2`, exactly as `resolve_progress/3` beside them
+  # already does, because there is no set of children to roll up.
 
   @spec resolve_movie_watch_status(map(), map(), Absinthe.Resolution.t()) ::
           {:ok, term()} | {:error, term()}

--- a/player/lib/core/graphql/watch/invalidation_rules.dart
+++ b/player/lib/core/graphql/watch/invalidation_rules.dart
@@ -25,6 +25,11 @@ abstract final class InvalidationRules {
   /// [seasonNumber] is the season the mutating screen is scoped to. Passing
   /// it adds that season's episode-list key to the set, for the same
   /// self-convergence reason as [favoriteToggled]'s [id].
+  ///
+  /// `tvShowsList`, `favoritesList`, and `unwatchedList` are here because
+  /// those grids render unwatched counts. `QueryKeys.unwatched` and
+  /// `QueryKeys.unwatchedList` are different keys, and the library grid uses
+  /// the latter, so listing only the former left the grid stale.
   static Set<QueryKey> watchedChanged({
     required String showId,
     int? seasonNumber,
@@ -32,6 +37,9 @@ abstract final class InvalidationRules {
       {
         QueryKeys.home,
         QueryKeys.unwatched,
+        QueryKeys.tvShowsList,
+        QueryKeys.favoritesList,
+        QueryKeys.unwatchedList,
         QueryKeys.showDetail(showId),
         if (seasonNumber != null)
           QueryKeys.seasonEpisodes(showId, seasonNumber),
@@ -49,6 +57,8 @@ abstract final class InvalidationRules {
         QueryKeys.home,
         QueryKeys.unwatched,
         QueryKeys.moviesList,
+        QueryKeys.favoritesList,
+        QueryKeys.unwatchedList,
         QueryKeys.movieDetail(movieId),
       };
 
@@ -64,6 +74,10 @@ abstract final class InvalidationRules {
       {
         QueryKeys.home,
         QueryKeys.unwatched,
+        QueryKeys.tvShowsList,
+        QueryKeys.moviesList,
+        QueryKeys.favoritesList,
+        QueryKeys.unwatchedList,
         if (mediaType == 'movie') QueryKeys.movieDetail(mediaId),
         if (mediaType == 'episode') QueryKeys.episodeDetail(mediaId),
         if (mediaType == 'episode' && showId != null)

--- a/player/lib/domain/models/recently_added_item.dart
+++ b/player/lib/domain/models/recently_added_item.dart
@@ -1,4 +1,5 @@
 import 'artwork.dart';
+import 'watch_status.dart';
 
 class RecentlyAddedItem {
   final String id;
@@ -10,6 +11,7 @@ class RecentlyAddedItem {
   final int? newEpisodeCount;
   final int? latestSeasonNumber;
   final int? latestEpisodeNumber;
+  final WatchStatus? watchStatus;
 
   const RecentlyAddedItem({
     required this.id,
@@ -21,6 +23,7 @@ class RecentlyAddedItem {
     this.newEpisodeCount,
     this.latestSeasonNumber,
     this.latestEpisodeNumber,
+    this.watchStatus,
   });
 
   factory RecentlyAddedItem.fromJson(Map<String, dynamic> json) {
@@ -36,6 +39,9 @@ class RecentlyAddedItem {
       newEpisodeCount: json['newEpisodeCount'] as int?,
       latestSeasonNumber: json['latestSeasonNumber'] as int?,
       latestEpisodeNumber: json['latestEpisodeNumber'] as int?,
+      watchStatus: json['watchStatus'] == null
+          ? null
+          : WatchStatus.fromJson(json['watchStatus'] as Map<String, dynamic>),
     );
   }
 

--- a/player/lib/domain/models/season_info.dart
+++ b/player/lib/domain/models/season_info.dart
@@ -1,14 +1,18 @@
+import 'watch_status.dart';
+
 class SeasonInfo {
   final int seasonNumber;
   final int episodeCount;
   final int airedEpisodeCount;
   final bool hasFiles;
+  final WatchStatus? watchStatus;
 
   const SeasonInfo({
     required this.seasonNumber,
     required this.episodeCount,
     required this.airedEpisodeCount,
     required this.hasFiles,
+    this.watchStatus,
   });
 
   factory SeasonInfo.fromJson(Map<String, dynamic> json) {
@@ -17,6 +21,9 @@ class SeasonInfo {
       episodeCount: json['episodeCount'] as int? ?? 0,
       airedEpisodeCount: json['airedEpisodeCount'] as int? ?? 0,
       hasFiles: json['hasFiles'] as bool? ?? false,
+      watchStatus: json['watchStatus'] == null
+          ? null
+          : WatchStatus.fromJson(json['watchStatus'] as Map<String, dynamic>),
     );
   }
 }

--- a/player/lib/domain/models/show_detail.dart
+++ b/player/lib/domain/models/show_detail.dart
@@ -4,6 +4,7 @@ import 'next_episode.dart';
 import 'show_next_up.dart';
 import 'cast_member.dart';
 import 'recently_added_item.dart';
+import 'watch_status.dart';
 
 class ShowDetail {
   final String id;
@@ -30,6 +31,7 @@ class ShowDetail {
   final List<CastMember> cast;
   final String? trailerUrl;
   final List<RecentlyAddedItem> similar;
+  final WatchStatus? watchStatus;
 
   const ShowDetail({
     required this.id,
@@ -56,6 +58,7 @@ class ShowDetail {
     this.cast = const [],
     this.trailerUrl,
     this.similar = const [],
+    this.watchStatus,
   });
 
   factory ShowDetail.fromJson(Map<String, dynamic> json) {
@@ -103,6 +106,9 @@ class ShowDetail {
                   (e) => RecentlyAddedItem.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [],
+      watchStatus: json['watchStatus'] == null
+          ? null
+          : WatchStatus.fromJson(json['watchStatus'] as Map<String, dynamic>),
     );
   }
 

--- a/player/lib/domain/models/watch_status.dart
+++ b/player/lib/domain/models/watch_status.dart
@@ -1,0 +1,65 @@
+import 'progress.dart';
+
+/// The rolled-up watch state a browse surface renders.
+///
+/// [Progress] is the per-user playback row used to resume a movie or an
+/// episode, and shows and seasons have no such row. This is the projection
+/// that covers all four, which is why the indicator widget takes one of these
+/// rather than a [Progress].
+///
+/// The three getters exist so [WatchIndicator] reads intent instead of
+/// re-deriving the rule from three nullable fields. The rule is ordered and
+/// the states are mutually exclusive: a watched item draws nothing, a
+/// container with unwatched episodes draws a count, a part-played item draws
+/// a bar, and anything else draws a dot.
+class WatchStatus {
+  /// True for a watched movie or episode, and for a show or season whose
+  /// every playable non-special episode is watched.
+  final bool watched;
+
+  /// Resume point on a 0 to 100 scale. Null for shows and seasons.
+  final double? percentage;
+
+  /// Unwatched episodes holding a file, specials excluded. Null for movies
+  /// and episodes, which are leaves rather than containers.
+  final int? unwatchedEpisodeCount;
+
+  const WatchStatus({
+    required this.watched,
+    this.percentage,
+    this.unwatchedEpisodeCount,
+  });
+
+  /// Defaults every field, so a response from a server predating this type
+  /// degrades to "untouched" instead of throwing.
+  factory WatchStatus.fromJson(Map<String, dynamic> json) {
+    return WatchStatus(
+      watched: json['watched'] as bool? ?? false,
+      percentage: (json['percentage'] as num?)?.toDouble(),
+      unwatchedEpisodeCount: json['unwatchedEpisodeCount'] as int?,
+    );
+  }
+
+  /// Adapts a leaf's playback row. Continue Watching uses this rather than
+  /// asking the server for a redundant `watchStatus` on a rail where every
+  /// item is part-played by definition.
+  factory WatchStatus.fromProgress(Progress progress) {
+    return WatchStatus(
+      watched: progress.watched,
+      percentage: progress.percentage,
+    );
+  }
+
+  bool get _hasUnwatchedEpisodes => (unwatchedEpisodeCount ?? 0) > 0;
+
+  /// A show or season with episodes left to watch.
+  bool get isUnwatchedContainer => !watched && _hasUnwatchedEpisodes;
+
+  /// A leaf the viewer started and did not finish.
+  bool get isInProgress =>
+      !watched && !_hasUnwatchedEpisodes && (percentage ?? 0) > 0;
+
+  /// Never played, and nothing left over to count.
+  bool get isUntouched =>
+      !watched && !_hasUnwatchedEpisodes && (percentage ?? 0) <= 0;
+}

--- a/player/lib/graphql/fragments/watch_status_fragment.graphql
+++ b/player/lib/graphql/fragments/watch_status_fragment.graphql
@@ -1,0 +1,5 @@
+fragment WatchStatusFragment on WatchStatus {
+  watched
+  percentage
+  unwatchedEpisodeCount
+}

--- a/player/lib/graphql/queries/movies_list.graphql
+++ b/player/lib/graphql/queries/movies_list.graphql
@@ -1,5 +1,6 @@
 #import '../fragments/artwork_fragment.graphql'
 #import '../fragments/progress_fragment.graphql'
+#import '../fragments/watch_status_fragment.graphql'
 
 query MoviesList($first: Int, $after: String, $category: MediaCategory) {
   movies(first: $first, after: $after, category: $category) {
@@ -18,6 +19,9 @@ query MoviesList($first: Int, $after: String, $category: MediaCategory) {
         }
         progress {
           ...ProgressFragment
+        }
+        watchStatus {
+          ...WatchStatusFragment
         }
         isFavorite
       }

--- a/player/lib/graphql/queries/show_detail.graphql
+++ b/player/lib/graphql/queries/show_detail.graphql
@@ -1,0 +1,93 @@
+#import '../fragments/watch_status_fragment.graphql'
+
+query TvShowDetail($id: ID!) {
+  tvShow(id: $id) {
+    id
+    title
+    originalTitle
+    year
+    overview
+    status
+    genres
+    contentRating
+    rating
+    tmdbId
+    imdbId
+    category
+    monitored
+    addedAt
+    seasonCount
+    episodeCount
+    artwork {
+      posterUrl
+      backdropUrl
+      thumbnailUrl
+    }
+    seasons {
+      seasonNumber
+      episodeCount
+      airedEpisodeCount
+      hasFiles
+      watchStatus {
+        ...WatchStatusFragment
+      }
+    }
+    nextEpisode {
+      id
+      seasonNumber
+      episodeNumber
+      title
+      airDate
+    }
+    nextUp {
+      progressState
+      episode {
+        id
+        seasonNumber
+        episodeNumber
+        title
+        runtime
+        files {
+          id
+          resolution
+          codec
+          audioCodec
+          hdrFormat
+          size
+          bitrate
+          directPlaySupported
+          streamUrl
+          directPlayUrl
+        }
+        progress {
+          positionSeconds
+          durationSeconds
+          percentage
+          watched
+          lastWatchedAt
+        }
+      }
+    }
+    isFavorite
+    cast {
+      name
+      character
+      profileUrl
+    }
+    trailerUrl
+    similar {
+      id
+      type
+      title
+      year
+      artwork {
+        posterUrl
+        backdropUrl
+        thumbnailUrl
+      }
+    }
+    watchStatus {
+      ...WatchStatusFragment
+    }
+  }
+}

--- a/player/lib/graphql/queries/tv_shows_list.graphql
+++ b/player/lib/graphql/queries/tv_shows_list.graphql
@@ -1,4 +1,5 @@
 #import '../fragments/artwork_fragment.graphql'
+#import '../fragments/watch_status_fragment.graphql'
 
 query TvShowsList($first: Int, $after: String, $category: MediaCategory) {
   tvShows(first: $first, after: $after, category: $category) {
@@ -16,6 +17,9 @@ query TvShowsList($first: Int, $after: String, $category: MediaCategory) {
         episodeCount
         artwork {
           ...ArtworkFragment
+        }
+        watchStatus {
+          ...WatchStatusFragment
         }
         isFavorite
         nextEpisode {

--- a/player/lib/presentation/models/library_data.dart
+++ b/player/lib/presentation/models/library_data.dart
@@ -1,3 +1,5 @@
+import '../../domain/models/watch_status.dart';
+
 class LibraryData {
   final List<LibraryItem> items;
   final bool hasMore;
@@ -34,6 +36,9 @@ class LibraryItem {
   final int? seasonCount;
   final int? episodeCount;
 
+  /// Rolled-up watch state, null when the server did not send one.
+  final WatchStatus? watchStatus;
+
   const LibraryItem({
     required this.id,
     required this.title,
@@ -46,5 +51,6 @@ class LibraryItem {
     this.subtitle,
     this.seasonCount,
     this.episodeCount,
+    this.watchStatus,
   });
 }

--- a/player/lib/presentation/screens/collections/collection_detail_controller.dart
+++ b/player/lib/presentation/screens/collections/collection_detail_controller.dart
@@ -20,6 +20,7 @@ query CollectionItems($collectionId: ID!, $first: Int) {
       thumbnailUrl
     }
     addedAt
+    watchStatus { watched percentage unwatchedEpisodeCount }
   }
 }
 ''';

--- a/player/lib/presentation/screens/collections/collection_detail_screen.dart
+++ b/player/lib/presentation/screens/collections/collection_detail_screen.dart
@@ -228,6 +228,7 @@ class CollectionDetailScreen extends ConsumerWidget {
               key: ValueKey(item.id),
               posterUrl: item.posterUrl,
               title: item.title,
+              watchStatus: item.watchStatus,
               onTap: () => _handleItemTap(context, item.id, item.type),
             );
           },

--- a/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
@@ -6,6 +6,7 @@ import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/layout/breakpoints.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/continue_watching_item.dart';
+import '../../../domain/models/watch_status.dart';
 import '../../widgets/browse_grid.dart';
 import '../../widgets/browse_scaffold.dart';
 import '../../widgets/media_poster.dart';
@@ -95,7 +96,15 @@ class _ContinueWatchingScreenState
                 posterUrl: item.posterUrl,
                 title: item.title,
                 subtitle: item.showTitle,
-                progressPercentage: item.progress?.percentage,
+                // Continue Watching keeps `ProgressFragment` and adapts it
+                // here rather than asking the server for a `watchStatus` it
+                // would have to compute for a rail where every item is
+                // part-played by definition. Going through `WatchStatus` is
+                // what puts this rail on the same rendering rule as every
+                // other surface, instead of the legacy percentage prop.
+                watchStatus: item.progress == null
+                    ? null
+                    : WatchStatus.fromProgress(item.progress!),
                 onTap: () => _handleItemTap(context, item),
               );
             },

--- a/player/lib/presentation/screens/favorites/favorites_controller.dart
+++ b/player/lib/presentation/screens/favorites/favorites_controller.dart
@@ -21,6 +21,7 @@ query Favorites($first: Int, $sort: SortInput) {
       thumbnailUrl
     }
     addedAt
+    watchStatus { watched percentage unwatchedEpisodeCount }
   }
 }
 ''';

--- a/player/lib/presentation/screens/favorites/favorites_screen.dart
+++ b/player/lib/presentation/screens/favorites/favorites_screen.dart
@@ -62,6 +62,7 @@ class FavoritesScreen extends ConsumerWidget {
                 key: ValueKey(item.id),
                 posterUrl: item.posterUrl,
                 title: item.title,
+                watchStatus: item.watchStatus,
                 onTap: () => _handleItemTap(context, item.id, item.type),
               );
             },

--- a/player/lib/presentation/screens/library/library_controller.dart
+++ b/player/lib/presentation/screens/library/library_controller.dart
@@ -125,6 +125,7 @@ query UnwatchedList($first: Int, $after: String, $types: [MediaType], $category:
       backdropUrl
       thumbnailUrl
     }
+    watchStatus { watched percentage unwatchedEpisodeCount }
   }
 }
 ''';
@@ -141,6 +142,7 @@ query FavoritesList($first: Int, $after: String, $types: [MediaType], $category:
       backdropUrl
       thumbnailUrl
     }
+    watchStatus { watched percentage unwatchedEpisodeCount }
   }
 }
 ''';
@@ -228,6 +230,10 @@ LibraryData _parseFlatList(
             posterUrl: (node['artwork'] as Map<String, dynamic>?)?['posterUrl']
                 as String?,
             progressPercentage: null,
+            watchStatus: node['watchStatus'] == null
+                ? null
+                : WatchStatus.fromJson(
+                    node['watchStatus'] as Map<String, dynamic>),
             rating: null,
             isFavorite: isFavorite,
             type: node['type'] as String? ?? 'movie',

--- a/player/lib/presentation/screens/library/library_controller.dart
+++ b/player/lib/presentation/screens/library/library_controller.dart
@@ -7,6 +7,7 @@ import '../../../core/graphql/watch/connection_merge.dart';
 import '../../../core/graphql/watch/controller_watcher.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/graphql/watch/query_watcher.dart';
+import '../../../domain/models/watch_status.dart';
 import '../../../domain/navigation/media_filter.dart';
 import '../../models/library_data.dart';
 
@@ -46,6 +47,11 @@ query MoviesList($first: Int, $after: String, $sort: SortInput, $category: Media
           watched
           lastWatchedAt
         }
+        watchStatus {
+          watched
+          percentage
+          unwatchedEpisodeCount
+        }
         isFavorite
       }
       cursor
@@ -80,6 +86,11 @@ query TvShowsList($first: Int, $after: String, $sort: SortInput, $category: Medi
           posterUrl
           backdropUrl
           thumbnailUrl
+        }
+        watchStatus {
+          watched
+          percentage
+          unwatchedEpisodeCount
         }
         isFavorite
         nextEpisode {
@@ -153,6 +164,9 @@ LibraryData _parseMovies(Map<String, dynamic> data) {
       isFavorite: node['isFavorite'] as bool,
       type: 'movie',
       subtitle: node['year']?.toString(),
+      watchStatus: node['watchStatus'] == null
+          ? null
+          : WatchStatus.fromJson(node['watchStatus'] as Map<String, dynamic>),
     ),
   );
 }
@@ -167,7 +181,6 @@ LibraryData _parseTvShows(Map<String, dynamic> data) {
       year: node['year'] as int?,
       posterUrl:
           (node['artwork'] as Map<String, dynamic>?)?['posterUrl'] as String?,
-      // TV shows have no overall progress.
       progressPercentage: null,
       rating: (node['rating'] as num?)?.toDouble(),
       isFavorite: node['isFavorite'] as bool,
@@ -175,6 +188,9 @@ LibraryData _parseTvShows(Map<String, dynamic> data) {
       subtitle: node['year'] != null ? '${node['year']}' : null,
       seasonCount: node['seasonCount'] as int?,
       episodeCount: node['episodeCount'] as int?,
+      watchStatus: node['watchStatus'] == null
+          ? null
+          : WatchStatus.fromJson(node['watchStatus'] as Map<String, dynamic>),
     ),
   );
 }

--- a/player/lib/presentation/screens/library/library_grid_body.dart
+++ b/player/lib/presentation/screens/library/library_grid_body.dart
@@ -311,6 +311,7 @@ class _LibraryMediaBodyState extends ConsumerState<LibraryMediaBody> {
               progressPercentage: item.progressPercentage,
               rating: item.rating,
               isFavorite: item.isFavorite,
+              watchStatus: item.watchStatus,
               onTap: () => _handleItemTap(item.id, item.type),
             );
           },
@@ -373,6 +374,7 @@ class LibraryListItem extends StatelessWidget {
                       title: item.title,
                       progressPercentage: item.progressPercentage,
                       isFavorite: item.isFavorite,
+                      watchStatus: item.watchStatus,
                       showTitle: false,
                       onTap: onTap,
                     ),

--- a/player/lib/presentation/screens/recently_added/recently_added_controller.dart
+++ b/player/lib/presentation/screens/recently_added/recently_added_controller.dart
@@ -23,6 +23,7 @@ query RecentlyAddedFull($first: Int) {
     newEpisodeCount
     latestSeasonNumber
     latestEpisodeNumber
+    watchStatus { watched percentage unwatchedEpisodeCount }
   }
 }
 ''';

--- a/player/lib/presentation/screens/recently_added/recently_added_screen.dart
+++ b/player/lib/presentation/screens/recently_added/recently_added_screen.dart
@@ -63,6 +63,7 @@ class RecentlyAddedScreen extends ConsumerWidget {
                 posterUrl: item.posterUrl,
                 title: item.title,
                 subtitle: item.newContentLabel,
+                watchStatus: item.watchStatus,
                 onTap: () => _handleItemTap(context, item.id, item.type),
               );
             },

--- a/player/lib/presentation/screens/show/show_detail_controller.dart
+++ b/player/lib/presentation/screens/show/show_detail_controller.dart
@@ -8,96 +8,9 @@ import '../../../core/graphql/watch/query_watcher.dart';
 import '../../../core/graphql/watch/watcher_registry.dart';
 import '../../../domain/models/show_detail.dart';
 import '../../../graphql/mutations/toggle_favorite.graphql.dart';
+import '../../../graphql/queries/show_detail.graphql.dart';
 
 part 'show_detail_controller.g.dart';
-
-const String tvShowDetailQuery = r'''
-query TvShowDetail($id: ID!) {
-  tvShow(id: $id) {
-    id
-    title
-    originalTitle
-    year
-    overview
-    status
-    genres
-    contentRating
-    rating
-    tmdbId
-    imdbId
-    category
-    monitored
-    addedAt
-    seasonCount
-    episodeCount
-    artwork {
-      posterUrl
-      backdropUrl
-      thumbnailUrl
-    }
-    seasons {
-      seasonNumber
-      episodeCount
-      airedEpisodeCount
-      hasFiles
-    }
-    nextEpisode {
-      id
-      seasonNumber
-      episodeNumber
-      title
-      airDate
-    }
-    nextUp {
-      progressState
-      episode {
-        id
-        seasonNumber
-        episodeNumber
-        title
-        runtime
-        files {
-          id
-          resolution
-          codec
-          audioCodec
-          hdrFormat
-          size
-          bitrate
-          directPlaySupported
-          streamUrl
-          directPlayUrl
-        }
-        progress {
-          positionSeconds
-          durationSeconds
-          percentage
-          watched
-          lastWatchedAt
-        }
-      }
-    }
-    isFavorite
-    cast {
-      name
-      character
-      profileUrl
-    }
-    trailerUrl
-    similar {
-      id
-      type
-      title
-      year
-      artwork {
-        posterUrl
-        backdropUrl
-        thumbnailUrl
-      }
-    }
-  }
-}
-''';
 
 ShowDetail _parseShow(Map<String, dynamic> data) {
   final show = data['tvShow'];
@@ -114,7 +27,7 @@ class ShowDetailController extends _$ShowDetailController {
     _watcher = createWatcher<ShowDetail>(
       ref,
       key: QueryKeys.showDetail(id),
-      document: gql(tvShowDetailQuery),
+      document: documentNodeQueryTvShowDetail,
       variables: {'id': id},
       parse: _parseShow,
     );
@@ -160,6 +73,7 @@ class ShowDetailController extends _$ShowDetailController {
         cast: currentState.cast,
         trailerUrl: currentState.trailerUrl,
         similar: currentState.similar,
+        watchStatus: currentState.watchStatus,
       ),
     );
 

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -14,6 +14,7 @@ import '../../../domain/models/show_detail.dart';
 import '../../../domain/models/season_info.dart';
 import '../../../domain/models/download.dart';
 import '../../../domain/models/episode.dart';
+import '../../../domain/models/watch_status.dart';
 import '../../widgets/episode_rail.dart';
 import '../../widgets/freshness_header.dart';
 import '../../widgets/quality_download_dialog.dart';
@@ -27,6 +28,7 @@ import '../../widgets/content_rail.dart';
 import '../../widgets/detail_action_row.dart';
 import '../../widgets/hero_play_control.dart';
 import '../../widgets/media_info/media_info_sheet.dart';
+import '../../widgets/watch_indicator.dart';
 
 /// Below this width the hero's action column and tag column stack instead
 /// of sitting side by side. Matches the movie detail hero's breakpoint — see
@@ -930,12 +932,15 @@ class ShowDetailScreen extends ConsumerWidget {
             itemCount: availableSeasons.length,
             itemBuilder: (context, index) {
               final season = availableSeasons[index];
+              final unwatched = season.watchStatus?.unwatchedEpisodeCount ?? 0;
               final isSelected = season.seasonNumber == selectedSeason;
 
               return Padding(
                 padding: const EdgeInsets.only(right: 10),
                 child: _SeasonChip(
                   label: 'Season ${season.seasonNumber}',
+                  unwatched: unwatched,
+                  watchStatus: season.watchStatus,
                   isSelected: isSelected,
                   onTap: () {
                     ref
@@ -1393,11 +1398,15 @@ class _SeasonActionsButton extends ConsumerWidget {
 
 class _SeasonChip extends StatefulWidget {
   final String label;
+  final int unwatched;
+  final WatchStatus? watchStatus;
   final bool isSelected;
   final VoidCallback onTap;
 
   const _SeasonChip({
     required this.label,
+    required this.unwatched,
+    required this.watchStatus,
     required this.isSelected,
     required this.onTap,
   });
@@ -1452,13 +1461,23 @@ class _SeasonChipState extends State<_SeasonChip>
                   : AppColors.divider.withValues(alpha: 0.3),
             ),
           ),
-          child: Text(
-            widget.label,
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-              color: widget.isSelected ? Colors.white : AppColors.textPrimary,
-            ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                widget.label,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color:
+                      widget.isSelected ? Colors.white : AppColors.textPrimary,
+                ),
+              ),
+              if (widget.unwatched > 0) ...[
+                const SizedBox(width: 6),
+                WatchIndicator(status: widget.watchStatus),
+              ],
+            ],
           ),
         ),
       ),

--- a/player/lib/presentation/screens/unwatched/unwatched_controller.dart
+++ b/player/lib/presentation/screens/unwatched/unwatched_controller.dart
@@ -21,6 +21,7 @@ query Unwatched($first: Int, $sort: SortInput) {
       thumbnailUrl
     }
     addedAt
+    watchStatus { watched percentage unwatchedEpisodeCount }
   }
 }
 ''';

--- a/player/lib/presentation/screens/unwatched/unwatched_screen.dart
+++ b/player/lib/presentation/screens/unwatched/unwatched_screen.dart
@@ -62,6 +62,7 @@ class UnwatchedScreen extends ConsumerWidget {
                 key: ValueKey(item.id),
                 posterUrl: item.posterUrl,
                 title: item.title,
+                watchStatus: item.watchStatus,
                 onTap: () => _handleItemTap(context, item.id, item.type),
               );
             },

--- a/player/lib/presentation/widgets/episode_rail_card.dart
+++ b/player/lib/presentation/widgets/episode_rail_card.dart
@@ -5,8 +5,10 @@ import '../../core/cache/poster_cache_manager.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/theme/colors.dart';
 import '../../domain/models/episode.dart';
+import '../../domain/models/watch_status.dart';
 import '../screens/show/season_episodes_controller.dart';
 import 'episode_download_button.dart';
+import 'watch_indicator.dart';
 
 /// A self-contained landscape (16:9) episode card for the horizontal episodes
 /// rail: a thumbnail with inline progress/watched overlays, the episode code +
@@ -107,6 +109,12 @@ class _EpisodeRailCardState extends ConsumerState<EpisodeRailCard> {
   }
 
   Widget _buildThumbnail(BuildContext context, CardSize cardSize) {
+    // Derived rather than fetched: this card already has the episode's own
+    // progress row, and an episode is a leaf, so there is no count to roll up.
+    final watchStatus = _episode.progress == null
+        ? const WatchStatus(watched: false)
+        : WatchStatus.fromProgress(_episode.progress!);
+
     return Container(
       key: const ValueKey('episode-card-border'),
       decoration: BoxDecoration(
@@ -228,6 +236,12 @@ class _EpisodeRailCardState extends ConsumerState<EpisodeRailCard> {
                     ),
                   ),
                 ),
+
+              Positioned(
+                top: 6,
+                left: 6,
+                child: WatchIndicator(status: watchStatus),
+              ),
 
               // Action overlay (top-right): download + watched-status menu, on a
               // dark scrim pill for contrast against the thumbnail.

--- a/player/lib/presentation/widgets/episode_rail_card.dart
+++ b/player/lib/presentation/widgets/episode_rail_card.dart
@@ -111,9 +111,17 @@ class _EpisodeRailCardState extends ConsumerState<EpisodeRailCard> {
   Widget _buildThumbnail(BuildContext context, CardSize cardSize) {
     // Derived rather than fetched: this card already has the episode's own
     // progress row, and an episode is a leaf, so there is no count to roll up.
-    final watchStatus = _episode.progress == null
-        ? const WatchStatus(watched: false)
-        : WatchStatus.fromProgress(_episode.progress!);
+    //
+    // A file-less episode gets no status at all, and so no dot. The rollup
+    // behind a show's badge counts only episodes that have a file, so marking
+    // an unplayable episode "unwatched" here would contradict the number on
+    // the poster one screen up: a show reading "3 unwatched" would sit above a
+    // season list showing ten dots.
+    final watchStatus = !_episode.hasFile
+        ? null
+        : _episode.progress == null
+            ? const WatchStatus(watched: false)
+            : WatchStatus.fromProgress(_episode.progress!);
 
     return Container(
       key: const ValueKey('episode-card-border'),

--- a/player/lib/presentation/widgets/media_card.dart
+++ b/player/lib/presentation/widgets/media_card.dart
@@ -3,9 +3,12 @@ import 'package:flutter/material.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/theme/colors.dart';
 import '../../domain/models/media_file.dart';
+import '../../domain/models/watch_status.dart';
+import 'poster_badge_corner.dart';
 import 'poster_frame.dart';
 import 'progress_overlay.dart';
 import 'quality_badge.dart';
+import 'watch_indicator.dart';
 
 /// What tapping a [MediaCard] does.
 ///
@@ -28,6 +31,9 @@ class MediaCard extends StatelessWidget {
   final String title;
   final String? subtitle;
   final double? progressPercentage;
+
+  /// Rolled-up watch state. Null renders no indicator.
+  final WatchStatus? watchStatus;
   final VoidCallback? onTap;
   final double? width;
   final double? height;
@@ -49,6 +55,7 @@ class MediaCard extends StatelessWidget {
     required this.title,
     this.subtitle,
     this.progressPercentage,
+    this.watchStatus,
     this.onTap,
     this.width,
     this.height,
@@ -135,16 +142,18 @@ class MediaCard extends StatelessWidget {
                   overlays: [
                     if (progress != null && progress > 0)
                       ProgressOverlay(percentage: progress),
+                    WatchProgressOverlay(status: watchStatus),
                     if (action == MediaCardAction.play) const _PlayBadge(),
-                    if (quality.hasQuality)
-                      Positioned(
-                        top: 8,
-                        right: 8,
-                        child: QualityBadgeRow(
-                          badges: quality.toBadges(),
-                          spacing: 4.0,
-                        ),
-                      ),
+                    PosterBadgeCorner(
+                      children: [
+                        WatchIndicator(status: watchStatus),
+                        if (quality.hasQuality)
+                          QualityBadgeRow(
+                            badges: quality.toBadges(),
+                            spacing: 4.0,
+                          ),
+                      ],
+                    ),
                   ],
                 ),
               ),

--- a/player/lib/presentation/widgets/media_poster.dart
+++ b/player/lib/presentation/widgets/media_poster.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 
 import '../../core/theme/colors.dart';
+import '../../domain/models/watch_status.dart';
+import 'poster_badge_corner.dart';
 import 'poster_frame.dart';
 import 'progress_overlay.dart';
 import 'rating_badge.dart';
+import 'watch_indicator.dart';
 
 /// A portrait poster for the library grid and list.
 ///
@@ -15,6 +18,10 @@ class MediaPoster extends StatelessWidget {
   final String title;
   final String? subtitle;
   final double? progressPercentage;
+
+  /// Rolled-up watch state. Null renders no indicator at all, which is what
+  /// an unauthenticated viewer and an un-migrated caller both get.
+  final WatchStatus? watchStatus;
 
   /// TMDB's score on a 0 to 10 scale. Null, or `0.0` for a title nobody has
   /// voted on, renders no chip at all.
@@ -29,6 +36,7 @@ class MediaPoster extends StatelessWidget {
     required this.title,
     this.subtitle,
     this.progressPercentage,
+    this.watchStatus,
     this.rating,
     this.isFavorite = false,
     this.onTap,
@@ -76,6 +84,7 @@ class MediaPoster extends StatelessWidget {
                 overlays: [
                   if (progress != null && progress > 0)
                     ProgressOverlay(percentage: progress),
+                  WatchProgressOverlay(status: watchStatus),
                   // TMDB reports 0.0 for a title nobody has voted on, so 0 and
                   // null both mean "no rating" and the overlay is omitted
                   // rather than rendered empty. RatingBadge's doc explains why
@@ -86,16 +95,17 @@ class MediaPoster extends StatelessWidget {
                       left: 8,
                       child: RatingBadge(rating: rating),
                     ),
-                  if (isFavorite)
-                    const Positioned(
-                      top: 8,
-                      right: 8,
-                      child: Icon(
-                        Icons.favorite,
-                        color: Colors.red,
-                        size: 20,
-                      ),
-                    ),
+                  PosterBadgeCorner(
+                    children: [
+                      WatchIndicator(status: watchStatus),
+                      if (isFavorite)
+                        const Icon(
+                          Icons.favorite,
+                          color: Colors.red,
+                          size: 20,
+                        ),
+                    ],
+                  ),
                 ],
               ),
             ),

--- a/player/lib/presentation/widgets/poster_badge_corner.dart
+++ b/player/lib/presentation/widgets/poster_badge_corner.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+/// The single owner of a poster's top-right corner.
+///
+/// Before this existed, `MediaPoster` hand-positioned the favourite heart at
+/// `top: 8, right: 8` and `MediaCard` hand-positioned `QualityBadgeRow` at the
+/// same coordinates. Adding a third occupant meant either overlapping one of
+/// them or a third hand-rolled `Positioned`, so the corner became a widget.
+///
+/// Order is the caller's, and the convention is that the watch indicator
+/// leads: it is the primary signal, and it reads first in a left-to-right
+/// scan.
+///
+/// Children that render nothing are dropped rather than spaced around, so a
+/// `SizedBox.shrink()` from [WatchIndicator] does not leave a gap where a
+/// badge used to be.
+class PosterBadgeCorner extends StatelessWidget {
+  final List<Widget> children;
+  final double spacing;
+
+  const PosterBadgeCorner({
+    super.key,
+    required this.children,
+    this.spacing = 4.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = children
+        .where((child) => child is! SizedBox || child.width != 0)
+        .toList();
+
+    if (visible.isEmpty) return const SizedBox.shrink();
+
+    return Positioned(
+      top: 8,
+      right: 8,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (var i = 0; i < visible.length; i++) ...[
+            if (i > 0) SizedBox(width: spacing),
+            visible[i],
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/watch_indicator.dart
+++ b/player/lib/presentation/widgets/watch_indicator.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+import '../../core/theme/colors.dart';
+import '../../domain/models/watch_status.dart';
+import 'progress_overlay.dart';
+
+/// The single owner of how watch state looks.
+///
+/// Every poster surface renders this rather than deciding for itself. The
+/// alternative was letting seven call sites each combine `watched`,
+/// `percentage`, and `unwatchedEpisodeCount` on their own, and
+/// `poster_frame.dart` documents where that ends up: the poster depth
+/// contract was hand-rolled three times, drifted once, and `SearchResultCard`
+/// broke it again during the rollout of the very widget built to prevent it.
+///
+/// The states are ordered and mutually exclusive:
+///
+///  * watched, draw nothing;
+///  * a show or season with episodes left, draw the count;
+///  * a leaf part-played, draw the bar via [WatchProgressOverlay];
+///  * anything else, draw the dot.
+///
+/// A part-played poster deliberately shows no dot. The bar already says "not
+/// finished", so a dot beside it would be saying it twice.
+///
+/// This widget draws only the corner mark. The bar lives in
+/// [WatchProgressOverlay] because it sits at the bottom of the overlay stack
+/// while the mark sits in the top-right corner, and a single widget cannot be
+/// in both places. Both read the same getters on [WatchStatus], so the rule
+/// stays in one file.
+class WatchIndicator extends StatelessWidget {
+  /// Null whenever the viewer is unauthenticated, or the query did not ask
+  /// for the field. Both draw nothing.
+  final WatchStatus? status;
+
+  const WatchIndicator({super.key, required this.status});
+
+  /// Lets tests assert on the dot without depending on its shape.
+  static const Key dotKey = Key('watch-indicator-dot');
+
+  static const double _dotDiameter = 10.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final status = this.status;
+
+    if (status == null) return const SizedBox.shrink();
+
+    if (status.isUnwatchedContainer) {
+      return _CountPill(count: status.unwatchedEpisodeCount!);
+    }
+
+    if (status.isUntouched) {
+      return Container(
+        key: dotKey,
+        width: _dotDiameter,
+        height: _dotDiameter,
+        decoration: const BoxDecoration(
+          color: AppColors.primary,
+          shape: BoxShape.circle,
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+}
+
+class _CountPill extends StatelessWidget {
+  final int count;
+
+  const _CountPill({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.primary,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      // No cap. A show with 137 unwatched episodes says 137, because "99+"
+      // would hide exactly the case the badge is most useful for.
+      child: Text(
+        '$count',
+        style: const TextStyle(
+          color: AppColors.surfaceVariant,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          height: 1.2,
+        ),
+      ),
+    );
+  }
+}
+
+/// The bottom progress bar half of the rule owned by [WatchIndicator].
+///
+/// Goes into a [PosterFrame]'s overlay list, where [ProgressOverlay]
+/// positions itself along the bottom edge.
+class WatchProgressOverlay extends StatelessWidget {
+  final WatchStatus? status;
+
+  const WatchProgressOverlay({super.key, required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final status = this.status;
+
+    if (status == null || !status.isInProgress) return const SizedBox.shrink();
+
+    return ProgressOverlay(percentage: status.percentage!);
+  }
+}

--- a/player/test/core/graphql/watch/invalidation_rules_test.dart
+++ b/player/test/core/graphql/watch/invalidation_rules_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/graphql/watch/invalidation_rules.dart';
+import 'package:player/core/graphql/watch/query_key.dart';
+
+void main() {
+  group('watchedChanged', () {
+    test('invalidates the show grid so poster counts do not go stale', () {
+      final keys = InvalidationRules.watchedChanged(showId: 's1');
+
+      expect(keys, contains(QueryKeys.tvShowsList));
+    });
+
+    test('invalidates the list-scoped favorites and unwatched keys', () {
+      final keys = InvalidationRules.watchedChanged(showId: 's1');
+
+      expect(keys, contains(QueryKeys.favoritesList));
+      expect(keys, contains(QueryKeys.unwatchedList));
+    });
+  });
+
+  group('movieWatchedChanged', () {
+    test('invalidates the list-scoped favorites and unwatched keys', () {
+      final keys = InvalidationRules.movieWatchedChanged(movieId: 'm1');
+
+      expect(keys, contains(QueryKeys.favoritesList));
+      expect(keys, contains(QueryKeys.unwatchedList));
+    });
+  });
+
+  group('playbackFinished', () {
+    test('invalidates every grid that now renders watch state', () {
+      final keys = InvalidationRules.playbackFinished(
+        mediaType: 'episode',
+        mediaId: 'e1',
+        showId: 's1',
+      );
+
+      expect(keys, contains(QueryKeys.tvShowsList));
+      expect(keys, contains(QueryKeys.moviesList));
+      expect(keys, contains(QueryKeys.favoritesList));
+      expect(keys, contains(QueryKeys.unwatchedList));
+    });
+  });
+
+  group('progressSynced', () {
+    test('still invalidates nothing', () {
+      expect(InvalidationRules.progressSynced, isEmpty);
+    });
+  });
+}

--- a/player/test/core/graphql/watch/invalidation_test.dart
+++ b/player/test/core/graphql/watch/invalidation_test.dart
@@ -138,6 +138,9 @@ void main() {
       expect(keys, {
         QueryKeys.home,
         QueryKeys.unwatched,
+        QueryKeys.tvShowsList,
+        QueryKeys.favoritesList,
+        QueryKeys.unwatchedList,
         QueryKeys.showDetail('7'),
       });
     });
@@ -156,6 +159,8 @@ void main() {
         QueryKeys.home,
         QueryKeys.unwatched,
         QueryKeys.moviesList,
+        QueryKeys.favoritesList,
+        QueryKeys.unwatchedList,
         QueryKeys.movieDetail('m1'),
       });
     });
@@ -182,6 +187,10 @@ void main() {
       expect(keys, {
         QueryKeys.home,
         QueryKeys.unwatched,
+        QueryKeys.tvShowsList,
+        QueryKeys.moviesList,
+        QueryKeys.favoritesList,
+        QueryKeys.unwatchedList,
         QueryKeys.movieDetail('m1'),
       });
     });

--- a/player/test/domain/models/season_info_test.dart
+++ b/player/test/domain/models/season_info_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/season_info.dart';
+
+void main() {
+  group('SeasonInfo.fromJson', () {
+    test('parses a season watch status', () {
+      final season = SeasonInfo.fromJson(const {
+        'seasonNumber': 1,
+        'episodeCount': 10,
+        'airedEpisodeCount': 10,
+        'hasFiles': true,
+        'watchStatus': {
+          'watched': false,
+          'percentage': null,
+          'unwatchedEpisodeCount': 4,
+        },
+      });
+
+      expect(season.watchStatus!.unwatchedEpisodeCount, 4);
+    });
+
+    test('leaves watch status null when absent', () {
+      final season = SeasonInfo.fromJson(const {
+        'seasonNumber': 1,
+        'episodeCount': 10,
+        'airedEpisodeCount': 10,
+        'hasFiles': true,
+      });
+
+      expect(season.watchStatus, isNull);
+    });
+  });
+}

--- a/player/test/domain/models/watch_status_test.dart
+++ b/player/test/domain/models/watch_status_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/progress.dart';
+import 'package:player/domain/models/watch_status.dart';
+
+void main() {
+  group('WatchStatus.fromJson', () {
+    test('reads all three fields', () {
+      final status = WatchStatus.fromJson(const {
+        'watched': false,
+        'percentage': 42.5,
+        'unwatchedEpisodeCount': null,
+      });
+
+      expect(status.watched, isFalse);
+      expect(status.percentage, 42.5);
+      expect(status.unwatchedEpisodeCount, isNull);
+    });
+
+    test('tolerates a missing watched flag from an older server', () {
+      final status = WatchStatus.fromJson(const {});
+
+      expect(status.watched, isFalse);
+      expect(status.percentage, isNull);
+      expect(status.unwatchedEpisodeCount, isNull);
+    });
+
+    test('coerces an integer percentage to double', () {
+      final status =
+          WatchStatus.fromJson(const {'watched': false, 'percentage': 40});
+
+      expect(status.percentage, 40.0);
+    });
+  });
+
+  group('WatchStatus.fromProgress', () {
+    test('carries watched and percentage across', () {
+      const progress = Progress(
+        positionSeconds: 30,
+        durationSeconds: 100,
+        percentage: 30.0,
+        watched: false,
+      );
+
+      final status = WatchStatus.fromProgress(progress);
+
+      expect(status.watched, isFalse);
+      expect(status.percentage, 30.0);
+      expect(status.unwatchedEpisodeCount, isNull);
+    });
+  });
+
+  group('state getters', () {
+    test('a container with unwatched episodes is a container', () {
+      const status = WatchStatus(watched: false, unwatchedEpisodeCount: 5);
+
+      expect(status.isUnwatchedContainer, isTrue);
+      expect(status.isInProgress, isFalse);
+      expect(status.isUntouched, isFalse);
+    });
+
+    test('a container with zero unwatched is not a container to badge', () {
+      const status = WatchStatus(watched: false, unwatchedEpisodeCount: 0);
+
+      expect(status.isUnwatchedContainer, isFalse);
+      expect(status.isUntouched, isTrue);
+    });
+
+    test('a part-played movie is in progress and not untouched', () {
+      const status = WatchStatus(watched: false, percentage: 40);
+
+      expect(status.isInProgress, isTrue);
+      expect(status.isUntouched, isFalse);
+      expect(status.isUnwatchedContainer, isFalse);
+    });
+
+    test('a never-played movie is untouched', () {
+      const status = WatchStatus(watched: false);
+
+      expect(status.isUntouched, isTrue);
+      expect(status.isInProgress, isFalse);
+    });
+
+    test('a zero percentage is untouched, not in progress', () {
+      const status = WatchStatus(watched: false, percentage: 0);
+
+      expect(status.isUntouched, isTrue);
+      expect(status.isInProgress, isFalse);
+    });
+
+    test('a watched item is none of the three', () {
+      const status = WatchStatus(watched: true, percentage: 100);
+
+      expect(status.isUnwatchedContainer, isFalse);
+      expect(status.isInProgress, isFalse);
+      expect(status.isUntouched, isFalse);
+    });
+  });
+}

--- a/player/test/presentation/screens/continue_watching/continue_watching_screen_test.dart
+++ b/player/test/presentation/screens/continue_watching/continue_watching_screen_test.dart
@@ -8,6 +8,8 @@ import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/presentation/screens/continue_watching/continue_watching_screen.dart';
 import 'package:player/presentation/widgets/browse_grid.dart';
 import 'package:player/presentation/widgets/media_poster.dart';
+import 'package:player/presentation/widgets/progress_overlay.dart';
+import 'package:player/presentation/widgets/watch_indicator.dart';
 
 import '../../../test_utils/mock_network_images.dart';
 import '../../../test_utils/stub_graphql_client.dart';
@@ -30,6 +32,7 @@ Map<String, dynamic> _continueWatchingItem({
   required String title,
   String type = 'movie',
   double? progressPercentage,
+  bool watched = false,
 }) =>
     {
       '__typename': 'ContinueWatchingItem',
@@ -48,7 +51,7 @@ Map<String, dynamic> _continueWatchingItem({
               'positionSeconds': 600,
               'durationSeconds': 3600,
               'percentage': progressPercentage,
-              'watched': false,
+              'watched': watched,
               'lastWatchedAt': '2026-07-01T00:00:00Z',
             }
           : null,
@@ -142,5 +145,62 @@ void main() {
     );
 
     expect(find.byType(BrowseGrid), findsOneWidget);
+  });
+
+  testWidgets('draws a progress bar and no dot for a part-played item',
+      (tester) async {
+    // Every item on this rail is part-played by definition, so the bar is the
+    // only mark it should ever carry.
+    await pumpContinueWatchingScreen(
+      tester,
+      link: StubLink.responses([
+        _continueWatchingResponse([
+          _continueWatchingItem(
+            id: 'cw-1',
+            title: 'In Progress Movie',
+            progressPercentage: 42,
+          ),
+        ]),
+      ]),
+    );
+
+    expect(find.byType(ProgressOverlay), findsOneWidget);
+    expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+  });
+
+  testWidgets('draws nothing when an item carries no progress', (tester) async {
+    await pumpContinueWatchingScreen(
+      tester,
+      link: StubLink.responses([
+        _continueWatchingResponse([
+          _continueWatchingItem(id: 'cw-2', title: 'No Progress'),
+        ]),
+      ]),
+    );
+
+    expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+  });
+
+  testWidgets('draws no bar for an item already marked watched',
+      (tester) async {
+    // This is what the adapter buys. The legacy `progressPercentage` prop
+    // draws a full bar for anything at 100%, watched or not. Routing through
+    // `WatchStatus` applies the shared rule instead, so a watched item draws
+    // nothing here exactly as it does on every other surface.
+    await pumpContinueWatchingScreen(
+      tester,
+      link: StubLink.responses([
+        _continueWatchingResponse([
+          _continueWatchingItem(
+            id: 'cw-3',
+            title: 'Finished Movie',
+            progressPercentage: 100,
+            watched: true,
+          ),
+        ]),
+      ]),
+    );
+
+    expect(find.byType(ProgressOverlay), findsNothing);
   });
 }

--- a/player/test/presentation/screens/library/library_controller_test.dart
+++ b/player/test/presentation/screens/library/library_controller_test.dart
@@ -24,6 +24,14 @@ MediaFilter _tvShowsFilter([LibrarySort sort = LibrarySort.defaultSort]) =>
       sort: sort,
     );
 
+MediaFilter _unwatchedFilter([LibrarySort sort = LibrarySort.defaultSort]) =>
+    MediaFilter(
+      kind: MediaKind.movies,
+      category: null,
+      watch: WatchScope.unwatched,
+      sort: sort,
+    );
+
 Map<String, dynamic> _moviesPage(
   List<String> ids, {
   required bool hasNextPage,
@@ -552,5 +560,47 @@ void main() {
     );
 
     expect(data.items.single.watchStatus, isNull);
+  });
+
+  test('carries an unwatched episode count through the unwatched list',
+      () async {
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith(
+          (ref) async => stubClient(
+            StubLink.responses([
+              {
+                '__typename': 'Query',
+                'unwatched': [
+                  {
+                    '__typename': 'RecentlyAddedItem',
+                    'id': 'i1',
+                    'title': 'Item',
+                    'year': 2021,
+                    'type': 'tv_show',
+                    'artwork': null,
+                    'watchStatus': {
+                      '__typename': 'WatchStatus',
+                      'watched': false,
+                      'percentage': null,
+                      'unwatchedEpisodeCount': 3,
+                    },
+                  },
+                ],
+              },
+            ]),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await waitForValue(
+      container,
+      libraryControllerProvider(_unwatchedFilter()),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(data.items.single.watchStatus!.unwatchedEpisodeCount, 3);
   });
 }

--- a/player/test/presentation/screens/library/library_controller_test.dart
+++ b/player/test/presentation/screens/library/library_controller_test.dart
@@ -28,6 +28,7 @@ Map<String, dynamic> _moviesPage(
   List<String> ids, {
   required bool hasNextPage,
   double? rating,
+  bool withWatchStatus = true,
 }) {
   return {
     '__typename': 'Query',
@@ -56,6 +57,13 @@ Map<String, dynamic> _moviesPage(
               },
               'progress': null,
               'isFavorite': false,
+              if (withWatchStatus)
+                'watchStatus': {
+                  '__typename': 'WatchStatus',
+                  'watched': false,
+                  'percentage': null,
+                  'unwatchedEpisodeCount': null,
+                },
             },
           }
       ],
@@ -437,5 +445,54 @@ void main() {
       link.requests.first.variables['sort'],
       {'field': 'RANDOM', 'seed': 777},
     );
+  });
+
+  test('carries watchStatus through to library items', () async {
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith(
+          (ref) async => stubClient(
+            StubLink.responses([
+              _moviesPage(['1'], hasNextPage: false),
+            ]),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await waitForValue(
+      container,
+      libraryControllerProvider(_moviesFilter()),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(data.items.single.watchStatus, isNotNull);
+    expect(data.items.single.watchStatus!.watched, isFalse);
+  });
+
+  test('leaves watchStatus null when the server omits it', () async {
+    // An older server that predates the field. The whole query still
+    // resolves, and the grid simply draws no indicator.
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith(
+          (ref) async => stubClient(
+            StubLink.responses([
+              _moviesPage(['1'], hasNextPage: false, withWatchStatus: false),
+            ]),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await waitForValue(
+      container,
+      libraryControllerProvider(_moviesFilter()),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(data.items.single.watchStatus, isNull);
   });
 }

--- a/player/test/presentation/screens/library/library_controller_test.dart
+++ b/player/test/presentation/screens/library/library_controller_test.dart
@@ -86,6 +86,7 @@ Map<String, dynamic> _tvShowsPage(
   List<String> ids, {
   required bool hasNextPage,
   double? rating,
+  int? unwatchedEpisodeCount,
 }) {
   return {
     '__typename': 'Query',
@@ -116,6 +117,14 @@ Map<String, dynamic> _tvShowsPage(
               },
               'isFavorite': false,
               'nextEpisode': null,
+              'watchStatus': unwatchedEpisodeCount == null
+                  ? null
+                  : {
+                      '__typename': 'WatchStatus',
+                      'watched': false,
+                      'percentage': null,
+                      'unwatchedEpisodeCount': unwatchedEpisodeCount,
+                    },
             },
           }
       ],
@@ -490,6 +499,55 @@ void main() {
     final data = await waitForValue(
       container,
       libraryControllerProvider(_moviesFilter()),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(data.items.single.watchStatus, isNull);
+  });
+
+  test('carries a show unwatched count through to library items', () async {
+    // The show badge is the headline of this feature and it runs through
+    // `_parseTvShows`, a different function from the movie path above.
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith(
+          (ref) async => stubClient(
+            StubLink.responses([
+              _tvShowsPage(['1'], hasNextPage: false, unwatchedEpisodeCount: 7),
+            ]),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await waitForValue(
+      container,
+      libraryControllerProvider(_tvShowsFilter()),
+      (value) => value.items.isNotEmpty,
+    );
+
+    expect(data.items.single.watchStatus!.unwatchedEpisodeCount, 7);
+    expect(data.items.single.watchStatus!.watched, isFalse);
+  });
+
+  test('leaves a show watch status null when the server omits it', () async {
+    final container = ProviderContainer(
+      overrides: [
+        asyncGraphqlClientProvider.overrideWith(
+          (ref) async => stubClient(
+            StubLink.responses([
+              _tvShowsPage(['1'], hasNextPage: false),
+            ]),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final data = await waitForValue(
+      container,
+      libraryControllerProvider(_tvShowsFilter()),
       (value) => value.items.isNotEmpty,
     );
 

--- a/player/test/presentation/screens/show/show_detail_query_test.dart
+++ b/player/test/presentation/screens/show/show_detail_query_test.dart
@@ -1,17 +1,19 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:player/presentation/screens/show/show_detail_controller.dart';
+import 'package:gql/language.dart' show printNode;
+import 'package:player/graphql/queries/show_detail.graphql.dart';
 
 void main() {
-  group('tvShowDetailQuery', () {
+  group('TvShowDetail query', () {
     test('selects nextUp with files, so the hero can pick one', () {
-      expect(tvShowDetailQuery, contains('nextUp'));
-      expect(tvShowDetailQuery, contains('progressState'));
+      final queryText = printNode(documentNodeQueryTvShowDetail);
+
+      expect(queryText, contains('nextUp'));
+      expect(queryText, contains('progressState'));
 
       // The original defect: a second, unused copy of this query requested
       // files while the executed one did not, leaving the play button
       // permanently disabled with nothing to select.
-      final nextUpBlock =
-          tvShowDetailQuery.substring(tvShowDetailQuery.indexOf('nextUp'));
+      final nextUpBlock = queryText.substring(queryText.indexOf('nextUp'));
       expect(nextUpBlock, contains('files'));
       expect(nextUpBlock, contains('directPlaySupported'));
       expect(nextUpBlock, contains('progress'));

--- a/player/test/presentation/screens/show/show_detail_screen_test.dart
+++ b/player/test/presentation/screens/show/show_detail_screen_test.dart
@@ -111,6 +111,7 @@ Map<String, dynamic> _showJson({
       'backdropUrl': null,
       'thumbnailUrl': null,
     },
+    'watchStatus': null,
     'seasons': seasons ??
         [
           {
@@ -119,6 +120,7 @@ Map<String, dynamic> _showJson({
             'episodeCount': 3,
             'airedEpisodeCount': 3,
             'hasFiles': true,
+            'watchStatus': null,
           },
         ],
     'nextEpisode': null,

--- a/player/test/presentation/screens/unwatched/unwatched_screen_test.dart
+++ b/player/test/presentation/screens/unwatched/unwatched_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/presentation/screens/unwatched/unwatched_screen.dart';
 import 'package:player/presentation/widgets/browse_grid.dart';
 import 'package:player/presentation/widgets/media_poster.dart';
+import 'package:player/presentation/widgets/watch_indicator.dart';
 
 import '../../../test_utils/mock_network_images.dart';
 import '../../../test_utils/stub_graphql_client.dart';
@@ -27,6 +28,8 @@ Map<String, dynamic> _unwatchedItem({
   required String id,
   required String title,
   String type = 'movie',
+  int? unwatchedEpisodeCount,
+  bool withWatchStatus = false,
 }) =>
     {
       '__typename': 'MediaItem',
@@ -41,6 +44,13 @@ Map<String, dynamic> _unwatchedItem({
         'thumbnailUrl': null,
       },
       'addedAt': '2026-07-01T00:00:00Z',
+      if (withWatchStatus)
+        'watchStatus': {
+          '__typename': 'WatchStatus',
+          'watched': false,
+          'percentage': null,
+          'unwatchedEpisodeCount': unwatchedEpisodeCount,
+        },
     };
 
 Future<void> pumpUnwatchedScreen(
@@ -103,5 +113,42 @@ void main() {
     );
 
     expect(find.text('All caught up!'), findsOneWidget);
+  });
+
+  testWidgets('draws an unwatched dot on a movie', (tester) async {
+    // The whole chain in one assertion: the query asks for `watchStatus`, the
+    // flat-list parser reads it, the screen hands it to `MediaPoster`, and the
+    // indicator renders. This screen showed no watch state at all before this
+    // work, which is what made it the clearest example of the gap.
+    await pumpUnwatchedScreen(
+      tester,
+      link: StubLink.responses([
+        _unwatchedResponse([
+          _unwatchedItem(
+              id: 'u-1', title: 'Unseen Movie', withWatchStatus: true),
+        ]),
+      ]),
+    );
+
+    expect(find.byKey(WatchIndicator.dotKey), findsOneWidget);
+  });
+
+  testWidgets('draws an unwatched count on a show', (tester) async {
+    await pumpUnwatchedScreen(
+      tester,
+      link: StubLink.responses([
+        _unwatchedResponse([
+          _unwatchedItem(
+            id: 'u-2',
+            title: 'Unseen Show',
+            type: 'tv_show',
+            withWatchStatus: true,
+            unwatchedEpisodeCount: 6,
+          ),
+        ]),
+      ]),
+    );
+
+    expect(find.text('6'), findsOneWidget);
   });
 }

--- a/player/test/presentation/widgets/episode_rail_card_test.dart
+++ b/player/test/presentation/widgets/episode_rail_card_test.dart
@@ -6,6 +6,7 @@ import 'package:player/core/theme/colors.dart';
 import 'package:player/domain/models/episode.dart';
 import 'package:player/domain/models/progress.dart';
 import 'package:player/presentation/widgets/episode_rail_card.dart';
+import 'package:player/presentation/widgets/watch_indicator.dart';
 
 import '../../test_utils/hover_affordance.dart';
 import '../../test_utils/mock_network_images.dart';
@@ -223,5 +224,47 @@ void main() {
 
     // The card already draws its real ring; a preview of it would be noise.
     expect(find.byKey(EpisodeRailCard.selectionPreviewKey), findsNothing);
+  });
+
+  group('EpisodeRailCard watch state', () {
+    testWidgets('draws an unwatched dot on an episode never played',
+        (tester) async {
+      await _pump(tester, _episode(progress: null));
+
+      expect(find.byKey(WatchIndicator.dotKey), findsOneWidget);
+    });
+
+    testWidgets('draws no dot once the episode is watched', (tester) async {
+      await _pump(
+        tester,
+        _episode(
+          progress: const Progress(
+            positionSeconds: 100,
+            durationSeconds: 100,
+            percentage: 100,
+            watched: true,
+          ),
+        ),
+      );
+
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+    });
+
+    testWidgets('draws no dot while the episode is part-played',
+        (tester) async {
+      await _pump(
+        tester,
+        _episode(
+          progress: const Progress(
+            positionSeconds: 40,
+            durationSeconds: 100,
+            percentage: 40,
+            watched: false,
+          ),
+        ),
+      );
+
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+    });
   });
 }

--- a/player/test/presentation/widgets/episode_rail_card_test.dart
+++ b/player/test/presentation/widgets/episode_rail_card_test.dart
@@ -250,6 +250,14 @@ void main() {
       expect(find.byKey(WatchIndicator.dotKey), findsNothing);
     });
 
+    testWidgets('draws no dot on an episode with no file', (tester) async {
+      // The show badge counts only has-file episodes, so a dot here would
+      // contradict the number on the poster one screen up.
+      await _pump(tester, _episode(hasFile: false, progress: null));
+
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+    });
+
     testWidgets('draws no dot while the episode is part-played',
         (tester) async {
       await _pump(

--- a/player/test/presentation/widgets/media_card_test.dart
+++ b/player/test/presentation/widgets/media_card_test.dart
@@ -4,8 +4,12 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/media_file.dart';
+import 'package:player/domain/models/watch_status.dart';
 import 'package:player/presentation/widgets/media_card.dart';
 import 'package:player/presentation/widgets/progress_overlay.dart';
+import 'package:player/presentation/widgets/quality_badge.dart';
+import 'package:player/presentation/widgets/watch_indicator.dart';
 
 import '../../test_utils/hover_affordance.dart';
 import '../../test_utils/poster_contract.dart';
@@ -194,4 +198,29 @@ void main() {
     ),
     size: _cardHost,
   );
+
+  testWidgets('keeps quality badges alongside the watch indicator',
+      (tester) async {
+    // Quality badges used to be their own hand-positioned overlay and now
+    // share PosterBadgeCorner with the watch mark. This is the only case that
+    // puts two visible children in that corner, so it is the only one that
+    // exercises the spacing between them.
+    await tester.pumpWidget(
+      posterHost(
+        const MediaCard(
+          title: 'Movie',
+          action: MediaCardAction.open,
+          watchStatus: WatchStatus(watched: false),
+          files: [
+            MediaFile(id: 'f1', resolution: '4K', directPlaySupported: true),
+          ],
+        ),
+        size: _cardHost,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(WatchIndicator.dotKey), findsOneWidget);
+    expect(find.byType(QualityBadgeRow), findsOneWidget);
+  });
 }

--- a/player/test/presentation/widgets/media_card_test.dart
+++ b/player/test/presentation/widgets/media_card_test.dart
@@ -9,6 +9,7 @@ import 'package:player/presentation/widgets/progress_overlay.dart';
 
 import '../../test_utils/hover_affordance.dart';
 import '../../test_utils/poster_contract.dart';
+import '../../test_utils/watch_indicator_contract.dart';
 
 // Tall enough for the 195px poster plus its gap and a two-line title, short
 // enough that the card's center still lands on the poster. Without this the
@@ -183,4 +184,14 @@ void main() {
       expect(tester.takeException(), isNull);
     });
   });
+
+  runWatchIndicatorContract(
+    description: 'MediaCard',
+    build: (status) => MediaCard(
+      title: 'Movie',
+      action: MediaCardAction.open,
+      watchStatus: status,
+    ),
+    size: _cardHost,
+  );
 }

--- a/player/test/presentation/widgets/media_poster_test.dart
+++ b/player/test/presentation/widgets/media_poster_test.dart
@@ -4,11 +4,14 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/watch_status.dart';
 import 'package:player/presentation/widgets/media_poster.dart';
 import 'package:player/presentation/widgets/rating_badge.dart';
+import 'package:player/presentation/widgets/watch_indicator.dart';
 
 import '../../test_utils/hover_affordance.dart';
 import '../../test_utils/poster_contract.dart';
+import '../../test_utils/watch_indicator_contract.dart';
 
 const _posterHost = Size(140, 230);
 
@@ -141,6 +144,32 @@ void main() {
       final heart = tester.getRect(find.byIcon(Icons.favorite));
 
       expect(chip.right, lessThan(heart.left));
+    });
+  });
+
+  runWatchIndicatorContract(
+    description: 'MediaPoster',
+    build: (status) => MediaPoster(title: 'Show', watchStatus: status),
+    size: _posterHost,
+  );
+
+  group('MediaPoster watch indicators', () {
+    testWidgets('keeps the favourite heart alongside the indicator',
+        (tester) async {
+      await tester.pumpWidget(
+        posterHost(
+          const MediaPoster(
+            title: 'Show',
+            isFavorite: true,
+            watchStatus: WatchStatus(watched: false),
+          ),
+          size: _posterHost,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(WatchIndicator.dotKey), findsOneWidget);
+      expect(find.byIcon(Icons.favorite), findsOneWidget);
     });
   });
 }

--- a/player/test/presentation/widgets/poster_badge_corner_test.dart
+++ b/player/test/presentation/widgets/poster_badge_corner_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/poster_badge_corner.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      home: Scaffold(
+        body: Stack(children: [
+          SizedBox(width: 200, height: 300, child: Stack(children: [child]))
+        ]),
+      ),
+    );
+
+void main() {
+  group('PosterBadgeCorner', () {
+    testWidgets('lays its children out left to right in the order given',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(const PosterBadgeCorner(
+          children: [Text('first'), Text('second')],
+        )),
+      );
+
+      final firstX = tester.getTopLeft(find.text('first')).dx;
+      final secondX = tester.getTopLeft(find.text('second')).dx;
+
+      expect(firstX, lessThan(secondX));
+    });
+
+    testWidgets('renders nothing when given no children', (tester) async {
+      await tester.pumpWidget(
+        _host(const PosterBadgeCorner(children: [])),
+      );
+
+      expect(find.byType(Row), findsNothing);
+    });
+
+    testWidgets('drops empty children so spacing does not accumulate',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(const PosterBadgeCorner(
+          children: [SizedBox.shrink(), Text('only')],
+        )),
+      );
+
+      expect(find.text('only'), findsOneWidget);
+    });
+
+    testWidgets('sits in the top-right of its stack', (tester) async {
+      await tester.pumpWidget(
+        _host(const PosterBadgeCorner(children: [Text('badge')])),
+      );
+
+      final badge = tester.getTopRight(find.text('badge'));
+      expect(badge.dx, closeTo(200 - 8, 1));
+      expect(tester.getTopLeft(find.text('badge')).dy, closeTo(8, 1));
+    });
+  });
+}

--- a/player/test/presentation/widgets/poster_badge_corner_test.dart
+++ b/player/test/presentation/widgets/poster_badge_corner_test.dart
@@ -36,13 +36,25 @@ void main() {
 
     testWidgets('drops empty children so spacing does not accumulate',
         (tester) async {
+      // Measure the Row, not the text.
+      //
+      // Asserting the text exists passes whether or not the filter works, and
+      // so does asserting the text's position: the Row is anchored at
+      // `right: 8` and the text is its last child, so the text's own edges
+      // never move no matter what precedes it. The Row's width is what grows
+      // when a dropped child leaves its `spacing` gap behind.
+      await tester.pumpWidget(
+        _host(const PosterBadgeCorner(children: [Text('only')])),
+      );
+      final alone = tester.getSize(find.byType(Row));
+
       await tester.pumpWidget(
         _host(const PosterBadgeCorner(
           children: [SizedBox.shrink(), Text('only')],
         )),
       );
 
-      expect(find.text('only'), findsOneWidget);
+      expect(tester.getSize(find.byType(Row)), alone);
     });
 
     testWidgets('sits in the top-right of its stack', (tester) async {

--- a/player/test/presentation/widgets/watch_indicator_test.dart
+++ b/player/test/presentation/widgets/watch_indicator_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/watch_status.dart';
+import 'package:player/presentation/widgets/progress_overlay.dart';
+import 'package:player/presentation/widgets/watch_indicator.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      home: Scaffold(body: Stack(children: [child])),
+    );
+
+void main() {
+  group('WatchIndicator', () {
+    testWidgets('draws a count for a container with episodes left',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchIndicator(
+          status: WatchStatus(watched: false, unwatchedEpisodeCount: 12),
+        )),
+      );
+
+      expect(find.text('12'), findsOneWidget);
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+    });
+
+    testWidgets('draws a dot for a never-played title', (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchIndicator(status: WatchStatus(watched: false))),
+      );
+
+      expect(find.byKey(WatchIndicator.dotKey), findsOneWidget);
+    });
+
+    testWidgets('draws nothing at all once watched', (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchIndicator(
+          status: WatchStatus(watched: true, percentage: 100),
+        )),
+      );
+
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+      expect(find.byType(Text), findsNothing);
+    });
+
+    testWidgets('draws no dot while a title is part-played', (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchIndicator(
+          status: WatchStatus(watched: false, percentage: 40),
+        )),
+      );
+
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+    });
+
+    testWidgets('draws nothing for a watched show with a zero count',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchIndicator(
+          status: WatchStatus(watched: true, unwatchedEpisodeCount: 0),
+        )),
+      );
+
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+      expect(find.byType(Text), findsNothing);
+    });
+
+    testWidgets('draws nothing when the server sent no status at all',
+        (tester) async {
+      await tester.pumpWidget(_host(const WatchIndicator(status: null)));
+
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+      expect(find.byType(Text), findsNothing);
+    });
+
+    testWidgets('renders a large count without truncating it', (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchIndicator(
+          status: WatchStatus(watched: false, unwatchedEpisodeCount: 137),
+        )),
+      );
+
+      expect(find.text('137'), findsOneWidget);
+    });
+  });
+
+  group('WatchProgressOverlay', () {
+    testWidgets('draws the bar for a part-played title', (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchProgressOverlay(
+          status: WatchStatus(watched: false, percentage: 40),
+        )),
+      );
+
+      expect(find.byType(ProgressOverlay), findsOneWidget);
+    });
+
+    testWidgets('draws no bar once watched', (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchProgressOverlay(
+          status: WatchStatus(watched: true, percentage: 100),
+        )),
+      );
+
+      expect(find.byType(ProgressOverlay), findsNothing);
+    });
+
+    testWidgets('draws no bar for a never-played title', (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchProgressOverlay(status: WatchStatus(watched: false))),
+      );
+
+      expect(find.byType(ProgressOverlay), findsNothing);
+    });
+
+    testWidgets('draws no bar for a show', (tester) async {
+      await tester.pumpWidget(
+        _host(const WatchProgressOverlay(
+          status: WatchStatus(watched: false, unwatchedEpisodeCount: 3),
+        )),
+      );
+
+      expect(find.byType(ProgressOverlay), findsNothing);
+    });
+  });
+}

--- a/player/test/presentation/widgets/watch_indicator_test.dart
+++ b/player/test/presentation/widgets/watch_indicator_test.dart
@@ -111,6 +111,15 @@ void main() {
       expect(find.byType(ProgressOverlay), findsNothing);
     });
 
+    testWidgets('draws no bar when the server sent no status', (tester) async {
+      // The degradation path for a player talking to a server that predates
+      // `watchStatus`: the field comes back absent, the status is null, and
+      // every surface must render as it did before rather than throw.
+      await tester.pumpWidget(_host(const WatchProgressOverlay(status: null)));
+
+      expect(find.byType(ProgressOverlay), findsNothing);
+    });
+
     testWidgets('draws no bar for a show', (tester) async {
       await tester.pumpWidget(
         _host(const WatchProgressOverlay(

--- a/player/test/test_utils/watch_indicator_contract.dart
+++ b/player/test/test_utils/watch_indicator_contract.dart
@@ -1,0 +1,74 @@
+// The shared watch-indicator contract.
+//
+// Every surface that composes WatchIndicator runs this, the same way every
+// surface composing PosterFrame runs runPosterDepthContract. Composing the
+// widget is necessary but not sufficient: a surface can still draw its own
+// dot, keep a stale progress bar beside the new one, or drop the indicator
+// out of its overlay list entirely, and none of that is visible from inside
+// WatchIndicator.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/watch_status.dart';
+import 'package:player/presentation/widgets/progress_overlay.dart';
+import 'package:player/presentation/widgets/watch_indicator.dart';
+
+import 'mock_network_images.dart';
+import 'poster_contract.dart';
+
+/// Asserts that [build] renders the four watch states the same way every
+/// other surface does.
+///
+/// [build] receives a status and must return the surface under test wired to
+/// it. Pass the same [size] the surface's other tests use.
+void runWatchIndicatorContract({
+  required String description,
+  required Widget Function(WatchStatus? status) build,
+  Size? size,
+}) {
+  Future<void> pump(WidgetTester tester, WatchStatus? status) async {
+    await mockNetworkImages(() async {
+      await tester.pumpWidget(posterHost(build(status), size: size));
+      await tester.pumpAndSettle();
+    });
+  }
+
+  group('$description watch indicator contract', () {
+    testWidgets('draws a dot when the title was never played', (tester) async {
+      await pump(tester, const WatchStatus(watched: false));
+
+      expect(find.byKey(WatchIndicator.dotKey), findsOneWidget);
+    });
+
+    testWidgets('draws the unwatched count for a container', (tester) async {
+      await pump(
+        tester,
+        const WatchStatus(watched: false, unwatchedEpisodeCount: 7),
+      );
+
+      expect(find.text('7'), findsOneWidget);
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+    });
+
+    testWidgets('draws a bar and no dot while part-played', (tester) async {
+      await pump(tester, const WatchStatus(watched: false, percentage: 40));
+
+      expect(find.byType(ProgressOverlay), findsOneWidget);
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+    });
+
+    testWidgets('draws nothing at all once watched', (tester) async {
+      await pump(tester, const WatchStatus(watched: true, percentage: 100));
+
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+      expect(find.byType(ProgressOverlay), findsNothing);
+    });
+
+    testWidgets('draws nothing when the server sent no status', (tester) async {
+      await pump(tester, null);
+
+      expect(find.byKey(WatchIndicator.dotKey), findsNothing);
+      expect(find.byType(ProgressOverlay), findsNothing);
+    });
+  });
+}

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -329,6 +329,9 @@ type RecentlyAddedItem {
 
   "Number of the newest arrived episode. Null for movies and for unmatched files."
   latestEpisodeNumber: Int
+
+  "Rolled-up watch state"
+  watchStatus: WatchStatus
 }
 
 "An item in the up next rail (next episode to watch)"
@@ -350,6 +353,18 @@ type Collection {
   visibility: String!
   itemCount: Int!
   posterPaths: [String]
+}
+
+"Rolled-up watch state for a browsable item"
+type WatchStatus {
+  "Movie or episode watched, or every has-file non-special episode watched"
+  watched: Boolean!
+
+  "Resume point, 0-100. Null for shows and seasons."
+  percentage: Float
+
+  "Unwatched episodes that have a file, excluding season 0. Null for movies."
+  unwatchedEpisodeCount: Int
 }
 
 "A cast member (actor) on a movie or TV show"
@@ -421,6 +436,9 @@ type Movie implements Node {
 
   "User playback progress"
   progress: Progress
+
+  "Rolled-up watch state"
+  watchStatus: WatchStatus
 
   "Whether this item is in user favorites"
   isFavorite: Boolean!
@@ -500,6 +518,9 @@ type TvShow implements Node {
   "Total number of episodes"
   episodeCount: Int
 
+  "Rolled-up watch state"
+  watchStatus: WatchStatus
+
   "Next episode to watch for the current user"
   nextEpisode: Episode
 
@@ -533,6 +554,9 @@ type Season implements Node {
   airedEpisodeCount: Int
 
   hasFiles: Boolean!
+
+  "Rolled-up watch state"
+  watchStatus: WatchStatus
 
   "Episodes in this season"
   episodes: [Episode]
@@ -574,6 +598,9 @@ type Episode implements Node {
 
   "User playback progress"
   progress: Progress
+
+  "Rolled-up watch state"
+  watchStatus: WatchStatus
 
   "Whether this episode has at least one file"
   hasFile: Boolean!

--- a/server/crates/api/src/mapping.rs
+++ b/server/crates/api/src/mapping.rs
@@ -251,6 +251,7 @@ pub fn movie_from(
         files: files_of(files, externals),
         // Progress and favorites land in Slice 4.
         progress: None,
+        watch_status: None,
         is_favorite: false,
     }
 }
@@ -276,6 +277,7 @@ pub fn episode_from(
         thumbnail_url: row.thumbnail_url.clone(),
         files: files_of(files, externals),
         progress: None,
+        watch_status: None,
         has_file: !files.is_empty(),
         show,
     }
@@ -309,6 +311,7 @@ pub fn tv_show_from(
                 episode_count: count,
                 aired_episode_count: Some(count),
                 has_files: in_season.iter().any(|(_, files)| !files.is_empty()),
+                watch_status: None,
                 episodes: Some(
                     in_season
                         .iter()
@@ -353,6 +356,7 @@ pub fn tv_show_from(
         seasons: Some(seasons),
         season_count: Some(i32::try_from(numbered_seasons).unwrap_or(i32::MAX)),
         episode_count: Some(i32::try_from(episodes.len()).unwrap_or(i32::MAX)),
+        watch_status: None,
         next_episode: next,
         // next_up needs watch state, which is Slice 4.
         next_up: None,

--- a/server/crates/api/src/types/media.rs
+++ b/server/crates/api/src/types/media.rs
@@ -54,6 +54,20 @@ pub struct Progress {
     pub last_watched_at: Option<DateTime<Utc>>,
 }
 
+/// Rolled-up watch state for a browsable item.
+///
+/// This server does not compute playback state yet, so every construction
+/// site sets `watch_status: None`, exactly as it already does for `progress`.
+/// The type exists to satisfy the structural contract in `sdl_parity.rs`:
+/// GraphQL rejects a whole document when it names an unknown field, so a
+/// missing field here breaks every player query that asks for it.
+#[derive(SimpleObject)]
+pub struct WatchStatus {
+    pub watched: bool,
+    pub percentage: Option<f64>,
+    pub unwatched_episode_count: Option<i32>,
+}
+
 #[derive(SimpleObject)]
 pub struct MediaSegment {
     #[graphql(name = "type")]
@@ -255,6 +269,7 @@ pub struct RecentlyAddedItem {
     pub new_episode_count: Option<i32>,
     pub latest_season_number: Option<i32>,
     pub latest_episode_number: Option<i32>,
+    pub watch_status: Option<WatchStatus>,
 }
 
 #[derive(SimpleObject)]
@@ -286,6 +301,7 @@ pub struct Movie {
     pub artwork: Option<Artwork>,
     pub files: Option<Vec<Option<MediaFile>>>,
     pub progress: Option<Progress>,
+    pub watch_status: Option<WatchStatus>,
     pub is_favorite: bool,
 }
 
@@ -344,6 +360,7 @@ pub struct TvShow {
     pub seasons: Option<Vec<Option<Season>>>,
     pub season_count: Option<i32>,
     pub episode_count: Option<i32>,
+    pub watch_status: Option<WatchStatus>,
     pub next_episode: Option<Episode>,
     pub next_up: Option<ShowNextUp>,
     pub is_favorite: bool,
@@ -382,6 +399,7 @@ pub struct Season {
     pub episode_count: i32,
     pub aired_episode_count: Option<i32>,
     pub has_files: bool,
+    pub watch_status: Option<WatchStatus>,
     pub episodes: Option<Vec<Option<Episode>>>,
 }
 
@@ -423,6 +441,7 @@ pub struct Episode {
     pub thumbnail_url: Option<String>,
     pub files: Option<Vec<Option<MediaFile>>>,
     pub progress: Option<Progress>,
+    pub watch_status: Option<WatchStatus>,
     pub has_file: bool,
     pub show: Option<Box<TvShow>>,
 }

--- a/test/mydia/playback/watch_status_query_count_test.exs
+++ b/test/mydia/playback/watch_status_query_count_test.exs
@@ -1,0 +1,75 @@
+defmodule Mydia.Playback.WatchStatusQueryCountTest do
+  # Deliberately synchronous, and deliberately in its own file, for exactly the
+  # reason spelled out at the top of on_deck_query_count_test.exs: the
+  # `:telemetry` handler this test attaches is global to the VM, so running
+  # async alongside the rest of the suite counts other modules' queries too.
+  use Mydia.DataCase, async: false
+
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
+  alias Mydia.Playback.WatchStatus
+
+  setup do
+    %{user: AccountsFixtures.user_fixture()}
+  end
+
+  defp show_with_episodes(count, title) do
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: title})
+
+    for n <- 1..count do
+      episode =
+        MediaFixtures.episode_fixture(%{
+          media_item_id: show.id,
+          season_number: 1,
+          episode_number: n
+        })
+
+      MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+    end
+
+    show
+  end
+
+  defp count_queries(fun) do
+    ref = make_ref()
+    parent = self()
+
+    handler = fn _event, _measurements, _metadata, _config ->
+      send(parent, {ref, :query})
+    end
+
+    :telemetry.attach(
+      "watch-status-query-count-#{inspect(ref)}",
+      [:mydia, :repo, :query],
+      handler,
+      nil
+    )
+
+    fun.()
+
+    :telemetry.detach("watch-status-query-count-#{inspect(ref)}")
+
+    drain = fn drain ->
+      receive do
+        {^ref, :query} -> 1 + drain.(drain)
+      after
+        0 -> 0
+      end
+    end
+
+    drain.(drain)
+  end
+
+  describe "load_shows/2 query count" do
+    test "the query count does not grow with the number of shows", ctx do
+      small_ids = for n <- 1..3, do: show_with_episodes(2, "Small #{n}").id
+      small = count_queries(fn -> WatchStatus.load_shows(ctx.user.id, small_ids) end)
+
+      large_ids = small_ids ++ for(n <- 4..15, do: show_with_episodes(2, "Large #{n}").id)
+      large = count_queries(fn -> WatchStatus.load_shows(ctx.user.id, large_ids) end)
+
+      assert small == large,
+             "expected a constant query count, got #{small} for 3 shows and #{large} for 15"
+    end
+  end
+end

--- a/test/mydia/playback/watch_status_test.exs
+++ b/test/mydia/playback/watch_status_test.exs
@@ -66,6 +66,19 @@ defmodule Mydia.Playback.WatchStatusTest do
                WatchStatus.from_episodes(episodes, files, Map.new([unwatched("e1")]))
     end
 
+    test "a progress row with a nil watched flag counts as unwatched" do
+      # `watched != true` rather than `watched == false` on purpose: the column
+      # defaults to false, but a row that predates the default, or one built in
+      # memory, can carry nil. Counting nil as watched would silently shrink
+      # every badge it touched.
+      episodes = [episode("e1", 1)]
+      files = MapSet.new(["e1"])
+      progress = %{"e1" => %Progress{episode_id: "e1", watched: nil}}
+
+      assert %WatchStatus{watched: false, unwatched_episode_count: 1} =
+               WatchStatus.from_episodes(episodes, files, progress)
+    end
+
     test "every countable episode watched reads as watched with a zero count" do
       episodes = [episode("e1", 1), episode("e2", 1)]
       files = MapSet.new(["e1", "e2"])

--- a/test/mydia/playback/watch_status_test.exs
+++ b/test/mydia/playback/watch_status_test.exs
@@ -201,6 +201,33 @@ defmodule Mydia.Playback.WatchStatusTest do
                WatchStatus.for_show(Map.fetch!(bundles, ctx.show.id))
     end
 
+    test "an episode whose only file is trashed does not count", ctx do
+      # The `is_nil(trashed_at)` filter is what keeps this rollup agreeing with
+      # `hasFile` on the same screen: `Mydia.Library.list_media_files/1`
+      # excludes trashed rows by default and `resolve_has_file/3` goes through
+      # it. Without this test, dropping that filter passes the whole suite.
+      trashed_only =
+        MediaFixtures.episode_fixture(%{
+          media_item_id: ctx.show.id,
+          season_number: 1,
+          episode_number: 2
+        })
+
+      file = MediaFixtures.media_file_fixture(%{episode_id: trashed_only.id})
+
+      {:ok, _} =
+        file
+        |> Ecto.Changeset.change(trashed_at: DateTime.utc_now() |> DateTime.truncate(:second))
+        |> Mydia.Repo.update()
+
+      bundles = WatchStatus.load_shows(ctx.user.id, [ctx.show.id])
+
+      # e1 and e2 still count. The trashed-only episode does not, so this stays
+      # 2 rather than rising to 3.
+      assert %WatchStatus{unwatched_episode_count: 2} =
+               WatchStatus.for_show(Map.fetch!(bundles, ctx.show.id))
+    end
+
     test "a nil user id yields counts with no progress applied", ctx do
       bundles = WatchStatus.load_shows(nil, [ctx.show.id])
 

--- a/test/mydia/playback/watch_status_test.exs
+++ b/test/mydia/playback/watch_status_test.exs
@@ -1,0 +1,99 @@
+defmodule Mydia.Playback.WatchStatusTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Media.Episode
+  alias Mydia.Playback.Progress
+  alias Mydia.Playback.WatchStatus
+
+  defp episode(id, season_number), do: %Episode{id: id, season_number: season_number}
+
+  defp watched(episode_id), do: {episode_id, %Progress{episode_id: episode_id, watched: true}}
+
+  defp unwatched(episode_id), do: {episode_id, %Progress{episode_id: episode_id, watched: false}}
+
+  describe "from_progress/1" do
+    test "a missing progress row is unwatched with no percentage" do
+      assert %WatchStatus{
+               watched: false,
+               percentage: nil,
+               unwatched_episode_count: nil
+             } = WatchStatus.from_progress(nil)
+    end
+
+    test "carries watched and completion_percentage across" do
+      progress = %Progress{watched: true, completion_percentage: 99.5}
+
+      assert %WatchStatus{watched: true, percentage: 99.5, unwatched_episode_count: nil} =
+               WatchStatus.from_progress(progress)
+    end
+
+    test "a nil watched flag reads as false rather than nil" do
+      assert %WatchStatus{watched: false} =
+               WatchStatus.from_progress(%Progress{watched: nil, completion_percentage: 10.0})
+    end
+  end
+
+  describe "from_episodes/3" do
+    test "counts episodes with a file and no progress row" do
+      episodes = [episode("e1", 1), episode("e2", 1)]
+      files = MapSet.new(["e1", "e2"])
+
+      assert %WatchStatus{watched: false, percentage: nil, unwatched_episode_count: 2} =
+               WatchStatus.from_episodes(episodes, files, %{})
+    end
+
+    test "excludes episodes without a file" do
+      episodes = [episode("e1", 1), episode("e2", 1)]
+      files = MapSet.new(["e1"])
+
+      assert %WatchStatus{unwatched_episode_count: 1} =
+               WatchStatus.from_episodes(episodes, files, %{})
+    end
+
+    test "excludes season 0 specials even when they have files" do
+      episodes = [episode("e1", 1), episode("s1", 0)]
+      files = MapSet.new(["e1", "s1"])
+
+      assert %WatchStatus{unwatched_episode_count: 1} =
+               WatchStatus.from_episodes(episodes, files, %{})
+    end
+
+    test "a progress row with watched false still counts as unwatched" do
+      episodes = [episode("e1", 1)]
+      files = MapSet.new(["e1"])
+
+      assert %WatchStatus{unwatched_episode_count: 1} =
+               WatchStatus.from_episodes(episodes, files, Map.new([unwatched("e1")]))
+    end
+
+    test "every countable episode watched reads as watched with a zero count" do
+      episodes = [episode("e1", 1), episode("e2", 1)]
+      files = MapSet.new(["e1", "e2"])
+      progress = Map.new([watched("e1"), watched("e2")])
+
+      assert %WatchStatus{watched: true, unwatched_episode_count: 0} =
+               WatchStatus.from_episodes(episodes, files, progress)
+    end
+
+    test "a show with no files at all is not watched, and draws nothing" do
+      episodes = [episode("e1", 1)]
+
+      assert %WatchStatus{watched: false, unwatched_episode_count: 0} =
+               WatchStatus.from_episodes(episodes, MapSet.new(), %{})
+    end
+
+    test "a show whose only files are specials is not watched" do
+      episodes = [episode("s1", 0)]
+
+      assert %WatchStatus{watched: false, unwatched_episode_count: 0} =
+               WatchStatus.from_episodes(episodes, MapSet.new(["s1"]), %{})
+    end
+
+    test "percentage is always nil for a rollup" do
+      episodes = [episode("e1", 1)]
+
+      assert %WatchStatus{percentage: nil} =
+               WatchStatus.from_episodes(episodes, MapSet.new(["e1"]), %{})
+    end
+  end
+end

--- a/test/mydia/playback/watch_status_test.exs
+++ b/test/mydia/playback/watch_status_test.exs
@@ -1,9 +1,12 @@
 defmodule Mydia.Playback.WatchStatusTest do
-  use ExUnit.Case, async: true
+  use Mydia.DataCase, async: true
 
   alias Mydia.Media.Episode
   alias Mydia.Playback.Progress
   alias Mydia.Playback.WatchStatus
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
+  alias Mydia.Playback
 
   defp episode(id, season_number), do: %Episode{id: id, season_number: season_number}
 
@@ -107,6 +110,115 @@ defmodule Mydia.Playback.WatchStatusTest do
 
       assert %WatchStatus{percentage: nil} =
                WatchStatus.from_episodes(episodes, MapSet.new(["e1"]), %{})
+    end
+  end
+
+  describe "load_shows/2" do
+    setup do
+      user = AccountsFixtures.user_fixture()
+      show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Bundled"})
+
+      e1 =
+        MediaFixtures.episode_fixture(%{
+          media_item_id: show.id,
+          season_number: 1,
+          episode_number: 1
+        })
+
+      e2 =
+        MediaFixtures.episode_fixture(%{
+          media_item_id: show.id,
+          season_number: 2,
+          episode_number: 1
+        })
+
+      special =
+        MediaFixtures.episode_fixture(%{
+          media_item_id: show.id,
+          season_number: 0,
+          episode_number: 1
+        })
+
+      MediaFixtures.media_file_fixture(%{episode_id: e1.id})
+      MediaFixtures.media_file_fixture(%{episode_id: e2.id})
+      MediaFixtures.media_file_fixture(%{episode_id: special.id})
+
+      %{user: user, show: show, e1: e1, e2: e2, special: special}
+    end
+
+    test "bundles every episode of the requested shows", ctx do
+      bundles = WatchStatus.load_shows(ctx.user.id, [ctx.show.id])
+      bundle = Map.fetch!(bundles, ctx.show.id)
+
+      assert length(WatchStatus.episodes(bundle)) == 3
+    end
+
+    test "for_show/1 applies the counting rule across all seasons", ctx do
+      bundles = WatchStatus.load_shows(ctx.user.id, [ctx.show.id])
+
+      assert %WatchStatus{watched: false, unwatched_episode_count: 2} =
+               WatchStatus.for_show(Map.fetch!(bundles, ctx.show.id))
+    end
+
+    test "for_season/2 scopes the count to one season", ctx do
+      bundles = WatchStatus.load_shows(ctx.user.id, [ctx.show.id])
+      bundle = Map.fetch!(bundles, ctx.show.id)
+
+      assert %WatchStatus{unwatched_episode_count: 1} = WatchStatus.for_season(bundle, 1)
+      assert %WatchStatus{unwatched_episode_count: 1} = WatchStatus.for_season(bundle, 2)
+      assert %WatchStatus{unwatched_episode_count: 0} = WatchStatus.for_season(bundle, 0)
+    end
+
+    test "watching every non-special episode marks the show watched", ctx do
+      for episode <- [ctx.e1, ctx.e2] do
+        {:ok, _} =
+          Playback.save_progress(
+            ctx.user.id,
+            [episode_id: episode.id],
+            %{position_seconds: 100, duration_seconds: 100, watched: true}
+          )
+      end
+
+      bundles = WatchStatus.load_shows(ctx.user.id, [ctx.show.id])
+
+      assert %WatchStatus{watched: true, unwatched_episode_count: 0} =
+               WatchStatus.for_show(Map.fetch!(bundles, ctx.show.id))
+    end
+
+    test "another user's progress never leaks into this user's count", ctx do
+      other = AccountsFixtures.user_fixture()
+
+      {:ok, _} =
+        Playback.save_progress(
+          other.id,
+          [episode_id: ctx.e1.id],
+          %{position_seconds: 100, duration_seconds: 100, watched: true}
+        )
+
+      bundles = WatchStatus.load_shows(ctx.user.id, [ctx.show.id])
+
+      assert %WatchStatus{unwatched_episode_count: 2} =
+               WatchStatus.for_show(Map.fetch!(bundles, ctx.show.id))
+    end
+
+    test "a nil user id yields counts with no progress applied", ctx do
+      bundles = WatchStatus.load_shows(nil, [ctx.show.id])
+
+      assert %WatchStatus{unwatched_episode_count: 2} =
+               WatchStatus.for_show(Map.fetch!(bundles, ctx.show.id))
+    end
+
+    test "a show id with no episodes still gets a bundle", ctx do
+      empty = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Empty"})
+      bundles = WatchStatus.load_shows(ctx.user.id, [ctx.show.id, empty.id])
+
+      assert %WatchStatus{watched: false, unwatched_episode_count: 0} =
+               WatchStatus.for_show(Map.fetch!(bundles, empty.id))
+    end
+
+    test "for_show/1 tolerates a missing bundle", _ctx do
+      assert %WatchStatus{watched: false, unwatched_episode_count: 0} =
+               WatchStatus.for_show(nil)
     end
   end
 end

--- a/test/mydia_web/schema/watch_status_test.exs
+++ b/test/mydia_web/schema/watch_status_test.exs
@@ -4,6 +4,8 @@ defmodule MydiaWeb.Schema.WatchStatusTest do
   alias Mydia.AccountsFixtures
   alias Mydia.MediaFixtures
   alias Mydia.Playback
+  alias Mydia.Playback.WatchStatus
+  alias MydiaWeb.Schema.Resolvers.MediaResolver
 
   defp run(query, user) do
     Absinthe.run(query, MydiaWeb.Schema, context: %{current_user: user})
@@ -147,6 +149,87 @@ defmodule MydiaWeb.Schema.WatchStatusTest do
 
       assert {:ok, %{data: %{"movie" => %{"watchStatus" => status}}}} = run(query, ctx.user)
       assert status == %{"watched" => false, "percentage" => nil}
+    end
+  end
+
+  describe "Episode.watchStatus" do
+    setup do
+      %{user: AccountsFixtures.user_fixture()}
+    end
+
+    test "carries the episode's own progress", ctx do
+      {_show, [episode | _]} = show_with_two_episodes()
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [episode_id: episode.id],
+          %{position_seconds: 100, duration_seconds: 100, watched: true}
+        )
+
+      assert {:ok, %WatchStatus{watched: true, unwatched_episode_count: nil}} =
+               MediaResolver.resolve_episode_watch_status(
+                 %{id: episode.id},
+                 %{},
+                 %{context: %{current_user: ctx.user}}
+               )
+    end
+
+    test "resolves to nil without a current user" do
+      {_show, [episode | _]} = show_with_two_episodes()
+
+      assert {:ok, nil} =
+               MediaResolver.resolve_episode_watch_status(
+                 %{id: episode.id},
+                 %{},
+                 %{context: %{}}
+               )
+    end
+  end
+
+  describe "RecentlyAddedItem.watchStatus" do
+    setup do
+      %{user: AccountsFixtures.user_fixture()}
+    end
+
+    test "rolls a show up through the batch path", ctx do
+      # RecentlyAddedItem is the type behind Favorites, Recently Added, and
+      # Unwatched, and its resolver is the only polymorphic one here. The show
+      # branch has to go through a real query rather than a direct call,
+      # because `batch/3` returns middleware rather than a value and only
+      # Absinthe resolves it.
+      {show, _episodes} = show_with_two_episodes()
+
+      query = """
+      query { recentlyAdded(first: 20) { id watchStatus { watched unwatchedEpisodeCount } } }
+      """
+
+      assert {:ok, %{data: %{"recentlyAdded" => items}}} = run(query, ctx.user)
+
+      item = Enum.find(items, &(&1["id"] == show.id))
+      refute is_nil(item), "expected the seeded show on the recently-added list"
+
+      assert item["watchStatus"] == %{"watched" => false, "unwatchedEpisodeCount" => 2}
+    end
+
+    test "takes the movie branch for a movie", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "Recently Added Movie"})
+
+      assert {:ok, %WatchStatus{watched: false, unwatched_episode_count: nil}} =
+               MediaResolver.resolve_recently_added_watch_status(
+                 %{id: movie.id, type: :movie},
+                 %{},
+                 %{context: %{current_user: ctx.user}}
+               )
+    end
+
+    test "resolves to nil without a current user" do
+      assert {:ok, nil} =
+               MediaResolver.resolve_recently_added_watch_status(
+                 %{id: "anything", type: :tv_show},
+                 %{},
+                 %{context: %{}}
+               )
     end
   end
 end

--- a/test/mydia_web/schema/watch_status_test.exs
+++ b/test/mydia_web/schema/watch_status_test.exs
@@ -1,0 +1,152 @@
+defmodule MydiaWeb.Schema.WatchStatusTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
+  alias Mydia.Playback
+
+  defp run(query, user) do
+    Absinthe.run(query, MydiaWeb.Schema, context: %{current_user: user})
+  end
+
+  defp show_with_two_episodes do
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Counted"})
+
+    episodes =
+      for n <- 1..2 do
+        episode =
+          MediaFixtures.episode_fixture(%{
+            media_item_id: show.id,
+            season_number: 1,
+            episode_number: n
+          })
+
+        MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+        episode
+      end
+
+    {show, episodes}
+  end
+
+  describe "TvShow.watchStatus" do
+    setup do
+      %{user: AccountsFixtures.user_fixture()}
+    end
+
+    test "reports every playable episode as unwatched before anything is played", ctx do
+      {show, _episodes} = show_with_two_episodes()
+
+      query = """
+      query { tvShow(id: "#{show.id}") { watchStatus { watched percentage unwatchedEpisodeCount } } }
+      """
+
+      assert {:ok, %{data: %{"tvShow" => %{"watchStatus" => status}}}} = run(query, ctx.user)
+
+      assert status == %{
+               "watched" => false,
+               "percentage" => nil,
+               "unwatchedEpisodeCount" => 2
+             }
+    end
+
+    test "drops to watched with a zero count once all episodes are watched", ctx do
+      {show, episodes} = show_with_two_episodes()
+
+      for episode <- episodes do
+        {:ok, _} =
+          Playback.save_progress(
+            ctx.user.id,
+            [episode_id: episode.id],
+            %{position_seconds: 100, duration_seconds: 100, watched: true}
+          )
+      end
+
+      query = """
+      query { tvShow(id: "#{show.id}") { watchStatus { watched unwatchedEpisodeCount } } }
+      """
+
+      assert {:ok, %{data: %{"tvShow" => %{"watchStatus" => status}}}} = run(query, ctx.user)
+      assert status == %{"watched" => true, "unwatchedEpisodeCount" => 0}
+    end
+
+    test "resolves to null without a current user" do
+      {show, _episodes} = show_with_two_episodes()
+
+      # Root queries are wrapped in RequireAuth, so `tvShow` never reaches
+      # nested resolvers when current_user is nil. Call the resolver directly
+      # to cover the unauthenticated branch the field itself implements.
+      assert {:ok, nil} =
+               MydiaWeb.Schema.Resolvers.MediaResolver.resolve_show_watch_status(
+                 %{id: show.id},
+                 %{},
+                 %{context: %{current_user: nil}}
+               )
+    end
+  end
+
+  describe "Season.watchStatus" do
+    setup do
+      %{user: AccountsFixtures.user_fixture()}
+    end
+
+    test "scopes the count to the season", ctx do
+      show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Seasoned"})
+
+      for {season, number} <- [{1, 1}, {1, 2}, {2, 1}] do
+        episode =
+          MediaFixtures.episode_fixture(%{
+            media_item_id: show.id,
+            season_number: season,
+            episode_number: number
+          })
+
+        MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+      end
+
+      query = """
+      query { tvShow(id: "#{show.id}") { seasons { seasonNumber watchStatus { unwatchedEpisodeCount } } } }
+      """
+
+      assert {:ok, %{data: %{"tvShow" => %{"seasons" => seasons}}}} = run(query, ctx.user)
+
+      by_number = Map.new(seasons, &{&1["seasonNumber"], &1["watchStatus"]})
+      assert by_number[1] == %{"unwatchedEpisodeCount" => 2}
+      assert by_number[2] == %{"unwatchedEpisodeCount" => 1}
+    end
+  end
+
+  describe "Movie.watchStatus" do
+    setup do
+      %{user: AccountsFixtures.user_fixture()}
+    end
+
+    test "carries the movie's own progress", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "Solo"})
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: movie.id],
+          %{position_seconds: 30, duration_seconds: 100}
+        )
+
+      query = """
+      query { movie(id: "#{movie.id}") { watchStatus { watched unwatchedEpisodeCount } } }
+      """
+
+      assert {:ok, %{data: %{"movie" => %{"watchStatus" => status}}}} = run(query, ctx.user)
+      assert status == %{"watched" => false, "unwatchedEpisodeCount" => nil}
+    end
+
+    test "an unplayed movie is unwatched rather than null", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "Untouched"})
+
+      query = """
+      query { movie(id: "#{movie.id}") { watchStatus { watched percentage } } }
+      """
+
+      assert {:ok, %{data: %{"movie" => %{"watchStatus" => status}}}} = run(query, ctx.user)
+      assert status == %{"watched" => false, "percentage" => nil}
+    end
+  end
+end


### PR DESCRIPTION
Gives the Flutter player Infuse-style watched indicators: a dot on anything untouched, an unwatched-episode count on shows and season chips, the existing bar for part-played titles, and nothing at all once watched.

Before this, a never-played movie and a fully-watched one rendered identically, TV shows carried no watch state anywhere, and the Unwatched screen itself displayed no unwatched indicators.

## What changed

**Schema.** A new `WatchStatus { watched, percentage, unwatchedEpisodeCount }` on `Movie`, `TvShow`, `Season`, `Episode`, and `RecentlyAddedItem`. One type rather than four scattered fields, so shows and movies share a client code path and the rendering rule lives in one place. `ContinueWatchingItem` deliberately does not get it: it already carries non-null `Progress`, and the screen adapts that client-side.

**Counting rule.** An episode counts as unwatched when it has a non-trashed file, is not in season 0, and has either no progress row or one whose `watched` is not true. That last clause reuses the predicate `NextEpisode.determine/2` already applies, so a badge count and a next-up selection cannot disagree.

**Batching, and an N+1 fix.** `seasonCount` and `episodeCount` each called `Media.list_episodes/1` separately, so a 50-show grid issued about 100 episode queries. All three now share one `Absinthe.Resolution.Helpers.batch/3` loader: three queries regardless of how many shows are on screen, pinned by a scale-invariance test.

**Rust parity.** `server/crates/api` mirrors the struct and fields so `sdl_parity` stays green.

**Client.** One `WatchIndicator` owns the whole rendering rule; one `PosterBadgeCorner` owns the top-right corner that the favourite heart and quality badges already occupied. Every surface composing the indicator runs a shared contract suite, the same way `PosterFrame` consumers run `runPosterDepthContract`.

**Invalidation.** `watchedChanged` never invalidated `tvShowsList`, and the rules referenced `unwatched`/`favorites` where the grids key off the distinct `unwatchedList`/`favoritesList`. Harmless while those surfaces rendered no watch state; a visible staleness bug the moment they render badges.

**Show detail query extracted** from its inline Dart string into `show_detail.graphql`, so codegen validates it. Inline GraphQL skips that check, which is how player favoriting stayed broken for the app's entire life.

## Two fixes found along the way

- The episode card's dot ignored `hasFile`, so a season list could show dots on episodes you cannot play while the show badge above counted only playable ones.
- Continue Watching was still on the legacy `progressPercentage` prop rather than the shared rule, so a watched item drew a full bar.

## Testing

Elixir 7611 / 0 failures. Flutter 2243 / 2243 (`--concurrency=1`). Rust 47. `mix precommit` green. All run locally against this branch.

Regression-pinned by deliberately breaking each guard and confirming the test fails: the trashed-file filter, the empty-child corner filter, the `hasFile` gate, and the shared contract suite against an unwired surface.

## Compatibility

There is no GraphQL-level version negotiation; `ProtocolVersion` and `update_required` cover only the four remote-access transport layers. A player updated ahead of its server will fail whole queries naming `watchStatus`. Every prior schema addition carried the same window. Worth a release-note line for whichever component ships first.
