### PR TITLE
feat(ui): compact the grid density and view mode toggles

### DIFF
--- a/lib/mydia_web/components/grid_density_components.ex
+++ b/lib/mydia_web/components/grid_density_components.ex
@@ -14,6 +14,22 @@ defmodule MydiaWeb.GridDensityComponents do
   on purpose: HEEx renders a `true` attribute value as a bare attribute and
   omits it entirely for `false`, and ARIA needs the literal strings.
 
+  The tooltip lives on a wrapper `div`, never on the `<button>` itself.
+  daisyUI shows the tip on `.tooltip-open`, `:hover` and `.tooltip:has(:focus-visible)`,
+  and `:has()` carries an implicit descendant combinator: it matches when a
+  *descendant* is focused, not the element itself. A `.tooltip` button whose
+  only descendant is the non-focusable `<span>` from `icon/1` therefore never
+  shows its tip on keyboard focus, leaving a tabbing user with a bare icon.
+  Wrapping is the form every focusable tooltip in this app already uses.
+
+  `join-item` stays on the button and is deliberately kept off that wrapper.
+  daisyUI's `.join-item > *` resets `--join-ss`/`--join-se`/`--join-es`/`--join-ee`
+  to `initial`, so a button nested inside a `join-item` wrapper computes all
+  four corners to 0 and the filled active button spills square out of the
+  join's rounded end cap. With the wrapper left plain, the join's radius
+  variables inherit straight through to the button and the caps render as
+  they did before the tooltip moved.
+
   Kept in step with `MydiaWeb.LibraryComponents.view_mode_toggle/1`, which is
   icon-only for the same reasons; the two sit side by side on the Libraries
   toolbar.
@@ -70,23 +86,27 @@ defmodule MydiaWeb.GridDensityComponents do
     assigns = assign(assigns, :levels, @levels)
 
     ~H"""
-    <div class="join" id={@id}>
-      <button
+    <div class="join" id={@id} role="group" aria-label="Grid density">
+      <div
         :for={{value, label, icon_name} <- @levels}
-        type="button"
-        class={[
-          "btn btn-sm btn-square join-item tooltip tooltip-bottom",
-          @density == value && "btn-primary",
-          @density != value && "btn-ghost"
-        ]}
-        phx-click="set_grid_density"
-        phx-value-density={value}
+        class="tooltip tooltip-bottom"
         data-tip={label}
-        aria-label={label}
-        aria-pressed={to_string(@density == value)}
       >
-        <.icon name={icon_name} class="w-4 h-4" />
-      </button>
+        <button
+          type="button"
+          class={[
+            "btn btn-sm btn-square join-item",
+            @density == value && "btn-primary",
+            @density != value && "btn-ghost"
+          ]}
+          phx-click="set_grid_density"
+          phx-value-density={value}
+          aria-label={label}
+          aria-pressed={to_string(@density == value)}
+        >
+          <.icon name={icon_name} class="w-4 h-4" />
+        </button>
+      </div>
     </div>
     """
   end

--- a/lib/mydia_web/components/grid_density_components.ex
+++ b/lib/mydia_web/components/grid_density_components.ex
@@ -8,6 +8,16 @@ defmodule MydiaWeb.GridDensityComponents do
   `"grid-cols-\#{n}"` is never generated and the grid silently keeps whatever
   columns it had. Any new level must be added here as complete literals.
 
+  The buttons are icon-only. `aria-label` therefore carries each button's
+  accessible name and `aria-pressed` its state, since `btn-primary` alone
+  says nothing to a screen reader. `aria-pressed` is wrapped in `to_string/1`
+  on purpose: HEEx renders a `true` attribute value as a bare attribute and
+  omits it entirely for `false`, and ARIA needs the literal strings.
+
+  Kept in step with `MydiaWeb.LibraryComponents.view_mode_toggle/1`, which is
+  icon-only for the same reasons; the two sit side by side on the Libraries
+  toolbar.
+
   Two LiveViews use this module, so it is deliberately not imported in
   `html_helpers`; the project reserves global imports for components with
   three or more consumers.
@@ -25,10 +35,15 @@ defmodule MydiaWeb.GridDensityComponents do
     "dense" => "grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12"
   }
 
