### PR TITLE
fix: two 0.13.x crash regressions found in the relay crash reports

### DIFF
--- a/lib/mydia/jobs/library_scanner.ex
+++ b/lib/mydia/jobs/library_scanner.ex
@@ -35,7 +35,8 @@ defmodule Mydia.Jobs.LibraryScanner do
     MusicScanner,
     BookScanner,
     AdultScanner,
-    SampleDetector
+    SampleDetector,
+    ScanSummary
   }
 
   alias Mydia.Library.ReleaseParser, as: FileParser
@@ -175,12 +176,12 @@ defmodule Mydia.Jobs.LibraryScanner do
     library_path = Settings.get_library_path!(library_path_id)
 
     case scan_library_path(library_path) do
-      {:ok, result} ->
+      {:ok, %ScanSummary{} = summary} ->
         Logger.info("Library scan completed successfully",
           library_path_id: library_path_id,
-          new_files: length(result.changes.new_files),
-          modified_files: length(result.changes.modified_files),
-          deleted_files: length(result.changes.deleted_files)
+          new_files: summary.new_files,
+          modified_files: summary.modified_files,
+          deleted_files: summary.deleted_files
         )
 
         :ok
@@ -279,25 +280,57 @@ defmodule Mydia.Jobs.LibraryScanner do
 
   # Dispatch to appropriate scanner based on library type
   defp process_scan_result_by_type(library_path, scan_result) do
-    case library_path.type do
-      :music ->
-        process_music_scan_result(library_path, scan_result)
+    result =
+      case library_path.type do
+        :music ->
+          process_music_scan_result(library_path, scan_result)
 
-      :books ->
-        process_books_scan_result(library_path, scan_result)
+        :books ->
+          process_books_scan_result(library_path, scan_result)
 
-      :adult ->
-        process_adult_scan_result(library_path, scan_result)
+        :adult ->
+          process_adult_scan_result(library_path, scan_result)
 
-      # Video-based library types use the standard video processing
-      type when type in [:movies, :series, :mixed] ->
-        process_scan_result(library_path, scan_result)
+        # Video-based library types use the standard video processing
+        type when type in [:movies, :series, :mixed] ->
+          process_scan_result(library_path, scan_result)
 
-      # Default to video processing for unknown types
-      _ ->
-        process_scan_result(library_path, scan_result)
-    end
+        # Default to video processing for unknown types
+        _ ->
+          process_scan_result(library_path, scan_result)
+      end
+
+    summarize(result)
   end
