### PR TITLE
fix(search): stop nil-field crash blanking results; collapse indexer status

### DIFF
--- a/lib/mydia/downloads/release_validator.ex
+++ b/lib/mydia/downloads/release_validator.ex
@@ -63,8 +63,11 @@ defmodule Mydia.Downloads.ReleaseValidator do
   - `:yenc_pattern` - Raw usenet binary encoding
   - `:no_meaningful_content` - No extractable title content
   - `:suspicious_extension` - Release name ends in an executable extension
+  - `:no_title` - Release has a nil title (malformed result)
   """
-  @spec validate_release(String.t()) :: {:ok, String.t()} | {:error, atom()}
+  @spec validate_release(String.t() | nil) :: {:ok, String.t()} | {:error, atom()}
+  def validate_release(nil), do: {:error, :no_title}
+
   def validate_release(name) when is_binary(name) do
     cond do
       suspicious_extension?(name) ->

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -648,11 +648,15 @@ defmodule Mydia.Indexers do
     end
   end
 
+  defp extract_hash_from_url(nil), do: nil
+
   defp normalize_title(title) when is_binary(title) do
     title
     |> String.downcase()
     |> String.replace(~r/[^a-z0-9]+/, "")
   end
+
+  defp normalize_title(nil), do: ""
 
   defp merge_duplicates([single]), do: single
 
@@ -675,11 +679,16 @@ defmodule Mydia.Indexers do
     # Use the unified ReleaseRanker for consistent scoring across manual and automated searches
     # This provides sophisticated ranking with size scoring, age scoring, seeder ratio multipliers,
     # and title relevance scoring
-    ranked_results =
-      ReleaseRanker.rank_all(results, min_seeders: min_seeders, search_query: search_query)
+    {rankable, titleless} = Enum.split_with(results, &is_binary(&1.title))
 
-    # Extract the SearchResult from each RankedResult to maintain the expected return type
-    Enum.map(ranked_results, fn ranked -> ranked.result end)
+    ranked_results =
+      rankable
+      |> ReleaseRanker.rank_all(min_seeders: min_seeders, search_query: search_query)
+      |> Enum.map(fn ranked -> ranked.result end)
+
+    # A result with a nil title can't be relevance-ranked (ReleaseRanker expects
+    # a binary title); surface it after the ranked results instead of crashing.
+    ranked_results ++ titleless
   end
 
   defp indexer_config_to_adapter_config(%Settings.IndexerConfig{} = config) do

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -679,16 +679,11 @@ defmodule Mydia.Indexers do
     # Use the unified ReleaseRanker for consistent scoring across manual and automated searches
     # This provides sophisticated ranking with size scoring, age scoring, seeder ratio multipliers,
     # and title relevance scoring
-    {rankable, titleless} = Enum.split_with(results, &is_binary(&1.title))
-
     ranked_results =
-      rankable
-      |> ReleaseRanker.rank_all(min_seeders: min_seeders, search_query: search_query)
-      |> Enum.map(fn ranked -> ranked.result end)
+      ReleaseRanker.rank_all(results, min_seeders: min_seeders, search_query: search_query)
 
-    # A result with a nil title can't be relevance-ranked (ReleaseRanker expects
-    # a binary title); surface it after the ranked results instead of crashing.
-    ranked_results ++ titleless
+    # Extract the SearchResult from each RankedResult to maintain the expected return type
+    Enum.map(ranked_results, fn ranked -> ranked.result end)
   end
 
   defp indexer_config_to_adapter_config(%Settings.IndexerConfig{} = config) do

--- a/lib/mydia_web/components/indexer_components.ex
+++ b/lib/mydia_web/components/indexer_components.ex
@@ -55,7 +55,11 @@ defmodule MydiaWeb.IndexerComponents do
         </summary>
         <div class="collapse-content">
           <ul class="menu w-full">
-            <li :for={row <- @rows} class="flex items-center gap-2">
+            <li
+              :for={row <- @rows}
+              id={"indexer-status-#{row.indexer_id}"}
+              class="flex items-center gap-2"
+            >
               <span :if={row.status == :pending} class="loading loading-spinner loading-xs"></span>
               <.icon
                 :if={row.status == :ok}

--- a/lib/mydia_web/components/indexer_components.ex
+++ b/lib/mydia_web/components/indexer_components.ex
@@ -15,8 +15,9 @@ defmodule MydiaWeb.IndexerComponents do
   alias Mydia.Indexers.Structs.IndexerProgress
 
   @doc """
