### PR TITLE
feat: TMDB recommendations rail on the detail page and Discover modal

### DIFF
--- a/lib/mydia/media/recommendations.ex
+++ b/lib/mydia/media/recommendations.ex
@@ -54,9 +54,31 @@ defmodule Mydia.Media.Recommendations do
   def for_tmdb_id(nil, _media_type, _config), do: :none
 
   def for_tmdb_id(tmdb_id, media_type, config) when media_type in [:movie, :tv_show] do
+    case normalize_tmdb_id(tmdb_id) do
+      {:ok, tmdb_id} -> fetch(tmdb_id, media_type, config)
+      :error -> :none
+    end
+  end
+
+  def for_tmdb_id(_tmdb_id, _media_type, _config), do: :none
+
+  # `""` and `"abc"` would otherwise be interpolated straight into a relay path
+  # and spend a request to learn what the shape already tells us.
+  defp normalize_tmdb_id(id) when is_integer(id) and id > 0, do: {:ok, to_string(id)}
+
+  defp normalize_tmdb_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {parsed, ""} when parsed > 0 -> {:ok, to_string(parsed)}
+      _ -> :error
+    end
+  end
+
+  defp normalize_tmdb_id(_), do: :error
+
+  defp fetch(tmdb_id, media_type, config) do
     config = config || Metadata.default_relay_config()
 
-    case Metadata.fetch_recommendations_cached(config, to_string(tmdb_id), media_type: media_type) do
+    case Metadata.fetch_recommendations_cached(config, tmdb_id, media_type: media_type) do
       {:ok, []} ->
         :none
 
@@ -71,6 +93,4 @@ defmodule Mydia.Media.Recommendations do
         :none
     end
   end
-
-  def for_tmdb_id(_tmdb_id, _media_type, _config), do: :none
 end

--- a/lib/mydia/media/recommendations.ex
+++ b/lib/mydia/media/recommendations.ex
@@ -1,0 +1,76 @@
+defmodule Mydia.Media.Recommendations do
+  @moduledoc """
+  Resolves TMDB's recommendations for a title.
+
+  Serves two surfaces with different inputs: the library detail page, which has a
+  `MediaItem` row, and the Discover modal, which has only a TMDB id and a type
+  because the title is not in the library.
+
+  Every outcome that is not a non-empty list collapses to `:none` — no tmdb_id,
+  an unsupported media type, an empty result, a relay error. The rail is meant to
+  be silently absent whenever the lookup does not work out, so the caller has
+  exactly one thing to check.
+
+  Results are deliberately **not** joined against the library here. That join
+  needs `MydiaWeb.Live.Helpers.MediaAddHelpers`, and a context under `Mydia.*`
+  must not depend on the web layer, so the LiveViews enrich what they render.
+  """
+
+  require Logger
+
+  alias Mydia.Media.MediaItem
+  alias Mydia.Metadata
+  alias Mydia.Metadata.Structs.SearchResult
+
+  @media_types %{"movie" => :movie, "tv_show" => :tv_show}
+
+  @doc """
+  Returns recommendations for a library item, or `:none`.
+
+  `config` is the relay configuration; it defaults to
+  `Metadata.default_relay_config/0` and exists so tests can inject a stub without
+  touching global environment.
+  """
+  @spec for_media_item(MediaItem.t(), map() | nil) :: {:ok, [SearchResult.t()]} | :none
+  def for_media_item(media_item, config \\ nil)
+
+  def for_media_item(%MediaItem{type: type, tmdb_id: tmdb_id}, config)
+      when is_integer(tmdb_id) and is_map_key(@media_types, type) do
+    for_tmdb_id(tmdb_id, Map.fetch!(@media_types, type), config)
+  end
+
+  def for_media_item(_media_item, _config), do: :none
+
+  @doc """
+  Returns recommendations for a bare TMDB id, or `:none`.
+
+  This is the entry point for the Discover modal, where the title has no
+  `MediaItem` row because it is not in the library.
+  """
+  @spec for_tmdb_id(integer() | String.t() | nil, :movie | :tv_show, map() | nil) ::
+          {:ok, [SearchResult.t()]} | :none
+  def for_tmdb_id(tmdb_id, media_type, config \\ nil)
+
+  def for_tmdb_id(nil, _media_type, _config), do: :none
+
+  def for_tmdb_id(tmdb_id, media_type, config) when media_type in [:movie, :tv_show] do
+    config = config || Metadata.default_relay_config()
+
+    case Metadata.fetch_recommendations_cached(config, to_string(tmdb_id), media_type: media_type) do
+      {:ok, []} ->
+        :none
+
+      {:ok, results} when is_list(results) ->
+        {:ok, results}
+
+      {:error, reason} ->
+        Logger.warning(
+          "Recommendations lookup failed for tmdb #{tmdb_id} (#{media_type}): #{inspect(reason)}"
+        )
+
+        :none
+    end
+  end
+
+  def for_tmdb_id(_tmdb_id, _media_type, _config), do: :none
+end

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -14,7 +14,7 @@ defmodule Mydia.Metadata do
 
   To search for media:
 
-      config = %{type: :metadata_relay, base_url: "https://metadata-relay.dorninger.co/tmdb"}
+      config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
       Mydia.Metadata.search(config, "The Matrix", media_type: :movie)
 
   ## Fetching Metadata
@@ -51,7 +51,7 @@ defmodule Mydia.Metadata do
   ## Registered Providers
 
   Currently supported providers:
-    - `:metadata_relay` - metadata-relay.dorninger.co proxy service (recommended)
+    - `:metadata_relay` - metadata-relay proxy service (recommended)
     - `:tmdb` - The Movie Database API (when implemented)
     - `:tvdb` - The TV Database API (when implemented)
   """
@@ -79,7 +79,7 @@ defmodule Mydia.Metadata do
 
   ## Examples
 
-      iex> config = %{type: :metadata_relay, base_url: "https://metadata-relay.dorninger.co/tmdb"}
+      iex> config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
       iex> Mydia.Metadata.test_connection(config)
       {:ok, %{status: "ok", provider: "metadata_relay"}}
   """
@@ -105,7 +105,7 @@ defmodule Mydia.Metadata do
 
   ## Examples
 
-      iex> config = %{type: :metadata_relay, base_url: "https://metadata-relay.dorninger.co/tmdb"}
+      iex> config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
       iex> Mydia.Metadata.search(config, "The Matrix", media_type: :movie, year: 1999)
       {:ok, [%{provider_id: "603", title: "The Matrix", ...}]}
   """
@@ -136,7 +136,7 @@ defmodule Mydia.Metadata do
 
   ## Examples
 
-      iex> config = %{type: :metadata_relay, base_url: "https://metadata-relay.dorninger.co/tmdb"}
+      iex> config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
       iex> Mydia.Metadata.search_cached(config, "The Matrix", media_type: :movie, year: 1999)
       {:ok, [%{provider_id: "603", title: "The Matrix", ...}]}
   """
@@ -183,7 +183,7 @@ defmodule Mydia.Metadata do
 
   ## Examples
 
-      iex> config = %{type: :metadata_relay, base_url: "https://metadata-relay.dorninger.co/tmdb"}
+      iex> config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
       iex> Mydia.Metadata.fetch_by_id(config, "603", media_type: :movie)
       {:ok, %{provider_id: "603", title: "The Matrix", runtime: 136, ...}}
   """
@@ -342,7 +342,7 @@ defmodule Mydia.Metadata do
 
   ## Examples
 
-      iex> config = %{type: :metadata_relay, base_url: "https://metadata-relay.dorninger.co/tmdb"}
+      iex> config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
       iex> Mydia.Metadata.fetch_images(config, "603", media_type: :movie)
       {:ok, %{posters: [...], backdrops: [...], logos: [...]}}
   """
@@ -366,7 +366,7 @@ defmodule Mydia.Metadata do
 
   ## Examples
 
-      iex> config = %{type: :metadata_relay, base_url: "https://metadata-relay.dorninger.co/tmdb"}
+      iex> config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
       iex> Mydia.Metadata.fetch_season(config, "1396", 1)
       {:ok, %{season_number: 1, episodes: [...], ...}}
   """
@@ -396,7 +396,7 @@ defmodule Mydia.Metadata do
 
   ## Examples
 
-      iex> config = %{type: :metadata_relay, base_url: "https://metadata-relay.dorninger.co/tmdb"}
+      iex> config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
       iex> Mydia.Metadata.fetch_season_cached(config, "1396", 1)
       {:ok, %{season_number: 1, episodes: [...], ...}}
   """
@@ -581,7 +581,7 @@ defmodule Mydia.Metadata do
 
   ## Examples
 
-      iex> config = %{type: :metadata_relay, base_url: "https://metadata-relay.dorninger.co"}
+      iex> config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
       iex> Mydia.Metadata.fetch_trending(config, media_type: :movie)
       {:ok, [%{provider_id: "603", title: "Trending Movie", ...}]}
   """

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -282,6 +282,52 @@ defmodule Mydia.Metadata do
   end
 
   @doc """
