### PR TITLE
fix(downloads): stop job cancel from deleting source media, hide original badges

### DIFF
--- a/lib/mydia/downloads/transcoding.ex
+++ b/lib/mydia/downloads/transcoding.ex
@@ -6,6 +6,7 @@ defmodule Mydia.Downloads.Transcoding do
 
   alias Mydia.Repo
   alias Mydia.Downloads.TranscodeJob
+  alias Mydia.Library.MediaFile
   alias Phoenix.PubSub
   require Logger
 
@@ -202,9 +203,7 @@ defmodule Mydia.Downloads.Transcoding do
     Repo.delete(job)
 
     # Clean up output file if it exists (only for downloads)
-    if job.output_path && File.exists?(job.output_path) do
-      File.rm(job.output_path)
-    end
+    maybe_remove_output_file(job)
 
     broadcast_job_update(job.id)
     {:ok, job}
@@ -224,6 +223,41 @@ defmodule Mydia.Downloads.Transcoding do
   end
 
   ## Private Functions
+
+  # An "original" download transcodes nothing, so complete_job/3 records the
+  # library file itself as the output path. Unlinking that would delete the
+  # user's media, so only artifacts we produced are removed.
+  defp maybe_remove_output_file(%TranscodeJob{output_path: nil}), do: :ok
+
+  defp maybe_remove_output_file(%TranscodeJob{output_path: output_path} = job) do
+    cond do
+      output_path in source_file_paths(job) ->
+        Logger.debug("Keeping #{output_path} on cancel: it is the source file, not a transcode")
+
+      File.exists?(output_path) ->
+        File.rm(output_path)
+
+      true ->
+        :ok
+    end
+
+    :ok
+  end
+
+  defp source_file_paths(%TranscodeJob{media_file_id: nil}), do: []
+
+  defp source_file_paths(%TranscodeJob{media_file_id: media_file_id}) do
+    case Repo.get(MediaFile, media_file_id) do
+      nil ->
+        []
+
+      media_file ->
+        media_file = Repo.preload(media_file, :library_path)
+
+        [MediaFile.absolute_path(media_file), media_file.path]
+        |> Enum.reject(&is_nil/1)
+    end
+  end
 
   defp maybe_filter_status(query, nil), do: query
 

--- a/lib/mydia_web/live/media_live/show/loaders.ex
+++ b/lib/mydia_web/live/media_live/show/loaders.ex
@@ -86,6 +86,10 @@ defmodule MydiaWeb.MediaLive.Show.Loaders do
 
   # Load transcode jobs for all media files in a media item
   # Returns a map of media_file_id => list of transcode jobs
+  #
+  # "original" jobs are dropped: they carry no transcoded rendition (the source
+  # file is served as-is), so surfacing them would only report that someone once
+  # downloaded the file.
   def load_transcode_jobs(media_item) do
     episode_files = Enum.flat_map(media_item.episodes || [], & &1.media_files)
     all_files = media_item.media_files ++ episode_files
@@ -94,6 +98,7 @@ defmodule MydiaWeb.MediaLive.Show.Loaders do
     |> Enum.flat_map(fn media_file ->
       Downloads.list_transcode_jobs_for_media_file(media_file.id)
     end)
+    |> Enum.reject(&(&1.resolution == "original"))
     |> Enum.group_by(& &1.media_file_id)
   end
 

--- a/test/mydia/downloads/transcode_job_test.exs
+++ b/test/mydia/downloads/transcode_job_test.exs
@@ -345,6 +345,60 @@ defmodule Mydia.Downloads.TranscodeJobTest do
     end
   end
 
