### PR TITLE
feat(player): refract the playback chrome instead of only blurring it

### DIFF
--- a/player/lib/core/theme/depth_tokens.dart
+++ b/player/lib/core/theme/depth_tokens.dart
@@ -293,4 +293,95 @@ abstract final class DepthTokens {
 
   /// Corner radius for the 36px-tall top-bar pills (fully rounded).
   static const double radiusPlayerPill = 18.0;
+
+  // ---------------------------------------------------------------------------
+  // Player chrome lensing (iOS 26 / 27 material)
+  //
+  // Parameters for the refracting glass material behind
+  // `GlassSurface.playerChrome`. Everything above this block describes a
+  // surface that only *blurs* its backdrop; these describe one that also
+  // *bends* it, which is the difference between frosted plastic and glass.
+  //
+  // Deliberately expressed as bare doubles and Flutter types, never as
+  // `liquid_glass_widgets` enums, even where the underlying knob is an enum
+  // (specular sharpness). `glass_surface.dart` is the single file allowed to
+  // import that package (see the dependency's comment in `pubspec.yaml`), and
+  // that seam is what makes a rollback to a plain `BackdropFilter` a one-file
+  // revert. A package type in this module would quietly spread the dependency
+  // into the token layer and every test that reads it.
+  //
+  // These are inert on tiers that render no shader; see
+  // `GlassSurface.playerChrome`.
+  // ---------------------------------------------------------------------------
+
+  /// Index of refraction for the panel's rim.
+  ///
+  /// 1.0 is a vacuum (no bending at all) and real glass is ~1.5. The package
+  /// defaults to 1.2, which barely reads at this panel's size. 1.4 sits near
+  /// real glass while stopping short of the fishbowl distortion that starts
+  /// to warp the control glyphs sitting on top of the lens.
+  static const double playerChromeRefractiveIndex = 1.4;
+
+  /// Apparent thickness of the glass slab, in logical pixels.
+  ///
+  /// Governs how wide the refracted band at the panel's edge is. Held just
+  /// under [radiusPlayerPanel] (16) so the lensing stays inside the corner
+  /// curve and does not intrude on the control row, which begins
+  /// `ChromePanel.verticalPadding` (10px) in from the top edge.
+  static const double playerChromeThickness = 14.0;
+
+  /// Per-channel dispersion at the refracted edge.
+  ///
+  /// Real lenses split colour slightly at their edges, and its total absence
+  /// is part of why a plain blur reads as synthetic. Kept at the package
+  /// default: this panel sits over video whose own colour is the subject, and
+  /// visible fringing on chrome would compete with it.
+  static const double playerChromeChromaticAberration = 0.01;
+
+  /// Specular highlight intensity along the lit edge.
+  ///
+  /// Raised well above the package default of 0.5, following the brighter
+  /// specular highlights iOS 27 introduced. This is the cue that survives on
+  /// the tiers that cannot refract, so it carries the material's read on web
+  /// as well as native.
+  static const double playerChromeLightIntensity = 0.8;
+
+  /// Direction of the virtual light, in radians, clockwise from +x.
+  ///
+  /// `-pi / 2` puts the source directly overhead, matching [playerRimTop]'s
+  /// premise that glass catches light on its upper edge. Kept consistent with
+  /// that rim rather than with the package default so the two treatments
+  /// agree about where the light is.
+  static const double playerChromeLightAngle = -1.5707963267948966; // -pi/2
+
+  /// Darkened outer edge, painted *outside* the panel silhouette (iOS 27).
+  ///
+  /// iOS 27 added a dark edge around glass elements for separation from busy
+  /// backdrops. This is ours to paint: `liquid_glass_widgets` exposes
+  /// `shadow`/`shadowElevation`, but both are documented "has no effect in
+  /// dark mode" in three places in `LiquidGlassSettings`, and this player's
+  /// theme is dark-only and never switches (see the note at the top of this
+  /// module). Passing them would silently do nothing.
+  ///
+  /// Tight and near-opaque rather than soft and wide: the goal is a defining
+  /// edge, not a floating drop shadow. [chrome] above is the latter, and this
+  /// panel deliberately does not use it.
+  ///
+  /// Expressed as a colour plus a blur sigma rather than a [BoxShadow],
+  /// because it is painted with `MaskFilter.blur(BlurStyle.outer, ...)` and
+  /// not by a [BoxDecoration]. That distinction is load-bearing rather than
+  /// stylistic: a [BoxShadow] paints *behind* its child, and this panel's
+  /// fill is translucent by design, so the shadow would show through and
+  /// darken it. That would silently shift the backdrop that
+  /// `glass_legibility_test.dart` models as uniform, moving the panel's
+  /// measured contrast without anything in that test changing.
+  /// [BlurStyle.outer] paints strictly outside the silhouette, so the fill is
+  /// untouched and the contrast contract holds.
+  static const Color playerChromeEdgeShadowColor = Color(0x4D000000); // 0.30
+
+  /// Blur sigma for [playerChromeEdgeShadowColor].
+  ///
+  /// Small on purpose. Wide enough and this stops reading as an edge and
+  /// starts reading as elevation, which is [chrome]'s job, not this one's.
+  static const double playerChromeEdgeShadowSigma = 2.0;
 }