+  Fetches TMDB recommendations for a title, cached in ETS for 24 hours.
+
+  Relay-only, for the same reason as `fetch_collection_cached/3`: the other
+  registered provider types (`:music_relay`, `:open_library`) have no equivalent
+  concept, so routing them to the relay adapter would cache a response under a key
+  naming a provider that never served it.
+
+  The language is part of the key so a non-English library never reads
+  English-cached entries. The media type is part of the key because TMDB movie and
+  TV ids overlap numerically.
+
+  24 hours matches `fetch_collection_cached/3`. TMDB recommendations shift over
+  weeks, and the relay caches upstream as well.
+
+  ## Examples
+
+      iex> config = Mydia.Metadata.default_relay_config()
+      iex> Mydia.Metadata.fetch_recommendations_cached(config, "965150", media_type: :movie)
+      {:ok, [%Mydia.Metadata.Structs.SearchResult{}]}
+  """
+  def fetch_recommendations_cached(config, provider_id, opts \\ [])
+
+  def fetch_recommendations_cached(%{type: :metadata_relay} = config, provider_id, opts) do
+    alias Mydia.Metadata.Cache
+    alias Mydia.Metadata.Provider.Relay
+
+    media_type = Keyword.get(opts, :media_type, :movie)
+    language = Keyword.get(opts, :language, config_language(config))
+
+    cache_key = "recommendations:metadata_relay:#{provider_id}:#{media_type}:#{language}"
+
+    Cache.fetch(
+      cache_key,
+      fn -> Relay.fetch_recommendations(config, provider_id, opts) end,
+      ttl: :timer.hours(24)
+    )
+  end
+
+  def fetch_recommendations_cached(%{type: type}, _provider_id, _opts) when is_atom(type) do
+    {:error,
+     Provider.Error.invalid_config(
+       "Recommendations are only available through the metadata relay, got: #{inspect(type)}"
+     )}
+  end
+
+  @doc """
   Fetches images for a specific media item.
 
   ## Parameters

--- a/lib/mydia/metadata/provider/relay.ex
+++ b/lib/mydia/metadata/provider/relay.ex
@@ -953,6 +953,56 @@ defmodule Mydia.Metadata.Provider.Relay do
   end
 
   @doc """
+  Fetches TMDB's recommendations for a movie or TV show.
+
+  TMDB exposes recommendations as a sub-object of the details endpoint rather than
+  as a standalone route the relay proxies, so this rides `append_to_response` on
+  the endpoint the relay already serves. That is what lets the feature ship
+  without a relay release.
+
+  The sub-object uses the same `%{"results" => [...]}` envelope as search and
+  trending, so `parse_search_results/2` consumes it unchanged. A response with no
+  `recommendations` key falls through that function's catch-all to `[]`, which is
+  why a missing sub-object is a normal empty result rather than an error.
+
+  ## Options
+    * `:media_type` - `:movie` or `:tv_show` (default: `:movie`)
+    * `:language` - overrides the configured language
+
+  ## Examples
+
+      iex> config = %{type: :metadata_relay, base_url: "https://relay.mydia.dev"}
+      iex> Relay.fetch_recommendations(config, "965150", media_type: :movie)
+      {:ok, [%Mydia.Metadata.Structs.SearchResult{title: "The Eternal Daughter"}]}
+  """
+  @spec fetch_recommendations(map(), String.t(), keyword()) ::
+          {:ok, [SearchResult.t()]} | {:error, Error.t()}
+  def fetch_recommendations(config, provider_id, opts \\ []) do
+    media_type = Keyword.get(opts, :media_type, :movie)
+    language = resolve_language(config, opts)
+
+    endpoint = build_details_endpoint(media_type, provider_id)
+    params = [language: language, append_to_response: "recommendations"]
+
+    req = HTTP.new_request(config)
+
+    case HTTP.get(req, endpoint, params: params) do
+      {:ok, %{status: 200, body: body}} ->
+        {:ok, parse_search_results(body["recommendations"], media_type)}
+
+      {:ok, %{status: 404}} ->
+        {:error, Error.not_found("Media not found: #{provider_id}")}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error,
+         Error.api_error("Fetch recommendations failed with status #{status}", %{body: body})}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @doc """
   Fetches the list of genres for a media type.
 
   Returns `{:ok, [%{id: integer, name: string}]}`.

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -33,6 +33,8 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :adding_item_id, :string, default: nil
   attr :requesting_item_id, :string, default: nil
   attr :libraries, :list, default: []
+  attr :on_select, :string, default: "show_details"
+  attr :navigate, :string, default: nil
 
   def trending_card(assigns) do
     ~H"""
@@ -58,27 +60,27 @@ defmodule MydiaWeb.DiscoverComponents do
           <% end %>
         </div>
       <% end %>
-      <figure
-        class="aspect-[2/3] bg-base-300 cursor-pointer"
-        phx-click="show_details"
-        phx-value-id={@item.provider_id}
-        phx-value-type={@media_type}
-      >
-        <%= if @item.poster_path do %>
-          <img
-            src={ImageUrl.poster_url(@item.poster_path)}
-            alt={@item.title}
-            class="w-full h-full object-cover"
-          />
-        <% else %>
-          <div class="flex items-center justify-center w-full h-full">
-            <.icon
-              name={if(@media_type == :movie, do: "hero-film", else: "hero-tv")}
-              class="w-16 h-16 text-base-content/20"
-            />
-          </div>
-        <% end %>
-      </figure>
+      <%= cond do %>
+        <% @navigate -> %>
+          <.link navigate={@navigate} class="block">
+            <figure class="aspect-[2/3] bg-base-300 cursor-pointer">
+              <.card_poster item={@item} media_type={@media_type} />
+            </figure>
+          </.link>
+        <% @on_select -> %>
+          <figure
+            class="aspect-[2/3] bg-base-300 cursor-pointer"
+            phx-click={@on_select}
+            phx-value-id={@item.provider_id}
+            phx-value-type={@media_type}
+          >
+            <.card_poster item={@item} media_type={@media_type} />
+          </figure>
+        <% true -> %>
+          <figure class="aspect-[2/3] bg-base-300">
+            <.card_poster item={@item} media_type={@media_type} />
+          </figure>
+      <% end %>
       <div class="card-body p-3">
         <h3 class="font-semibold text-sm line-clamp-2" title={@item.title}>
           {@item.title}
@@ -94,6 +96,51 @@ defmodule MydiaWeb.DiscoverComponents do
           requesting_item_id={@requesting_item_id}
           libraries={@libraries}
         />
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a horizontal strip of recommended titles.
+
+  Reuses `trending_card/1` so an owned title carries the same badge and an unowned
+  one the same add-or-request action as it would on the Discover grid. The strip
+  renders nothing at all when `items` is empty, which is the designed behaviour for
+  a title TMDB has no recommendations for.
+
+  An item may carry a `:navigate` key. When it does, that card's poster becomes a
+  link instead of a click target, which is how an owned title on the media detail
+  page reaches its own page from a LiveView that has no `show_details` handler.
+  """
+  attr :items, :list, required: true
+  attr :media_type, :atom, required: true
+  attr :current_user, :map, required: true
+  attr :adding_item_id, :string, default: nil
+  attr :requesting_item_id, :string, default: nil
+  attr :libraries, :list, default: []
+  attr :id, :string, default: "recommendations-rail"
+  attr :title, :string, default: "More like this"
+  attr :on_select, :string, default: "show_details"
+
+  def recommendations_rail(assigns) do
+    ~H"""
+    <div :if={@items != []} id={@id} class="mb-6 md:mb-8">
+      <h2 class="text-lg md:text-xl font-semibold mb-3">{@title}</h2>
+
+      <div class="flex gap-3 overflow-x-auto snap-x scroll-smooth pb-2">
+        <div :for={item <- @items} class="snap-start flex-shrink-0 w-36">
+          <.trending_card
+            item={item}
+            media_type={@media_type}
+            current_user={@current_user}
+            adding_item_id={@adding_item_id}
+            requesting_item_id={@requesting_item_id}
+            libraries={@libraries}
+            on_select={@on_select}
+            navigate={Map.get(item, :navigate)}
+          />
+        </div>
       </div>
     </div>
     """
@@ -165,4 +212,26 @@ defmodule MydiaWeb.DiscoverComponents do
 
   defp library_path(:movie, id), do: "/movies/#{id}"
   defp library_path(:tv_show, id), do: "/tv/#{id}"
+
+  attr :item, :map, required: true
+  attr :media_type, :atom, required: true
+
+  defp card_poster(assigns) do
+    ~H"""
+    <%= if @item.poster_path do %>
+      <img
+        src={ImageUrl.poster_url(@item.poster_path)}
+        alt={@item.title}
+        class="w-full h-full object-cover"
+      />
+    <% else %>
+      <div class="flex items-center justify-center w-full h-full">
+        <.icon
+          name={if(@media_type == :movie, do: "hero-film", else: "hero-tv")}
+          class="w-16 h-16 text-base-content/20"
+        />
+      </div>
+    <% end %>
+    """
+  end
 end

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -33,7 +33,11 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :adding_item_id, :string, default: nil
   attr :requesting_item_id, :string, default: nil
   attr :libraries, :list, default: []
-  attr :on_select, :string, default: "show_details"
+  # :any rather than :string because nil is a meaningful value here: it renders
+  # an inert poster, which is what a LiveView with no select handler needs.
+  # Typing this :string makes `on_select={nil}` a compile error under
+  # --warnings-as-errors.
+  attr :on_select, :any, default: "show_details"
   attr :navigate, :string, default: nil
 
   def trending_card(assigns) do
@@ -121,7 +125,9 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :libraries, :list, default: []
   attr :id, :string, default: "recommendations-rail"
   attr :title, :string, default: "More like this"
-  attr :on_select, :string, default: "show_details"
+  # :any, not :string — see the note on trending_card/1. The media detail page
+  # passes nil here because it has no show_details handler.
+  attr :on_select, :any, default: "show_details"
 
   def recommendations_rail(assigns) do
     ~H"""

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -39,6 +39,14 @@ defmodule MydiaWeb.DiscoverComponents do
   # --warnings-as-errors.
   attr :on_select, :any, default: "show_details"
   attr :navigate, :string, default: nil
