### PR TITLE
fix(subtitles): stop the subtitle search modal crashing on every file

### DIFF
--- a/lib/mydia/library/media_file.ex
+++ b/lib/mydia/library/media_file.ex
@@ -127,6 +127,44 @@ defmodule Mydia.Library.MediaFile do
   def absolute_path(%__MODULE__{}), do: nil
 
   @doc """
+  Best path to show an operator, or nil when the file has no location at all.
+
+  `absolute_path/1` is the answer whenever the library_path is preloaded and
+  set. It falls back to the relative path so an unloaded association degrades
+  into a partial answer instead of nothing. The legacy `path` column is never
+  consulted: nothing has written it in a long time, so every row carries nil.
+
+  ## Examples
+
+      iex> file = %MediaFile{relative_path: "Movie.mkv", library_path: %LibraryPath{path: "/movies"}}
+      iex> MediaFile.display_path(file)
+      "/movies/Movie.mkv"
+
+      iex> file = %MediaFile{relative_path: "Movie.mkv", library_path: nil}
+      iex> MediaFile.display_path(file)
+      "Movie.mkv"
+  """
+  @spec display_path(t()) :: String.t() | nil
+  def display_path(%__MODULE__{} = media_file) do
+    absolute_path(media_file) || media_file.relative_path
+  end
+
+  @doc """
+  File name to show an operator, never nil.
+
+  Templates render this directly, so it must not raise for a file whose
+  location cannot be resolved. `Path.basename/1` raises on nil, which is how a
+  single unresolvable file used to take down the whole LiveView.
+  """
+  @spec display_name(t()) :: String.t()
+  def display_name(%__MODULE__{} = media_file) do
+    case display_path(media_file) do
+      nil -> "Unknown file"
+      path -> Path.basename(path)
+    end
+  end
+
+  @doc """
   Returns true when a media item / episode is compatible with a library path type.
 
   Shared rule behind both the changeset-level validation and pre-flight checks

--- a/lib/mydia/library/media_file.ex
+++ b/lib/mydia/library/media_file.ex
@@ -131,8 +131,14 @@ defmodule Mydia.Library.MediaFile do
 
   `absolute_path/1` is the answer whenever the library_path is preloaded and
   set. It falls back to the relative path so an unloaded association degrades
-  into a partial answer instead of nothing. The legacy `path` column is never
-  consulted: nothing has written it in a long time, so every row carries nil.
+  into a partial answer instead of nothing, and then to the legacy `path`
+  column as a last resort.
+
+  That last fallback looks dead — every row on a current install carries
+  `path: nil` — but `populate_media_file_relative_paths` skips files sitting
+  outside every configured library path, leaving them with no relative_path and
+  no library_path_id. On an install that upgraded from a version which still
+  wrote `path`, that column is the only location such a row has left.
 
   ## Examples
 
@@ -146,7 +152,7 @@ defmodule Mydia.Library.MediaFile do
   """
   @spec display_path(t()) :: String.t() | nil
   def display_path(%__MODULE__{} = media_file) do