--- a/player/lib/main.dart
+++ b/player/lib/main.dart
@@ -13,6 +13,7 @@ import 'core/navigation/sidebar_layout_providers.dart';
 import 'core/window/desktop_window.dart';
 import 'core/startup/startup_error_app.dart';
 import 'core/startup/startup_lock.dart';
+import 'presentation/widgets/glass_surface.dart';
 
 import 'package:player/native/frb_generated.dart';
 
@@ -135,6 +136,25 @@ Future<void> _startApp() async {
     MediaKit.ensureInitialized();
   } catch (e, st) {
     debugPrint('[MediaKit] Failed to initialize: $e');
+    debugPrint('Stack trace: $st');
+  }
+
+  // Pre-compile the playback chrome's glass shaders. Paired with the
+  // MediaKit call above deliberately: both exist so that *starting playback*
+  // is cheap, and the OSD's first frame is the first thing drawn once it
+  // does. Compiling inline there instead costs 100-800ms on mid-range
+  // Android GLES hardware, landing precisely on the frame the viewer is
+  // watching for.
+  //
+  // Best-effort, in the same style as the rest of this function: the glass
+  // renderer falls back to a tinted passthrough while a shader is missing,
+  // so a failure here is a briefly plainer OSD and never a broken app. Must
+  // not be allowed to throw, or it would break this function's invariant
+  // that `runApp` is called exactly once on every path.
+  try {
+    await GlassSurface.warmUpShaders();
+  } catch (e, st) {
+    debugPrint('[GlassSurface] Shader warm-up failed: $e');
     debugPrint('Stack trace: $st');
   }
 

--- a/player/lib/presentation/widgets/glass_surface.dart
+++ b/player/lib/presentation/widgets/glass_surface.dart
@@ -1,6 +1,13 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+// Prefixed, and imported *only* here. This file is the seam that keeps the
+// dependency swappable (see the `liquid_glass_widgets` entry in
+// `pubspec.yaml`): nothing else in the app may import it, and a rollback to a
+// plain `BackdropFilter` is a revert of this one file. The prefix also keeps
+// the package's large export surface — GlassCard, GlassButton, GlassScaffold,
+// and dozens more we do not use — out of this library's namespace.
+import 'package:liquid_glass_widgets/liquid_glass_widgets.dart' as lg;
 
 import '../../core/player/platform_features.dart';
 import '../../core/theme/colors.dart';
