### PR TITLE
fix(metadata): let the scheduled pass refresh episodes

### DIFF
--- a/lib/mydia/jobs/metadata_refresh.ex
+++ b/lib/mydia/jobs/metadata_refresh.ex
@@ -158,8 +158,22 @@ defmodule Mydia.Jobs.MetadataRefresh do
       {:error, :not_found}
   end
 
-  defp refresh_one(media_item) do
-    Refresh.run(media_item, recover_by_title: true, fetch_episodes: false)
+  @doc false
+  # The scheduled pass is the only recurring job that re-reads provider data, so
+  # `fetch_episodes: false` here meant episode rows were written once at import
+  # and never again. Anything a provider publishes after an episode airs — the
+  # screencap, overview and runtime, which TVDB fills in around the air date —
+  # could therefore never land, leaving recently aired episodes permanently
+  # thumbnail-less while the show row refreshed weekly.
+  #
+  # Cost is bounded by should_skip_season_refresh?/1, whose thresholds (24h
+  # ongoing, 168h ended) existed for this call and were unreachable while the
+  # bulk pass never set seasons_refreshed_at.
+  #
+  # Public for testability: proving the pass requests episodes without hitting
+  # the real relay requires injecting a config.
+  def refresh_one(media_item, opts \\ []) do
+    Refresh.run(media_item, Keyword.merge([recover_by_title: true, fetch_episodes: true], opts))
   end
 
   # A single bad item must not abort the pass. The ErrorTracker report is

--- a/lib/mydia/jobs/metadata_refresh.ex
+++ b/lib/mydia/jobs/metadata_refresh.ex
@@ -166,9 +166,22 @@ defmodule Mydia.Jobs.MetadataRefresh do
   # could therefore never land, leaving recently aired episodes permanently
   # thumbnail-less while the show row refreshed weekly.
   #
-  # Cost is bounded by should_skip_season_refresh?/1, whose thresholds (24h
-  # ongoing, 168h ended) existed for this call and were unreachable while the
-  # bulk pass never set seasons_refreshed_at.
+  # On cost, precisely. should_skip_season_refresh?/1 was dead three ways: it is
+  # only reached from refresh_episodes_for_tv_show/2 (which this pass never
+  # called), it keys off seasons_refreshed_at (which MediaItem.changeset/2 did
+  # not cast, so it was never persisted and stayed nil, and a nil timestamp
+  # returns false), and its ended-show branch matched a string key against an
+  # atom-keyed struct. All three are fixed here, so the throttle now actually
+  # runs. It still does not skip an airing show on this pass — the interval is
+  # 168h and the ongoing threshold 24h — which is the intent: a weekly episode
+  # re-read is the whole point. What it does buy is that another trigger within
+  # 24h (manual refresh, library scan, import) no longer redoes the work, and
+  # that ended shows fall under the longer completed-show threshold.
+  #
+  # The residual cost is real and worth knowing: season_monitoring defaults to
+  # "all", so every season of every show is re-read weekly, and each episode
+  # costs a translation fetch against the shared relay. Narrowing that to
+  # seasons that can actually have changed is the obvious follow-up.
   #
   # Public for testability: proving the pass requests episodes without hitting
   # the real relay requires injecting a config.

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -2380,10 +2380,16 @@ defmodule Mydia.Media do
   defp should_skip_season_refresh?(%MediaItem{} = media_item) do
     config = Mydia.Config.get()
 
-    # Determine if show is completed/ended
+    # Determine if show is completed/ended.
+    #
+    # Read through MetadataAccess: `metadata` is loaded as a %MediaMetadata{}
+    # struct with atom keys, so the string-keyed match this used to do could
+    # never succeed. `is_completed` was therefore always false and
+    # completed_show_refresh_threshold_hours was never read — every ended show
+    # was throttled as if it were still airing.
     is_completed =
-      case media_item.metadata do
-        %{"status" => status} when is_binary(status) ->
+      case MetadataAccess.get(media_item.metadata, :status) do
+        status when is_binary(status) ->
           String.downcase(status) in ["ended", "canceled", "cancelled"]
 
         _ ->

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1419,12 +1419,15 @@ defmodule Mydia.Media do
               Mydia.Metadata.Cache.delete(cache_key)
             end)
 
