### PR TITLE
fix(streaming): choose the audio track by language, and remember the viewer's choice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,28 @@ SQLITE_BUSY_TIMEOUT=5000
 # Can also be set from Settings → Configuration → Metadata in the admin UI.
 # METADATA_LANGUAGE=en-US
 
+# Playback Configuration
+# ----------------------
+# Which audio track a playback picks when a file carries several, most
+# preferred first, comma separated. Codes are matched loosely, so "en" matches
+# a track tagged "eng" or "en-US".
+#
+# The literal "original" resolves per title to its original language from
+# TMDB, which is why it leads the default: a US series then plays English, and
+# anime plays Japanese rather than an English dub. Set "en" for English
+# wherever it exists, or "de,original" to prefer a German dub and fall back to
+# the original. Leave empty for no preference at all.
+#
+# Separate from METADATA_LANGUAGE above, deliberately: wanting German titles
+# and descriptions is not the same as wanting German audio.
+# AUDIO_LANGUAGE=original,en
+
+# Honour the file's own "default audio track" flag ahead of AUDIO_LANGUAGE.
+# Off, because a flag that says Russian on an English show is the thing
+# AUDIO_LANGUAGE exists to override. Turn it on if you tag your own files and
+# want your flags respected.
+# PREFER_DEFAULT_AUDIO_TRACK=false
+
 # Authentication Configuration
 # ----------------------------
 # Enable local username/password authentication

--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,12 @@ SQLITE_BUSY_TIMEOUT=5000
 # TMDB, which is why it leads the default: a US series then plays English, and
 # anime plays Japanese rather than an English dub. Set "en" for English
 # wherever it exists, or "de,original" to prefer a German dub and fall back to
-# the original. Leave empty for no preference at all.
+# the original.
+#
+# Setting this to the empty string does nothing: an empty env var is treated
+# as unset throughout, so the default below stays in force. To turn language
+# preference off entirely, set audio_language to [] in config.yaml or clear it
+# in the admin UI.
 #
 # Separate from METADATA_LANGUAGE above, deliberately: wanting German titles
 # and descriptions is not the same as wanting German audio.

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -279,6 +279,16 @@ defmodule Mydia.Config.Loader do
       System.get_env("MAX_TRANSCODE_HEIGHT"),
       &parse_integer/1
     )
+    |> put_if_present(
+      :audio_language,
+      System.get_env("AUDIO_LANGUAGE"),
+      &parse_string_list/1
+    )
+    |> put_if_present(
+      :prefer_default_audio_track,
+      System.get_env("PREFER_DEFAULT_AUDIO_TRACK"),
+      &parse_boolean/1
+    )
   end
 
   defp load_logging_env do

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -445,9 +445,12 @@ defmodule Mydia.Config.Schema do
 
   # An empty list is allowed and means "no language preference": selection
   # falls through to the container's default flag, which is the behaviour
-  # every mydia before this field had. Blank entries are rejected rather than
-  # dropped, because a stray comma in AUDIO_LANGUAGE should be a startup error
-  # an operator can see, not a silently shortened preference list.
+  # every mydia before this field had.
+  #
+  # Blank entries are rejected rather than dropped. Not reachable from
+  # AUDIO_LANGUAGE, whose parser already strips them, but very much reachable
+  # from a YAML list or a DB/UI value, where a stray empty string would
+  # otherwise become a preference that silently matches nothing.
   defp validate_audio_language(changeset) do
     case get_field(changeset, :audio_language) do
       nil ->

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -142,6 +142,32 @@ defmodule Mydia.Config.Schema do
       # taking whichever is lower. See
       # Mydia.Streaming.FfmpegHlsTranscoder.effective_max_height/1.
       field :max_transcode_height, :integer
+
+      # Which audio language a playback picks when a file carries several, most
+      # preferred first. Codes are matched loosely, so "en" matches a track
+      # tagged "eng" or "en-US" (see Mydia.Metadata.LanguageCode).
+      #
+      # The literal "original" resolves per item to the show's or film's
+      # original language from TMDB metadata, which is why it leads the
+      # default: a US series then plays English, and anime plays Japanese
+      # rather than an English dub. Set ["en"] for English wherever it exists,
+      # or ["de", "original"] to prefer a German dub and fall back to the
+      # original.
+      #
+      # Composes with the per-device preference a player sends and with the
+      # per-show preference a viewer sets by picking a track; see
+      # Mydia.Streaming.AudioTrackSelector.resolve_preferences/2 for the
+      # precedence.
+      field :audio_language, {:array, :string}, default: ["original", "en"]
+
+      # Honour the container's own "default" disposition flag ahead of
+      # audio_language. Off, because a flag that says Russian on an English
+      # show is exactly the thing audio_language exists to override. An
+      # operator who tags their own files and trusts those flags turns this on
+      # to get the muxer's choice back. Jellyfin ships the same escape hatch
+      # ("Play default audio track regardless of language") for the same
+      # reason.
+      field :prefer_default_audio_track, :boolean, default: false
     end
 
     embeds_one :logging, Logging, on_replace: :update, primary_key: false do
@@ -409,11 +435,34 @@ defmodule Mydia.Config.Schema do
 
   defp streaming_changeset(schema, attrs) do
     schema
-    |> cast(attrs, [:max_transcode_height])
+    |> cast(attrs, [:max_transcode_height, :audio_language, :prefer_default_audio_track])
     # Not validate_required: nil is the default and means "no ceiling". A
     # zero or negative ceiling would scale every transcode to nothing, so it
     # is rejected here rather than discovered as a dead encoder later.
     |> validate_number(:max_transcode_height, greater_than: 0)
+    |> validate_audio_language()
+  end
+
+  # An empty list is allowed and means "no language preference": selection
+  # falls through to the container's default flag, which is the behaviour
+  # every mydia before this field had. Blank entries are rejected rather than
+  # dropped, because a stray comma in AUDIO_LANGUAGE should be a startup error
+  # an operator can see, not a silently shortened preference list.
+  defp validate_audio_language(changeset) do
+    case get_field(changeset, :audio_language) do
+      nil ->
+        changeset
+
+      codes when is_list(codes) ->
+        if Enum.all?(codes, &(is_binary(&1) and String.trim(&1) != "")) do
+          changeset
+        else
+          add_error(changeset, :audio_language, "must contain only non-empty language codes")
+        end
+
+      _ ->
+        add_error(changeset, :audio_language, "must be a list of language codes")
+    end
   end
 
   defp logging_changeset(schema, attrs) do

--- a/lib/mydia/metadata/language_code.ex
+++ b/lib/mydia/metadata/language_code.ex
@@ -1,7 +1,8 @@
 defmodule Mydia.Metadata.LanguageCode do
   @moduledoc """
-  Maps configured language codes to the form TVDB uses, and selects a
-  translation from a TVDB translation bundle by an ordered preference list.
+  Maps configured language codes to the form TVDB uses, selects a translation
+  from a TVDB translation bundle by an ordered preference list, and decides
+  whether two language tags name the same language.
 
   The configured metadata language arrives as a BCP-47 / ISO 639-1 value
   (e.g. `"en-US"`, `"de"`, `"ja-JP"`), while TVDB extended endpoints key
@@ -9,6 +10,14 @@ defmodule Mydia.Metadata.LanguageCode do
   `"jpn"`). This module bridges the two and centralizes the selection logic
   that was previously duplicated (and hardcoded to English) across the relay
   transform and the season/episode structs.
+
+  `matches?/2` serves a different consumer: matching a configured audio
+  language against the tag ffprobe read off a media file. That needs a wider
+  table than TVDB does, and specifically needs ISO 639-2/B (bibliographic)
+  codes, because Matroska writes `"ger"` and `"fre"` where the /T variants
+  are `"deu"` and `"fra"`. Keeping both tables here means one place to look
+  when a language does not match; `@iso_639_1_to_639_2` stays narrow so TVDB
+  lookups keep their existing behaviour.
   """
 
   # ISO 639-1 (primary subtag) -> ISO 639-2/T, covering the metadata config's
@@ -126,4 +135,195 @@ defmodule Mydia.Metadata.LanguageCode do
   end
 
   def select_translation(_translations, _field, _preferred_codes), do: nil
+
+  # ISO 639-1 -> every 3-letter form that names the same language. Where a
+  # language has both a terminological (/T) and a bibliographic (/B) code,
+  # both are listed, /T first. Matroska and ffprobe overwhelmingly write /B,
+  # so omitting those would leave German and French tracks unmatchable.
+  #
+  # Wider than @iso_639_1_to_639_2 because that map answers "what does TVDB
+  # call this", bounded by the languages mydia offers for metadata, while this
+  # one answers "is this the same language as that", bounded only by what
+  # someone might have muxed into a file.
+  @equivalents %{
+    "af" => ["afr"],
+    "am" => ["amh"],
+    "ar" => ["ara"],
+    "az" => ["aze"],
+    "be" => ["bel"],
+    "bg" => ["bul"],
+    "bn" => ["ben"],
+    "bs" => ["bos"],
+    "ca" => ["cat"],
+    "cs" => ["ces", "cze"],
+    "cy" => ["cym", "wel"],
+    "da" => ["dan"],
+    "de" => ["deu", "ger"],
+    "el" => ["ell", "gre"],
+    "en" => ["eng"],
+    "eo" => ["epo"],
+    "es" => ["spa"],
+    "et" => ["est"],
+    "eu" => ["eus", "baq"],
+    "fa" => ["fas", "per"],
+    "fi" => ["fin"],
+    "fr" => ["fra", "fre"],
+    "ga" => ["gle"],
+    "gl" => ["glg"],
+    "gu" => ["guj"],
+    "ha" => ["hau"],
+    "he" => ["heb"],
+    "hi" => ["hin"],
+    "hr" => ["hrv"],
+    "hu" => ["hun"],
+    "hy" => ["hye", "arm"],
+    "id" => ["ind"],
+    "ig" => ["ibo"],
+    "is" => ["isl", "ice"],
+    "it" => ["ita"],
+    "ja" => ["jpn"],
+    "ka" => ["kat", "geo"],
+    "kk" => ["kaz"],
+    "km" => ["khm"],
+    "kn" => ["kan"],
+    "ko" => ["kor"],
+    "la" => ["lat"],
+    "lo" => ["lao"],
+    "lt" => ["lit"],
+    "lv" => ["lav"],
+    "mi" => ["mri", "mao"],
+    "mk" => ["mkd", "mac"],
+    "ml" => ["mal"],
+    "mn" => ["mon"],
+    "mr" => ["mar"],
+    "ms" => ["msa", "may"],
+    "my" => ["mya", "bur"],
+    "ne" => ["nep"],
+    "nl" => ["nld", "dut"],
+    "no" => ["nor"],
+    "pa" => ["pan"],
+    "pl" => ["pol"],
+    "pt" => ["por"],
+    "ro" => ["ron", "rum"],
+    "ru" => ["rus"],
+    "si" => ["sin"],
+    "sk" => ["slk", "slo"],
+    "sl" => ["slv"],
+    "sq" => ["sqi", "alb"],
+    "sr" => ["srp"],
+    "sv" => ["swe"],
+    "sw" => ["swa"],
+    "ta" => ["tam"],
+    "te" => ["tel"],
+    "th" => ["tha"],
+    "tl" => ["tgl"],
+    "tr" => ["tur"],
+    "uk" => ["ukr"],
+    "ur" => ["urd"],
+    "uz" => ["uzb"],
+    "vi" => ["vie"],
+    "xh" => ["xho"],
+    "yi" => ["yid"],
+    "yo" => ["yor"],
+    "zh" => ["zho", "chi"],
+    "zu" => ["zul"]
+  }
+
+  # Reverse index, so a 3-letter tag resolves back to its 2-letter form
+  # without scanning the map on every comparison.
+  @three_to_two Map.new(
+                  for {two, threes} <- @equivalents, three <- threes do
+                    {three, two}
+                  end
+                )
+
+  @doc """
+  Every code naming the same language as `code`, including `code` itself,
+  lowercased and with any region suffix stripped.
+
+  Accepts ISO 639-1 (`"de"`), BCP-47 (`"pt-BR"`), ISO 639-2/T (`"deu"`) or
+  ISO 639-2/B (`"ger"`). Unknown codes return just themselves, so an
+  unrecognised tag still matches an identical one.
+
+  ## Examples
+
+      iex> Mydia.Metadata.LanguageCode.equivalents("de")
+      ["de", "deu", "ger"]
+
+      iex> Mydia.Metadata.LanguageCode.equivalents("ger")
+      ["de", "deu", "ger"]
+
+      iex> Mydia.Metadata.LanguageCode.equivalents("pt-BR")
+      ["pt", "por"]
+
+      iex> Mydia.Metadata.LanguageCode.equivalents("kling")
+      ["kling"]
+  """
+  @spec equivalents(String.t() | nil) :: [String.t()]
+  def equivalents(code) when is_binary(code) do
+    primary =
+      code
+      |> String.downcase()
+      |> String.trim()
+      |> String.split(["-", "_"], parts: 2)
+      |> List.first()
+
+    equivalents_for_primary(primary)
+  end
+
+  def equivalents(_), do: []
+
+  # "und" is ffprobe's explicit "undetermined" tag, and a bare "" is what a
+  # file with no language tag at all yields. Neither names a language, so
+  # neither may satisfy a request for one.
+  defp equivalents_for_primary(primary) when primary in ["", "und"], do: []
+
+  defp equivalents_for_primary(primary) do
+    case Map.get(@equivalents, primary) do
+      nil ->
+        # Either a 3-letter tag, or something not in the table at all.
+        case Map.get(@three_to_two, primary) do
+          nil -> [primary]
+          two -> [two | Map.fetch!(@equivalents, two)]
+        end
+
+      threes ->
+        [primary | threes]
+    end
+  end
+
+  @doc """
+  Whether two language tags name the same language, across ISO 639-1,
+  639-2/T, 639-2/B and BCP-47 region suffixes.
+
+  Blank or `nil` on either side is never a match: an untagged audio track must
+  not satisfy a viewer's request for a specific language.
+
+  ## Examples
+
+      iex> Mydia.Metadata.LanguageCode.matches?("en", "eng")
+      true
+
+      iex> Mydia.Metadata.LanguageCode.matches?("de", "ger")
+      true
+
+      iex> Mydia.Metadata.LanguageCode.matches?("pt-BR", "por")
+      true
+
+      iex> Mydia.Metadata.LanguageCode.matches?("en", "rus")
+      false
+
+      iex> Mydia.Metadata.LanguageCode.matches?("en", nil)
+      false
+  """
+  @spec matches?(String.t() | nil, String.t() | nil) :: boolean()
+  def matches?(a, b) when is_binary(a) and is_binary(b) do
+    case {equivalents(a), equivalents(b)} do
+      {[], _} -> false
+      {_, []} -> false
+      {left, right} -> Enum.any?(left, &(&1 in right))
+    end
+  end
+
+  def matches?(_, _), do: false
 end

--- a/lib/mydia/streaming/audio_language_preference.ex
+++ b/lib/mydia/streaming/audio_language_preference.ex
@@ -1,0 +1,60 @@
+defmodule Mydia.Streaming.AudioLanguagePreference do
+  @moduledoc """
+  One viewer's audio language choice for one show or film.
+
+  Written when someone picks a track in the player's audio selector, and read
+  back on every later playback of the same item, so choosing English on
+  episode 3 holds for episode 4. That stickiness is the thing Plex, Jellyfin
+  and Infuse all leave open: all three treat a manual pick as a per-playback
+  override and make the viewer repeat it every episode.
+
+  Scoped to the media item, never the episode. A per-episode row would
+  reproduce exactly the behaviour this exists to remove.
+
+  Deliberately not folded into `Mydia.Accounts.UserPreference`'s map column,
+  which is where a flexible per-user setting would otherwise live: this grows
+  one entry per show watched, and a map column would have to be
+  read-modified-written, so two devices setting a language at once could lose
+  one of the writes. A row with a unique index upserts atomically instead.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          language: String.t(),
+          user_id: binary(),
+          media_item_id: binary(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "audio_language_preferences" do
+    field :language, :string
+
+    belongs_to :user, Mydia.Accounts.User
+    belongs_to :media_item, Mydia.Media.MediaItem
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Builds a changeset for a preference.
+
+  `user_id` and `media_item_id` are set programmatically by the context rather
+  than cast, so a client cannot write a preference onto another account.
+  """
+  def changeset(preference, attrs) do
+    preference
+    |> cast(attrs, [:language])
+    |> validate_required([:language])
+    # Long enough for "pt-BR", short enough to reject anything that is not a
+    # language tag. The value reaches ffmpeg's -map selection and mpv's alang,
+    # so it is bounded here rather than trusted from the client.
+    |> validate_length(:language, min: 2, max: 16)
+    |> unique_constraint([:user_id, :media_item_id])
+  end
+end

