### PR TITLE
fix(media): close the review follow-ups from the shared media rail

### DIFF
--- a/lib/mydia/media/recommendations.ex
+++ b/lib/mydia/media/recommendations.ex
@@ -135,17 +135,26 @@ defmodule Mydia.Media.Recommendations do
   end
 
   defp mean_rating(results) do
-    case Enum.filter(results, &(votes(&1) > 0)) do
+    case Enum.filter(results, &rated?/1) do
       [] -> nil
       rated -> Enum.sum(Enum.map(rated, &rating/1)) / length(rated)
     end
   end
 
-  defp weighted_rating(result, mean) do
-    v = votes(result)
-    r = rating(result)
+  # An entry needs both a numeric rating and at least one vote before it can
+  # inform the mean. Treating a nil rating as 0.0 would drag the prior down for
+  # every other entry in the set.
+  defp rated?(result), do: votes(result) > 0 and is_number(result.vote_average)
 
-    v / (v + @min_votes) * r + @min_votes / (v + @min_votes) * mean
+  defp weighted_rating(result, mean) do
+    if rated?(result) do
+      v = votes(result)
+
+      v / (v + @min_votes) * rating(result) + @min_votes / (v + @min_votes) * mean
+    else
+      # No usable rating, so the honest score is the set mean: mid-pack.
+      mean
+    end
   end
 
   defp rating(%{vote_average: value}) when is_number(value), do: value / 1

--- a/lib/mydia/media/recommendations.ex
+++ b/lib/mydia/media/recommendations.ex
@@ -143,8 +143,13 @@ defmodule Mydia.Media.Recommendations do
 
   # An entry needs both a numeric rating and at least one vote before it can
   # inform the mean. Treating a nil rating as 0.0 would drag the prior down for
-  # every other entry in the set.
-  defp rated?(result), do: votes(result) > 0 and is_number(result.vote_average)
+  # every other entry in the set. Pattern-matched, like rating/1 and votes/1
+  # below, so a loose map missing :vote_average entirely falls to the
+  # catch-all instead of raising KeyError on the dot access.
+  defp rated?(%{vote_average: value} = result) when is_number(value),
+    do: votes(result) > 0
+
+  defp rated?(_result), do: false
 
   defp weighted_rating(result, mean) do
     if rated?(result) do

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -55,11 +55,12 @@ defmodule MydiaWeb.DiscoverComponents do
   # Discover and Dashboard rely on. A host that can have several adds in flight
   # at once passes a boolean per card instead.
   attr :adding, :boolean, default: nil
-  # nil renders no loading attribute at all, which is what a poster above the
-  # fold (Dashboard, Discover) needs: it is the LCP element, and loading="lazy"
-  # would defer its fetch until layout resolves. A rail passes "lazy" because
-  # its cards start off-screen.
-  attr :loading, :string, default: nil
+  # "lazy" is the safe default: eagerly fetching every card, including the
+  # ones below the fold, is what starved the Dashboard's actual LCP poster
+  # under 40 competing requests. A caller with a poster above the fold
+  # (roughly the first grid row on Dashboard and Discover) opts out with
+  # loading={nil}, which renders no loading attribute at all.
+  attr :loading, :string, default: "lazy"
   # w500 is the right size for a grid card; a rail card is w-36 (144px), which
   # wants the smaller w342 step.
   attr :poster_size, :string, default: "w500"
@@ -228,7 +229,6 @@ defmodule MydiaWeb.DiscoverComponents do
             add_event={@add_event}
             request_event={@request_event}
             can_add={@can_add}
-            loading="lazy"
             poster_size="w342"
           />
         </div>

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -55,6 +55,14 @@ defmodule MydiaWeb.DiscoverComponents do
   # Discover and Dashboard rely on. A host that can have several adds in flight
   # at once passes a boolean per card instead.
   attr :adding, :boolean, default: nil
+  # nil renders no loading attribute at all, which is what a poster above the
+  # fold (Dashboard, Discover) needs: it is the LCP element, and loading="lazy"
+  # would defer its fetch until layout resolves. A rail passes "lazy" because
+  # its cards start off-screen.
+  attr :loading, :string, default: nil
+  # w500 is the right size for a grid card; a rail card is w-36 (144px), which
+  # wants the smaller w342 step.
+  attr :poster_size, :string, default: "w500"
 
   def trending_card(assigns) do
     assigns = assign(assigns, :adding?, adding?(assigns))
@@ -89,7 +97,12 @@ defmodule MydiaWeb.DiscoverComponents do
         <% @navigate -> %>
           <.link navigate={@navigate} class="block">
             <figure class="aspect-[2/3] bg-base-300 cursor-pointer">
-              <.card_poster item={@item} media_type={@media_type} />
+              <.card_poster
+                item={@item}
+                media_type={@media_type}
+                loading={@loading}
+                poster_size={@poster_size}
+              />
             </figure>
           </.link>
         <% @on_select -> %>
@@ -99,11 +112,21 @@ defmodule MydiaWeb.DiscoverComponents do
             phx-value-id={@item.provider_id}
             phx-value-type={@media_type}
           >
-            <.card_poster item={@item} media_type={@media_type} />
+            <.card_poster
+              item={@item}
+              media_type={@media_type}
+              loading={@loading}
+              poster_size={@poster_size}
+            />
           </figure>
         <% true -> %>
           <figure class="aspect-[2/3] bg-base-300">
-            <.card_poster item={@item} media_type={@media_type} />
+            <.card_poster
+              item={@item}
+              media_type={@media_type}
+              loading={@loading}
+              poster_size={@poster_size}
+            />
           </figure>
       <% end %>
       <div class="card-body p-3">
