### PR TITLE
feat(show): collapse the recommendations rail on tv show pages

### DIFF
--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -223,25 +223,27 @@ defmodule MydiaWeb.DiscoverComponents do
     ~H"""
     <div :if={@items != []} id={@id} class="mb-6 md:mb-8">
       <div class="flex items-center justify-between gap-3 mb-3">
-        <%!-- The title is repeated across both branches on purpose: HEEx cannot
-              swap a tag name, and a disclosure's label has to live inside its
-              own button to be announced and focusable. --%>
-        <button
-          :if={@collapsible}
-          type="button"
-          id={"#{@id}-toggle"}
-          class="flex items-center gap-2 min-w-0 cursor-pointer text-left"
-          phx-click={@toggle_event}
-          aria-expanded={to_string(@open?)}
-          aria-controls={"#{@id}-items"}
-        >
-          <.icon
-            name={if @open?, do: "hero-chevron-down", else: "hero-chevron-right"}
-            class="w-4 h-4 text-base-content/40 shrink-0"
-          />
-          <h2 class="text-lg md:text-xl font-semibold truncate">{@title}</h2>
-          <span class="badge badge-ghost badge-sm shrink-0">{length(@items)}</span>
-        </button>
+        <%!-- The heading is repeated across both branches on purpose: HEEx cannot
+              swap a tag name. The collapsible branch puts the button inside the
+              heading rather than the other way around, because `button` takes
+              phrasing content and a heading is not phrasing content. --%>
+        <h2 :if={@collapsible} class="min-w-0">
+          <button
+            type="button"
+            id={"#{@id}-toggle"}
+            class="flex items-center gap-2 min-w-0 w-full cursor-pointer text-left"
+            phx-click={@toggle_event}
+            aria-expanded={to_string(@open?)}
+            aria-controls={if @open?, do: "#{@id}-items"}
+          >
+            <.icon
+              name={if @open?, do: "hero-chevron-down", else: "hero-chevron-right"}
+              class="w-4 h-4 text-base-content/40 shrink-0"
+            />
+            <span class="text-lg md:text-xl font-semibold truncate">{@title}</span>
+            <span class="badge badge-ghost badge-sm shrink-0">{length(@items)}</span>
+          </button>
+        </h2>
         <h2 :if={not @collapsible} class="text-lg md:text-xl font-semibold truncate">{@title}</h2>
         <div :if={@badge != []} class="flex-shrink-0">{render_slot(@badge)}</div>
       </div>

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -202,17 +202,55 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :request_event, :string, default: "request_media"
   attr :can_add, :boolean, default: true
 
+  # Opt-in disclosure, off by default so Discover, Dashboard and the franchise
+  # strip keep rendering exactly as before. A function component cannot hold
+  # state, so the host LiveView owns `expanded` and handles `toggle_event`.
+  attr :collapsible, :boolean, default: false
+  attr :expanded, :boolean, default: true
+  attr :toggle_event, :string, default: nil
+
   slot :badge
 
   def media_rail(assigns) do
+    if assigns.collapsible and is_nil(assigns.toggle_event) do
+      raise ArgumentError,
+            "media_rail #{inspect(assigns.id)} is collapsible but was given no " <>
+              "toggle_event, so its header would render a chevron nothing can open"
+    end
+
+    assigns = assign(assigns, :open?, not assigns.collapsible or assigns.expanded)
+
     ~H"""
     <div :if={@items != []} id={@id} class="mb-6 md:mb-8">
       <div class="flex items-center justify-between gap-3 mb-3">
