### PR TITLE
fix(player): stop browsers pinning an old web player bundle

### DIFF
--- a/lib/mydia_web/controllers/player_controller.ex
+++ b/lib/mydia_web/controllers/player_controller.ex
@@ -43,6 +43,12 @@ defmodule MydiaWeb.PlayerController do
 
         conn
         |> put_resp_content_type("text/html")
+        # This document is per-user and carries a Guardian JWT in
+        # `window.mydiaConfig`, so it must not be written to any cache. It is
+        # also the only thing pointing at the asset URLs, which is the other
+        # reason it can never be served from one: a stale shell would reinstate
+        # exactly the pinned-old-client problem the static mount below fixes.
+        |> put_resp_header("cache-control", "no-store")
         |> send_resp(200, modified_html)
 
       {:error, :not_found} ->

--- a/lib/mydia_web/endpoint.ex
+++ b/lib/mydia_web/endpoint.ex
@@ -38,6 +38,28 @@ defmodule MydiaWeb.Endpoint do
     websocket: true,
     longpoll: false
 
+  # The Flutter web player, ahead of the catch-all below so its cache policy
+  # wins for "/player/*".
+  #
+  # Flutter does not content-hash its web output: every build overwrites
+  # `main.dart.js` at the same URL. Plug.Static's default `cache_control_for_etags`
+  # is "public", which carries no `max-age` and no `Last-Modified`, so a browser
+  # is free to reuse its copy on heuristic freshness alone and never ask whether
+  # a newer one exists. An operator upgrading the container then keeps serving
+  # the new bundle to clients that go on running the previous one, with no error
+  # anywhere: the server answers every query correctly, the old app just never
+  # asks for the fields it does not know about. That is how the watch indicators
+  # shipped to a browser that kept rendering a build from before them.
+  #
+  # "no-cache" still stores the entity, it only forbids reusing it without
+  # revalidating, which the etag settles with a bodiless 304.
+  plug Plug.Static,
+    at: "/player",
+    from: {:mydia, "priv/static/player"},
+    gzip: not code_reloading?,
+    cache_control_for_etags: "no-cache",
+    cache_control_for_vsn_requests: "no-cache"
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # When code reloading is disabled (e.g., in production),

--- a/lib/mydia_web/endpoint.ex
+++ b/lib/mydia_web/endpoint.ex
@@ -52,13 +52,25 @@ defmodule MydiaWeb.Endpoint do
   # shipped to a browser that kept rendering a build from before them.
   #
   # "no-cache" still stores the entity, it only forbids reusing it without
-  # revalidating, which the etag settles with a bodiless 304.
+  # revalidating, which the etag settles with a bodiless 304. The bundle stays
+  # in the browser's cache; all it loses is the right to serve it unasked.
+  #
+  # That revalidation is only cheap because `:etag_generation` hashes the bytes.
+  # Plug.Static's default validator is phash2({size, mtime}), and a container
+  # image stamps a fresh mtime on every file it ships, so the default would
+  # re-download the whole tree on each deploy to discover that canvaskit and
+  # the fonts had not changed. See `MydiaWeb.PlayerAssets`.
+  #
+  # `cache_control_for_vsn_requests` stays "no-cache" on purpose: these URLs
+  # carry no version, so the immutable default would be a promise this tree
+  # cannot keep.
   plug Plug.Static,
     at: "/player",
     from: {:mydia, "priv/static/player"},
     gzip: not code_reloading?,
     cache_control_for_etags: "no-cache",
-    cache_control_for_vsn_requests: "no-cache"
+    cache_control_for_vsn_requests: "no-cache",
+    etag_generation: {MydiaWeb.PlayerAssets, :etag, []}
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/lib/mydia_web/endpoint.ex
+++ b/lib/mydia_web/endpoint.ex
@@ -61,9 +61,12 @@ defmodule MydiaWeb.Endpoint do
   # re-download the whole tree on each deploy to discover that canvaskit and
   # the fonts had not changed. See `MydiaWeb.PlayerAssets`.
   #