-  Renders one chip per indexer, showing whether it is still searching, how many
-  results it returned, or why it failed.
+  Renders a collapsed summary of the search's progress — total results,
+  completion count, and a failed count — with an expandable `<details>` list of
+  one row per indexer.
 
   `progress` is a map of `indexer_id => %IndexerProgress{}`. Pass `retry_event`
   to render a retry button on failed and timed-out indexers; the button sends
@@ -26,55 +27,79 @@ defmodule MydiaWeb.IndexerComponents do
   attr :retry_event, :string, default: nil
 
   def indexer_search_status(assigns) do
-    assigns = assign(assigns, :rows, sort_rows(assigns.progress))
+    rows = sort_rows(assigns.progress)
+
+    total_results =
+      rows
+      |> Enum.filter(&(&1.status == :ok))
+      |> Enum.reduce(0, &(&2 + (&1.result_count || 0)))
+
+    done = Enum.count(rows, &(&1.status in [:ok, :error, :timeout]))
+    total = length(rows)
+    failed = Enum.count(rows, &(&1.status in [:error, :timeout]))
+
+    assigns =
+      assigns
+      |> assign(:rows, rows)
+      |> assign(:total_results, total_results)
+      |> assign(:done, done)
+      |> assign(:total, total)
+      |> assign(:failed, failed)
 
     ~H"""
     <div :if={@rows != []} id="indexer-search-status" class="mb-4">
-      <div class="flex flex-wrap items-center gap-2">
-        <div
-          :for={row <- @rows}
-          id={"indexer-status-#{row.indexer_id}"}
-          class={["badge badge-lg gap-2 py-3", status_class(row.status)]}
-        >
-          <span :if={row.status == :pending} class="loading loading-spinner loading-xs"></span>
-          <.icon :if={row.status == :ok} name="hero-check-circle" class="w-4 h-4 shrink-0" />
-          <.icon
-            :if={row.status == :error}
-            name="hero-exclamation-triangle"
-            class="w-4 h-4 shrink-0"
-          />
-          <.icon :if={row.status == :timeout} name="hero-clock" class="w-4 h-4 shrink-0" />
+      <details class="collapse collapse-arrow bg-base-200/50 border border-base-300">
+        <summary class="collapse-title text-sm font-medium flex items-center gap-2">
+          <span>{@total_results} results · {@done}/{@total} indexers</span>
+          <span :if={@failed > 0} class="badge badge-sm badge-error">{@failed} failed</span>
+        </summary>
+        <div class="collapse-content">
+          <ul class="menu w-full">
+            <li :for={row <- @rows} class="flex items-center gap-2">
+              <span :if={row.status == :pending} class="loading loading-spinner loading-xs"></span>
+              <.icon
+                :if={row.status == :ok}
+                name="hero-check-circle"
+                class="w-4 h-4 shrink-0 text-success"
+              />
+              <.icon
+                :if={row.status == :error}
+                name="hero-exclamation-triangle"
+                class="w-4 h-4 shrink-0 text-error"
+              />
+              <.icon
+                :if={row.status == :timeout}
+                name="hero-clock"
+                class="w-4 h-4 shrink-0 text-warning"
+              />
 
-          <span class="font-medium">{row.indexer}</span>
-          <span class="text-xs opacity-70">{status_label(row)}</span>
+              <span class="font-medium">{row.indexer}</span>
+              <span class="text-xs opacity-70">{status_label(row)}</span>
 
-          <button
-            :if={@retry_event && row.status in [:error, :timeout]}
-            type="button"
-            class="btn btn-ghost btn-xs"
-            phx-click={@retry_event}
-            phx-value-id={row.indexer_id}
-          >
-            Retry
-          </button>
+              <button
+                :if={@retry_event && row.status in [:error, :timeout]}
+                type="button"
+                class="btn btn-ghost btn-xs"
+                phx-click={@retry_event}
+                phx-value-id={row.indexer_id}
+              >
+                Retry
+              </button>
+            </li>
+          </ul>
         </div>
-      </div>
+      </details>
     </div>
     """
   end
 