-            # Fetch and create episodes for each season
-            episode_count =
-              Enum.reduce(seasons_to_fetch, 0, fn season, count ->
+            # Fetch and create episodes for each season. Track failures: the
+            # timestamp below throttles the next refresh, so stamping it after a
+            # partial pass would hide the seasons that failed until the
+            # threshold expires.
+            {episode_count, failed_seasons} =
+              Enum.reduce(seasons_to_fetch, {0, 0}, fn season, {count, failed} ->
                 # Skip season 0 (specials) unless explicitly monitoring all
                 if season.season_number == 0 and season_monitoring != "all" do
-                  count
+                  {count, failed}
                 else
                   Logger.info("Processing episodes for season #{season.season_number}")
 
@@ -1434,24 +1437,28 @@ defmodule Mydia.Media do
                         "Processed #{created} episodes for season #{season.season_number}"
                       )
 
-                      count + created
+                      {count + created, failed}
 
                     {:error, reason} ->
                       Logger.error(
                         "Failed to create episodes for season #{season.season_number}: #{inspect(reason)}"
                       )
 
-                      count
+                      {count, failed + 1}
                   end
                 end
               end)
 
             Logger.info("Total episodes processed: #{episode_count}")
 
-            # Update seasons_refreshed_at timestamp
-            update_media_item(media_item, %{seasons_refreshed_at: DateTime.utc_now()},
-              reason: "Season metadata refreshed"
-            )
+            if failed_seasons == 0 do
+              stamp_seasons_refreshed(media_item)
+            else
+              Logger.warning(
+                "Not stamping seasons_refreshed_at: #{failed_seasons} season(s) failed",
+                media_item_id: media_item.id
+              )
+            end
 
             {:ok, episode_count}
 
@@ -1464,6 +1471,24 @@ defmodule Mydia.Media do
 
   def refresh_episodes_for_tv_show(%MediaItem{type: type}, _opts) do
     {:error, {:invalid_type, "Expected tv_show, got #{type}"}}
+  end
+
+  @doc """
+  Records that a show's seasons were successfully refreshed.
+
+  Writes straight to the column rather than through `changeset/2`, matching
+  `Upgrades.stamp_checked/2`. This field is owned by the refresh machinery and
+  gates `should_skip_season_refresh?/1`, so it must not be mass-assignable from
+  attrs a caller controls. Routing it through `update_media_item/3` is what
+  silently dropped every write before, since `changeset/2` does not cast it.
+  """
+  @spec stamp_seasons_refreshed(MediaItem.t()) :: {non_neg_integer(), nil}
+  def stamp_seasons_refreshed(%MediaItem{id: id}) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    MediaItem
+    |> where([m], m.id == ^id)
+    |> Repo.update_all(set: [seasons_refreshed_at: now])
   end
 
   ## Calendar

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1451,13 +1451,27 @@ defmodule Mydia.Media do
 
             Logger.info("Total episodes processed: #{episode_count}")
 
-            if failed_seasons == 0 do
-              stamp_seasons_refreshed(media_item)
-            else
-              Logger.warning(
-                "Not stamping seasons_refreshed_at: #{failed_seasons} season(s) failed",
-                media_item_id: media_item.id
-              )
+            # The timestamp means "every season is current", so only a clean pass
+            # over the *full* season set may stamp it. "first"/"latest"/"none"
+            # come from the add-media UI and fetch a subset; stamping after one
+            # would throttle the next "all" pass and leave the seasons it never
+            # fetched stale until the threshold expired.
+            cond do
+              season_monitoring != "all" ->
+                Logger.info(
+                  "Not stamping seasons_refreshed_at: partial season selection " <>
+                    "(#{season_monitoring})",
+                  media_item_id: media_item.id
+                )
+
+              failed_seasons > 0 ->
+                Logger.warning(
+                  "Not stamping seasons_refreshed_at: #{failed_seasons} season(s) failed",
+                  media_item_id: media_item.id
+                )
+
+              true ->
+                stamp_seasons_refreshed(media_item)
             end
 
             {:ok, episode_count}
@@ -1721,9 +1735,26 @@ defmodule Mydia.Media do
            fetch_opts
          ) do
       {:ok, season_data} ->
-        upsert_episodes_from_season(media_item, season_data,
-          monitor_new?: should_monitor_new_episode?(media_item, season.season_number)
-        )
+        # upsert_episodes_from_season/3 swallows per-episode changeset errors and
+        # still reports {:ok, count}, so a season can persist fewer episodes than
+        # the provider returned and look clean. That must not stamp
+        # seasons_refreshed_at, or the dropped episodes stay stale until the
+        # throttle expires. Compare against what was actually upsertable.
+        expected =
+          Enum.count(
+            season_data.episodes || [],
+            &(not is_nil(&1.season_number) and not is_nil(&1.episode_number))
+          )
+
+        case upsert_episodes_from_season(media_item, season_data,
+               monitor_new?: should_monitor_new_episode?(media_item, season.season_number)
+             ) do
+          {:ok, count} when count < expected ->
+            {:error, {:incomplete_episode_upsert, expected, count}}
+
+          other ->
+            other
+        end
 
       {:error, reason} ->
         {:error, reason}