+  describe "Downloads.cancel_transcode_job/1 output file cleanup" do
+    setup do
+      tmp_dir = Path.join(System.tmp_dir!(), "mydia-cancel-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      library = insert(:library_path, type: :movies, path: tmp_dir)
+      media_item = insert(:media_item, type: "movie")
+
+      media_file =
+        insert(:media_file,
+          media_item: media_item,
+          library_path: library,
+          relative_path: "movie.mkv",
+          size: 1_000_000_000
+        )
+
+      source_path = Path.join(tmp_dir, "movie.mkv")
+      File.write!(source_path, "source bytes")
+
+      %{media_file: media_file, source_path: source_path, tmp_dir: tmp_dir}
+    end
+
+    test "keeps the source file when the job output is the media file itself", %{
+      media_file: media_file,
+      source_path: source_path
+    } do
+      # An "original" download transcodes nothing, so complete_job/3 records the
+      # library file itself as the output.
+      {:ok, job} = Downloads.get_or_create_job(media_file.id, "original")
+      {:ok, job} = Downloads.complete_job(job, source_path, 12)
+
+      {:ok, _cancelled} = Downloads.cancel_transcode_job(job)
+
+      assert File.exists?(source_path)
+      assert Repo.get(TranscodeJob, job.id) == nil
+    end
+
+    test "removes a transcoded artifact that is not the source file", %{
+      media_file: media_file,
+      tmp_dir: tmp_dir
+    } do
+      artifact_path = Path.join(tmp_dir, "transcode-720p.mp4")
+      File.write!(artifact_path, "transcoded bytes")
+
+      {:ok, job} = Downloads.get_or_create_job(media_file.id, "720p")
+      {:ok, job} = Downloads.complete_job(job, artifact_path, 12)
+
+      {:ok, _cancelled} = Downloads.cancel_transcode_job(job)
+
+      refute File.exists?(artifact_path)
+    end
+  end
+
   describe "unique constraint" do
     setup do
       library = insert(:library_path, type: :movies)

--- a/test/mydia_web/live/media_live/show/loaders_transcode_jobs_test.exs
+++ b/test/mydia_web/live/media_live/show/loaders_transcode_jobs_test.exs
@@ -1,0 +1,45 @@
+defmodule MydiaWeb.MediaLive.Show.LoadersTranscodeJobsTest do
+  use Mydia.DataCase
+
+  alias Mydia.Downloads
+  alias MydiaWeb.MediaLive.Show.Loaders
+
+  describe "load_transcode_jobs/1" do
+    setup do
+      library = insert(:library_path, type: :series)
+      show = insert(:tv_show)
+      episode = insert(:episode, media_item: show)
+
+      media_file =
+        insert(:media_file,
+          episode: episode,
+          library_path: library,
+          relative_path: "s01e01.mkv"
+        )
+
+      media_item = Repo.preload(show, [:media_files, episodes: :media_files])
+
+      %{media_item: media_item, media_file: media_file}
+    end
+
+    test "omits original download jobs, which have no transcoded artifact", %{
+      media_item: media_item,
+      media_file: media_file
+    } do
+      {:ok, _job} = Downloads.get_or_create_job(media_file.id, "original")
+
+      assert Loaders.load_transcode_jobs(media_item) == %{}
+    end
+
+    test "keeps download jobs for transcoded resolutions", %{
+      media_item: media_item,
+      media_file: media_file
+    } do
+      {:ok, job} = Downloads.get_or_create_job(media_file.id, "720p")
+      file_id = media_file.id
+
+      assert %{^file_id => [loaded]} = Loaders.load_transcode_jobs(media_item)
+      assert loaded.id == job.id
+    end
+  end
+end


### PR DESCRIPTION
## What

Two fixes with one root cause: an "original" download job is not a transcode.

`DownloadService.prepare/3` completes an Original job immediately and records the **library file itself** as `output_path` (nothing is re-encoded, the source is served as-is).

### 1. Cancelling such a job deleted the user's media

`cancel_transcode_job/1` deleted the row and then unlinked `output_path`, which for an Original job is the file in the library. Reachable through `DELETE /api/v1/download/job/:job_id` and the `cancelDownloadJob` mutation; `delete_all_completed_jobs/0` would sweep every such file at once if it were ever wired to a button.

Not reachable from the player today, since an Original prepare returns `ready` and the task is stored with `isProgressive: false`, so the client-side cancel never calls the server. The LiveView badge also only offers cancel for `pending`/`transcoding`.

Cleanup now skips any path matching the media file's `absolute_path` or its legacy `path` column. Streaming and direct-play jobs never set `output_path`, so they short-circuit with no extra query.

### 2. The `original` badge under each file was noise

It named no rendition. It only recorded that someone once downloaded that file, and since nothing removes these rows it persisted forever. `load_transcode_jobs/1` now drops them, which clears the badge from both the episode file rows and the movie Media Files section.

`list_transcode_jobs_for_media_file/1` is deliberately unchanged: `calculate_quality_options/1` still needs the Original job to report its status in the player's download sheet.

## Tests

Written first, both failed for the right reason. The cancel test literally deleted the source file on the red run.

- `transcode_job_test.exs`: source file survives cancel; a real transcode artifact is still removed.
- `loaders_transcode_jobs_test.exs`: original excluded, 720p retained.

Full suite: 7707 tests, 0 failures.