-  # Sorted by name so chips keep a stable position as indexers settle out of
+  # Sorted by name so rows keep a stable position as indexers settle out of
   # order. Sorting by status would make rows jump around mid-search.
   defp sort_rows(progress) do
     progress
     |> Map.values()
     |> Enum.sort_by(& &1.indexer)
   end
-
-  defp status_class(:pending), do: "badge-ghost"
-  defp status_class(:ok), do: "badge-success badge-outline"
-  defp status_class(:error), do: "badge-error badge-outline"
-  defp status_class(:timeout), do: "badge-warning badge-outline"
 
   defp status_label(%IndexerProgress{status: :pending}), do: "searching..."
 

--- a/lib/mydia_web/components/indexer_components.ex
+++ b/lib/mydia_web/components/indexer_components.ex
@@ -10,7 +10,7 @@ defmodule MydiaWeb.IndexerComponents do
 
   use Phoenix.Component
 
-  import MydiaWeb.CoreComponents, only: [icon: 1]
+  import MydiaWeb.CoreComponents, only: [button: 1, icon: 1]
 
   alias Mydia.Indexers.Structs.IndexerProgress
 
@@ -80,7 +80,7 @@ defmodule MydiaWeb.IndexerComponents do
               <span class="font-medium">{row.indexer}</span>
               <span class="text-xs opacity-70">{status_label(row)}</span>
 
-              <button
+              <.button
                 :if={@retry_event && row.status in [:error, :timeout]}
                 type="button"
                 class="btn btn-ghost btn-xs"
@@ -88,7 +88,7 @@ defmodule MydiaWeb.IndexerComponents do
                 phx-value-id={row.indexer_id}
               >
                 Retry
-              </button>
+              </.button>
             </li>
           </ul>
         </div>

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -783,5 +783,21 @@ defmodule Mydia.IndexersTest do
 
       assert length(ranked) == 2
     end
+
+    test "rank_and_dedupe/3 survives nil download_url and title" do
+      result = %SearchResult{
+        title: "Dune.2021.1080p.BluRay",
+        download_url: nil,
+        seeders: 100,
+        size: 8_000_000_000,
+        leechers: 2,
+        indexer: "tracker"
+      }
+
+      assert [_] = Indexers.rank_and_dedupe([result], "Dune", [])
+
+      nil_title = %{result | title: nil, download_url: "magnet:?xt=urn:btih:abc"}
+      assert [_] = Indexers.rank_and_dedupe([nil_title], "Dune", [])
+    end
   end
 end

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -784,7 +784,7 @@ defmodule Mydia.IndexersTest do
       assert length(ranked) == 2
     end
 
-    test "rank_and_dedupe/3 survives nil download_url and title" do
+    test "rank_and_dedupe/3 survives nil download_url and drops nil title" do
       result = %SearchResult{
         title: "Dune.2021.1080p.BluRay",
         download_url: nil,
@@ -797,7 +797,7 @@ defmodule Mydia.IndexersTest do
       assert [_] = Indexers.rank_and_dedupe([result], "Dune", [])
 
       nil_title = %{result | title: nil, download_url: "magnet:?xt=urn:btih:abc"}
-      assert [_] = Indexers.rank_and_dedupe([nil_title], "Dune", [])
+      assert [] = Indexers.rank_and_dedupe([nil_title], "Dune", [])
     end
   end
 end

--- a/test/mydia_web/components/indexer_components_test.exs
+++ b/test/mydia_web/components/indexer_components_test.exs
@@ -28,7 +28,7 @@ defmodule MydiaWeb.IndexerComponentsTest do
         retry_event: "retry_indexer"
       )
 
-    assert html =~ "5 results"
+    assert html =~ "5 results · 2/3 indexers"
     assert html =~ "2/3 indexers"
     assert html =~ "1 failed"
 

--- a/test/mydia_web/components/indexer_components_test.exs
+++ b/test/mydia_web/components/indexer_components_test.exs
@@ -9,28 +9,56 @@ defmodule MydiaWeb.IndexerComponentsTest do
     Map.new(entries, fn entry -> {entry.indexer_id, entry} end)
   end
 
