### PR TITLE
fix(media): sync TV monitoring between presets and manual season toggles

### DIFF
--- a/lib/mydia/jobs/library_scanner.ex
+++ b/lib/mydia/jobs/library_scanner.ex
@@ -1505,7 +1505,11 @@ defmodule Mydia.Jobs.LibraryScanner do
 
   # Creates/updates episodes from season data using the consolidated function
   defp create_episodes_from_season(media_item, season_data) do
-    {:ok, count} = Mydia.Media.upsert_episodes_from_season(media_item, season_data)
+    {:ok, count} =
+      Mydia.Media.upsert_episodes_from_season(media_item, season_data,
+        monitor_new?:
+          Mydia.Media.should_monitor_new_episode?(media_item, season_data.season_number)
+      )
 
     Logger.debug("Upserted #{count} episodes from season data",
       media_item_id: media_item.id,

--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -443,7 +443,10 @@ defmodule Mydia.Library.MetadataEnricher do
   defp get_seasons_list(_), do: []
 
   defp create_episodes_for_season(media_item, season_data) do
-    {:ok, count} = Media.upsert_episodes_from_season(media_item, season_data)
+    {:ok, count} =
+      Media.upsert_episodes_from_season(media_item, season_data,
+        monitor_new?: Media.should_monitor_new_episode?(media_item, season_data.season_number)
+      )
 
     Logger.debug("Upserted #{count} episodes",
       media_item_id: media_item.id,

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -969,7 +969,12 @@ defmodule Mydia.Media do
     end)
   end
 
-  @monitoring_presets [:all, :missing, :future, :none]
+  # :existing is not redundant with the Upgrades sweep, it is what enables it:
+  # `Mydia.Upgrades` only considers episodes with `monitored == true`, so this
+  # is the one way to say "upgrade the files I have, stop chasing the ones I
+  # never found". :first_season and :latest_season are gone because the season
+  # header toggle does each in one click.
+  @monitoring_presets [:all, :missing, :existing, :future, :none]
 
   @doc """
   Returns the list of valid monitoring presets.
@@ -994,29 +999,40 @@ defmodule Mydia.Media do
   def derive_monitoring_preset(episodes) do
     monitored = MapSet.new(Enum.filter(episodes, & &1.monitored), & &1.id)
 
-    Enum.find(@monitoring_presets, :custom, fn preset ->
-      {to_monitor, _} = partition_episodes_by_preset(episodes, preset)
-      MapSet.new(to_monitor, & &1.id) == monitored
-    end)
+    # Nothing monitored is :none, decided before the search rather than during
+    # it. Several partitions can produce the empty set (:future on a show whose
+    # episodes have all aired, :existing on a show with no files), so a
+    # first-match walk would answer "Future Episodes" for a show the user just
+    # set to "No Episodes".
+    if MapSet.size(monitored) == 0 do
+      :none
+    else
+      Enum.find(@monitoring_presets, :custom, fn preset ->
+        {to_monitor, _} = partition_episodes_by_preset(episodes, preset)
+        MapSet.new(to_monitor, & &1.id) == monitored
+      end)
+    end
   end
 
   @doc """
   Applies a monitoring preset to the episodes of a TV show.
 
-  This is a one-shot bulk rewrite of `episodes.monitored`. Nothing is persisted
-  on the show, because the preset describes an action taken once rather than a
-  standing rule. What happens to episodes discovered later is decided by
-  `should_monitor_new_episode?/2`.
+  A one-shot bulk rewrite of `episodes.monitored`, and nothing else. The show
+  row is untouched, because the preset describes an action taken once rather
+  than a standing rule. What happens to episodes discovered later is decided by
+  `should_monitor_new_episode?/2`, reading the season they land in and, for a
+  season that does not exist yet, `monitor_new_seasons`.
 
   ## Presets
 
-  - `:all` - Monitor all episodes (except specials)
-  - `:future` - Only episodes where air_date > today
-  - `:missing` - Episodes without files OR air_date > today
-  - `:existing` - Only episodes that have associated media files
-  - `:first_season` - Only season 1 episodes
-  - `:latest_season` - Latest season number + any future seasons
-  - `:none` - No episodes monitored
+  All of them exclude season 0; specials are opt-in.
+
+  - `:all` - Every episode
+  - `:missing` - Episodes without files, or not yet aired
+  - `:existing` - Only episodes that have files, which is what leaves the
+    Upgrades sweep something to work on without searching for what is absent
+  - `:future` - Only episodes that have not aired
+  - `:none` - Nothing
 
   ## Returns
 
@@ -1039,23 +1055,8 @@ defmodule Mydia.Media do
       written =
         set_episodes_monitored(to_monitor, true) + set_episodes_monitored(to_unmonitor, false)
 
-      # Every preset already implies a verdict on a season that does not exist
-      # yet, so applying one answers that question too rather than making the
-      # user say it twice in a separate control.
-      #
-      # update_all rather than a changeset: the caller's struct may be stale,
-      # and a changeset whose value matches the stale struct produces no change,
-      # so the write would silently skip while the row still held the old value.
-      MediaItem
-      |> where([m], m.id == ^media_item.id)
-      |> Repo.update_all(
-        set: [monitor_new_seasons: new_season_default(preset), updated_at: DateTime.utc_now()]
-      )
-
-      updated = get_media_item!(media_item.id)
-
       Events.media_item_updated(
-        updated,
+        media_item,
         :user,
         "media_context",
         "Applied '#{preset}' monitoring to episodes"
@@ -1065,7 +1066,8 @@ defmodule Mydia.Media do
     end)
   end
 
-  def apply_episode_monitoring(%MediaItem{type: type}, _preset) do
+  def apply_episode_monitoring(%MediaItem{type: type}, preset)
+      when preset in @monitoring_presets do
     {:error, {:invalid_type, "apply_episode_monitoring only works for TV shows, got #{type}"}}
   end
 
@@ -1087,16 +1089,36 @@ defmodule Mydia.Media do
   end
 
   @doc """
-  The verdict a preset implies for a season that does not exist yet.
+  Sets whether seasons that do not exist yet arrive monitored.
 
-  This is not a separate decision the user makes. "Future Episodes" and
-  "Latest Season" mean new seasons are wanted; "Existing Episodes" and
-  "First Season" mean they are not. Reading it off the preset keeps that
-  intent in one place instead of asking for it twice.
+  Deliberately independent of the presets. Inferring it from the preset made
+  two states unreachable: "monitor everything I have but do not chase new
+  seasons", and setting the flag at all without a bulk rewrite that destroys
+  hand-curated per-season monitoring. It also let a preset contradict itself,
+  since :future unmonitors every aired episode while implying new seasons are
+  wanted.
   """
-  @spec new_season_default(atom()) :: :all | :none
-  def new_season_default(preset) when preset in [:all, :missing, :future], do: :all
-  def new_season_default(:none), do: :none
+  @spec set_monitor_new_seasons(MediaItem.t(), :all | :none) ::
+          {:ok, MediaItem.t()} | {:error, term()}
+  def set_monitor_new_seasons(%MediaItem{} = media_item, mode) when mode in [:all, :none] do
+    # update_all rather than a changeset: the caller's struct may be stale, and
+    # a changeset whose value matches the stale struct produces no change, so
+    # the write would silently skip while the row still held the old value.
+    MediaItem
+    |> where([m], m.id == ^media_item.id)
+    |> Repo.update_all(set: [monitor_new_seasons: mode, updated_at: DateTime.utc_now()])
+
+    updated = get_media_item!(media_item.id)
+
+    Events.media_item_updated(
+      updated,
+      :user,
+      "media_context",
+      "New season monitoring set to #{mode}"
+    )
+
+    {:ok, updated}
+  end
 
   # Partition episodes into those to monitor and those to unmonitor based on preset
   defp partition_episodes_by_preset(episodes, :all) do
@@ -1112,11 +1134,16 @@ defmodule Mydia.Media do
     {[], episodes}
   end
 
+  # Every preset below excludes season 0. Specials are opt-in through the
+  # season header or the per-episode toggle, never swept in by a bulk action.
+  # Without this guard :missing monitored fileless specials, which then left
+  # `should_monitor_new_episode?/2` admitting every future special forever,
+  # because its season-0 guard only covers the empty-season branch.
   defp partition_episodes_by_preset(episodes, :future) do
     today = Date.utc_today()
 
     Enum.split_with(episodes, fn ep ->
-      ep.air_date && Date.compare(ep.air_date, today) == :gt
+      ep.season_number > 0 && ep.air_date && Date.compare(ep.air_date, today) == :gt
     end)
   end
 
@@ -1126,7 +1153,13 @@ defmodule Mydia.Media do
     Enum.split_with(episodes, fn ep ->
       has_no_files = Enum.empty?(ep.media_files)
       is_future = ep.air_date && Date.compare(ep.air_date, today) == :gt
-      has_no_files || is_future
+      ep.season_number > 0 && (has_no_files || is_future)
+    end)
+  end
+
+  defp partition_episodes_by_preset(episodes, :existing) do
+    Enum.split_with(episodes, fn ep ->
+      ep.season_number > 0 && not Enum.empty?(ep.media_files)
     end)
   end
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1563,16 +1563,17 @@ defmodule Mydia.Media do
   from season data — all callers should use this instead of duplicating logic.
 
   ## Options
-    - `:monitor_fn` - Function `(season_number, air_date) -> boolean` to determine
-      if a new episode should be monitored. Defaults to monitoring all non-special episodes.
+    - `:monitor_new?` - Required boolean. Whether newly created episodes arrive
+      monitored. Compute it once per season with `should_monitor_new_episode?/2`.
   ## Returns
     - `{:ok, count}` - Number of episodes processed (created + updated)
   """
   @spec upsert_episodes_from_season(MediaItem.t(), struct(), keyword()) ::
           {:ok, non_neg_integer()}
   def upsert_episodes_from_season(media_item, season_data, opts \\ []) do
-    default_monitor = fn season_num, _air_date -> season_num > 0 end
-    monitor_fn = Keyword.get(opts, :monitor_fn, default_monitor)
+    # Required on purpose. A default here is what let the scanner and enricher
+    # drift into monitoring everything regardless of the show's intent.
+    monitor_new? = Keyword.fetch!(opts, :monitor_new?)
 
     episodes = season_data.episodes || []
 
@@ -1590,8 +1591,6 @@ defmodule Mydia.Media do
           air_date = parse_air_date(episode.air_date)
 
           if is_nil(existing) do
-            should_monitor = monitor_fn.(season_num, air_date)
-
             case create_episode(%{
                    media_item_id: media_item.id,
                    season_number: season_num,
@@ -1599,7 +1598,7 @@ defmodule Mydia.Media do
                    title: episode.name,
                    air_date: air_date,
                    metadata: Map.from_struct(episode),
-                   monitored: should_monitor
+                   monitored: monitor_new?
                  }) do
               {:ok, _episode} -> acc + 1
               {:error, _changeset} -> acc
@@ -1667,9 +1666,7 @@ defmodule Mydia.Media do
          ) do
       {:ok, season_data} ->
         upsert_episodes_from_season(media_item, season_data,
-          monitor_fn: fn season_num, air_date ->
-            should_monitor_new_episode?(media_item, season_num, air_date)
-          end
+          monitor_new?: should_monitor_new_episode?(media_item, season.season_number)
         )
 
       {:error, reason} ->
@@ -1689,58 +1686,48 @@ defmodule Mydia.Media do
 
   defp parse_air_date(_), do: nil
 
-  # Determines if a new episode should be monitored based on the media_item's monitoring preset.
-  # This is used when creating new episodes during metadata refresh.
-  def should_monitor_new_episode?(media_item, season_number, air_date) do
-    # If the media_item itself isn't monitored, don't monitor episodes
-    if media_item.monitored do
-      preset = media_item.monitoring_preset || :all
-      today = Date.utc_today()
+  @doc """
+  Classifies a season's monitoring state from its already-loaded episodes.
 
-      case preset do
-        :all ->
-          # Monitor all episodes except specials (season 0)
-          season_number > 0
+  Pure, so the UI can call it on episodes it already has in memory rather than
+  issuing another query.
+  """
+  @spec season_monitoring_state([Episode.t()]) :: :none | :partial | :all
+  def season_monitoring_state([]), do: :none
 
-        :none ->
-          false
-
-        :future ->
-          # Monitor if air_date is in the future or not set
-          is_nil(air_date) || Date.compare(air_date, today) == :gt
-
-        :missing ->
-          # New episodes have no files, so always monitor
-          # (unless it's a special)
-          season_number > 0
-
-        :existing ->
-          # Only monitor episodes with files - new episodes have none
-          false
-
-        :first_season ->
-          season_number == 1
-
-        :latest_season ->
-          # For new episodes, we need to determine if this is the latest season
-          # Query existing episodes to find the current latest season
-          latest_season = get_latest_season_number(media_item.id)
-          # Monitor if this episode's season is >= the latest known season
-          # This handles the case where a new season is being added
-          season_number >= latest_season && season_number > 0
-      end
-    else
-      false
+  def season_monitoring_state(episodes) do
+    cond do
+      Enum.all?(episodes, & &1.monitored) -> :all
+      Enum.any?(episodes, & &1.monitored) -> :partial
+      true -> :none
     end
   end
 
-  # Gets the highest season number for a media item
-  defp get_latest_season_number(media_item_id) do
-    Episode
-    |> where([e], e.media_item_id == ^media_item_id)
-    |> where([e], e.season_number > 0)
-    |> select([e], max(e.season_number))
-    |> Repo.one() || 1
+  @doc """
+  Decides whether an episode discovered by a refresh, scan, or provider switch
+  should arrive monitored.
+
+  A new episode inherits the season it lands in, so unmonitoring a season also
+  stops that season's future episodes. A season that does not exist yet has
+  nothing to inherit, so it falls back to the show's `monitor_new_seasons`
+  setting. Specials are opt-in: a brand-new season 0 is never admitted, but an
+  existing season 0 that the user has monitored is.
+  """
+  @spec should_monitor_new_episode?(MediaItem.t(), integer()) :: boolean()
+  def should_monitor_new_episode?(%MediaItem{monitored: false}, _season_number), do: false
+
+  def should_monitor_new_episode?(%MediaItem{} = media_item, season_number) do
+    monitored_flags =
+      Episode
+      |> where([e], e.media_item_id == ^media_item.id)
+      |> where([e], e.season_number == ^season_number)
+      |> select([e], e.monitored)
+      |> Repo.all()
+
+    case monitored_flags do
+      [] -> season_number > 0 and media_item.monitor_new_seasons == :all
+      flags -> Enum.any?(flags)
+    end
   end
 
   defp apply_media_item_filters(query, opts) do

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -969,13 +969,36 @@ defmodule Mydia.Media do
     end)
   end
 
-  @monitoring_presets [:all, :future, :missing, :existing, :first_season, :latest_season, :none]
+  @monitoring_presets [:all, :missing, :future, :none]
 
   @doc """
   Returns the list of valid monitoring presets.
   """
   @spec monitoring_presets() :: [atom()]
   def monitoring_presets, do: @monitoring_presets
+
+  @doc """
+  Reads the current episode rows back as whichever preset describes them, or
+  `:custom` when none does.
+
+  Derived rather than stored on purpose. Storing the last preset applied is
+  what made the old label go stale the moment someone toggled a season by
+  hand, since nothing wrote it back. Computing it from the rows means the
+  label is either true or says `:custom`.
+
+  Episodes must have `media_files` preloaded, which the show page already does.
+  """
+  @spec derive_monitoring_preset([Episode.t()]) :: atom()
+  def derive_monitoring_preset([]), do: :none
+
+  def derive_monitoring_preset(episodes) do
+    monitored = MapSet.new(Enum.filter(episodes, & &1.monitored), & &1.id)
+
+    Enum.find(@monitoring_presets, :custom, fn preset ->
+      {to_monitor, _} = partition_episodes_by_preset(episodes, preset)
+      MapSet.new(to_monitor, & &1.id) == monitored
+    end)
+  end
 
   @doc """
   Applies a monitoring preset to the episodes of a TV show.
@@ -1016,8 +1039,23 @@ defmodule Mydia.Media do
       written =
         set_episodes_monitored(to_monitor, true) + set_episodes_monitored(to_unmonitor, false)
 
+      # Every preset already implies a verdict on a season that does not exist
+      # yet, so applying one answers that question too rather than making the
+      # user say it twice in a separate control.
+      #
+      # update_all rather than a changeset: the caller's struct may be stale,
+      # and a changeset whose value matches the stale struct produces no change,
+      # so the write would silently skip while the row still held the old value.
+      MediaItem
+      |> where([m], m.id == ^media_item.id)
+      |> Repo.update_all(
+        set: [monitor_new_seasons: new_season_default(preset), updated_at: DateTime.utc_now()]
+      )
+
+      updated = get_media_item!(media_item.id)
+
       Events.media_item_updated(
-        media_item,
+        updated,
         :user,
         "media_context",
         "Applied '#{preset}' monitoring to episodes"
@@ -1049,29 +1087,16 @@ defmodule Mydia.Media do
   end
 
   @doc """
-  Sets whether seasons that do not exist yet should arrive monitored.
+  The verdict a preset implies for a season that does not exist yet.
+
+  This is not a separate decision the user makes. "Future Episodes" and
+  "Latest Season" mean new seasons are wanted; "Existing Episodes" and
+  "First Season" mean they are not. Reading it off the preset keeps that
+  intent in one place instead of asking for it twice.
   """
-  @spec set_monitor_new_seasons(MediaItem.t(), :all | :none) ::
-          {:ok, MediaItem.t()} | {:error, Ecto.Changeset.t()}
-  def set_monitor_new_seasons(%MediaItem{} = media_item, mode) when mode in [:all, :none] do
-    media_item
-    |> MediaItem.changeset(%{monitor_new_seasons: mode})
-    |> Repo.update()
-    |> case do
-      {:ok, updated} ->
-        Events.media_item_updated(
-          updated,
-          :user,
-          "media_context",
-          "New season monitoring set to #{mode}"
-        )
-
-        {:ok, updated}
-
-      {:error, changeset} ->
-        {:error, changeset}
-    end
-  end
+  @spec new_season_default(atom()) :: :all | :none
+  def new_season_default(preset) when preset in [:all, :missing, :future], do: :all
+  def new_season_default(:none), do: :none
 
   # Partition episodes into those to monitor and those to unmonitor based on preset
   defp partition_episodes_by_preset(episodes, :all) do
@@ -1102,31 +1127,6 @@ defmodule Mydia.Media do
       has_no_files = Enum.empty?(ep.media_files)
       is_future = ep.air_date && Date.compare(ep.air_date, today) == :gt
       has_no_files || is_future
-    end)
-  end
-
-  defp partition_episodes_by_preset(episodes, :existing) do
-    Enum.split_with(episodes, fn ep ->
-      not Enum.empty?(ep.media_files)
-    end)
-  end
-
-  defp partition_episodes_by_preset(episodes, :first_season) do
-    Enum.split_with(episodes, fn ep ->
-      ep.season_number == 1
-    end)
-  end
-
-  defp partition_episodes_by_preset(episodes, :latest_season) do
-    # Find the latest season number (excluding specials)
-    latest_season =
-      episodes
-      |> Enum.filter(&(&1.season_number > 0))
-      |> Enum.map(& &1.season_number)
-      |> Enum.max(fn -> 0 end)
-
-    Enum.split_with(episodes, fn ep ->
-      ep.season_number >= latest_season && ep.season_number > 0
     end)
   end
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -978,12 +978,12 @@ defmodule Mydia.Media do
   def monitoring_presets, do: @monitoring_presets
 
   @doc """
-  Applies a monitoring preset to all episodes of a TV show.
+  Applies a monitoring preset to the episodes of a TV show.
 
-  This function:
-  1. Determines which episodes should be monitored based on the preset
-  2. Updates all episode monitored states accordingly
-  3. Saves the preset to the media_item record
+  This is a one-shot bulk rewrite of `episodes.monitored`. Nothing is persisted
+  on the show, because the preset describes an action taken once rather than a
+  standing rule. What happens to episodes discovered later is decided by
+  `should_monitor_new_episode?/2`.
 
   ## Presets
 
@@ -997,82 +997,80 @@ defmodule Mydia.Media do
 
   ## Returns
 
-  - `{:ok, media_item, count}` - Success with updated media_item and count of episodes changed
-  - `{:error, reason}` - Error with reason
+  - `{:ok, count}` - Number of episodes whose monitored flag was written
+  - `{:error, reason}`
 
   ## Examples
 
-      iex> apply_monitoring_preset(media_item, :all)
-      {:ok, %MediaItem{monitoring_preset: :all}, 24}
-
-      iex> apply_monitoring_preset(media_item, :future)
-      {:ok, %MediaItem{monitoring_preset: :future}, 8}
+      iex> apply_episode_monitoring(media_item, :all)
+      {:ok, 24}
   """
-  @spec apply_monitoring_preset(MediaItem.t(), atom()) ::
-          {:ok, MediaItem.t(), non_neg_integer()} | {:error, term()}
-  def apply_monitoring_preset(%MediaItem{type: "tv_show"} = media_item, preset)
+  @spec apply_episode_monitoring(MediaItem.t(), atom()) ::
+          {:ok, non_neg_integer()} | {:error, term()}
+  def apply_episode_monitoring(%MediaItem{type: "tv_show"} = media_item, preset)
       when preset in @monitoring_presets do
     Repo.transaction(fn ->
-      # Get all episodes for this media item with media_files preloaded
       episodes = list_episodes(media_item.id, preload: [:media_files])
-
-      # Determine which episodes should be monitored based on the preset
       {to_monitor, to_unmonitor} = partition_episodes_by_preset(episodes, preset)
 
-      # Update episodes that should be monitored
-      monitored_count =
-        if to_monitor != [] do
-          monitored_ids = Enum.map(to_monitor, & &1.id)
+      written =
+        set_episodes_monitored(to_monitor, true) + set_episodes_monitored(to_unmonitor, false)
 
-          Episode
-          |> where([e], e.id in ^monitored_ids)
-          |> Repo.update_all(set: [monitored: true, updated_at: DateTime.utc_now()])
-          |> elem(0)
-        else
-          0
-        end
-
-      # Update episodes that should not be monitored
-      unmonitored_count =
-        if to_unmonitor != [] do
-          unmonitored_ids = Enum.map(to_unmonitor, & &1.id)
-
-          Episode
-          |> where([e], e.id in ^unmonitored_ids)
-          |> Repo.update_all(set: [monitored: false, updated_at: DateTime.utc_now()])
-          |> elem(0)
-        else
-          0
-        end
-
-      # Save the preset to the media item
-      {:ok, updated_media_item} =
-        media_item
-        |> MediaItem.changeset(%{monitoring_preset: preset})
-        |> Repo.update()
-
-      # Track the monitoring preset change
       Events.media_item_updated(
-        updated_media_item,
+        media_item,
         :user,
         "media_context",
-        "Monitoring preset changed to #{preset}"
+        "Applied '#{preset}' monitoring to episodes"
       )
 
-      {updated_media_item, monitored_count + unmonitored_count}
+      written
     end)
-    |> case do
-      {:ok, {media_item, count}} -> {:ok, media_item, count}
-      {:error, reason} -> {:error, reason}
-    end
   end
 
-  def apply_monitoring_preset(%MediaItem{type: type}, _preset) do
-    {:error, {:invalid_type, "apply_monitoring_preset only works for TV shows, got #{type}"}}
+  def apply_episode_monitoring(%MediaItem{type: type}, _preset) do
+    {:error, {:invalid_type, "apply_episode_monitoring only works for TV shows, got #{type}"}}
   end
 
-  def apply_monitoring_preset(_media_item, preset) when preset not in @monitoring_presets do
+  def apply_episode_monitoring(_media_item, preset) when preset not in @monitoring_presets do
     {:error, {:invalid_preset, "Unknown preset: #{preset}"}}
+  end
+
+  # Both branches of the bulk apply wrote the same update_all with a different
+  # boolean, so it lives in one place.
+  defp set_episodes_monitored([], _monitored), do: 0
+
+  defp set_episodes_monitored(episodes, monitored) do
+    ids = Enum.map(episodes, & &1.id)
+
+    Episode
+    |> where([e], e.id in ^ids)
+    |> Repo.update_all(set: [monitored: monitored, updated_at: DateTime.utc_now()])
+    |> elem(0)
+  end
+
+  @doc """
+  Sets whether seasons that do not exist yet should arrive monitored.
+  """
+  @spec set_monitor_new_seasons(MediaItem.t(), :all | :none) ::
+          {:ok, MediaItem.t()} | {:error, Ecto.Changeset.t()}
+  def set_monitor_new_seasons(%MediaItem{} = media_item, mode) when mode in [:all, :none] do
+    media_item
+    |> MediaItem.changeset(%{monitor_new_seasons: mode})
+    |> Repo.update()
+    |> case do
+      {:ok, updated} ->
+        Events.media_item_updated(
+          updated,
+          :user,
+          "media_context",
+          "New season monitoring set to #{mode}"
+        )
+
+        {:ok, updated}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   # Partition episodes into those to monitor and those to unmonitor based on preset

--- a/lib/mydia/media/media_item.ex
+++ b/lib/mydia/media/media_item.ex
@@ -20,7 +20,6 @@ defmodule Mydia.Media.MediaItem do
           metadata_source: atom() | nil,
           metadata: Mydia.Metadata.Structs.MediaMetadata.t() | nil,
           monitored: boolean(),
-          monitoring_preset: atom(),
           monitor_new_seasons: :all | :none,
           category: String.t() | nil,
           category_override: boolean(),
@@ -54,10 +53,6 @@ defmodule Mydia.Media.MediaItem do
     field :metadata_source, Ecto.Enum, values: [:tvdb, :tmdb]
     field :metadata, Mydia.Media.MetadataType
     field :monitored, :boolean, default: true
-
-    field :monitoring_preset, Ecto.Enum,
-      values: [:all, :future, :missing, :existing, :first_season, :latest_season, :none],
-      default: :all
 
     # Governs only seasons that do not exist yet. Whether a new episode in an
     # *existing* season is monitored is derived from that season's episodes.
@@ -96,7 +91,6 @@ defmodule Mydia.Media.MediaItem do
       :metadata_source,
       :metadata,
       :monitored,
-      :monitoring_preset,
       :monitor_new_seasons,
       :quality_profile_id,
       :library_path_id

--- a/lib/mydia/media/media_item.ex
+++ b/lib/mydia/media/media_item.ex
@@ -21,6 +21,7 @@ defmodule Mydia.Media.MediaItem do
           metadata: Mydia.Metadata.Structs.MediaMetadata.t() | nil,
           monitored: boolean(),
           monitoring_preset: atom(),
+          monitor_new_seasons: :all | :none,
           category: String.t() | nil,
           category_override: boolean(),
           seasons_refreshed_at: DateTime.t() | nil,
@@ -58,6 +59,10 @@ defmodule Mydia.Media.MediaItem do
       values: [:all, :future, :missing, :existing, :first_season, :latest_season, :none],
       default: :all
 
+    # Governs only seasons that do not exist yet. Whether a new episode in an
+    # *existing* season is monitored is derived from that season's episodes.
+    field :monitor_new_seasons, Ecto.Enum, values: [:all, :none], default: :all
+
     field :category, :string
     field :category_override, :boolean, default: false
     field :seasons_refreshed_at, :utc_datetime
@@ -92,6 +97,7 @@ defmodule Mydia.Media.MediaItem do
       :metadata,
       :monitored,
       :monitoring_preset,
+      :monitor_new_seasons,
       :quality_profile_id,
       :library_path_id
     ])