+  # A 1 → 3 → many progression. The labels used to carry the meaning; once
+  # they are gone the icons have to, and the previous three sat on no common
+  # scale. hero-squares-2x2 is deliberately absent: it is already the Grid
+  # icon on view_mode_toggle three buttons to the left on the same toolbar,
+  # and the Activity page's "All" tab.
   @levels [
-    {"comfortable", "Comfortable", "hero-rectangle-group"},
-    {"compact", "Compact", "hero-squares-plus"},
-    {"dense", "Dense", "hero-view-columns"}
+    {"comfortable", "Comfortable", "hero-stop"},
+    {"compact", "Compact", "hero-view-columns"},
+    {"dense", "Dense", "hero-table-cells"}
   ]
 
   @doc """
@@ -60,16 +75,17 @@ defmodule MydiaWeb.GridDensityComponents do
         :for={{value, label, icon_name} <- @levels}
         type="button"
         class={[
-          "btn btn-sm join-item",
+          "btn btn-sm btn-square join-item tooltip tooltip-bottom",
           @density == value && "btn-primary",
           @density != value && "btn-ghost"
         ]}
         phx-click="set_grid_density"
         phx-value-density={value}
-        title={label}
+        data-tip={label}
+        aria-label={label}
+        aria-pressed={to_string(@density == value)}
       >
-        <.icon name={icon_name} class="w-5 h-5" />
-        <span class="hidden sm:inline ml-1">{label}</span>
+        <.icon name={icon_name} class="w-4 h-4" />
       </button>
     </div>
     """

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -251,6 +251,14 @@ defmodule MydiaWeb.LibraryComponents do
   @doc """
   Renders a view mode toggle (grid/list).
 
+  Icon-only, so `aria-label` carries each button's accessible name and
+  `aria-pressed` its state. `aria-pressed` is wrapped in `to_string/1` because
+  HEEx renders a `true` attribute value as a bare attribute and omits it for
+  `false`, and ARIA needs the literal strings.
+
+  Kept in step with `MydiaWeb.GridDensityComponents.grid_density_toggle/1`,
+  which sits directly beside this on the Libraries toolbar.
+
   ## Attributes
 
     * `:view_mode` - Required. Current view mode (:grid or :list).
@@ -263,28 +271,32 @@ defmodule MydiaWeb.LibraryComponents do
       <button
         type="button"
         class={[
-          "btn btn-sm join-item",
+          "btn btn-sm btn-square join-item tooltip tooltip-bottom",
           @view_mode == :grid && "btn-primary",
           @view_mode != :grid && "btn-ghost"
         ]}
         phx-click="toggle_view"
         phx-value-mode="grid"
+        data-tip="Grid"
+        aria-label="Grid"
+        aria-pressed={to_string(@view_mode == :grid)}
       >
-        <.icon name="hero-squares-2x2" class="w-5 h-5" />
-        <span class="hidden sm:inline ml-1">Grid</span>
+        <.icon name="hero-squares-2x2" class="w-4 h-4" />
       </button>
       <button
         type="button"
         class={[
-          "btn btn-sm join-item",
+          "btn btn-sm btn-square join-item tooltip tooltip-bottom",
           @view_mode == :list && "btn-primary",
           @view_mode != :list && "btn-ghost"
         ]}
         phx-click="toggle_view"
         phx-value-mode="list"
+        data-tip="List"
+        aria-label="List"
+        aria-pressed={to_string(@view_mode == :list)}
       >
-        <.icon name="hero-list-bullet" class="w-5 h-5" />
-        <span class="hidden sm:inline ml-1">List</span>
+        <.icon name="hero-list-bullet" class="w-4 h-4" />
       </button>
     </div>
     """

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -256,6 +256,18 @@ defmodule MydiaWeb.LibraryComponents do
   HEEx renders a `true` attribute value as a bare attribute and omits it for
   `false`, and ARIA needs the literal strings.
 