-    absolute_path(media_file) || media_file.relative_path
+    absolute_path(media_file) || media_file.relative_path || media_file.path
   end
 
   @doc """

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -785,9 +785,11 @@ defmodule MydiaWeb.MediaLive.Show.Components do
         <%!-- Filename row --%>
         <div class="flex items-center gap-2">
           <.icon name="hero-document" class="w-4 h-4 text-base-content/50 flex-shrink-0" />
-          <% absolute_path = Mydia.Library.MediaFile.absolute_path(@file) %>
-          <span class="font-mono text-sm truncate" title={absolute_path}>
-            {Path.basename(absolute_path)}
+          <span
+            class="font-mono text-sm truncate"
+            title={Mydia.Library.MediaFile.display_path(@file)}
+          >
+            {Mydia.Library.MediaFile.display_name(@file)}
           </span>
         </div>
         <%!-- Technical details row --%>
@@ -919,12 +921,12 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                   <%!-- Left side: File info --%>
                   <div class="flex-1 min-w-0 flex flex-col gap-2">
                     <%!-- File path --%>
-                    <% absolute_path = Mydia.Library.MediaFile.absolute_path(file) %>
+                    <% file_path = Mydia.Library.MediaFile.display_path(file) %>
                     <p
                       class="text-sm font-mono text-base-content break-all leading-relaxed"
-                      title={absolute_path}
+                      title={file_path}
                     >
-                      {absolute_path}
+                      {file_path}
                     </p>
                     <%!-- Technical details with quality badge --%>
                     <div class="flex flex-wrap gap-4 text-xs text-base-content/70 items-center">

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -1221,12 +1221,11 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                   <%!-- File info header --%>
                   <div class="flex items-start justify-between gap-4 mb-3">
                     <div class="flex-1 min-w-0">
-                      <% absolute_path = Mydia.Library.MediaFile.absolute_path(media_file) %>
                       <p
                         class="text-sm font-mono text-base-content/80 break-all"
-                        title={absolute_path}
+                        title={Mydia.Library.MediaFile.display_path(media_file)}
                       >
-                        {Path.basename(absolute_path)}
+                        {Mydia.Library.MediaFile.display_name(media_file)}
                       </p>
                       <div class="flex gap-2 mt-1">
                         <span class="badge badge-primary badge-xs">

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -926,7 +926,9 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       class="text-sm font-mono text-base-content break-all leading-relaxed"
                       title={file_path}
                     >
-                      {file_path}
+                      <%!-- display_name/1 is the "Unknown file" label when there is no path,
+                            so an orphaned row reads the same here as everywhere else. --%>
+                      {file_path || Mydia.Library.MediaFile.display_name(file)}
                     </p>
                     <%!-- Technical details with quality badge --%>
                     <div class="flex flex-wrap gap-4 text-xs text-base-content/70 items-center">

--- a/lib/mydia_web/live/media_live/show/helpers.ex
+++ b/lib/mydia_web/live/media_live/show/helpers.ex
@@ -255,8 +255,7 @@ defmodule MydiaWeb.MediaLive.Show.Helpers do
       [_ | _] = files ->
         filenames =
           Enum.map_join(files, "\n", fn file ->
-            absolute_path = Mydia.Library.MediaFile.absolute_path(file)
-            basename = Path.basename(absolute_path)
+            basename = Mydia.Library.MediaFile.display_name(file)
             resolution = file.resolution || "?"
             "• #{basename} (#{resolution})"
           end)

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -11,6 +11,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   import MydiaWeb.MediaLive.Show.SearchHelpers
 
   alias Mydia.Indexers.SearchResult
+  alias Mydia.Library.MediaFile
 
   @doc """
   Delete confirmation modal for removing media item from library.
@@ -1199,8 +1200,11 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
           <div class="flex items-start justify-between gap-4">
             <div class="min-w-0">
               <h3 class="text-xl sm:text-2xl font-bold">Search Subtitles</h3>
-              <p class="text-sm text-base-content/70 truncate mt-1" title={@media_file.path}>
-                {Path.basename(@media_file.path)}
+              <p
+                class="text-sm text-base-content/70 truncate mt-1"
+                title={MediaFile.display_path(@media_file)}
+              >
+                {MediaFile.display_name(@media_file)}
               </p>
             </div>
             <button

--- a/lib/mydia_web/live/media_live/show/subtitle_events.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_events.ex
@@ -10,7 +10,8 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
   require Logger
 
   def open_subtitle_search(%{"media-file-id" => media_file_id}, socket) do