@@ -73,6 +80,20 @@ class GlassSurface extends StatelessWidget {
   /// the corners to avoid that.
   final Gradient? rimGradient;
 
+  /// When non-null, this surface renders the *refracting* playback-chrome
+  /// material for the given tier instead of the plain
+  /// blur-and-fill composition every other constructor uses.
+  ///
+  /// Only [GlassSurface.playerChrome] sets this. Null (every other named
+  /// constructor, and the unnamed one) leaves [build] on the original
+  /// `BackdropFilter` path, so no existing surface changes behaviour.
+  ///
+  /// [PlayerGlassTier.faux] is deliberately *not* excluded here: [build]
+  /// routes it back to the no-live-blur path, because there is no point
+  /// paying for a refraction shader on a tier whose entire premise is that
+  /// the device cannot afford one.
+  final PlayerGlassTier? playerTier;
+
   final Widget? child;
 
   const GlassSurface({
@@ -86,8 +107,24 @@ class GlassSurface extends StatelessWidget {
     this.grouped = false,
     this.saturation = 1.0,
     this.rimGradient,
+    this.playerTier,
     this.child,
   });
+
+  /// Pre-compiles the glass fragment shaders.
+  ///
+  /// Call once from `main()` before `runApp`. Without it the first frame that
+  /// mounts playback chrome pays the shader compile inline — the package
+  /// documents 100-800ms on mid-range Android GLES hardware — and that first
+  /// frame is exactly when the OSD appears at playback start. The renderer
+  /// degrades to a tinted passthrough rather than throwing while the shader
+  /// is missing, so a skipped or failed warm-up is a visible pop, not a
+  /// crash.
+  ///
+  /// Wrapped here rather than called directly from `main.dart` so this file
+  /// stays the only importer of `liquid_glass_widgets`; see the import
+  /// comment at the top.
+  static Future<void> warmUpShaders() => lg.LiquidGlassWidgets.initialize();
 
   /// App-bar chrome glass: chrome blur sigma, [AppColors.background] fill at the
   /// chrome fill opacity, no border, square corners. Pass [opacity] to override
@@ -235,13 +272,16 @@ class GlassSurface extends StatelessWidget {
         end: Alignment.bottomCenter,
         colors: [DepthTokens.playerRimTop, DepthTokens.playerRimBottom],
       ),
+      playerTier: resolvedTier,
       child: child,
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    // Faux-glass: no BackdropFilter at all (R8).
+    // Faux-glass: no BackdropFilter at all (R8). Checked before [playerTier]
+    // so PlayerGlassTier.faux keeps landing here rather than paying for a
+    // refraction shader (see [playerTier]'s dartdoc).
     if (!live) {
       return RepaintBoundary(
         child: ClipRRect(
@@ -250,6 +290,9 @@ class GlassSurface extends StatelessWidget {
         ),
       );
     }
+
+    final tier = playerTier;
+    if (tier != null) return _buildLensed(tier);
 
     final blur = ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma);
     final filter = saturation == 1.0
@@ -266,6 +309,86 @@ class GlassSurface extends StatelessWidget {
       child: ClipRRect(
         borderRadius: borderRadius,
         child: _withRim(backdrop),
+      ),
+    );
+  }
+
+  /// The refracting playback-chrome material.
+  ///
+  /// Differs from the [BackdropFilter] path above in what it does to the
+  /// backdrop: that one only blurs, this one also *bends*, sampling the video
+  /// behind the panel at displaced coordinates so the rim reads as a lens
+  /// rather than a frosted rectangle.
+  ///
+  /// The fill stays ours. `glassColor` is fully transparent so the package
+  /// contributes no tint of its own, and [_fill]'s gradient
+  /// ([DepthTokens.playerChromeFillTopAlpha] -> `...BottomAlpha`) remains the
+  /// only thing standing between the controls and the video. That is
+  /// deliberate and load-bearing: `glass_legibility_test.dart` derives the
+  /// panel's WCAG contrast analytically from those two tokens, and the
+  /// package has no gradient fill at all (`LiquidGlassSettings.glassColor` is
+  /// a single [Color]). Letting it own the fill would flatten the gradient to
+  /// one alpha *and* move the contrast contract out of our tests.
+  ///
+  /// That analytic model survives this change. Over the spatially uniform
+  /// worst-case backdrop it assumes, refraction and chromatic aberration are
+  /// both the identity — displaced samples of a constant field are that same
+  /// constant — exactly as blur and the saturation matrix already were. The
+  /// one genuinely new term is the specular highlight, which *adds* light and
+  /// so lowers contrast for white glyphs wherever it lands. It is confined to
+  /// the lit edge, and [ChromePanel] holds row 1 a further
+  /// `ChromePanel.verticalPadding` (10px) inboard of that edge, so it falls
+  /// on padding rather than on any glyph. Narrow the padding, raise
+  /// [DepthTokens.playerChromeLightIntensity], or put content flush to the
+  /// top edge and that stops being true.
+  Widget _buildLensed(PlayerGlassTier tier) {
+    final settings = lg.LiquidGlassSettings(
+      // Transparent: see above. The package must add no tint of its own.
+      glassColor: const Color(0x00000000),
+      blur: blurSigma,
+      saturation: saturation,
+      thickness: DepthTokens.playerChromeThickness,
+      refractiveIndex: DepthTokens.playerChromeRefractiveIndex,
+      chromaticAberration: DepthTokens.playerChromeChromaticAberration,
+      lightIntensity: DepthTokens.playerChromeLightIntensity,
+      lightAngle: DepthTokens.playerChromeLightAngle,
+      specularSharpness: lg.GlassSpecularSharpness.medium,
+    );
+
+    return RepaintBoundary(
+      // The iOS 27 darkened outer edge, painted by us. The package's own
+      // `shadow`/`shadowElevation` are documented "has no effect in dark
+      // mode" in three separate places in `LiquidGlassSettings`, and this
+      // player's theme is dark-only and never switches, so passing them
+      // would be a silent no-op.
+      //
+      // A painter rather than a `DecoratedBox(boxShadow:)` for the reason in
+      // DepthTokens.playerChromeEdgeShadowColor's dartdoc: a box shadow would
+      // paint behind the translucent fill and darken it. It also keeps this
+      // from becoming the first DecoratedBox under the surface, which is how
+      // several tests locate the *fill*.
+      child: CustomPaint(
+        painter: PlayerChromeEdgeShadowPainter(borderRadius: borderRadius),
+        child: lg.GlassContainer(
+          shape: lg.LiquidRoundedSuperellipse(
+            borderRadius: borderRadius.topLeft.x,
+          ),
+          settings: settings,
+          // premium captures a backdrop texture for true refraction and is
+          // Impeller-only; standard runs the lightweight single-pass shader,
+          // which still pushes a BackdropFilterLayer (so web keeps the blur
+          // and saturation it has today) but cannot lens without that
+          // texture. faux never reaches here.
+          quality: tier == PlayerGlassTier.full
+              ? lg.GlassQuality.premium
+              : lg.GlassQuality.standard,
+          // Required, not cosmetic: playback chrome sits over the video
+          // surface, and on hybrid composition a live BackdropFilter is the
+          // only path that blurs a PlatformView at all. Without this the
+          // panel renders over unblurred video.
+          platformViewBackdrop: true,
+          child: _withRim(_fill()),
+        ),
       ),
     );
   }
@@ -347,6 +470,50 @@ class PlayerChromeRimPainter extends CustomPainter {
     return oldDelegate.borderRadius != borderRadius ||
         oldDelegate.gradient != gradient ||
         oldDelegate.strokeWidth != strokeWidth;
+  }
+}
+
+/// Paints the playback panel's darkened outer edge (iOS 27) strictly
+/// *outside* the [borderRadius] silhouette.
+///
+/// [BlurStyle.outer] is the whole point. The obvious implementation, a
+/// [BoxDecoration] with a [BoxShadow], paints behind its child — and this
+/// panel's fill is deliberately translucent (see
+/// [DepthTokens.playerChromeFillTopAlpha]), so that shadow would read through
+/// the glass and darken it. Beyond looking wrong, it would move the panel's
+/// real contrast away from what `glass_legibility_test.dart` computes, with
+/// nothing in that test changing to reveal it. Painting outer-only leaves
+/// every pixel inside the silhouette untouched.
+///
+/// Public rather than library-private so tests can assert on its fields
+/// directly instead of re-deriving them from painted pixels, matching
+/// [PlayerChromeRimPainter].
+@visibleForTesting
+class PlayerChromeEdgeShadowPainter extends CustomPainter {
+  const PlayerChromeEdgeShadowPainter({
+    required this.borderRadius,
+    this.color = DepthTokens.playerChromeEdgeShadowColor,
+    this.sigma = DepthTokens.playerChromeEdgeShadowSigma,
+  });
+
+  final BorderRadius borderRadius;
+  final Color color;
+  final double sigma;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rrect = borderRadius.toRRect(Offset.zero & size);
+    final paint = Paint()
+      ..color = color
+      ..maskFilter = MaskFilter.blur(BlurStyle.outer, sigma);
+    canvas.drawRRect(rrect, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant PlayerChromeEdgeShadowPainter oldDelegate) {
+    return oldDelegate.borderRadius != borderRadius ||
+        oldDelegate.color != color ||
+        oldDelegate.sigma != sigma;
   }
 }
 