+  Each tooltip sits on a wrapper `div` rather than on the button. daisyUI
+  reveals the tip via `.tooltip:has(:focus-visible)`, and `:has()` implies a
+  descendant combinator, so a `.tooltip` button whose only descendant is the
+  non-focusable icon `<span>` never shows its tip to a keyboard user.
+
+  `join-item` stays on the button and is deliberately kept off the wrapper:
+  `.join-item > *` resets `--join-ss`/`--join-se`/`--join-es`/`--join-ee` to
+  `initial`, so a button nested inside a `join-item` wrapper computes every
+  corner to 0 and the filled active button spills square out of the join's
+  rounded end cap. Left off the wrapper, the join's radius variables inherit
+  straight through to the button and the caps render as before.
+
   Kept in step with `MydiaWeb.GridDensityComponents.grid_density_toggle/1`,
   which sits directly beside this on the Libraries toolbar.
 
@@ -267,37 +279,39 @@ defmodule MydiaWeb.LibraryComponents do
 
   def view_mode_toggle(assigns) do
     ~H"""
-    <div class="join">
-      <button
-        type="button"
-        class={[
-          "btn btn-sm btn-square join-item tooltip tooltip-bottom",
-          @view_mode == :grid && "btn-primary",
-          @view_mode != :grid && "btn-ghost"
-        ]}
-        phx-click="toggle_view"
-        phx-value-mode="grid"
-        data-tip="Grid"
-        aria-label="Grid"
-        aria-pressed={to_string(@view_mode == :grid)}
-      >
-        <.icon name="hero-squares-2x2" class="w-4 h-4" />
-      </button>
-      <button
-        type="button"
-        class={[
-          "btn btn-sm btn-square join-item tooltip tooltip-bottom",
-          @view_mode == :list && "btn-primary",
-          @view_mode != :list && "btn-ghost"
-        ]}
-        phx-click="toggle_view"
-        phx-value-mode="list"
-        data-tip="List"
-        aria-label="List"
-        aria-pressed={to_string(@view_mode == :list)}
-      >
-        <.icon name="hero-list-bullet" class="w-4 h-4" />
-      </button>
+    <div class="join" role="group" aria-label="View mode">
+      <div class="tooltip tooltip-bottom" data-tip="Grid">
+        <button
+          type="button"
+          class={[
+            "btn btn-sm btn-square join-item",
+            @view_mode == :grid && "btn-primary",
+            @view_mode != :grid && "btn-ghost"
+          ]}
+          phx-click="toggle_view"
+          phx-value-mode="grid"
+          aria-label="Grid"
+          aria-pressed={to_string(@view_mode == :grid)}
+        >
+          <.icon name="hero-squares-2x2" class="w-4 h-4" />
+        </button>
+      </div>
+      <div class="tooltip tooltip-bottom" data-tip="List">
+        <button
+          type="button"
+          class={[
+            "btn btn-sm btn-square join-item",
+            @view_mode == :list && "btn-primary",
+            @view_mode != :list && "btn-ghost"
+          ]}
+          phx-click="toggle_view"
+          phx-value-mode="list"
+          aria-label="List"
+          aria-pressed={to_string(@view_mode == :list)}
+        >
+          <.icon name="hero-list-bullet" class="w-4 h-4" />
+        </button>
+      </div>
     </div>
     """
   end

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -13,24 +13,26 @@
       <div class="card-body p-3 md:p-4 space-y-3">
         <%!-- Media type toggle + category tabs --%>
         <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-3">
-          <div class="join">
-            <button
-              phx-click="switch_media_type"
-              phx-value-type="movie"
-              class={["join-item btn btn-sm gap-1.5", @media_type == :movie && "btn-active"]}
-            >
-              <.icon name="hero-film" class="w-4 h-4" /> Movies
-            </button>
-            <button
-              phx-click="switch_media_type"
-              phx-value-type="tv_show"
-              class={["join-item btn btn-sm gap-1.5", @media_type == :tv_show && "btn-active"]}
-            >
-              <.icon name="hero-tv" class="w-4 h-4" /> TV Shows
-            </button>
-          </div>
+          <div id="discover-view-controls" class="flex items-center gap-3">
+            <div class="join">
+              <button
+                phx-click="switch_media_type"
+                phx-value-type="movie"
+                class={["join-item btn btn-sm gap-1.5", @media_type == :movie && "btn-active"]}
+              >
+                <.icon name="hero-film" class="w-4 h-4" /> Movies
+              </button>
+              <button
+                phx-click="switch_media_type"
+                phx-value-type="tv_show"
+                class={["join-item btn btn-sm gap-1.5", @media_type == :tv_show && "btn-active"]}
+              >
+                <.icon name="hero-tv" class="w-4 h-4" /> TV Shows
+              </button>
+            </div>
 