+  # The action buttons are the card's event contract with its host LiveView.
+  # Discover handles "add_to_library"/"request_media", so those stay the
+  # defaults, but a host with different handlers must be able to say so:
+  # emitting an event the host does not handle raises FunctionClauseError and
+  # kills the LiveView process on the very first click.
+  attr :add_event, :string, default: "add_to_library"
+  attr :request_event, :string, default: "request_media"
+  attr :can_add, :boolean, default: true
 
   def trending_card(assigns) do
     ~H"""
@@ -99,6 +107,9 @@ defmodule MydiaWeb.DiscoverComponents do
           adding_item_id={@adding_item_id}
           requesting_item_id={@requesting_item_id}
           libraries={@libraries}
+          add_event={@add_event}
+          request_event={@request_event}
+          can_add={@can_add}
         />
       </div>
     </div>
@@ -128,6 +139,12 @@ defmodule MydiaWeb.DiscoverComponents do
   # :any, not :string — see the note on trending_card/1. The media detail page
   # passes nil here because it has no show_details handler.
   attr :on_select, :any, default: "show_details"
+  # Forwarded to trending_card/1. A host LiveView that does not handle
+  # "add_to_library"/"request_media" must override these or the first click on
+  # an unowned card crashes it.
+  attr :add_event, :string, default: "add_to_library"
+  attr :request_event, :string, default: "request_media"
+  attr :can_add, :boolean, default: true
 
   def recommendations_rail(assigns) do
     ~H"""
@@ -145,6 +162,9 @@ defmodule MydiaWeb.DiscoverComponents do
             libraries={@libraries}
             on_select={@on_select}
             navigate={Map.get(item, :navigate)}
+            add_event={@add_event}
+            request_event={@request_event}
+            can_add={@can_add}
           />
         </div>
       </div>
@@ -158,13 +178,16 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :adding_item_id, :string, default: nil
   attr :requesting_item_id, :string, default: nil
   attr :libraries, :list, default: []
+  attr :add_event, :string, default: "add_to_library"
+  attr :request_event, :string, default: "request_media"
+  attr :can_add, :boolean, default: true
 
   defp trending_card_action(assigns) do
     ~H"""
-    <%= if not @item.in_library do %>
-      <%= if @current_user && @current_user.role == "guest" do %>
+    <%= if not @item.in_library and (@can_add or guest?(@current_user)) do %>
+      <%= if guest?(@current_user) do %>
         <button
-          phx-click="request_media"
+          phx-click={@request_event}
           phx-value-tmdb_id={@item.provider_id}
           phx-value-media_type={@media_type}
           disabled={requested?(@item) or requesting?(@item, @requesting_item_id)}
@@ -182,7 +205,7 @@ defmodule MydiaWeb.DiscoverComponents do
       <% else %>
         <div class="join w-full mt-2">
           <button
-            phx-click="add_to_library"
+            phx-click={@add_event}
             phx-value-tmdb_id={@item.provider_id}
             phx-value-media_type={@media_type}
             disabled={@adding_item_id == to_string(@item.provider_id)}
@@ -196,7 +219,7 @@ defmodule MydiaWeb.DiscoverComponents do
           </button>
           <LibraryComponents.library_picker_menu
             libraries={@libraries}
-            event="add_to_library"
+            event={@add_event}
             tmdb_id={@item.provider_id}
             media_type={@media_type}
           />
@@ -210,6 +233,11 @@ defmodule MydiaWeb.DiscoverComponents do
     <% end %>
     """
   end
+
+  # A guest requests rather than adds, so the guest branch is gated on the
+  # request permission, not on `can_add`.
+  defp guest?(%{role: "guest"}), do: true
+  defp guest?(_), do: false
 
   defp requested?(item), do: Map.get(item, :request_status) != nil
 

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -166,6 +166,13 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
             <% end %>
           </div>
 
+          <%!-- Optional trailing content, e.g. a recommendations rail. Rendered
+               inside the modal box so it scrolls with the body; a rail placed
+               beside the <dialog> would sit behind the backdrop. --%>
+          <div :if={@rail != []} class="px-4 md:px-6 pb-4">
+            {render_slot(@rail)}
+          </div>
+
           <%!-- Footer actions --%>
           <div class="p-4 md:p-6 border-t border-base-300 bg-base-100 flex justify-end gap-2">
             <button class="btn btn-ghost" phx-click="close_details">
@@ -229,7 +236,9 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
      |> assign_new(:open, fn -> false end)
      |> assign_new(:loading, fn -> false end)
      |> assign_new(:metadata, fn -> nil end)
-     |> assign_new(:libraries, fn -> [] end)}
+     |> assign_new(:libraries, fn -> [] end)
+     # Optional slot: the dashboard renders this modal without one.
+     |> assign_new(:rail, fn -> [] end)}
   end
 
   # Helper functions for accessing data from either SearchResult (item) or MediaMetadata

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -6,6 +6,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
   require Logger
 
   alias Mydia.Media
+  alias Mydia.Media.Recommendations
   alias Mydia.Metadata
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
@@ -53,6 +54,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
       |> assign(:request_status_map, %{})
       |> assign(:selected_item, nil)
       |> assign(:selected_metadata, nil)
+      |> assign(:selected_recommendations, [])
       |> assign(:load_error, nil)
       |> assign(:detail_loading, false)
       |> assign(:libraries, [])
@@ -242,13 +244,20 @@ defmodule MydiaWeb.DiscoverLive.Index do
 
   def handle_event("show_details", %{"id" => id, "type" => type}, socket) do
     with {:ok, media_type} <- parse_event_media_type(type),
-         item when not is_nil(item) <- Enum.find(socket.assigns.items, &(&1.provider_id == id)) do
+         item when not is_nil(item) <-
+           find_selectable_item(
+             socket.assigns.items,
+             socket.assigns.selected_recommendations,
+             id
+           ) do
       send(self(), {:fetch_detail_metadata, id, media_type})
+      send(self(), {:fetch_recommendations, id, media_type})
 
       {:noreply,
        socket
        |> assign(:selected_item, item)
        |> assign(:selected_metadata, nil)
+       |> assign(:selected_recommendations, [])
        |> assign(:detail_loading, true)}
     else
       _ -> {:noreply, socket}
@@ -343,6 +352,22 @@ defmodule MydiaWeb.DiscoverLive.Index do
     end
   end
 
+  def handle_info({:fetch_recommendations, tmdb_id, media_type}, socket) do
+    case Recommendations.for_tmdb_id(tmdb_id, media_type, nil) do
+      {:ok, results} ->
+        enriched =
+          MediaAddHelpers.enrich_with_library_status(
+            results,
+            socket.assigns.library_status_map
+          )
+
+        {:noreply, assign(socket, :selected_recommendations, enriched)}
+
+      :none ->
+        {:noreply, assign(socket, :selected_recommendations, [])}
+    end
+  end
+
   def handle_info({:add_media_to_library, provider_id, media_type, library_path_id}, socket) do
     # Comes from client params, so a blank string is possible. "" is truthy in
     # Elixir and would reach the changeset as library_path_id: "", failing the
@@ -432,6 +457,19 @@ defmodule MydiaWeb.DiscoverLive.Index do
     do: "Could not submit the request: #{MediaAddHelpers.format_changeset_errors(changeset)}"
 
   defp request_error_message(_), do: "Could not submit the request. Please try again."
+
+  @doc """
+  Resolves a clicked provider id against the current grid page, then the
+  recommendations rail.
+
+  A recommendation is not part of the grid page, so resolving against `items`
+  alone drops the click and the modal never swaps — a failure that looks like
+  nothing happening. Public so it can be exercised without a live process.
+  """
+  def find_selectable_item(items, recommendations, id) do
+    Enum.find(items, &(&1.provider_id == id)) ||
+      Enum.find(recommendations, &(&1.provider_id == id))
+  end
 
   # Private helpers
 

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -352,20 +352,16 @@ defmodule MydiaWeb.DiscoverLive.Index do
     end
   end
 
+  # Runs through start_async rather than inline: on a cache miss this makes a
+  # relay call with the config's timeout, and doing that in the handle_info
+  # would block the LiveView process. The modal is already on screen by then, so
+  # close_details, add and request would all queue behind the fetch and the
+  # modal would look frozen.
   def handle_info({:fetch_recommendations, tmdb_id, media_type}, socket) do
-    case Recommendations.for_tmdb_id(tmdb_id, media_type, nil) do
-      {:ok, results} ->
-        enriched =
-          MediaAddHelpers.enrich_with_library_status(
-            results,
-            socket.assigns.library_status_map
-          )
-
-        {:noreply, assign(socket, :selected_recommendations, enriched)}
-
-      :none ->
-        {:noreply, assign(socket, :selected_recommendations, [])}
-    end
+    {:noreply,
+     start_async(socket, :load_recommendations, fn ->
+       Recommendations.for_tmdb_id(tmdb_id, media_type, nil)
+     end)}
   end
 
   def handle_info({:add_media_to_library, provider_id, media_type, library_path_id}, socket) do
@@ -391,11 +387,21 @@ defmodule MydiaWeb.DiscoverLive.Index do
           |> MediaAddHelpers.enrich_with_library_status(updated_map)
           |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
