### PR TITLE
feat(ui): season count, grid density, and a Recently Added dashboard rail

### DIFF
--- a/lib/mydia/accounts/user_preference.ex
+++ b/lib/mydia/accounts/user_preference.ex
@@ -17,12 +17,14 @@ defmodule Mydia.Accounts.UserPreference do
     "metadata_language" => "en",
     "interface_language" => "en",
     "theme" => "system",
-    "close_manual_search_after_grab" => false
+    "close_manual_search_after_grab" => false,
+    "grid_density" => "comfortable"
   }
 
   # Valid values for each preference
   @valid_themes ~w(system light dark)
   @valid_languages ~w(en es fr de it pt ja zh ko ru)
+  @valid_densities ~w(comfortable compact dense)
 
   @type t :: %__MODULE__{
           id: binary(),
@@ -74,6 +76,13 @@ defmodule Mydia.Accounts.UserPreference do
   end
 
   @doc """
+  Grid density for the Discover and Libraries poster grids.
+  """
+  def grid_density(%__MODULE__{preferences: prefs}) do
+    Map.get(prefs, "grid_density", @defaults["grid_density"])
+  end
+
+  @doc """
   Changeset for creating or updating user preferences.
 
   The `preferences` param should be a map with string keys, e.g.:
@@ -108,6 +117,7 @@ defmodule Mydia.Accounts.UserPreference do
     |> validate_preference_value("metadata_language", @valid_languages)
     |> validate_preference_value("interface_language", @valid_languages)
     |> validate_preference_value("close_manual_search_after_grab", [true, false])
+    |> validate_preference_value("grid_density", @valid_densities)
   end
 
   defp validate_preference_value(changeset, key, valid_values) do

--- a/lib/mydia_web/components/grid_density_components.ex
+++ b/lib/mydia_web/components/grid_density_components.ex
@@ -26,7 +26,7 @@ defmodule MydiaWeb.GridDensityComponents do
   }
 
   @levels [
-    {"comfortable", "Comfortable", "hero-squares-2x2"},
+    {"comfortable", "Comfortable", "hero-rectangle-group"},
     {"compact", "Compact", "hero-squares-plus"},
     {"dense", "Dense", "hero-view-columns"}
   ]

--- a/lib/mydia_web/components/grid_density_components.ex
+++ b/lib/mydia_web/components/grid_density_components.ex
@@ -1,0 +1,77 @@
+defmodule MydiaWeb.GridDensityComponents do
+  @moduledoc """
+  A shared poster-grid density control for Discover and the Libraries grid.
+
+  The class strings below are written out in full on purpose. Tailwind v4
+  scans source text for class names (`assets/css/app.css` declares
+  `@source "../../lib/mydia_web"`), so a class built by interpolation such as
+  `"grid-cols-\#{n}"` is never generated and the grid silently keeps whatever
+  columns it had. Any new level must be added here as complete literals.
+
+  Two LiveViews use this module, so it is deliberately not imported in
+  `html_helpers`; the project reserves global imports for components with
+  three or more consumers.
+  """
+
+  use Phoenix.Component
+
+  import MydiaWeb.CoreComponents, only: [icon: 1]
+
+  @default "comfortable"
+
+  @classes %{
+    "comfortable" => "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6",
+    "compact" => "grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8",
+    "dense" => "grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12"
+  }
+
+  @levels [
+    {"comfortable", "Comfortable", "hero-squares-2x2"},
+    {"compact", "Compact", "hero-squares-plus"},
+    {"dense", "Dense", "hero-view-columns"}
+  ]
+
+  @doc """
+  Maps a density to its complete grid-column class string.
+
+  Falls back to the default for any unrecognized value, so a preference row
+  written by a different version of the app cannot break rendering.
+  """
+  @spec grid_columns_class(String.t() | nil) :: String.t()
+  def grid_columns_class(density) do
+    Map.get(@classes, density, @classes[@default])
+  end
+
+  @doc """
+  Segmented control for choosing grid density.
+
+  Mirrors `MydiaWeb.LibraryComponents.view_mode_toggle/1` so the two controls
+  sit together on the Libraries toolbar without looking mismatched.
+  """
+  attr :density, :string, required: true
+  attr :id, :string, required: true
+
+  def grid_density_toggle(assigns) do
+    assigns = assign(assigns, :levels, @levels)
+
+    ~H"""
+    <div class="join" id={@id}>
+      <button
+        :for={{value, label, icon_name} <- @levels}
+        type="button"
+        class={[
+          "btn btn-sm join-item",
+          @density == value && "btn-primary",
+          @density != value && "btn-ghost"
+        ]}
+        phx-click="set_grid_density"
+        phx-value-density={value}
+        title={label}
+      >
+        <.icon name={icon_name} class="w-5 h-5" />
+        <span class="hidden sm:inline ml-1">{label}</span>
+      </button>
+    </div>
+    """
+  end
+end

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -88,6 +88,11 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
                     <%= if runtime(@metadata) do %>
                       <span class="badge badge-ghost">{format_runtime(runtime(@metadata))}</span>
                     <% end %>
+                    <%= if format_seasons(seasons(@metadata)) do %>
+                      <span class="badge badge-ghost">
+                        {format_seasons(seasons(@metadata))}
+                      </span>
+                    <% end %>
                     <%= if genres(@metadata) != [] do %>
                       <span class="text-white/40">•</span>
                     <% end %>
@@ -264,6 +269,9 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
   defp runtime(nil), do: nil
   defp runtime(metadata), do: metadata.runtime
 
+  defp seasons(nil), do: nil
+  defp seasons(metadata), do: metadata.number_of_seasons
+
   defp genres(nil), do: []
   defp genres(metadata), do: metadata.genres || []
 
@@ -320,4 +328,12 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
   end
 
   defp format_runtime(_), do: nil
+
+  defp format_seasons(1), do: "1 season"
+
+  defp format_seasons(count) when is_integer(count) and count > 0 do
+    "#{count} seasons"
+  end
+
+  defp format_seasons(_), do: nil
 end

--- a/lib/mydia_web/live/dashboard_live/components.ex
+++ b/lib/mydia_web/live/dashboard_live/components.ex
@@ -1,0 +1,83 @@
+defmodule MydiaWeb.DashboardLive.Components do
+  @moduledoc """
+  Dashboard-only function components.
+
+  The recently-added rail is deliberately separate from
+  `MydiaWeb.DiscoverComponents.media_rail/1`. That component is built around
+  `trending_card/1`, whose vocabulary is "add to library" and "request media",
+  and feeding it owned library content would mean passing dead event props and
+  would make any future `trending_card` change a dashboard regression.
+  """
+
+  use Phoenix.Component
+  use MydiaWeb, :verified_routes
+
+  alias MydiaWeb.Live.Helpers.MediaImages
+
+  @doc """
+  A horizontally scrolling rail of recently added titles.
+
+  Takes `Mydia.Media.RecentlyAdded.Entry` structs. Renders nothing at all when
+  the list is empty, so a fresh install sees no empty placeholder.
+  """
+  attr :entries, :list, required: true
+  attr :id, :string, default: "recently-added-rail"
+  attr :title, :string, default: "Recently Added"
+
+  def recently_added_rail(assigns) do
+    ~H"""
+    <div :if={@entries != []} id={@id} class="mb-6 md:mb-8">
+      <div class="flex items-center justify-between gap-3 mb-3">
+        <h2 class="text-2xl font-bold truncate">{@title}</h2>
+        <.link navigate={~p"/movies"} class="btn btn-ghost btn-sm">
+          View library
+        </.link>
+      </div>
+
+      <div class="flex gap-3 overflow-x-auto snap-x scroll-smooth pb-2">
+        <div
+          :for={{entry, index} <- Enum.with_index(@entries)}
+          id={"#{@id}-item-#{entry.media_item.id}"}
+          class="snap-start flex-shrink-0 w-36"
+        >
+          <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
+            <.link navigate={~p"/media/#{entry.media_item.id}"}>
+              <figure class="relative aspect-[2/3] overflow-hidden bg-base-300">
+                <img
+                  src={MediaImages.poster_url(entry.media_item)}
+                  alt={entry.media_item.title}
+                  class="w-full h-full object-cover"
+                  loading={if index < 6, do: nil, else: "lazy"}
+                />
+                <span
+                  :if={new_episode_label(entry)}
+                  class="absolute bottom-1 left-1 right-1 badge badge-primary badge-sm justify-center truncate"
+                >
+                  {new_episode_label(entry)}
+                </span>
+              </figure>
+            </.link>
+            <div class="card-body p-3">
+              <h3 class="card-title text-sm line-clamp-2" title={entry.media_item.title}>
+                {entry.media_item.title}
+              </h3>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # Only shows carry a count. A movie's arrival is the card itself, so a badge
+  # would say nothing the poster does not already say.
+  defp new_episode_label(%{media_item: %{type: "tv_show"}, new_episode_count: 1}),
+    do: "1 new episode"
+
+  defp new_episode_label(%{media_item: %{type: "tv_show"}, new_episode_count: count})
+       when is_integer(count) and count > 1 do
+    "#{count} new episodes"
+  end
+
+  defp new_episode_label(_entry), do: nil
+end

--- a/lib/mydia_web/live/dashboard_live/components.ex
+++ b/lib/mydia_web/live/dashboard_live/components.ex
@@ -27,11 +27,8 @@ defmodule MydiaWeb.DashboardLive.Components do
   def recently_added_rail(assigns) do
     ~H"""
     <div :if={@entries != []} id={@id} class="mb-6 md:mb-8">
-      <div class="flex items-center justify-between gap-3 mb-3">
+      <div class="flex items-center gap-3 mb-3">
         <h2 class="text-2xl font-bold truncate">{@title}</h2>
-        <.link navigate={~p"/movies"} class="btn btn-ghost btn-sm">
-          View library
-        </.link>
       </div>
 
       <div class="flex gap-3 overflow-x-auto snap-x scroll-smooth pb-2">

--- a/lib/mydia_web/live/dashboard_live/components.ex
+++ b/lib/mydia_web/live/dashboard_live/components.ex
@@ -41,7 +41,7 @@ defmodule MydiaWeb.DashboardLive.Components do
             <.link navigate={~p"/media/#{entry.media_item.id}"}>
               <figure class="relative aspect-[2/3] overflow-hidden bg-base-300">
                 <img
-                  src={MediaImages.poster_url(entry.media_item)}
+                  src={MediaImages.poster_url(entry.media_item, "w342")}
                   alt={entry.media_item.title}
                   class="w-full h-full object-cover"
                   loading={if index < 6, do: nil, else: "lazy"}

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -6,11 +6,13 @@ defmodule MydiaWeb.DashboardLive.Index do
   require Logger
 
   alias Mydia.Media
+  alias Mydia.Media.RecentlyAdded
   alias Mydia.Library
   alias Mydia.Downloads
   alias Mydia.Metadata
   alias Mydia.MediaRequests
   alias Mydia.Accounts.Authorization
+  alias MydiaWeb.DashboardLive.Components
   alias MydiaWeb.Live.Authorization, as: LiveAuthorization
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
@@ -50,6 +52,7 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:total_storage, "0 GB")
         |> assign(:recent_episodes, [])
         |> assign(:upcoming_episodes, [])
+        |> assign(:recently_added, [])
         |> assign(:library_status_map, %{})
         |> assign(:adding_item_id, nil)
         |> assign(:requesting_item_id, nil)
@@ -102,6 +105,17 @@ defmodule MydiaWeb.DashboardLive.Index do
     send(self(), :load_trending_movies)
     send(self(), :load_trending_tv)
 
+    # Same window and semantics the player's rail uses
+    # (discovery_resolver.ex:39), so both clients agree on what "recently
+    # added" means. This is a local query, so unlike the trending rails below
+    # it does not need to be pushed off the mount path.
+    recently_added =
+      RecentlyAdded.list_recent(
+        since: DateTime.add(DateTime.utc_now(), -30, :day),
+        types: nil,
+        limit: 12
+      )
+
     socket
     |> assign(:movie_count, movie_count)
     |> assign(:tv_show_count, tv_show_count)
@@ -112,6 +126,7 @@ defmodule MydiaWeb.DashboardLive.Index do
     |> assign(:recent_episodes, Enum.take(recent_episodes, 10))
     |> assign(:upcoming_episodes, Enum.take(upcoming_episodes, 10))
     |> assign(:pending_requests_count, pending_requests_count)
+    |> assign(:recently_added, recently_added)
   end
 
   @impl true

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -196,6 +196,8 @@
     </div>
   </div>
 
+  <Components.recently_added_rail entries={@recently_added} />
+
   <!-- Trending Movies -->
   <div class="mb-6 md:mb-8">
     <div class="flex items-center justify-between mb-3 md:mb-4">

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -2,7 +2,6 @@ defmodule MydiaWeb.DiscoverLive.Index do
   use MydiaWeb, :live_view
 
   import MydiaWeb.DiscoverComponents
-  import MydiaWeb.GridDensityComponents
 
   require Logger
 
@@ -13,6 +12,8 @@ defmodule MydiaWeb.DiscoverLive.Index do
   alias MydiaWeb.Live.Helpers.GridDensity
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
+
+  import MydiaWeb.GridDensityComponents
 
   @movie_categories [
     {:trending, "Trending"},

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -2,6 +2,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
   use MydiaWeb, :live_view
 
   import MydiaWeb.DiscoverComponents
+  import MydiaWeb.GridDensityComponents
 
   require Logger
 
@@ -9,6 +10,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
   alias Mydia.Media.Recommendations
   alias Mydia.Metadata
   alias MydiaWeb.Live.Authorization
+  alias MydiaWeb.Live.Helpers.GridDensity
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
@@ -59,6 +61,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
       |> assign(:load_error, nil)
       |> assign(:detail_loading, false)
       |> assign(:libraries, [])
+      |> GridDensity.assign_current()
 
     {:ok, socket}
   end
@@ -271,6 +274,10 @@ defmodule MydiaWeb.DiscoverLive.Index do
      |> assign(:selected_item, nil)
      |> assign(:selected_metadata, nil)
      |> assign(:detail_loading, false)}
+  end
+
+  def handle_event("set_grid_density", %{"density" => density}, socket) do
+    {:noreply, GridDensity.put(socket, density)}
   end
 
   # Info handlers

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -30,6 +30,8 @@
             </button>
           </div>
 
+          <.grid_density_toggle id="discover-density-toggle" density={@grid_density} />
+
           <div role="tablist" class="tabs tabs-box w-fit">
             <%= for {cat_key, cat_label} <- @categories do %>
               <button
@@ -157,7 +159,10 @@
           </div>
         </div>
       <% true -> %>
-        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-5">
+        <div
+          id="discover-grid"
+          class={["grid gap-4 md:gap-5", grid_columns_class(@grid_density)]}
+        >
           <%= for {item, index} <- Enum.with_index(@items) do %>
             <.trending_card
               item={item}

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -12,7 +12,7 @@
     <div class="card bg-base-100 shadow-sm">
       <div class="card-body p-3 md:p-4 space-y-3">
         <%!-- Media type toggle + category tabs --%>
-        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-3">
           <div class="join">
             <button
               phx-click="switch_media_type"

--- a/lib/mydia_web/live/helpers/grid_density.ex
+++ b/lib/mydia_web/live/helpers/grid_density.ex
@@ -1,0 +1,57 @@
+defmodule MydiaWeb.Live.Helpers.GridDensity do
+  @moduledoc """
+  Reads and persists the shared poster-grid density preference for the
+  Discover and Libraries LiveViews.
+
+  Both pages read the same preference key, so the read and the write live
+  here rather than being copied into each LiveView. An unauthenticated or
+  guest render has no preference row to read: it gets the default, and its
+  toggle clicks change the current view without being persisted.
+  """
+
+  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.LiveView, only: [put_flash: 3]
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.UserPreference
+
+  @assign :grid_density
+
+  @doc """
+  Assigns the viewer's stored density, or the default when there is no user.
+  """
+  def assign_current(socket) do
+    assign(socket, @assign, current(socket))
+  end
+
+  @doc """
+  The viewer's stored density, or the default when there is no user.
+  """
+  def current(socket) do
+    case socket.assigns[:current_user] do
+      nil -> UserPreference.defaults()["grid_density"]
+      user -> user |> Accounts.get_user_preference!() |> UserPreference.grid_density()
+    end
+  end
+
+  @doc """
+  Persists a density for the viewer and reassigns it.
+
+  A rejected changeset leaves the stored preference alone and flashes, rather
+  than silently showing a density that will not survive a reload.
+  """
+  def put(socket, density) do
+    case socket.assigns[:current_user] do
+      nil ->
+        assign(socket, @assign, density)
+
+      user ->
+        preference = Accounts.get_user_preference!(user)
+
+        case Accounts.update_preference(preference, %{"grid_density" => density}) do
+          {:ok, _} -> assign(socket, @assign, density)
+          {:error, _changeset} -> put_flash(socket, :error, "Could not save that grid density")
+        end
+    end
+  end
+end

--- a/lib/mydia_web/live/helpers/media_images.ex
+++ b/lib/mydia_web/live/helpers/media_images.ex
@@ -1,0 +1,25 @@
+defmodule MydiaWeb.Live.Helpers.MediaImages do
+  @moduledoc """
+  Image URLs for a `Mydia.Media.MediaItem`.
+
+  Shared by the media library grid, the media detail page, and the dashboard
+  recently-added rail. The search-result variants in `AddMediaLive` and
+  `RequestMediaLive` take a different shape and are intentionally separate.
+  """
+
+  alias Mydia.Metadata.ImageUrl
+  alias Mydia.Metadata.Structs.MediaMetadata
+
+  @placeholder "/images/no-poster.svg"
+
+  @doc """
+  Poster URL for a media item, or a placeholder when it has no poster path.
+  """
+  @spec poster_url(struct()) :: String.t()
+  def poster_url(media_item) do
+    case media_item.metadata do
+      %MediaMetadata{poster_path: path} when is_binary(path) -> ImageUrl.poster_url(path)
+      _ -> @placeholder
+    end
+  end
+end

--- a/lib/mydia_web/live/helpers/media_images.ex
+++ b/lib/mydia_web/live/helpers/media_images.ex
@@ -14,11 +14,17 @@ defmodule MydiaWeb.Live.Helpers.MediaImages do
 
   @doc """
   Poster URL for a media item, or a placeholder when it has no poster path.
+
+  `size` is a TMDB image size. It defaults to `"w500"`, which is what the
+  full-width library grid wants. Narrow callers should ask for something
+  smaller: the dashboard rail renders 144px-wide cards and passes `"w342"`,
+  matching what `DiscoverComponents.media_rail` already requests for the
+  same card size.
   """
-  @spec poster_url(struct()) :: String.t()
-  def poster_url(media_item) do
+  @spec poster_url(struct(), String.t()) :: String.t()
+  def poster_url(media_item, size \\ "w500") do
     case media_item.metadata do
-      %MediaMetadata{poster_path: path} when is_binary(path) -> ImageUrl.poster_url(path)
+      %MediaMetadata{poster_path: path} when is_binary(path) -> ImageUrl.poster_url(path, size)
       _ -> @placeholder
     end
   end

--- a/lib/mydia_web/live/helpers/media_images.ex
+++ b/lib/mydia_web/live/helpers/media_images.ex
@@ -24,8 +24,11 @@ defmodule MydiaWeb.Live.Helpers.MediaImages do
   @spec poster_url(struct(), String.t()) :: String.t()
   def poster_url(media_item, size \\ "w500") do
     case media_item.metadata do
-      %MediaMetadata{poster_path: path} when is_binary(path) -> ImageUrl.poster_url(path, size)
-      _ -> @placeholder
+      %MediaMetadata{poster_path: path} when is_binary(path) and path != "" ->
+        ImageUrl.poster_url(path, size)
+
+      _ ->
+        @placeholder
     end
   end
 end

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -947,15 +947,8 @@ defmodule MydiaWeb.MediaLive.Index do
     end
   end
 
-  defp get_poster_url(media_item) do
-    case media_item.metadata do
-      %MediaMetadata{poster_path: path} when is_binary(path) ->
-        ImageUrl.poster_url(path)
-
-      _ ->
-        "/images/no-poster.svg"
-    end
-  end
+  defp get_poster_url(media_item),
+    do: MydiaWeb.Live.Helpers.MediaImages.poster_url(media_item)
 
   defp get_progress(media_item) do
     # Since playback_progress is has_many but filtered by user_id,

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -7,6 +7,9 @@ defmodule MydiaWeb.MediaLive.Index do
   alias Mydia.Collections
   alias Mydia.Search
   alias MydiaWeb.Live.Authorization
+  alias MydiaWeb.Live.Helpers.GridDensity
+
+  import MydiaWeb.GridDensityComponents
 
   require Logger
 
@@ -24,6 +27,7 @@ defmodule MydiaWeb.MediaLive.Index do
     {:ok,
      socket
      |> assign(:view_mode, :grid)
+     |> GridDensity.assign_current()
      |> assign(:search_query, "")
      |> assign(:filter_progress, nil)
      |> assign(:filter_monitored, nil)
@@ -91,6 +95,10 @@ defmodule MydiaWeb.MediaLive.Index do
      |> assign(:view_mode, view_mode)
      |> assign(:page, 0)
      |> load_media_items(reset: true)}
+  end
+
+  def handle_event("set_grid_density", %{"density" => density}, socket) do
+    {:noreply, GridDensity.put(socket, density)}
   end
 
   def handle_event("search", params, socket) do

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -10,7 +10,7 @@
       </div>
 
       <%!-- Actions and view controls --%>
-      <div class="flex items-center gap-2">
+      <div class="flex flex-wrap items-center gap-2">
         <%!-- Selection controls --%>
         <.selection_controls
           selection_mode={@selection_mode}

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -80,6 +80,11 @@
 
         <%!-- View mode toggle --%>
         <.view_mode_toggle view_mode={@view_mode} />
+        <.grid_density_toggle
+          :if={@view_mode == :grid}
+          id="library-density-toggle"
+          density={@grid_density}
+        />
       </div>
     </div>
 
@@ -298,8 +303,8 @@
       phx-update="stream"
       phx-viewport-bottom="load_more"
       class={[
-        @view_mode == :grid &&
-          "grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 md:gap-4 pb-6 md:pb-8",
+        @view_mode == :grid && "grid gap-3 md:gap-4 pb-6 md:pb-8",
+        @view_mode == :grid && grid_columns_class(@grid_density),
         @view_mode == :list && "card bg-base-100 shadow-lg overflow-hidden -mt-px",
         @selection_mode && "selection-mode"
       ]}

--- a/lib/mydia_web/live/media_live/show/helpers.ex
+++ b/lib/mydia_web/live/media_live/show/helpers.ex
@@ -30,15 +30,8 @@ defmodule MydiaWeb.MediaLive.Show.Helpers do
     movie_files || episode_files
   end
 
-  def get_poster_url(media_item) do
-    case media_item.metadata do
-      %MediaMetadata{poster_path: path} when is_binary(path) ->
-        Mydia.Metadata.ImageUrl.poster_url(path)
-
-      _ ->
-        "/images/no-poster.svg"
-    end
-  end
+  def get_poster_url(media_item),
+    do: MydiaWeb.Live.Helpers.MediaImages.poster_url(media_item)
 
   def get_backdrop_url(media_item) do
     case media_item.metadata do

--- a/test/mydia/accounts/grid_density_preference_test.exs
+++ b/test/mydia/accounts/grid_density_preference_test.exs
@@ -1,0 +1,46 @@
+defmodule Mydia.Accounts.GridDensityPreferenceTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.UserPreference
+
+  test "defaults to comfortable" do
+    user = user_fixture()
+    pref = Accounts.get_user_preference!(user)
+
+    assert UserPreference.grid_density(pref) == "comfortable"
+  end
+
+  test "persists a valid density via update_preference/2" do
+    user = user_fixture()
+    pref = Accounts.get_user_preference!(user)
+
+    {:ok, _} = Accounts.update_preference(pref, %{"grid_density" => "dense"})
+
+    reloaded = Accounts.get_user_preference!(user)
+    assert UserPreference.grid_density(reloaded) == "dense"
+  end
+
+  test "rejects an unknown density" do
+    user = user_fixture()
+    pref = Accounts.get_user_preference!(user)
+
+    assert {:error, changeset} = Accounts.update_preference(pref, %{"grid_density" => "tiny"})
+
+    assert %{preferences: [_ | _]} = errors_on(changeset)
+  end
+
+  test "leaves other preferences intact when density changes" do
+    user = user_fixture()
+    pref = Accounts.get_user_preference!(user)
+
+    {:ok, pref} = Accounts.update_preference(pref, %{"theme" => "dark"})
+    {:ok, _} = Accounts.update_preference(pref, %{"grid_density" => "compact"})
+
+    reloaded = Accounts.get_user_preference!(user)
+    assert UserPreference.theme(reloaded) == "dark"
+    assert UserPreference.grid_density(reloaded) == "compact"
+  end
+end

--- a/test/mydia_web/live/components/grid_density_toggle_test.exs
+++ b/test/mydia_web/live/components/grid_density_toggle_test.exs
@@ -1,0 +1,47 @@
+defmodule MydiaWeb.Components.GridDensityToggleTest do
+  @moduledoc """
+  The class map must return complete literal strings. Tailwind v4 scans source
+  text, so a class assembled by interpolation is never generated and the grid
+  silently keeps its previous columns.
+  """
+
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias MydiaWeb.GridDensityComponents
+
+  test "comfortable keeps the columns the grids used before the toggle existed" do
+    assert GridDensityComponents.grid_columns_class("comfortable") ==
+             "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+  end
+
+  test "compact and dense each return a distinct complete class string" do
+    compact = GridDensityComponents.grid_columns_class("compact")
+    dense = GridDensityComponents.grid_columns_class("dense")
+
+    assert compact == "grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8"
+    assert dense == "grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12"
+    refute compact == dense
+  end
+
+  test "an unknown density falls back to comfortable" do
+    assert GridDensityComponents.grid_columns_class("tiny") ==
+             GridDensityComponents.grid_columns_class("comfortable")
+  end
+
+  test "the toggle renders one button per level, marking the active one" do
+    html =
+      render_component(&GridDensityComponents.grid_density_toggle/1,
+        density: "compact",
+        id: "library-density-toggle"
+      )
+
+    assert html =~ ~s(id="library-density-toggle")
+    assert html =~ ~s(phx-value-density="comfortable")
+    assert html =~ ~s(phx-value-density="compact")
+    assert html =~ ~s(phx-value-density="dense")
+    assert html =~ "set_grid_density"
+    assert html =~ "btn-primary"
+  end
+end

--- a/test/mydia_web/live/components/recently_added_rail_test.exs
+++ b/test/mydia_web/live/components/recently_added_rail_test.exs
@@ -40,7 +40,10 @@ defmodule MydiaWeb.Components.RecentlyAddedRailTest do
   test "renders nothing when there are no entries" do
     html = render_component(&Components.recently_added_rail/1, entries: [])
 
-    refute html =~ "recently-added-rail"
+    # Asserts true emptiness rather than the absence of one substring. The
+    # requirement is that a fresh install sees no trace of the rail, so a
+    # differently-worded empty-state placeholder must fail this too.
+    assert String.trim(html) == ""
   end
 
   test "renders one linked card per entry" do

--- a/test/mydia_web/live/components/recently_added_rail_test.exs
+++ b/test/mydia_web/live/components/recently_added_rail_test.exs
@@ -1,0 +1,93 @@
+defmodule MydiaWeb.Components.RecentlyAddedRailTest do
+  @moduledoc """
+  The new-episode badge matters more than it looks: without it, a show already
+  in the library reappearing at the front of the rail reads as a bug rather
+  than as new episodes arriving.
+  """
+
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Media.RecentlyAdded.Entry
+  alias MydiaWeb.DashboardLive.Components
+
+  defp entry(attrs) do
+    struct(
+      Entry,
+      Enum.into(attrs, %{
+        content_added_at: ~U[2026-08-14 12:00:00Z],
+        new_episode_count: nil,
+        latest_episode: nil
+      })
+    )
+  end
+
+  defp movie(title) do
+    %Mydia.Media.MediaItem{
+      id: Ecto.UUID.generate(),
+      type: "movie",
+      title: title,
+      year: 2024,
+      metadata: nil
+    }
+  end
+
+  defp show(title) do
+    %{movie(title) | type: "tv_show"}
+  end
+
+  test "renders nothing when there are no entries" do
+    html = render_component(&Components.recently_added_rail/1, entries: [])
+
+    refute html =~ "recently-added-rail"
+  end
+
+  test "renders one linked card per entry" do
+    movie = movie("Arrival")
+
+    html =
+      render_component(&Components.recently_added_rail/1, entries: [entry(%{media_item: movie})])
+
+    assert html =~ "recently-added-rail"
+    assert html =~ "Arrival"
+    assert html =~ ~s(href="/media/#{movie.id}")
+  end
+
+  test "falls back to the placeholder poster when metadata is missing" do
+    html =
+      render_component(&Components.recently_added_rail/1,
+        entries: [entry(%{media_item: movie("Arrival")})]
+      )
+
+    assert html =~ "/images/no-poster.svg"
+  end
+
+  test "badges a show with its new episode count, pluralized" do
+    html =
+      render_component(&Components.recently_added_rail/1,
+        entries: [entry(%{media_item: show("Severance"), new_episode_count: 2})]
+      )
+
+    assert html =~ "2 new episodes"
+  end
+
+  test "uses the singular for exactly one new episode" do
+    html =
+      render_component(&Components.recently_added_rail/1,
+        entries: [entry(%{media_item: show("Severance"), new_episode_count: 1})]
+      )
+
+    assert html =~ "1 new episode"
+    refute html =~ "1 new episodes"
+  end
+
+  test "shows no badge for a movie" do
+    html =
+      render_component(&Components.recently_added_rail/1,
+        entries: [entry(%{media_item: movie("Arrival"), new_episode_count: nil})]
+      )
+
+    refute html =~ "new episode"
+  end
+end

--- a/test/mydia_web/live/components/trending_detail_modal_test.exs
+++ b/test/mydia_web/live/components/trending_detail_modal_test.exs
@@ -66,6 +66,6 @@ defmodule MydiaWeb.Components.TrendingDetailModalTest do
   test "renders no season badge for a movie" do
     html = render_modal(item(%{media_type: :movie}), metadata(%{number_of_seasons: nil}))
 
-    refute html =~ "season"
+    refute html =~ ~r/\d+ seasons?/
   end
 end

--- a/test/mydia_web/live/components/trending_detail_modal_test.exs
+++ b/test/mydia_web/live/components/trending_detail_modal_test.exs
@@ -1,0 +1,71 @@
+defmodule MydiaWeb.Components.TrendingDetailModalTest do
+  @moduledoc """
+  The season badge is the only thing under test here. Movies carry
+  number_of_seasons: nil, so the absence case proves the guard rather than a
+  media-type branch.
+  """
+
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Metadata.Structs.MediaMetadata
+  alias MydiaWeb.Live.Components.TrendingDetailModal
+
+  defp item(attrs \\ %{}) do
+    Enum.into(attrs, %{
+      id: nil,
+      provider_id: "101",
+      title: "The Eternal Daughter",
+      year: 2022,
+      poster_path: "/poster.jpg",
+      backdrop_path: "/backdrop.jpg",
+      overview: "An overview.",
+      vote_average: 6.9,
+      media_type: :tv_show,
+      in_library: false,
+      monitored: false
+    })
+  end
+
+  defp metadata(attrs \\ %{}) do
+    struct(MediaMetadata, Enum.into(attrs, %{title: "The Eternal Daughter", year: 2022}))
+  end
+
+  # `open: true` is mandatory. The whole modal body sits behind
+  # `<%= if @open do %>` (trending_detail_modal.ex:40), so omitting it renders
+  # an empty dialog and every assertion below fails for the wrong reason.
+  # `rail: []` is an undeclared slot the template calls `render_slot/1` on;
+  # without it the render raises KeyError.
+  defp render_modal(item, metadata) do
+    render_component(TrendingDetailModal,
+      id: "trending-detail-modal",
+      open: true,
+      item: item,
+      metadata: metadata,
+      loading: false,
+      current_user: %{id: Ecto.UUID.generate(), role: "admin", username: "admin"},
+      libraries: [],
+      rail: []
+    )
+  end
+
+  test "renders a pluralized season badge for a show" do
+    html = render_modal(item(), metadata(%{number_of_seasons: 3}))
+
+    assert html =~ "3 seasons"
+  end
+
+  test "renders a singular season badge for a one-season show" do
+    html = render_modal(item(), metadata(%{number_of_seasons: 1}))
+
+    assert html =~ "1 season"
+    refute html =~ "1 seasons"
+  end
+
+  test "renders no season badge for a movie" do
+    html = render_modal(item(%{media_type: :movie}), metadata(%{number_of_seasons: nil}))
+
+    refute html =~ "season"
+  end
+end

--- a/test/mydia_web/live/components/trending_detail_modal_test.exs
+++ b/test/mydia_web/live/components/trending_detail_modal_test.exs
@@ -28,7 +28,7 @@ defmodule MydiaWeb.Components.TrendingDetailModalTest do
     })
   end
 
-  defp metadata(attrs \\ %{}) do
+  defp metadata(attrs) do
     struct(MediaMetadata, Enum.into(attrs, %{title: "The Eternal Daughter", year: 2022}))
   end
 

--- a/test/mydia_web/live/dashboard_live/recently_added_test.exs
+++ b/test/mydia_web/live/dashboard_live/recently_added_test.exs
@@ -1,0 +1,69 @@
+defmodule MydiaWeb.DashboardLive.RecentlyAddedTest do
+  @moduledoc """
+  The ordering assertion is the requirement from issue #466: the dashboard
+  should lead with library content rather than with external trending content.
+  """
+
+  # async: false — the Postgres non-shared sandbox hides these rows from the
+  # LiveView mount process otherwise.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+
+  setup %{conn: conn} do
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  test "omits the rail entirely on an empty library", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    refute has_element?(view, "#recently-added-rail")
+  end
+
+  test "shows a movie whose file just arrived", %{conn: conn} do
+    movie = media_item_fixture(%{type: "movie", title: "Arrival"})
+    media_file_fixture(%{media_item_id: movie.id})
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(view, "#recently-added-rail")
+    assert has_element?(view, "#recently-added-rail-item-#{movie.id}")
+  end
+
+  test "shows a TV show whose file hangs off an episode", %{conn: conn} do
+    show = media_item_fixture(%{type: "tv_show", title: "Severance"})
+    episode = episode_fixture(%{media_item_id: show.id})
+    media_file_fixture(%{episode_id: episode.id})
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(view, "#recently-added-rail-item-#{show.id}")
+  end
+
+  test "omits a title whose only file arrived outside the 30 day window", %{conn: conn} do
+    movie = media_item_fixture(%{type: "movie", title: "Stale"})
+
+    %{media_item_id: movie.id}
+    |> media_file_fixture()
+    |> backdate_media_file(~U[2024-01-01 00:00:00Z])
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    refute has_element?(view, "#recently-added-rail-item-#{movie.id}")
+  end
+
+  test "places the rail above the trending sections", %{conn: conn} do
+    movie = media_item_fixture(%{type: "movie", title: "Arrival"})
+    media_file_fixture(%{media_item_id: movie.id})
+
+    {:ok, _view, html} = live(conn, ~p"/")
+
+    rail_at = :binary.match(html, "recently-added-rail") |> elem(0)
+    trending_at = :binary.match(html, "Trending Movies") |> elem(0)
+
+    assert rail_at < trending_at
+  end
+end

--- a/test/mydia_web/live/grid_density_test.exs
+++ b/test/mydia_web/live/grid_density_test.exs
@@ -1,0 +1,53 @@
+defmodule MydiaWeb.GridDensityTest do
+  @moduledoc """
+  Density is one preference shared by two pages. The cross-page test is the
+  point: it fails if either LiveView keeps density in socket state instead of
+  reading the stored preference on mount.
+  """
+
+  # async: false — the Postgres non-shared sandbox hides these rows from the
+  # LiveView mount process otherwise.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.UserPreference
+
+  setup %{conn: conn} do
+    user = admin_user_fixture()
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
+  test "libraries grid defaults to comfortable columns", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/movies")
+
+    assert html =~ "xl:grid-cols-6"
+  end
+
+  test "choosing dense re-renders the libraries grid and persists", %{conn: conn, user: user} do
+    {:ok, view, _html} = live(conn, ~p"/movies")
+
+    html =
+      view
+      |> element("#library-density-toggle button[phx-value-density='dense']")
+      |> render_click()
+
+    assert html =~ "xl:grid-cols-12"
+
+    assert user
+           |> Accounts.get_user_preference!()
+           |> UserPreference.grid_density() == "dense"
+  end
+
+  test "the density chosen on libraries applies on discover", %{conn: conn, user: user} do
+    {:ok, _} =
+      Accounts.update_preference(Accounts.get_user_preference!(user), %{"grid_density" => "dense"})
+
+    {:ok, _view, html} = live(conn, ~p"/discover")
+
+    assert html =~ "xl:grid-cols-12"
+  end
+end

--- a/test/mydia_web/live/grid_density_test.exs
+++ b/test/mydia_web/live/grid_density_test.exs
@@ -46,8 +46,18 @@ defmodule MydiaWeb.GridDensityTest do
     {:ok, _} =
       Accounts.update_preference(Accounts.get_user_preference!(user), %{"grid_density" => "dense"})
 
-    {:ok, _view, html} = live(conn, ~p"/discover")
+    {:ok, view, _html} = live(conn, ~p"/discover")
 
-    assert html =~ "xl:grid-cols-12"
+    # Asserts on the toolbar toggle, not the grid. Discover's grid sits behind
+    # an async metadata-relay fetch (index.html.heex:129), so the first
+    # connected render is always the loading spinner and no grid class exists
+    # yet; asserting there would also make this test depend on a live external
+    # call, which test_helper.exs excludes by tag elsewhere. The toggle
+    # (index.html.heex:33) renders from @grid_density on mount, so it proves
+    # the stored preference was read without any network dependency.
+    assert has_element?(
+             view,
+             "#discover-density-toggle button[phx-value-density='dense'].btn-primary"
+           )
   end
 end

--- a/test/mydia_web/live/helpers/media_images_test.exs
+++ b/test/mydia_web/live/helpers/media_images_test.exs
@@ -1,0 +1,57 @@
+defmodule MydiaWeb.Live.Helpers.MediaImagesTest do
+  @moduledoc """
+  `poster_url/2`'s populated branch had no coverage on this branch: every rail
+  test builds `metadata: nil`, so only the placeholder path was ever exercised.
+  This covers the populated path (including that the `size` argument is
+  actually threaded through to `ImageUrl.poster_url/2`, not silently dropped)
+  alongside the two placeholder cases.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Mydia.Metadata.Structs.MediaMetadata
+  alias MydiaWeb.Live.Helpers.MediaImages
+
+  @placeholder "/images/no-poster.svg"
+
+  defp media_item(metadata), do: %{metadata: metadata}
+
+  defp metadata(attrs) do
+    struct(
+      MediaMetadata,
+      Enum.into(attrs, %{provider_id: "101", provider: :tmdb, media_type: :movie})
+    )
+  end
+
+  test "returns a poster URL built from the metadata's poster_path" do
+    item = media_item(metadata(%{poster_path: "/abc123.jpg"}))
+
+    url = MediaImages.poster_url(item)
+
+    assert url != @placeholder
+    assert url =~ "/abc123.jpg"
+    assert url =~ "/w500/"
+  end
+
+  test "threads an explicit size through instead of ignoring it" do
+    item = media_item(metadata(%{poster_path: "/abc123.jpg"}))
+
+    default_size_url = MediaImages.poster_url(item)
+    narrow_url = MediaImages.poster_url(item, "w342")
+
+    assert narrow_url != default_size_url
+    assert narrow_url =~ "/w342/"
+  end
+
+  test "returns the placeholder when the media item has no metadata" do
+    item = media_item(nil)
+
+    assert MediaImages.poster_url(item) == @placeholder
+  end
+
+  test "returns the placeholder when metadata has no poster_path" do
+    item = media_item(metadata(%{poster_path: nil}))
+
+    assert MediaImages.poster_url(item) == @placeholder
+  end
+end

--- a/test/mydia_web/live/helpers/media_images_test.exs
+++ b/test/mydia_web/live/helpers/media_images_test.exs
@@ -54,4 +54,10 @@ defmodule MydiaWeb.Live.Helpers.MediaImagesTest do
 
     assert MediaImages.poster_url(item) == @placeholder
   end
+
+  test "returns the placeholder when poster_path is an empty string" do
+    item = media_item(metadata(%{poster_path: ""}))
+
+    assert MediaImages.poster_url(item) == @placeholder
+  end
 end


### PR DESCRIPTION
Implements the three still-open items from #466, a batch of small UI requests that arrived through in-app feedback on v0.13.2.

## Season count in the Discovery detail popup

Clicking a TV show on Discovery opens a modal showing year, rating, runtime, and genres, but never how many seasons the show has. `number_of_seasons` was already parsed onto `MediaMetadata` and already handed to the modal, so this is render-only: a nil-guarded accessor and a pluralized badge beside the runtime. Movies carry `number_of_seasons: nil`, so no media-type branch is needed.

## Shared grid density control

Discover and the Libraries grid both hardcoded the same breakpoints with no way to change them. Both now share a three-level density preference:

- Comfortable: 2/3/4/5/6 columns (what both grids did before)
- Compact: 3/4/6/7/8
- Dense: 4/6/8/10/12

It is one preference across both pages, stored in the existing `user_preferences` map column, so there is no migration. `MydiaWeb.GridDensityComponents` holds the class map and the toggle; `MydiaWeb.Live.Helpers.GridDensity` holds the read and the write, so each LiveView needs one mount call and a three-line handler rather than its own copy.

The class strings are written out in full on purpose. Tailwind v4 scans source text, so an interpolated class such as `"grid-cols-#{n}"` is never generated and the grid silently keeps its old columns.

The Discover grid container had no DOM id and now has `id="discover-grid"`.

## Recently Added leads the dashboard

The dashboard opened with two Trending rails fetched from TMDB, duplicating what Discover already does. It now leads with the viewer's own library.

No new query was needed. `Mydia.Media.RecentlyAdded.list_recent/1` already existed and already backs the Flutter player's Recently Added rail through GraphQL; the Phoenix dashboard simply never got one. The dashboard calls it with the same 30-day window and arguments the player's resolver uses, so both clients agree on what "recently added" means.

"Recently added" is the newest file per title, not the date the title row was created, which is the only definition that survives a bulk import where every title shares one `inserted_at`. A show whose new season just landed resurfaces, with a badge saying how many episodes arrived.

Trending keeps all of its behaviour and moves down the page. New section order: stats, Quick Actions, Recently Added, Trending Movies, Trending TV Shows, Your Activity.

## Already shipped, no action needed

Two items in #466 turned out to be done already, which is worth passing back to the reporter:

- The recommendations rail on the media detail page landed a while ago and has taken several follow-up fixes since (`show.html.heex:203`).
- Collapsing the season list on the TV show page shipped in v0.10.0 (`episode_events.ex:153`).

## Out of scope

Clickable actors leading to a person page needs a route, a LiveView, and a person-credits query with no equivalent in the codebase today. It is larger than these three combined and belongs in its own change.

## Verification

- Full suite: 7933 tests, 0 failures
- `mix credo --strict`: no issues across 1249 files
- `mix format --check-formatted` and `mix deps.unlock --unused`: clean
- 29 new tests across 7 new test files

The test worth pointing at is the cross-page density test: it is the one that fails if either page keeps density in socket state instead of reading the stored preference. On the dashboard side, the rail test covers a TV show whose only file hangs off an episode, which is the case where a naive query silently returns movies and drops every show.

## Follow-ups noted, not addressed here

- Discover's LiveView tests reach the live metadata relay unstubbed. This predates the change (the existing Discover tests do it too), but CI is one relay outage from red and it deserves a tracked issue.
- `RecentlyAdded.list_recent/1` without an `:ids` filter scans and groups `media_files`; the dashboard now runs it once per mount. Same shape the player's resolver already runs per request. Worth an indexing pass if a large library reports a slow dashboard.
- Density levels are a visual judgement. Dense at the `xl` breakpoint is 12 columns and should get a look on a wide monitor before this ships.

Addresses #466. Leaving the issue open for the actor/person page, which is the only remaining item.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comfortable, compact, and dense grid display options across Discover and media libraries, with preferences saved for signed-in users.
  - Added a dashboard rail showing recently added movies and TV shows from the past 30 days.
  - Added TV season counts to trending details and new-episode badges for recently added shows.
  - Improved poster handling with consistent placeholder images when artwork is unavailable.

- **Bug Fixes**
  - Unknown or missing grid settings now safely use the comfortable layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->