--- a/lib/mydia/streaming/audio_preferences.ex
+++ b/lib/mydia/streaming/audio_preferences.ex
@@ -1,0 +1,100 @@
+defmodule Mydia.Streaming.AudioPreferences do
+  @moduledoc """
+  Reads and writes the per-show audio language a viewer chose.
+
+  The strongest of the three preference levels
+  `Mydia.Streaming.AudioTrackSelector.resolve_preferences/1` folds together:
+  a language someone picked for this show outranks the preference their device
+  carries, which outranks the operator's `streaming.audio_language`.
+
+  Every function takes a `user_id` explicitly rather than reading a process
+  dictionary or a scope: these are called from a GraphQL resolver, a
+  controller and a GenServer, and threading the id keeps the "whose
+  preference" question answerable at every call site.
+  """
+
+  import Ecto.Query
+
+  alias Mydia.Repo
+  alias Mydia.Streaming.AudioLanguagePreference
+
+  @doc """
+  The language this viewer chose for this item, or `nil` if they never chose.
+  """
+  @spec get(binary() | nil, binary() | nil) :: String.t() | nil
+  def get(nil, _media_item_id), do: nil
+  def get(_user_id, nil), do: nil
+
+  def get(user_id, media_item_id) do
+    AudioLanguagePreference
+    |> where([p], p.user_id == ^user_id and p.media_item_id == ^media_item_id)
+    |> select([p], p.language)
+    |> Repo.one()
+  rescue
+    # A malformed id (a client sending something that is not a UUID) is a
+    # missing preference, not a crashed playback.
+    Ecto.Query.CastError -> nil
+  end
+
+  @doc """
+  Records this viewer's choice for this item, replacing any earlier one.
+
+  An upsert rather than a fetch-then-update: the unique index makes the write
+  atomic, so two devices choosing at once settle on one row instead of one of
+  them failing on a duplicate key.
+  """
+  @spec put(binary(), binary(), String.t()) ::
+          {:ok, AudioLanguagePreference.t()} | {:error, Ecto.Changeset.t()}
+  def put(user_id, media_item_id, language) do
+    %AudioLanguagePreference{user_id: user_id, media_item_id: media_item_id}
+    |> AudioLanguagePreference.changeset(%{language: language})
+    |> Repo.insert(
+      on_conflict: {:replace, [:language, :updated_at]},
+      conflict_target: [:user_id, :media_item_id]
+    )
+  end
+
+  @doc """
+  Forgets this viewer's choice for this item, returning them to the device and
+  operator defaults. Succeeds whether or not a preference existed.
+  """
+  @spec delete(binary(), binary()) :: :ok
+  def delete(user_id, media_item_id) do
+    AudioLanguagePreference
+    |> where([p], p.user_id == ^user_id and p.media_item_id == ^media_item_id)
+    |> Repo.delete_all()
+
+    :ok
+  end
+
+  @doc """
+  The language this viewer chose for the item a media file belongs to, as a
+  list ready for `AudioTrackSelector.resolve_preferences/1`.
+
+  Returns `[]` rather than `nil` for "no preference", because an empty list is
+  how that function spells "this level has no opinion, defer to the next".
+  """
+  @spec for_media_file(binary() | nil, struct() | nil) :: [String.t()]
+  def for_media_file(nil, _media_file), do: []
+  def for_media_file(_user_id, nil), do: []
+
+  def for_media_file(user_id, media_file) do
+    case get(user_id, media_item_id_of(media_file)) do
+      nil -> []
+      language -> [language]
+    end
+  end
+
+  @doc """
+  The media item a file belongs to.
+
+  A TV media_file carries a null `media_item_id` and reaches its show only
+  through the episode, so reading `media_item_id` alone returns nil for every
+  episode and silently disables this feature for the entire TV library. Both
+  shapes are handled, movie first.
+  """
+  @spec media_item_id_of(struct() | nil) :: binary() | nil
+  def media_item_id_of(%{media_item_id: id}) when is_binary(id), do: id
+  def media_item_id_of(%{episode: %{media_item_id: id}}) when is_binary(id), do: id
+  def media_item_id_of(_), do: nil
+end

--- a/lib/mydia/streaming/audio_preferences.ex
+++ b/lib/mydia/streaming/audio_preferences.ex
@@ -86,6 +86,25 @@ defmodule Mydia.Streaming.AudioPreferences do
   end
 
   @doc """
+  The session and remux options carrying this viewer's per-show language, or
+  `[]` when they have no preference for this item.
+
+  Exists so every entry point that starts a session spells this the same way.
+  There are four (the GraphQL resolver, both REST controllers, and the
+  remuxer), and `show_audio_language` is a `session_matches?/2` discriminator:
+  a caller that omits it does not merely lose the preference, it fails to
+  match a running session that has one and tears down a live encode to start
+  an identical replacement without it.
+  """
+  @spec session_opts(binary() | nil, struct() | nil) :: keyword()
+  def session_opts(user_id, media_file) do
+    case for_media_file(user_id, media_file) do
+      [] -> []
+      languages -> [show_audio_language: languages]
+    end
+  end
+
+  @doc """
   The media item a file belongs to.
 
   A TV media_file carries a null `media_item_id` and reaches its show only

--- a/lib/mydia/streaming/audio_track_selector.ex
+++ b/lib/mydia/streaming/audio_track_selector.ex
@@ -1,0 +1,326 @@
+defmodule Mydia.Streaming.AudioTrackSelector do
+  @moduledoc """
+  Picks which audio stream a playback should use.
+
+  Before this module, nothing chose. The server built its ffmpeg commands with
+  no `-map`, so ffmpeg applied its own implicit selection and took the audio
+  stream with the most channels; the player constructed a bare media_kit
+  `Player`, so mpv took whichever stream the container flagged `default`. Two
+  different rules, neither of them the viewer's, and both of them wrong on the
+  common dual-audio release that muxes a dub first and flags it default. That
+  is why a show with an English original could open in Russian.
+
+  Selection keys on *language*, never on a track index, for the same reason
+  Plex, Jellyfin and Infuse all do: an index means nothing across two files,
+  and the next episode's tracks may be in a different order.
+
+  ## Order of decisions
+
+  1. `prefer_default_track` short-circuits everything and returns the stream
+     the container flagged, if there is one. This is the escape hatch for
+     operators who tag their own files, matching Jellyfin's "Play default
+     audio track regardless of language".
+  2. Commentary tracks are set aside. They carry the same language tag as the
+     feature, so matching on language alone would hand a viewer the
+     director's commentary. They come back only if there is nothing else.
+  3. Each preference is tried in order. The first one with a matching track
+     wins, and ties within that language break toward the flagged track, then
+     the most channels, then the earliest.
+  4. Failing every preference, the container's `default` flag decides, and
+     failing that, the first audio stream. So a file with nothing the viewer
+     asked for still plays.
+
+  The literal `"original"` in a preference list resolves to the item's own
+  original language, which is what keeps anime in Japanese rather than
+  handing over an English dub.
+  """
+
+  require Logger
+
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Metadata.LanguageCode
+
+  @original "original"
+
+  @typedoc """
+  An ordered preference list, most preferred first. May contain `"original"`.
+  """
+  @type preferences :: [String.t()]
+
+  @doc """
+  Chooses an audio stream from `streams`, or `:none` when there is no audio.
+
+  `streams` may contain video and subtitle streams; they are ignored. The
+  returned struct's `:index` is the absolute container index ffprobe reported,
+  which is what `-map 0:<index>` expects.
+
+  ## Options
+
+    * `:original_language` - the item's original language, used to resolve the
+      `"original"` sentinel. Without it the sentinel is skipped rather than
+      treated as a language named "original".
+    * `:prefer_default_track` - when true, the container's `default` flag wins
+      outright and `preferences` is ignored. Defaults to false.
+  """
+  @spec select([StreamInfo.t()], preferences(), keyword()) :: {:ok, StreamInfo.t()} | :none
+  def select(streams, preferences, opts \\ []) do
+    case audio_streams(streams) do
+      [] ->
+        :none
+
+      audio ->
+        {:ok, choose(audio, preferences, opts)}
+    end
+  end
+
+  @doc """
+  Chooses an audio stream for a `Mydia.Library.MediaFile`, reading its analysed
+  streams and resolving `"original"` from the item's metadata.
+
+  Returns `:none` when the file has no analysed audio streams, which is the
+  case for anything scanned before stream analysis existed. Callers must treat
+  that as "leave ffmpeg's implicit selection alone" rather than as an error:
+  degrading to the old behaviour keeps an unanalysed file playing.
+
+  Accepts the same options as `select/3`, except that `:original_language`
+  is derived from the file when not given explicitly.
+  """
+  @spec select_for(struct(), preferences(), keyword()) :: {:ok, StreamInfo.t()} | :none
+  def select_for(media_file, preferences, opts \\ []) do
+    opts =
+      Keyword.put_new_lazy(opts, :original_language, fn ->
+        original_language_of(media_file)
+      end)
+
+    media_file
+    |> streams_of()
+    |> select(preferences, opts)
+  end
+
+  defp streams_of(%{metadata: %{streams: streams}}) when is_list(streams), do: streams
+  defp streams_of(_), do: []
+
+  # A TV media_file carries a null media_item_id and reaches its item through
+  # the episode, so this must not gate on media_item alone: doing that drops
+  # every episode to nil and has shipped as a bug here before. Both shapes are
+  # matched, movie first.
+  #
+  # `%Ecto.Association.NotLoaded{}` has no :metadata or :media_item key, so an
+  # unpreloaded association falls through these clauses rather than raising.
+  defp original_language_of(%{media_item: %{metadata: metadata}}),
+    do: LanguageCode.original_language_from(metadata)
+
+  defp original_language_of(%{episode: %{media_item: %{metadata: metadata}}}),
+    do: LanguageCode.original_language_from(metadata)
+
+  defp original_language_of(_), do: nil
+
+  defp choose(audio, preferences, opts) do
+    if Keyword.get(opts, :prefer_default_track, false) do
+      # Deliberately checked against every audio stream, commentary included:
+      # an operator who turned this on is asking for the container's choice
+      # verbatim, and second-guessing it here would defeat the setting.
+      Enum.find(audio, &default?/1) || by_preference(audio, preferences, opts)
+    else
+      by_preference(audio, preferences, opts)
+    end
+  end
+
+  defp by_preference(audio, preferences, opts) do
+    candidates = selectable(audio)
+    codes = expand(preferences, Keyword.get(opts, :original_language))
+
+    matched(candidates, codes) || Enum.find(candidates, &default?/1) || List.first(candidates)
+  end
+
+  # Commentary is excluded from automatic selection but never from playback:
+  # a file whose only audio is a commentary track still has to play, so the
+  # exclusion is dropped rather than leaving the viewer with silence.
+  defp selectable(audio) do
+    case Enum.reject(audio, & &1.is_commentary) do
+      [] -> audio
+      rest -> rest
+    end
+  end
+
+  # The first preference with any match wins outright. Scoring every stream
+  # into one ranking, the way Jellyfin does, lets a strong tiebreak on a
+  # lower-ranked language beat an exact match on a higher-ranked one; walking
+  # the list in order cannot.
+  defp matched(candidates, codes) do
+    Enum.find_value(codes, fn code ->
+      candidates
+      |> Enum.filter(&LanguageCode.matches?(code, &1.language))
+      |> best()
+    end)
+  end
+
+  defp best([]), do: nil
+  defp best([only]), do: only
+
+  defp best(streams) do
+    Enum.min_by(streams, fn stream ->
+      {if(default?(stream), do: 0, else: 1), -(stream.channels || 0), stream.index || 0}
+    end)
+  end
+
+  # `is_default` is nil for a stream ffprobe reported no disposition for, so
+  # this cannot be a bare truthiness check on a three-valued field.
+  defp default?(%StreamInfo{is_default: true}), do: true
+  defp default?(_), do: false
+
+  defp audio_streams(streams) when is_list(streams) do
+    streams
+    |> Enum.filter(&match?(%StreamInfo{type: :audio}, &1))
+    |> Enum.sort_by(& &1.index)
+  end
+
+  defp audio_streams(_), do: []
+
+  # Resolves the "original" sentinel and drops anything blank. An item with no
+  # original language recorded simply loses that entry, falling through to the
+  # next preference, which is why ["original", "en"] still yields English on a
+  # film mydia has no metadata for.
+  defp expand(preferences, original_language) when is_list(preferences) do
+    preferences
+    |> Enum.flat_map(fn
+      @original -> List.wrap(presence(original_language))
+      code -> List.wrap(presence(code))
+    end)
+    |> Enum.uniq()
+  end
+
+  defp expand(_, _), do: []
+
+  defp presence(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp presence(_), do: nil
+
+  @doc """
+  Collapses the preference sources into the one list that decides playback.
+
+  Precedence, strongest first: the per-show preference a viewer set by picking
+  a track, then the per-device preference that device carries, then the
+  server's `streaming.audio_language`.
+
+  An empty or missing list at any level means "no opinion" and defers to the
+  next, rather than meaning "no preference at all". That distinction matters:
+  a device that has never been configured sends `[]`, and reading that as a
+  silencing override would wipe the operator's setting for every new client.
+  Someone who genuinely wants no preference sets the server config to `[]`,
+  which no other level then overrides.
+
+  ## Examples
+
+      iex> Mydia.Streaming.AudioTrackSelector.resolve_preferences(
+      ...>   device: ["fr"], config: ["en"]
+      ...> )
+      ["fr"]
+
+      iex> Mydia.Streaming.AudioTrackSelector.resolve_preferences(
+      ...>   device: [], config: ["original", "en"]
+      ...> )
+      ["original", "en"]
+  """
+  @spec resolve_preferences(keyword()) :: preferences()
+  def resolve_preferences(sources) do
+    Enum.find_value([:show, :device, :config], [], fn level ->
+      case Keyword.get(sources, level) do
+        [_ | _] = codes -> codes
+        _ -> nil
+      end
+    end)
+  end
+
+  @doc """
+  Resolves the audio stream for a playback from a media file and the session's
+  options, folding in the operator's configuration.
+
+  This is the entry point both ffmpeg builders use, so the transcode and remux
+  paths cannot drift apart on which track they pick. Returns `nil` rather than
+  `:none` because callers treat "no selection" as "emit no `-map`".
+
+  Reads `:audio_language` (the per-device preference the player sent) and
+  `:show_audio_language` (the per-show preference the viewer set) from `opts`.
+  """
+  @spec select_for_playback(struct() | nil, keyword()) :: StreamInfo.t() | nil
+  def select_for_playback(nil, _opts), do: nil
+
+  def select_for_playback(media_file, opts) do
+    {configured, prefer_default} = configured()
+
+    preferences =
+      resolve_preferences(
+        show: Keyword.get(opts, :show_audio_language) || [],
+        device: Keyword.get(opts, :audio_language) || [],
+        config: configured
+      )
+
+    case select_for(media_file, preferences, prefer_default_track: prefer_default) do
+      {:ok, stream} ->
+        Logger.info(
+          "Selected audio stream #{stream.index} (#{stream.language || "untagged"}, " <>
+            "#{stream.codec}, #{stream.channels || "?"}ch) from preferences #{inspect(preferences)}"
+        )
+
+        stream
+
+      :none ->
+        nil
+    end
+  end
+
+  @doc """
+  The ffmpeg arguments that pin output stream selection to `stream`.
+
+  Given no `-map` at all, ffmpeg applies its own implicit selection and takes
+  the audio stream with the most channels, which on a dual-language release is
+  routinely the 5.1 dub rather than the stereo original the viewer asked for.
+  Worse, the output then holds exactly one audio track, so the player's track
+  selector has nothing to switch to.
+
+  `0:V:0` rather than `0:v:0`: the capital form skips attached pictures, so an
+  embedded cover-art JPEG muxed as a video stream cannot be mistaken for the
+  video track. The lowercase form would regress those files.
+
+  Returns `[]` for `nil`, which is what a file analysed before per-stream
+  metadata existed yields. Emitting no `-map` leaves ffmpeg's implicit
+  selection in place, so such a file keeps playing exactly as it did before
+  rather than failing.
+  """
+  @spec ffmpeg_map_args(StreamInfo.t() | nil) :: [String.t()]
+  def ffmpeg_map_args(%StreamInfo{index: index}) when is_integer(index) do
+    ["-map", "0:V:0", "-map", "0:#{index}"]
+  end
+
+  def ffmpeg_map_args(_), do: []
+
+  @doc """
+  The operator's `streaming.audio_language` and `streaming.prefer_default_audio_track`,
+  as `{preferences, prefer_default_track?}`.
+
+  Read from the layered runtime config (env > DB/UI > YAML > schema defaults)
+  rather than a flat `Application.get_env/3` key, for the reason
+  `Mydia.Streaming.FfmpegHlsTranscoder.effective_max_height/1` documents:
+  nothing explodes the resolved config struct back out to flat keys, so a flat
+  read would silently ignore both `AUDIO_LANGUAGE` and the settings UI.
+
+  Falls back to `{[], false}` when the config is unreachable, which reproduces
+  the pre-existing behaviour of letting the container's flag decide.
+  """
+  @spec configured() :: {preferences(), boolean()}
+  def configured do
+    case Mydia.Config.get() do
+      %{streaming: %{audio_language: languages, prefer_default_audio_track: prefer_default}} ->
+        {List.wrap(languages), prefer_default == true}
+
+      _ ->
+        {[], false}
+    end
+  end
+end

--- a/lib/mydia/streaming/audio_track_selector.ex
+++ b/lib/mydia/streaming/audio_track_selector.ex
@@ -276,6 +276,41 @@ defmodule Mydia.Streaming.AudioTrackSelector do
   end
 
   @doc """