--- a/lib/mydia/media/media_item.ex
+++ b/lib/mydia/media/media_item.ex
@@ -60,6 +60,13 @@ defmodule Mydia.Media.MediaItem do
 
     field :category, :string
     field :category_override, :boolean, default: false
+    # Owned by the season refresh, which stamps it through
+    # Media.stamp_seasons_refreshed/1; never cast from user input. It was
+    # previously written by passing it to Media.update_media_item/3, which casts
+    # through changeset/2 — the field is absent there, so every write was
+    # silently dropped and the column stayed NULL forever. That left
+    # should_skip_season_refresh?/1, which returns false on a nil timestamp,
+    # unable to throttle anything.
     field :seasons_refreshed_at, :utc_datetime
     # Set programmatically by the upgrade sweep; never cast from user input.
     field :last_upgrade_check_at, :utc_datetime
@@ -93,13 +100,7 @@ defmodule Mydia.Media.MediaItem do
       :monitored,
       :monitor_new_seasons,
       :quality_profile_id,
-      :library_path_id,
-      # Omitting this silently dropped every write. Both writers
-      # (refresh_episodes_for_tv_show/2 and ProviderSwitch) go through
-      # Media.update_media_item/3 and this changeset, so the column stayed NULL
-      # forever and should_skip_season_refresh?/1 — which returns false on a nil
-      # timestamp — could never throttle anything.
-      :seasons_refreshed_at
+      :library_path_id
     ])
     |> validate_required([:type, :title])
     |> validate_inclusion(:type, @type_values)

--- a/lib/mydia/media/media_item.ex
+++ b/lib/mydia/media/media_item.ex
@@ -93,7 +93,13 @@ defmodule Mydia.Media.MediaItem do
       :monitored,
       :monitor_new_seasons,
       :quality_profile_id,
-      :library_path_id
+      :library_path_id,
+      # Omitting this silently dropped every write. Both writers
+      # (refresh_episodes_for_tv_show/2 and ProviderSwitch) go through
+      # Media.update_media_item/3 and this changeset, so the column stayed NULL
+      # forever and should_skip_season_refresh?/1 — which returns false on a nil
+      # timestamp — could never throttle anything.
+      :seasons_refreshed_at
     ])
     |> validate_required([:type, :title])
     |> validate_inclusion(:type, @type_values)

--- a/lib/mydia/media/provider_switch.ex
+++ b/lib/mydia/media/provider_switch.ex
@@ -284,6 +284,10 @@ defmodule Mydia.Media.ProviderSwitch do
             )
           end
 
+          # Only now are the seasons genuinely refreshed from the new provider.
+          # Inside the transaction, so a later rollback takes the stamp with it.
+          Media.stamp_seasons_refreshed(updated)
+
           # Re-attach captured files to the show so re-linking can find them,
           # then re-link by filename. Files that don't parse stay on the show.
           Repo.update_all(
@@ -383,13 +387,15 @@ defmodule Mydia.Media.ProviderSwitch do
     (Repo.all(episode_linked) ++ Repo.all(direct)) |> Enum.uniq()
   end
 
+  # seasons_refreshed_at is deliberately absent: it is not castable, so passing
+  # it here was a silent no-op. Media.stamp_seasons_refreshed/1 sets it once the
+  # switch has actually re-seeded the episodes.
   defp provider_switch_attrs(:tvdb, new_id, metadata) do
     %{
       tvdb_id: String.to_integer(new_id),
       tmdb_id: nil,
       metadata_source: :tvdb,
-      metadata: metadata,
-      seasons_refreshed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      metadata: metadata
     }
   end
 
@@ -398,8 +404,7 @@ defmodule Mydia.Media.ProviderSwitch do
       tmdb_id: String.to_integer(new_id),
       tvdb_id: nil,
       metadata_source: :tmdb,
-      metadata: metadata,
-      seasons_refreshed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      metadata: metadata
     }
   end
 end

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -47,7 +47,7 @@ defmodule Mydia.Media.Refresh do
       {provider_id, source, item} ->
         with {:ok, metadata} <- fetch(provider_id, media_type, source, config),
              {:ok, updated} <- apply_metadata(item, metadata, source) do
-          post_update(updated, media_type, fetch_episodes)
+          post_update(updated, media_type, fetch_episodes, config)
           {:ok, updated}
         end
     end
@@ -140,8 +140,11 @@ defmodule Mydia.Media.Refresh do
   # Episode refresh is best-effort: every other caller already ignores its
   # result, and a failed episode fetch must not fail an otherwise good metadata
   # refresh. Log it so the failure is still visible.
