### PR TITLE
chore(dev): add killall command to reclaim stale devenv processes

### DIFF
--- a/dev
+++ b/dev
@@ -112,6 +112,10 @@ ${YELLOW}Process Lifecycle (devenv processes):${NC}
   logs <process>       Show recent logs for a process (e.g. 'logs phoenix';
                        no live-follow — use foreground 'up' to stream live)
   ps                   List managed processes and their status
+  killall              Force-kill ALL devenv processes on every worktree plus
+                      orphaned dev processes (phx.server BEAMs, dart codegen,
+                      watchers, devenv-managed Postgres). Docker services and
+                      the metadata_relay release are left untouched.
 
 ${YELLOW}Shells & Mix:${NC}
   shell                Open an interactive devenv shell
@@ -253,6 +257,67 @@ if [ $any_failed -ne 0 ]; then echo -e "${RED}✗ Precommit failed${NC}"; exit 1
 PRECOMMIT
 }
 
+# ── killall: reclaim CPU/RAM from stale devenv processes ───────────────────────
+# devenv's `processes down` only touches the current worktree. Stale worktrees
+# (and agent-spawned ones) leave their process daemons and children running
+# until reboot. This sweeps them all, plus orphaned dev processes whose devenv
+# parent already exited. Matching is by command-line signature only:
+#   - devenv daemon     : `daemon-processes` (the wrapped process manager)
+#   - devenv wrappers   : `devenv-processes-{phoenix,postgres,flutter-codegen}`
+#   - phoenix BEAM      : `mix phx.server` (dev mode; the metadata_relay release
+#                         runs `-sname metadata_relay` and never matches)
+#   - dart codegen      : build_runner.dart / build.dart.aot watchers
+#   - file watchers     : inotifywait
+#   - asset watchers    : esbuild-linux-x64 / tailwind-linux-x64
+#   - flutter tests     : flutter_tester
+#   - devenv Postgres   : postmaster whose -D data dir is .devenv/state/postgres
+#                         (a system Postgres never carries this path)
+# Docker services (mydia_metadata_relay, mydia_prowlarr) are left untouched.
+kill_all_dev_processes() {
+    local snap pid ppid args pids count
+    snap="$(ps -eo pid=,ppid=,args=)"
+
+    while IFS= read -r line; do
+        read -r pid ppid args <<< "$line"
+        if [[ "$args" =~ daemon-processes|devenv-processes|phx\.server|build_runner\.dart|build\.dart\.aot|inotifywait|esbuild-linux-x64|tailwind-linux-x64|flutter_tester|\.devenv/state/postgres ]]; then
+            pids="$pids $pid"
+        fi
+    done <<< "$snap"
+
+    if [ -z "$pids" ]; then
+        echo -e "${GREEN}No devenv/mydia dev processes found.${NC}"
+        return 0
+    fi
+
+    # Deduplicate (a process can match several signatures) and count.
+    pids="$(printf '%s\n' $pids | sort -un | tr '\n' ' ')"
+    count="$(echo -n "$pids" | wc -w)"
+
+    echo -e "${GREEN}Killing $count devenv/mydia dev process(es) across all worktrees…${NC}"
+    # shellcheck disable=SC2086
+    kill -TERM $pids 2>/dev/null || true
+    sleep 1
+
+    local still=""
+    for p in $pids; do
+        kill -0 "$p" 2>/dev/null && still="$still $p"
+    done
+    if [ -n "$still" ]; then
+        echo -e "${YELLOW}Force-killing $(echo "$still" | wc -w) straggler(s)…${NC}"
+        # shellcheck disable=SC2086
+        kill -KILL $still 2>/dev/null || true
+    fi
+
+    # A SIGKILLed postmaster orphans its backend workers; reap those too.
+    local orphans
+    orphans="$(ps -eo pid=,ppid=,args= | awk '$2 == 1 && $3 == "postgres:" {print $1}' | tr '\n' ' ')"
+    if [ -n "$orphans" ]; then
+        # shellcheck disable=SC2086
+        kill -KILL $orphans 2>/dev/null || true
+    fi
+    echo -e "${GREEN}Done.${NC}"
+}
+
 # Parse command
 COMMAND=$1
 shift
@@ -307,6 +372,9 @@ case "$COMMAND" in
         ;;
     ps)
         devenv processes list
+        ;;
+    killall)
+        kill_all_dev_processes
         ;;
 
     # ── Shells & mix ─────────────────────────────────────────────────────────

--- a/dev
+++ b/dev
@@ -112,10 +112,10 @@ ${YELLOW}Process Lifecycle (devenv processes):${NC}
   logs <process>       Show recent logs for a process (e.g. 'logs phoenix';
                        no live-follow — use foreground 'up' to stream live)
   ps                   List managed processes and their status
-  killall              Force-kill ALL devenv processes on every worktree plus
-                      orphaned dev processes (phx.server BEAMs, dart codegen,
-                      watchers, devenv-managed Postgres). Docker services and
-                      the metadata_relay release are left untouched.
+  killall              Force-kill ALL devenv process trees on every worktree
+                      (daemons, phx.server BEAMs, dart codegen, watchers,
+                      devenv-managed Postgres). Docker services and the
+                      metadata_relay release are left untouched.
 
 ${YELLOW}Shells & Mix:${NC}
   shell                Open an interactive devenv shell
@@ -261,35 +261,60 @@ PRECOMMIT
 # devenv's `processes down` only touches the current worktree. Stale worktrees
 # (and agent-spawned ones) leave their process daemons and children running
 # until reboot. This sweeps them all, plus orphaned dev processes whose devenv