-    media_file = Mydia.Library.get_media_file!(media_file_id)
+    # library_path is what resolves the file's location for the modal header.
+    media_file = Mydia.Library.get_media_file!(media_file_id, preload: [:library_path])
 
     {:noreply,
      socket

--- a/test/mydia/library/media_file_test.exs
+++ b/test/mydia/library/media_file_test.exs
@@ -114,15 +114,27 @@ defmodule Mydia.Library.MediaFileTest do
       assert MediaFile.display_name(media_file) == "Unknown file"
     end
 
-    test "ignore the dead legacy path column" do
-      # Every row in the wild carries path: nil, so nothing may depend on it.
+    test "prefer the resolved location over the legacy path column" do
       media_file = %MediaFile{
-        path: "/legacy/ignored.mkv",
+        path: "/legacy/stale.mkv",
         relative_path: "Movie.mkv",
         library_path: %LibraryPath{path: "/media/movies"}
       }
 
       assert MediaFile.display_path(media_file) == "/media/movies/Movie.mkv"
+    end
+
+    test "fall back to the legacy path column for an orphaned row" do
+      # The relative_path backfill skips files outside every configured library
+      # path, so on an upgraded install `path` can be all such a row has left.
+      media_file = %MediaFile{
+        path: "/somewhere/outside/Movie.mkv",
+        relative_path: nil,
+        library_path: nil
+      }
+
+      assert MediaFile.display_path(media_file) == "/somewhere/outside/Movie.mkv"
+      assert MediaFile.display_name(media_file) == "Movie.mkv"
     end
   end
 

--- a/test/mydia/library/media_file_test.exs
+++ b/test/mydia/library/media_file_test.exs
@@ -70,6 +70,62 @@ defmodule Mydia.Library.MediaFileTest do
     end
   end
 
+  describe "display_path/1 and display_name/1" do
+    test "prefer the resolved absolute path" do
+      media_file = %MediaFile{
+        relative_path: "The Matrix (1999)/The Matrix (1999) [1080p].mkv",
+        library_path: %LibraryPath{path: "/media/movies"}
+      }
+
+      assert MediaFile.display_path(media_file) ==
+               "/media/movies/The Matrix (1999)/The Matrix (1999) [1080p].mkv"
+
+      assert MediaFile.display_name(media_file) == "The Matrix (1999) [1080p].mkv"
+    end
+
+    test "fall back to the relative path when library_path is missing" do
+      media_file = %MediaFile{relative_path: "Movie.mkv", library_path: nil}
+
+      assert MediaFile.display_path(media_file) == "Movie.mkv"
+      assert MediaFile.display_name(media_file) == "Movie.mkv"
+    end
+
+    test "fall back to the relative path when library_path is not loaded" do
+      media_file = %MediaFile{
+        id: "mf-1",
+        relative_path: "Season 01/S01E01.mkv",
+        library_path: %Ecto.Association.NotLoaded{
+          __field__: :library_path,
+          __owner__: MediaFile,
+          __cardinality__: :one
+        }
+      }
+
+      capture_log(fn ->
+        assert MediaFile.display_path(media_file) == "Season 01/S01E01.mkv"
+        assert MediaFile.display_name(media_file) == "S01E01.mkv"
+      end)
+    end
+
+    test "never raise for a file with no resolvable location" do
+      media_file = %MediaFile{relative_path: nil, library_path: nil}
+
+      assert MediaFile.display_path(media_file) == nil
+      assert MediaFile.display_name(media_file) == "Unknown file"
+    end
+
+    test "ignore the dead legacy path column" do
+      # Every row in the wild carries path: nil, so nothing may depend on it.
+      media_file = %MediaFile{
+        path: "/legacy/ignored.mkv",
+        relative_path: "Movie.mkv",
+        library_path: %LibraryPath{path: "/media/movies"}
+      }
+
+      assert MediaFile.display_path(media_file) == "/media/movies/Movie.mkv"
+    end
+  end
+
   describe "library type compatibility validation" do
     setup do
       # Create library paths with different types (using unique paths to avoid conflicts)

--- a/test/mydia_web/live/media_live/show/episode_file_path_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_file_path_test.exs
@@ -1,0 +1,76 @@
+defmodule MydiaWeb.MediaLive.Show.EpisodeFilePathTest do
+  @moduledoc """
+  An episode file whose location cannot be resolved must not take down the
+  media detail page. These two call sites render on page load, so a single
+  orphaned row used to be fatal before the page was even interacted with.
+  """
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.Episode
+  alias Mydia.Settings.LibraryPath
+  alias MydiaWeb.MediaLive.Show.Components
+  alias MydiaWeb.MediaLive.Show.Helpers
+
+  defp resolvable_file do
+    %MediaFile{
+      id: "mf-1",
+      path: nil,
+      relative_path: "Season 01/S01E01 - Pilot.mkv",
+      library_path: %LibraryPath{path: "/media/series"},
+      resolution: "1080p"
+    }
+  end
+
+  # The backfill migration leaves files outside every library path with no
+  # relative_path and no library_path_id.
+  defp orphaned_file do
+    %MediaFile{
+      id: "mf-2",
+      path: nil,
+      relative_path: nil,
+      library_path: nil,
+      resolution: nil
+    }
+  end
+
+  defp file_row_assigns(file) do
+    [
+      file: file,
+      episode: %Episode{id: "ep-1", monitored: true, media_files: [file]},
+      playback_enabled: false,
+      transcode_jobs: []
+    ]
+  end
+
+  describe "episode_file_row/1" do
+    test "names a resolvable file" do
+      html = render_component(&Components.episode_file_row/1, file_row_assigns(resolvable_file()))
+
+      assert html =~ "S01E01 - Pilot.mkv"
+      assert html =~ ~s|title="/media/series/Season 01/S01E01 - Pilot.mkv"|
+    end
+
+    test "renders an orphaned file instead of crashing the page" do
+      html = render_component(&Components.episode_file_row/1, file_row_assigns(orphaned_file()))
+
+      assert html =~ "Unknown file"
+    end
+  end
+
+  describe "episode_status_tooltip/1" do
+    test "lists a resolvable file by name" do
+      episode = %Episode{monitored: true, media_files: [resolvable_file()]}
+
+      assert Helpers.episode_status_tooltip(episode) =~ "S01E01 - Pilot.mkv (1080p)"
+    end
+
+    test "tolerates an orphaned file instead of crashing the page" do
+      episode = %Episode{monitored: true, media_files: [orphaned_file()]}
+
+      assert Helpers.episode_status_tooltip(episode) =~ "Unknown file (?)"
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/episode_file_path_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_file_path_test.exs
@@ -45,18 +45,27 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeFilePathTest do
     ]
   end
 