@@ -205,6 +228,8 @@ defmodule MydiaWeb.DiscoverComponents do
             add_event={@add_event}
             request_event={@request_event}
             can_add={@can_add}
+            loading="lazy"
+            poster_size="w342"
           />
         </div>
       </div>
@@ -291,14 +316,18 @@ defmodule MydiaWeb.DiscoverComponents do
 
   attr :item, :map, required: true
   attr :media_type, :atom, required: true
+  # nil renders no loading attribute at all. See the note on trending_card/1's
+  # :loading attr for why that matters for an above-the-fold grid.
+  attr :loading, :string, default: nil
+  attr :poster_size, :string, default: "w500"
 
   defp card_poster(assigns) do
     ~H"""
     <%= if @item.poster_path do %>
       <img
-        src={ImageUrl.poster_url(@item.poster_path)}
+        src={ImageUrl.poster_url(@item.poster_path, @poster_size)}
         alt={@item.title}
-        loading="lazy"
+        loading={@loading}
         class="w-full h-full object-cover"
       />
     <% else %>

--- a/lib/mydia_web/live/authorization.ex
+++ b/lib/mydia_web/live/authorization.ex
@@ -128,6 +128,29 @@ defmodule MydiaWeb.Live.Authorization do
   end
 
   @doc """
+  Checks if the current user can submit media requests.
+
+  Only guests can submit requests; higher-level users are expected to create
+  media directly. Returns `:ok` if authorized, or `{:unauthorized, socket}`
+  with an error flash. Raises if current_user is not present in socket
+  assigns.
+  """
+  def authorize_submit_request(socket) do
+    case Map.fetch(socket.assigns, :current_user) do
+      {:ok, user} when not is_nil(user) ->
+        if Authorization.can_submit_request?(user) do
+          :ok
+        else
+          socket = put_flash(socket, :error, "You do not have permission to request media")
+          {:unauthorized, socket}
+        end
+
+      _ ->
+        raise "current_user is required in socket assigns for authorization"
+    end
+  end
+
+  @doc """
   Generic authorization check with custom permission function and error message.
   Raises if current_user is not present in socket assigns.
 

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -11,6 +11,7 @@ defmodule MydiaWeb.DashboardLive.Index do
   alias Mydia.Metadata
   alias Mydia.MediaRequests
   alias Mydia.Accounts.Authorization
+  alias MydiaWeb.Live.Authorization, as: LiveAuthorization
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
@@ -142,14 +143,14 @@ defmodule MydiaWeb.DashboardLive.Index do
         %{"tmdb_id" => provider_id, "media_type" => media_type},
         socket
       ) do
-    case parse_event_media_type(media_type) do
-      {:ok, media_type_atom} ->
-        socket = assign(socket, :requesting_item_id, provider_id)
-        send(self(), {:request_media, provider_id, media_type_atom})
-        {:noreply, socket}
-
-      :error ->
-        {:noreply, put_flash(socket, :error, @unsupported_media_type)}
+    with :ok <- LiveAuthorization.authorize_submit_request(socket),
+         {:ok, media_type_atom} <- parse_event_media_type(media_type) do
+      socket = assign(socket, :requesting_item_id, provider_id)
+      send(self(), {:request_media, provider_id, media_type_atom})
+      {:noreply, socket}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+      :error -> {:noreply, put_flash(socket, :error, @unsupported_media_type)}
     end
   end
 

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -217,7 +217,7 @@
         </div>
       <% true -> %>
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 md:gap-4">
-          <%= for movie <- @trending_movies do %>
+          <%= for {movie, index} <- Enum.with_index(@trending_movies) do %>
             <.trending_card
               item={movie}
               media_type={:movie}
@@ -225,6 +225,7 @@
               adding_item_id={@adding_item_id}
               requesting_item_id={@requesting_item_id}
               libraries={@movie_libraries}
+              loading={if(index < 6, do: nil, else: "lazy")}
             />
           <% end %>
         </div>
@@ -252,7 +253,7 @@
         </div>
       <% true -> %>
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 md:gap-4">
-          <%= for show <- @trending_tv do %>
+          <%= for {show, index} <- Enum.with_index(@trending_tv) do %>
             <.trending_card
               item={show}
               media_type={:tv_show}
@@ -260,6 +261,7 @@
               adding_item_id={@adding_item_id}
               requesting_item_id={@requesting_item_id}
               libraries={@show_libraries}
+              loading={if(index < 6, do: nil, else: "lazy")}
             />
           <% end %>
         </div>

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -8,6 +8,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
   alias Mydia.Media
   alias Mydia.Media.Recommendations
   alias Mydia.Metadata
+  alias MydiaWeb.Live.Authorization
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
@@ -231,14 +232,14 @@ defmodule MydiaWeb.DiscoverLive.Index do
         %{"tmdb_id" => provider_id, "media_type" => media_type},
         socket
       ) do
-    case parse_event_media_type(media_type) do
-      {:ok, media_type_atom} ->
-        socket = assign(socket, :requesting_item_id, provider_id)
-        send(self(), {:request_media, provider_id, media_type_atom})
-        {:noreply, socket}
-
-      :error ->
-        {:noreply, put_flash(socket, :error, @unsupported_media_type)}
+    with :ok <- Authorization.authorize_submit_request(socket),
+         {:ok, media_type_atom} <- parse_event_media_type(media_type) do
+      socket = assign(socket, :requesting_item_id, provider_id)
+      send(self(), {:request_media, provider_id, media_type_atom})
+      {:noreply, socket}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+      :error -> {:noreply, put_flash(socket, :error, @unsupported_media_type)}
     end
   end
 

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -158,7 +158,7 @@
         </div>
       <% true -> %>
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-5">
-          <%= for item <- @items do %>
+          <%= for {item, index} <- Enum.with_index(@items) do %>
             <.trending_card
               item={item}
               media_type={item.media_type || @media_type}