-  # `cache_control_for_vsn_requests` stays "no-cache" on purpose: these URLs
-  # carry no version, so the immutable default would be a promise this tree
-  # cannot keep.
+  # `cache_control_for_vsn_requests` stays "no-cache" because nothing Flutter
+  # emits appends "?vsn=", so the immutable default would be a year-long
+  # promise made on behalf of a URL that carries no version. Plug.Static skips
+  # the etag entirely on that branch, so a stray versioned request costs a full
+  # transfer either way; this at least keeps it from being cached under a
+  # version that means nothing.
   plug Plug.Static,
     at: "/player",
     from: {:mydia, "priv/static/player"},

--- a/lib/mydia_web/player_assets.ex
+++ b/lib/mydia_web/player_assets.ex
@@ -1,0 +1,97 @@
+defmodule MydiaWeb.PlayerAssets do
+  @moduledoc """
+  Content-addressed etags for the built Flutter web player.
+
+  Flutter does not content-hash its web output, so every build overwrites
+  `main.dart.js` at the same URL and the bundle can only be cached against a
+  validator. `Plug.Static`'s default validator is `phash2({size, mtime})`,
+  which is wrong for this tree in a way that only shows up in production: a
+  container image stamps a fresh mtime on every file it ships, so each deploy
+  invalidates the whole player, including the canvaskit blobs and fonts whose
+  bytes have not changed since the Flutter SDK was last bumped. The browser
+  re-downloads several megabytes to learn that nothing moved.
+
+  Hashing the bytes instead means the validator tracks content, so a redeploy
+  costs one conditional request per asset and re-transfers only what actually
+  changed. Paired with `cache-control: no-cache` on the same tree, the result
+  is a bundle that is always correct and almost never re-sent.
+
+  The hash is memoized against the file's size and mtime, so it is computed
+  once per file per deploy rather than per request, and a dev rebuild is
+  picked up without a restart. A file the clock says is still settling is
+  hashed outright, because mtime only has one-second resolution and a rewrite
+  inside that second at the same byte count is otherwise invisible.
+  """
+
+  require Logger
+
+  @doc """
+  Builds the etag `Plug.Static` sends for `path`.
+
+  Wired in as `:et_generation`, which is why this returns the header value
+  complete with its quotes rather than a bare digest.
+  """
+  @spec etag(Path.t()) :: binary()
+  def etag(path) do
+    case File.stat(path, time: :posix) do
+      {:ok, %File.Stat{size: size, mtime: mtime}} ->
+        cached_or_hash(path, size, mtime)
+
+      {:error, reason} ->
+        # Plug.Static has already stat'd this file to decide it is servable,
+        # so a failure here means it moved underneath us mid-request. Return a
+        # validator that cannot match, which costs one re-transfer and never
+        # pins a client to bytes we can no longer read.
+        Logger.warning(
+          "Player asset vanished while building its etag: #{path} (#{inspect(reason)})"
+        )
+
+        quoted(Base.encode16(:crypto.strong_rand_bytes(8), case: :lower))
+    end
+  end
+
+  # A file whose mtime is not yet @settle_seconds old may be rewritten again
+  # inside the same second at the same byte count, which {size, mtime} cannot
+  # tell apart from no change at all. Hash those outright and only memoize a
+  # file that has stopped moving. Anything shipped in a container image is
+  # settled the moment the process starts, so this costs nothing in production
+  # and keeps a dev rebuild honest.
+  @settle_seconds 2
+
+  defp cached_or_hash(path, size, mtime) do
+    if System.os_time(:second) - mtime < @settle_seconds do
+      hash(path)
+    else
+      memoized(path, size, mtime)
+    end
+  end
+
+  defp memoized(path, size, mtime) do
+    key = {__MODULE__, path}
+
+    case :persistent_term.get(key, nil) do
+      {^size, ^mtime, etag} ->
+        etag
+
+      _ ->
+        etag = hash(path)
+        # Written once per file per deploy. The global scan a put costs is
+        # affordable at that rate and buys a hash-free steady state.
+        :persistent_term.put(key, {size, mtime, etag})
+        etag
+    end
+  end
+
+  defp hash(path) do
+    path
+    |> File.stream!(2_097_152)
+    |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
+    |> :crypto.hash_final()
+    |> Base.encode16(case: :lower)
+    # A prefix, because an etag is compared for equality and never inverted.
+    |> binary_part(0, 32)
+    |> quoted()
+  end
+
+  defp quoted(digest), do: <<?", digest::binary, ?">>
+end