+  # The filename also appears in the title attribute, so asserting on the whole
+  # document would pass even if the visible text went missing.
+  defp visible_filename(html) do
+    html
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query("span.font-mono")
+    |> LazyHTML.text()
+  end
+
   describe "episode_file_row/1" do
     test "names a resolvable file" do
       html = render_component(&Components.episode_file_row/1, file_row_assigns(resolvable_file()))
 
-      assert html =~ "S01E01 - Pilot.mkv"
+      assert visible_filename(html) =~ "S01E01 - Pilot.mkv"
       assert html =~ ~s|title="/media/series/Season 01/S01E01 - Pilot.mkv"|
     end
 
     test "renders an orphaned file instead of crashing the page" do
       html = render_component(&Components.episode_file_row/1, file_row_assigns(orphaned_file()))
 
-      assert html =~ "Unknown file"
+      assert visible_filename(html) =~ "Unknown file"
     end
   end
 

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -4,7 +4,9 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
   import Phoenix.LiveViewTest
 
   alias MydiaWeb.MediaLive.Show.Modals
+  alias Mydia.Library.MediaFile
   alias Mydia.Metadata.Structs.SearchResult
+  alias Mydia.Settings.LibraryPath
 
   defp candidate(id, title, year) do
     %SearchResult{
@@ -16,9 +18,14 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
     }
   end
 