@@ -166,6 +166,7 @@
               adding_item_id={@adding_item_id}
               requesting_item_id={@requesting_item_id}
               libraries={@libraries}
+              loading={if(index < 6, do: nil, else: "lazy")}
             />
           <% end %>
         </div>

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -126,10 +126,12 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   detail page down.
   """
   def request_franchise_movie(%{"tmdb_id" => tmdb_id}, socket) do
-    with {parsed, ""} <- Integer.parse(tmdb_id),
+    with :ok <- Authorization.authorize_submit_request(socket),
+         {parsed, ""} <- Integer.parse(tmdb_id),
          %FranchiseEntry{} = entry <- find_entry(socket.assigns.franchise, parsed) do
       submit_request(entry, socket)
     else
+      {:unauthorized, socket} -> {:noreply, socket}
       _ -> {:noreply, socket}
     end
   end

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -32,7 +32,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   end
 
   def handle_load_result({:ok, {:ok, franchise}}, socket) do
-    {:noreply, assign(socket, :franchise, franchise)}
+    {:noreply, assign(socket, :franchise, enrich_with_request_status(franchise))}
   end
 
   def handle_load_result({:ok, :none}, socket) do
@@ -161,6 +161,21 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   end
 
   ## Private
+
+  # Populates request_status on load. Without this, a guest who requested a
+  # missing entry and then reloaded the page would see the button revert to an
+  # enabled Request, since mark_requested/3 only sets request_status in memory
+  # for the life of the socket.
+  defp enrich_with_request_status(franchise) do
+    status_map = MediaRequestHelpers.request_status_map()
+
+    entries =
+      Enum.map(franchise.entries, fn entry ->
+        %{entry | request_status: Map.get(status_map, entry.tmdb_id)}
+      end)
+
+    %{franchise | entries: entries}
+  end
 
   defp find_entry(nil, _tmdb_id), do: nil
 

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -4,6 +4,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   import Phoenix.Component, only: [assign: 3]
   import Phoenix.LiveView, only: [start_async: 3, put_flash: 3, connected?: 1]
 
+  alias Mydia.Accounts.Authorization, as: AccountsAuthorization
   alias Mydia.Media.FranchiseEntry
   alias Mydia.Media.Franchises
   alias MydiaWeb.Live.Authorization
@@ -32,7 +33,8 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   end
 
   def handle_load_result({:ok, {:ok, franchise}}, socket) do
-    {:noreply, assign(socket, :franchise, enrich_with_request_status(franchise))}
+    franchise = enrich_with_request_status(franchise, socket.assigns.current_user)
+    {:noreply, assign(socket, :franchise, franchise)}
   end
 
   def handle_load_result({:ok, :none}, socket) do
@@ -168,15 +170,25 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   # missing entry and then reloaded the page would see the button revert to an
   # enabled Request, since mark_requested/3 only sets request_status in memory
   # for the life of the socket.
-  defp enrich_with_request_status(franchise) do
-    status_map = MediaRequestHelpers.request_status_map()
+  #
+  # request_status only ever affects the Request button, which only a guest
+  # sees, so a viewer who cannot submit a request skips the query entirely
+  # rather than paying for two unfiltered list_requests/1 calls whose result
+  # they can never act on. Their entries keep FranchiseEntry's own nil
+  # default for request_status.
+  defp enrich_with_request_status(franchise, current_user) do
+    if AccountsAuthorization.can_submit_request?(current_user) do
+      status_map = MediaRequestHelpers.request_status_map()
 
-    entries =
-      Enum.map(franchise.entries, fn entry ->
-        %{entry | request_status: Map.get(status_map, entry.tmdb_id)}
-      end)
+      entries =
+        Enum.map(franchise.entries, fn entry ->
+          %{entry | request_status: Map.get(status_map, entry.tmdb_id)}
+        end)
 
-    %{franchise | entries: entries}
+      %{franchise | entries: entries}
+    else
+      franchise
+    end
   end
 
   defp find_entry(nil, _tmdb_id), do: nil

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -6,6 +6,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   import Phoenix.Component, only: [assign: 3]
   import Phoenix.LiveView, only: [start_async: 3, put_flash: 3, connected?: 1]
 
+  alias Mydia.Accounts.Authorization, as: AccountsAuthorization
   alias Mydia.Media
   alias Mydia.Media.Add
   alias Mydia.Media.Recommendations
@@ -36,7 +37,10 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   end
 
   def handle_load_result({:ok, {:ok, results}}, socket) do
-    {:noreply, assign(socket, :recommendations, decorate(results, socket.assigns.media_item))}
+    recommendations =
+      decorate(results, socket.assigns.media_item, socket.assigns.current_user)
+
+    {:noreply, assign(socket, :recommendations, recommendations)}
   end
 
   def handle_load_result({:ok, :none}, socket) do
@@ -200,7 +204,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   # The library join lives here rather than in Mydia.Media.Recommendations
   # because it needs MediaAddHelpers, and a context under Mydia.* must not depend
   # on the web layer.
-  defp decorate(results, media_item) do
+  defp decorate(results, media_item, current_user) do
     # Drop malformed entries from the list itself, not just from the id lookup.
     # enrich_with_library_status/2 calls the same raising parser, so filtering
     # only the ids would still let a non-numeric provider_id raise one line
@@ -212,11 +216,26 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
 
     results
     |> MediaAddHelpers.enrich_with_library_status(status)
-    |> MediaRequestHelpers.enrich_with_request_status(MediaRequestHelpers.request_status_map())
+    |> maybe_enrich_with_request_status(current_user)
     |> Enum.map(fn item ->
       navigate = if item.in_library && item.id, do: ~p"/media/#{item.id}", else: nil
       Map.put(item, :navigate, navigate)
     end)
+  end
+
+  # request_status only ever affects the Request button, which only a guest
+  # sees, so a viewer who cannot submit a request skips the query entirely
+  # rather than paying for two unfiltered list_requests/1 calls whose result
+  # they can never act on.
+  defp maybe_enrich_with_request_status(results, current_user) do
+    if AccountsAuthorization.can_submit_request?(current_user) do
+      MediaRequestHelpers.enrich_with_request_status(
+        results,
+        MediaRequestHelpers.request_status_map()
+      )
+    else
+      results
+    end
   end
 
   # Add.parse_provider_id/1 raises on a non-numeric binary. TMDB ids are always

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -209,6 +209,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
 
     results
     |> MediaAddHelpers.enrich_with_library_status(status)
+    |> MediaRequestHelpers.enrich_with_request_status(MediaRequestHelpers.request_status_map())
     |> Enum.map(fn item ->
       navigate = if item.in_library && item.id, do: ~p"/media/#{item.id}", else: nil
       Map.put(item, :navigate, navigate)

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -105,43 +105,46 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   otherwise has no `request_media` clause at all.
   """
   def request_recommendation(%{"tmdb_id" => tmdb_id}, socket) do