+  The concrete, ordered language codes a client should hand to its own player,
+  with `"original"` already resolved against this item's metadata.
+
+  Direct play never reaches ffmpeg, so the server cannot pick the track for it;
+  mpv does, and mpv needs a plain list. Resolving here rather than in the
+  client keeps one implementation of the precedence rules and means the client
+  needs no access to the item's original language.
+
+  Returns `[]` when `prefer_default_audio_track` is set, which is the honest
+  answer for "what language should the player insist on": none. The client
+  then leaves its own selection alone and the container's flag decides, which
+  is what that setting asks for.
+  """
+  @spec resolved_languages(struct() | nil, keyword()) :: [String.t()]
+  def resolved_languages(media_file, opts \\ []) do
+    case configured() do
+      {_configured, true} ->
+        []
+
+      {configured, false} ->
+        preferences =
+          resolve_preferences(
+            show: Keyword.get(opts, :show_audio_language) || [],
+            device: Keyword.get(opts, :audio_language) || [],
+            config: configured
+          )
+
+        original =
+          Keyword.get(opts, :original_language) || original_language_of(media_file)
+
+        expand(preferences, original)
+    end
+  end
+
+  @doc """
   The ffmpeg arguments that pin output stream selection to `stream`.
 
   Given no `-map` at all, ffmpeg applies its own implicit selection and takes

--- a/lib/mydia/streaming/audio_track_selector.ex
+++ b/lib/mydia/streaming/audio_track_selector.ex
@@ -288,6 +288,16 @@ defmodule Mydia.Streaming.AudioTrackSelector do
   answer for "what language should the player insist on": none. The client
   then leaves its own selection alone and the container's flag decides, which
   is what that setting asks for.
+
+  Every code is expanded through `LanguageCode.equivalents/1`, so `["ja"]`
+  goes out as `["ja", "jpn"]`. This is not cosmetic. The list is handed
+  straight to mpv's `alang`, TMDB reports original languages as ISO 639-1,
+  and Matroska tags its tracks with the 3-letter forms; mpv only gained
+  lenient matching between the two in 0.36, so on an older bundled libmpv a
+  bare `ja` matches nothing and mpv falls back to the container's `default`
+  flag, which is the dub this whole feature exists to stop selecting.
+  Expanding here means the behaviour does not depend on which libmpv the
+  player happens to ship.
   """
   @spec resolved_languages(struct() | nil, keyword()) :: [String.t()]
   def resolved_languages(media_file, opts \\ []) do
@@ -306,7 +316,10 @@ defmodule Mydia.Streaming.AudioTrackSelector do
         original =
           Keyword.get(opts, :original_language) || original_language_of(media_file)
 
-        expand(preferences, original)
+        preferences
+        |> expand(original)
+        |> Enum.flat_map(&LanguageCode.equivalents/1)
+        |> Enum.uniq()
     end
   end
 
@@ -327,10 +340,19 @@ defmodule Mydia.Streaming.AudioTrackSelector do
   metadata existed yields. Emitting no `-map` leaves ffmpeg's implicit
   selection in place, so such a file keeps playing exactly as it did before
   rather than failing.
+
+  Both maps carry ffmpeg's trailing `?`, which makes them optional. The index
+  comes from `metadata.streams`, recorded when the file was analysed, and a
+  file replaced on disk without re-analysis can leave it pointing past the end
+  of the real stream list. Without the `?` ffmpeg aborts with
+  `Stream map '0:N' matches no streams` and the playback is simply dead, where
+  before this change the same file played under implicit selection. With it,
+  the worst case degrades to a stream that is missing rather than a session
+  that will not start.
   """
   @spec ffmpeg_map_args(StreamInfo.t() | nil) :: [String.t()]
   def ffmpeg_map_args(%StreamInfo{index: index}) when is_integer(index) do
-    ["-map", "0:V:0", "-map", "0:#{index}"]
+    ["-map", "0:V:0?", "-map", "0:#{index}?"]
   end
 
   def ffmpeg_map_args(_), do: []

--- a/lib/mydia/streaming/candidates.ex
+++ b/lib/mydia/streaming/candidates.ex
@@ -14,7 +14,7 @@ defmodule Mydia.Streaming.Candidates do
   alias Mydia.Library.{FileAnalyzer, FileRanking, MediaFile}
   alias Mydia.Library.Structs.FileMetadata
   alias Mydia.Repo
-  alias Mydia.Streaming.{CodecString, Compatibility}
+  alias Mydia.Streaming.{AudioTrackSelector, CodecString, Compatibility}
 
   @default_max_attempts 3
 
@@ -142,8 +142,22 @@ defmodule Mydia.Streaming.Candidates do
       hdr_format: media_file.hdr_format,
       original_codec: media_file.codec,
       original_audio_codec: media_file.audio_codec,
-      container: metadata.container
+      container: metadata.container,
+      preferred_audio_languages:
+        AudioTrackSelector.resolved_languages(with_item_metadata(media_file))
     }
+  end
+
+  # resolve_media_file/2 preloads only :library_path, so the item this file
+  # belongs to is absent here and the "original" audio preference would
+  # silently resolve to nothing. Preloading is a no-op for the associations
+  # already loaded, and this runs once per candidates request on a path that
+  # already makes several queries.
+  #
+  # `episode: :media_item` is the half that matters: a TV media_file carries a
+  # null media_item_id and reaches its item only through the episode.
+  defp with_item_metadata(media_file) do
+    Repo.preload(media_file, [:media_item, episode: :media_item])
   end
 
   defp build_candidate(strategy, container, video_codec, audio_codec) do

--- a/lib/mydia/streaming/candidates.ex
+++ b/lib/mydia/streaming/candidates.ex
@@ -14,7 +14,7 @@ defmodule Mydia.Streaming.Candidates do
   alias Mydia.Library.{FileAnalyzer, FileRanking, MediaFile}
   alias Mydia.Library.Structs.FileMetadata
   alias Mydia.Repo
-  alias Mydia.Streaming.{AudioTrackSelector, CodecString, Compatibility}
+  alias Mydia.Streaming.{AudioPreferences, AudioTrackSelector, CodecString, Compatibility}
 
   @default_max_attempts 3
 
@@ -130,8 +130,16 @@ defmodule Mydia.Streaming.Candidates do
   @doc """
   Builds metadata response for a media file.
   """
-  def build_metadata_response(media_file) do
+  def build_metadata_response(media_file, opts \\ []) do
     metadata = media_file.metadata || FileMetadata.empty()
+    with_item = with_item_metadata(media_file)
+
+    # The viewer's own choice for this show, if they made one. Passed as the
+    # strongest preference level so a picked language survives to the next
+    # episode, including on direct play, where the server never sees the
+    # track selection itself.
+    show_preference =
+      AudioPreferences.for_media_file(Keyword.get(opts, :user_id), with_item)
 
     %{
       duration: metadata.duration,
@@ -144,7 +152,9 @@ defmodule Mydia.Streaming.Candidates do
       original_audio_codec: media_file.audio_codec,
       container: metadata.container,
       preferred_audio_languages:
-        AudioTrackSelector.resolved_languages(with_item_metadata(media_file))
+        AudioTrackSelector.resolved_languages(with_item,
+          show_audio_language: show_preference
+        )
     }
   end
 

--- a/lib/mydia/streaming/compatibility.ex
+++ b/lib/mydia/streaming/compatibility.ex
@@ -147,10 +147,20 @@ defmodule Mydia.Streaming.Compatibility do
     end
   end
 
-  # Audio codecs that browsers support natively
-  defp compatible_audio_codec?(nil), do: false
+  @doc """
+  Whether a browser can decode this audio codec natively.
 
-  defp compatible_audio_codec?(codec) do
+  Public because the remuxer has to ask it about the *specific* stream it
+  maps, not about `media_file.audio_codec`. That column describes the first
+  audio stream, which is what chose the REMUX strategy in the first place; if
+  language selection then maps a different stream, `-c copy` would put a codec
+  in the fMP4 that the client's `canPlayType` check never approved and the
+  advertised MIME no longer describes.
+  """
+  @spec compatible_audio_codec?(String.t() | nil) :: boolean()
+  def compatible_audio_codec?(nil), do: false
+
+  def compatible_audio_codec?(codec) do
     normalized = String.downcase(codec)
 
     # Check for compatible codecs - handle formatted strings like "AAC 5.1" or "MP3 Stereo"

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -34,6 +34,9 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   use GenServer
   require Logger
 
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Streaming.AudioTrackSelector
+
   @type transcode_opts :: [
           input_path: String.t(),
           output_dir: String.t(),
@@ -445,20 +448,33 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
           "libx264"
       end
 
+    # Which audio stream this playback carries, resolved before the codec
+    # decision because that decision has to be about the stream actually being
+    # mapped. `media_file.audio_codec` describes the *first* audio stream
+    # (see Mydia.Library.FileAnalyzer), so on a file whose first track is
+    # stereo AAC and whose second is 5.1 DTS, deciding "aac, so copy" from the
+    # first and then mapping the second puts a DTS stream in an HLS segment no
+    # browser can decode. Silent audio, no error.
+    selected_audio = AudioTrackSelector.select_for_playback(media_file, opts)
+
+    audio_source_codec =
+      case selected_audio do
+        %StreamInfo{codec: codec} when is_binary(codec) -> codec
+        _ -> media_file && media_file.audio_codec
+      end
+
     # Determine audio codec - use copy if compatible and policy allows, otherwise transcode
     audio_codec =
       case Keyword.get(opts, :audio_codec) do
         nil when not is_nil(media_file) and transcode_policy == :copy_when_compatible ->
-          if should_copy_audio?(media_file.audio_codec) do
+          if should_copy_audio?(audio_source_codec) do
             Logger.info(
-              "Audio codec #{media_file.audio_codec} is compatible, using stream copy (fast, no quality loss)"
+              "Audio codec #{audio_source_codec} is compatible, using stream copy (fast, no quality loss)"
             )
 
             "copy"
           else
-            Logger.info(
-              "Audio codec #{media_file.audio_codec || "unknown"} needs transcoding to AAC"
-            )
+            Logger.info("Audio codec #{audio_source_codec || "unknown"} needs transcoding to AAC")
 
             "aac"
           end
@@ -586,8 +602,11 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
       playlist_path
     ]
 
-    # Combine all args
-    base_args ++ video_args ++ audio_args ++ hls_args
+    # Combine all args. The maps sit directly after the input and before the
+    # codec flags, which is where ffmpeg expects output stream selection.
+    base_args ++
+      AudioTrackSelector.ffmpeg_map_args(selected_audio) ++
+      video_args ++ audio_args ++ hls_args
   end
 
   # Start FFmpeg process using Port

--- a/lib/mydia/streaming/ffmpeg_remuxer.ex
+++ b/lib/mydia/streaming/ffmpeg_remuxer.ex
@@ -44,6 +44,8 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
 
   require Logger
 
