### PR TITLE
fix(rail): track in-flight adds as a set on every media rail

### DIFF
--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -25,12 +25,17 @@ defmodule MydiaWeb.DiscoverComponents do
       `id`, `provider_id`, `poster_path`, `title`, `year` fields.
     * `media_type` - `:movie` or `:tv_show`.
     * `current_user` - current user struct (for guest vs admin logic).
-    * `adding_item_id` - provider_id (string) of the item currently being added.
+    * `adding_ids` - MapSet of provider ids whose add is in flight.
   """
   attr :item, :map, required: true
   attr :media_type, :atom, required: true
   attr :current_user, :map, required: true
-  attr :adding_item_id, :string, default: nil
+  # The ids whose add is in flight. A MapSet rather than a single id because
+  # every rail can have several adds running at once, and a single id has to
+  # pick an arbitrary survivor when one of them finishes (#459). Members are
+  # compared as strings: the detail page sets hold parsed integers while a
+  # SearchResult's provider_id is a string.
+  attr :adding_ids, MapSet, default: MapSet.new()
   attr :requesting_item_id, :string, default: nil
   attr :libraries, :list, default: []
   # :any rather than :string because nil is a meaningful value here: it renders
@@ -51,10 +56,6 @@ defmodule MydiaWeb.DiscoverComponents do
   # renders no action, because a "Go to Movie" pointing at the current page is
   # nonsense.
   attr :current, :boolean, default: false
-  # nil means "fall back to comparing against adding_item_id", which is what
-  # Discover and Dashboard rely on. A host that can have several adds in flight
-  # at once passes a boolean per card instead.
-  attr :adding, :boolean, default: nil
   # "lazy" is the safe default: eagerly fetching every card, including the
   # ones below the fold, is what starved the Dashboard's actual LCP poster
   # under 40 competing requests. A caller with a poster above the fold
@@ -154,13 +155,13 @@ defmodule MydiaWeb.DiscoverComponents do
     """
   end
 
-  # Discover and Dashboard track a single in-flight add and pass `adding_item_id`.
-  # The franchise strip can have several running at once, so a card may carry its
-  # own flag; that wins when it is set.
-  defp adding?(%{adding: adding}) when is_boolean(adding), do: adding
-
-  defp adding?(%{item: item, adding_item_id: adding_item_id}),
-    do: adding_item_id != nil and adding_item_id == to_string(item.provider_id)
+  # Members and provider ids are normalised to strings on both sides. The hosts
+  # genuinely disagree about the type and cannot cheaply be made to agree, and a
+  # mismatch under MapSet.member?/2 would silently draw no spinner at all.
+  defp adding?(%{item: item, adding_ids: adding_ids}) do
+    provider_id = to_string(item.provider_id)
+    Enum.any?(adding_ids, &(to_string(&1) == provider_id))
+  end
 
   @doc """
   Renders a horizontal strip of media cards under a heading.
@@ -178,13 +179,11 @@ defmodule MydiaWeb.DiscoverComponents do
       `show_details` handler.
     * `:current` - the card draws the primary ring and renders no action,
       because this is the title whose page the user is already on.
-    * `:adding` - overrides the `adding_item_id` comparison for hosts that can
-      have several adds in flight at once.
   """
   attr :items, :list, required: true
   attr :media_type, :atom, required: true
   attr :current_user, :map, required: true
-  attr :adding_item_id, :string, default: nil
+  attr :adding_ids, MapSet, default: MapSet.new()
   attr :requesting_item_id, :string, default: nil
   # No libraries attr on purpose. The rail is a horizontal scroll container, so
   # a library picker dropdown cannot escape it at any placement (#465). Rail
@@ -262,8 +261,7 @@ defmodule MydiaWeb.DiscoverComponents do
             item={item}
             media_type={@media_type}
             current_user={@current_user}
-            adding_item_id={@adding_item_id}
-            adding={Map.get(item, :adding)}
+            adding_ids={@adding_ids}
             current={Map.get(item, :current, false)}
             requesting_item_id={@requesting_item_id}
             on_select={@on_select}

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -31,7 +31,7 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:trending_movies, [])
         |> assign(:trending_tv, [])
         |> assign(:library_status_map, %{})
