### PR TITLE
fix(discover): stop the library picker rendering clipped inside the poster card

### DIFF
--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -186,7 +186,9 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :current_user, :map, required: true
   attr :adding_item_id, :string, default: nil
   attr :requesting_item_id, :string, default: nil
-  attr :libraries, :list, default: []
+  # No libraries attr on purpose. The rail is a horizontal scroll container, so
+  # a library picker dropdown cannot escape it at any placement (#465). Rail
+  # cards add to the default library.
   attr :id, :string, default: "media-rail"
   attr :title, :string, default: "More like this"
   # :any, not :string - see the note on trending_card/1. The media detail page
@@ -223,7 +225,6 @@ defmodule MydiaWeb.DiscoverComponents do
             adding={Map.get(item, :adding)}
             current={Map.get(item, :current, false)}
             requesting_item_id={@requesting_item_id}
-            libraries={@libraries}
             on_select={@on_select}
             navigate={Map.get(item, :navigate)}
             add_event={@add_event}

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -70,7 +70,7 @@ defmodule MydiaWeb.DiscoverComponents do
 
     ~H"""
     <div class={[
-      "card bg-base-100 shadow-sm hover:shadow-md transition-shadow relative overflow-hidden",
+      "card bg-base-100 shadow-sm hover:shadow-md transition-shadow relative",
       @current && "ring-2 ring-primary"
     ]}>
       <%= if (vote = Map.get(@item, :vote_average)) && vote > 0 do %>
@@ -97,7 +97,7 @@ defmodule MydiaWeb.DiscoverComponents do
       <%= cond do %>
         <% @navigate -> %>
           <.link navigate={@navigate} class="block">
-            <figure class="aspect-[2/3] bg-base-300 cursor-pointer">
+            <figure class="aspect-[2/3] bg-base-300 cursor-pointer overflow-hidden rounded-t-box">
               <.card_poster
                 item={@item}
                 media_type={@media_type}
@@ -108,7 +108,7 @@ defmodule MydiaWeb.DiscoverComponents do
           </.link>
         <% @on_select -> %>
           <figure
-            class="aspect-[2/3] bg-base-300 cursor-pointer"
+            class="aspect-[2/3] bg-base-300 cursor-pointer overflow-hidden rounded-t-box"
             phx-click={@on_select}
             phx-value-id={@item.provider_id}
             phx-value-type={@media_type}
@@ -121,7 +121,7 @@ defmodule MydiaWeb.DiscoverComponents do
             />
           </figure>
         <% true -> %>
-          <figure class="aspect-[2/3] bg-base-300">
+          <figure class="aspect-[2/3] bg-base-300 overflow-hidden rounded-t-box">
             <.card_poster
               item={@item}
               media_type={@media_type}

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -189,6 +189,7 @@ defmodule MydiaWeb.DiscoverComponents do
   # No libraries attr on purpose. The rail is a horizontal scroll container, so
   # a library picker dropdown cannot escape it at any placement (#465). Rail
   # cards add to the default library.
+
   attr :id, :string, default: "media-rail"
   attr :title, :string, default: "More like this"
   # :any, not :string - see the note on trending_card/1. The media detail page

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -542,9 +542,17 @@ defmodule MydiaWeb.LibraryComponents do
   attr :media_type, :any, default: nil
   attr :selected_id, :string, default: nil
 
+  # A host that has no room below the caret opens the menu upward instead. An
+  # atom with `values:` rather than a pass-through class string, so a typo is a
+  # compile error and daisyUI class names stay inside this component.
+  attr :placement, :atom, default: :bottom, values: [:bottom, :top]
+
   def library_picker_menu(assigns) do
     ~H"""
-    <div :if={length(@libraries) > 1} class="dropdown dropdown-end">
+    <div
+      :if={length(@libraries) > 1}
+      class={["dropdown dropdown-end", @placement == :top && "dropdown-top"]}
+    >
       <div
         tabindex="0"
         role="button"
@@ -556,7 +564,7 @@ defmodule MydiaWeb.LibraryComponents do
       </div>
       <ul
         tabindex="0"