+        # The rail is a second list of the same shape. Without this it keeps the
+        # pre-add status and offers "Add to Library" for a title that is now in
+        # the library, which a second click would fail on the tmdb_id index.
+        recommendations =
+          MediaAddHelpers.enrich_with_library_status(
+            socket.assigns.selected_recommendations,
+            updated_map
+          )
+
         {:noreply,
          socket
          |> assign(:adding_item_id, nil)
          |> assign(:library_status_map, updated_map)
          |> assign(:items, items)
+         |> assign(:selected_recommendations, recommendations)
          |> put_flash(:info, "#{media_item.title} has been added to your library")}
 
       {:error, {:changeset, changeset}} ->
@@ -416,7 +422,14 @@ defmodule MydiaWeb.DiscoverLive.Index do
   end
 
   def handle_info({:request_media, provider_id, media_type}, socket) do
-    case Enum.find(socket.assigns.items, &(to_string(&1.provider_id) == provider_id)) do
+    # Also resolves against the recommendations rail. A rail title is not in
+    # `items`, so searching only that list made a guest's Request click from
+    # inside the modal silently do nothing.
+    case find_selectable_item(
+           socket.assigns.items,
+           socket.assigns.selected_recommendations,
+           provider_id
+         ) do
       nil ->
         {:noreply, assign(socket, :requesting_item_id, nil)}
 
@@ -437,10 +450,17 @@ defmodule MydiaWeb.DiscoverLive.Index do
         items =
           MediaRequestHelpers.enrich_with_request_status(socket.assigns.items, request_status_map)
 
+        recommendations =
+          MediaRequestHelpers.enrich_with_request_status(
+            socket.assigns.selected_recommendations,
+            request_status_map
+          )
+
         socket
         |> assign(:requesting_item_id, nil)
         |> assign(:request_status_map, request_status_map)
         |> assign(:items, items)
+        |> assign(:selected_recommendations, recommendations)
         |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")
 
       {:error, reason} ->
@@ -448,6 +468,29 @@ defmodule MydiaWeb.DiscoverLive.Index do
         |> assign(:requesting_item_id, nil)
         |> put_flash(:error, request_error_message(reason))
     end
+  end
+
+  @impl true
+  def handle_async(:load_recommendations, {:ok, {:ok, results}}, socket) do
+    {:noreply, assign(socket, :selected_recommendations, enrich_recommendations(socket, results))}
+  end
+
+  def handle_async(:load_recommendations, {:ok, :none}, socket) do
+    {:noreply, assign(socket, :selected_recommendations, [])}
+  end
+
+  def handle_async(:load_recommendations, {:exit, reason}, socket) do
+    Logger.warning("Discover recommendations lookup crashed: #{inspect(reason)}")
+    {:noreply, assign(socket, :selected_recommendations, [])}
+  end
+
+  # Request status matters as much as library status here: without it
+  # `requested?/1` reads nil on every card and a guest is offered Request for a
+  # title they have already requested, which the duplicate check then rejects.
+  defp enrich_recommendations(socket, results) do
+    results
+    |> MediaAddHelpers.enrich_with_library_status(socket.assigns.library_status_map)
+    |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
   end
 
   defp request_error_message(:duplicate_media), do: "That title is already in the library."
@@ -467,8 +510,10 @@ defmodule MydiaWeb.DiscoverLive.Index do
   nothing happening. Public so it can be exercised without a live process.
   """
   def find_selectable_item(items, recommendations, id) do
-    Enum.find(items, &(&1.provider_id == id)) ||
-      Enum.find(recommendations, &(&1.provider_id == id))
+    id = to_string(id)
+
+    Enum.find(items, &(to_string(&1.provider_id) == id)) ||
+      Enum.find(recommendations, &(to_string(&1.provider_id) == id))
   end
 
   # Private helpers

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -200,4 +200,15 @@
     open={@selected_item != nil}
     libraries={@libraries}
   />
+
+  <.recommendations_rail
+    :if={@selected_item}
+    id="discover-recommendations-rail"
+    items={@selected_recommendations}
+    media_type={@selected_item.media_type}
+    current_user={@current_user}
+    adding_item_id={@adding_item_id}
+    requesting_item_id={@requesting_item_id}
+    libraries={@libraries}
+  />
 </Layouts.app>

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -199,16 +199,18 @@
     current_user={@current_user}
     open={@selected_item != nil}
     libraries={@libraries}
-  />
-
-  <.recommendations_rail
-    :if={@selected_item}
-    id="discover-recommendations-rail"
-    items={@selected_recommendations}
-    media_type={@selected_item.media_type}
-    current_user={@current_user}
-    adding_item_id={@adding_item_id}
-    requesting_item_id={@requesting_item_id}
-    libraries={@libraries}
-  />
+  >
+    <:rail>
+      <.recommendations_rail
+        :if={@selected_item}
+        id="discover-recommendations-rail"
+        items={@selected_recommendations}
+        media_type={@selected_item.media_type}
+        current_user={@current_user}
+        adding_item_id={@adding_item_id}
+        requesting_item_id={@requesting_item_id}
+        libraries={@libraries}
+      />
+    </:rail>
+  </.live_component>
 </Layouts.app>

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -152,6 +152,8 @@ defmodule MydiaWeb.MediaLive.Show do
      # Recommendations rail state
      |> assign(:recommendations, [])
      |> assign(:adding_recommendation_tmdb_ids, MapSet.new())
+     |> assign(:adding_recommendation_id, nil)
+     |> assign(:requesting_recommendation_id, nil)
      |> assign_new(:metadata_config, fn -> Mydia.Metadata.default_relay_config() end)
      |> assign(
        :can_create_media,
@@ -420,6 +422,10 @@ defmodule MydiaWeb.MediaLive.Show do
   @impl true
   def handle_event("add_recommendation", params, socket),
     do: RecommendationEvents.add_recommendation(params, socket)
+
+  @impl true
+  def handle_event("request_recommendation", params, socket),
+    do: RecommendationEvents.request_recommendation(params, socket)
 
   @impl true
   def handle_info({:download_created, download}, socket) do

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -16,6 +16,8 @@ defmodule MydiaWeb.MediaLive.Show do
   alias MydiaWeb.MediaLive.Show.SearchEvents
   alias MydiaWeb.MediaLive.Show.SegmentEvents
   alias MydiaWeb.MediaLive.Show.FranchiseEvents
+  alias MydiaWeb.MediaLive.Show.RecommendationEvents
+  alias MydiaWeb.DiscoverComponents
 
   # Import helper modules
   import MydiaWeb.MediaLive.Show.Formatters
@@ -147,6 +149,9 @@ defmodule MydiaWeb.MediaLive.Show do
      # Franchise section state
      |> assign(:franchise, nil)
      |> assign(:adding_franchise_tmdb_ids, MapSet.new())
+     # Recommendations rail state
+     |> assign(:recommendations, [])
+     |> assign(:adding_recommendation_tmdb_ids, MapSet.new())
      |> assign_new(:metadata_config, fn -> Mydia.Metadata.default_relay_config() end)
      |> assign(
        :can_create_media,
@@ -163,6 +168,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> CollectionEvents.load_collection_data(media_item)
      |> SegmentEvents.assign_segment_status(media_item)
      |> FranchiseEvents.maybe_load()
+     |> RecommendationEvents.maybe_load()
      |> assign_target_library(media_item)
      |> stream_configure(:search_results, dom_id: &generate_positioned_id/1)
      |> stream(:search_results, [])}
@@ -412,6 +418,10 @@ defmodule MydiaWeb.MediaLive.Show do
     do: FranchiseEvents.add_franchise_movie(params, socket)
 
   @impl true
+  def handle_event("add_recommendation", params, socket),
+    do: RecommendationEvents.add_recommendation(params, socket)
+
+  @impl true
   def handle_info({:download_created, download}, socket) do
     if download_for_media?(download, socket.assigns.media_item) do
       media_item = load_media_item(socket.assigns.media_item.id)
@@ -614,6 +624,12 @@ defmodule MydiaWeb.MediaLive.Show do
 
   def handle_async({:add_franchise_movie, tmdb_id}, result, socket),
     do: FranchiseEvents.handle_add_result(tmdb_id, result, socket)
+
+  def handle_async(:load_recommendations, result, socket),
+    do: RecommendationEvents.handle_load_result(result, socket)
+
+  def handle_async({:add_recommendation, tmdb_id}, result, socket),
+    do: RecommendationEvents.handle_add_result(tmdb_id, result, socket)
 
   # Private helpers
 

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -199,6 +199,13 @@
             can_add={@can_create_media}
             adding_tmdb_ids={@adding_franchise_tmdb_ids}
           />
+          <DiscoverComponents.recommendations_rail
+            items={@recommendations}
+            media_type={if @media_item.type == "tv_show", do: :tv_show, else: :movie}
+            current_user={@current_user}
+            libraries={[]}
+            on_select={nil}
+          />
           <%!-- Episodes Section (TV Shows Only) --%>
           <Components.episodes_section
             media_item={@media_item}

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -203,8 +203,13 @@
             items={@recommendations}
             media_type={if @media_item.type == "tv_show", do: :tv_show, else: :movie}
             current_user={@current_user}
-            libraries={[]}
+            libraries={@target_library_candidates}
+            adding_item_id={@adding_recommendation_id}
+            requesting_item_id={@requesting_recommendation_id}
+            can_add={@can_create_media}
             on_select={nil}
+            add_event="add_recommendation"
+            request_event="request_recommendation"
           />
           <%!-- Episodes Section (TV Shows Only) --%>
           <Components.episodes_section

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -11,6 +11,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   alias Mydia.Media.Recommendations
   alias MydiaWeb.Live.Authorization
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
+  alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
   require Logger
 
@@ -97,6 +98,54 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   end
 
   @doc """