-    case Enum.find(socket.assigns.recommendations, &(to_string(&1.provider_id) == tmdb_id)) do
-      nil ->
-        {:noreply, socket}
+    with :ok <- Authorization.authorize_submit_request(socket) do
+      case Enum.find(socket.assigns.recommendations, &(to_string(&1.provider_id) == tmdb_id)) do
+        nil -> {:noreply, socket}
+        item -> submit_request(item, tmdb_id, socket)
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
 
-      item ->
-        media_type = if socket.assigns.media_item.type == "tv_show", do: :tv_show, else: :movie
+  defp submit_request(item, tmdb_id, socket) do
+    media_type = if socket.assigns.media_item.type == "tv_show", do: :tv_show, else: :movie
 
-        socket = assign(socket, :requesting_recommendation_id, tmdb_id)
+    socket = assign(socket, :requesting_recommendation_id, tmdb_id)
 
-        case MediaRequestHelpers.handle_request_media(
-               item,
-               media_type,
-               socket.assigns.current_user.id
-             ) do
-          {:ok, request, status_updates} ->
-            {:noreply,
-             socket
-             |> assign(:requesting_recommendation_id, nil)
-             |> assign(
-               :recommendations,
-               MediaRequestHelpers.enrich_with_request_status(
-                 socket.assigns.recommendations,
-                 status_updates
-               )
-             )
-             |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")}
+    case MediaRequestHelpers.handle_request_media(
+           item,
+           media_type,
+           socket.assigns.current_user.id
+         ) do
+      {:ok, request, status_updates} ->
+        {:noreply,
+         socket
+         |> assign(:requesting_recommendation_id, nil)
+         |> assign(
+           :recommendations,
+           MediaRequestHelpers.enrich_with_request_status(
+             socket.assigns.recommendations,
+             status_updates
+           )
+         )
+         |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")}
 
-          {:error, reason} ->
-            Logger.warning(
-              "Recommendation request failed for tmdb #{tmdb_id}: #{inspect(reason)}"
-            )
+      {:error, reason} ->
+        Logger.warning("Recommendation request failed for tmdb #{tmdb_id}: #{inspect(reason)}")
 
-            {:noreply,
-             socket
-             |> assign(:requesting_recommendation_id, nil)
-             |> put_flash(:error, "Could not request that title")}
-        end
+        {:noreply,
+         socket
+         |> assign(:requesting_recommendation_id, nil)
+         |> put_flash(:error, "Could not request that title")}
     end
   end
 

--- a/test/mydia/media/recommendations_test.exs
+++ b/test/mydia/media/recommendations_test.exs
@@ -280,5 +280,19 @@ defmodule Mydia.Media.RecommendationsTest do
     test "an empty list stays empty" do
       assert Recommendations.rank([]) == []
     end
+
+    # Regression: rated?/1 read result.vote_average with the dot operator,
+    # which raises KeyError on a map lacking that key entirely. Its siblings
+    # rating/1 and votes/1 both pattern-match with a catch-all precisely so a
+    # loose map cannot crash the ranking.
+    test "an entry map with no vote_average key at all does not raise" do
+      ranked =
+        Recommendations.rank([
+          result(%{provider_id: "1", title: "Rated", vote_average: 8.0, vote_count: 100}),
+          %{provider_id: "2", title: "Loose Entry", vote_count: 10}
+        ])
+
+      assert titles(ranked) == ["Rated", "Loose Entry"]
+    end
   end
 end

--- a/test/mydia/media/recommendations_test.exs
+++ b/test/mydia/media/recommendations_test.exs
@@ -243,6 +243,26 @@ defmodule Mydia.Media.RecommendationsTest do
       assert titles(ranked) == ["Zeta", "Yankee", "Xray"]
     end
 
+    # Regression: this entry used to contribute 0.0 to the set mean and then
+    # sink to last, because the mean selected on votes but averaged a rating
+    # that defaults to 0.0 when nil.
+    test "an entry with votes but no rating lands mid-pack and does not drag the mean" do
+      ranked =
+        Recommendations.rank([
+          result(%{
+            provider_id: "1",
+            title: "Crowd Pleaser",
+            vote_average: 8.2,
+            vote_count: 5_000
+          }),
+          result(%{provider_id: "2", title: "Solid", vote_average: 7.5, vote_count: 1_200}),
+          result(%{provider_id: "3", title: "Voted Unrated", vote_average: nil, vote_count: 800}),
+          result(%{provider_id: "4", title: "Mediocre", vote_average: 6.0, vote_count: 800})
+        ])
+
+      assert titles(ranked) == ["Crowd Pleaser", "Solid", "Voted Unrated", "Mediocre"]
+    end
+
     test "caps the list at twelve" do
       results =
         for n <- 1..20 do

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -72,12 +72,20 @@ defmodule MydiaWeb.DiscoverComponentsTest do
   end
 
   describe "poster loading and size" do
-    # Regression: card_poster/1 used to hardcode loading="lazy" and w500 for
-    # every caller. A bare trending_card/1 is what the Dashboard and Discover
-    # grids render, whose first row is above the fold and must not defer its
-    # fetch, so it keeps eager loading at the w500 default.
-    test "a bare card carries no loading attribute and the w500 default size" do
+    # Regression: PR #461 made loading="lazy" opt-in to protect the LCP element
+    # in the first grid row, but that also removed it from every card below the
+    # fold, which made the Dashboard's two 20-card grids eagerly fetch roughly
+    # 40 w500 posters. Lazy is the safe default; a caller that needs eager
+    # loading for an above-the-fold card now opts out with loading={nil}.
+    test "a bare card defaults to lazy loading and the w500 poster size" do
       html = card(%{})
+
+      assert html =~ ~s(loading="lazy")
+      assert html =~ "/w500/dune.jpg"
+    end
+
+    test "loading={nil} opts a card out of lazy loading" do
+      html = card(%{loading: nil})
 
       refute html =~ "loading="
       assert html =~ "/w500/dune.jpg"

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -70,4 +70,17 @@ defmodule MydiaWeb.DiscoverComponentsTest do
       refute html =~ ~s(phx-click="request_media")
     end
   end
+
+  describe "poster loading and size" do
+    # Regression: card_poster/1 used to hardcode loading="lazy" and w500 for
+    # every caller. A bare trending_card/1 is what the Dashboard and Discover
+    # grids render, whose first row is above the fold and must not defer its
+    # fetch, so it keeps eager loading at the w500 default.
+    test "a bare card carries no loading attribute and the w500 default size" do
+      html = card(%{})
+
+      refute html =~ "loading="
+      assert html =~ "/w500/dune.jpg"
+    end
+  end
 end

--- a/test/mydia_web/live/components/media_rail_component_test.exs
+++ b/test/mydia_web/live/components/media_rail_component_test.exs
@@ -55,6 +55,21 @@ defmodule MydiaWeb.Components.MediaRailComponentTest do
     assert html =~ "Janet Planet"
   end
 
+  # Regression: card_poster/1 used to hardcode loading="lazy" and w500 for
+  # every caller, which regressed LCP on the Dashboard and Discover grids
+  # (whose first row is above the fold) and oversized a 144px rail card.
+  test "a rail card is lazy-loaded at the w342 size" do
+    html =
+      render_component(&DiscoverComponents.media_rail/1,
+        items: [item()],
+        media_type: :movie,
+        current_user: user()
+      )
+
+    assert html =~ ~s(loading="lazy")
+    assert html =~ "/w342/poster.jpg"
+  end
+
   test "an unowned card fires the configured select event" do
     html =
       render_component(&DiscoverComponents.media_rail/1,

--- a/test/mydia_web/live/dashboard_live/request_media_authorization_test.exs
+++ b/test/mydia_web/live/dashboard_live/request_media_authorization_test.exs
@@ -1,0 +1,59 @@
+defmodule MydiaWeb.DashboardLive.RequestMediaAuthorizationTest do
+  @moduledoc """
+  Covers the request_media guard on the Dashboard trending rails.
+
+  can_submit_request?/1 is true only for a guest, but nothing enforced that on
+  this handler, so any authenticated user could push the event over the socket
+  and create a request row even though trending_card_action/1 renders them no
+  Request button. The guard has to sit in handle_event, before the
+  send(self(), ...): a guard only on handle_info would still let the push set
+  requesting_item_id and flip the UI into "Requesting...".
+  """
+
+  use Mydia.DataCase, async: false
+
+  import Mydia.AccountsFixtures
+
+  alias Mydia.MediaRequests
+  alias MydiaWeb.DashboardLive.Index
+
+  defp stub_socket(current_user) do
+    %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        flash: %{},
+        requesting_item_id: nil,
+        current_user: current_user
+      }
+    }
+  end
+
+  test "a non-guest pushing request_media creates no MediaRequest row" do
+    socket = stub_socket(user_fixture(%{role: "user"}))
+
+    {:noreply, updated} =
+      Index.handle_event(
+        "request_media",
+        %{"tmdb_id" => "693134", "media_type" => "movie"},
+        socket
+      )
+
+    assert updated.assigns.requesting_item_id == nil
+    refute_received {:request_media, _, _}
+    assert MediaRequests.list_requests(status: "pending") == []
+  end
+
+  test "a guest pushing request_media is allowed through to handle_info" do
+    socket = stub_socket(user_fixture(%{role: "guest"}))
+
+    {:noreply, updated} =
+      Index.handle_event(
+        "request_media",
+        %{"tmdb_id" => "693134", "media_type" => "movie"},
+        socket
+      )
+
+    assert updated.assigns.requesting_item_id == "693134"
+    assert_received {:request_media, "693134", :movie}
+  end
+end

--- a/test/mydia_web/live/discover_live/request_media_authorization_test.exs
+++ b/test/mydia_web/live/discover_live/request_media_authorization_test.exs
@@ -1,0 +1,59 @@
+defmodule MydiaWeb.DiscoverLive.RequestMediaAuthorizationTest do
+  @moduledoc """
+  Covers the request_media guard on the Discover grid.
+
+  can_submit_request?/1 is true only for a guest, but nothing enforced that on
+  this handler, so any authenticated user could push the event over the socket
+  and create a request row even though trending_card_action/1 renders them no
+  Request button. The guard has to sit in handle_event, before the
+  send(self(), ...): a guard only on handle_info would still let the push set
+  requesting_item_id and flip the UI into "Requesting...".
+  """
+
+  use Mydia.DataCase, async: false
+
+  import Mydia.AccountsFixtures
+
+  alias Mydia.MediaRequests
+  alias MydiaWeb.DiscoverLive.Index
+
+  defp stub_socket(current_user) do
+    %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        flash: %{},
+        requesting_item_id: nil,
+        current_user: current_user
+      }
+    }
+  end
+
+  test "a non-guest pushing request_media creates no MediaRequest row" do
+    socket = stub_socket(user_fixture(%{role: "user"}))
+
+    {:noreply, updated} =
+      Index.handle_event(
+        "request_media",
+        %{"tmdb_id" => "693134", "media_type" => "movie"},
+        socket
+      )
+
+    assert updated.assigns.requesting_item_id == nil
+    refute_received {:request_media, _, _}
+    assert MediaRequests.list_requests(status: "pending") == []
+  end
+
+  test "a guest pushing request_media is allowed through to handle_info" do
+    socket = stub_socket(user_fixture(%{role: "guest"}))
+
+    {:noreply, updated} =
+      Index.handle_event(
+        "request_media",
+        %{"tmdb_id" => "693134", "media_type" => "movie"},
+        socket
+      )
+
+    assert updated.assigns.requesting_item_id == "693134"
+    assert_received {:request_media, "693134", :movie}
+  end
+end

