### PR TITLE
chore(review): pin CodeRabbit auto-review config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://www.coderabbit.ai/integrations/schema.v2.json
+#
+# Anything not set here keeps CodeRabbit's defaults: chill profile, drafts
+# skipped, findings advisory rather than merge-blocking.
+reviews:
+  auto_review:
+    enabled: true
+
+    # PRs targeting master were silently skipped with "auto reviews are disabled
+    # on base/target branches other than the default branch" (PR #451), even
+    # though master is this repo's default branch. Pinning it here keeps review
+    # coverage in the repo instead of a dashboard setting nobody can diff.
+    base_branches: [".*"]
+
+    # Default is 5, which pauses incremental review after five reviewed commits.
+    # PRs here routinely iterate past that, and those later commits are exactly
+    # the ones that would otherwise go unreviewed.
+    auto_pause_after_reviewed_commits: 0


### PR DESCRIPTION
CodeRabbit was skipping PRs with "auto reviews are disabled on base/target branches other than the default branch", even on PRs targeting `master`, which the GitHub API confirms is this repo's default branch (seen on #451). The behavior was coming from dashboard settings, which are invisible in code review and cannot be diffed, so this pins it in the repo.

Two non-default settings, both validated against CodeRabbit's live `schema.v2.json`:

- `base_branches: [".*"]` (default `[]`) so no PR is skipped for its target branch, including stacked PRs onto feature branches.
- `auto_pause_after_reviewed_commits: 0` (default `5`) so incremental review does not stop partway through a PR. PRs here regularly iterate past five commits, and those later commits are exactly the ones that would go unreviewed.

Everything else stays on CodeRabbit defaults: chill profile, drafts skipped, findings advisory rather than merge-blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated code reviews for all base branches.
  * Configured reviews to continue beyond five reviewed commits.
  * Added configuration metadata and explanatory guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->