### PR TITLE
feat(player): scroll horizontal rails with a plain mouse

### DIFF
--- a/player/lib/app.dart
+++ b/player/lib/app.dart
@@ -13,6 +13,7 @@ import 'core/graphql/watch/watcher_registry.dart';
 import 'core/cast/cast_providers.dart';
 import 'core/downloads/download_providers.dart';
 import 'core/downloads/download_service.dart';
+import 'core/scroll/app_scroll_behavior.dart';
 import 'presentation/widgets/cast_mini_controller.dart';
 import 'package:player/core/p2p/p2p_service.dart';
 
@@ -130,6 +131,7 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
       return MaterialApp(
         title: 'Mydia Player',
         debugShowCheckedModeBanner: false,
+        scrollBehavior: const AppScrollBehavior(),
         theme: AppTheme.darkTheme,
         home: const Scaffold(
           body: Center(
@@ -152,6 +154,7 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
       return MaterialApp(
         title: 'Mydia Player',
         debugShowCheckedModeBanner: false,
+        scrollBehavior: const AppScrollBehavior(),
         theme: AppTheme.darkTheme,
         home: Scaffold(
           body: Center(
@@ -176,6 +179,7 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
     return MaterialApp.router(
       title: 'Mydia Player',
       debugShowCheckedModeBanner: false,
+      scrollBehavior: const AppScrollBehavior(),
       theme: AppTheme.darkTheme,
       routerConfig: router,
       // Float the cast mini controller above every route. `CastBarLayer`

--- a/player/lib/core/scroll/app_scroll_behavior.dart
+++ b/player/lib/core/scroll/app_scroll_behavior.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+/// The app's scroll behavior.
+///
+/// Flutter's stock [ScrollBehavior.dragDevices] omits [PointerDeviceKind.mouse],
+/// on the reasoning that a desktop user scrolls with a wheel rather than by
+/// grabbing content. That leaves the horizontal rails unreachable for anyone on
+/// a plain mouse, because a vertical wheel does not move a horizontal axis
+/// either. Adding mouse here makes grab-and-drag work on every scrollable in
+/// the app.
+///
+/// Spread over `super.dragDevices` rather than listing the set literally, so a
+/// future Flutter that adds a device kind does not silently lose it here.
+class AppScrollBehavior extends MaterialScrollBehavior {
+  const AppScrollBehavior();
+
+  @override
+  Set<PointerDeviceKind> get dragDevices => {
+        ...super.dragDevices,
+        PointerDeviceKind.mouse,
+      };
+}

--- a/player/lib/presentation/screens/downloads/downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/downloads_screen.dart
@@ -277,10 +277,12 @@ class DownloadsScreen extends ConsumerWidget {
               scrollDirection: Axis.horizontal,
               itemCount: failed.length,
               itemBuilder: (context, index) {
+                final task = failed[index];
                 return Container(
+                  key: ValueKey('failed-download-${task.id}'),
                   width: 300,
                   margin: const EdgeInsets.only(right: 12),
-                  child: _buildFailedDownloadCard(context, ref, failed[index]),
+                  child: _buildFailedDownloadCard(context, ref, task),
                 );
               },
             ),

--- a/player/lib/presentation/screens/downloads/downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/downloads_screen.dart
@@ -8,6 +8,7 @@ import '../../widgets/ambient_backdrop_provider.dart';
 import '../../widgets/cast_actions.dart';
 import '../../widgets/cast_button.dart';
 import '../../widgets/glass_surface.dart';
+import '../../widgets/horizontal_wheel_scroll.dart';
 import '../../../core/downloads/download_providers.dart';
 import '../../../core/downloads/download_queue_providers.dart';
 import '../../../core/downloads/storage_quota_providers.dart';
@@ -269,17 +270,20 @@ class DownloadsScreen extends ConsumerWidget {
         ),
         SizedBox(
           height: 160,
-          child: ListView.builder(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            scrollDirection: Axis.horizontal,
-            itemCount: failed.length,
-            itemBuilder: (context, index) {
-              return Container(
-                width: 300,
-                margin: const EdgeInsets.only(right: 12),
-                child: _buildFailedDownloadCard(context, ref, failed[index]),
-              );
-            },
+          child: HorizontalWheelScroll(
+            builder: (context, controller) => ListView.builder(
+              controller: controller,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              scrollDirection: Axis.horizontal,
+              itemCount: failed.length,
+              itemBuilder: (context, index) {
+                return Container(
+                  width: 300,
+                  margin: const EdgeInsets.only(right: 12),
+                  child: _buildFailedDownloadCard(context, ref, failed[index]),
+                );
+              },
+            ),
           ),
         ),
       ],

--- a/player/lib/presentation/screens/search/search_screen.dart
+++ b/player/lib/presentation/screens/search/search_screen.dart
@@ -9,6 +9,7 @@ import '../../../core/layout/dock_insets.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/search_result.dart';
 import '../../widgets/browse_scaffold.dart';
+import '../../widgets/horizontal_wheel_scroll.dart';
 import 'search_controller.dart';
 import 'widgets/episode_result_row.dart';
 import 'widgets/search_filter_chip.dart';
@@ -195,31 +196,34 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   };
 
   Widget _buildFilterChips(SearchState searchState) {
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
-        children: [
-          for (final type in SearchResultType.values) ...[
-            SearchFilterChip(
-              label: type.sectionTitle,
-              icon: _chipIcons[type] ?? Icons.search_rounded,
-              isSelected: searchState.selectedTypes.contains(type),
-              onTap: () => _onToggleType(searchState, type),
-            ),
-            const SizedBox(width: 8),
+    return HorizontalWheelScroll(
+      builder: (context, controller) => SingleChildScrollView(
+        controller: controller,
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          children: [
+            for (final type in SearchResultType.values) ...[
+              SearchFilterChip(
+                label: type.sectionTitle,
+                icon: _chipIcons[type] ?? Icons.search_rounded,
+                isSelected: searchState.selectedTypes.contains(type),
+                onTap: () => _onToggleType(searchState, type),
+              ),
+              const SizedBox(width: 8),
+            ],
+            if (searchState.selectedTypes.isNotEmpty)
+              TextButton(
+                onPressed: () {
+                  ref.read(searchControllerProvider.notifier).clearFilters();
+                  if (searchState.query.isNotEmpty) {
+                    ref.read(searchControllerProvider.notifier).search();
+                  }
+                },
+                child: const Text('Clear filters'),
+              ),
           ],
-          if (searchState.selectedTypes.isNotEmpty)
-            TextButton(
-              onPressed: () {
-                ref.read(searchControllerProvider.notifier).clearFilters();
-                if (searchState.query.isNotEmpty) {
-                  ref.read(searchControllerProvider.notifier).search();
-                }
-              },
-              child: const Text('Clear filters'),
-            ),
-        ],
+        ),
       ),
     );
   }

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -944,6 +944,7 @@ class ShowDetailScreen extends ConsumerWidget {
                 final isSelected = season.seasonNumber == selectedSeason;
 
                 return Padding(
+                  key: ValueKey('season-chip-${season.seasonNumber}'),
                   padding: const EdgeInsets.only(right: 10),
                   child: _SeasonChip(
                     label: 'Season ${season.seasonNumber}',

--- a/player/lib/presentation/screens/show/show_detail_screen.dart
+++ b/player/lib/presentation/screens/show/show_detail_screen.dart
@@ -27,6 +27,7 @@ import '../../widgets/cast_rail.dart';
 import '../../widgets/content_rail.dart';
 import '../../widgets/detail_action_row.dart';
 import '../../widgets/hero_play_control.dart';
+import '../../widgets/horizontal_wheel_scroll.dart';
 import '../../widgets/media_info/media_info_sheet.dart';
 import '../../widgets/watch_indicator.dart';
 
@@ -930,30 +931,34 @@ class ShowDetailScreen extends ConsumerWidget {
         const SizedBox(height: 16),
         SizedBox(
           height: 44,
-          child: ListView.builder(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            itemCount: availableSeasons.length,
-            itemBuilder: (context, index) {
-              final season = availableSeasons[index];
-              final unwatched = season.watchStatus?.unwatchedEpisodeCount ?? 0;
-              final isSelected = season.seasonNumber == selectedSeason;
+          child: HorizontalWheelScroll(
+            builder: (context, controller) => ListView.builder(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              itemCount: availableSeasons.length,
+              itemBuilder: (context, index) {
+                final season = availableSeasons[index];
+                final unwatched =
+                    season.watchStatus?.unwatchedEpisodeCount ?? 0;
+                final isSelected = season.seasonNumber == selectedSeason;
 
-              return Padding(
-                padding: const EdgeInsets.only(right: 10),
-                child: _SeasonChip(
-                  label: 'Season ${season.seasonNumber}',
-                  unwatched: unwatched,
-                  watchStatus: season.watchStatus,
-                  isSelected: isSelected,
-                  onTap: () {
-                    ref
-                        .read(selectedSeasonProvider(id).notifier)
-                        .select(season.seasonNumber);
-                  },
-                ),
-              );
-            },
+                return Padding(
+                  padding: const EdgeInsets.only(right: 10),
+                  child: _SeasonChip(
+                    label: 'Season ${season.seasonNumber}',
+                    unwatched: unwatched,
+                    watchStatus: season.watchStatus,
+                    isSelected: isSelected,
+                    onTap: () {
+                      ref
+                          .read(selectedSeasonProvider(id).notifier)
+                          .select(season.seasonNumber);
+                    },
+                  ),
+                );
+              },
+            ),
           ),
         ),
       ],

--- a/player/lib/presentation/widgets/cast_rail.dart
+++ b/player/lib/presentation/widgets/cast_rail.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import '../../core/theme/colors.dart';
 import '../../domain/models/cast_member.dart';
+import 'horizontal_wheel_scroll.dart';
 
 /// Horizontal rail of cast members below the detail hero. Renders nothing
 /// when [members] is empty — there is no empty state, the section just
@@ -43,18 +44,21 @@ class CastRail extends StatelessWidget {
         const SizedBox(height: 14),
         SizedBox(
           height: 128,
-          child: ListView.builder(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            itemCount: members.length,
-            itemBuilder: (context, index) {
-              final member = members[index];
-              return Padding(
-                key: ValueKey('cast-${member.name}-$index'),
-                padding: const EdgeInsets.only(right: 14),
-                child: _CastCard(member: member),
-              );
-            },
+          child: HorizontalWheelScroll(
+            builder: (context, controller) => ListView.builder(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              itemCount: members.length,
+              itemBuilder: (context, index) {
+                final member = members[index];
+                return Padding(
+                  key: ValueKey('cast-${member.name}-$index'),
+                  padding: const EdgeInsets.only(right: 14),
+                  child: _CastCard(member: member),
+                );
+              },
+            ),
           ),
         ),
       ],

--- a/player/lib/presentation/widgets/content_rail.dart
+++ b/player/lib/presentation/widgets/content_rail.dart
@@ -5,6 +5,7 @@ import '../../domain/models/continue_watching_item.dart';
 import '../../domain/models/recently_added_item.dart';
 import '../../domain/models/up_next_item.dart';
 import '../../domain/models/watch_status.dart';
+import 'horizontal_wheel_scroll.dart';
 import 'media_card.dart';
 import 'media_context_menu.dart';
 
@@ -191,22 +192,27 @@ class _ContentRailState extends State<ContentRail> {
   Widget _buildRailBody(double horizontalPadding, double cardSpacing) {
     return Stack(
       children: [
-        // Main scrollable list
-        ListView.builder(
+        // Main scrollable list. The wrapper is what makes a plain mouse wheel
+        // move it; the controller stays owned here because the edge fades
+        // listen to it.
+        HorizontalWheelScroll(
           controller: _scrollController,
-          scrollDirection: Axis.horizontal,
-          padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-          itemCount: widget.items.length,
-          itemBuilder: (context, index) {
-            final item = widget.items[index];
-            return Padding(
-              key: _keyFor(item, index),
-              padding: EdgeInsets.only(
-                right: index < widget.items.length - 1 ? cardSpacing : 0,
-              ),
-              child: _buildCard(context, item),
-            );
-          },
+          builder: (context, controller) => ListView.builder(
+            controller: controller,
+            scrollDirection: Axis.horizontal,
+            padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+            itemCount: widget.items.length,
+            itemBuilder: (context, index) {
+              final item = widget.items[index];
+              return Padding(
+                key: _keyFor(item, index),
+                padding: EdgeInsets.only(
+                  right: index < widget.items.length - 1 ? cardSpacing : 0,
+                ),
+                child: _buildCard(context, item),
+              );
+            },
+          ),
         ),
 
         // Left fade gradient

--- a/player/lib/presentation/widgets/horizontal_rail.dart
+++ b/player/lib/presentation/widgets/horizontal_rail.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/theme/colors.dart';
+import 'horizontal_wheel_scroll.dart';
 
 /// The scroll-and-fade shell shared by the app's horizontal rails.
 ///
@@ -104,19 +105,24 @@ class _HorizontalRailState extends State<HorizontalRail> {
       height: widget.height,
       child: Stack(
         children: [
-          ListView.builder(
+          // The wrapper is what makes a plain mouse wheel move the rail; the
+          // controller stays owned here because the edge fades listen to it.
+          HorizontalWheelScroll(
             controller: _scrollController,
-            scrollDirection: Axis.horizontal,
-            padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-            itemCount: widget.itemCount,
-            itemBuilder: (context, index) {
-              return Padding(
-                padding: EdgeInsets.only(
-                  right: index < widget.itemCount - 1 ? cardSpacing : 0,
-                ),
-                child: widget.itemBuilder(context, index),
-              );
-            },
+            builder: (context, controller) => ListView.builder(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+              itemCount: widget.itemCount,
+              itemBuilder: (context, index) {
+                return Padding(
+                  padding: EdgeInsets.only(
+                    right: index < widget.itemCount - 1 ? cardSpacing : 0,
+                  ),
+                  child: widget.itemBuilder(context, index),
+                );
+              },
+            ),
           ),
           if (_showLeftFade) _buildFade(widget.leftFadeKey, atStart: true),
           if (_showRightFade) _buildFade(widget.rightFadeKey, atStart: false),

--- a/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
+++ b/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
@@ -60,15 +60,12 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
   /// is replaced, so this dependency costs nothing per frame.
   ScrollableState? _verticalAncestor;
 
-  ScrollController get _controller => widget.controller ?? _ownedController!;
-
-  @override
-  void initState() {
-    super.initState();
-    if (widget.controller == null) {
-      _ownedController = ScrollController();
-    }
-  }
+  /// Creates the owned controller on first use rather than in `initState`, so
+  /// a rebuild that swaps a caller's controller for null still has one to hand
+  /// back. No call site does that today; creating it lazily just means the
+  /// widget cannot be crashed by one that later does.
+  ScrollController get _controller =>
+      widget.controller ?? (_ownedController ??= ScrollController());
 
   @override
   void didChangeDependencies() {

--- a/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
+++ b/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
@@ -17,12 +17,13 @@ const _glideCurve = Curves.easeOutCubic;
 /// It claims it only while the rail can actually use it, so vertical page
 /// scrolling still works over a rail that has nowhere left to go.
 ///
-/// There is deliberately no check for "the page is already scrolling". Every
-/// [ScrollActivity] whose `isScrolling` is true also sets `shouldIgnorePointer`,
-/// and [Scrollable] wraps its viewport in an `IgnorePointer` driven by that
-/// flag. A rail inside a moving page is therefore already outside the hit-test
-/// path, so such a check could never fire. An earlier revision of this widget
-/// carried one; it was removed as unreachable.
+/// The page-in-motion check in `_onPointerSignal` looks redundant and mostly
+/// is: [Scrollable] wraps its viewport in an `IgnorePointer` while scrolling,
+/// so a rail inside a moving page is usually not hit-tested at all. It is not
+/// redundant during an overscroll bounce-back, where `setPixels` forces
+/// `setIgnorePointer(false)` while the position is out of range and the rail
+/// becomes reachable again. That case is the platform default on macOS and
+/// iOS. The check was deleted once as dead code and had to be restored.
 class HorizontalWheelScroll extends StatefulWidget {
   /// The scrollable's controller. Pass one when the call site already owns it,
   /// as the rails do for their edge fades. When null this widget creates and
@@ -54,6 +55,11 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
   /// of each tick restarting from wherever the animation happens to be.
   double? _target;
 
+  /// The page scroller this rail sits inside, resolved once per dependency
+  /// change. `_ScrollableScope` only notifies when the position object itself
+  /// is replaced, so this dependency costs nothing per frame.
+  ScrollableState? _verticalAncestor;
+
   ScrollController get _controller => widget.controller ?? _ownedController!;
 
   @override
@@ -62,6 +68,12 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
     if (widget.controller == null) {
       _ownedController = ScrollController();
     }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _verticalAncestor = Scrollable.maybeOf(context, axis: Axis.vertical);
   }
 
   @override
@@ -85,6 +97,16 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
     // Mirrors Scrollable's own guard, so a NeverScrollableScrollPhysics rail
     // stays inert instead of being scrolled from here.
     if (!position.physics.shouldAcceptUserOffset(position)) return;
+
+    // A page scroll already in flight keeps the wheel until it settles, so a
+    // flick down the home screen is not snagged by a rail it passes over.
+    //
+    // Mostly redundant: while a page scrolls it wraps its viewport in an
+    // IgnorePointer, so the rail is usually not in the hit-test path at all.
+    // The exception is an overscroll bounce-back under BouncingScrollPhysics,
+    // where setPixels forces setIgnorePointer(false) while out of range. There
+    // the rail IS reachable and this line is the only thing declining.
+    if (_verticalAncestor?.position.isScrollingNotifier.value ?? false) return;
 
     // `pixels` is direction-normalised, so `dy` maps onto it unsigned in both
     // LTR and RTL: down always means further through the list.

--- a/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
+++ b/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
@@ -16,6 +16,13 @@ const _glideCurve = Curves.easeOutCubic;
 ///
 /// It claims it only while the rail can actually use it, so vertical page
 /// scrolling still works over a rail that has nowhere left to go.
+///
+/// There is deliberately no check for "the page is already scrolling". Every
+/// [ScrollActivity] whose `isScrolling` is true also sets `shouldIgnorePointer`,
+/// and [Scrollable] wraps its viewport in an `IgnorePointer` driven by that
+/// flag. A rail inside a moving page is therefore already outside the hit-test
+/// path, so such a check could never fire. An earlier revision of this widget
+/// carried one; it was removed as unreachable.
 class HorizontalWheelScroll extends StatefulWidget {
   /// The scrollable's controller. Pass one when the call site already owns it,
   /// as the rails do for their edge fades. When null this widget creates and
@@ -47,11 +54,6 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
   /// of each tick restarting from wherever the animation happens to be.
   double? _target;
 
-  /// The page scroller this rail sits inside, resolved once per dependency
-  /// change. `_ScrollableScope` only notifies when the position object itself
-  /// is replaced, so this dependency costs nothing per frame.
-  ScrollableState? _verticalAncestor;
-
   ScrollController get _controller => widget.controller ?? _ownedController!;
 
   @override
@@ -60,12 +62,6 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
     if (widget.controller == null) {
       _ownedController = ScrollController();
     }
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _verticalAncestor = Scrollable.maybeOf(context, axis: Axis.vertical);
   }
 
   @override
@@ -89,12 +85,6 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
     // Mirrors Scrollable's own guard, so a NeverScrollableScrollPhysics rail
     // stays inert instead of being scrolled from here.
     if (!position.physics.shouldAcceptUserOffset(position)) return;
-
-    // A page scroll already in flight keeps the wheel until it settles, so a
-    // flick down the home screen is not snagged by a rail it passes over. It
-    // also covers the mirror case: once a rail hands off at its end, the page
-    // holds the wheel rather than bouncing back.
-    if (_verticalAncestor?.position.isScrollingNotifier.value ?? false) return;
 
     // `pixels` is direction-normalised, so `dy` maps onto it unsigned in both
     // LTR and RTL: down always means further through the list.

--- a/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
+++ b/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
@@ -140,7 +140,14 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
   Widget build(BuildContext context) {
     return Listener(
       onPointerSignal: _onPointerSignal,
-      child: widget.builder(context, _controller),
+      // Says the rail is draggable, now that AppScrollBehavior makes it so.
+      // The cards' own InkWells set `click` on their own regions and are
+      // descendants, so a card reads as clickable and the gaps read as
+      // grabbable.
+      child: MouseRegion(
+        cursor: SystemMouseCursors.grab,
+        child: widget.builder(context, _controller),
+      ),
     );
   }
 }

--- a/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
+++ b/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
@@ -64,18 +64,32 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
   }
 
   void _onPointerSignal(PointerSignalEvent event) {
+    // Trackpads arrive as pan-zoom events and already scroll both axes.
     if (event is! PointerScrollEvent) return;
+    // A tilt or horizontal wheel already lands on the rail's own axis.
+    if (event.scrollDelta.dy == 0) return;
 
     final controller = _controller;
     if (!controller.hasClients) return;
 
     final position = controller.position;
+    // A rail that fits on screen has no business eating the page's wheel.
+    if (position.maxScrollExtent <= 0) return;
+    // Mirrors Scrollable's own guard, so a NeverScrollableScrollPhysics rail
+    // stays inert instead of being scrolled from here.
+    if (!position.physics.shouldAcceptUserOffset(position)) return;
+
+    // `pixels` is direction-normalised, so `dy` maps onto it unsigned in both
+    // LTR and RTL: down always means further through the list.
     final base = _target ?? position.pixels;
     final next = clampDouble(
       base + event.scrollDelta.dy,
       position.minScrollExtent,
       position.maxScrollExtent,
     );
+    // Already at that end. Declining, rather than registering a no-op, is what
+    // lets the page take the event.
+    if (next == base) return;
 
     GestureBinding.instance.pointerSignalResolver
         .register(event, (_) => _glideTo(next));

--- a/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
+++ b/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/foundation.dart' show clampDouble;
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+/// One wheel tick's animation. GTK delivers coarse discrete deltas on Linux,
+/// so each tick animates; jumping on every tick reads as teleporting.
+const _glideDuration = Duration(milliseconds: 150);
+const _glideCurve = Curves.easeOutCubic;
+
+/// Makes a horizontal scrollable respond to a vertical mouse wheel.
+///
+/// Flutter maps a wheel event onto the scrollable's own axis, so `scrollDelta.dy`
+/// over a horizontal `ListView` resolves to nothing, the rail declines the
+/// event, and it falls through to the page. That is why a rail cannot be
+/// scrolled with a plain mouse. This wrapper claims the event instead.
+///
+/// It claims it only while the rail can actually use it, so vertical page
+/// scrolling still works over a rail that has nowhere left to go.
+class HorizontalWheelScroll extends StatefulWidget {
+  /// The scrollable's controller. Pass one when the call site already owns it,
+  /// as the rails do for their edge fades. When null this widget creates and
+  /// disposes its own, which keeps a call site from needing a `State` class
+  /// solely to hold a controller.
+  final ScrollController? controller;
+
+  /// Builds the scrollable. The controller handed back is either [controller]
+  /// or the internally owned one, and must be attached to the scrollable this
+  /// returns.
+  final Widget Function(BuildContext context, ScrollController controller)
+      builder;
+
+  const HorizontalWheelScroll({
+    super.key,
+    this.controller,
+    required this.builder,
+  });
+
+  @override
+  State<HorizontalWheelScroll> createState() => _HorizontalWheelScrollState();
+}
+
+class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
+  ScrollController? _ownedController;
+
+  /// Where the in-flight glide is heading. Ticks accumulate onto this rather
+  /// than onto the live offset, so a burst compounds into one motion instead
+  /// of each tick restarting from wherever the animation happens to be.
+  double? _target;
+
+  ScrollController get _controller => widget.controller ?? _ownedController!;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.controller == null) {
+      _ownedController = ScrollController();
+    }
+  }
+
+  @override
+  void dispose() {
+    _ownedController?.dispose();
+    super.dispose();
+  }
+
+  void _onPointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent) return;
+
+    final controller = _controller;
+    if (!controller.hasClients) return;
+
+    final position = controller.position;
+    final base = _target ?? position.pixels;
+    final next = clampDouble(
+      base + event.scrollDelta.dy,
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+
+    GestureBinding.instance.pointerSignalResolver
+        .register(event, (_) => _glideTo(next));
+  }
+
+  void _glideTo(double next) {
+    _target = next;
+    _controller
+        .animateTo(next, duration: _glideDuration, curve: _glideCurve)
+        .whenComplete(() {
+      // Completes on interruption as well as on completion, so a drag that
+      // cuts a glide short re-bases the next tick off the real offset. The
+      // guard stops a stale completion from clearing a newer target.
+      if (mounted && _target == next) _target = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerSignal: _onPointerSignal,
+      child: widget.builder(context, _controller),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
+++ b/player/lib/presentation/widgets/horizontal_wheel_scroll.dart
@@ -47,6 +47,11 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
   /// of each tick restarting from wherever the animation happens to be.
   double? _target;
 
+  /// The page scroller this rail sits inside, resolved once per dependency
+  /// change. `_ScrollableScope` only notifies when the position object itself
+  /// is replaced, so this dependency costs nothing per frame.
+  ScrollableState? _verticalAncestor;
+
   ScrollController get _controller => widget.controller ?? _ownedController!;
 
   @override
@@ -55,6 +60,12 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
     if (widget.controller == null) {
       _ownedController = ScrollController();
     }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _verticalAncestor = Scrollable.maybeOf(context, axis: Axis.vertical);
   }
 
   @override
@@ -78,6 +89,12 @@ class _HorizontalWheelScrollState extends State<HorizontalWheelScroll> {
     // Mirrors Scrollable's own guard, so a NeverScrollableScrollPhysics rail
     // stays inert instead of being scrolled from here.
     if (!position.physics.shouldAcceptUserOffset(position)) return;
+
+    // A page scroll already in flight keeps the wheel until it settles, so a
+    // flick down the home screen is not snagged by a rail it passes over. It
+    // also covers the mirror case: once a rail hands off at its end, the page
+    // holds the wheel rather than bouncing back.
+    if (_verticalAncestor?.position.isScrollingNotifier.value ?? false) return;
 
     // `pixels` is direction-normalised, so `dy` maps onto it unsigned in both
     // LTR and RTL: down always means further through the list.

--- a/player/test/app_scroll_behavior_wiring_test.dart
+++ b/player/test/app_scroll_behavior_wiring_test.dart
@@ -1,0 +1,75 @@
+// `app.dart` builds three different MaterialApps depending on auth state. All
+// three must carry AppScrollBehavior: only the router one has scrollables
+// today, but a loading or error screen that grows one later must not silently
+// fall back to the stock behavior.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/app.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/cast/cast_capabilities.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/cast/cast_session_manager.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/core/scroll/app_scroll_behavior.dart';
+
+/// Auth notifier whose state the test drives directly.
+class _FakeAuthNotifier extends AuthStateNotifier {
+  _FakeAuthNotifier(this._initial);
+
+  final AsyncValue<AuthStatus> _initial;
+
+  @override
+  AsyncValue<AuthStatus> build() => _initial;
+}
+
+void main() {
+  Future<void> pumpApp(
+    WidgetTester tester,
+    AsyncValue<AuthStatus> auth,
+  ) async {
+    final container = ProviderContainer(overrides: [
+      castCapabilitiesProvider.overrideWithValue(const CastCapabilities.full()),
+      authStateProvider.overrideWith(() => _FakeAuthNotifier(auth)),
+      asyncGraphqlClientProvider
+          .overrideWith((ref) => Completer<GraphQLClient>().future),
+      castSessionProvider.overrideWith((ref) => Stream.value(null)),
+      castSessionManagerProvider
+          .overrideWith((ref) => Completer<CastSessionManager>().future),
+    ]);
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: const MyApp(),
+    ));
+    await tester.pump();
+  }
+
+  void expectBehavior(WidgetTester tester) {
+    final app = tester.widget<MaterialApp>(find.byType(MaterialApp));
+    expect(app.scrollBehavior, isA<AppScrollBehavior>());
+  }
+
+  testWidgets('the loading app carries AppScrollBehavior', (tester) async {
+    await pumpApp(tester, const AsyncValue.loading());
+    expectBehavior(tester);
+  });
+
+  testWidgets('the error app carries AppScrollBehavior', (tester) async {
+    await pumpApp(
+      tester,
+      AsyncValue.error(Exception('nope'), StackTrace.empty),
+    );
+    expectBehavior(tester);
+  });
+
+  testWidgets('the router app carries AppScrollBehavior', (tester) async {
+    await pumpApp(tester, const AsyncValue.data(AuthStatus.authenticated));
+    expectBehavior(tester);
+  });
+}

--- a/player/test/core/scroll/app_scroll_behavior_test.dart
+++ b/player/test/core/scroll/app_scroll_behavior_test.dart
@@ -1,0 +1,78 @@
+// The stock MaterialScrollBehavior leaves PointerDeviceKind.mouse out of
+// dragDevices, so grabbing a list with a mouse does nothing. These tests pin
+// both halves: that the override adds mouse, and that the stock behavior
+// really is what was broken.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/scroll/app_scroll_behavior.dart';
+
+Widget _host({
+  required ScrollController controller,
+  ScrollBehavior? behavior,
+}) {
+  return MaterialApp(
+    scrollBehavior: behavior,
+    home: Scaffold(
+      body: ListView.builder(
+        controller: controller,
+        itemCount: 50,
+        itemBuilder: (context, i) => SizedBox(
+          height: 100,
+          child: Text('row $i'),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  test('adds mouse without dropping any stock drag device', () {
+    const behavior = AppScrollBehavior();
+
+    expect(behavior.dragDevices, contains(PointerDeviceKind.mouse));
+    expect(
+      behavior.dragDevices,
+      containsAll(const MaterialScrollBehavior().dragDevices),
+    );
+  });
+
+  testWidgets('a mouse drag scrolls a list under AppScrollBehavior',
+      (tester) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      _host(controller: controller, behavior: const AppScrollBehavior()),
+    );
+
+    await tester.drag(
+      find.text('row 0'),
+      const Offset(0, -300),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, greaterThan(0));
+  });
+
+  testWidgets('the same drag does nothing under the stock behavior',
+      (tester) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(_host(controller: controller));
+
+    await tester.drag(
+      find.text('row 0'),
+      const Offset(0, -300),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, 0,
+        reason: 'this is the bug the override fixes; if this ever passes, '
+            'Flutter changed its defaults and the override may be redundant');
+  });
+}

--- a/player/test/presentation/widgets/cast_rail_test.dart
+++ b/player/test/presentation/widgets/cast_rail_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -38,5 +39,34 @@ void main() {
     )));
 
     expect(find.byIcon(Icons.person_rounded), findsOneWidget);
+  });
+
+  testWidgets('a vertical wheel scrolls the cast rail', (tester) async {
+    await tester.pumpWidget(_host(CastRail(
+      members: List.generate(
+        20,
+        (i) => CastMember(name: 'Actor $i', character: 'Role $i'),
+      ),
+    )));
+
+    final position = tester
+        .stateList<ScrollableState>(find.byType(Scrollable))
+        .map((s) => s.position)
+        .firstWhere((p) => p.axis == Axis.horizontal);
+
+    // Hovers over the ListView itself, not the CastRail widget: CastRail's
+    // Column defaults to MainAxisSize.max, and this test's `_host` makes it
+    // the sole, unconstrained-height child of a Scaffold body, so its render
+    // box stretches to the full 600px test surface even though the rail only
+    // paints its top ~166px. getCenter(find.byType(CastRail)) then lands in
+    // that empty lower region and never reaches the wheel listener. In the
+    // real app CastRail sits inside a scrolling page body, where its box
+    // hugs its content and this divergence does not occur.
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    pointer.hover(tester.getCenter(find.byType(ListView)));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0, 200)));
+    await tester.pumpAndSettle();
+
+    expect(position.pixels, greaterThan(0));
   });
 }

--- a/player/test/presentation/widgets/content_rail_test.dart
+++ b/player/test/presentation/widgets/content_rail_test.dart
@@ -6,6 +6,7 @@
 // id-based keys (player key convention), and the scroll-edge fade gradients
 // still render.
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -76,6 +77,24 @@ void main() {
       await tester.pump();
 
       expect(find.byType(MediaCard), findsNothing);
+    });
+
+    testWidgets('a vertical wheel scrolls the rail', (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(title: 'Recently Added', items: _items(30))),
+      );
+
+      final position = tester
+          .stateList<ScrollableState>(find.byType(Scrollable))
+          .map((s) => s.position)
+          .firstWhere((p) => p.axis == Axis.horizontal);
+
+      final pointer = TestPointer(1, PointerDeviceKind.mouse);
+      pointer.hover(tester.getCenter(find.byType(ContentRail)));
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 200)));
+      await tester.pumpAndSettle();
+
+      expect(position.pixels, greaterThan(0));
     });
   });
 

--- a/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
+++ b/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
@@ -52,9 +52,15 @@ Widget _host({
   );
 }
 
+/// `skipOffstage: false` because reading a scroll offset must not depend on
+/// whether that scrollable is currently on screen. Several tests below assert
+/// the rail did NOT move while the page scrolled instead, and a page scroll
+/// large enough to carry the rail off the top would otherwise make the rail
+/// unfindable and throw `StateError` out of `firstWhere` — a fixture failure
+/// wearing the costume of a behavior failure.
 ScrollPosition _positionOn(WidgetTester tester, Axis axis) {
   return tester
-      .stateList<ScrollableState>(find.byType(Scrollable))
+      .stateList<ScrollableState>(find.byType(Scrollable, skipOffstage: false))
       .map((s) => s.position)
       .firstWhere((p) => p.axis == axis);
 }
@@ -155,5 +161,95 @@ void main() {
 
     expect(rail.offset, greaterThan(0));
     expect(rail.offset, _rail(tester).pixels);
+  });
+
+  testWidgets('a rail that fits on screen leaves the wheel to the page',
+      (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    // Two cards at 100px in a 400px viewport: nothing to scroll.
+    await tester.pumpWidget(_host(pageController: page, cards: 2));
+
+    expect(_rail(tester).maxScrollExtent, 0);
+
+    await _wheelOverRail(tester, 120);
+    await tester.pumpAndSettle();
+
+    expect(_rail(tester).pixels, 0);
+    expect(_page(tester).pixels, greaterThan(0));
+  });
+
+  testWidgets('a rail at its end hands the wheel to the page', (tester) async {
+    final page = ScrollController();
+    final rail = ScrollController();
+    addTearDown(page.dispose);
+    addTearDown(rail.dispose);
+
+    await tester.pumpWidget(_host(pageController: page, railController: rail));
+    rail.jumpTo(rail.position.maxScrollExtent);
+    await tester.pump();
+
+    final atEnd = rail.offset;
+
+    await _wheelOverRail(tester, 120);
+    await tester.pumpAndSettle();
+
+    expect(rail.offset, atEnd);
+    expect(_page(tester).pixels, greaterThan(0));
+  });
+
+  testWidgets('a rail at its end still scrolls back the other way',
+      (tester) async {
+    final page = ScrollController();
+    final rail = ScrollController();
+    addTearDown(page.dispose);
+    addTearDown(rail.dispose);
+
+    await tester.pumpWidget(_host(pageController: page, railController: rail));
+    rail.jumpTo(rail.position.maxScrollExtent);
+    await tester.pump();
+
+    final atEnd = rail.offset;
+
+    await _wheelOverRail(tester, -120);
+    await tester.pumpAndSettle();
+
+    expect(rail.offset, lessThan(atEnd));
+    expect(_page(tester).pixels, 0);
+  });
+
+  testWidgets('an unscrollable rail leaves the wheel to the page',
+      (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(
+      pageController: page,
+      railPhysics: const NeverScrollableScrollPhysics(),
+    ));
+
+    await _wheelOverRail(tester, 120);
+    await tester.pumpAndSettle();
+
+    expect(_rail(tester).pixels, 0);
+    expect(_page(tester).pixels, greaterThan(0));
+  });
+
+  testWidgets('a horizontal wheel is left to the rail itself', (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(pageController: page));
+
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    pointer.hover(tester.getCenter(find.byType(HorizontalWheelScroll)));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(30, 0)));
+    await tester.pump();
+
+    // Flutter's own handling is instant, so the offset is already exact one
+    // frame in. An intercepted event would still be mid-glide here.
+    expect(_rail(tester).pixels, 30);
+    expect(_page(tester).pixels, 0);
   });
 }

