### PR TITLE
fix(search): stream indexer results so one dead indexer cannot stall or blank a manual search

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -421,6 +421,12 @@ config :mydia, :indexer_search,
   # automatic searches getting users rate-limited and banned by indexer sites.
   # Manual searches do not use this; they fan out fully for latency.
   background_max_concurrency: 2,
+  # Milliseconds before a single indexer is abandoned during an UNATTENDED
+  # background search. Tighter than the 120s manual deadline on purpose: no
+  # user is waiting, background jobs walk their items sequentially, and the
+  # Oban :search queue has no execution timeout, so this is what bounds a
+  # long sweep. See Mydia.Indexers.background_search_opts/0.
+  background_deadline_ms: 60_000,
   # Default rate limit for Cardigann indexers (requests per minute per indexer)
   # Cardigann indexers hit sites directly, so conservative limits prevent bans
   default_cardigann_rate_limit: 3

--- a/config/config.exs
+++ b/config/config.exs
@@ -408,9 +408,19 @@ config :mydia, :auto_search,
 # Indexer search throttling
 # Controls concurrency and rate limiting for indexer queries
 config :mydia, :indexer_search,
-  # Max concurrent indexer requests per search query
-  # Lower values reduce pressure on indexer sites
-  max_concurrency: 2,
+  # Max concurrent indexer requests per MANUAL search query. No value here on
+  # purpose: Mydia.Indexers.search_all/2 defaults to searching every selected
+  # indexer at once (capped at 16) unless a deployment explicitly sets
+  # max_concurrency here, which still wins over that default. This used to be
+  # hardcoded to 2 both here and in indexers.ex, which meant six 30s indexers
+  # took 90 seconds even when every one of them was healthy. Manual search is
+  # user-initiated and one at a time, so full fan-out is safe.
+  #
+  # Concurrency for UNATTENDED background searches (MovieSearch, TVShowSearch).
+  # Deliberately low: see 02be582a, which reduced this from ~8 to 2 to stop
+  # automatic searches getting users rate-limited and banned by indexer sites.
+  # Manual searches do not use this; they fan out fully for latency.
+  background_max_concurrency: 2,
   # Default rate limit for Cardigann indexers (requests per minute per indexer)
   # Cardigann indexers hit sites directly, so conservative limits prevent bans
   default_cardigann_rate_limit: 3

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -158,6 +158,12 @@ defmodule Mydia.Indexers do
         for a library type (e.g., `:movies`, `:series`, `:music`, `:books`, `:adult`)
       - `:indexer_ids` - List of indexer config IDs to search (default: all enabled)
         When provided, only the specified indexers will be searched.
+      - `:max_concurrency` - Maximum indexers searched at once (default: every
+        selected indexer, capped at 16). Falls back to the `:indexer_search`
+        application config, then the default.
+      - `:deadline_ms` - Milliseconds before a single indexer's search is
+        killed and reported as timed out (default: 120_000). Falls back to
+        the `:indexer_search` application config, then the default.
 
   ## Examples
 
@@ -219,9 +225,10 @@ defmodule Mydia.Indexers do
         all_indexers
         |> Task.async_stream(
           fn config -> search_with_metrics(config, query, opts) end,
-          timeout: :infinity,
-          max_concurrency: get_search_concurrency(),
-          on_timeout: :kill_task
+          timeout: search_deadline_ms(opts),
+          max_concurrency: get_search_concurrency(length(all_indexers), opts),
+          on_timeout: :kill_task,
+          zip_input_on_exit: true
         )
         |> Enum.reduce({[], []}, fn
           {:ok, {metrics, results}}, {acc_results, acc_errors} ->
@@ -232,10 +239,16 @@ defmodule Mydia.Indexers do
               {acc_results, [error | acc_errors]}
             end
 
-          {:exit, reason}, {acc_results, acc_errors} ->
-            Logger.error("Indexer search task crashed: #{inspect(reason)}")
-            error = %{indexer: "unknown", error: "Task crashed: #{inspect(reason)}"}
-            {acc_results, [error | acc_errors]}
+          # zip_input_on_exit: true puts the input config in the exit tuple.
+          # Without it Task.async_stream never says which element died, which is
+          # why this branch used to report "unknown".
+          {:exit, {config, reason}}, {acc_results, acc_errors} ->
+            name = indexer_display_name(config)
+            message = format_exit_reason(reason)
+
+            Logger.error("Indexer search failed for #{name}: #{inspect(reason)}")
+
+            {acc_results, [%{indexer: name, error: message} | acc_errors]}
         end)
 
       results = rank_and_dedupe(all_results, query, opts)
@@ -413,10 +426,31 @@ defmodule Mydia.Indexers do
     |> Keyword.get(:default_cardigann_rate_limit, 3)
   end
 
-  defp get_search_concurrency do
-    Application.get_env(:mydia, :indexer_search, [])
-    |> Keyword.get(:max_concurrency, 2)
+  # Defaults to searching every selected indexer at once, capped at 16. The
+  # previous default of 2 meant six indexers at a normal 30s response took 90
+  # seconds even when all were healthy, and a single wedged indexer held one of
+  # only two slots for its whole duration. An explicit config value still wins,
+  # so a deployment that deliberately throttled stays throttled.
+  defp get_search_concurrency(indexer_count, opts) do
+    Keyword.get(opts, :max_concurrency) ||
+      Application.get_env(:mydia, :indexer_search, [])[:max_concurrency] ||
+      min(max(indexer_count, 1), 16)
   end
+
+  # 4x a normal 30s response. Generous on purpose: indexers here are legitimately
+  # slow and do eventually answer, so this is a backstop against a wedged
+  # connection rather than a latency budget.
+  defp search_deadline_ms(opts) do
+    Keyword.get(opts, :deadline_ms) ||
+      Application.get_env(:mydia, :indexer_search, [])[:deadline_ms] ||
+      120_000
+  end
+
+  defp indexer_display_name(%{name: name}) when is_binary(name), do: name
+  defp indexer_display_name(_config), do: "unknown"
+
+  defp format_exit_reason(:timeout), do: "Timed out"
+  defp format_exit_reason(reason), do: "Task crashed: #{inspect(reason)}"
 
   defp search_with_metrics(config, query, opts) do
     start_time = System.monotonic_time(:millisecond)

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -349,13 +349,27 @@ defmodule Mydia.Indexers do
   Background searches run repeatedly across a whole library, so they stay
   throttled to avoid indexer bans. Manual searches deliberately do not use
   this: they fan out fully because a user is waiting.
+
+  The deadline is deliberately tighter than the interactive one (120s).
+  `MovieSearch` and `TVShowSearch` walk their items one at a time and the Oban
+  `:search` queue sets no execution timeout, so a per-indexer deadline is the
+  only thing bounding a sweep: with `max_concurrency: 2`, one query costs up to
+  `ceil(indexers / 2) * deadline`, multiplied again by every monitored item in
+  the run. Nobody is waiting on the answer, so a slow host is worth much less
+  patience here than in the manual dialog. 60s still clears the 30-45s a
+  Prowlarr or Jackett instance can legitimately take when it fans out to a cold
+  upstream tracker, while halving the worst-case tail.
+
+  Override with `:background_deadline_ms` in the `:indexer_search` config block,
+  alongside `:background_max_concurrency`.
   """
   @spec background_search_opts() :: keyword()
   def background_search_opts do
-    concurrency =
-      Application.get_env(:mydia, :indexer_search, [])[:background_max_concurrency] || 2
+    config = Application.get_env(:mydia, :indexer_search, [])
+    concurrency = config[:background_max_concurrency] || 2
+    deadline_ms = config[:background_deadline_ms] || 60_000
 
-    [max_concurrency: concurrency]
+    [max_concurrency: concurrency, deadline_ms: deadline_ms]
   end
 
   @doc """

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -31,6 +31,7 @@ defmodule Mydia.Indexers do
   alias Mydia.Indexers.CardigannAuth
   alias Mydia.Indexers.CardigannDownload
   alias Mydia.Indexers.CardigannParser
+  alias Mydia.Indexers.Structs.IndexerProgress
   alias Mydia.Settings
   alias Mydia.Repo
   import Ecto.Query
@@ -185,6 +186,8 @@ defmodule Mydia.Indexers do
           {:ok, %{results: [SearchResult.t()], indexer_errors: [map()]}}
   def search_all(query, opts \\ []) do
     indexer_ids = Keyword.get(opts, :indexer_ids)
+    on_start = Keyword.get(opts, :on_start, fn _pending -> :ok end)
+    on_indexer_result = Keyword.get(opts, :on_indexer_result, fn _progress -> :ok end)
 
     # Get traditional indexers (Prowlarr, Jackett)
     indexers = Settings.list_indexer_configs()
@@ -220,35 +223,72 @@ defmodule Mydia.Indexers do
       {:ok, %{results: [], indexer_errors: []}}
     else
       start_time = System.monotonic_time(:millisecond)
+      total = length(all_indexers)
 
-      {all_results, indexer_errors} =
+      on_start.(
+        Enum.map(all_indexers, fn config ->
+          %IndexerProgress{
+            indexer: indexer_display_name(config),
+            indexer_id: Map.get(config, :id),
+            status: :pending,
+            total: total
+          }
+        end)
+      )
+
+      {all_results, indexer_errors, _completed} =
         all_indexers
         |> Task.async_stream(
           fn config -> search_with_metrics(config, query, opts) end,
           timeout: search_deadline_ms(opts),
-          max_concurrency: get_search_concurrency(length(all_indexers), opts),
+          max_concurrency: get_search_concurrency(total, opts),
           on_timeout: :kill_task,
           zip_input_on_exit: true
         )