+  Requests a recommended title on behalf of a guest.
+
+  The rail renders a Request button rather than Add for guests, so this LiveView
+  needs its own handler for it: the card's event reaches `MediaLive.Show`, which
+  otherwise has no `request_media` clause at all.
+  """
+  def request_recommendation(%{"tmdb_id" => tmdb_id}, socket) do
+    case Enum.find(socket.assigns.recommendations, &(to_string(&1.provider_id) == tmdb_id)) do
+      nil ->
+        {:noreply, socket}
+
+      item ->
+        media_type = if socket.assigns.media_item.type == "tv_show", do: :tv_show, else: :movie
+
+        socket = assign(socket, :requesting_recommendation_id, tmdb_id)
+
+        case MediaRequestHelpers.handle_request_media(
+               item,
+               media_type,
+               socket.assigns.current_user.id
+             ) do
+          {:ok, request, status_updates} ->
+            {:noreply,
+             socket
+             |> assign(:requesting_recommendation_id, nil)
+             |> assign(
+               :recommendations,
+               MediaRequestHelpers.enrich_with_request_status(
+                 socket.assigns.recommendations,
+                 status_updates
+               )
+             )
+             |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")}
+
+          {:error, reason} ->
+            Logger.warning(
+              "Recommendation request failed for tmdb #{tmdb_id}: #{inspect(reason)}"
+            )
+
+            {:noreply,
+             socket
+             |> assign(:requesting_recommendation_id, nil)
+             |> put_flash(:error, "Could not request that title")}
+        end
+    end
+  end
+
+  @doc """
   Performs the add. Public so it can be exercised directly in tests without a
   live process.
   """
@@ -149,10 +198,12 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   # because it needs MediaAddHelpers, and a context under Mydia.* must not depend
   # on the web layer.
   defp decorate(results, media_item) do
-    tmdb_ids =
-      results
-      |> Enum.map(&safe_provider_id/1)
-      |> Enum.reject(&is_nil/1)
+    # Drop malformed entries from the list itself, not just from the id lookup.
+    # enrich_with_library_status/2 calls the same raising parser, so filtering
+    # only the ids would still let a non-numeric provider_id raise one line
+    # later, inside handle_load_result/2, taking the detail page down.
+    results = Enum.filter(results, &(safe_provider_id(&1) != nil))
+    tmdb_ids = Enum.map(results, &safe_provider_id/1)
 
     status = Media.library_status_for_tmdb_ids(tmdb_ids, media_item.type)
 
@@ -172,19 +223,26 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
     ArgumentError -> nil
   end
 
+  # The MapSet is the source of truth for "is this id already in flight" and is
+  # what prevents a double-click from racing two adds. The single id alongside
+  # it is only what the card compares against to show its spinner.
   defp mark_in_flight(socket, tmdb_id) do
-    assign(
-      socket,
+    socket
+    |> assign(
       :adding_recommendation_tmdb_ids,
       MapSet.put(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
     )
+    |> assign(:adding_recommendation_id, to_string(tmdb_id))
   end
 
   defp clear_in_flight(socket, tmdb_id) do
-    assign(
-      socket,
-      :adding_recommendation_tmdb_ids,
-      MapSet.delete(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
+    remaining = MapSet.delete(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
+
+    socket
+    |> assign(:adding_recommendation_tmdb_ids, remaining)
+    |> assign(
+      :adding_recommendation_id,
+      remaining |> Enum.at(0) |> then(&if(&1, do: to_string(&1)))
     )
   end
 

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -1,0 +1,209 @@
+defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
+  @moduledoc false
+
+  use MydiaWeb, :verified_routes
+
+  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.LiveView, only: [start_async: 3, put_flash: 3, connected?: 1]
+
+  alias Mydia.Media
+  alias Mydia.Media.Add
+  alias Mydia.Media.Recommendations
+  alias MydiaWeb.Live.Authorization
+  alias MydiaWeb.Live.Helpers.MediaAddHelpers
+
+  require Logger
+
+  @doc """
+  Starts the recommendations lookup on the connected mount.
+
+  A no-op on the dead render, which must not pay for an HTTP call, and for
+  anything that is not a movie or show with a TMDB id.
+  """
+  def maybe_load(socket) do
+    media_item = socket.assigns.media_item
+    config = socket.assigns.metadata_config
+
+    if connected?(socket) && media_item.type in ["movie", "tv_show"] &&
+         is_integer(media_item.tmdb_id) do
+      start_async(socket, :load_recommendations, fn ->
+        Recommendations.for_media_item(media_item, config)
+      end)
+    else
+      socket
+    end
+  end
+
+  def handle_load_result({:ok, {:ok, results}}, socket) do
+    {:noreply, assign(socket, :recommendations, decorate(results, socket.assigns.media_item))}
+  end
+
+  def handle_load_result({:ok, :none}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_load_result({:exit, reason}, socket) do
+    Logger.warning("Recommendations lookup crashed: #{inspect(reason)}")
+    {:noreply, socket}
+  end
+
+  # Defensive, for the same reason as the franchise strip: an unmatched shape
+  # would raise in the LiveView process, the client would reconnect, re-mount and
+  # crash again, taking the whole detail page down for a section that is meant to
+  # be silently absent when the lookup does not work out.
+  def handle_load_result(other, socket) do
+    Logger.warning("Recommendations lookup returned an unexpected result: #{inspect(other)}")
+    {:noreply, socket}
+  end
+
+  @doc """
+  Adds a recommended title, inheriting the viewed item's quality profile and
+  monitored flag.
+
+  Keyed per TMDB id so several can be in flight at once: `start_async/3`
+  overwrites rather than cancels under an existing key, which would silently drop
+  the first result.
+  """
+  def add_recommendation(%{"tmdb_id" => tmdb_id}, socket) do
+    with :ok <- Authorization.authorize_create_media(socket) do
+      case Integer.parse(tmdb_id) do
+        {parsed, ""} -> dispatch_add(parsed, socket)
+        _ -> {:noreply, socket}
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  # An impatient double-click sends the event twice. The second add would hit the
+  # tmdb_id unique index and flash a failure for a row the first add just
+  # created, so a repeat for an id already in flight is dropped.
+  defp dispatch_add(tmdb_id, socket) do
+    if MapSet.member?(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id) do
+      {:noreply, socket}
+    else
+      media_item = socket.assigns.media_item
+      config = socket.assigns.metadata_config
+
+      socket =
+        socket
+        |> mark_in_flight(tmdb_id)
+        |> start_async({:add_recommendation, tmdb_id}, fn ->
+          perform_add(media_item, tmdb_id, config)
+        end)
+
+      {:noreply, socket}
+    end
+  end
+
+  @doc """
+  Performs the add. Public so it can be exercised directly in tests without a
+  live process.
+  """
+  def perform_add(media_item, tmdb_id, config) do
+    media_type = if media_item.type == "tv_show", do: :tv_show, else: :movie
+
+    MediaAddHelpers.handle_add_media_to_library(
+      to_string(tmdb_id),
+      media_type,
+      %{},
+      config,
+      monitored: media_item.monitored,
+      quality_profile_id: media_item.quality_profile_id
+    )
+    |> case do
+      {:ok, added, _status_map} -> {:ok, added}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def handle_add_result(tmdb_id, {:ok, {:ok, added}}, socket) do
+    {:noreply,
+     socket
+     |> clear_in_flight(tmdb_id)
+     |> assign(:recommendations, mark_owned(socket.assigns.recommendations, added))
+     |> put_flash(:info, "Added #{added.title} to your library")}
+  end
+
+  def handle_add_result(tmdb_id, {:ok, {:error, reason}}, socket) do
+    Logger.warning("Recommendation add failed for tmdb #{tmdb_id}: #{inspect(reason)}")
+
+    {:noreply,
+     socket
+     |> clear_in_flight(tmdb_id)
+     |> put_flash(:error, "Could not add that title: #{describe(reason)}")}
+  end
+
+  def handle_add_result(tmdb_id, {:exit, reason}, socket) do
+    Logger.warning("Recommendation add crashed: #{inspect(reason)}")
+
+    {:noreply,
+     socket
+     |> clear_in_flight(tmdb_id)
+     |> put_flash(:error, "Could not add that title")}
+  end
+
+  ## Private
+
+  # The library join lives here rather than in Mydia.Media.Recommendations
+  # because it needs MediaAddHelpers, and a context under Mydia.* must not depend
+  # on the web layer.
+  defp decorate(results, media_item) do
+    tmdb_ids =
+      results
+      |> Enum.map(&safe_provider_id/1)
+      |> Enum.reject(&is_nil/1)
+
+    status = Media.library_status_for_tmdb_ids(tmdb_ids, media_item.type)
+
+    results
+    |> MediaAddHelpers.enrich_with_library_status(status)
+    |> Enum.map(fn item ->
+      navigate = if item.in_library && item.id, do: ~p"/media/#{item.id}", else: nil
+      Map.put(item, :navigate, navigate)
+    end)
+  end
+
+  # Add.parse_provider_id/1 raises on a non-numeric binary. TMDB ids are always
+  # numeric, but one malformed entry must not take down the whole rail.
+  defp safe_provider_id(result) do
+    Add.parse_provider_id(result.provider_id)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp mark_in_flight(socket, tmdb_id) do
+    assign(
+      socket,
+      :adding_recommendation_tmdb_ids,
+      MapSet.put(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
+    )
+  end
+
+  defp clear_in_flight(socket, tmdb_id) do
+    assign(
+      socket,
+      :adding_recommendation_tmdb_ids,
+      MapSet.delete(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
+    )
+  end
+
+  defp mark_owned(recommendations, added) do
+    Enum.map(recommendations, fn item ->
+      if safe_provider_id(item) == added.tmdb_id do
+        item
+        |> Map.put(:in_library, true)
+        |> Map.put(:id, added.id)
+        |> Map.put(:navigate, ~p"/media/#{added.id}")
+      else
+        item
+      end
+    end)
+  end
+
+  defp describe({:changeset, changeset}),
+    do: MediaAddHelpers.format_changeset_errors(changeset)
+
+  defp describe({:metadata, _reason}), do: "the metadata service could not be reached"
+  defp describe(reason), do: inspect(reason)
+end

--- a/test/mydia/media/recommendations_test.exs
+++ b/test/mydia/media/recommendations_test.exs
@@ -1,0 +1,143 @@
+defmodule Mydia.Media.RecommendationsTest do
+  @moduledoc """
+  Covers the collapse of every provider outcome into `{:ok, results}` or `:none`,
+  which is the whole reason this module exists: the two LiveViews that render the
+  rail should have exactly one thing to check.
+  """
+
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+  import ExUnit.CaptureLog
+
+  alias Mydia.Media.{MediaItem, Recommendations}
+  alias Mydia.Metadata.Cache
+
+  setup do
+    bypass = Bypass.open()
+
+    config = %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false, timeout: 2_000}
+    }
+
+    tmdb_id = 900_000_000 + System.unique_integer([:positive])
+
+    on_exit(fn ->
+      for media_type <- [:movie, :tv_show] do
+        Cache.delete("recommendations:metadata_relay:#{tmdb_id}:#{media_type}:en-US")
+      end
+    end)
+
+    %{bypass: bypass, config: config, tmdb_id: tmdb_id}
+  end
+
+  defp json(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(status, Jason.encode!(body))
+  end
+
+  defp stub_recommendations(bypass, tmdb_id, results) do
+    Bypass.stub(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+      json(conn, 200, %{
+        "id" => tmdb_id,
+        "title" => "Source Movie",
+        "recommendations" => %{
+          "page" => 1,
+          "results" => results,
+          "total_pages" => 1,
+          "total_results" => length(results)
+        }
+      })
+    end)
+  end
+
+  describe "for_media_item/2" do
+    test "returns parsed recommendations for a movie", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      stub_recommendations(bypass, tmdb_id, [
+        %{"id" => 101, "title" => "The Eternal Daughter", "release_date" => "2022-12-02"}
+      ])
+
+      item = media_item_fixture(%{type: "movie", title: "Aftersun", tmdb_id: tmdb_id})
+
+      assert {:ok, [first]} = Recommendations.for_media_item(item, config)
+      assert first.title == "The Eternal Daughter"
+      assert first.provider_id == "101"
+    end
+
+    test "returns :none when TMDB has no recommendations", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      stub_recommendations(bypass, tmdb_id, [])
+
+      item = media_item_fixture(%{type: "movie", title: "Obscure", tmdb_id: tmdb_id})
+
+      assert :none = Recommendations.for_media_item(item, config)
+    end
+
+    test "returns :none for an item with no tmdb_id", %{config: config} do
+      item = %MediaItem{type: "movie", title: "No Id", tmdb_id: nil}
+
+      assert :none = Recommendations.for_media_item(item, config)
+    end
+
+    test "returns :none and logs when the relay errors", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      Bypass.stub(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        json(conn, 500, %{"status_message" => "boom"})
+      end)
+
+      item = media_item_fixture(%{type: "movie", title: "Broken", tmdb_id: tmdb_id})
+
+      log =
+        capture_log(fn ->
+          assert :none = Recommendations.for_media_item(item, config)
+        end)
+
+      assert log =~ "Recommendations lookup failed"
+    end
+
+    test "returns :none for an unsupported media type", %{config: config, tmdb_id: tmdb_id} do
+      item = %MediaItem{type: "music", title: "Album", tmdb_id: tmdb_id}
+
+      assert :none = Recommendations.for_media_item(item, config)
+    end
+  end
+
+  describe "for_tmdb_id/3" do
+    test "serves a title that is not in the library", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      stub_recommendations(bypass, tmdb_id, [
+        %{"id" => 102, "title" => "Janet Planet", "release_date" => "2024-06-21"}
+      ])
+
+      assert {:ok, [first]} = Recommendations.for_tmdb_id(tmdb_id, :movie, config)
+      assert first.title == "Janet Planet"
+    end
+
+    test "accepts a string id", %{bypass: bypass, config: config, tmdb_id: tmdb_id} do
+      stub_recommendations(bypass, tmdb_id, [%{"id" => 103, "title" => "Tigertail"}])
+
+      assert {:ok, [first]} = Recommendations.for_tmdb_id(to_string(tmdb_id), :movie, config)
+      assert first.title == "Tigertail"
+    end
+
+    test "returns :none for a nil id", %{config: config} do
+      assert :none = Recommendations.for_tmdb_id(nil, :movie, config)
+    end
+  end
+end

--- a/test/mydia/media/recommendations_test.exs
+++ b/test/mydia/media/recommendations_test.exs
@@ -139,5 +139,19 @@ defmodule Mydia.Media.RecommendationsTest do
     test "returns :none for a nil id", %{config: config} do
       assert :none = Recommendations.for_tmdb_id(nil, :movie, config)
     end
+
+    # A Bypass with no stub fails the test on any request, so these also prove
+    # the malformed ids never reach the relay rather than merely degrading once
+    # they get there.
+    test "returns :none for malformed ids without calling the relay", %{config: config} do
+      for id <- ["", "abc", "12abc", " 12", 0, -5, %{}] do
+        assert :none = Recommendations.for_tmdb_id(id, :movie, config),
+               "expected :none for #{inspect(id)}"
+      end
+    end
+
+    test "returns :none for an unsupported media type", %{config: config} do
+      assert :none = Recommendations.for_tmdb_id(603, :music, config)
+    end
   end
 end

--- a/test/mydia/metadata/provider/relay_recommendations_test.exs
+++ b/test/mydia/metadata/provider/relay_recommendations_test.exs
@@ -1,0 +1,202 @@
+defmodule Mydia.Metadata.Provider.RelayRecommendationsTest do
+  @moduledoc """
+  Offline coverage for TMDB recommendations, which ride along on the details
+  endpoint via `append_to_response` rather than a dedicated relay route.
+
+  Deliberately NOT tagged `:external` — `test/test_helper.exs` excludes that tag,
+  and this parsing has to run in CI. The relay is stubbed with Bypass.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.Provider.{Error, Relay}
+
+  setup do
+    bypass = Bypass.open()
+
+    config = %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{
+        language: "en-US",
+        include_adult: false,
+        timeout: 2_000,
+        connect_timeout: 1_000
+      }
+    }
+
+    # Offset well past any real provider id so the process-global
+    # Mydia.Metadata.ProviderIDRegistry entries these tests create can never
+    # collide with another test file's ids.
+    tmdb_id = to_string(900_000_000 + System.unique_integer([:positive]))
+
+    {:ok, bypass: bypass, config: config, tmdb_id: tmdb_id}
+  end
+
+  # Req only decodes a body when the response declares a JSON content type.
+  # Without this the assertions below would run against a raw string.
+  defp json(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(status, Jason.encode!(body))
+  end
+
+  defp movie_rec(id, title) do
+    %{
+      "id" => id,
+      "title" => title,
+      "release_date" => "2022-10-21",
+      "poster_path" => "/poster#{id}.jpg",
+      "vote_average" => 7.6,
+      "overview" => "Overview for #{title}"
+    }
+  end
+
+  defp tv_rec(id, name) do
+    %{
+      "id" => id,
+      "name" => name,
+      "first_air_date" => "2008-01-20",
+      "poster_path" => "/poster#{id}.jpg",
+      "vote_average" => 8.9,
+      "overview" => "Overview for #{name}"
+    }
+  end
+
+  describe "fetch_recommendations/3 for movies" do
+    test "sends append_to_response and parses the sub-object", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      test_pid = self()
+
+      Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        send(test_pid, {:query_params, conn.query_params})
+
+        json(conn, 200, %{
+          "id" => String.to_integer(tmdb_id),
+          "title" => "Aftersun",
+          "recommendations" => %{
+            "page" => 1,
+            "results" => [
+              movie_rec(101, "The Eternal Daughter"),
+              movie_rec(102, "Janet Planet")
+            ],
+            "total_pages" => 1,
+            "total_results" => 2
+          }
+        })
+      end)
+
+      assert {:ok, [first, second]} =
+               Relay.fetch_recommendations(config, tmdb_id, media_type: :movie)
+
+      assert_receive {:query_params, params}
+      assert params["append_to_response"] == "recommendations"
+      assert params["language"] == "en-US"
+
+      assert first.provider_id == "101"
+      assert first.title == "The Eternal Daughter"
+      assert first.media_type == :movie
+      assert second.provider_id == "102"
+    end
+
+    test "returns an empty list when the sub-object has no results", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        json(conn, 200, %{
+          "id" => String.to_integer(tmdb_id),
+          "title" => "Obscure Film",
+          "recommendations" => %{
+            "page" => 1,
+            "results" => [],
+            "total_pages" => 0,
+            "total_results" => 0
+          }
+        })
+      end)
+
+      assert {:ok, []} = Relay.fetch_recommendations(config, tmdb_id, media_type: :movie)
+    end
+
+    test "returns an empty list when the response has no recommendations key", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        json(conn, 200, %{"id" => String.to_integer(tmdb_id), "title" => "No Append"})
+      end)
+
+      assert {:ok, []} = Relay.fetch_recommendations(config, tmdb_id, media_type: :movie)
+    end
+
+    test "returns a not_found error on 404", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        json(conn, 404, %{"status_message" => "The resource you requested could not be found."})
+      end)
+
+      assert {:error, %Error{type: :not_found}} =
+               Relay.fetch_recommendations(config, tmdb_id, media_type: :movie)
+    end
+
+    test "honours an explicit language override", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      test_pid = self()
+
+      Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        send(test_pid, {:query_params, conn.query_params})
+        json(conn, 200, %{"id" => String.to_integer(tmdb_id), "title" => "Aftersun"})
+      end)
+
+      assert {:ok, []} =
+               Relay.fetch_recommendations(config, tmdb_id,
+                 media_type: :movie,
+                 language: "fr-FR"
+               )
+
+      assert_receive {:query_params, params}
+      assert params["language"] == "fr-FR"
+    end
+  end
+
+  describe "fetch_recommendations/3 for TV shows" do
+    test "uses the TV details endpoint and tags results as tv_show", %{
+      bypass: bypass,
+      config: config,
+      tmdb_id: tmdb_id
+    } do
+      Bypass.expect_once(bypass, "GET", "/tmdb/tv/shows/#{tmdb_id}", fn conn ->
+        json(conn, 200, %{
+          "id" => String.to_integer(tmdb_id),
+          "name" => "Breaking Bad",
+          "recommendations" => %{
+            "page" => 1,
+            "results" => [tv_rec(201, "Better Call Saul")],
+            "total_pages" => 1,
+            "total_results" => 1
+          }
+        })
+      end)
+
+      assert {:ok, [first]} =
+               Relay.fetch_recommendations(config, tmdb_id, media_type: :tv_show)
+
+      assert first.provider_id == "201"
+      assert first.media_type == :tv_show
+    end
+  end
+end