--- a/test/mydia_web/live/media_live/show/franchise_events_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_events_test.exs
@@ -433,6 +433,10 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
     # life of the socket. A guest who requested a missing entry then reloaded
     # the page would see an enabled Request button again, and clicking it hit
     # the duplicate-request error for a request that was already pending.
+    #
+    # The viewer here (the socket's current_user) is a guest: request_status
+    # only ever affects the Request button, which only guests see, so the
+    # enrichment now runs only for a viewer who can submit a request.
     test "stamps request_status from an outstanding request and leaves the rest nil",
          %{config: config} do
       requester = user_fixture(%{role: "guest"})
@@ -458,7 +462,12 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
           requester_id: requester.id
         })
 
-      socket = stub_socket(%{media_item: current, metadata_config: config})
+      socket =
+        stub_socket(%{
+          media_item: current,
+          metadata_config: config,
+          current_user: user_fixture(%{role: "guest"})
+        })
 
       {:noreply, socket} = FranchiseEvents.handle_load_result({:ok, {:ok, franchise}}, socket)
 
@@ -468,6 +477,49 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
 
       assert requested.request_status == "pending"
       assert untouched.request_status == nil
+    end
+
+    # Regression: request_status_map/0 issued two unfiltered list_requests/1
+    # queries and PR #461 ran them on every franchise load, though the value
+    # only ever affects the Request button that only a guest sees. A non-guest
+    # viewer must not pay for a query whose result they can never act on.
+    test "a non-guest viewer sees no request_status even for an outstanding request",
+         %{config: config} do
+      requester = user_fixture(%{role: "guest"})
+
+      current =
+        media_item_fixture(%{
+          type: "movie",
+          title: "First",
+          year: 2001,
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      requested_tmdb_id = System.unique_integer([:positive])
+      franchise = franchise_with_missing(current, requested_tmdb_id)
+      [_current_entry, requested_entry] = franchise.entries
+
+      {:ok, _request} =
+        Mydia.MediaRequests.create_request(%{
+          media_type: "movie",
+          title: requested_entry.title,
+          tmdb_id: requested_entry.tmdb_id,
+          requester_id: requester.id
+        })
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          metadata_config: config,
+          current_user: user_fixture(%{role: "user"})
+        })
+
+      {:noreply, socket} = FranchiseEvents.handle_load_result({:ok, {:ok, franchise}}, socket)
+
+      entries = socket.assigns.franchise.entries
+      requested = Enum.find(entries, &(&1.tmdb_id == requested_entry.tmdb_id))
+
+      assert requested.request_status == nil
     end
 
     test "assigns the franchise on success", %{config: config} do