--- a/lib/mydia_web/player_assets.ex
+++ b/lib/mydia_web/player_assets.ex
@@ -28,7 +28,7 @@ defmodule MydiaWeb.PlayerAssets do
   @doc """
   Builds the etag `Plug.Static` sends for `path`.
 
-  Wired in as `:et_generation`, which is why this returns the header value
+  Wired in as `:etag_generation`, which is why this returns the header value
   complete with its quotes rather than a bare digest.
   """
   @spec etag(Path.t()) :: binary()
@@ -38,10 +38,10 @@ defmodule MydiaWeb.PlayerAssets do
         cached_or_hash(path, size, mtime)
 
       {:error, reason} ->
-        # Plug.Static has already stat'd this file to decide it is servable,
-        # so a failure here means it moved underneath us mid-request. Return a
-        # validator that cannot match, which costs one re-transfer and never
-        # pins a client to bytes we can no longer read.
+        # Plug.Static only calls this after its own stat has decided the file
+        # is servable, so a failure here means it moved underneath us and the
+        # send that follows is going to fail regardless of what we return.
+        # A validator that cannot match is simply the honest answer.
         Logger.warning(
           "Player asset vanished while building its etag: #{path} (#{inspect(reason)})"
         )
@@ -50,7 +50,7 @@ defmodule MydiaWeb.PlayerAssets do
     end
   end
 
-  # A file whose mtime is not yet @settle_seconds old may be rewritten again
+  # A file whose mtime is younger than @settle_seconds may be rewritten again
   # inside the same second at the same byte count, which {size, mtime} cannot
   # tell apart from no change at all. Hash those outright and only memoize a
   # file that has stopped moving. Anything shipped in a container image is
@@ -59,7 +59,15 @@ defmodule MydiaWeb.PlayerAssets do
   @settle_seconds 2
 
   defp cached_or_hash(path, size, mtime) do
-    if System.os_time(:second) - mtime < @settle_seconds do
+    age = System.os_time(:second) - mtime
+
+    # `age >= 0` matters as much as the upper bound. A file dated in the future
+    # is not unsettled, it is a clock disagreement: a NAS whose RTC has not
+    # caught up with NTP, or an image built minutes ahead of the host pulling
+    # it. Testing only the upper bound would put every asset on that host in
+    # the re-hash branch permanently, turning each anonymous GET of a 4.5MB
+    # bundle into a full read and sha256.
+    if age >= 0 and age < @settle_seconds do
       hash(path)
     else
       memoized(path, size, mtime)

--- a/test/mydia_web/controllers/player_controller_test.exs
+++ b/test/mydia_web/controllers/player_controller_test.exs
@@ -186,13 +186,7 @@ defmodule MydiaWeb.PlayerControllerTest do
     end
 
     test "an unchanged bundle still revalidates to a bodiless 304", %{conn: conn} do
-      etag =
-        build_conn()
-        |> get("/player/main.dart.js")
-        |> get_resp_header("etag")
-        |> List.first()
-
-      assert etag
+      etag = fetch_etag()
 
       conn =
         conn
@@ -200,6 +194,49 @@ defmodule MydiaWeb.PlayerControllerTest do
         |> get("/player/main.dart.js")
 
       assert response(conn, 304) == ""
