### PR TITLE
feat(show): restore collapsible seasons on the TV show page

### DIFF
--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -53,26 +53,12 @@ defmodule MydiaWeb.MediaLive.Show do
     # Load timeline events from Events system
     timeline_events = load_timeline_events(media_item)
 
-    # Initialize expanded seasons - expand the first (most recent) season by default
-    expanded_seasons =
-      case media_item.type do
-        "tv_show" ->
-          media_item.episodes
-          |> Enum.map(& &1.season_number)
-          |> Enum.uniq()
-          |> Enum.sort(:desc)
-          |> List.first()
-          |> case do
-            nil -> MapSet.new()
-            season_num -> MapSet.new([season_num])
-          end
-
-        _ ->
-          MapSet.new()
-      end
-
     # Load next episode for TV shows
     {next_episode, next_episode_state} = load_next_episode(media_item, socket)
+
+    # Expand the season of the next episode, or the newest season when there is
+    # no next episode.
+    expanded_seasons = default_expanded_seasons(media_item, next_episode)
 
     {:ok,
      socket

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -8,6 +8,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
 
   alias MydiaWeb.MediaLive.Show.LibraryComponents
   alias MydiaWeb.MediaLive.Show.SegmentComponents
+  alias MydiaWeb.MediaLive.Show.SeasonComponents
 
   @doc """
   Hero section with backdrop image, poster, and quick action buttons.
@@ -436,10 +437,11 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   end
 
   @doc """
-  Episodes section for TV shows with non-collapsible seasons.
+  Episodes section for TV shows. Each season is a disclosure, delegated to
+  `SeasonComponents.season_section/1`.
   """
   attr :media_item, :map, required: true
-  attr :expanded_seasons, :map, required: true
+  attr :expanded_seasons, :any, required: true
   attr :expanded_episodes, :map, default: MapSet.new()
   attr :auto_searching_season, :any, default: nil
   attr :rescanning_season, :any, default: nil
@@ -529,240 +531,19 @@ defmodule MydiaWeb.MediaLive.Show.Components do
         <%!-- All seasons in one container --%>
         <div class="divide-y divide-base-300">
           <%= for {season_num, episodes} <- grouped_seasons do %>
-            <% season_available = Enum.count(episodes, &(length(&1.media_files) > 0))
-            season_total = length(episodes) %>
-
-            <div class="p-4">
-              <%!-- Season header row --%>
-              <div class="flex flex-wrap items-center gap-2 mb-3">
-                <span class="badge badge-primary badge-lg font-bold shrink-0">S{season_num}</span>
-                <span class="text-sm text-base-content/70 shrink-0">
-                  {season_available}/{season_total}
-                </span>
-                <progress
-                  class="progress progress-success w-16 shrink-0"
-                  value={season_available}
-                  max={season_total}
-                ></progress>
-
-                <%!-- Season actions --%>
-                <div class="flex items-center gap-1">
-                  <div class="tooltip tooltip-bottom" data-tip="Auto search season">
-                    <button
-                      type="button"
-                      phx-click="auto_search_season"
-                      phx-value-season-number={season_num}
-                      class="btn btn-sm btn-primary"
-                      disabled={@auto_searching_season == season_num}
-                    >
-                      <%= if @auto_searching_season == season_num do %>
-                        <span class="loading loading-spinner loading-sm"></span>
-                      <% else %>
-                        <.icon name="hero-bolt" class="w-4 h-4" />
-                      <% end %>
-                    </button>
-                  </div>
-                  <div class="tooltip tooltip-bottom" data-tip="Manual search">
-                    <button
-                      type="button"
-                      phx-click="manual_search_season"
-                      phx-value-season-number={season_num}
-                      class="btn btn-sm btn-ghost"
-                    >
-                      <.icon name="hero-magnifying-glass" class="w-4 h-4" />
-                    </button>
-                  </div>
-                  <div class="tooltip tooltip-bottom" data-tip="Re-scan">
-                    <button
-                      type="button"
-                      phx-click="rescan_season"
-                      phx-value-season-number={season_num}
-                      class="btn btn-sm btn-ghost"
-                      disabled={@rescanning_season == season_num}
-                    >
-                      <%= if @rescanning_season == season_num do %>
-                        <span class="loading loading-spinner loading-sm"></span>
-                      <% else %>
-                        <.icon name="hero-arrow-path" class="w-4 h-4" />
-                      <% end %>
-                    </button>
-                  </div>
-                  <% season_state = Mydia.Media.season_monitoring_state(episodes) %>
-                  <div
-                    class="tooltip tooltip-bottom"
-                    data-tip={season_monitoring_tooltip(season_state)}
-                  >
-                    <button
-                      type="button"
-                      id={"season-#{season_num}-monitor-toggle"}
-                      phx-click={
-                        if season_state == :all, do: "unmonitor_season", else: "monitor_season"
-                      }
-                      phx-value-season-number={season_num}
-                      class={[
-                        "btn btn-sm btn-ghost",
-                        season_state == :none && "opacity-60"
-                      ]}
-                    >
-                      <.monitoring_icon state={season_state} class="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              <SegmentComponents.segment_status_row
-                :if={@segment_detection_available}
-                season_number={season_num}
-                status={Map.get(@segment_statuses, season_num)}
-              />
-
-              <%!-- Episodes list --%>
-              <div class="bg-base-100 rounded-lg divide-y divide-base-200">
-                <%= for episode <- Enum.sort_by(episodes, & &1.episode_number, :desc) do %>
-                  <% has_files = length(episode.media_files) > 0
-                  is_expanded = MapSet.member?(@expanded_episodes, episode.id)
-                  status = get_episode_status(episode) %>
-
-                  <div class={["py-2 px-3", has_files && "border-l-2 border-l-success"]}>
-                    <%!-- Mobile: two rows. Desktop: single row --%>
-                    <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
-                      <%!-- Row 1: Episode number + Title --%>
-                      <div class="flex items-center gap-1 flex-1 min-w-0">
-                        <%!-- Episode number with expand toggle --%>
-                        <div
-                          class={[
-                            "flex items-center flex-shrink-0",
-                            has_files && "gap-1 cursor-pointer hover:text-primary"
-                          ]}
-                          phx-click={has_files && "toggle_episode_expanded"}
-                          phx-value-episode-id={episode.id}
-                        >
-                          <%= if has_files do %>
-                            <.icon
-                              name={
-                                if is_expanded, do: "hero-chevron-down", else: "hero-chevron-right"
-                              }
-                              class="w-3 h-3 text-base-content/40"
-                            />
-                          <% end %>
-                          <span class="font-mono text-sm font-medium text-base-content/70">
-                            {episode.episode_number}
-                          </span>
-                        </div>
-
-                        <%!-- Title --%>
-                        <div
-                          class={["flex-1 min-w-0", has_files && "cursor-pointer"]}
-                          phx-click={has_files && "toggle_episode_expanded"}
-                          phx-value-episode-id={episode.id}
-                        >
-                          <span class={[
-                            "text-sm font-medium truncate block",
-                            has_files && "hover:text-primary"
-                          ]}>
-                            {episode.title || "TBA"}
-                          </span>
-                        </div>
-                      </div>
-
-                      <%!-- Row 2 on mobile / inline on desktop: metadata + actions --%>
-                      <div class="flex items-center justify-between sm:justify-end gap-2 sm:pl-0">
-                        <%!-- Metadata: quality + air date --%>
-                        <div class="flex items-center gap-2 text-xs text-base-content/50">
-                          <%= if quality = get_episode_quality_badge(episode) do %>
-                            <span class="badge badge-primary badge-xs">{quality}</span>
-                          <% end %>
-                          <%= if episode.air_date do %>
-                            <span>{format_date(episode.air_date)}</span>
-                          <% end %>
-                        </div>
-
-                        <%!-- Status + Actions --%>
-                        <div class="flex items-center gap-1 flex-shrink-0">
-                          <%!-- Status indicator --%>
-                          <div class="tooltip tooltip-left" data-tip={episode_status_tooltip(episode)}>
-                            <span class={["badge badge-xs", episode_status_color(status)]}>
-                              <.icon name={episode_status_icon(status)} class="w-3 h-3" />
-                            </span>
-                          </div>
-                          <%= if @playback_enabled && has_files do %>
-                            <% episode_best_file = get_best_media_file(episode.media_files) %>
-                            <a
-                              href={
-                                flutter_player_url("episode", episode.id,
-                                  file_id: episode_best_file.id,
-                                  title: episode.title
-                                )
-                              }
-                              class="btn btn-success btn-sm btn-square"
-                              title="Play"
-                            >
-                              <.icon name="hero-play-solid" class="w-4 h-4" />
-                            </a>
-                          <% end %>
-                          <button
-                            type="button"
-                            phx-click="auto_search_episode"
-                            phx-value-episode-id={episode.id}
-                            class="btn btn-primary btn-sm btn-square"
-                            disabled={@auto_searching_episode == episode.id}
-                            title="Auto search"
-                          >
-                            <%= if @auto_searching_episode == episode.id do %>
-                              <span class="loading loading-spinner loading-sm"></span>
-                            <% else %>
-                              <.icon name="hero-bolt" class="w-4 h-4" />
-                            <% end %>
-                          </button>
-                          <button
-                            type="button"
-                            phx-click="search_episode"
-                            phx-value-episode-id={episode.id}
-                            class="btn btn-ghost btn-sm btn-square"
-                            title="Manual search"
-                          >
-                            <.icon name="hero-magnifying-glass" class="w-4 h-4" />
-                          </button>
-                          <button
-                            type="button"
-                            phx-click="toggle_episode_monitored"
-                            phx-value-episode-id={episode.id}
-                            class={[
-                              "btn btn-sm btn-square",
-                              if(episode.monitored, do: "btn-ghost", else: "btn-ghost opacity-40")
-                            ]}
-                            title={
-                              if episode.monitored, do: "Stop monitoring", else: "Start monitoring"
-                            }
-                          >
-                            <.icon
-                              name={
-                                if episode.monitored, do: "hero-bookmark-solid", else: "hero-bookmark"
-                              }
-                              class="w-4 h-4"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-
-                    <%!-- Expanded file details --%>
-                    <%= if is_expanded && has_files do %>
-                      <div class="mt-2 ml-8 space-y-1">
-                        <div :for={file <- episode.media_files} class="bg-base-200/50 rounded p-2">
-                          <.episode_file_row
-                            file={file}
-                            episode={episode}
-                            playback_enabled={@playback_enabled}
-                            transcode_jobs={Map.get(@transcode_jobs, file.id, [])}
-                          />
-                        </div>
-                      </div>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
-            </div>
+            <SeasonComponents.season_section
+              season_number={season_num}
+              episodes={episodes}
+              expanded?={MapSet.member?(@expanded_seasons, season_num)}
+              expanded_episodes={@expanded_episodes}
+              auto_searching_season={@auto_searching_season}
+              rescanning_season={@rescanning_season}
+              auto_searching_episode={@auto_searching_episode}
+              playback_enabled={@playback_enabled}
+              transcode_jobs={@transcode_jobs}
+              segment_statuses={@segment_statuses}
+              segment_detection_available={@segment_detection_available}
+            />
           <% end %>
         </div>
       </div>
@@ -1319,39 +1100,6 @@ defmodule MydiaWeb.MediaLive.Show.Components do
       />
       <span>{if @media_item.monitored, do: "Monitored", else: "Not Monitored"}</span>
     </button>
-    """
-  end
-
-  @doc """
-  Bookmark icon for a season's derived monitoring state.
-
-  - `:all` - solid bookmark
-  - `:partial` - half-filled, built from two stacked icons
-  - `:none` - outline bookmark
-  """
-  attr :state, :atom, required: true
-  attr :class, :string, default: "w-5 h-5"
-
-  def monitoring_icon(%{state: :all} = assigns) do
-    ~H"""
-    <.icon name="hero-bookmark-solid" class={@class} />
-    """
-  end
-
-  def monitoring_icon(%{state: :none} = assigns) do
-    ~H"""
-    <.icon name="hero-bookmark" class={@class} />
-    """
-  end
-
-  def monitoring_icon(assigns) do
-    ~H"""
-    <span class="relative inline-flex">
-      <.icon name="hero-bookmark" class={@class} />
-      <span class="absolute inset-0 overflow-hidden" style="clip-path: inset(50% 0 0 0);">
-        <.icon name="hero-bookmark-solid" class={@class} />
-      </span>
-    </span>
     """
   end
 end

--- a/lib/mydia_web/live/media_live/show/helpers.ex
+++ b/lib/mydia_web/live/media_live/show/helpers.ex
@@ -206,6 +206,63 @@ defmodule MydiaWeb.MediaLive.Show.Helpers do
     |> Enum.sort_by(fn {season, _} -> season end, :desc)
   end
 
+  @doc """
+  The season(s) to expand by default on mount.
+
+  The season of the next episode wins, so the page opens on what the user would
+  actually play next. When there is no next episode — `:all_watched`, a show
+  `get_next_episode/2` returns `nil` for, or a next episode whose season is not
+  in the grouped list — falls back to the newest season. Non-TV shows and shows
+  with no episodes expand nothing.
+  """
+  def default_expanded_seasons(%{type: "tv_show"} = media_item, next_episode) do
+    season_numbers =
+      media_item.episodes
+      |> Enum.map(& &1.season_number)
+      |> Enum.uniq()
+
+    preferred =
+      case next_episode do
+        %{season_number: season} when is_integer(season) -> season
+        _ -> nil
+      end
+
+    season =
+      cond do
+        preferred in season_numbers -> preferred
+        season_numbers != [] -> Enum.max(season_numbers)
+        true -> nil
+      end
+
+    case season do
+      nil -> MapSet.new()
+      season -> MapSet.new([season])
+    end
+  end
+
+  def default_expanded_seasons(_media_item, _next_episode), do: MapSet.new()
+
+  @doc """
+  Counts one season's episodes by availability in a single pass.
+
+  `available` counts `:downloaded` episodes — those with a media file. The
+  `{available}/{total}` header figure and the status chip both read from this,
+  so they can never disagree.
+  """
+  def season_episode_counts(episodes) do
+    counts =
+      Enum.reduce(episodes, %{available: 0, missing: 0, upcoming: 0}, fn episode, acc ->
+        case get_episode_status(episode).state do
+          :downloaded -> %{acc | available: acc.available + 1}
+          :missing -> %{acc | missing: acc.missing + 1}
+          :upcoming -> %{acc | upcoming: acc.upcoming + 1}
+          _ -> acc
+        end
+      end)
+
+    Map.put(counts, :total, length(episodes))
+  end
+
   def get_episode_quality_badge(episode) do
     case episode.media_files do
       [] ->

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -1,0 +1,356 @@
+defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
+  @moduledoc """
+  Per-season UI for the TV show page: the disclosure header and the episode
+  list it toggles.
+  """
+
+  use MydiaWeb, :html
+
+  import MydiaWeb.MediaLive.Show.Formatters
+  import MydiaWeb.MediaLive.Show.Helpers
+
+  alias MydiaWeb.MediaLive.Show.Components
+  alias MydiaWeb.MediaLive.Show.SegmentComponents
+
+  @doc """
+  One season: the disclosure header, the segment status row, and the episode
+  list. The episode list (and the segment row) render only when expanded.
+  """
+  attr :season_number, :integer, required: true
+  attr :episodes, :list, required: true
+  attr :expanded?, :boolean, required: true
+  attr :expanded_episodes, :any, required: true
+  attr :auto_searching_season, :any, default: nil
+  attr :rescanning_season, :any, default: nil
+  attr :auto_searching_episode, :any, default: nil
+  attr :playback_enabled, :boolean, required: true
+  attr :transcode_jobs, :map, default: %{}
+  attr :segment_statuses, :map, default: %{}
+  attr :segment_detection_available, :boolean, default: true
+
+  def season_section(assigns) do
+    ~H"""
+    <div id={"season-#{@season_number}"} class="p-4">
+      <.season_header
+        season_number={@season_number}
+        episodes={@episodes}
+        expanded?={@expanded?}
+        auto_searching_season={@auto_searching_season}
+        rescanning_season={@rescanning_season}
+      />
+
+      <%= if @expanded? do %>
+        <SegmentComponents.segment_status_row
+          :if={@segment_detection_available}
+          season_number={@season_number}
+          status={Map.get(@segment_statuses, @season_number)}
+        />
+
+        <%!-- Episodes list --%>
+        <div
+          id={"season-#{@season_number}-episodes"}
+          class="bg-base-100 rounded-lg divide-y divide-base-200"
+        >
+          <%= for episode <- Enum.sort_by(@episodes, & &1.episode_number, :desc) do %>
+            <% has_files = length(episode.media_files) > 0
+            is_expanded = MapSet.member?(@expanded_episodes, episode.id)
+            status = get_episode_status(episode) %>
+
+            <div class={["py-2 px-3", has_files && "border-l-2 border-l-success"]}>
+              <%!-- Mobile: two rows. Desktop: single row --%>
+              <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
+                <%!-- Row 1: Episode number + Title --%>
+                <div class="flex items-center gap-1 flex-1 min-w-0">
+                  <%!-- Episode number with expand toggle --%>
+                  <div
+                    class={[
+                      "flex items-center flex-shrink-0",
+                      has_files && "gap-1 cursor-pointer hover:text-primary"
+                    ]}
+                    phx-click={has_files && "toggle_episode_expanded"}
+                    phx-value-episode-id={episode.id}
+                  >
+                    <%= if has_files do %>
+                      <.icon
+                        name={if is_expanded, do: "hero-chevron-down", else: "hero-chevron-right"}
+                        class="w-3 h-3 text-base-content/40"
+                      />
+                    <% end %>
+                    <span class="font-mono text-sm font-medium text-base-content/70">
+                      {episode.episode_number}
+                    </span>
+                  </div>
+
+                  <%!-- Title --%>
+                  <div
+                    class={["flex-1 min-w-0", has_files && "cursor-pointer"]}
+                    phx-click={has_files && "toggle_episode_expanded"}
+                    phx-value-episode-id={episode.id}
+                  >
+                    <span class={[
+                      "text-sm font-medium truncate block",
+                      has_files && "hover:text-primary"
+                    ]}>
+                      {episode.title || "TBA"}
+                    </span>
+                  </div>
+                </div>
+
+                <%!-- Row 2 on mobile / inline on desktop: metadata + actions --%>
+                <div class="flex items-center justify-between sm:justify-end gap-2 sm:pl-0">
+                  <%!-- Metadata: quality + air date --%>
+                  <div class="flex items-center gap-2 text-xs text-base-content/50">
+                    <%= if quality = get_episode_quality_badge(episode) do %>
+                      <span class="badge badge-primary badge-xs">{quality}</span>
+                    <% end %>
+                    <%= if episode.air_date do %>
+                      <span>{format_date(episode.air_date)}</span>
+                    <% end %>
+                  </div>
+
+                  <%!-- Status + Actions --%>
+                  <div class="flex items-center gap-1 flex-shrink-0">
+                    <%!-- Status indicator --%>
+                    <div class="tooltip tooltip-left" data-tip={episode_status_tooltip(episode)}>
+                      <span class={["badge badge-xs", episode_status_color(status)]}>
+                        <.icon name={episode_status_icon(status)} class="w-3 h-3" />
+                      </span>
+                    </div>
+                    <%= if @playback_enabled && has_files do %>
+                      <% episode_best_file = get_best_media_file(episode.media_files) %>
+                      <a
+                        href={
+                          flutter_player_url("episode", episode.id,
+                            file_id: episode_best_file.id,
+                            title: episode.title
+                          )
+                        }
+                        class="btn btn-success btn-sm btn-square"
+                        title="Play"
+                      >
+                        <.icon name="hero-play-solid" class="w-4 h-4" />
+                      </a>
+                    <% end %>
+                    <button
+                      type="button"
+                      phx-click="auto_search_episode"
+                      phx-value-episode-id={episode.id}
+                      class="btn btn-primary btn-sm btn-square"
+                      disabled={@auto_searching_episode == episode.id}
+                      title="Auto search"
+                    >
+                      <%= if @auto_searching_episode == episode.id do %>
+                        <span class="loading loading-spinner loading-sm"></span>
+                      <% else %>
+                        <.icon name="hero-bolt" class="w-4 h-4" />
+                      <% end %>
+                    </button>
+                    <button
+                      type="button"
+                      phx-click="search_episode"
+                      phx-value-episode-id={episode.id}
+                      class="btn btn-ghost btn-sm btn-square"
+                      title="Manual search"
+                    >
+                      <.icon name="hero-magnifying-glass" class="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      phx-click="toggle_episode_monitored"
+                      phx-value-episode-id={episode.id}
+                      class={[
+                        "btn btn-sm btn-square",
+                        if(episode.monitored, do: "btn-ghost", else: "btn-ghost opacity-40")
+                      ]}
+                      title={if episode.monitored, do: "Stop monitoring", else: "Start monitoring"}
+                    >
+                      <.icon
+                        name={if episode.monitored, do: "hero-bookmark-solid", else: "hero-bookmark"}
+                        class="w-4 h-4"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <%!-- Expanded file details --%>
+              <%= if is_expanded && has_files do %>
+                <div class="mt-2 ml-8 space-y-1">
+                  <div :for={file <- episode.media_files} class="bg-base-200/50 rounded p-2">
+                    <Components.episode_file_row
+                      file={file}
+                      episode={episode}
+                      playback_enabled={@playback_enabled}
+                      transcode_jobs={Map.get(@transcode_jobs, file.id, [])}
+                    />
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  @doc """
+  The disclosure row: a toggle button carrying the chevron, badge, counts,
+  progress bar, and status chip, with the five season action buttons as
+  siblings (so a click on "auto search" does not also collapse the season).
+  """
+  attr :season_number, :integer, required: true
+  attr :episodes, :list, required: true
+  attr :expanded?, :boolean, required: true
+  attr :auto_searching_season, :any, default: nil
+  attr :rescanning_season, :any, default: nil
+
+  def season_header(assigns) do
+    counts = season_episode_counts(assigns.episodes)
+    season_state = Mydia.Media.season_monitoring_state(assigns.episodes)
+
+    chip =
+      cond do
+        counts.missing > 0 ->
+          %{class: "badge badge-warning", label: "#{counts.missing} missing"}
+
+        counts.upcoming > 0 ->
+          %{class: "badge badge-ghost", label: "#{counts.upcoming} upcoming"}
+
+        counts.available == counts.total ->
+          %{class: "badge badge-success", label: "complete"}
+
+        true ->
+          nil
+      end
+
+    assigns =
+      assign(assigns, :counts, counts)
+      |> assign(:season_state, season_state)
+      |> assign(:chip, chip)
+
+    ~H"""
+    <div class="flex flex-wrap items-center gap-2 mb-3">
+      <button
+        type="button"
+        id={"season-#{@season_number}-toggle"}
+        class="flex flex-wrap items-center gap-2 cursor-pointer text-left"
+        phx-click="toggle_season_expanded"
+        phx-value-season-number={@season_number}
+        aria-expanded={to_string(@expanded?)}
+        aria-controls={"season-#{@season_number}-episodes"}
+      >
+        <.icon
+          name={if @expanded?, do: "hero-chevron-down", else: "hero-chevron-right"}
+          class="w-4 h-4 text-base-content/40"
+        />
+        <span class="badge badge-primary badge-lg font-bold shrink-0">S{@season_number}</span>
+        <span class="text-sm text-base-content/70 shrink-0">{@counts.available}/{@counts.total}</span>
+        <progress
+          class="progress progress-success w-16 shrink-0"
+          value={@counts.available}
+          max={@counts.total}
+        ></progress>
+        <%= if @chip do %>
+          <span class={@chip.class}>{@chip.label}</span>
+        <% end %>
+      </button>
+
+      <%!-- Season actions: siblings of the toggle, so they never collapse it --%>
+      <div class="flex items-center gap-1">
+        <div class="tooltip tooltip-bottom" data-tip="Auto search season">
+          <button
+            type="button"
+            id={"season-#{@season_number}-auto-search"}
+            phx-click="auto_search_season"
+            phx-value-season-number={@season_number}
+            class="btn btn-sm btn-primary"
+            disabled={@auto_searching_season == @season_number}
+          >
+            <%= if @auto_searching_season == @season_number do %>
+              <span class="loading loading-spinner loading-sm"></span>
+            <% else %>
+              <.icon name="hero-bolt" class="w-4 h-4" />
+            <% end %>
+          </button>
+        </div>
+        <div class="tooltip tooltip-bottom" data-tip="Manual search">
+          <button
+            type="button"
+            phx-click="manual_search_season"
+            phx-value-season-number={@season_number}
+            class="btn btn-sm btn-ghost"
+          >
+            <.icon name="hero-magnifying-glass" class="w-4 h-4" />
+          </button>
+        </div>
+        <div class="tooltip tooltip-bottom" data-tip="Re-scan">
+          <button
+            type="button"
+            phx-click="rescan_season"
+            phx-value-season-number={@season_number}
+            class="btn btn-sm btn-ghost"
+            disabled={@rescanning_season == @season_number}
+          >
+            <%= if @rescanning_season == @season_number do %>
+              <span class="loading loading-spinner loading-sm"></span>
+            <% else %>
+              <.icon name="hero-arrow-path" class="w-4 h-4" />
+            <% end %>
+          </button>
+        </div>
+        <div
+          class="tooltip tooltip-bottom"
+          data-tip={season_monitoring_tooltip(@season_state)}
+        >
+          <button
+            type="button"
+            id={"season-#{@season_number}-monitor-toggle"}
+            phx-click={if @season_state == :all, do: "unmonitor_season", else: "monitor_season"}
+            phx-value-season-number={@season_number}
+            class={[
+              "btn btn-sm btn-ghost",
+              @season_state == :none && "opacity-60"
+            ]}
+          >
+            <.monitoring_icon state={@season_state} class="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Bookmark icon for a season's derived monitoring state.
+
+  - `:all` - solid bookmark
+  - `:partial` - half-filled, built from two stacked icons
+  - `:none` - outline bookmark
+  """
+  attr :state, :atom, required: true
+  attr :class, :string, default: "w-5 h-5"
+
+  def monitoring_icon(%{state: :all} = assigns) do
+    ~H"""
+    <.icon name="hero-bookmark-solid" class={@class} />
+    """
+  end
+
+  def monitoring_icon(%{state: :none} = assigns) do
+    ~H"""
+    <.icon name="hero-bookmark" class={@class} />
+    """
+  end
+
+  def monitoring_icon(assigns) do
+    ~H"""
+    <span class="relative inline-flex">
+      <.icon name="hero-bookmark" class={@class} />
+      <span class="absolute inset-0 overflow-hidden" style="clip-path: inset(50% 0 0 0);">
+        <.icon name="hero-bookmark-solid" class={@class} />
+      </span>
+    </span>
+    """
+  end
+end

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -264,6 +264,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             id={"season-#{@season_number}-auto-search"}
             phx-click="auto_search_season"
             phx-value-season-number={@season_number}
+            aria-label="Auto search season"
             class="btn btn-sm btn-primary"
             disabled={@auto_searching_season == @season_number}
           >
@@ -279,6 +280,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             type="button"
             phx-click="manual_search_season"
             phx-value-season-number={@season_number}
+            aria-label="Manual search"
             class="btn btn-sm btn-ghost"
           >
             <.icon name="hero-magnifying-glass" class="w-4 h-4" />
@@ -289,6 +291,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             type="button"
             phx-click="rescan_season"
             phx-value-season-number={@season_number}
+            aria-label="Re-scan"
             class="btn btn-sm btn-ghost"
             disabled={@rescanning_season == @season_number}
           >
@@ -308,6 +311,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             id={"season-#{@season_number}-monitor-toggle"}
             phx-click={if @season_state == :all, do: "unmonitor_season", else: "monitor_season"}
             phx-value-season-number={@season_number}
+            aria-label={season_monitoring_tooltip(@season_state)}
             class={[
               "btn btn-sm btn-ghost",
               @season_state == :none && "opacity-60"

--- a/test/mydia_web/live/media_live/show/season_collapse_test.exs
+++ b/test/mydia_web/live/media_live/show/season_collapse_test.exs
@@ -140,4 +140,85 @@ defmodule MydiaWeb.MediaLive.Show.SeasonCollapseTest do
       rescanning_season: nil
     )
   end
+
+  describe "collapse at mount and on click" do
+    test "expands the next episode's season at mount and collapses the rest", %{conn: conn} do
+      {media_item, _ep_1, _ep_2} = two_season_show()
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+      assert has_element?(view, "#season-1-episodes")
+      refute has_element?(view, "#season-2-episodes")
+    end
+
+    test "a fully watched show falls back to the newest season", %{conn: conn, admin: admin} do
+      {media_item, ep_1, ep_2} = two_season_show()
+
+      mark_watched!(admin, ep_1)
+      mark_watched!(admin, ep_2)
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+      assert has_element?(view, "#season-2-episodes")
+      refute has_element?(view, "#season-1-episodes")
+    end
+
+    test "the toggle expands and collapses a season", %{conn: conn} do
+      {media_item, _ep_1, _ep_2} = two_season_show()
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+      refute has_element?(view, "#season-2-episodes")
+
+      view |> element("#season-2-toggle") |> render_click()
+      assert has_element?(view, "#season-2-episodes")
+
+      view |> element("#season-2-toggle") |> render_click()
+      refute has_element?(view, "#season-2-episodes")
+    end
+
+    test "clicking a season's auto search never toggles the season", %{conn: conn} do
+      {media_item, _ep_1, _ep_2} = two_season_show()
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+      refute has_element?(view, "#season-2-episodes")
+      view |> element("#season-2-auto-search") |> render_click()
+      refute has_element?(view, "#season-2-episodes")
+
+      assert has_element?(view, "#season-1-episodes")
+      view |> element("#season-1-auto-search") |> render_click()
+      assert has_element?(view, "#season-1-episodes")
+    end
+  end
+
+  # A two-season show, one file per season, so the next episode is season 1's
+  # first episode (episodes are ordered season asc, episode asc, then filtered
+  # to those with files).
+  defp two_season_show do
+    media_item = media_item_fixture(%{type: "tv_show"})
+
+    ep_1 = episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 1})
+    media_file_fixture(%{episode_id: ep_1.id})
+
+    ep_2 = episode_fixture(%{media_item_id: media_item.id, season_number: 2, episode_number: 1})
+    media_file_fixture(%{episode_id: ep_2.id})
+
+    {media_item, ep_1, ep_2}
+  end
+
+  defp mark_watched!(user, episode) do
+    %Progress{}
+    |> Progress.changeset(
+      %{
+        user_id: user.id,
+        episode_id: episode.id,
+        position_seconds: 0,
+        duration_seconds: 100,
+        watched: true
+      },
+      authoritative_watched: true
+    )
+    |> Repo.insert!()
+  end
 end

--- a/test/mydia_web/live/media_live/show/season_collapse_test.exs
+++ b/test/mydia_web/live/media_live/show/season_collapse_test.exs
@@ -100,4 +100,44 @@ defmodule MydiaWeb.MediaLive.Show.SeasonCollapseTest do
              }
     end
   end
+
+  describe "season_header/1 chip" do
+    test "shows the missing chip first" do
+      html = render_season_header([episode(air_date: ~D[2024-01-01], media_files: [])])
+
+      assert html =~ "1 missing"
+    end
+
+    test "a season with only future episodes reads upcoming, never missing" do
+      html =
+        render_season_header([episode(air_date: Date.add(Date.utc_today(), 30), media_files: [])])
+
+      assert html =~ "1 upcoming"
+      refute html =~ "missing"
+    end
+
+    test "a fully available season reads complete" do
+      html = render_season_header([episode(media_files: [%MediaFile{}])])
+
+      assert html =~ "complete"
+    end
+
+    test "an all-TBA season renders no chip" do
+      html = render_season_header([episode(air_date: nil, media_files: [])])
+
+      refute html =~ "missing"
+      refute html =~ "upcoming"
+      refute html =~ "complete"
+    end
+  end
+
+  defp render_season_header(episodes) do
+    render_component(&SeasonComponents.season_header/1,
+      season_number: 1,
+      episodes: episodes,
+      expanded?: false,
+      auto_searching_season: nil,
+      rescanning_season: nil
+    )
+  end
 end

--- a/test/mydia_web/live/media_live/show/season_collapse_test.exs
+++ b/test/mydia_web/live/media_live/show/season_collapse_test.exs
@@ -1,0 +1,103 @@
+defmodule MydiaWeb.MediaLive.Show.SeasonCollapseTest do
+  # async: false — connected LiveView tests hit the Postgres non-shared
+  # sandbox, which hides test rows from the mount process.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.Episode
+  alias Mydia.Playback.Progress
+  alias Mydia.Repo
+  alias MydiaWeb.MediaLive.Show.Helpers
+  alias MydiaWeb.MediaLive.Show.SeasonComponents
+
+  defp episode(attrs) do
+    struct!(
+      %Episode{monitored: true, air_date: ~D[2024-01-01], media_files: [], downloads: []},
+      attrs
+    )
+  end
+
+  setup %{conn: conn} do
+    # The app disables Oban in test (engine: false), so Oban.insert cannot run
+    # from the LiveView process. Start an isolated, manual-mode instance so the
+    # auto-search click in the bubbling guard can enqueue without a live queue.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Repo, engine: engine, testing: :manual})
+
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin), admin: admin}
+  end
+
+  describe "default_expanded_seasons/2" do
+    test "expands the next episode's season" do
+      media_item = %{
+        type: "tv_show",
+        episodes: [episode(season_number: 1), episode(season_number: 2)]
+      }
+
+      assert Helpers.default_expanded_seasons(media_item, episode(season_number: 2)) ==
+               MapSet.new([2])
+    end
+
+    test "falls back to the newest season when there is no next episode" do
+      media_item = %{
+        type: "tv_show",
+        episodes: [
+          episode(season_number: 1),
+          episode(season_number: 3),
+          episode(season_number: 2)
+        ]
+      }
+
+      assert Helpers.default_expanded_seasons(media_item, nil) == MapSet.new([3])
+    end
+
+    test "falls back to the newest season when the next episode names an unknown season" do
+      media_item = %{type: "tv_show", episodes: [episode(season_number: 1)]}
+
+      assert Helpers.default_expanded_seasons(media_item, episode(season_number: 9)) ==
+               MapSet.new([1])
+    end
+
+    test "expands nothing for a non-tv item or a show with no episodes" do
+      assert Helpers.default_expanded_seasons(%{type: "movie", episodes: []}, nil) == MapSet.new()
+
+      assert Helpers.default_expanded_seasons(%{type: "tv_show", episodes: []}, nil) ==
+               MapSet.new()
+    end
+  end
+
+  describe "season_episode_counts/1" do
+    test "counts downloaded, missing, upcoming, and total in one pass" do
+      episodes = [
+        episode(media_files: [%MediaFile{}]),
+        episode(air_date: ~D[2024-01-01], media_files: []),
+        episode(air_date: Date.add(Date.utc_today(), 30), media_files: []),
+        episode(air_date: nil, media_files: [])
+      ]
+
+      assert Helpers.season_episode_counts(episodes) == %{
+               available: 1,
+               missing: 1,
+               upcoming: 1,
+               total: 4
+             }
+    end
+
+    test "a future air_date counts as upcoming, never missing" do
+      episodes = [episode(air_date: Date.add(Date.utc_today(), 1), media_files: [])]
+
+      assert Helpers.season_episode_counts(episodes) == %{
+               available: 0,
+               missing: 0,
+               upcoming: 1,
+               total: 1
+             }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Restores per-season collapsibility on the TV show page, which PR #469's description claimed shipped in v0.10.0 but did not.

## Problem

Commit `d917b500` (the media-detail redesign) rewrote `episodes_section/1` and dropped both the `phx-click="toggle_season_expanded"` binding and the conditional render of the episode list, leaving the entire `expanded_seasons` state machine inert for ~8 months. On long shows the page rendered a single wall of episode rows. Reported by `t00n1x` in https://github.com/getmydia/mydia/pull/469#issuecomment-5304697017.

## Changes

- Extract the per-season block into a new `MydiaWeb.MediaLive.Show.SeasonComponents` module (`season_section/1`, `season_header/1`, `monitoring_icon/1`), taking `components.ex` from 1356 to ~1150 lines.
- Restore the disclosure: every season is a `<button>` toggle (chevron + `S{n}` badge + `{available}/{total}` + progress bar + status chip), with the five action buttons as siblings so a click on "auto search" never collapses the season mid-action.
- Default exactly one season open at mount — the next-episode season, else the newest, else none — via a new pure `Helpers.default_expanded_seasons/2` (reusing the existing `next_episode` assign, no new query).
- Add a status chip so a collapsed header still answers "is anything missing?" — `{n} missing` / `{n} upcoming` / `complete`, derived from a single pass over `EpisodeStatus.get_episode_status_with_downloads/1` so unaired episodes read `upcoming` (never `missing`) and in-flight downloads stay out of `missing`.
- Move the per-season `segment_status_row/1` inside the expanded region.

Render-only: no query, migration, or preload changes (`loaders.ex` still hydrates every episode at mount).

## Testing

New `test/mydia_web/live/media_live/show/season_collapse_test.exs` (`async: false`) covers: next-episode season expanded at mount, `:all_watched` fallback to the newest season, toggle expand/collapse, the auto-search non-bubbling guard, and all four chip states.

Full suite green (`mix precommit`: 8067 tests, 0 failures).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - TV show seasons now open to the season containing the next episode, making it easier to continue watching.
  - Season headers display episode availability counts, progress, and status indicators.
  - Seasons can be expanded or collapsed, with monitoring controls and episode actions available within each section.

- **Bug Fixes**
  - Improved initial season display when shows have no upcoming episode or contain no seasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->