+  alias Mydia.Streaming.AudioTrackSelector
+
   @type remux_opts :: [
           seek_seconds: number() | nil,
           duration: number() | nil
@@ -74,9 +76,8 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
   @spec start_remux(String.t(), remux_opts()) :: {:ok, port(), integer()} | {:error, term()}
   def start_remux(input_path, opts \\ []) do
     seek_seconds = Keyword.get(opts, :seek_seconds)
-    duration = Keyword.get(opts, :duration)
 
-    args = build_ffmpeg_args(input_path, seek_seconds, duration)
+    args = build_ffmpeg_args(input_path, opts)
 
     Logger.info(
       "Starting fMP4 remux: #{input_path}" <>
@@ -146,7 +147,14 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
   ## Private Functions
 
   # Build FFmpeg command arguments for fMP4 remuxing
-  defp build_ffmpeg_args(input_path, seek_seconds, duration) do
+  @doc false
+  # Public only so the argument construction can be unit-tested directly,
+  # matching FfmpegHlsTranscoder.build_ffmpeg_args/3; nothing outside this
+  # module should call it.
+  def build_ffmpeg_args(input_path, opts) do
+    seek_seconds = Keyword.get(opts, :seek_seconds)
+    duration = Keyword.get(opts, :duration)
+
     # Base args - seek first for efficiency (input seeking)
     seek_args =
       if seek_seconds && seek_seconds > 0 do
@@ -156,6 +164,17 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
       end
 
     input_args = ["-i", input_path]
+
+    # Which audio stream survives the remux. `-c copy` copies the codec, not
+    # every stream: without an explicit -map ffmpeg still reduces to one
+    # stream per type and picks the audio track with the most channels, so a
+    # dual-language file silently loses its original-language track here just
+    # as it does on the transcode path.
+    map_args =
+      opts
+      |> Keyword.get(:media_file)
+      |> AudioTrackSelector.select_for_playback(opts)
+      |> AudioTrackSelector.ffmpeg_map_args()
 
     # Stream copy (no transcoding)
     codec_args = ["-c", "copy"]
@@ -191,7 +210,7 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
       "pipe:1"
     ]
 
-    seek_args ++ input_args ++ codec_args ++ duration_args ++ output_args
+    seek_args ++ input_args ++ map_args ++ codec_args ++ duration_args ++ output_args
   end
 
   # Start FFmpeg process using Port

--- a/lib/mydia/streaming/ffmpeg_remuxer.ex
+++ b/lib/mydia/streaming/ffmpeg_remuxer.ex
@@ -44,11 +44,20 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
 
   require Logger
 
+  alias Mydia.Library.Structs.StreamInfo
   alias Mydia.Streaming.AudioTrackSelector
+  alias Mydia.Streaming.Compatibility
+
+  # Matches FfmpegHlsTranscoder's budget, so a stream that has to be encoded
+  # on either path lands at the same bitrate.
+  @audio_bitrate_kbps 128
 
   @type remux_opts :: [
           seek_seconds: number() | nil,
-          duration: number() | nil
+          duration: number() | nil,
+          media_file: Mydia.Library.MediaFile.t() | nil,
+          audio_language: [String.t()] | nil,
+          show_audio_language: [String.t()] | nil
         ]
 
   @doc """
@@ -170,14 +179,24 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
     # stream per type and picks the audio track with the most channels, so a
     # dual-language file silently loses its original-language track here just
     # as it does on the transcode path.
-    map_args =
+    selected_audio =
       opts
       |> Keyword.get(:media_file)
       |> AudioTrackSelector.select_for_playback(opts)
-      |> AudioTrackSelector.ffmpeg_map_args()
 
-    # Stream copy (no transcoding)
-    codec_args = ["-c", "copy"]
+    map_args = AudioTrackSelector.ffmpeg_map_args(selected_audio)
+
+    # Video is always copied: it is the expensive stream and the REMUX
+    # strategy was offered precisely because the client can decode it.
+    #
+    # Audio is copied only when the *mapped* stream is one the client can
+    # decode. The strategy was chosen from `media_file.audio_codec`, which
+    # describes the first audio stream; when language selection maps a
+    # different one, a blanket `-c copy` would put e.g. AC3 into the fMP4
+    # while the advertised MIME still said `mp4a.40.2`. Encoding that one
+    # stream to AAC keeps the promise the candidate made, and still avoids
+    # touching the video.
+    codec_args = remux_codec_args(selected_audio)
 
     # Duration args - tell FFmpeg the total duration so it writes correct metadata
     # This prevents the browser from showing progressively increasing duration
@@ -211,6 +230,21 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
     ]
 
     seek_args ++ input_args ++ map_args ++ codec_args ++ duration_args ++ output_args
+  end
+
+  # No stream was selected, so no -map was emitted and ffmpeg's implicit
+  # selection stands. That is the pre-existing behaviour for an unanalysed
+  # file, and the codec the strategy was chosen from is the one it will pick.
+  defp remux_codec_args(nil), do: ["-c", "copy"]
+
+  defp remux_codec_args(%StreamInfo{codec: codec}) do
+    if Compatibility.compatible_audio_codec?(codec) do
+      ["-c", "copy"]
+    else
+      Logger.info("Remux: mapped audio stream is #{codec}, encoding to AAC for playability")
+
+      ["-c:v", "copy", "-c:a", "aac", "-b:a", "#{@audio_bitrate_kbps}k", "-ac", "2"]
+    end
   end
 
   # Start FFmpeg process using Port

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -231,6 +231,7 @@ defmodule Mydia.Streaming.HlsSession do
                max_bitrate: max_bitrate,
                max_height: max_height,
                audio_language: playback.audio_language,
+               show_audio_language: playback.show_audio_language,
                started_at: DateTime.utc_now()
              }
            ) do

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -185,10 +185,29 @@ defmodule Mydia.Streaming.HlsSession do
     max_height = Keyword.get(opts, :max_height)
     start_position = Keyword.get(opts, :start_position, 0)
 
+    # Everything that shapes the encoded output, carried as one map rather
+    # than as a growing positional list. Registered in the Registry too, so
+    # HlsSessionSupervisor.session_matches?/2 can tell whether a running
+    # session can serve the next request.
+    playback = %{
+      max_bitrate: max_bitrate,
+      max_height: max_height,
+      start_position: start_position,
+      audio_language: Keyword.get(opts, :audio_language),
+      show_audio_language: Keyword.get(opts, :show_audio_language)
+    }
+
     # Load media file with metadata
     try do
+      # `episode: :media_item` is not decoration: a TV media_file carries a
+      # null media_item_id and reaches its item through the episode, so
+      # without this nested preload every episode looks like it has no
+      # original language and the "original" audio preference silently does
+      # nothing for the entire TV library.
       media_file =
-        Library.get_media_file!(media_file_id, preload: [:media_item, :episode, :library_path])
+        Library.get_media_file!(media_file_id,
+          preload: [:media_item, :library_path, episode: :media_item]
+        )
 
       # Register this session in the Registry. This is a `:unique` key, so two
       # concurrent callers can race here (e.g. HlsSessionSupervisor replacing a
@@ -211,19 +230,12 @@ defmodule Mydia.Streaming.HlsSession do
                start_position: start_position,
                max_bitrate: max_bitrate,
                max_height: max_height,
+               audio_language: playback.audio_language,
                started_at: DateTime.utc_now()
              }
            ) do
         {:ok, _owner} ->
-          start_registered_session(
-            media_file_id,
-            user_id,
-            mode,
-            max_bitrate,
-            max_height,
-            start_position,
-            media_file
-          )
+          start_registered_session(media_file_id, user_id, mode, media_file, playback)
 
         {:error, {:already_registered, pid}} ->
           {:stop, {:already_registered, pid}}
@@ -238,15 +250,9 @@ defmodule Mydia.Streaming.HlsSession do
   # Continues session setup once this process has won the registration race
   # for its (media_file_id, user_id) key. Creates the temp dir, the DB job
   # record, and starts the FFmpeg backend.
-  defp start_registered_session(
-         media_file_id,
-         user_id,
-         mode,
-         max_bitrate,
-         max_height,
-         start_position,
-         media_file
-       ) do
+  defp start_registered_session(media_file_id, user_id, mode, media_file, playback) do
+    %{max_bitrate: max_bitrate, max_height: max_height, start_position: start_position} = playback
+
     # Generate session ID and create temp directory
     session_id = generate_session_id()
     temp_dir = Path.join(@temp_base_dir, session_id)
@@ -298,7 +304,9 @@ defmodule Mydia.Streaming.HlsSession do
         case start_backend(:ffmpeg, media_file, temp_dir, job.id,
                max_bitrate: max_bitrate,
                max_height: max_height,
-               start_position: start_position
+               start_position: start_position,
+               audio_language: playback.audio_language,
+               show_audio_language: playback.show_audio_language
              ) do
           {:ok, backend_pid} ->
             # Link to backend process so we terminate if it crashes
@@ -496,7 +504,12 @@ defmodule Mydia.Streaming.HlsSession do
         start_position: Keyword.get(opts, :start_position, 0)
       ] ++
         if(opts[:max_bitrate], do: [max_bitrate: opts[:max_bitrate]], else: []) ++
-        if(opts[:max_height], do: [max_height: opts[:max_height]], else: [])
+        if(opts[:max_height], do: [max_height: opts[:max_height]], else: []) ++
+        if(opts[:audio_language], do: [audio_language: opts[:audio_language]], else: []) ++
+        if(opts[:show_audio_language],
+          do: [show_audio_language: opts[:show_audio_language]],
+          else: []
+        )
 
     transcoder_opts =
       base_opts ++

--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -53,22 +53,22 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   """
   def start_session(media_file_id, user_id, mode \\ :transcode, opts \\ []) do
     session_key = session_key(media_file_id, user_id)
-    start_position = Keyword.get(opts, :start_position, 0)
-    max_bitrate = Keyword.get(opts, :max_bitrate)
-    max_height = Keyword.get(opts, :max_height)
 
     case Registry.lookup(@registry_name, session_key) do
       [{pid, metadata}] ->
-        if session_matches?(metadata, start_position, max_bitrate, max_height) do
+        if session_matches?(metadata, session_request(opts)) do
           {:ok, pid}
         else
           # A session transcoding from a different offset cannot serve this
           # request: its playlist simply does not contain the wanted range. A
           # session running at a different quality cannot serve it either: its
-          # segments are already encoded at the old rung. Replace it rather
-          # than keying sessions by offset and quality, so a user scrubbing
-          # around or flipping rungs does not accumulate concurrent FFmpeg
-          # processes.
+          # segments are already encoded at the old rung. Nor can one running
+          # a different audio language: the track it mapped is already baked
+          # into those segments, so a viewer switching language needs a fresh
+          # encode rather than the running one. Replace it rather than keying
+          # sessions by every one of those, so a user scrubbing around,
+          # flipping rungs or changing language does not accumulate concurrent
+          # FFmpeg processes.
           stop_gracefully(pid)
           start_new_session(media_file_id, user_id, mode, opts, session_key)
         end
@@ -78,15 +78,41 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
     end
   end
 
+  # Every request option that shapes the transcode output, mapped to the value
+  # a Registry entry predating that option is assumed to have carried. A
+  # session is reusable only when all of them agree.
+  @session_discriminators %{
+    start_position: 0,
+    max_bitrate: nil,
+    max_height: nil,
+    audio_language: nil
+  }
+
   @doc false
-  # Public for unit testing. Metadata registered before the quality fields
-  # existed is treated as an uncapped session at offset zero rather than as a
-  # wildcard that matches any request.
-  def session_matches?(metadata, start_position, max_bitrate, max_height) do
-    Map.get(metadata, :start_position, 0) == start_position and
-      Map.get(metadata, :max_bitrate) == max_bitrate and
-      Map.get(metadata, :max_height) == max_height
+  # Public for unit testing. Metadata registered before one of these fields
+  # existed is treated as carrying that field's default rather than as a
+  # wildcard that matches every request.
+  def session_matches?(metadata, request) do
+    Enum.all?(@session_discriminators, fn {key, default} ->
+      Map.get(metadata, key, default) == Map.get(request, key, default)
+    end)
   end
+
+  @doc false
+  # The discriminating slice of a request's options, normalised so the two
+  # ways of saying "no audio preference" compare equal: a client too old to
+  # send the field at all, and a new one sending an empty list.
+  def session_request(opts) do
+    %{
+      start_position: Keyword.get(opts, :start_position, 0),
+      max_bitrate: Keyword.get(opts, :max_bitrate),
+      max_height: Keyword.get(opts, :max_height),
+      audio_language: normalize_audio_language(Keyword.get(opts, :audio_language))
+    }
+  end
+
+  defp normalize_audio_language([]), do: nil
+  defp normalize_audio_language(value), do: value
 
   # Stops a session the way `endStreamingSession` does, rather than through
   # `DynamicSupervisor.terminate_child/2`. `HlsSession` does not trap exits,

--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -85,7 +85,8 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
     start_position: 0,
     max_bitrate: nil,
     max_height: nil,
-    audio_language: nil
+    audio_language: nil,
+    show_audio_language: nil
   }
 
   @doc false
@@ -107,7 +108,8 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
       start_position: Keyword.get(opts, :start_position, 0),
       max_bitrate: Keyword.get(opts, :max_bitrate),
       max_height: Keyword.get(opts, :max_height),
-      audio_language: normalize_audio_language(Keyword.get(opts, :audio_language))
+      audio_language: normalize_audio_language(Keyword.get(opts, :audio_language)),
+      show_audio_language: normalize_audio_language(Keyword.get(opts, :show_audio_language))
     }
   end
 

--- a/lib/mydia_web/controllers/api/hls_controller.ex
+++ b/lib/mydia_web/controllers/api/hls_controller.ex
@@ -3,7 +3,7 @@ defmodule MydiaWeb.Api.HlsController do
 
   require Logger
 