+    end
+
+    test "a redeploy that only restamps mtimes does not re-send the bundle", %{conn: conn} do
+      etag = fetch_etag()
+
+      # A container image gives every file it ships a fresh mtime, so the
+      # default phash2({size, mtime}) validator would miss here and push the
+      # whole bundle again to prove nothing changed.
+      bundle = Path.join([:code.priv_dir(:mydia), "static", "player", "main.dart.js"])
+      File.touch!(bundle, System.os_time(:second) + 60)
+
+      conn =
+        conn
+        |> put_req_header("if-none-match", etag)
+        |> get("/player/main.dart.js")
+
+      assert response(conn, 304) == ""
+    end
+
+    test "a genuinely new build does re-send", %{conn: conn} do
+      etag = fetch_etag()
+
+      bundle = Path.join([:code.priv_dir(:mydia), "static", "player", "main.dart.js"])
+      File.write!(bundle, "console.log('next build');")
+      File.touch!(bundle, System.os_time(:second) + 60)
+
+      conn =
+        conn
+        |> put_req_header("if-none-match", etag)
+        |> get("/player/main.dart.js")
+
+      assert response(conn, 200) =~ "next build"
+    end
+
+    defp fetch_etag do
+      etag =
+        build_conn()
+        |> get("/player/main.dart.js")
+        |> get_resp_header("etag")
+        |> List.first()
+
+      assert etag
+      etag
     end
   end
 end

--- a/test/mydia_web/controllers/player_controller_test.exs
+++ b/test/mydia_web/controllers/player_controller_test.exs
@@ -168,10 +168,24 @@ defmodule MydiaWeb.PlayerControllerTest do
       player_dir = Path.join([:code.priv_dir(:mydia), "static", "player"])
       File.mkdir_p!(player_dir)
       bundle = Path.join(player_dir, "main.dart.js")
-      File.write!(bundle, "console.log('bundle');")
-      on_exit(fn -> File.rm(bundle) end)
 
-      :ok
+      # In a dev checkout this is a real Flutter build that costs a full
+      # `flutter build web` to replace, so put back whatever was here.
+      previous = File.read(bundle)
+
+      File.write!(bundle, "console.log('bundle');")
+      # Dated, so the etag memo is exercised rather than bypassed by the
+      # settle window the way a just-written file would be.
+      File.touch!(bundle, System.os_time(:second) - 3600)
+
+      on_exit(fn ->
+        case previous do
+          {:ok, content} -> File.write!(bundle, content)
+          {:error, _} -> File.rm(bundle)
+        end
+      end)
+
+      {:ok, bundle: bundle}
     end
 
     test "the bundle must be revalidated rather than reused on heuristic freshness",
@@ -196,14 +210,14 @@ defmodule MydiaWeb.PlayerControllerTest do
       assert response(conn, 304) == ""
     end
 
-    test "a redeploy that only restamps mtimes does not re-send the bundle", %{conn: conn} do
+    test "a redeploy that only restamps mtimes does not re-send the bundle",
+         %{conn: conn, bundle: bundle} do
       etag = fetch_etag()
 
       # A container image gives every file it ships a fresh mtime, so the
       # default phash2({size, mtime}) validator would miss here and push the
       # whole bundle again to prove nothing changed.
-      bundle = Path.join([:code.priv_dir(:mydia), "static", "player", "main.dart.js"])
-      File.touch!(bundle, System.os_time(:second) + 60)
+      File.touch!(bundle, System.os_time(:second) - 60)
 
       conn =
         conn
@@ -213,12 +227,25 @@ defmodule MydiaWeb.PlayerControllerTest do
       assert response(conn, 304) == ""
     end
 
-    test "a genuinely new build does re-send", %{conn: conn} do
+    test "a build whose clock ran ahead of this host is still cacheable",
+         %{conn: conn, bundle: bundle} do
       etag = fetch_etag()
 
-      bundle = Path.join([:code.priv_dir(:mydia), "static", "player", "main.dart.js"])
+      File.touch!(bundle, System.os_time(:second) + 3600)
+
+      conn =
+        conn
+        |> put_req_header("if-none-match", etag)
+        |> get("/player/main.dart.js")
+
+      assert response(conn, 304) == ""
+    end
+
+    test "a genuinely new build does re-send", %{conn: conn, bundle: bundle} do
+      etag = fetch_etag()
+
       File.write!(bundle, "console.log('next build');")
-      File.touch!(bundle, System.os_time(:second) + 60)
+      File.touch!(bundle, System.os_time(:second) - 60)
 
       conn =
         conn
@@ -226,6 +253,31 @@ defmodule MydiaWeb.PlayerControllerTest do
         |> get("/player/main.dart.js")
 
       assert response(conn, 200) =~ "next build"