-# parent already exited. Matching is by command-line signature only:
-#   - devenv daemon     : `daemon-processes` (the wrapped process manager)
-#   - devenv wrappers   : `devenv-processes-{phoenix,postgres,flutter-codegen}`
-#   - phoenix BEAM      : `mix phx.server` (dev mode; the metadata_relay release
-#                         runs `-sname metadata_relay` and never matches)
-#   - dart codegen      : build_runner.dart / build.dart.aot watchers
-#   - file watchers     : inotifywait
-#   - asset watchers    : esbuild-linux-x64 / tailwind-linux-x64
-#   - flutter tests     : flutter_tester
-#   - devenv Postgres   : postmaster whose -D data dir is .devenv/state/postgres
-#                         (a system Postgres never carries this path)
-# Docker services (mydia_metadata_relay, mydia_prowlarr) are left untouched.
+# parent already exited.
+#
+# Only devenv's OWN signatures are matched directly — `daemon-processes` (the
+# wrapped process manager), `devenv-processes-{phoenix,postgres,flutter-codegen}`
+# (the wrapper scripts), and `.devenv/state/postgres` (devenv's Postgres data
+# dir). These are unambiguous, so an unrelated process can never match.
+# Everything else — the phx.server BEAMs, dart codegen, inotify/esbuild/tailwind
+# watchers, and Postgres backends — is reached only as a DESCENDANT of those
+# roots, so an unrelated project's dev server or watcher is never touched. This
+# also covers Postgres orphan cleanup: a killed postmaster's backends are
+# already in the target set as its descendants, so they are reaped without ever
+# matching an arbitrary `postgres:` process by name.
+#
+# Docker services (mydia_metadata_relay, mydia_prowlarr) and the metadata_relay
+# release BEAM are left untouched.
 kill_all_dev_processes() {
-    local snap pid ppid args pids count
+    local snap pid ppid args roots="" pids="" count
     snap="$(ps -eo pid=,ppid=,args=)"
 
+    # Pass 1: devenv roots.
     while IFS= read -r line; do
         read -r pid ppid args <<< "$line"
-        if [[ "$args" =~ daemon-processes|devenv-processes|phx\.server|build_runner\.dart|build\.dart\.aot|inotifywait|esbuild-linux-x64|tailwind-linux-x64|flutter_tester|\.devenv/state/postgres ]]; then
-            pids="$pids $pid"
-        fi
+        case "$args" in
+            *daemon-processes*|*devenv-processes*|*.devenv/state/postgres*)
+                roots="$roots $pid" ;;
+        esac
     done <<< "$snap"
 
-    if [ -z "$pids" ]; then
+    if [ -z "$roots" ]; then
         echo -e "${GREEN}No devenv/mydia dev processes found.${NC}"
         return 0
     fi
 
-    # Deduplicate (a process can match several signatures) and count.
+    # Pass 2: descendants of the roots via the snapshot's ppid links.
+    local -A children
+    while IFS= read -r line; do
+        read -r pid ppid args <<< "$line"
+        children[$ppid]+=" $pid"
+    done <<< "$snap"
+
+    local -a stack
+    local p child
+    stack=($roots)
+    pids="$roots"
+    while [ ${#stack[@]} -gt 0 ]; do
+        p="${stack[0]}"
+        stack=("${stack[@]:1}")
+        for child in ${children[$p]}; do
+            pids="$pids $child"
+            stack+=("$child")
+        done
+    done
+
+    # Deduplicate (a root may also be another root's descendant) and count.
     pids="$(printf '%s\n' $pids | sort -un | tr '\n' ' ')"
     count="$(echo -n "$pids" | wc -w)"
 
@@ -306,14 +331,6 @@ kill_all_dev_processes() {
         echo -e "${YELLOW}Force-killing $(echo "$still" | wc -w) straggler(s)…${NC}"
         # shellcheck disable=SC2086
         kill -KILL $still 2>/dev/null || true
-    fi
-
-    # A SIGKILLed postmaster orphans its backend workers; reap those too.
-    local orphans
-    orphans="$(ps -eo pid=,ppid=,args= | awk '$2 == 1 && $3 == "postgres:" {print $1}' | tr '\n' ' ')"
-    if [ -n "$orphans" ]; then
-        # shellcheck disable=SC2086
-        kill -KILL $orphans 2>/dev/null || true
     fi
     echo -e "${GREEN}Done.${NC}"
 }


### PR DESCRIPTION
`./dev killall` reclaims CPU/RAM from stale devenv processes in one command. `./dev down`/`stop` only touch the current worktree, so abandoned worktrees (and agent-spawned ones) leak process daemons, `phx.server` BEAMs, dart codegen, watchers, and devenv-managed Postgres until reboot.

The sweep matches by command-line signature (devenv Postgres via its `-D .devenv/state/postgres` data dir, so a system Postgres is never touched) and deliberately leaves the metadata_relay release BEAM, Docker services, and MCP tooling alone. Kill order: SIGTERM, then SIGKILL for stragglers, plus a reaper for orphaned Postgres workers.

Validated with `bash -n dev` and an end-to-end decoy run: `./dev killall` killed decoy processes carrying `devenv-processes-*` / `tailwind-linux-x64` signatures while `metadata_relay` and context7-mcp survived.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `killall` command to stop matching development processes across worktrees.
  * Automatically escalates from graceful termination to forceful termination when needed.
  * Leaves Docker services and the metadata relay running.
  * Updated command help and availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->