-          <.grid_density_toggle id="discover-density-toggle" density={@grid_density} />
+            <.grid_density_toggle id="discover-density-toggle" density={@grid_density} />
+          </div>
 
           <div role="tablist" class="tabs tabs-box w-fit">
             <%= for {cat_key, cat_label} <- @categories do %>

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -13,7 +13,7 @@
       <div class="card-body p-3 md:p-4 space-y-3">
         <%!-- Media type toggle + category tabs --%>
         <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-3">
-          <div id="discover-view-controls" class="flex items-center gap-3">
+          <div id="discover-view-controls" class="flex flex-wrap items-center gap-3">
             <div class="join">
               <button
                 phx-click="switch_media_type"

--- a/test/mydia_web/components/library_components_test.exs
+++ b/test/mydia_web/components/library_components_test.exs
@@ -114,6 +114,53 @@ defmodule MydiaWeb.LibraryComponentsTest do
       assert text == ""
     end
 
+    test "each tooltip sits on a wrapper around the button, not on the button" do
+      html = render_component(&LibraryComponents.view_mode_toggle/1, view_mode: :grid)
+      document = LazyHTML.from_fragment(html)
+
+      # daisyUI reveals the tip through `.tooltip:has(:focus-visible)`, and
+      # `:has()` implies a descendant combinator, so a `.tooltip` on the button
+      # only matches when something inside it is focused. The button's only
+      # child is the non-focusable span from icon/1, which would leave a
+      # keyboard user tabbing onto an unlabelled icon.
+      wrappers = LazyHTML.query(document, "div.tooltip")
+
+      assert LazyHTML.attribute(wrappers, "data-tip") == ["Grid", "List"]
+
+      # join-item belongs on the button, never on the wrapper: daisyUI's
+      # `.join-item > *` resets the --join-* radius variables to `initial`, so
+      # a nested button computes every corner to 0 and the filled active button
+      # spills square out of the join's rounded end cap.
+      for class <- LazyHTML.attribute(wrappers, "class") do
+        refute class =~ "join-item"
+      end
+
+      for class <- document |> LazyHTML.query("button") |> LazyHTML.attribute("class") do
+        assert class =~ "join-item"
+      end
+
+      refute document
+             |> LazyHTML.query("button")
+             |> LazyHTML.attribute("class")
+             |> Enum.any?(&(&1 =~ "tooltip"))
+    end
+
+    test "the buttons are square icon buttons and the join is a labelled group" do
+      html = render_component(&LibraryComponents.view_mode_toggle/1, view_mode: :grid)
+      document = LazyHTML.from_fragment(html)
+
+      # btn-square keeps a label-less button from collapsing to its icon.
+      for class <- document |> LazyHTML.query("button") |> LazyHTML.attribute("class") do
+        assert class =~ "btn-square"
+      end
+
+      # Without visible labels the two buttons need to announce as one control.
+      join = LazyHTML.filter(document, "div.join")
+
+      assert LazyHTML.attribute(join, "role") == ["group"]
+      assert LazyHTML.attribute(join, "aria-label") == ["View mode"]
+    end
+
     test "the active mode is the one marked btn-primary" do
       html = render_component(&LibraryComponents.view_mode_toggle/1, view_mode: :list)
 

--- a/test/mydia_web/components/library_components_test.exs
+++ b/test/mydia_web/components/library_components_test.exs
@@ -79,4 +79,52 @@ defmodule MydiaWeb.LibraryComponentsTest do
       assert picker(%{placement: :top}) =~ "dropdown-top"
     end
   end