+    end
+
+    test "a deep link still falls through to the player shell", %{conn: conn} do
+      # The new static mount sits in front of the router's "/player/*path"
+      # glob. A miss must pass through rather than 404, or every Flutter
+      # route stops resolving on a cold load.
+      {conn, _user} = register_and_log_in_user(conn)
+
+      index = Path.join([:code.priv_dir(:mydia), "static", "player", "index.html"])
+      File.mkdir_p!(Path.dirname(index))
+      previous = File.read(index)
+
+      File.write!(
+        index,
+        "<html><body><script src=\"flutter_bootstrap.js\"></script></body></html>"
+      )
+
+      on_exit(fn ->
+        case previous do
+          {:ok, content} -> File.write!(index, content)
+          {:error, _} -> File.rm(index)
+        end
+      end)
+
+      assert conn |> get("/player/movies/123") |> response(200) =~ "flutter_bootstrap.js"
     end
 
     defp fetch_etag do

--- a/test/mydia_web/controllers/player_controller_test.exs
+++ b/test/mydia_web/controllers/player_controller_test.exs
@@ -162,4 +162,44 @@ defmodule MydiaWeb.PlayerControllerTest do
       assert response(conn, 404)
     end
   end
+
+  describe "player bundle caching" do
+    setup do
+      player_dir = Path.join([:code.priv_dir(:mydia), "static", "player"])
+      File.mkdir_p!(player_dir)
+      bundle = Path.join(player_dir, "main.dart.js")
+      File.write!(bundle, "console.log('bundle');")
+      on_exit(fn -> File.rm(bundle) end)
+
+      :ok
+    end
+
+    test "the bundle must be revalidated rather than reused on heuristic freshness",
+         %{conn: conn} do
+      # Flutter reuses the same URL for every build, so a cached copy that a
+      # browser may serve without asking is a client pinned to whichever build
+      # it happened to fetch. "public" alone permits exactly that.
+      conn = get(conn, "/player/main.dart.js")
+
+      assert response(conn, 200)
+      assert get_resp_header(conn, "cache-control") == ["no-cache"]
+    end
+
+    test "an unchanged bundle still revalidates to a bodiless 304", %{conn: conn} do
+      etag =
+        build_conn()
+        |> get("/player/main.dart.js")
+        |> get_resp_header("etag")
+        |> List.first()
+
+      assert etag
+
+      conn =
+        conn
+        |> put_req_header("if-none-match", etag)
+        |> get("/player/main.dart.js")
+
+      assert response(conn, 304) == ""
+    end
+  end
 end

--- a/test/mydia_web/player_assets_test.exs
+++ b/test/mydia_web/player_assets_test.exs
@@ -9,15 +9,22 @@ defmodule MydiaWeb.PlayerAssetsTest do
     {:ok, bundle: Path.join(tmp_dir, "main.dart.js")}
   end
 
+  # A deploy stamps mtimes from the clock of whatever built the image, which
+  # may land either side of the clock on the host serving it.
+  defp stamp(bundle, offset), do: File.touch!(bundle, System.os_time(:second) + offset)
+
+  defp memo(bundle), do: :persistent_term.get({PlayerAssets, bundle}, :absent)
+
   describe "etag/1" do
     test "survives the mtime churn a redeploy inflicts on unchanged bytes", %{bundle: bundle} do
       File.write!(bundle, "console.log('unchanged');")
+      stamp(bundle, -3600)
       before = PlayerAssets.etag(bundle)
 
       # What shipping a new container image does to every file in the tree,
       # including the canvaskit blobs nobody touched. The default
       # phash2({size, mtime}) validator changes here; a content hash must not.
-      File.touch!(bundle, System.os_time(:second) + 60)
+      stamp(bundle, -60)
 
       assert PlayerAssets.etag(bundle) == before
     end
@@ -44,16 +51,40 @@ defmodule MydiaWeb.PlayerAssetsTest do
 
     test "reuses the memo once the file has settled", %{bundle: bundle} do
       File.write!(bundle, "console.log('settled');")
-      File.touch!(bundle, System.os_time(:second) - 3600)
+      settled = System.os_time(:second) - 3600
+      File.touch!(bundle, settled)
 
       first = PlayerAssets.etag(bundle)
 
       # Corrupting the bytes without moving size or mtime is the only way to