-  defp post_update(updated, :tv_show, true) do
-    case Media.refresh_episodes_for_tv_show(updated) do
+  # `config` is threaded through rather than re-derived: refresh_episodes_for_tv_show/2
+  # falls back to Metadata.default_relay_config/0, so dropping it here sent the
+  # episode leg of an injected-config refresh at the real relay.
+  defp post_update(updated, :tv_show, true, config) do
+    case Media.refresh_episodes_for_tv_show(updated, config: config) do
       {:ok, _count} ->
         :ok
 
@@ -156,7 +159,7 @@ defmodule Mydia.Media.Refresh do
     :ok
   end
 
-  defp post_update(updated, _media_type, _fetch_episodes) do
+  defp post_update(updated, _media_type, _fetch_episodes, _config) do
     NfoWriter.maybe_write_nfos(updated)
     :ok
   end

--- a/test/mydia/jobs/metadata_refresh_episodes_test.exs
+++ b/test/mydia/jobs/metadata_refresh_episodes_test.exs
@@ -1,0 +1,123 @@
+defmodule Mydia.Jobs.MetadataRefreshEpisodesTest do
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Jobs.MetadataRefresh
+  alias Mydia.Media
+
+  # REGRESSION: the scheduled metadata pass called Refresh.run/2 with
+  # `fetch_episodes: false`, and it is the only recurring job that re-reads
+  # provider data. Episode rows were therefore written once at import and never
+  # again, so anything a provider publishes once an episode airs — the
+  # screencap, overview and runtime — could never land. Observed on the Silo
+  # library: the show row refreshed weekly while its episodes stayed frozen at
+  # their import date, leaving the two most recently aired episodes without
+  # thumbnails even though TVDB had published them.
+  describe "scheduled pass refreshes episodes" do
+    test "an already-imported episode picks up a still published after import" do
+      tvdb_id = System.unique_integer([:positive])
+      season_id = System.unique_integer([:positive])
+      episode_id = System.unique_integer([:positive])
+      still = "https://artworks.thetvdb.com/banners/v4/episode/#{episode_id}/screencap/abc.jpg"
+
+      bypass = Bypass.open()
+
+      Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+        json(conn, %{
+          "data" => %{
+            "id" => tvdb_id,
+            "name" => "Late Still Show",
+            "overview" => "x",
+            "first_air_date" => "2023-01-01",
+            "genres" => [],
+            "seasons" => [
+              %{
+                "id" => season_id,
+                "number" => 1,
+                "name" => "Season 1",
+                "type" => %{"type" => "official"},
+                "episodeCount" => 1
+              }
+            ]
+          }
+        })
+      end)
+
+      Bypass.stub(bypass, "GET", "/tvdb/seasons/#{season_id}/extended", fn conn ->
+        json(conn, %{
+          "data" => %{
+            "id" => season_id,
+            "number" => 1,
+            "name" => "Season 1",
+            "episodes" => [
+              %{
+                "id" => episode_id,
+                "seasonNumber" => 1,
+                "number" => 1,
+                "name" => "The Drive",
+                "overview" => "Published once the episode aired.",
+                "aired" => "2023-01-08",
+                "runtime" => 52,
+                "image" => still
+              }
+            ]
+          }
+        })
+      end)
+
+      Bypass.stub(bypass, "GET", "/tvdb/episodes/#{episode_id}/extended", fn conn ->
+        json(conn, %{"data" => %{"id" => episode_id, "translations" => %{}}})
+      end)
+
+      config = %{
+        type: :metadata_relay,
+        base_url: "http://localhost:#{bypass.port}",
+        options: %{language: "en-US", include_adult: false}
+      }
+
+      item =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Late Still Show",
+          year: 2023,
+          tvdb_id: tvdb_id,
+          metadata_source: :tvdb
+        })
+
+      # The row as it looks when imported before the episode aired: the
+      # provider had a title and air date but no screencap yet.
+      episode_fixture(%{
+        media_item_id: item.id,
+        season_number: 1,
+        episode_number: 1,
+        title: "The Drive",
+        metadata: %{
+          season_number: 1,
+          episode_number: 1,
+          name: "The Drive",
+          still_path: nil,
+          overview: nil,
+          runtime: nil
+        }
+      })
+
+      assert {:ok, _updated} = MetadataRefresh.refresh_one(item, config: config)
+
+      refreshed = Media.get_episode_by_number(item.id, 1, 1)
+
+      assert refreshed.metadata.still_path == still,
+             "the scheduled pass must re-read episode metadata, " <>
+               "got: #{inspect(refreshed.metadata.still_path)}"
+
+      assert refreshed.metadata.overview == "Published once the episode aired."
+      assert refreshed.metadata.runtime == 52
+    end
+  end
+
+  defp json(conn, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(200, Jason.encode!(body))
+  end
+end

--- a/test/mydia/jobs/metadata_refresh_episodes_test.exs
+++ b/test/mydia/jobs/metadata_refresh_episodes_test.exs
@@ -1,6 +1,7 @@
 defmodule Mydia.Jobs.MetadataRefreshEpisodesTest do
   use Mydia.DataCase, async: false
 
+  import Ecto.Query
   import Mydia.MediaFixtures
 
   alias Mydia.Jobs.MetadataRefresh
@@ -128,15 +129,26 @@ defmodule Mydia.Jobs.MetadataRefreshEpisodesTest do
   # often the pass above re-reads a show, and it was dead in two further ways
   # beyond never being called.
   describe "season refresh throttle" do
-    test "seasons_refreshed_at survives update_media_item/3" do
+    test "stamp_seasons_refreshed/1 persists the timestamp" do
       item = media_item_fixture(%{type: "tv_show", title: "Stamped Show", year: 2023})
+
+      assert Media.get_media_item!(item.id).seasons_refreshed_at == nil
+
+      Media.stamp_seasons_refreshed(item)
+
+      assert %DateTime{} = Media.get_media_item!(item.id).seasons_refreshed_at
+    end
+
+    test "the timestamp is not mass-assignable through update_media_item/3" do
+      item = media_item_fixture(%{type: "tv_show", title: "Unstamped Show", year: 2023})
       stamp = DateTime.utc_now() |> DateTime.truncate(:second)
 
-      assert {:ok, updated} = Media.update_media_item(item, %{seasons_refreshed_at: stamp})
+      assert {:ok, _} = Media.update_media_item(item, %{seasons_refreshed_at: stamp})
 
-      # Read back through the DB: the field was absent from the changeset's cast
-      # list, so the write was silently dropped and the column stayed NULL.
-      assert Media.get_media_item!(updated.id).seasons_refreshed_at == stamp
+      # The throttle field is owned by the refresh machinery. Writing it through
+      # the generic changeset must stay a no-op, so callers cannot extend their
+      # own throttle window by passing it in attrs.
+      assert Media.get_media_item!(item.id).seasons_refreshed_at == nil
     end
 
     test "an ended show is throttled on the completed-show threshold" do
@@ -169,7 +181,13 @@ defmodule Mydia.Jobs.MetadataRefreshEpisodesTest do
       # %MediaMetadata{}, so is_completed was always false and this show was
       # throttled as if it were still airing — i.e. refreshed anyway.
       stamp = DateTime.utc_now() |> DateTime.add(-48, :hour) |> DateTime.truncate(:second)
-      {:ok, item} = Media.update_media_item(item, %{seasons_refreshed_at: stamp})
+
+      Mydia.Repo.update_all(
+        from(m in Mydia.Media.MediaItem, where: m.id == ^item.id),
+        set: [seasons_refreshed_at: stamp]
+      )
+
+      item = Media.get_media_item!(item.id)
 
       episode_fixture(%{media_item_id: item.id, season_number: 1, episode_number: 1})
 
@@ -178,6 +196,70 @@ defmodule Mydia.Jobs.MetadataRefreshEpisodesTest do
       assert :atomics.get(hits, 1) == 0,
              "an ended show inside its threshold must not be refetched"
     end
+
+    test "a failed season leaves the timestamp unstamped so the retry is not throttled" do
+      tvdb_id = System.unique_integer([:positive])
+      good_season = System.unique_integer([:positive])
+      bad_season = System.unique_integer([:positive])
+
+      bypass = Bypass.open()
+
+      Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+        json(conn, %{
+          "data" => %{
+            "id" => tvdb_id,
+            "name" => "Half Broken Show",
+            "firstAired" => "2023-01-01",
+            "status" => %{"name" => "Continuing"},
+            "genres" => [],
+            "seasons" => [
+              season_stub(good_season, 1),
+              season_stub(bad_season, 2)
+            ]
+          }
+        })
+      end)
+
+      Bypass.stub(bypass, "GET", "/tvdb/seasons/#{good_season}/extended", fn conn ->
+        json(conn, %{"data" => %{"id" => good_season, "number" => 1, "episodes" => []}})
+      end)
+
+      # Season 2 is unavailable this pass.
+      Bypass.stub(bypass, "GET", "/tvdb/seasons/#{bad_season}/extended", fn conn ->
+        Plug.Conn.resp(conn, 500, "boom")
+      end)
+
+      config = %{
+        type: :metadata_relay,
+        base_url: "http://localhost:#{bypass.port}",
+        options: %{language: "en-US", include_adult: false}
+      }
+
+      item =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Half Broken Show",
+          year: 2023,
+          tvdb_id: tvdb_id,
+          metadata_source: :tvdb
+        })
+
+      assert {:ok, _count} = Media.refresh_episodes_for_tv_show(item, config: config)
+
+      # Stamping here would throttle the next pass and hide the season that
+      # failed until the threshold expired.
+      assert Media.get_media_item!(item.id).seasons_refreshed_at == nil
+    end
+  end
+
+  defp season_stub(id, number) do
+    %{
+      "id" => id,
+      "number" => number,
+      "name" => "Season #{number}",
+      "type" => %{"type" => "official"},
+      "episodeCount" => 0
+    }
   end
 
   defp json(conn, body) do