-        class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-60 border border-base-300"
+        class="dropdown-content z-20 menu p-2 shadow-lg bg-base-100 rounded-box w-60 border border-base-300"
       >
         <li class="menu-title text-xs">Add to library</li>
         <li :for={library <- @libraries}>

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -551,7 +551,7 @@ defmodule MydiaWeb.LibraryComponents do
     ~H"""
     <div
       :if={length(@libraries) > 1}
-      class={["dropdown dropdown-end", @placement == :top && "dropdown-top"]}
+      class={["dropdown dropdown-end z-20", @placement == :top && "dropdown-top"]}
     >
       <div
         tabindex="0"
@@ -564,7 +564,7 @@ defmodule MydiaWeb.LibraryComponents do
       </div>
       <ul
         tabindex="0"
-        class="dropdown-content z-20 menu p-2 shadow-lg bg-base-100 rounded-box w-60 border border-base-300"
+        class="dropdown-content menu p-2 shadow-lg bg-base-100 rounded-box w-60 border border-base-300"
       >
         <li class="menu-title text-xs">Add to library</li>
         <li :for={library <- @libraries}>

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -208,6 +208,7 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
                     event="add_to_library"
                     tmdb_id={@item.provider_id}
                     media_type={media_type_string(@item)}
+                    placement={:top}
                   />
                 </div>
               <% end %>

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -210,7 +210,6 @@
         current_user={@current_user}
         adding_item_id={@adding_item_id}
         requesting_item_id={@requesting_item_id}
-        libraries={@libraries}
       />
     </:rail>
   </.live_component>

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -205,7 +205,6 @@
             items={@recommendations}
             media_type={if @media_item.type == "tv_show", do: :tv_show, else: :movie}
             current_user={@current_user}
-            libraries={@target_library_candidates}
             adding_item_id={@adding_recommendation_id}
             requesting_item_id={@requesting_recommendation_id}
             can_add={@can_create_media}

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -54,6 +54,31 @@ defmodule MydiaWeb.DiscoverComponentsTest do
     |> LazyHTML.attribute("class")
   end
 
+  defp rail(overrides) do
+    item = %{
+      provider_id: "693134",
+      title: "Dune: Part Two",
+      year: 2024,
+      poster_path: "/dune.jpg",
+      in_library: false,
+      monitored: false,
+      id: nil,
+      request_status: nil
+    }
+
+    assigns =
+      Map.merge(
+        %{
+          items: [item],
+          media_type: :movie,
+          current_user: %{role: "admin", id: "admin-1"}
+        },
+        overrides
+      )
+
+    render_component(&DiscoverComponents.media_rail/1, assigns)
+  end
+
   describe "guest request button" do
     test "renders a request_media button rather than a link to the search page" do
       html = card(%{})
@@ -142,6 +167,20 @@ defmodule MydiaWeb.DiscoverComponentsTest do
 
       assert class =~ "overflow-hidden"
       assert class =~ "rounded-t-box"
+    end
+  end
+
+  # The rail is a horizontal scroll container (overflow-x-auto, which makes
+  # overflow-y compute to auto as well) and is one card tall, so a dropdown
+  # cannot escape it at any placement. The picker is withdrawn there rather
+  # than shipped broken: the plain add button still works against the default
+  # library. See #465.
+  describe "media_rail picker suppression" do
+    test "a rail renders the add button but never a library picker" do
+      html = rail(%{})
+
+      assert html =~ "Add to Library"
+      refute html =~ "library-picker-caret"
     end
   end
 end

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -177,7 +177,10 @@ defmodule MydiaWeb.DiscoverComponentsTest do
   # library. See #465.
   describe "media_rail picker suppression" do
     test "a rail renders the add button but never a library picker" do
-      html = rail(%{})
+      html =
+        rail(%{
+          libraries: [%{id: "a", path: "/m/a"}, %{id: "b", path: "/m/b"}]
+        })
 
       assert html =~ "Add to Library"
       refute html =~ "library-picker-caret"

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -37,6 +37,23 @@ defmodule MydiaWeb.DiscoverComponentsTest do
     render_component(&DiscoverComponents.trending_card/1, assigns)
   end
 
+  defp root_class(html) do
+    html
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.filter("div.card")
+    |> LazyHTML.attribute("class")
+    |> List.first()
+  end
+
+  defp figure_classes(html) do
+    html
+    |> LazyHTML.from_fragment()
+    # LazyHTML.filter/2 only matches root nodes of the fragment; the figure
+    # is nested inside the card div, so it needs query/2 to be found at all.
+    |> LazyHTML.query("figure")
+    |> LazyHTML.attribute("class")
+  end
+
   describe "guest request button" do
     test "renders a request_media button rather than a link to the search page" do
       html = card(%{})
@@ -89,6 +106,42 @@ defmodule MydiaWeb.DiscoverComponentsTest do
 
       refute html =~ "loading="
       assert html =~ "/w500/dune.jpg"
+    end
+  end
+
+  # Regression for #465. The card root used to carry overflow-hidden, which
+  # trapped the absolutely positioned library picker menu inside the card so
+  # only its top line was visible. The poster keeps its own clipping instead.
+  describe "picker containment" do
+    test "the card root does not clip its children" do
+      refute root_class(card(%{})) =~ "overflow-hidden"
+    end
+
+    test "the card root still draws the ring for the current title" do
+      assert root_class(card(%{current: true})) =~ "ring-2"
+    end
+
+    # One case per branch of the poster cond: navigate wins first, then
+    # on_select (the default), then the inert figure when both are nil.
+    test "the poster clips itself in the navigate branch" do
+      [class] = figure_classes(card(%{navigate: "/movies/1"}))
+
+      assert class =~ "overflow-hidden"
+      assert class =~ "rounded-t-box"
+    end
+
+    test "the poster clips itself in the on_select branch" do
+      [class] = figure_classes(card(%{}))
+
+      assert class =~ "overflow-hidden"
+      assert class =~ "rounded-t-box"
+    end
+
+    test "the poster clips itself in the inert branch" do
+      [class] = figure_classes(card(%{on_select: nil}))
+
+      assert class =~ "overflow-hidden"
+      assert class =~ "rounded-t-box"
     end
   end
 end

--- a/test/mydia_web/components/library_components_test.exs
+++ b/test/mydia_web/components/library_components_test.exs
@@ -1,0 +1,57 @@
+defmodule MydiaWeb.LibraryComponentsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias MydiaWeb.LibraryComponents
+
+  # Libraries have no name column, only a path, which is why the menu shows a
+  # basename with the full path underneath.
+  defp libraries(count) do
+    for i <- 1..count, do: %{id: "lib-#{i}", path: "/media/movies-#{i}"}
+  end
+
+  defp picker(overrides \\ %{}) do
+    assigns =
+      Map.merge(
+        %{libraries: libraries(2), event: "add_to_library"},
+        overrides
+      )
+
+    render_component(&LibraryComponents.library_picker_menu/1, assigns)
+  end
+
+  describe "library_picker_menu/1" do
+    test "renders nothing when there is only one candidate library" do
+      html = picker(%{libraries: libraries(1)})
+
+      refute html =~ "library-picker-caret"
+    end
+
+    test "renders a caret and one entry per library when there are several" do
+      html = picker()
+
+      assert html =~ ~s(data-test="library-picker-caret")
+      assert html =~ "movies-1"
+      assert html =~ "movies-2"
+    end
+
+    # Regression for #465: the menu sat at z-[1] while the trending card's
+    # rating and in-library badges sit at z-10, so even the unclipped sliver
+    # rendered underneath them.
+    test "the menu stacks above the trending card badges" do
+      html = picker()
+
+      assert html =~ "z-20"
+      refute html =~ "z-[1]"
+    end
+
+    test "opens downward by default" do
+      refute picker() =~ "dropdown-top"
+    end
+
+    test "opens upward when placement is :top" do
+      assert picker(%{placement: :top}) =~ "dropdown-top"
+    end
+  end
+end

--- a/test/mydia_web/components/library_components_test.exs
+++ b/test/mydia_web/components/library_components_test.exs
@@ -39,11 +39,36 @@ defmodule MydiaWeb.LibraryComponentsTest do
     # Regression for #465: the menu sat at z-[1] while the trending card's
     # rating and in-library badges sit at z-10, so even the unclipped sliver
     # rendered underneath them.
+    #
+    # daisyUI's `.join > :where(:focus, :has(:focus))` rule stamps z-index: 1
+    # on the `.dropdown` wrapper the moment the caret is focused (the same
+    # condition that opens the menu), which creates a stacking context on
+    # that `position: relative` div. A z-index on the inner `<ul>` is then
+    # confined below that context regardless of its value, so the wrapper
+    # itself must carry the z-index, not the menu list.
     test "the menu stacks above the trending card badges" do
       html = picker()
+      document = LazyHTML.from_fragment(html)
 
-      assert html =~ "z-20"
-      refute html =~ "z-[1]"
+      # The `.dropdown` div is the root node of this component's output, so
+      # filter/2 (root nodes only) is correct here.
+      wrapper_class =
+        document
+        |> LazyHTML.filter("div.dropdown")
+        |> LazyHTML.attribute("class")
+        |> List.first()
+
+      assert wrapper_class =~ "z-20"
+
+      # The `<ul>` is nested inside the wrapper, so it needs query/2, not
+      # filter/2, to be found at all.
+      menu_class =
+        document
+        |> LazyHTML.query("ul.dropdown-content")
+        |> LazyHTML.attribute("class")
+        |> List.first()
+
+      refute menu_class =~ "z-20"
     end
 
     test "opens downward by default" do

--- a/test/mydia_web/live/components/media_rail_component_test.exs
+++ b/test/mydia_web/live/components/media_rail_component_test.exs
@@ -106,9 +106,13 @@ defmodule MydiaWeb.Components.MediaRailComponentTest do
         on_select: nil
       )
 
+    document = LazyHTML.from_fragment(html)
+
     # Poster must not fire show_details; action buttons may still use phx-click.
     refute html =~ ~s(phx-click="show_details")
-    assert html =~ ~s(<figure class="aspect-[2/3] bg-base-300">)
+    assert Enum.count(LazyHTML.query(document, "figure")) == 1
+    assert Enum.empty?(LazyHTML.query(document, "figure[phx-click]"))
+    assert Enum.empty?(LazyHTML.query(document, "a figure"))
   end
 
   describe "action event contract" do


### PR DESCRIPTION
Fixes #465.

## The bug

On Discovery, the caret beside "Add to Library" opened the library picker but the menu rendered clipped inside the poster card, so the libraries could be neither read nor clicked. Two independent defects, both regressions from the library-targeting work in #402.

## Containment

`trending_card`'s root carried `overflow-hidden`, and an absolutely positioned `dropdown-content` cannot escape that. Removing it alone would have squared off the poster, because daisyUI's `.card :where(figure:first-child)` rule does not apply here: the two badge divs render before the figure, and the `@navigate` branch wraps the figure in `<.link class="block">`, where `border-radius: inherit` resolves to zero. So the clipping moves onto the poster explicitly, on all three branches of the poster `cond`.

Worth noting the `@navigate` branch already had square poster corners on master for exactly that `inherit` reason. This fixes that too.

## Stacking

The menu sat at `z-[1]` against `z-10` badges. The first attempt raised the `dropdown-content` to `z-20`, which did not work, and the review caught it: daisyUI ships `.join > :where(:focus, :has(:focus)) { z-index: 1 }`, and the picker's root `.dropdown` is a direct child of `.join` and holds the `tabindex="0"` caret. The very act of opening the menu stamps `z-index: 1` on the wrapper, creating a stacking context that confines anything inside it below the `z-10` badges of the grid row beneath. The `z-20` therefore belongs on the wrapper, which is where it now sits, with no z utility on the inner list so daisyUI's own value stands.

## Modal

The picker is the last child of `modal-box max-h-[90vh] overflow-y-auto`, so a downward menu was clipped completely. It now opens upward via a new constrained attribute, `attr :placement, :atom, default: :bottom, values: [:bottom, :top]`, so a typo is a compile error and daisyUI class names stay inside the component.

## Deliberate behaviour change: no picker in horizontal rails

`media_rail` wraps its cards in `flex gap-3 overflow-x-auto`. When `overflow-x` is `auto` and `overflow-y` is `visible`, CSS computes `overflow-y` to `auto`, so the rail clips vertically as well and is only one card tall. No placement escapes it, and the cards are `w-36` against a `w-60` menu.

The picker is therefore withdrawn from rails rather than shipped broken. The `libraries` attr is removed from `media_rail` entirely, so `warnings_as_errors` turns any reintroduction into a compile error.

Consequence, stated plainly: on the media detail page and in the Discovery modal's recommendations rail, "Add to Library" still works but targets the default library instead of offering a choice.

One mitigating detail found during review: on the media detail page that picker was already a no-op, because `RecommendationEvents.add_recommendation/2` matches only `%{"tmdb_id" => tmdb_id}` and drops `library_path_id`. It rendered choices and ignored them. Only the Discovery modal rail is a real reduction, and the control was unusable there anyway.

## Testing, and its limits

Full suite green at 7919 tests, 0 failures. Compile, format, Credo strict, and `deps.unlock --unused` all clean.

The new tests assert CSS class presence and DOM structure. None of them proves the menu is visually unclipped, because this repo has no browser-level harness for the web UI. That limit is exactly how the z-index defect above survived a passing test in the first place, so the visual check below matters more than usual.

Manual verification still outstanding, and worth doing before merge:

- Discovery grid, non-guest, two or more movie library paths, on a card that has a row below it. Open the picker and confirm the menu escapes the card and that the row-below card's rating badge and in-library circle do not show through it.
- A card with a rating badge, picker closed: confirm the poster's top corners are still round. That is the real regression risk from dropping root `overflow-hidden`.
- Trending detail modal footer: menu opens upward and is fully readable.
- Media detail page and Discovery modal rails: no caret, and "Add to Library" still works.

## Known, not addressed

The menu has no height bound (`w-60`, no `max-h`). An operator with many target paths gets a tall menu, which the new `:top` placement makes newly reachable in the modal. Left alone to keep this a presentational bug fix; happy to add `max-h-64 overflow-y-auto` if you want it here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Library picker menus can now open above or below their trigger.
  - Trending detail menus open upward when needed to avoid visual overlap.

- **Bug Fixes**
  - Improved trending card poster clipping and rounded top corners.
  - Prevented unnecessary library pickers from appearing in media rails while retaining add actions.
  - Improved dropdown stacking behavior around trending badges.
  - Ensured inactive posters remain non-interactive and are not nested in links.

- **Tests**
  - Added coverage for poster styling, media rail behavior, menu placement, and inactive poster interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->