### PR TITLE
fix(player): keep the media proxy alive across a next-episode handoff

### DIFF
--- a/player/lib/core/downloads/p2p_download_job_service.dart
+++ b/player/lib/core/downloads/p2p_download_job_service.dart
@@ -162,22 +162,30 @@ class P2pDownloadJobService implements DownloadJobService {
 
   @override
   Future<String> getDownloadUrl(String jobId) async {
-    // Take a hold on the shared proxy, rather than only starting it when it
-    // happens to be down. Downloads and playback serve from one proxy, and
-    // the old `if (!isRunning)` guard left this holding nothing in the common
-    // case — playback already had it up — which is exactly when the player's
-    // `dispose()` could stop it out from under a transfer in progress.
-    // Starting an already-running proxy just re-targets it.
+    // Take a hold on the shared proxy either way, but only configure it when
+    // nothing else has. Downloads and playback serve from one proxy, and
+    // holding nothing is what let the player's `dispose()` stop it out from
+    // under a transfer in progress.
+    //
+    // The split matters: `start` re-targets a proxy that is already running,
+    // and the peer and token here were captured when this service was built.
+    // A token refresh since then leaves them stale, so configuring a proxy
+    // playback is already streaming through would point it at the wrong token
+    // and get playback's own range requests rejected.
     //
     // The hold outlives an individual job: nothing here observes a download
     // finishing, so once any download has run the proxy stays up for the rest
     // of the session. That is a loopback listener with no traffic on it,
     // which beats a download dying mid-transfer.
-    await _localProxy.start(
-      owner: this,
-      targetPeer: _serverNodeAddr,
-      authToken: _authToken,
-    );
+    if (_localProxy.isRunning) {
+      _localProxy.acquireLease(this);
+    } else {
+      await _localProxy.start(
+        owner: this,
+        targetPeer: _serverNodeAddr,
+        authToken: _authToken,
+      );
+    }
     return 'http://127.0.0.1:${_localProxy.port}/download/$jobId/file';
   }
 }

--- a/player/lib/core/downloads/p2p_download_job_service.dart
+++ b/player/lib/core/downloads/p2p_download_job_service.dart
@@ -162,15 +162,22 @@ class P2pDownloadJobService implements DownloadJobService {
 
   @override
   Future<String> getDownloadUrl(String jobId) async {
-    // Ensure the local proxy is running for download requests.
-    // The proxy may not have been started yet if the user hasn't played
-    // any media in this session (it's normally started by PlayerScreen).
-    if (!_localProxy.isRunning) {
-      await _localProxy.start(
-        targetPeer: _serverNodeAddr,
-        authToken: _authToken,
-      );
-    }
+    // Take a hold on the shared proxy, rather than only starting it when it
+    // happens to be down. Downloads and playback serve from one proxy, and
+    // the old `if (!isRunning)` guard left this holding nothing in the common
+    // case — playback already had it up — which is exactly when the player's
+    // `dispose()` could stop it out from under a transfer in progress.
+    // Starting an already-running proxy just re-targets it.
+    //
+    // The hold outlives an individual job: nothing here observes a download
+    // finishing, so once any download has run the proxy stays up for the rest
+    // of the session. That is a loopback listener with no traffic on it,
+    // which beats a download dying mid-transfer.
+    await _localProxy.start(
+      owner: this,
+      targetPeer: _serverNodeAddr,
+      authToken: _authToken,
+    );
     return 'http://127.0.0.1:${_localProxy.port}/download/$jobId/file';
   }
 }

--- a/player/lib/core/p2p/local_proxy_service.dart
+++ b/player/lib/core/p2p/local_proxy_service.dart
@@ -16,7 +16,7 @@ import 'package:player/native/lib.dart'
 final localProxyServiceProvider = Provider<LocalProxyService>((ref) {
   final p2p = ref.watch(p2pServiceProvider);
   final service = LocalProxyService(p2p);
-  ref.onDispose(() => service.stop());
+  ref.onDispose(() => service.shutdown());
   return service;
 });
 