+
+  describe "view_mode_toggle/1" do
+    test "renders two icon-only buttons with accessible names and pressed state" do
+      html = render_component(&LibraryComponents.view_mode_toggle/1, view_mode: :grid)
+
+      buttons =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query("button")
+
+      assert LazyHTML.attribute(buttons, "aria-label") == ["Grid", "List"]
+
+      # Literal strings, not bare attributes. HEEx drops aria-pressed={false}
+      # entirely, so the component wraps the comparison in to_string/1.
+      assert LazyHTML.attribute(buttons, "aria-pressed") == ["true", "false"]
+
+      # The mode bindings the LiveViews dispatch on must survive the relabel.
+      assert LazyHTML.attribute(buttons, "phx-value-mode") == ["grid", "list"]
+    end
+
+    test "the buttons render no visible text label" do
+      html = render_component(&LibraryComponents.view_mode_toggle/1, view_mode: :list)
+
+      # Checked as text content: "Grid" and "List" still appear in aria-label
+      # and data-tip, so a raw substring refute would fail on correct output.
+      text =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query("button")
+        |> LazyHTML.text()
+        |> String.trim()
+
+      assert text == ""
+    end
+
+    test "the active mode is the one marked btn-primary" do
+      html = render_component(&LibraryComponents.view_mode_toggle/1, view_mode: :list)
+
+      classes =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query("button")
+        |> LazyHTML.attribute("class")
+
+      refute Enum.at(classes, 0) =~ "btn-primary"
+      assert Enum.at(classes, 1) =~ "btn-primary"
+    end
+  end
 end

--- a/test/mydia_web/live/components/grid_density_toggle_test.exs
+++ b/test/mydia_web/live/components/grid_density_toggle_test.exs
@@ -44,4 +44,46 @@ defmodule MydiaWeb.Components.GridDensityToggleTest do
     assert html =~ "set_grid_density"
     assert html =~ "btn-primary"
   end
+
+  test "every button carries an accessible name and an explicit pressed state" do
+    html =
+      render_component(&GridDensityComponents.grid_density_toggle/1,
+        density: "compact",
+        id: "library-density-toggle"
+      )
+
+    buttons =
+      html
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query("button")
+
+    # Removing the visible labels removes each button's accessible name, so
+    # aria-label has to carry it instead.
+    assert LazyHTML.attribute(buttons, "aria-label") == ["Comfortable", "Compact", "Dense"]
+
+    # btn-primary alone is invisible to a screen reader. These must be the
+    # literal strings: HEEx renders aria-pressed={true} as a bare attribute
+    # and drops it entirely for false, so the component needs to_string/1.
+    assert LazyHTML.attribute(buttons, "aria-pressed") == ["false", "true", "false"]
+  end
+
+  test "the buttons render no visible text label" do
+    html =
+      render_component(&GridDensityComponents.grid_density_toggle/1,
+        density: "compact",
+        id: "library-density-toggle"
+      )
+
+    # Checked as text content, not as a substring of the raw HTML: the level
+    # names still appear inside aria-label and data-tip, so `refute html =~
+    # "Compact"` would fail even on a correct implementation.
+    text =
+      html
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query("button")
+      |> LazyHTML.text()
+      |> String.trim()
+
+    assert text == ""
+  end
 end

--- a/test/mydia_web/live/components/grid_density_toggle_test.exs
+++ b/test/mydia_web/live/components/grid_density_toggle_test.exs
@@ -67,6 +67,67 @@ defmodule MydiaWeb.Components.GridDensityToggleTest do
     assert LazyHTML.attribute(buttons, "aria-pressed") == ["false", "true", "false"]
   end
 