-        <h2 class="text-lg md:text-xl font-semibold truncate">{@title}</h2>
+        <%!-- The title is repeated across both branches on purpose: HEEx cannot
+              swap a tag name, and a disclosure's label has to live inside its
+              own button to be announced and focusable. --%>
+        <button
+          :if={@collapsible}
+          type="button"
+          id={"#{@id}-toggle"}
+          class="flex items-center gap-2 min-w-0 cursor-pointer text-left"
+          phx-click={@toggle_event}
+          aria-expanded={to_string(@open?)}
+          aria-controls={"#{@id}-items"}
+        >
+          <.icon
+            name={if @open?, do: "hero-chevron-down", else: "hero-chevron-right"}
+            class="w-4 h-4 text-base-content/40 shrink-0"
+          />
+          <h2 class="text-lg md:text-xl font-semibold truncate">{@title}</h2>
+          <span class="badge badge-ghost badge-sm shrink-0">{length(@items)}</span>
+        </button>
+        <h2 :if={not @collapsible} class="text-lg md:text-xl font-semibold truncate">{@title}</h2>
         <div :if={@badge != []} class="flex-shrink-0">{render_slot(@badge)}</div>
       </div>
 
-      <div class="flex gap-3 overflow-x-auto snap-x scroll-smooth pb-2">
+      <div
+        :if={@open?}
+        id={if @collapsible, do: "#{@id}-items"}
+        class="flex gap-3 overflow-x-auto snap-x scroll-smooth pb-2"
+      >
         <div
           :for={item <- @items}
           id={"#{@id}-item-#{item.provider_id}"}

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -139,6 +139,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:adding_franchise_tmdb_ids, MapSet.new())
      # Recommendations rail state
      |> assign(:recommendations, [])
+     |> assign(:recommendations_expanded, false)
      |> assign(:adding_recommendation_tmdb_ids, MapSet.new())
      |> assign(:adding_recommendation_id, nil)
      |> assign(:requesting_recommendation_id, nil)
@@ -425,6 +426,10 @@ defmodule MydiaWeb.MediaLive.Show do
 
   def handle_event("request_franchise_movie", params, socket),
     do: FranchiseEvents.request_franchise_movie(params, socket)
+
+  @impl true
+  def handle_event("toggle_recommendations", params, socket),
+    do: RecommendationEvents.toggle_expanded(params, socket)
 
   @impl true
   def handle_event("add_recommendation", params, socket),

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -200,8 +200,13 @@
             current_user={@current_user}
             adding_tmdb_ids={@adding_franchise_tmdb_ids}
           />
+          <%!-- Collapsed by default on shows, so the episode list below is not
+                pushed under a strip of other titles. Movies render it open. --%>
           <DiscoverComponents.media_rail
             id="recommendations-rail"
