### PR TITLE
fix(player): watched titles drew a progress bar, and the home rails had no indicators

### DIFF
--- a/player/lib/presentation/screens/home/home_controller.dart
+++ b/player/lib/presentation/screens/home/home_controller.dart
@@ -58,6 +58,7 @@ query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $favorit
     newEpisodeCount
     latestSeasonNumber
     latestEpisodeNumber
+    watchStatus { watched percentage unwatchedEpisodeCount }
   }
 
   favorites(first: $favoritesLimit) {
@@ -71,6 +72,7 @@ query HomeScreen($continueWatchingLimit: Int, $recentlyAddedLimit: Int, $favorit
       thumbnailUrl
     }
     addedAt
+    watchStatus { watched percentage unwatchedEpisodeCount }
   }
 }
 ''';

--- a/player/lib/presentation/widgets/content_rail.dart
+++ b/player/lib/presentation/widgets/content_rail.dart
@@ -4,6 +4,7 @@ import '../../core/theme/colors.dart';
 import '../../domain/models/continue_watching_item.dart';
 import '../../domain/models/recently_added_item.dart';
 import '../../domain/models/up_next_item.dart';
+import '../../domain/models/watch_status.dart';
 import 'media_card.dart';
 import 'media_context_menu.dart';
 
@@ -208,7 +209,13 @@ class _ContentRailState extends State<ContentRail> {
         posterUrl: item.posterUrl,
         title: item.title,
         subtitle: item.railSubtitle,
-        progressPercentage: item.progress?.percentage,
+        // Derived here for the same reason the Continue Watching screen
+        // derives it: `ContinueWatchingItem` carries a `Progress` row and no
+        // `watchStatus`, and adapting it puts this rail on the shared
+        // rendering rule instead of the legacy percentage prop.
+        watchStatus: item.progress == null
+            ? null
+            : WatchStatus.fromProgress(item.progress!),
         width: cardSize.width,
         height: cardSize.height,
         action: _actionFor(target),
@@ -223,6 +230,7 @@ class _ContentRailState extends State<ContentRail> {
         posterUrl: item.posterUrl,
         title: item.title,
         subtitle: item.newContentLabel ?? item.year?.toString(),
+        watchStatus: item.watchStatus,
         width: cardSize.width,
         height: cardSize.height,
         action: _actionFor(target),
@@ -241,6 +249,9 @@ class _ContentRailState extends State<ContentRail> {
         posterUrl: item.posterUrl,
         title: item.show.title,
         subtitle: item.episode.episodeCode,
+        watchStatus: item.episode.progress == null
+            ? null
+            : WatchStatus.fromProgress(item.episode.progress!),
         width: cardSize.width,
         height: cardSize.height,
         action: _actionFor(target),

--- a/player/lib/presentation/widgets/media_card.dart
+++ b/player/lib/presentation/widgets/media_card.dart
@@ -140,7 +140,9 @@ class MediaCard extends StatelessWidget {
                   imageUrl: posterUrl,
                   placeholder: _buildPlaceholder(),
                   overlays: [
-                    if (progress != null && progress > 0)
+                    // `watchStatus` supersedes `progressPercentage` when both
+                    // arrive. See the same guard in `MediaPoster` for why.
+                    if (watchStatus == null && progress != null && progress > 0)
                       ProgressOverlay(percentage: progress),
                     WatchProgressOverlay(status: watchStatus),
                     if (action == MediaCardAction.play) const _PlayBadge(),

--- a/player/lib/presentation/widgets/media_poster.dart
+++ b/player/lib/presentation/widgets/media_poster.dart
@@ -82,7 +82,13 @@ class MediaPoster extends StatelessWidget {
                 placeholder: _placeholder,
                 loadingPlaceholder: _loadingPlaceholder,
                 overlays: [
-                  if (progress != null && progress > 0)
+                  // `watchStatus` supersedes `progressPercentage` when both
+                  // arrive. They coexisted during the rollout, and rendering
+                  // both drew a full bar on watched titles, since the legacy
+                  // prop knows a percentage but not that the title is
+                  // finished. A surface that has not migrated still passes
+                  // only the legacy prop and is unaffected.
+                  if (watchStatus == null && progress != null && progress > 0)
                     ProgressOverlay(percentage: progress),
                   WatchProgressOverlay(status: watchStatus),
                   // TMDB reports 0.0 for a title nobody has voted on, so 0 and

--- a/player/test/presentation/screens/home/home_controller_test.dart
+++ b/player/test/presentation/screens/home/home_controller_test.dart
@@ -29,6 +29,10 @@ Map<String, dynamic> _homeData(String title) => {
           'newEpisodeCount': null,
           'latestSeasonNumber': null,
           'latestEpisodeNumber': null,
+          // Required because the query selects it. A stub missing a selected
+          // field does not error: the normalized cache returns partial data,
+          // and the failure surfaces somewhere unrelated.
+          'watchStatus': null,
         }
       ],
       'upNext': <dynamic>[],

--- a/player/test/presentation/widgets/content_rail_test.dart
+++ b/player/test/presentation/widgets/content_rail_test.dart
@@ -11,11 +11,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/domain/models/continue_watching_item.dart';
 import 'package:player/domain/models/media_file.dart';
+import 'package:player/domain/models/progress.dart';
 import 'package:player/domain/models/recently_added_item.dart';
 import 'package:player/domain/models/up_next_item.dart';
+import 'package:player/domain/models/watch_status.dart';
 import 'package:player/presentation/widgets/content_rail.dart';
 import 'package:player/presentation/widgets/media_card.dart';
 import 'package:player/presentation/widgets/media_context_menu.dart';
+import 'package:player/presentation/widgets/progress_overlay.dart';
+import 'package:player/presentation/widgets/watch_indicator.dart';
 
 List<RecentlyAddedItem> _items(int n) => List.generate(
       n,
@@ -248,6 +252,67 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(PopupMenuItem<MediaContextAction>), findsNothing);
+    });
+  });
+
+  group('ContentRail watch indicators', () {
+    testWidgets('draws an unwatched dot on a recently added movie',
+        (tester) async {
+      const item = RecentlyAddedItem(
+        id: 'ra-1',
+        type: 'movie',
+        title: 'Fresh Movie',
+        watchStatus: WatchStatus(watched: false),
+      );
+
+      await tester.pumpWidget(
+        _host(const ContentRail(title: 'Recently Added', items: [item])),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(WatchIndicator.dotKey), findsOneWidget);
+    });
+
+    testWidgets('draws an unwatched count on a recently added show',
+        (tester) async {
+      const item = RecentlyAddedItem(
+        id: 'ra-2',
+        type: 'tv_show',
+        title: 'Fresh Show',
+        watchStatus: WatchStatus(watched: false, unwatchedEpisodeCount: 4),
+      );
+
+      await tester.pumpWidget(
+        _host(const ContentRail(title: 'Recently Added', items: [item])),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('4'), findsOneWidget);
+    });
+
+    testWidgets('draws no bar for a watched continue-watching item',
+        (tester) async {
+      // The rail carried the legacy `progressPercentage` and no status, so a
+      // finished item drew a full bar here while every other surface drew
+      // nothing.
+      const item = ContinueWatchingItem(
+        id: 'cw-2',
+        type: 'movie',
+        title: 'Finished',
+        progress: Progress(
+          positionSeconds: 100,
+          durationSeconds: 100,
+          percentage: 100,
+          watched: true,
+        ),
+      );
+
+      await tester.pumpWidget(
+        _host(const ContentRail(title: 'Continue Watching', items: [item])),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ProgressOverlay), findsNothing);
     });
   });
 }

--- a/player/test/presentation/widgets/media_card_test.dart
+++ b/player/test/presentation/widgets/media_card_test.dart
@@ -191,10 +191,11 @@ void main() {
 
   runWatchIndicatorContract(
     description: 'MediaCard',
-    build: (status) => MediaCard(
+    build: (status, legacyProgress) => MediaCard(
       title: 'Movie',
       action: MediaCardAction.open,
       watchStatus: status,
+      progressPercentage: legacyProgress,
     ),
     size: _cardHost,
   );

--- a/player/test/presentation/widgets/media_poster_test.dart
+++ b/player/test/presentation/widgets/media_poster_test.dart
@@ -149,7 +149,11 @@ void main() {
 
   runWatchIndicatorContract(
     description: 'MediaPoster',
-    build: (status) => MediaPoster(title: 'Show', watchStatus: status),
+    build: (status, legacyProgress) => MediaPoster(
+      title: 'Show',
+      watchStatus: status,
+      progressPercentage: legacyProgress,
+    ),
     size: _posterHost,
   );
 

--- a/player/test/test_utils/watch_indicator_contract.dart
+++ b/player/test/test_utils/watch_indicator_contract.dart
@@ -19,16 +19,29 @@ import 'poster_contract.dart';
 /// Asserts that [build] renders the four watch states the same way every
 /// other surface does.
 ///
-/// [build] receives a status and must return the surface under test wired to
-/// it. Pass the same [size] the surface's other tests use.
+/// [build] receives a status and the surface's legacy `progressPercentage`,
+/// and must return the surface under test wired to both. Pass the same [size]
+/// the surface's other tests use.
+///
+/// The legacy argument exists because the two props coexisted during the
+/// rollout, and a surface passing both is what shipped a full progress bar on
+/// watched titles in the library grid: `watchStatus` correctly drew nothing
+/// while `progressPercentage: 100` drew a bar right beside it. The last two
+/// cases below pin that.
 void runWatchIndicatorContract({
   required String description,
-  required Widget Function(WatchStatus? status) build,
+  required Widget Function(WatchStatus? status, double? legacyProgress) build,
   Size? size,
 }) {
-  Future<void> pump(WidgetTester tester, WatchStatus? status) async {
+  Future<void> pump(
+    WidgetTester tester,
+    WatchStatus? status, [
+    double? legacyProgress,
+  ]) async {
     await mockNetworkImages(() async {
-      await tester.pumpWidget(posterHost(build(status), size: size));
+      await tester.pumpWidget(
+        posterHost(build(status, legacyProgress), size: size),
+      );
       await tester.pumpAndSettle();
     });
   }
@@ -69,6 +82,36 @@ void runWatchIndicatorContract({
 
       expect(find.byKey(WatchIndicator.dotKey), findsNothing);
       expect(find.byType(ProgressOverlay), findsNothing);
+    });
+
+    testWidgets('lets a watched status override the legacy progress prop',
+        (tester) async {
+      await pump(
+        tester,
+        const WatchStatus(watched: true, percentage: 100),
+        100,
+      );
+
+      expect(find.byType(ProgressOverlay), findsNothing);
+    });
+
+    testWidgets('draws one bar, not two, when both sources are supplied',
+        (tester) async {
+      await pump(
+        tester,
+        const WatchStatus(watched: false, percentage: 40),
+        40,
+      );
+
+      expect(find.byType(ProgressOverlay), findsOneWidget);
+    });
+
+    testWidgets('still honours the legacy prop when there is no status',
+        (tester) async {
+      // Surfaces that have not migrated keep working unchanged.
+      await pump(tester, null, 40);
+
+      expect(find.byType(ProgressOverlay), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Two defects in the watched indicators from #443, both found by looking at the actual call sites rather than the widgets.

## Watched titles still drew a progress bar

`library_grid_body.dart` passes `progressPercentage` **and** `watchStatus` to `MediaPoster`, and the widget rendered overlays from both. So a watched movie in the library grid drew a full bar from the legacy prop while `watchStatus` correctly drew nothing beside it, and a part-played movie drew two stacked `ProgressOverlay`s.

`watchStatus` now supersedes `progressPercentage` in both `MediaPoster` and `MediaCard`. The legacy prop is deliberately kept at the call sites: when an older server sends no `watchStatus`, it remains the fallback that still draws the bar.

## The home rails had no indicators at all

`content_rail.dart` passed the legacy prop and never passed `watchStatus`, and the home query never selected the field. #443 wired the `MediaCard` widget and tested it in isolation, but nothing wired the actual `ContentRail` call sites, so Home rendered the old bar and nothing else.

`ContentRail` now supplies a status for all three of its item types: derived from `Progress` for `ContinueWatchingItem` and `UpNextItem` (neither carries `watchStatus`, by design), and passed straight through for `RecentlyAddedItem`. `homeScreenQuery` selects `watchStatus` on its `recentlyAdded` and `favorites` rails. `homeScreenQueryLegacy` is left alone as the older-server fallback.

## Why the tests missed both

The shared contract suite pumped each surface with `watchStatus` and no `progressPercentage`, so it never exercised the combination every real caller uses. And it tests widgets, not call sites, so nothing asserted that `ContentRail` passes anything at all.

The contract now takes both props and pins three more cases for every surface that runs it: a watched status overrides the legacy prop, both sources together draw exactly one bar, and the legacy prop still works alone for un-migrated surfaces. `ContentRail` gets its own indicator tests. All five new assertions were confirmed to fail before the fix.

One test stub needed a `watchStatus: null` after the home query grew, which is the partial-data trap rather than a product issue: a stub missing a selected field yields degraded data instead of an error.

## Testing

Flutter 2252/2252 (`--concurrency=1`). No Elixir or Rust changes; the schema is unchanged from #443.