-        |> Enum.reduce({[], []}, fn
-          {:ok, {metrics, results}}, {acc_results, acc_errors} ->
+        |> Enum.reduce({[], [], 0}, fn
+          {:ok, {metrics, results}}, {acc_results, acc_errors, completed} ->
+            completed = completed + 1
+
+            on_indexer_result.(%IndexerProgress{
+              indexer: metrics.indexer,
+              indexer_id: metrics.indexer_id,
+              status: if(metrics.success, do: :ok, else: :error),
+              results: results,
+              result_count: length(results),
+              error: metrics.error,
+              duration_ms: metrics.duration_ms,
+              completed: completed,
+              total: total
+            })
+
             if metrics.success do
-              {results ++ acc_results, acc_errors}
+              {results ++ acc_results, acc_errors, completed}
             else
               error = %{indexer: metrics.indexer, error: metrics.error}
-              {acc_results, [error | acc_errors]}
+              {acc_results, [error | acc_errors], completed}
             end
 
           # zip_input_on_exit: true puts the input config in the exit tuple.
           # Without it Task.async_stream never says which element died, which is
           # why this branch used to report "unknown".
-          {:exit, {config, reason}}, {acc_results, acc_errors} ->
+          {:exit, {config, reason}}, {acc_results, acc_errors, completed} ->
+            completed = completed + 1
             name = indexer_display_name(config)
             message = format_exit_reason(reason)
 
             Logger.error("Indexer search failed for #{name}: #{inspect(reason)}")
 
-            {acc_results, [%{indexer: name, error: message} | acc_errors]}
+            on_indexer_result.(%IndexerProgress{
+              indexer: name,
+              indexer_id: Map.get(config, :id),
+              status: if(reason == :timeout, do: :timeout, else: :error),
+              result_count: 0,
+              error: message,
+              completed: completed,
+              total: total
+            })
+
+            {acc_results, [%{indexer: name, error: message} | acc_errors], completed}
         end)
 
       results = rank_and_dedupe(all_results, query, opts)
@@ -256,7 +296,7 @@ defmodule Mydia.Indexers do
       total_time = System.monotonic_time(:millisecond) - start_time
 
       Logger.info(
-        "Search completed: query=#{query}, indexers=#{length(all_indexers)}, " <>
+        "Search completed: query=#{query}, indexers=#{total}, " <>
           "cardigann=#{length(cardigann_configs)}, results=#{length(results)}, " <>
           "errors=#{length(indexer_errors)}, time=#{total_time}ms"
       )
@@ -497,6 +537,7 @@ defmodule Mydia.Indexers do
 
     metrics = %{
       indexer: config.name,
+      indexer_id: Map.get(config, :id),
       success: success,
       duration_ms: duration,
       result_count: length(results),

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -295,6 +295,21 @@ defmodule Mydia.Indexers do
   end
 
   @doc """
+  Search options for unattended background jobs.
+
+  Background searches run repeatedly across a whole library, so they stay
+  throttled to avoid indexer bans. Manual searches deliberately do not use
+  this: they fan out fully because a user is waiting.
+  """
+  @spec background_search_opts() :: keyword()
+  def background_search_opts do
+    concurrency =
+      Application.get_env(:mydia, :indexer_search, [])[:background_max_concurrency] || 2
+
+    [max_concurrency: concurrency]
+  end
+
+  @doc """
   Tests the connection to an indexer.
 
   ## Examples

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -165,6 +165,14 @@ defmodule Mydia.Indexers do
       - `:deadline_ms` - Milliseconds before a single indexer's search is
         killed and reported as timed out (default: 120_000). Falls back to
         the `:indexer_search` application config, then the default.
+      - `:on_start` - `([IndexerProgress.t()] -> any())` called once, before
+        any request is made, with one `:pending` entry per indexer to be
+        searched. Defaults to a no-op.
+      - `:on_indexer_result` - `(IndexerProgress.t() -> any())` called once
+        per indexer as it settles (`:ok`, `:error`, or `:timeout`), in
+        completion order rather than input order. Runs in the caller's
+        process, so a manual-search LiveView can `send/2` to itself from
+        this callback without extra synchronization. Defaults to a no-op.
 
   ## Examples
 
@@ -243,7 +251,8 @@ defmodule Mydia.Indexers do
           timeout: search_deadline_ms(opts),
           max_concurrency: get_search_concurrency(total, opts),
           on_timeout: :kill_task,
-          zip_input_on_exit: true
+          zip_input_on_exit: true,
+          ordered: false
         )
         |> Enum.reduce({[], [], 0}, fn
           {:ok, {metrics, results}}, {acc_results, acc_errors, completed} ->

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -178,9 +178,6 @@ defmodule Mydia.Indexers do
   @spec search_all(binary(), keyword()) ::
           {:ok, %{results: [SearchResult.t()], indexer_errors: [map()]}}
   def search_all(query, opts \\ []) do
-    min_seeders = Keyword.get(opts, :min_seeders, 0)
-    max_results = Keyword.get(opts, :max_results, 100)
-    should_deduplicate = Keyword.get(opts, :deduplicate, true)
     indexer_ids = Keyword.get(opts, :indexer_ids)
 
     # Get traditional indexers (Prowlarr, Jackett)
@@ -241,14 +238,7 @@ defmodule Mydia.Indexers do
             {acc_results, [error | acc_errors]}
         end)
 
-      results =
-        all_results
-        |> filter_by_seeders(min_seeders)
-        |> then(fn results ->
-          if should_deduplicate, do: deduplicate_results(results), else: results
-        end)
-        |> rank_results(query, min_seeders)
-        |> Enum.take(max_results)
+      results = rank_and_dedupe(all_results, query, opts)
 
       total_time = System.monotonic_time(:millisecond) - start_time
 
@@ -260,6 +250,35 @@ defmodule Mydia.Indexers do
 
       {:ok, %{results: results, indexer_errors: Enum.reverse(indexer_errors)}}
     end
+  end
+
+  @doc """
+  Filters, deduplicates and ranks a raw result set.
+
+  Extracted from `search_all/2` so the manual-search LiveViews can re-rank an
+  accumulating result set as each indexer reports, without reimplementing
+  ranking in the web layer.
+
+  ## Options
+
+    - `:min_seeders` - drop torrents below this seeder count (default: 0).
+      NZB results have nil seeders and are always kept.
+    - `:max_results` - truncate to this many results (default: 100)
+    - `:deduplicate` - merge duplicate releases (default: true)
+  """
+  @spec rank_and_dedupe([SearchResult.t()], binary(), keyword()) :: [SearchResult.t()]
+  def rank_and_dedupe(results, query, opts \\ []) do
+    min_seeders = Keyword.get(opts, :min_seeders, 0)
+    max_results = Keyword.get(opts, :max_results, 100)
+    should_deduplicate = Keyword.get(opts, :deduplicate, true)
+
+    results
+    |> filter_by_seeders(min_seeders)
+    |> then(fn results ->
+      if should_deduplicate, do: deduplicate_results(results), else: results
+    end)
+    |> rank_results(query, min_seeders)
+    |> Enum.take(max_results)
   end
 
   @doc """

--- a/lib/mydia/indexers/adapter/jackett.ex
+++ b/lib/mydia/indexers/adapter/jackett.ex
@@ -48,6 +48,8 @@ defmodule Mydia.Indexers.Adapter.Jackett do
 
   require Logger
 
+  @connect_timeout 10_000
+
   # Torznab XML namespace
   @torznab_ns "http://torznab.com/schemas/2015/feed"
 
@@ -84,7 +86,11 @@ defmodule Mydia.Indexers.Adapter.Jackett do
 
     Logger.debug("Jackett search: #{url}")
 
-    case Req.get(url, receive_timeout: timeout) do
+    case Req.get(url,
+           receive_timeout: timeout,
+           connect_options: [timeout: @connect_timeout],
+           retry: false
+         ) do
       {:ok, %Req.Response{status: 200, body: body}} ->
         parse_search_response(body, config.name)
 

--- a/lib/mydia/indexers/adapter/nzbhydra2.ex
+++ b/lib/mydia/indexers/adapter/nzbhydra2.ex
@@ -46,6 +46,8 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
 
   require Logger
 
+  @connect_timeout 10_000
+
   # Newznab XML namespace
   @newznab_ns "http://www.newznab.com/DTD/2010/feeds/attributes/"
 
@@ -86,7 +88,11 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
 
     Logger.debug("NZBHydra2 search: #{url}")
 
-    case Req.get(url, receive_timeout: timeout, retry: false) do
+    case Req.get(url,
+           receive_timeout: timeout,
+           connect_options: [timeout: @connect_timeout],
+           retry: false
+         ) do
       {:ok, %Req.Response{status: 200, body: body}} ->
         parse_search_response(body, config.name)
 

--- a/lib/mydia/indexers/adapter/prowlarr.ex
+++ b/lib/mydia/indexers/adapter/prowlarr.ex
@@ -51,6 +51,11 @@ defmodule Mydia.Indexers.Adapter.Prowlarr do
 
   require Logger
 
+  # A host that drops SYN packets hangs in TCP connect, a phase receive_timeout
+  # does not govern. Slow-but-reachable indexers are unaffected: they connect
+  # promptly and then take their time replying, which receive_timeout covers.
+  @connect_timeout 10_000
+
   alias Mydia.Downloads.TorrentHash
 
   @impl true
@@ -89,7 +94,12 @@ defmodule Mydia.Indexers.Adapter.Prowlarr do
 
     Logger.debug("Prowlarr search: #{url}")
 
-    case Req.get(url, headers: headers, receive_timeout: timeout) do
+    case Req.get(url,
+           headers: headers,
+           receive_timeout: timeout,
+           connect_options: [timeout: @connect_timeout],
+           retry: false
+         ) do
       {:ok, %Req.Response{status: 200, body: body}} ->
         parse_search_response(body, config.name)
 

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -762,6 +762,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     base_opts = [
       headers: request_params.headers,
       receive_timeout: 30_000,
+      connect_options: [timeout: 10_000],
       redirect: definition.follow_redirect,
       retry: false
     ]

--- a/lib/mydia/indexers/structs/indexer_progress.ex
+++ b/lib/mydia/indexers/structs/indexer_progress.ex
@@ -1,0 +1,45 @@
+defmodule Mydia.Indexers.Structs.IndexerProgress do
+  @moduledoc """
+  One indexer's outcome within a `Mydia.Indexers.search_all/2` fan-out.
+
+  Delivered incrementally through the `:on_start` and `:on_indexer_result`
+  callbacks so a manual-search LiveView can render each indexer as it settles
+  instead of waiting for the slowest one.
+
+  `:on_start` emits one `:pending` entry per indexer before any request is
+  made. `:on_indexer_result` emits the settled replacement, keyed by the same
+  `indexer_id`.
+
+  `results` carries the actual releases and can be large. Consumers that keep
+  these structs in LiveView assigns should clear `results` after folding them
+  into their own accumulator and rely on `result_count` for display.
+  """
+
+  alias Mydia.Indexers.SearchResult
+
+  @type status :: :pending | :ok | :error | :timeout
+
+  @type t :: %__MODULE__{
+          indexer: String.t(),
+          indexer_id: String.t() | nil,
+          status: status(),
+          results: [SearchResult.t()],
+          result_count: non_neg_integer() | nil,
+          error: String.t() | nil,
+          duration_ms: non_neg_integer() | nil,
+          completed: non_neg_integer() | nil,
+          total: pos_integer() | nil
+        }
+
+  defstruct [
+    :indexer,
+    :indexer_id,
+    :result_count,
+    :error,
+    :duration_ms,
+    :completed,
+    :total,
+    status: :pending,
+    results: []
+  ]
+end

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -312,7 +312,10 @@ defmodule Mydia.Jobs.MovieSearch do
 
     min_seeders = get_min_seeders()
 
-    case Indexers.search_all(query, min_seeders: min_seeders) do
+    case Indexers.search_all(
+           query,
+           [min_seeders: min_seeders] ++ Indexers.background_search_opts()
+         ) do
       {:ok, %{results: [], indexer_errors: indexer_errors}} ->
         if indexer_errors != [] do
           Logger.warning("Movie search failed due to indexer errors",
@@ -510,7 +513,10 @@ defmodule Mydia.Jobs.MovieSearch do
     min_seeders = get_min_seeders()
     resource_type = Keyword.get(opts, :backoff_resource_type, "movie")
 
-    case Indexers.search_all(query, min_seeders: min_seeders) do
+    case Indexers.search_all(
+           query,
+           [min_seeders: min_seeders] ++ Indexers.background_search_opts()
+         ) do
       {:ok, %{results: [], indexer_errors: indexer_errors}} ->
         if indexer_errors != [] do
           Logger.warning("Movie search failed due to indexer errors",

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -929,7 +929,10 @@ defmodule Mydia.Jobs.TVShowSearch do
       query: query
     )
 
-    case Indexers.search_all(query, min_seeders: get_min_seeders()) do
+    case Indexers.search_all(
+           query,
+           [min_seeders: get_min_seeders()] ++ Indexers.background_search_opts()
+         ) do
       {:ok, %{results: []}} ->
         Logger.warning("No season pack results found",
           media_item_id: media_item.id,
@@ -1290,7 +1293,10 @@ defmodule Mydia.Jobs.TVShowSearch do
       query: query
     )
 
-    case Indexers.search_all(query, min_seeders: get_min_seeders()) do
+    case Indexers.search_all(
+           query,
+           [min_seeders: get_min_seeders()] ++ Indexers.background_search_opts()
+         ) do
       {:ok, %{results: []}} ->
         Logger.warning("No results found for episode",
           episode_id: episode.id,
@@ -2087,7 +2093,10 @@ defmodule Mydia.Jobs.TVShowSearch do
     # Increment counter for the season pack search
     new_count = search_count + 1
 
-    case Indexers.search_all(query, min_seeders: get_min_seeders()) do
+    case Indexers.search_all(
+           query,
+           [min_seeders: get_min_seeders()] ++ Indexers.background_search_opts()
+         ) do
       {:ok, %{results: []}} ->
         Logger.warning("No season pack results found, falling back to individual episodes",
           media_item_id: media_item.id,
@@ -2284,7 +2293,10 @@ defmodule Mydia.Jobs.TVShowSearch do
       query: query
     )
 
-    case Indexers.search_all(query, min_seeders: get_min_seeders()) do
+    case Indexers.search_all(
+           query,
+           [min_seeders: get_min_seeders()] ++ Indexers.background_search_opts()
+         ) do
       {:ok, %{results: []}} ->
         Logger.warning("No results found for episode",
           episode_id: episode.id,

--- a/lib/mydia_web/components/indexer_components.ex
+++ b/lib/mydia_web/components/indexer_components.ex
@@ -1,0 +1,86 @@
+defmodule MydiaWeb.IndexerComponents do
+  @moduledoc """
+  Per-indexer progress display for manual search.
+
+  Used by `MydiaWeb.SearchLive.Index` and the manual-search modal in
+  `MydiaWeb.MediaLive.Show`. Imported explicitly by both rather than added to
+  `html_helpers`: with two consumers it sits below the 3+ bar in CLAUDE.md's
+  component organization rules.
+  """
+
+  use Phoenix.Component
+
+  import MydiaWeb.CoreComponents, only: [icon: 1]
+
+  alias Mydia.Indexers.Structs.IndexerProgress
+
+  @doc """
+  Renders one chip per indexer, showing whether it is still searching, how many
+  results it returned, or why it failed.
+
+  `progress` is a map of `indexer_id => %IndexerProgress{}`. Pass `retry_event`
+  to render a retry button on failed and timed-out indexers; the button sends
+  that event with `phx-value-id` set to the indexer id.
+  """
+  attr :progress, :map, required: true
+  attr :retry_event, :string, default: nil
+
+  def indexer_search_status(assigns) do
+    assigns = assign(assigns, :rows, sort_rows(assigns.progress))
+
+    ~H"""
+    <div :if={@rows != []} id="indexer-search-status" class="mb-4">
+      <div class="flex flex-wrap items-center gap-2">
+        <div
+          :for={row <- @rows}
+          id={"indexer-status-#{row.indexer_id}"}
+          class={["badge badge-lg gap-2 py-3", status_class(row.status)]}
+        >
+          <span :if={row.status == :pending} class="loading loading-spinner loading-xs"></span>
+          <.icon :if={row.status == :ok} name="hero-check-circle" class="w-4 h-4 shrink-0" />
+          <.icon
+            :if={row.status == :error}
+            name="hero-exclamation-triangle"
+            class="w-4 h-4 shrink-0"
+          />
+          <.icon :if={row.status == :timeout} name="hero-clock" class="w-4 h-4 shrink-0" />
+
+          <span class="font-medium">{row.indexer}</span>
+          <span class="text-xs opacity-70">{status_label(row)}</span>
+
+          <button
+            :if={@retry_event && row.status in [:error, :timeout]}
+            type="button"
+            class="btn btn-ghost btn-xs"
+            phx-click={@retry_event}
+            phx-value-id={row.indexer_id}
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # Sorted by name so chips keep a stable position as indexers settle out of
+  # order. Sorting by status would make rows jump around mid-search.
+  defp sort_rows(progress) do
+    progress
+    |> Map.values()
+    |> Enum.sort_by(& &1.indexer)
+  end
+
+  defp status_class(:pending), do: "badge-ghost"
+  defp status_class(:ok), do: "badge-success badge-outline"
+  defp status_class(:error), do: "badge-error badge-outline"
+  defp status_class(:timeout), do: "badge-warning badge-outline"
+
+  defp status_label(%IndexerProgress{status: :pending}), do: "searching..."
+
+  defp status_label(%IndexerProgress{status: :ok} = row),
+    do: "#{row.result_count} results · #{row.duration_ms}ms"
+
+  defp status_label(%IndexerProgress{status: :timeout}), do: "timed out"
+  defp status_label(%IndexerProgress{status: :error} = row), do: row.error || "failed"
+end

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -115,6 +115,8 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:sort_by, :quality)
      |> assign(:results_empty?, false)
      |> assign(:indexer_errors, [])
+     |> assign(:indexer_progress, %{})
+     |> assign(:search_id, 0)
      # Auto search state
      |> assign(:auto_searching, false)
      |> assign(:auto_searching_season, nil)
@@ -160,6 +162,13 @@ defmodule MydiaWeb.MediaLive.Show do
        Mydia.Accounts.Authorization.can_create_media?(socket.assigns.current_user)
      )
      |> assign(:raw_search_results, [])
+     # Untruncated, undeduplicated pool of every release seen so far in the
+     # current manual search, keyed by download_url. Progress messages fold
+     # onto this (never onto :raw_search_results, which is already truncated
+     # and deduplicated) so a later, weaker duplicate can never crown itself
+     # over a stronger release evicted by an earlier round's truncation. See
+     # apply_indexer_progress/2 in SearchHelpers.
+     |> assign(:indexer_raw_results, %{})
      # Category modal state
      |> assign(:show_category_modal, false)
      |> assign(:category_form, nil)
@@ -589,6 +598,23 @@ defmodule MydiaWeb.MediaLive.Show do
 
   def handle_info({:grab_duplicate, payload}, socket),
     do: SearchEvents.handle_grab_duplicate(payload, socket)
+
+  def handle_info({:indexer_search_started, search_id, pending}, socket) do
+    if search_id == socket.assigns.search_id do
+      progress = Map.new(pending, fn entry -> {entry.indexer_id, entry} end)
+      {:noreply, assign(socket, :indexer_progress, progress)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info({:indexer_progress, search_id, progress}, socket) do
+    if search_id == socket.assigns.search_id do
+      {:noreply, apply_indexer_progress(socket, progress)}
+    else
+      {:noreply, socket}
+    end
+  end
 
   def handle_info(_msg, socket), do: {:noreply, socket}
 

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -604,7 +604,18 @@ defmodule MydiaWeb.MediaLive.Show do
 
   def handle_info({:indexer_search_started, search_id, pending}, socket) do
     if search_id == socket.assigns.search_id do
-      progress = Map.new(pending, fn entry -> {entry.indexer_id, entry} end)
+      incoming = Map.new(pending, fn entry -> {entry.indexer_id, entry} end)
+
+      # Merge rather than replace: a scoped retry's on_start message only
+      # covers the indexer(s) actually being retried, so a full replace here
+      # would wipe every OTHER indexer's chip (success counts, durations,
+      # errors) out of indexer_progress, even though those indexers were
+      # never re-searched and will never report in again this search. A
+      # fresh search still resets indexer_progress to %{} before starting
+      # (see SearchEvents.manual_search/2), so merge and replace are
+      # equivalent there; this only changes behavior for the scoped-retry
+      # case.
+      progress = Map.merge(socket.assigns.indexer_progress, incoming)
       {:noreply, assign(socket, :indexer_progress, progress)}
     else
       {:noreply, socket}

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -169,6 +169,12 @@ defmodule MydiaWeb.MediaLive.Show do
      # over a stronger release evicted by an earlier round's truncation. See
      # apply_indexer_progress/2 in SearchHelpers.
      |> assign(:indexer_raw_results, %{})
+     # Per-row grab state (:downloading, :downloaded, :duplicate, :grab_failed)
+     # keyed by download_url. The stream is rebuilt with reset: true on every
+     # progress message, filter change and re-sort, and a reset drops anything
+     # that only lived in the stream, so this is the assign those badges
+     # actually survive in. See SearchHelpers.stream_prepared_results/2.
+     |> assign(:result_states, %{})
      # Category modal state
      |> assign(:show_category_modal, false)
      |> assign(:category_form, nil)
@@ -638,7 +644,8 @@ defmodule MydiaWeb.MediaLive.Show do
   def handle_async(:search, result, socket),
     do: SearchEvents.handle_search_async(result, socket)
 
-  def handle_async({:retry, _indexer_id}, _result, socket), do: {:noreply, socket}
+  def handle_async({:retry, indexer_id}, result, socket),
+    do: SearchEvents.handle_retry_async(indexer_id, result, socket)
 
   def handle_async(:refresh_files, result, socket),
     do: FileEvents.handle_refresh_files_async(result, socket)

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -354,6 +354,9 @@ defmodule MydiaWeb.MediaLive.Show do
   def handle_event("download_from_search", params, socket),
     do: SearchEvents.download_from_search(params, socket)
 
+  def handle_event("retry_indexer", %{"id" => indexer_id}, socket),
+    do: SearchEvents.handle_retry_indexer(indexer_id, socket)
+
   # Subtitle events
 
   def handle_event("open_subtitle_search", params, socket),
@@ -623,6 +626,8 @@ defmodule MydiaWeb.MediaLive.Show do
   @impl true
   def handle_async(:search, result, socket),
     do: SearchEvents.handle_search_async(result, socket)
+
+  def handle_async({:retry, _indexer_id}, _result, socket), do: {:noreply, socket}
 
   def handle_async(:refresh_files, result, socket),
     do: FileEvents.handle_refresh_files_async(result, socket)

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -278,6 +278,7 @@
       close_after_grab={@close_after_grab}
       download_error={@download_error}
       results_empty?={@results_empty?}
+      raw_results_empty?={@raw_search_results == []}
       indexer_errors={@indexer_errors}
       indexer_progress={@indexer_progress}
       streams={@streams}

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -279,6 +279,7 @@
       download_error={@download_error}
       results_empty?={@results_empty?}
       indexer_errors={@indexer_errors}
+      indexer_progress={@indexer_progress}
       streams={@streams}
       quality_filter={@quality_filter}
       min_seeders={@min_seeders}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -118,6 +118,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           </button>
           <button
             type="button"
+            id="manual-search-button"
             phx-click="manual_search"
             class="btn btn-outline"
           >

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -4,6 +4,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   """
   use Phoenix.Component
   import MydiaWeb.CoreComponents
+  import MydiaWeb.IndexerComponents
 
   # Import the formatting and search helper functions
   import MydiaWeb.MediaLive.Show.Formatters
@@ -573,6 +574,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   attr :download_error, :any, default: nil
   attr :results_empty?, :boolean, required: true
   attr :indexer_errors, :list, default: []
+  attr :indexer_progress, :map, default: %{}
   attr :streams, :map, required: true
   attr :quality_filter, :string, default: nil
   attr :min_seeders, :integer, default: 0
@@ -696,24 +698,12 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
               <span class="text-sm">{@download_error}</span>
             </div>
           <% end %>
-          <%!-- Indexer Error Warning --%>
-          <%= if @indexer_errors != [] && !@searching do %>
-            <div class="alert alert-warning mx-4 mt-3 mb-1">
-              <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
-              <div class="flex-1">
-                <div class="text-sm font-medium">
-                  {length(@indexer_errors)} indexer(s) failed
-                </div>
-                <ul class="text-xs opacity-80 mt-1">
-                  <%= for error <- @indexer_errors do %>
-                    <li>{error.indexer}: {error.error}</li>
-                  <% end %>
-                </ul>
-              </div>
-            </div>
-          <% end %>
+          <%!-- Per-indexer search progress --%>
+          <div class="px-4">
+            <.indexer_search_status progress={@indexer_progress} retry_event="retry_indexer" />
+          </div>
           <%!-- Loading State --%>
-          <%= if @searching do %>
+          <%= if @searching && @results_empty? do %>
             <div class="flex flex-col items-center justify-center py-16">
               <span class="loading loading-spinner loading-lg text-primary mb-4"></span>
               <h3 class="text-xl font-semibold text-base-content/70 mb-2">
@@ -741,7 +731,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
             </div>
           <% end %>
           <%!-- Results List --%>
-          <%= if !@searching && !@results_empty? do %>
+          <%= if !@results_empty? do %>
             <ul id="manual-search-results" class="list bg-base-100" phx-update="stream">
               <li
                 :for={{id, result} <- @streams.search_results}

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -573,6 +573,10 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   attr :close_after_grab, :boolean, default: false
   attr :download_error, :any, default: nil
   attr :results_empty?, :boolean, required: true
+  # Whether the accumulated (pre-filter) result pool is still empty. Gates the
+  # filters bar: see the comment on it below for why this is not
+  # `results_empty?`.
+  attr :raw_results_empty?, :boolean, default: true
   attr :indexer_errors, :list, default: []
   attr :indexer_progress, :map, default: %{}
   attr :streams, :map, required: true
@@ -640,7 +644,19 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
           </div>
         </div>
         <%!-- Filters Bar (compact) --%>
-        <%= if !@searching do %>
+        <%!-- Additive to the old `!@searching` gate. Results now stream in
+             indexer by indexer, so gating only on the search being over left
+             the user staring at rows they could not filter or re-sort for up
+             to the full 120s deadline. Adding "or the accumulated pool is not
+             empty" opens the bar as soon as the first indexer reports.
+
+             The extra condition is the PRE-filter pool, not `!@results_empty?`
+             (what the results list below uses). `results_empty?` is the
+             post-filter display set, so a quality filter that happens to match
+             nothing would hide the very controls needed to undo it. Keeping
+             `!@searching` as a floor also keeps the "Close after grabbing"
+             preference reachable after a search that found nothing. --%>
+        <%= if !@raw_results_empty? or !@searching do %>
           <div class="bg-base-200/50 border-b border-base-300 px-4 py-3">
             <div class="flex flex-wrap items-center gap-3">
               <form phx-change="filter_search" class="flex flex-wrap items-center gap-3">

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -704,7 +704,10 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
           </div>
           <%!-- Loading State --%>
           <%= if @searching && @results_empty? do %>
-            <div class="flex flex-col items-center justify-center py-16">
+            <div
+              id="manual-search-loading-state"
+              class="flex flex-col items-center justify-center py-16"
+            >
               <span class="loading loading-spinner loading-lg text-primary mb-4"></span>
               <h3 class="text-xl font-semibold text-base-content/70 mb-2">
                 Searching across indexers...

--- a/lib/mydia_web/live/media_live/show/search_events.ex
+++ b/lib/mydia_web/live/media_live/show/search_events.ex
@@ -33,6 +33,8 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
         end
 
       min_seeders = socket.assigns.min_seeders
+      lv = self()
+      search_id = socket.assigns.search_id + 1
 
       {:noreply,
        socket
@@ -42,8 +44,15 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
        |> assign(:searching, true)
        |> assign(:results_empty?, false)
        |> assign(:download_error, nil)
+       |> assign(:search_id, search_id)
+       |> assign(:indexer_progress, %{})
+       |> assign(:indexer_raw_results, %{})
+       |> assign(:indexer_errors, [])
+       |> assign(:raw_search_results, [])
        |> stream(:search_results, [], reset: true)
-       |> start_async(:search, fn -> perform_search(search_query, min_seeders) end)}
+       |> start_async(:search, fn ->
+         perform_search(search_query, min_seeders, lv, search_id)
+       end)}
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -101,6 +110,8 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
       "#{media_item.title} S#{String.pad_leading(to_string(episode.season_number), 2, "0")}E#{String.pad_leading(to_string(episode.episode_number), 2, "0")}"
 
     min_seeders = socket.assigns.min_seeders
+    lv = self()
+    search_id = socket.assigns.search_id + 1
 
     {:noreply,
      socket
@@ -118,8 +129,15 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
      |> assign(:searching, true)
      |> assign(:results_empty?, false)
      |> assign(:download_error, nil)
+     |> assign(:search_id, search_id)
+     |> assign(:indexer_progress, %{})
+     |> assign(:indexer_raw_results, %{})
+     |> assign(:indexer_errors, [])
+     |> assign(:raw_search_results, [])
      |> stream(:search_results, [], reset: true)
-     |> start_async(:search, fn -> perform_search(search_query, min_seeders) end)}
+     |> start_async(:search, fn ->
+       perform_search(search_query, min_seeders, lv, search_id)
+     end)}
   end
 
   def manual_search_season(%{"season-number" => season_number_str}, socket) do
@@ -130,6 +148,8 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
       "#{media_item.title} S#{String.pad_leading(to_string(season_num), 2, "0")}"
 
     min_seeders = socket.assigns.min_seeders
+    lv = self()
+    search_id = socket.assigns.search_id + 1
 
     {:noreply,
      socket
@@ -139,8 +159,15 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
      |> assign(:searching, true)
      |> assign(:results_empty?, false)
      |> assign(:download_error, nil)
+     |> assign(:search_id, search_id)
+     |> assign(:indexer_progress, %{})
+     |> assign(:indexer_raw_results, %{})
+     |> assign(:indexer_errors, [])
+     |> assign(:raw_search_results, [])
      |> stream(:search_results, [], reset: true)
-     |> start_async(:search, fn -> perform_search(search_query, min_seeders) end)}
+     |> start_async(:search, fn ->
+       perform_search(search_query, min_seeders, lv, search_id)
+     end)}
   end
 
   def auto_search_season(%{"season-number" => season_number_str}, socket) do
@@ -202,6 +229,8 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
     |> assign(:results_empty?, false)
     |> assign(:raw_search_results, [])
     |> assign(:indexer_errors, [])
+    |> assign(:indexer_progress, %{})
+    |> assign(:indexer_raw_results, %{})
     |> assign(:download_error, nil)
     |> stream(:search_results, [], reset: true)
   end

--- a/lib/mydia_web/live/media_live/show/search_events.ex
+++ b/lib/mydia_web/live/media_live/show/search_events.ex
@@ -42,7 +42,15 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
        |> assign(:manual_search_query, search_query)
        |> assign(:manual_search_context, %{type: :media_item})
        |> assign(:searching, true)
-       |> assign(:results_empty?, false)
+       # TRUE, not false: the display set is genuinely empty until the first
+       # indexer reports. The modal's loading gate is
+       # `@searching && @results_empty?` and its results list is gated on
+       # `!@results_empty?`, so starting at false suppresses the spinner and
+       # renders an empty <ul> with no message for the whole search window.
+       # The "No Results Found" state is gated on `!@searching`, so it stays
+       # hidden until the search actually ends. The other two search entry
+       # points below do the same for the same reason.
+       |> assign(:results_empty?, true)
        |> assign(:download_error, nil)
        |> assign(:search_id, search_id)
        |> assign(:indexer_progress, %{})
@@ -127,7 +135,9 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
        }
      )
      |> assign(:searching, true)
-     |> assign(:results_empty?, false)
+     # true so the spinner shows until the first indexer reports; see
+     # manual_search/2 above.
+     |> assign(:results_empty?, true)
      |> assign(:download_error, nil)
      |> assign(:search_id, search_id)
      |> assign(:indexer_progress, %{})
@@ -157,7 +167,9 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
      |> assign(:manual_search_query, search_query)
      |> assign(:manual_search_context, %{type: :season, season_number: season_num})
      |> assign(:searching, true)
-     |> assign(:results_empty?, false)
+     # true so the spinner shows until the first indexer reports; see
+     # manual_search/2 above.
+     |> assign(:results_empty?, true)
      |> assign(:download_error, nil)
      |> assign(:search_id, search_id)
      |> assign(:indexer_progress, %{})
@@ -225,11 +237,12 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
   # the key matches) and reuses the current search_id so its progress
   # messages pass the stale-guard in handle_info({:indexer_progress, ...}).
   #
-  # This re-runs SearchHelpers.perform_search/4 for every indexer, since it
-  # takes no indexer_ids parameter to scope to just one. That is acceptable
-  # for a manual retry: results merge idempotently through
-  # apply_indexer_progress/2, which re-ranks and deduplicates on every
-  # arrival.
+  # The retry is SCOPED to the one indexer via perform_search/5's indexer_ids
+  # argument. Re-running every indexer would not just waste requests against
+  # hosts that ban on rate: since handle_info({:indexer_search_started, ...})
+  # merges rather than replaces, an unscoped retry's on_start carries a
+  # :pending entry for EVERY indexer, so clicking Retry on one failed chip
+  # would visibly restart all of them.
   def handle_retry_indexer(indexer_id, socket) do
     query = socket.assigns.manual_search_query
     min_seeders = socket.assigns.min_seeders
@@ -251,7 +264,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
      socket
      |> assign(:indexer_progress, indexer_progress)
      |> start_async({:retry, indexer_id}, fn ->
-       perform_search(query, min_seeders, lv, search_id)
+       perform_search(query, min_seeders, lv, search_id, [indexer_id])
      end)}
   end
 
@@ -421,34 +434,41 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
 
   # handle_async dispatches
 
+  # Terminal handler for the full search. It deliberately does NOT touch the
+  # displayed results.
+  #
+  # Every indexer's output already arrived through `on_indexer_result`:
+  # Indexers.search_all/2 invokes it on the success branch, the error branch
+  # and the exit/timeout branch alike, and start_async delivers this reply
+  # from the same process that sent those progress messages, so all of them
+  # have already been folded in by SearchHelpers.apply_indexer_progress/2
+  # (which owns :raw_search_results, :indexer_raw_results, :results_empty?
+  # and the stream).
+  #
+  # `results` here is the aggregate of the FULL search only. Re-streaming it
+  # with reset: true would silently delete anything a single-indexer retry
+  # contributed, which is the ordinary case rather than an exotic race: the
+  # Retry button appears as soon as one indexer errors, while slow indexers
+  # are still pending, so a retry against a fast-failing host normally
+  # settles before the slow ones finish.
+  #
+  # The zero-indexer case is why this clause still has to end the search:
+  # search_all/2 returns early there, before `on_start`, so no progress
+  # message ever arrives and nothing else can clear :searching.
+  # :results_empty? was set to true when the search started and nothing has
+  # flipped it, so the "No Results Found" state renders correctly.
   def handle_search_async({:ok, {:ok, results, indexer_errors}}, socket) do
-    start_time = System.monotonic_time(:millisecond)
-
-    search_query = socket.assigns.manual_search_query
-
-    filtered_results = filter_search_results(results, socket.assigns)
-    ranking_opts = build_manual_ranking_opts(socket.assigns)
-
-    sorted_results =
-      sort_search_results_with_opts(filtered_results, socket.assigns.sort_by, ranking_opts)
-
-    prepared_results = prepare_for_stream(sorted_results)
-
-    duration = System.monotonic_time(:millisecond) - start_time
-
     Logger.info(
-      "Search completed: query=\"#{search_query}\", " <>
-        "results=#{length(results)}, filtered=#{length(filtered_results)}, " <>
-        "indexer_errors=#{length(indexer_errors)}, processing_time=#{duration}ms"
+      "Search completed: query=\"#{socket.assigns.manual_search_query}\", " <>
+        "aggregate_results=#{length(results)}, " <>
+        "displayed=#{length(Map.get(socket.assigns, :raw_search_results, []))}, " <>
+        "indexer_errors=#{length(indexer_errors)}"
     )
 
     {:noreply,
      socket
      |> assign(:searching, false)
-     |> assign(:results_empty?, sorted_results == [])
-     |> assign(:raw_search_results, results)
-     |> assign(:indexer_errors, indexer_errors)
-     |> stream(:search_results, prepared_results, reset: true)}
+     |> assign(:indexer_errors, indexer_errors)}
   end
 
   def handle_search_async({:ok, {:error, reason}}, socket) do

--- a/lib/mydia_web/live/media_live/show/search_events.ex
+++ b/lib/mydia_web/live/media_live/show/search_events.ex
@@ -57,6 +57,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
        |> assign(:indexer_raw_results, %{})
        |> assign(:indexer_errors, [])
        |> assign(:raw_search_results, [])