--- a/lib/mydia/media/provider_switch.ex
+++ b/lib/mydia/media/provider_switch.ex
@@ -241,9 +241,7 @@ defmodule Mydia.Media.ProviderSwitch do
 
           Enum.each(season_datas, fn season_data ->
             Media.upsert_episodes_from_season(updated, season_data,
-              monitor_fn: fn season_num, air_date ->
-                Media.should_monitor_new_episode?(updated, season_num, air_date)
-              end
+              monitor_new?: Media.should_monitor_new_episode?(updated, season_data.season_number)
             )
           end)
 

--- a/lib/mydia/media/provider_switch.ex
+++ b/lib/mydia/media/provider_switch.ex
@@ -228,16 +228,18 @@ defmodule Mydia.Media.ProviderSwitch do
           # erases it. Capture the per-season verdict first and replay it, or
           # every season the user deliberately unmonitored comes back monitored
           # under the show's new-season default.
+          # Folded in Elixir rather than aggregated in SQL: PostgreSQL has a
+          # real boolean type and refuses `max(cast(bool as int))`, while SQLite
+          # stores booleans as integers and accepts it. One portable query beats
+          # branching on the adapter.
           monitored_by_season =
             from(e in Episode,
               where: e.media_item_id == ^item.id,
-              group_by: e.season_number,
-              select: {e.season_number, max(type(e.monitored, :integer))}
+              select: {e.season_number, e.monitored}
             )
             |> Repo.all()