--- a/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
+++ b/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/presentation/widgets/horizontal_wheel_scroll.dart';
 
@@ -408,5 +409,25 @@ void main() {
     expect(_rail(tester).pixels, greaterThan(0),
         reason: 'pixels are direction-normalised, so down means further '
             'through the list in both directions');
+  });
+
+  testWidgets('the rail shows a grab cursor', (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(pageController: page));
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    await gesture.moveTo(tester.getCenter(find.byType(HorizontalWheelScroll)));
+    await tester.pump();
+
+    expect(
+      RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
+      SystemMouseCursors.grab,
+    );
   });
 }

--- a/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
+++ b/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
@@ -19,6 +19,7 @@ Widget _host({
   ScrollController? railController,
   int cards = 40,
   ScrollPhysics? railPhysics,
+  ScrollPhysics? pagePhysics,
   TextDirection textDirection = TextDirection.ltr,
 }) {
   return Directionality(
@@ -28,6 +29,7 @@ Widget _host({
       child: Material(
         child: ListView(
           controller: pageController,
+          physics: pagePhysics,
           children: [
             SizedBox(
               height: _railHeight,
@@ -314,5 +316,46 @@ void main() {
     expect(_rail(tester).pixels, greaterThan(0),
         reason: 'the IgnorePointer is transient; a settled page must hand the '
             'rail back its wheel');
+  });
+
+  testWidgets('a page bouncing back from overscroll keeps the wheel',
+      (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    // BouncingScrollPhysics explicitly, because it is the platform default on
+    // macOS and iOS but not on the Android default the test binding uses. Under
+    // ClampingScrollPhysics the page can never go out of range, and this test
+    // would pass whether or not the momentum lock exists.
+    await tester.pumpWidget(_host(
+      pageController: page,
+      pagePhysics: const BouncingScrollPhysics(),
+    ));
+
+    // Drag the page past its top edge and release into the bounce-back. This
+    // is the one window where Flutter reports the page as scrolling while
+    // still delivering pointer events to its children: setPixels forces
+    // setIgnorePointer(false) whenever the position is out of range.
+    final drag = await tester.startGesture(
+      tester.getCenter(find.text('spacer').first),
+    );
+    await drag.moveBy(const Offset(0, 120));
+    await tester.pump();
+    await drag.up();
+    await tester.pump();
+
+    expect(_page(tester).outOfRange, isTrue,
+        reason: 'premise guard: the page must actually be overscrolled');
+    expect(_page(tester).isScrollingNotifier.value, isTrue,
+        reason: 'premise guard: the bounce-back must be running');
+
+    await _wheelOverRail(tester, 120);
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(_rail(tester).pixels, 0,
+        reason: 'a bouncing page still delivers pointers to its children, so '
+            'only the momentum lock stops the rail claiming this wheel');
+
+    await tester.pumpAndSettle();
   });
 }

--- a/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
+++ b/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
@@ -4,6 +4,8 @@
 // Scrollables rather than off controllers, so tests cover the case where the
 // wrapper owns the controller itself.
 
+import 'dart:async';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -253,46 +255,55 @@ void main() {
     expect(_page(tester).pixels, 0);
   });
 
-  testWidgets('a page scroll already in flight keeps the wheel',
+  // The next two tests cover a guarantee this widget relies on but does not
+  // implement. Scrollable wraps its viewport in an IgnorePointer while it is
+  // scrolling, so a rail inside a moving page cannot receive the wheel at all.
+  // That is what stops a page scroll from being snagged by a rail it passes
+  // over, and it is why this widget carries no momentum lock of its own. If
+  // Flutter ever changes it, these fail and the widget needs the clause back.
+
+  testWidgets('a moving page keeps the wheel from reaching the rail',
       (tester) async {
     final page = ScrollController();
     addTearDown(page.dispose);
 
     await tester.pumpWidget(_host(pageController: page));
 
-    // Hold a page drag open so the page position reports as scrolling.
-    final drag = await tester.startGesture(
-      tester.getCenter(find.text('spacer').first),
-    );
-    await drag.moveBy(const Offset(0, -60));
+    // Short travel over a long duration on purpose: sampled early, the page has
+    // moved only a few pixels, so the rail is still under the pointer.
+    unawaited(page.animateTo(
+      40,
+      duration: const Duration(milliseconds: 600),
+      curve: Curves.linear,
+    ));
     await tester.pump();
+    await tester.pump(const Duration(milliseconds: 60));
 
-    expect(_page(tester).isScrollingNotifier.value, isTrue);
+    expect(_page(tester).isScrollingNotifier.value, isTrue,
+        reason: 'premise guard: the page must actually be in motion');
 
     await _wheelOverRail(tester, 120);
-    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 100));
 
     expect(_rail(tester).pixels, 0,
         reason: 'a flick down the page must not be snagged by a rail it '
             'passes over');
 
-    await drag.up();
     await tester.pumpAndSettle();
   });
 
-  testWidgets('the wheel returns to the rail once the page settles',
+  testWidgets('the wheel reaches the rail again once the page settles',
       (tester) async {
     final page = ScrollController();
     addTearDown(page.dispose);
 
     await tester.pumpWidget(_host(pageController: page));
 
-    final drag = await tester.startGesture(
-      tester.getCenter(find.text('spacer').first),
-    );
-    await drag.moveBy(const Offset(0, -60));
-    await tester.pump();
-    await drag.up();
+    unawaited(page.animateTo(
+      40,
+      duration: const Duration(milliseconds: 600),
+      curve: Curves.linear,
+    ));
     await tester.pumpAndSettle();
 
     expect(_page(tester).isScrollingNotifier.value, isFalse);
@@ -300,6 +311,8 @@ void main() {
     await _wheelOverRail(tester, 120);
     await tester.pumpAndSettle();
 
-    expect(_rail(tester).pixels, greaterThan(0));
+    expect(_rail(tester).pixels, greaterThan(0),
+        reason: 'the IgnorePointer is transient; a settled page must hand the '
+            'rail back its wheel');
   });
 }

--- a/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
+++ b/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
@@ -358,4 +358,55 @@ void main() {
 
     await tester.pumpAndSettle();
   });
+
+  testWidgets('a trackpad pan is left alone', (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(pageController: page));
+
+    final at = tester.getCenter(find.byType(HorizontalWheelScroll));
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.trackpad,
+    );
+    await gesture.panZoomStart(at);
+
+    // Stream the pan in increments, the way real trackpad hardware does.
+    // `Scrollable` uses `DragStartBehavior.start`, so a single large jump is
+    // consumed whole as the distance that wins the gesture arena and never
+    // becomes scroll delta, leaving the page motionless and the test asserting
+    // nothing. `pan` is cumulative from `panZoomStart`.
+    for (var dy = -20.0; dy >= -120.0; dy -= 20.0) {
+      await gesture.panZoomUpdate(at, pan: Offset(0, dy));
+      await tester.pump();
+    }
+
+    await gesture.panZoomEnd();
+    await tester.pumpAndSettle();
+
+    expect(_rail(tester).pixels, 0,
+        reason: 'a trackpad already scrolls both axes; intercepting its pan '
+            'would fight the framework');
+    expect(_page(tester).pixels, greaterThan(0));
+  });
+
+  testWidgets('an RTL rail advances on wheel-down, same as LTR',
+      (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(
+      _host(pageController: page, textDirection: TextDirection.rtl),
+    );
+
+    expect(_rail(tester).axisDirection, AxisDirection.left,
+        reason: 'guards the premise: RTL really does reverse the axis');
+
+    await _wheelOverRail(tester, 120);
+    await tester.pumpAndSettle();
+
+    expect(_rail(tester).pixels, greaterThan(0),
+        reason: 'pixels are direction-normalised, so down means further '
+            'through the list in both directions');
+  });
 }

--- a/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
+++ b/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
@@ -252,4 +252,54 @@ void main() {
     expect(_rail(tester).pixels, 30);
     expect(_page(tester).pixels, 0);
   });