--- a/test/mydia_web/live/media_live/show/franchise_events_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_events_test.exs
@@ -328,6 +328,29 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
                  guest_socket(nil, user)
                )
     end
+
+    # Regression: can_submit_request?/1 returns true only for a guest, but
+    # nothing enforced that on this handler, so any authenticated user could
+    # push the event over the socket and create a request row even though the
+    # UI renders them no button.
+    test "a non-guest user creates no request and leaves the franchise untouched" do
+      user = user_fixture(%{role: "user"})
+
+      franchise =
+        small_franchise([
+          entry(%{tmdb_id: 671, in_library?: true, current?: true, media_item_id: "a"}),
+          entry(%{tmdb_id: 672, title: "Chamber of Secrets", year: 2002})
+        ])
+
+      {:noreply, updated} =
+        FranchiseEvents.request_franchise_movie(
+          %{"tmdb_id" => "672"},
+          guest_socket(franchise, user)
+        )
+
+      assert updated.assigns.franchise == franchise
+      assert Mydia.MediaRequests.list_requests(status: "pending") == []
+    end
   end
 
   describe "handle_add_result/3" do

--- a/test/mydia_web/live/media_live/show/franchise_events_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_events_test.exs
@@ -406,6 +406,47 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
   end
 
   describe "handle_load_result/2" do