--- a/player/pubspec.lock
+++ b/player/pubspec.lock
@@ -361,6 +361,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.12"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -515,6 +523,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.2"
+  flutter_shaders:
+    dependency: transitive
+    description:
+      name: flutter_shaders
+      sha256: "34794acadd8275d971e02df03afee3dee0f98dbfb8c4837082ad0034f612a3e2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -831,6 +847,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  liquid_glass_widgets:
+    dependency: "direct main"
+    description:
+      name: liquid_glass_widgets
+      sha256: e839a79985305f732763591a005a39f8b85e225ce8688c2a97fc04ba8f33fc82
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.29.5"
   logging:
     dependency: transitive
     description:

--- a/player/pubspec.yaml
+++ b/player/pubspec.yaml
@@ -4,7 +4,11 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  # Floor raised from 3.3.0 by liquid_glass_widgets, which requires Dart
+  # >=3.5.0. The toolchain in player/.fvmrc (Flutter 3.44.2) ships a much
+  # newer Dart than either bound, so this only tightens what the manifest
+  # *claims* to support; nothing in resolution or CI changes.
+  sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -52,6 +56,19 @@ dependencies:
   # Direct, not transitive: window geometry restore needs the display work
   # areas to decide whether a saved rect is still reachable.
   screen_retriever: ^0.2.2