@@ -32,7 +32,7 @@ final localProxyServiceProvider = Provider<LocalProxyService>((ref) {
 ///
 /// Direct stream: /direct/{file_id}/stream
 /// Download: /download/{job_id}/file
-class LocalProxyService implements MediaProxy {
+class LocalProxyService with MediaProxyLeases implements MediaProxy {
   final P2pService _p2p;
   HttpServer? _server;
 
@@ -98,9 +98,12 @@ class LocalProxyService implements MediaProxy {
   /// [authToken] - Optional auth token for HLS requests.
   @override
   Future<void> start({
+    required Object owner,
     required String targetPeer,
     String? authToken,
   }) async {
+    acquireLease(owner);
+
     if (_server != null) {
       // Update config if already running
       _targetPeer = targetPeer;
@@ -121,8 +124,25 @@ class LocalProxyService implements MediaProxy {
   }
 
   @override
-  Future<void> stop() async {
-    await _server?.close();
+  Future<void> stop(Object owner) async {
+    if (!releaseLease(owner)) return;
+    await _tearDown();
+  }
+
+  @override
+  Future<void> shutdown() async {
+    clearLeases();
+    await _tearDown();
+  }
+
+  Future<void> _tearDown() async {
+    // Forced. An ordinary close stops the listener and returns, but leaves
+    // connections already accepted to carry on being served — by a proxy
+    // whose target peer and auth token the next few lines null out. The
+    // connection open here is the video pipeline's own: mpv holds a range
+    // request for the whole file, so unforced it is left waiting on a socket
+    // nothing will ever answer instead of seeing its stream end.
+    await _server?.close(force: true);
     _server = null;
     _targetPeer = null;
     _authToken = null;
@@ -236,7 +256,11 @@ class LocalProxyService implements MediaProxy {
       _lanToken = null;
     }
 
-    await _server?.close();
+    // Forced for the same reason as [_tearDown]: rebinding on a fresh port
+    // invalidates whatever URL the video pipeline is holding regardless, and
+    // the caller restarts local playback afterwards. Left unforced, the
+    // request in flight against the old port would hang rather than end.
+    await _server?.close(force: true);
     _server = null;
 
     if (peer == null) {

--- a/player/lib/core/p2p/media_proxy.dart
+++ b/player/lib/core/p2p/media_proxy.dart
@@ -1,14 +1,47 @@
+import 'dart:collection';
+
 /// Serves media bytes to the platform's video pipeline from a p2p connection.
 ///
 /// Native runs a loopback HTTP server. A browser cannot, so it registers a
 /// Service Worker that claims the same paths. Both expose the same URL
 /// contract through [baseUrl], so call sites build one URL for both.
+///
+/// One proxy is shared by every call site that needs it — playback and
+/// downloads alike — so it is started and stopped against an *owner* rather
+/// than outright. See [start] and [stop].
 abstract class MediaProxy {
-  /// Begin serving, targeting [targetPeer].
-  Future<void> start({required String targetPeer, String? authToken});
+  /// Begin serving for [owner], targeting [targetPeer].
+  ///
+  /// [owner] is any object with a stable identity that stands for the call
+  /// site relying on the proxy — a `PlayerScreen` state, a download service.
+  /// Repeat calls from the same owner re-target an already running proxy and
+  /// still leave it held exactly once, which is what makes this safe to call
+  /// from a path that re-runs (a session restart, a cast rebind).
+  Future<void> start({
+    required Object owner,
+    required String targetPeer,
+    String? authToken,
+  });
 
-  /// Stop serving. Safe to call more than once.
-  Future<void> stop();
+  /// Release [owner]'s hold. Serving stops once the last owner lets go.
+  ///
+  /// Ownership, rather than an unconditional teardown, is what keeps a screen
+  /// being disposed from cutting off the screen that replaced it. Flutter
+  /// mounts the incoming route before it disposes the outgoing one, so on a
+  /// next-episode navigation the new screen has already started the proxy and
+  /// taken its URL by the time the old screen's `dispose()` runs. An
+  /// unconditional stop there closed the server underneath the episode that
+  /// was just starting, and mpv opened a dead URL.
+  ///
+  /// Safe to call more than once, and safe to call from something that never
+  /// started the proxy: both are no-ops.
+  Future<void> stop(Object owner);
+
+  /// Stop serving outright, whoever still holds it.
+  ///
+  /// For tearing the whole thing down — provider disposal, app shutdown —
+  /// where there is no later owner left to serve.
+  Future<void> shutdown();
 
   bool get isRunning;
 
@@ -28,4 +61,35 @@ abstract class MediaProxy {
 
   /// URL that streams a media file's own bytes, with no transcoding.
   String buildDirectStreamUrl(String fileId);
+}
+
+/// Tracks which call sites currently need the proxy up.
+///
+/// Shared by both implementations so the ownership rules in [MediaProxy.start]
+/// and [MediaProxy.stop] are written once. An implementation supplies only the
+/// binding and teardown; when those run is decided here.
+mixin MediaProxyLeases {
+  /// Identity-keyed on purpose: an owner is "this particular object", never
+  /// "something equal to it". A `State` that implemented `==` in terms of its
+  /// route arguments would otherwise collide with its own replacement across a
+  /// next-episode navigation — the exact handoff this exists to protect.
+  final Set<Object> _owners = LinkedHashSet<Object>(
+    equals: identical,
+    hashCode: identityHashCode,
+  );
+
+  /// Whether any call site still needs the proxy up.
+  bool get hasOwners => _owners.isNotEmpty;
+
+  /// Records [owner] as needing the proxy. Idempotent per owner.
+  void acquireLease(Object owner) => _owners.add(owner);
+
+  /// Drops [owner]'s hold, reporting whether that was the last one.
+  ///
+  /// False when [owner] never held it, so a stray stop cannot tear down a
+  /// proxy someone else is using.
+  bool releaseLease(Object owner) => _owners.remove(owner) && _owners.isEmpty;
+
+  /// Forgets every owner, for an unconditional [MediaProxy.shutdown].
+  void clearLeases() => _owners.clear();
 }

--- a/player/lib/core/p2p/media_proxy_web.dart
+++ b/player/lib/core/p2p/media_proxy_web.dart
@@ -44,7 +44,7 @@ const _scriptPath = 'sw.js';
 /// purpose: the browser is free to terminate an idle Service Worker, and a
 /// QUIC connection living there would go with it mid-playback. This object,
 /// which lives in the page, owns the connection.
-class ServiceWorkerMediaProxy implements MediaProxy {
+class ServiceWorkerMediaProxy with MediaProxyLeases implements MediaProxy {
   ServiceWorkerMediaProxy(this._p2p);
 
   final P2pService _p2p;
@@ -81,7 +81,13 @@ class ServiceWorkerMediaProxy implements MediaProxy {
       MediaRoutes.directStream(baseUrl, fileId);
 
   @override
-  Future<void> start({required String targetPeer, String? authToken}) async {
+  Future<void> start({
+    required Object owner,
+    required String targetPeer,
+    String? authToken,
+  }) async {
+    acquireLease(owner);
+
     // Assigned before the await so a request that arrives while an already
     // running proxy is being retargeted uses the new peer, matching
     // LocalProxyService's "update config if already running" behavior.
@@ -104,7 +110,18 @@ class ServiceWorkerMediaProxy implements MediaProxy {
   }
 
   @override
-  Future<void> stop() async {
+  Future<void> stop(Object owner) async {
+    if (!releaseLease(owner)) return;
+    await _tearDown();
+  }
+
+  @override
+  Future<void> shutdown() async {
+    clearLeases();
+    await _tearDown();
+  }
+
+  Future<void> _tearDown() async {
     final registration = _registration;
     _registration = null;
     _targetPeer = null;
@@ -350,6 +367,6 @@ class _Exchange {
 
 MediaProxy createMediaProxy(Ref ref) {
   final proxy = ServiceWorkerMediaProxy(ref.watch(p2pServiceProvider));
-  ref.onDispose(() => proxy.stop());
+  ref.onDispose(() => proxy.shutdown());
   return proxy;
 }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -957,7 +957,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         }
 
         final proxy = ref.read(mediaProxyProvider);
+        // Held against this State, and released by [_terminateHlsSession] at
+        // dispose. This method re-runs within one screen's life (a session
+        // restart past the transcoded end, a cast rebind); the hold is per
+        // owner, so those re-runs re-target the proxy without stacking up a
+        // debt that a single stop could not settle.
         await proxy.start(
+          owner: this,
           targetPeer: serverNodeAddr,
           authToken: token,
         );
@@ -2722,8 +2728,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     // Stop local proxy if P2P mode
     if (_isP2PMode) {
       try {
-        await _mediaProxy.stop();
-        debugPrint('[PlayerScreen] Media proxy stopped');
+        // Releases this screen's hold rather than stopping the proxy
+        // outright. On a next-episode navigation the incoming screen has
+        // already started it — Flutter mounts the new route before disposing
+        // the old one — so an unconditional stop here closed the server the
+        // episode now playing was streaming from.
+        await _mediaProxy.stop(this);
+        debugPrint('[PlayerScreen] Media proxy released');
       } catch (e) {
         debugPrint('[PlayerScreen] Error stopping local proxy: $e');
       }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -185,25 +185,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// [_terminateHlsSession] instead of a `dispose()`-time `ref.read`.
   late final MediaProxy _mediaProxy;
 
-  /// The current P2P connection mode, kept in sync via `ref.listenManual`
-  /// (set up in [initState]) rather than read in `dispose()`:
-  /// `ref.read`/`ref.watch` are unsafe there — `BuildContext.mounted` is
-  /// already `false` throughout `State.dispose()`, a core Flutter
-  /// invariant, not a Riverpod-specific one. [_terminateHlsSession] needs
-  /// the *current* mode at termination time, and the user can switch modes
-  /// mid-session, so a one-time capture (at [initState] or anywhere else)
-  /// would risk going stale; the listener keeps it live for the whole
-  /// widget lifetime instead, matching what a fresh `ref.read` would have
-  /// returned at any given moment.
-  ///
-  /// The `ref.listenManual` subscription itself is set up in [initState] but
-  /// not stored: `ConsumerStatefulElement` already keeps its own reference
-  /// (to close automatically at unmount) whether or not the caller keeps
-  /// one too, and this widget never needs to cancel it early.
-  bool _isP2PMode = false;
-
   /// The most recently resolved GraphQL client, kept in sync via
-  /// `ref.listenManual` for the same reason as [_isP2PMode]: a long
+  /// `ref.listenManual` rather than read in `dispose()`: a long
   /// playback session can outlive a token refresh or reconnect that
   /// produces a new client, so this is refreshed continuously rather than
   /// captured once. Null until the first resolution completes;
@@ -551,15 +534,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     // initialization branches must honour that, not just the streaming one.
     _resumeOverrideSeconds = widget.resumeSeconds;
 
-    // Set up before `_initializePlayer` so both are live for the whole
-    // widget lifetime, regardless of which playback branch runs (offline,
+    // Set up before `_initializePlayer` so it is live for the whole widget
+    // lifetime, regardless of which playback branch runs (offline,
     // already-downloaded, or streaming) — `_terminateHlsSession` is called
     // unconditionally from `dispose()` no matter which branch was taken.
-    ref.listenManual<conn.ConnectionState>(
-      conn.connectionProvider,
-      (previous, next) => _isP2PMode = next.isP2PMode,
-      fireImmediately: true,
-    );
     ref.listenManual<AsyncValue<GraphQLClient>>(
       asyncGraphqlClientProvider,
       (previous, next) => next.whenData((client) => _graphqlClient = client),
@@ -2717,27 +2695,33 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   /// Terminate the HLS session on the server and clean up P2P resources.
   /// This stops FFmpeg and cleans up server-side resources.
   ///
-  /// Reads only the fields captured in [initState] ([_isP2PMode],
-  /// [_mediaProxy], [_graphqlClient]) — never `ref` directly. This
+  /// Reads only the fields captured in [initState] ([_mediaProxy],
+  /// [_graphqlClient]) — never `ref` directly. This
   /// runs from `dispose()` (as well as the web beforeunload handler), and
   /// `ref.read`/`ref.watch` unconditionally throw once `dispose()` has
   /// started: `BuildContext.mounted` is already `false` throughout it, a
   /// core Flutter invariant. Before this, every call from `dispose()` threw
   /// on its very first line, before doing any of the cleanup below.
   Future<void> _terminateHlsSession() async {
-    // Stop local proxy if P2P mode
-    if (_isP2PMode) {
-      try {
-        // Releases this screen's hold rather than stopping the proxy
-        // outright. On a next-episode navigation the incoming screen has
-        // already started it — Flutter mounts the new route before disposing
-        // the old one — so an unconditional stop here closed the server the
-        // episode now playing was streaming from.
-        await _mediaProxy.stop(this);
-        debugPrint('[PlayerScreen] Media proxy released');
-      } catch (e) {
-        debugPrint('[PlayerScreen] Error stopping local proxy: $e');
-      }
+    // Releases this screen's hold rather than stopping the proxy outright.
+    // On a next-episode navigation the incoming screen has already started
+    // it — Flutter mounts the new route before disposing the old one — so an
+    // unconditional stop here closed the server the episode now playing was
+    // streaming from.
+    //
+    // Deliberately unconditional. This used to run only while the connection
+    // was still in p2p mode, which tracked the *current* mode rather than the
+    // one this screen took the proxy under — and a reconnect can move a
+    // viewer between the two mid-episode. Skipping the release then stranded
+    // the hold for good: it is keyed on a State that is about to stop
+    // existing, so nothing could ever let go of it and the proxy stayed up
+    // for the rest of the session. Releasing a hold that was never taken is
+    // a no-op, so there is nothing to guard against.
+    try {
+      await _mediaProxy.stop(this);
+      debugPrint('[PlayerScreen] Media proxy released');
+    } catch (e) {
+      debugPrint('[PlayerScreen] Error stopping local proxy: $e');
     }
 
     // End HLS session via GraphQL (works for both modes)

--- a/player/test/core/downloads/p2p_download_job_service_test.dart
+++ b/player/test/core/downloads/p2p_download_job_service_test.dart
@@ -5,6 +5,9 @@ import 'package:player/core/p2p/local_proxy_service.dart';
 import 'package:player/core/p2p/p2p_service.dart';
 import 'package:player/domain/models/download_option.dart';
 
+import '../p2p/proxy_fetch.dart';
+import '../p2p/test_p2p_service.dart';
+
 class GraphqlCall {
   final String peer;
   final String query;
@@ -239,6 +242,65 @@ void main() {
     test('getDownloadUrl returns local proxy URL', () async {
       final url = await service.getDownloadUrl('job-42');
       expect(url, equals('http://127.0.0.1:12345/download/job-42/file'));
+    });
+
+    // Downloads and playback serve from one proxy, but each captured its own
+    // peer and token — this service at construction, the player when it
+    // initialised. A token refresh between the two leaves this one holding a
+    // stale value, and `start` re-targets a proxy that is already running, so
+    // asking for a download URL could point live playback at the wrong token
+    // and get its range requests rejected.
+    group('sharing the proxy with playback', () {
+      late TestP2pService proxyPeer;
+      late LocalProxyService sharedProxy;
+      late Object playback;
+      late P2pDownloadJobService downloads;
+
+      setUp(() async {
+        proxyPeer = TestP2pService();
+        sharedProxy = LocalProxyService(proxyPeer);
+        playback = Object();
+
+        await sharedProxy.start(
+          owner: playback,
+          targetPeer: 'playback-peer',
+          authToken: 'fresh-token',
+        );
+        addTearDown(sharedProxy.shutdown);
+
+        downloads = P2pDownloadJobService(
+          p2pService: p2p,
+          localProxy: sharedProxy,
+          serverNodeAddr: 'stale-peer',
+          authToken: 'stale-token',
+        );
+      });
+
+      test('a download leaves playback\'s peer and token alone', () async {
+        await downloads.getDownloadUrl('job-42');
+
+        proxyPeer.onSendHlsRequest = (_) async => testHlsResponse(
+              status: 200,
+              contentType: 'application/vnd.apple.mpegurl',
+              data: const [],
+            );
+        await proxyGet(
+          'http://127.0.0.1:${sharedProxy.port}/hls/sess-1/index.m3u8',
+        );
+
+        final call = proxyPeer.calls.single;
+        expect(call.peer, 'playback-peer');
+        expect(call.authToken, 'fresh-token');
+      });
+
+      test('a download still holds the proxy when playback lets go', () async {
+        await downloads.getDownloadUrl('job-42');
+
+        await sharedProxy.stop(playback);
+
+        expect(sharedProxy.isRunning, isTrue,
+            reason: 'the transfer is still pulling bytes through this proxy');
+      });
     });
   });
 }

--- a/player/test/core/p2p/local_proxy_lan_test.dart
+++ b/player/test/core/p2p/local_proxy_lan_test.dart
@@ -1,9 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/p2p/local_proxy_service.dart';
 
+/// The call site these tests hold the proxy as. Each test builds its own
+/// service, so one shared identity is enough to stand for "somebody needs
+/// this up"; none of them is about ownership itself.
+final testOwner = Object();
+
 void main() {
   group('LocalProxyService LAN access', () {
-    test('resolveLanAddress returns a non-loopback IPv4 address or null', () async {
+    test('resolveLanAddress returns a non-loopback IPv4 address or null',
+        () async {
       final address = await LocalProxyService.resolveLanAddress();
 
       if (address != null) {
@@ -21,8 +27,8 @@ void main() {
 
     test('buildHlsUrl uses loopback with no token prefix by default', () async {
       final service = LocalProxyService.forTesting();
-      await service.start(targetPeer: 'peer-1');
-      addTearDown(service.stop);
+      await service.start(owner: testOwner, targetPeer: 'peer-1');
+      addTearDown(service.shutdown);
 
       final url = service.buildHlsUrl('sess-1');
 
@@ -31,10 +37,11 @@ void main() {
       expect(url, isNot(contains('/g/')));
     });
 
-    test('enabling LAN access exposes a token-prefixed non-loopback URL', () async {
+    test('enabling LAN access exposes a token-prefixed non-loopback URL',
+        () async {
       final service = LocalProxyService.forTesting();
-      await service.start(targetPeer: 'peer-1');
-      addTearDown(service.stop);
+      await service.start(owner: testOwner, targetPeer: 'peer-1');
+      addTearDown(service.shutdown);
 
       await service.setLanAccess(true);
 
@@ -53,8 +60,8 @@ void main() {
     test('requests without the token prefix are rejected when LAN-exposed',
         () async {
       final service = LocalProxyService.forTesting();
-      await service.start(targetPeer: 'peer-1');
-      addTearDown(service.stop);
+      await service.start(owner: testOwner, targetPeer: 'peer-1');
+      addTearDown(service.shutdown);
 
       await service.setLanAccess(true);
       if (!service.isLanAccessible) return;
@@ -112,8 +119,8 @@ void main() {
 
     test('disabling LAN access returns the proxy to loopback', () async {
       final service = LocalProxyService.forTesting();
-      await service.start(targetPeer: 'peer-1');
-      addTearDown(service.stop);
+      await service.start(owner: testOwner, targetPeer: 'peer-1');
+      addTearDown(service.shutdown);
 
       await service.setLanAccess(true);
       await service.setLanAccess(false);

--- a/player/test/core/p2p/local_proxy_service_test.dart
+++ b/player/test/core/p2p/local_proxy_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -28,13 +29,19 @@ void main() {
     late LocalProxyService proxy;
     late TestP2pService p2p;
 
+    /// The call site these tests hold the proxy as. Ownership itself is
+    /// covered by the conformance suite; here it is just the one holder every
+    /// test needs so the proxy comes up and goes away again.
+    late Object owner;
+
     setUp(() {
       p2p = TestP2pService();
       proxy = LocalProxyService(p2p);
+      owner = Object();
     });
 
     tearDown(() async {
-      await proxy.stop();
+      await proxy.shutdown();
     });
 
     Future<HttpResult> makeRequest(String path, {String? rangeHeader}) async {
@@ -65,7 +72,8 @@ void main() {
 
     group('initialization', () {
       test('starts on loopback address', () async {
-        await proxy.start(targetPeer: 'test-peer-id', authToken: 'test-token');
+        await proxy.start(
+            owner: owner, targetPeer: 'test-peer-id', authToken: 'test-token');
 
         expect(proxy.isRunning, isTrue);
         expect(proxy.port, greaterThan(0));
@@ -83,18 +91,21 @@ void main() {
       });
 
       test('can update target peer when already running', () async {
-        await proxy.start(targetPeer: 'peer1', authToken: 'token1');
-        await proxy.start(targetPeer: 'peer2', authToken: 'token2');
+        await proxy.start(
+            owner: owner, targetPeer: 'peer1', authToken: 'token1');
+        await proxy.start(
+            owner: owner, targetPeer: 'peer2', authToken: 'token2');
 
         expect(proxy.isRunning, isTrue);
       });
 
       test('stop clears all state', () async {
-        await proxy.start(targetPeer: 'test-peer', authToken: 'test-token');
+        await proxy.start(
+            owner: owner, targetPeer: 'test-peer', authToken: 'test-token');
 
         expect(proxy.isRunning, isTrue);
 
-        await proxy.stop();
+        await proxy.stop(owner);
 
         expect(proxy.isRunning, isFalse);
         expect(proxy.port, equals(0));
@@ -103,7 +114,8 @@ void main() {
 
     group('HTTP behavior', () {
       test('returns 404 for non-HLS paths with CORS', () async {
-        await proxy.start(targetPeer: 'test-peer', authToken: 'test-token');
+        await proxy.start(
+            owner: owner, targetPeer: 'test-peer', authToken: 'test-token');
 
         final response = await makeRequest('/not-hls/path');
 
@@ -114,7 +126,8 @@ void main() {
       });
 
       test('returns 400 for invalid HLS path format with CORS', () async {
-        await proxy.start(targetPeer: 'test-peer', authToken: 'test-token');
+        await proxy.start(
+            owner: owner, targetPeer: 'test-peer', authToken: 'test-token');
 
         final response = await makeRequest('/hls/');
 
@@ -126,6 +139,7 @@ void main() {
 
       test('forwards HLS request to P2P and serves payload', () async {
         await proxy.start(
+          owner: owner,
           targetPeer: 'target-peer-id',
           authToken: 'test-auth-token',
         );
@@ -160,6 +174,7 @@ void main() {
 
       test('parses and forwards range headers', () async {
         await proxy.start(
+          owner: owner,
           targetPeer: 'target-peer-id',
           authToken: 'test-auth-token',
         );
@@ -182,6 +197,7 @@ void main() {
 
       test('invalid range header forwards null range values', () async {
         await proxy.start(
+          owner: owner,
           targetPeer: 'target-peer-id',
           authToken: 'test-auth-token',
         );
@@ -203,6 +219,7 @@ void main() {
 
       test('returns 500 with CORS when P2P request fails', () async {
         await proxy.start(
+          owner: owner,
           targetPeer: 'target-peer-id',
           authToken: 'test-auth-token',
         );
@@ -221,6 +238,7 @@ void main() {
       test('recovers after write error and serves subsequent requests',
           () async {
         await proxy.start(
+          owner: owner,
           targetPeer: 'target-peer-id',
           authToken: 'test-auth-token',
         );
@@ -249,6 +267,49 @@ void main() {
         final second = await makeRequest('/hls/session123/index.m3u8');
         expect(second.statusCode, equals(HttpStatus.ok));
         expect(second.body, contains('#EXTM3U'));
+      });
+    });
+
+    group('teardown', () {
+      // An unforced `HttpServer.close()` stops the listener and returns, but
+      // leaves connections already accepted to carry on being served — by a
+      // proxy whose target peer and auth token this has just nulled out.
+      // mpv holds one such connection for the whole file, so without the
+      // forced close the video pipeline is left waiting on a socket nobody
+      // will ever answer, instead of seeing its stream end and reporting it.
+      test('drops the connections it was serving rather than orphaning them',
+          () async {
+        final started = Completer<void>();
+
+        // A response that never arrives, standing in for a request still
+        // being served when the screen goes away.
+        p2p.onSendHlsRequest = (_) async {
+          started.complete();
+          await Completer<void>().future;
+          return testHlsResponse(
+            status: HttpStatus.ok,
+            contentType: 'video/mp2t',
+            data: const [],
+          );
+        };
+
+        await proxy.start(owner: owner, targetPeer: 'peer-1');
+
+        // Deliberately not awaited yet: this request is still open when the
+        // teardown runs, which is the state under test.
+        final inFlight = makeRequest('/hls/session123/segment_001.ts');
+        await started.future;
+
+        await proxy.stop(owner);
+        expect(proxy.isRunning, isFalse);
+
+        await expectLater(
+          inFlight,
+          throwsA(anything),
+          reason: 'the teardown closed the socket, so the client in flight '
+              'finds out; an unforced close would leave it hanging on a '
+              'connection the proxy no longer has the state to answer',
+        );
       });
     });
   });

--- a/player/test/core/p2p/media_proxy_conformance.dart
+++ b/player/test/core/p2p/media_proxy_conformance.dart
@@ -31,14 +31,23 @@ void mediaProxyConformanceTests(
     late TestP2pService p2p;
     late MediaProxy proxy;
 
+    /// The call site these tests hold the proxy as. Identity is all an owner
+    /// is, so a bare object is the honest stand-in for a screen or a service.
+    late Object owner;
+
     setUp(() {
       p2p = TestP2pService();
       proxy = create(p2p);
+      owner = Object();
     });
 
     Future<void> startProxy() async {
-      await proxy.start(targetPeer: 'peer-1', authToken: 'token-1');
-      addTearDown(proxy.stop);
+      await proxy.start(
+        owner: owner,
+        targetPeer: 'peer-1',
+        authToken: 'token-1',
+      );
+      addTearDown(proxy.shutdown);
     }
 
     test('is not running before start', () {
@@ -65,10 +74,107 @@ void mediaProxyConformanceTests(
     });
 
     test('stop is idempotent', () async {
-      await proxy.start(targetPeer: 'peer-1', authToken: 'token-1');
-      await proxy.stop();
-      await proxy.stop();
+      await proxy.start(
+        owner: owner,
+        targetPeer: 'peer-1',
+        authToken: 'token-1',
+      );
+      await proxy.stop(owner);
+      await proxy.stop(owner);
       expect(proxy.isRunning, isFalse);
+    });
+
+    group('ownership', () {
+      late Object other;
+
+      setUp(() => other = Object());
+
+      Future<void> startAs(Object who) => proxy.start(
+            owner: who,
+            targetPeer: 'peer-1',
+            authToken: 'token-1',
+          );
+
+      // The next-episode handoff, in the order Flutter actually runs it: the
+      // incoming screen mounts and starts the proxy, then the outgoing
+      // screen's dispose releases its own hold. Before ownership, that
+      // release closed the server the new episode was already streaming
+      // from, and mpv opened a dead URL.
+      test('keeps serving when one of two owners lets go', () async {
+        await startAs(owner);
+        await startAs(other);
+        addTearDown(proxy.shutdown);
+
+        await proxy.stop(owner);
+
+        expect(proxy.isRunning, isTrue);
+      });
+
+      test('stops serving once the last owner lets go', () async {
+        await startAs(owner);
+        await startAs(other);
+
+        await proxy.stop(owner);
+        await proxy.stop(other);
+
+        expect(proxy.isRunning, isFalse);
+      });
+
+      // `_initializePlayer` re-runs within a single screen's life — a session
+      // restart past the transcoded end, a cast rebind — so one owner starts
+      // the proxy several times and still releases it exactly once. A
+      // reference count would strand the proxy up forever here.
+      test('an owner that starts twice still releases with one stop', () async {
+        await startAs(owner);
+        await startAs(owner);
+
+        await proxy.stop(owner);
+
+        expect(proxy.isRunning, isFalse);
+      });
+
+      test('a stop from something that never started it changes nothing',
+          () async {
+        await startAs(owner);
+        addTearDown(proxy.shutdown);
+
+        await proxy.stop(other);
+
+        expect(proxy.isRunning, isTrue);
+      });
+
+      test('shutdown stops serving even while owners remain', () async {
+        await startAs(owner);
+        await startAs(other);
+
+        await proxy.shutdown();
+
+        expect(proxy.isRunning, isFalse);
+      });
+
+      // Whoever is left keeps a working proxy, not a husk that reports
+      // running while its target is gone.
+      test('still serves the remaining owner after the other lets go',
+          () async {
+        await startAs(owner);
+        await startAs(other);
+        addTearDown(proxy.shutdown);
+
+        await proxy.stop(owner);
+
+        p2p.onSendHlsRequest = (_) async => testHlsResponse(
+              status: 200,
+              contentType: 'application/vnd.apple.mpegurl',
+              data: utf8.encode(manifest),
+            );
+
+        final response =
+            await proxyGet('${proxy.baseUrl}/hls/$sessionId/index.m3u8');
+
+        expect(response.status, 200);
+        expect(utf8.decode(response.body), manifest);
+        expect(p2p.calls.single.authToken, 'token-1');
+      });
     });
 
     test('serves the manifest bytes the peer returned', () async {

--- a/player/test/presentation/screens/player/player_screen_proxy_handoff_test.dart
+++ b/player/test/presentation/screens/player/player_screen_proxy_handoff_test.dart
@@ -1,0 +1,121 @@
+// Regression coverage for the next-episode handoff killing the shared proxy.
+//
+// One loopback proxy serves every call site that needs p2p media bytes.
+// `_terminateHlsSession` used to stop it outright from `dispose()`, which on
+// an Up Next navigation closed the server the episode that had just started
+// was streaming from: mpv reported
+// `Failed to open http://127.0.0.1:<port>/direct/<file>/stream`, the screen
+// detected zero audio and subtitle tracks, and playback sat at position 0.
+//
+// The captured log of that failure has the incoming screen's
+// `Media proxy serving at http://127.0.0.1:45273` at 22:37:25 and the
+// outgoing screen's `Media proxy stopped` at 22:41:59 — the new screen took
+// the proxy first and the old one closed it afterwards. That ordering is what
+// makes an unconditional stop wrong, and it is what the first test drives.
+//
+// It stands a plain object in for the incoming screen rather than mounting a
+// second `PlayerScreen`: `_initializePlayer` reaches `proxy.start` only after
+// several awaits, while `dispose()` runs at the end of the frame, so a keyed
+// swap of two real screens lands the release *before* the second acquire —
+// the harmless order, which would leave the regression unpinned. What
+// `PlayerScreen` owns here is the release, and that is what this asserts.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+/// Whether [request] carries the named operation.
+///
+/// `request.operation.operationName` is null for everything this screen
+/// issues, because `QueryOptions` never sets it. The printed query text names
+/// the operation on its first line, which is what is left to match on.
+bool _isOperation(Request request, String name) =>
+    request.operation.toString().contains(name);
+
+/// Answers per operation rather than per call index, so the script does not
+/// depend on the order the screen happens to issue its queries in.
+StubLink _link() {
+  return StubLink((request, _) {
+    if (_isOperation(request, 'query MovieSegments')) {
+      return movieSegmentsResponse();
+    }
+    if (_isOperation(request, 'query MovieDetail')) {
+      return movieDetailResponse();
+    }
+    if (_isOperation(request, 'endStreamingSession')) {
+      return endStreamingSessionResponse();
+    }
+    return streamingCandidatesResponse(duration: 5400, directPlay: true);
+  });
+}
+
+void main() {
+  testWidgets(
+      'dispose() releases only this screen\'s hold, leaving the proxy up for '
+      'the screen that replaced it', (tester) async {
+    final proxyService = TrackingLocalProxyService();
+
+    final container = buildPlayerScreenContainer(
+      link: _link(),
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: CapturingCastSessionManager(),
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(tester, () => proxyService.directStreamFileIds.isNotEmpty);
+    expect(proxyService.directStreamFileIds, isNotEmpty,
+        reason: 'sanity check: this screen must actually have taken the '
+            'proxy, or its release below proves nothing');
+
+    // The episode Up Next moved to, which has already started the proxy and
+    // built its stream URL against it by the time the outgoing screen is
+    // disposed.
+    final incoming = Object();
+    await proxyService.start(owner: incoming, targetPeer: 'node-addr');
+    addTearDown(proxyService.shutdown);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    expect(proxyService.isRunning, isTrue,
+        reason: 'the outgoing screen released its own hold, not the proxy: '
+            'the episode now playing is still streaming from it');
+    expect(proxyService.stopped, isFalse,
+        reason: 'nothing tore the proxy down while a call site still needed '
+            'it');
+  });
+
+  testWidgets('dispose() stops the proxy when nothing else holds it',
+      (tester) async {
+    final proxyService = TrackingLocalProxyService();
+
+    final container = buildPlayerScreenContainer(
+      link: _link(),
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: CapturingCastSessionManager(),
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(tester, () => proxyService.directStreamFileIds.isNotEmpty);
+
+    // Leaving the player altogether rather than moving between episodes.
+    // Holding the proxy open past the last screen would leak a bound socket
+    // and the auth token it serves with, so the release still has to happen.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+
+    expect(proxyService.isRunning, isFalse);
+    expect(proxyService.stopped, isTrue,
+        reason: 'the last holder let go, so the proxy is torn down rather '
+            'than left bound for the rest of the session');
+  });
+}

--- a/player/test/presentation/screens/player/player_screen_proxy_handoff_test.dart
+++ b/player/test/presentation/screens/player/player_screen_proxy_handoff_test.dart
@@ -92,6 +92,44 @@ void main() {
             'it');
   });
 
+  // `_isP2PMode` tracks the *current* connection mode, not the one this
+  // screen took the proxy under, and a reconnect can move a viewer between
+  // the two mid-episode. Gating the release on it means a screen that started
+  // the proxy over p2p and ended up on a direct connection never lets go —
+  // and because the hold is keyed on a State that is now gone, nothing can
+  // ever release it and the proxy is stuck up for the rest of the session.
+  testWidgets('dispose() releases its hold even if the mode changed since',
+      (tester) async {
+    final proxyService = TrackingLocalProxyService();
+
+    final container = buildPlayerScreenContainer(
+      link: _link(),
+      connectionState: conn.ConnectionState.p2p(serverNodeAddr: 'node-addr'),
+      castManager: CapturingCastSessionManager(),
+      proxyService: proxyService,
+    );
+    addTearDown(container.dispose);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(tester, () => proxyService.directStreamFileIds.isNotEmpty);
+    expect(proxyService.isRunning, isTrue,
+        reason: 'sanity check: the screen took the proxy while on p2p');
+
+    // The viewer reconnects onto a direct connection mid-playback.
+    (container.read(conn.connectionProvider.notifier)
+            as FixedConnectionNotifier)
+        .switchTo(conn.ConnectionState.direct());
+    await tester.pump();
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+
+    expect(proxyService.isRunning, isFalse,
+        reason: 'the hold is keyed on a State that no longer exists, so a '
+            'release skipped here can never happen at all');
+    expect(proxyService.stopped, isTrue);
+  });
+
   testWidgets('dispose() stops the proxy when nothing else holds it',
       (tester) async {
     final proxyService = TrackingLocalProxyService();

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -26,6 +26,7 @@ import 'package:player/core/downloads/download_providers.dart';
 import 'package:player/core/downloads/download_service.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/core/p2p/local_proxy_service.dart';
+import 'package:player/core/p2p/media_proxy.dart';
 import 'package:player/core/playback/local_playback_progress.dart';
 import 'package:player/core/playback/playback_progress_providers.dart';
 import 'package:player/core/playback/playback_progress_store.dart';
@@ -171,10 +172,23 @@ class FakeSettingsService extends Fake implements SettingsService {
   Future<bool> getAutoSkipSegments() async => autoSkipSegments;
 }
 
-/// Tracks whether `stop()` ran, without touching a real P2P/HTTP stack.
-class TrackingLocalProxyService extends Fake implements LocalProxyService {
+/// Tracks whether the proxy was torn down, without touching a real P2P/HTTP
+/// stack.
+///
+/// Mixes in the production [MediaProxyLeases], so ownership behaves here
+/// exactly as it does in `LocalProxyService`: a test that mounts two screens
+/// and unmounts one is asserting against the real rule, not a fake that was
+/// taught the answer.
+class TrackingLocalProxyService extends Fake
+    with MediaProxyLeases
+    implements LocalProxyService {
+  /// Whether the proxy was actually torn down — the last owner let go, or
+  /// something shut it down outright. Not merely "stop() was called": a stop
+  /// from one of two owners is meant to be a no-op.
   bool stopped = false;
   bool startCalled = false;
+
+  bool _running = false;
 
   /// Every file id direct playback has been pointed at, in order.
   ///
@@ -191,14 +205,20 @@ class TrackingLocalProxyService extends Fake implements LocalProxyService {
   @override
   String get baseUrl => 'http://127.0.0.1:$port';
 
-  /// The screen asks this before building a URL against [baseUrl], and `Fake`
-  /// throws on any member it is not given.
+  /// Reflects real state rather than a hardcoded `true`, so a test can tell
+  /// "still serving the screen that replaced me" from "torn down".
   @override
-  bool get isRunning => true;
+  bool get isRunning => _running;
 
   @override
-  Future<void> start({required String targetPeer, String? authToken}) async {
+  Future<void> start({
+    required Object owner,
+    required String targetPeer,
+    String? authToken,
+  }) async {
+    acquireLease(owner);
     startCalled = true;
+    _running = true;
   }
 
   @override
@@ -212,8 +232,17 @@ class TrackingLocalProxyService extends Fake implements LocalProxyService {
   }
 
   @override
-  Future<void> stop() async {
+  Future<void> stop(Object owner) async {
+    if (!releaseLease(owner)) return;
     stopped = true;
+    _running = false;
+  }
+
+  @override
+  Future<void> shutdown() async {
+    clearLeases();
+    stopped = true;
+    _running = false;
   }
 }
 

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -59,6 +59,15 @@ class FixedConnectionNotifier extends conn.ConnectionNotifier {
 
   @override
   conn.ConnectionState build() => _state;
+
+  /// Switches the reported mode mid-test.
+  ///
+  /// The connection a viewer is on is not fixed for the life of a player
+  /// screen — a reconnect can move them between p2p and direct while the
+  /// episode plays — and `PlayerScreen` tracks that through a
+  /// `ref.listenManual`. Anything in `dispose()` keyed on the *current* mode
+  /// therefore has to be exercised against a mode that changed.
+  void switchTo(conn.ConnectionState next) => state = next;
 }
 
 class FakeDownloadService extends Fake implements DownloadService {


### PR DESCRIPTION
## The bug

Using Up Next on the Linux desktop player froze the app and left the next
episode dead: no video, no tracks, position stuck at 0.

One loopback proxy serves every p2p call site, and it is a plain
(non-autoDispose) Riverpod singleton. `PlayerScreen.dispose()` stopped it
outright. Flutter mounts the incoming route *before* it disposes the outgoing
one, so on a next-episode navigation the new screen had already started the
proxy and built its stream URL by the time the old screen tore it down.

Straight from the captured journald log of the failure:

```
22:37:25  [AppRouter] Redirect check: path=/player/episode/fd2c0b53...
22:37:25  [PlayerScreen] Media proxy serving at http://127.0.0.1:45273
22:37:26  [PlayerScreen] Direct play for file_id=1a12cc25-...
          ...app wedged, every thread at 0% CPU...
22:41:59  [LocalProxy] Stopped
22:41:59  [PlayerScreen] Media proxy stopped
22:41:59  [PlayerScreen] Playback error: Failed to open
            http://127.0.0.1:45273/direct/1a12cc25-.../stream
22:41:59  [PlayerScreen] Detected 0 audio tracks, 0 subtitle tracks
22:42:10+ [ProgressService] Syncing episode progress: position=0, duration=1350
```

Both episodes logged the same port, which is the tell that one shared
instance was involved rather than a proxy per screen. The control case is in
the same log: the first episode at 22:16:08 runs the identical path with no
preceding screen to dispose, and plays.

Guarded by `if (_isP2PMode)`, so this is the p2p path only.

## The fix

`start` and `stop` take an owner, and serving ends only when the last owner
lets go. The bookkeeping is a `MediaProxyLeases` mixin shared by both
implementations, so the loopback server and the Service Worker cannot drift.

Ownership is a set keyed by identity, **not** a reference count.
`_initializePlayer` re-runs within a single screen's life — a session restart
past the transcoded end, a cast rebind — so a count would climb past what one
stop could settle and strand the proxy up for good. There is a test for that
case.

Two things came along with it:

- **The download service now takes a real hold.** It serves from the same
  proxy, and its `if (!isRunning)` guard left it holding nothing whenever
  playback already had the proxy up — which is exactly the case where the
  player's dispose could cut off a transfer in progress. Its hold outlives an
  individual job (nothing observes a download finishing), so once any download
  runs the proxy stays up for the session. That is an idle loopback listener,
  which beats a download dying mid-transfer. Releasing per job is a reasonable
  follow-up.
- **Teardown force-closes.** An unforced close stops the listener and returns
  but leaves accepted connections being served by a proxy whose target peer and
  auth token have just been cleared, so the client in flight waits on a socket
  nothing will answer instead of seeing its stream end.

## Tests

Written first, each watched failing before the fix existed.

- Six ownership tests in the shared conformance suite, so they run against
  **both** implementations — CI covers the Service Worker half under
  `--platform chrome`. The headline one reproduces the production bug: two
  holders, one lets go, the proxy must keep serving. Before the fix it failed
  with `Expected: true / Actual: <false>` and `[LocalProxy] Started` →
  `[LocalProxy] Stopped` in the log.
- A teardown test pinning the forced close: an in-flight client must be told
  the connection is gone. Without `force: true` it hangs to a 30s timeout.
- Two `PlayerScreen` tests: dispose releases only its own hold, and still tears
  the proxy down when nothing else holds it. Verified to fail when the
  unconditional teardown is put back.

Full player suite green (2353 tests), `flutter analyze` clean.

## What this does not claim

The multi-minute freeze itself is **not** explained by this change. The dead
proxy is proven from the log and fixed here; the wedge is a separate open
question. Two things I could not stand behind:

- The frozen process recovered within seconds of a `gdb` attach, so the freeze
  may have been indefinite rather than the ~4.5 minutes the log shows.
- I first attributed the wedge to `HttpServer.close()` blocking on in-flight
  connections. A test written to assert that passed *without* `force: true`,
  disproving it — an unforced close stops the listener and returns. `force` is
  kept for the different, tested reason above.

A two-real-screens widget swap also cannot pin this bug: `_initializePlayer`
reaches `proxy.start` only after several awaits while `dispose()` runs at
end-of-frame, so the swap lands the release before the second acquire — the
harmless order. Production had the harmful one. The tests drive that order
deterministically instead, and the file says so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer-to-peer playback reliability during downloads and player-screen transitions.
  * Prevented shared media proxy sessions from stopping prematurely when another active playback session still needs them.
  * Ensured proxy connections close cleanly when service shutdown is required.

* **Tests**
  * Added coverage for concurrent proxy ownership, player handoffs, duplicate starts, and final-session cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->