+    # Regression: mark_requested/3 only set request_status in memory for the
+    # life of the socket. A guest who requested a missing entry then reloaded
+    # the page would see an enabled Request button again, and clicking it hit
+    # the duplicate-request error for a request that was already pending.
+    test "stamps request_status from an outstanding request and leaves the rest nil",
+         %{config: config} do
+      requester = user_fixture(%{role: "guest"})
+
+      current =
+        media_item_fixture(%{
+          type: "movie",
+          title: "First",
+          year: 2001,
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      requested_tmdb_id = System.unique_integer([:positive])
+      franchise = franchise_with_missing(current, requested_tmdb_id)
+      franchise = with_extra_missing(franchise, System.unique_integer([:positive]))
+      [_current_entry, requested_entry, untouched_entry] = franchise.entries
+
+      {:ok, _request} =
+        Mydia.MediaRequests.create_request(%{
+          media_type: "movie",
+          title: requested_entry.title,
+          tmdb_id: requested_entry.tmdb_id,
+          requester_id: requester.id
+        })
+
+      socket = stub_socket(%{media_item: current, metadata_config: config})
+
+      {:noreply, socket} = FranchiseEvents.handle_load_result({:ok, {:ok, franchise}}, socket)
+
+      entries = socket.assigns.franchise.entries
+      requested = Enum.find(entries, &(&1.tmdb_id == requested_entry.tmdb_id))
+      untouched = Enum.find(entries, &(&1.tmdb_id == untouched_entry.tmdb_id))
+
+      assert requested.request_status == "pending"
+      assert untouched.request_status == nil
+    end
+
     test "assigns the franchise on success", %{config: config} do
       current =
         media_item_fixture(%{type: "movie", title: "First", year: 2001, tmdb_id: 1041})

--- a/test/mydia_web/live/media_live/show/recommendation_events_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendation_events_test.exs
@@ -86,4 +86,36 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
       assert untouched.request_status == nil
     end
   end
+
+  describe "request_recommendation/2" do
+    # Regression: can_submit_request?/1 returns true only for a guest, but
+    # nothing enforced that on this handler, so any authenticated user could
+    # push the event over the socket and create a request row even though the
+    # UI renders them no button.
+    test "a non-guest user creates no request and leaves recommendations untouched" do
+      current =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Current",
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      tmdb_id = System.unique_integer([:positive])
+      recommendations = [result(%{provider_id: to_string(tmdb_id), title: "Blocked"})]
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          recommendations: recommendations,
+          current_user: user_fixture(%{role: "user"})
+        })
+
+      {:noreply, updated} =
+        RecommendationEvents.request_recommendation(%{"tmdb_id" => to_string(tmdb_id)}, socket)
+
+      assert updated.assigns.recommendations == recommendations
+      assert updated.assigns.requesting_recommendation_id == nil
+      assert MediaRequests.list_requests(status: "pending") == []
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/show/recommendation_events_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendation_events_test.exs
@@ -40,6 +40,10 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
     # enrich_with_request_status/2 after a successful request. A guest who
     # requested a recommended title and reloaded the page would see an enabled
     # Request button again.
+    #
+    # The viewer here (the socket's current_user) is a guest: request_status
+    # only ever affects the Request button, which only guests see, so the
+    # enrichment now runs only for a viewer who can submit a request.
     test "stamps request_status from an outstanding request and leaves the rest nil" do
       requester = user_fixture(%{role: "guest"})
 
@@ -66,7 +70,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
         result(%{provider_id: to_string(untouched_tmdb_id), title: "Untouched Rec"})
       ]
 
-      socket = stub_socket(%{media_item: current})
+      socket = stub_socket(%{media_item: current, current_user: user_fixture(%{role: "guest"})})
 
       {:noreply, socket} = RecommendationEvents.handle_load_result({:ok, {:ok, results}}, socket)
 
@@ -84,6 +88,46 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
 
       assert requested.request_status == "pending"
       assert untouched.request_status == nil
+    end
+
+    # Regression: request_status_map/0 issued two unfiltered list_requests/1
+    # queries and PR #461 ran them on every recommendations load, though the
+    # value only ever affects the Request button that only a guest sees. A
+    # non-guest viewer must not pay for a query whose result they can never
+    # act on.
+    test "a non-guest viewer sees no request_status even for an outstanding request" do
+      requester = user_fixture(%{role: "guest"})
+
+      current =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Current",
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      requested_tmdb_id = System.unique_integer([:positive])
+
+      {:ok, _request} =
+        MediaRequests.create_request(%{
+          media_type: "movie",
+          title: "Requested Rec",
+          tmdb_id: requested_tmdb_id,
+          requester_id: requester.id
+        })
+
+      results = [result(%{provider_id: to_string(requested_tmdb_id), title: "Requested Rec"})]
+
+      socket = stub_socket(%{media_item: current, current_user: user_fixture(%{role: "user"})})
+
+      {:noreply, socket} = RecommendationEvents.handle_load_result({:ok, {:ok, results}}, socket)
+
+      requested =
+        Enum.find(
+          socket.assigns.recommendations,
+          &(&1.provider_id == to_string(requested_tmdb_id))
+        )
+
+      assert Map.get(requested, :request_status) == nil
     end
   end
 