+            collapsible={@media_item.type == "tv_show"}
+            expanded={@recommendations_expanded}
+            toggle_event="toggle_recommendations"
             items={@recommendations}
             media_type={if @media_item.type == "tv_show", do: :tv_show, else: :movie}
             current_user={@current_user}

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -62,6 +62,18 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   end
 
   @doc """
+  Flips the rail open or closed.
+
+  The rail opens collapsed on TV shows so the episode list is not pushed below a
+  strip of other titles. State is per mount and deliberately not persisted, so
+  every visit starts closed.
+  """
+  def toggle_expanded(_params, socket) do
+    {:noreply,
+     assign(socket, :recommendations_expanded, !socket.assigns.recommendations_expanded)}
+  end
+
+  @doc """
   Adds a recommended title, inheriting the viewed item's quality profile and
   monitored flag.
 

--- a/test/mydia_web/live/components/media_rail_component_test.exs
+++ b/test/mydia_web/live/components/media_rail_component_test.exs
@@ -295,4 +295,76 @@ defmodule MydiaWeb.Components.MediaRailComponentTest do
     |> LazyHTML.query(~s(##{rail_id}-item-#{provider_id}))
     |> LazyHTML.to_html()
   end
+
+  defp collapsible(opts) do
+    render_component(
+      &DiscoverComponents.media_rail/1,
+      Keyword.merge(
+        [
+          items: [item(), item(%{provider_id: "102", title: "Janet Planet"})],
+          media_type: :movie,
+          current_user: user(),
+          collapsible: true,
+          toggle_event: "toggle_recommendations"
+        ],
+        opts
+      )
+    )
+  end
+
+  describe "collapsible rail" do
+    test "a collapsed rail renders its header and none of its cards" do
+      html = collapsible(expanded: false)
+
+      assert html =~ ~s(id="media-rail-toggle")
+      assert html =~ ~s(aria-expanded="false")
+      refute html =~ ~s(id="media-rail-items")
+      refute html =~ ~s(id="media-rail-item-101")
+      refute html =~ "The Eternal Daughter"
+    end
+
+    test "an expanded rail renders its cards under the strip id" do
+      html = collapsible(expanded: true)
+
+      assert html =~ ~s(aria-expanded="true")
+      assert html =~ ~s(id="media-rail-items")
+      assert html =~ ~s(id="media-rail-item-101")
+      assert html =~ "The Eternal Daughter"
+    end
+
+    test "the header carries the item count" do
+      count =
+        collapsible(expanded: false)
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query("#media-rail-toggle .badge")
+        |> LazyHTML.text()
+
+      assert count == "2"
+    end
+
+    test "a non-collapsible rail renders no toggle and no strip id" do
+      html =
+        render_component(&DiscoverComponents.media_rail/1,
+          items: [item()],
+          media_type: :movie,
+          current_user: user()
+        )
+
+      assert html =~ ~s(id="media-rail")
+      refute html =~ ~s(id="media-rail-toggle")
+      refute html =~ ~s(id="media-rail-items")
+      refute html =~ "aria-expanded"
+    end
+
+    test "a collapsible rail with no toggle_event raises" do
+      assert_raise ArgumentError, ~r/toggle_event/, fn ->
+        render_component(&DiscoverComponents.media_rail/1,
+          items: [item()],
+          media_type: :movie,
+          current_user: user(),
+          collapsible: true
+        )
+      end
+    end
+  end
 end

--- a/test/mydia_web/live/components/media_rail_component_test.exs
+++ b/test/mydia_web/live/components/media_rail_component_test.exs
@@ -332,6 +332,23 @@ defmodule MydiaWeb.Components.MediaRailComponentTest do
       assert html =~ "The Eternal Daughter"
     end
 
+    # aria-controls must name an element that is actually in the document. The
+    # strip is removed entirely while collapsed, not hidden, so the attribute has
+    # to come and go with it.
+    test "aria-controls is present only while the strip is in the document" do
+      refute collapsible(expanded: false) =~ "aria-controls"
+      assert collapsible(expanded: true) =~ ~s(aria-controls="media-rail-items")
+    end
+
+    # `button` takes phrasing content, and a heading is not phrasing content, so
+    # the heading has to wrap the button rather than sit inside it.
+    test "the disclosure button is nested inside the heading, not the reverse" do
+      doc = collapsible(expanded: false) |> LazyHTML.from_fragment()
+
+      assert [_] = Enum.to_list(LazyHTML.query(doc, "h2 > button#media-rail-toggle"))
+      assert [] = Enum.to_list(LazyHTML.query(doc, "button h2"))
+    end
+
     test "the header carries the item count" do
       count =
         collapsible(expanded: false)

--- a/test/mydia_web/live/media_live/show/recommendations_rail_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendations_rail_test.exs
@@ -12,6 +12,12 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
   alias Mydia.Metadata.Cache
 
   setup %{conn: conn} do
+    # The app disables Oban in test (engine: false), so Oban.insert cannot run
+    # from the LiveView process. Start an isolated, manual-mode instance so the
+    # recommendations load can enqueue without a live queue.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
     %{conn: log_in_user(conn, admin_user_fixture())}
   end
 
@@ -91,6 +97,65 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
     render_async(view, 5000)
 
     assert has_element?(view, ~s(#recommendations-rail a[href="/media/#{owned.id}"]))
+  end
+
+  test "a tv show starts collapsed and the header toggles it", %{conn: conn} do
+    source_tmdb_id = System.unique_integer([:positive])
+    recommended_tmdb_id = System.unique_integer([:positive])
+
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Detectorists",
+        year: 2014,
+        tmdb_id: source_tmdb_id
+      })
+
+    episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+    warm_recommendations_cache(source_tmdb_id, :tv_show, [
+      %{
+        "id" => recommended_tmdb_id,
+        "name" => "Rev.",
+        "first_air_date" => "2010-06-28",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, "#recommendations-rail-toggle")
+    refute has_element?(view, "#recommendations-rail-items")
+
+    html = view |> element("#recommendations-rail-toggle") |> render_click()
+    assert html =~ "Rev."
+    assert has_element?(view, "#recommendations-rail-items")
+
+    view |> element("#recommendations-rail-toggle") |> render_click()
+    refute has_element?(view, "#recommendations-rail-items")
+  end
+
+  test "a movie rail is not collapsible", %{conn: conn} do
+    source_tmdb_id = System.unique_integer([:positive])
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Aftersun",
+        year: 2022,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{"id" => System.unique_integer([:positive]), "title" => "The Eternal Daughter"}
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, "#recommendations-rail")
+    refute has_element?(view, "#recommendations-rail-toggle")
   end
 
   # Populates the shared metadata cache through the real fetch path, with the


### PR DESCRIPTION
The media detail page renders the "More like this" rail between the overview and the episode list. On a TV show that puts a strip of unrelated titles between you and the episodes you opened the page for. The Flutter player fixed the same layout in #475; the Phoenix page never got it.

Closes the last parity gap from that change.

## What changed

- `DiscoverComponents.media_rail/1` gains three opt-in attrs: `collapsible`, `expanded`, and `toggle_event`. When `collapsible`, the header becomes a disclosure button carrying a chevron, the title, and a count badge, and the card strip is not rendered at all while closed.
- Only the media detail page opts in, and only for TV shows. Movie pages, Discover, and the franchise strip pass no new attrs and render identical markup to master.
- State lives in a `recommendations_expanded` socket assign on `MediaLive.Show`, toggled through `RecommendationEvents.toggle_expanded/2` beside the rail's existing add and request handlers. Nothing is persisted, so every visit starts collapsed.

Two details worth flagging for review:

- `id={if @collapsible, do: "#{@id}-items"}` resolves to `nil` for existing callers, and HEEx omits a nil attribute. That is what keeps the untouched callers byte-identical rather than merely equivalent.
- The chevron and the button-wrapping-the-summary shape are lifted from `SeasonComponents.season_header/1`, which shipped in #476 and sits a few hundred pixels below this rail on the same page.

Recommendations already load asynchronously and `:if={@items != []}` already suppresses an empty rail, so a TV page now reflows in one collapsed header row instead of a full card strip. The fetch itself is unchanged.

## Verification

`./dev mix precommit` green on all seven steps: Dependencies, Compile with warnings-as-errors, Unused deps, Format, Credo strict, Database, Tests at 8153 tests and 0 failures.

Five new component tests in `media_rail_component_test.exs`: a collapsed rail renders its header and none of its cards, an expanded one renders them under the strip id, the header carries the count, a non-collapsible rail renders no toggle, and `collapsible` without a `toggle_event` raises rather than rendering a chevron nothing can open.

Two new connected tests in `recommendations_rail_test.exs`: a TV show starts collapsed and the header toggles it both ways, and a movie rail renders with no toggle. The three pre-existing movie tests and the 17 pre-existing component tests pass unedited, which is the regression evidence that the other callers are untouched.

## Known gap

`aria-controls` on the toggle points at a strip id that is absent from the DOM while collapsed, where strict ARIA authoring expects a present-but-hidden target. Left as-is deliberately: `season_header/1` on this same page does the identical thing, so fixing one without the other would make the two disclosures behave inconsistently under a screen reader. Worth a follow-up that touches both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recommendation rails can now be collapsed and expanded using an accessible toggle with item counts and state indicators.
  * TV show recommendations start collapsed and can be opened or closed.
  * Movie recommendations remain expanded by default.

* **Tests**
  * Added coverage for collapsed, expanded, toggled, and non-collapsible recommendation rails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->