-  alias Mydia.Streaming.{HlsSessionSupervisor, HlsSession}
+  alias Mydia.Streaming.{AudioPreferences, HlsSessionSupervisor, HlsSession}
 
   @doc """
   Serves the HLS master playlist for a session.
@@ -295,7 +295,9 @@ defmodule MydiaWeb.Api.HlsController do
   def start_session(conn, %{"media_file_id" => media_file_id}) do
     with {:ok, user_id} <- get_user_id(conn),
          {media_file_id, ""} <- Integer.parse(to_string(media_file_id)),
-         {:ok, _pid} <- HlsSessionSupervisor.start_session(media_file_id, user_id),
+         session_opts <- audio_session_opts(user_id, media_file_id),
+         {:ok, _pid} <-
+           HlsSessionSupervisor.start_session(media_file_id, user_id, :transcode, session_opts),
          {:ok, session_info} <- get_session_info(media_file_id, user_id) do
       # Construct master playlist URL
       master_playlist_url = url(~p"/api/v1/hls/#{session_info.session_id}/index.m3u8")
@@ -346,6 +348,24 @@ defmodule MydiaWeb.Api.HlsController do
       nil -> {:error, :no_user}
       user -> {:ok, user.id}
     end
+  end
+
+  # The viewer's per-show audio language, in the shape start_session/4 wants.
+  #
+  # Passing this is not optional politeness. `show_audio_language` is one of
+  # the values `HlsSessionSupervisor.session_matches?/2` compares, so a caller
+  # that omits it fails to match a session already running with a preference
+  # and tears that live encode down to start an identical one without it.
+  #
+  # A file that cannot be loaded yields no preference rather than an error:
+  # start_session/4 is about to fail on the same id anyway, and with a clearer
+  # message than this could give.
+  defp audio_session_opts(user_id, media_file_id) do
+    media_file = Mydia.Library.get_media_file!(media_file_id, preload: [:episode])
+    AudioPreferences.session_opts(user_id, media_file)
+  rescue
+    Ecto.NoResultsError -> []
+    Ecto.Query.CastError -> []
   end
 
   defp get_session_temp_dir(session_id, user_id) do

--- a/lib/mydia_web/controllers/api/stream_controller.ex
+++ b/lib/mydia_web/controllers/api/stream_controller.ex
@@ -475,7 +475,7 @@ defmodule MydiaWeb.Api.StreamController do
 
     Logger.info("Starting remux for #{file_path} with duration: #{inspect(duration)}")
 
-    case FfmpegRemuxer.start_remux(file_path, duration: duration) do
+    case FfmpegRemuxer.start_remux(file_path, duration: duration, media_file: media_file) do
       {:ok, port, os_pid} ->
         # Stream the remuxed content to the client
         FfmpegRemuxer.stream_to_conn(conn, port, os_pid)

--- a/lib/mydia_web/controllers/api/stream_controller.ex
+++ b/lib/mydia_web/controllers/api/stream_controller.ex
@@ -9,6 +9,7 @@ defmodule MydiaWeb.Api.StreamController do
   alias Mydia.Repo
 
   alias Mydia.Streaming.{
+    AudioPreferences,
     Candidates,
     Compatibility,
     FfmpegRemuxer,
@@ -96,7 +97,13 @@ defmodule MydiaWeb.Api.StreamController do
       media_file =
         from(mf in MediaFile,
           where: is_nil(mf.trashed_at),
-          preload: [:media_item, :episode, :library_path]
+          # `episode: :media_item` rather than a bare `:episode`: a TV
+          # media_file has a null media_item_id and reaches its show only
+          # through the episode, so the flat preload leaves
+          # AudioTrackSelector with no original language and silently drops
+          # the "original" audio preference for the whole TV library on this
+          # path while the HLS path honours it.
+          preload: [:media_item, :library_path, episode: :media_item]
         )
         |> Repo.get!(media_file_id)
 
@@ -150,7 +157,16 @@ defmodule MydiaWeb.Api.StreamController do
       {:ok, media_file} ->
         media_file = Candidates.ensure_codec_info(media_file)
         candidates = Candidates.build_streaming_candidates(media_file)
-        metadata = Candidates.build_metadata_response(media_file)
+        # Carries the viewer through, so this endpoint's
+        # preferred_audio_languages reflects a stored per-show choice the same
+        # way the GraphQL resolver's does. Without it a web client doing
+        # direct play gets the config-only list while the Flutter client gets
+        # the personalised one, from the same server, for the same file.
+        metadata =
+          case get_user_id(conn) do
+            {:ok, user_id} -> Candidates.build_metadata_response(media_file, user_id: user_id)
+            _ -> Candidates.build_metadata_response(media_file)
+          end
 
         json(conn, %{
           candidates: candidates,
@@ -301,7 +317,9 @@ defmodule MydiaWeb.Api.StreamController do
           "Starting HLS session for media_file_id=#{media_file.id}, user_id=#{user_id}, mode=#{hls_mode}"
         )
 
-        case HlsSessionSupervisor.start_session(media_file.id, user_id, hls_mode) do
+        session_opts = AudioPreferences.session_opts(user_id, media_file)
+
+        case HlsSessionSupervisor.start_session(media_file.id, user_id, hls_mode, session_opts) do
           {:ok, _pid} ->
             # Get session info to retrieve session_id
             case HlsSessionSupervisor.get_session(media_file.id, user_id) do
@@ -475,7 +493,18 @@ defmodule MydiaWeb.Api.StreamController do
 
     Logger.info("Starting remux for #{file_path} with duration: #{inspect(duration)}")
 
-    case FfmpegRemuxer.start_remux(file_path, duration: duration, media_file: media_file) do
+    # Same per-show language the HLS path applies. Without it a viewer who
+    # picked English on one episode gets the operator default on the next
+    # whenever the client happens to choose REMUX, which is precisely the
+    # stickiness this is meant to provide.
+    remux_opts =
+      [duration: duration, media_file: media_file] ++
+        case get_user_id(conn) do
+          {:ok, user_id} -> AudioPreferences.session_opts(user_id, media_file)
+          _ -> []
+        end
+
+    case FfmpegRemuxer.start_remux(file_path, remux_opts) do
       {:ok, port, os_pid} ->
         # Stream the remuxed content to the client
         FfmpegRemuxer.stream_to_conn(conn, port, os_pid)

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -481,6 +481,21 @@ defmodule MydiaWeb.Schema.CommonTypes do
           "override its player's selection."
   end
 
+  @desc "Outcome of remembering a viewer's audio language choice"
+  object :audio_language_preference_result do
+    field :media_item_id, non_null(:id),
+      description: "The show or film the preference was stored against"
+
+    field :language, :string,
+      description: "The remembered language, or null if the choice was forgotten"
+
+    field :preferred_audio_languages, list_of(non_null(:string)),
+      description:
+        "The full preference list now in effect for this item, most preferred " <>
+          "first, with the new choice already folded in. A client can apply this " <>
+          "directly rather than re-querying streamingCandidates."
+  end
+
   @desc "Result of streaming candidates query"
   object :streaming_candidates_result do
     field :file_id, non_null(:id), description: "The resolved media file ID"

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -469,6 +469,16 @@ defmodule MydiaWeb.Schema.CommonTypes do
     field :original_codec, :string, description: "Original video codec"
     field :original_audio_codec, :string, description: "Original audio codec"
     field :container, :string, description: "Original container format"
+
+    field :preferred_audio_languages, list_of(non_null(:string)),
+      description:
+        "Audio languages this playback should prefer, most preferred first, " <>
+          "already resolved against the item's original language. Direct play " <>
+          "never reaches the server's transcoder, so a client must apply this " <>
+          "itself (mpv's `alang`) to avoid opening on whichever track the " <>
+          "container happened to flag default. Empty means the operator asked " <>
+          "for the container's own flag to win, so the client should not " <>
+          "override its player's selection."
   end
 
   @desc "Result of streaming candidates query"

--- a/lib/mydia_web/schema/mutation_types.ex
+++ b/lib/mydia_web/schema/mutation_types.ex
@@ -157,6 +157,23 @@ defmodule MydiaWeb.Schema.MutationTypes do
       resolve(&StreamingResolver.start_streaming_session/3)
     end
 
+    @desc "Remember which audio language this viewer wants for a show or film"
+    field :set_audio_language_preference, :audio_language_preference_result do
+      arg(:file_id, non_null(:id),
+        description:
+          "Any file of the show or film. The preference is stored against the " <>
+            "item it belongs to, so a choice made on one episode applies to the rest."
+      )
+
+      arg(:language, :string,
+        description:
+          "Language code to remember, e.g. \"eng\". Null forgets the choice and " <>
+            "returns this item to the device and server defaults."
+      )
+
+      resolve(&StreamingResolver.set_audio_language_preference/3)
+    end
+
     @desc "End an HLS streaming session"
     field :end_streaming_session, :boolean do
       arg(:session_id, non_null(:string))

--- a/lib/mydia_web/schema/resolvers/streaming_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/streaming_resolver.ex
@@ -10,6 +10,9 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
 
   alias Mydia.Library
   alias Mydia.Library.MediaFile
+  alias Mydia.Repo
+  alias Mydia.Streaming.AudioPreferences
+  alias Mydia.Streaming.AudioTrackSelector
   alias Mydia.Streaming.Candidates
   alias Mydia.Streaming.FfmpegHlsTranscoder
   alias Mydia.Streaming.HlsSessionSupervisor
@@ -28,12 +31,12 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
       nil ->
         {:error, "Authentication required"}
 
-      _user ->
+      user ->
         case Candidates.resolve_media_file(content_type, id) do
           {:ok, media_file} ->
             media_file = Candidates.ensure_codec_info(media_file)
             candidates = Candidates.build_streaming_candidates(media_file)
-            metadata = Candidates.build_metadata_response(media_file)
+            metadata = Candidates.build_metadata_response(media_file, user_id: user.id)
 
             # For relay connections, only allow TRANSCODE (direct play won't work
             # within relay bandwidth limits)
@@ -185,6 +188,78 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
   defp positive_or_nil(value) when is_integer(value) and value > 0, do: value
   defp positive_or_nil(_), do: nil
 
+  @doc """
+  Remembers, or forgets, this viewer's audio language for a show or film.
+
+  Takes a file id rather than an item id because that is what the player holds
+  during playback, and resolves the item from it. A choice made on one episode
+  is therefore stored against the series and applies to every later episode,
+  which is the whole point of storing it at all.
+  """
+  @spec set_audio_language_preference(map(), map(), Absinthe.Resolution.t()) ::
+          {:ok, map()} | {:error, term()}
+  def set_audio_language_preference(_parent, %{file_id: file_id} = args, %{context: context}) do
+    case context[:current_user] do
+      nil ->
+        {:error, "Authentication required"}
+
+      user ->
+        with {:ok, media_file} <- load_media_file(file_id),
+             media_item_id when is_binary(media_item_id) <-
+               AudioPreferences.media_item_id_of(media_file) do
+          apply_audio_language_preference(user.id, media_item_id, media_file, args[:language])
+        else
+          {:error, :not_found} ->
+            {:error, "File not found"}
+
+          # A file that belongs to neither an item nor an episode has nothing
+          # to hang a per-show preference on. Rare, but reachable for an
+          # orphaned row, and worth saying plainly rather than storing the
+          # preference somewhere it can never be read back.
+          nil ->
+            {:error, "File is not attached to a show or film"}
+        end
+    end
+  end
+
+  defp apply_audio_language_preference(user_id, media_item_id, media_file, nil) do
+    AudioPreferences.delete(user_id, media_item_id)
+    {:ok, audio_language_preference_result(user_id, media_item_id, media_file, nil)}
+  end
+
+  defp apply_audio_language_preference(user_id, media_item_id, media_file, language) do
+    case AudioPreferences.put(user_id, media_item_id, language) do
+      {:ok, preference} ->
+        {:ok,
+         audio_language_preference_result(
+           user_id,
+           media_item_id,
+           media_file,
+           preference.language
+         )}
+
+      {:error, changeset} ->
+        Logger.warning("Rejected audio language preference: #{inspect(changeset.errors)}")
+        {:error, "Invalid audio language"}
+    end
+  end
+
+  # Echoes the list now in effect, not just the stored code, so a client can
+  # apply the result directly. The stored choice is only the strongest of
+  # three levels, and the operator's list still supplies the fallbacks behind
+  # it.
+  defp audio_language_preference_result(user_id, media_item_id, media_file, language) do
+    %{
+      media_item_id: media_item_id,
+      language: language,
+      preferred_audio_languages:
+        AudioTrackSelector.resolved_languages(
+          Repo.preload(media_file, [:media_item, episode: :media_item]),
+          show_audio_language: AudioPreferences.for_media_file(user_id, media_file)
+        )
+    }
+  end
+
   defp start_session_for_user(
          file_id,
          user_id,
@@ -199,7 +274,9 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
          media_file <- ensure_duration_known(media_file),
          duration <- get_duration_from_metadata(media_file),
          start_position <- clamp_start_position(requested_position, duration),
-         session_opts <- build_session_opts(max_bitrate, max_height, start_position),
+         show_audio_language <- AudioPreferences.for_media_file(user_id, media_file),
+         session_opts <-
+           build_session_opts(max_bitrate, max_height, start_position, show_audio_language),
          {:ok, pid} <-
            HlsSessionSupervisor.start_session(media_file.id, user_id, mode, session_opts),
          {:ok, info} <- HlsSession.get_info(pid) do
@@ -239,9 +316,18 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
     end
   end
 
-  defp build_session_opts(max_bitrate, max_height, start_position) do
+  defp build_session_opts(max_bitrate, max_height, start_position, show_audio_language) do
     opts = if max_bitrate, do: [max_bitrate: max_bitrate], else: []
     opts = if max_height, do: [{:max_height, max_height} | opts], else: opts
+
+    # Reaches HlsSessionSupervisor.session_matches?/2 as well as the
+    # transcoder, so switching language on a running session replaces it
+    # rather than returning segments with the old track already encoded in.
+    opts =
+      if show_audio_language != [],
+        do: [{:show_audio_language, show_audio_language} | opts],
+        else: opts
+
     if start_position > 0, do: [{:start_position, start_position} | opts], else: opts
   end
 
@@ -301,7 +387,11 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
   def ensure_duration_known(media_file, _budget_ms), do: media_file
 
   defp load_media_file(file_id) do
-    {:ok, Library.get_media_file!(file_id, preload: [:library_path])}
+    # `:episode` is loaded for the per-show audio preference, not for the
+    # session itself: a TV media_file has a null media_item_id and names its
+    # show only through the episode, so without this every episode looks like
+    # it belongs to no show and the preference never applies to TV.
+    {:ok, Library.get_media_file!(file_id, preload: [:library_path, :episode])}
   rescue
     Ecto.NoResultsError ->
       {:error, :not_found}

--- a/player/lib/core/player/audio_language.dart
+++ b/player/lib/core/player/audio_language.dart
@@ -1,0 +1,42 @@
+import 'package:media_kit/media_kit.dart';
+
+import 'audio_language_stub.dart'
+    if (dart.library.io) 'audio_language_native.dart' as platform;
+
+/// Tells the underlying player which audio language to open a file on.
+///
+/// mpv runs with `alang` unset unless someone sets it, and then falls through
+/// to whatever the container flagged `default`. On a dual-language release
+/// that flag is routinely on the dub, which is how a show with English
+/// original audio could open in Russian.
+///
+/// The ordered list comes from the server
+/// (`streamingCandidates.metadata.preferredAudioLanguages`) rather than being
+/// assembled here. Resolving it needs the item's original language from TMDB
+/// metadata and the operator's `streaming.audio_language` config, neither of
+/// which the client holds, and keeping one implementation means direct play
+/// and the transcode path cannot disagree about which track is right.
+///
+/// Split across a conditional import because the mpv property API only exists
+/// on native: media_kit's web `NativePlayer` is a stub class with no
+/// `setProperty` at all, so a direct call would not compile for web.
+class AudioLanguage {
+  /// Applies [languages] to [player], most preferred first.
+  ///
+  /// Must be called *before* `player.open`. mpv chooses its tracks while
+  /// loading the file, so a preference set afterwards does not retroactively
+  /// reselect, and the viewer would still get the first few seconds of the
+  /// wrong language even if a later switch corrected it.
+  ///
+  /// An empty [languages] is a deliberate no-op meaning "no opinion": either
+  /// the operator set `prefer_default_audio_track` and wants the container's
+  /// flag to win, or the server predates the field. Forcing a guess in that
+  /// case would override a choice someone made on purpose.
+  ///
+  /// Never throws. Losing the preference costs this playback its language;
+  /// letting the failure escape would cost the playback itself.
+  static Future<void> apply(Player player, List<String> languages) async {
+    if (languages.isEmpty) return;
+    await platform.setAudioLanguage(player, languages);
+  }
+}

--- a/player/lib/core/player/audio_language_native.dart
+++ b/player/lib/core/player/audio_language_native.dart
@@ -1,0 +1,31 @@
+/// Native audio-language selection, via mpv's `alang` property.
+library;
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:media_kit/media_kit.dart';
+
+/// Sets mpv's `alang` to [languages], most preferred first.
+///
+/// mpv takes a comma-separated list and scores each audio track against it,
+/// so passing the whole list at once (rather than one code) is what makes the
+/// fallback work: `jpn,eng` plays Japanese where it exists and English
+/// otherwise, with the container's `default` flag deciding only when neither
+/// is present.
+///
+/// The `is NativePlayer` guard is not redundant with the conditional import.
+/// A native build can still be handed a player whose platform is something
+/// else, and `player.platform` is nullable until the player finishes
+/// initialising.
+Future<void> setAudioLanguage(Player player, List<String> languages) async {
+  final platform = player.platform;
+  if (platform is! NativePlayer) return;
+
+  try {
+    await platform.setProperty('alang', languages.join(','));
+  } catch (e) {
+    // A failed property set costs this playback its language preference and
+    // nothing more: mpv falls back to the container's own flag, which is the
+    // behaviour that existed before this was wired at all.
+    debugPrint('[AudioLanguage] Could not set alang=$languages: $e');
+  }
+}

--- a/player/lib/core/player/audio_language_stub.dart
+++ b/player/lib/core/player/audio_language_stub.dart
@@ -1,0 +1,12 @@
+/// Stub audio-language selection for web.
+///
+/// media_kit's web backend drives an `HTMLVideoElement`, whose `audioTracks`
+/// is unimplemented in Chrome and Firefox. There is no property to set and no
+/// track list to choose from, so the browser's own selection stands. The
+/// server-side `-map` still applies on the HLS and remux paths, which is
+/// where web playback gets its audio anyway.
+library;
+
+import 'package:media_kit/media_kit.dart';
+
+Future<void> setAudioLanguage(Player player, List<String> languages) async {}

--- a/player/lib/graphql/mutations/set_audio_language_preference.graphql
+++ b/player/lib/graphql/mutations/set_audio_language_preference.graphql
@@ -1,0 +1,12 @@
+# Remembers the audio language the viewer just picked, against the show or
+# film the file belongs to, so the next episode opens on it without a second
+# pick. Plex, Jellyfin and Infuse all treat a manual pick as a one-off
+# override and make the viewer repeat it every episode; this is the whole
+# reason the mutation exists.
+mutation SetAudioLanguagePreference($fileId: ID!, $language: String) {
+  setAudioLanguagePreference(fileId: $fileId, language: $language) {
+    mediaItemId
+    language
+    preferredAudioLanguages
+  }
+}

--- a/player/lib/graphql/queries/streaming_candidates.graphql
+++ b/player/lib/graphql/queries/streaming_candidates.graphql
@@ -12,6 +12,7 @@ query StreamingCandidates($contentType: String!, $id: ID!) {
       duration
       width
       height
+      preferredAudioLanguages
     }
   }
 }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -973,11 +973,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       final candidatesResult = candidatesFetch.candidates;
 
       // Held for _openPlayerAndStart, which builds the media_kit Player and
-      // has to set mpv's alang before opening the media. Null covers both a
-      // failed candidates call and a server too old to carry the field; both
-      // mean "no opinion", and mpv keeps its own selection.
-      _preferredAudioLanguages =
-          candidatesResult?.metadata.preferredAudioLanguages ?? const [];
+      // has to set mpv's alang before opening the media.
+      //
+      // Only overwritten when the server actually answered. A null here is
+      // either a failed candidates call (offline fall-through, transient
+      // error) or a server too old to carry the field, and neither is a
+      // statement that the viewer has no preference. Assigning `const []`
+      // unconditionally would discard what `_rememberAudioLanguage` stored on
+      // the previous episode, which is exactly the case where a season
+      // playing through must keep it: go_router reuses this screen state, so
+      // this field is the only thing carrying the choice forward.
+      final serverPreference =
+          candidatesResult?.metadata.preferredAudioLanguages;
+      if (serverPreference != null) {
+        _preferredAudioLanguages = serverPreference;
+      }
 
       // The file actually being played. Normally the user's choice; on the
       // offline fall-through, or when the selected file was rejected by the

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -62,6 +62,7 @@ import '../../../graphql/queries/season_episodes.graphql.dart';
 import '../../../graphql/mutations/start_streaming_session.graphql.dart';
 import '../../../graphql/mutations/start_streaming_session_legacy.graphql.dart';
 import '../../../graphql/mutations/end_streaming_session.graphql.dart';
+import '../../../graphql/mutations/set_audio_language_preference.graphql.dart';
 import '../../../graphql/queries/streaming_candidates.graphql.dart';
 import '../../../graphql/queries/subtitle_content.graphql.dart';
 import '../../../graphql/queries/subtitle_search.graphql.dart';
@@ -3252,6 +3253,65 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         debugPrint(
             '[PlayerScreen] No media_kit track found for: ${selected.id}');
       }
+
+      // Applied to this playback above; remembered here so the next episode
+      // opens on it too. Every other media server treats a pick as a one-off
+      // and makes the viewer repeat it, which is the complaint this removes.
+      await _rememberAudioLanguage(selected.language);
+    }
+  }
+
+  /// Stores the picked language against the show or film, so later episodes
+  /// open on it without another pick.
+  ///
+  /// Deliberately fire-and-forget from the viewer's perspective: the track
+  /// has already changed by the time this runs, so a failure here costs the
+  /// preference and not the playback the person is watching. It is awaited
+  /// only so the debug line reports the real outcome.
+  ///
+  /// Skips an untagged track. `'und'` is ffprobe's "undetermined", and
+  /// storing it would pin the show to a preference that can never match
+  /// anything on the next file.
+  Future<void> _rememberAudioLanguage(String language) async {
+    if (language.isEmpty || language == 'und') return;
+    if (widget.fileId == 'offline') return;
+
+    final graphqlClient = _graphqlClient;
+    if (graphqlClient == null) return;
+
+    try {
+      final result = await graphqlClient.mutate(
+        MutationOptions(
+          document: documentNodeMutationSetAudioLanguagePreference,
+          variables: Variables$Mutation$SetAudioLanguagePreference(
+            fileId: widget.fileId,
+            language: language,
+          ).toJson(),
+        ),
+      );
+
+      if (result.hasException) {
+        // A server too old to know this mutation answers with a GraphQL
+        // validation error. That is a version gap, not a fault, and it stays
+        // silent for the viewer: the track they picked has already changed.
+        debugPrint(
+            '[PlayerScreen] Could not remember audio language: ${result.exception}');
+        return;
+      }
+
+      // Kept for the next media this screen opens without remounting, which
+      // is what a season playing through does: go_router keys the page by
+      // route pattern, so `initState` does not run again for the next
+      // episode and the fresh Player built there reads this field.
+      final data = result.data?['setAudioLanguagePreference'];
+      final updated = data?['preferredAudioLanguages'];
+      if (updated is List) {
+        _preferredAudioLanguages = updated.cast<String>();
+      }
+
+      debugPrint('[PlayerScreen] Remembered audio language: $language');
+    } catch (e) {
+      debugPrint('[PlayerScreen] Could not remember audio language: $e');
     }
   }
 

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -15,6 +15,7 @@ import '../../../core/connection/connection_provider.dart' as conn;
 import '../../../core/graphql/graphql_provider.dart';
 import '../../../core/graphql/watch/invalidation_rules.dart';
 import '../../../core/graphql/watch/watcher_registry.dart';
+import '../../../core/player/audio_language.dart';
 import '../../../core/player/codec_support.dart';
 import '../../../core/player/progress_service.dart';
 import '../../../core/playback/playback_progress_providers.dart';
@@ -310,6 +311,16 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   app_models.SubtitleTrack? _selectedSubtitleTrack;
   List<app_models_audio.AudioTrack> _audioTracks = [];
   app_models_audio.AudioTrack? _selectedAudioTrack;
+
+  /// Audio languages this playback should open on, most preferred first, as
+  /// resolved by the server from the operator's config and the item's own
+  /// original language.
+  ///
+  /// Populated from the streaming-candidates response and applied to mpv
+  /// before the media opens. Empty means no opinion — a server that predates
+  /// the field, a failed candidates call, or an operator who asked for the
+  /// container's `default` flag to win — and mpv keeps its own selection.
+  List<String> _preferredAudioLanguages = const [];
 
   /// The target of the subtitle selection attempt currently in flight, or
   /// most recently concluded — as opposed to [_selectedSubtitleTrack],
@@ -960,6 +971,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
 
       final candidatesResult = candidatesFetch.candidates;
 
+      // Held for _openPlayerAndStart, which builds the media_kit Player and
+      // has to set mpv's alang before opening the media. Null covers both a
+      // failed candidates call and a server too old to carry the field; both
+      // mean "no opinion", and mpv keeps its own selection.
+      _preferredAudioLanguages =
+          candidatesResult?.metadata.preferredAudioLanguages ?? const [];
+
       // The file actually being played. Normally the user's choice; on the
       // offline fall-through, or when the selected file was rejected by the
       // server and re-asked above, it is whatever the server ranked highest
@@ -1420,6 +1438,14 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
       player.stream.tracks,
       _onAudioTracksDetected,
     );
+
+    // Before `open`, deliberately: mpv chooses its audio track while loading
+    // the file, so a preference applied afterwards does not reselect and the
+    // viewer still starts on the wrong language. Without this, mpv falls
+    // through to whatever the container flagged `default`, which on a
+    // dual-language release is routinely the dub — the reason an English show
+    // could open in Russian.
+    await AudioLanguage.apply(player, _preferredAudioLanguages);
 
     // Open media
     await player.open(

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -375,6 +375,7 @@ Map<String, dynamic> streamingCandidatesResponse({
   bool directPlay = false,
   int? height,
   String fileId = 'file-1',
+  List<String>? preferredAudioLanguages,
 }) {
   return {
     '__typename': 'Query',
@@ -392,11 +393,16 @@ Map<String, dynamic> streamingCandidatesResponse({
             'audioCodec': 'mp4a.40.2',
           },
       ],
+      // Every field the StreamingCandidates document selects has to be here.
+      // graphql's normalizer rejects a partial object outright — the whole
+      // query fails with PartialDataException, not just the missing field —
+      // so omitting one breaks tests that never mention it.
       'metadata': {
         '__typename': 'StreamingMetadata',
         'duration': duration,
         'width': null,
         'height': height,
+        'preferredAudioLanguages': preferredAudioLanguages,
       },
     },
   };

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -156,6 +156,15 @@ type RootMutationType {
     startPosition: Int
   ): StreamingSessionResult
 
+  "Remember which audio language this viewer wants for a show or film"
+  setAudioLanguagePreference(
+    "Any file of the show or film. The preference is stored against the item it belongs to, so a choice made on one episode applies to the rest."
+    fileId: ID!
+
+    "Language code to remember, e.g. \"eng\". Null forgets the choice and returns this item to the device and server defaults."
+    language: String
+  ): AudioLanguagePreferenceResult
+
   "End an HLS streaming session"
   endStreamingSession(sessionId: String!): Boolean
 
@@ -1223,6 +1232,18 @@ type StreamingMetadata {
   container: String
 
   "Audio languages this playback should prefer, most preferred first, already resolved against the item's original language. Direct play never reaches the server's transcoder, so a client must apply this itself (mpv's `alang`) to avoid opening on whichever track the container happened to flag default. Empty means the operator asked for the container's own flag to win, so the client should not override its player's selection."
+  preferredAudioLanguages: [String!]
+}
+
+"Outcome of remembering a viewer's audio language choice"
+type AudioLanguagePreferenceResult {
+  "The show or film the preference was stored against"
+  mediaItemId: ID!
+
+  "The remembered language, or null if the choice was forgotten"
+  language: String
+
+  "The full preference list now in effect for this item, most preferred first, with the new choice already folded in. A client can apply this directly rather than re-querying streamingCandidates."
   preferredAudioLanguages: [String!]
 }
 

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -1221,6 +1221,9 @@ type StreamingMetadata {
 
   "Original container format"
   container: String
+
+  "Audio languages this playback should prefer, most preferred first, already resolved against the item's original language. Direct play never reaches the server's transcoder, so a client must apply this itself (mpv's `alang`) to avoid opening on whichever track the container happened to flag default. Empty means the operator asked for the container's own flag to win, so the client should not override its player's selection."
+  preferredAudioLanguages: [String!]
 }
 
 "Result of streaming candidates query"

--- a/priv/repo/migrations/20260813160000_create_audio_language_preferences.exs
+++ b/priv/repo/migrations/20260813160000_create_audio_language_preferences.exs
@@ -1,0 +1,32 @@
+defmodule Mydia.Repo.Migrations.CreateAudioLanguagePreferences do
+  use Ecto.Migration
+
+  def change do
+    # Keyed on the media item rather than the episode, deliberately. Picking
+    # English once on episode 3 is meant to hold for the rest of the series,
+    # which is the gap Plex, Jellyfin and Infuse all leave open. A per-episode
+    # row would make the viewer re-pick every episode, which is the behaviour
+    # this exists to remove. Movies key on the same column, so a film gets one
+    # row of its own.
+    create table(:audio_language_preferences, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :media_item_id, references(:media_items, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      # A single code, not a list. This records one deliberate choice a person
+      # made about one show; the ordered fallback list is the operator's
+      # setting and stays in streaming.audio_language.
+      add :language, :string, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    # One preference per viewer per show, which is also what lets the write be
+    # an atomic upsert. Two devices setting a language at once then resolve to
+    # a last-writer-wins row rather than racing a read-modify-write.
+    create unique_index(:audio_language_preferences, [:user_id, :media_item_id])
+  end
+end

--- a/server/crates/api/src/mutation.rs
+++ b/server/crates/api/src/mutation.rs
@@ -16,8 +16,8 @@ use crate::types::auth::{
 use crate::types::common::StreamingStrategy;
 use crate::types::media::{Episode, Movie, Progress, SubtitleTrack, TvShow};
 use crate::types::streaming::{
-    CancelDownloadResult, DownloadJobStatus, DownloadOption, PrepareDownloadResult,
-    StreamingSessionResult,
+    AudioLanguagePreferenceResult, CancelDownloadResult, DownloadJobStatus, DownloadOption,
+    PrepareDownloadResult, StreamingSessionResult,
 };
 
 /// A wrong username and a wrong password produce the same message, so the
@@ -313,6 +313,19 @@ impl RootMutationType {
         _start_position: Option<i32>,
     ) -> Result<Option<StreamingSessionResult>> {
         Err(not_implemented("startStreamingSession"))
+    }
+
+    /// Remember which audio language this viewer wants for a show or film
+    async fn set_audio_language_preference(
+        &self,
+        _ctx: &Context<'_>,
+        // Any file of the show or film; the preference is stored against the
+        // item it belongs to.
+        _file_id: ID,
+        // Language code to remember. Null forgets the choice.
+        _language: Option<String>,
+    ) -> Result<Option<AudioLanguagePreferenceResult>> {
+        Err(not_implemented("setAudioLanguagePreference"))
     }
 
     /// End an HLS streaming session

--- a/server/crates/api/src/streaming.rs
+++ b/server/crates/api/src/streaming.rs
@@ -77,5 +77,6 @@ fn metadata_for(row: &MediaFileRow) -> StreamingMetadata {
         original_codec: row.codec.clone(),
         original_audio_codec: row.audio_codec.clone(),
         container: row.container.clone(),
+        preferred_audio_languages: None,
     }
 }

--- a/server/crates/api/src/types/streaming.rs
+++ b/server/crates/api/src/types/streaming.rs
@@ -36,6 +36,16 @@ pub struct StreamingMetadata {
     pub original_codec: Option<String>,
     pub original_audio_codec: Option<String>,
     pub container: Option<String>,
+    /// Audio languages the playback should prefer, most preferred first.
+    ///
+    /// Always `None` here for now, which the player reads as "this server has
+    /// no opinion" and leaves mpv's own track selection alone — the behaviour
+    /// this server already had. Answering properly needs two things it does
+    /// not yet carry: the per-stream language tags (`MediaFileRow` stops at
+    /// one flat `audio_codec`) and the layered `streaming.audio_language`
+    /// config. The field exists regardless because `sdl_parity` gates on
+    /// structure, and a query naming a field this schema lacks fails whole.
+    pub preferred_audio_languages: Option<Vec<String>>,
 }
 
 #[derive(SimpleObject)]

--- a/server/crates/api/src/types/streaming.rs
+++ b/server/crates/api/src/types/streaming.rs
@@ -48,6 +48,18 @@ pub struct StreamingMetadata {
     pub preferred_audio_languages: Option<Vec<String>>,
 }
 
+/// Outcome of remembering a viewer's audio language choice.
+///
+/// Declared but never constructed here: `setAudioLanguagePreference` returns
+/// `not_implemented`, the same as the other streaming mutations this server
+/// does not serve. The type exists because `sdl_parity` gates on structure.
+#[derive(SimpleObject)]
+pub struct AudioLanguagePreferenceResult {
+    pub media_item_id: ID,
+    pub language: Option<String>,
+    pub preferred_audio_languages: Option<Vec<String>>,
+}
+
 #[derive(SimpleObject)]
 pub struct StreamingSessionResult {
     pub session_id: String,

--- a/test/mydia/metadata/language_code_test.exs
+++ b/test/mydia/metadata/language_code_test.exs
@@ -109,4 +109,74 @@ defmodule Mydia.Metadata.LanguageCodeTest do
       assert LanguageCode.select_translation(%{}, "name", ["eng"]) == nil
     end
   end
+
+  describe "equivalents/1" do
+    test "expands a two-letter code to its three-letter forms" do
+      assert LanguageCode.equivalents("en") == ["en", "eng"]
+      assert LanguageCode.equivalents("de") == ["de", "deu", "ger"]
+    end
+
+    test "resolves a three-letter code back to the same set" do
+      assert LanguageCode.equivalents("ger") == ["de", "deu", "ger"]
+      assert LanguageCode.equivalents("deu") == ["de", "deu", "ger"]
+    end
+
+    test "strips region suffixes and normalises case" do
+      assert LanguageCode.equivalents("pt-BR") == ["pt", "por"]
+      assert LanguageCode.equivalents("EN_us") == ["en", "eng"]
+    end
+
+    test "returns an unknown code unchanged so it can still match itself" do
+      assert LanguageCode.equivalents("kling") == ["kling"]
+    end
+
+    test "returns nothing for blank, undetermined, and non-string input" do
+      assert LanguageCode.equivalents("") == []
+      assert LanguageCode.equivalents("   ") == []
+      assert LanguageCode.equivalents("und") == []
+      assert LanguageCode.equivalents(nil) == []
+      assert LanguageCode.equivalents(123) == []
+    end
+  end
+
+  describe "matches?/2" do
+    test "matches across ISO 639-1 and 639-2/T" do
+      assert LanguageCode.matches?("en", "eng")
+      assert LanguageCode.matches?("ja", "jpn")
+    end
+
+    test "matches ISO 639-2/B, which is what Matroska writes" do
+      # The reason this function exists rather than reusing tvdb_candidates/1:
+      # a German track in an .mkv is tagged "ger", not "deu".
+      assert LanguageCode.matches?("de", "ger")
+      assert LanguageCode.matches?("fr", "fre")
+      assert LanguageCode.matches?("cs", "cze")
+      assert LanguageCode.matches?("nl", "dut")
+    end
+
+    test "matches across region suffixes in either position" do
+      assert LanguageCode.matches?("pt-BR", "por")
+      assert LanguageCode.matches?("por", "pt-PT")
+    end
+
+    test "is symmetric" do
+      assert LanguageCode.matches?("ger", "de")
+      assert LanguageCode.matches?("eng", "en")
+    end
+
+    test "does not match different languages" do
+      refute LanguageCode.matches?("en", "rus")
+      refute LanguageCode.matches?("de", "nl")
+    end
+
+    test "never matches an untagged or undetermined track" do
+      # An audio track with no language tag must not satisfy a request for a
+      # specific language, or every unlabelled file would answer every query.
+      refute LanguageCode.matches?("en", nil)
+      refute LanguageCode.matches?("en", "")
+      refute LanguageCode.matches?("en", "und")
+      refute LanguageCode.matches?(nil, "eng")
+      refute LanguageCode.matches?("und", "und")
+    end
+  end
 end

--- a/test/mydia/streaming/audio_preferences_test.exs
+++ b/test/mydia/streaming/audio_preferences_test.exs
@@ -1,0 +1,185 @@
+defmodule Mydia.Streaming.AudioPreferencesTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+
+  alias Mydia.Repo
+  alias Mydia.Streaming.AudioPreferences
+
+  setup do
+    %{user: user_fixture()}
+  end
+
+  describe "get/2 and put/3" do
+    test "returns nil before anything is chosen", %{user: user} do
+      item = media_item_fixture()
+
+      assert AudioPreferences.get(user.id, item.id) == nil
+    end
+
+    test "reads back what was written", %{user: user} do
+      item = media_item_fixture()
+
+      assert {:ok, _} = AudioPreferences.put(user.id, item.id, "eng")
+      assert AudioPreferences.get(user.id, item.id) == "eng"
+    end
+
+    test "replaces an earlier choice rather than failing on the unique index", %{user: user} do
+      item = media_item_fixture()
+
+      assert {:ok, _} = AudioPreferences.put(user.id, item.id, "eng")
+      assert {:ok, _} = AudioPreferences.put(user.id, item.id, "jpn")
+
+      assert AudioPreferences.get(user.id, item.id) == "jpn"
+    end
+
+    test "keeps one row per viewer per item across repeated writes", %{user: user} do
+      # The upsert is what makes two devices choosing at once safe. If it
+      # degraded into insert-on-conflict-nothing, or into a second row, this
+      # count would drift.
+      item = media_item_fixture()
+
+      for language <- ["eng", "jpn", "deu", "eng"] do
+        assert {:ok, _} = AudioPreferences.put(user.id, item.id, language)
+      end
+
+      assert Repo.aggregate(Mydia.Streaming.AudioLanguagePreference, :count) == 1
+    end
+
+    test "keeps viewers independent", %{user: user} do
+      other = user_fixture()
+      item = media_item_fixture()
+
+      assert {:ok, _} = AudioPreferences.put(user.id, item.id, "eng")
+      assert {:ok, _} = AudioPreferences.put(other.id, item.id, "rus")
+
+      assert AudioPreferences.get(user.id, item.id) == "eng"
+      assert AudioPreferences.get(other.id, item.id) == "rus"
+    end
+
+    test "keeps items independent", %{user: user} do
+      one = media_item_fixture()
+      two = media_item_fixture()
+
+      assert {:ok, _} = AudioPreferences.put(user.id, one.id, "eng")
+
+      assert AudioPreferences.get(user.id, two.id) == nil
+    end
+
+    test "rejects a language that is not plausibly a language tag", %{user: user} do
+      item = media_item_fixture()
+
+      assert {:error, changeset} = AudioPreferences.put(user.id, item.id, "e")
+      assert %{language: _} = errors_on(changeset)
+
+      assert AudioPreferences.get(user.id, item.id) == nil
+    end
+
+    test "treats a nil user or item as no preference rather than raising", %{user: user} do
+      item = media_item_fixture()
+
+      assert AudioPreferences.get(nil, item.id) == nil
+      assert AudioPreferences.get(user.id, nil) == nil
+    end
+  end
+
+  describe "delete/2" do
+    test "forgets the choice", %{user: user} do
+      item = media_item_fixture()
+      assert {:ok, _} = AudioPreferences.put(user.id, item.id, "eng")
+
+      assert :ok = AudioPreferences.delete(user.id, item.id)
+      assert AudioPreferences.get(user.id, item.id) == nil
+    end
+
+    test "succeeds when there was nothing to forget", %{user: user} do
+      item = media_item_fixture()
+
+      assert :ok = AudioPreferences.delete(user.id, item.id)
+    end
+  end
+
+  describe "for_media_file/2" do
+    test "finds a movie's preference through media_item_id", %{user: user} do
+      item = media_item_fixture(%{type: "movie"})
+      file = media_file_fixture(%{media_item_id: item.id})
+
+      assert {:ok, _} = AudioPreferences.put(user.id, item.id, "eng")
+
+      assert AudioPreferences.for_media_file(user.id, file) == ["eng"]
+    end
+
+    test "finds a TV file's preference through the episode", %{user: user} do
+      # The trap this guards: a TV media_file has a NULL media_item_id and
+      # names its show only through the episode. Reading media_item_id alone
+      # returns nil for every episode, which silently disables the whole
+      # feature for TV while movies keep working.
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id})
+      file = media_file_fixture(%{episode_id: episode.id})
+
+      assert file.media_item_id == nil
+
+      assert {:ok, _} = AudioPreferences.put(user.id, show.id, "jpn")
+
+      file = Repo.preload(file, :episode)
+      assert AudioPreferences.for_media_file(user.id, file) == ["jpn"]
+    end
+
+    test "a preference set on one episode applies to another of the same show", %{user: user} do
+      # The point of storing this at all: pick English on episode 3, get
+      # English on episode 4 without picking again.
+      show = media_item_fixture(%{type: "tv_show"})
+      third = episode_fixture(%{media_item_id: show.id, episode_number: 3})
+      fourth = episode_fixture(%{media_item_id: show.id, episode_number: 4})
+
+      third_file = Repo.preload(media_file_fixture(%{episode_id: third.id}), :episode)
+      fourth_file = Repo.preload(media_file_fixture(%{episode_id: fourth.id}), :episode)
+
+      assert {:ok, _} =
+               AudioPreferences.put(
+                 user.id,
+                 AudioPreferences.media_item_id_of(third_file),
+                 "eng"
+               )
+
+      assert AudioPreferences.for_media_file(user.id, fourth_file) == ["eng"]
+    end
+
+    test "returns an empty list, not nil, when nothing was chosen", %{user: user} do
+      # AudioTrackSelector.resolve_preferences/1 spells "no opinion" as [], so
+      # a nil here would have to be normalised at every call site.
+      file = media_file_fixture()
+
+      assert AudioPreferences.for_media_file(user.id, file) == []
+    end
+
+    test "returns an empty list for a nil user or file", %{user: user} do
+      assert AudioPreferences.for_media_file(nil, media_file_fixture()) == []
+      assert AudioPreferences.for_media_file(user.id, nil) == []
+    end
+  end
+
+  describe "media_item_id_of/1" do
+    test "prefers the direct column when both are present" do
+      item = media_item_fixture(%{type: "movie"})
+
+      assert AudioPreferences.media_item_id_of(%{media_item_id: item.id}) == item.id
+    end
+
+    test "falls through to the episode when the column is null" do
+      show = media_item_fixture(%{type: "tv_show"})
+
+      assert AudioPreferences.media_item_id_of(%{
+               media_item_id: nil,
+               episode: %{media_item_id: show.id}
+             }) == show.id
+    end
+
+    test "returns nil for a file attached to neither" do
+      assert AudioPreferences.media_item_id_of(%{media_item_id: nil, episode: nil}) == nil
+      assert AudioPreferences.media_item_id_of(%{}) == nil
+    end
+  end
+end

--- a/test/mydia/streaming/audio_track_selector_test.exs
+++ b/test/mydia/streaming/audio_track_selector_test.exs
@@ -224,6 +224,62 @@ defmodule Mydia.Streaming.AudioTrackSelectorTest do
     end
   end
 
+  describe "resolved_languages/2" do
+    # What the server hands a client to feed straight into mpv's `alang`.
+    defp file_with(original_language) do
+      %{
+        metadata: %{streams: []},
+        media_item: %{metadata: %{original_language: original_language}}
+      }
+    end
+
+    test "expands every code to its three-letter forms" do
+      # This is the finding that mattered: TMDB reports original languages as
+      # ISO 639-1 while Matroska tags tracks with the 3-letter forms, and mpv
+      # only gained lenient matching between them in 0.36. Sending a bare
+      # "ja" to an older libmpv matches nothing, so mpv falls back to the
+      # container's default flag — the dub this feature exists to avoid.
+      languages = AudioTrackSelector.resolved_languages(file_with("ja"))
+
+      assert "ja" in languages
+      assert "jpn" in languages
+      assert "en" in languages
+      assert "eng" in languages
+    end
+
+    test "keeps the preference order across the expansion" do
+      # jpn must still outrank eng, or the expansion would have silently
+      # reordered the very thing it exists to preserve.
+      languages = AudioTrackSelector.resolved_languages(file_with("ja"))
+
+      assert Enum.find_index(languages, &(&1 == "jpn")) <
+               Enum.find_index(languages, &(&1 == "eng"))
+    end
+
+    test "expands to the bibliographic form Matroska actually writes" do
+      languages = AudioTrackSelector.resolved_languages(file_with("de"))
+
+      assert "ger" in languages
+      assert "deu" in languages
+    end
+
+    test "collapses to English when the item has no original language" do
+      languages = AudioTrackSelector.resolved_languages(file_with(nil))
+
+      assert languages == ["en", "eng"]
+    end
+
+    test "emits no duplicates when original and fallback are the same language" do
+      # A US series resolves "original" to English, which is also the
+      # fallback. mpv would tolerate the repeat, but a duplicated list is a
+      # sign the sentinel was not resolved before expansion.
+      languages = AudioTrackSelector.resolved_languages(file_with("en"))
+
+      assert languages == Enum.uniq(languages)
+      assert languages == ["en", "eng"]
+    end
+  end
+
   describe "resolve_preferences/2" do
     test "per-show preference outranks every other source" do
       assert ["de"] =

--- a/test/mydia/streaming/audio_track_selector_test.exs
+++ b/test/mydia/streaming/audio_track_selector_test.exs
@@ -1,0 +1,256 @@
+defmodule Mydia.Streaming.AudioTrackSelectorTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Streaming.AudioTrackSelector
+
+  # ffprobe numbers every elementary stream in one sequence, so a file's first
+  # audio track is rarely index 0. These fixtures keep that offset because the
+  # `-map` argument the selector feeds ffmpeg is an absolute container index,
+  # and a helper that quietly renumbered from zero would let an off-by-one
+  # through the whole suite.
+  defp audio(index, language, opts \\ []) do
+    %StreamInfo{
+      index: index,
+      type: :audio,
+      codec: Keyword.get(opts, :codec, "aac"),
+      language: language,
+      title: Keyword.get(opts, :title),
+      channels: Keyword.get(opts, :channels, 2),
+      is_default: Keyword.get(opts, :is_default, false),
+      is_forced: false,
+      is_commentary: Keyword.get(opts, :is_commentary, false)
+    }
+  end
+
+  defp video(index \\ 0) do
+    %StreamInfo{index: index, type: :video, codec: "h264", width: 1920, height: 1080}
+  end
+
+  describe "select/3 with a language preference" do
+    test "picks English over a Russian track the container flags default" do
+      # The reported bug, in its exact shape: a release that muxes the Russian
+      # dub first and flags it default, with the English original second.
+      streams = [
+        video(),
+        audio(1, "rus", is_default: true, channels: 6),
+        audio(2, "eng")
+      ]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.index == 2
+      assert track.language == "eng"
+    end
+
+    test "honours preference order, not container order" do
+      streams = [video(), audio(1, "eng"), audio(2, "jpn")]
+
+      assert {:ok, japanese} = AudioTrackSelector.select(streams, ["ja", "en"])
+      assert japanese.language == "jpn"
+
+      assert {:ok, english} = AudioTrackSelector.select(streams, ["en", "ja"])
+      assert english.language == "eng"
+    end
+
+    test "falls through to the next preference when the first is absent" do
+      streams = [video(), audio(1, "rus", is_default: true), audio(2, "eng")]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["de", "fr", "en"])
+      assert track.language == "eng"
+    end
+
+    test "matches a two-letter preference against ffprobe's three-letter tag" do
+      streams = [video(), audio(1, "rus", is_default: true), audio(2, "eng")]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.language == "eng"
+    end
+
+    test "matches ISO 639-2/B codes, which is what Matroska actually carries" do
+      # Matroska writes the bibliographic variant: "ger" not "deu", "fre" not
+      # "fra". A table with only the terminological form silently never
+      # matches a German or French track.
+      streams = [video(), audio(1, "eng", is_default: true), audio(2, "ger"), audio(3, "fre")]
+
+      assert {:ok, german} = AudioTrackSelector.select(streams, ["de"])
+      assert german.language == "ger"
+
+      assert {:ok, french} = AudioTrackSelector.select(streams, ["fr"])
+      assert french.language == "fre"
+    end
+
+    test "matches a region-suffixed preference against a bare tag" do
+      streams = [video(), audio(1, "rus", is_default: true), audio(2, "por")]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["pt-BR"])
+      assert track.language == "por"
+    end
+  end
+
+  describe "select/3 with the original-language sentinel" do
+    test "resolves \"original\" to the item's original language" do
+      streams = [video(), audio(1, "eng", is_default: true), audio(2, "jpn")]
+
+      assert {:ok, track} =
+               AudioTrackSelector.select(streams, ["original"], original_language: "ja")
+
+      assert track.language == "jpn"
+    end
+
+    test "skips the sentinel when the item has no original language" do
+      streams = [video(), audio(1, "rus", is_default: true), audio(2, "eng")]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["original", "en"])
+      assert track.language == "eng"
+    end
+
+    test "prefers the original language ahead of English when both exist" do
+      # Why "original" leads the shipped default: this must not hand an anime
+      # viewer the English dub.
+      streams = [video(), audio(1, "eng", is_default: true), audio(2, "jpn")]
+
+      assert {:ok, track} =
+               AudioTrackSelector.select(streams, ["original", "en"], original_language: "ja")
+
+      assert track.language == "jpn"
+    end
+  end
+
+  describe "select/3 fallbacks" do
+    test "uses the container default when no preference matches" do
+      streams = [video(), audio(1, "rus"), audio(2, "ita", is_default: true)]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.language == "ita"
+    end
+
+    test "uses the first audio track when nothing matches and nothing is flagged" do
+      streams = [video(), audio(1, "rus"), audio(2, "ita")]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.index == 1
+    end
+
+    test "treats an empty preference list as no preference at all" do
+      # Which is every mydia before this field existed: the container's flag
+      # decides. Someone who liked that behaviour sets audio_language to [].
+      streams = [video(), audio(1, "rus"), audio(2, "ita", is_default: true)]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, [])
+      assert track.language == "ita"
+    end
+
+    test "returns :none for a file with no audio at all" do
+      assert :none = AudioTrackSelector.select([video()], ["en"])
+    end
+
+    test "returns :none for an empty stream list" do
+      assert :none = AudioTrackSelector.select([], ["en"])
+    end
+
+    test "ignores an untagged track when a preference is set, but still falls back to it" do
+      streams = [video(), audio(1, nil), audio(2, nil)]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.index == 1
+    end
+  end
+
+  describe "select/3 and commentary tracks" do
+    test "never auto-selects a commentary track that matches the preference" do
+      # A director's commentary is tagged with the same language as the film.
+      # Matching on language alone would hand the viewer the commentary.
+      streams = [
+        video(),
+        audio(1, "rus", is_default: true),
+        audio(2, "eng", is_commentary: true, title: "Director's Commentary"),
+        audio(3, "eng")
+      ]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.index == 3
+    end
+
+    test "falls back to a commentary track only when it is the sole audio stream" do
+      streams = [video(), audio(1, "eng", is_commentary: true)]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.index == 1
+    end
+  end
+
+  describe "select/3 with prefer_default_track" do
+    test "short-circuits to the flagged track, ignoring the preference" do
+      # Jellyfin's "Play default audio track regardless of language" escape
+      # hatch, for operators who tag their own files.
+      streams = [video(), audio(1, "rus", is_default: true), audio(2, "eng")]
+
+      assert {:ok, track} =
+               AudioTrackSelector.select(streams, ["en"], prefer_default_track: true)
+
+      assert track.language == "rus"
+    end
+
+    test "still applies the preference when nothing is flagged default" do
+      streams = [video(), audio(1, "rus"), audio(2, "eng")]
+
+      assert {:ok, track} =
+               AudioTrackSelector.select(streams, ["en"], prefer_default_track: true)
+
+      assert track.language == "eng"
+    end
+  end
+
+  describe "select/3 tie-breaking between same-language tracks" do
+    test "prefers the flagged track when two tracks share the language" do
+      streams = [video(), audio(1, "eng", channels: 2), audio(2, "eng", is_default: true)]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.index == 2
+    end
+
+    test "prefers more channels when neither same-language track is flagged" do
+      streams = [video(), audio(1, "eng", channels: 2), audio(2, "eng", channels: 6)]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.index == 2
+    end
+
+    test "prefers the earlier track when channels tie too" do
+      streams = [video(), audio(1, "eng", channels: 6), audio(2, "eng", channels: 6)]
+
+      assert {:ok, track} = AudioTrackSelector.select(streams, ["en"])
+      assert track.index == 1
+    end
+  end
+
+  describe "resolve_preferences/2" do
+    test "per-show preference outranks every other source" do
+      assert ["de"] =
+               AudioTrackSelector.resolve_preferences(
+                 show: ["de"],
+                 device: ["fr"],
+                 config: ["en"]
+               )
+    end
+
+    test "per-device preference outranks the server config" do
+      assert ["fr"] = AudioTrackSelector.resolve_preferences(device: ["fr"], config: ["en"])
+    end
+
+    test "falls back to the server config when nothing overrides it" do
+      assert ["original", "en"] =
+               AudioTrackSelector.resolve_preferences(config: ["original", "en"])
+    end
+
+    test "treats an empty list as an absent override, not as a silencing one" do
+      # A device that has never been configured sends [], which must not read
+      # as "this viewer wants no preference" and wipe the server's setting.
+      assert ["en"] = AudioTrackSelector.resolve_preferences(device: [], config: ["en"])
+    end
+
+    test "returns an empty list when no source supplies a preference" do
+      assert [] = AudioTrackSelector.resolve_preferences([])
+    end
+  end
+end

--- a/test/mydia/streaming/ffmpeg_audio_map_test.exs
+++ b/test/mydia/streaming/ffmpeg_audio_map_test.exs
@@ -62,7 +62,7 @@ defmodule Mydia.Streaming.FfmpegAudioMapTest do
           audio(2, "eng", channels: 2)
         ])
 
-      assert maps(args(media_file: file, audio_language: ["en"])) == ["0:V:0", "0:2"]
+      assert maps(args(media_file: file, audio_language: ["en"])) == ["0:V:0?", "0:2?"]
     end
 
     test "maps the video stream as 0:V:0 so embedded cover art cannot win" do
@@ -71,7 +71,7 @@ defmodule Mydia.Streaming.FfmpegAudioMapTest do
       # track under 0:v:0.
       file = media_file([video_stream(), audio(1, "eng")])
 
-      assert value_after(args(media_file: file, audio_language: ["en"]), "-map") == "0:V:0"
+      assert value_after(args(media_file: file, audio_language: ["en"]), "-map") == "0:V:0?"
     end
 
     test "maps by absolute container index, not audio-relative position" do
@@ -85,21 +85,36 @@ defmodule Mydia.Streaming.FfmpegAudioMapTest do
           audio(3, "eng")
         ])
 
-      assert maps(args(media_file: file, audio_language: ["en"])) == ["0:V:0", "0:3"]
+      assert maps(args(media_file: file, audio_language: ["en"])) == ["0:V:0?", "0:3?"]
     end
 
     test "honours the configured preference order through the device override" do
       file = media_file([video_stream(), audio(1, "eng"), audio(2, "jpn")])
 
-      assert maps(args(media_file: file, audio_language: ["ja"])) == ["0:V:0", "0:2"]
-      assert maps(args(media_file: file, audio_language: ["en"])) == ["0:V:0", "0:1"]
+      assert maps(args(media_file: file, audio_language: ["ja"])) == ["0:V:0?", "0:2?"]
+      assert maps(args(media_file: file, audio_language: ["en"])) == ["0:V:0?", "0:1?"]
     end
 
     test "the per-show preference outranks the per-device one" do
       file = media_file([video_stream(), audio(1, "eng"), audio(2, "jpn")])
 
       assert maps(args(media_file: file, audio_language: ["en"], show_audio_language: ["ja"])) ==
-               ["0:V:0", "0:2"]
+               ["0:V:0?", "0:2?"]
+    end
+
+    test "both maps are optional so a stale index degrades instead of aborting" do
+      # The index comes from metadata.streams, written at analysis time. A
+      # file replaced on disk without re-analysis can leave it pointing past
+      # the real stream list, and a mandatory map makes ffmpeg exit with
+      # "Stream map '0:N' matches no streams" rather than play. That is a
+      # regression against the implicit selection this replaced, so both maps
+      # carry ffmpeg's trailing `?`.
+      file = media_file([video_stream(), audio(1, "eng")])
+
+      assert Enum.all?(
+               maps(args(media_file: file, audio_language: ["en"])),
+               &String.ends_with?(&1, "?")
+             )
     end
   end
 
@@ -140,7 +155,7 @@ defmodule Mydia.Streaming.FfmpegAudioMapTest do
           audio(2, "eng", channels: 2)
         ])
 
-      assert maps(remux_args(media_file: file, audio_language: ["en"])) == ["0:V:0", "0:2"]
+      assert maps(remux_args(media_file: file, audio_language: ["en"])) == ["0:V:0?", "0:2?"]
     end
 
     test "still stream-copies rather than re-encoding" do
@@ -148,6 +163,44 @@ defmodule Mydia.Streaming.FfmpegAudioMapTest do
       args = remux_args(media_file: file, audio_language: ["en"])
 
       assert value_after(args, "-c") == "copy"
+    end
+
+    test "encodes the audio when the mapped stream is one the client cannot decode" do
+      # REMUX is offered on the strength of media_file.audio_codec, the FIRST
+      # audio stream. Here that is AAC, so the candidate advertised
+      # mp4a.40.2 — and then language selection maps the AC3 track. A blanket
+      # `-c copy` would put AC3 in the fMP4 under an MIME promising AAC, which
+      # the client's canPlayType check never approved.
+      file =
+        media_file(
+          [
+            video_stream(),
+            audio(1, "eng", codec: "aac", channels: 2),
+            audio(2, "jpn", codec: "ac3", channels: 6)
+          ],
+          audio_codec: "aac"
+        )
+
+      args = remux_args(media_file: file, audio_language: ["ja"])
+
+      assert value_after(args, "-c:a") == "aac"
+      # The video is why REMUX was chosen; it must not start re-encoding.
+      assert value_after(args, "-c:v") == "copy"
+      refute value_after(args, "-c") == "copy"
+    end
+
+    test "keeps the blanket copy when the mapped stream is already compatible" do
+      file =
+        media_file(
+          [
+            video_stream(),
+            audio(1, "jpn", codec: "ac3", channels: 6),
+            audio(2, "eng", codec: "aac", channels: 2)
+          ],
+          audio_codec: "ac3"
+        )
+
+      assert value_after(remux_args(media_file: file, audio_language: ["en"]), "-c") == "copy"
     end
 
     test "emits no -map for an unanalysed file, preserving the old behaviour" do

--- a/test/mydia/streaming/ffmpeg_audio_map_test.exs
+++ b/test/mydia/streaming/ffmpeg_audio_map_test.exs
@@ -1,0 +1,207 @@
+defmodule Mydia.Streaming.FfmpegAudioMapTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.Structs.FileMetadata
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+
+  defp args(opts) do
+    FfmpegHlsTranscoder.build_ffmpeg_args("/tmp/in.mkv", "/tmp/out", opts)
+  end
+
+  # Every "-map" argument's value, in order, so a test can assert on the
+  # mapping without depending on where it sits among the codec flags.
+  defp maps(args) do
+    args
+    |> Enum.zip(Enum.drop(args, 1))
+    |> Enum.filter(fn {flag, _value} -> flag == "-map" end)
+    |> Enum.map(fn {_flag, value} -> value end)
+  end
+
+  defp value_after(args, flag) do
+    case Enum.find_index(args, &(&1 == flag)) do
+      nil -> nil
+      index -> Enum.at(args, index + 1)
+    end
+  end
+
+  defp audio(index, language, opts \\ []) do
+    %StreamInfo{
+      index: index,
+      type: :audio,
+      codec: Keyword.get(opts, :codec, "aac"),
+      language: language,
+      channels: Keyword.get(opts, :channels, 2),
+      is_default: Keyword.get(opts, :is_default, false),
+      is_commentary: false
+    }
+  end
+
+  defp media_file(streams, attrs \\ []) do
+    %MediaFile{
+      path: "/tmp/in.mkv",
+      codec: "h264",
+      audio_codec: Keyword.get(attrs, :audio_codec, "aac"),
+      media_item: Keyword.get(attrs, :media_item),
+      episode: Keyword.get(attrs, :episode),
+      metadata: %FileMetadata{streams: streams}
+    }
+  end
+
+  defp video_stream, do: %StreamInfo{index: 0, type: :video, codec: "h264", height: 1080}
+
+  describe "audio stream mapping" do
+    test "maps the English track over a Russian one the container flags default" do
+      # The reported bug. Without -map, ffmpeg's implicit selection takes the
+      # stream with the most channels, which is the 5.1 Russian dub here.
+      file =
+        media_file([
+          video_stream(),
+          audio(1, "rus", is_default: true, channels: 6),
+          audio(2, "eng", channels: 2)
+        ])
+
+      assert maps(args(media_file: file, audio_language: ["en"])) == ["0:V:0", "0:2"]
+    end
+
+    test "maps the video stream as 0:V:0 so embedded cover art cannot win" do
+      # Capital V excludes attached pictures. A file with a cover-art JPEG
+      # muxed as a video stream would otherwise be able to become the video
+      # track under 0:v:0.
+      file = media_file([video_stream(), audio(1, "eng")])
+
+      assert value_after(args(media_file: file, audio_language: ["en"]), "-map") == "0:V:0"
+    end
+
+    test "maps by absolute container index, not audio-relative position" do
+      # `-map 0:2` and `-map 0:a:2` mean different streams. StreamInfo stores
+      # ffprobe's absolute index, so the argument has to be the absolute form.
+      file =
+        media_file([
+          video_stream(),
+          audio(1, "rus", is_default: true),
+          audio(2, "fre"),
+          audio(3, "eng")
+        ])
+
+      assert maps(args(media_file: file, audio_language: ["en"])) == ["0:V:0", "0:3"]
+    end
+
+    test "honours the configured preference order through the device override" do
+      file = media_file([video_stream(), audio(1, "eng"), audio(2, "jpn")])
+
+      assert maps(args(media_file: file, audio_language: ["ja"])) == ["0:V:0", "0:2"]
+      assert maps(args(media_file: file, audio_language: ["en"])) == ["0:V:0", "0:1"]
+    end
+
+    test "the per-show preference outranks the per-device one" do
+      file = media_file([video_stream(), audio(1, "eng"), audio(2, "jpn")])
+
+      assert maps(args(media_file: file, audio_language: ["en"], show_audio_language: ["ja"])) ==
+               ["0:V:0", "0:2"]
+    end
+  end
+
+  describe "backward compatibility" do
+    test "emits no -map for a file with no analysed streams" do
+      # Anything scanned before per-stream analysis existed. Emitting no -map
+      # leaves ffmpeg's implicit selection in place, which is exactly how those
+      # files played before this change: unchanged, rather than broken.
+      file = media_file([])
+
+      assert maps(args(media_file: file, audio_language: ["en"])) == []
+    end
+
+    test "emits no -map when there is no media_file at all" do
+      assert maps(args(video_codec: "libx264")) == []
+    end
+
+    test "emits no -map for a file whose streams are video only" do
+      file = media_file([video_stream()])
+
+      assert maps(args(media_file: file, audio_language: ["en"])) == []
+    end
+  end
+
+  describe "remux path" do
+    defp remux_args(opts) do
+      Mydia.Streaming.FfmpegRemuxer.build_ffmpeg_args("/tmp/in.mkv", opts)
+    end
+
+    test "maps the preferred track instead of letting -c copy reduce to one" do
+      # `-c copy` copies the codec, not every stream. Without -map, ffmpeg
+      # still reduces to one stream per type, so remux dropped the
+      # original-language track exactly as the transcode path did.
+      file =
+        media_file([
+          video_stream(),
+          audio(1, "rus", is_default: true, channels: 6),
+          audio(2, "eng", channels: 2)
+        ])
+
+      assert maps(remux_args(media_file: file, audio_language: ["en"])) == ["0:V:0", "0:2"]
+    end
+
+    test "still stream-copies rather than re-encoding" do
+      file = media_file([video_stream(), audio(1, "eng")])
+      args = remux_args(media_file: file, audio_language: ["en"])
+
+      assert value_after(args, "-c") == "copy"
+    end
+
+    test "emits no -map for an unanalysed file, preserving the old behaviour" do
+      assert maps(remux_args(duration: 100.0)) == []
+    end
+
+    test "keeps the seek and duration arguments intact" do
+      file = media_file([video_stream(), audio(1, "eng")])
+      args = remux_args(media_file: file, seek_seconds: 120, duration: 300.0)
+
+      assert value_after(args, "-ss") == "120"
+      assert value_after(args, "-t") == "180.0"
+    end
+
+    test "places -map after the input, where ffmpeg expects output selection" do
+      # -map before -i would refer to an input that does not exist yet.
+      file = media_file([video_stream(), audio(1, "eng")])
+      args = remux_args(media_file: file, audio_language: ["en"])
+
+      assert Enum.find_index(args, &(&1 == "-i")) <
+               Enum.find_index(args, &(&1 == "-map"))
+    end
+  end
+
+  describe "codec decision follows the mapped stream" do
+    test "transcodes when the selected track is not browser-compatible" do
+      # media_file.audio_codec describes the FIRST audio stream. Here that is
+      # AAC, so the old code would emit "-c:a copy" while mapping the DTS
+      # track, putting an undecodable stream in the segments.
+      file =
+        media_file(
+          [
+            video_stream(),
+            audio(1, "eng", codec: "aac", channels: 2),
+            audio(2, "rus", codec: "dts", channels: 6)
+          ],
+          audio_codec: "aac"
+        )
+
+      assert value_after(args(media_file: file, audio_language: ["ru"]), "-c:a") == "aac"
+    end
+
+    test "copies when the selected track is browser-compatible" do
+      file =
+        media_file(
+          [
+            video_stream(),
+            audio(1, "rus", codec: "dts", channels: 6),
+            audio(2, "eng", codec: "aac", channels: 2)
+          ],
+          audio_codec: "dts"
+        )
+
+      assert value_after(args(media_file: file, audio_language: ["en"]), "-c:a") == "copy"
+    end
+  end
+end

--- a/test/mydia/streaming/hls_session_offset_test.exs
+++ b/test/mydia/streaming/hls_session_offset_test.exs
@@ -3,22 +3,20 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
 
   alias Mydia.Streaming.HlsSessionSupervisor
 
-  describe "session_matches?/4" do
+  describe "session_matches?/2" do
+    defp request(opts \\ []), do: HlsSessionSupervisor.session_request(opts)
+
     test "matches when offset and both quality values are equal" do
       assert HlsSessionSupervisor.session_matches?(
                %{start_position: 600, max_bitrate: 4000, max_height: 720},
-               600,
-               4000,
-               720
+               request(start_position: 600, max_bitrate: 4000, max_height: 720)
              )
     end
 
     test "does not match a different offset" do
       refute HlsSessionSupervisor.session_matches?(
                %{start_position: 0, max_bitrate: nil, max_height: nil},
-               4200,
-               nil,
-               nil
+               request(start_position: 4200)
              )
     end
 
@@ -27,18 +25,14 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
       # new rung hands back the session already running at the old one.
       refute HlsSessionSupervisor.session_matches?(
                %{start_position: 600, max_bitrate: 4000, max_height: 720},
-               600,
-               1500,
-               720
+               request(start_position: 600, max_bitrate: 1500, max_height: 720)
              )
     end
 
     test "does not match a different height at the same offset and bitrate" do
       refute HlsSessionSupervisor.session_matches?(
                %{start_position: 600, max_bitrate: 4000, max_height: 720},
-               600,
-               4000,
-               480
+               request(start_position: 600, max_bitrate: 4000, max_height: 480)
              )
     end
 
@@ -46,18 +40,58 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
       # Registry metadata is in-memory, but a session registered before these
       # fields existed must not be mistaken for a capped one, nor treated as
       # a wildcard that matches every request.
-      assert HlsSessionSupervisor.session_matches?(%{mode: :transcode}, 0, nil, nil)
-      refute HlsSessionSupervisor.session_matches?(%{mode: :transcode}, 0, 4000, 720)
-      refute HlsSessionSupervisor.session_matches?(%{mode: :transcode}, 4200, nil, nil)
+      assert HlsSessionSupervisor.session_matches?(%{mode: :transcode}, request())
+
+      refute HlsSessionSupervisor.session_matches?(
+               %{mode: :transcode},
+               request(max_bitrate: 4000, max_height: 720)
+             )
+
+      refute HlsSessionSupervisor.session_matches?(
+               %{mode: :transcode},
+               request(start_position: 4200)
+             )
     end
 
     test "matches an explicitly uncapped session against an uncapped request" do
       # Original quality: no cap on either side.
       assert HlsSessionSupervisor.session_matches?(
                %{start_position: 0, max_bitrate: nil, max_height: nil},
-               0,
-               nil,
-               nil
+               request()
+             )
+    end
+
+    test "does not match a different audio language" do
+      # The mapped audio track is already baked into the segments the running
+      # session has written, so a viewer switching to English cannot be handed
+      # the session still encoding Russian.
+      refute HlsSessionSupervisor.session_matches?(
+               %{start_position: 0, audio_language: ["ru"]},
+               request(audio_language: ["en"])
+             )
+    end
+
+    test "matches the same audio language" do
+      assert HlsSessionSupervisor.session_matches?(
+               %{start_position: 0, max_bitrate: nil, max_height: nil, audio_language: ["en"]},
+               request(audio_language: ["en"])
+             )
+    end
+
+    test "treats an absent and an empty audio language as the same request" do
+      # A client too old to send the field and a new one sending [] both mean
+      # "no preference of my own". Reading those as different requests would
+      # tear down and rebuild a perfectly good session on every poll.
+      assert HlsSessionSupervisor.session_matches?(
+               %{start_position: 0},
+               request(audio_language: [])
+             )
+    end
+
+    test "does not hand a language-specific request a session that had none" do
+      refute HlsSessionSupervisor.session_matches?(
+               %{start_position: 0},
+               request(audio_language: ["en"])
              )
     end
   end


### PR DESCRIPTION
Some TV shows opened in Russian. The reason is that nothing in mydia was choosing the audio track at all.

## Why it happened

Two mechanisms, neither of them the viewer's, and which one bit depended on the delivery mode.

**Direct play.** `player_screen.dart` built a bare `Player()`. mpv therefore ran with `alang` unset and fell through to whatever the container flagged `default`. Dual-language releases routinely mux the dub first and flag it, so mpv faithfully played Russian on a show whose original audio is English. Nothing called `setAudioTrack` at startup either; the only call site was the user's selector sheet.

The repo already documented this as intended. `audio_track_detection_test.dart` pins it against a real file:

```dart
/// Mirrors the real streams in `Silo.S03E03.A.Dark.Web.2160p...ENG.ITA...mkv`.
const _italian = AudioTrack('1', null, 'ita', isDefault: true);
const _english = AudioTrack('2', null, 'eng');
```

**HLS and remux.** Both ffmpeg commands were built with no `-map` at all. Without one, ffmpeg applies implicit stream selection and takes the audio stream with the **most channels**, so a 5.1 dub beats a 2.0 original. `-c copy` does not save the remux path: it copies the codec, not every stream, so ffmpeg still reduced to one stream per type. The output then physically held a single audio track, which is why the track selector had nothing to switch to.

## How the fix chooses

Selection keys on **language**, never a track index, because an index means nothing across two files and the next episode may order its tracks differently. Plex, Jellyfin and Infuse all key on language for the same reason.

`streaming.audio_language` defaults to `["original", "en"]`. The literal `"original"` resolves per title to its original language from TMDB, which is why it leads: a US series then plays English, and anime plays Japanese rather than an English dub. An operator who wants English wherever it exists sets `["en"]`; one who wants a German dub sets `["de", "original"]`.

`streaming.prefer_default_audio_track` restores the container's own flag, off by default. Jellyfin ships the same escape hatch, and it exists because a chunk of operators tag their own files and want those flags honoured.

Both settings ride the existing layered config, so they arrive as env vars, YAML, or admin-UI values with no new plumbing.

Ordering inside a language breaks toward the flagged track, then the most channels, then the earliest. Commentary tracks are set aside before any of that, since they carry the feature's own language tag and would otherwise win on a match.

## Sticky per show

Picking English on episode 3 now holds for episode 4.

This is the gap every comparable server leaves open. Plex, Jellyfin and Infuse all treat a manual pick as a per-playback override and make the viewer repeat it, which is what spawned third-party tools like Plex Auto Languages. Plex is the only one offering per-series preferences at all, and only as a manual metadata edit rather than something learned from playback.

Deliberately **not** a global learn. None of the three do that, and the reason is sound: picking Russian once for one film should not retune the whole library.

Stored in its own table rather than a key in `Accounts.UserPreference`'s map column. This grows one entry per show watched, and a map would need a read-modify-write, so two devices choosing at once could lose a write. A unique index upserts atomically instead.

## Two bugs found on the way

**The codec decision was about the wrong stream.** `media_file.audio_codec` describes the *first* audio stream. On a file whose first track is stereo AAC and whose second is 5.1 DTS, the transcoder decided "aac, so copy" from the first while ffmpeg encoded the second, putting a DTS stream in an HLS segment no browser can decode. Silent audio, no error. Now that a stream is chosen deliberately this would have got worse, so the decision reads the selected stream's codec.

**`tvdb_candidates/1` could not match a German or French track.** Matroska writes ISO 639-2/B codes: `"ger"` and `"fre"`, where the /T variants are `"deu"` and `"fra"`. The existing table held only /T, and only for the ten languages the metadata config offers. `LanguageCode.matches?/2` adds a bidirectional table covering both variants.

## Cross-version behaviour

`preferredAudioLanguages` is nullable and an absent value means "no opinion", so a newer player against an older server keeps mpv's existing selection rather than failing. `setAudioLanguagePreference` on an older server returns a GraphQL validation error, which the player swallows: the track it just switched has already changed, and only the memory of it is lost.

The Rust server returns `not_implemented` for the mutation and `None` for the field, matching its other streaming mutations. `MediaFileRow` stops at one flat `audio_codec` and carries no per-stream languages, so answering properly is separate work. The type and field exist there because `sdl_parity` gates on structure and a query naming an absent field fails whole.

## From review

Eleven findings, all real, all fixed. Three of them mattered:

- **The list handed to mpv was in the wrong alphabet.** `resolved_languages/2` resolved the `"original"` sentinel but never expanded through the equivalents table, so an anime item produced `alang=ja,en` while its tracks are tagged `jpn`/`eng`. mpv only gained lenient 639-1↔639-2 matching in 0.36; on anything older every entry misses and mpv falls back to the container `default` flag, which is the dub. The client-side half of this fix would have been inert depending on which libmpv the player happened to bundle. Now expanded server-side, so it does not depend on that.
- **Remux could ship a codec the client never approved.** The REMUX strategy is chosen from `media_file.audio_codec`, the first audio stream. Map a different one and `-c copy` puts, say, AC3 into the fMP4 while the advertised MIME still says `mp4a.40.2`. The audio for that stream is now encoded to AAC while the video stays copied.
- **Two REST paths started sessions without the preference,** and since `show_audio_language` is a `session_matches?/2` discriminator, they did worse than ignore it: they failed to match a running session that had one and tore down a live encode to start an identical replacement without it. All four entry points now go through `AudioPreferences.session_opts/2`.

The rest: the remux and direct-play controller kept the flat `:episode` preload, so `"original"` silently resolved to nothing for TV on those paths while HLS honoured it; the remux call and the REST candidates endpoint never received the viewer, so a stored per-show choice did not reach either; `-map` was mandatory, meaning a stale index from a file replaced without re-analysis aborted ffmpeg outright where it used to play, now optional so it degrades instead; `@type remux_opts` had not grown the new keys, which breaks the spec under Dialyzer; the player overwrote a remembered language with `const []` whenever a candidates call failed, discarding the previous episode's choice on exactly the fall-through where it needed to survive; and two comments promised behaviour the code did not have (`AUDIO_LANGUAGE=` empty is a no-op, not "no preference", and the blank-entry validation is unreachable from the env path the comment cited).

## Not included

The **per-device override**. The `:device` level exists inside `resolve_preferences/1`, but it has no GraphQL entry point and no player settings screen, so a store for it would be unreachable today. Server config and per-show sticky both work end to end without it.

## Testing

- Elixir: 7743 tests, 0 failures
- Player: 2252 tests, 0 failures
- `sdl_parity` passes; `flutter analyze` clean

`AudioTrackSelector` has 27 unit tests covering the reported shape directly (Russian flagged default, English second), the `"original"` sentinel, commentary exclusion, ISO 639-2/B matching, and every fallback. The ffmpeg tests assert the emitted `-map` arguments on both the transcode and remux paths, including that an unanalysed file emits none at all so it keeps playing exactly as before.

Adding a field to the `StreamingCandidates` document failed 22 player tests that never mention audio: graphql's normalizer rejects a partial object outright, so the shared harness had to carry it. Noted here because it will catch the next person too.