-            |> Map.new(fn {season_number, any_monitored} ->
-              {season_number, any_monitored == 1}
-            end)
+            |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+            |> Map.new(fn {season_number, flags} -> {season_number, Enum.any?(flags)} end)
 
           Repo.delete_all(from(e in Episode, where: e.media_item_id == ^item.id))
 

--- a/lib/mydia/media/provider_switch.ex
+++ b/lib/mydia/media/provider_switch.ex
@@ -224,6 +224,21 @@ defmodule Mydia.Media.ProviderSwitch do
         Repo.transaction(fn ->
           file_ids = linked_media_file_ids(item)
 
+          # Season monitoring lives in the episode rows, so the wipe below
+          # erases it. Capture the per-season verdict first and replay it, or
+          # every season the user deliberately unmonitored comes back monitored
+          # under the show's new-season default.
+          monitored_by_season =
+            from(e in Episode,
+              where: e.media_item_id == ^item.id,
+              group_by: e.season_number,
+              select: {e.season_number, max(type(e.monitored, :integer))}
+            )
+            |> Repo.all()
+            |> Map.new(fn {season_number, any_monitored} ->
+              {season_number, any_monitored == 1}
+            end)
+
           Repo.delete_all(from(e in Episode, where: e.media_item_id == ^item.id))
 
           # Roll back (preserving the just-deleted episodes) instead of raising a
@@ -240,9 +255,15 @@ defmodule Mydia.Media.ProviderSwitch do
             end
 
           Enum.each(season_datas, fn season_data ->
-            Media.upsert_episodes_from_season(updated, season_data,
-              monitor_new?: Media.should_monitor_new_episode?(updated, season_data.season_number)
-            )
+            monitor_new? =
+              case Map.fetch(monitored_by_season, season_data.season_number) do
+                # A season the show already had keeps whatever the user decided.
+                {:ok, was_monitored?} -> was_monitored?
+                # Genuinely new to this provider, so the normal rule applies.
+                :error -> Media.should_monitor_new_episode?(updated, season_data.season_number)
+              end
+
+            Media.upsert_episodes_from_season(updated, season_data, monitor_new?: monitor_new?)
           end)
 
           # `upsert_episodes_from_season/3` swallows per-episode insert errors

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -133,8 +133,6 @@ defmodule MydiaWeb.MediaLive.Show do
      # Next episode for TV shows
      |> assign(:next_episode, next_episode)
      |> assign(:next_episode_state, next_episode_state)
-     # Monitoring preset state
-     |> assign(:applying_episode_monitoring, false)
      # Subtitle state
      |> assign(:show_subtitle_search_modal, false)
      |> assign(:subtitle_search_state, :idle)
@@ -182,6 +180,9 @@ defmodule MydiaWeb.MediaLive.Show do
   @impl true
   def handle_event("apply_episode_monitoring", params, socket),
     do: EpisodeEvents.apply_episode_monitoring(params, socket)
+
+  def handle_event("toggle_monitor_new_seasons", params, socket),
+    do: EpisodeEvents.toggle_monitor_new_seasons(params, socket)
 
   def handle_event("manual_search", params, socket),
     do: SearchEvents.manual_search(params, socket)

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -183,9 +183,6 @@ defmodule MydiaWeb.MediaLive.Show do
   def handle_event("apply_episode_monitoring", params, socket),
     do: EpisodeEvents.apply_episode_monitoring(params, socket)
 
-  def handle_event("set_monitor_new_seasons", params, socket),
-    do: EpisodeEvents.set_monitor_new_seasons(params, socket)
-
   def handle_event("manual_search", params, socket),
     do: SearchEvents.manual_search(params, socket)
 

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -134,7 +134,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:next_episode, next_episode)
      |> assign(:next_episode_state, next_episode_state)
      # Monitoring preset state
-     |> assign(:applying_monitoring_preset, false)
+     |> assign(:applying_episode_monitoring, false)
      # Subtitle state
      |> assign(:show_subtitle_search_modal, false)
      |> assign(:subtitle_search_state, :idle)
@@ -180,8 +180,11 @@ defmodule MydiaWeb.MediaLive.Show do
     do: EpisodeEvents.toggle_monitored(params, socket)
 
   @impl true
-  def handle_event("apply_monitoring_preset", params, socket),
-    do: EpisodeEvents.apply_monitoring_preset(params, socket)
+  def handle_event("apply_episode_monitoring", params, socket),
+    do: EpisodeEvents.apply_episode_monitoring(params, socket)
+
+  def handle_event("set_monitor_new_seasons", params, socket),
+    do: EpisodeEvents.set_monitor_new_seasons(params, socket)
 
   def handle_event("manual_search", params, socket),
     do: SearchEvents.manual_search(params, socket)

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -211,7 +211,6 @@
             transcode_jobs={@transcode_jobs}
             segment_statuses={@segment_statuses}
             segment_detection_available={@segment_detection_available}
-            applying_episode_monitoring={@applying_episode_monitoring}
           />
           <%!-- Media Files Section --%>
           <Components.media_files_section

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -26,7 +26,7 @@
           downloads_with_status={@downloads_with_status}
           quality_profiles={@quality_profiles}
           default_quality_profile_name={@default_quality_profile_name}
-          applying_monitoring_preset={@applying_monitoring_preset}
+          applying_episode_monitoring={@applying_episode_monitoring}
           is_favorite={@is_favorite}
           item_collections={@item_collections}
           user_collections={@user_collections}

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -26,7 +26,6 @@
           downloads_with_status={@downloads_with_status}
           quality_profiles={@quality_profiles}
           default_quality_profile_name={@default_quality_profile_name}
-          applying_episode_monitoring={@applying_episode_monitoring}
           is_favorite={@is_favorite}
           item_collections={@item_collections}
           user_collections={@user_collections}
@@ -212,6 +211,7 @@
             transcode_jobs={@transcode_jobs}
             segment_statuses={@segment_statuses}
             segment_detection_available={@segment_detection_available}
+            applying_episode_monitoring={@applying_episode_monitoring}
           />
           <%!-- Media Files Section --%>
           <Components.media_files_section

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -23,24 +23,21 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :target_library, :map, default: nil
   attr :target_reason, :atom, default: nil
   attr :target_library_candidates, :list, default: []
-  attr :applying_episode_monitoring, :boolean, default: false
   attr :is_favorite, :boolean, default: false
   attr :item_collections, :list, default: []
   attr :user_collections, :list, default: []
 
+  # First Season and Latest Season were bulk shortcuts for something the season
+  # header toggle now does in one click, and Existing Episodes duplicated the
+  # Upgrades system. What is left is the four things a user actually asks for.
   @monitoring_presets [
-    {:all, "All Episodes", "Monitor all episodes"},
-    {:future, "Future Episodes", "Only unaired episodes"},
-    {:missing, "Missing Episodes", "Episodes without files"},
-    {:existing, "Existing Episodes", "Only episodes with files"},
-    {:first_season, "First Season", "Only season 1"},
-    {:latest_season, "Latest Season", "Latest + future seasons"},
-    {:none, "None", "Don't monitor any episodes"}
+    {:all, "All Episodes"},
+    {:missing, "Missing Episodes"},
+    {:future, "Future Episodes"},
+    {:none, "No Episodes"}
   ]
 
   def hero_section(assigns) do
-    assigns = assign(assigns, :monitoring_presets, @monitoring_presets)
-
     ~H"""
     <%!-- Left Column: Poster and Quick Actions --%>
     <div class="w-full md:w-64 lg:w-80 flex-shrink-0">
@@ -200,75 +197,10 @@ defmodule MydiaWeb.MediaLive.Show.Components do
 
         <%!-- Secondary actions --%>
         <div class="flex flex-col gap-2">
+          <%!-- Show-level on/off only. The bulk episode actions live in the
+                Seasons & Episodes header, next to what they act on. --%>
           <%= if @media_item.type == "tv_show" do %>
             <.monitored_toggle id="show-monitored-toggle" media_item={@media_item} />
-
-            <%!-- One-shot actions. The label is static on purpose: it describes
-                  what the menu does, never what the episodes currently are. --%>
-            <div class="dropdown dropdown-end w-full">
-              <div
-                tabindex="0"
-                role="button"
-                id="episode-monitoring-menu"
-                class="btn btn-ghost w-full"
-                disabled={@applying_episode_monitoring}
-              >
-                <%= if @applying_episode_monitoring do %>
-                  <span class="loading loading-spinner loading-xs"></span>
-                <% else %>
-                  <.icon name="hero-adjustments-horizontal" class="w-5 h-5" />
-                <% end %>
-                <span>Episode Monitoring</span>
-                <.icon name="hero-chevron-down" class="w-3 h-3 opacity-70" />
-              </div>
-              <ul
-                tabindex="0"
-                class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-64 border border-base-300"
-              >
-                <li class="menu-title text-xs">Apply to episodes</li>
-                <li :for={{preset, label, description} <- @monitoring_presets}>
-                  <button
-                    type="button"
-                    id={"episode-monitoring-menu-preset-#{preset}"}
-                    phx-click="apply_episode_monitoring"
-                    phx-value-preset={preset}
-                    class="flex flex-col items-start"
-                  >
-                    <span class="font-medium">{label}</span>
-                    <span class="text-xs text-base-content/60">{description}</span>
-                  </button>
-                </li>
-                <li class="menu-title text-xs">New seasons</li>
-                <li>
-                  <div class="join w-full p-0">
-                    <button
-                      type="button"
-                      id="monitor-new-seasons-all"
-                      phx-click="set_monitor_new_seasons"
-                      phx-value-mode="all"
-                      class={[
-                        "btn btn-xs join-item flex-1",
-                        @media_item.monitor_new_seasons == :all && "btn-active"
-                      ]}
-                    >
-                      All
-                    </button>
-                    <button
-                      type="button"
-                      id="monitor-new-seasons-none"
-                      phx-click="set_monitor_new_seasons"
-                      phx-value-mode="none"
-                      class={[
-                        "btn btn-xs join-item flex-1",
-                        @media_item.monitor_new_seasons == :none && "btn-active"
-                      ]}
-                    >
-                      None
-                    </button>
-                  </div>
-                </li>
-              </ul>
-            </div>
           <% else %>
             <.monitored_toggle id="movie-monitored-toggle" media_item={@media_item} />
           <% end %>
@@ -510,11 +442,15 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :transcode_jobs, :map, default: %{}
   attr :segment_statuses, :map, default: %{}
   attr :segment_detection_available, :boolean, default: true
+  attr :applying_episode_monitoring, :boolean, default: false
 
   def episodes_section(assigns) do
+    assigns = assign(assigns, :monitoring_presets, @monitoring_presets)
+
     ~H"""
     <%= if @media_item.type == "tv_show" && length(@media_item.episodes) > 0 do %>