-        |> assign(:adding_item_id, nil)
+        |> assign(:adding_item_ids, MapSet.new())
         |> assign(:requesting_item_id, nil)
         |> assign(:request_status_map, %{})
         |> assign(:selected_item, nil)
@@ -54,7 +54,7 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:upcoming_episodes, [])
         |> assign(:recently_added, [])
         |> assign(:library_status_map, %{})
-        |> assign(:adding_item_id, nil)
+        |> assign(:adding_item_ids, MapSet.new())
         |> assign(:requesting_item_id, nil)
         |> assign(:request_status_map, %{})
         |> assign(:pending_requests_count, 0)
@@ -137,8 +137,12 @@ defmodule MydiaWeb.DashboardLive.Index do
       ) do
     case parse_event_media_type(media_type) do
       {:ok, media_type_atom} ->
-        # Set the adding state
-        socket = assign(socket, :adding_item_id, provider_id)
+        socket =
+          assign(
+            socket,
+            :adding_item_ids,
+            MapSet.put(socket.assigns.adding_item_ids, provider_id)
+          )
 
         # Start async task to add media
         send(
@@ -289,7 +293,7 @@ defmodule MydiaWeb.DashboardLive.Index do
 
         {:noreply,
          socket
-         |> assign(:adding_item_id, nil)
+         |> clear_adding(provider_id)
          |> assign(:library_status_map, updated_map)
          |> assign(:trending_movies, trending_movies)
          |> assign(:trending_tv, trending_tv)
@@ -308,7 +312,7 @@ defmodule MydiaWeb.DashboardLive.Index do
 
         {:noreply,
          socket
-         |> assign(:adding_item_id, nil)
+         |> clear_adding(provider_id)
          |> assign(:library_status_map, updated_map)
          |> assign(:trending_movies, trending_movies)
          |> assign(:trending_tv, trending_tv)
@@ -317,7 +321,7 @@ defmodule MydiaWeb.DashboardLive.Index do
       {:error, {:changeset, changeset}} ->
         {:noreply,
          socket
-         |> assign(:adding_item_id, nil)
+         |> clear_adding(provider_id)
          |> put_flash(
            :error,
            "Failed to add: #{MediaAddHelpers.format_changeset_errors(changeset)}"
@@ -326,7 +330,7 @@ defmodule MydiaWeb.DashboardLive.Index do
       {:error, {:metadata, reason}} ->
         {:noreply,
          socket
-         |> assign(:adding_item_id, nil)
+         |> clear_adding(provider_id)
          |> put_flash(:error, "Failed to fetch metadata: #{inspect(reason)}")}
     end
   end
@@ -357,6 +361,12 @@ defmodule MydiaWeb.DashboardLive.Index do
   end
 
   ## Private Helpers
+
+  # Four completion clauses all retire the same id. A MapSet rather than a
+  # single id so a second add cannot blank the first one's spinner (#459).
+  defp clear_adding(socket, provider_id) do
+    assign(socket, :adding_item_ids, MapSet.delete(socket.assigns.adding_item_ids, provider_id))
+  end
 
   defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
 

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -137,20 +137,28 @@ defmodule MydiaWeb.DashboardLive.Index do
       ) do
     case parse_event_media_type(media_type) do
       {:ok, media_type_atom} ->
-        socket =
-          assign(
-            socket,
-            :adding_item_ids,
-            MapSet.put(socket.assigns.adding_item_ids, provider_id)
+        # An impatient double-click sends the event twice before the first
+        # handle_info runs. Without this guard the second add lands on a title
+        # the first just created, and resolves to :already_in_library, flashing
+        # a false failure for a title the user only meant to add once.
+        if MapSet.member?(socket.assigns.adding_item_ids, provider_id) do
+          {:noreply, socket}
+        else
+          socket =
+            assign(
+              socket,
+              :adding_item_ids,
+              MapSet.put(socket.assigns.adding_item_ids, provider_id)
+            )
+
+          # Start async task to add media
+          send(
+            self(),
+            {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
           )
 
-        # Start async task to add media
-        send(
-          self(),
-          {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
-        )
-
-        {:noreply, socket}
+          {:noreply, socket}
+        end
 
       :error ->
         {:noreply, put_flash(socket, :error, @unsupported_media_type)}

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -224,7 +224,7 @@
               item={movie}
               media_type={:movie}
               current_user={@current_user}
-              adding_item_id={@adding_item_id}
+              adding_ids={@adding_item_ids}
               requesting_item_id={@requesting_item_id}
               libraries={@movie_libraries}
               loading={if(index < 6, do: nil, else: "lazy")}
@@ -260,7 +260,7 @@
               item={show}
               media_type={:tv_show}
               current_user={@current_user}
-              adding_item_id={@adding_item_id}
+              adding_ids={@adding_item_ids}
               requesting_item_id={@requesting_item_id}
               libraries={@show_libraries}
               loading={if(index < 6, do: nil, else: "lazy")}

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -217,19 +217,27 @@ defmodule MydiaWeb.DiscoverLive.Index do
       ) do
     case parse_event_media_type(media_type) do
       {:ok, media_type_atom} ->
-        socket =
-          assign(
-            socket,
-            :adding_item_ids,
-            MapSet.put(socket.assigns.adding_item_ids, provider_id)
+        # An impatient double-click sends the event twice before the first
+        # handle_info runs. Without this guard the second add lands on a title
+        # the first just created, and resolves to :already_in_library, flashing
+        # a false failure for a title the user only meant to add once.
+        if MapSet.member?(socket.assigns.adding_item_ids, provider_id) do
+          {:noreply, socket}
+        else
+          socket =
+            assign(
+              socket,
+              :adding_item_ids,
+              MapSet.put(socket.assigns.adding_item_ids, provider_id)
+            )
+
+          send(
+            self(),
+            {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
           )
 
-        send(
-          self(),
-          {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
-        )
-
-        {:noreply, socket}
+          {:noreply, socket}
+        end
 
       :error ->
         {:noreply, put_flash(socket, :error, @unsupported_media_type)}

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -53,7 +53,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
       |> assign(:has_more, false)
       |> assign(:genres, [])
       |> assign(:library_status_map, %{})
-      |> assign(:adding_item_id, nil)
+      |> assign(:adding_item_ids, MapSet.new())
       |> assign(:requesting_item_id, nil)
       |> assign(:request_status_map, %{})
       |> assign(:selected_item, nil)
@@ -217,7 +217,12 @@ defmodule MydiaWeb.DiscoverLive.Index do
       ) do
     case parse_event_media_type(media_type) do
       {:ok, media_type_atom} ->
-        socket = assign(socket, :adding_item_id, provider_id)
+        socket =
+          assign(
+            socket,
+            :adding_item_ids,
+            MapSet.put(socket.assigns.adding_item_ids, provider_id)
+          )
 
         send(
           self(),
@@ -407,7 +412,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
 
         {:noreply,
          socket
-         |> assign(:adding_item_id, nil)
+         |> clear_adding(provider_id)
          |> assign(:library_status_map, updated_map)
          |> assign(:items, items)
          |> assign(:selected_recommendations, recommendations)
@@ -421,7 +426,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
 
         {:noreply,
          socket
-         |> assign(:adding_item_id, nil)
+         |> clear_adding(provider_id)
          |> assign(:library_status_map, updated_map)
          |> assign(:items, items)
          |> put_flash(:info, "#{media_item.title} is already in your library")}
@@ -429,7 +434,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
       {:error, {:changeset, changeset}} ->
         {:noreply,
          socket
-         |> assign(:adding_item_id, nil)
+         |> clear_adding(provider_id)
          |> put_flash(
            :error,
            "Failed to add: #{MediaAddHelpers.format_changeset_errors(changeset)}"
@@ -438,7 +443,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
       {:error, {:metadata, reason}} ->
         {:noreply,
          socket
-         |> assign(:adding_item_id, nil)
+         |> clear_adding(provider_id)
          |> put_flash(:error, "Failed to fetch metadata: #{inspect(reason)}")}
     end
   end
@@ -513,6 +518,12 @@ defmodule MydiaWeb.DiscoverLive.Index do
     results
     |> MediaAddHelpers.enrich_with_library_status(socket.assigns.library_status_map)
     |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
+  end
+
+  # Four completion clauses all retire the same id. A MapSet rather than a
+  # single id so a second add cannot blank the first one's spinner (#459).
+  defp clear_adding(socket, provider_id) do
+    assign(socket, :adding_item_ids, MapSet.delete(socket.assigns.adding_item_ids, provider_id))
   end
 
   defp request_error_message(:duplicate_media), do: "That title is already in the library."

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -170,7 +170,7 @@
               item={item}
               media_type={item.media_type || @media_type}
               current_user={@current_user}
-              adding_item_id={@adding_item_id}
+              adding_ids={@adding_item_ids}
               requesting_item_id={@requesting_item_id}
               libraries={@libraries}
               loading={if(index < 6, do: nil, else: "lazy")}
@@ -215,7 +215,7 @@
         items={@selected_recommendations}
         media_type={@selected_item.media_type}
         current_user={@current_user}
-        adding_item_id={@adding_item_id}
+        adding_ids={@adding_item_ids}
         requesting_item_id={@requesting_item_id}
       />
     </:rail>

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -141,7 +141,6 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:recommendations, [])
      |> assign(:recommendations_expanded, false)
      |> assign(:adding_recommendation_tmdb_ids, MapSet.new())
-     |> assign(:adding_recommendation_id, nil)
      |> assign(:requesting_recommendation_id, nil)
      |> assign_new(:metadata_config, fn -> Mydia.Metadata.default_relay_config() end)
      |> assign(

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -210,7 +210,7 @@
             items={@recommendations}
             media_type={if @media_item.type == "tv_show", do: :tv_show, else: :movie}
             current_user={@current_user}
-            adding_item_id={@adding_recommendation_id}
+            adding_ids={@adding_recommendation_tmdb_ids}
             requesting_item_id={@requesting_recommendation_id}
             can_add={@can_create_media}
             on_select={nil}

--- a/lib/mydia_web/live/media_live/show/franchise_components.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_components.ex
@@ -24,7 +24,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
   attr :current_user, :map, required: true
 
   def franchise_section(assigns) do
-    assigns = assign(assigns, :items, items(assigns.franchise, assigns.adding_tmdb_ids))
+    assigns = assign(assigns, :items, items(assigns.franchise))
 
     ~H"""
     <DiscoverComponents.media_rail
@@ -34,6 +34,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
       media_type={:movie}
       current_user={@current_user}
       can_add={@can_add}
+      adding_ids={@adding_tmdb_ids}
       on_select={nil}
       add_event="add_franchise_movie"
       request_event="request_franchise_movie"
@@ -53,7 +54,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
     """
   end
 
-  defp items(franchise, adding_tmdb_ids) do
+  defp items(franchise) do
     Enum.map(franchise.entries, fn entry ->
       %{
         provider_id: entry.tmdb_id,
@@ -66,7 +67,6 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
         id: entry.media_item_id,
         navigate: navigate_to(entry),
         current: entry.current?,
-        adding: MapSet.member?(adding_tmdb_ids, entry.tmdb_id),
         request_status: entry.request_status
       }
     end)

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -258,26 +258,19 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
     ArgumentError -> nil
   end
 
-  # The MapSet is the source of truth for "is this id already in flight" and is
-  # what prevents a double-click from racing two adds. The single id alongside
-  # it is only what the card compares against to show its spinner.
   defp mark_in_flight(socket, tmdb_id) do
-    socket
-    |> assign(
+    assign(
+      socket,
       :adding_recommendation_tmdb_ids,
       MapSet.put(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
     )
-    |> assign(:adding_recommendation_id, to_string(tmdb_id))
   end
 
   defp clear_in_flight(socket, tmdb_id) do
-    remaining = MapSet.delete(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
-
-    socket
-    |> assign(:adding_recommendation_tmdb_ids, remaining)
-    |> assign(
-      :adding_recommendation_id,
-      remaining |> Enum.at(0) |> then(&if(&1, do: to_string(&1)))
+    assign(
+      socket,
+      :adding_recommendation_tmdb_ids,
+      MapSet.delete(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
     )
   end
 

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -28,7 +28,7 @@ defmodule MydiaWeb.DiscoverComponentsTest do
         item: item,
         media_type: :movie,
         current_user: guest(),
-        adding_item_id: nil,
+        adding_ids: MapSet.new(),
         requesting_item_id: nil,
         libraries: []
       }
@@ -71,7 +71,8 @@ defmodule MydiaWeb.DiscoverComponentsTest do
         %{
           items: [item],
           media_type: :movie,
-          current_user: %{role: "admin", id: "admin-1"}
+          current_user: %{role: "admin", id: "admin-1"},
+          adding_ids: MapSet.new()
         },
         overrides
       )

--- a/test/mydia_web/live/components/media_rail_component_test.exs
+++ b/test/mydia_web/live/components/media_rail_component_test.exs
@@ -5,8 +5,8 @@ defmodule MydiaWeb.Components.MediaRailComponentTest do
   where neither applies. The detail page has no `show_details` handler, so the
   inert case is what keeps a poster click from crashing that LiveView.
 
-  Also covers the two per-item keys the franchise adapter depends on, `:current`
-  and `:adding`.
+  Also covers `:current`, the per-item key the franchise adapter depends on, and
+  the shared `adding_ids` set.
   """
 
   use MydiaWeb.ConnCase, async: true
@@ -234,38 +234,64 @@ defmodule MydiaWeb.Components.MediaRailComponentTest do
       refute html =~ "Add to Library"
     end
 
-    # `adding_item_id` can only name one in-flight add. The franchise strip
-    # routinely has several, so an item may carry its own flag.
-    test "an item's own adding flag beats the single adding_item_id" do
+    # Regression for #459. Two adds can be in flight at once on the
+    # recommendations rail, and the old contract could only name one of them:
+    # when the first finished, an arbitrary survivor was chosen and the other
+    # still-running card silently lost its spinner.
+    test "every id in the set draws a spinner, and nothing else does" do
       html =
         render_component(&DiscoverComponents.media_rail/1,
           items: [
-            item(%{provider_id: "201", title: "Busy", adding: true}),
-            item(%{provider_id: "202", title: "Idle", adding: false})
+            item(%{provider_id: "201", title: "Busy One"}),
+            item(%{provider_id: "202", title: "Busy Two"}),
+            item(%{provider_id: "203", title: "Idle"})
           ],
+          media_type: :movie,
+          current_user: user(),
+          adding_ids: MapSet.new(["201", "202"])
+        )
+
+      first = extract_item(html, "media-rail", "201")
+      second = extract_item(html, "media-rail", "202")
+      idle = extract_item(html, "media-rail", "203")
+
+      assert first =~ "loading-spinner"
+      assert first =~ "disabled"
+      assert second =~ "loading-spinner"
+      assert second =~ "disabled"
+      refute idle =~ "loading-spinner"
+    end
+
+    # The hosts do not agree on id types and cannot be made to. The two detail
+    # page sets hold parsed integers because dispatch_add/2 dedupes on the
+    # integer and keys start_async with it, while a SearchResult's provider_id
+    # is a string. A strict MapSet.member?/2 across that mix would match
+    # nothing and draw no spinner, with no compile-time signal.
+    test "matches an integer set against string provider ids" do
+      html =
+        render_component(&DiscoverComponents.media_rail/1,
+          items: [
+            item(%{provider_id: "201", title: "Busy"}),
+            item(%{provider_id: "202", title: "Idle"})
+          ],
+          media_type: :movie,
+          current_user: user(),
+          adding_ids: MapSet.new([201])
+        )
+
+      assert extract_item(html, "media-rail", "201") =~ "loading-spinner"
+      refute extract_item(html, "media-rail", "202") =~ "loading-spinner"
+    end
+
+    test "an omitted adding_ids draws no spinners" do
+      html =
+        render_component(&DiscoverComponents.media_rail/1,
+          items: [item(%{provider_id: "201"})],
           media_type: :movie,
           current_user: user()
         )
 
-      busy = extract_item(html, "media-rail", "201")
-      idle = extract_item(html, "media-rail", "202")
-
-      assert busy =~ "loading-spinner"
-      assert busy =~ "disabled"
-      refute idle =~ "loading-spinner"
-    end
-
-    test "falls back to adding_item_id when an item carries no flag" do
-      html =
-        render_component(&DiscoverComponents.media_rail/1,
-          items: [item(%{provider_id: "301"}), item(%{provider_id: "302"})],
-          media_type: :movie,
-          current_user: user(),
-          adding_item_id: "301"
-        )
-
-      assert extract_item(html, "media-rail", "301") =~ "loading-spinner"
-      refute extract_item(html, "media-rail", "302") =~ "loading-spinner"
+      refute html =~ "loading-spinner"
     end
 
     # Regression: an unowned card for a user who may neither add nor request

--- a/test/mydia_web/live/dashboard_live/add_to_library_guard_test.exs
+++ b/test/mydia_web/live/dashboard_live/add_to_library_guard_test.exs
@@ -1,0 +1,57 @@
+defmodule MydiaWeb.DashboardLive.AddToLibraryGuardTest do
+  @moduledoc """
+  Covers the in-flight guard on add_to_library.
+
+  An impatient double-click sends the add_to_library event twice before the
+  first handle_info runs. Without a guard the second event re-enters the
+  success branch, sends a second :add_media_to_library message, and the
+  duplicate add resolves to :already_in_library, flashing a false failure for
+  a title the user only meant to add once. A connected LiveView test cannot
+  reproduce this: render_click is a synchronous round trip, so the first
+  click's handle_info completes before a second render_click is delivered.
+  Calling handle_event/3 directly, the way request_media_authorization_test.exs
+  does, is the seam that actually exercises the guard.
+  """
+
+  use Mydia.DataCase, async: false
+
+  alias MydiaWeb.DashboardLive.Index
+
+  defp stub_socket(adding_item_ids) do
+    %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        flash: %{},
+        adding_item_ids: adding_item_ids
+      }
+    }
+  end
+
+  test "a repeat add_to_library for an id already in flight is dropped" do
+    socket = stub_socket(MapSet.new(["693134"]))
+
+    {:noreply, updated} =
+      Index.handle_event(
+        "add_to_library",
+        %{"tmdb_id" => "693134", "media_type" => "movie"},
+        socket
+      )
+
+    assert updated.assigns.adding_item_ids == MapSet.new(["693134"])
+    refute_received {:add_media_to_library, _, _, _}
+  end
+
+  test "the first add_to_library for an id marks it in flight and dispatches the add" do
+    socket = stub_socket(MapSet.new())
+
+    {:noreply, updated} =
+      Index.handle_event(
+        "add_to_library",
+        %{"tmdb_id" => "693134", "media_type" => "movie"},
+        socket
+      )
+
+    assert updated.assigns.adding_item_ids == MapSet.new(["693134"])
+    assert_received {:add_media_to_library, "693134", :movie, nil}
+  end
+end

--- a/test/mydia_web/live/discover_live/add_to_library_guard_test.exs
+++ b/test/mydia_web/live/discover_live/add_to_library_guard_test.exs
@@ -1,0 +1,57 @@
+defmodule MydiaWeb.DiscoverLive.AddToLibraryGuardTest do
+  @moduledoc """
+  Covers the in-flight guard on add_to_library.
+
+  An impatient double-click sends the add_to_library event twice before the
+  first handle_info runs. Without a guard the second event re-enters the
+  success branch, sends a second :add_media_to_library message, and the
+  duplicate add resolves to :already_in_library, flashing a false failure for
+  a title the user only meant to add once. A connected LiveView test cannot
+  reproduce this: render_click is a synchronous round trip, so the first
+  click's handle_info completes before a second render_click is delivered.
+  Calling handle_event/3 directly, the way request_media_authorization_test.exs
+  does, is the seam that actually exercises the guard.
+  """
+
+  use Mydia.DataCase, async: false
+
+  alias MydiaWeb.DiscoverLive.Index
+
+  defp stub_socket(adding_item_ids) do
+    %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        flash: %{},
+        adding_item_ids: adding_item_ids
+      }
+    }
+  end
+
+  test "a repeat add_to_library for an id already in flight is dropped" do
+    socket = stub_socket(MapSet.new(["693134"]))
+
+    {:noreply, updated} =
+      Index.handle_event(
+        "add_to_library",
+        %{"tmdb_id" => "693134", "media_type" => "movie"},
+        socket
+      )
+
+    assert updated.assigns.adding_item_ids == MapSet.new(["693134"])
+    refute_received {:add_media_to_library, _, _, _}
+  end
+
+  test "the first add_to_library for an id marks it in flight and dispatches the add" do
+    socket = stub_socket(MapSet.new())
+
+    {:noreply, updated} =
+      Index.handle_event(
+        "add_to_library",
+        %{"tmdb_id" => "693134", "media_type" => "movie"},
+        socket
+      )
+
+    assert updated.assigns.adding_item_ids == MapSet.new(["693134"])
+    assert_received {:add_media_to_library, "693134", :movie, nil}
+  end
+end

--- a/test/mydia_web/live/media_live/show/recommendation_events_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendation_events_test.exs
@@ -23,7 +23,6 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
       flash: %{},
       recommendations: [],
       adding_recommendation_tmdb_ids: MapSet.new(),
-      adding_recommendation_id: nil,
       requesting_recommendation_id: nil,
       current_user: user_fixture()
     }
@@ -160,6 +159,31 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
       assert updated.assigns.recommendations == recommendations
       assert updated.assigns.requesting_recommendation_id == nil
       assert MediaRequests.list_requests(status: "pending") == []
+    end
+  end
+
+  describe "handle_add_result/3" do
+    # A completion must retire exactly its own id. The old code also derived a
+    # single :adding_recommendation_id from whatever survived, via Enum.at(0),
+    # which is how a still-running card lost its spinner (#459). This asserts
+    # the set itself, which is now the only in-flight state there is.
+    test "retires only the finished id and leaves the other in-flight adds" do
+      socket =
+        stub_socket(%{adding_recommendation_tmdb_ids: MapSet.new([11, 22, 33])})
+
+      {:noreply, socket} =
+        RecommendationEvents.handle_add_result(11, {:ok, {:error, :boom}}, socket)
+
+      assert socket.assigns.adding_recommendation_tmdb_ids == MapSet.new([22, 33])
+    end
+
+    test "an exit retires its id like any other completion" do
+      socket = stub_socket(%{adding_recommendation_tmdb_ids: MapSet.new([11, 22])})
+
+      {:noreply, socket} =
+        RecommendationEvents.handle_add_result(22, {:exit, :killed}, socket)
+
+      assert socket.assigns.adding_recommendation_tmdb_ids == MapSet.new([11])
     end
   end
 end


### PR DESCRIPTION
Adding two titles from the "More like this" rail at once made one card's
spinner vanish while its add was still running, and a re-click on that card
was then silently swallowed by the dedupe guard.

The card could learn "I am adding" two ways and its hosts tracked it three:
an `adding_item_id` string, a per-item `:adding` boolean added in #457, and
the `MapSet` in the LiveView. The recommendations rail was wired to the
weakest of the three, and `clear_in_flight/2` picked an arbitrary survivor
with `Enum.at(0)`, so finishing one add could blank a different card's
spinner.

`trending_card/1` and `media_rail/1` now take a single `adding_ids` MapSet.
`adding_item_id`, the per-item `:adding` key and the derived
`:adding_recommendation_id` assign are all deleted, and all four hosts pass a
set. Members are compared as strings on both sides, because the detail page
sets hold parsed integers while a `SearchResult`'s `provider_id` is a string,
and a strict `MapSet.member?/2` across that mix would draw no spinner at all
with no compile-time signal.

Discover and Dashboard were converted too. Their adds run in a blocking
`handle_info`, so they could not actually get two in flight; converting them
is what makes one mechanism true everywhere and lets the fallback clause go.

Deleting the attr is the sweep's own gate: with `warnings_as_errors` set
outside prod, a host left passing `adding_item_id` fails the build.

Tests: a rail rendering a set of two ids now asserts two concurrent spinners,
which the old single-id API could not express, plus an integer-set against
string `provider_id` case that pins the normalisation.

Fixes #459


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adding media to the library from trending, discovery, and recommendation views.
  * Multiple media items can now be added simultaneously, with accurate progress indicators for each item.
  * Duplicate add requests are safely ignored while an item is already being added.
  * Progress indicators remain correct when individual additions complete or encounter errors.
  * Improved matching of media IDs across different formats.

* **Tests**
  * Added coverage for concurrent additions, duplicate requests, ID matching, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->