-  @subtitle_media_file %{
+  # Production shape. The legacy `path` column is never written any more, so
+  # every row carries `path: nil` and the real location is relative_path joined
+  # onto the preloaded library_path.
+  @subtitle_media_file %MediaFile{
     id: "mf-1",
-    path: "/media/movies/The Matrix (1999)/The.Matrix.1999.1080p.BluRay.mkv"
+    path: nil,
+    relative_path: "The Matrix (1999)/The.Matrix.1999.1080p.BluRay.mkv",
+    library_path: %LibraryPath{path: "/media/movies"}
   }
 
   defp subtitle_modal_html(overrides \\ []) do
@@ -205,6 +212,40 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
       # Header X only; the footer Close button is gone.
       refute html =~ "modal-action"
       # The body is a dedicated scroll region.
+      assert html =~ ~s(id="subtitle-search-body")
+    end
+
+    test "names the file from library_path + relative_path, not the dead path column" do
+      html = subtitle_modal_html()
+
+      assert html =~ "The.Matrix.1999.1080p.BluRay.mkv"
+      # The tooltip still carries the resolved absolute location.
+      assert html =~ ~s|title="/media/movies/The Matrix|
+    end
+
+    test "opens for a file whose library_path was not preloaded" do
+      media_file = %MediaFile{
+        id: "mf-2",
+        path: nil,
+        relative_path: "The Matrix (1999)/The.Matrix.1999.1080p.BluRay.mkv",
+        library_path: %Ecto.Association.NotLoaded{
+          __field__: :library_path,
+          __owner__: MediaFile,
+          __cardinality__: :one
+        }
+      }
+
+      html = subtitle_modal_html(media_file: media_file)
+
+      # Falls back to the relative path rather than crashing the LiveView.
+      assert html =~ "The.Matrix.1999.1080p.BluRay.mkv"
+    end
+
+    test "opens for a file with no resolvable location at all" do
+      media_file = %MediaFile{id: "mf-3", path: nil, relative_path: nil, library_path: nil}
+
+      html = subtitle_modal_html(media_file: media_file)
+
       assert html =~ ~s(id="subtitle-search-body")
     end
 

--- a/test/mydia_web/live/media_live/show/subtitles_section_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitles_section_test.exs
@@ -1,0 +1,50 @@
+defmodule MydiaWeb.MediaLive.Show.SubtitlesSectionTest do
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Settings.LibraryPath
+  alias MydiaWeb.MediaLive.Show.Components
+
+  defp section_html(media_file) do
+    render_component(&Components.subtitles_section/1,
+      media_item: %{media_files: [media_file]},
+      media_file_subtitles: %{}
+    )
+  end
+
+  describe "subtitles_section/1 file naming" do
+    test "names the file from library_path + relative_path" do
+      media_file = %MediaFile{
+        id: "mf-1",
+        path: nil,
+        relative_path: "The Matrix (1999)/The.Matrix.1999.1080p.BluRay.mkv",
+        library_path: %LibraryPath{path: "/media/movies"},
+        resolution: "1080p",
+        codec: "h264"
+      }
+
+      html = section_html(media_file)
+
+      assert html =~ "The.Matrix.1999.1080p.BluRay.mkv"
+      assert html =~ ~s|phx-value-media-file-id="mf-1"|
+    end
+
+    test "renders a file whose location cannot be resolved instead of crashing" do
+      media_file = %MediaFile{
+        id: "mf-2",
+        path: nil,
+        relative_path: nil,
+        library_path: nil,
+        resolution: nil,
+        codec: nil
+      }
+
+      html = section_html(media_file)
+
+      # The Search button still renders; one broken row must not take the page down.
+      assert html =~ ~s|phx-click="open_subtitle_search"|
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/subtitles_section_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitles_section_test.exs
@@ -45,6 +45,36 @@ defmodule MydiaWeb.MediaLive.Show.SubtitlesSectionTest do
 
       # The Search button still renders; one broken row must not take the page down.
       assert html =~ ~s|phx-click="open_subtitle_search"|
+      # And the row is labelled rather than left blank.
+      assert html =~ "Unknown file"
+    end
+  end
+
+  describe "media_files_section/1 file naming" do
+    defp files_section_html(media_file) do
+      render_component(&Components.media_files_section/1,
+        media_item: %{media_files: [media_file]},
+        refreshing_file_metadata: false,
+        transcode_jobs: %{}
+      )
+    end
+
+    test "shows the full resolved path" do
+      media_file = %MediaFile{
+        id: "mf-3",
+        path: nil,
+        relative_path: "The Matrix (1999)/The.Matrix.1999.1080p.BluRay.mkv",
+        library_path: %LibraryPath{path: "/media/movies"}
+      }
+
+      assert files_section_html(media_file) =~
+               "/media/movies/The Matrix (1999)/The.Matrix.1999.1080p.BluRay.mkv"
+    end
+
+    test "labels an unresolvable file rather than rendering a blank path" do
+      media_file = %MediaFile{id: "mf-4", path: nil, relative_path: nil, library_path: nil}
+
+      assert files_section_html(media_file) =~ "Unknown file"
     end
   end
 end


### PR DESCRIPTION
## What broke

Clicking **Search** in the subtitles section of a movie took the whole page down.

The modal header rendered `Path.basename(@media_file.path)`, but nothing has written the legacy `path` column in a long time. On the production instance **all 2288 `media_files` rows carry `path: nil`** (all 353 movie files included), and `Path.basename(nil)` raises, killing the LiveView the instant the modal renders.

Stacktrace reproduced against production data:

```
FunctionClauseError: no function clause matching in IO.chardata_to_string/1
    (elixir 1.19.5) lib/io.ex:738: IO.chardata_to_string(nil)
    (elixir 1.19.5) lib/path.ex:513: Path.basename/1
    (mydia) lib/mydia_web/live/media_live/show/modals.ex:1203
    (phoenix_live_view) lib/phoenix_live_view/engine.ex:134
```

This was not a search failure. `Mydia.Subtitles.search_candidates/2` returns a healthy `{:ok, ...}` for these files; the page died before the search ever ran.

## Why the section next to it looked fine

`subtitles_section` resolved the location properly through `MediaFile.absolute_path/1`, so the page rendered until you clicked. That call site carried the same latent crash from the other direction: `absolute_path/1` returns `nil` for an unloaded `library_path`, and it fed that straight into `Path.basename/1` too.

## The fix

One nil-safe source of truth on `MediaFile`, used by both call sites:

- `display_path/1` prefers the resolved absolute path, degrades to the relative one, never consults the dead `path` column.
- `display_name/1` never returns nil, so a file with no resolvable location renders as `Unknown file` rather than taking down the page.

Opening the modal now preloads `library_path`, so the header shows the full path instead of degrading to the relative one. Verified against five real production movies: titles resolve to `/media/Movies/...` and the text to the bare filename.

## Why tests never caught it

The modal test fixture was a plain map with an invented `path:` value that production never has. It is a real `%MediaFile{}` in production shape now (`path: nil`, `relative_path` + preloaded `library_path`), which reproduces the crash: 20 of 28 tests in that file failed before the fix.

New coverage:
- `display_path/1` / `display_name/1` unit tests, including unloaded association and no-location-at-all.
- `subtitles_section/1` render tests (the component had none).
- Modal renders for an unloaded `library_path` and for a file with no resolvable location.

## Verification

- `mix test test/mydia_web/live/ test/mydia/library/` — 1968 tests, 0 failures
- `mix compile --warnings-as-errors` clean
- `mix credo --strict` on the four changed lib files: no issues
- `mix format` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved media file names and paths displayed in episode, subtitle, and search views.
  - Added fallback handling for unavailable file locations, including a clear “Unknown file” label.
  - Subtitle searches now use resolved library file locations when available.

- **Bug Fixes**
  - Prevented media and subtitle views from failing when file locations cannot be resolved.

- **Tests**
  - Added coverage for resolved paths, fallback names, missing locations, and rendered file information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->