-      <% grouped_seasons = group_episodes_by_season(@media_item.episodes) %>
+      <% grouped_seasons = group_episodes_by_season(@media_item.episodes)
+      derived_preset = Mydia.Media.derive_monitoring_preset(@media_item.episodes) %>
 
       <div class="card bg-base-200 shadow-lg">
         <%!-- Card header with stats --%>
@@ -531,6 +467,41 @@ defmodule MydiaWeb.MediaLive.Show.Components do
               </span>
               <span class="text-base-content/60">/</span>
               <span>{length(@media_item.episodes)} total</span>
+
+              <%!-- Bulk actions, one-shot. The label is static on purpose: it
+                    says what the menu does, never what the episodes are. --%>
+              <div class="dropdown dropdown-end">
+                <div
+                  tabindex="0"
+                  role="button"
+                  id="episode-monitoring-menu"
+                  class="btn btn-sm btn-ghost gap-1"
+                  disabled={@applying_episode_monitoring}
+                >
+                  <%= if @applying_episode_monitoring do %>
+                    <span class="loading loading-spinner loading-xs"></span>
+                  <% else %>
+                    <.icon name="hero-adjustments-horizontal" class="w-4 h-4" />
+                  <% end %>
+                  <span>{monitoring_preset_label(derived_preset)}</span>
+                  <.icon name="hero-chevron-down" class="w-3 h-3 opacity-70" />
+                </div>
+                <ul
+                  tabindex="0"
+                  class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-56 border border-base-300"
+                >
+                  <li :for={{preset, label} <- @monitoring_presets}>
+                    <button
+                      type="button"
+                      id={"episode-monitoring-menu-preset-#{preset}"}
+                      phx-click="apply_episode_monitoring"
+                      phx-value-preset={preset}
+                    >
+                      {label}
+                    </button>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
           <SegmentComponents.segment_unavailable_note :if={!@segment_detection_available} />

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -23,7 +23,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :target_library, :map, default: nil
   attr :target_reason, :atom, default: nil
   attr :target_library_candidates, :list, default: []
-  attr :applying_monitoring_preset, :boolean, default: false
+  attr :applying_episode_monitoring, :boolean, default: false
   attr :is_favorite, :boolean, default: false
   attr :item_collections, :list, default: []
   attr :user_collections, :list, default: []
@@ -201,70 +201,76 @@ defmodule MydiaWeb.MediaLive.Show.Components do
         <%!-- Secondary actions --%>
         <div class="flex flex-col gap-2">
           <%= if @media_item.type == "tv_show" do %>
-            <%!-- Monitoring Preset Dropdown (TV shows only) --%>
+            <.monitored_toggle id="show-monitored-toggle" media_item={@media_item} />
+
+            <%!-- One-shot actions. The label is static on purpose: it describes
+                  what the menu does, never what the episodes currently are. --%>
             <div class="dropdown dropdown-end w-full">
               <div
                 tabindex="0"
                 role="button"
-                class={[
-                  "btn w-full",
-                  @media_item.monitored && "btn-success",
-                  !@media_item.monitored && "btn-ghost"
-                ]}
-                disabled={@applying_monitoring_preset}
+                id="episode-monitoring-menu"
+                class="btn btn-ghost w-full"
+                disabled={@applying_episode_monitoring}
               >
-                <%= if @applying_monitoring_preset do %>
+                <%= if @applying_episode_monitoring do %>
                   <span class="loading loading-spinner loading-xs"></span>
                 <% else %>
-                  <.monitoring_icon
-                    preset={@media_item.monitoring_preset}
-                    class="w-5 h-5"
-                  />
+                  <.icon name="hero-adjustments-horizontal" class="w-5 h-5" />
                 <% end %>
-                <span>
-                  {monitoring_preset_label(@media_item.monitoring_preset)}
-                </span>
+                <span>Episode Monitoring</span>
                 <.icon name="hero-chevron-down" class="w-3 h-3 opacity-70" />
               </div>
               <ul
                 tabindex="0"
                 class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-64 border border-base-300"
               >
+                <li class="menu-title text-xs">Apply to episodes</li>
                 <li :for={{preset, label, description} <- @monitoring_presets}>
                   <button
                     type="button"
-                    phx-click="apply_monitoring_preset"
+                    id={"episode-monitoring-menu-preset-#{preset}"}
+                    phx-click="apply_episode_monitoring"
                     phx-value-preset={preset}
-                    class={[
-                      "flex flex-col items-start",
-                      @media_item.monitoring_preset == preset && "active"
-                    ]}
+                    class="flex flex-col items-start"
                   >
                     <span class="font-medium">{label}</span>
                     <span class="text-xs text-base-content/60">{description}</span>
                   </button>
                 </li>
+                <li class="menu-title text-xs">New seasons</li>
+                <li>
+                  <div class="join w-full p-0">
+                    <button
+                      type="button"
+                      id="monitor-new-seasons-all"
+                      phx-click="set_monitor_new_seasons"
+                      phx-value-mode="all"
+                      class={[
+                        "btn btn-xs join-item flex-1",
+                        @media_item.monitor_new_seasons == :all && "btn-active"
+                      ]}
+                    >
+                      All
+                    </button>
+                    <button
+                      type="button"
+                      id="monitor-new-seasons-none"
+                      phx-click="set_monitor_new_seasons"
+                      phx-value-mode="none"
+                      class={[
+                        "btn btn-xs join-item flex-1",
+                        @media_item.monitor_new_seasons == :none && "btn-active"
+                      ]}
+                    >
+                      None
+                    </button>
+                  </div>
+                </li>
               </ul>
             </div>
           <% else %>
-            <%!-- Simple monitored toggle for movies --%>
-            <button
-              type="button"
-              phx-click="toggle_monitored"
-              class={[
-                "btn w-full",
-                @media_item.monitored && "btn-success",
-                !@media_item.monitored && "btn-ghost"
-              ]}
-            >
-              <.icon
-                name={if @media_item.monitored, do: "hero-bookmark-solid", else: "hero-bookmark"}
-                class="w-5 h-5"
-              />
-              <span>
-                {if @media_item.monitored, do: "Monitored", else: "Not Monitored"}
-              </span>
-            </button>
+            <.monitored_toggle id="movie-monitored-toggle" media_item={@media_item} />
           <% end %>
         </div>
 
@@ -1298,6 +1304,30 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   # Helper functions for monitoring preset labels
 
   # monitoring_preset_label/1 is provided by MydiaWeb.MediaLive.Show.Helpers (imported above)
+
+  attr :id, :string, required: true
+  attr :media_item, :map, required: true
+
+  def monitored_toggle(assigns) do
+    ~H"""
+    <button
+      type="button"
+      id={@id}
+      phx-click="toggle_monitored"
+      class={[
+        "btn w-full",
+        @media_item.monitored && "btn-success",
+        !@media_item.monitored && "btn-ghost"
+      ]}
+    >
+      <.icon
+        name={if @media_item.monitored, do: "hero-bookmark-solid", else: "hero-bookmark"}
+        class="w-5 h-5"
+      />
+      <span>{if @media_item.monitored, do: "Monitored", else: "Not Monitored"}</span>
+    </button>
+    """
+  end
 
   @doc """
   Monitoring icon that shows different states:

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -27,15 +27,20 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :item_collections, :list, default: []
   attr :user_collections, :list, default: []
 
-  # First Season and Latest Season were bulk shortcuts for something the season
-  # header toggle now does in one click, and Existing Episodes duplicated the
-  # Upgrades system. What is left is the four things a user actually asks for.
-  @monitoring_presets [
-    {:all, "All Episodes"},
-    {:missing, "Missing Episodes"},
-    {:future, "Future Episodes"},
-    {:none, "No Episodes"}
-  ]
+  # Labels only. The list of valid presets is Media.monitoring_presets/0, and
+  # this is checked against it at compile time so the two cannot drift.
+  @preset_labels %{
+    all: "All Episodes",
+    missing: "Missing Episodes",
+    existing: "Existing Episodes",
+    future: "Future Episodes",
+    none: "No Episodes"
+  }
+
+  @monitoring_presets Enum.map(
+                        Mydia.Media.monitoring_presets(),
+                        &{&1, Map.fetch!(@preset_labels, &1)}
+                      )
 
   def hero_section(assigns) do
     ~H"""
@@ -442,7 +447,6 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :transcode_jobs, :map, default: %{}
   attr :segment_statuses, :map, default: %{}
   attr :segment_detection_available, :boolean, default: true
-  attr :applying_episode_monitoring, :boolean, default: false
 
   def episodes_section(assigns) do
     assigns = assign(assigns, :monitoring_presets, @monitoring_presets)
@@ -468,21 +472,35 @@ defmodule MydiaWeb.MediaLive.Show.Components do
               <span class="text-base-content/60">/</span>
               <span>{length(@media_item.episodes)} total</span>
 
-              <%!-- Bulk actions, one-shot. The label is static on purpose: it
-                    says what the menu does, never what the episodes are. --%>
+              <%!-- Standing rule, not an action. Independent of the presets
+                    on purpose: "everything I have, but do not chase new
+                    seasons" is a real thing to want, and inferring this from
+                    the preset made it unsayable. --%>
+              <label
+                class="flex items-center gap-1.5 cursor-pointer text-base-content/70"
+                title="Whether a season added later arrives monitored. Episodes added to a season you already have follow that season instead."
+              >
+                <input
+                  type="checkbox"
+                  id="monitor-new-seasons-toggle"
+                  class="checkbox checkbox-xs"
+                  checked={@media_item.monitor_new_seasons == :all}
+                  phx-click="toggle_monitor_new_seasons"
+                />
+                <span>New seasons</span>
+              </label>
+
+              <%!-- One-shot bulk actions. The label reads the episode rows
+                    back rather than storing what was picked, so a manual
+                    season toggle shows as Custom instead of going stale. --%>
               <div class="dropdown dropdown-end">
                 <div
                   tabindex="0"
                   role="button"
                   id="episode-monitoring-menu"
                   class="btn btn-sm btn-ghost gap-1"
-                  disabled={@applying_episode_monitoring}
                 >
-                  <%= if @applying_episode_monitoring do %>
-                    <span class="loading loading-spinner loading-xs"></span>
-                  <% else %>
-                    <.icon name="hero-adjustments-horizontal" class="w-4 h-4" />
-                  <% end %>
+                  <.icon name="hero-adjustments-horizontal" class="w-4 h-4" />
                   <span>{monitoring_preset_label(derived_preset)}</span>
                   <.icon name="hero-chevron-down" class="w-3 h-3 opacity-70" />
                 </div>

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -597,24 +597,24 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       <% end %>
                     </button>
                   </div>
-                  <div class="tooltip tooltip-bottom" data-tip="Monitor all">
+                  <% season_state = Mydia.Media.season_monitoring_state(episodes) %>
+                  <div
+                    class="tooltip tooltip-bottom"
+                    data-tip={season_monitoring_tooltip(season_state)}
+                  >
                     <button
                       type="button"
-                      phx-click="monitor_season"
+                      id={"season-#{season_num}-monitor-toggle"}
+                      phx-click={
+                        if season_state == :all, do: "unmonitor_season", else: "monitor_season"
+                      }
                       phx-value-season-number={season_num}
-                      class="btn btn-sm btn-ghost"
+                      class={[
+                        "btn btn-sm btn-ghost",
+                        season_state == :none && "opacity-60"
+                      ]}
                     >