-  test "renders a row per indexer with a stable DOM id" do
-    progress =
-      progress_map([
-        %IndexerProgress{indexer: "Prowlarr", indexer_id: "a", status: :pending, total: 2},
-        %IndexerProgress{
-          indexer: "Nyaa",
-          indexer_id: "b",
-          status: :ok,
-          result_count: 12,
-          duration_ms: 840,
-          total: 2
-        }
-      ])
+  test "summary shows total results, completion, and hides the detail by default" do
+    progress = %{
+      "a" => %IndexerProgress{
+        indexer_id: "a",
+        indexer: "Alpha",
+        status: :ok,
+        result_count: 5,
+        duration_ms: 400
+      },
+      "b" => %IndexerProgress{indexer_id: "b", indexer: "Beta", status: :pending},
+      "c" => %IndexerProgress{indexer_id: "c", indexer: "Gamma", status: :error, error: "boom"}
+    }
 
     html =
-      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: progress)
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1,
+        progress: progress,
+        retry_event: "retry_indexer"
+      )
+
+    assert html =~ "5 results"
+    assert html =~ "2/3 indexers"
+    assert html =~ "1 failed"
+
+    # The detail list is collapsed by default: <details> has no `open` attribute.
+    document = LazyHTML.from_fragment(html)
+    assert LazyHTML.query(document, "details[open]") |> Enum.empty?()
+  end
+
+  test "failed row renders a retry button with the indexer id" do
+    progress = %{
+      "c" => %IndexerProgress{indexer_id: "c", indexer: "Gamma", status: :error, error: "boom"}
+    }
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1,
+        progress: progress,
+        retry_event: "retry_indexer"
+      )
+
+    assert html =~ ~s(phx-click="retry_indexer")
+    assert html =~ ~s(phx-value-id="c")
+  end
+
+  test "renders nothing when there is no progress" do
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: %{})
 
     document = LazyHTML.from_fragment(html)
 
-    assert LazyHTML.query(document, "#indexer-status-a") |> Enum.count() == 1
-    assert LazyHTML.query(document, "#indexer-status-b") |> Enum.count() == 1
-    assert html =~ "12 results"
+    assert LazyHTML.query(document, "#indexer-search-status") |> Enum.empty?()
   end
 
   test "a pending indexer shows a spinner and no retry button" do
@@ -47,8 +75,8 @@ defmodule MydiaWeb.IndexerComponentsTest do
 
     document = LazyHTML.from_fragment(html)
 
-    assert LazyHTML.query(document, "#indexer-status-a .loading") |> Enum.count() == 1
-    assert LazyHTML.query(document, "#indexer-status-a button") |> Enum.empty?()
+    assert LazyHTML.query(document, "#indexer-search-status .loading") |> Enum.count() == 1
+    assert LazyHTML.query(document, "#indexer-search-status button") |> Enum.empty?()
   end
 
   test "a failed indexer shows its error and a retry button when the event is given" do
@@ -69,10 +97,15 @@ defmodule MydiaWeb.IndexerComponentsTest do
         retry_event: "retry_indexer"
       )
 
+    assert html =~ "econnrefused"
+
     document = LazyHTML.from_fragment(html)
 
-    assert html =~ "econnrefused"
-    assert LazyHTML.query(document, "#indexer-status-c button") |> Enum.count() == 1
+    assert LazyHTML.query(document, "#indexer-search-status button") |> Enum.count() == 1
+
+    assert LazyHTML.query(document, "#indexer-search-status button")
+           |> LazyHTML.attribute("phx-value-id") ==
+             ["c"]
   end
 
   test "a timed-out indexer renders without a retry button when no event is given" do
@@ -90,19 +123,11 @@ defmodule MydiaWeb.IndexerComponentsTest do
     html =
       render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: progress)
 
-    document = LazyHTML.from_fragment(html)
-
     assert html =~ "timed out"
-    assert LazyHTML.query(document, "#indexer-status-d button") |> Enum.empty?()
-  end
-
-  test "renders nothing when there is no progress" do
-    html =
-      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: %{})
 
     document = LazyHTML.from_fragment(html)
 
-    assert LazyHTML.query(document, "#indexer-search-status") |> Enum.empty?()
+    assert LazyHTML.query(document, "#indexer-search-status button") |> Enum.empty?()
   end
 
   test "rows render in alphabetical order by indexer name, regardless of status or map order" do
@@ -131,12 +156,12 @@ defmodule MydiaWeb.IndexerComponentsTest do
 
     document = LazyHTML.from_fragment(html)
 