+       |> assign(:result_states, %{})
        |> stream(:search_results, [], reset: true)
        |> start_async(:search, fn ->
          perform_search(search_query, min_seeders, lv, search_id)
@@ -144,6 +145,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
      |> assign(:indexer_raw_results, %{})
      |> assign(:indexer_errors, [])
      |> assign(:raw_search_results, [])
+     |> assign(:result_states, %{})
      |> stream(:search_results, [], reset: true)
      |> start_async(:search, fn ->
        perform_search(search_query, min_seeders, lv, search_id)
@@ -176,6 +178,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
      |> assign(:indexer_raw_results, %{})
      |> assign(:indexer_errors, [])
      |> assign(:raw_search_results, [])
+     |> assign(:result_states, %{})
      |> stream(:search_results, [], reset: true)
      |> start_async(:search, fn ->
        perform_search(search_query, min_seeders, lv, search_id)
@@ -243,29 +246,77 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
   # merges rather than replaces, an unscoped retry's on_start carries a
   # :pending entry for EVERY indexer, so clicking Retry on one failed chip
   # would visibly restart all of them.
+  #
+  # Authorized exactly like the other three entry points that start an indexer
+  # search (manual_search/2, auto_search_download/2, download_from_search/2):
+  # Retry hits the same indexers with the same query, so it must sit behind
+  # the same permission check rather than being a side door around it.
   def handle_retry_indexer(indexer_id, socket) do
-    query = socket.assigns.manual_search_query
-    min_seeders = socket.assigns.min_seeders
-    lv = self()
-    search_id = socket.assigns.search_id
+    with :ok <- Authorization.authorize_manage_downloads(socket) do
+      query = socket.assigns.manual_search_query
+      min_seeders = socket.assigns.min_seeders
+      lv = self()
+      search_id = socket.assigns.search_id
 
-    # Map.replace_lazy/3 no-ops when indexer_id isn't a key in the map, rather
-    # than inserting `indexer_id => nil` (as Map.update/4's default would),
-    # which would otherwise flow a nil straight into the status chip
-    # component. Not reachable through the shipped UI today (the Retry
-    # button only renders for rows already present in the map), but an
-    # unknown or forged id should be a clean no-op, not a crash landmine.
+      # Map.replace_lazy/3 no-ops when indexer_id isn't a key in the map, rather
+      # than inserting `indexer_id => nil` (as Map.update/4's default would),
+      # which would otherwise flow a nil straight into the status chip
+      # component. Not reachable through the shipped UI today (the Retry
+      # button only renders for rows already present in the map), but an
+      # unknown or forged id should be a clean no-op, not a crash landmine.
+      indexer_progress =
+        Map.replace_lazy(socket.assigns.indexer_progress, indexer_id, fn entry ->
+          %{entry | status: :pending, error: nil, result_count: nil, duration_ms: nil}
+        end)
+
+      {:noreply,
+       socket
+       |> assign(:indexer_progress, indexer_progress)
+       |> start_async({:retry, indexer_id}, fn ->
+         perform_search(query, min_seeders, lv, search_id, [indexer_id])
+       end)}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  # Terminal handler for a single-indexer retry.
+  #
+  # The SUCCESS case is deliberately a no-op: every release the retry found
+  # already arrived through `on_indexer_result` (see handle_search_async/2's
+  # note above), and the batched aggregate carries ONLY the retried indexer,
+  # so applying it would clobber every other indexer's contribution.
+  #
+  # The failure cases are not no-ops. handle_retry_indexer/2 sets the chip to
+  # `:pending` before starting the task; if that task dies or returns an error
+  # before any progress message lands, nothing else ever clears `:pending`, so
+  # the chip spins forever AND the Retry button disappears (it only renders
+  # for `:error`/`:timeout`). Restoring an error state puts the indexer back
+  # into an actionable state.
+  def handle_retry_async(_indexer_id, {:ok, {:ok, _results, _indexer_errors}}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_retry_async(indexer_id, {:ok, {:error, reason}}, socket) do
+    Logger.error("Indexer retry failed: #{inspect(reason)}")
+    {:noreply, restore_retry_error(socket, indexer_id, "Retry failed: #{inspect(reason)}")}
+  end
+
+  def handle_retry_async(indexer_id, {:exit, reason}, socket) do
+    Logger.error("Indexer retry crashed: #{inspect(reason)}")
+    {:noreply, restore_retry_error(socket, indexer_id, "Retry failed unexpectedly")}
+  end
+
+  # Map.replace_lazy/3 for the same reason handle_retry_indexer/2 uses it: an
+  # id that is not already in the map must be a clean no-op, never an insert
+  # of a half-built entry.
+  defp restore_retry_error(socket, indexer_id, message) do
     indexer_progress =
       Map.replace_lazy(socket.assigns.indexer_progress, indexer_id, fn entry ->
-        %{entry | status: :pending, error: nil, result_count: nil, duration_ms: nil}
+        %{entry | status: :error, error: message, result_count: nil, duration_ms: nil}
       end)
 
-    {:noreply,
-     socket
-     |> assign(:indexer_progress, indexer_progress)
-     |> start_async({:retry, indexer_id}, fn ->
-       perform_search(query, min_seeders, lv, search_id, [indexer_id])
-     end)}
+    assign(socket, :indexer_progress, indexer_progress)
   end
 
   defp reset_search_modal(socket) do
@@ -279,6 +330,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
     |> assign(:indexer_errors, [])
     |> assign(:indexer_progress, %{})
     |> assign(:indexer_raw_results, %{})
+    |> assign(:result_states, %{})
     |> assign(:download_error, nil)
     |> stream(:search_results, [], reset: true)
   end
@@ -413,10 +465,32 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
   # Re-stream a single result row with extra fields merged in (e.g. `:downloading`,
   # `:downloaded`). Streams don't re-render existing items on parent assign changes,
   # so per-row state must be pushed via stream_insert.
+  #
+  # The same state is also recorded in `:result_states`, keyed by download_url.
+  # The stream is rebuilt with `reset: true` on every progress message, filter
+  # change and re-sort, and a reset drops anything that only ever lived in the
+  # stream. `:result_states` is what SearchHelpers.stream_prepared_results/2
+  # folds back in on each rebuild, so a badge survives the next indexer
+  # reporting mid-search.
   defp mark_result(socket, download_url, extra) do
+    states =
+      Map.update(
+        Map.get(socket.assigns, :result_states, %{}),
+        download_url,
+        extra,
+        &Map.merge(&1, extra)
+      )
+
+    socket = assign(socket, :result_states, states)
+
     case find_prepared_result(socket, download_url) do
-      nil -> socket
-      item -> stream_insert(socket, :search_results, Map.merge(item, extra))
+      nil ->
+        socket
+
+      item ->
+        # Merge the ACCUMULATED state, not just this call's `extra`, so the row
+        # rendered here matches exactly what a later stream rebuild produces.
+        stream_insert(socket, :search_results, Map.merge(item, Map.fetch!(states, download_url)))
     end
   end
 

--- a/lib/mydia_web/live/media_live/show/search_events.ex
+++ b/lib/mydia_web/live/media_live/show/search_events.ex
@@ -220,6 +220,35 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
     {:noreply, reset_search_modal(socket)}
   end
 
+  # Retries a single indexer under a distinct start_async key so it cannot
+  # cancel an in-flight full search (LiveView only cancels a prior async when
+  # the key matches) and reuses the current search_id so its progress
+  # messages pass the stale-guard in handle_info({:indexer_progress, ...}).
+  #
+  # This re-runs SearchHelpers.perform_search/4 for every indexer, since it
+  # takes no indexer_ids parameter to scope to just one. That is acceptable
+  # for a manual retry: results merge idempotently through
+  # apply_indexer_progress/2, which re-ranks and deduplicates on every
+  # arrival.
+  def handle_retry_indexer(indexer_id, socket) do
+    query = socket.assigns.manual_search_query
+    min_seeders = socket.assigns.min_seeders
+    lv = self()
+    search_id = socket.assigns.search_id
+
+    indexer_progress =
+      Map.update(socket.assigns.indexer_progress, indexer_id, nil, fn entry ->
+        %{entry | status: :pending, error: nil, result_count: nil, duration_ms: nil}
+      end)
+
+    {:noreply,
+     socket
+     |> assign(:indexer_progress, indexer_progress)
+     |> start_async({:retry, indexer_id}, fn ->
+       perform_search(query, min_seeders, lv, search_id)
+     end)}
+  end
+
   defp reset_search_modal(socket) do
     socket
     |> assign(:show_manual_search_modal, false)

--- a/lib/mydia_web/live/media_live/show/search_events.ex
+++ b/lib/mydia_web/live/media_live/show/search_events.ex
@@ -236,8 +236,14 @@ defmodule MydiaWeb.MediaLive.Show.SearchEvents do
     lv = self()
     search_id = socket.assigns.search_id
 
+    # Map.replace_lazy/3 no-ops when indexer_id isn't a key in the map, rather
+    # than inserting `indexer_id => nil` (as Map.update/4's default would),
+    # which would otherwise flow a nil straight into the status chip
+    # component. Not reachable through the shipped UI today (the Retry
+    # button only renders for rows already present in the map), but an
+    # unknown or forged id should be a clean no-op, not a crash landmine.
     indexer_progress =
-      Map.update(socket.assigns.indexer_progress, indexer_id, nil, fn entry ->
+      Map.replace_lazy(socket.assigns.indexer_progress, indexer_id, fn entry ->
         %{entry | status: :pending, error: nil, result_count: nil, duration_ms: nil}
       end)
 

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -10,6 +10,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   alias Mydia.Indexers.ReleaseRanker
   alias Mydia.Indexers.SearchResult
   alias Mydia.Indexers.SearchScorer
+  alias Mydia.Indexers.Structs.IndexerProgress
   alias Mydia.Media
   alias Mydia.Settings.CustomFormats
 
@@ -41,16 +42,83 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
 
   def generate_positioned_id(result), do: generate_result_id(result)
 
-  def perform_search(query, min_seeders) do
+  def perform_search(query, min_seeders, lv, search_id) do
     opts = [
       min_seeders: min_seeders,
-      deduplicate: true
+      deduplicate: true,
+      on_start: fn pending -> send(lv, {:indexer_search_started, search_id, pending}) end,
+      on_indexer_result: fn progress -> send(lv, {:indexer_progress, search_id, progress}) end
     ]
 
-    {:ok, %{results: results, indexer_errors: indexer_errors}} =
-      Indexers.search_all(query, opts)
+    case Indexers.search_all(query, opts) do
+      {:ok, %{results: results, indexer_errors: indexer_errors}} ->
+        {:ok, results, indexer_errors}
 
-    {:ok, results, indexer_errors}
+      other ->
+        {:error, other}
+    end
+  end
+
+  @doc """
+  Folds one indexer's results into the accumulated set and re-ranks everything,
+  so the list stays correctly ordered as indexers report out of order.
+
+  Two collections are kept deliberately, and must NOT be collapsed into one:
+
+    - `:indexer_raw_results` - every release seen so far this search, keyed by
+      `download_url`, UNTRUNCATED. This is what future progress messages fold
+      new results onto.
+    - `:raw_search_results` - the ranked-and-deduplicated (and therefore
+      truncated-to-max_results) set, matching what `handle_search_async/2`
+      assigns at the end of a search. `apply_search_filters/1` re-filters
+      straight from it without deduplicating, so it must stay deduplicated.
+
+  Folding new results directly onto `:raw_search_results` (rather than a
+  separate untruncated pool) would corrupt deduplication across rounds: an
+  item can be evicted by `rank_and_dedupe/3`'s `max_results` truncation while
+  it was the sole member of its dedup group, having never lost a dedup
+  comparison. If a WEAKER duplicate of that same release arrives in a later
+  round, deduping against the truncated set would only see the weak
+  duplicate (the true winner already evicted) and crown it as the group's
+  representative. Re-ranking from the full untruncated pool every round
+  means deduplication always compares every variant of a release ever seen,
+  so the strongest one always wins.
+
+  `results` is cleared from the stored progress struct before it's put in
+  `:indexer_progress`, because it can be large and the releases already live
+  in `:indexer_raw_results`.
+  """
+  def apply_indexer_progress(socket, %IndexerProgress{} = progress) do
+    indexer_progress =
+      Map.put(socket.assigns.indexer_progress, progress.indexer_id, %{progress | results: []})
+
+    raw_pool =
+      Enum.reduce(progress.results, socket.assigns.indexer_raw_results, fn result, acc ->
+        Map.put(acc, result.download_url, result)
+      end)
+
+    ranked =
+      raw_pool
+      |> Map.values()
+      |> Indexers.rank_and_dedupe(socket.assigns.manual_search_query,
+        min_seeders: socket.assigns.min_seeders
+      )
+
+    ranking_opts = build_manual_ranking_opts(socket.assigns)
+
+    sorted =
+      ranked
+      |> filter_search_results(socket.assigns)
+      |> sort_search_results_with_opts(socket.assigns.sort_by, ranking_opts)
+
+    prepared = prepare_for_stream(sorted)
+
+    socket
+    |> Phoenix.Component.assign(:indexer_progress, indexer_progress)
+    |> Phoenix.Component.assign(:indexer_raw_results, raw_pool)
+    |> Phoenix.Component.assign(:raw_search_results, ranked)
+    |> Phoenix.Component.assign(:results_empty?, sorted == [])
+    |> Phoenix.LiveView.stream(:search_results, prepared, reset: true)
   end
 
   def apply_search_filters(socket) do

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -43,6 +43,38 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   def generate_positioned_id(result), do: generate_result_id(result)
 
   @doc """
+  Rebuild the `:search_results` stream from a freshly sorted list, re-applying
+  the per-row grab state held in `:result_states`.
+
+  Per-row flags (`:downloading`, `:downloaded`, `:duplicate`, `:grab_failed`)
+  are written into the stream by `SearchEvents.mark_result/3` and live nowhere
+  else, so every `reset: true` rebuild would erase them. That used to be
+  unreachable: results were only clickable once the search had finished, and
+  nothing rebuilt the stream after that. Now that results stream in while slow
+  indexers are still running, a user can grab a release and watch the badge
+  vanish the moment the next indexer reports.
+
+  `:result_states` is the backing assign that survives those rebuilds, mirroring
+  how `MydiaWeb.SearchLive.Index` keeps `:downloading_urls` in assigns and
+  re-derives per-row state after each re-stream.
+  """
+  def stream_prepared_results(socket, sorted_results) do
+    states = Map.get(socket.assigns, :result_states, %{})
+
+    prepared =
+      sorted_results
+      |> prepare_for_stream()
+      |> Enum.map(fn result ->
+        case Map.get(states, result.download_url) do
+          nil -> result
+          state -> Map.merge(result, state)
+        end
+      end)
+
+    Phoenix.LiveView.stream(socket, :search_results, prepared, reset: true)
+  end
+
+  @doc """
   Run a manual search, streaming per-indexer progress back to `lv`.
 
   `indexer_ids` scopes the search to a subset of the enabled indexers. It
@@ -121,14 +153,12 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
       |> filter_search_results(socket.assigns)
       |> sort_search_results_with_opts(socket.assigns.sort_by, ranking_opts)
 
-    prepared = prepare_for_stream(sorted)
-
     socket
     |> Phoenix.Component.assign(:indexer_progress, indexer_progress)
     |> Phoenix.Component.assign(:indexer_raw_results, raw_pool)
     |> Phoenix.Component.assign(:raw_search_results, ranked)
     |> Phoenix.Component.assign(:results_empty?, sorted == [])
-    |> Phoenix.LiveView.stream(:search_results, prepared, reset: true)
+    |> stream_prepared_results(sorted)
   end
 
   def apply_search_filters(socket) do
@@ -140,11 +170,9 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
     sorted_results =
       sort_search_results_with_opts(filtered_results, socket.assigns.sort_by, ranking_opts)
 
-    prepared_results = prepare_for_stream(sorted_results)
-
     socket
     |> Phoenix.Component.assign(:results_empty?, sorted_results == [])
-    |> Phoenix.LiveView.stream(:search_results, prepared_results, reset: true)
+    |> stream_prepared_results(sorted_results)
   end
 
   def apply_search_sort(socket) do
@@ -156,10 +184,7 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
     sorted_results =
       sort_search_results_with_opts(filtered_results, socket.assigns.sort_by, ranking_opts)
 
-    prepared_results = prepare_for_stream(sorted_results)
-
-    socket
-    |> Phoenix.LiveView.stream(:search_results, prepared_results, reset: true)
+    stream_prepared_results(socket, sorted_results)
   end
 
   def filter_search_results(results, assigns) do

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -42,10 +42,20 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
 
   def generate_positioned_id(result), do: generate_result_id(result)
 
-  def perform_search(query, min_seeders, lv, search_id) do
+  @doc """
+  Run a manual search, streaming per-indexer progress back to `lv`.
+
+  `indexer_ids` scopes the search to a subset of the enabled indexers. It
+  defaults to `nil`, which searches all of them; the single-indexer retry
+  passes `[indexer_id]` so retrying one failed chip does not re-run (and
+  re-set to `:pending`) every other indexer. `Indexers.search_all/2` treats a
+  `nil` value the same as the option being absent.
+  """
+  def perform_search(query, min_seeders, lv, search_id, indexer_ids \\ nil) do
     opts = [
       min_seeders: min_seeders,
       deduplicate: true,
+      indexer_ids: indexer_ids,
       on_start: fn pending -> send(lv, {:indexer_search_started, search_id, pending}) end,
       on_indexer_result: fn progress -> send(lv, {:indexer_progress, search_id, progress}) end
     ]

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -515,8 +515,14 @@ defmodule MydiaWeb.SearchLive.Index do
     lv = self()
     search_id = socket.assigns.search_id
 
+    # Map.replace_lazy/3 no-ops when indexer_id isn't a key in the map, rather
+    # than inserting `indexer_id => nil` (as Map.update/4's default would),
+    # which would otherwise flow a nil straight into the status chip
+    # component. Not reachable through the shipped UI today (the Retry
+    # button only renders for rows already present in the map), but an
+    # unknown or forged id should be a clean no-op, not a crash landmine.
     indexer_progress =
-      Map.update(socket.assigns.indexer_progress, indexer_id, nil, fn entry ->
+      Map.replace_lazy(socket.assigns.indexer_progress, indexer_id, fn entry ->
         %{entry | status: :pending, error: nil, result_count: nil, duration_ms: nil}
       end)
 
@@ -616,7 +622,17 @@ defmodule MydiaWeb.SearchLive.Index do
 
   def handle_info({:indexer_search_started, search_id, pending}, socket) do
     if search_id == socket.assigns.search_id do
-      progress = Map.new(pending, fn entry -> {entry.indexer_id, entry} end)
+      incoming = Map.new(pending, fn entry -> {entry.indexer_id, entry} end)
+
+      # Merge rather than replace: a scoped retry's on_start message only
+      # covers the indexer(s) actually being retried, so a full replace here
+      # would wipe every OTHER indexer's chip (success counts, durations,
+      # errors) out of indexer_progress, even though those indexers were
+      # never re-searched and will never report in again this search. A
+      # fresh search still resets indexer_progress to %{} before starting
+      # (see start_search/2), so merge and replace are equivalent there;
+      # this only changes behavior for the scoped-retry case.
+      progress = Map.merge(socket.assigns.indexer_progress, incoming)
       {:noreply, assign(socket, :indexer_progress, progress)}
     else
       {:noreply, socket}

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -9,6 +9,10 @@ defmodule MydiaWeb.SearchLive.Index do
   alias Mydia.Downloads
   alias Mydia.Settings
 
+  import MydiaWeb.IndexerComponents
+
+  alias Mydia.Indexers.Structs.IndexerProgress
+
   require Logger
 
   # Library type options for the filter
@@ -70,6 +74,8 @@ defmodule MydiaWeb.SearchLive.Index do
      |> assign(:sort_by, :quality)
      |> assign(:results_empty?, false)
      |> assign(:indexer_errors, [])
+     |> assign(:indexer_progress, %{})
+     |> assign(:search_id, 0)
      |> assign(:show_disambiguation_modal, false)
      |> assign(:metadata_matches, [])
      |> assign(:metadata_media_type, nil)
@@ -103,14 +109,7 @@ defmodule MydiaWeb.SearchLive.Index do
     socket =
       case params do
         %{"q" => query} when is_binary(query) and query != "" ->
-          # Trigger a search with the query parameter
-          min_seeders = socket.assigns.min_seeders
-          indexer_ids = MapSet.to_list(socket.assigns.selected_indexer_ids)
-
-          socket
-          |> assign(:search_query, query)
-          |> assign(:searching, true)
-          |> start_async(:search, fn -> perform_search(query, min_seeders, indexer_ids) end)
+          start_search(socket, query)
 
         _ ->
           socket
@@ -130,15 +129,7 @@ defmodule MydiaWeb.SearchLive.Index do
        |> assign(:results_empty?, false)
        |> stream(:search_results, [], reset: true)}
     else
-      # Extract only needed values to avoid copying the whole assigns to the async task
-      min_seeders = socket.assigns.min_seeders
-      indexer_ids = MapSet.to_list(socket.assigns.selected_indexer_ids)
-
-      {:noreply,
-       socket
-       |> assign(:search_query, query)
-       |> assign(:searching, true)
-       |> start_async(:search, fn -> perform_search(query, min_seeders, indexer_ids) end)}
+      {:noreply, push_patch(socket, to: ~p"/search?#{[q: query]}")}
     end
   end
 
@@ -602,6 +593,23 @@ defmodule MydiaWeb.SearchLive.Index do
   def handle_info({:grab_failed, _payload}, socket), do: {:noreply, socket}
   def handle_info({:grab_duplicate, _payload}, socket), do: {:noreply, socket}
 
+  def handle_info({:indexer_search_started, search_id, pending}, socket) do
+    if search_id == socket.assigns.search_id do
+      progress = Map.new(pending, fn entry -> {entry.indexer_id, entry} end)
+      {:noreply, assign(socket, :indexer_progress, progress)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info({:indexer_progress, search_id, %IndexerProgress{} = progress}, socket) do
+    if search_id == socket.assigns.search_id do
+      {:noreply, apply_indexer_progress(socket, progress)}
+    else
+      {:noreply, socket}
+    end
+  end
+
   def handle_info(msg, socket) do
     # Catch-all for unhandled messages to prevent crashes
     Logger.warning("Unhandled message in SearchLive.Index: #{inspect(msg)}")
@@ -899,17 +907,43 @@ defmodule MydiaWeb.SearchLive.Index do
     "search-result-#{hash}"
   end
 
-  defp perform_search(query, min_seeders, indexer_ids) do
+  defp start_search(socket, query) do
+    min_seeders = socket.assigns.min_seeders
+    indexer_ids = MapSet.to_list(socket.assigns.selected_indexer_ids)
+    # self() inside start_async is the task, not the LiveView, so capture it here.
+    lv = self()
+    search_id = socket.assigns.search_id + 1
+
+    socket
+    |> assign(:search_query, query)
+    |> assign(:searching, true)
+    |> assign(:search_id, search_id)
+    |> assign(:indexer_progress, %{})
+    |> assign(:indexer_errors, [])
+    |> assign(:search_results_map, %{})
+    |> assign(:results_empty?, false)
+    |> stream(:search_results, [], reset: true)
+    |> start_async(:search, fn ->
+      perform_search(query, min_seeders, indexer_ids, lv, search_id)
+    end)
+  end
+
+  defp perform_search(query, min_seeders, indexer_ids, lv, search_id) do
     opts = [
       min_seeders: min_seeders,
       deduplicate: true,
-      indexer_ids: indexer_ids
+      indexer_ids: indexer_ids,
+      on_start: fn pending -> send(lv, {:indexer_search_started, search_id, pending}) end,
+      on_indexer_result: fn progress -> send(lv, {:indexer_progress, search_id, progress}) end
     ]
 
-    {:ok, %{results: results, indexer_errors: indexer_errors}} =
-      Indexers.search_all(query, opts)
+    case Indexers.search_all(query, opts) do
+      {:ok, %{results: results, indexer_errors: indexer_errors}} ->
+        {:ok, results, indexer_errors}
 
-    {:ok, results, indexer_errors}
+      other ->
+        {:error, other}
+    end
   end
 
   defp apply_filters(socket) do
@@ -921,6 +955,47 @@ defmodule MydiaWeb.SearchLive.Index do
     socket
     |> assign(:results_empty?, sorted_results == [])
     |> stream(:search_results, sorted_results, reset: true)
+  end
+
+  # Folds one indexer's results into the accumulated set and re-ranks the whole
+  # thing, so the list stays correctly ordered as indexers report out of order.
+  #
+  # search_results_map keeps the ranked-and-deduplicated set rather than the raw
+  # accumulation, matching what handle_async assigns at the end of a search.
+  # apply_filters/1 re-filters straight from this map without deduplicating, so
+  # storing raw results here would surface duplicates the moment a user touched a
+  # filter mid-search.
+  #
+  # `results` is cleared from the stored progress struct: it can be large and the
+  # releases already live in search_results_map.
+  defp apply_indexer_progress(socket, %IndexerProgress{} = progress) do
+    indexer_progress =
+      Map.put(socket.assigns.indexer_progress, progress.indexer_id, %{progress | results: []})
+
+    accumulated =
+      Enum.reduce(progress.results, socket.assigns.search_results_map, fn result, acc ->
+        Map.put(acc, result.download_url, result)
+      end)
+
+    ranked =
+      accumulated
+      |> Map.values()
+      |> Indexers.rank_and_dedupe(socket.assigns.search_query,
+        min_seeders: socket.assigns.min_seeders
+      )
+
+    results_map = Map.new(ranked, fn result -> {result.download_url, result} end)
+
+    sorted =
+      ranked
+      |> filter_results(socket.assigns)
+      |> sort_results(socket.assigns.sort_by)
+
+    socket
+    |> assign(:indexer_progress, indexer_progress)
+    |> assign(:search_results_map, results_map)
+    |> assign(:results_empty?, sorted == [])
+    |> stream(:search_results, sorted, reset: true)
   end
 
   defp apply_sort(socket) do

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -973,13 +973,22 @@ defmodule MydiaWeb.SearchLive.Index do
   #     assigns at the end of a search. apply_filters/1 re-filters straight
   #     from this map without deduplicating, so it must stay deduplicated.
   #
-  # Folding new results onto search_results_map instead of the raw map would
-  # rank each indexer's results against an already-truncated pool: a release
-  # that looked weak against the first max_results candidates would be
-  # dropped for good and never reconsidered once more results arrive, even
-  # though it might rank in the true top set once the full history is
-  # visible. Always re-rank from the raw map, then re-derive the truncated
-  # display set from that ranked output.
+  # Plain truncation is NOT why the raw map exists: Indexers.rank_and_dedupe/3
+  # scores each result independently of the rest of the pool, so an item's
+  # rank can only stay the same or worsen as the pool grows. An item outside
+  # round one's top max_results is outside the full-history top max_results
+  # too, and folding onto a truncated base can never lose a genuine contender
+  # to truncation alone.
+  #
+  # The real reason is DEDUPLICATION across rounds. An item can be evicted by
+  # truncation while it was the sole member of its dedup group, having never
+  # lost a dedup comparison. If a WEAKER duplicate of that same group arrives
+  # in a later round, deduping against the truncated search_results_map would
+  # see only the weak duplicate (the true winner already gone) and crown it
+  # as the group's representative, showing the wrong release or dropping the
+  # group when the true winner would have qualified. Re-ranking from the full
+  # raw_search_results_map every round means deduplication always compares
+  # every variant of a release ever seen, so the strongest one always wins.
   #
   # `results` is cleared from the stored progress struct: it can be large and
   # the releases already live in raw_search_results_map.

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -90,6 +90,7 @@ defmodule MydiaWeb.SearchLive.Index do
      |> assign(:show_retry_modal, false)
      |> assign(:retry_error_message, nil)
      |> assign(:search_results_map, %{})
+     |> assign(:raw_search_results_map, %{})
      |> assign(:show_detail_modal, false)
      |> assign(:selected_result, nil)
      |> assign(:show_download_modal, false)
@@ -921,6 +922,7 @@ defmodule MydiaWeb.SearchLive.Index do
     |> assign(:indexer_progress, %{})
     |> assign(:indexer_errors, [])
     |> assign(:search_results_map, %{})
+    |> assign(:raw_search_results_map, %{})
     |> assign(:results_empty?, false)
     |> stream(:search_results, [], reset: true)
     |> start_async(:search, fn ->
@@ -960,25 +962,38 @@ defmodule MydiaWeb.SearchLive.Index do
   # Folds one indexer's results into the accumulated set and re-ranks the whole
   # thing, so the list stays correctly ordered as indexers report out of order.
   #
-  # search_results_map keeps the ranked-and-deduplicated set rather than the raw
-  # accumulation, matching what handle_async assigns at the end of a search.
-  # apply_filters/1 re-filters straight from this map without deduplicating, so
-  # storing raw results here would surface duplicates the moment a user touched a
-  # filter mid-search.
+  # Two collections are kept deliberately, and must NOT be collapsed back into
+  # one:
   #
-  # `results` is cleared from the stored progress struct: it can be large and the
-  # releases already live in search_results_map.
+  #   - raw_search_results_map: every release ever seen this search, keyed by
+  #     download_url, UNTRUNCATED. This is what future progress messages fold
+  #     new results onto.
+  #   - search_results_map: the ranked-and-deduplicated (and therefore
+  #     truncated-to-max_results) DISPLAY set, matching what handle_async
+  #     assigns at the end of a search. apply_filters/1 re-filters straight
+  #     from this map without deduplicating, so it must stay deduplicated.
+  #
+  # Folding new results onto search_results_map instead of the raw map would
+  # rank each indexer's results against an already-truncated pool: a release
+  # that looked weak against the first max_results candidates would be
+  # dropped for good and never reconsidered once more results arrive, even
+  # though it might rank in the true top set once the full history is
+  # visible. Always re-rank from the raw map, then re-derive the truncated
+  # display set from that ranked output.
+  #
+  # `results` is cleared from the stored progress struct: it can be large and
+  # the releases already live in raw_search_results_map.
   defp apply_indexer_progress(socket, %IndexerProgress{} = progress) do
     indexer_progress =
       Map.put(socket.assigns.indexer_progress, progress.indexer_id, %{progress | results: []})
 
-    accumulated =
-      Enum.reduce(progress.results, socket.assigns.search_results_map, fn result, acc ->
+    raw_results =
+      Enum.reduce(progress.results, socket.assigns.raw_search_results_map, fn result, acc ->
         Map.put(acc, result.download_url, result)
       end)
 
     ranked =
-      accumulated
+      raw_results
       |> Map.values()
       |> Indexers.rank_and_dedupe(socket.assigns.search_query,
         min_seeders: socket.assigns.min_seeders
@@ -993,6 +1008,7 @@ defmodule MydiaWeb.SearchLive.Index do
 
     socket
     |> assign(:indexer_progress, indexer_progress)
+    |> assign(:raw_search_results_map, raw_results)
     |> assign(:search_results_map, results_map)
     |> assign(:results_empty?, sorted == [])
     |> stream(:search_results, sorted, reset: true)

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -709,10 +709,27 @@ defmodule MydiaWeb.SearchLive.Index do
      |> put_flash(:error, "Search failed unexpectedly")}
   end
 
-  def handle_async({:retry, _indexer_id}, _result, socket) do
-    # Results already arrived through the :indexer_progress messages; the final
-    # batched value carries only this one indexer and would clobber the rest.
+  # Results already arrived through the :indexer_progress messages; the final
+  # batched value carries only this one indexer and would clobber the rest, so
+  # success is a no-op.
+  def handle_async({:retry, _indexer_id}, {:ok, {:ok, _results, _indexer_errors}}, socket) do
     {:noreply, socket}
+  end
+
+  # Failure is NOT a no-op. handle_event("retry_indexer", ...) sets the chip to
+  # :pending before starting the task; if that task dies or returns an error
+  # before any progress message lands, nothing else ever clears :pending, so
+  # the chip spins forever AND the Retry button disappears (it only renders for
+  # :error/:timeout). Restoring an error state puts the indexer back into an
+  # actionable state.
+  def handle_async({:retry, indexer_id}, {:ok, {:error, reason}}, socket) do
+    Logger.error("Indexer retry failed: #{inspect(reason)}")
+    {:noreply, restore_retry_error(socket, indexer_id, "Retry failed: #{inspect(reason)}")}
+  end
+
+  def handle_async({:retry, indexer_id}, {:exit, reason}, socket) do
+    Logger.error("Indexer retry crashed: #{inspect(reason)}")
+    {:noreply, restore_retry_error(socket, indexer_id, "Retry failed unexpectedly")}
   end
 
   def handle_async(
@@ -923,6 +940,18 @@ defmodule MydiaWeb.SearchLive.Index do
   end
 
   ## Private Functions
+
+  # Map.replace_lazy/3 for the same reason handle_event("retry_indexer", ...)
+  # uses it: an id that is not already in the map must be a clean no-op, never
+  # an insert of a half-built entry.
+  defp restore_retry_error(socket, indexer_id, message) do
+    indexer_progress =
+      Map.replace_lazy(socket.assigns.indexer_progress, indexer_id, fn entry ->
+        %{entry | status: :error, error: message, result_count: nil, duration_ms: nil}
+      end)
+
+    assign(socket, :indexer_progress, indexer_progress)
+  end
 
   defp close_download_modal(socket) do
     # Clear the downloading URL if there was one and re-insert result to update UI

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -509,6 +509,26 @@ defmodule MydiaWeb.SearchLive.Index do
      |> assign(:selected_result, nil)}
   end
 
+  def handle_event("retry_indexer", %{"id" => indexer_id}, socket) do
+    query = socket.assigns.search_query
+    min_seeders = socket.assigns.min_seeders
+    lv = self()
+    search_id = socket.assigns.search_id
+
+    indexer_progress =
+      Map.update(socket.assigns.indexer_progress, indexer_id, nil, fn entry ->
+        %{entry | status: :pending, error: nil, result_count: nil, duration_ms: nil}
+      end)
+
+    {:noreply,
+     socket
+     |> assign(:indexer_progress, indexer_progress)
+     # A distinct key so a retry never cancels an in-flight full search.
+     |> start_async({:retry, indexer_id}, fn ->
+       perform_search(query, min_seeders, [indexer_id], lv, search_id)
+     end)}
+  end
+
   @impl true
   def handle_info({:download_updated, _download_id}, socket) do
     # Just trigger a re-render to update the downloads counter in the sidebar
@@ -669,6 +689,12 @@ defmodule MydiaWeb.SearchLive.Index do
      socket
      |> assign(:searching, false)
      |> put_flash(:error, "Search failed unexpectedly")}
+  end
+
+  def handle_async({:retry, _indexer_id}, _result, socket) do
+    # Results already arrived through the :indexer_progress messages; the final
+    # batched value carries only this one indexer and would clobber the rest.
+    {:noreply, socket}
   end
 
   def handle_async(

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -653,40 +653,42 @@ defmodule MydiaWeb.SearchLive.Index do
     {:noreply, socket}
   end
 
+  # Terminal handler for the full search. It deliberately does NOT touch the
+  # displayed results.
+  #
+  # Every indexer's output already arrived through `on_indexer_result`:
+  # Indexers.search_all/2 invokes it on the success branch, the error branch
+  # and the exit/timeout branch alike, and start_async delivers this reply
+  # from the same process that sent those progress messages, so all of them
+  # have already been folded in by apply_indexer_progress/2 (which owns
+  # search_results_map, raw_search_results_map, results_empty? and the
+  # stream).
+  #
+  # `results` here is the aggregate of the FULL search only. Re-streaming it
+  # with reset: true would silently delete anything a single-indexer retry
+  # contributed, which is the ordinary case rather than an exotic race: the
+  # Retry button appears as soon as one indexer errors, while slow indexers
+  # are still pending, so a retry against a fast-failing host normally
+  # settles before the slow ones finish.
+  #
+  # The zero-indexer case is why this clause still has to end the search:
+  # search_all/2 returns early there, before `on_start`, so no progress
+  # message ever arrives and nothing else can clear :searching.
+  # results_empty? was set to true when the search started and nothing has
+  # flipped it, so the "No Results Found" empty state renders correctly.
   @impl true
   def handle_async(:search, {:ok, {:ok, results, indexer_errors}}, socket) do
-    start_time = System.monotonic_time(:millisecond)
-
-    filtered_results = filter_results(results, socket.assigns)
-    sorted_results = sort_results(filtered_results, socket.assigns.sort_by)
-
-    duration = System.monotonic_time(:millisecond) - start_time
-
     Logger.info(
       "Search completed: query=\"#{socket.assigns.search_query}\", " <>
-        "results=#{length(results)}, filtered=#{length(filtered_results)}, " <>
-        "indexer_errors=#{length(indexer_errors)}, processing_time=#{duration}ms"
+        "aggregate_results=#{length(results)}, " <>
+        "displayed=#{map_size(socket.assigns.search_results_map)}, " <>
+        "indexer_errors=#{length(indexer_errors)}"
     )
-
-    # Store results in a map for quick lookup by download_url
-    results_map =
-      results
-      |> Enum.map(fn result ->
-        Logger.info(
-          "Storing result in map: #{result.title}, protocol: #{inspect(result.download_protocol)}"
-        )
-
-        {result.download_url, result}
-      end)
-      |> Map.new()
 
     {:noreply,
      socket
      |> assign(:searching, false)
-     |> assign(:results_empty?, sorted_results == [])
-     |> assign(:indexer_errors, indexer_errors)
-     |> assign(:search_results_map, results_map)
-     |> stream(:search_results, sorted_results, reset: true)}
+     |> assign(:indexer_errors, indexer_errors)}
   end
 
   def handle_async(:search, {:ok, {:error, reason}}, socket) do
@@ -965,7 +967,14 @@ defmodule MydiaWeb.SearchLive.Index do
     |> assign(:indexer_errors, [])
     |> assign(:search_results_map, %{})
     |> assign(:raw_search_results_map, %{})
-    |> assign(:results_empty?, false)
+    # TRUE, not false: the display set is genuinely empty until the first
+    # indexer reports. The loading gate is `@searching && @results_empty?`
+    # and the results gate is `!@results_empty?`, so starting at false
+    # suppresses the spinner and renders the results card with a count of
+    # zero ("0 results for Dune") for the whole search window. The "No
+    # Results Found" empty state is gated on `!@searching`, so it stays
+    # hidden until the search actually ends.
+    |> assign(:results_empty?, true)
     |> stream(:search_results, [], reset: true)
     |> start_async(:search, fn ->
       perform_search(query, min_seeders, indexer_ids, lv, search_id)

--- a/lib/mydia_web/live/search_live/index.html.heex
+++ b/lib/mydia_web/live/search_live/index.html.heex
@@ -167,15 +167,15 @@
       </div>
     <% end %>
 
-    <%!-- Loading State --%>
-    <%= if @searching do %>
+    <%!-- Loading State: only before the first indexer reports --%>
+    <%= if @searching && @results_empty? do %>
       <div class="card bg-base-100 shadow-lg">
         <div class="card-body flex flex-col items-center justify-center py-16">
           <span class="loading loading-spinner loading-lg text-primary mb-4"></span>
           <h3 class="text-xl font-semibold text-base-content/70 mb-2">
             Searching indexers...
           </h3>
-          <p class="text-base-content/50">This may take a few seconds</p>
+          <p class="text-base-content/50">Results appear as each indexer responds</p>
         </div>
       </div>
     <% end %>
@@ -193,22 +193,8 @@
       </div>
     <% end %>
 
-    <%!-- Indexer Error Warning --%>
-    <%= if @indexer_errors != [] && !@searching do %>
-      <div class="alert alert-warning shadow-lg mb-4">
-        <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
-        <div class="flex-1">
-          <div class="text-sm font-medium">
-            {length(@indexer_errors)} indexer(s) failed
-          </div>
-          <ul class="text-xs opacity-80 mt-1">
-            <%= for error <- @indexer_errors do %>
-              <li>{error.indexer}: {error.error}</li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    <% end %>
+    <%!-- Per-indexer search progress --%>
+    <.indexer_search_status progress={@indexer_progress} retry_event="retry_indexer" />
     <%!-- Empty State (no results) --%>
     <%= if @results_empty? && @search_query != "" && !@searching do %>
       <div class="card bg-base-100 shadow-lg">
@@ -231,7 +217,7 @@
     <% end %>
 
     <%!-- Results --%>
-    <%= if @search_query != "" && !@searching && !@results_empty? do %>
+    <%= if @search_query != "" && !@results_empty? do %>
       <div class="card bg-base-100 shadow-lg overflow-hidden">
         <%!-- Results count --%>
         <div class="px-4 py-3 bg-base-200 border-b border-base-300 flex items-center justify-between">

--- a/lib/mydia_web/live/search_live/index.html.heex
+++ b/lib/mydia_web/live/search_live/index.html.heex
@@ -169,7 +169,7 @@
 
     <%!-- Loading State: only before the first indexer reports --%>
     <%= if @searching && @results_empty? do %>
-      <div class="card bg-base-100 shadow-lg">
+      <div id="search-loading-state" class="card bg-base-100 shadow-lg">
         <div class="card-body flex flex-col items-center justify-center py-16">
           <span class="loading loading-spinner loading-lg text-primary mb-4"></span>
           <h3 class="text-xl font-semibold text-base-content/70 mb-2">
@@ -221,7 +221,7 @@
       <div class="card bg-base-100 shadow-lg overflow-hidden">
         <%!-- Results count --%>
         <div class="px-4 py-3 bg-base-200 border-b border-base-300 flex items-center justify-between">
-          <span class="text-sm font-medium">
+          <span id="search-results-count" class="text-sm font-medium">
             {map_size(@search_results_map)} results for "{@search_query}"
           </span>
         </div>

--- a/test/mydia/indexers/adapter/jackett_test.exs
+++ b/test/mydia/indexers/adapter/jackett_test.exs
@@ -27,6 +27,7 @@ defmodule Mydia.Indexers.Adapter.JackettTest do
       assert info.app_name == "Jackett"
     end
 
+    @tag :skip
     test "fails with invalid API key" do
       config = %{
         type: :jackett,
@@ -41,6 +42,7 @@ defmodule Mydia.Indexers.Adapter.JackettTest do
       assert {:error, %Error{type: :connection_failed}} = Jackett.test_connection(config)
     end
 
+    @tag :skip
     test "fails with invalid host" do
       config = %{
         type: :jackett,
@@ -104,6 +106,7 @@ defmodule Mydia.Indexers.Adapter.JackettTest do
       assert is_list(results)
     end
 
+    @tag :skip
     test "handles invalid API key" do
       config = %{
         type: :jackett,

--- a/test/mydia/indexers/adapter/jackett_test.exs
+++ b/test/mydia/indexers/adapter/jackett_test.exs
@@ -4,7 +4,10 @@ defmodule Mydia.Indexers.Adapter.JackettTest do
   alias Mydia.Indexers.Adapter.Jackett
   alias Mydia.Indexers.Adapter.Error
 
-  @moduletag :external
+  # Previously the whole module was tagged :external, which excluded every
+  # test by default (including the Bypass-driven, fully offline ones). The
+  # legitimately-network-dependent tests are already individually tagged
+  # `:skip`, so no module-level gate is needed.
 
   describe "test_connection/1" do
     @tag :skip

--- a/test/mydia/indexers/adapter/jackett_test.exs
+++ b/test/mydia/indexers/adapter/jackett_test.exs
@@ -215,4 +215,37 @@ defmodule Mydia.Indexers.Adapter.JackettTest do
       assert error_type in [:connection_failed, :search_failed]
     end
   end
+
+  describe "search/3 retry behavior" do
+    setup do
+      {:ok, bypass: Bypass.open()}
+    end
+
+    test "a failing search is attempted exactly once", %{bypass: bypass} do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      Bypass.expect(bypass, fn conn ->
+        Agent.update(counter, &(&1 + 1))
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/xml")
+        |> Plug.Conn.resp(500, "<error/>")
+      end)
+
+      config = %{
+        type: :jackett,
+        name: "Test Jackett",
+        host: "localhost",
+        port: bypass.port,
+        api_key: "test-api-key",
+        use_ssl: false,
+        options: %{timeout: 5_000}
+      }
+
+      assert {:error, _} = Jackett.search(config, "Ubuntu")
+
+      assert Agent.get(counter, & &1) == 1,
+             "expected exactly one attempt, Req retried a transient failure"
+    end
+  end
 end

--- a/test/mydia/indexers/adapter/jackett_test.exs
+++ b/test/mydia/indexers/adapter/jackett_test.exs
@@ -6,8 +6,9 @@ defmodule Mydia.Indexers.Adapter.JackettTest do
 
   # Previously the whole module was tagged :external, which excluded every
   # test by default (including the Bypass-driven, fully offline ones). The
-  # legitimately-network-dependent tests are already individually tagged
-  # `:skip`, so no module-level gate is needed.
+  # tests that genuinely need a live Jackett are individually tagged `:skip`,
+  # and every remaining test is offline by construction (Bypass, or a port
+  # Bypass has vacated), so no module-level gate is needed.
 
   describe "test_connection/1" do
     @tag :skip
@@ -188,35 +189,61 @@ defmodule Mydia.Indexers.Adapter.JackettTest do
   end
 
   describe "use_ssl defaults (GitHub issue #28)" do
-    test "test_connection works without use_ssl key - fails gracefully" do
+    # These two guard a real regression: a config with no :use_ssl key (what
+    # the web UI produces) used to raise KeyError instead of failing
+    # gracefully. That is why they must NOT be tagged :skip like the
+    # network-dependent tests above -- skipping means the guard never runs.
+    #
+    # They used to point at port 9117, which made them environment-dependent
+    # in exactly the way the :skip tags elsewhere in this file exist to avoid:
+    # they passed on a machine with nothing listening there and failed on a
+    # developer machine actually running Jackett. Opening a Bypass and
+    # immediately shutting it down yields a port the OS just confirmed was
+    # free and that now has nothing behind it, so the connection refusal is
+    # guaranteed regardless of what is running locally.
+    #
+    # The connection target is incidental to what these assert: only that the
+    # call returns an error tuple rather than raising. A KeyError would fail
+    # the match below rather than satisfy it.
+    setup do
+      bypass = Bypass.open()
+      port = bypass.port
+      Bypass.down(bypass)
+
+      {:ok, closed_port: port}
+    end
+
+    test "test_connection works without use_ssl key - fails gracefully", %{
+      closed_port: closed_port
+    } do
       # Config WITHOUT use_ssl key - simulates web UI config
       config = %{
         type: :jackett,
         name: "Test Jackett",
         host: "localhost",
-        port: 9117,
+        port: closed_port,
         api_key: "test-api-key",
         options: %{}
       }
 
       # This should not crash with KeyError but return a connection error
-      # (since there's no Jackett server running)
+      # (nothing is listening on closed_port)
       assert {:error, %Error{type: :connection_failed}} = Jackett.test_connection(config)
     end
 
-    test "search works without use_ssl key - fails gracefully" do
+    test "search works without use_ssl key - fails gracefully", %{closed_port: closed_port} do
       # Config WITHOUT use_ssl key - simulates web UI config
       config = %{
         type: :jackett,
         name: "Test Jackett",
         host: "localhost",
-        port: 9117,
+        port: closed_port,
         api_key: "test-api-key",
         options: %{}
       }
 
       # This should not crash with KeyError but return a connection/search error
-      # (since there's no Jackett server running)
+      # (nothing is listening on closed_port)
       assert {:error, %Error{type: error_type}} = Jackett.search(config, "test")
       assert error_type in [:connection_failed, :search_failed]
     end

--- a/test/mydia/indexers/adapter/prowlarr_test.exs
+++ b/test/mydia/indexers/adapter/prowlarr_test.exs
@@ -573,4 +573,27 @@ defmodule Mydia.Indexers.Adapter.ProwlarrTest do
       assert_in_delta(actual, expected, 0.0001)
     end
   end
+
+  describe "search/3 retry behavior" do
+    setup do
+      {:ok, bypass: Bypass.open()}
+    end
+
+    test "a failing search is attempted exactly once", %{bypass: bypass} do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
+        Agent.update(counter, &(&1 + 1))
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(500, ~s({"message":"boom"}))
+      end)
+
+      assert {:error, _} = Prowlarr.search(build_config(bypass), "Ubuntu")
+
+      assert Agent.get(counter, & &1) == 1,
+             "expected exactly one attempt, Req retried a transient failure"
+    end
+  end
 end

--- a/test/mydia/indexers/structs/indexer_progress_test.exs
+++ b/test/mydia/indexers/structs/indexer_progress_test.exs
@@ -1,7 +1,19 @@
 defmodule Mydia.Indexers.Structs.IndexerProgressTest do
   use ExUnit.Case, async: true
 
+  alias Mydia.Indexers.SearchResult
   alias Mydia.Indexers.Structs.IndexerProgress
+
+  defp search_result(title) do
+    %SearchResult{
+      title: title,
+      download_url: "magnet:?xt=urn:btih:#{:erlang.phash2(title)}",
+      indexer: "Prowlarr",
+      size: 8_000_000_000,
+      seeders: 100,
+      leechers: 2
+    }
+  end
 
   describe "defaults" do
     test "a bare struct is a pending indexer with no results" do
@@ -16,11 +28,13 @@ defmodule Mydia.Indexers.Structs.IndexerProgressTest do
     end
 
     test "a settled struct carries results and timing" do
+      results = [search_result("Dune.2021.1080p"), search_result("Dune.2021.2160p")]
+
       progress = %IndexerProgress{
         indexer: "Prowlarr",
         indexer_id: "abc-123",
         status: :ok,
-        results: [:a, :b],
+        results: results,
         result_count: 2,
         duration_ms: 812,
         completed: 1,
@@ -28,6 +42,7 @@ defmodule Mydia.Indexers.Structs.IndexerProgressTest do
       }
 
       assert progress.status == :ok
+      assert progress.results == results
       assert progress.result_count == 2
       assert progress.duration_ms == 812
     end

--- a/test/mydia/indexers/structs/indexer_progress_test.exs
+++ b/test/mydia/indexers/structs/indexer_progress_test.exs
@@ -1,0 +1,35 @@
+defmodule Mydia.Indexers.Structs.IndexerProgressTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Indexers.Structs.IndexerProgress
+
+  describe "defaults" do
+    test "a bare struct is a pending indexer with no results" do
+      progress = %IndexerProgress{indexer: "Prowlarr", indexer_id: "abc-123", total: 3}
+
+      assert progress.status == :pending
+      assert progress.results == []
+      assert progress.result_count == nil
+      assert progress.error == nil
+      assert progress.duration_ms == nil
+      assert progress.completed == nil
+    end
+
+    test "a settled struct carries results and timing" do
+      progress = %IndexerProgress{
+        indexer: "Prowlarr",
+        indexer_id: "abc-123",
+        status: :ok,
+        results: [:a, :b],
+        result_count: 2,
+        duration_ms: 812,
+        completed: 1,
+        total: 3
+      }
+
+      assert progress.status == :ok
+      assert progress.result_count == 2
+      assert progress.duration_ms == 812
+    end
+  end
+end

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -1,6 +1,8 @@
 defmodule Mydia.IndexersTest do
   use Mydia.DataCase, async: false
 
+  import Mydia.SettingsFixtures
+
   alias Mydia.Indexers
   alias Mydia.Indexers.SearchResult
   alias Mydia.Settings
@@ -163,6 +165,83 @@ defmodule Mydia.IndexersTest do
       # This is tested indirectly through the ranking implementation
       assert {:ok, %{results: results}} = Indexers.search_all("test")
       assert is_list(results)
+    end
+  end
+
+  describe "search_all/2 fan-out" do
+    setup do
+      fast = Bypass.open()
+      slow = Bypass.open()
+
+      Bypass.expect(fast, "GET", "/api/v1/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!([prowlarr_item("Fast.Movie.2021.1080p")]))
+      end)
+
+      Bypass.expect(slow, "GET", "/api/v1/search", fn conn ->
+        # Bypass.pass/1 must run before the sleep: the deadline test kills the
+        # client mid-request, which makes Cowboy tear down this plug process
+        # with reason :shutdown. Without marking the expectation passed first,
+        # Bypass's on_exit verification re-raises that as a test crash, even
+        # though the abandoned connection is exactly what the deadline is
+        # supposed to produce.
+        Bypass.pass(slow)
+        Process.sleep(2_000)
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!([prowlarr_item("Slow.Movie.2021.1080p")]))
+      end)
+
+      indexer_config_fixture(%{
+        name: "fast-indexer",
+        type: :prowlarr,
+        base_url: "http://localhost:#{fast.port}"
+      })
+
+      indexer_config_fixture(%{
+        name: "slow-indexer",
+        type: :prowlarr,
+        base_url: "http://localhost:#{slow.port}"
+      })
+
+      :ok
+    end
+
+    defp prowlarr_item(title) do
+      %{
+        "title" => title,
+        "size" => 8_000_000_000,
+        "seeders" => 100,
+        "leechers" => 5,
+        "magnetUrl" => "magnet:?xt=urn:btih:#{:erlang.phash2(title)}",
+        "indexer" => "upstream"
+      }
+    end
+
+    test "a slow indexer does not serialize behind the fast one" do
+      started = System.monotonic_time(:millisecond)
+
+      {:ok, %{results: results}} = Indexers.search_all("Movie 2021")
+
+      elapsed = System.monotonic_time(:millisecond) - started
+
+      assert length(results) == 2
+
+      assert elapsed < 3_500,
+             "two indexers ran sequentially (#{elapsed}ms); expected concurrent fan-out"
+    end
+
+    test "an indexer past the deadline is reported by name, not as unknown" do
+      {:ok, %{results: results, indexer_errors: errors}} =
+        Indexers.search_all("Movie 2021", deadline_ms: 500)
+
+      assert length(results) == 1
+      assert hd(results).title =~ "Fast.Movie"
+
+      assert [%{indexer: "slow-indexer"} = error] = errors
+      assert error.error =~ "Timed out"
     end
   end
 

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -466,4 +466,44 @@ defmodule Mydia.IndexersTest do
       assert info.version == "1.25.0"
     end
   end
+
+  describe "rank_and_dedupe/3" do
+    alias Mydia.Indexers.SearchResult
+
+    defp result(title, seeders) do
+      %SearchResult{
+        title: title,
+        download_url: "magnet:?xt=urn:btih:#{:erlang.phash2(title)}",
+        indexer: "Test",
+        size: 1_000_000_000,
+        seeders: seeders,
+        leechers: 0
+      }
+    end
+
+    test "drops results below min_seeders" do
+      results = [result("Movie.2021.1080p", 1), result("Movie.2021.720p", 50)]
+
+      ranked = Indexers.rank_and_dedupe(results, "Movie 2021", min_seeders: 10)
+
+      assert length(ranked) == 1
+      assert hd(ranked).seeders == 50
+    end
+
+    test "truncates to max_results" do
+      results = Enum.map(1..10, fn n -> result("Movie.2021.Release#{n}", n) end)
+
+      ranked = Indexers.rank_and_dedupe(results, "Movie 2021", max_results: 3)
+
+      assert length(ranked) == 3
+    end
+
+    test "deduplicate: false keeps identical titles" do
+      results = [result("Movie.2021.1080p", 5), result("Movie.2021.1080p", 5)]
+
+      ranked = Indexers.rank_and_dedupe(results, "Movie 2021", deduplicate: false)
+
+      assert length(ranked) == 2
+    end
+  end
 end

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -169,29 +169,21 @@ defmodule Mydia.IndexersTest do
   end
 
   describe "search_all/2 fan-out" do
+    # 1 fast + 3 slow indexers, permanently (not temporary scaffolding). With
+    # only 2 indexers, `get_search_concurrency(2, [])` computes `min(2, 16) ==
+    # 2`, identical to the old hardcoded default of 2 - a test with 2
+    # indexers passes under both the old and the new code and proves nothing.
+    # 4 indexers force a genuine RED under the old default (2 waves of 2, one
+    # of which is two 3s sleepers back to back: ~6000ms) vs GREEN under full
+    # fan-out (all 4 concurrent: ~3000ms), with headroom on both sides of the
+    # 4_500ms assertion below.
     setup do
       fast = Bypass.open()
-      slow = Bypass.open()
 
       Bypass.expect(fast, "GET", "/api/v1/search", fn conn ->
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.resp(200, Jason.encode!([prowlarr_item("Fast.Movie.2021.1080p")]))
-      end)
-
-      Bypass.expect(slow, "GET", "/api/v1/search", fn conn ->
-        # Bypass.pass/1 must run before the sleep: the deadline test kills the
-        # client mid-request, which makes Cowboy tear down this plug process
-        # with reason :shutdown. Without marking the expectation passed first,
-        # Bypass's on_exit verification re-raises that as a test crash, even
-        # though the abandoned connection is exactly what the deadline is
-        # supposed to produce.
-        Bypass.pass(slow)
-        Process.sleep(2_000)
-
-        conn
-        |> Plug.Conn.put_resp_content_type("application/json")
-        |> Plug.Conn.resp(200, Jason.encode!([prowlarr_item("Slow.Movie.2021.1080p")]))
       end)
 
       indexer_config_fixture(%{
@@ -200,11 +192,30 @@ defmodule Mydia.IndexersTest do
         base_url: "http://localhost:#{fast.port}"
       })
 
-      indexer_config_fixture(%{
-        name: "slow-indexer",
-        type: :prowlarr,
-        base_url: "http://localhost:#{slow.port}"
-      })
+      for n <- 1..3 do
+        slow = Bypass.open()
+
+        Bypass.expect(slow, "GET", "/api/v1/search", fn conn ->
+          # Bypass.pass/1 must run before the sleep: the deadline test kills
+          # the client mid-request, which makes Cowboy tear down this plug
+          # process with reason :shutdown. Without marking the expectation
+          # passed first, Bypass's on_exit verification re-raises that as a
+          # test crash, even though the abandoned connection is exactly what
+          # the deadline is supposed to produce.
+          Bypass.pass(slow)
+          Process.sleep(3_000)
+
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.resp(200, Jason.encode!([prowlarr_item("Slow#{n}.Movie.2021.1080p")]))
+        end)
+
+        indexer_config_fixture(%{
+          name: "slow-indexer-#{n}",
+          type: :prowlarr,
+          base_url: "http://localhost:#{slow.port}"
+        })
+      end
 
       :ok
     end
@@ -227,10 +238,10 @@ defmodule Mydia.IndexersTest do
 
       elapsed = System.monotonic_time(:millisecond) - started
 
-      assert length(results) == 2
+      assert length(results) == 4
 
-      assert elapsed < 3_500,
-             "two indexers ran sequentially (#{elapsed}ms); expected concurrent fan-out"
+      assert elapsed < 4_500,
+             "indexers ran serialized (#{elapsed}ms); expected concurrent fan-out"
     end
 
     test "an indexer past the deadline is reported by name, not as unknown" do
@@ -240,8 +251,18 @@ defmodule Mydia.IndexersTest do
       assert length(results) == 1
       assert hd(results).title =~ "Fast.Movie"
 
-      assert [%{indexer: "slow-indexer"} = error] = errors
-      assert error.error =~ "Timed out"
+      assert length(errors) == 3
+
+      assert errors |> Enum.map(& &1.indexer) |> Enum.sort() ==
+               ["slow-indexer-1", "slow-indexer-2", "slow-indexer-3"]
+
+      assert Enum.all?(errors, fn error -> error.error =~ "Timed out" end)
+    end
+  end
+
+  describe "background_search_opts/0" do
+    test "defaults to max_concurrency: 2" do
+      assert Indexers.background_search_opts() == [max_concurrency: 2]
     end
   end
 

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -258,6 +258,93 @@ defmodule Mydia.IndexersTest do
 
       assert Enum.all?(errors, fn error -> error.error =~ "Timed out" end)
     end
+
+    test "on_start reports every indexer as pending before any request" do
+      parent = self()
+
+      Indexers.search_all("Movie 2021",
+        on_start: fn pending -> send(parent, {:started, pending}) end
+      )
+
+      assert_received {:started, pending}
+      assert length(pending) == 4
+      assert Enum.all?(pending, &(&1.status == :pending))
+      assert Enum.all?(pending, &(&1.total == 4))
+      assert Enum.all?(pending, &is_binary(&1.indexer_id))
+
+      assert Enum.sort(Enum.map(pending, & &1.indexer)) ==
+               ["fast-indexer", "slow-indexer-1", "slow-indexer-2", "slow-indexer-3"]
+    end
+
+    test "on_indexer_result fires once per indexer with counts and timing" do
+      parent = self()
+
+      Indexers.search_all("Movie 2021",
+        on_indexer_result: fn progress -> send(parent, {:progress, progress}) end
+      )
+
+      assert_received {:progress, first}
+
+      # The fast indexer settles first because fan-out is concurrent; the
+      # three slow indexers race each other after that, in no fixed order.
+      assert first.indexer == "fast-indexer"
+      assert first.status == :ok
+      assert first.completed == 1
+      assert first.total == 4
+      assert first.result_count == 1
+      assert length(first.results) == 1
+      assert is_integer(first.duration_ms)
+
+      rest = collect_progress([])
+      assert length(rest) == 3
+      assert Enum.all?(rest, &(&1.status == :ok))
+      assert Enum.map(rest, & &1.completed) |> Enum.sort() == [2, 3, 4]
+
+      assert Enum.map(rest, & &1.indexer) |> Enum.sort() ==
+               ["slow-indexer-1", "slow-indexer-2", "slow-indexer-3"]
+    end
+
+    test "a timed-out indexer reports :timeout status through the callback" do
+      parent = self()
+
+      Indexers.search_all("Movie 2021",
+        deadline_ms: 500,
+        on_indexer_result: fn progress -> send(parent, {:progress, progress}) end
+      )
+
+      progress = collect_progress([])
+
+      assert %{status: :ok, indexer: "fast-indexer"} = Enum.find(progress, &(&1.status == :ok))
+
+      timed_out = Enum.filter(progress, &(&1.status == :timeout))
+      assert length(timed_out) == 3
+
+      assert Enum.map(timed_out, & &1.indexer) |> Enum.sort() ==
+               ["slow-indexer-1", "slow-indexer-2", "slow-indexer-3"]
+
+      assert Enum.all?(timed_out, &(&1.error =~ "Timed out"))
+      assert Enum.all?(timed_out, &(&1.results == []))
+    end
+
+    defp collect_progress(acc) do
+      receive do
+        {:progress, progress} -> collect_progress([progress | acc])
+      after
+        0 -> Enum.reverse(acc)
+      end
+    end
+
+    test "omitting the callbacks leaves the return value unchanged" do
+      {:ok, with_callbacks} =
+        Indexers.search_all("Movie 2021", on_indexer_result: fn _ -> :ok end)
+
+      {:ok, without_callbacks} = Indexers.search_all("Movie 2021")
+
+      assert Enum.map(with_callbacks.results, & &1.title) ==
+               Enum.map(without_callbacks.results, & &1.title)
+
+      assert with_callbacks.indexer_errors == without_callbacks.indexer_errors
+    end
   end
 
   describe "background_search_opts/0" do

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -285,8 +285,12 @@ defmodule Mydia.IndexersTest do
 
       assert_received {:progress, first}
 
-      # The fast indexer settles first because fan-out is concurrent; the
-      # three slow indexers race each other after that, in no fixed order.
+      # The fast indexer settles first because fan-out is concurrent. With
+      # `ordered: false`, Task.async_stream emits each indexer's result as it
+      # settles rather than buffering to input order, so among the three slow
+      # indexers - identical 3000ms sleeps started at the same time - which
+      # one lands 2nd/3rd/4th is a genuine race with no fixed outcome. Only
+      # the set of who finished and their status/counts is asserted below.
       assert first.indexer == "fast-indexer"
       assert first.status == :ok
       assert first.completed == 1
@@ -344,6 +348,71 @@ defmodule Mydia.IndexersTest do
                Enum.map(without_callbacks.results, & &1.title)
 
       assert with_callbacks.indexer_errors == without_callbacks.indexer_errors
+    end
+  end
+
+  describe "search_all/2 fan-out ordering" do
+    # Named so the slow indexers sort BEFORE the fast one alphabetically -
+    # list_indexer_configs orders enabled, equal-priority indexers by name
+    # ascending, so this is the reverse of the "search_all/2 fan-out" describe
+    # block above. That inversion is the point: Task.async_stream defaults to
+    # `ordered: true`, which buffers each element's result until it's that
+    # element's turn in *input* order, not completion order. Under that
+    # default, the fast indexer's already-available result would sit behind
+    # three 3000ms sleeps and the assertion below would fail. search_all/2
+    # passes `ordered: false` specifically so results stream out as they
+    # settle instead.
+    setup do
+      for n <- 1..3 do
+        slow = Bypass.open()
+
+        Bypass.expect(slow, "GET", "/api/v1/search", fn conn ->
+          # See the sibling describe block above for why Bypass.pass/1 must
+          # run before the sleep.
+          Bypass.pass(slow)
+          Process.sleep(3_000)
+
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.resp(200, Jason.encode!([prowlarr_item("Slow#{n}.Movie.2021.1080p")]))
+        end)
+
+        indexer_config_fixture(%{
+          name: "aaa-slow-indexer-#{n}",
+          type: :prowlarr,
+          base_url: "http://localhost:#{slow.port}"
+        })
+      end
+
+      fast = Bypass.open()
+
+      Bypass.expect(fast, "GET", "/api/v1/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!([prowlarr_item("Fast.Movie.2021.1080p")]))
+      end)
+
+      indexer_config_fixture(%{
+        name: "zzz-fast-indexer",
+        type: :prowlarr,
+        base_url: "http://localhost:#{fast.port}"
+      })
+
+      :ok
+    end
+
+    test "on_indexer_result fires in completion order, not input order" do
+      parent = self()
+
+      Indexers.search_all("Movie 2021",
+        on_indexer_result: fn progress -> send(parent, {:progress, progress}) end
+      )
+
+      assert_received {:progress, first}
+
+      assert first.indexer == "zzz-fast-indexer",
+             "expected the fast indexer's callback first (completion order); " <>
+               "got #{first.indexer} instead - results are being buffered to input order"
     end
   end
 

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -8,17 +8,28 @@ defmodule Mydia.IndexersTest do
   alias Mydia.Settings
   alias Mydia.IndexerMock
 
+  # Disable every DB-persisted indexer config so a describe block's own
+  # fixtures are the only enabled indexers. Any test that pins an exact result
+  # count, or an exact set of indexer names, needs this or a config left
+  # enabled by an earlier setup silently breaks it.
+  #
+  # Runtime configs (inserted_at == nil, configured through environment
+  # variables) cannot be updated and stay enabled; see the "returns empty list
+  # when no indexers are enabled" test for how that case is handled.
+  defp disable_persisted_indexer_configs do
+    Settings.list_indexer_configs()
+    |> Enum.filter(fn config -> not is_nil(config.inserted_at) end)
+    |> Enum.each(fn config ->
+      Settings.update_indexer_config(config, %{enabled: false})
+    end)
+  end
+
   describe "search_all/2" do
     setup do
       # Ensure adapters are registered (needed for CI environment)
       Indexers.register_adapters()
 
-      # Disable all existing indexer configs from test database
-      Settings.list_indexer_configs()
-      |> Enum.filter(fn config -> not is_nil(config.inserted_at) end)
-      |> Enum.each(fn config ->
-        Settings.update_indexer_config(config, %{enabled: false})
-      end)
+      disable_persisted_indexer_configs()
 
       # Set up mock Prowlarr servers
       bypass1 = Bypass.open()
@@ -178,6 +189,8 @@ defmodule Mydia.IndexersTest do
     # fan-out (all 4 concurrent: ~3000ms), with headroom on both sides of the
     # 4_500ms assertion below.
     setup do
+      disable_persisted_indexer_configs()
+
       fast = Bypass.open()
 
       Bypass.expect(fast, "GET", "/api/v1/search", fn conn ->
@@ -363,6 +376,8 @@ defmodule Mydia.IndexersTest do
     # passes `ordered: false` specifically so results stream out as they
     # settle instead.
     setup do
+      disable_persisted_indexer_configs()
+
       for n <- 1..3 do
         slow = Bypass.open()
 
@@ -417,8 +432,15 @@ defmodule Mydia.IndexersTest do
   end
 
   describe "background_search_opts/0" do
-    test "defaults to max_concurrency: 2" do
-      assert Indexers.background_search_opts() == [max_concurrency: 2]
+    test "defaults to throttled concurrency and a bounded deadline" do
+      assert Indexers.background_search_opts() == [max_concurrency: 2, deadline_ms: 60_000]
+    end
+
+    # The deadline exists to stop an unattended sweep inheriting the 120s
+    # interactive one. Asserting it is strictly tighter keeps that intent from
+    # being undone by a config edit that happens to leave the test above green.
+    test "the background deadline is tighter than the manual one" do
+      assert Indexers.background_search_opts()[:deadline_ms] < 120_000
     end
   end
 

--- a/test/mydia_web/components/indexer_components_test.exs
+++ b/test/mydia_web/components/indexer_components_test.exs
@@ -1,0 +1,107 @@
+defmodule MydiaWeb.IndexerComponentsTest do
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Indexers.Structs.IndexerProgress
+
+  defp progress_map(entries) do
+    Map.new(entries, fn entry -> {entry.indexer_id, entry} end)
+  end
+
+  test "renders a row per indexer with a stable DOM id" do
+    progress =
+      progress_map([
+        %IndexerProgress{indexer: "Prowlarr", indexer_id: "a", status: :pending, total: 2},
+        %IndexerProgress{
+          indexer: "Nyaa",
+          indexer_id: "b",
+          status: :ok,
+          result_count: 12,
+          duration_ms: 840,
+          total: 2
+        }
+      ])
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: progress)
+
+    document = LazyHTML.from_fragment(html)
+
+    assert LazyHTML.query(document, "#indexer-status-a") |> Enum.count() == 1
+    assert LazyHTML.query(document, "#indexer-status-b") |> Enum.count() == 1
+    assert html =~ "12 results"
+  end
+
+  test "a pending indexer shows a spinner and no retry button" do
+    progress =
+      progress_map([
+        %IndexerProgress{indexer: "Prowlarr", indexer_id: "a", status: :pending, total: 1}
+      ])
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1,
+        progress: progress,
+        retry_event: "retry_indexer"
+      )
+
+    document = LazyHTML.from_fragment(html)
+
+    assert LazyHTML.query(document, "#indexer-status-a .loading") |> Enum.count() == 1
+    assert LazyHTML.query(document, "#indexer-status-a button") |> Enum.empty?()
+  end
+
+  test "a failed indexer shows its error and a retry button when the event is given" do
+    progress =
+      progress_map([
+        %IndexerProgress{
+          indexer: "AnimeTosho",
+          indexer_id: "c",
+          status: :error,
+          error: "Connection failed: :econnrefused",
+          total: 1
+        }
+      ])
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1,
+        progress: progress,
+        retry_event: "retry_indexer"
+      )
+
+    document = LazyHTML.from_fragment(html)
+
+    assert html =~ "econnrefused"
+    assert LazyHTML.query(document, "#indexer-status-c button") |> Enum.count() == 1
+  end
+
+  test "a timed-out indexer renders without a retry button when no event is given" do
+    progress =
+      progress_map([
+        %IndexerProgress{
+          indexer: "FileList",
+          indexer_id: "d",
+          status: :timeout,
+          error: "Timed out",
+          total: 1
+        }
+      ])
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: progress)
+
+    document = LazyHTML.from_fragment(html)
+
+    assert html =~ "timed out"
+    assert LazyHTML.query(document, "#indexer-status-d button") |> Enum.empty?()
+  end
+
+  test "renders nothing when there is no progress" do
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: %{})
+
+    document = LazyHTML.from_fragment(html)
+
+    assert LazyHTML.query(document, "#indexer-search-status") |> Enum.empty?()
+  end
+end

--- a/test/mydia_web/components/indexer_components_test.exs
+++ b/test/mydia_web/components/indexer_components_test.exs
@@ -104,4 +104,87 @@ defmodule MydiaWeb.IndexerComponentsTest do
 
     assert LazyHTML.query(document, "#indexer-search-status") |> Enum.empty?()
   end
+
+  test "rows render in alphabetical order by indexer name, regardless of status or map order" do
+    progress =
+      progress_map([
+        %IndexerProgress{
+          indexer: "Zeta",
+          indexer_id: "z",
+          status: :error,
+          error: "boom",
+          total: 3
+        },
+        %IndexerProgress{
+          indexer: "Alpha",
+          indexer_id: "a",
+          status: :ok,
+          result_count: 1,
+          duration_ms: 10,
+          total: 3
+        },
+        %IndexerProgress{indexer: "Mango", indexer_id: "m", status: :pending, total: 3}
+      ])
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: progress)
+
+    document = LazyHTML.from_fragment(html)
+
+    ids =
+      document
+      |> LazyHTML.query("#indexer-search-status [id^=\"indexer-status-\"]")
+      |> LazyHTML.attribute("id")
+
+    assert ids == ["indexer-status-a", "indexer-status-m", "indexer-status-z"]
+  end
+
+  test "a timed-out indexer shows a retry button when the event is given" do
+    progress =
+      progress_map([
+        %IndexerProgress{
+          indexer: "FileList",
+          indexer_id: "d",
+          status: :timeout,
+          error: "Timed out",
+          total: 1
+        }
+      ])
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1,
+        progress: progress,
+        retry_event: "retry_indexer"
+      )
+
+    document = LazyHTML.from_fragment(html)
+
+    buttons = LazyHTML.query(document, "#indexer-status-d button")
+
+    assert LazyHTML.attribute(buttons, "phx-value-id") == ["d"]
+  end
+
+  test "an ok indexer shows no retry button even when the event is given" do
+    progress =
+      progress_map([
+        %IndexerProgress{
+          indexer: "Nyaa",
+          indexer_id: "b",
+          status: :ok,
+          result_count: 12,
+          duration_ms: 840,
+          total: 1
+        }
+      ])
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1,
+        progress: progress,
+        retry_event: "retry_indexer"
+      )
+
+    document = LazyHTML.from_fragment(html)
+
+    assert LazyHTML.query(document, "#indexer-status-b button") |> Enum.empty?()
+  end
 end

--- a/test/mydia_web/live/media_live/manual_search_streaming_test.exs
+++ b/test/mydia_web/live/media_live/manual_search_streaming_test.exs
@@ -169,13 +169,43 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
     assert has_element?(view, "#indexer-status-old-id")
   end
 
-  test "retrying a failed indexer marks it pending again", %{conn: conn} do
+  # A single indexer cannot prove handle_info({:indexer_search_started, ...})
+  # MERGES rather than REPLACES: with one entry in indexer_progress, "wiped
+  # the map down to just this one pending entry" and "correctly updated this
+  # one entry to pending" are indistinguishable. A second entry ("succeeded-
+  # id") makes the two hypotheses diverge. It is deliberately NOT backed by a
+  # real indexer_config (same pattern as the "old"/"old-id" entries used
+  # elsewhere in this file), so it can never appear in any real on_start's
+  # pending list: SearchHelpers.perform_search/4 re-searches every ENABLED
+  # indexer_config on retry (it has no indexer_ids scoping, unlike /search),
+  # so "flaky-indexer" being the only REAL config in the DB is what makes the
+  # retry's on_start list end up scoped to it alone in practice, exactly
+  # mirroring an indexer that already finished and should NOT be touched. A
+  # REPLACE-based handler would wipe "succeeded-id" out of indexer_progress
+  # the moment that real on_start message lands; a MERGE-based one preserves
+  # it.
+  test "retrying a failed indexer marks it pending again without wiping other indexers", %{
+    conn: conn
+  } do
     media_item = media_item_fixture(%{title: "Dune", type: "movie"})
     indexer = pending_indexer_fixture("flaky-indexer")
 
     {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
     view |> element("#manual-search-button") |> render_click()
     wait_for_indexer_progress(view)
+
+    succeeded = %IndexerProgress{
+      indexer: "succeeded-indexer",
+      indexer_id: "succeeded-id",
+      status: :ok,
+      results: [],
+      result_count: 3,
+      duration_ms: 500,
+      completed: 1,
+      total: 1
+    }
+
+    send(view.pid, {:indexer_progress, current_search_id(view), succeeded})
 
     failed = %IndexerProgress{
       indexer: "flaky-indexer",
@@ -194,8 +224,16 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
     |> element("#indexer-status-#{indexer.id} button")
     |> render_click()
 
-    assert :sys.get_state(view.pid).socket.assigns.indexer_progress[indexer.id].status ==
-             :pending
+    # The retry's own real on_start fires before any HTTP request (same
+    # timing as the initial search's on_start above), so this short wait
+    # reliably outlasts it before we inspect final state.
+    Process.sleep(200)
+
+    progress = :sys.get_state(view.pid).socket.assigns.indexer_progress
+
+    assert progress[indexer.id].status == :pending
+    assert progress["succeeded-id"].status == :ok
+    assert progress["succeeded-id"].result_count == 3
   end
 
   # Before this task, no handle_event("retry_indexer", ...) clause existed on

--- a/test/mydia_web/live/media_live/manual_search_streaming_test.exs
+++ b/test/mydia_web/live/media_live/manual_search_streaming_test.exs
@@ -67,10 +67,15 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
   # the search provably cannot finish while the gate is shut.
   defp gated_indexer_fixture(name) do
     bypass = Bypass.open()
-    {:ok, gate} = Agent.start_link(fn -> %{open: false, timed_out: false} end)
+
+    {:ok, gate} =
+      Agent.start_link(fn ->
+        %{open: false, entered: false, already_open_at_entry: false, timed_out: false}
+      end)
 
     Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
       Bypass.pass(bypass)
+      enter_gate(gate)
       await_gate(gate)
 
       conn
@@ -89,6 +94,39 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
   end
 
   defp open_gate(gate), do: Agent.update(gate, &%{&1 | open: true})
+
+  # See MydiaWeb.SearchLive.StreamingTest for the full rationale. `entered`
+  # alone would not prove the handler ever waited (an already-open gate lets
+  # await_gate/2 return immediately while `entered` still flips to true), so
+  # the state of the gate AT ENTRY is recorded too, once, and refuted by
+  # assert_gate_held/1.
+  defp enter_gate(gate) do
+    Agent.update(gate, fn
+      %{entered: false} = state -> %{state | entered: true, already_open_at_entry: state.open}
+      state -> state
+    end)
+  end
+
+  # Must be awaited before the test opens the gate, or whether the search is
+  # actually held is a coin flip on whether the HTTP request happens to start
+  # before or after open_gate/1.
+  defp wait_until_gate_entered(gate, retries \\ 500)
+
+  defp wait_until_gate_entered(_gate, 0) do
+    flunk(
+      "timed out waiting for the gated indexer to receive its request; " <>
+        "nothing was ever parked behind the gate"
+    )
+  end
+
+  defp wait_until_gate_entered(gate, retries) do
+    if Agent.get(gate, & &1.entered) do
+      :ok
+    else
+      Process.sleep(10)
+      wait_until_gate_entered(gate, retries - 1)
+    end
+  end
 
   # See MydiaWeb.SearchLive.StreamingTest for the full rationale. In short: a
   # gate that is never opened must surface as a failure, never as a hung suite
@@ -118,9 +156,17 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
   end
 
   # Must run in the test process; see await_gate/2 for why the handler cannot
-  # report this itself.
+  # report either of these itself. The two guard different failures: one that
+  # the request never waited at all, one that it waited and then gave up.
   defp assert_gate_held(gate) do
-    refute Agent.get(gate, & &1.timed_out),
+    state = Agent.get(gate, & &1)
+
+    refute state.already_open_at_entry,
+           "the gated indexer's request arrived when the gate was already open, so it " <>
+             "was never held and the full search's completion was not ordered after the " <>
+             "retry's result at all"
+
+    refute state.timed_out,
            "the gated indexer stopped waiting and answered on its own, so the full " <>
              "search was never actually held behind the gate and this test proved nothing"
   end
@@ -229,6 +275,11 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
     {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
     view |> element("#manual-search-button") |> render_click()
     wait_for_indexer_progress(view)
+
+    # on_start fires before any HTTP request, so wait_for_indexer_progress/1
+    # above does NOT mean the gated indexer has been contacted yet. Everything
+    # below depends on the search being genuinely parked behind the gate.
+    wait_until_gate_entered(gate)
 
     dune = search_result("Dune.2024.2160p.UHD")
 

--- a/test/mydia_web/live/media_live/manual_search_streaming_test.exs
+++ b/test/mydia_web/live/media_live/manual_search_streaming_test.exs
@@ -27,6 +27,15 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
     :sys.get_state(view.pid).socket.assigns.search_id
   end
 
+  # Mirrors SearchHelpers.generate_positioned_id/1, which MediaLive.Show
+  # installs as the :search_results stream's :dom_id, so tests can assert on
+  # real result rows by element id instead of raw HTML text. `pos` defaults to
+  # 0, the top row, which is where a lone result lands.
+  defp positioned_result_dom_id(result, pos \\ 0) do
+    hash = :erlang.phash2({result.download_url, result.indexer})
+    "search-result-#{String.pad_leading(Integer.to_string(pos), 5, "0")}-#{hash}"
+  end
+
   # Mirrors MydiaWeb.SearchLive.StreamingTest's fixture of the same name: a
   # real indexer whose HTTP call is parked behind a Bypass server that sleeps
   # past the test's lifetime. Retrying an indexer starts a second real search
@@ -51,6 +60,65 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
     })
   end
 
+  # Like pending_indexer_fixture/1, but the HTTP call is held open until the
+  # test explicitly releases it with open_gate/1 (rather than parked past the
+  # test's lifetime). That turns "the full search completes AFTER a retry's
+  # result is already on screen" from a race into a deterministic ordering:
+  # the search provably cannot finish while the gate is shut.
+  defp gated_indexer_fixture(name) do
+    bypass = Bypass.open()
+    {:ok, gate} = Agent.start_link(fn -> false end)
+
+    Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
+      Bypass.pass(bypass)
+      await_gate(gate)
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, "[]")
+    end)
+
+    config =
+      indexer_config_fixture(%{
+        name: name,
+        type: :prowlarr,
+        base_url: "http://localhost:#{bypass.port}"
+      })
+
+    {config, gate}
+  end
+
+  defp open_gate(gate), do: Agent.update(gate, fn _ -> true end)
+
+  # Bounded on purpose: a gate that is never opened must surface as a failed
+  # assertion in the test, never as a hung suite.
+  defp await_gate(gate, retries \\ 500)
+  defp await_gate(_gate, 0), do: :ok
+
+  defp await_gate(gate, retries) do
+    if Agent.get(gate, & &1) do
+      :ok
+    else
+      Process.sleep(10)
+      await_gate(gate, retries - 1)
+    end
+  end
+
+  defp wait_until_search_finished(view, retries \\ 300)
+
+  defp wait_until_search_finished(_view, 0) do
+    flunk("timed out waiting for handle_search_async/2 to clear :searching")
+  end
+
+  defp wait_until_search_finished(view, retries) do
+    if :sys.get_state(view.pid).socket.assigns.searching do
+      Process.sleep(10)
+      wait_until_search_finished(view, retries - 1)
+    else
+      :ok
+    end
+  end
+
   # See MydiaWeb.SearchLive.StreamingTest for the full rationale: the on_start
   # callback fires (and does a full-replace assign of indexer_progress)
   # before any HTTP request, so synthetic progress sent before it lands can be
@@ -70,6 +138,165 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
       progress ->
         progress
     end
+  end
+
+  # From the moment the modal opens until the first indexer reports, the
+  # display set is genuinely empty: the spinner must be up and the results
+  # <ul> must not be rendered at all. Starting :results_empty? at false
+  # inverts both gates -- `@searching && @results_empty?` suppresses the
+  # spinner while `!@results_empty?` renders the list -- leaving the modal
+  # body showing an empty list with no spinner and no message.
+  #
+  # The indexer is parked behind a Bypass that sleeps past this test's
+  # lifetime, so neither on_indexer_result nor handle_search_async can land.
+  test "a freshly opened manual search shows the spinner, not an empty list", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    pending_indexer_fixture("slow-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    view |> element("#manual-search-button") |> render_click()
+
+    assert has_element?(view, "#manual-search-loading-state")
+    refute has_element?(view, "#manual-search-results")
+  end
+
+  # Positive control for the refutation above: once an indexer reports
+  # results, the list appears and the spinner goes away. Without this, a
+  # passing refute could just mean "#manual-search-results" never renders
+  # under any circumstance.
+  test "the results list appears once an indexer reports", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    indexer = pending_indexer_fixture("slow-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+    wait_for_indexer_progress(view)
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "slow-indexer",
+         indexer_id: indexer.id,
+         status: :ok,
+         results: [search_result("Dune.2024.2160p.UHD")],
+         result_count: 1,
+         duration_ms: 700,
+         completed: 1,
+         total: 1
+       }}
+    )
+
+    render(view)
+
+    assert has_element?(view, "#manual-search-results")
+    refute has_element?(view, "#manual-search-loading-state")
+  end
+
+  # A result that reached the display set through on_indexer_result but is NOT
+  # in the full search's aggregate return value is exactly what a
+  # single-indexer retry produces: the retry runs under its own start_async
+  # key ({:retry, id}), so its releases only ever arrive as progress messages
+  # and never appear in the aggregate that handle_search_async/2 receives.
+  # Injecting one directly models that precisely, and avoids clicking Retry
+  # only to have the retry park on the same gated Bypass.
+  test "a result contributed by a retry survives the full search completing", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    {_indexer, gate} = gated_indexer_fixture("gated-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+    wait_for_indexer_progress(view)
+
+    dune = search_result("Dune.2024.2160p.UHD")
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "retried",
+         indexer_id: "retried-id",
+         status: :ok,
+         results: [dune],
+         result_count: 1,
+         duration_ms: 120,
+         completed: 1,
+         total: 1
+       }}
+    )
+
+    assert has_element?(view, "##{positioned_result_dom_id(dune)}"),
+           "precondition failed: the retry's result never made it on screen"
+
+    open_gate(gate)
+    wait_until_search_finished(view)
+
+    assert has_element?(view, "##{positioned_result_dom_id(dune)}")
+  end
+
+  # Retrying ONE failed chip must not restart every other indexer. Both
+  # indexers here are real, enabled DB-backed configs, which is what makes the
+  # assertion discriminate: an unscoped retry re-runs search_all/2 over every
+  # enabled indexer, so its on_start carries a :pending entry for
+  # "healthy-indexer" too, and the Map.merge/2 in
+  # handle_info({:indexer_search_started, ...}) flips that chip from :ok back
+  # to :pending. Scoping the retry to [indexer_id] keeps the healthy chip
+  # untouched (and stops multiplying load against indexers that ban on rate).
+  test "retrying one indexer leaves the other indexers' chips untouched", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    flaky = pending_indexer_fixture("flaky-indexer")
+    healthy = pending_indexer_fixture("healthy-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+    wait_for_indexer_progress(view)
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "healthy-indexer",
+         indexer_id: healthy.id,
+         status: :ok,
+         results: [],
+         result_count: 3,
+         duration_ms: 500,
+         completed: 1,
+         total: 2
+       }}
+    )
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "flaky-indexer",
+         indexer_id: flaky.id,
+         status: :error,
+         error: "Connection failed: :econnrefused",
+         completed: 2,
+         total: 2
+       }}
+    )
+
+    assert has_element?(view, "#indexer-status-#{flaky.id} button")
+
+    view
+    |> element("#indexer-status-#{flaky.id} button")
+    |> render_click()
+
+    # The retry's own real on_start fires before any HTTP request (same
+    # timing as the initial search's on_start above), so this outlasts it.
+    # Both indexers' real on_indexer_result callbacks are still parked 3s
+    # behind Bypass, well past this window.
+    Process.sleep(300)
+
+    progress = :sys.get_state(view.pid).socket.assigns.indexer_progress
+
+    assert progress[flaky.id].status == :pending
+    assert progress[healthy.id].status == :ok
+    assert progress[healthy.id].result_count == 3
   end
 
   test "one indexer's results render while another is pending", %{conn: conn} do
@@ -176,14 +403,15 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
   # id") makes the two hypotheses diverge. It is deliberately NOT backed by a
   # real indexer_config (same pattern as the "old"/"old-id" entries used
   # elsewhere in this file), so it can never appear in any real on_start's
-  # pending list: SearchHelpers.perform_search/4 re-searches every ENABLED
-  # indexer_config on retry (it has no indexer_ids scoping, unlike /search),
-  # so "flaky-indexer" being the only REAL config in the DB is what makes the
-  # retry's on_start list end up scoped to it alone in practice, exactly
-  # mirroring an indexer that already finished and should NOT be touched. A
-  # REPLACE-based handler would wipe "succeeded-id" out of indexer_progress
-  # the moment that real on_start message lands; a MERGE-based one preserves
-  # it.
+  # pending list, exactly mirroring an indexer that already finished and
+  # should NOT be touched. A REPLACE-based handler would wipe "succeeded-id"
+  # out of indexer_progress the moment the retry's real on_start message
+  # lands; a MERGE-based one preserves it.
+  #
+  # The companion test "retrying one indexer leaves the other indexers' chips
+  # untouched" covers the other half of the same pairing: that the retry's
+  # on_start is SCOPED to the retried indexer, using two real DB-backed
+  # configs so an unscoped retry would be visible.
   test "retrying a failed indexer marks it pending again without wiping other indexers", %{
     conn: conn
   } do

--- a/test/mydia_web/live/media_live/manual_search_streaming_test.exs
+++ b/test/mydia_web/live/media_live/manual_search_streaming_test.exs
@@ -3,6 +3,7 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
 
   import Phoenix.LiveViewTest
   import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
 
   alias Mydia.Indexers.Structs.IndexerProgress
 
@@ -24,6 +25,51 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
 
   defp current_search_id(view) do
     :sys.get_state(view.pid).socket.assigns.search_id
+  end
+
+  # Mirrors MydiaWeb.SearchLive.StreamingTest's fixture of the same name: a
+  # real indexer whose HTTP call is parked behind a Bypass server that sleeps
+  # past the test's lifetime. Retrying an indexer starts a second real search
+  # under the SAME search_id (by design), so a fast-resolving indexer (e.g. a
+  # plain indexer_config_fixture hitting localhost:9696, which fails almost
+  # instantly) can race the test's post-click assertion and legitimately
+  # overwrite the status the test is trying to observe. This removes that
+  # race entirely rather than narrowing it.
+  defp pending_indexer_fixture(name) do
+    bypass = Bypass.open()
+
+    Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
+      Bypass.pass(bypass)
+      Process.sleep(3_000)
+      Plug.Conn.resp(conn, 200, "[]")
+    end)
+
+    indexer_config_fixture(%{
+      name: name,
+      type: :prowlarr,
+      base_url: "http://localhost:#{bypass.port}"
+    })
+  end
+
+  # See MydiaWeb.SearchLive.StreamingTest for the full rationale: the on_start
+  # callback fires (and does a full-replace assign of indexer_progress)
+  # before any HTTP request, so synthetic progress sent before it lands can be
+  # silently wiped out by the real message arriving later.
+  defp wait_for_indexer_progress(view, retries \\ 50)
+
+  defp wait_for_indexer_progress(_view, 0) do
+    flunk("timed out waiting for the real on_start message to populate indexer_progress")
+  end
+
+  defp wait_for_indexer_progress(view, retries) do
+    case :sys.get_state(view.pid).socket.assigns.indexer_progress do
+      progress when progress == %{} ->
+        Process.sleep(10)
+        wait_for_indexer_progress(view, retries - 1)
+
+      progress ->
+        progress
+    end
   end
 
   test "one indexer's results render while another is pending", %{conn: conn} do
@@ -121,5 +167,66 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
 
     assert html =~ "Dune.2024.2160p.UHD"
     assert has_element?(view, "#indexer-status-old-id")
+  end
+
+  test "retrying a failed indexer marks it pending again", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    indexer = pending_indexer_fixture("flaky-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+    wait_for_indexer_progress(view)
+
+    failed = %IndexerProgress{
+      indexer: "flaky-indexer",
+      indexer_id: indexer.id,
+      status: :error,
+      error: "Connection failed: :econnrefused",
+      completed: 1,
+      total: 1
+    }
+
+    send(view.pid, {:indexer_progress, current_search_id(view), failed})
+
+    assert has_element?(view, "#indexer-status-#{indexer.id} button")
+
+    view
+    |> element("#indexer-status-#{indexer.id} button")
+    |> render_click()
+
+    assert :sys.get_state(view.pid).socket.assigns.indexer_progress[indexer.id].status ==
+             :pending
+  end
+
+  # Before this task, no handle_event("retry_indexer", ...) clause existed on
+  # this LiveView, so clicking Retry raised a FunctionClauseError and crashed
+  # the process. render_click/1 re-raises that crash in the test process, so
+  # simply completing the click and then successfully rendering the view
+  # again is direct proof the crash is gone.
+  test "retrying a failed indexer does not crash the LiveView", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    indexer = pending_indexer_fixture("flaky-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+    wait_for_indexer_progress(view)
+
+    failed = %IndexerProgress{
+      indexer: "flaky-indexer",
+      indexer_id: indexer.id,
+      status: :error,
+      error: "Connection failed: :econnrefused",
+      completed: 1,
+      total: 1
+    }
+
+    send(view.pid, {:indexer_progress, current_search_id(view), failed})
+
+    view
+    |> element("#indexer-status-#{indexer.id} button")
+    |> render_click()
+
+    assert Process.alive?(view.pid)
+    assert render(view) =~ "flaky-indexer"
   end
 end

--- a/test/mydia_web/live/media_live/manual_search_streaming_test.exs
+++ b/test/mydia_web/live/media_live/manual_search_streaming_test.exs
@@ -67,7 +67,7 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
   # the search provably cannot finish while the gate is shut.
   defp gated_indexer_fixture(name) do
     bypass = Bypass.open()
-    {:ok, gate} = Agent.start_link(fn -> false end)
+    {:ok, gate} = Agent.start_link(fn -> %{open: false, timed_out: false} end)
 
     Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
       Bypass.pass(bypass)
@@ -88,20 +88,41 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
     {config, gate}
   end
 
-  defp open_gate(gate), do: Agent.update(gate, fn _ -> true end)
+  defp open_gate(gate), do: Agent.update(gate, &%{&1 | open: true})
 
-  # Bounded on purpose: a gate that is never opened must surface as a failed
-  # assertion in the test, never as a hung suite.
+  # See MydiaWeb.SearchLive.StreamingTest for the full rationale. In short: a
+  # gate that is never opened must surface as a failure, never as a hung suite
+  # -- and never as a PASS. This clause used to return :ok, which let the
+  # Bypass handler answer anyway, so the search completed normally and the
+  # ordering the gated test exists to establish was never established.
+  #
+  # flunk/1 alone does not fix that: this runs in the Bypass plug process and
+  # Bypass.pass/1 has already marked the expectation passed, so the raise is
+  # swallowed. The give-up is recorded in the Agent first, and
+  # assert_gate_held/1 (which runs in the test process) turns it into a
+  # failure.
   defp await_gate(gate, retries \\ 500)
-  defp await_gate(_gate, 0), do: :ok
+
+  defp await_gate(gate, 0) do
+    Agent.update(gate, &%{&1 | timed_out: true})
+    flunk("timed out waiting for the gated indexer to be released; the gate was never opened")
+  end
 
   defp await_gate(gate, retries) do
-    if Agent.get(gate, & &1) do
+    if Agent.get(gate, & &1.open) do
       :ok
     else
       Process.sleep(10)
       await_gate(gate, retries - 1)
     end
+  end
+
+  # Must run in the test process; see await_gate/2 for why the handler cannot
+  # report this itself.
+  defp assert_gate_held(gate) do
+    refute Agent.get(gate, & &1.timed_out),
+           "the gated indexer stopped waiting and answered on its own, so the full " <>
+             "search was never actually held behind the gate and this test proved nothing"
   end
 
   defp wait_until_search_finished(view, retries \\ 300)
@@ -232,6 +253,7 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
     open_gate(gate)
     wait_until_search_finished(view)
 
+    assert_gate_held(gate)
     assert has_element?(view, "##{positioned_result_dom_id(dune)}")
   end
 
@@ -494,5 +516,292 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
 
     assert Process.alive?(view.pid)
     assert render(view) =~ "flaky-indexer"
+  end
+
+  # Retry starts a real indexer search, exactly like the three other entry
+  # points on this LiveView (manual search, auto search, grab), all of which
+  # sit behind Authorization.authorize_manage_downloads/1. It shipped without
+  # that check, so a role that cannot manage downloads could still drive
+  # indexer traffic by pushing the event over the socket.
+  #
+  # The event is pushed directly rather than clicked: a guest never sees the
+  # Retry button (they cannot open the modal at all), and pushing over the
+  # socket is precisely the attack the guard has to stop.
+  #
+  # The positive control is the pair of tests above, which push the same event
+  # as the default "user" role from setup and observe the chip flip to
+  # :pending. A guard that rejected everyone would fail those.
+  test "a role that cannot manage downloads cannot retry an indexer" do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    {conn, _guest} = register_and_log_in_user(build_conn(), %{role: "guest"})
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    failed = %IndexerProgress{
+      indexer: "flaky-indexer",
+      indexer_id: "flaky-id",
+      status: :error,
+      error: "Connection failed: :econnrefused",
+      completed: 1,
+      total: 1
+    }
+
+    # search_id is still 0 for a user who never started a search, so this
+    # passes the stale-guard in handle_info({:indexer_progress, ...}).
+    send(view.pid, {:indexer_progress, current_search_id(view), failed})
+    render(view)
+
+    render_click(view, "retry_indexer", %{"id" => "flaky-id"})
+
+    state = :sys.get_state(view.pid).socket.assigns
+
+    assert state.indexer_progress["flaky-id"].status == :error,
+           "the retry ran despite the user lacking manage-downloads permission"
+
+    assert state.flash["error"] =~ "permission"
+  end
+
+  # handle_retry_indexer/2 sets the chip to :pending before starting the task.
+  # If that task dies or errors before any progress message lands, nothing else
+  # ever clears :pending: the chip spins forever and the Retry button is gone,
+  # because it only renders for :error/:timeout. These drive handle_async/3
+  # directly because the failure modes (a crashed task, a non-:ok return from
+  # search_all/2) cannot be provoked through a live indexer.
+  describe "handle_async({:retry, id}, ...)" do
+    defp retry_socket(indexer_progress) do
+      %Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{}, indexer_progress: indexer_progress}
+      }
+    end
+
+    defp pending_retry_progress do
+      %{
+        "flaky-id" => %IndexerProgress{
+          indexer: "flaky-indexer",
+          indexer_id: "flaky-id",
+          status: :pending,
+          result_count: nil,
+          duration_ms: nil,
+          total: 1
+        }
+      }
+    end
+
+    test "a crashed retry leaves the indexer actionable, not pending forever" do
+      {:noreply, socket} =
+        MydiaWeb.MediaLive.Show.handle_async(
+          {:retry, "flaky-id"},
+          {:exit, :killed},
+          retry_socket(pending_retry_progress())
+        )
+
+      entry = socket.assigns.indexer_progress["flaky-id"]
+
+      assert entry.status == :error
+      assert is_binary(entry.error) and entry.error != ""
+      assert entry.result_count == nil
+      assert entry.duration_ms == nil
+    end
+
+    test "a retry that returns an error leaves the indexer actionable" do
+      {:noreply, socket} =
+        MydiaWeb.MediaLive.Show.handle_async(
+          {:retry, "flaky-id"},
+          {:ok, {:error, :boom}},
+          retry_socket(pending_retry_progress())
+        )
+
+      assert socket.assigns.indexer_progress["flaky-id"].status == :error
+    end
+
+    # The success case must stay a no-op: the retry's releases already arrived
+    # as progress messages, and its batched aggregate covers only the retried
+    # indexer, so applying it would clobber every other indexer's chip.
+    test "a successful retry does not touch indexer_progress" do
+      progress = pending_retry_progress()
+
+      {:noreply, socket} =
+        MydiaWeb.MediaLive.Show.handle_async(
+          {:retry, "flaky-id"},
+          {:ok, {:ok, [], []}},
+          retry_socket(progress)
+        )
+
+      assert socket.assigns.indexer_progress == progress
+    end
+
+    test "an unknown indexer id is a clean no-op rather than an insert" do
+      progress = pending_retry_progress()
+
+      {:noreply, socket} =
+        MydiaWeb.MediaLive.Show.handle_async(
+          {:retry, "never-seen-id"},
+          {:exit, :killed},
+          retry_socket(progress)
+        )
+
+      assert socket.assigns.indexer_progress == progress
+    end
+  end
+
+  # Per-row grab flags are written into the stream by mark_result/3 and live
+  # nowhere else, while every progress message rebuilds that stream with
+  # reset: true. Before results streamed in, rows were only clickable once the
+  # search had finished, so no reset could follow a grab. Now a user can grab
+  # while a slow indexer is still running and watch the badge disappear when
+  # the next indexer reports.
+  #
+  # The second progress message deliberately carries NO results: an unchanged
+  # pool keeps the row's rank (and therefore its positioned DOM id) fixed, so
+  # a failure can only mean the flag was dropped, never that the row moved.
+  test "a grab badge survives the next indexer reporting", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    indexer = pending_indexer_fixture("slow-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+    wait_for_indexer_progress(view)
+
+    dune = search_result("Dune.2024.2160p.UHD")
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "slow-indexer",
+         indexer_id: indexer.id,
+         status: :ok,
+         results: [dune],
+         result_count: 1,
+         duration_ms: 700,
+         completed: 1,
+         total: 2
+       }}
+    )
+
+    render(view)
+
+    # The same message Downloads.Grabber broadcasts on the "downloads" topic
+    # when a grab lands, which is what flips the row to "Grabbed".
+    send(view.pid, {:grab_completed, %{download_url: dune.download_url}})
+    render(view)
+
+    row = "##{positioned_result_dom_id(dune)}"
+
+    assert has_element?(view, "#{row} .btn-success"),
+           "precondition failed: the grabbed badge never rendered"
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "other-indexer",
+         indexer_id: "other-id",
+         status: :ok,
+         results: [],
+         result_count: 0,
+         duration_ms: 90,
+         completed: 2,
+         total: 2
+       }}
+    )
+
+    render(view)
+
+    assert has_element?(view, "#{row} .btn-success"),
+           "the grabbed badge was erased by the next indexer's progress message"
+  end
+
+  # The results list renders as soon as the first indexer reports, but the
+  # filters bar above it used to stay gated on `!@searching`, so a user could
+  # see streamed results and not be able to filter or re-sort them until the
+  # slowest indexer settled, which can be the full 120s deadline.
+  test "filter and sort controls are available while a slow indexer runs", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    indexer = pending_indexer_fixture("slow-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+    wait_for_indexer_progress(view)
+
+    # Nothing has arrived yet, so there is nothing to filter and the bar must
+    # stay hidden. Without this the assertion below could pass on a bar that
+    # simply always renders.
+    refute has_element?(view, "#close-after-grab-toggle")
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "slow-indexer",
+         indexer_id: indexer.id,
+         status: :ok,
+         results: [search_result("Dune.2024.2160p.UHD")],
+         result_count: 1,
+         duration_ms: 700,
+         completed: 1,
+         total: 2
+       }}
+    )
+
+    render(view)
+
+    assert :sys.get_state(view.pid).socket.assigns.searching,
+           "precondition failed: the search already ended, so this proves nothing"
+
+    assert has_element?(view, ~s(#manual-search-modal form[phx-change="filter_search"]))
+    assert has_element?(view, ~s(#manual-search-modal form[phx-change="sort_search"]))
+    assert has_element?(view, "#close-after-grab-toggle")
+  end
+
+  # Two things at once: the filter handler re-filters the accumulated set
+  # correctly mid-search, and filtering down to nothing does NOT take the
+  # controls away with it. That second half is why the bar is gated on the
+  # pre-filter pool rather than on `!@results_empty?` like the results list:
+  # test fixtures carry no parsed quality, so a resolution filter matches
+  # nothing, and gating on the post-filter set would strand the user with no
+  # way to undo the filter they just applied.
+  test "a filter applied mid-search re-filters without stranding the user", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    indexer = pending_indexer_fixture("slow-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+    wait_for_indexer_progress(view)
+
+    dune = search_result("Dune.2024.2160p.UHD")
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "slow-indexer",
+         indexer_id: indexer.id,
+         status: :ok,
+         results: [dune],
+         result_count: 1,
+         duration_ms: 700,
+         completed: 1,
+         total: 2
+       }}
+    )
+
+    render(view)
+    assert has_element?(view, "##{positioned_result_dom_id(dune)}")
+
+    view
+    |> element(~s(#manual-search-modal form[phx-change="filter_search"]))
+    |> render_change(%{"quality" => "2160p", "min_seeders" => "0"})
+
+    refute has_element?(view, "##{positioned_result_dom_id(dune)}")
+
+    assert has_element?(view, ~s(#manual-search-modal form[phx-change="filter_search"])),
+           "the filter that matched nothing also removed the controls needed to undo it"
+
+    view
+    |> element(~s(#manual-search-modal form[phx-change="filter_search"]))
+    |> render_change(%{"quality" => "", "min_seeders" => "0"})
+
+    assert has_element?(view, "##{positioned_result_dom_id(dune)}")
   end
 end

--- a/test/mydia_web/live/media_live/manual_search_streaming_test.exs
+++ b/test/mydia_web/live/media_live/manual_search_streaming_test.exs
@@ -1,0 +1,125 @@
+defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+
+  alias Mydia.Indexers.Structs.IndexerProgress
+
+  setup %{conn: conn} do
+    {conn, user} = register_and_log_in_user(conn)
+    %{conn: conn, user: user}
+  end
+
+  defp search_result(title) do
+    %Mydia.Indexers.SearchResult{
+      title: title,
+      download_url: "magnet:?xt=urn:btih:#{:erlang.phash2(title)}",
+      indexer: "Fast",
+      size: 8_000_000_000,
+      seeders: 100,
+      leechers: 2
+    }
+  end
+
+  defp current_search_id(view) do
+    :sys.get_state(view.pid).socket.assigns.search_id
+  end
+
+  test "one indexer's results render while another is pending", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    view |> element("#manual-search-button") |> render_click()
+
+    search_id = current_search_id(view)
+
+    send(
+      view.pid,
+      {:indexer_search_started, search_id,
+       [
+         %IndexerProgress{indexer: "fast", indexer_id: "fast-id", status: :pending, total: 2},
+         %IndexerProgress{indexer: "slow", indexer_id: "slow-id", status: :pending, total: 2}
+       ]}
+    )
+
+    send(
+      view.pid,
+      {:indexer_progress, search_id,
+       %IndexerProgress{
+         indexer: "fast",
+         indexer_id: "fast-id",
+         status: :ok,
+         results: [search_result("Dune.2021.2160p.UHD")],
+         result_count: 1,
+         duration_ms: 700,
+         completed: 1,
+         total: 2
+       }}
+    )
+
+    html = render(view)
+
+    assert html =~ "Dune.2021.2160p.UHD"
+    assert has_element?(view, "#indexer-status-fast-id")
+    assert has_element?(view, "#indexer-status-slow-id")
+  end
+
+  # The stale result's title genuinely matches the search query ("Dune 2024",
+  # since media_item_fixture/1 defaults year to 2024) rather than something
+  # unrelated. If it didn't, ReleaseRanker's title-relevance filter (when a
+  # quality profile is present) could explain the result's absence just as
+  # well as the search_id guard, making the assertion below ambiguous about
+  # which mechanism is actually responsible.
+  defp stale_progress(indexer_id, title) do
+    %IndexerProgress{
+      indexer: "old",
+      indexer_id: indexer_id,
+      status: :ok,
+      results: [search_result(title)],
+      result_count: 1,
+      duration_ms: 100,
+      completed: 1,
+      total: 1
+    }
+  end
+
+  test "stale progress is ignored", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view) - 1,
+       stale_progress("old-id", "Dune.2024.2160p.UHD")}
+    )
+
+    refute render(view) =~ "Dune.2024.2160p.UHD"
+  end
+
+  # Positive control for the test above: the exact same message, differing
+  # only in carrying the CURRENT search_id, must surface the result. Without
+  # this, a passing refute in the stale test could just as easily mean the
+  # element selector or title never renders under any circumstance, rather
+  # than proving the search_id guard is what's filtering it out.
+  test "a matching (non-stale) search_id does surface the same content", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+    view |> element("#manual-search-button") |> render_click()
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       stale_progress("old-id", "Dune.2024.2160p.UHD")}
+    )
+
+    html = render(view)
+
+    assert html =~ "Dune.2024.2160p.UHD"
+    assert has_element?(view, "#indexer-status-old-id")
+  end
+end

--- a/test/mydia_web/live/search_live/streaming_test.exs
+++ b/test/mydia_web/live/search_live/streaming_test.exs
@@ -1,0 +1,141 @@
+defmodule MydiaWeb.SearchLive.StreamingTest do
+  # async: false is required. Connected LiveView tests deadlock under the
+  # Postgres sandbox when run concurrently.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Indexers.Structs.IndexerProgress
+
+  setup %{conn: conn} do
+    {conn, user} = register_and_log_in_user(conn)
+    %{conn: conn, user: user}
+  end
+
+  defp search_result(title) do
+    %Mydia.Indexers.SearchResult{
+      title: title,
+      download_url: "magnet:?xt=urn:btih:#{:erlang.phash2(title)}",
+      indexer: "Fast",
+      size: 8_000_000_000,
+      seeders: 100,
+      leechers: 2
+    }
+  end
+
+  # handle_params/3 always kicks off a REAL background search (that's the
+  # point of Task 6: a remount re-runs the search instead of blanking). Left
+  # pointed at a real host, that search's own completion races the synthetic
+  # :indexer_search_started / :indexer_progress messages the tests inject
+  # below and can clobber them via the authoritative handle_async(:search,
+  # ...) completion before assertions run. Pointing every indexer at a
+  # Bypass server that never answers within the test's lifetime removes the
+  # race entirely.
+  defp pending_indexer_fixture(name) do
+    bypass = Bypass.open()
+
+    Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
+      # Bypass.pass/1 first: the test ends (and its connection is torn down)
+      # long before the sleep elapses. Without marking the expectation
+      # passed, Bypass's on_exit verification would report the abandoned
+      # connection as a test crash.
+      Bypass.pass(bypass)
+      Process.sleep(3_000)
+      Plug.Conn.resp(conn, 200, "[]")
+    end)
+
+    indexer_config_fixture(%{
+      name: name,
+      type: :prowlarr,
+      base_url: "http://localhost:#{bypass.port}"
+    })
+  end
+
+  test "results from one indexer render while another is still pending", %{conn: conn} do
+    pending_indexer_fixture("fast-indexer")
+    pending_indexer_fixture("slow-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+
+    fast = %IndexerProgress{
+      indexer: "fast-indexer",
+      indexer_id: "fast-id",
+      status: :ok,
+      results: [search_result("Dune.2021.1080p.BluRay")],
+      result_count: 1,
+      duration_ms: 800,
+      completed: 1,
+      total: 2
+    }
+
+    pending = %IndexerProgress{
+      indexer: "slow-indexer",
+      indexer_id: "slow-id",
+      status: :pending,
+      total: 2
+    }
+
+    # Drive handle_params so the LiveView is mid-search with a known search_id.
+    render_patch(view, ~p"/search?q=Dune")
+
+    send(view.pid, {:indexer_search_started, current_search_id(view), [fast_pending(), pending]})
+    send(view.pid, {:indexer_progress, current_search_id(view), fast})
+
+    html = render(view)
+
+    assert html =~ "Dune.2021.1080p.BluRay"
+    assert has_element?(view, "#indexer-status-fast-id")
+    assert has_element?(view, "#indexer-status-slow-id")
+  end
+
+  defp fast_pending do
+    %IndexerProgress{
+      indexer: "fast-indexer",
+      indexer_id: "fast-id",
+      status: :pending,
+      total: 2
+    }
+  end
+
+  defp current_search_id(view) do
+    :sys.get_state(view.pid).socket.assigns.search_id
+  end
+
+  test "progress from a superseded search is ignored", %{conn: conn} do
+    indexer_config_fixture(%{name: "fast-indexer", type: :prowlarr})
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+    render_patch(view, ~p"/search?q=Dune")
+
+    stale = %IndexerProgress{
+      indexer: "old-indexer",
+      indexer_id: "old-id",
+      status: :ok,
+      results: [search_result("Stale.Result.From.Old.Search")],
+      result_count: 1,
+      duration_ms: 100,
+      completed: 1,
+      total: 1
+    }
+
+    send(view.pid, {:indexer_progress, current_search_id(view) - 1, stale})
+
+    html = render(view)
+
+    refute html =~ "Stale.Result.From.Old.Search"
+    refute has_element?(view, "#indexer-status-old-id")
+  end
+
+  test "submitting a search pushes the query into the URL", %{conn: conn} do
+    indexer_config_fixture(%{name: "fast-indexer", type: :prowlarr})
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+
+    view
+    |> element("#indexer-search-form")
+    |> render_submit(%{"search" => "Dune"})
+
+    assert_patched(view, ~p"/search?q=Dune")
+  end
+end

--- a/test/mydia_web/live/search_live/streaming_test.exs
+++ b/test/mydia_web/live/search_live/streaming_test.exs
@@ -195,4 +195,72 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
 
     assert_patched(view, ~p"/search?q=Dune")
   end
+
+  # The retry itself starts a real (second) search against the indexer, keyed
+  # to the SAME search_id (by design, see the retry_indexer handler). If that
+  # indexer resolved fast (e.g. a plain indexer_config_fixture hitting
+  # localhost:9696, which fails almost instantly with econnrefused), its own
+  # on_indexer_result callback can race the test's post-click assertion and
+  # legitimately overwrite the :pending status back to :error before
+  # :sys.get_state runs. Using the slow Bypass-backed fixture (like the
+  # completion-race avoidance above) keeps the retry's real HTTP call parked
+  # well past the test's lifetime, removing that race entirely.
+  test "retrying a failed indexer marks it pending again", %{conn: conn} do
+    indexer = pending_indexer_fixture("flaky-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+    render_patch(view, ~p"/search?q=Dune")
+    wait_for_indexer_progress(view)
+
+    failed = %IndexerProgress{
+      indexer: "flaky-indexer",
+      indexer_id: indexer.id,
+      status: :error,
+      error: "Connection failed: :econnrefused",
+      completed: 1,
+      total: 1
+    }
+
+    send(view.pid, {:indexer_progress, current_search_id(view), failed})
+
+    assert has_element?(view, "#indexer-status-#{indexer.id} button")
+
+    view
+    |> element("#indexer-status-#{indexer.id} button")
+    |> render_click()
+
+    assert :sys.get_state(view.pid).socket.assigns.indexer_progress[indexer.id].status ==
+             :pending
+  end
+
+  # Before this task, no handle_event("retry_indexer", ...) clause existed
+  # anywhere in the LiveView, so clicking Retry raised a FunctionClauseError
+  # and crashed the process. render_click/1 re-raises that crash in the test
+  # process, so simply completing the click and then successfully rendering
+  # the view again is direct proof the crash is gone.
+  test "retrying a failed indexer does not crash the LiveView", %{conn: conn} do
+    indexer = pending_indexer_fixture("flaky-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+    render_patch(view, ~p"/search?q=Dune")
+    wait_for_indexer_progress(view)
+
+    failed = %IndexerProgress{
+      indexer: "flaky-indexer",
+      indexer_id: indexer.id,
+      status: :error,
+      error: "Connection failed: :econnrefused",
+      completed: 1,
+      total: 1
+    }
+
+    send(view.pid, {:indexer_progress, current_search_id(view), failed})
+
+    view
+    |> element("#indexer-status-#{indexer.id} button")
+    |> render_click()
+
+    assert Process.alive?(view.pid)
+    assert render(view) =~ "flaky-indexer"
+  end
 end

--- a/test/mydia_web/live/search_live/streaming_test.exs
+++ b/test/mydia_web/live/search_live/streaming_test.exs
@@ -67,7 +67,7 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
   # the search provably cannot finish while the gate is shut.
   defp gated_indexer_fixture(name) do
     bypass = Bypass.open()
-    {:ok, gate} = Agent.start_link(fn -> false end)
+    {:ok, gate} = Agent.start_link(fn -> %{open: false, timed_out: false} end)
 
     Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
       Bypass.pass(bypass)
@@ -88,20 +88,44 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
     {config, gate}
   end
 
-  defp open_gate(gate), do: Agent.update(gate, fn _ -> true end)
+  defp open_gate(gate), do: Agent.update(gate, &%{&1 | open: true})
 
-  # Bounded on purpose: a gate that is never opened must surface as a failed
-  # assertion in the test, never as a hung suite.
+  # Bounded on purpose: a gate that is never opened must surface as a failure,
+  # never as a hung suite -- and never as a PASS. This clause used to return
+  # :ok, which let the Bypass handler answer anyway: the full search then
+  # completed normally and the ordering the gated test exists to establish was
+  # never actually established, yet the test still passed.
+  #
+  # flunk/1 alone does not fix that. This runs in the Bypass plug process, and
+  # Bypass.pass/1 has already marked the expectation passed, so the raise is
+  # swallowed: the connection simply errors, the indexer reports a failure and
+  # the search proceeds exactly as if the gate had opened. (Verified: with the
+  # retry budget cut to 3, the test still passed on the flunk alone.) The
+  # give-up is therefore recorded in the Agent FIRST, and assert_gate_held/1,
+  # which runs in the test process, is what turns it into a failure. The raise
+  # is still worth keeping: it stops the handler returning a normal 200.
   defp await_gate(gate, retries \\ 500)
-  defp await_gate(_gate, 0), do: :ok
+
+  defp await_gate(gate, 0) do
+    Agent.update(gate, &%{&1 | timed_out: true})
+    flunk("timed out waiting for the gated indexer to be released; the gate was never opened")
+  end
 
   defp await_gate(gate, retries) do
-    if Agent.get(gate, & &1) do
+    if Agent.get(gate, & &1.open) do
       :ok
     else
       Process.sleep(10)
       await_gate(gate, retries - 1)
     end
+  end
+
+  # Must run in the test process; see await_gate/2 for why the handler cannot
+  # report this itself.
+  defp assert_gate_held(gate) do
+    refute Agent.get(gate, & &1.timed_out),
+           "the gated indexer stopped waiting and answered on its own, so the full " <>
+             "search was never actually held behind the gate and this test proved nothing"
   end
 
   defp wait_until_search_finished(view, retries \\ 300)
@@ -251,6 +275,7 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
     open_gate(gate)
     wait_until_search_finished(view)
 
+    assert_gate_held(gate)
     assert has_element?(view, "##{result_dom_id(dune)}")
   end
 
@@ -462,5 +487,89 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
 
     assert Process.alive?(view.pid)
     assert render(view) =~ "flaky-indexer"
+  end
+
+  # handle_event("retry_indexer", ...) sets the chip to :pending before starting
+  # the task. If that task dies or errors before any progress message lands,
+  # nothing else ever clears :pending: the chip spins forever and the Retry
+  # button is gone, because it only renders for :error/:timeout. These drive
+  # handle_async/3 directly because the failure modes (a crashed task, a
+  # non-:ok return from search_all/2) cannot be provoked through a live
+  # indexer.
+  describe "handle_async({:retry, id}, ...)" do
+    defp retry_socket(indexer_progress) do
+      %Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{}, indexer_progress: indexer_progress}
+      }
+    end
+
+    defp pending_retry_progress do
+      %{
+        "flaky-id" => %IndexerProgress{
+          indexer: "flaky-indexer",
+          indexer_id: "flaky-id",
+          status: :pending,
+          result_count: nil,
+          duration_ms: nil,
+          total: 1
+        }
+      }
+    end
+
+    test "a crashed retry leaves the indexer actionable, not pending forever" do
+      {:noreply, socket} =
+        MydiaWeb.SearchLive.Index.handle_async(
+          {:retry, "flaky-id"},
+          {:exit, :killed},
+          retry_socket(pending_retry_progress())
+        )
+
+      entry = socket.assigns.indexer_progress["flaky-id"]
+
+      assert entry.status == :error
+      assert is_binary(entry.error) and entry.error != ""
+      assert entry.result_count == nil
+      assert entry.duration_ms == nil
+    end
+
+    test "a retry that returns an error leaves the indexer actionable" do
+      {:noreply, socket} =
+        MydiaWeb.SearchLive.Index.handle_async(
+          {:retry, "flaky-id"},
+          {:ok, {:error, :boom}},
+          retry_socket(pending_retry_progress())
+        )
+
+      assert socket.assigns.indexer_progress["flaky-id"].status == :error
+    end
+
+    # The success case must stay a no-op: the retry's releases already arrived
+    # as progress messages, and its batched aggregate covers only the retried
+    # indexer, so applying it would clobber every other indexer's chip.
+    test "a successful retry does not touch indexer_progress" do
+      progress = pending_retry_progress()
+
+      {:noreply, socket} =
+        MydiaWeb.SearchLive.Index.handle_async(
+          {:retry, "flaky-id"},
+          {:ok, {:ok, [], []}},
+          retry_socket(progress)
+        )
+
+      assert socket.assigns.indexer_progress == progress
+    end
+
+    test "an unknown indexer id is a clean no-op rather than an insert" do
+      progress = pending_retry_progress()
+
+      {:noreply, socket} =
+        MydiaWeb.SearchLive.Index.handle_async(
+          {:retry, "never-seen-id"},
+          {:exit, :killed},
+          retry_socket(progress)
+        )
+
+      assert socket.assigns.indexer_progress == progress
+    end
   end
 end

--- a/test/mydia_web/live/search_live/streaming_test.exs
+++ b/test/mydia_web/live/search_live/streaming_test.exs
@@ -67,10 +67,15 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
   # the search provably cannot finish while the gate is shut.
   defp gated_indexer_fixture(name) do
     bypass = Bypass.open()
-    {:ok, gate} = Agent.start_link(fn -> %{open: false, timed_out: false} end)
+
+    {:ok, gate} =
+      Agent.start_link(fn ->
+        %{open: false, entered: false, already_open_at_entry: false, timed_out: false}
+      end)
 
     Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
       Bypass.pass(bypass)
+      enter_gate(gate)
       await_gate(gate)
 
       conn
@@ -89,6 +94,49 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
   end
 
   defp open_gate(gate), do: Agent.update(gate, &%{&1 | open: true})
+
+  # Records, once, that a request reached the gated indexer AND whether the
+  # gate was already open when it did.
+  #
+  # `entered` on its own would not prove the handler ever waited: if the gate
+  # were already open when the request arrived, await_gate/2 returns
+  # immediately and `entered` still flips to true. `already_open_at_entry` is
+  # what separates "the search was genuinely held" from "the request walked
+  # straight through", and assert_gate_held/1 refutes it.
+  #
+  # Only the FIRST entry is recorded, so a stray second request (which would
+  # legitimately find the gate open) cannot rewrite the verdict on the one
+  # request that mattered.
+  defp enter_gate(gate) do
+    Agent.update(gate, fn
+      %{entered: false} = state -> %{state | entered: true, already_open_at_entry: state.open}
+      state -> state
+    end)
+  end
+
+  # Must be awaited before the test opens the gate. Without it, whether the
+  # search is actually held is a coin flip on whether the HTTP request happens
+  # to start before or after open_gate/1: the callbacks this test synchronizes
+  # on (on_start) fire before any request is issued, so the request can easily
+  # still be in flight. Waiting here makes entry-before-open true by
+  # construction rather than by luck.
+  defp wait_until_gate_entered(gate, retries \\ 500)
+
+  defp wait_until_gate_entered(_gate, 0) do
+    flunk(
+      "timed out waiting for the gated indexer to receive its request; " <>
+        "nothing was ever parked behind the gate"
+    )
+  end
+
+  defp wait_until_gate_entered(gate, retries) do
+    if Agent.get(gate, & &1.entered) do
+      :ok
+    else
+      Process.sleep(10)
+      wait_until_gate_entered(gate, retries - 1)
+    end
+  end
 
   # Bounded on purpose: a gate that is never opened must surface as a failure,
   # never as a hung suite -- and never as a PASS. This clause used to return
@@ -121,9 +169,17 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
   end
 
   # Must run in the test process; see await_gate/2 for why the handler cannot
-  # report this itself.
+  # report either of these itself. The two guard different failures: one that
+  # the request never waited at all, one that it waited and then gave up.
   defp assert_gate_held(gate) do
-    refute Agent.get(gate, & &1.timed_out),
+    state = Agent.get(gate, & &1)
+
+    refute state.already_open_at_entry,
+           "the gated indexer's request arrived when the gate was already open, so it " <>
+             "was never held and the full search's completion was not ordered after the " <>
+             "retry's result at all"
+
+    refute state.timed_out,
            "the gated indexer stopped waiting and answered on its own, so the full " <>
              "search was never actually held behind the gate and this test proved nothing"
   end
@@ -249,6 +305,12 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
     {:ok, view, _html} = live(conn, ~p"/search")
     render_patch(view, ~p"/search?q=Dune")
     wait_for_indexer_progress(view)
+
+    # on_start fires before any HTTP request, so wait_for_indexer_progress/1
+    # above does NOT mean the gated indexer has been contacted yet. Everything
+    # below depends on the search being genuinely parked behind the gate, so
+    # wait for the request to actually arrive there first.
+    wait_until_gate_entered(gate)
 
     dune = search_result("Dune.2021.1080p.BluRay")
 

--- a/test/mydia_web/live/search_live/streaming_test.exs
+++ b/test/mydia_web/live/search_live/streaming_test.exs
@@ -205,12 +205,40 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
   # :sys.get_state runs. Using the slow Bypass-backed fixture (like the
   # completion-race avoidance above) keeps the retry's real HTTP call parked
   # well past the test's lifetime, removing that race entirely.
-  test "retrying a failed indexer marks it pending again", %{conn: conn} do
+  #
+  # A single indexer cannot prove handle_info({:indexer_search_started, ...})
+  # MERGES rather than REPLACES: with one entry in indexer_progress, "wiped
+  # the map down to just this one pending entry" and "correctly updated this
+  # one entry to pending" are indistinguishable. A second entry ("succeeded-
+  # id") makes the two hypotheses diverge. It is deliberately NOT backed by a
+  # real indexer_config (same pattern as the "old-indexer"/"old-id" entries
+  # used elsewhere in this file), so it can never appear in any real
+  # on_start's pending list -- exactly mirroring an indexer that already
+  # finished and is NOT part of the scoped retry. Retrying "flaky-indexer"
+  # sends a real, scoped on_start covering only flaky-indexer; a REPLACE-
+  # based handler would wipe "succeeded-id" out of indexer_progress the
+  # moment that real message lands, a MERGE-based one preserves it.
+  test "retrying a failed indexer marks it pending again without wiping other indexers", %{
+    conn: conn
+  } do
     indexer = pending_indexer_fixture("flaky-indexer")
 
     {:ok, view, _html} = live(conn, ~p"/search")
     render_patch(view, ~p"/search?q=Dune")
     wait_for_indexer_progress(view)
+
+    succeeded = %IndexerProgress{
+      indexer: "succeeded-indexer",
+      indexer_id: "succeeded-id",
+      status: :ok,
+      results: [],
+      result_count: 3,
+      duration_ms: 500,
+      completed: 1,
+      total: 1
+    }
+
+    send(view.pid, {:indexer_progress, current_search_id(view), succeeded})
 
     failed = %IndexerProgress{
       indexer: "flaky-indexer",
@@ -229,8 +257,17 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
     |> element("#indexer-status-#{indexer.id} button")
     |> render_click()
 
-    assert :sys.get_state(view.pid).socket.assigns.indexer_progress[indexer.id].status ==
-             :pending
+    # The retry's own real on_start fires before any HTTP request (same
+    # timing as the initial search's on_start above, which wait_for_indexer_
+    # progress/1 confirms lands within tens of ms in this suite), so this
+    # short wait reliably outlasts it before we inspect final state.
+    Process.sleep(200)
+
+    progress = :sys.get_state(view.pid).socket.assigns.indexer_progress
+
+    assert progress[indexer.id].status == :pending
+    assert progress["succeeded-id"].status == :ok
+    assert progress["succeeded-id"].result_count == 3
   end
 
   # Before this task, no handle_event("retry_indexer", ...) clause existed

--- a/test/mydia_web/live/search_live/streaming_test.exs
+++ b/test/mydia_web/live/search_live/streaming_test.exs
@@ -13,25 +13,33 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
     %{conn: conn, user: user}
   end
 
-  defp search_result(title) do
+  defp search_result(title, opts \\ []) do
     %Mydia.Indexers.SearchResult{
       title: title,
-      download_url: "magnet:?xt=urn:btih:#{:erlang.phash2(title)}",
-      indexer: "Fast",
+      download_url:
+        Keyword.get(opts, :download_url, "magnet:?xt=urn:btih:#{:erlang.phash2(title)}"),
+      indexer: Keyword.get(opts, :indexer, "Fast"),
       size: 8_000_000_000,
-      seeders: 100,
+      seeders: Keyword.get(opts, :seeders, 100),
       leechers: 2
     }
+  end
+
+  # Mirrors the private MydiaWeb.SearchLive.Index.generate_result_id/1 so
+  # tests can assert on real result rows by DOM id instead of raw HTML text,
+  # per this project's standard of asserting against element ids.
+  defp result_dom_id(result) do
+    hash = :erlang.phash2({result.download_url, result.indexer})
+    "search-result-#{hash}"
   end
 
   # handle_params/3 always kicks off a REAL background search (that's the
   # point of Task 6: a remount re-runs the search instead of blanking). Left
   # pointed at a real host, that search's own completion races the synthetic
-  # :indexer_search_started / :indexer_progress messages the tests inject
-  # below and can clobber them via the authoritative handle_async(:search,
-  # ...) completion before assertions run. Pointing every indexer at a
-  # Bypass server that never answers within the test's lifetime removes the
-  # race entirely.
+  # progress messages the tests inject below and can clobber them via the
+  # authoritative handle_async(:search, ...) completion before assertions
+  # run. Pointing every indexer at a Bypass server that never answers within
+  # the test's lifetime removes that completion race entirely.
   defp pending_indexer_fixture(name) do
     bypass = Bypass.open()
 
@@ -52,67 +60,84 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
     })
   end
 
-  test "results from one indexer render while another is still pending", %{conn: conn} do
-    pending_indexer_fixture("fast-indexer")
-    pending_indexer_fixture("slow-indexer")
+  # search_all/2's on_start callback fires before any HTTP request -- right
+  # after the DB query for indexer configs -- so it is NOT delayed by the
+  # Bypass sleep above. handle_info({:indexer_search_started, ...}) does a
+  # full assign REPLACE of indexer_progress, not a merge. If that real,
+  # DB-backed message landed between two synthetic sends keyed by invented
+  # ids, it would silently wipe them (a second, earlier race than the
+  # completion race above). Waiting for it here, then keying synthetic
+  # progress to the SAME real indexer ids, turns the later
+  # handle_info({:indexer_progress, ...}) into a Map.put merge instead of a
+  # colliding replace, removing the race entirely rather than narrowing it.
+  defp wait_for_indexer_progress(view, retries \\ 50)
 
-    {:ok, view, _html} = live(conn, ~p"/search")
-
-    fast = %IndexerProgress{
-      indexer: "fast-indexer",
-      indexer_id: "fast-id",
-      status: :ok,
-      results: [search_result("Dune.2021.1080p.BluRay")],
-      result_count: 1,
-      duration_ms: 800,
-      completed: 1,
-      total: 2
-    }
-
-    pending = %IndexerProgress{
-      indexer: "slow-indexer",
-      indexer_id: "slow-id",
-      status: :pending,
-      total: 2
-    }
-
-    # Drive handle_params so the LiveView is mid-search with a known search_id.
-    render_patch(view, ~p"/search?q=Dune")
-
-    send(view.pid, {:indexer_search_started, current_search_id(view), [fast_pending(), pending]})
-    send(view.pid, {:indexer_progress, current_search_id(view), fast})
-
-    html = render(view)
-
-    assert html =~ "Dune.2021.1080p.BluRay"
-    assert has_element?(view, "#indexer-status-fast-id")
-    assert has_element?(view, "#indexer-status-slow-id")
+  defp wait_for_indexer_progress(_view, 0) do
+    flunk("timed out waiting for the real on_start message to populate indexer_progress")
   end
 
-  defp fast_pending do
-    %IndexerProgress{
-      indexer: "fast-indexer",
-      indexer_id: "fast-id",
-      status: :pending,
-      total: 2
-    }
+  defp wait_for_indexer_progress(view, retries) do
+    case :sys.get_state(view.pid).socket.assigns.indexer_progress do
+      progress when progress == %{} ->
+        Process.sleep(10)
+        wait_for_indexer_progress(view, retries - 1)
+
+      progress ->
+        progress
+    end
   end
 
   defp current_search_id(view) do
     :sys.get_state(view.pid).socket.assigns.search_id
   end
 
+  test "results from one indexer render while another is still pending", %{conn: conn} do
+    fast_indexer = pending_indexer_fixture("fast-indexer")
+    slow_indexer = pending_indexer_fixture("slow-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+
+    render_patch(view, ~p"/search?q=Dune")
+
+    # Let the real on_start land (keyed to fast_indexer.id and
+    # slow_indexer.id) before sending anything synthetic.
+    wait_for_indexer_progress(view)
+
+    dune = search_result("Dune.2021.1080p.BluRay")
+
+    fast = %IndexerProgress{
+      indexer: "fast-indexer",
+      indexer_id: fast_indexer.id,
+      status: :ok,
+      results: [dune],
+      result_count: 1,
+      duration_ms: 800,
+      completed: 1,
+      total: 2
+    }
+
+    send(view.pid, {:indexer_progress, current_search_id(view), fast})
+
+    render(view)
+
+    assert has_element?(view, "##{result_dom_id(dune)}")
+    assert has_element?(view, "#indexer-status-#{fast_indexer.id}")
+    assert has_element?(view, "#indexer-status-#{slow_indexer.id}")
+  end
+
   test "progress from a superseded search is ignored", %{conn: conn} do
-    indexer_config_fixture(%{name: "fast-indexer", type: :prowlarr})
+    pending_indexer_fixture("fast-indexer")
 
     {:ok, view, _html} = live(conn, ~p"/search")
     render_patch(view, ~p"/search?q=Dune")
+
+    stale_result = search_result("Dune.Stale.Result.From.Old.Search")
 
     stale = %IndexerProgress{
       indexer: "old-indexer",
       indexer_id: "old-id",
       status: :ok,
-      results: [search_result("Stale.Result.From.Old.Search")],
+      results: [stale_result],
       result_count: 1,
       duration_ms: 100,
       completed: 1,
@@ -121,14 +146,46 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
 
     send(view.pid, {:indexer_progress, current_search_id(view) - 1, stale})
 
-    html = render(view)
+    render(view)
 
-    refute html =~ "Stale.Result.From.Old.Search"
+    refute has_element?(view, "##{result_dom_id(stale_result)}")
     refute has_element?(view, "#indexer-status-old-id")
   end
 
+  # Confirms the two refutations above are not vacuously true (i.e. the
+  # element selectors themselves are correct and would catch a regression):
+  # apply the exact same stale progress with a search_id that DOES match the
+  # current search, and assert the result and status chip now DO appear.
+  test "a matching (non-stale) search_id does surface the same content", %{conn: conn} do
+    pending_indexer_fixture("fast-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+    render_patch(view, ~p"/search?q=Dune")
+    wait_for_indexer_progress(view)
+
+    result = search_result("Dune.Stale.Result.From.Old.Search")
+
+    progress = %IndexerProgress{
+      indexer: "old-indexer",
+      indexer_id: "old-id",
+      status: :ok,
+      results: [result],
+      result_count: 1,
+      duration_ms: 100,
+      completed: 1,
+      total: 1
+    }
+
+    send(view.pid, {:indexer_progress, current_search_id(view), progress})
+
+    render(view)
+
+    assert has_element?(view, "##{result_dom_id(result)}")
+    assert has_element?(view, "#indexer-status-old-id")
+  end
+
   test "submitting a search pushes the query into the URL", %{conn: conn} do
-    indexer_config_fixture(%{name: "fast-indexer", type: :prowlarr})
+    pending_indexer_fixture("fast-indexer")
 
     {:ok, view, _html} = live(conn, ~p"/search")
 

--- a/test/mydia_web/live/search_live/streaming_test.exs
+++ b/test/mydia_web/live/search_live/streaming_test.exs
@@ -60,6 +60,65 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
     })
   end
 
+  # Like pending_indexer_fixture/1, but the HTTP call is held open until the
+  # test explicitly releases it with open_gate/1 (rather than parked past the
+  # test's lifetime). That turns "the full search completes AFTER a retry's
+  # result is already on screen" from a race into a deterministic ordering:
+  # the search provably cannot finish while the gate is shut.
+  defp gated_indexer_fixture(name) do
+    bypass = Bypass.open()
+    {:ok, gate} = Agent.start_link(fn -> false end)
+
+    Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
+      Bypass.pass(bypass)
+      await_gate(gate)
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, "[]")
+    end)
+
+    config =
+      indexer_config_fixture(%{
+        name: name,
+        type: :prowlarr,
+        base_url: "http://localhost:#{bypass.port}"
+      })
+
+    {config, gate}
+  end
+
+  defp open_gate(gate), do: Agent.update(gate, fn _ -> true end)
+
+  # Bounded on purpose: a gate that is never opened must surface as a failed
+  # assertion in the test, never as a hung suite.
+  defp await_gate(gate, retries \\ 500)
+  defp await_gate(_gate, 0), do: :ok
+
+  defp await_gate(gate, retries) do
+    if Agent.get(gate, & &1) do
+      :ok
+    else
+      Process.sleep(10)
+      await_gate(gate, retries - 1)
+    end
+  end
+
+  defp wait_until_search_finished(view, retries \\ 300)
+
+  defp wait_until_search_finished(_view, 0) do
+    flunk("timed out waiting for handle_async(:search, ...) to clear :searching")
+  end
+
+  defp wait_until_search_finished(view, retries) do
+    if :sys.get_state(view.pid).socket.assigns.searching do
+      Process.sleep(10)
+      wait_until_search_finished(view, retries - 1)
+    else
+      :ok
+    end
+  end
+
   # search_all/2's on_start callback fires before any HTTP request -- right
   # after the DB query for indexer configs -- so it is NOT delayed by the
   # Bypass sleep above. handle_info({:indexer_search_started, ...}) does a
@@ -89,6 +148,110 @@ defmodule MydiaWeb.SearchLive.StreamingTest do
 
   defp current_search_id(view) do
     :sys.get_state(view.pid).socket.assigns.search_id
+  end
+
+  # From search start until the first indexer reports, the display set is
+  # genuinely empty: the spinner must be up and the results card (which would
+  # read "0 results for Dune") must not be rendered at all. Starting
+  # :results_empty? at false inverts both gates -- `@searching &&
+  # @results_empty?` suppresses the spinner while `!@results_empty?` shows the
+  # card -- so the user's first impression of every search is "0 results",
+  # which is exactly the failure this branch set out to fix.
+  #
+  # The indexer is parked behind a Bypass that sleeps past this test's
+  # lifetime, so neither on_indexer_result nor handle_async can land: the
+  # state under assertion is the fresh-search state and it stays put.
+  test "a fresh search shows the spinner, not a zero-result card", %{conn: conn} do
+    pending_indexer_fixture("slow-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+
+    render_patch(view, ~p"/search?q=Dune")
+
+    assert has_element?(view, "#search-loading-state")
+    refute has_element?(view, "#search-results-count")
+  end
+
+  # Positive control for the refutation above: once an indexer reports
+  # results, the card appears and the spinner goes away. Without this, a
+  # passing refute could just mean "#search-results-count" never renders under
+  # any circumstance.
+  test "the results card appears once an indexer reports", %{conn: conn} do
+    indexer = pending_indexer_fixture("slow-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+    render_patch(view, ~p"/search?q=Dune")
+    wait_for_indexer_progress(view)
+
+    dune = search_result("Dune.2021.1080p.BluRay")
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "slow-indexer",
+         indexer_id: indexer.id,
+         status: :ok,
+         results: [dune],
+         result_count: 1,
+         duration_ms: 800,
+         completed: 1,
+         total: 1
+       }}
+    )
+
+    render(view)
+
+    assert has_element?(view, "#search-results-count")
+    refute has_element?(view, "#search-loading-state")
+  end
+
+  # A result that reached the display set through on_indexer_result but is NOT
+  # in the full search's aggregate return value is exactly what a
+  # single-indexer retry produces: the retry runs under its own start_async
+  # key ({:retry, id}), so its releases only ever arrive as progress messages
+  # and never appear in the aggregate that handle_async(:search, ...)
+  # receives. Injecting one directly models that precisely, and avoids
+  # clicking Retry only to have the retry park on the same gated Bypass.
+  #
+  # This is the ordinary ordering, not an exotic race: the Retry button
+  # appears as soon as one indexer errors, while slow indexers are still
+  # pending, so a retry against a fast-failing host normally settles well
+  # before the slow ones finish. The gate makes that ordering deterministic
+  # here.
+  test "a result contributed by a retry survives the full search completing", %{conn: conn} do
+    {_indexer, gate} = gated_indexer_fixture("gated-indexer")
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+    render_patch(view, ~p"/search?q=Dune")
+    wait_for_indexer_progress(view)
+
+    dune = search_result("Dune.2021.1080p.BluRay")
+
+    send(
+      view.pid,
+      {:indexer_progress, current_search_id(view),
+       %IndexerProgress{
+         indexer: "retried-indexer",
+         indexer_id: "retried-id",
+         status: :ok,
+         results: [dune],
+         result_count: 1,
+         duration_ms: 120,
+         completed: 1,
+         total: 1
+       }}
+    )
+
+    render(view)
+
+    assert has_element?(view, "##{result_dom_id(dune)}"),
+           "precondition failed: the retry's result never made it on screen"
+
+    open_gate(gate)
+    wait_until_search_finished(view)
+
+    assert has_element?(view, "##{result_dom_id(dune)}")
   end
 
   test "results from one indexer render while another is still pending", %{conn: conn} do


### PR DESCRIPTION
## Problem

During a manual search, one non-responding indexer made the whole search take minutes and frequently end showing no results at all.

Five defects compounded:

1. `max_concurrency` defaulted to 2 (`indexers.ex`), so six indexers at a normal 30s response took three serialized waves even when every one was healthy.
2. `Task.async_stream(timeout: :infinity, on_timeout: :kill_task)` made the kill switch dead code, so nothing bounded a search.
3. Req's default `retry: :safe_transient` was left on in the Prowlarr and Jackett search paths. `test_connection` in the same modules already passed `retry: false`; only search was missed.
4. No connect timeout anywhere, so a host dropping SYN packets hung in TCP connect, a phase `receive_timeout` does not govern.
5. Results were all-or-nothing, and the query was never pushed into the URL, so a websocket drop mid-search remounted to a blank page.

## What changed

**Context layer**

- `search_all/2` gains `:on_start` and `:on_indexer_result` callbacks, both defaulting to no-ops so the six background job call sites are unaffected. Its return value is unchanged.
- Full fan-out (capped at 16) replaces the hardcoded 2, with a real 120s deadline. Both are per-call opts with app-config fallback, so tests never mutate global env.
- `ordered: false`, without which `Task.async_stream` buffers completed results to emit them in input order. A fast indexer sorted after a slow one would have had its results withheld for up to the full deadline.
- `zip_input_on_exit: true` so a timed-out indexer is named instead of logged as `"unknown"`.
- `retry: false` and a 10s connect bound on all four adapter search paths.
- Background jobs keep their throttle through a new `background_max_concurrency` key and `Indexers.background_search_opts/0`, preserving the ban-prevention behavior from 02be582a. Manual search fans out; unattended jobs stay at 2.

**UI**

- New `MydiaWeb.IndexerComponents.indexer_search_status/1` renders one chip per indexer: pending, ok with counts and duration, error, or timeout.
- Both manual-search surfaces stream results as each indexer settles, re-ranking the accumulated set on every arrival.
- `search_id` guard drops progress from a superseded search.
- `?q=` on `/search`, so a remount after a websocket drop re-runs rather than blanking. `handle_params/3` is now the single place a search starts.
- Per-indexer retry. Before this, both surfaces rendered a `phx-click="retry_indexer"` button with no handler, so clicking it raised `FunctionClauseError` and crashed the LiveView.

## Measured

Against an unroutable host (`10.255.255.1`):

| | Before | After |
| --- | --- | --- |
| Dead indexer resolves | 26957 ms | 10045 ms |

Note on framing: a SYN-drop yields a single attempt, because `:safe_transient` does not retry that timeout. The four-attempt retry multiplication is real but applies to connection-refused and 5xx errors, which the adapter tests cover directly. The dominant win for the reported bug is concurrency plus streaming, not the connect bound.

## Verification

- SQLite: 7978 tests, 0 failures
- PostgreSQL: 7972 tests, 0 failures (run at 4dc1c0c8)
- `mix format --check-formatted` clean
- `mix credo --strict`: 14,755 functions, no issues

## Known gaps

- The media detail modal still has no URL state, so a websocket drop there remounts to a closed modal. Closing that needs the supervised search-session process the design lists as a non-goal.
- No regression test for the dedup-across-truncation hazard that motivates the separate raw accumulator. Reproducing it needs more than 100 distinct results plus a dedup collapse in a later batch. The mechanism is documented at `apply_indexer_progress/2`.
- One retry test uses a fixed sleep where a state poll on `total` would be strictly better.
- `:indexer_errors` is now dead on both surfaces, superseded by the status component. Left for a separate sweep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now appear progressively as individual indexers respond.
  * Added per-indexer status indicators for pending, successful, failed, and timed-out searches.
  * Users can retry failed or timed-out indexers without restarting the entire search.
  * Results remain visible and filters stay available while searches continue.

* **Bug Fixes**
  * Prevented stale search updates from replacing results from newer searches.
  * Improved connection timeout and retry handling for indexer requests.

* **Performance**
  * Improved concurrency for manual searches while maintaining controlled background-search limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->