-                      <.icon name="hero-bookmark-solid" class="w-4 h-4" />
-                    </button>
-                  </div>
-                  <div class="tooltip tooltip-bottom" data-tip="Unmonitor all">
-                    <button
-                      type="button"
-                      phx-click="unmonitor_season"
-                      phx-value-season-number={season_num}
-                      class="btn btn-sm btn-ghost"
-                    >
-                      <.icon name="hero-bookmark" class="w-4 h-4" />
+                      <.monitoring_icon state={season_state} class="w-4 h-4" />
                     </button>
                   </div>
                 </div>
@@ -1330,28 +1330,28 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   end
 
   @doc """
-  Monitoring icon that shows different states:
-  - All: solid bookmark (fully monitored)
-  - None: outline bookmark (not monitored)
-  - Partial presets: half-filled bookmark effect
+  Bookmark icon for a season's derived monitoring state.
+
+  - `:all` - solid bookmark
+  - `:partial` - half-filled, built from two stacked icons
+  - `:none` - outline bookmark
   """
-  attr :preset, :atom, required: true
+  attr :state, :atom, required: true
   attr :class, :string, default: "w-5 h-5"
 
-  def monitoring_icon(%{preset: preset} = assigns) when preset in [nil, :all] do
+  def monitoring_icon(%{state: :all} = assigns) do
     ~H"""
     <.icon name="hero-bookmark-solid" class={@class} />
     """
   end
 
-  def monitoring_icon(%{preset: :none} = assigns) do
+  def monitoring_icon(%{state: :none} = assigns) do
     ~H"""
     <.icon name="hero-bookmark" class={@class} />
     """
   end
 
   def monitoring_icon(assigns) do