+
+  testWidgets('a page scroll already in flight keeps the wheel',
+      (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(pageController: page));
+
+    // Hold a page drag open so the page position reports as scrolling.
+    final drag = await tester.startGesture(
+      tester.getCenter(find.text('spacer').first),
+    );
+    await drag.moveBy(const Offset(0, -60));
+    await tester.pump();
+
+    expect(_page(tester).isScrollingNotifier.value, isTrue);
+
+    await _wheelOverRail(tester, 120);
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(_rail(tester).pixels, 0,
+        reason: 'a flick down the page must not be snagged by a rail it '
+            'passes over');
+
+    await drag.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the wheel returns to the rail once the page settles',
+      (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(pageController: page));
+
+    final drag = await tester.startGesture(
+      tester.getCenter(find.text('spacer').first),
+    );
+    await drag.moveBy(const Offset(0, -60));
+    await tester.pump();
+    await drag.up();
+    await tester.pumpAndSettle();
+
+    expect(_page(tester).isScrollingNotifier.value, isFalse);
+
+    await _wheelOverRail(tester, 120);
+    await tester.pumpAndSettle();
+
+    expect(_rail(tester).pixels, greaterThan(0));
+  });
 }

--- a/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
+++ b/player/test/presentation/widgets/horizontal_wheel_scroll_test.dart
@@ -1,0 +1,159 @@
+// Contract tests for the wheel-to-horizontal wrapper. Each test pumps the
+// arrangement every real call site lives in: a vertically scrolling page with
+// a horizontal rail inside it. The two positions are read off the live
+// Scrollables rather than off controllers, so tests cover the case where the
+// wrapper owns the controller itself.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/horizontal_wheel_scroll.dart';
+
+const _railHeight = 120.0;
+const _cardWidth = 100.0;
+
+Widget _host({
+  required ScrollController pageController,
+  ScrollController? railController,
+  int cards = 40,
+  ScrollPhysics? railPhysics,
+  TextDirection textDirection = TextDirection.ltr,
+}) {
+  return Directionality(
+    textDirection: textDirection,
+    child: MediaQuery(
+      data: const MediaQueryData(size: Size(400, 600)),
+      child: Material(
+        child: ListView(
+          controller: pageController,
+          children: [
+            SizedBox(
+              height: _railHeight,
+              child: HorizontalWheelScroll(
+                controller: railController,
+                builder: (context, controller) => ListView.builder(
+                  controller: controller,
+                  scrollDirection: Axis.horizontal,
+                  physics: railPhysics,
+                  itemCount: cards,
+                  itemBuilder: (context, i) => SizedBox(
+                    width: _cardWidth,
+                    child: Text('card $i'),
+                  ),
+                ),
+              ),
+            ),
+            for (int i = 0; i < 10; i++)
+              const SizedBox(height: 200, child: Text('spacer')),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+ScrollPosition _positionOn(WidgetTester tester, Axis axis) {
+  return tester
+      .stateList<ScrollableState>(find.byType(Scrollable))
+      .map((s) => s.position)
+      .firstWhere((p) => p.axis == axis);
+}
+
+ScrollPosition _rail(WidgetTester tester) =>
+    _positionOn(tester, Axis.horizontal);
+
+ScrollPosition _page(WidgetTester tester) => _positionOn(tester, Axis.vertical);
+
+/// Sends one wheel tick with the pointer parked over the rail.
+///
+/// Targets the wrapper rather than a card. The wrapper's box moves with the
+/// page but not with the rail, so it stays under the pointer across ticks; a
+/// card the finder located on one tick has glided out from under the pointer
+/// by the next one, and that wheel event would hit nothing.
+Future<void> _wheelOverRail(WidgetTester tester, double dy) async {
+  final pointer = TestPointer(1, PointerDeviceKind.mouse);
+  pointer.hover(tester.getCenter(find.byType(HorizontalWheelScroll)));
+  await tester.sendEventToBinding(pointer.scroll(Offset(0, dy)));
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('a vertical wheel scrolls an overflowing rail', (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(pageController: page));
+
+    await _wheelOverRail(tester, 120);
+    await tester.pumpAndSettle();
+
+    expect(_rail(tester).pixels, greaterThan(0));
+    expect(_page(tester).pixels, 0,
+        reason: 'the rail claimed the event, so the page must not move');
+  });
+
+  testWidgets('the rail glides rather than jumping', (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(pageController: page));
+
+    await _wheelOverRail(tester, 120);
+    // One frame in, an animation is partway there; a jumpTo would already be
+    // at its destination.
+    await tester.pump(const Duration(milliseconds: 40));
+    final midway = _rail(tester).pixels;
+
+    await tester.pumpAndSettle();
+
+    expect(midway, greaterThan(0));
+    expect(midway, lessThan(_rail(tester).pixels));
+  });
+
+  testWidgets('consecutive ticks accumulate instead of restarting',
+      (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(pageController: page));
+
+    await _wheelOverRail(tester, 120);
+    await tester.pump(const Duration(milliseconds: 30));
+    await _wheelOverRail(tester, 120);
+    await tester.pumpAndSettle();
+
+    expect(_rail(tester).pixels, 240,
+        reason: 'the second tick must build on the first target, not on '
+            'wherever the animation happened to be');
+  });
+
+  testWidgets('the wrapper owns a controller when none is given',
+      (tester) async {
+    final page = ScrollController();
+    addTearDown(page.dispose);
+
+    await tester.pumpWidget(_host(pageController: page, railController: null));
+
+    await _wheelOverRail(tester, 120);
+    await tester.pumpAndSettle();
+
+    expect(_rail(tester).pixels, greaterThan(0));
+  });
+
+  testWidgets('a caller-owned controller drives the same rail', (tester) async {
+    final page = ScrollController();
+    final rail = ScrollController();
+    addTearDown(page.dispose);
+    addTearDown(rail.dispose);
+
+    await tester.pumpWidget(
+      _host(pageController: page, railController: rail),
+    );
+
+    await _wheelOverRail(tester, 120);
+    await tester.pumpAndSettle();
+
+    expect(rail.offset, greaterThan(0));
+    expect(rail.offset, _rail(tester).pixels);
+  });
+}


### PR DESCRIPTION
On Linux the player's horizontal rails could not be scrolled with a mouse at all. Neither the wheel nor a click-drag moved them, so everything past the first screenful of a rail was unreachable.

Two independent causes, both stock Flutter defaults the player had never overridden:

- `ScrollBehavior.dragDevices` omits `PointerDeviceKind.mouse`, so grabbing any scrollable with a mouse is a no-op by design.
- `Scrollable` maps a wheel event onto its own axis, so `scrollDelta.dy` over a horizontal `ListView` resolves to nothing and falls through to the page. The page moved; the rail did not.

## What this does

`AppScrollBehavior` (`lib/core/scroll/app_scroll_behavior.dart`) adds mouse to `dragDevices` and is set on all three `MaterialApp`s in `app.dart`. That fixes click-drag for every scrollable in the app.

`HorizontalWheelScroll` (`lib/presentation/widgets/horizontal_wheel_scroll.dart`) converts a vertical wheel into an animated horizontal glide, and shows a `grab` cursor so the rail advertises that it is draggable. Ticks accumulate onto a running target, so a burst compounds into one motion instead of each tick restarting the animation.

It claims the wheel only while the rail can actually use it. It declines, letting the page scroller take the event, when the delta is not vertical, when the rail fits on screen, when the physics reject the offset, when the rail is already at that end, and while an enclosing page scroll is in flight. Declining means never calling `pointerSignalResolver.register`, which is how Flutter's own `Scrollable` passes up an event it cannot use.

Adopted at all six interactive horizontal surfaces: `ContentRail`, `HorizontalRail`, `CastRail`, the season chips on the show detail screen, the search filter chips, and the failed-downloads row. `ShimmerCard`'s rail is deliberately excluded as a non-interactive loading skeleton.

## The momentum lock, which is the interesting part

The in-flight-page-scroll clause looks like dead code and was deleted as such mid-implementation, then restored when review disproved that reading. The history is preserved in the commits rather than squashed, because the next person to read this will reach the same wrong conclusion.

`Scrollable` wraps its viewport in an `IgnorePointer` while scrolling, so a rail inside a moving page is usually not hit-tested at all, which makes the clause look redundant. It is not redundant during an overscroll bounce-back: `ScrollPosition.shouldIgnorePointer` is gated on `!outOfRange`, and `setPixels` forces `setIgnorePointer(false)` every tick while out of range, deliberately, so children keep receiving pointer events as the view settles back. In that window the rail is reachable and this clause is the only thing declining.

That window is reachable here, not hypothetical. `BouncingScrollPhysics` is the platform default on macOS and iOS, neither `MaterialScrollBehavior` nor `AppScrollBehavior` overrides `getScrollPhysics`, and this PR's own `dragDevices` change means one hand on one mouse can overscroll the page by dragging, release into the bounce-back, and spin the wheel during it.

Every attempt to test the clause came back green with it commented out, which is what prompted the deletion. The reason is that the test binding defaults to the Android target platform, hence `ClampingScrollPhysics`, which clamps `pixels` and can never go `outOfRange`. The test now sets `BouncingScrollPhysics` explicitly and fails when the clause is removed.

## Testing

16 tests in `horizontal_wheel_scroll_test.dart`, one per clause of the pointer-signal contract plus the overscroll case, the trackpad pass-through, and the RTL direction. `app_scroll_behavior_test.dart` asserts a mouse drag scrolls under the new behavior and does not under the stock one, so it proves the fix rather than restating it. `app_scroll_behavior_wiring_test.dart` pumps all three auth branches of `MyApp`.

Full player suite: 2368 passing. `dart analyze --fatal-warnings` exits 0; the 56 reported infos are pre-existing and none are in a file this branch created.

## Not verified

Manual verification on a real Linux desktop session has not been done, since this was built headless. Worth a hands-on pass on the home screen: wheel over a rail, wheel past its end and confirm the page takes over, flick the page down across a rail, and grab-drag a rail by the gap between two posters.

Design notes: `docs/superpowers/specs/2026-08-17-player-horizontal-scroll-design.md` (gitignored scratch, not in this diff).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mouse dragging support for scrollable content.
  * Added vertical mouse-wheel scrolling for horizontal rails, filters, seasons, cast lists, and download lists.
  * Added smooth, cumulative scrolling with boundary handoff to surrounding page content.
  * Added grab cursor feedback for horizontally scrollable areas.

* **Tests**
  * Added coverage for mouse dragging, wheel scrolling, scrolling boundaries, RTL layouts, and nested scroll behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->