--- a/test/mydia/metadata_recommendations_cached_test.exs
+++ b/test/mydia/metadata_recommendations_cached_test.exs
@@ -1,0 +1,133 @@
+defmodule Mydia.MetadataRecommendationsCachedTest do
+  @moduledoc """
+  Covers the ETS memoisation around `Relay.fetch_recommendations/3`, in
+  particular that the cache key varies by the two dimensions that would
+  otherwise serve one library's results to another: language and media type.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Mydia.Metadata
+  alias Mydia.Metadata.Cache
+  alias Mydia.Metadata.Provider.Error
+
+  setup do
+    bypass = Bypass.open()
+
+    config = %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false, timeout: 2_000}
+    }
+
+    tmdb_id = to_string(900_000_000 + System.unique_integer([:positive]))
+
+    on_exit(fn ->
+      for media_type <- [:movie, :tv_show], language <- ["en-US", "fr-FR"] do
+        Cache.delete("recommendations:metadata_relay:#{tmdb_id}:#{media_type}:#{language}")
+      end
+    end)
+
+    {:ok, bypass: bypass, config: config, tmdb_id: tmdb_id}
+  end
+
+  defp json(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(status, Jason.encode!(body))
+  end
+
+  defp recommendations_body(tmdb_id, title) do
+    %{
+      "id" => String.to_integer(tmdb_id),
+      "title" => "Source",
+      "recommendations" => %{
+        "page" => 1,
+        "results" => [
+          %{
+            "id" => 101,
+            "title" => title,
+            "release_date" => "2022-10-21",
+            "poster_path" => "/p.jpg"
+          }
+        ],
+        "total_pages" => 1,
+        "total_results" => 1
+      }
+    }
+  end
+
+  test "serves a repeat call from cache without a second request", %{
+    bypass: bypass,
+    config: config,
+    tmdb_id: tmdb_id
+  } do
+    Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+      json(conn, 200, recommendations_body(tmdb_id, "Cached Title"))
+    end)
+
+    assert {:ok, [first]} =
+             Metadata.fetch_recommendations_cached(config, tmdb_id, media_type: :movie)
+
+    assert first.title == "Cached Title"
+
+    # Bypass.expect_once would fail on a second request.
+    assert {:ok, [^first]} =
+             Metadata.fetch_recommendations_cached(config, tmdb_id, media_type: :movie)
+  end
+
+  test "keys the cache by language", %{bypass: bypass, config: config, tmdb_id: tmdb_id} do
+    Bypass.expect(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+      conn = Plug.Conn.fetch_query_params(conn)
+      title = if conn.query_params["language"] == "fr-FR", do: "Titre", else: "Title"
+      json(conn, 200, recommendations_body(tmdb_id, title))
+    end)
+
+    assert {:ok, [english]} =
+             Metadata.fetch_recommendations_cached(config, tmdb_id, media_type: :movie)
+
+    assert {:ok, [french]} =
+             Metadata.fetch_recommendations_cached(config, tmdb_id,
+               media_type: :movie,
+               language: "fr-FR"
+             )
+
+    assert english.title == "Title"
+    assert french.title == "Titre"
+  end
+
+  test "keys the cache by media type", %{bypass: bypass, config: config, tmdb_id: tmdb_id} do
+    Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+      json(conn, 200, recommendations_body(tmdb_id, "A Movie"))
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/tmdb/tv/shows/#{tmdb_id}", fn conn ->
+      json(conn, 200, %{
+        "id" => String.to_integer(tmdb_id),
+        "name" => "Source Show",
+        "recommendations" => %{
+          "page" => 1,
+          "results" => [%{"id" => 202, "name" => "A Show", "first_air_date" => "2008-01-20"}],
+          "total_pages" => 1,
+          "total_results" => 1
+        }
+      })
+    end)
+
+    assert {:ok, [movie]} =
+             Metadata.fetch_recommendations_cached(config, tmdb_id, media_type: :movie)
+
+    assert {:ok, [show]} =
+             Metadata.fetch_recommendations_cached(config, tmdb_id, media_type: :tv_show)
+
+    assert movie.title == "A Movie"
+    assert show.media_type == :tv_show
+  end
+
+  test "rejects a non-relay provider config", %{tmdb_id: tmdb_id} do
+    assert {:error, %Error{type: :invalid_config}} =
+             Metadata.fetch_recommendations_cached(%{type: :open_library}, tmdb_id,
+               media_type: :movie
+             )
+  end
+end

--- a/test/mydia_web/live/components/recommendations_rail_component_test.exs
+++ b/test/mydia_web/live/components/recommendations_rail_component_test.exs
@@ -1,0 +1,94 @@
+defmodule MydiaWeb.Components.RecommendationsRailComponentTest do
+  @moduledoc """
+  Covers the three poster behaviours the rail needs: a click event on Discover,
+  a navigate link for an owned title on the detail page, and an inert poster
+  where neither applies. The detail page has no `show_details` handler, so the
+  inert case is what keeps a poster click from crashing that LiveView.
+  """
+
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias MydiaWeb.DiscoverComponents
+
+  defp item(attrs \\ %{}) do
+    Enum.into(attrs, %{
+      provider_id: "101",
+      title: "The Eternal Daughter",
+      year: 2022,
+      poster_path: "/poster.jpg",
+      vote_average: 6.9,
+      in_library: false,
+      monitored: false,
+      id: nil
+    })
+  end
+
+  defp user, do: %{id: Ecto.UUID.generate(), role: "admin", username: "admin"}
+
+  test "renders nothing when there are no items" do
+    html =
+      render_component(&DiscoverComponents.recommendations_rail/1,
+        items: [],
+        media_type: :movie,
+        current_user: user()
+      )
+
+    refute html =~ "recommendations-rail"
+  end
+
+  test "renders one card per item under the rail id" do
+    html =
+      render_component(&DiscoverComponents.recommendations_rail/1,
+        items: [item(), item(%{provider_id: "102", title: "Janet Planet"})],
+        media_type: :movie,
+        current_user: user()
+      )
+
+    assert html =~ ~s(id="recommendations-rail")
+    assert html =~ "The Eternal Daughter"
+    assert html =~ "Janet Planet"
+  end
+
+  test "an unowned card fires the configured select event" do
+    html =
+      render_component(&DiscoverComponents.recommendations_rail/1,
+        items: [item()],
+        media_type: :movie,
+        current_user: user(),
+        on_select: "show_details"
+      )
+
+    assert html =~ ~s(phx-click="show_details")
+    assert html =~ ~s(phx-value-id="101")
+  end
+
+  test "an owned card with a navigate target renders a link, not a click handler" do
+    owned = item(%{in_library: true, id: "abc-123", navigate: "/media/abc-123"})
+
+    html =
+      render_component(&DiscoverComponents.recommendations_rail/1,
+        items: [owned],
+        media_type: :movie,
+        current_user: user()
+      )
+
+    assert html =~ ~s(href="/media/abc-123")
+    refute html =~ ~s(phx-click="show_details")
+  end
+
+  test "a nil on_select renders an inert poster" do
+    html =
+      render_component(&DiscoverComponents.recommendations_rail/1,
+        items: [item()],
+        media_type: :movie,
+        current_user: user(),
+        on_select: nil
+      )
+
+    # Poster must not fire show_details; action buttons may still use phx-click.
+    refute html =~ ~s(phx-click="show_details")
+    assert html =~ ~s(<figure class="aspect-[2/3] bg-base-300">)
+  end
+end

--- a/test/mydia_web/live/components/recommendations_rail_component_test.exs
+++ b/test/mydia_web/live/components/recommendations_rail_component_test.exs
@@ -91,4 +91,71 @@ defmodule MydiaWeb.Components.RecommendationsRailComponentTest do
     refute html =~ ~s(phx-click="show_details")
     assert html =~ ~s(<figure class="aspect-[2/3] bg-base-300">)
   end
+
+  describe "action event contract" do
+    # Regression: the rail defaults to Discover's events. On a host with
+    # different handlers that meant the first click on an unowned card emitted
+    # an event nobody handled, which raises FunctionClauseError and kills the
+    # LiveView. The host must be able to name its own events.
+    test "defaults to the Discover event names" do
+      html =
+        render_component(&DiscoverComponents.recommendations_rail/1,
+          items: [item()],
+          media_type: :movie,
+          current_user: user()
+        )
+
+      assert html =~ ~s(phx-click="add_to_library")
+    end
+
+    test "emits the host's add event when overridden" do
+      html =
+        render_component(&DiscoverComponents.recommendations_rail/1,
+          items: [item()],
+          media_type: :movie,
+          current_user: user(),
+          add_event: "add_recommendation"
+        )
+
+      assert html =~ ~s(phx-click="add_recommendation")
+      refute html =~ ~s(phx-click="add_to_library")
+    end
+
+    test "emits the host's request event for a guest" do
+      html =
+        render_component(&DiscoverComponents.recommendations_rail/1,
+          items: [item()],
+          media_type: :movie,
+          current_user: %{id: Ecto.UUID.generate(), role: "guest", username: "g"},
+          request_event: "request_recommendation"
+        )
+
+      assert html =~ ~s(phx-click="request_recommendation")
+      refute html =~ ~s(phx-click="request_media")
+    end
+
+    test "renders no add affordance when the user cannot create media" do
+      html =
+        render_component(&DiscoverComponents.recommendations_rail/1,
+          items: [item()],
+          media_type: :movie,
+          current_user: user(),
+          can_add: false
+        )
+
+      refute html =~ "Add to Library"
+    end
+
+    test "a guest keeps the request affordance even when can_add is false" do
+      html =
+        render_component(&DiscoverComponents.recommendations_rail/1,
+          items: [item()],
+          media_type: :movie,
+          current_user: %{id: Ecto.UUID.generate(), role: "guest", username: "g"},
+          can_add: false
+        )
+
+      assert html =~ ~s(phx-click="request_media")
+    end
+  end
 end

--- a/test/mydia_web/live/discover_live/recommendations_lookup_test.exs
+++ b/test/mydia_web/live/discover_live/recommendations_lookup_test.exs
@@ -1,0 +1,40 @@
+defmodule MydiaWeb.DiscoverLive.RecommendationsLookupTest do
+  @moduledoc """
+  Covers the widened `show_details` lookup.
+
+  A recommendation is not part of the current grid page, so resolving the click
+  against `items` alone silently drops it and the modal never swaps. That failure
+  is invisible in the UI, which is why it gets a direct test.
+
+  No rendering test here on purpose: see the header of library_picker_test.exs.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias MydiaWeb.DiscoverLive.Index
+
+  defp result(provider_id), do: %{provider_id: provider_id, title: "Title #{provider_id}"}
+
+  test "finds an item on the current grid page" do
+    items = [result("1"), result("2")]
+
+    assert %{provider_id: "2"} = Index.find_selectable_item(items, [], "2")
+  end
+
+  test "finds an item that exists only in the recommendations rail" do
+    recommendations = [result("101")]
+
+    assert %{provider_id: "101"} = Index.find_selectable_item([], recommendations, "101")
+  end
+
+  test "prefers the grid item when both lists carry the id" do
+    grid = %{provider_id: "5", title: "From grid"}
+    rail = %{provider_id: "5", title: "From rail"}
+
+    assert %{title: "From grid"} = Index.find_selectable_item([grid], [rail], "5")
+  end
+
+  test "returns nil for an unknown id" do
+    assert is_nil(Index.find_selectable_item([result("1")], [result("101")], "999"))
+  end
+end

