### PR TITLE
fix(import): restore library icons, show scan progress, never strand a run

### DIFF
--- a/lib/mydia/jobs/import_run.ex
+++ b/lib/mydia/jobs/import_run.ex
@@ -92,15 +92,28 @@ defmodule Mydia.Jobs.ImportRun do
   end
 
   defp execute(run, job) do
-    with :ok <- run_scan_phase(run),
-         :ok <- run_match_phase(Library.get_import_run(run.id)) do
-      finish(run, :done)
-    else
-      :stopped ->
-        finish(run, :stopped)
+    try do
+      with :ok <- run_scan_phase(run),
+           :ok <- run_match_phase(Library.get_import_run(run.id)) do
+        finish(run, :done)
+      else
+        :stopped ->
+          finish(run, :stopped)
 
-      {:error, reason} ->
-        fail(run, reason, job)
+        {:error, reason} ->
+          fail(run, reason, job)
+      end
+    rescue
+      # A crash that escapes the phases above still has to take the run to a
+      # terminal state. Without this, an exception (for example
+      # `Ecto.MultipleResultsError` on a duplicate row) makes Oban discard the
+      # job after its retries while the run row stays `:running` forever: Start
+      # is refused, Stop only writes `:stopping` (also active), and the panel
+      # spins with no worker behind it. `fail/3` writes `:failed` on the final
+      # attempt and keeps the run active otherwise, matching the returned-error
+      # path exactly.
+      error ->
+        fail(run, error, job)
     end
   end
 
@@ -223,7 +236,12 @@ defmodule Mydia.Jobs.ImportRun do
   end
 
   defp scan_tree(run, library_path, extensions, after_batch) do
-    case Scanner.scan(library_path.path, video_extensions: extensions) do
+    path_callback = fn path -> note_scan_path(run, library_path, path) end
+
+    case Scanner.scan(library_path.path,
+           video_extensions: extensions,
+           path_callback: path_callback
+         ) do
       {:ok, scan_result} ->
         scan_result.files
         |> Enum.reject(&sample_or_extra?/1)