+  # Supplies the playback chrome's glass material only (GlassContainer,
+  # LiquidGlassSettings, GlassQuality) — see GlassSurface.playerChrome. None of
+  # the package's widget kit (GlassScaffold, GlassButton, GlassTextField, ...)
+  # is used, and nothing outside `glass_surface.dart` may import it: that one
+  # file is the seam that keeps a rollback to a plain BackdropFilter a
+  # single-file revert.
+  #
+  # Pinned exact, not caret. The package is pre-1.0 (0.29.x) and ships
+  # breaking changes on minor bumps, and the fragment shaders behind
+  # LiquidGlassSettings are what the OSD's whole appearance rides on. An
+  # unattended `pub upgrade` moving this is a visual regression nobody
+  # reviewed.
+  liquid_glass_widgets: 0.29.5
 
 dev_dependencies:
   flutter_test:

--- a/player/test/presentation/widgets/glass_surface_test.dart
+++ b/player/test/presentation/widgets/glass_surface_test.dart
@@ -301,19 +301,26 @@ void main() {
           ),
         );
 
+    /// The panel's *fill* decoration.
+    ///
+    /// Identified by carrying a gradient rather than by being the first
+    /// [DecoratedBox] under the surface. The fill is the only decoration on
+    /// this surface with one, and position-based lookup is not stable: the
+    /// lensed path nests the fill inside the glass package's own widgets,
+    /// which contribute [DecoratedBox]es of their own ahead of it.
     BoxDecoration decorationOf(WidgetTester tester) => tester