--- a/test/mydia_web/live/media_live/show/recommendations_rail_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendations_rail_test.exs
@@ -1,0 +1,137 @@
+defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
+  # Connected LiveView tests must stay sync: the Postgres sandbox is only shared
+  # with the mount process when the case is not async.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Metadata
+  alias Mydia.Metadata.Cache
+
+  setup %{conn: conn} do
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  test "a movie with recommendations renders the rail", %{conn: conn} do
+    source_tmdb_id = System.unique_integer([:positive])
+    recommended_tmdb_id = System.unique_integer([:positive])
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Aftersun",
+        year: 2022,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{
+        "id" => recommended_tmdb_id,
+        "title" => "The Eternal Daughter",
+        "release_date" => "2022-12-02",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, "#recommendations-rail")
+    assert render(view) =~ "The Eternal Daughter"
+  end
+
+  test "a movie with no recommendations renders no rail", %{conn: conn} do
+    source_tmdb_id = System.unique_integer([:positive])
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Obscure",
+        year: 2019,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    refute has_element?(view, "#recommendations-rail")
+  end
+
+  test "an owned recommendation links to its page instead of offering an add",
+       %{conn: conn} do
+    source_tmdb_id = System.unique_integer([:positive])
+    owned_tmdb_id = System.unique_integer([:positive])
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Aftersun",
+        year: 2022,
+        tmdb_id: source_tmdb_id
+      })
+
+    owned =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Already Here",
+        year: 2013,
+        tmdb_id: owned_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{"id" => owned_tmdb_id, "title" => "Already Here", "release_date" => "2013-01-01"}
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, ~s(#recommendations-rail a[href="/media/#{owned.id}"]))
+  end
+
+  # Populates the shared metadata cache through the real fetch path, with the
+  # relay response coming from Bypass. `fetch_recommendations_cached/3` keys on
+  # the provider type, id, media type and language but NOT the base URL, so the
+  # LiveView's own default config reads this entry back without any outbound
+  # request.
+  defp warm_recommendations_cache(tmdb_id, media_type, results) do
+    bypass = Bypass.open()
+    relay = Metadata.default_relay_config()
+    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
+
+    on_exit(fn ->
+      Cache.delete(
+        "recommendations:#{relay.type}:#{tmdb_id}:#{media_type}:#{relay.options.language}"
+      )
+    end)
+
+    path =
+      if media_type == :tv_show, do: "/tmdb/tv/shows/#{tmdb_id}", else: "/tmdb/movies/#{tmdb_id}"
+
+    Bypass.expect_once(bypass, "GET", path, fn conn ->
+      body = %{
+        "id" => tmdb_id,
+        "title" => "Source",
+        "recommendations" => %{
+          "page" => 1,
+          "results" => results,
+          "total_pages" => 1,
+          "total_results" => length(results)
+        }
+      }
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    {:ok, _results} =
+      Metadata.fetch_recommendations_cached(config, to_string(tmdb_id), media_type: media_type)
+
+    :ok
+  end
+end


### PR DESCRIPTION
Adds a "More like this" rail to the media detail page and the Discover detail modal, sourced from TMDB's behavioural recommendations ("people who liked X liked Y").

## What this does

- Owned titles appear badged and link to their library page; unowned titles get the existing add or request action.
- The rail is absent entirely when TMDB returns nothing, which is common for obscure titles. No genre-based filler.
- In the Discover modal the rail is chainable: open a title, walk its neighbours.

## Why it needs no relay change

TMDB exposes recommendations as a sub-object of the details endpoint via `append_to_response`, which the relay already proxies. Reading it there rather than adding a dedicated relay route means this works on every existing install immediately, with no `metadata-relay-v*` release and no cross-version window.

The sub-object uses the same `{page, results, total_pages}` envelope as search and trending, so the existing `parse_search_results/2` consumes it unchanged.

## Notes

- Mydia already requested `recommendations` in `@shared_append_to_response` and parsed it down to bare ids in `recommended_tmdb_ids`, discarding titles and posters. Those ids fed only the GraphQL `similar` field, which intersects with the library and so returns only titles you already own. That field is unchanged here.
- No GraphQL or player changes, deliberately, to stay clear of the Rust SDL parity gate.
- 24h ETS cache keyed by title, media type and language.

## Also fixed

Ten docstrings in `lib/mydia/metadata.ex` pointed at `metadata-relay.dorninger.co`, which no longer runs the relay and today answers with an unrelated service that silently ignores `append_to_response`. They now point at `relay.mydia.dev`.

## Testing

Full suite: 7828 tests, 4 failures. Those 4 (TVShowSearch, MovieSearch, MetadataEnricher) pass in isolation (107 tests, 0 failures) and are cross-test pollution unrelated to this branch, which only adds functions to `relay.ex` and `metadata.ex` without modifying existing ones.

New coverage: provider (6), cache wrapper (4), context (8), rail component (5), detail page (3), Discover lookup (4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added recommendation rails to Discover details and media pages.
  - Browse, select, navigate to, add, or request recommended movies and TV shows directly.
  - Added language-aware recommendation results with 24-hour caching.
  - Guest users can request recommendations where supported.

- **Bug Fixes**
  - Gracefully handles unavailable, unsupported, empty, or invalid recommendations.
  - Preserves library status, request state, and existing media links for recommended items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->