-    # Partial monitoring: show a half-filled effect using stacked icons
     ~H"""
     <span class="relative inline-flex">
       <.icon name="hero-bookmark" class={@class} />

--- a/lib/mydia_web/live/media_live/show/episode_events.ex
+++ b/lib/mydia_web/live/media_live/show/episode_events.ex
@@ -12,7 +12,8 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeEvents do
 
   require Logger
 
-  @valid_monitoring_presets ~w(all missing future none)
+  # Derived from the context so the two lists cannot drift apart.
+  @valid_monitoring_presets Enum.map(Media.monitoring_presets(), &Atom.to_string/1)
 
   def toggle_monitored(_params, socket) do
     with :ok <- Authorization.authorize_update_media(socket) do
@@ -42,8 +43,6 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeEvents do
       media_item = socket.assigns.media_item
       preset = String.to_existing_atom(preset_str)
 
-      socket = assign(socket, :applying_episode_monitoring, true)
-
       case Media.apply_episode_monitoring(media_item, preset) do
         {:ok, count} ->
           preset_label = monitoring_preset_label(preset)
@@ -51,16 +50,12 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeEvents do
           {:noreply,
            socket
            |> assign(:media_item, load_media_item(media_item.id))
-           |> assign(:applying_episode_monitoring, false)
            |> put_flash(:info, "Applied '#{preset_label}' monitoring to #{count} episodes")}
 
         {:error, reason} ->
           Logger.error("Failed to apply episode monitoring: #{inspect(reason)}")
 
-          {:noreply,
-           socket
-           |> assign(:applying_episode_monitoring, false)
-           |> put_flash(:error, "Failed to apply episode monitoring")}
+          {:noreply, put_flash(socket, :error, "Failed to apply episode monitoring")}
       end
     else
       {:unauthorized, socket} ->
@@ -68,6 +63,27 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeEvents do
 
       false ->
         {:noreply, put_flash(socket, :error, "Invalid monitoring preset")}
+    end
+  end
+
+  def toggle_monitor_new_seasons(_params, socket) do
+    with :ok <- Authorization.authorize_update_media(socket) do
+      media_item = socket.assigns.media_item
+      mode = if media_item.monitor_new_seasons == :all, do: :none, else: :all
+
+      {:ok, updated} = Media.set_monitor_new_seasons(media_item, mode)
+
+      message =
+        if mode == :all,
+          do: "New seasons will be monitored",
+          else: "New seasons will not be monitored"
+
+      {:noreply,
+       socket
+       |> assign(:media_item, load_media_item(updated.id))
+       |> put_flash(:info, message)}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
     end
   end
 

--- a/lib/mydia_web/live/media_live/show/episode_events.ex
+++ b/lib/mydia_web/live/media_live/show/episode_events.ex
@@ -12,8 +12,7 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeEvents do
 
   require Logger
 
-  @valid_monitoring_presets ~w(all future missing existing first_season latest_season none)
-  @valid_new_season_modes ~w(all none)
+  @valid_monitoring_presets ~w(all missing future none)
 
   def toggle_monitored(_params, socket) do
     with :ok <- Authorization.authorize_update_media(socket) do
@@ -69,35 +68,6 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeEvents do
 
       false ->
         {:noreply, put_flash(socket, :error, "Invalid monitoring preset")}
-    end
-  end
-
-  def set_monitor_new_seasons(%{"mode" => mode_str}, socket) do
-    with :ok <- Authorization.authorize_update_media(socket),
-         true <- mode_str in @valid_new_season_modes do
-      mode = String.to_existing_atom(mode_str)
-
-      case Media.set_monitor_new_seasons(socket.assigns.media_item, mode) do
-        {:ok, updated} ->
-          message =
-            if mode == :all,
-              do: "New seasons will be monitored",
-              else: "New seasons will not be monitored"
-
-          {:noreply,
-           socket
-           |> assign(:media_item, load_media_item(updated.id))
-           |> put_flash(:info, message)}
-
-        {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to update new season monitoring")}
-      end
-    else
-      {:unauthorized, socket} ->
-        {:noreply, socket}
-
-      false ->
-        {:noreply, put_flash(socket, :error, "Invalid mode")}
     end
   end
 

--- a/lib/mydia_web/live/media_live/show/episode_events.ex
+++ b/lib/mydia_web/live/media_live/show/episode_events.ex
@@ -13,6 +13,7 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeEvents do
   require Logger
 
   @valid_monitoring_presets ~w(all future missing existing first_season latest_season none)
+  @valid_new_season_modes ~w(all none)
 
   def toggle_monitored(_params, socket) do
     with :ok <- Authorization.authorize_update_media(socket) do
@@ -36,32 +37,31 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeEvents do
     end
   end
 
-  def apply_monitoring_preset(%{"preset" => preset_str}, socket) do
+  def apply_episode_monitoring(%{"preset" => preset_str}, socket) do
     with :ok <- Authorization.authorize_update_media(socket),
          true <- preset_str in @valid_monitoring_presets do
       media_item = socket.assigns.media_item
       preset = String.to_existing_atom(preset_str)
 
-      socket = assign(socket, :applying_monitoring_preset, true)
+      socket = assign(socket, :applying_episode_monitoring, true)
 
-      case Media.apply_monitoring_preset(media_item, preset) do
-        {:ok, updated_item, count} ->
-          reloaded_item = load_media_item(updated_item.id)
+      case Media.apply_episode_monitoring(media_item, preset) do
+        {:ok, count} ->
           preset_label = monitoring_preset_label(preset)
 
           {:noreply,
            socket
-           |> assign(:media_item, reloaded_item)
-           |> assign(:applying_monitoring_preset, false)
+           |> assign(:media_item, load_media_item(media_item.id))
+           |> assign(:applying_episode_monitoring, false)
            |> put_flash(:info, "Applied '#{preset_label}' monitoring to #{count} episodes")}
 
         {:error, reason} ->
-          Logger.error("Failed to apply monitoring preset: #{inspect(reason)}")
+          Logger.error("Failed to apply episode monitoring: #{inspect(reason)}")
 
           {:noreply,
            socket
-           |> assign(:applying_monitoring_preset, false)
-           |> put_flash(:error, "Failed to apply monitoring preset")}
+           |> assign(:applying_episode_monitoring, false)
+           |> put_flash(:error, "Failed to apply episode monitoring")}
       end
     else
       {:unauthorized, socket} ->
@@ -69,6 +69,35 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeEvents do
 
       false ->
         {:noreply, put_flash(socket, :error, "Invalid monitoring preset")}
+    end
+  end
+
+  def set_monitor_new_seasons(%{"mode" => mode_str}, socket) do
+    with :ok <- Authorization.authorize_update_media(socket),
+         true <- mode_str in @valid_new_season_modes do
+      mode = String.to_existing_atom(mode_str)
+
+      case Media.set_monitor_new_seasons(socket.assigns.media_item, mode) do
+        {:ok, updated} ->
+          message =
+            if mode == :all,
+              do: "New seasons will be monitored",
+              else: "New seasons will not be monitored"
+
+          {:noreply,
+           socket
+           |> assign(:media_item, load_media_item(updated.id))
+           |> put_flash(:info, message)}
+
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, "Failed to update new season monitoring")}
+      end
+    else
+      {:unauthorized, socket} ->
+        {:noreply, socket}
+
+      false ->
+        {:noreply, put_flash(socket, :error, "Invalid mode")}
     end
   end
 

--- a/lib/mydia_web/live/media_live/show/helpers.ex
+++ b/lib/mydia_web/live/media_live/show/helpers.ex
@@ -526,4 +526,9 @@ defmodule MydiaWeb.MediaLive.Show.Helpers do
   def monitoring_preset_label(:first_season), do: "First Season"
   def monitoring_preset_label(:latest_season), do: "Latest Season"
   def monitoring_preset_label(:none), do: "None"
+
+  # Season monitoring toggle tooltips, keyed on the season's derived state
+  def season_monitoring_tooltip(:all), do: "Unmonitor season"
+  def season_monitoring_tooltip(:partial), do: "Monitor all episodes"
+  def season_monitoring_tooltip(:none), do: "Monitor season"
 end

--- a/lib/mydia_web/live/media_live/show/helpers.ex
+++ b/lib/mydia_web/live/media_live/show/helpers.ex
@@ -520,6 +520,7 @@ defmodule MydiaWeb.MediaLive.Show.Helpers do
   # Monitoring preset labels (shared between events and components)
   def monitoring_preset_label(:all), do: "All Episodes"
   def monitoring_preset_label(:missing), do: "Missing Episodes"
+  def monitoring_preset_label(:existing), do: "Existing Episodes"
   def monitoring_preset_label(:future), do: "Future Episodes"
   def monitoring_preset_label(:none), do: "No Episodes"
   # Not a preset anyone can pick: what the episodes read as once they no longer

--- a/lib/mydia_web/live/media_live/show/helpers.ex
+++ b/lib/mydia_web/live/media_live/show/helpers.ex
@@ -518,7 +518,6 @@ defmodule MydiaWeb.MediaLive.Show.Helpers do
   def media_type_path(_), do: "/"
 
   # Monitoring preset labels (shared between events and components)
-  def monitoring_preset_label(nil), do: "All Episodes"
   def monitoring_preset_label(:all), do: "All Episodes"
   def monitoring_preset_label(:future), do: "Future Episodes"
   def monitoring_preset_label(:missing), do: "Missing Episodes"

--- a/lib/mydia_web/live/media_live/show/helpers.ex
+++ b/lib/mydia_web/live/media_live/show/helpers.ex
@@ -519,12 +519,12 @@ defmodule MydiaWeb.MediaLive.Show.Helpers do
 
   # Monitoring preset labels (shared between events and components)
   def monitoring_preset_label(:all), do: "All Episodes"
-  def monitoring_preset_label(:future), do: "Future Episodes"
   def monitoring_preset_label(:missing), do: "Missing Episodes"
-  def monitoring_preset_label(:existing), do: "Existing Episodes"
-  def monitoring_preset_label(:first_season), do: "First Season"
-  def monitoring_preset_label(:latest_season), do: "Latest Season"
-  def monitoring_preset_label(:none), do: "None"
+  def monitoring_preset_label(:future), do: "Future Episodes"
+  def monitoring_preset_label(:none), do: "No Episodes"
+  # Not a preset anyone can pick: what the episodes read as once they no longer
+  # match any of them, usually because a season or episode was toggled by hand.
+  def monitoring_preset_label(:custom), do: "Custom"
 
   # Season monitoring toggle tooltips, keyed on the season's derived state
   def season_monitoring_tooltip(:all), do: "Unmonitor season"

--- a/priv/repo/migrations/20260813120000_add_monitor_new_seasons_to_media_items.exs
+++ b/priv/repo/migrations/20260813120000_add_monitor_new_seasons_to_media_items.exs
@@ -1,0 +1,31 @@
+defmodule Mydia.Repo.Migrations.AddMonitorNewSeasonsToMediaItems do
+  use Ecto.Migration
+
+  # `monitoring_preset` conflated a one-shot bulk action with a forward-looking
+  # rule. This column takes over only the forward-looking half: whether a
+  # season that does not exist yet should arrive monitored. Everything else is
+  # derived from the episode rows.
+  #
+  # Only a column add and a data update, so SQLite and PostgreSQL take the same
+  # path with no table rebuild.
+  def up do
+    alter table(:media_items) do
+      add :monitor_new_seasons, :string, default: "all"
+    end
+
+    # Existing rows: only an explicit :none preset meant "do not monitor new
+    # content". Every other preset admitted at least some new episodes, so it
+    # maps to "all".
+    execute("UPDATE media_items SET monitor_new_seasons = 'all'")
+
+    execute(
+      "UPDATE media_items SET monitor_new_seasons = 'none' WHERE monitoring_preset = 'none'"
+    )
+  end
+
+  def down do
+    alter table(:media_items) do
+      remove :monitor_new_seasons
+    end
+  end
+end

--- a/priv/repo/migrations/20260813130000_drop_monitoring_preset_from_media_items.exs
+++ b/priv/repo/migrations/20260813130000_drop_monitoring_preset_from_media_items.exs
@@ -1,0 +1,25 @@
+defmodule Mydia.Repo.Migrations.DropMonitoringPresetFromMediaItems do
+  use Ecto.Migration
+
+  # The preset is now a one-shot action rather than stored state. Its only
+  # remaining job, deciding what happens to content discovered later, moved to
+  # `monitor_new_seasons` plus the season's own episodes.
+  #
+  # No table rebuild needed on either adapter: the bundled SQLite is 3.53.x,
+  # well past the 3.35 floor for DROP COLUMN, and the column carries no index.
+  def up do
+    alter table(:media_items) do
+      remove :monitoring_preset
+    end
+  end
+
+  def down do
+    alter table(:media_items) do
+      add :monitoring_preset, :string, default: "all"
+    end
+
+    execute(
+      "UPDATE media_items SET monitoring_preset = 'none' WHERE monitor_new_seasons = 'none'"
+    )
+  end
+end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -198,13 +198,39 @@ defmodule Mydia.MediaTest do
       assert {:error, {:invalid_type, _}} = Media.apply_episode_monitoring(media_item, :all)
     end
 
-    test "set_monitor_new_seasons/2 persists the mode" do
-      media_item = media_item_fixture(%{type: "tv_show"})
+    test "applying a preset carries its verdict on new seasons" do
+      # The user says what they want once. :none means new seasons are not
+      # wanted either, and :all means they are, so there is no second control.
+      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+      episode_fixture(media_item_id: media_item.id, season_number: 1, episode_number: 1)
 
-      {:ok, updated} = Media.set_monitor_new_seasons(media_item, :none)
-
-      assert updated.monitor_new_seasons == :none
+      {:ok, _} = Media.apply_episode_monitoring(media_item, :none)
       assert Media.get_media_item!(media_item.id).monitor_new_seasons == :none
+
+      {:ok, _} = Media.apply_episode_monitoring(media_item, :all)
+      assert Media.get_media_item!(media_item.id).monitor_new_seasons == :all
+    end
+
+    test "new_season_default/1 maps every preset" do
+      assert Media.new_season_default(:all) == :all
+      assert Media.new_season_default(:missing) == :all
+      assert Media.new_season_default(:future) == :all
+      assert Media.new_season_default(:none) == :none
+    end
+
+    test "derive_monitoring_preset/1 reads the rows back, or says :custom" do
+      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+      episode_fixture(media_item_id: media_item.id, season_number: 1, episode_number: 1)
+      episode_fixture(media_item_id: media_item.id, season_number: 2, episode_number: 1)
+
+      {:ok, _} = Media.apply_episode_monitoring(media_item, :all)
+      episodes = Media.list_episodes(media_item.id, preload: [:media_files])
+      assert Media.derive_monitoring_preset(episodes) == :all
+
+      # A manual season toggle is exactly what used to leave the label lying.
+      {:ok, _} = Media.update_season_monitoring(media_item.id, 2, false)
+      episodes = Media.list_episodes(media_item.id, preload: [:media_files])
+      assert Media.derive_monitoring_preset(episodes) == :custom
     end
   end
 
@@ -747,13 +773,10 @@ defmodule Mydia.MediaTest do
     test "monitoring_presets/0 returns all valid presets" do
       presets = Media.monitoring_presets()
       assert :all in presets
-      assert :future in presets
       assert :missing in presets
-      assert :existing in presets
-      assert :first_season in presets
-      assert :latest_season in presets
+      assert :future in presets
       assert :none in presets
-      assert length(presets) == 7
+      assert length(presets) == 4
     end
 
     # Movie invalid-type covered by media_items "apply_episode_monitoring/2 returns an error for movies"
@@ -867,133 +890,6 @@ defmodule Mydia.MediaTest do
 
       refute past_ep.monitored
       assert future_ep.monitored
-    end
-
-    test "apply_episode_monitoring/2 with :first_season monitors only season 1" do
-      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
-
-      # Create episodes in multiple seasons
-      episode_fixture(
-        media_item_id: media_item.id,
-        season_number: 1,
-        episode_number: 1,
-        monitored: false
-      )
-
-      episode_fixture(
-        media_item_id: media_item.id,
-        season_number: 1,
-        episode_number: 2,
-        monitored: false
-      )
-
-      episode_fixture(
-        media_item_id: media_item.id,
-        season_number: 2,
-        episode_number: 1,
-        monitored: true
-      )
-
-      episode_fixture(
-        media_item_id: media_item.id,
-        season_number: 3,
-        episode_number: 1,
-        monitored: true
-      )
-
-      {:ok, _count} = Media.apply_episode_monitoring(media_item, :first_season)
-
-      # Verify episode states
-      episodes = Media.list_episodes(media_item.id)
-
-      s1_episodes = Enum.filter(episodes, &(&1.season_number == 1))
-      s2_episodes = Enum.filter(episodes, &(&1.season_number == 2))
-      s3_episodes = Enum.filter(episodes, &(&1.season_number == 3))
-
-      assert Enum.all?(s1_episodes, & &1.monitored)
-      refute Enum.any?(s2_episodes, & &1.monitored)
-      refute Enum.any?(s3_episodes, & &1.monitored)
-    end
-
-    test "apply_episode_monitoring/2 with :latest_season monitors only the latest season" do
-      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
-
-      # Create episodes in multiple seasons
-      episode_fixture(
-        media_item_id: media_item.id,
-        season_number: 1,
-        episode_number: 1,
-        monitored: true
-      )
-
-      episode_fixture(
-        media_item_id: media_item.id,
-        season_number: 2,
-        episode_number: 1,
-        monitored: false
-      )
-
-      episode_fixture(
-        media_item_id: media_item.id,
-        season_number: 3,
-        episode_number: 1,
-        monitored: false
-      )
-
-      episode_fixture(
-        media_item_id: media_item.id,
-        season_number: 3,
-        episode_number: 2,
-        monitored: false
-      )
-
-      {:ok, _count} = Media.apply_episode_monitoring(media_item, :latest_season)
-
-      # Verify episode states
-      episodes = Media.list_episodes(media_item.id)
-
-      s1_episodes = Enum.filter(episodes, &(&1.season_number == 1))
-      s2_episodes = Enum.filter(episodes, &(&1.season_number == 2))
-      s3_episodes = Enum.filter(episodes, &(&1.season_number == 3))
-
-      refute Enum.any?(s1_episodes, & &1.monitored)
-      refute Enum.any?(s2_episodes, & &1.monitored)
-      assert Enum.all?(s3_episodes, & &1.monitored)
-    end
-
-    test "apply_episode_monitoring/2 with :existing monitors only episodes with files" do
-      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
-
-      # Create episodes
-      ep_with_file =
-        episode_fixture(
-          media_item_id: media_item.id,
-          season_number: 1,
-          episode_number: 1,
-          monitored: false
-        )
-
-      _ep_without_file =
-        episode_fixture(
-          media_item_id: media_item.id,
-          season_number: 1,
-          episode_number: 2,
-          monitored: true
-        )
-
-      # Add a media file to the first episode
-      media_file_fixture(episode_id: ep_with_file.id)
-
-      {:ok, _count} = Media.apply_episode_monitoring(media_item, :existing)
-
-      # Verify episode states
-      episodes = Media.list_episodes(media_item.id, preload: [:media_files])
-
-      ep_with = Enum.find(episodes, &(&1.episode_number == 1))
-      ep_without = Enum.find(episodes, &(&1.episode_number == 2))
-
-      assert ep_with.monitored
-      refute ep_without.monitored
     end
 
     test "apply_episode_monitoring/2 with :missing monitors episodes without files or future" do

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -174,9 +174,12 @@ defmodule Mydia.MediaTest do
       refute new_episode.monitored
     end
 
-    test "apply_episode_monitoring/2 does not persist anything on the show" do
+    test "apply_episode_monitoring/2 leaves the show row alone" do
+      # Starts at :none so an accidental write to :all would be visible. The
+      # earlier version of this test started at :all and asserted :all, which
+      # passed no matter what the function did.
       media_item =
-        media_item_fixture(%{type: "tv_show", monitored: true, monitor_new_seasons: :all})
+        media_item_fixture(%{type: "tv_show", monitored: true, monitor_new_seasons: :none})
 
       episode_fixture(
         media_item_id: media_item.id,
@@ -188,8 +191,7 @@ defmodule Mydia.MediaTest do
       {:ok, count} = Media.apply_episode_monitoring(media_item, :all)
 
       assert count == 1
-      reloaded = Media.get_media_item!(media_item.id)
-      assert reloaded.monitor_new_seasons == :all
+      assert Media.get_media_item!(media_item.id).monitor_new_seasons == :none
     end
 
     test "apply_episode_monitoring/2 returns an error for movies" do
@@ -198,24 +200,72 @@ defmodule Mydia.MediaTest do
       assert {:error, {:invalid_type, _}} = Media.apply_episode_monitoring(media_item, :all)
     end
 
-    test "applying a preset carries its verdict on new seasons" do
-      # The user says what they want once. :none means new seasons are not
-      # wanted either, and :all means they are, so there is no second control.
+    test "set_monitor_new_seasons/2 is independent of the presets" do
+      # The state the folded-in version could not express: keep everything I
+      # have monitored, but do not chase seasons that show up later.
       media_item = media_item_fixture(%{type: "tv_show", monitored: true})
       episode_fixture(media_item_id: media_item.id, season_number: 1, episode_number: 1)
 
-      {:ok, _} = Media.apply_episode_monitoring(media_item, :none)
-      assert Media.get_media_item!(media_item.id).monitor_new_seasons == :none
-
       {:ok, _} = Media.apply_episode_monitoring(media_item, :all)
+      {:ok, updated} = Media.set_monitor_new_seasons(media_item, :none)
+
+      assert updated.monitor_new_seasons == :none
+      assert Enum.all?(Media.list_episodes(media_item.id), & &1.monitored)
+      refute Media.should_monitor_new_episode?(updated, 9)
+      assert Media.should_monitor_new_episode?(updated, 1)
+    end
+
+    test "set_monitor_new_seasons/2 writes through a stale struct" do
+      media_item = media_item_fixture(%{type: "tv_show", monitor_new_seasons: :all})
+
+      {:ok, _} = Media.set_monitor_new_seasons(media_item, :none)
+      # media_item is now stale, still holding :all. A changeset would see no
+      # change and skip the write.
+      {:ok, _} = Media.set_monitor_new_seasons(media_item, :all)
+
       assert Media.get_media_item!(media_item.id).monitor_new_seasons == :all
     end
 
-    test "new_season_default/1 maps every preset" do
-      assert Media.new_season_default(:all) == :all
-      assert Media.new_season_default(:missing) == :all
-      assert Media.new_season_default(:future) == :all
-      assert Media.new_season_default(:none) == :none
+    test "derive_monitoring_preset/1 says :none when nothing is monitored" do
+      # Regression: :none was checked last and several partitions produce the
+      # empty set, so a fully-aired show with nothing monitored read back as
+      # "Future Episodes" and clicking "No Episodes" never showed "No Episodes".
+      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+      episode_fixture(
+        media_item_id: media_item.id,
+        season_number: 1,
+        episode_number: 1,
+        air_date: ~D[2020-01-01]
+      )
+
+      {:ok, _} = Media.apply_episode_monitoring(media_item, :none)
+      episodes = Media.list_episodes(media_item.id, preload: [:media_files])
+
+      assert Media.derive_monitoring_preset(episodes) == :none
+    end
+
+    test "no preset sweeps in specials" do
+      # Regression: :missing and :future had no season 0 guard, so a bulk apply
+      # monitored fileless specials, which then left should_monitor_new_episode?
+      # admitting every future special forever.
+      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+      episode_fixture(media_item_id: media_item.id, season_number: 0, episode_number: 1)
+      episode_fixture(media_item_id: media_item.id, season_number: 1, episode_number: 1)
+
+      for preset <- Media.monitoring_presets() do
+        {:ok, _} = Media.apply_episode_monitoring(media_item, preset)
+        special = Media.get_episode_by_number(media_item.id, 0, 1)
+
+        refute special.monitored, "#{preset} monitored a special"
+      end
+    end
+
+    test "a TV show with an unknown preset reports the preset, not the type" do
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      assert {:error, {:invalid_preset, _}} =
+               Media.apply_episode_monitoring(media_item, :first_season)
     end
 
     test "derive_monitoring_preset/1 reads the rows back, or says :custom" do
@@ -774,9 +824,11 @@ defmodule Mydia.MediaTest do
       presets = Media.monitoring_presets()
       assert :all in presets
       assert :missing in presets
+      # :existing is what leaves the Upgrades sweep something to act on.
+      assert :existing in presets
       assert :future in presets
       assert :none in presets
-      assert length(presets) == 4
+      assert length(presets) == 5
     end
 
     # Movie invalid-type covered by media_items "apply_episode_monitoring/2 returns an error for movies"

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -137,6 +137,164 @@ defmodule Mydia.MediaTest do
 
       assert Ecto.Changeset.get_change(changeset, :monitor_new_seasons) == :none
     end
+
+    test "a new episode in an unmonitored season arrives unmonitored" do
+      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+      episode_fixture(
+        media_item_id: media_item.id,
+        season_number: 3,
+        episode_number: 1,
+        monitored: true
+      )
+
+      {:ok, _count} = Media.update_season_monitoring(media_item.id, 3, false)
+
+      # `upsert_episodes_from_season/3` calls `Map.from_struct/1` on each episode,
+      # so these must be %EpisodeData{} structs, not plain maps. `season_data`
+      # itself is only dot-accessed, so a plain map is fine there.
+      season_data = %{
+        season_number: 3,
+        episodes: [
+          %Mydia.Metadata.Structs.EpisodeData{
+            season_number: 3,
+            episode_number: 11,
+            name: "New One",
+            air_date: ~D[2026-09-01]
+          }
+        ]
+      }
+
+      {:ok, 1} =
+        Media.upsert_episodes_from_season(media_item, season_data,
+          monitor_new?: Media.should_monitor_new_episode?(media_item, 3)
+        )
+
+      new_episode = Media.get_episode_by_number(media_item.id, 3, 11)
+      refute new_episode.monitored
+    end
+  end
+
+  # Nested describe is invalid in ExUnit. These live as siblings of "media_items"
+  # with their own MediaFixtures import (allowed by the plan's global constraints).
+  describe "new episode admission" do
+    import Mydia.MediaFixtures
+
+    test "an unmonitored show admits nothing" do
+      media_item = media_item_fixture(%{type: "tv_show", monitored: false})
+
+      episode_fixture(
+        media_item_id: media_item.id,
+        season_number: 1,
+        episode_number: 1,
+        monitored: true
+      )
+
+      refute Media.should_monitor_new_episode?(media_item, 1)
+    end
+
+    test "a season with any monitored episode admits new episodes" do
+      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+      episode_fixture(
+        media_item_id: media_item.id,
+        season_number: 3,
+        episode_number: 1,
+        monitored: false
+      )
+
+      episode_fixture(
+        media_item_id: media_item.id,
+        season_number: 3,
+        episode_number: 2,
+        monitored: true
+      )
+
+      assert Media.should_monitor_new_episode?(media_item, 3)
+    end
+
+    test "a fully unmonitored season admits nothing" do
+      # This is the reported bug: unmonitoring season 3 must also stop future
+      # episodes in season 3.
+      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+      episode_fixture(
+        media_item_id: media_item.id,
+        season_number: 3,
+        episode_number: 1,
+        monitored: false
+      )
+
+      episode_fixture(
+        media_item_id: media_item.id,
+        season_number: 3,
+        episode_number: 2,
+        monitored: false
+      )
+
+      refute Media.should_monitor_new_episode?(media_item, 3)
+    end
+
+    test "a brand new season follows monitor_new_seasons: :all" do
+      media_item =
+        media_item_fixture(%{type: "tv_show", monitored: true, monitor_new_seasons: :all})
+
+      assert Media.should_monitor_new_episode?(media_item, 4)
+    end
+
+    test "a brand new season follows monitor_new_seasons: :none" do
+      media_item =
+        media_item_fixture(%{type: "tv_show", monitored: true, monitor_new_seasons: :none})
+
+      refute Media.should_monitor_new_episode?(media_item, 4)
+    end
+
+    test "a brand new specials season is never admitted" do
+      media_item =
+        media_item_fixture(%{type: "tv_show", monitored: true, monitor_new_seasons: :all})
+
+      refute Media.should_monitor_new_episode?(media_item, 0)
+    end
+
+    test "an existing specials season with a monitored special is admitted" do
+      media_item =
+        media_item_fixture(%{type: "tv_show", monitored: true, monitor_new_seasons: :none})
+
+      episode_fixture(
+        media_item_id: media_item.id,
+        season_number: 0,
+        episode_number: 1,
+        monitored: true
+      )
+
+      assert Media.should_monitor_new_episode?(media_item, 0)
+    end
+  end
+
+  describe "season_monitoring_state/1" do
+    test "classifies all, partial, none, and empty" do
+      all = [%Mydia.Media.Episode{monitored: true}, %Mydia.Media.Episode{monitored: true}]
+      partial = [%Mydia.Media.Episode{monitored: true}, %Mydia.Media.Episode{monitored: false}]
+      none = [%Mydia.Media.Episode{monitored: false}]
+
+      assert Media.season_monitoring_state(all) == :all
+      assert Media.season_monitoring_state(partial) == :partial
+      assert Media.season_monitoring_state(none) == :none
+      assert Media.season_monitoring_state([]) == :none
+    end
+  end
+
+  describe "upsert_episodes_from_season/3 monitor_new? option" do
+    import Mydia.MediaFixtures
+
+    test "raises when :monitor_new? is omitted" do
+      media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+      season_data = %{season_number: 1, episodes: []}
+
+      assert_raise KeyError, fn ->
+        Media.upsert_episodes_from_season(media_item, season_data)
+      end
+    end
   end
 
   describe "episodes" do

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -173,6 +173,39 @@ defmodule Mydia.MediaTest do
       new_episode = Media.get_episode_by_number(media_item.id, 3, 11)
       refute new_episode.monitored
     end
+
+    test "apply_episode_monitoring/2 does not persist anything on the show" do
+      media_item =
+        media_item_fixture(%{type: "tv_show", monitored: true, monitor_new_seasons: :all})
+
+      episode_fixture(
+        media_item_id: media_item.id,
+        season_number: 1,
+        episode_number: 1,
+        monitored: false
+      )
+
+      {:ok, count} = Media.apply_episode_monitoring(media_item, :all)
+
+      assert count == 1
+      reloaded = Media.get_media_item!(media_item.id)
+      assert reloaded.monitor_new_seasons == :all
+    end
+
+    test "apply_episode_monitoring/2 returns an error for movies" do
+      media_item = media_item_fixture(%{type: "movie"})
+
+      assert {:error, {:invalid_type, _}} = Media.apply_episode_monitoring(media_item, :all)
+    end
+
+    test "set_monitor_new_seasons/2 persists the mode" do
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      {:ok, updated} = Media.set_monitor_new_seasons(media_item, :none)
+
+      assert updated.monitor_new_seasons == :none
+      assert Media.get_media_item!(media_item.id).monitor_new_seasons == :none
+    end
   end
 
   # Nested describe is invalid in ExUnit. These live as siblings of "media_items"
@@ -723,13 +756,9 @@ defmodule Mydia.MediaTest do
       assert length(presets) == 7
     end
 
-    test "apply_monitoring_preset/2 returns error for movies" do
-      media_item = media_item_fixture(%{type: "movie"})
+    # Movie invalid-type covered by media_items "apply_episode_monitoring/2 returns an error for movies"
 
-      assert {:error, {:invalid_type, _}} = Media.apply_monitoring_preset(media_item, :all)
-    end
-
-    test "apply_monitoring_preset/2 with :all monitors all episodes except specials" do
+    test "apply_episode_monitoring/2 with :all monitors all episodes except specials" do
       media_item = media_item_fixture(%{type: "tv_show", monitored: true})
 
       # Create episodes in different seasons including specials
@@ -761,9 +790,8 @@ defmodule Mydia.MediaTest do
         monitored: false
       )
 
-      {:ok, updated_item, count} = Media.apply_monitoring_preset(media_item, :all)
+      {:ok, count} = Media.apply_episode_monitoring(media_item, :all)
 
-      assert updated_item.monitoring_preset == :all
       assert count == 4
 
       # Verify episode states
@@ -779,7 +807,7 @@ defmodule Mydia.MediaTest do
       assert s2e1.monitored
     end
 
-    test "apply_monitoring_preset/2 with :none unmonitors all episodes" do
+    test "apply_episode_monitoring/2 with :none unmonitors all episodes" do
       media_item = media_item_fixture(%{type: "tv_show", monitored: true})
 
       # Create monitored episodes
@@ -797,9 +825,8 @@ defmodule Mydia.MediaTest do
         monitored: true
       )
 
-      {:ok, updated_item, count} = Media.apply_monitoring_preset(media_item, :none)
+      {:ok, count} = Media.apply_episode_monitoring(media_item, :none)
 
-      assert updated_item.monitoring_preset == :none
       assert count == 2
 
       # Verify all episodes are unmonitored
@@ -807,7 +834,7 @@ defmodule Mydia.MediaTest do
       assert Enum.all?(episodes, &(!&1.monitored))
     end
 
-    test "apply_monitoring_preset/2 with :future monitors only future episodes" do
+    test "apply_episode_monitoring/2 with :future monitors only future episodes" do
       media_item = media_item_fixture(%{type: "tv_show", monitored: true})
 
       today = Date.utc_today()
@@ -831,9 +858,7 @@ defmodule Mydia.MediaTest do
         monitored: false
       )
 
-      {:ok, updated_item, _count} = Media.apply_monitoring_preset(media_item, :future)
-
-      assert updated_item.monitoring_preset == :future
+      {:ok, _count} = Media.apply_episode_monitoring(media_item, :future)
 
       # Verify episode states
       episodes = Media.list_episodes(media_item.id)
@@ -844,7 +869,7 @@ defmodule Mydia.MediaTest do
       assert future_ep.monitored
     end
 
-    test "apply_monitoring_preset/2 with :first_season monitors only season 1" do
+    test "apply_episode_monitoring/2 with :first_season monitors only season 1" do
       media_item = media_item_fixture(%{type: "tv_show", monitored: true})
 
       # Create episodes in multiple seasons
@@ -876,9 +901,7 @@ defmodule Mydia.MediaTest do
         monitored: true
       )
 
-      {:ok, updated_item, _count} = Media.apply_monitoring_preset(media_item, :first_season)
-
-      assert updated_item.monitoring_preset == :first_season
+      {:ok, _count} = Media.apply_episode_monitoring(media_item, :first_season)
 
       # Verify episode states
       episodes = Media.list_episodes(media_item.id)
@@ -892,7 +915,7 @@ defmodule Mydia.MediaTest do
       refute Enum.any?(s3_episodes, & &1.monitored)
     end
 
-    test "apply_monitoring_preset/2 with :latest_season monitors only the latest season" do
+    test "apply_episode_monitoring/2 with :latest_season monitors only the latest season" do
       media_item = media_item_fixture(%{type: "tv_show", monitored: true})
 
       # Create episodes in multiple seasons
@@ -924,9 +947,7 @@ defmodule Mydia.MediaTest do
         monitored: false
       )
 
-      {:ok, updated_item, _count} = Media.apply_monitoring_preset(media_item, :latest_season)
-
-      assert updated_item.monitoring_preset == :latest_season
+      {:ok, _count} = Media.apply_episode_monitoring(media_item, :latest_season)
 
       # Verify episode states
       episodes = Media.list_episodes(media_item.id)
@@ -940,7 +961,7 @@ defmodule Mydia.MediaTest do
       assert Enum.all?(s3_episodes, & &1.monitored)
     end
 
-    test "apply_monitoring_preset/2 with :existing monitors only episodes with files" do
+    test "apply_episode_monitoring/2 with :existing monitors only episodes with files" do
       media_item = media_item_fixture(%{type: "tv_show", monitored: true})
 
       # Create episodes
@@ -963,9 +984,7 @@ defmodule Mydia.MediaTest do
       # Add a media file to the first episode
       media_file_fixture(episode_id: ep_with_file.id)
 
-      {:ok, updated_item, _count} = Media.apply_monitoring_preset(media_item, :existing)
-
-      assert updated_item.monitoring_preset == :existing
+      {:ok, _count} = Media.apply_episode_monitoring(media_item, :existing)
 
       # Verify episode states
       episodes = Media.list_episodes(media_item.id, preload: [:media_files])
@@ -977,7 +996,7 @@ defmodule Mydia.MediaTest do
       refute ep_without.monitored
     end
 
-    test "apply_monitoring_preset/2 with :missing monitors episodes without files or future" do
+    test "apply_episode_monitoring/2 with :missing monitors episodes without files or future" do
       media_item = media_item_fixture(%{type: "tv_show", monitored: true})
 
       today = Date.utc_today()
@@ -1012,9 +1031,7 @@ defmodule Mydia.MediaTest do
       # Add a media file to the first episode
       media_file_fixture(episode_id: ep_with_file.id)
 
-      {:ok, updated_item, _count} = Media.apply_monitoring_preset(media_item, :missing)
-
-      assert updated_item.monitoring_preset == :missing
+      {:ok, _count} = Media.apply_episode_monitoring(media_item, :missing)
 
       # Verify episode states
       episodes = Media.list_episodes(media_item.id, preload: [:media_files])
@@ -1031,27 +1048,16 @@ defmodule Mydia.MediaTest do
       assert ep_future.monitored
     end
 
-    test "apply_monitoring_preset/2 persists the preset to media_item" do
-      media_item = media_item_fixture(%{type: "tv_show"})
+    # "persists the preset" removed: apply is now stateless; covered by
+    # media_items "apply_episode_monitoring/2 does not persist anything on the show"
 
-      # Create an episode
-      episode_fixture(media_item_id: media_item.id, season_number: 1, episode_number: 1)
-
-      {:ok, updated_item, _count} = Media.apply_monitoring_preset(media_item, :future)
-
-      # Reload from database to ensure persistence
-      reloaded = Media.get_media_item!(media_item.id)
-      assert reloaded.monitoring_preset == :future
-    end
-
-    test "apply_monitoring_preset/2 handles empty episode list" do
+    test "apply_episode_monitoring/2 handles empty episode list" do
       media_item = media_item_fixture(%{type: "tv_show"})
 
       # No episodes created
 
-      {:ok, updated_item, count} = Media.apply_monitoring_preset(media_item, :all)
+      {:ok, count} = Media.apply_episode_monitoring(media_item, :all)
 
-      assert updated_item.monitoring_preset == :all
       assert count == 0
     end
   end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -123,6 +123,20 @@ defmodule Mydia.MediaTest do
       media_item = media_item_fixture()
       assert %Ecto.Changeset{} = Media.change_media_item(media_item)
     end
+
+    test "media items default to monitoring new seasons" do
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      assert media_item.monitor_new_seasons == :all
+    end
+
+    test "monitor_new_seasons is castable through the changeset" do
+      media_item = media_item_fixture(%{type: "tv_show"})
+
+      changeset = Mydia.Media.MediaItem.changeset(media_item, %{monitor_new_seasons: :none})
+
+      assert Ecto.Changeset.get_change(changeset, :monitor_new_seasons) == :none
+    end
   end
 
   describe "episodes" do

--- a/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
+++ b/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
@@ -101,4 +101,31 @@ defmodule MydiaWeb.MediaLive.Show.MonitoringControlsTest do
     assert has_element?(view, "#season-1-monitor-toggle[phx-click='unmonitor_season']")
     assert has_element?(view, "#season-2-monitor-toggle[phx-click='monitor_season']")
   end
+
+  test "a fully unmonitored season is de-emphasised and offers to monitor", %{conn: conn} do
+    # The :none branch of season_monitoring_state/1 and monitoring_icon/1. It is
+    # the state a user lands in right after unmonitoring a whole season, which
+    # is the case this whole change exists to fix, so it should not be the one
+    # state nothing renders in a test.
+    media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 3,
+      episode_number: 1,
+      monitored: false
+    )
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 3,
+      episode_number: 2,
+      monitored: false
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    assert has_element?(view, "#season-3-monitor-toggle[phx-click='monitor_season']")
+    assert has_element?(view, "#season-3-monitor-toggle.opacity-60")
+  end
 end

--- a/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
+++ b/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
@@ -69,4 +69,36 @@ defmodule MydiaWeb.MediaLive.Show.MonitoringControlsTest do
 
     assert Mydia.Media.get_media_item!(media_item.id).monitor_new_seasons == :none
   end
+
+  test "a fully monitored season offers to unmonitor, a partial one offers to monitor", %{
+    conn: conn
+  } do
+    media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 1,
+      episode_number: 1,
+      monitored: true
+    )
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 2,
+      episode_number: 1,
+      monitored: true
+    )
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 2,
+      episode_number: 2,
+      monitored: false
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    assert has_element?(view, "#season-1-monitor-toggle[phx-click='unmonitor_season']")
+    assert has_element?(view, "#season-2-monitor-toggle[phx-click='monitor_season']")
+  end
 end

--- a/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
+++ b/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
@@ -79,8 +79,9 @@ defmodule MydiaWeb.MediaLive.Show.MonitoringControlsTest do
     refute Mydia.Media.get_episode_by_number(media_item.id, 1, 1).monitored
   end
 
-  test "applying a preset also sets the new-season verdict", %{conn: conn} do
-    media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+  test "the new seasons checkbox is visible and toggles independently", %{conn: conn} do
+    media_item =
+      media_item_fixture(%{type: "tv_show", monitored: true, monitor_new_seasons: :all})
 
     episode_fixture(
       media_item_id: media_item.id,
@@ -91,8 +92,12 @@ defmodule MydiaWeb.MediaLive.Show.MonitoringControlsTest do
 
     {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
 
-    view |> element("#episode-monitoring-menu-preset-none") |> render_click()
+    assert has_element?(view, "#monitor-new-seasons-toggle")
+    view |> element("#monitor-new-seasons-toggle") |> render_click()
 
+    assert Mydia.Media.get_media_item!(media_item.id).monitor_new_seasons == :none
+    # Applying a preset must not silently move it back.
+    view |> element("#episode-monitoring-menu-preset-all") |> render_click()
     assert Mydia.Media.get_media_item!(media_item.id).monitor_new_seasons == :none
   end
 

--- a/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
+++ b/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
@@ -31,7 +31,33 @@ defmodule MydiaWeb.MediaLive.Show.MonitoringControlsTest do
 
     assert has_element?(view, "#show-monitored-toggle")
     assert has_element?(view, "#episode-monitoring-menu")
-    assert has_element?(view, "#monitor-new-seasons-all")
+  end
+
+  test "the monitoring menu label reads the episodes back", %{conn: conn} do
+    media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 1,
+      episode_number: 1,
+      monitored: true
+    )
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 2,
+      episode_number: 1,
+      monitored: true
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    assert render(view) =~ "All Episodes"
+
+    # Toggling a season by hand is what used to leave the label stale.
+    {:ok, _} = Mydia.Media.update_season_monitoring(media_item.id, 2, false)
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    assert render(view) =~ "Custom"
   end
 
   test "applying a preset rewrites episode monitoring", %{conn: conn} do
@@ -53,7 +79,7 @@ defmodule MydiaWeb.MediaLive.Show.MonitoringControlsTest do
     refute Mydia.Media.get_episode_by_number(media_item.id, 1, 1).monitored
   end
 
-  test "the new seasons toggle persists", %{conn: conn} do
+  test "applying a preset also sets the new-season verdict", %{conn: conn} do
     media_item = media_item_fixture(%{type: "tv_show", monitored: true})
 
     episode_fixture(
@@ -65,7 +91,7 @@ defmodule MydiaWeb.MediaLive.Show.MonitoringControlsTest do
 
     {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
 
-    view |> element("#monitor-new-seasons-none") |> render_click()
+    view |> element("#episode-monitoring-menu-preset-none") |> render_click()
 
     assert Mydia.Media.get_media_item!(media_item.id).monitor_new_seasons == :none
   end

--- a/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
+++ b/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
@@ -1,0 +1,72 @@
+defmodule MydiaWeb.MediaLive.Show.MonitoringControlsTest do
+  @moduledoc """
+  Tests the split monitoring controls: a show-level monitored toggle, a
+  one-shot episode monitoring menu, and the new-seasons rule.
+  """
+  # async: false — connected LiveView tests hit the Postgres non-shared sandbox,
+  # which hides test rows from the mount process.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import MydiaWeb.AuthHelpers
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin)}
+  end
+
+  test "a tv show exposes both a monitored toggle and an episode monitoring menu", %{conn: conn} do
+    media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 1,
+      episode_number: 1,
+      monitored: true
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    assert has_element?(view, "#show-monitored-toggle")
+    assert has_element?(view, "#episode-monitoring-menu")
+    assert has_element?(view, "#monitor-new-seasons-all")
+  end
+
+  test "applying a preset rewrites episode monitoring", %{conn: conn} do
+    media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 1,
+      episode_number: 1,
+      monitored: true
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    view
+    |> element("#episode-monitoring-menu-preset-none")
+    |> render_click()
+
+    refute Mydia.Media.get_episode_by_number(media_item.id, 1, 1).monitored
+  end
+
+  test "the new seasons toggle persists", %{conn: conn} do
+    media_item = media_item_fixture(%{type: "tv_show", monitored: true})
+
+    episode_fixture(
+      media_item_id: media_item.id,
+      season_number: 1,
+      episode_number: 1,
+      monitored: true
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    view |> element("#monitor-new-seasons-none") |> render_click()
+
+    assert Mydia.Media.get_media_item!(media_item.id).monitor_new_seasons == :none
+  end
+end


### PR DESCRIPTION
## The bug

`media_items.monitoring_preset` was one stored field doing two unrelated jobs: a one-shot bulk action that rewrote every episode's `monitored` flag, and the standing rule consulted when a refresh discovered a *new* episode.

Manual season toggles wrote only episode rows and never touched the stored preset, so two things broke:

- The show page label went stale. Unmonitor season 3 and the button still read "All Episodes".
- New episodes ignored the manual edit. A newly aired season 3 episode arrived monitored, because the stored preset still said `:all`.

## The fix

The two jobs are separated. Applying a preset is now a stateless bulk rewrite. Whether a newly discovered episode is monitored is decided by the season it lands in.

Admission order in `should_monitor_new_episode?/2`:

1. Show unmonitored → no
2. Season already has episodes → inherit them (any monitored → monitored)
3. Season 0 → no; specials stay opt-in
4. Otherwise (a season that does not exist yet) → `monitor_new_seasons`

Season monitoring is **derived** from the episode rows rather than stored in a `seasons` table. Sonarr needs season records because its UI lists provider-announced seasons before episodes exist; Mydia renders seasons only by grouping existing episodes, so that state is neither visible nor settable here. One source of truth instead of two that can disagree.

`monitor_new_seasons` (`:all | :none`) replaces `monitoring_preset` and covers the only case the rows cannot answer: a season with no episodes yet. It is independent of the presets on purpose. Inferring it from the applied preset was tried and reverted — it made "keep everything I have, but do not chase new seasons" unsayable, forced a bulk rewrite to set the flag at all, and let `:future` contradict itself by unmonitoring every aired episode while implying new seasons were wanted.

## UI

- TV shows get a real **Monitored** toggle. That slot previously held the preset dropdown, so a show's own `monitored` flag was unreachable from its page, despite the admission rule gating on it.
- Bulk actions moved to the **Seasons & Episodes** header, next to what they act on, alongside a visible **New seasons** checkbox.
- The menu label is derived from the episode rows and reads `Custom` when they match no preset, so it cannot go stale.
- Season headers show derived state (solid / half-filled / outline bookmark) instead of two always-visible buttons that showed nothing.
- Presets trimmed to All / Missing / Existing / Future / None. `:first_season` and `:latest_season` are each one click on the season header now.

## Also fixed

- `:missing` and `:future` had no season-0 guard, so a bulk apply monitored fileless specials and then left `should_monitor_new_episode?` admitting every future special forever.
- The `:invalid_type` clause shadowed `:invalid_preset`, so a TV show with an unknown preset reported "only works for TV shows, got tv_show".
- A provider switch reset every season's monitoring, because it deletes all episodes before re-upserting. It now captures the per-season verdict first and replays it.
- The library scanner and metadata enricher never passed a monitoring rule at all, so they monitored every non-special episode regardless of the show's intent. All four call sites now route through one rule, and `:monitor_new?` is required via `Keyword.fetch!` so a future call site cannot silently reintroduce a default.

## Migrations

Two, both adapter-safe on SQLite and PostgreSQL. Add + backfill `monitor_new_seasons` (`monitoring_preset == 'none'` → `:none`, everything else → `:all`), then drop `monitoring_preset`. No table rebuild needed: bundled SQLite is 3.53.3, well past the 3.35 floor for `DROP COLUMN`, and the column carried no index. Both directions verified.

## Testing

7703 tests, 0 failures. New coverage for the admission rule (including the reported case: a fully unmonitored season refuses new episodes), the derived label and its `:none`/`:custom` resolution, the specials guard across every preset, and the independence of `monitor_new_seasons` from the presets.

No GraphQL, Rust, or player surface is touched — `monitoring_preset` was never exposed, so the `sdl_parity` gate is unaffected.

## Known limitation

`upsert_episodes_from_season/3` computes `monitor_new?` once per season rather than per episode. No live provider path returns a payload whose episodes span season numbers, so this is latent, but the two call sites do disagree about which season number is authoritative (`SeasonInfo` vs. the fetched response). Left documented rather than reverted, since a per-episode function reintroduces an N+1.