-        .widget<DecoratedBox>(
-          find
-              .descendant(
-                of: find.byType(GlassSurface),
-                matching: find.byType(DecoratedBox),
-              )
-              .first,
+        .widgetList<DecoratedBox>(
+          find.descendant(
+            of: find.byType(GlassSurface),
+            matching: find.byType(DecoratedBox),
+          ),
         )
-        .decoration as BoxDecoration;
+        .map((box) => box.decoration)
+        .whereType<BoxDecoration>()
+        .firstWhere((decoration) => decoration.gradient != null);
 
     testWidgets(
-        'full tier composes blur with the exact Rec.709 saturation matrix',
+        'full tier composes blur with a saturation matrix, at the token sigma',
         (tester) async {
       await tester.pumpWidget(
         host(
@@ -330,40 +337,51 @@ void main() {
       expect(surface.blurSigma, DepthTokens.blurPlayerChrome);
       expect(surface.saturation, DepthTokens.playerChromeSaturation);
 
-      expect(find.byType(BackdropFilter), findsOneWidget);
-      final filter =
-          tester.widget<BackdropFilter>(find.byType(BackdropFilter)).filter;
+      // Two backdrop passes, not one: the lensed material applies the blur
+      // and the saturation matrix as separate BackdropFilters rather than a
+      // single `ImageFilter.compose`. Both must be present — a bare blur
+      // with no matrix would mean the saturation token never reached the
+      // material.
+      final filters = tester
+          .widgetList<BackdropFilter>(find.byType(BackdropFilter))
+          .map((backdrop) => backdrop.filter)
+          .toList();
 
-      // Pin the exact composed filter: the right sigma, the right
-      // saturation token, and compose()/ColorFilter.matrix wired the right
-      // way round. A wrong sigma, a wrong saturation constant, a
-      // transposed matrix, or non-Rec.709 coefficients would all fail this
-      // -- unlike a bare "differs from an uncomposed blur" check, which
-      // passes for any of those bugs. The matrix's own coefficients
-      // (identity at s=1.0, luminance preservation for any s) are
-      // unit-tested directly against saturationColorMatrix in the group
-      // below, independent of this wiring check.
-      final expectedFilter = ImageFilter.compose(
-        outer: ImageFilter.blur(
-          sigmaX: DepthTokens.blurPlayerChrome,
-          sigmaY: DepthTokens.blurPlayerChrome,
-        ),
-        inner: ColorFilter.matrix(
-          saturationColorMatrix(DepthTokens.playerChromeSaturation),
-        ),
-      );
-      expect(filter, expectedFilter);
-
-      // Still confirm it's not merely a bare blur, guarding against a
-      // future change that accidentally short-circuits the saturation
-      // branch back to the uncomposed filter.
       expect(
-        filter,
-        isNot(ImageFilter.blur(
+        filters,
+        contains(ImageFilter.blur(
           sigmaX: DepthTokens.blurPlayerChrome,
           sigmaY: DepthTokens.blurPlayerChrome,
         )),
+        reason: 'the blur pass must run at the player chrome sigma',
       );
+      expect(
+        filters.any((f) => f is ColorFilter),
+        isTrue,
+        reason: 'the saturation token must reach the material as a matrix',
+      );
+
+      // This deliberately no longer pins the *exact* composed filter.
+      //
+      // It used to, because this file built it: `ImageFilter.compose` with
+      // `saturationColorMatrix`'s Rec.709 coefficients. On the lensed path
+      // `liquid_glass_widgets` composes the blur and the colour matrix
+      // itself, and its matrix uses Rec.601 luma coefficients
+      // (0.299/0.587/0.114) rather than Rec.709 (0.2126/0.7152/0.0722),
+      // despite a comment in that package naming Rec.709. Both preserve
+      // luminance under their own definition, so neutral backdrops are
+      // unaffected and only saturated ones shift slightly in hue.
+      //
+      // Reconstructing their matrix here to assert equality would hard-code
+      // a package internal into our suite and break on any version bump,
+      // which is worse coverage than none. What still matters is asserted
+      // above instead: the blur runs at our sigma, and a colour matrix is
+      // present at all rather than the saturation token being silently
+      // dropped.
+      //
+      // `saturationColorMatrix`'s own coefficients stay directly unit-tested
+      // in the group above; that function is still this app's reference
+      // implementation and what the non-lensed path would use on revert.
     });
 
     testWidgets('reduced tier uses a bare blur, no colour matrix',
@@ -442,16 +460,20 @@ void main() {
       // rounded corners continuously.
       expect(decorationOf(tester).border, isNull);
 
+      // Selected by painter type, not by position. The lensed material adds
+      // a second CustomPaint above this one for the outer edge shadow (which
+      // uses `painter`, not `foregroundPainter`), so `.first` would return
+      // that one and read a null foregroundPainter.
       final painter = tester
-          .widget<CustomPaint>(
-            find
-                .descendant(
-                  of: find.byType(GlassSurface),
-                  matching: find.byType(CustomPaint),
-                )
-                .first,
+          .widgetList<CustomPaint>(
+            find.descendant(
+              of: find.byType(GlassSurface),
+              matching: find.byType(CustomPaint),
+            ),
           )
-          .foregroundPainter! as PlayerChromeRimPainter;
+          .map((paint) => paint.foregroundPainter)
+          .whereType<PlayerChromeRimPainter>()
+          .single;
 
       expect(
         painter.borderRadius,

--- a/player/test/presentation/widgets/video_controls/chrome_panel_test.dart
+++ b/player/test/presentation/widgets/video_controls/chrome_panel_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show ImageFilter;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/player/platform_features.dart';
@@ -186,7 +188,21 @@ void main() {
 
     testWidgets('renders the player glass material', (tester) async {
       await tester.pumpWidget(host(PanelMetrics.forWidth(1600)));
-      expect(find.byType(BackdropFilter), findsOneWidget);
+
+      // Not `findsOneWidget`: the lensed material runs the blur and the
+      // saturation matrix as separate backdrop passes. Assert on the sigma
+      // instead of the count, which is what actually distinguishes the
+      // player material from the browse chrome one.
+      final filters = tester
+          .widgetList<BackdropFilter>(find.byType(BackdropFilter))
+          .map((backdrop) => backdrop.filter);
+      expect(
+        filters,
+        contains(ImageFilter.blur(
+          sigmaX: DepthTokens.blurPlayerChrome,
+          sigmaY: DepthTokens.blurPlayerChrome,
+        )),
+      );
     });
 
     testWidgets('renders transport and scrubber', (tester) async {
@@ -197,11 +213,21 @@ void main() {
 
     testWidgets('clips to DepthTokens.radiusPlayerPanel', (tester) async {
       await tester.pumpWidget(host(PanelMetrics.forWidth(1600)));
-      final clip = tester.widget<ClipRRect>(find.byType(ClipRRect));
-      expect(
-        clip.borderRadius,
-        const BorderRadius.all(Radius.circular(DepthTokens.radiusPlayerPanel)),
-      );
+
+      // Accepts either clip widget, and asserts the radius rather than the
+      // type. The contract here is the panel's corner geometry, not which
+      // primitive draws it: the lensed material clips with
+      // ClipRSuperellipse (an Apple-style squircle at the same radius),
+      // where the plain BackdropFilter path used ClipRRect.
+      final radii = <double>[
+        ...tester
+            .widgetList<ClipRSuperellipse>(find.byType(ClipRSuperellipse))
+            .map((clip) => clip.borderRadius.resolve(null).topLeft.x),
+        ...tester
+            .widgetList<ClipRRect>(find.byType(ClipRRect))
+            .map((clip) => clip.borderRadius.resolve(null).topLeft.x),
+      ];
+      expect(radii, contains(DepthTokens.radiusPlayerPanel));
     });
 
     testWidgets('omits the volume slot when not supplied', (tester) async {

--- a/player/test/presentation/widgets/video_controls/video_controls_glass_test.dart
+++ b/player/test/presentation/widgets/video_controls/video_controls_glass_test.dart
@@ -60,16 +60,16 @@ void main() {
         (tester) async {
       await tester.pumpWidget(_host(_panel(PlayerGlassTier.full)));
 
+      // Located by carrying a gradient, not by position under a
+      // BackdropFilter. The fill is the only decoration on this panel with
+      // one, and anchoring on BackdropFilter is not stable: on the lensed
+      // path the glass package owns the backdrop pass, so the fill is no
+      // longer a descendant of any BackdropFilter this app builds.
       final decoration = tester
-          .widget<DecoratedBox>(
-            find
-                .descendant(
-                  of: find.byType(BackdropFilter),
-                  matching: find.byType(DecoratedBox),
-                )
-                .first,
-          )
-          .decoration as BoxDecoration;
+          .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+          .map((box) => box.decoration)
+          .whereType<BoxDecoration>()
+          .firstWhere((decoration) => decoration.gradient != null);
       final gradient = decoration.gradient! as LinearGradient;
 
       // The gradient is asymmetric and dense-at-the-top: ChromePanel puts the


### PR DESCRIPTION
## What

The OSD glass blurred its backdrop but never bent it, which reads as frosted plastic rather than glass. This swaps the playback chrome's **material** so it refracts, and adds the two iOS 27 cues Apple introduced underneath apps like Infuse: a darkened outer edge and a brighter specular highlight.

**Structure is deliberately untouched.** `ChromePanel` keeps its single slab, both rows, and the scrubber inside the glass. `PanelMetrics` and its tiering are unchanged. Infuse's OSD structure did not change either; what improved there was the material.

## Why a package

Hand-rolling refraction means writing and maintaining a fragment shader across six platforms. Of the published options, `liquid_glass_widgets` is the only one covering all six the player ships (android, ios, linux, macos, web, windows):

| package | platforms | health |
|---|---|---|
| `liquid_glass_renderer` | iOS/Android/macOS; web, Windows, Linux explicitly unsupported | 881 likes, last release 9 months ago |
| `liquid_glass_easy` | no Linux | unverified uploader |
| **`liquid_glass_widgets`** | all six | verified publisher, MIT, 486★, 48k weekly, pushed this week |

Its own `minimal` tier is documented as a `BackdropFilter` blur plus a Rec.709 saturation matrix, which is exactly what `GlassSurface.playerChrome` already did. Our previous implementation is this package's floor, so the downside is bounded and the upside is the Impeller refraction path.

## Design

`glass_surface.dart` is the only file permitted to import the package. That seam is why the new `DepthTokens` entries are bare doubles rather than package enums, and why rollback is a one-file revert.

```
RepaintBoundary
└ CustomPaint(PlayerChromeEdgeShadowPainter)   ← iOS 27 dark edge, ours, outer-only
  └ GlassContainer(platformViewBackdrop: true) ← blur, refraction, specular
    └ CustomPaint(PlayerChromeRimPainter)      ← existing directional rim
      └ DecoratedBox(gradient 0.56 → 0.38)     ← existing fill, unchanged
```

`glassColor` is transparent so the package contributes no tint, and our vertical gradient stays the only thing between the controls and the video. That keeps `glass_legibility_test.dart` valid **unmodified**, which is the safety story: over the uniform worst-case backdrop it models, refraction and chromatic aberration are the identity just as blur and saturation already were.

`platformViewBackdrop: true` is required rather than cosmetic; a live `BackdropFilter` is the only thing that blurs a hybrid-composed PlatformView, and this panel sits over video.

## Three findings worth reviewing

1. **The dark edge cannot come from the package.** Its `shadow`/`shadowElevation` are documented "has no effect in dark mode" in three separate places, and this theme is dark-only. We paint it, using `MaskFilter.blur(BlurStyle.outer)` rather than a `BoxShadow`. That also avoids a real defect: a box shadow paints *behind* the translucent fill and would have darkened it, silently moving the panel's true contrast away from what the legibility test computes.
2. **The package's saturation matrix is Rec.601, not Rec.709**, despite a comment naming Rec.709. Verified empirically as `[1.5608, -0.4696, -0.0912, ...]` at our 1.8 token. Both preserve luminance under their own definition, so neutral backdrops are unaffected and only saturated ones shift slightly in hue. Accepted and documented rather than forked.
3. **Shaders are pre-compiled in `main()`**, next to `MediaKit.ensureInitialized()`. Compiling inline costs a documented 100-800ms on mid-range Android GLES, landing precisely on the frame the OSD appears.

## Tests

Full player suite: **2252 passed**. `flutter analyze` clean on all changed files.

Four assertions moved from testing the *composition* to testing the *contract*, because the interior changed:

- full tier no longer pins an exact composed `ImageFilter` (the package composes it now); asserts the blur sigma and that a colour matrix is present at all
- fill and rim located by gradient and painter type rather than by `.first`
- glass material asserted by sigma, not `BackdropFilter` count (premium emits two passes)
- clip accepts `ClipRSuperellipse` or `ClipRRect` and asserts the radius, since the contract is corner geometry

## Known gaps

- ⚠️ **The three `chrome_panel_*.png` goldens are stale.** They are `@TestOn('mac-os')`, so they skipped here and skip in CI. They will fail on a macOS run until regenerated there with `flutter test --update-goldens`. The file header states macOS-generated images are not portable to Linux, so this needs a Mac.
- **Goldens cannot cover the effect that motivated this.** `flutter test` renders on Skia, never Impeller, so any golden captures the `standard` path.
- **Shader warm-up is unmeasured on a real device.** The 100-800ms figure is the package's documentation. This is the risk most likely to warrant backing the change out.
- **Web gains the edge, specular, and squircle, not lensing.** The lightweight path still pushes a `BackdropFilterLayer`, so web keeps today's blur, but without backdrop texture capture it cannot refract.
- **Linux and Windows may silently take the standard path**; they resolve to `full` → `premium`, which self-heals to standard off Impeller.
- Dependency is pre-1.0 and pinned exact for that reason.

## Verification

Rendered before/after on the Skia/`standard` tier (the only one capturable from a widget test): 28.7% of pixels changed, max channel delta 68, with the dark outer edge and brighter rim clearly visible at the panel boundary. The refracting `premium` tier still needs eyes on a real device.