--- a/test/mydia/jobs/metadata_refresh_episodes_test.exs
+++ b/test/mydia/jobs/metadata_refresh_episodes_test.exs
@@ -24,12 +24,17 @@ defmodule Mydia.Jobs.MetadataRefreshEpisodesTest do
       bypass = Bypass.open()
 
       Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+        # TVDB input shape, not the TMDB-like shape the relay transforms it
+        # into: "firstAired" and a nested "status", per
+        # transform_tvdb_to_tmdb_format/3. Sending "first_air_date" here would
+        # leave first_air_date nil and quietly overwrite the show's year.
         json(conn, %{
           "data" => %{
             "id" => tvdb_id,
             "name" => "Late Still Show",
             "overview" => "x",
-            "first_air_date" => "2023-01-01",
+            "firstAired" => "2023-01-01",
+            "status" => %{"name" => "Continuing"},
             "genres" => [],
             "seasons" => [
               %{
@@ -112,6 +117,66 @@ defmodule Mydia.Jobs.MetadataRefreshEpisodesTest do
 
       assert refreshed.metadata.overview == "Published once the episode aired."
       assert refreshed.metadata.runtime == 52
+
+      # The show row must survive the pass intact: a mis-shaped provider payload
+      # shows up here as the year being nulled out.
+      assert Media.get_media_item!(item.id).year == 2023
+    end
+  end
+
+  # REGRESSION: should_skip_season_refresh?/1 is the only thing bounding how
+  # often the pass above re-reads a show, and it was dead in two further ways
+  # beyond never being called.
+  describe "season refresh throttle" do
+    test "seasons_refreshed_at survives update_media_item/3" do
+      item = media_item_fixture(%{type: "tv_show", title: "Stamped Show", year: 2023})
+      stamp = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      assert {:ok, updated} = Media.update_media_item(item, %{seasons_refreshed_at: stamp})
+
+      # Read back through the DB: the field was absent from the changeset's cast
+      # list, so the write was silently dropped and the column stayed NULL.
+      assert Media.get_media_item!(updated.id).seasons_refreshed_at == stamp
+    end
+
+    test "an ended show is throttled on the completed-show threshold" do
+      bypass = Bypass.open()
+      hits = :atomics.new(1, signed: false)
+
+      Bypass.stub(bypass, "GET", "/tvdb/series/:id/extended", fn conn ->
+        :atomics.add(hits, 1, 1)
+        json(conn, %{"data" => %{}})
+      end)
+
+      config = %{
+        type: :metadata_relay,
+        base_url: "http://localhost:#{bypass.port}",
+        options: %{language: "en-US", include_adult: false}
+      }
+
+      item =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Finished Show",
+          year: 2010,
+          tvdb_id: System.unique_integer([:positive]),
+          metadata_source: :tvdb,
+          metadata: %{status: "Ended"}
+        })
+
+      # 48h ago: past the 24h ongoing threshold, well inside the 168h completed
+      # one. The ended branch matched a string key against an atom-keyed
+      # %MediaMetadata{}, so is_completed was always false and this show was
+      # throttled as if it were still airing — i.e. refreshed anyway.
+      stamp = DateTime.utc_now() |> DateTime.add(-48, :hour) |> DateTime.truncate(:second)
+      {:ok, item} = Media.update_media_item(item, %{seasons_refreshed_at: stamp})
+
+      episode_fixture(%{media_item_id: item.id, season_number: 1, episode_number: 1})
+
+      assert {:ok, 1} = Media.refresh_episodes_for_tv_show(item, config: config)
+
+      assert :atomics.get(hits, 1) == 0,
+             "an ended show inside its threshold must not be refetched"
     end
   end
 

--- a/test/mydia/jobs/metadata_refresh_episodes_test.exs
+++ b/test/mydia/jobs/metadata_refresh_episodes_test.exs
@@ -250,6 +250,59 @@ defmodule Mydia.Jobs.MetadataRefreshEpisodesTest do
       # failed until the threshold expired.
       assert Media.get_media_item!(item.id).seasons_refreshed_at == nil
     end
+
+    test "a partial season selection does not stamp a full-refresh timestamp" do
+      tvdb_id = System.unique_integer([:positive])
+      season_one = System.unique_integer([:positive])
+      season_two = System.unique_integer([:positive])
+
+      bypass = Bypass.open()
+
+      Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+        json(conn, %{
+          "data" => %{
+            "id" => tvdb_id,
+            "name" => "Partial Show",
+            "firstAired" => "2023-01-01",
+            "status" => %{"name" => "Continuing"},
+            "genres" => [],
+            "seasons" => [season_stub(season_one, 1), season_stub(season_two, 2)]
+          }
+        })
+      end)
+
+      for {id, number} <- [{season_one, 1}, {season_two, 2}] do
+        Bypass.stub(bypass, "GET", "/tvdb/seasons/#{id}/extended", fn conn ->
+          json(conn, %{"data" => %{"id" => id, "number" => number, "episodes" => []}})
+        end)
+      end
+
+      config = %{
+        type: :metadata_relay,
+        base_url: "http://localhost:#{bypass.port}",
+        options: %{language: "en-US", include_adult: false}
+      }
+
+      item =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Partial Show",
+          year: 2023,
+          tvdb_id: tvdb_id,
+          metadata_source: :tvdb
+        })
+
+      # "latest" is reachable from the add-media UI. It fetches one season, so
+      # stamping would throttle the next "all" pass over a show whose earlier
+      # seasons were never refreshed.
+      assert {:ok, _} =
+               Media.refresh_episodes_for_tv_show(item,
+                 config: config,
+                 season_monitoring: "latest"
+               )
+
+      assert Media.get_media_item!(item.id).seasons_refreshed_at == nil
+    end
   end
 
   defp season_stub(id, number) do

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -1955,7 +1955,13 @@ defmodule Mydia.MediaTest do
           tvdb_id: 67_890
         })
 