-      # observe the memo from outside. A second call must not re-read.
+      # observe the memo from outside. A second call must not re-read. Both
+      # touches carry the same literal timestamp, so the memo key cannot drift
+      # across a second boundary mid-test.
       File.write!(bundle, "console.log('CORRUPT');")
-      File.touch!(bundle, System.os_time(:second) - 3600)
+      File.touch!(bundle, settled)
 
       assert PlayerAssets.etag(bundle) == first
+    end
+
+    test "memoizes a file dated in the future rather than re-hashing forever", %{bundle: bundle} do
+      # A host whose clock trails the machine that built the image sees every
+      # asset in the tree dated ahead of now. Reading that as "still settling"
+      # would strand the whole player outside the memo, turning each request
+      # for a multi-megabyte bundle into a full read and hash.
+      File.write!(bundle, "console.log('future');")
+      stamp(bundle, 3600)
+
+      assert PlayerAssets.etag(bundle)
+
+      assert {_size, _mtime, _etag} = memo(bundle)
+    end
+
+    test "does not memoize a file that is still settling", %{bundle: bundle} do
+      File.write!(bundle, "console.log('just written');")
+
+      assert PlayerAssets.etag(bundle)
+
+      assert memo(bundle) == :absent
     end
 
     test "is quoted, since Plug.Static sends it as the header verbatim", %{bundle: bundle} do

--- a/test/mydia_web/player_assets_test.exs
+++ b/test/mydia_web/player_assets_test.exs
@@ -1,0 +1,74 @@
+defmodule MydiaWeb.PlayerAssetsTest do
+  use ExUnit.Case, async: true
+
+  alias MydiaWeb.PlayerAssets
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: tmp_dir} do
+    {:ok, bundle: Path.join(tmp_dir, "main.dart.js")}
+  end
+
+  describe "etag/1" do
+    test "survives the mtime churn a redeploy inflicts on unchanged bytes", %{bundle: bundle} do
+      File.write!(bundle, "console.log('unchanged');")
+      before = PlayerAssets.etag(bundle)
+
+      # What shipping a new container image does to every file in the tree,
+      # including the canvaskit blobs nobody touched. The default
+      # phash2({size, mtime}) validator changes here; a content hash must not.
+      File.touch!(bundle, System.os_time(:second) + 60)
+
+      assert PlayerAssets.etag(bundle) == before
+    end
+
+    test "changes when the bundle actually changes", %{bundle: bundle} do
+      File.write!(bundle, "console.log('old build');")
+      before = PlayerAssets.etag(bundle)
+
+      File.write!(bundle, "console.log('new build');")
+
+      refute PlayerAssets.etag(bundle) == before
+    end
+
+    test "notices a same-second rewrite that keeps the byte count identical", %{bundle: bundle} do
+      File.write!(bundle, "aaaa")
+      before = PlayerAssets.etag(bundle)
+
+      # Same size, same second, so {size, mtime} reads as unchanged. Only the
+      # settle window saves this from serving a stale validator.
+      File.write!(bundle, "bbbb")
+
+      refute PlayerAssets.etag(bundle) == before
+    end
+
+    test "reuses the memo once the file has settled", %{bundle: bundle} do
+      File.write!(bundle, "console.log('settled');")
+      File.touch!(bundle, System.os_time(:second) - 3600)
+
+      first = PlayerAssets.etag(bundle)
+
+      # Corrupting the bytes without moving size or mtime is the only way to
+      # observe the memo from outside. A second call must not re-read.
+      File.write!(bundle, "console.log('CORRUPT');")
+      File.touch!(bundle, System.os_time(:second) - 3600)
+
+      assert PlayerAssets.etag(bundle) == first
+    end
+
+    test "is quoted, since Plug.Static sends it as the header verbatim", %{bundle: bundle} do
+      File.write!(bundle, "console.log('bundle');")
+
+      etag = PlayerAssets.etag(bundle)
+
+      assert <<?", _rest::binary>> = etag
+      assert String.ends_with?(etag, "\"")
+    end
+
+    test "yields a validator that cannot match when the file is gone", %{bundle: bundle} do
+      refute File.exists?(bundle)
+
+      assert PlayerAssets.etag(bundle) != PlayerAssets.etag(bundle)
+    end
+  end
+end