-    ids =
+    names =
       document
-      |> LazyHTML.query("#indexer-search-status [id^=\"indexer-status-\"]")
-      |> LazyHTML.attribute("id")
+      |> LazyHTML.query("#indexer-search-status ul li .font-medium")
+      |> LazyHTML.text(separator: ",")
 
-    assert ids == ["indexer-status-a", "indexer-status-m", "indexer-status-z"]
+    assert names == "Alpha,Mango,Zeta"
   end
 
   test "a timed-out indexer shows a retry button when the event is given" do
@@ -159,7 +184,7 @@ defmodule MydiaWeb.IndexerComponentsTest do
 
     document = LazyHTML.from_fragment(html)
 
-    buttons = LazyHTML.query(document, "#indexer-status-d button")
+    buttons = LazyHTML.query(document, "#indexer-search-status button")
 
     assert LazyHTML.attribute(buttons, "phx-value-id") == ["d"]
   end
@@ -185,6 +210,6 @@ defmodule MydiaWeb.IndexerComponentsTest do
 
     document = LazyHTML.from_fragment(html)
 
-    assert LazyHTML.query(document, "#indexer-status-b button") |> Enum.empty?()
+    assert LazyHTML.query(document, "#indexer-search-status button") |> Enum.empty?()
   end
 end

--- a/test/mydia_web/live/media_live/manual_search_streaming_test.exs
+++ b/test/mydia_web/live/media_live/manual_search_streaming_test.exs
@@ -36,6 +36,49 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
     "search-result-#{String.pad_leading(Integer.to_string(pos), 5, "0")}-#{hash}"
   end
 
+  # The raw Prowlarr JSON item returned by the Bypass indexer in the
+  # real-fan-out test below. `magnetUrl` is what Adapter.Prowlarr turns into
+  # the result's download_url, and `indexer` names the upstream tracker (as
+  # opposed to the configured indexer's own name).
+  defp real_result_item(title) do
+    %{
+      "title" => title,
+      "size" => 8_000_000_000,
+      "seeders" => 100,
+      "leechers" => 5,
+      "magnetUrl" => "magnet:?xt=urn:btih:#{:erlang.phash2(title)}",
+      "indexer" => "upstream"
+    }
+  end
+
+  # The %SearchResult{} Adapter.Prowlarr builds from real_result_item/1,
+  # mirroring the parse so the test can compute the positioned DOM id the real
+  # result row will render under. Only the fields participate in the dom id
+  # (download_url + indexer) and the ranking survival (title + seeders).
+  defp real_result(title) do
+    %Mydia.Indexers.SearchResult{
+      title: title,
+      download_url: "magnet:?xt=urn:btih:#{:erlang.phash2(title)}",
+      indexer: "upstream",
+      size: 8_000_000_000,
+      seeders: 100,
+      leechers: 5
+    }
+  end
+
+  defp wait_until_result_renders(view, row, retries \\ 200) do
+    if retries == 0 do
+      flunk("timed out waiting for #{row} to render")
+    else
+      if has_element?(view, row) do
+        :ok
+      else
+        Process.sleep(10)
+        wait_until_result_renders(view, row, retries - 1)
+      end
+    end
+  end
+
   # Mirrors MydiaWeb.SearchLive.StreamingTest's fixture of the same name: a
   # real indexer whose HTTP call is parked behind a Bypass server that sleeps
   # past the test's lifetime. Retrying an indexer starts a second real search
@@ -854,5 +897,38 @@ defmodule MydiaWeb.MediaLive.ManualSearchStreamingTest do
     |> render_change(%{"quality" => "", "min_seeders" => "0"})
 
     assert has_element?(view, "##{positioned_result_dom_id(dune)}")