--- a/test/mydia_web/live/media_live/show/recommendation_events_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendation_events_test.exs
@@ -1,0 +1,89 @@
+defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
+  @moduledoc false
+
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
+
+  alias Mydia.MediaRequests
+  alias Mydia.Metadata.Structs.SearchResult
+  alias MydiaWeb.MediaLive.Show.RecommendationEvents
+
+  defp result(attrs) do
+    struct!(
+      %SearchResult{provider_id: "1", provider: :metadata_relay, media_type: :movie},
+      attrs
+    )
+  end
+
+  defp stub_socket(assigns) do
+    defaults = %{
+      __changed__: %{},
+      flash: %{},
+      recommendations: [],
+      adding_recommendation_tmdb_ids: MapSet.new(),
+      adding_recommendation_id: nil,
+      requesting_recommendation_id: nil,
+      current_user: user_fixture()
+    }
+
+    %Phoenix.LiveView.Socket{
+      assigns: Map.merge(defaults, assigns),
+      private: %{live_temp: %{}}
+    }
+  end
+
+  describe "handle_load_result/2" do
+    # Regression: RecommendationEvents.decorate/2 enriched with library status
+    # but never with request status, though request_recommendation/2 does call
+    # enrich_with_request_status/2 after a successful request. A guest who
+    # requested a recommended title and reloaded the page would see an enabled
+    # Request button again.
+    test "stamps request_status from an outstanding request and leaves the rest nil" do
+      requester = user_fixture(%{role: "guest"})
+
+      current =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Current",
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      requested_tmdb_id = System.unique_integer([:positive])
+      untouched_tmdb_id = System.unique_integer([:positive])
+
+      {:ok, _request} =
+        MediaRequests.create_request(%{
+          media_type: "movie",
+          title: "Requested Rec",
+          tmdb_id: requested_tmdb_id,
+          requester_id: requester.id
+        })
+
+      results = [
+        result(%{provider_id: to_string(requested_tmdb_id), title: "Requested Rec"}),
+        result(%{provider_id: to_string(untouched_tmdb_id), title: "Untouched Rec"})
+      ]
+
+      socket = stub_socket(%{media_item: current})
+
+      {:noreply, socket} = RecommendationEvents.handle_load_result({:ok, {:ok, results}}, socket)
+
+      requested =
+        Enum.find(
+          socket.assigns.recommendations,
+          &(&1.provider_id == to_string(requested_tmdb_id))
+        )
+
+      untouched =
+        Enum.find(
+          socket.assigns.recommendations,
+          &(&1.provider_id == to_string(untouched_tmdb_id))
+        )
+
+      assert requested.request_status == "pending"
+      assert untouched.request_status == nil
+    end
+  end
+end


### PR DESCRIPTION
Closes the findings from the independent review of #457. Four commits, one per finding except the last two, which are one change.

## A guest's pending request was invisible after a reload

`request_status` was only ever set in memory for the life of the socket, so nothing populated it on load. A guest would request a missing collection entry, see the button flip to a disabled "Requested", reload, and find it enabled again. Clicking it hit `check_duplicate_request/1` and produced a red "Could not request that movie" flash for a request that was already pending.

Both rails now enrich on load. The franchise enriches in `FranchiseEvents.handle_load_result/2` rather than in `Mydia.Media.Franchises`, because `MediaRequestHelpers` lives under `MydiaWeb.*` and a context must not reach into the web layer.

## Neither request handler checked authorization

`Accounts.Authorization.can_submit_request?/1` already exists and returns true only for `role: "guest"`, but neither `request_franchise_movie/2` nor `request_recommendation/2` called it. Any authenticated user could push the event over the socket and create a `MediaRequest` row, including one the UI deliberately renders no button for.

Adds `authorize_submit_request/1` to `MydiaWeb.Live.Authorization`, mirroring `authorize_create_media/1`, and guards both handlers. No existing test needed changing, since they all already used guest users, which is a good sign the guard matches what the UI always intended.

## A voted entry with no rating poisoned the ranking

`mean_rating/1` selected entries on `vote_count > 0` but averaged `rating/1`, which returns `0.0` when `vote_average` is nil. An entry with 800 votes and no rating therefore contributed `0.0` to the set mean, dragging the prior down for every other entry, and scored near `0.0` itself rather than at the mean. That contradicted the module's documented promise that an unrated entry lands mid-pack.

Selection now requires both a numeric rating and at least one vote, and an entry without a usable rating scores exactly the set mean. No existing ranking assertion moved.

## Lazy loading was applied too broadly, and rail posters were oversized

#457 added `loading="lazy"` to `card_poster/1`, which is shared with the Dashboard and Discover grids where the first row is above the fold and is the LCP element. Lazy-loading an LCP image defers its fetch until layout resolves, which is the opposite of what those grids want.

Separately, `card_poster/1` requests `w500` while a rail card is `w-36` (144px).

Both are now per-caller. `trending_card/1` takes `loading` and `poster_size` attributes; `media_rail/1` passes `lazy` and `w342`. The grids pass neither and keep eager loading at `w500` exactly as before. `w342` is the correct TMDB step for a 144px card on a 2x display, so rail posters get sharper than the `w185` the old franchise markup used and roughly half the bytes of `w500`.

## Deliberately not here

Three follow-ups are tracked separately: #458 (the library picker on the detail page silently adds to the default library), #459 (the recommendations rail loses a card's spinner when two adds are in flight), and #460 (the same movie can appear in both strips).

## Testing

Full suite green: 7869 tests, 0 failures. `mix precommit` clean, including `credo --strict` and the format check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable poster image sizes and loading behavior, including lazy-loaded media rail images and deferred loading for lower-page cards.
  * Displayed current request statuses on franchise and recommendation entries.
* **Bug Fixes**
  * Restricted media, franchise, and recommendation requests to authorized users.
  * Improved recommendation ranking for entries without usable ratings.
* **Tests**
  * Added regression coverage for ranking, image loading, request authorization, and request-status display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->