### PR DESCRIPTION
The watch indicators shipped to master and deployed correctly, and the web player still did not draw them. Nothing was wrong with the feature.

## Why it happened

`main.dart.js` is not content-hashed by Flutter, so every build overwrites it at the same URL. `Plug.Static` served it with the default `cache_control_for_etags: "public"`, which carries no `max-age` and no `Last-Modified`. That leaves a browser free to reuse its copy without ever asking whether a newer one exists.

The failure is silent in both directions. Upgrading the container swaps the bundle and the GraphQL schema together, the server answers every query correctly, and the client keeps running the build it cached, simply never selecting the fields it does not know about.

Measured on the production instance:

| main.dart.js fetch | gzip size |
|---|---|
| 09:59 EDT browser | 1313063 |
| 13:32 EDT browser hard-reload | 1313063 |
| new image deployed 14:42 EDT | |
| 15:11 EDT page load, queries ran | *no fetch, served from cache* |
| current bundle | 1314320 |

This was a page load, not a stale tab: Caddy logged `GET /player` at 15:11:46 and again at 15:11:56, and no request for `main.dart.js` in that window. A navigation that fetches the shell but not the script it references is a browser serving that script from cache unvalidated.

## The fix, in two parts

**Correctness.** Serve `/player` ahead of the catch-all with `no-cache`. That still stores the entity and only forbids reusing it unvalidated, so the bundle stays in the browser cache and all it loses is the right to serve itself unasked.

**Cost.** `no-cache` on its own would have been expensive. Plug.Static's default validator is `phash2({size, mtime})`, and a container image stamps a fresh mtime on every file it ships, so each deploy would invalidate the entire tree and re-send canvaskit, the fonts and the icons in full to establish that none of their bytes had changed. `MydiaWeb.PlayerAssets` hashes contents instead, wired in through `:etag_generation`. A redeploy now costs one conditional request per asset and re-transfers only what actually moved, which is normally just `main.dart.js`.

The digest is memoized against size and mtime, computed once per file per deploy rather than per request. A file inside the settle window is hashed outright, since mtime resolves to the second and a same-second rewrite at an identical byte count is otherwise invisible.

The player shell also now goes out `no-store`. It embeds a Guardian JWT and is the only document naming the asset URLs, so a cache holding it would reinstate the very problem the static mount fixes.

An earlier draft used a versioned `<base href>` to make every asset immutable. That was dropped: the player uses Flutter's default hash routing, where `prepareExternalUrl` prefixes the base path, so the cache token would have surfaced in the user's address bar.

## From review

- **The settle window tested only an upper bound.** A file dated in the future gave a negative age that passed trivially, so those files never reached the memo and re-hashed on every single request, defeating the entire point of the second commit. A host whose clock trails the machine that built the image puts its whole player tree on that path. Fixed by requiring a non-negative age.
- **Every redeploy test simulated the restamp with a future mtime**, so they exercised only that broken branch and would have passed whether memoization worked or not. They now use past mtimes and assert against the memo directly.
- Added coverage for the deep-link fall-through, the one real regression risk of mounting static ahead of the router's `/player/*path` glob. The behaviour was already correct.
- The caching tests now restore a developer's real `main.dart.js` rather than deleting it, since replacing it costs a full `flutter build web`.

## Testing

`test/mydia_web/player_assets_test.exs` covers the validator: stable across an mtime restamp, moves when bytes move, catches a same-second same-size rewrite, memoizes a future-dated file, and skips the memo while still settling.

In `player_controller_test.exs`, the header test fails on master with `["public"]` against `["no-cache"]`, reproducing the production defect. The redeploy test caught a real bug during development, where the option had been written as `:et_generation` and Plug.Static silently ignored it and fell back to mtime.

`mix test test/mydia_web/` is green at 1019 tests, passing at seeds 0 and 424242, and the app compiles clean under `--warnings-as-errors`.