+  end
+
+  # Every test above injects %IndexerProgress{} directly and never runs the
+  # real Indexers.search_all/2 fan-out — the exact gap that let the nil-field
+  # crash ship. This test drives the real fan-out through a Bypass-backed
+  # Prowlarr indexer returning realistic JSON and asserts the parsed result
+  # row renders, proving the end-to-end path (Prowlarr parse -> rank/dedupe ->
+  # apply_indexer_progress -> stream) survives without injected progress.
+  test "a real search_all fan-out renders a result in the manual search modal", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune", type: "movie"})
+    bypass = Bypass.open()
+
+    Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!([real_result_item("Dune.2021.1080p.BluRay")]))
+    end)
+
+    indexer_config_fixture(%{
+      name: "real-indexer",
+      type: :prowlarr,
+      base_url: "http://localhost:#{bypass.port}"
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    view |> element("#manual-search-button") |> render_click()
+
+    row = "##{positioned_result_dom_id(real_result("Dune.2021.1080p.BluRay"))}"
+
+    wait_until_result_renders(view, row)
+
+    assert has_element?(view, row)
   end
 end

--- a/test/mydia_web/live/search_live/real_fanout_test.exs
+++ b/test/mydia_web/live/search_live/real_fanout_test.exs
@@ -1,0 +1,56 @@
+defmodule MydiaWeb.SearchLive.RealFanoutTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.SettingsFixtures
+
+  setup %{conn: conn} do
+    {conn, _user} = register_and_log_in_user(conn)
+    %{conn: conn}
+  end
+
+  defp real_result_item(title) do
+    %{
+      "title" => title,
+      "size" => 8_000_000_000,
+      "seeders" => 100,
+      "leechers" => 5,
+      "magnetUrl" => "magnet:?xt=urn:btih:#{:erlang.phash2(title)}",
+      "indexer" => "upstream"
+    }
+  end
+
+  defp eventually(view, assertion, retries \\ 100) do
+    if retries == 0 do
+      flunk("timed out waiting for assertion")
+    else
+      html = render(view)
+
+      if assertion.(html),
+        do: html,
+        else: Process.sleep(50) && eventually(view, assertion, retries - 1)
+    end
+  end
+
+  test "a real search_all fan-out renders results on /search", %{conn: conn} do
+    bypass = Bypass.open()
+
+    Bypass.expect(bypass, "GET", "/api/v1/search", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!([real_result_item("Dune.2021.1080p.BluRay")]))
+    end)
+
+    indexer_config_fixture(%{
+      name: "real-indexer",
+      type: :prowlarr,
+      base_url: "http://localhost:#{bypass.port}"
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/search")
+    render_patch(view, ~p"/search?q=Dune")
+
+    html = eventually(view, fn html -> html =~ "search-results-count" end)
+    assert html =~ "Dune.2021.1080p.BluRay"
+  end
+end


### PR DESCRIPTION
## Summary

Two fixes to the streaming indexer search (#474) that landed broken.

1. **No results despite trackers returning results.** The incremental fold crashed with `FunctionClauseError` on any `SearchResult` with a nil `download_url` or nil `title` — reachable via Cardigann's `resolve_url(nil, _) -> nil` — which raised inside the LiveView's `apply_indexer_progress/2` and killed the LiveView mid-search. `extract_hash_from_url/1` and `normalize_title/1` now handle nil, and `ReleaseValidator.validate_release/1` drops nil-title releases at the single `ReleaseRanker.rank_all/2` choke point (so both the search page and the manual-search modal are covered).

2. **Oversized per-indexer status strip.** Replaced the one-`badge-lg`-per-indexer row with a collapsed daisyUI summary (`N results · X/Y indexers`, plus a `failed` badge only when failures exist) whose expandable detail keeps the per-indexer status and Retry button.

## Changes

- `lib/mydia/indexers.ex` — nil-safe `extract_hash_from_url/1` / `normalize_title/1`.
- `lib/mydia/downloads/release_validator.ex` — `validate_release(nil) -> {:error, :no_title}`.
- `lib/mydia_web/components/indexer_components.ex` — summary + collapsed `<details>` detail (attr surface unchanged).
- Tests: nil-field unit tests, component summary/detail tests, and real-`search_all/2` fan-out regression tests on both `/search` and the manual-search modal (the earlier tests injected `IndexerProgress` directly and never exercised the real fan-out).

## Verification

`mix precommit` green: compile, `format --check-formatted`, `credo --strict` (0 issues), full suite 8123 tests / 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a collapsible indexer search status summary with result totals, completion status, failures, and per-indexer details.
  - Added status-specific indicators and retry controls for failed or timed-out indexers.
  - Improved visibility of search results as they arrive during manual and full searches.

- **Bug Fixes**
  - Improved handling of searches with missing titles or download URLs to prevent errors.
  - Improved resilience when indexers return incomplete or unavailable result information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->