@@ -254,10 +272,10 @@ defmodule Mydia.Jobs.ImportRun do
         Enum.count(batch, fn file_info ->
           relative_path = Path.relative_to(file_info.path, library_path.path)
 
-          case Library.get_media_file_by_relative_path(library_path.id, relative_path,
+          case Library.list_media_files_by_relative_path(library_path.id, relative_path,
                  include_trashed: true
                ) do
-            nil ->
+            [] ->
               case Library.create_scanned_media_file(%{
                      library_path_id: library_path.id,
                      relative_path: relative_path,
@@ -268,12 +286,19 @@ defmodule Mydia.Jobs.ImportRun do
                 {:error, _} -> false
               end
 
-            %{trashed_at: trashed_at} = trashed when not is_nil(trashed_at) ->
-              match?({:ok, _}, Library.restore_media_file(trashed))
+            existing ->
+              # A file is "already recorded" when any live row exists, even
+              # alongside a trashed duplicate -- restoring the trashed copy
+              # would resurrect a path that is already owned. Only when every
+              # row is trashed does a restore make sense.
+              case Enum.find(existing, &is_nil(&1.trashed_at)) do
+                nil ->
+                  match?({:ok, _}, Library.restore_media_file(List.first(existing)))
 
-            _existing ->
-              # Already recorded by an earlier run. This is the resume path.
-              false
+                _live ->
+                  # Already recorded by an earlier run. This is the resume path.
+                  false
+              end
           end
         end)
       end)
@@ -424,6 +449,25 @@ defmodule Mydia.Jobs.ImportRun do
       Mydia.PubSub,
       progress_topic(run.id),
       {:import_run_current_file, Path.basename(path)}
+    )
+  end
+
+  # Reports the directory or file the scanner is walking, relative to the
+  # library root, so "Finding files" shows *what* it is looking at rather than
+  # an anonymous spinner. The scan phase writes no run row per path (a full
+  # library would turn this into a write storm), so this is PubSub-only, the
+  # same contract `note_current_file/2` uses during matching.
+  defp note_scan_path(run, library_path, path) do
+    relative =
+      case Path.relative_to(path, library_path.path) do
+        "." -> Path.basename(library_path.path)
+        rel -> rel
+      end
+
+    Phoenix.PubSub.broadcast(
+      Mydia.PubSub,
+      progress_topic(run.id),
+      {:import_run_current_file, relative}
     )
   end
 

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -140,6 +140,32 @@ defmodule Mydia.Library do
   end
 
   @doc """
+  Returns every media file at a relative path, live files first.
+
+  `get_media_file_by_relative_path/3` raises `Ecto.MultipleResultsError` when
+  duplicate rows exist for one path, a state the database has reached before
+  (a path imported by two builds of the scanner). Callers that only need to
+  answer "does this file already exist" use this instead so a duplicate row is
+  data to skip, not a crash.
+  """
+  @spec list_media_files_by_relative_path(binary(), String.t(), keyword()) :: [MediaFile.t()]
+  def list_media_files_by_relative_path(library_path_id, relative_path, opts \\ []) do
+    query =
+      MediaFile
+      |> where([f], f.library_path_id == ^library_path_id and f.relative_path == ^relative_path)
+
+    query =
+      if Keyword.get(opts, :include_trashed, false),
+        do: query,
+        else: where(query, [f], is_nil(f.trashed_at))
+
+    query
+    |> order_by([f], asc: f.trashed_at)
+    |> maybe_preload(opts[:preload])
+    |> Repo.all()
+  end
+
+  @doc """
   Returns true when the episode already has a media file that has not been trashed.
 
   Used by the importer to skip season-pack files for episodes the library
@@ -2499,45 +2525,6 @@ defmodule Mydia.Library do
 
       run ->
         update_import_run(run, %{status: :stopping})
-    end
-  end
-
-  @doc """
-  Forces an active run into a terminal state.
-
-  The escape hatch for a run boot reconciliation could not reach: the node
-  never restarted, so nothing ran the sweep, but the coordinator is gone all
-  the same (a cancelled job, a killed queue). Without this the only recovery
-  is editing the database by hand.
-
-  Re-reads and refuses a run that is already terminal, mirroring
-  `request_import_run_stop/1`. Same race, same shape: the run can reach `:done`
-  between the panel rendering and the click landing, and overwriting that with
-  `:stopped` would throw away the real outcome and replace it with a message
-  saying a human ended it.
-  """
-  @spec release_import_run(ImportRun.t() | binary()) ::
-          {:ok, ImportRun.t()}
-          | {:error, :not_active | :not_found | Ecto.Changeset.t()}
-  def release_import_run(%ImportRun{id: id}), do: release_import_run(id)
-
-  def release_import_run(id) when is_binary(id) do
-    case get_import_run(id) do
-      nil ->
-        {:error, :not_found}
-
-      %ImportRun{status: status} = run ->
-        if status in ImportRun.active_statuses() do
-          update_import_run(run, %{
-            status: :stopped,
-            phase: :finished,
-            current_file: nil,
-            error:
-              "Marked as not running from the import page. Everything it had already added was kept."
-          })
-        else
-          {:error, :not_active}
-        end
     end
   end
 

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -160,7 +160,7 @@ defmodule Mydia.Library do
         else: where(query, [f], is_nil(f.trashed_at))
 
     query
-    |> order_by([f], asc: f.trashed_at)
+    |> order_by([f], asc_nulls_first: f.trashed_at)
     |> maybe_preload(opts[:preload])
     |> Repo.all()
   end

--- a/lib/mydia/library/scanner.ex
+++ b/lib/mydia/library/scanner.ex
@@ -33,6 +33,7 @@ defmodule Mydia.Library.Scanner do
     - `:recursive` - Whether to scan subdirectories (default: true)
     - `:video_extensions` - List of video file extensions to detect (default: common formats)
     - `:progress_callback` - Function called with progress updates (file_count)
+    - `:path_callback` - Function called with each directory entered and each video file found
 
   ## Examples
 
@@ -48,12 +49,13 @@ defmodule Mydia.Library.Scanner do
     recursive = Keyword.get(opts, :recursive, true)
     extensions = Keyword.get(opts, :video_extensions, @video_extensions)
     progress_callback = Keyword.get(opts, :progress_callback)
+    path_callback = Keyword.get(opts, :path_callback)
 
     Logger.info("Starting library scan", directory: directory_path, recursive: recursive)
 
     case validate_directory(directory_path) do
       :ok ->
-        result = do_scan(directory_path, recursive, extensions, progress_callback)
+        result = do_scan(directory_path, recursive, extensions, progress_callback, path_callback)
 
         Logger.info("Library scan completed",
           directory: directory_path,
@@ -187,7 +189,7 @@ defmodule Mydia.Library.Scanner do
     end
   end
 
-  defp do_scan(directory_path, recursive, extensions, progress_callback) do
+  defp do_scan(directory_path, recursive, extensions, progress_callback, path_callback) do
     initial_state = %{
       files: [],
       errors: [],
@@ -196,7 +198,14 @@ defmodule Mydia.Library.Scanner do
     }
 
     result =
-      walk_directory(directory_path, recursive, extensions, progress_callback, initial_state)
+      walk_directory(
+        directory_path,
+        recursive,
+        extensions,
+        progress_callback,
+        path_callback,
+        initial_state
+      )
 
     %{
       files: Enum.reverse(result.files),
@@ -206,12 +215,14 @@ defmodule Mydia.Library.Scanner do
     }
   end
 
-  defp walk_directory(path, recursive, extensions, progress_callback, state) do
+  defp walk_directory(path, recursive, extensions, progress_callback, path_callback, state) do
+    if path_callback, do: path_callback.(path)
+
     case File.ls(path) do
       {:ok, entries} ->
         Enum.reduce(entries, state, fn entry, acc ->
           full_path = Path.join(path, entry)
-          process_entry(full_path, recursive, extensions, progress_callback, acc)
+          process_entry(full_path, recursive, extensions, progress_callback, path_callback, acc)
         end)
 
       {:error, reason} ->
@@ -221,12 +232,12 @@ defmodule Mydia.Library.Scanner do
     end
   end
 
-  defp process_entry(path, recursive, extensions, progress_callback, state) do
+  defp process_entry(path, recursive, extensions, progress_callback, path_callback, state) do
     # Use lstat to detect symlinks without following them
     case File.lstat(path) do
       {:ok, %File.Stat{type: :directory}} ->
         if recursive and not trash_directory?(path) do
-          walk_directory(path, recursive, extensions, progress_callback, state)
+          walk_directory(path, recursive, extensions, progress_callback, path_callback, state)
         else
           state
         end
@@ -238,11 +249,11 @@ defmodule Mydia.Library.Scanner do
             if trash_directory?(path) do
               state
             else
-              walk_directory(path, recursive, extensions, progress_callback, state)
+              walk_directory(path, recursive, extensions, progress_callback, path_callback, state)
             end
 
           {:ok, %File.Stat{type: :regular}} ->
-            process_file(path, extensions, progress_callback, state)
+            process_file(path, extensions, progress_callback, path_callback, state)
 
           {:ok, _} ->
             state
@@ -254,7 +265,7 @@ defmodule Mydia.Library.Scanner do
         end
 
       {:ok, %File.Stat{type: :regular}} ->
-        process_file(path, extensions, progress_callback, state)
+        process_file(path, extensions, progress_callback, path_callback, state)
 
       {:ok, _} ->
         # Other file types (device, pipe, etc.) - skip
@@ -275,13 +286,15 @@ defmodule Mydia.Library.Scanner do
   # row, undoing the trash.
   defp trash_directory?(path), do: Path.basename(path) == TrashStore.dir_name()
 
-  defp process_file(path, extensions, progress_callback, state) do
+  defp process_file(path, extensions, progress_callback, path_callback, state) do
     if video_file?(path, extensions) do
       case extract_file_metadata(path) do
         {:ok, file_info} ->
           new_count = state.file_count + 1
 
-          # Report progress every 100 files
+          # Report the file and, every 100 files, a count.
+          if path_callback, do: path_callback.(path)
+
           if progress_callback && rem(new_count, 100) == 0 do
             progress_callback.(new_count)
           end

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -158,31 +158,6 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     end
   end
 
-  def handle_event("release_run", _params, socket) do
-    with :ok <- Authorization.authorize_import_media(socket) do
-      case socket.assigns.active_run do
-        nil ->
-          {:noreply, socket}
-
-        run ->
-          case Library.release_import_run(run.id) do
-            {:ok, released} ->
-              {:noreply,
-               socket
-               |> show_outcome(released)
-               |> put_flash(:info, "Marked as not running. You can start a new import now.")}
-
-            # Already terminal, or gone. Either way there is nothing to
-            # release, and the run's real outcome is what should be on screen.
-            {:error, _reason} ->
-              {:noreply, show_outcome(socket, Library.get_import_run(run.id))}
-          end
-      end
-    else
-      {:unauthorized, socket} -> {:noreply, socket}
-    end
-  end
-
   # An unknown filter or a malformed offset leaves the inbox exactly as it is,
   # with no flash: these are view controls, so the honest response to a value
   # the server does not recognise is to keep showing what is already on screen

--- a/lib/mydia_web/live/import_media_live/run_control.ex
+++ b/lib/mydia_web/live/import_media_live/run_control.ex
@@ -48,15 +48,46 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
       phx-submit="start_run"
       class="flex flex-col gap-4"
     >
-      <.input
-        id="start-run-library"
-        name="library_path_id"
-        type="select"
-        label="Library"
-        value={default_library_path_id(@library_paths)}
-        options={Enum.map(@library_paths, &{&1.path, &1.id})}
-        required
-      />
+      <fieldset class="flex flex-col gap-2">
+        <legend class="text-sm font-medium opacity-80">Library</legend>
+        <div class="grid gap-3">
+          <%= for path <- @library_paths do %>
+            <label class={[
+              "group card card-compact bg-base-100 border border-base-300 cursor-pointer transition-all duration-200",
+              "hover:border-primary hover:shadow-lg",
+              "has-checked:border-primary has-checked:bg-primary/5 has-checked:ring-2 has-checked:ring-primary/40"
+            ]}>
+              <input
+                type="radio"
+                name="library_path_id"
+                value={path.id}
+                class="sr-only"
+                checked={path.id == default_library_path_id(@library_paths)}
+              />
+              <div class="card-body flex-row items-center gap-4">
+                <div class={[
+                  "flex items-center justify-center w-12 h-12 rounded-lg shrink-0 transition-transform group-hover:scale-105",
+                  library_type_bg_class(path.type)
+                ]}>
+                  <.icon name={library_type_icon(path.type)} class="w-6 h-6" />
+                </div>
+                <div class="flex-1 min-w-0">
+                  <span class={["badge badge-sm mb-1", library_type_badge_class(path.type)]}>
+                    {library_type_display(path.type)}
+                  </span>
+                  <p class="font-mono text-sm truncate text-base-content/80 group-has-checked:text-base-content">
+                    {path.path}
+                  </p>
+                </div>
+                <.icon
+                  name="hero-check"
+                  class="w-5 h-5 text-primary shrink-0 opacity-0 group-has-checked:opacity-100 transition-opacity"
+                />
+              </div>
+            </label>
+          <% end %>
+        </div>
+      </fieldset>
 
       <.input
         id="start-run-mode"
@@ -109,29 +140,6 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
       >
         Stop and keep progress
       </.button>
-
-      <%!--
-        The escape hatch for a run whose coordinator is gone but whose row
-        still says otherwise. Boot reconciliation
-        (Mydia.Jobs.ImportRun.reconcile_interrupted_runs/0) covers the common
-        case, a restart, but a job cancelled from the jobs page leaves no
-        restart to trigger it. Without something here, recovery means editing
-        the database: Start is refused for this path and Stop only writes
-        :stopping, which is also active.
-      --%>
-      <div class="flex flex-col gap-1">
-        <.button
-          id="release-run-button"
-          phx-click="release_run"
-          data-confirm="Mark this import as not running? Everything it already added is kept, and you will be able to start a new import for this library."
-          class="btn btn-ghost btn-xs self-start"
-        >
-          <.icon name="hero-wrench-screwdriver" class="w-3.5 h-3.5" /> Not actually running?
-        </.button>
-        <p class="text-xs opacity-60">
-          Use this only if the import has been stuck since a restart or a crash.
-        </p>
-      </div>
     </div>
     """
   end
@@ -227,4 +235,28 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
   end
 
   defp number(_), do: "0"
+
+  # Icon, badge and accent styling per library type, mirroring the old
+  # wizard's path-selection cards. `LibraryPath` only knows :movies, :series
+  # and :mixed today; the fallbacks exist so a new type degrades visibly
+  # instead of crashing the template.
+  defp library_type_icon(:series), do: "hero-tv"
+  defp library_type_icon(:movies), do: "hero-film"
+  defp library_type_icon(:mixed), do: "hero-square-3-stack-3d"
+  defp library_type_icon(_), do: "hero-folder"
+
+  defp library_type_bg_class(:series), do: "bg-info/10 text-info"
+  defp library_type_bg_class(:movies), do: "bg-accent/10 text-accent"
+  defp library_type_bg_class(:mixed), do: "bg-secondary/10 text-secondary"
+  defp library_type_bg_class(_), do: "bg-base-200 text-base-content/70"
+
+  defp library_type_badge_class(:series), do: "badge-info"
+  defp library_type_badge_class(:movies), do: "badge-accent"
+  defp library_type_badge_class(:mixed), do: "badge-secondary"
+  defp library_type_badge_class(_), do: "badge-ghost"
+
+  defp library_type_display(:series), do: "TV Series"
+  defp library_type_display(:movies), do: "Movies"
+  defp library_type_display(:mixed), do: "Mixed"
+  defp library_type_display(type), do: to_string(type)
 end

--- a/test/mydia/jobs/import_run_job_test.exs
+++ b/test/mydia/jobs/import_run_job_test.exs
@@ -66,6 +66,49 @@ defmodule Mydia.Jobs.ImportRunJobTest do
       assert length(Library.list_media_files(library_path_id: lp.id)) == 3
     end
 
+    test "tolerates duplicate rows for one path without crashing or adding more", %{
+      run: run,
+      library_path: lp
+    } do
+      # The data anomaly that used to strand a run: two builds of the scanner
+      # (or a scanner racing the import coordinator) created two rows for the
+      # same relative path. get_media_file_by_relative_path/3 raised
+      # Ecto.MultipleResultsError here, which Oban discarded after retries,
+      # leaving the run row :running forever.
+      relative_path = "Season 01/Bluey.S01E01.mkv"
+
+      for _ <- 1..2 do
+        {:ok, _} =
+          Library.create_scanned_media_file(%{
+            library_path_id: lp.id,
+            relative_path: relative_path,
+            size: 1,
+            verified_at: DateTime.utc_now()
+          })
+      end
+
+      assert :ok = ImportRunJob.run_scan_phase(Library.get_import_run(run.id))
+
+      files = Library.list_media_files(library_path_id: lp.id)
+      assert Enum.count(files, &(&1.relative_path == relative_path)) == 2
+    end
+
+    test "broadcasts the path being scanned", %{run: run} do
+      Phoenix.PubSub.subscribe(Mydia.PubSub, ImportRunJob.progress_topic(run.id))
+
+      assert :ok = ImportRunJob.run_scan_phase(Library.get_import_run(run.id))
+
+      # The scanner reports every directory it enters and every file it finds,
+      # relative to the library root, so the page can show what "Finding files"
+      # is looking at. The exact set depends on File.ls ordering, so assert the
+      # shapes rather than a specific sequence.
+      paths =
+        receive_scan_paths([])
+
+      assert "Season 01" in paths
+      assert "Season 01/Bluey.S01E01.mkv" in paths
+    end
+
     test "stops when a stop was requested", %{run: run} do
       {:ok, _} = Library.request_import_run_stop(Library.get_import_run(run.id))
 
@@ -216,6 +259,18 @@ defmodule Mydia.Jobs.ImportRunJobTest do
         Library.upsert_match_candidate(%{media_file_id: file_id, rank: 0, attempts: 1})
 
       assert length(Library.list_unmatched_media_file_paths(lp.id, 100)) == 2
+    end
+  end
+
+  # Drains the scan-progress messages `run_scan_phase/2` already broadcast
+  # into the test process's mailbox (the scan is synchronous, so they are all
+  # queued by the time this runs). The short timeout only bounds an empty
+  # mailbox, not a slow scan.
+  defp receive_scan_paths(acc) do
+    receive do
+      {:import_run_current_file, path} -> receive_scan_paths([path | acc])
+    after
+      200 -> acc
     end
   end
 end

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -146,43 +146,14 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     refute Library.active_import_run(lp.id)
   end
 
-  test "offers a recovery control that releases a run stuck in flight", %{
+  test "renders one selectable library card per path, with an icon", %{
     conn: conn,
-    library_path: lp,
-    user: user
+    library_path: lp
   } do
-    {:ok, run} =
-      Library.create_import_run(%{library_path_id: lp.id, user_id: user.id, mode: :review})
-
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    assert has_element?(view, "#release-run-button")
-
-    view |> element("#release-run-button") |> render_click()
-
-    assert Library.get_import_run(run.id).status == :stopped
-    refute Library.active_import_run(lp.id)
-  end
-
-  test "releasing a run that finished in the meantime keeps its real outcome", %{
-    conn: conn,
-    library_path: lp,
-    user: user
-  } do
-    {:ok, run} =
-      Library.create_import_run(%{library_path_id: lp.id, user_id: user.id, mode: :review})
-
-    {:ok, view, _html} = live(conn, ~p"/import")
-
-    # Same render-then-click race the Stop button is guarded against. Writing
-    # :stopped over a :done row would replace the run's real outcome with a
-    # message saying a human ended it.
-    {:ok, _} = Library.update_import_run(run, %{status: :done, phase: :finished})
-
-    view |> element("#release-run-button") |> render_click()
-
-    assert Library.get_import_run(run.id).status == :done
-    assert is_nil(Library.get_import_run(run.id).error)
+    assert has_element?(view, "input[type=radio][name=library_path_id][value='#{lp.id}']")
+    assert has_element?(view, "label.card")
   end
 
   describe "library types that cannot be imported" do

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -152,8 +152,16 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
   } do
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    assert has_element?(view, "input[type=radio][name=library_path_id][value='#{lp.id}']")
-    assert has_element?(view, "label.card")
+    assert has_element?(
+             view,
+             "label.card input[type=radio][name=library_path_id][value='#{lp.id}']"
+           )
+
+    # The first path is preselected so the form always submits a real id.
+    assert has_element?(
+             view,
+             "input[type=radio][name=library_path_id][value='#{lp.id}'][checked]"
+           )
   end
 
   describe "library types that cannot be imported" do


### PR DESCRIPTION
## What

Three fixes to Import Media, all observed on a real stuck instance:

1. **Icon-based library selection is back.** The wizard's path cards (type icon, badge, mono path, selected check) replace the dropdown that had replaced them.
2. **"Finding files" shows what it is scanning.** The scanner now reports each directory entered and file found, broadcast to the page as `current_file` (relative to the library root) instead of an anonymous spinner.
3. **A run can no longer strand itself.** The scan phase crashed on `Ecto.MultipleResultsError` from duplicate `media_file` rows for one relative path; the raised exception never reached the terminal-state writer, so Oban discarded the job after retries while the run row stayed `:running` forever. The manual "Not actually running?" escape hatch is removed.

## Root cause

`get_media_file_by_relative_path/3` calls `Repo.one`, which raises on the duplicate rows galactica had (153 of them). The exception escaped `perform/1`, bypassing `fail/3` (which only runs on *returned* errors). Boot reconciliation only runs at boot, so a continuously-running node was stuck until someone pressed the recovery button.

## Changes

- `Scanner.scan/2` gains `:path_callback`, threaded through the directory walk.
- `Library.list_media_files_by_relative_path/3` — a duplicate-tolerant list lookup (live files first).
- `insert_batch` uses it; duplicates are skipped/restored instead of crashing.
- `execute/2` wraps the phases in `try/rescue`, routing exceptions through `fail/3` so every path terminates (`:done`/`:stopped`/`:failed`).
- Removed the "Not actually running?" button, `release_run` handler, and `Library.release_import_run/2`.

## Verification

- `mix test` — 8138 tests, 0 failures.
- `mix format --check-formatted` and `mix credo --strict` clean.
- `has-checked:`/`group-has-checked:` variants confirmed present in the built `app.css`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import scans now show directories and video files being processed in real time.
  * Library selection during import uses visual cards with icons, paths, and type labels.

* **Bug Fixes**
  * Imports recover more reliably from interruptions and unexpected failures.
  * Duplicate media paths no longer cause scans to fail, while active files are preserved.
  * Previously trashed files are restored appropriately during imports.

* **UI Updates**
  * Removed the recovery control for runs that appear stuck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->