### PR TITLE
fix(show): keep every in-flight add's spinner on the recommendations rail

### DIFF
--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -141,7 +141,6 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:recommendations, [])
      |> assign(:recommendations_expanded, false)
      |> assign(:adding_recommendation_tmdb_ids, MapSet.new())
-     |> assign(:adding_recommendation_id, nil)
      |> assign(:requesting_recommendation_id, nil)
      |> assign_new(:metadata_config, fn -> Mydia.Metadata.default_relay_config() end)
      |> assign(

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -207,10 +207,14 @@
             collapsible={@media_item.type == "tv_show"}
             expanded={@recommendations_expanded}
             toggle_event="toggle_recommendations"
-            items={@recommendations}
+            items={
+              RecommendationEvents.with_in_flight(
+                @recommendations,
+                @adding_recommendation_tmdb_ids
+              )
+            }
             media_type={if @media_item.type == "tv_show", do: :tv_show, else: :movie}
             current_user={@current_user}
-            adding_item_id={@adding_recommendation_id}
             requesting_item_id={@requesting_recommendation_id}
             can_add={@can_create_media}
             on_select={nil}

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -211,6 +211,20 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
      |> put_flash(:error, "Could not add that title")}
   end
 
+  @doc """
+  Stamps each item's `:adding` flag from the set of in-flight adds.
+
+  Applied at render rather than inside `decorate/3`, because the set changes on
+  every add and every result while `decorate/3` runs once, when the lookup lands.
+  A single id cannot describe more than one in-flight add, which is what #459
+  was: clicking a second Add blanked the first card's spinner.
+  """
+  def with_in_flight(recommendations, in_flight) do
+    Enum.map(recommendations, fn item ->
+      Map.put(item, :adding, MapSet.member?(in_flight, safe_provider_id(item)))
+    end)
+  end
+
   ## Private
 
   # The library join lives here rather than in Mydia.Media.Recommendations
@@ -258,26 +272,21 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
     ArgumentError -> nil
   end
 
-  # The MapSet is the source of truth for "is this id already in flight" and is
-  # what prevents a double-click from racing two adds. The single id alongside
-  # it is only what the card compares against to show its spinner.
+  # The MapSet is the only in-flight state: it prevents a double-click from
+  # racing two adds, and `with_in_flight/2` turns it into the per-card spinner.
   defp mark_in_flight(socket, tmdb_id) do
-    socket
-    |> assign(
+    assign(
+      socket,
       :adding_recommendation_tmdb_ids,
       MapSet.put(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
     )
-    |> assign(:adding_recommendation_id, to_string(tmdb_id))
   end
 
   defp clear_in_flight(socket, tmdb_id) do
-    remaining = MapSet.delete(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
-
-    socket
-    |> assign(:adding_recommendation_tmdb_ids, remaining)
-    |> assign(
-      :adding_recommendation_id,
-      remaining |> Enum.at(0) |> then(&if(&1, do: to_string(&1)))
+    assign(
+      socket,
+      :adding_recommendation_tmdb_ids,
+      MapSet.delete(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id)
     )
   end
 

--- a/test/mydia_web/live/media_live/show/recommendation_events_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendation_events_test.exs
@@ -23,7 +23,6 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
       flash: %{},
       recommendations: [],
       adding_recommendation_tmdb_ids: MapSet.new(),
-      adding_recommendation_id: nil,
       requesting_recommendation_id: nil,
       current_user: user_fixture()
     }
@@ -160,6 +159,45 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
       assert updated.assigns.recommendations == recommendations
       assert updated.assigns.requesting_recommendation_id == nil
       assert MediaRequests.list_requests(status: "pending") == []
+    end
+  end
+
+  describe "with_in_flight/2" do
+    # Regression for #459: the rail used to read a single
+    # :adding_recommendation_id, which can only ever name one card. Clicking a
+    # second Add overwrote it, so the first card lost its spinner while its add
+    # was still running and read as unresponsive.
+    test "flags every id in the set, not only the most recent" do
+      items = [
+        result(%{provider_id: "1"}),
+        result(%{provider_id: "2"}),
+        result(%{provider_id: "3"})
+      ]
+
+      [first, second, third] =
+        RecommendationEvents.with_in_flight(items, MapSet.new([1, 2]))
+
+      assert first.adding
+      assert second.adding
+      refute third.adding
+    end
+
+    test "flags nothing when no add is in flight" do
+      items = [result(%{provider_id: "1"})]
+
+      [only] = RecommendationEvents.with_in_flight(items, MapSet.new())
+
+      refute only.adding
+    end
+
+    # A malformed provider_id must not raise here: safe_provider_id/1 returns nil
+    # for one, and nil is simply not a member of the in-flight set.
+    test "treats an unparseable provider_id as not in flight" do
+      items = [result(%{provider_id: "not-a-number"})]
+
+      [only] = RecommendationEvents.with_in_flight(items, MapSet.new([1]))
+
+      refute only.adding
     end
   end
 end


### PR DESCRIPTION
Adding two titles at once from the "More like this" rail made one card's spinner vanish while its add was still running, and a re-click on that card did nothing visible.

Closes #459.

## Root cause

One step earlier than the issue describes. The issue points at `clear_in_flight/2` picking an arbitrary survivor with `Enum.at(remaining, 0)`, which is real but only bites with three or more adds in flight.

The primary defect was `mark_in_flight/2`. It overwrote `:adding_recommendation_id` with the newest id, and that single id was the only thing the card compared against to decide whether to draw a spinner. So the first card lost its spinner the moment Add was clicked on a second card, before anything had finished. The re-click was then correctly dropped by the `MapSet.member?/2` guard in `dispatch_add/2`, which is what made the card look stuck rather than merely idle.

Both symptoms are the same error: a single id cannot represent a set.

## What changed

- `RecommendationEvents.with_in_flight/2` stamps the per-item `:adding` flag that `trending_card/1` already honours (`discover_components.ex:160`), computed from the MapSet at render. It runs at render rather than inside `decorate/3` because the set changes on every add and every result, while `decorate/3` runs once when the lookup lands.
- The MapSet is now the only in-flight state. The `:adding_recommendation_id` assign, both of its writes, and `adding_item_id` at the call site are deleted. `clear_in_flight/2` is a plain `MapSet.delete`, so the arbitrary-survivor logic is gone rather than corrected.

This is the pattern the franchise strip has used since #457 (`franchise_components.ex:69`). The recommendations rail was left on the old single-id path.

## Verification

`./dev mix precommit` green on all seven steps: 8168 tests, 0 failures.

Three new tests, written before the fix and confirmed failing on the missing function:

- a two-element in-flight set flags both items and leaves a third alone, which is the issue's exact scenario
- an empty set flags nothing
- an unparseable `provider_id` is treated as not in flight rather than raising, since `safe_provider_id/1` returns nil there

The wiring itself has no dedicated test. Driving two real adds through a connected LiveView would need heavy stubbing of the add path for little gain, and the existing connected rail tests already render through the new template expression, so a wrong arity or assign name fails them.