+
+  # The per-type processors return two different shapes: the video processor
+  # returns lists under :changes, the others return integer counts. Normalize
+  # both into a ScanSummary so callers have a single contract.
+  defp summarize({:ok, %{changes: changes} = details}) do
+    {:ok,
+     %ScanSummary{
+       new_files: length(changes.new_files),
+       modified_files: length(changes.modified_files),
+       deleted_files: length(changes.deleted_files),
+       details: details
+     }}
+  end
+
+  defp summarize(
+         {:ok, %{new_files: new, modified_files: modified, deleted_files: deleted} = details}
+       )
+       when is_integer(new) and is_integer(modified) and is_integer(deleted) do
+    {:ok,
+     %ScanSummary{
+       new_files: new,
+       modified_files: modified,
+       deleted_files: deleted,
+       details: details
+     }}
+  end
+
+  # Errors from handle_scan_error/2 pass through unchanged.
+  defp summarize(other), do: other
 
   defp process_music_scan_result(library_path, scan_result) do
     Logger.info("Processing music library scan",

--- a/lib/mydia/library/media_file.ex
+++ b/lib/mydia/library/media_file.ex
@@ -4,6 +4,7 @@ defmodule Mydia.Library.MediaFile do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  require Logger
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -106,9 +107,21 @@ defmodule Mydia.Library.MediaFile do
       iex> MediaFile.absolute_path(file)
       nil
   """
-  def absolute_path(%__MODULE__{relative_path: relative_path, library_path: library_path})
-      when not is_nil(relative_path) and not is_nil(library_path) do
-    Path.join(library_path.path, relative_path)
+  def absolute_path(%__MODULE__{
+        relative_path: relative_path,
+        library_path: %Mydia.Settings.LibraryPath{path: path}
+      })
+      when not is_nil(relative_path) and not is_nil(path) do
+    Path.join(path, relative_path)
+  end
+
+  def absolute_path(%__MODULE__{id: id, library_path: %Ecto.Association.NotLoaded{}}) do
+    Logger.warning(
+      "MediaFile.absolute_path/1 called with an unloaded library_path association",
+      media_file_id: id
+    )
+
+    nil
   end
 
   def absolute_path(%__MODULE__{}), do: nil

--- a/lib/mydia/library/scan_summary.ex
+++ b/lib/mydia/library/scan_summary.ex
@@ -1,0 +1,25 @@
+defmodule Mydia.Library.ScanSummary do
+  @moduledoc """
+  Normalized result of scanning a single library path.
+
+  `Mydia.Jobs.LibraryScanner` dispatches scanning by library type, and the
+  per-type processors return different shapes. The video processor returns
+  lists of changed files under a `:changes` key, while the music, books and
+  adult processors return integer counts directly. This struct is the single
+  contract at that dispatch boundary, so callers cannot accidentally depend on
+  one branch's shape.
+
+  `details` carries the originating processor's own return value unchanged, so
+  branch-specific data such as `new_media_files` stays reachable by the code
+  that already relies on it.
+  """
+
+  @type t :: %__MODULE__{
+          new_files: non_neg_integer(),
+          modified_files: non_neg_integer(),
+          deleted_files: non_neg_integer(),
+          details: map()
+        }
+
+  defstruct new_files: 0, modified_files: 0, deleted_files: 0, details: %{}
+end

--- a/test/mydia/jobs/library_scanner_test.exs
+++ b/test/mydia/jobs/library_scanner_test.exs
@@ -55,5 +55,67 @@ defmodule Mydia.Jobs.LibraryScannerTest do
       # Verify monitored item still exists (job doesn't modify items)
       assert Mydia.Media.get_media_item!(monitored.id).monitored == true
     end
+
+    setup do
+      original_level = Logger.level()
+      Logger.configure(level: :info)
+      on_exit(fn -> Logger.configure(level: original_level) end)
+      :ok
+    end
+
+    test "completes a scan of a music library path" do
+      {:ok, library_path} =
+        Settings.create_library_path(%{
+          path: empty_library_dir(),
+          type: "music",
+          monitored: true
+        })
+
+      assert :ok = perform_job(LibraryScanner, %{"library_path_id" => library_path.id})
+      assert Settings.get_library_path!(library_path.id).last_scan_status == :success
+    end
+
+    test "completes a scan of a books library path" do
+      {:ok, library_path} =
+        Settings.create_library_path(%{
+          path: empty_library_dir(),
+          type: "books",
+          monitored: true
+        })
+
+      assert :ok = perform_job(LibraryScanner, %{"library_path_id" => library_path.id})
+      assert Settings.get_library_path!(library_path.id).last_scan_status == :success
+    end
+
+    test "completes a scan of an adult library path" do
+      {:ok, library_path} =
+        Settings.create_library_path(%{
+          path: empty_library_dir(),
+          type: "adult",
+          monitored: true
+        })
+
+      assert :ok = perform_job(LibraryScanner, %{"library_path_id" => library_path.id})
+      assert Settings.get_library_path!(library_path.id).last_scan_status == :success
+    end
+
+    test "completes a scan of a movies library path" do
+      {:ok, library_path} =
+        Settings.create_library_path(%{
+          path: empty_library_dir(),
+          type: "movies",
+          monitored: true
+        })
+
+      assert :ok = perform_job(LibraryScanner, %{"library_path_id" => library_path.id})
+      assert Settings.get_library_path!(library_path.id).last_scan_status == :success
+    end
+  end
+
+  defp empty_library_dir do
+    path = Path.join(System.tmp_dir!(), "mydia_scan_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(path)
+    on_exit(fn -> File.rm_rf(path) end)
+    path
   end
 end

--- a/test/mydia/library/media_file_test.exs
+++ b/test/mydia/library/media_file_test.exs
@@ -1,5 +1,6 @@
 defmodule Mydia.Library.MediaFileTest do
   use Mydia.DataCase
+  import ExUnit.CaptureLog
 
   alias Mydia.Library.MediaFile
   alias Mydia.Settings.LibraryPath
@@ -17,13 +18,32 @@ defmodule Mydia.Library.MediaFileTest do
                "/media/movies/The Matrix (1999)/The Matrix (1999) [1080p].mkv"
     end
 
-    test "returns nil when library_path is not preloaded" do
+    test "returns nil when library_path is nil" do
       media_file = %MediaFile{
         relative_path: "Movie.mkv",
         library_path: nil
       }
 
       assert MediaFile.absolute_path(media_file) == nil
+    end
+
+    test "returns nil and warns when library_path is not loaded" do
+      media_file = %MediaFile{
+        id: "11111111-1111-1111-1111-111111111111",
+        relative_path: "Movie.mkv",
+        library_path: %Ecto.Association.NotLoaded{
+          __field__: :library_path,
+          __owner__: MediaFile,
+          __cardinality__: :one
+        }
+      }
+
+      log =
+        capture_log(fn ->
+          assert MediaFile.absolute_path(media_file) == nil
+        end)
+
+      assert log =~ "unloaded library_path"
     end
 
     test "returns nil when relative_path is nil" do


### PR DESCRIPTION
Fixes two crashes reported by production instances on 0.13.1. Neither had a GitHub issue. Both were verified still present on master before being fixed.

Both were found by ranking metadata-relay crash reports by distinct reporting install rather than by raw occurrence count. Raw counts are dominated by a single development instance, which buries low-volume defects affecting real users.

## Library scan reports successful work as failed

`process_scan_result_by_type/2` dispatches on library type, and its branches returned two incompatible shapes. The video branch returns lists under `:changes`, while the music, books and adult branches return integer counts. The shared success log read only the first shape, so scanning a music, books or adult library path raised `KeyError` after the scan had already completed and committed its work.

Both shapes are now normalized into a `ScanSummary` struct at the dispatch boundary. Scanner internals are untouched, and the struct stays correct after the planned music/books/adult removal.

Only single-library scans ever crashed. `scan_all_libraries/0` and `scan_libraries_by_type/1` match on `{:ok, _}` without reading the payload, so they were unaffected.

## Unloaded association raises instead of returning nil

`MediaFile.absolute_path/1` guarded with `not is_nil(library_path)`. An `%Ecto.Association.NotLoaded{}` is a struct and passes that guard, so it reached the clause dereferencing `library_path.path` and raised.

The function has more than fifteen callers, essentially all already written as `case ... do nil -> skip`, so every one was a latent crash site and all are fixed by the single change. An unloaded association now returns nil and logs a warning naming the media file, which is what will identify the caller that skipped the preload.

## Why the test suite never caught either one

Worth flagging for reviewers, because it generalizes beyond this PR.

The scanner crash lives inside the metadata of a `Logger.info/2` call. `Logger.info/2` is a macro and does not evaluate its arguments when the configured level is above `:info`. `config/test.exs` sets `level: :warning`, so `length(result.changes.new_files)` never executed under `mix test` while crashing every install running at `:info`. A correct end-to-end regression test still passed against the broken code until the level was raised for the block.

**Any defect inside `Logger.info` or `Logger.debug` metadata is invisible to this test suite by default.** Prefer computing a value into a variable before logging it.

The second defect had a matching problem: the existing test was named "returns nil when library_path is not preloaded" but passed `library_path: nil`, so it never exercised the unloaded case despite its name. It has been renamed to describe what it actually covers, with a real test added alongside.

## Testing

- Full `mix precommit`: 7635 tests, 0 failures, Credo and Format green
- Targeted sweep across every `absolute_path` caller (`library`, `streaming`, `metadata`, `jobs`): 2039 tests, 0 failures
- Each `summarize/1` clause confirmed to actually execute rather than inferred from a green suite: the integer-count clause via the music/books/adult tests, the `:changes` clause via the movies test, and the error passthrough via the pre-existing non-existent-path test