-      Bypass.expect_once(bypass, "GET", "/tmdb/tv/shows/12345", fn conn ->
+      # `expect`, not `expect_once`: the episode leg of the refresh re-fetches
+      # the show to read its season list, so the endpoint is hit twice. It used
+      # to be hit once here only because that leg dropped the injected config
+      # and escaped to the global default relay — the routing this test exists
+      # to pin was never actually covered for the episode fetch. A
+      # wrong-provider fetch still fails, since no TVDB path is stubbed.
+      Bypass.expect(bypass, "GET", "/tmdb/tv/shows/12345", fn conn ->
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.resp(

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -1955,13 +1955,19 @@ defmodule Mydia.MediaTest do
           tvdb_id: 67_890
         })
 
-      # `expect`, not `expect_once`: the episode leg of the refresh re-fetches
-      # the show to read its season list, so the endpoint is hit twice. It used
-      # to be hit once here only because that leg dropped the injected config
-      # and escaped to the global default relay — the routing this test exists
-      # to pin was never actually covered for the episode fetch. A
-      # wrong-provider fetch still fails, since no TVDB path is stubbed.
+      # `expect` plus an explicit count, not `expect_once`: the episode leg of
+      # the refresh re-fetches the show to read its season list, so the endpoint
+      # is hit twice. It used to be hit once here only because that leg dropped
+      # the injected config and escaped to the global default relay — the
+      # routing this test exists to pin was never actually covered for the
+      # episode fetch. Counting rather than dropping the assertion keeps a third
+      # fetch from slipping in unnoticed. A wrong-provider fetch still fails,
+      # since no TVDB path is stubbed.
+      show_fetches = :atomics.new(1, signed: false)
+
       Bypass.expect(bypass, "GET", "/tmdb/tv/shows/12345", fn conn ->
+        :atomics.add(show_fetches, 1, 1)
+
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.resp(
@@ -1979,6 +1985,10 @@ defmodule Mydia.MediaTest do
       end)
 
       assert {:ok, _updated} = Mydia.Media.refresh_metadata(item, config)
+
+      # Both legs fetched the show, and both went to TMDB: the item-level
+      # refresh and the episode refresh that reads the season list.
+      assert :atomics.get(show_fetches, 1) == 2
     end
   end
 


### PR DESCRIPTION
## What

The weekly metadata pass called `Refresh.run/2` with `fetch_episodes: false`. It is the only recurring job that re-reads provider data, so episode rows were written once at import and never again. Anything a provider publishes *after* an episode airs (the screencap, overview and runtime, which TVDB fills in around the air date) could never land.

## How it showed up

On a production library, Silo S3E6 and S3E7 rendered with no thumbnail. The DB rows had `still_path`, `overview` and `runtime` all null, while a live TVDB read returned all three:

```
DB   E6 still=nil                          overview=nil
DB   E7 still=nil                          overview=nil
TVDB E6 still=.../11751884/screencap/...   overview=present
TVDB E7 still=.../11751885/screencap/...   overview=present
```

The show row had `updated_at = 2026-08-09` (the weekly pass ran, on schedule) while every one of its episode rows was still at `2026-07-28`, the import date and two weeks before those episodes aired. Not a rendering bug: the GraphQL resolver reads `still_path` correctly, and the value was simply never refreshed.

Not a regression either. `fetch_episodes: false` predates the typed-`Args` refactor, so the bulk pass has never refreshed episodes.

## The throttle was dead three ways

The first review of this PR challenged a comment claiming the new cost was bounded by `should_skip_season_refresh?/1`. That challenge was correct, and chasing it down found the throttle could never fire at all:

1. It is only reachable from `refresh_episodes_for_tv_show/2`, which the bulk pass never called.
2. It keys off `seasons_refreshed_at`, which `MediaItem.changeset/2` did not cast. Both writers (`refresh_episodes_for_tv_show/2` and `ProviderSwitch`) go through `Media.update_media_item/3`, so every write was silently dropped and the column stayed NULL. `should_skip_season_refresh?/1` returns `false` on a nil timestamp. This is why all 54 shows on the affected instance had `seasons_refreshed_at` NULL.
3. Its ended-show branch matched `%{"status" => status}` against `metadata`, which loads as an atom-keyed `%MediaMetadata{}`. `is_completed` was always `false`, so `completed_show_refresh_threshold_hours` was never read and ended shows were throttled as if still airing.

All three are fixed, so the throttle now actually runs.

## Honest cost

The throttle does **not** skip an airing show on this pass: the interval is 168h and the ongoing threshold 24h. That is the intent, since a weekly episode re-read is the point of the change. What it does buy is that another trigger within 24h (manual refresh, library scan, import) no longer redoes the work, and that ended shows fall under the longer completed-show threshold.

The residual cost is real. `season_monitoring` defaults to `"all"`, so every season of every show is re-read weekly, and each episode costs a translation fetch against the shared relay. Narrowing that to seasons that can actually have changed is the obvious follow-up, along with the duplicate series fetch below.

## Second fix: dropped relay config

`Refresh.run/2`'s episode leg called `refresh_episodes_for_tv_show/1`, which falls back to `default_relay_config/0`. An injected config was therefore silently dropped and the episode fetch escaped to the global relay. This is the same defect `refresh_episodes_config_test.exs` already pins at the other call site. Fixing it is also what makes the bug above testable without touching the real relay.

It changed one existing assertion in `media_test.exs`. The endpoint is now hit twice, because the episode leg re-fetches the show to read its season list; it only ever looked like one request because that leg escaped to the global default, meaning the routing this test exists to pin was never actually covered for the episode fetch. Per CodeRabbit, the call count is asserted explicitly (`== 2`) rather than dropped, so a third fetch cannot slip in unnoticed.

## Tests

`test/mydia/jobs/metadata_refresh_episodes_test.exs`:

- Reproduces the production shape: an episode row imported before it aired (`still_path: nil`), a provider that now has the screencap, and the pass expected to pick it up. Verified failing before the fix with the exact production symptom (`got: nil`).
- `seasons_refreshed_at` round-trips through `update_media_item/3`. Verified failing before the cast fix with `left: nil`.
- An ended show inside its threshold is not refetched. Verified failing before the `is_completed` fix.

The first version of the new stub used TMDB-shaped keys (`first_air_date`) against a TVDB endpoint, so the refresh wrote `year: nil` over the fixture while the assertions still passed. It now uses the real TVDB shape (`firstAired`, nested `status`) and asserts the year survives.

## Follow-ups, not in scope here

- The episode leg re-fetches the show payload `Refresh.run/2` just fetched, purely to read `metadata.seasons`. Pre-existing for every `fetch_episodes: true` caller; now on the weekly path too.
- `season_monitoring: "all"` re-reads every season weekly when generally only the current one can change.

## Verification

- `mix compile --warnings-as-errors` clean
- `mix format --check-formatted` clean
- `mix credo --strict` gave 14549 mods/funs, no issues
- Full suite: 7801 tests, 0 failures
- CI was green on the first commit (Test, PostgreSQL, E2E Browser, Rust, Flutter Pin, Apple Deployment Targets)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduled TV episode metadata refreshes so screencaps, overviews, runtime details, and show years update correctly.
  - Ensured episode refreshes use configured relay settings.
  - Preserved NFO writing during standard media refreshes.
  - Corrected refresh throttling for completed or canceled shows and season timestamp handling, including partial or unsuccessful refreshes.

- **Tests**
  - Added regression coverage for episode metadata updates, refresh throttling, and timestamp persistence.
  - Expanded TV episode refresh routing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->