+  test "each tooltip sits on a wrapper around the button, not on the button" do
+    html =
+      render_component(&GridDensityComponents.grid_density_toggle/1,
+        density: "compact",
+        id: "library-density-toggle"
+      )
+
+    document = LazyHTML.from_fragment(html)
+
+    # daisyUI reveals the tip through `.tooltip:has(:focus-visible)`, and
+    # `:has()` implies a descendant combinator. A `.tooltip` on the button
+    # itself only ever matches when something *inside* it takes focus, and the
+    # button's only child is the non-focusable span from icon/1 — so a
+    # keyboard user would tab onto a bare icon with no tip at all.
+    wrappers = LazyHTML.query(document, "div.tooltip")
+
+    assert LazyHTML.attribute(wrappers, "data-tip") == ["Comfortable", "Compact", "Dense"]
+
+    # join-item belongs on the button, never on the wrapper. daisyUI's
+    # `.join-item > *` resets the four --join-* radius variables to `initial`,
+    # so a button inside a join-item wrapper computes every corner to 0 and the
+    # filled active button spills square out of the join's rounded end cap.
+    for class <- LazyHTML.attribute(wrappers, "class") do
+      refute class =~ "join-item"
+    end
+
+    for class <- document |> LazyHTML.query("button") |> LazyHTML.attribute("class") do
+      assert class =~ "join-item"
+    end
+
+    refute document
+           |> LazyHTML.query("button")
+           |> LazyHTML.attribute("class")
+           |> Enum.any?(&(&1 =~ "tooltip"))
+  end
+
+  test "the buttons are square icon buttons and the join is a labelled group" do
+    html =
+      render_component(&GridDensityComponents.grid_density_toggle/1,
+        density: "compact",
+        id: "library-density-toggle"
+      )
+
+    document = LazyHTML.from_fragment(html)
+
+    # btn-square is what keeps a label-less button from collapsing to the
+    # width of its icon's padding.
+    for class <- document |> LazyHTML.query("button") |> LazyHTML.attribute("class") do
+      assert class =~ "btn-square"
+    end
+
+    # Without the labels, a screen reader otherwise announces three unrelated
+    # toggle buttons with no hint that they are one control.
+    join =
+      document
+      |> LazyHTML.filter("div.join")
+
+    assert LazyHTML.attribute(join, "role") == ["group"]
+    assert LazyHTML.attribute(join, "aria-label") == ["Grid density"]
+  end
+
   test "the buttons render no visible text label" do
     html =
       render_component(&GridDensityComponents.grid_density_toggle/1,

--- a/test/mydia_web/live/grid_density_test.exs
+++ b/test/mydia_web/live/grid_density_test.exs
@@ -49,12 +49,12 @@ defmodule MydiaWeb.GridDensityTest do
     {:ok, view, _html} = live(conn, ~p"/discover")
 
     # Asserts on the toolbar toggle, not the grid. Discover's grid sits behind
-    # an async metadata-relay fetch (index.html.heex:129), so the first
-    # connected render is always the loading spinner and no grid class exists
-    # yet; asserting there would also make this test depend on a live external
-    # call, which test_helper.exs excludes by tag elsewhere. The toggle
-    # (index.html.heex:33) renders from @grid_density on mount, so it proves
-    # the stored preference was read without any network dependency.
+    # an async metadata-relay fetch, so the first connected render is always
+    # the loading spinner and no grid class exists yet; asserting there would
+    # also make this test depend on a live external call, which
+    # test_helper.exs excludes by tag elsewhere. The density toggle in
+    # discover_live/index.html.heex renders from @grid_density on mount, so it
+    # proves the stored preference was read without any network dependency.
     assert has_element?(
              view,
              "#discover-density-toggle button[phx-value-density='dense'].btn-primary"

--- a/test/mydia_web/live/grid_density_test.exs
+++ b/test/mydia_web/live/grid_density_test.exs
@@ -60,4 +60,14 @@ defmodule MydiaWeb.GridDensityTest do
              "#discover-density-toggle button[phx-value-density='dense'].btn-primary"
            )
   end
+
+  test "discover groups the density toggle with the media-type join", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/discover")
+
+    # The row is sm:justify-between with three children. Once the density
+    # toggle shrank to icons, an ungrouped middle child floats in dead centre.
+    # Asserting the toggle is inside the cluster keeps that grouping from
+    # being undone by a later edit to the toolbar.
+    assert has_element?(view, "#discover-view-controls #discover-density-toggle")
+  end
 end


### PR DESCRIPTION
Follow-up polish on the grid density control from #469. The reporter's note on #466 was that it is "huge buttons right now".

Both view controls on the Libraries toolbar become icon-only square buttons, taking the pair from roughly 400px to roughly 150px. Labels stay on the buttons that perform an action (Re-scan, Add Movie, Import Files) and come off the ones that set a view preference, which is the hierarchy the toolbar was missing.

- Density buttons lose their text and gain a 1-to-3-to-many icon progression: `hero-stop`, `hero-view-columns`, `hero-table-cells`. The previous three icons sat on no common scale, which stops being survivable once the labels are gone.
- `hero-squares-2x2` is deliberately not used for a density level. It is already the Grid icon three buttons to the left on the same toolbar, and the Activity page's "All" tab.
- The grid/list toggle gets the same treatment, so the two controls stay matched. Collections inherits it as the other consumer.
- Both toggles gain `aria-label` and `aria-pressed`, plus `role="group"` and an `aria-label` on each join. The visible labels were previously supplying the accessible name, and `btn-primary` alone told a screen reader nothing about which level is active.
- Discover's toolbar groups the density toggle with the media-type join, so the shrunken control stops floating in the middle of a `justify-between` row.

No event, preference key, column breakpoint, or schema changed. `grid_columns_class/1`, `set_grid_density`, and `MydiaWeb.Live.Helpers.GridDensity` are untouched.

## The keyboard regression this nearly shipped with

Worth calling out, because it was the whole point of reviewing this twice.

Removing the visible labels makes the tooltip the affordance that replaces them. The first implementation put `tooltip tooltip-bottom` directly on the `<button>`, which looked right and worked on hover. But daisyUI reveals a tip on `.tooltip-open`, `:hover`, and `.tooltip:has(:focus-visible)` only, and `:has()` carries an implicit descendant combinator. With `.tooltip` on the button itself, the only descendant is the non-focusable `<span>` that `icon/1` renders, so **tabbing the toolbar landed on a bare icon with no tip and no label**. There is no `.tooltip:focus-visible` rule anywhere in the bundle.

Fixed by moving the tooltip onto a wrapper div, the form every other focusable tooltip in the app already uses. Verified with a real Tab-focus screenshot, mouse parked away.

`join-item` deliberately stays on the **button**, not the wrapper. daisyUI resets the four `--join-*` radius variables on `.join-item > *`; those are unregistered custom properties, so `initial` is the guaranteed-invalid value, `border-*-radius: var(--join-ss)` becomes invalid at computed-value time, and every corner computes to 0 — the filled active button then paints square and spills out of the join's rounded end cap. Left off the wrapper, those variables inherit through to the button and the caps render exactly as before (measured 8px/0/0/8px and 0/8px/8px/0, matching the pre-change baseline).

One accepted side effect: the button is now `:first-child` of its own wrapper, so `.join-item:not(:first-child)` no longer applies its `-1px` overlap. The density join widens 94px to 96px. Adjacent borders no longer collapse, but `btn-ghost` sets `--btn-border` transparent and `btn-primary`'s border matches its fill, so nothing is visible. It would show as a doubled 2px seam if either join ever gains a `btn-outline` button.

## Testing

`mix precommit` green: compile, `deps.unlock --unused`, `format --check-formatted`, `credo --strict`, test. 8156 tests, 0 failures.

The pre-existing density tests pass unedited, which was the point of keeping the button shape. New coverage asserts every button has a non-empty `aria-label`; that `aria-pressed` is the literal string rather than a bare HEEx boolean attribute (HEEx renders `aria-pressed={true}` as a bare attribute and omits it entirely for `false`, hence the `to_string/1`); that no visible level text renders; and that `btn-square`, `data-tip`, and the `role`/`aria-label` group semantics are present.

Verified by screenshot: the rendered toolbar, join end caps, tooltip on keyboard focus, grid reflow across all three densities, and Discover's cluster wrapping at 375px.

## Known, not fixed here

Two pre-existing app-wide tooltip defects surfaced while verifying this. Neither is caused by this branch, and both deserve their own change:

1. `tooltip-bottom` renders the tip **above**, not below, everywhere in the app (7+ shipped call sites). daisyUI emits its `.tooltip`/`.tooltip-top` positioning block twice and the second copy lands after `.tooltip-bottom` at equal specificity in the same layer, so plain source order wins. Roughly three lines of unlayered author CSS would fix it app-wide, since unlayered author styles beat any layered rule regardless of order.
2. `mydiaTheme.ts` sets `--color-neutral` to Slate-100 for `mydia-light`, and daisyUI's `--tt-bg` is `var(--color-neutral)`, so every light-theme tooltip bubble is near-white on a near-white surface. The tip text is legible; the bubble is not visible.

Refs #466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Added accessible labels and explicit active-state indicators to grid density and view mode controls.
  - Added tooltips to icon-only controls for clearer guidance.

- **UI Improvements**
  - Updated density and view mode controls with compact square buttons and refreshed icons.
  - Preserved joined styling for related controls.
  - Grouped media type and grid density controls in a responsive toolbar on the Discover page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->