### PR TITLE
Make scan completion feedback transient

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -27,6 +27,7 @@ import topbar from "../vendor/topbar";
 import VideoPlayer from "./hooks/video_player";
 import PlexOAuth from "./hooks/plex_oauth";
 import DockNav from "./hooks/dock_nav";
+import PersistedCheckbox from "./hooks/persisted_checkbox.mjs";
 // Alpine.js for reactive UI components
 import Alpine from "alpinejs";
 import { videoPlayer } from "./alpine_components/video_player";
@@ -440,6 +441,7 @@ const liveSocket = new LiveSocket("/live", Socket, {
     VideoPreview,
     PlexOAuth,
     DockNav,
+    PersistedCheckbox,
     AddDirectUrl,
     BatchSelect,
   },

--- a/assets/js/hooks/persisted_checkbox.mjs
+++ b/assets/js/hooks/persisted_checkbox.mjs
@@ -1,0 +1,33 @@
+const STORAGE_KEY = "mydia:auto-import-confident-matches";
+
+export function applyStoredPreference(checkbox, storage) {
+  try {
+    const saved = storage.getItem(STORAGE_KEY);
+    checkbox.checked = saved === null ? true : saved === "true";
+  } catch (_error) {
+    checkbox.checked = true;
+  }
+}
+
+export function persistPreference(checkbox, storage) {
+  try {
+    storage.setItem(STORAGE_KEY, checkbox.checked.toString());
+  } catch (_error) {
+    // Storage can be unavailable in privacy modes. The checkbox still works
+    // for the current form submission, even when its preference cannot persist.
+  }
+}
+
+const PersistedCheckbox = {
+  mounted() {
+    applyStoredPreference(this.el, window.localStorage);
+    this.persistPreference = () => persistPreference(this.el, window.localStorage);
+    this.el.addEventListener("change", this.persistPreference);
+  },
+
+  destroyed() {
+    this.el.removeEventListener("change", this.persistPreference);
+  },
+};
+
+export default PersistedCheckbox;

--- a/assets/js/hooks/persisted_checkbox.mjs
+++ b/assets/js/hooks/persisted_checkbox.mjs
@@ -20,8 +20,23 @@ export function persistPreference(checkbox, storage) {
 
 const PersistedCheckbox = {
   mounted() {
-    applyStoredPreference(this.el, window.localStorage);
-    this.persistPreference = () => persistPreference(this.el, window.localStorage);
+    let storage;
+
+    try {
+      storage = window.localStorage;
+    } catch (_error) {
+      storage = null;
+    }
+
+    if (storage) {
+      applyStoredPreference(this.el, storage);
+    } else {
+      this.el.checked = true;
+    }
+
+    this.persistPreference = () => {
+      if (storage) persistPreference(this.el, storage);
+    };
     this.el.addEventListener("change", this.persistPreference);
   },
 

--- a/assets/package.json
+++ b/assets/package.json
@@ -8,6 +8,7 @@
     "deploy": "cd .. && mix assets.deploy && rm -f _build/esbuild*",
     "screenshots": "node screenshots.js",
     "populate-media": "node populate-media.js",
+    "test:unit": "node --test test/unit/*.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",

--- a/assets/test/unit/persisted_checkbox.test.mjs
+++ b/assets/test/unit/persisted_checkbox.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyStoredPreference,
+  persistPreference,
+} from "../../js/hooks/persisted_checkbox.mjs";
+
+function memoryStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, value);
+    },
+  };
+}
+
+test("defaults auto import to on when no preference has been saved", () => {
+  const checkbox = { checked: false };
+
+  applyStoredPreference(checkbox, memoryStorage());
+
+  assert.equal(checkbox.checked, true);
+});
+
+test("restores a saved off preference after the checkbox is recreated", () => {
+  const storage = memoryStorage({ "mydia:auto-import-confident-matches": "false" });
+  const checkbox = { checked: true };
+
+  applyStoredPreference(checkbox, storage);
+
+  assert.equal(checkbox.checked, false);
+});
+
+test("persists the checkbox state for the next render", () => {
+  const storage = memoryStorage();
+
+  persistPreference({ checked: false }, storage);
+
+  assert.equal(storage.getItem("mydia:auto-import-confident-matches"), "false");
+});

--- a/assets/test/unit/persisted_checkbox.test.mjs
+++ b/assets/test/unit/persisted_checkbox.test.mjs
@@ -5,6 +5,7 @@ import {
   applyStoredPreference,
   persistPreference,
 } from "../../js/hooks/persisted_checkbox.mjs";
+import PersistedCheckbox from "../../js/hooks/persisted_checkbox.mjs";
 
 function memoryStorage(initial = {}) {
   const values = new Map(Object.entries(initial));
@@ -42,4 +43,31 @@ test("persists the checkbox state for the next render", () => {
   persistPreference({ checked: false }, storage);
 
   assert.equal(storage.getItem("mydia:auto-import-confident-matches"), "false");
+});
+
+test("mount remains usable when accessing localStorage throws", () => {
+  const previousWindow = globalThis.window;
+  const listeners = new Map();
+  const checkbox = {
+    checked: false,
+    addEventListener(event, handler) {
+      listeners.set(event, handler);
+    },
+  };
+
+  globalThis.window = {};
+  Object.defineProperty(globalThis.window, "localStorage", {
+    get() {
+      throw new Error("storage blocked");
+    },
+  });
+
+  try {
+    PersistedCheckbox.mounted.call({ el: checkbox });
+    assert.equal(checkbox.checked, true);
+    assert.equal(typeof listeners.get("change"), "function");
+    assert.doesNotThrow(() => listeners.get("change")());
+  } finally {
+    globalThis.window = previousWindow;
+  }
 });

--- a/lib/mydia/import_groups.ex
+++ b/lib/mydia/import_groups.ex
@@ -17,7 +17,9 @@ defmodule Mydia.ImportGroups do
   alias Mydia.Library.SelectionScope
   alias Mydia.Media
   alias Mydia.Media.Episode
+  alias Mydia.Metadata
   alias Mydia.Repo
+  alias Mydia.Settings
 
   @auto_accept_threshold 0.85
   @default_page_size 50
@@ -202,8 +204,28 @@ defmodule Mydia.ImportGroups do
       |> Map.new()
 
     stamp_members(library_path, group_ids)
+    prune_obsolete_groups(library_path.id)
 
     {:ok, %{groups: map_size(group_ids), files: file_count}}
+  end
+
+  defp prune_obsolete_groups(library_path_id) do
+    referenced_group_ids_query =
+      MediaFile
+      |> where([f], f.library_path_id == ^library_path_id)
+      |> where(
+        [f],
+        is_nil(f.media_item_id) and is_nil(f.episode_id) and is_nil(f.trashed_at) and
+          not is_nil(f.import_group_id)
+      )
+      |> select([f], f.import_group_id)
+      |> distinct(true)
+
+    from(g in ImportGroup,
+      where: g.library_path_id == ^library_path_id and g.status == "pending",
+      where: g.id not in subquery(referenced_group_ids_query)
+    )
+    |> Repo.delete_all()
   end
 
   defp base_query(library_path_id, status) do
@@ -327,16 +349,55 @@ defmodule Mydia.ImportGroups do
     })
   end
 
-  defp fold_row(row, acc, library_path) do
-    anchor =
-      PathAnchor.anchor_for(Path.join(library_path.path, row.relative_path), library_path.path)
+  defp movie_row?(row, library_path) do
+    library_path.type == :movies or row.media_type == "movie"
+  end
 
-    Map.update(
-      acc,
-      anchor.cluster_key,
-      initial_rollup(anchor, row),
-      &merge_rollup(&1, anchor, row)
-    )
+  defp cluster_key_for(row, library_path) do
+    if movie_row?(row, library_path) do
+      "file-" <> row.id
+    else
+      PathAnchor.anchor_for(
+        Path.join(library_path.path, row.relative_path),
+        library_path.path
+      ).cluster_key
+    end
+  end
+
+  defp fold_row(row, acc, library_path) do
+    if movie_row?(row, library_path) do
+      key = "file-" <> row.id
+      title = row.title || Path.rootname(Path.basename(row.relative_path || ""))
+
+      Map.put(
+        acc,
+        key,
+        %{
+          anchor_path: row.relative_path,
+          display_title: title,
+          file_count: 1,
+          numbered_count: 0,
+          provider_ids: MapSet.new(List.wrap(row.provider_id)),
+          provider_id: row.provider_id,
+          provider_type: row.provider_type,
+          suggested_title: row.title,
+          suggested_year: row.year,
+          media_type: "movie",
+          min_confidence: row.confidence,
+          seasons: MapSet.new()
+        }
+      )
+    else
+      anchor =
+        PathAnchor.anchor_for(Path.join(library_path.path, row.relative_path), library_path.path)
+
+      Map.update(
+        acc,
+        anchor.cluster_key,
+        initial_rollup(anchor, row),
+        &merge_rollup(&1, anchor, row)
+      )
+    end
   end
 
   defp initial_rollup(anchor, row) do
@@ -449,8 +510,14 @@ defmodule Mydia.ImportGroups do
         is_nil(existing) ->
           attrs
 
+        existing.provider_type == "local" and existing.status == "applied" ->
+          Map.drop(attrs, [:provider_type, :provider_id])
+
         existing.provider_type == "local" ->
           Map.drop(attrs, [:status, :provider_type, :provider_id])
+
+        existing.status == "applied" ->
+          attrs
 
         true ->
           Map.drop(attrs, [:status])
@@ -480,13 +547,9 @@ defmodule Mydia.ImportGroups do
     library_path
     |> stream_unresolved()
     |> Enum.reduce(%{}, fn row, buffers ->
-      anchor =
-        PathAnchor.anchor_for(
-          Path.join(library_path.path, row.relative_path),
-          library_path.path
-        )
+      cluster_key = cluster_key_for(row, library_path)
 
-      case Map.fetch(group_ids, anchor.cluster_key) do
+      case Map.fetch(group_ids, cluster_key) do
         :error ->
           buffers
 
@@ -580,21 +643,25 @@ defmodule Mydia.ImportGroups do
   end
 
   @doc """
-  Restores one ignored group to "pending".
+  Restores one or more ignored groups to "pending".
 
-  `ignore/1` used to be a one-way door: `write_group/4` preserves an
-  existing group's `status` across every rescan (that is the whole
-  rescan-stability mechanism), so nothing short of this function could ever
-  bring an ignored group back, and there was no UI that could even see one
-  to reconsider it.
-
+  Accepts either a single group binary id, or a `%SelectionScope{}`.
   Guarded on `status == "ignored"` rather than an unconditional update, so a
-  stale or double-clicked Restore -- the group was already restored by
-  another tab, or reached some other status in between -- is a silent no-op
-  (`{:ok, 0}`) instead of clobbering whatever decided it in the meantime.
+  stale or double-clicked Restore is a silent no-op (`{:ok, 0}`).
   """
-  @spec restore(binary()) :: {:ok, non_neg_integer()}
-  def restore(group_id) do
+  @spec restore(SelectionScope.t() | binary()) :: {:ok, non_neg_integer()}
+  def restore(%SelectionScope{} = scope) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {count, _} =
+      scope
+      |> SelectionScope.to_query()
+      |> Repo.update_all(set: [status: "pending", decided_at: nil, updated_at: now])
+
+    {:ok, count}
+  end
+
+  def restore(group_id) when is_binary(group_id) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     {count, _} =
@@ -603,6 +670,61 @@ defmodule Mydia.ImportGroups do
       |> Repo.update_all(set: [status: "pending", decided_at: nil, updated_at: now])
 
     {:ok, count}
+  end
+
+  @doc """
+  Re-runs metadata matching for media files in the selected groups.
+
+  Runs `BatchMatcher.match_paths/2`, writes the resulting candidates, and updates
+  the import groups' rollups.
+  """
+  @spec rematch(SelectionScope.t(), keyword()) :: {:ok, non_neg_integer()}
+  def rematch(%SelectionScope{} = scope, opts \\ []) do
+    library_path = Settings.get_library_path!(scope.library_path_id)
+    matcher = Keyword.get(opts, :matcher, Mydia.Library.MetadataMatcher)
+    config = Keyword.get(opts, :config) || Metadata.default_relay_config()
+
+    files =
+      MediaFile
+      |> where([f], f.library_path_id == ^scope.library_path_id)
+      |> where([f], is_nil(f.media_item_id) and is_nil(f.episode_id) and is_nil(f.trashed_at))
+      |> join(:inner, [f], g in subquery(SelectionScope.to_query(scope)),
+        on: f.import_group_id == g.id
+      )
+      |> Repo.all()
+
+    if files != [] do
+      files_by_path =
+        Map.new(files, fn f -> {Path.join(library_path.path, f.relative_path), f} end)
+
+      paths = Map.keys(files_by_path)
+
+      match_results =
+        Mydia.Library.BatchMatcher.match_paths(paths,
+          library_root: library_path.path,
+          matcher: matcher,
+          config: config
+        )
+
+      Enum.each(match_results, fn {path, match_outcome} ->
+        with %MediaFile{} = media_file <- Map.get(files_by_path, path) do
+          match_data =
+            case match_outcome do
+              {:ok, data} -> data
+              _ -> nil
+            end
+
+          Mydia.Library.FileIngest.ingest(media_file, match_data,
+            policy: :local_only,
+            config: config
+          )
+        end
+      end)
+
+      upsert_for_library(library_path)
+    end
+
+    {:ok, SelectionScope.count(scope)}
   end
 
   @doc """
@@ -758,6 +880,136 @@ defmodule Mydia.ImportGroups do
   end
 
   @doc """
+  Updates the assigned season and episode numbers for a group member file.
+
+  Updates or creates the member's rank-0 `MatchCandidate` with the updated
+  `parsed_info` and recalculates the parent group's `season_span` and
+  `numbered_count`.
+  """
+  @spec update_member_episode(
+          binary(),
+          integer() | String.t() | nil,
+          integer() | String.t() | nil
+        ) ::
+          {:ok, %{media_file: MediaFile.t(), candidate: MatchCandidate.t()}}
+          | {:error, :not_found | Ecto.Changeset.t()}
+  def update_member_episode(media_file_id, season, episode) do
+    with %MediaFile{} = file <- Repo.get(MediaFile, media_file_id) do
+      parsed_season = parse_int(season)
+      parsed_ep = parse_int(episode)
+      episodes_list = if parsed_ep, do: [parsed_ep], else: []
+
+      candidate = Repo.get_by(MatchCandidate, media_file_id: file.id, rank: 0)
+
+      candidate_result =
+        if candidate do
+          parsed_info =
+            (candidate.parsed_info || %{})
+            |> Map.put("season", parsed_season)
+            |> Map.put("episodes", episodes_list)
+
+          candidate
+          |> MatchCandidate.changeset(%{parsed_info: parsed_info})
+          |> Repo.update()
+        else
+          group =
+            if file.import_group_id, do: Repo.get(ImportGroup, file.import_group_id), else: nil
+
+          parsed_info = %{
+            "season" => parsed_season,
+            "episodes" => episodes_list
+          }
+
+          %MatchCandidate{}
+          |> MatchCandidate.changeset(%{
+            media_file_id: file.id,
+            rank: 0,
+            title:
+              (group && group.suggested_title) ||
+                Path.rootname(Path.basename(file.relative_path || file.path || "")),
+            year: group && group.suggested_year,
+            provider_type: group && group.provider_type,
+            provider_id: group && group.provider_id,
+            media_type: (group && group.media_type) || "tv_show",
+            confidence: (group && group.min_confidence) || 1.0,
+            parsed_info: parsed_info
+          })
+          |> Repo.insert()
+        end
+
+      case candidate_result do
+        {:ok, updated_candidate} ->
+          if file.import_group_id do
+            refresh_group_stats(file.import_group_id)
+          end
+
+          {:ok, %{media_file: file, candidate: updated_candidate}}
+
+        {:error, changeset} ->
+          {:error, changeset}
+      end
+    else
+      nil -> {:error, :not_found}
+    end
+  end
+
+  defp parse_int(nil), do: nil
+  defp parse_int(""), do: nil
+  defp parse_int(i) when is_integer(i), do: i
+
+  defp parse_int(s) when is_binary(s) do
+    case Integer.parse(String.trim(s)) do
+      {val, ""} -> val
+      _ -> nil
+    end
+  end
+
+  defp parse_int(_), do: nil
+
+  defp refresh_group_stats(group_id) do
+    group = Repo.get(ImportGroup, group_id)
+
+    if group do
+      members_data =
+        MediaFile
+        |> where([f], f.import_group_id == ^group_id)
+        |> where([f], is_nil(f.media_item_id) and is_nil(f.episode_id) and is_nil(f.trashed_at))
+        |> join(:left, [f], c in MatchCandidate, on: c.media_file_id == f.id and c.rank == 0)
+        |> select([f, c], %{relative_path: f.relative_path, parsed_info: c.parsed_info})
+        |> Repo.all()
+
+      seasons =
+        members_data
+        |> Enum.reduce(MapSet.new(), fn row, acc ->
+          case row.parsed_info do
+            %{"season" => s} when is_integer(s) ->
+              MapSet.put(acc, s)
+
+            _ ->
+              case PathAnchor.anchor_for(row.relative_path || "", "") do
+                %{season_hint: s} when is_integer(s) -> MapSet.put(acc, s)
+                _ -> acc
+              end
+          end
+        end)
+        |> MapSet.to_list()
+        |> Enum.sort()
+
+      numbered_count =
+        Enum.count(members_data, fn row ->
+          match?(%{"episodes" => [_ | _]}, row.parsed_info)
+        end)
+
+      group
+      |> ImportGroup.changeset(%{
+        season_span: seasons,
+        numbered_count: numbered_count
+      })
+      |> Repo.update()
+    end
+  end
+
+  @doc """
   Creates a local show from a group's folder name, for media no provider carries.
 
   Some libraries hold shows that TVDB and TMDB simply do not have. Without this
@@ -852,6 +1104,35 @@ defmodule Mydia.ImportGroups do
           {:ok, item}
         end
     end
+  end
+
+  @doc """
+  Creates local shows for selected groups from their folder names.
+
+  Only processes pending groups with no provider_id and not already created as local.
+  Returns `{:ok, %{created: count, skipped: count}}`.
+  """
+  @spec create_local_shows(SelectionScope.t()) ::
+          {:ok, %{created: non_neg_integer(), skipped: non_neg_integer()}}
+  def create_local_shows(%SelectionScope{} = scope) do
+    groups =
+      scope
+      |> SelectionScope.to_query()
+      |> where(
+        [g],
+        is_nil(g.provider_id) and (is_nil(g.provider_type) or g.provider_type != "local")
+      )
+      |> Repo.all()
+
+    result =
+      Enum.reduce(groups, %{created: 0, skipped: 0}, fn group, acc ->
+        case create_local_show(group.id) do
+          {:ok, _item} -> %{acc | created: acc.created + 1}
+          {:error, _reason} -> %{acc | skipped: acc.skipped + 1}
+        end
+      end)
+
+    {:ok, result}
   end
 
   # Finds or creates the episode this file's parsed numbering points at, then

--- a/lib/mydia/import_groups.ex
+++ b/lib/mydia/import_groups.ex
@@ -11,6 +11,7 @@ defmodule Mydia.ImportGroups do
   import Ecto.Query
 
   alias Mydia.Library.ImportGroup
+  alias Mydia.Library.ImportRun
   alias Mydia.Library.MatchCandidate
   alias Mydia.Library.MediaFile
   alias Mydia.Library.PathAnchor
@@ -40,6 +41,49 @@ defmodule Mydia.ImportGroups do
   """
   @spec auto_accept_threshold() :: float()
   def auto_accept_threshold, do: @auto_accept_threshold
+
+  @doc """
+  Clears the derived scan and review state for one library path.
+
+  Imported media files are preserved. Active scans are refused so their
+  coordinator cannot recreate groups while the clear is in progress.
+  """
+  @spec clear_for_library(binary()) ::
+          {:ok, non_neg_integer()} | {:error, :active_run}
+  def clear_for_library(library_path_id) do
+    result =
+      Repo.transaction(fn ->
+        active_statuses = ImportRun.active_statuses()
+
+        if Repo.exists?(
+             from(r in ImportRun,
+               where: r.library_path_id == ^library_path_id and r.status in ^active_statuses
+             )
+           ) do
+          Repo.rollback(:active_run)
+        end
+
+        {group_count, _} =
+          ImportGroup
+          |> where([g], g.library_path_id == ^library_path_id)
+          |> Repo.delete_all()
+
+        ImportRun
+        |> where([r], r.library_path_id == ^library_path_id)
+        |> Repo.delete_all()
+
+        group_count
+      end)
+
+    with {:ok, group_count} <- result do
+      Phoenix.PubSub.broadcast(Mydia.PubSub, "import_groups:#{library_path_id}", {
+        :import_groups_changed,
+        library_path_id
+      })
+
+      {:ok, group_count}
+    end
+  end
 
   @doc """
   Which review band a group falls into.
@@ -610,15 +654,39 @@ defmodule Mydia.ImportGroups do
   """
   @spec accept(SelectionScope.t()) :: {:ok, non_neg_integer()} | {:error, term()}
   def accept(%SelectionScope{} = scope) do
+    scope
+    |> SelectionScope.to_query()
+    |> accept_query(scope.library_path_id)
+  end
+
+  @doc """
+  Accepts every pending provider-matched group for one library path.
+
+  Unmatched and synthetic local groups are excluded because the apply worker
+  cannot link them. Confidence is deliberately not filtered: this is the
+  explicit human override represented by the Import All control.
+  """
+  @spec accept_all_matched(binary()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def accept_all_matched(library_path_id) do
+    ImportGroup
+    |> where(
+      [g],
+      g.library_path_id == ^library_path_id and g.status == "pending" and
+        not is_nil(g.provider_id) and
+        (is_nil(g.provider_type) or g.provider_type != "local")
+    )
+    |> accept_query(library_path_id)
+  end
+
+  defp accept_query(query, library_path_id) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     {count, _} =
-      scope
-      |> SelectionScope.to_query()
+      query
       |> Repo.update_all(set: [status: "accepted", decided_at: now, updated_at: now])
 
     if count > 0 do
-      case %{"library_path_id" => scope.library_path_id}
+      case %{"library_path_id" => library_path_id}
            |> Mydia.Jobs.ApplyImportGroups.new()
            |> insert_job() do
         {:ok, _job} -> {:ok, count}

--- a/lib/mydia/import_groups.ex
+++ b/lib/mydia/import_groups.ex
@@ -10,6 +10,8 @@ defmodule Mydia.ImportGroups do
 
   import Ecto.Query
 
+  require Logger
+
   alias Mydia.Library.ImportGroup
   alias Mydia.Library.ImportRun
   alias Mydia.Library.MatchCandidate
@@ -724,6 +726,7 @@ defmodule Mydia.ImportGroups do
     {count, _} =
       scope
       |> SelectionScope.to_query()
+      |> where([g], g.status == "ignored")
       |> Repo.update_all(set: [status: "pending", decided_at: nil, updated_at: now])
 
     {:ok, count}
@@ -740,59 +743,108 @@ defmodule Mydia.ImportGroups do
     {:ok, count}
   end
 
-  @doc """
-  Re-runs metadata matching for media files in the selected groups.
-
-  Runs `BatchMatcher.match_paths/2`, writes the resulting candidates, and updates
-  the import groups' rollups.
-  """
+  @doc "Re-runs metadata matching for media files in the selected groups."
   @spec rematch(SelectionScope.t(), keyword()) :: {:ok, non_neg_integer()}
   def rematch(%SelectionScope{} = scope, opts \\ []) do
+    with {:ok, stats} <- rematch_with_stats(scope, opts) do
+      {:ok, stats.groups}
+    end
+  end
+
+  @doc "Re-matches a selection in bounded pages and reports file-level failures."
+  @spec rematch_with_stats(SelectionScope.t(), keyword()) ::
+          {:ok,
+           %{groups: non_neg_integer(), files: non_neg_integer(), failures: non_neg_integer()}}
+  def rematch_with_stats(%SelectionScope{} = scope, opts \\ []) do
     library_path = Settings.get_library_path!(scope.library_path_id)
     matcher = Keyword.get(opts, :matcher, Mydia.Library.MetadataMatcher)
     config = Keyword.get(opts, :config) || Metadata.default_relay_config()
+    page_size = Keyword.get(opts, :page_size, 250)
 
-    files =
-      MediaFile
-      |> where([f], f.library_path_id == ^scope.library_path_id)
-      |> where([f], is_nil(f.media_item_id) and is_nil(f.episode_id) and is_nil(f.trashed_at))
-      |> join(:inner, [f], g in subquery(SelectionScope.to_query(scope)),
-        on: f.import_group_id == g.id
-      )
-      |> Repo.all()
+    stats =
+      rematch_pages(scope, library_path, matcher, config, page_size, nil, %{files: 0, failures: 0})
 
-    if files != [] do
-      files_by_path =
-        Map.new(files, fn f -> {Path.join(library_path.path, f.relative_path), f} end)
+    upsert_for_library(library_path)
 
-      paths = Map.keys(files_by_path)
+    {:ok, Map.put(stats, :groups, SelectionScope.count(scope))}
+  end
 
-      match_results =
-        Mydia.Library.BatchMatcher.match_paths(paths,
-          library_root: library_path.path,
-          matcher: matcher,
-          config: config
-        )
+  defp rematch_pages(scope, library_path, matcher, config, page_size, after_id, stats) do
+    rows = rematch_page(scope, page_size, after_id)
 
-      Enum.each(match_results, fn {path, match_outcome} ->
-        with %MediaFile{} = media_file <- Map.get(files_by_path, path) do
-          match_data =
-            case match_outcome do
-              {:ok, data} -> data
-              _ -> nil
-            end
+    case rows do
+      [] ->
+        stats
 
-          Mydia.Library.FileIngest.ingest(media_file, match_data,
-            policy: :local_only,
-            config: config
-          )
-        end
-      end)
-
-      upsert_for_library(library_path)
+      rows ->
+        page_stats = rematch_rows(rows, library_path, matcher, config)
+        stats = Map.merge(stats, page_stats, fn _key, left, right -> left + right end)
+        rematch_pages(scope, library_path, matcher, config, page_size, List.last(rows).id, stats)
     end
+  end
 
-    {:ok, SelectionScope.count(scope)}
+  defp rematch_page(scope, page_size, after_id) do
+    MediaFile
+    |> where([f], f.library_path_id == ^scope.library_path_id)
+    |> where([f], is_nil(f.media_item_id) and is_nil(f.episode_id) and is_nil(f.trashed_at))
+    |> join(:inner, [f], g in subquery(SelectionScope.to_query(scope)),
+      on: f.import_group_id == g.id
+    )
+    |> then(fn query ->
+      if after_id, do: where(query, [f], f.id > ^after_id), else: query
+    end)
+    |> order_by([f], asc: f.id)
+    |> limit(^page_size)
+    |> select([f], %{id: f.id, relative_path: f.relative_path})
+    |> Repo.all()
+  end
+
+  defp rematch_rows(rows, library_path, matcher, config) do
+    rows_by_path = Map.new(rows, &{Path.join(library_path.path, &1.relative_path), &1.id})
+
+    rows_by_path
+    |> Map.keys()
+    |> Mydia.Library.BatchMatcher.match_paths(
+      library_root: library_path.path,
+      matcher: matcher,
+      config: config
+    )
+    |> Enum.reduce(%{files: 0, failures: 0}, fn {path, outcome}, stats ->
+      case rematch_file(rows_by_path[path], outcome, config) do
+        :ok -> %{stats | files: stats.files + 1}
+        :error -> %{stats | failures: stats.failures + 1}
+      end
+    end)
+  end
+
+  defp rematch_file(media_file_id, outcome, config) do
+    match_data =
+      case outcome do
+        {:ok, data} -> data
+        {:error, reason} when reason in [:no_match, :no_matches_found, :unknown_media_type] -> nil
+        {:error, _reason} -> :failed
+      end
+
+    with match_data when match_data != :failed <- match_data,
+         %MediaFile{} = media_file <- Repo.get(MediaFile, media_file_id) do
+      case Mydia.Library.FileIngest.ingest(media_file, match_data,
+             policy: :local_only,
+             config: config
+           ) do
+        {:error, _reason} -> :error
+        _success -> :ok
+      end
+    else
+      _failure -> :error
+    end
+  rescue
+    error ->
+      Logger.error("Re-matching an import file failed",
+        media_file_id: media_file_id,
+        error: Exception.format(:error, error, __STACKTRACE__)
+      )
+
+      :error
   end
 
   @doc """
@@ -1038,6 +1090,8 @@ defmodule Mydia.ImportGroups do
     group = Repo.get(ImportGroup, group_id)
 
     if group do
+      library_path = Settings.get_library_path!(group.library_path_id)
+
       members_data =
         MediaFile
         |> where([f], f.import_group_id == ^group_id)
@@ -1054,7 +1108,10 @@ defmodule Mydia.ImportGroups do
               MapSet.put(acc, s)
 
             _ ->
-              case PathAnchor.anchor_for(row.relative_path || "", "") do
+              case PathAnchor.anchor_for(
+                     Path.join(library_path.path, row.relative_path || ""),
+                     library_path.path
+                   ) do
                 %{season_hint: s} when is_integer(s) -> MapSet.put(acc, s)
                 _ -> acc
               end
@@ -1133,6 +1190,14 @@ defmodule Mydia.ImportGroups do
   """
   @spec create_local_show(binary()) :: {:ok, Media.MediaItem.t()} | {:error, term()}
   def create_local_show(group_id) do
+    Repo.transaction(fn -> create_local_show_transaction(group_id) end)
+    |> case do
+      {:ok, result} -> result
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp create_local_show_transaction(group_id) do
     group = Repo.get!(ImportGroup, group_id)
 
     cond do
@@ -1194,13 +1259,19 @@ defmodule Mydia.ImportGroups do
 
     result =
       Enum.reduce(groups, %{created: 0, skipped: 0}, fn group, acc ->
-        case create_local_show(group.id) do
+        case safe_create_local_show(group.id) do
           {:ok, _item} -> %{acc | created: acc.created + 1}
           {:error, _reason} -> %{acc | skipped: acc.skipped + 1}
         end
       end)
 
     {:ok, result}
+  end
+
+  defp safe_create_local_show(group_id) do
+    create_local_show(group_id)
+  rescue
+    Ecto.NoResultsError -> {:error, :not_found}
   end
 
   # Finds or creates the episode this file's parsed numbering points at, then

--- a/lib/mydia/jobs/apply_import_groups.ex
+++ b/lib/mydia/jobs/apply_import_groups.ex
@@ -6,10 +6,11 @@ defmodule Mydia.Jobs.ApplyImportGroups do
   for the duration of a library scan. An accept queued behind a multi-hour run
   would look like the button did nothing.
 
-  One transaction per page, never one for the group. On SQLite a single
-  transaction over a whole group holds the global write lock for its duration
-  and blocks the scanner; on Postgres it overflows the 64-entry subxid cache.
-  Per-page also means a crash loses at most one page's progress, and
+  Members are fetched in bounded pages, but the worker does not wrap a page in
+  a transaction. `FileIngest` performs metadata network requests while linking
+  a member, so a worker-owned transaction would hold SQLite's global write lock
+  across slow external I/O and make unrelated pages unavailable. The contexts
+  called by `FileIngest` own their individual, short database writes, while
   `unresolved_count` tells a restarted job where it got to.
 
   `unique` is keyed on `library_path_id` alone (not the full args, so a custom
@@ -110,8 +111,8 @@ defmodule Mydia.Jobs.ApplyImportGroups do
   # status because members remain, and then stalls forever: nothing re-enqueues
   # the job.
   #
-  # One transaction per page, never one for the group: on SQLite a single
-  # transaction over a whole show holds the global write lock for its duration.
+  # The page is only a bound on fetched work. It must not become a transaction
+  # boundary because ingesting a member includes external metadata requests.
   defp drain(group, remaining_before, page) do
     commit_page(group, page)
 
@@ -132,50 +133,19 @@ defmodule Mydia.Jobs.ApplyImportGroups do
     end
   end
 
-  # `safe_ingest/2`'s rescue only covers an Elixir-level exception raised
-  # before any DB write lands, which is the dominant failure class: the
-  # connection stays healthy, the page's transaction commits, and one bad
-  # member costs only itself. Every write on this path is changeset-mapped, so
-  # an ordinary constraint violation comes back as `{:error, changeset}`, not a
-  # raise -- what actually reaches here is a deadlock, a statement timeout, or
-  # a lost connection, none of which a changeset can catch. Postgres marks the
-  # *whole* transaction aborted regardless of that rescue, so
-  # `Repo.transaction/1` comes back `{:error, :rollback}` and every member in
-  # the page is lost, including ones that had already linked successfully
-  # earlier in the same page.
-  #
-  # So the result is inspected: on a clean commit the page is done. On a
-  # rollback, the page is replayed one member at a time, each in its own
-  # transaction, so a poisoned member costs only itself and its page-mates
-  # still commit. The fast path stays per-page deliberately — per-member
-  # transactions on SQLite mean one global write-lock acquisition per file, so
-  # the slow path is only paid on a page that actually failed.
+  # Do not add an outer transaction here. `safe_ingest/2` reaches metadata
+  # providers and can spend seconds waiting on the network after an earlier
+  # write. Keeping each member outside a worker-owned transaction lets the
+  # lower-level contexts acquire SQLite's write lock only for their actual DB
+  # operations, and one failed member does not roll back its page-mates.
   defp commit_page(group, page) do
-    members = ImportGroups.members(group.id, limit: page)
-
-    case Repo.transaction(fn -> Enum.each(members, &safe_ingest(&1, group)) end) do
-      {:ok, _} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("An import group page failed to commit, replaying it per member",
-          import_group_id: group.id,
-          members: length(members),
-          reason: inspect(reason)
-        )
-
-        Enum.each(members, fn member ->
-          Repo.transaction(fn -> safe_ingest(member, group) end)
-        end)
-
-        :ok
-    end
+    group.id
+    |> ImportGroups.members(limit: page)
+    |> Enum.each(&safe_ingest(&1, group))
   end
 
-  # One member's exception must not roll back the page's whole transaction:
-  # without this, a single bad member discards every link that already
-  # succeeded in the same page, and the log carries no member-level detail to
-  # act on.
+  # One member's exception must not stop the rest of the page, and the log must
+  # carry enough member-level detail to act on it.
   defp safe_ingest(member, group) do
     ingest_member(member, group)
   rescue

--- a/lib/mydia/jobs/rematch_import_groups.ex
+++ b/lib/mydia/jobs/rematch_import_groups.ex
@@ -1,0 +1,44 @@
+defmodule Mydia.Jobs.RematchImportGroups do
+  @moduledoc """
+  Re-runs matching for a review selection outside the LiveView process.
+
+  One incomplete job per library is allowed, and the import context pages the
+  selected files so large libraries do not become one unbounded allocation.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [period: 300, keys: [:library_path_id], states: :incomplete]
+
+  require Logger
+
+  alias Mydia.ImportGroups
+  alias Mydia.Library.SelectionScope
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"library_path_id" => library_path_id, "selection" => args}}) do
+    scope = SelectionScope.from_args(args)
+
+    {:ok, stats} = ImportGroups.rematch_with_stats(scope)
+
+    if stats.failures > 0 do
+      Logger.warning("Import group re-match completed with file failures",
+        library_path_id: library_path_id,
+        processed_files: stats.files,
+        failed_files: stats.failures
+      )
+    end
+
+    broadcast(library_path_id)
+    :ok
+  end
+
+  defp broadcast(library_path_id) do
+    Phoenix.PubSub.broadcast(
+      Mydia.PubSub,
+      "import_groups:#{library_path_id}",
+      {:import_groups_changed, library_path_id}
+    )
+  end
+end

--- a/lib/mydia/library/batch_matcher.ex
+++ b/lib/mydia/library/batch_matcher.ex
@@ -128,8 +128,17 @@ defmodule Mydia.Library.BatchMatcher do
   # names the media, not the filename: two hundred episodes of one show are
   # one decision, and the grouping holds even when filenames are noisy, which
   # is exactly when per-filename grouping falls apart.
+  #
+  # Loose files (those with no enclosing folder under library_root, or whose
+  # folders were denylisted) do not share an anchor folder and must not share
+  # a single resolution. Each loose file gets its own path as the key so it
+  # is matched independently on its own filename.
   defp group_key(path, library_root) do
-    PathAnchor.anchor_for(path, library_root).cluster_key
+    case PathAnchor.anchor_for(path, library_root) do
+      %{anchor_path: ""} -> path
+      %{cluster_key: "__root__"} -> path
+      anchor -> anchor.cluster_key
+    end
   end
 
   ## Matching

--- a/lib/mydia/library/selection_scope.ex
+++ b/lib/mydia/library/selection_scope.ex
@@ -23,6 +23,7 @@ defmodule Mydia.Library.SelectionScope do
 
   defstruct mode: :none,
             library_path_id: nil,
+            status: "pending",
             filter: %{},
             included_ids: MapSet.new(),
             excluded_ids: MapSet.new()
@@ -30,18 +31,20 @@ defmodule Mydia.Library.SelectionScope do
   @type t :: %__MODULE__{
           mode: :none | :page | :filter,
           library_path_id: binary() | nil,
+          status: String.t(),
           filter: map(),
           included_ids: MapSet.t(),
           excluded_ids: MapSet.t()
         }
 
-  @doc "An empty selection for one library path."
-  @spec new(binary()) :: t()
-  def new(library_path_id), do: %__MODULE__{library_path_id: library_path_id}
+  @doc "An empty selection for one library path and optional status (defaults to pending)."
+  @spec new(binary(), String.t()) :: t()
+  def new(library_path_id, status \\ "pending"),
+    do: %__MODULE__{library_path_id: library_path_id, status: status}
 
-  @doc "Clears the selection, keeping the library path."
+  @doc "Clears the selection, keeping the library path and status."
   @spec clear(t()) :: t()
-  def clear(%__MODULE__{library_path_id: id}), do: new(id)
+  def clear(%__MODULE__{library_path_id: id, status: status}), do: new(id, status)
 
   @doc """
   Selects exactly the given ids, replacing any previous selection.
@@ -158,17 +161,20 @@ defmodule Mydia.Library.SelectionScope do
 
   def to_query(%__MODULE__{mode: :page} = scope) do
     ImportGroup
-    |> where([g], g.library_path_id == ^scope.library_path_id and g.status == "pending")
+    |> where([g], g.library_path_id == ^scope.library_path_id and g.status == ^scope.status)
     |> where([g], g.id in ^MapSet.to_list(scope.included_ids))
   end
 
   def to_query(%__MODULE__{mode: :filter} = scope) do
     ImportGroup
-    |> where([g], g.library_path_id == ^scope.library_path_id and g.status == "pending")
-    |> apply_band(scope.filter[:band])
+    |> where([g], g.library_path_id == ^scope.library_path_id and g.status == ^scope.status)
+    |> apply_band(scope.status, scope.filter[:band])
     |> apply_search(scope.filter[:q])
     |> exclude_ids(MapSet.to_list(scope.excluded_ids))
   end
+
+  defp apply_band(query, "pending", band), do: apply_band(query, band)
+  defp apply_band(query, _status, _band), do: query
 
   defp apply_band(query, nil), do: query
   defp apply_band(query, :all), do: query

--- a/lib/mydia/library/selection_scope.ex
+++ b/lib/mydia/library/selection_scope.ex
@@ -240,4 +240,53 @@ defmodule Mydia.Library.SelectionScope do
   @doc "The per-query id bind cap, exposed for tests and callers that chunk."
   @spec max_id_binds() :: pos_integer()
   def max_id_binds, do: @max_id_binds
+
+  @doc "Serializes a scope into JSON-safe Oban arguments."
+  @spec to_args(t()) :: map()
+  def to_args(%__MODULE__{} = scope) do
+    %{
+      "mode" => Atom.to_string(scope.mode),
+      "library_path_id" => scope.library_path_id,
+      "status" => scope.status,
+      "filter" =>
+        Map.new(scope.filter, fn {key, value} -> {Atom.to_string(key), encode_filter(value)} end),
+      "included_ids" => MapSet.to_list(scope.included_ids),
+      "excluded_ids" => MapSet.to_list(scope.excluded_ids)
+    }
+  end
+
+  @doc "Restores a selection scope from trusted Oban arguments."
+  @spec from_args(map()) :: t()
+  def from_args(args) do
+    %__MODULE__{
+      mode: decode_mode(args["mode"]),
+      library_path_id: args["library_path_id"],
+      status: args["status"] || "pending",
+      filter: decode_filter(args["filter"] || %{}),
+      included_ids: MapSet.new(args["included_ids"] || []),
+      excluded_ids: MapSet.new(args["excluded_ids"] || [])
+    }
+  end
+
+  defp encode_filter(value) when is_atom(value), do: Atom.to_string(value)
+  defp encode_filter(value), do: value
+
+  defp decode_filter(filter) do
+    %{}
+    |> maybe_put_filter(:q, filter["q"])
+    |> maybe_put_filter(:band, decode_band(filter["band"]))
+  end
+
+  defp maybe_put_filter(filter, _key, nil), do: filter
+  defp maybe_put_filter(filter, key, value), do: Map.put(filter, key, value)
+
+  defp decode_mode("page"), do: :page
+  defp decode_mode("filter"), do: :filter
+  defp decode_mode(_), do: :none
+
+  defp decode_band("all"), do: :all
+  defp decode_band("ready"), do: :ready
+  defp decode_band("needs_attention"), do: :needs_attention
+  defp decode_band("no_match"), do: :no_match
+  defp decode_band(_), do: nil
 end

--- a/lib/mydia_web/components/core_components.ex
+++ b/lib/mydia_web/components/core_components.ex
@@ -161,6 +161,11 @@ defmodule MydiaWeb.CoreComponents do
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
   attr :class, :string, default: nil, doc: "the input class to use over defaults"
+
+  attr :container_class, :string,
+    default: "fieldset mb-2",
+    doc: "the class for the input's outer container"
+
   attr :error_class, :string, default: nil, doc: "the input error class to use over defaults"
 
   attr :hint, :string,
@@ -189,7 +194,7 @@ defmodule MydiaWeb.CoreComponents do
       end)
 
     ~H"""
-    <div class="fieldset mb-2">
+    <div class={@container_class}>
       <label>
         <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} />
         <span class="label">
@@ -211,7 +216,7 @@ defmodule MydiaWeb.CoreComponents do
 
   def input(%{type: "select"} = assigns) do
     ~H"""
-    <div class="fieldset mb-2">
+    <div class={@container_class}>
       <label>
         <span :if={@label} class="label mb-1 text-sm font-medium text-base-content/80">{@label}</span>
         <select
@@ -236,7 +241,7 @@ defmodule MydiaWeb.CoreComponents do
 
   def input(%{type: "textarea"} = assigns) do
     ~H"""
-    <div class="fieldset mb-2">
+    <div class={@container_class}>
       <label>
         <span :if={@label} class="label mb-1 text-sm font-medium text-base-content/80">{@label}</span>
         <textarea
@@ -259,7 +264,7 @@ defmodule MydiaWeb.CoreComponents do
   # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(assigns) do
     ~H"""
-    <div class="fieldset mb-2">
+    <div class={@container_class}>
       <label>
         <span :if={@label} class="label mb-1 text-sm font-medium text-base-content/80">{@label}</span>
         <input

--- a/lib/mydia_web/live/import_media_live/components.ex
+++ b/lib/mydia_web/live/import_media_live/components.ex
@@ -13,45 +13,60 @@ defmodule MydiaWeb.ImportMediaLive.Components do
   alias Mydia.Metadata.ImageUrl
 
   @doc """
-  A row of buttons for switching which library the review section shows.
+  Page-level tabs for switching the library shared by scanning and review.
 
-  Only meaningful with more than one importable library path -- the caller
-  is expected to gate rendering on that, same as the `filter` this row of
-  buttons resembles. `counts` maps `library_path_id` to its pending group
-  total (`ImportGroups.band_counts/1`'s `:total`, one call per path), so a
-  user picking between two libraries can see where the work actually is
-  before switching to it.
+  `counts` maps `library_path_id` to its pending group total, while
+  `active_library_ids` marks tabs with scans in flight. The tab remains
+  useful with one path because it makes the page's scope explicit.
   """
   attr :library_paths, :list, required: true
   attr :selected_id, :string, required: true
   attr :counts, :map, required: true
+  attr :active_library_ids, :list, default: []
 
   def library_picker(assigns) do
     ~H"""
-    <div class="flex items-center gap-1.5 flex-wrap bg-base-200/50 p-1 rounded-xl border border-base-200">
+    <div
+      id="library-tabs"
+      role="tablist"
+      class="tabs tabs-box bg-base-200/60 p-1.5 rounded-xl border border-base-200 flex flex-wrap h-auto gap-1"
+    >
       <button
         :for={path <- @library_paths}
         type="button"
-        id={"library-picker-#{path.id}"}
+        id={"library-tab-#{path.id}"}
+        role="tab"
+        aria-selected={to_string(path.id == @selected_id)}
         class={[
-          "btn btn-sm transition-all",
+          "tab h-auto min-h-10 px-3 py-2 gap-2 rounded-lg transition-all",
           if(path.id == @selected_id,
-            do: "btn-primary shadow-sm",
-            else: "btn-ghost text-base-content/70 hover:text-base-content"
+            do: "tab-active bg-base-100 shadow-sm font-semibold text-primary",
+            else: "text-base-content/65 hover:text-base-content hover:bg-base-100/60"
           )
         ]}
         phx-click="select_library"
         phx-value-library_path_id={path.id}
       >
         <.icon
-          name={if(path.type == :movies, do: "hero-film", else: "hero-tv")}
-          class="w-4 h-4 mr-1 opacity-70"
+          name={
+            case path.type do
+              :movies -> "hero-film"
+              :series -> "hero-tv"
+              _ -> "hero-square-3-stack-3d"
+            end
+          }
+          class="w-4 h-4 opacity-70"
         />
-        {path.path}
+        <span class="max-w-52 truncate">{path.path}</span>
+        <span
+          :if={path.id in @active_library_ids}
+          class="loading loading-spinner loading-xs text-primary"
+          aria-label="Scan in progress"
+        />
         <span class={[
-          "badge badge-sm ml-1",
+          "badge badge-sm",
           if(path.id == @selected_id,
-            do: "badge-primary-content text-primary font-bold",
+            do: "badge-primary text-primary-content font-bold",
             else: "badge-ghost"
           )
         ]}>

--- a/lib/mydia_web/live/import_media_live/components.ex
+++ b/lib/mydia_web/live/import_media_live/components.ex
@@ -28,17 +28,35 @@ defmodule MydiaWeb.ImportMediaLive.Components do
 
   def library_picker(assigns) do
     ~H"""
-    <div class="flex items-center gap-2 flex-wrap">
+    <div class="flex items-center gap-1.5 flex-wrap bg-base-200/50 p-1 rounded-xl border border-base-200">
       <button
         :for={path <- @library_paths}
         type="button"
         id={"library-picker-#{path.id}"}
-        class={["btn btn-sm", if(path.id == @selected_id, do: "btn-primary", else: "btn-ghost")]}
+        class={[
+          "btn btn-sm transition-all",
+          if(path.id == @selected_id,
+            do: "btn-primary shadow-sm",
+            else: "btn-ghost text-base-content/70 hover:text-base-content"
+          )
+        ]}
         phx-click="select_library"
         phx-value-library_path_id={path.id}
       >
+        <.icon
+          name={if(path.type == :movies, do: "hero-film", else: "hero-tv")}
+          class="w-4 h-4 mr-1 opacity-70"
+        />
         {path.path}
-        <span class="badge badge-sm">{Map.get(@counts, path.id, 0)}</span>
+        <span class={[
+          "badge badge-sm ml-1",
+          if(path.id == @selected_id,
+            do: "badge-primary-content text-primary font-bold",
+            else: "badge-ghost"
+          )
+        ]}>
+          {Map.get(@counts, path.id, 0)}
+        </span>
       </button>
     </div>
     """
@@ -64,8 +82,8 @@ defmodule MydiaWeb.ImportMediaLive.Components do
 
   def band_filter(assigns) do
     ~H"""
-    <div class="flex items-center gap-2 flex-wrap">
-      <div class="filter">
+    <div class="flex items-center justify-between gap-3 flex-wrap">
+      <div class="filter flex items-center gap-1.5 flex-wrap">
         <label
           :for={
             {band, id, label} <- [
@@ -77,25 +95,42 @@ defmodule MydiaWeb.ImportMediaLive.Components do
             ]
           }
           id={id}
-          class={["btn btn-sm gap-1.5", @band == band && "btn-active"]}
+          class={[
+            "btn btn-sm gap-1.5 rounded-lg border cursor-pointer",
+            if(@band == band,
+              do: "btn-active btn-primary border-primary",
+              else: "btn-ghost border-base-200 bg-base-100 hover:bg-base-200"
+            )
+          ]}
           phx-click="select_band"
           phx-value-band={band}
         >
-          <input type="checkbox" class="checkbox checkbox-xs" checked={@band == band} tabindex="-1" />
+          <input type="checkbox" class="sr-only" checked={@band == band} tabindex="-1" />
           {label}
-          <span class="badge badge-sm">{count_for(@counts, band)}</span>
+          <span class={[
+            "badge badge-sm font-semibold",
+            if(@band == band, do: "badge-primary-content text-primary", else: "badge-ghost")
+          ]}>
+            {count_for(@counts, band)}
+          </span>
         </label>
       </div>
 
-      <form phx-change="search" id="import-search-form" class="ml-auto">
-        <input
-          type="text"
-          name="q"
-          value={@search}
-          placeholder="Search folder…"
-          phx-debounce="300"
-          class="input input-sm input-bordered"
-        />
+      <form phx-change="search" id="import-search-form" class="ml-auto w-full sm:w-auto">
+        <div class="relative">
+          <.icon
+            name="hero-magnifying-glass"
+            class="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 opacity-50"
+          />
+          <input
+            type="text"
+            name="q"
+            value={@search}
+            placeholder="Search folder…"
+            phx-debounce="300"
+            class="input input-sm input-bordered pl-9 w-full sm:w-64"
+          />
+        </div>
       </form>
     </div>
     """
@@ -121,41 +156,80 @@ defmodule MydiaWeb.ImportMediaLive.Components do
   """
   attr :count, :integer, required: true
   attr :matching_count, :integer, required: true
+  attr :page_count, :integer, default: 0
+  attr :band, :atom, default: :all
 
   def bulk_bar(assigns) do
     ~H"""
-    <div class="alert alert-info flex-wrap gap-2" id="bulk-bar">
-      <span>{@count} group(s) selected.</span>
+    <div
+      class="alert alert-info shadow-sm flex items-center justify-between flex-wrap gap-3 py-2.5 px-4"
+      id="bulk-bar"
+    >
+      <div class="flex items-center gap-2.5 flex-wrap">
+        <.icon name="hero-check-circle" class="w-5 h-5 shrink-0" />
+        <span class="font-medium text-sm">{@count} group(s) selected</span>
 
-      <button
-        :if={@matching_count > @count}
-        id="select-all-matching"
-        class="btn btn-xs btn-ghost"
-        phx-click="select_all_matching"
-      >
-        Select all {@matching_count} matching this filter
-      </button>
+        <button
+          :if={@page_count > 0 and @count < @page_count}
+          id="select-current-page"
+          class="btn btn-xs btn-ghost underline hover:no-underline"
+          phx-click="select_current_page"
+        >
+          Select page ({@page_count})
+        </button>
 
-      <div class="ml-auto flex gap-2">
         <button
-          id="accept-selected"
-          class="btn btn-sm btn-primary"
-          disabled={@count == 0}
-          phx-click="accept_selected"
+          :if={@matching_count > @count}
+          id="select-all-matching"
+          class="btn btn-xs btn-ghost underline hover:no-underline"
+          phx-click="select_all_matching"
         >
-          Accept {@count}
+          Select all {@matching_count} matching this filter
         </button>
-        <button
-          id="ignore-selected"
-          class="btn btn-sm btn-ghost"
-          disabled={@count == 0}
-          phx-click="ignore_selected"
-        >
-          Ignore
-        </button>
-        <button id="clear-selection" class="btn btn-sm btn-ghost" phx-click="clear_selection">
-          Clear
-        </button>
+      </div>
+
+      <div class="flex items-center gap-2 ml-auto flex-wrap">
+        <%= if @band == :ignored do %>
+          <button
+            id="restore-selected"
+            class="btn btn-sm btn-primary"
+            disabled={@count == 0}
+            phx-click="restore_selected"
+          >
+            <.icon name="hero-arrow-uturn-left" class="w-4 h-4 mr-1" /> Restore {@count}
+          </button>
+          <button id="clear-selection" class="btn btn-sm btn-ghost" phx-click="clear_selection">
+            Clear
+          </button>
+        <% else %>
+          <button
+            id="accept-selected"
+            class="btn btn-sm btn-primary"
+            disabled={@count == 0}
+            phx-click="accept_selected"
+          >
+            <.icon name="hero-check" class="w-4 h-4 mr-1" /> Accept {@count}
+          </button>
+          <button
+            id="rematch-selected"
+            class="btn btn-sm btn-outline"
+            disabled={@count == 0}
+            phx-click="rematch_selected"
+          >
+            <.icon name="hero-arrow-path" class="w-4 h-4 mr-1" /> Re-match
+          </button>
+          <button
+            id="ignore-selected"
+            class="btn btn-sm btn-ghost"
+            disabled={@count == 0}
+            phx-click="ignore_selected"
+          >
+            Ignore
+          </button>
+          <button id="clear-selection" class="btn btn-sm btn-ghost" phx-click="clear_selection">
+            Clear
+          </button>
+        <% end %>
       </div>
     </div>
     """
@@ -181,11 +255,11 @@ defmodule MydiaWeb.ImportMediaLive.Components do
 
   def group_row(assigns) do
     ~H"""
-    <div id={@id} class="py-3">
-      <div class="flex items-center gap-3">
+    <div id={@id} class="p-3.5 sm:p-4 hover:bg-base-200/40 transition-colors flex flex-col gap-2">
+      <div class="flex items-center gap-3 min-w-0">
         <input
           type="checkbox"
-          class="checkbox checkbox-sm"
+          class="checkbox checkbox-primary checkbox-sm shrink-0"
           checked={@selected}
           aria-label={"Select #{@group.display_title}"}
           phx-click="toggle_group"
@@ -195,81 +269,190 @@ defmodule MydiaWeb.ImportMediaLive.Components do
         <button
           type="button"
           id={"group-toggle-#{@group.id}"}
-          class="flex-1 flex items-center gap-2 text-left"
+          class="flex-1 flex items-center gap-2 min-w-0 text-left cursor-pointer group/title"
           phx-click="expand_group"
           phx-value-id={@group.id}
         >
           <.icon
             name={if(@expanded, do: "hero-chevron-down", else: "hero-chevron-right")}
-            class="w-4 h-4 opacity-60"
+            class="w-4 h-4 opacity-50 group-hover/title:opacity-100 transition-opacity shrink-0"
           />
-          <span class="font-semibold">{@group.display_title}</span>
-          <span class="badge badge-sm">{@group.file_count} files</span>
-          <span :if={season_label(@group)} class="badge badge-ghost badge-sm">
+          <span class="font-semibold text-sm truncate group-hover/title:text-primary transition-colors">
+            {@group.display_title}
+          </span>
+          <span class="badge badge-ghost badge-sm shrink-0 font-normal">
+            {@group.file_count} file{if @group.file_count == 1, do: "", else: "s"}
+          </span>
+          <span :if={season_label(@group)} class="badge badge-ghost badge-sm shrink-0">
             {season_label(@group)}
           </span>
         </button>
 
-        <span class={["badge badge-sm", band_class(@band)]}>{band_label(@band)}</span>
+        <span class={["badge badge-sm shrink-0 font-medium", band_class(@band)]}>
+          {band_label(@band)}
+        </span>
       </div>
 
-      <p class="pl-10 text-sm opacity-70 flex items-center gap-2 flex-wrap">
-        {suggestion_line(@group)}
-        <span :if={evidence_label(@group.evidence)} class="badge badge-ghost badge-xs">
-          {evidence_label(@group.evidence)}
-        </span>
-        <button
-          id={"change-match-#{@group.id}"}
-          class="btn btn-xs btn-outline"
-          phx-click="open_match_search"
-          phx-value-id={@group.id}
-        >
-          {if @band == :no_match, do: "Identify", else: "Change match"}
-        </button>
-        <button
-          :if={@band == :no_match}
-          id={"create-local-#{@group.id}"}
-          class="btn btn-xs btn-outline"
-          phx-click="create_local_show"
-          phx-value-id={@group.id}
-        >
-          Create show from folder
-        </button>
-      </p>
+      <div class="pl-7 sm:pl-9 flex items-center justify-between gap-3 flex-wrap">
+        <div class="flex items-center gap-2 flex-wrap min-w-0 text-xs text-base-content/70">
+          <span class="font-medium text-base-content/90 truncate max-w-md">
+            {suggestion_line(@group)}
+          </span>
+          <span
+            :if={evidence_label(@group.evidence)}
+            class="badge badge-ghost badge-xs text-base-content/60"
+          >
+            {evidence_label(@group.evidence)}
+          </span>
+        </div>
 
-      <ul :if={@expanded} id={"members-#{@group.id}"} phx-update="stream" class="pl-10 pt-2">
-        <li :for={{member_dom_id, member} <- @members} id={member_dom_id} class="text-sm py-1">
-          <span id={"member-#{member.media_file.id}"}>{member.media_file.relative_path}</span>
-        </li>
-      </ul>
+        <div class="flex items-center gap-2 shrink-0">
+          <button
+            id={"change-match-#{@group.id}"}
+            class="btn btn-xs btn-outline"
+            phx-click="open_match_search"
+            phx-value-id={@group.id}
+          >
+            <.icon name="hero-pencil-square" class="w-3.5 h-3.5 mr-1 opacity-70" />
+            {if @band == :no_match, do: "Identify", else: "Change match"}
+          </button>
+          <button
+            :if={@band == :no_match}
+            id={"create-local-#{@group.id}"}
+            class="btn btn-xs btn-outline"
+            phx-click="create_local_show"
+            phx-value-id={@group.id}
+          >
+            <.icon name="hero-folder-plus" class="w-3.5 h-3.5 mr-1 opacity-70" />
+            Create show from folder
+          </button>
+        </div>
+      </div>
+
+      <div :if={@expanded} class="pl-7 sm:pl-9 pt-1">
+        <ul
+          id={"members-#{@group.id}"}
+          phx-update="stream"
+          class="bg-base-200/50 rounded-xl p-3 divide-y divide-base-200/60 max-h-80 overflow-y-auto"
+        >
+          <li
+            :for={{member_dom_id, member} <- @members}
+            id={member_dom_id}
+            class="py-2 first:pt-0 last:pb-0 flex flex-col sm:flex-row sm:items-center justify-between gap-2.5"
+          >
+            <div class="flex items-center gap-2.5 min-w-0 flex-1">
+              <.icon name="hero-film" class="w-4 h-4 shrink-0 opacity-40 text-base-content" />
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2 flex-wrap min-w-0">
+                  <span
+                    id={"member-#{member.media_file.id}"}
+                    class="font-mono font-medium text-xs text-base-content/90 truncate"
+                    title={member.media_file.relative_path}
+                  >
+                    {member_filename(member)}
+                  </span>
+                  <span
+                    :if={@group.media_type != "movie"}
+                    class={[
+                      "badge badge-xs font-mono font-medium shrink-0",
+                      if(member_episode_badge(member) != "No episode",
+                        do: "badge-primary/20 text-primary",
+                        else: "badge-warning/20 text-warning"
+                      )
+                    ]}
+                  >
+                    {member_episode_badge(member)}
+                  </span>
+                </div>
+                <p
+                  :if={member_folder(member)}
+                  class="text-[11px] font-mono text-base-content/50 truncate mt-0.5"
+                >
+                  {member_folder(member)}
+                </p>
+              </div>
+            </div>
+
+            <form
+              :if={@group.media_type != "movie"}
+              id={"member-form-#{member.media_file.id}"}
+              phx-change="update_member_episode"
+              phx-submit="update_member_episode"
+              class="flex items-center gap-1.5 shrink-0 self-end sm:self-center"
+            >
+              <input type="hidden" name="file_id" value={member.media_file.id} />
+              <div class="join items-center bg-base-100 rounded-lg border border-base-300 shadow-xs">
+                <span class="join-item px-1.5 text-[11px] text-base-content/60 font-mono font-bold">
+                  S
+                </span>
+                <input
+                  type="number"
+                  name="season"
+                  value={member_season(member)}
+                  placeholder="--"
+                  min="0"
+                  max="999"
+                  phx-debounce="400"
+                  class="join-item input input-xs w-12 text-center font-mono border-0 focus:outline-none"
+                  aria-label={"Season for #{member_filename(member)}"}
+                />
+                <span class="join-item px-1.5 text-[11px] text-base-content/60 font-mono font-bold">
+                  E
+                </span>
+                <input
+                  type="number"
+                  name="episode"
+                  value={member_episode(member)}
+                  placeholder="--"
+                  min="0"
+                  max="9999"
+                  phx-debounce="400"
+                  class="join-item input input-xs w-14 text-center font-mono border-0 focus:outline-none"
+                  aria-label={"Episode for #{member_filename(member)}"}
+                />
+              </div>
+            </form>
+          </li>
+        </ul>
+      </div>
     </div>
     """
   end
 
   @doc """
   One row on the Ignored view.
-
-  Deliberately not a variant of `group_row/1`: an ignored group has nothing
-  to select, accept, change or expand -- accept/ignore/change_match all
-  refuse a non-"pending" group, and `SelectionScope`'s own query is hardcoded
-  to `status == "pending"`, so a checkbox here would either do nothing or
-  lie about what it does. The one thing this view offers is the way back.
   """
   attr :id, :string, required: true
   attr :group, :map, required: true
+  attr :selected, :boolean, default: false
 
   def ignored_group_row(assigns) do
     ~H"""
-    <div id={@id} class="py-3 flex items-center gap-3">
-      <span class="flex-1 flex items-center gap-2 min-w-0">
-        <span class="font-semibold truncate">{@group.display_title}</span>
-        <span class="badge badge-sm">{@group.file_count} files</span>
-        <span :if={season_label(@group)} class="badge badge-ghost badge-sm">
-          {season_label(@group)}
-        </span>
-      </span>
+    <div
+      id={@id}
+      class="p-3.5 sm:p-4 hover:bg-base-200/40 transition-colors flex items-center justify-between gap-3"
+    >
+      <div class="flex items-center gap-3 min-w-0 flex-1">
+        <input
+          type="checkbox"
+          class="checkbox checkbox-primary checkbox-sm shrink-0"
+          checked={@selected}
+          aria-label={"Select #{@group.display_title}"}
+          phx-click="toggle_group"
+          phx-value-id={@group.id}
+        />
 
-      <p class="text-sm opacity-70 truncate">{suggestion_line(@group)}</p>
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2">
+            <span class="font-semibold text-sm truncate opacity-70">{@group.display_title}</span>
+            <span class="badge badge-ghost badge-sm shrink-0">{@group.file_count} files</span>
+            <span :if={season_label(@group)} class="badge badge-ghost badge-sm shrink-0">
+              {season_label(@group)}
+            </span>
+          </div>
+          <p class="text-xs text-base-content/50 truncate mt-0.5">{suggestion_line(@group)}</p>
+        </div>
+      </div>
 
       <button
         id={"restore-#{@group.id}"}
@@ -277,7 +460,7 @@ defmodule MydiaWeb.ImportMediaLive.Components do
         phx-click="restore_group"
         phx-value-id={@group.id}
       >
-        Restore
+        <.icon name="hero-arrow-uturn-left" class="w-3.5 h-3.5 mr-1" /> Restore
       </button>
     </div>
     """
@@ -298,39 +481,58 @@ defmodule MydiaWeb.ImportMediaLive.Components do
   def match_search_modal(assigns) do
     ~H"""
     <.modal id="match-search-modal" show={not is_nil(@state)} on_cancel="close_match_search">
-      <:title>Change match</:title>
+      <:title>
+        <div class="flex items-center gap-2">
+          <.icon name="hero-magnifying-glass" class="w-5 h-5 text-primary" />
+          <span>Change match</span>
+        </div>
+      </:title>
 
-      <form phx-change="match_search_query" id="match-search-form">
-        <input
-          type="text"
-          name="q"
-          value={@state && @state.query}
-          placeholder="Search by title…"
-          phx-debounce="300"
-          class="input input-bordered w-full"
-        />
+      <form phx-change="match_search_query" id="match-search-form" class="mt-3">
+        <div class="relative">
+          <.icon
+            name="hero-magnifying-glass"
+            class="w-4 h-4 absolute left-3.5 top-1/2 -translate-y-1/2 opacity-50"
+          />
+          <input
+            type="text"
+            name="q"
+            value={@state && @state.query}
+            placeholder="Search by title…"
+            phx-debounce="300"
+            class="input input-bordered w-full pl-10"
+          />
+        </div>
       </form>
 
-      <div :if={@state} class="mt-4 flex flex-col gap-1 max-h-96 overflow-y-auto" id="match-results">
-        <div :if={@state.searching} class="flex justify-center py-6">
-          <span class="loading loading-spinner loading-md"></span>
+      <div
+        :if={@state}
+        class="mt-4 flex flex-col gap-1.5 max-h-96 overflow-y-auto"
+        id="match-results"
+      >
+        <div :if={@state.searching} class="flex justify-center py-8">
+          <span class="loading loading-spinner loading-md text-primary"></span>
         </div>
 
         <div :if={!@state.searching}>
-          <p :if={@state.error} class="text-error text-sm py-2">{@state.error}</p>
+          <div :if={@state.error} class="alert alert-error text-xs py-2 mb-2">
+            <.icon name="hero-exclamation-triangle" class="w-4 h-4 shrink-0" />
+            <span>{@state.error}</span>
+          </div>
 
-          <p
+          <div
             :if={!@state.error && @state.results == []}
-            class="text-sm opacity-70 text-center py-6"
+            class="text-sm text-base-content/60 text-center py-10"
           >
-            No results.
-          </p>
+            <.icon name="hero-film" class="w-8 h-8 mx-auto mb-2 opacity-30" />
+            <p>No results found.</p>
+          </div>
 
           <button
             :for={result <- @state.results}
             type="button"
             id={"match-result-#{result.provider_id}-#{result.provider}"}
-            class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-200 text-left w-full"
+            class="flex items-center gap-3.5 p-2.5 rounded-xl hover:bg-base-200 text-left w-full transition-colors border border-transparent hover:border-base-300"
             phx-click="select_match"
             phx-value-provider_id={result.provider_id}
             phx-value-provider={result.provider}
@@ -338,21 +540,24 @@ defmodule MydiaWeb.ImportMediaLive.Components do
             <img
               :if={result.poster_path}
               src={ImageUrl.image_url(result.poster_path, "w92")}
-              class="w-10 h-14 object-cover rounded shrink-0"
+              class="w-12 h-16 object-cover rounded-lg shrink-0 shadow-sm"
             />
             <div
               :if={!result.poster_path}
-              class="w-10 h-14 bg-base-300 rounded flex items-center justify-center shrink-0"
+              class="w-12 h-16 bg-base-300 rounded-lg flex items-center justify-center shrink-0"
             >
-              <.icon name="hero-film" class="w-5 h-5 opacity-40" />
+              <.icon name="hero-film" class="w-6 h-6 opacity-30" />
             </div>
             <div class="flex-1 min-w-0">
-              <p class="font-medium truncate">{result.title}</p>
-              <p class="text-xs opacity-60 flex items-center gap-1.5">
-                <span :if={result.year}>{result.year}</span>
-                <span class="badge badge-ghost badge-xs">{media_type_label(result.media_type)}</span>
+              <p class="font-semibold text-sm truncate">{result.title}</p>
+              <p class="text-xs text-base-content/60 flex items-center gap-1.5 mt-1">
+                <span :if={result.year} class="font-mono">{result.year}</span>
+                <span class="badge badge-ghost badge-xs font-medium">
+                  {media_type_label(result.media_type)}
+                </span>
               </p>
             </div>
+            <.icon name="hero-chevron-right" class="w-4 h-4 opacity-40 shrink-0" />
           </button>
         </div>
       </div>
@@ -375,6 +580,8 @@ defmodule MydiaWeb.ImportMediaLive.Components do
   defp band_label(:ready), do: "ready"
   defp band_label(:needs_attention), do: "needs attention"
   defp band_label(:no_match), do: "no match"
+
+  defp season_label(%{media_type: "movie"}), do: nil
 
   defp season_label(group) do
     case Mydia.Library.ImportGroup.season_span(group) do
@@ -419,4 +626,52 @@ defmodule MydiaWeb.ImportMediaLive.Components do
   defp evidence_label(%{"kind" => "none"}), do: nil
   defp evidence_label(%{"kind" => kind}) when is_binary(kind), do: kind
   defp evidence_label(_), do: nil
+
+  defp member_filename(member) do
+    Path.basename(member.media_file.relative_path || member.media_file.path || "")
+  end
+
+  defp member_folder(member) do
+    dir = Path.dirname(member.media_file.relative_path || member.media_file.path || "")
+    if dir in [".", "", "/"], do: nil, else: dir
+  end
+
+  defp member_season(%{candidate: %{parsed_info: %{} = info}}) do
+    case Map.get(info, "season") || Map.get(info, :season) do
+      s when is_integer(s) -> s
+      _ -> nil
+    end
+  end
+
+  defp member_season(_), do: nil
+
+  defp member_episode(%{candidate: %{parsed_info: %{} = info}}) do
+    episodes = Map.get(info, "episodes") || Map.get(info, :episodes) || []
+
+    case episodes do
+      [ep | _] when is_integer(ep) -> ep
+      _ -> nil
+    end
+  end
+
+  defp member_episode(_), do: nil
+
+  defp member_episode_badge(member) do
+    season = member_season(member)
+    episode = member_episode(member)
+
+    cond do
+      season != nil and episode != nil ->
+        "S#{String.pad_leading(to_string(season), 2, "0")}E#{String.pad_leading(to_string(episode), 2, "0")}"
+
+      season != nil ->
+        "S#{String.pad_leading(to_string(season), 2, "0")}"
+
+      episode != nil ->
+        "E#{String.pad_leading(to_string(episode), 2, "0")}"
+
+      true ->
+        "No episode"
+    end
+  end
 end

--- a/lib/mydia_web/live/import_media_live/components.ex
+++ b/lib/mydia_web/live/import_media_live/components.ex
@@ -120,7 +120,14 @@ defmodule MydiaWeb.ImportMediaLive.Components do
           phx-click="select_band"
           phx-value-band={band}
         >
-          <input type="checkbox" class="sr-only" checked={@band == band} tabindex="-1" />
+          <input
+            id={"#{id}-input"}
+            type="checkbox"
+            class="sr-only"
+            checked={@band == band}
+            phx-click="select_band"
+            phx-value-band={band}
+          />
           {label}
           <span class={[
             "badge badge-sm font-semibold",
@@ -366,18 +373,20 @@ defmodule MydiaWeb.ImportMediaLive.Components do
                   >
                     {member_filename(member)}
                   </span>
-                  <span
-                    :if={@group.media_type != "movie"}
-                    class={[
-                      "badge badge-xs font-mono font-medium shrink-0",
-                      if(member_episode_badge(member) != "No episode",
-                        do: "badge-primary/20 text-primary",
-                        else: "badge-warning/20 text-warning"
-                      )
-                    ]}
-                  >
-                    {member_episode_badge(member)}
-                  </span>
+                  <%= if @group.media_type != "movie" do %>
+                    <%= case member_episode_badge(member) do %>
+                      <% {known?, label} -> %>
+                        <span class={[
+                          "badge badge-xs font-mono font-medium shrink-0",
+                          if(known?,
+                            do: "badge-primary/20 text-primary",
+                            else: "badge-warning/20 text-warning"
+                          )
+                        ]}>
+                          {label}
+                        </span>
+                    <% end %>
+                  <% end %>
                 </div>
                 <p
                   :if={member_folder(member)}
@@ -400,7 +409,7 @@ defmodule MydiaWeb.ImportMediaLive.Components do
                 <span class="join-item px-1.5 text-[11px] text-base-content/60 font-mono font-bold">
                   S
                 </span>
-                <input
+                <.input
                   type="number"
                   name="season"
                   value={member_season(member)}
@@ -409,12 +418,13 @@ defmodule MydiaWeb.ImportMediaLive.Components do
                   max="999"
                   phx-debounce="400"
                   class="join-item input input-xs w-12 text-center font-mono border-0 focus:outline-none"
+                  container_class="contents"
                   aria-label={"Season for #{member_filename(member)}"}
                 />
                 <span class="join-item px-1.5 text-[11px] text-base-content/60 font-mono font-bold">
                   E
                 </span>
-                <input
+                <.input
                   type="number"
                   name="episode"
                   value={member_episode(member)}
@@ -423,6 +433,7 @@ defmodule MydiaWeb.ImportMediaLive.Components do
                   max="9999"
                   phx-debounce="400"
                   class="join-item input input-xs w-14 text-center font-mono border-0 focus:outline-none"
+                  container_class="contents"
                   aria-label={"Episode for #{member_filename(member)}"}
                 />
               </div>
@@ -677,16 +688,17 @@ defmodule MydiaWeb.ImportMediaLive.Components do
 
     cond do
       season != nil and episode != nil ->
-        "S#{String.pad_leading(to_string(season), 2, "0")}E#{String.pad_leading(to_string(episode), 2, "0")}"
+        {true,
+         "S#{String.pad_leading(to_string(season), 2, "0")}E#{String.pad_leading(to_string(episode), 2, "0")}"}
 
       season != nil ->
-        "S#{String.pad_leading(to_string(season), 2, "0")}"
+        {true, "S#{String.pad_leading(to_string(season), 2, "0")}"}
 
       episode != nil ->
-        "E#{String.pad_leading(to_string(episode), 2, "0")}"
+        {true, "E#{String.pad_leading(to_string(episode), 2, "0")}"}
 
       true ->
-        "No episode"
+        {false, "No episode"}
     end
   end
 end

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -863,15 +863,15 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   end
 
   defp resolve_library_by_type(type, library_paths) when type in ["movies", "movie"] do
-    Enum.find_value(library_paths, fn lp -> lp.type == :movies && lp.id end) ||
-      Enum.find_value(library_paths, fn lp -> lp.default_for_movies && lp.id end) ||
+    Enum.find_value(library_paths, fn lp -> lp.default_for_movies && lp.id end) ||
+      Enum.find_value(library_paths, fn lp -> lp.type == :movies && lp.id end) ||
       Enum.find_value(library_paths, fn lp -> lp.type == :mixed && lp.id end)
   end
 
   defp resolve_library_by_type(type, library_paths)
        when type in ["tv", "series", "tv_show", "shows"] do
-    Enum.find_value(library_paths, fn lp -> lp.type == :series && lp.id end) ||
-      Enum.find_value(library_paths, fn lp -> lp.default_for_series && lp.id end) ||
+    Enum.find_value(library_paths, fn lp -> lp.default_for_series && lp.id end) ||
+      Enum.find_value(library_paths, fn lp -> lp.type == :series && lp.id end) ||
       Enum.find_value(library_paths, fn lp -> lp.type == :mixed && lp.id end)
   end
 

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -19,17 +19,9 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   alias MydiaWeb.Live.Authorization
   alias MydiaWeb.ImportMediaLive.{Components, RunControl}
 
-  # Everything a client can name is mapped from an explicit table rather than
-  # converted. `String.to_existing_atom/1` and `String.to_integer/1` both raise
-  # on anything unexpected, and a raise inside a handler takes the LiveView
-  # process down: a tab left open across a deploy, a replayed event, or a
-  # crafted one would close the page instead of getting an answer back.
-  @modes %{"review" => :review, "unattended" => :unattended}
-
-  # Same reasoning as @modes: `phx-value-band` is client-controlled, so the
-  # atom it names is looked up rather than converted. An unknown value is a
-  # silent no-op -- unlike an unknown mode, there is no form state to explain
-  # a rejection to, so there is nothing useful to flash.
+  # `phx-value-band` is client-controlled, so the atom it names is looked up
+  # rather than converted. An unknown value is a silent no-op because there is
+  # no form state to explain a rejection to.
   # `:ignored` is not a confidence band -- it is a status -- but it rides the
   # same chip row and the same client-controlled atom lookup as the real
   # bands, and load_groups/1 translates it into ImportGroups.page/2's
@@ -59,27 +51,31 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   @impl true
   def mount(params, _session, socket) do
     library_paths = Settings.list_library_paths()
-    active_run = Enum.find_value(library_paths, &Library.active_import_run(&1.id))
-
-    # No run in flight: fall back to the most recent one so a finished,
-    # failed, or stopped run stays visible after a reload instead of the
-    # panel silently reverting to a blank start form. active_import_run/1
-    # itself stays untouched -- Task 6's coordinator and Task 2's uniqueness
-    # guard both depend on it excluding terminal states.
-    outcome_run =
-      if active_run do
-        nil
-      else
-        Enum.find_value(library_paths, &Library.last_import_run(&1.id))
-      end
-
-    run_to_watch = active_run || outcome_run
     importable_library_paths = Enum.filter(library_paths, &importable?/1)
     selected_library_path_id = resolve_library_path_id(params, importable_library_paths)
 
+    selected_library_path =
+      Enum.find(importable_library_paths, &(&1.id == selected_library_path_id))
+
+    active_runs_by_library =
+      Library.list_active_import_runs()
+      |> Map.new(&{&1.library_path_id, &1})
+
+    active_run = Map.get(active_runs_by_library, selected_library_path_id)
+
+    # Run state follows the one library selected by the page-level tabs. A
+    # scan on another path is represented by that tab's activity indicator,
+    # not by replacing the selected library's scan controls and review list.
+    outcome_run =
+      if active_run || is_nil(selected_library_path_id) do
+        nil
+      else
+        Library.last_import_run(selected_library_path_id)
+      end
+
     if connected?(socket) do
-      if run_to_watch do
-        Phoenix.PubSub.subscribe(Mydia.PubSub, ImportRunJob.progress_topic(run_to_watch.id))
+      if active_run do
+        Phoenix.PubSub.subscribe(Mydia.PubSub, ImportRunJob.progress_topic(active_run.id))
       end
 
       if selected_library_path_id do
@@ -88,13 +84,6 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     end
 
     outcome_group_count = group_count_for_outcome(outcome_run)
-
-    run_control_open =
-      cond do
-        active_run != nil -> true
-        outcome_group_count > 0 -> false
-        true -> true
-      end
 
     socket =
       socket
@@ -105,9 +94,9 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       # music path by an older build is still found, shown, and stoppable.
       |> assign(:importable_library_paths, importable_library_paths)
       |> assign(:active_run, active_run)
+      |> assign(:active_runs_by_library, active_runs_by_library)
       |> assign(:outcome_run, outcome_run)
       |> assign(:outcome_group_count, outcome_group_count)
-      |> assign(:run_control_open, run_control_open)
       |> assign(:band, :all)
       |> assign(:search, "")
       |> assign(:cursor, nil)
@@ -124,6 +113,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       |> assign(:matching_count, 0)
       |> assign(:page_group_ids, [])
       |> assign(:selected_library_path_id, selected_library_path_id)
+      |> assign(:selected_library_path, selected_library_path)
       |> assign(:selection, SelectionScope.new(selected_library_path_id))
       # Guards the :import_groups_changed debounce below: true while a
       # deferred refresh is already scheduled, so a burst of broadcasts
@@ -186,10 +176,11 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   end
 
   @impl true
-  def handle_event("start_run", %{"library_path_id" => path_id, "mode" => mode}, socket) do
+  def handle_event("start_run", %{"library_path_id" => path_id} = params, socket) do
+    mode = if params["auto_import"] == "true", do: :unattended, else: :review
+
     with :ok <- Authorization.authorize_import_media(socket),
-         :ok <- authorize_library_path(socket, path_id),
-         {:ok, mode} <- Map.fetch(@modes, mode) do
+         :ok <- authorize_library_path(socket, path_id) do
       attrs = %{
         library_path_id: path_id,
         user_id: socket.assigns.current_user.id,
@@ -208,10 +199,9 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
           {:noreply,
            socket
-           |> assign(:active_run, run)
+           |> put_active_run(run)
            |> assign(:outcome_run, nil)
-           |> assign(:outcome_group_count, 0)
-           |> assign(:run_control_open, true)}
+           |> assign(:outcome_group_count, 0)}
 
         {:error, _changeset} ->
           {:noreply, put_flash(socket, :error, "That library is already being imported.")}
@@ -222,12 +212,44 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
       {:unsupported_type, socket} ->
         {:noreply, socket}
+    end
+  end
 
-      # Map.fetch/2 on an unknown mode. Only reachable from a stale or crafted
-      # form, so the sentence is deliberately vague rather than echoing back
-      # whatever string arrived.
-      :error ->
-        {:noreply, put_flash(socket, :error, "That import mode is not available.")}
+  def handle_event("clear_scan_results", %{"library_path_id" => path_id}, socket) do
+    with :ok <- Authorization.authorize_import_media(socket),
+         :ok <- authorize_library_path(socket, path_id),
+         {:ok, count} <- ImportGroups.clear_for_library(path_id) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Cleared #{count} scan result group(s).")
+       |> assign(:outcome_run, nil)
+       |> assign(:outcome_group_count, 0)
+       |> assign(:selection, SelectionScope.new(path_id))
+       |> assign(:match_search, nil)
+       |> load_groups()
+       |> refresh_counts()}
+    else
+      {:unauthorized, socket} ->
+        {:noreply, socket}
+
+      {:unsupported_type, socket} ->
+        {:noreply, socket}
+
+      {:error, :active_run} ->
+        {:noreply, put_flash(socket, :error, "Stop this library's scan before clearing results.")}
+    end
+  end
+
+  def handle_event("import_all_results", _params, socket) do
+    with :ok <- Authorization.authorize_import_media(socket),
+         library_path_id when is_binary(library_path_id) <-
+           socket.assigns.selected_library_path_id do
+      {:noreply,
+       socket
+       |> accept_result(ImportGroups.accept_all_matched(library_path_id))}
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+      nil -> {:noreply, put_flash(socket, :error, "Select a library before importing results.")}
     end
   end
 
@@ -240,7 +262,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
         run ->
           case Library.request_import_run_stop(run.id) do
             {:ok, stopping} ->
-              {:noreply, assign(socket, :active_run, stopping)}
+              {:noreply, put_active_run(socket, stopping)}
 
             # The run reached a terminal state between this page rendering and
             # the click landing. Show what it actually did rather than forcing
@@ -378,43 +400,9 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
   def handle_event("accept_selected", _params, socket) do
     with :ok <- Authorization.authorize_import_media(socket) do
-      # accept/1 can fail at the enqueue step, in which case the groups are
-      # marked accepted but nothing will apply them. Say so rather than
-      # reporting success.
-      case ImportGroups.accept(socket.assigns.selection) do
-        {:ok, count} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Accepted #{count} group(s). Linking in the background.")
-           |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
-           |> load_groups()
-           |> refresh_counts()}
-
-        {:error, reason} ->
-          Logger.error("Could not enqueue the import group apply job", reason: inspect(reason))
-
-          # accept/1 flips status to "accepted" *before* it tries to enqueue,
-          # so the affected rows are already gone from the "pending" set both
-          # page/2 and SelectionScope filter on -- regardless of whether the
-          # enqueue itself succeeded. Reload so the stream (and the counts)
-          # match the database instead of continuing to show rows that no
-          # longer match the query, and clear the selection: it names ids
-          # that can no longer be acted on, and re-running accept/1 against
-          # them would select nothing, short-circuit, and return {:ok, 0} --
-          # a second, silent "success" for a selection that already failed
-          # once.
-          {:noreply,
-           socket
-           |> put_flash(
-             :error,
-             "Marked for import, but the background job could not be started. " <>
-               "They are not lost: the next successful accept for this library " <>
-               "will pick them up."
-           )
-           |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
-           |> load_groups()
-           |> refresh_counts()}
-      end
+      {:noreply,
+       socket
+       |> accept_result(ImportGroups.accept(socket.assigns.selection))}
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -452,18 +440,14 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
   def handle_event("rematch_selected", _params, socket) do
     with :ok <- Authorization.authorize_import_media(socket) do
-      case ImportGroups.rematch(socket.assigns.selection) do
-        {:ok, count} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Re-matched #{count} group(s).")
-           |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
-           |> load_groups()
-           |> refresh_counts()}
+      {:ok, count} = ImportGroups.rematch(socket.assigns.selection)
 
-        {:error, reason} ->
-          {:noreply, put_flash(socket, :error, "Could not rematch: #{inspect(reason)}")}
-      end
+      {:noreply,
+       socket
+       |> put_flash(:info, "Re-matched #{count} group(s).")
+       |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
+       |> load_groups()
+       |> refresh_counts()}
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -716,14 +700,11 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   def handle_info({:import_run_progress, run}, socket) do
     socket =
       if run.status in [:running, :stopping] do
-        socket
-        |> assign(:active_run, run)
-        |> assign(:run_control_open, true)
+        put_active_run(socket, run)
       else
         # Terminal: don't just clear the panel. Keep the run visible as an
-        # outcome so a user who walked away comes back to "it finished" /
-        # "it failed" / "it stopped", not a blank start form that looks like
-        # nothing ever happened.
+        # outcome so a user who walked away comes back to the scan result, not
+        # a blank start form that looks like nothing ever happened.
         socket
         |> show_outcome(run)
         |> load_groups()
@@ -772,12 +753,45 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   # set; this layer only exists so the user gets a sentence instead of a run
   # that starts and immediately fails.
   defp authorize_library_path(socket, path_id) do
-    if Enum.any?(socket.assigns.importable_library_paths, &(&1.id == path_id)) do
-      :ok
-    else
-      {:unsupported_type,
-       put_flash(socket, :error, "Only movie, TV and mixed libraries can be imported.")}
+    cond do
+      path_id != socket.assigns.selected_library_path_id ->
+        {:unsupported_type,
+         put_flash(socket, :error, "Select that library before starting its scan.")}
+
+      Enum.any?(socket.assigns.importable_library_paths, &(&1.id == path_id)) ->
+        :ok
+
+      true ->
+        {:unsupported_type,
+         put_flash(socket, :error, "Only movie, TV and mixed libraries can be imported.")}
     end
+  end
+
+  defp accept_result(socket, {:ok, count}) do
+    socket
+    |> put_flash(:info, "Accepted #{count} group(s). Linking in the background.")
+    |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
+    |> load_groups()
+    |> refresh_counts()
+  end
+
+  defp accept_result(socket, {:error, reason}) do
+    Logger.error("Could not enqueue the import group apply job", reason: inspect(reason))
+
+    # The status update commits before the enqueue is attempted, so affected
+    # rows are already outside the pending review query even on this error.
+    # Refresh the page and keep the recovery guidance consistent for selected
+    # accepts and Import All.
+    socket
+    |> put_flash(
+      :error,
+      "Marked for import, but the background job could not be started. " <>
+        "They are not lost: the next successful accept for this library " <>
+        "will pick them up."
+    )
+    |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
+    |> load_groups()
+    |> refresh_counts()
   end
 
   # A terminal run stays on screen as an outcome rather than reverting the
@@ -785,13 +799,19 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   defp show_outcome(socket, run) do
     socket
     |> assign(:active_run, nil)
+    |> update(:active_runs_by_library, &Map.delete(&1, run.library_path_id))
     |> assign(:outcome_run, run)
     |> assign(:outcome_group_count, group_count_for_outcome(run))
   end
 
+  defp put_active_run(socket, run) do
+    socket
+    |> assign(:active_run, run)
+    |> update(:active_runs_by_library, &Map.put(&1, run.library_path_id, run))
+  end
+
   # Queries the pending group count once when a run reaches a terminal state
-  # so the outcome_review_cta component never calls the DB directly from its
-  # body.
+  # so the outcome summary never calls the DB from its component body.
   #
   # Deliberately `band_counts/1` (scoped to this run's own library path), not
   # `ImportGroups.count_pending/0` (the global nav-badge total, see its own
@@ -841,28 +861,43 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
   defp resolve_library_by_type(_type, _library_paths), do: nil
 
-  # The review section works one library path at a time. On mount it defaults
-  # to the first importable path, same as the start form's own radio default;
-  # after that, select_library/2 (via the picker) is what changes it.
+  # Scanning and review work on one library path at a time. On mount the
+  # page-level tabs default to the first importable path; after that,
+  # select_library/2 changes the shared page context.
   defp default_library_path_id([%{id: id} | _rest]), do: id
   defp default_library_path_id([]), do: nil
 
-  # Switches which library path the review section shows. Every piece of
-  # state the review section owns is either library-scoped (selection,
-  # paging, expansion) or would silently act on rows no longer on screen if
-  # left as-is (a filter-mode selection built against the old library's
-  # groups, most of all) -- so all of it resets here rather than only the
-  # pieces that would visibly break.
+  # Switches the library shared by scan controls and review. Every piece of
+  # review state is library-scoped, and run subscriptions must move with the
+  # same selection so another library's progress never takes over this tab.
   defp switch_library(socket, id) do
     previous_id = socket.assigns.selected_library_path_id
+    previous_run = socket.assigns.active_run
+    active_run = Library.active_import_run(id)
+    outcome_run = if active_run, do: nil, else: Library.last_import_run(id)
+    selected_library_path = Enum.find(socket.assigns.importable_library_paths, &(&1.id == id))
 
     if connected?(socket) and previous_id != id do
       if previous_id, do: Phoenix.PubSub.unsubscribe(Mydia.PubSub, "import_groups:#{previous_id}")
+
+      if previous_run,
+        do: Phoenix.PubSub.unsubscribe(Mydia.PubSub, ImportRunJob.progress_topic(previous_run.id))
+
       Phoenix.PubSub.subscribe(Mydia.PubSub, "import_groups:#{id}")
+
+      if active_run,
+        do: Phoenix.PubSub.subscribe(Mydia.PubSub, ImportRunJob.progress_topic(active_run.id))
     end
 
     socket
     |> assign(:selected_library_path_id, id)
+    |> assign(:selected_library_path, selected_library_path)
+    |> assign(:active_run, active_run)
+    |> update(:active_runs_by_library, fn runs ->
+      if active_run, do: Map.put(runs, id, active_run), else: Map.delete(runs, id)
+    end)
+    |> assign(:outcome_run, outcome_run)
+    |> assign(:outcome_group_count, group_count_for_outcome(outcome_run))
     |> assign(:cursor, nil)
     |> assign(:cursor_stack, [])
     |> assign(:expanded_ids, MapSet.new())
@@ -917,20 +952,12 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       |> Enum.map(& &1.id)
       |> MapSet.new()
 
-    run_control_open =
-      cond do
-        socket.assigns.active_run != nil -> true
-        groups != [] or socket.assigns.outcome_group_count > 0 -> false
-        true -> true
-      end
-
     socket
     |> stream(:groups, groups, reset: true)
     |> assign(:page_group_ids, Enum.map(groups, & &1.id))
     |> assign(:next_cursor, next_cursor)
     |> assign(:matching_count, matching_count)
     |> assign(:expanded_ids, expanded)
-    |> assign(:run_control_open, run_control_open)
   end
 
   # Recomputes the counts that only change when a group's status changes,

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -47,6 +47,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   # receiving end here instead of the sending end there, since this
   # broadcast has no single producer to throttle.
   @refresh_debounce_ms 500
+  @scan_complete_display_ms 5_000
 
   @impl true
   def mount(params, _session, socket) do
@@ -70,7 +71,9 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       if active_run || is_nil(selected_library_path_id) do
         nil
       else
-        Library.last_import_run(selected_library_path_id)
+        selected_library_path_id
+        |> Library.last_import_run()
+        |> persistent_outcome()
       end
 
     if connected?(socket) do
@@ -83,8 +86,6 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       end
     end
 
-    outcome_group_count = group_count_for_outcome(outcome_run)
-
     socket =
       socket
       |> assign(:page_title, "Import Media")
@@ -96,7 +97,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       |> assign(:active_run, active_run)
       |> assign(:active_runs_by_library, active_runs_by_library)
       |> assign(:outcome_run, outcome_run)
-      |> assign(:outcome_group_count, outcome_group_count)
+      |> assign(:scan_complete_run_id, nil)
       |> assign(:band, :all)
       |> assign(:search, "")
       |> assign(:cursor, nil)
@@ -201,7 +202,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
            socket
            |> put_active_run(run)
            |> assign(:outcome_run, nil)
-           |> assign(:outcome_group_count, 0)}
+           |> assign(:scan_complete_run_id, nil)}
 
         {:error, _changeset} ->
           {:noreply, put_flash(socket, :error, "That library is already being imported.")}
@@ -223,7 +224,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
        socket
        |> put_flash(:info, "Cleared #{count} scan result group(s).")
        |> assign(:outcome_run, nil)
-       |> assign(:outcome_group_count, 0)
+       |> assign(:scan_complete_run_id, nil)
        |> assign(:selection, SelectionScope.new(path_id))
        |> assign(:match_search, nil)
        |> load_groups()
@@ -702,13 +703,23 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       if run.status in [:running, :stopping] do
         put_active_run(socket, run)
       else
-        # Terminal: don't just clear the panel. Keep the run visible as an
-        # outcome so a user who walked away comes back to the scan result, not
-        # a blank start form that looks like nothing ever happened.
+        # Successful completion is a short acknowledgement beside Review;
+        # failed and stopped runs remain in the scan panel with their details.
         socket
         |> show_outcome(run)
         |> load_groups()
         |> refresh_counts()
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_info({:dismiss_scan_complete, run_id}, socket) do
+    socket =
+      if socket.assigns.scan_complete_run_id == run_id do
+        assign(socket, :scan_complete_run_id, nil)
+      else
+        socket
       end
 
     {:noreply, socket}
@@ -794,14 +805,27 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     |> refresh_counts()
   end
 
-  # A terminal run stays on screen as an outcome rather than reverting the
-  # panel to a blank start form, matching what mount/3 does after a reload.
   defp show_outcome(socket, run) do
-    socket
-    |> assign(:active_run, nil)
-    |> update(:active_runs_by_library, &Map.delete(&1, run.library_path_id))
-    |> assign(:outcome_run, run)
-    |> assign(:outcome_group_count, group_count_for_outcome(run))
+    socket =
+      socket
+      |> assign(:active_run, nil)
+      |> update(:active_runs_by_library, &Map.delete(&1, run.library_path_id))
+
+    if run.status == :done do
+      Process.send_after(
+        self(),
+        {:dismiss_scan_complete, run.id},
+        @scan_complete_display_ms
+      )
+
+      socket
+      |> assign(:outcome_run, nil)
+      |> assign(:scan_complete_run_id, run.id)
+    else
+      socket
+      |> assign(:outcome_run, persistent_outcome(run))
+      |> assign(:scan_complete_run_id, nil)
+    end
   end
 
   defp put_active_run(socket, run) do
@@ -810,27 +834,11 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     |> update(:active_runs_by_library, &Map.put(&1, run.library_path_id, run))
   end
 
-  # Queries the pending group count once when a run reaches a terminal state
-  # so the outcome summary never calls the DB from its component body.
-  #
-  # Deliberately `band_counts/1` (scoped to this run's own library path), not
-  # `ImportGroups.count_pending/0` (the global nav-badge total, see its own
-  # doc): this CTA reports what one specific run just found, and a global
-  # count would fold in every other library's backlog too, showing a number
-  # that could disagree with -- and in a multi-library install often would --
-  # what `/import` actually displays for the library this run touched.
-  #
-  # Was `Library.count_inbox_files/1`, a `MediaFile`/`MatchCandidate` query
-  # that has nothing to do with `import_groups`, the table the review page
-  # actually reads. That mismatch is Critical 1 from the whole-branch review:
-  # the CTA could say "review N files" while the page it linked to showed
-  # nothing at all. Sourcing both from the same table is what makes the
-  # number and the destination agree.
-  defp group_count_for_outcome(nil), do: 0
+  defp persistent_outcome(%ImportRun{status: status} = run)
+       when status in [:failed, :stopped],
+       do: run
 
-  defp group_count_for_outcome(run) do
-    ImportGroups.band_counts(run.library_path_id).total
-  end
+  defp persistent_outcome(_run), do: nil
 
   defp resolve_library_path_id(params, library_paths) do
     cond do
@@ -874,7 +882,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     previous_id = socket.assigns.selected_library_path_id
     previous_run = socket.assigns.active_run
     active_run = Library.active_import_run(id)
-    outcome_run = if active_run, do: nil, else: Library.last_import_run(id)
+    outcome_run = if active_run, do: nil, else: persistent_outcome(Library.last_import_run(id))
     selected_library_path = Enum.find(socket.assigns.importable_library_paths, &(&1.id == id))
 
     if connected?(socket) and previous_id != id do
@@ -897,7 +905,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       if active_run, do: Map.put(runs, id, active_run), else: Map.delete(runs, id)
     end)
     |> assign(:outcome_run, outcome_run)
-    |> assign(:outcome_group_count, group_count_for_outcome(outcome_run))
+    |> assign(:scan_complete_run_id, nil)
     |> assign(:cursor, nil)
     |> assign(:cursor_stack, [])
     |> assign(:expanded_ids, MapSet.new())

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -14,6 +14,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
   alias Mydia.{Library, Metadata, Repo, Settings}
   alias Mydia.ImportGroups
+  alias Mydia.Jobs.RematchImportGroups
   alias Mydia.Jobs.ImportRun, as: ImportRunJob
   alias Mydia.Library.{ImportGroup, ImportRun, SelectionScope}
   alias MydiaWeb.Live.Authorization
@@ -441,14 +442,21 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
   def handle_event("rematch_selected", _params, socket) do
     with :ok <- Authorization.authorize_import_media(socket) do
-      {:ok, count} = ImportGroups.rematch(socket.assigns.selection)
+      selection = socket.assigns.selection
+      count = SelectionScope.count(selection)
+
+      %{
+        "library_path_id" => selection.library_path_id,
+        "selection" => SelectionScope.to_args(selection)
+      }
+      |> RematchImportGroups.new()
+      |> Oban.insert!()
 
       {:noreply,
        socket
-       |> put_flash(:info, "Re-matched #{count} group(s).")
+       |> put_flash(:info, "Queued #{count} group(s) for re-match.")
        |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
-       |> load_groups()
-       |> refresh_counts()}
+       |> load_groups()}
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -855,15 +863,15 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   end
 
   defp resolve_library_by_type(type, library_paths) when type in ["movies", "movie"] do
-    Enum.find_value(library_paths, fn lp -> lp.default_for_movies && lp.id end) ||
-      Enum.find_value(library_paths, fn lp -> lp.type == :movies && lp.id end) ||
+    Enum.find_value(library_paths, fn lp -> lp.type == :movies && lp.id end) ||
+      Enum.find_value(library_paths, fn lp -> lp.default_for_movies && lp.id end) ||
       Enum.find_value(library_paths, fn lp -> lp.type == :mixed && lp.id end)
   end
 
   defp resolve_library_by_type(type, library_paths)
        when type in ["tv", "series", "tv_show", "shows"] do
-    Enum.find_value(library_paths, fn lp -> lp.default_for_series && lp.id end) ||
-      Enum.find_value(library_paths, fn lp -> lp.type == :series && lp.id end) ||
+    Enum.find_value(library_paths, fn lp -> lp.type == :series && lp.id end) ||
+      Enum.find_value(library_paths, fn lp -> lp.default_for_series && lp.id end) ||
       Enum.find_value(library_paths, fn lp -> lp.type == :mixed && lp.id end)
   end
 
@@ -979,6 +987,10 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   defp refresh_counts(socket) do
     library_path_id = socket.assigns.selected_library_path_id
 
+    active_runs_by_library =
+      Library.list_active_import_runs()
+      |> Map.new(&{&1.library_path_id, &1})
+
     band_counts =
       library_path_id
       |> ImportGroups.band_counts()
@@ -986,6 +998,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
     socket
     |> assign(:band_counts, band_counts)
+    |> assign(:active_runs_by_library, active_runs_by_library)
     |> assign(
       :library_group_counts,
       Map.new(socket.assigns.importable_library_paths, fn path ->

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -57,7 +57,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   @refresh_debounce_ms 500
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     library_paths = Settings.list_library_paths()
     active_run = Enum.find_value(library_paths, &Library.active_import_run(&1.id))
 
@@ -75,7 +75,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
     run_to_watch = active_run || outcome_run
     importable_library_paths = Enum.filter(library_paths, &importable?/1)
-    selected_library_path_id = default_library_path_id(importable_library_paths)
+    selected_library_path_id = resolve_library_path_id(params, importable_library_paths)
 
     if connected?(socket) do
       if run_to_watch do
@@ -87,6 +87,15 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       end
     end
 
+    outcome_group_count = group_count_for_outcome(outcome_run)
+
+    run_control_open =
+      cond do
+        active_run != nil -> true
+        outcome_group_count > 0 -> false
+        true -> true
+      end
+
     socket =
       socket
       |> assign(:page_title, "Import Media")
@@ -97,7 +106,8 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       |> assign(:importable_library_paths, importable_library_paths)
       |> assign(:active_run, active_run)
       |> assign(:outcome_run, outcome_run)
-      |> assign(:outcome_group_count, group_count_for_outcome(outcome_run))
+      |> assign(:outcome_group_count, outcome_group_count)
+      |> assign(:run_control_open, run_control_open)
       |> assign(:band, :all)
       |> assign(:search, "")
       |> assign(:cursor, nil)
@@ -112,6 +122,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       # matching band_counts's own placeholder above.
       |> assign(:library_group_counts, %{})
       |> assign(:matching_count, 0)
+      |> assign(:page_group_ids, [])
       |> assign(:selected_library_path_id, selected_library_path_id)
       |> assign(:selection, SelectionScope.new(selected_library_path_id))
       # Guards the :import_groups_changed debounce below: true while a
@@ -153,7 +164,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
+  def handle_params(params, uri, socket) do
     # `/review` is kept as a redirect for old bookmarks and links -- the
     # module it used to point to is gone, and this page is the only one there
     # is now. Nothing still links here on purpose; `RunControl`'s outcome CTA
@@ -161,6 +172,15 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     if URI.parse(uri).path == "/review" do
       {:noreply, push_navigate(socket, to: ~p"/import")}
     else
+      target_id = resolve_library_path_id(params, socket.assigns.importable_library_paths)
+
+      socket =
+        if target_id && target_id != socket.assigns.selected_library_path_id do
+          switch_library(socket, target_id)
+        else
+          socket
+        end
+
       {:noreply, socket}
     end
   end
@@ -190,7 +210,8 @@ defmodule MydiaWeb.ImportMediaLive.Index do
            socket
            |> assign(:active_run, run)
            |> assign(:outcome_run, nil)
-           |> assign(:outcome_group_count, 0)}
+           |> assign(:outcome_group_count, 0)
+           |> assign(:run_control_open, true)}
 
         {:error, _changeset} ->
           {:noreply, put_flash(socket, :error, "That library is already being imported.")}
@@ -237,7 +258,8 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   # event can still name any id -- same guard shape as
   # authorize_library_path/2 above.
   def handle_event("select_library", %{"library_path_id" => id}, socket) do
-    if Enum.any?(socket.assigns.importable_library_paths, &(&1.id == id)) do
+    if Enum.any?(socket.assigns.importable_library_paths, &(&1.id == id)) and
+         id != socket.assigns.selected_library_path_id do
       {:noreply, switch_library(socket, id)}
     else
       {:noreply, socket}
@@ -247,12 +269,17 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   def handle_event("select_band", %{"band" => band}, socket) do
     case Map.fetch(@bands, band) do
       {:ok, band} ->
+        status = if band == :ignored, do: "ignored", else: "pending"
+
         {:noreply,
          socket
          |> assign(:band, band)
          |> assign(:cursor, nil)
          |> assign(:cursor_stack, [])
-         |> assign(:selection, SelectionScope.new(socket.assigns.selected_library_path_id))
+         |> assign(
+           :selection,
+           SelectionScope.new(socket.assigns.selected_library_path_id, status)
+         )
          |> load_groups()}
 
       :error ->
@@ -261,6 +288,8 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   end
 
   def handle_event("search", %{"q" => q}, socket) do
+    status = if socket.assigns.band == :ignored, do: "ignored", else: "pending"
+
     {:noreply,
      socket
      |> assign(:search, q)
@@ -272,7 +301,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
      # accept_selected/ignore_selected act on) would otherwise disagree with
      # what is actually on screen after the search changes. select_band/1
      # resets the selection for the same reason.
-     |> assign(:selection, SelectionScope.new(socket.assigns.selected_library_path_id))
+     |> assign(:selection, SelectionScope.new(socket.assigns.selected_library_path_id, status))
      |> load_groups()}
   end
 
@@ -309,33 +338,35 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     {:noreply, refresh_group_row(socket, id)}
   end
 
-  # The button this responds to is never rendered on the Ignored view (see
-  # ignored_group_row/1 -- ignored rows carry no checkbox at all), but the
-  # event name itself is still a valid target for a crafted or stale request.
-  # `SelectionScope.apply_band/2` has no clause for `:ignored` (it is a
-  # status, not a real band), so building a filter-mode scope with it would
-  # raise the first time anything read the scope back -- refusing here instead
-  # keeps that a routine no-op rather than a crash.
+  def handle_event("select_current_page", _params, socket) do
+    status = if socket.assigns.band == :ignored, do: "ignored", else: "pending"
+
+    selection =
+      socket.assigns.selected_library_path_id
+      |> SelectionScope.new(status)
+      |> SelectionScope.select_page(socket.assigns.page_group_ids)
+
+    {:noreply, socket |> assign(:selection, selection) |> load_groups()}
+  end
+
   def handle_event("select_all_matching", _params, socket) do
-    if socket.assigns.band == :ignored do
-      {:noreply, socket}
-    else
-      filter = %{band: socket.assigns.band, q: socket.assigns.search}
+    status = if socket.assigns.band == :ignored, do: "ignored", else: "pending"
+    page_band = if socket.assigns.band == :ignored, do: :all, else: socket.assigns.band
+    filter = %{band: page_band, q: socket.assigns.search}
 
-      selection =
-        socket.assigns.selected_library_path_id
-        |> SelectionScope.new()
-        |> SelectionScope.select_all_matching(filter)
+    selection =
+      socket.assigns.selected_library_path_id
+      |> SelectionScope.new(status)
+      |> SelectionScope.select_all_matching(filter)
 
-      # `selected?/2` reads `:selection` fresh on every render, but a stream
-      # item's rendered body does not: switching to :filter mode here selects
-      # every matching row in the database without touching the `:groups`
-      # stream, so every checkbox currently on screen would stay visually
-      # unchecked. load_groups/1 re-inserts the whole current page, which is
-      # the only thing that makes a stream item's `selected` attribute
-      # re-evaluate -- see refresh_group_row/2's comment for the general rule.
-      {:noreply, socket |> assign(:selection, selection) |> load_groups()}
-    end
+    # `selected?/2` reads `:selection` fresh on every render, but a stream
+    # item's rendered body does not: switching to :filter mode here selects
+    # every matching row in the database without touching the `:groups`
+    # stream, so every checkbox currently on screen would stay visually
+    # unchecked. load_groups/1 re-inserts the whole current page, which is
+    # the only thing that makes a stream item's `selected` attribute
+    # re-evaluate -- see refresh_group_row/2's comment for the general rule.
+    {:noreply, socket |> assign(:selection, selection) |> load_groups()}
   end
 
   def handle_event("clear_selection", _params, socket) do
@@ -404,52 +435,96 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     end
   end
 
-  # `expanded_ids` tracks which groups are visually open (the chevron); a
-  # settled group starts absent from it, an unsettled one starts present
-  # (seeded in load_groups/1). `expanded_group_id` is a separate, single
-  # value tracking which one group's members are actually loaded into
-  # `@streams.members` -- auto-expanding every unsettled group on the page
-  # must not mean eagerly loading members for all of them, so opening a
-  # group only ever populates the member list for the group most recently
-  # clicked; every other open group renders its `<ul>` with an empty member
-  # list until it, too, is clicked.
-  def handle_event("expand_group", %{"id" => id}, socket) do
-    expanded = socket.assigns.expanded_ids
+  def handle_event("restore_selected", _params, socket) do
+    with :ok <- Authorization.authorize_import_media(socket) do
+      {:ok, count} = ImportGroups.restore(socket.assigns.selection)
 
-    # A group row's `expanded` and `members` are computed from assigns
-    # outside the `:groups` stream itself. Stream items only redraw when
-    # explicitly re-inserted -- LiveView diffs a stream by its own
-    # insert/delete/reset operations, not by the outer assigns a `:for` over
-    # it happens to close over -- so every row whose derived output just
-    # changed must be re-inserted, or neither its chevron nor its member
-    # list would ever change on screen.
-    if MapSet.member?(expanded, id) do
       {:noreply,
        socket
-       |> assign(:expanded_ids, MapSet.delete(expanded, id))
-       |> refresh_group_row(id)}
+       |> put_flash(:info, "Restored #{count} group(s) to pending.")
+       |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
+       |> load_groups()
+       |> refresh_counts()}
     else
-      previously_loaded = socket.assigns.expanded_group_id
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("rematch_selected", _params, socket) do
+    with :ok <- Authorization.authorize_import_media(socket) do
+      case ImportGroups.rematch(socket.assigns.selection) do
+        {:ok, count} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Re-matched #{count} group(s).")
+           |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
+           |> load_groups()
+           |> refresh_counts()}
+
+        {:error, reason} ->
+          {:noreply, put_flash(socket, :error, "Could not rematch: #{inspect(reason)}")}
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
+  # `expanded_ids` tracks which groups are visually open (the chevron).
+  # Expanding a group populates `@streams.members` with its files and collapses
+  # any previously open group so that only the active group shows as expanded
+  # and the file list matches the open chevron.
+  def handle_event("expand_group", %{"id" => id}, socket) do
+    if socket.assigns.expanded_group_id == id do
+      # Collapsing the currently open group
+      socket =
+        socket
+        |> assign(:expanded_ids, MapSet.delete(socket.assigns.expanded_ids, id))
+        |> assign(:expanded_group_id, nil)
+        |> stream(:members, [], reset: true)
+        |> refresh_group_row(id)
+
+      {:noreply, socket}
+    else
+      # Expanding a new group: collapse any previously expanded group so
+      # state stays in sync and only the active group shows open.
+      old_expanded_ids = socket.assigns.expanded_ids
 
       socket =
         socket
-        |> assign(:expanded_ids, MapSet.put(expanded, id))
+        |> assign(:expanded_ids, MapSet.new([id]))
         |> assign(:expanded_group_id, id)
         |> stream(:members, ImportGroups.members(id, limit: 200), reset: true)
         |> refresh_group_row(id)
 
-      # The group that previously held the loaded member list, if any and if
-      # different, just lost it (its `@members` prop now evaluates to `[]`)
-      # even though it may still be visually open -- that row needs
-      # re-inserting too.
+      # Redraw any rows that were previously expanded so their chevrons close
       socket =
-        if previously_loaded && previously_loaded != id do
-          refresh_group_row(socket, previously_loaded)
-        else
-          socket
-        end
+        Enum.reduce(old_expanded_ids, socket, fn old_id, acc ->
+          if old_id != id, do: refresh_group_row(acc, old_id), else: acc
+        end)
 
       {:noreply, socket}
+    end
+  end
+
+  def handle_event("update_member_episode", %{"file_id" => file_id} = params, socket) do
+    with :ok <- Authorization.authorize_import_media(socket) do
+      season = Map.get(params, "season")
+      episode = Map.get(params, "episode")
+
+      case ImportGroups.update_member_episode(file_id, season, episode) do
+        {:ok, updated_member} ->
+          socket =
+            socket
+            |> stream_insert(:members, updated_member)
+            |> maybe_refresh_group_row(updated_member.media_file.import_group_id)
+
+          {:noreply, socket}
+
+        {:error, _reason} ->
+          {:noreply, socket}
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
     end
   end
 
@@ -641,16 +716,18 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   def handle_info({:import_run_progress, run}, socket) do
     socket =
       if run.status in [:running, :stopping] do
-        assign(socket, :active_run, run)
+        socket
+        |> assign(:active_run, run)
+        |> assign(:run_control_open, true)
       else
         # Terminal: don't just clear the panel. Keep the run visible as an
         # outcome so a user who walked away comes back to "it finished" /
         # "it failed" / "it stopped", not a blank start form that looks like
         # nothing ever happened.
         socket
-        |> assign(:active_run, nil)
-        |> assign(:outcome_run, run)
-        |> assign(:outcome_group_count, group_count_for_outcome(run))
+        |> show_outcome(run)
+        |> load_groups()
+        |> refresh_counts()
       end
 
     {:noreply, socket}
@@ -735,6 +812,35 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     ImportGroups.band_counts(run.library_path_id).total
   end
 
+  defp resolve_library_path_id(params, library_paths) do
+    cond do
+      id = params["library_path_id"] || params["library_id"] ->
+        Enum.find_value(library_paths, &(&1.id == id && &1.id)) ||
+          default_library_path_id(library_paths)
+
+      type = params["type"] || params["library_type"] ->
+        resolve_library_by_type(type, library_paths) || default_library_path_id(library_paths)
+
+      true ->
+        default_library_path_id(library_paths)
+    end
+  end
+
+  defp resolve_library_by_type(type, library_paths) when type in ["movies", "movie"] do
+    Enum.find_value(library_paths, fn lp -> lp.default_for_movies && lp.id end) ||
+      Enum.find_value(library_paths, fn lp -> lp.type == :movies && lp.id end) ||
+      Enum.find_value(library_paths, fn lp -> lp.type == :mixed && lp.id end)
+  end
+
+  defp resolve_library_by_type(type, library_paths)
+       when type in ["tv", "series", "tv_show", "shows"] do
+    Enum.find_value(library_paths, fn lp -> lp.default_for_series && lp.id end) ||
+      Enum.find_value(library_paths, fn lp -> lp.type == :series && lp.id end) ||
+      Enum.find_value(library_paths, fn lp -> lp.type == :mixed && lp.id end)
+  end
+
+  defp resolve_library_by_type(_type, _library_paths), do: nil
+
   # The review section works one library path at a time. On mount it defaults
   # to the first importable path, same as the start form's own radio default;
   # after that, select_library/2 (via the picker) is what changes it.
@@ -796,19 +902,11 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     # box. A `SelectionScope.count/1` in :filter mode is a single SQL COUNT
     # against the same predicate select_all_matching/1 itself would use, so
     # this stays correct without duplicating that predicate here.
-    #
-    # Skipped entirely on the Ignored view: SelectionScope's own query is
-    # hardcoded to `status == "pending"` (nothing there is selectable), and
-    # its `apply_band/2` has no `:ignored` clause to run in the first place.
     matching_count =
-      if band == :ignored do
-        0
-      else
-        library_path_id
-        |> SelectionScope.new()
-        |> SelectionScope.select_all_matching(filter)
-        |> SelectionScope.count()
-      end
+      library_path_id
+      |> SelectionScope.new(status)
+      |> SelectionScope.select_all_matching(filter)
+      |> SelectionScope.count()
 
     # The wizard pre-collapsed any season whose episodes all matched confidently,
     # and losing that is why the rewritten page read as one huge list. Same rule,
@@ -819,11 +917,20 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       |> Enum.map(& &1.id)
       |> MapSet.new()
 
+    run_control_open =
+      cond do
+        socket.assigns.active_run != nil -> true
+        groups != [] or socket.assigns.outcome_group_count > 0 -> false
+        true -> true
+      end
+
     socket
     |> stream(:groups, groups, reset: true)
+    |> assign(:page_group_ids, Enum.map(groups, & &1.id))
     |> assign(:next_cursor, next_cursor)
     |> assign(:matching_count, matching_count)
     |> assign(:expanded_ids, expanded)
+    |> assign(:run_control_open, run_control_open)
   end
 
   # Recomputes the counts that only change when a group's status changes,
@@ -869,6 +976,9 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       group -> stream_insert(socket, :groups, group)
     end
   end
+
+  defp maybe_refresh_group_row(socket, nil), do: socket
+  defp maybe_refresh_group_row(socket, id), do: refresh_group_row(socket, id)
 
   # Fires (or re-fires) the group match search asynchronously -- the page
   # this replaced ran two synchronous relay calls inline in a keystroke

--- a/lib/mydia_web/live/import_media_live/index.html.heex
+++ b/lib/mydia_web/live/import_media_live/index.html.heex
@@ -1,69 +1,91 @@
 <Layouts.app {assigns}>
   <div class="max-w-5xl mx-auto p-4 flex flex-col gap-6">
-    <h1 class="text-3xl font-bold">Import</h1>
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <h1 class="text-3xl font-bold">Import</h1>
+        <p class="text-sm text-base-content/70 mt-1">
+          Scan media folders, match titles against metadata providers, and organize into your library
+        </p>
+      </div>
+    </div>
 
     <RunControl.run_control
       library_paths={@importable_library_paths}
+      selected_library_path_id={@selected_library_path_id}
       active_run={@active_run}
       outcome_run={@outcome_run}
       outcome_group_count={@outcome_group_count}
+      open={@run_control_open}
     />
 
-    <Components.library_picker
-      :if={length(@importable_library_paths) > 1}
-      library_paths={@importable_library_paths}
-      selected_id={@selected_library_path_id}
-      counts={@library_group_counts}
-    />
-
-    <Components.band_filter band={@band} counts={@band_counts} search={@search} />
-
-    <Components.bulk_bar
-      :if={
-        SelectionScope.count(@selection) > 0 or (@band != :all and @band != :ignored) or
-          @search != ""
-      }
-      count={SelectionScope.count(@selection)}
-      matching_count={@matching_count}
-    />
-
-    <div id="groups" phx-update="stream" class="flex flex-col divide-y divide-base-300">
-      <div id="no-groups" class="hidden only:block p-8 text-center opacity-70">
-        Nothing to review. Every file in this library is linked.
+    <div class="flex flex-col gap-4 mt-2">
+      <div class="flex items-center justify-between gap-4 flex-wrap">
+        <Components.library_picker
+          :if={length(@importable_library_paths) > 1}
+          library_paths={@importable_library_paths}
+          selected_id={@selected_library_path_id}
+          counts={@library_group_counts}
+        />
       </div>
-      <%= for {dom_id, group} <- @streams.groups do %>
-        <%= if group.status == "ignored" do %>
-          <Components.ignored_group_row id={dom_id} group={group} />
-        <% else %>
-          <Components.group_row
-            id={dom_id}
-            group={group}
-            band={ImportGroups.band(group)}
-            selected={SelectionScope.selected?(@selection, group.id)}
-            expanded={MapSet.member?(@expanded_ids, group.id)}
-            members={if @expanded_group_id == group.id, do: @streams.members, else: []}
-          />
-        <% end %>
-      <% end %>
-    </div>
 
-    <div class="join self-center">
-      <button
-        id="prev-page"
-        class="join-item btn btn-sm"
-        disabled={@cursor_stack == []}
-        phx-click="prev_page"
+      <Components.band_filter band={@band} counts={@band_counts} search={@search} />
+
+      <Components.bulk_bar
+        :if={SelectionScope.count(@selection) > 0 or @band != :all or @search != ""}
+        count={SelectionScope.count(@selection)}
+        matching_count={@matching_count}
+        page_count={length(@page_group_ids)}
+        band={@band}
+      />
+
+      <div
+        id="groups"
+        phx-update="stream"
+        class="list bg-base-100 rounded-box shadow-md border border-base-200 divide-y divide-base-200 overflow-hidden"
       >
-        Previous
-      </button>
-      <button
-        id="next-page"
-        class="join-item btn btn-sm"
-        disabled={is_nil(@next_cursor)}
-        phx-click="next_page"
-      >
-        Next
-      </button>
+        <div id="no-groups" class="hidden only:block p-12 text-center text-base-content/60">
+          <.icon name="hero-check-circle" class="w-10 h-10 mx-auto mb-2 opacity-30 text-success" />
+          <p class="font-medium text-base text-base-content/80">Nothing to review</p>
+          <p class="text-xs text-base-content/50 mt-1">Every file in this library is linked.</p>
+        </div>
+        <%= for {dom_id, group} <- @streams.groups do %>
+          <%= if group.status == "ignored" do %>
+            <Components.ignored_group_row
+              id={dom_id}
+              group={group}
+              selected={SelectionScope.selected?(@selection, group.id)}
+            />
+          <% else %>
+            <Components.group_row
+              id={dom_id}
+              group={group}
+              band={ImportGroups.band(group)}
+              selected={SelectionScope.selected?(@selection, group.id)}
+              expanded={MapSet.member?(@expanded_ids, group.id)}
+              members={if @expanded_group_id == group.id, do: @streams.members, else: []}
+            />
+          <% end %>
+        <% end %>
+      </div>
+
+      <div class="join self-center pt-2">
+        <button
+          id="prev-page"
+          class="join-item btn btn-sm"
+          disabled={@cursor_stack == []}
+          phx-click="prev_page"
+        >
+          <.icon name="hero-chevron-left" class="w-4 h-4 mr-0.5" /> Previous
+        </button>
+        <button
+          id="next-page"
+          class="join-item btn btn-sm"
+          disabled={is_nil(@next_cursor)}
+          phx-click="next_page"
+        >
+          Next <.icon name="hero-chevron-right" class="w-4 h-4 ml-0.5" />
+        </button>
+      </div>
     </div>
 
     <Components.match_search_modal state={@match_search} />

--- a/lib/mydia_web/live/import_media_live/index.html.heex
+++ b/lib/mydia_web/live/import_media_live/index.html.heex
@@ -21,13 +21,21 @@
       library_path={@selected_library_path}
       active_run={@active_run}
       outcome_run={@outcome_run}
-      outcome_group_count={@outcome_group_count}
     />
 
     <section :if={is_nil(@active_run)} id="review-section" class="flex flex-col gap-4 mt-2">
       <div class="flex items-center justify-between gap-4">
         <div>
-          <h2 class="text-xl font-bold">Review</h2>
+          <div id="review-heading" class="flex items-center gap-2.5">
+            <h2 class="text-xl font-bold">Review</h2>
+            <span
+              :if={@scan_complete_run_id}
+              id="scan-complete-status"
+              class="badge badge-success badge-sm gap-1"
+            >
+              <.icon name="hero-check" class="w-3.5 h-3.5" /> Scan complete
+            </span>
+          </div>
           <p class="text-sm text-base-content/60 mt-0.5">
             Confirm matches before they are added to the selected library.
           </p>

--- a/lib/mydia_web/live/import_media_live/index.html.heex
+++ b/lib/mydia_web/live/import_media_live/index.html.heex
@@ -9,25 +9,58 @@
       </div>
     </div>
 
-    <RunControl.run_control
+    <Components.library_picker
+      :if={@importable_library_paths != []}
       library_paths={@importable_library_paths}
-      selected_library_path_id={@selected_library_path_id}
+      selected_id={@selected_library_path_id}
+      counts={@library_group_counts}
+      active_library_ids={Map.keys(@active_runs_by_library)}
+    />
+
+    <RunControl.run_control
+      library_path={@selected_library_path}
       active_run={@active_run}
       outcome_run={@outcome_run}
       outcome_group_count={@outcome_group_count}
-      open={@run_control_open}
     />
 
-    <div class="flex flex-col gap-4 mt-2">
-      <div class="flex items-center justify-between gap-4 flex-wrap">
-        <Components.library_picker
-          :if={length(@importable_library_paths) > 1}
-          library_paths={@importable_library_paths}
-          selected_id={@selected_library_path_id}
-          counts={@library_group_counts}
-        />
-      </div>
+    <section :if={is_nil(@active_run)} id="review-section" class="flex flex-col gap-4 mt-2">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <h2 class="text-xl font-bold">Review</h2>
+          <p class="text-sm text-base-content/60 mt-0.5">
+            Confirm matches before they are added to the selected library.
+          </p>
+        </div>
 
+        <div
+          :if={@selected_library_path}
+          id="review-actions"
+          class="flex items-center gap-2 shrink-0"
+        >
+          <button
+            id="import-all-results"
+            type="button"
+            class="btn btn-primary btn-sm"
+            phx-click="import_all_results"
+            phx-disable-with="Importing…"
+            data-confirm="Import every matched result for this library? This includes lower-confidence matches."
+          >
+            <.icon name="hero-check-circle" class="w-4 h-4" /> Import All
+          </button>
+
+          <button
+            id="clear-scan-results"
+            type="button"
+            class="btn btn-ghost btn-sm text-error"
+            phx-click="clear_scan_results"
+            phx-value-library_path_id={@selected_library_path.id}
+            data-confirm="Clear all scan and review results for this library? Imported media will not be removed."
+          >
+            <.icon name="hero-trash" class="w-4 h-4" /> Clear
+          </button>
+        </div>
+      </div>
       <Components.band_filter band={@band} counts={@band_counts} search={@search} />
 
       <Components.bulk_bar
@@ -86,7 +119,7 @@
           Next <.icon name="hero-chevron-right" class="w-4 h-4 ml-0.5" />
         </button>
       </div>
-    </div>
+    </section>
 
     <Components.match_search_modal state={@match_search} />
   </div>

--- a/lib/mydia_web/live/import_media_live/run_control.ex
+++ b/lib/mydia_web/live/import_media_live/run_control.ex
@@ -8,168 +8,91 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
   """
   use MydiaWeb, :html
 
-  attr :library_paths, :list, required: true
-  attr :selected_library_path_id, :string, default: nil
+  attr :library_path, :map, default: nil
   attr :active_run, :map, default: nil
   attr :outcome_run, :map, default: nil
   attr :outcome_group_count, :integer, default: 0
-  attr :open, :boolean, default: true
 
   def run_control(assigns) do
     ~H"""
-    <details
+    <section
       id="import-run-control"
-      class="group collapse collapse-arrow bg-base-100 shadow-md border border-base-200 rounded-2xl"
-      open={@open}
+      class={[
+        "bg-base-100 shadow-md border border-base-200 rounded-2xl p-4 sm:p-6",
+        @active_run && "min-h-80 flex flex-col justify-center"
+      ]}
     >
-      <summary class="collapse-title p-4 sm:p-5 cursor-pointer select-none flex items-center justify-between gap-4">
-        <div class="flex items-center gap-3 min-w-0">
-          <div class="w-8 h-8 rounded-lg bg-primary/10 text-primary flex items-center justify-center shrink-0">
-            <.icon name="hero-arrow-down-tray" class="w-4 h-4" />
-          </div>
-          <div class="flex items-center gap-2.5 flex-wrap min-w-0">
-            <h2 class="text-lg sm:text-xl font-bold">Import a library</h2>
-            <%= cond do %>
-              <% @active_run -> %>
-                <span class="badge badge-primary badge-sm gap-1 font-medium">
-                  <span class="loading loading-spinner loading-xs"></span>
-                  {phase_label(@active_run.phase)}
-                </span>
-              <% @outcome_run -> %>
-                <span class={["badge badge-sm font-medium", outcome_badge_class(@outcome_run.status)]}>
-                  {outcome_label(@outcome_run.status)}
-                </span>
-              <% true -> %>
-                <span class="badge badge-ghost badge-sm text-xs font-normal">New Import</span>
-            <% end %>
-          </div>
-        </div>
-      </summary>
-
-      <div class="collapse-content px-4 pb-4 sm:px-6 sm:pb-6 flex flex-col gap-5 pt-1">
-        <.run_outcome
-          :if={@outcome_run}
-          run={@outcome_run}
-          pending_groups={@outcome_group_count}
-        />
-
-        <%= if @active_run do %>
-          <.run_progress run={@active_run} />
-        <% else %>
-          <.start_form
-            library_paths={@library_paths}
-            selected_library_path_id={@selected_library_path_id}
-          />
-        <% end %>
+      <div :if={is_nil(@library_path)} class="alert alert-info">
+        <.icon name="hero-information-circle" class="w-5 h-5 shrink-0" />
+        <span>
+          There is no movie or TV library to import yet. Add one under Settings, then come back.
+        </span>
       </div>
-    </details>
+
+      <%= if @library_path do %>
+        <div :if={@active_run} class="flex flex-col gap-6 max-w-3xl w-full mx-auto">
+          <div class="text-center">
+            <div class="w-12 h-12 rounded-2xl bg-primary/10 text-primary flex items-center justify-center mx-auto mb-3">
+              <span class="loading loading-spinner loading-md" />
+            </div>
+            <h2 class="text-2xl font-bold">Scanning {@library_path.path}</h2>
+            <p class="text-sm text-base-content/60 mt-1 font-mono truncate">
+              {@library_path.path}
+            </p>
+          </div>
+          <.run_progress run={@active_run} />
+        </div>
+
+        <div :if={is_nil(@active_run)} class="flex flex-col gap-5">
+          <.run_outcome
+            :if={@outcome_run}
+            run={@outcome_run}
+            pending_groups={@outcome_group_count}
+          />
+          <.start_form library_path={@library_path} />
+        </div>
+      <% end %>
+    </section>
     """
   end
 
-  attr :library_paths, :list, required: true
-  attr :selected_library_path_id, :string, default: nil
+  attr :library_path, :map, required: true
 
   defp start_form(assigns) do
     ~H"""
-    <div :if={@library_paths == []} class="alert alert-info">
-      <.icon name="hero-information-circle" class="w-5 h-5 shrink-0" />
-      <span>
-        There is no movie or TV library to import yet. Add one under Settings, then come back.
-      </span>
-    </div>
-
     <.form
-      :if={@library_paths != []}
       for={%{}}
       id="start-run-form"
-      phx-change="select_library"
       phx-submit="start_run"
-      class="flex flex-col gap-5"
+      class="flex flex-col sm:flex-row sm:items-center gap-4"
     >
-      <fieldset class="flex flex-col gap-2">
-        <legend class="text-sm font-semibold text-base-content/80">Select Library</legend>
-        <div class="grid gap-3 sm:grid-cols-2">
-          <%= for path <- @library_paths do %>
-            <label class={[
-              "group card card-compact bg-base-200/40 border border-base-200 cursor-pointer transition-all duration-150 rounded-xl",
-              "hover:border-base-300 hover:bg-base-200/80",
-              "has-checked:border-primary has-checked:bg-primary/5 has-checked:ring-1 has-checked:ring-primary"
-            ]}>
-              <input
-                type="radio"
-                name="library_path_id"
-                value={path.id}
-                class="sr-only"
-                checked={
-                  path.id == (@selected_library_path_id || default_library_path_id(@library_paths))
-                }
-              />
-              <div class="card-body flex-row items-center gap-3.5 p-3.5">
-                <div class={[
-                  "flex items-center justify-center w-10 h-10 rounded-lg shrink-0 transition-transform group-hover:scale-105",
-                  library_type_bg_class(path.type)
-                ]}>
-                  <.icon name={library_type_icon(path.type)} class="w-5 h-5" />
-                </div>
-                <div class="flex-1 min-w-0">
-                  <span class={[
-                    "badge badge-xs font-medium mb-1",
-                    library_type_badge_class(path.type)
-                  ]}>
-                    {library_type_display(path.type)}
-                  </span>
-                  <p class="font-mono text-xs truncate text-base-content/70 group-has-checked:text-base-content group-has-checked:font-semibold">
-                    {path.path}
-                  </p>
-                </div>
-                <div class="shrink-0 flex items-center justify-center w-5 h-5 rounded-full border border-base-300 group-has-checked:border-primary group-has-checked:bg-primary text-primary-content transition-all">
-                  <.icon
-                    name="hero-check"
-                    class="w-3.5 h-3.5 opacity-0 group-has-checked:opacity-100 transition-opacity"
-                  />
-                </div>
-              </div>
-            </label>
-          <% end %>
-        </div>
-      </fieldset>
+      <input type="hidden" name="library_path_id" value={@library_path.id} />
 
-      <div class="max-w-md">
-        <.input
-          id="start-run-mode"
-          name="mode"
-          type="select"
-          label="Mode"
-          value="review"
-          options={[
-            {"Review every match before it is added", "review"},
-            {"Add confident matches automatically", "unattended"}
-          ]}
+      <div class="flex-1 min-w-0">
+        <h2 class="text-lg font-bold">Scan this library</h2>
+        <p class="text-xs text-base-content/60 mt-1 font-mono truncate">{@library_path.path}</p>
+      </div>
+
+      <label class="flex items-center gap-3 cursor-pointer rounded-xl border border-base-200 bg-base-200/40 px-3.5 py-2.5 hover:bg-base-200 transition-colors">
+        <input
+          id="auto-import-toggle"
+          type="checkbox"
+          name="auto_import"
+          value="true"
+          checked
+          phx-hook="PersistedCheckbox"
+          phx-update="ignore"
+          class="toggle toggle-primary toggle-sm"
         />
-      </div>
+        <span class="text-sm font-medium whitespace-nowrap">Automatically import confident matches</span>
+      </label>
 
-      <p class="text-xs text-base-content/60 flex items-center gap-1.5">
-        <.icon name="hero-information-circle" class="w-4 h-4 shrink-0 text-base-content/40" />
-        <span>
-          The run keeps going if you close this page. You can stop it at any point and keep
-          everything it has already done.
-        </span>
-      </p>
-
-      <div>
-        <.button id="start-run-button" type="submit" variant="primary">
-          <.icon name="hero-play" class="w-4 h-4 mr-1.5" /> Start
-        </.button>
-      </div>
+      <.button id="start-run-button" type="submit" variant="primary">
+        <.icon name="hero-play" class="w-4 h-4 mr-1.5" /> Start scan
+      </.button>
     </.form>
     """
   end
-
-  # Marks the first option as selected rather than leaving the select with no
-  # value at all, so what the form submits matches what a user sees before they
-  # touch it.
-  defp default_library_path_id([%{id: id} | _rest]), do: id
-  defp default_library_path_id(_library_paths), do: nil
 
   attr :run, :map, required: true
 
@@ -182,10 +105,7 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
           <span class="font-semibold text-base">{phase_label(@run.phase)}</span>
           <span :if={@run.status == :stopping} class="badge badge-warning badge-sm">Stopping</span>
         </div>
-        <span class="badge badge-ghost badge-sm">{mode_label(@run.mode)} mode</span>
       </div>
-
-      <.run_stats run={@run} />
 
       <div
         :if={@run.current_file}
@@ -219,21 +139,31 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
 
   defp run_outcome(assigns) do
     ~H"""
-    <div id="run-outcome" class="flex flex-col gap-4">
-      <div class={[
-        "alert flex items-center justify-between gap-3 py-3 px-4 shadow-sm",
-        outcome_alert_class(@run.status)
-      ]}>
+    <div id="run-outcome" class="flex flex-col gap-3">
+      <div
+        :if={@run.status == :done}
+        class="flex items-center justify-between gap-3 rounded-xl border border-base-200 bg-base-200/40 px-4 py-3"
+      >
         <div class="flex items-center gap-2.5 min-w-0">
-          <.icon name={outcome_icon(@run.status)} class="w-5 h-5 shrink-0" />
-          <span class="font-semibold">{outcome_label(@run.status)}</span>
-          <span class="badge badge-sm badge-ghost opacity-80">{mode_label(@run.mode)}</span>
+          <.icon name="hero-check-circle" class="w-5 h-5 shrink-0 text-success" />
+          <span class="font-semibold">Scan complete</span>
         </div>
 
-        <.outcome_review_cta pending_groups={@pending_groups} />
+        <span :if={@pending_groups > 0} class="badge badge-sm badge-ghost shrink-0">
+          {@pending_groups} {if @pending_groups == 1, do: "group", else: "groups"} ready to review
+        </span>
       </div>
 
-      <.run_stats run={@run} />
+      <div
+        :if={@run.status in [:failed, :stopped]}
+        class={[
+          "alert flex items-center gap-2.5 py-3 px-4 shadow-sm",
+          outcome_alert_class(@run.status)
+        ]}
+      >
+        <.icon name={outcome_icon(@run.status)} class="w-5 h-5 shrink-0" />
+        <span class="font-semibold">{outcome_label(@run.status)}</span>
+      </div>
 
       <%!--
         Rendered for any status that carries an error, not only :failed. A run
@@ -252,109 +182,19 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
     """
   end
 
-  # `pending_groups` is `ImportGroups.band_counts/1`'s `:total` for this run's
-  # own library path, computed once in the parent LiveView
-  # (`group_count_for_outcome/1`) so this component never queries the DB from
-  # its body. It is a group count, not a file count -- one group can hold a
-  # whole season -- matching the "group(s)" language the rest of this page
-  # uses for accept/ignore counts.
-  attr :pending_groups, :integer, default: 0
-
-  defp outcome_review_cta(assigns) do
-    ~H"""
-    <div :if={@pending_groups > 0} class="shrink-0">
-      <.link navigate={~p"/import"} class="btn btn-xs sm:btn-sm btn-primary shadow-sm">
-        <.icon name="hero-inbox-stack" class="w-4 h-4 mr-1" />
-        Review {@pending_groups} group(s) that need attention
-      </.link>
-    </div>
-    """
-  end
-
-  attr :run, :map, required: true
-
-  defp run_stats(assigns) do
-    ~H"""
-    <div class="stats stats-horizontal bg-base-200/50 border border-base-200 w-full grid grid-cols-3 divide-x divide-base-200 rounded-xl overflow-hidden">
-      <div class="stat px-4 py-3">
-        <div class="stat-title text-xs font-medium text-base-content/60">Found</div>
-        <div class="stat-value text-xl font-bold text-base-content">
-          {number(@run.files_discovered)}
-        </div>
-      </div>
-      <div class="stat px-4 py-3">
-        <div class="stat-title text-xs font-medium text-base-content/60">Matched</div>
-        <div class="stat-value text-xl font-bold text-base-content">{number(@run.files_matched)}</div>
-      </div>
-      <div class="stat px-4 py-3">
-        <div class="stat-title text-xs font-medium text-base-content/60">Added</div>
-        <div class="stat-value text-xl font-bold text-success">{number(@run.files_linked)}</div>
-      </div>
-    </div>
-    """
-  end
-
   defp phase_label(:scanning), do: "Finding files"
   defp phase_label(:matching), do: "Identifying files"
   defp phase_label(:finished), do: "Finished"
 
-  defp outcome_label(:done), do: "Import finished"
-  defp outcome_label(:failed), do: "Import failed"
-  defp outcome_label(:stopped), do: "Import stopped"
+  defp outcome_label(:failed), do: "Scan failed"
+  defp outcome_label(:stopped), do: "Scan stopped"
 
   defp error_label(:failed), do: "Error details"
   defp error_label(_status), do: "What happened"
 
-  defp outcome_alert_class(:done), do: "alert-success"
   defp outcome_alert_class(:failed), do: "alert-error"
   defp outcome_alert_class(:stopped), do: "alert-warning"
 
-  defp outcome_badge_class(:done), do: "badge-success"
-  defp outcome_badge_class(:failed), do: "badge-error"
-  defp outcome_badge_class(:stopped), do: "badge-warning"
-
-  defp outcome_icon(:done), do: "hero-check-circle"
   defp outcome_icon(:failed), do: "hero-exclamation-triangle"
   defp outcome_icon(:stopped), do: "hero-stop-circle"
-
-  defp mode_label(:review), do: "Review"
-  defp mode_label(:unattended), do: "Unattended"
-
-  # Thousands separators, because these numbers get large enough that a bare
-  # digit string stops being readable at a glance.
-  defp number(n) when is_integer(n) do
-    n
-    |> Integer.to_string()
-    |> String.graphemes()
-    |> Enum.reverse()
-    |> Enum.chunk_every(3)
-    |> Enum.map_join(",", &Enum.join/1)
-    |> String.reverse()
-  end
-
-  defp number(_), do: "0"
-
-  # Icon, badge and accent styling per library type, mirroring the old
-  # wizard's path-selection cards. `LibraryPath` only knows :movies, :series
-  # and :mixed today; the fallbacks exist so a new type degrades visibly
-  # instead of crashing the template.
-  defp library_type_icon(:series), do: "hero-tv"
-  defp library_type_icon(:movies), do: "hero-film"
-  defp library_type_icon(:mixed), do: "hero-square-3-stack-3d"
-  defp library_type_icon(_), do: "hero-folder"
-
-  defp library_type_bg_class(:series), do: "bg-info/10 text-info"
-  defp library_type_bg_class(:movies), do: "bg-accent/10 text-accent"
-  defp library_type_bg_class(:mixed), do: "bg-secondary/10 text-secondary"
-  defp library_type_bg_class(_), do: "bg-base-200 text-base-content/70"
-
-  defp library_type_badge_class(:series), do: "badge-info"
-  defp library_type_badge_class(:movies), do: "badge-accent"
-  defp library_type_badge_class(:mixed), do: "badge-secondary"
-  defp library_type_badge_class(_), do: "badge-ghost"
-
-  defp library_type_display(:series), do: "TV Series"
-  defp library_type_display(:movies), do: "Movies"
-  defp library_type_display(:mixed), do: "Mixed"
-  defp library_type_display(type), do: to_string(type)
 end

--- a/lib/mydia_web/live/import_media_live/run_control.ex
+++ b/lib/mydia_web/live/import_media_live/run_control.ex
@@ -11,7 +11,6 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
   attr :library_path, :map, default: nil
   attr :active_run, :map, default: nil
   attr :outcome_run, :map, default: nil
-  attr :outcome_group_count, :integer, default: 0
 
   def run_control(assigns) do
     ~H"""
@@ -44,11 +43,7 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
         </div>
 
         <div :if={is_nil(@active_run)} class="flex flex-col gap-5">
-          <.run_outcome
-            :if={@outcome_run}
-            run={@outcome_run}
-            pending_groups={@outcome_group_count}
-          />
+          <.run_outcome :if={@outcome_run} run={@outcome_run} />
           <.start_form library_path={@library_path} />
         </div>
       <% end %>
@@ -129,31 +124,14 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
     """
   end
 
-  # Shown in place of the start form once a run has reached a terminal
-  # state (:done, :failed, or :stopped). The run row stays exactly as the
-  # coordinator left it -- nothing here is socket state -- so this renders
-  # identically whether the outcome arrived over PubSub in-session or was
-  # read back from `Library.last_import_run/1` after a reload.
+  # Failed and stopped outcomes persist across reloads so recovery details
+  # remain visible. Successful completion is transient and belongs beside
+  # the review results instead of in the next scan's controls.
   attr :run, :map, required: true
-  attr :pending_groups, :integer, default: 0
 
   defp run_outcome(assigns) do
     ~H"""
     <div id="run-outcome" class="flex flex-col gap-3">
-      <div
-        :if={@run.status == :done}
-        class="flex items-center justify-between gap-3 rounded-xl border border-base-200 bg-base-200/40 px-4 py-3"
-      >
-        <div class="flex items-center gap-2.5 min-w-0">
-          <.icon name="hero-check-circle" class="w-5 h-5 shrink-0 text-success" />
-          <span class="font-semibold">Scan complete</span>
-        </div>
-
-        <span :if={@pending_groups > 0} class="badge badge-sm badge-ghost shrink-0">
-          {@pending_groups} {if @pending_groups == 1, do: "group", else: "groups"} ready to review
-        </span>
-      </div>
-
       <div
         :if={@run.status in [:failed, :stopped]}
         class={[

--- a/lib/mydia_web/live/import_media_live/run_control.ex
+++ b/lib/mydia_web/live/import_media_live/run_control.ex
@@ -34,7 +34,7 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
             <div class="w-12 h-12 rounded-2xl bg-primary/10 text-primary flex items-center justify-center mx-auto mb-3">
               <span class="loading loading-spinner loading-md" />
             </div>
-            <h2 class="text-2xl font-bold">Scanning {@library_path.path}</h2>
+            <h2 class="text-2xl font-bold">Scanning library</h2>
             <p class="text-sm text-base-content/60 mt-1 font-mono truncate">
               {@library_path.path}
             </p>
@@ -132,13 +132,10 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
   defp run_outcome(assigns) do
     ~H"""
     <div id="run-outcome" class="flex flex-col gap-3">
-      <div
-        :if={@run.status in [:failed, :stopped]}
-        class={[
-          "alert flex items-center gap-2.5 py-3 px-4 shadow-sm",
-          outcome_alert_class(@run.status)
-        ]}
-      >
+      <div class={[
+        "alert flex items-center gap-2.5 py-3 px-4 shadow-sm",
+        outcome_alert_class(@run.status)
+      ]}>
         <.icon name={outcome_icon(@run.status)} class="w-5 h-5 shrink-0" />
         <span class="font-semibold">{outcome_label(@run.status)}</span>
       </div>

--- a/lib/mydia_web/live/import_media_live/run_control.ex
+++ b/lib/mydia_web/live/import_media_live/run_control.ex
@@ -9,16 +9,44 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
   use MydiaWeb, :html
 
   attr :library_paths, :list, required: true
+  attr :selected_library_path_id, :string, default: nil
   attr :active_run, :map, default: nil
   attr :outcome_run, :map, default: nil
   attr :outcome_group_count, :integer, default: 0
+  attr :open, :boolean, default: true
 
   def run_control(assigns) do
     ~H"""
-    <section id="import-run-control" class="card bg-base-100 shadow-xl">
-      <div class="card-body">
-        <h2 class="card-title">Import a library</h2>
+    <details
+      id="import-run-control"
+      class="group collapse collapse-arrow bg-base-100 shadow-md border border-base-200 rounded-2xl"
+      open={@open}
+    >
+      <summary class="collapse-title p-4 sm:p-5 cursor-pointer select-none flex items-center justify-between gap-4">
+        <div class="flex items-center gap-3 min-w-0">
+          <div class="w-8 h-8 rounded-lg bg-primary/10 text-primary flex items-center justify-center shrink-0">
+            <.icon name="hero-arrow-down-tray" class="w-4 h-4" />
+          </div>
+          <div class="flex items-center gap-2.5 flex-wrap min-w-0">
+            <h2 class="text-lg sm:text-xl font-bold">Import a library</h2>
+            <%= cond do %>
+              <% @active_run -> %>
+                <span class="badge badge-primary badge-sm gap-1 font-medium">
+                  <span class="loading loading-spinner loading-xs"></span>
+                  {phase_label(@active_run.phase)}
+                </span>
+              <% @outcome_run -> %>
+                <span class={["badge badge-sm font-medium", outcome_badge_class(@outcome_run.status)]}>
+                  {outcome_label(@outcome_run.status)}
+                </span>
+              <% true -> %>
+                <span class="badge badge-ghost badge-sm text-xs font-normal">New Import</span>
+            <% end %>
+          </div>
+        </div>
+      </summary>
 
+      <div class="collapse-content px-4 pb-4 sm:px-6 sm:pb-6 flex flex-col gap-5 pt-1">
         <.run_outcome
           :if={@outcome_run}
           run={@outcome_run}
@@ -28,14 +56,18 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
         <%= if @active_run do %>
           <.run_progress run={@active_run} />
         <% else %>
-          <.start_form library_paths={@library_paths} />
+          <.start_form
+            library_paths={@library_paths}
+            selected_library_path_id={@selected_library_path_id}
+          />
         <% end %>
       </div>
-    </section>
+    </details>
     """
   end
 
   attr :library_paths, :list, required: true
+  attr :selected_library_path_id, :string, default: nil
 
   defp start_form(assigns) do
     ~H"""
@@ -50,68 +82,85 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
       :if={@library_paths != []}
       for={%{}}
       id="start-run-form"
+      phx-change="select_library"
       phx-submit="start_run"
-      class="flex flex-col gap-4"
+      class="flex flex-col gap-5"
     >
       <fieldset class="flex flex-col gap-2">
-        <legend class="text-sm font-medium opacity-80">Library</legend>
-        <div class="grid gap-3">
+        <legend class="text-sm font-semibold text-base-content/80">Select Library</legend>
+        <div class="grid gap-3 sm:grid-cols-2">
           <%= for path <- @library_paths do %>
             <label class={[
-              "group card card-compact bg-base-100 border border-base-300 cursor-pointer transition-all duration-200",
-              "hover:border-primary hover:shadow-lg",
-              "has-checked:border-primary has-checked:bg-primary/5 has-checked:ring-2 has-checked:ring-primary/40"
+              "group card card-compact bg-base-200/40 border border-base-200 cursor-pointer transition-all duration-150 rounded-xl",
+              "hover:border-base-300 hover:bg-base-200/80",
+              "has-checked:border-primary has-checked:bg-primary/5 has-checked:ring-1 has-checked:ring-primary"
             ]}>
               <input
                 type="radio"
                 name="library_path_id"
                 value={path.id}
                 class="sr-only"
-                checked={path.id == default_library_path_id(@library_paths)}
+                checked={
+                  path.id == (@selected_library_path_id || default_library_path_id(@library_paths))
+                }
               />
-              <div class="card-body flex-row items-center gap-4">
+              <div class="card-body flex-row items-center gap-3.5 p-3.5">
                 <div class={[
-                  "flex items-center justify-center w-12 h-12 rounded-lg shrink-0 transition-transform group-hover:scale-105",
+                  "flex items-center justify-center w-10 h-10 rounded-lg shrink-0 transition-transform group-hover:scale-105",
                   library_type_bg_class(path.type)
                 ]}>
-                  <.icon name={library_type_icon(path.type)} class="w-6 h-6" />
+                  <.icon name={library_type_icon(path.type)} class="w-5 h-5" />
                 </div>
                 <div class="flex-1 min-w-0">
-                  <span class={["badge badge-sm mb-1", library_type_badge_class(path.type)]}>
+                  <span class={[
+                    "badge badge-xs font-medium mb-1",
+                    library_type_badge_class(path.type)
+                  ]}>
                     {library_type_display(path.type)}
                   </span>
-                  <p class="font-mono text-sm truncate text-base-content/80 group-has-checked:text-base-content">
+                  <p class="font-mono text-xs truncate text-base-content/70 group-has-checked:text-base-content group-has-checked:font-semibold">
                     {path.path}
                   </p>
                 </div>
-                <.icon
-                  name="hero-check"
-                  class="w-5 h-5 text-primary shrink-0 opacity-0 group-has-checked:opacity-100 transition-opacity"
-                />
+                <div class="shrink-0 flex items-center justify-center w-5 h-5 rounded-full border border-base-300 group-has-checked:border-primary group-has-checked:bg-primary text-primary-content transition-all">
+                  <.icon
+                    name="hero-check"
+                    class="w-3.5 h-3.5 opacity-0 group-has-checked:opacity-100 transition-opacity"
+                  />
+                </div>
               </div>
             </label>
           <% end %>
         </div>
       </fieldset>
 
-      <.input
-        id="start-run-mode"
-        name="mode"
-        type="select"
-        label="Mode"
-        value="review"
-        options={[
-          {"Review every match before it is added", "review"},
-          {"Add confident matches automatically", "unattended"}
-        ]}
-      />
+      <div class="max-w-md">
+        <.input
+          id="start-run-mode"
+          name="mode"
+          type="select"
+          label="Mode"
+          value="review"
+          options={[
+            {"Review every match before it is added", "review"},
+            {"Add confident matches automatically", "unattended"}
+          ]}
+        />
+      </div>
 
-      <p class="text-sm opacity-70">
-        The run keeps going if you close this page. You can stop it at any point and keep
-        everything it has already done.
+      <p class="text-xs text-base-content/60 flex items-center gap-1.5">
+        <.icon name="hero-information-circle" class="w-4 h-4 shrink-0 text-base-content/40" />
+        <span>
+          The run keeps going if you close this page. You can stop it at any point and keep
+          everything it has already done.
+        </span>
       </p>
 
-      <.button id="start-run-button" type="submit" variant="primary">Start</.button>
+      <div>
+        <.button id="start-run-button" type="submit" variant="primary">
+          <.icon name="hero-play" class="w-4 h-4 mr-1.5" /> Start
+        </.button>
+      </div>
     </.form>
     """
   end
@@ -126,25 +175,36 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
 
   defp run_progress(assigns) do
     ~H"""
-    <div id="run-progress" class="flex flex-col gap-3">
-      <div class="flex items-center gap-2">
-        <span class="loading loading-spinner loading-sm" />
-        <span class="font-medium">{phase_label(@run.phase)}</span>
-        <span :if={@run.status == :stopping} class="badge badge-warning">Stopping</span>
+    <div id="run-progress" class="flex flex-col gap-4">
+      <div class="flex items-center justify-between gap-3 flex-wrap">
+        <div class="flex items-center gap-2.5">
+          <span class="loading loading-spinner loading-sm text-primary" />
+          <span class="font-semibold text-base">{phase_label(@run.phase)}</span>
+          <span :if={@run.status == :stopping} class="badge badge-warning badge-sm">Stopping</span>
+        </div>
+        <span class="badge badge-ghost badge-sm">{mode_label(@run.mode)} mode</span>
       </div>
 
       <.run_stats run={@run} />
 
-      <p :if={@run.current_file} class="text-sm opacity-70 truncate">{@run.current_file}</p>
-
-      <.button
-        id="stop-run-button"
-        phx-click="stop_run"
-        disabled={@run.status == :stopping}
-        class="btn btn-outline btn-warning"
+      <div
+        :if={@run.current_file}
+        class="bg-base-200/50 rounded-lg px-3 py-2 text-xs font-mono text-base-content/70 truncate flex items-center gap-2 border border-base-200"
       >
-        Stop and keep progress
-      </.button>
+        <.icon name="hero-document" class="w-3.5 h-3.5 shrink-0 opacity-50" />
+        <span class="truncate">{@run.current_file}</span>
+      </div>
+
+      <div class="pt-1">
+        <.button
+          id="stop-run-button"
+          phx-click="stop_run"
+          disabled={@run.status == :stopping}
+          class="btn btn-sm btn-outline btn-warning"
+        >
+          <.icon name="hero-stop" class="w-4 h-4 mr-1" /> Stop and keep progress
+        </.button>
+      </div>
     </div>
     """
   end
@@ -159,19 +219,21 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
 
   defp run_outcome(assigns) do
     ~H"""
-    <div
-      id="run-outcome"
-      class={["alert flex-col items-start gap-3", outcome_alert_class(@run.status)]}
-    >
-      <div class="flex items-center gap-2 w-full">
-        <.icon name={outcome_icon(@run.status)} class="w-5 h-5 shrink-0" />
-        <span class="font-medium">{outcome_label(@run.status)}</span>
-        <span class="badge badge-ghost">{mode_label(@run.mode)}</span>
+    <div id="run-outcome" class="flex flex-col gap-4">
+      <div class={[
+        "alert flex items-center justify-between gap-3 py-3 px-4 shadow-sm",
+        outcome_alert_class(@run.status)
+      ]}>
+        <div class="flex items-center gap-2.5 min-w-0">
+          <.icon name={outcome_icon(@run.status)} class="w-5 h-5 shrink-0" />
+          <span class="font-semibold">{outcome_label(@run.status)}</span>
+          <span class="badge badge-sm badge-ghost opacity-80">{mode_label(@run.mode)}</span>
+        </div>
+
+        <.outcome_review_cta pending_groups={@pending_groups} />
       </div>
 
       <.run_stats run={@run} />
-
-      <.outcome_review_cta pending_groups={@pending_groups} />
 
       <%!--
         Rendered for any status that carries an error, not only :failed. A run
@@ -179,9 +241,12 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
         lands on :stopped with the explanation in this field, and hiding it
         would leave the user with a bare "Import stopped" and no reason.
       --%>
-      <div :if={@run.error} class="w-full">
-        <p class="text-sm opacity-70 mb-1">{error_label(@run.status)}</p>
-        <pre class="text-xs whitespace-pre-wrap break-all bg-base-100/60 rounded-lg p-2">{@run.error}</pre>
+      <div :if={@run.error} class="bg-error/10 border border-error/20 rounded-xl p-3.5 text-xs">
+        <p class="font-semibold text-error mb-1.5 flex items-center gap-1.5">
+          <.icon name="hero-exclamation-triangle" class="w-4 h-4 shrink-0" />
+          {error_label(@run.status)}
+        </p>
+        <pre class="font-mono text-xs whitespace-pre-wrap break-all bg-base-100/90 rounded-lg p-2.5 text-base-content/90 border border-base-200">{@run.error}</pre>
       </div>
     </div>
     """
@@ -197,9 +262,9 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
 
   defp outcome_review_cta(assigns) do
     ~H"""
-    <div :if={@pending_groups > 0} class="w-full">
-      <.link navigate={~p"/import"} class="btn btn-sm btn-outline">
-        <.icon name="hero-inbox-stack" class="w-4 h-4" />
+    <div :if={@pending_groups > 0} class="shrink-0">
+      <.link navigate={~p"/import"} class="btn btn-xs sm:btn-sm btn-primary shadow-sm">
+        <.icon name="hero-inbox-stack" class="w-4 h-4 mr-1" />
         Review {@pending_groups} group(s) that need attention
       </.link>
     </div>
@@ -210,18 +275,20 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
 
   defp run_stats(assigns) do
     ~H"""
-    <div class="stats stats-horizontal shadow">
-      <div class="stat">
-        <div class="stat-title">Found</div>
-        <div class="stat-value text-2xl">{number(@run.files_discovered)}</div>
+    <div class="stats stats-horizontal bg-base-200/50 border border-base-200 w-full grid grid-cols-3 divide-x divide-base-200 rounded-xl overflow-hidden">
+      <div class="stat px-4 py-3">
+        <div class="stat-title text-xs font-medium text-base-content/60">Found</div>
+        <div class="stat-value text-xl font-bold text-base-content">
+          {number(@run.files_discovered)}
+        </div>
       </div>
-      <div class="stat">
-        <div class="stat-title">Matched</div>
-        <div class="stat-value text-2xl">{number(@run.files_matched)}</div>
+      <div class="stat px-4 py-3">
+        <div class="stat-title text-xs font-medium text-base-content/60">Matched</div>
+        <div class="stat-value text-xl font-bold text-base-content">{number(@run.files_matched)}</div>
       </div>
-      <div class="stat">
-        <div class="stat-title">Added</div>
-        <div class="stat-value text-2xl">{number(@run.files_linked)}</div>
+      <div class="stat px-4 py-3">
+        <div class="stat-title text-xs font-medium text-base-content/60">Added</div>
+        <div class="stat-value text-xl font-bold text-success">{number(@run.files_linked)}</div>
       </div>
     </div>
     """
@@ -241,6 +308,10 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
   defp outcome_alert_class(:done), do: "alert-success"
   defp outcome_alert_class(:failed), do: "alert-error"
   defp outcome_alert_class(:stopped), do: "alert-warning"
+
+  defp outcome_badge_class(:done), do: "badge-success"
+  defp outcome_badge_class(:failed), do: "badge-error"
+  defp outcome_badge_class(:stopped), do: "badge-warning"
 
   defp outcome_icon(:done), do: "hero-check-circle"
   defp outcome_icon(:failed), do: "hero-exclamation-triangle"

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -72,7 +72,12 @@
 
         <%!-- Import button (shown on Movies and TV Shows pages) --%>
         <%= if @filter_type in ["movie", "tv_show"] do %>
-          <.link navigate={~p"/import"} class="btn btn-secondary btn-sm">
+          <.link
+            navigate={
+              if @filter_type == "movie", do: ~p"/import?type=movies", else: ~p"/import?type=tv"
+            }
+            class="btn btn-secondary btn-sm"
+          >
             <.icon name="hero-arrow-down-tray" class="w-5 h-5" />
             <span class="hidden sm:inline ml-1">Import Files</span>
           </.link>

--- a/test/mydia/import_groups_test.exs
+++ b/test/mydia/import_groups_test.exs
@@ -51,6 +51,36 @@ defmodule Mydia.ImportGroupsTest do
     end
   end
 
+  describe "clear_for_library/1" do
+    test "clears only the selected library's review groups and finished scan history" do
+      selected = library_path_fixture(%{type: "movies"})
+      other = library_path_fixture(%{type: "series"})
+      selected_group = group(selected, cluster_key: "selected")
+      other_group = group(other, cluster_key: "other")
+
+      {:ok, run} =
+        Mydia.Library.create_import_run(%{library_path_id: selected.id, mode: :review})
+
+      {:ok, _run} = Mydia.Library.update_import_run(run, %{status: :done, phase: :finished})
+
+      assert {:ok, 1} = ImportGroups.clear_for_library(selected.id)
+      refute Repo.get(ImportGroup, selected_group.id)
+      assert Repo.get(ImportGroup, other_group.id)
+      refute Mydia.Library.last_import_run(selected.id)
+    end
+
+    test "refuses to clear while the selected library is scanning" do
+      library_path = library_path_fixture(%{type: "movies"})
+      import_group = group(library_path, cluster_key: "active")
+
+      {:ok, _run} =
+        Mydia.Library.create_import_run(%{library_path_id: library_path.id, mode: :review})
+
+      assert {:error, :active_run} = ImportGroups.clear_for_library(library_path.id)
+      assert Repo.get(ImportGroup, import_group.id)
+    end
+  end
+
   describe "band_counts/1" do
     test "counts each band" do
       lp = library_path_fixture(%{type: "series"})

--- a/test/mydia/import_groups_test.exs
+++ b/test/mydia/import_groups_test.exs
@@ -1174,6 +1174,20 @@ defmodule Mydia.ImportGroupsTest do
       assert Repo.reload!(g2).status == "pending"
       assert Repo.reload!(g3).status == "ignored"
     end
+
+    test "does not rewrite a pending group selected by a stale ignored scope" do
+      lp = library_path_fixture(%{type: "series"})
+      decided_at = ~U[2026-01-01 12:00:00Z]
+      pending = group(lp, cluster_key: "pending", status: "pending", decided_at: decided_at)
+
+      scope =
+        lp.id
+        |> SelectionScope.new("ignored")
+        |> SelectionScope.select_page([pending.id])
+
+      assert {:ok, 0} = ImportGroups.restore(scope)
+      assert Repo.reload!(pending).decided_at == decided_at
+    end
   end
 
   describe "create_local_shows/1" do

--- a/test/mydia/import_groups_test.exs
+++ b/test/mydia/import_groups_test.exs
@@ -578,6 +578,41 @@ defmodule Mydia.ImportGroupsTest do
 
       assert Repo.reload!(group).provider_id == "222"
     end
+
+    test "an applied group with newly unresolved files reverts to pending", %{
+      library_path: lp
+    } do
+      _f1 =
+        unresolved_file(
+          lp,
+          "Show (2023)/Season 01/ep1.mkv",
+          provider_id: "111",
+          provider_type: "tvdb",
+          confidence: 0.9
+        )
+
+      {:ok, _} = ImportGroups.upsert_for_library(lp)
+      group = Repo.one!(ImportGroup)
+      assert group.status == "pending"
+
+      # Simulate previous files having linked and group marked applied
+      group |> Ecto.Changeset.change(status: "applied", unresolved_count: 0) |> Repo.update!()
+
+      # A new unresolved file arrives in the folder
+      _f2 =
+        unresolved_file(
+          lp,
+          "Show (2023)/Season 01/ep2.mkv",
+          provider_id: "111",
+          provider_type: "tvdb",
+          confidence: 0.9
+        )
+
+      {:ok, _} = ImportGroups.upsert_for_library(lp)
+      reloaded = Repo.reload!(group)
+      assert reloaded.status == "pending"
+      assert reloaded.unresolved_count == 2
+    end
   end
 
   describe "create_local_show/1" do
@@ -926,6 +961,279 @@ defmodule Mydia.ImportGroupsTest do
       # own exclusion and left permanently stuck. Staying "pending" is what
       # keeps it reachable.
       assert Repo.reload!(group).status == "pending"
+    end
+  end
+
+  describe "update_member_episode/3" do
+    test "updates existing candidate season and episode, updating group season_span and numbered_count" do
+      lp = library_path_fixture(%{type: "series"})
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Show/Season 01/S01E01.mkv"
+        })
+
+      %MatchCandidate{}
+      |> MatchCandidate.changeset(%{
+        media_file_id: file.id,
+        rank: 0,
+        provider_type: "tvdb",
+        provider_id: "123",
+        title: "Show",
+        confidence: 1.0,
+        parsed_info: %{"season" => 1, "episodes" => [1]}
+      })
+      |> Repo.insert!()
+
+      {:ok, _} = ImportGroups.upsert_for_library(lp)
+      group = Repo.one!(ImportGroup)
+      assert ImportGroup.season_span(group) == [1]
+      assert group.numbered_count == 1
+
+      assert {:ok, result} = ImportGroups.update_member_episode(file.id, 2, 5)
+      assert result.media_file.id == file.id
+      assert result.candidate.parsed_info["season"] == 2
+      assert result.candidate.parsed_info["episodes"] == [5]
+
+      reloaded_group = Repo.reload!(group)
+      assert ImportGroup.season_span(reloaded_group) == [2]
+      assert reloaded_group.numbered_count == 1
+    end
+
+    test "creates a rank-0 candidate if none existed and accepts string inputs" do
+      lp = library_path_fixture(%{type: "series"})
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Unmatched/sample.mkv"
+        })
+
+      {:ok, _} = ImportGroups.upsert_for_library(lp)
+      group = Repo.one!(ImportGroup)
+      assert group.numbered_count == 0
+
+      assert {:ok, result} = ImportGroups.update_member_episode(file.id, "3", "12")
+      assert result.candidate.parsed_info["season"] == 3
+      assert result.candidate.parsed_info["episodes"] == [12]
+
+      reloaded_group = Repo.reload!(group)
+      assert ImportGroup.season_span(reloaded_group) == [3]
+      assert reloaded_group.numbered_count == 1
+    end
+
+    test "clears episode when passed empty strings or nil" do
+      lp = library_path_fixture(%{type: "series"})
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Show/Season 01/S01E01.mkv"
+        })
+
+      assert {:ok, result} = ImportGroups.update_member_episode(file.id, 1, 1)
+      assert result.candidate.parsed_info["episodes"] == [1]
+
+      assert {:ok, cleared} = ImportGroups.update_member_episode(file.id, "", "")
+      assert is_nil(cleared.candidate.parsed_info["season"])
+      assert cleared.candidate.parsed_info["episodes"] == []
+    end
+
+    test "returns {:error, :not_found} for unknown media file" do
+      assert {:error, :not_found} =
+               ImportGroups.update_member_episode(Ecto.UUID.generate(), 1, 1)
+    end
+  end
+
+  describe "movie library independence" do
+    test "each movie file gets its own independent group with no season span" do
+      lp = library_path_fixture(%{type: "movies"})
+
+      f1 =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Inception (2010)/Inception.2010.1080p.mkv"
+        })
+
+      f2 =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Inception (2010)/Inception.2010.720p.mkv"
+        })
+
+      f3 =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Loose_Movie.mkv"
+        })
+
+      {:ok, %{groups: 3, files: 3}} = ImportGroups.upsert_for_library(lp)
+
+      groups = Repo.all(ImportGroup)
+      assert length(groups) == 3
+
+      for group <- groups do
+        assert group.file_count == 1
+        assert group.media_type == "movie"
+        assert ImportGroup.season_span(group) == []
+      end
+
+      # Each file is stamped to its own group
+      f1_reloaded = Repo.reload!(f1)
+      f2_reloaded = Repo.reload!(f2)
+      f3_reloaded = Repo.reload!(f3)
+
+      refute is_nil(f1_reloaded.import_group_id)
+      refute is_nil(f2_reloaded.import_group_id)
+      refute is_nil(f3_reloaded.import_group_id)
+
+      assert f1_reloaded.import_group_id != f2_reloaded.import_group_id
+      assert f1_reloaded.import_group_id != f3_reloaded.import_group_id
+    end
+
+    test "prunes obsolete pending groups that have no remaining unresolved files" do
+      lp = library_path_fixture(%{type: "movies"})
+
+      # Seed an obsolete group directly
+      obsolete_group =
+        %ImportGroup{}
+        |> ImportGroup.changeset(%{
+          library_path_id: lp.id,
+          anchor_path: "",
+          cluster_key: "__root__",
+          display_title: "Loose files",
+          file_count: 3,
+          unresolved_count: 3,
+          status: "pending"
+        })
+        |> Repo.insert!()
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Inception.mkv"
+        })
+
+      {:ok, %{groups: 1, files: 1}} = ImportGroups.upsert_for_library(lp)
+
+      # Obsolete group is deleted; new group exists for the file
+      assert is_nil(Repo.get(ImportGroup, obsolete_group.id))
+      assert [active_group] = Repo.all(ImportGroup)
+      assert active_group.display_title == "Inception"
+      assert Repo.reload!(file).import_group_id == active_group.id
+    end
+  end
+
+  describe "restore/1 with SelectionScope" do
+    test "restores selected ignored groups back to pending" do
+      lp = library_path_fixture(%{type: "series"})
+
+      g1 = group(lp, cluster_key: "g1", status: "ignored")
+      g2 = group(lp, cluster_key: "g2", status: "ignored")
+      g3 = group(lp, cluster_key: "g3", status: "ignored")
+
+      scope =
+        lp.id
+        |> SelectionScope.new("ignored")
+        |> SelectionScope.select_page([g1.id, g2.id])
+
+      assert {:ok, 2} = ImportGroups.restore(scope)
+
+      assert Repo.reload!(g1).status == "pending"
+      assert Repo.reload!(g2).status == "pending"
+      assert Repo.reload!(g3).status == "ignored"
+    end
+  end
+
+  describe "create_local_shows/1" do
+    test "creates local shows for unmatched groups in selection" do
+      lp = library_path_fixture(%{type: "series", path: "/media/Series"})
+
+      file1 =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Show One (2020)/Season 01/ep1.mkv"
+        })
+
+      %MatchCandidate{}
+      |> MatchCandidate.changeset(%{
+        media_file_id: file1.id,
+        rank: 0,
+        last_error: "no_match",
+        parsed_info: %{"season" => 1, "episodes" => [1]}
+      })
+      |> Repo.insert!()
+
+      file2 =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Show Two (2021)/Season 01/ep1.mkv"
+        })
+
+      %MatchCandidate{}
+      |> MatchCandidate.changeset(%{
+        media_file_id: file2.id,
+        rank: 0,
+        last_error: "no_match",
+        parsed_info: %{"season" => 1, "episodes" => [1]}
+      })
+      |> Repo.insert!()
+
+      {:ok, _} = ImportGroups.upsert_for_library(lp)
+      groups = Repo.all(ImportGroup)
+      assert length(groups) == 2
+
+      scope =
+        lp.id
+        |> SelectionScope.new()
+        |> SelectionScope.select_page(Enum.map(groups, & &1.id))
+
+      assert {:ok, %{created: 2, skipped: 0}} = ImportGroups.create_local_shows(scope)
+
+      for g <- groups do
+        reloaded = Repo.reload!(g)
+        assert reloaded.status == "applied"
+        assert reloaded.provider_type == "local"
+      end
+
+      assert Repo.aggregate(Mydia.Media.MediaItem, :count) == 2
+    end
+  end
+
+  describe "rematch/2" do
+    test "re-runs matcher on selected groups and updates candidates and group rollups" do
+      lp = library_path_fixture(%{type: "series", path: "/media/Series"})
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Doctor Who (2005)/Season 01/Doctor Who - S01E01.mkv"
+        })
+
+      %MatchCandidate{}
+      |> MatchCandidate.changeset(%{
+        media_file_id: file.id,
+        rank: 0,
+        last_error: "no_match"
+      })
+      |> Repo.insert!()
+
+      {:ok, _} = ImportGroups.upsert_for_library(lp)
+      group = Repo.one!(ImportGroup)
+      assert group.provider_id == nil
+
+      scope =
+        lp.id
+        |> SelectionScope.new()
+        |> SelectionScope.select_page([group.id])
+
+      assert {:ok, 1} = ImportGroups.rematch(scope, matcher: Mydia.Library.ParsedInfoMatcher)
+
+      reloaded_group = Repo.reload!(group)
+      assert reloaded_group.provider_id == "stub"
+      assert reloaded_group.suggested_title == "Doctor Who"
+      assert reloaded_group.min_confidence == 1.0
     end
   end
 end

--- a/test/mydia/jobs/apply_import_groups_test.exs
+++ b/test/mydia/jobs/apply_import_groups_test.exs
@@ -230,50 +230,53 @@ defmodule Mydia.Jobs.ApplyImportGroupsTest do
   # `drain/2`'s recursive branch never runs there. This test forces it with a
   # tiny `member_page` job arg instead of inserting a thousand rows: three
   # resolvable members, paged two at a time, so applying the group takes two
-  # `drain/2` calls, not one. Movie files are used (rather than a second TV
-  # season) because a movie's association is per-file, not per-episode, so
-  # three separate files can all resolve against the stub's single movie
-  # without running into the stub's two-episode-per-season ceiling.
+  # `drain/2` calls, not one.
   test "drains a group across multiple pages when member_page caps below its size" do
-    movie_lp = library_path_fixture(%{type: "movies", path: "/media/Movies"})
-    movie_title = MetadataStubProvider.movie_title()
-    movie_id = MetadataStubProvider.movie_tmdb_id() |> to_string()
+    series_lp = library_path_fixture(%{type: "series", path: "/media/TV"})
+    series_title = MetadataStubProvider.series_title()
+    series_id = MetadataStubProvider.series_tvdb_id() |> to_string()
 
-    for n <- 1..3 do
+    episodes = [
+      {"Season 01/S01E01.mkv", 1, 1},
+      {"Season 01/S01E02.mkv", 1, 2},
+      {"Season 02/S02E01.mkv", 2, 1}
+    ]
+
+    for {rel_path, season, ep} <- episodes do
       file =
         orphaned_media_file_fixture(%{
-          library_path_id: movie_lp.id,
-          relative_path: "#{movie_title} (1999)/copy#{n}.mkv"
+          library_path_id: series_lp.id,
+          relative_path: "#{series_title} (2020)/#{rel_path}"
         })
 
       %Mydia.Library.MatchCandidate{}
       |> Mydia.Library.MatchCandidate.changeset(%{
         media_file_id: file.id,
         rank: 0,
-        provider_id: movie_id,
-        provider_type: "tmdb",
-        title: movie_title,
-        media_type: "movie",
+        provider_id: series_id,
+        provider_type: "tvdb",
+        title: series_title,
+        media_type: "tv_show",
         confidence: 1.0,
-        parsed_info: %{}
+        parsed_info: %{"season" => season, "episodes" => [ep]}
       })
       |> Repo.insert!()
     end
 
-    {:ok, _} = ImportGroups.upsert_for_library(movie_lp)
+    {:ok, _} = ImportGroups.upsert_for_library(series_lp)
 
     scope =
-      movie_lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{band: :ready})
+      series_lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{band: :ready})
 
     assert {:ok, 1} = ImportGroups.accept(scope)
 
     assert :ok =
              perform_job(ApplyImportGroups, %{
-               "library_path_id" => movie_lp.id,
+               "library_path_id" => series_lp.id,
                "member_page" => 2
              })
 
-    group = Repo.get_by!(ImportGroup, library_path_id: movie_lp.id)
+    group = Repo.get_by!(ImportGroup, library_path_id: series_lp.id)
     assert group.status == "applied"
     assert group.unresolved_count == 0
   end

--- a/test/mydia/jobs/apply_import_groups_test.exs
+++ b/test/mydia/jobs/apply_import_groups_test.exs
@@ -87,6 +87,34 @@ defmodule Mydia.Jobs.ApplyImportGroupsTest do
     assert group.unresolved_count == 0
   end
 
+  test "slow metadata fetches do not hold SQLite's write lock", %{library_path: lp} do
+    if Mydia.DB.sqlite?() do
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{band: :ready})
+      {:ok, 1} = ImportGroups.accept(scope)
+
+      block_ref = MetadataStubProvider.block_next_season_fetch(self())
+      on_exit(fn -> MetadataStubProvider.clear_season_fetch_block(block_ref) end)
+
+      import_task =
+        Task.async(fn ->
+          perform_job(ApplyImportGroups, %{"library_path_id" => lp.id})
+        end)
+
+      assert_receive {:metadata_season_fetch_started, ^block_ref, fetch_pid}, 5_000
+
+      writer_task = Task.async(&probe_unrelated_sqlite_write/0)
+      writer_result = Task.yield(writer_task, 500)
+
+      send(fetch_pid, {:release_metadata_season_fetch, block_ref})
+      import_result = Task.await(import_task, 5_000)
+
+      if is_nil(writer_result), do: Task.await(writer_task, 5_000)
+
+      assert writer_result == {:ok, :ok}
+      assert import_result == :ok
+    end
+  end
+
   # The load-bearing regression guard for `ImportGroups.change_match/2`:
   # `ingest_member/2` builds each file's match from `candidate.provider_id ||
   # group.provider_id` -- candidate first. If change_match/2 only rewrote the
@@ -206,6 +234,13 @@ defmodule Mydia.Jobs.ApplyImportGroupsTest do
     group = Repo.get_by!(ImportGroup, library_path_id: lp.id)
     assert group.status == "applied"
     assert group.unresolved_count == 0
+  end
+
+  defp probe_unrelated_sqlite_write do
+    case Repo.query("UPDATE schema_migrations SET version = version WHERE 0") do
+      {:ok, _result} -> :ok
+      {:error, error} -> {:error, Exception.message(error)}
+    end
   end
 
   test "a group whose files vanished still completes", %{library_path: lp} do

--- a/test/mydia/jobs/import_run_match_test.exs
+++ b/test/mydia/jobs/import_run_match_test.exs
@@ -144,6 +144,66 @@ defmodule Mydia.Jobs.ImportRunMatchTest do
     assert :counters.get(counter, 1) > 0
   end
 
+  test "loose files in root match independently against metadata relay", %{
+    bypass: bypass,
+    config: config
+  } do
+    Bypass.stub(bypass, "GET", "/tmdb/movies/search", fn conn ->
+      conn = Plug.Conn.fetch_query_params(conn)
+      query = conn.query_params["query"]
+
+      results =
+        case query do
+          "The Matrix" ->
+            [%{"id" => 603, "title" => "The Matrix", "release_date" => "1999-03-30"}]
+
+          "Inception" ->
+            [%{"id" => 27205, "title" => "Inception", "release_date" => "2010-07-15"}]
+
+          _ ->
+            []
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(%{"results" => results}))
+    end)
+
+    dir = Path.join(System.tmp_dir!(), "loose_match_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "The.Matrix.1999.1080p.mkv"), "x")
+    File.write!(Path.join(dir, "Inception.2010.1080p.mkv"), "x")
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    lp = library_path_fixture(%{path: dir, type: "movies"})
+
+    {:ok, run} =
+      Library.create_import_run(%{
+        library_path_id: lp.id,
+        user_id: user_fixture().id,
+        mode: :review
+      })
+
+    :ok = ImportRunJob.run_scan_phase(Library.get_import_run(run.id))
+    :ok = ImportRunJob.run_match_phase(Library.get_import_run(run.id), config: config)
+
+    matrix_file =
+      Library.list_media_files_by_relative_path(lp.id, "The.Matrix.1999.1080p.mkv")
+      |> List.first()
+
+    inception_file =
+      Library.list_media_files_by_relative_path(lp.id, "Inception.2010.1080p.mkv") |> List.first()
+
+    matrix_candidate = Library.list_match_candidates(matrix_file.id) |> List.first()
+    inception_candidate = Library.list_match_candidates(inception_file.id) |> List.first()
+
+    assert matrix_candidate.title == "The Matrix"
+    assert matrix_candidate.provider_id == "603"
+
+    assert inception_candidate.title == "Inception"
+    assert inception_candidate.provider_id == "27205"
+  end
+
   test "stops at the chunk boundary when asked", %{run: run, config: config, counter: counter} do
     {:ok, _} = Library.request_import_run_stop(Library.get_import_run(run.id))
 

--- a/test/mydia/library/batch_matcher_test.exs
+++ b/test/mydia/library/batch_matcher_test.exs
@@ -356,6 +356,27 @@ defmodule Mydia.Library.BatchMatcherTest do
       assert length(Enum.uniq(titles)) == 2
     end
 
+    test "loose files in the library root resolve independently" do
+      root = "/media/Movies"
+
+      paths = [
+        "#{root}/The Matrix (1999).mkv",
+        "#{root}/Inception (2010).mkv",
+        "#{root}/Interstellar (2014).mkv"
+      ]
+
+      results = BatchMatcher.match_paths(paths, library_root: root, matcher: EchoMatcher)
+
+      titles = for {_path, {:ok, match}} <- results, do: match.title
+
+      # Loose files have no shared folder anchor, so each must resolve on its own
+      # rather than reusing the first file's match for the others.
+      assert length(Enum.uniq(titles)) == 3
+      assert "The Matrix (1999).mkv" in titles
+      assert "Inception (2010).mkv" in titles
+      assert "Interstellar (2014).mkv" in titles
+    end
+
     test "every input path still gets exactly one result when the anchor match fails" do
       root = "/media/Series"
 

--- a/test/mydia/library/selection_scope_test.exs
+++ b/test/mydia/library/selection_scope_test.exs
@@ -89,11 +89,9 @@ defmodule Mydia.Library.SelectionScopeTest do
     {sql, small_params} = Repo.to_sql(:all, SelectionScope.to_query(scope))
 
     assert is_binary(sql)
-    # library_path_id and the band threshold are the only pinned (^) values in
-    # the query; the "pending" status literal is unpinned, so Ecto compiles it
-    # directly into the SQL text rather than binding it. Two params, none of
-    # them per-row.
-    assert length(small_params) == 2
+    # library_path_id, status, and the band threshold are the pinned (^) values in
+    # the query. Three params, none of them per-row.
+    assert length(small_params) == 3
 
     # Prove it's a shape property, not an artifact of the 3-row fixture: adding
     # hundreds more matching rows (well past `max_id_binds/0`) must not change
@@ -108,16 +106,64 @@ defmodule Mydia.Library.SelectionScopeTest do
     refute sql =~ ~r/\bIN\s*\(/i
   end
 
-  test "clear resets to none" do
+  test "selection scope works for status: 'ignored'" do
+    lp = library_path_fixture(%{type: "series"})
+
+    ignored1 =
+      insert_group(%{
+        library_path_id: lp.id,
+        anchor_path: "Ignored1",
+        cluster_key: "ig-1",
+        status: "ignored"
+      })
+
+    ignored2 =
+      insert_group(%{
+        library_path_id: lp.id,
+        anchor_path: "Ignored2",
+        cluster_key: "ig-2",
+        status: "ignored"
+      })
+
+    _pending =
+      insert_group(%{
+        library_path_id: lp.id,
+        anchor_path: "Pending",
+        cluster_key: "pend",
+        status: "pending"
+      })
+
+    # page mode
+    page_scope =
+      lp.id
+      |> SelectionScope.new("ignored")
+      |> SelectionScope.select_page([ignored1.id])
+
+    assert SelectionScope.selected?(page_scope, ignored1.id)
+    refute SelectionScope.selected?(page_scope, ignored2.id)
+    assert SelectionScope.count(page_scope) == 1
+
+    # filter mode (select all ignored)
+    filter_scope =
+      lp.id
+      |> SelectionScope.new("ignored")
+      |> SelectionScope.select_all_matching(%{})
+
+    assert SelectionScope.count(filter_scope) == 2
+    assert query_ids(filter_scope) == MapSet.new([ignored1.id, ignored2.id])
+  end
+
+  test "clear resets to none and preserves status" do
     lp = library_path_fixture(%{type: "series"})
     [a | _] = seed(lp, 2, 1.0)
 
     scope =
       lp.id
-      |> SelectionScope.new()
+      |> SelectionScope.new("ignored")
       |> SelectionScope.select_page([a.id])
       |> SelectionScope.clear()
 
+    assert scope.status == "ignored"
     assert SelectionScope.count(scope) == 0
     assert Repo.aggregate(SelectionScope.to_query(scope), :count) == 0
   end

--- a/test/mydia/metadata_stub_provider_test.exs
+++ b/test/mydia/metadata_stub_provider_test.exs
@@ -38,8 +38,9 @@ defmodule Mydia.MetadataStubProviderTest do
         Metadata.fetch_by_id(config, result.provider_id, media_type: :tv_show, provider: :tvdb)
 
       assert metadata.title == MetadataStubProvider.series_title()
-      assert [season] = metadata.seasons
-      assert season.season_number == 1
+      assert [season1, season2] = metadata.seasons
+      assert season1.season_number == 1
+      assert season2.season_number == 2
     end
 
     test "the reserved missing id always fails the fetch" do

--- a/test/mydia_web/live/import_media_review_test.exs
+++ b/test/mydia_web/live/import_media_review_test.exs
@@ -1,5 +1,6 @@
 defmodule MydiaWeb.ImportMediaReviewTest do
   use MydiaWeb.ConnCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
 
   import Ecto.Query
   import Phoenix.LiveViewTest
@@ -15,6 +16,9 @@ defmodule MydiaWeb.ImportMediaReviewTest do
   setup :setup_metadata_stub
 
   setup %{conn: conn} do
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
     user = user_fixture()
     {:ok, conn: log_in_user(conn, user), user: user}
   end
@@ -743,6 +747,28 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     lp = library_path_fixture(%{type: "series"})
     group = seed_group(lp, cluster_key: "readonly-batch-rematch", provider_id: nil)
 
+    file =
+      orphaned_media_file_fixture(%{
+        library_path_id: lp.id,
+        relative_path: "Readonly Show/Season 01/Readonly Show - S01E01.mkv"
+      })
+
+    candidate =
+      %Mydia.Library.MatchCandidate{}
+      |> Mydia.Library.MatchCandidate.changeset(%{
+        media_file_id: file.id,
+        rank: 0,
+        provider_id: "before",
+        provider_type: "tvdb",
+        title: "Before",
+        confidence: 0.5
+      })
+      |> Repo.insert!()
+
+    Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id == ^file.id),
+      set: [import_group_id: group.id]
+    )
+
     readonly_conn = log_in_user(conn, user_fixture(%{role: "readonly"}))
     {:ok, view, _html} = live(readonly_conn, ~p"/import")
 
@@ -750,6 +776,8 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     render_click(view, "rematch_selected", %{})
 
     assert Repo.reload!(group).provider_id == nil
+    assert Repo.reload!(candidate).provider_id == "before"
+    refute_enqueued(worker: Mydia.Jobs.RematchImportGroups)
   end
 
   describe "Change match" do
@@ -1267,7 +1295,12 @@ defmodule MydiaWeb.ImportMediaReviewTest do
 
       render_click(view, "rematch_selected", %{})
 
-      assert render(view) =~ "Re-matched 1 group(s)."
+      assert render(view) =~ "Queued 1 group(s) for re-match."
+
+      assert_enqueued(
+        worker: Mydia.Jobs.RematchImportGroups,
+        args: %{"library_path_id" => lp.id}
+      )
     end
   end
 end

--- a/test/mydia_web/live/import_media_review_test.exs
+++ b/test/mydia_web/live/import_media_review_test.exs
@@ -323,6 +323,47 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     assert has_element?(view, "#member-#{file.id}")
   end
 
+  test "expanding another group collapses the previously expanded group", %{conn: conn} do
+    lp = library_path_fixture(%{type: "series"})
+    group_a = seed_group(lp, cluster_key: "a", display_title: "Show A", min_confidence: 1.0)
+    group_b = seed_group(lp, cluster_key: "b", display_title: "Show B", min_confidence: 1.0)
+
+    file_a =
+      orphaned_media_file_fixture(%{
+        library_path_id: lp.id,
+        relative_path: "Show A/Season 01/a.mkv"
+      })
+
+    file_b =
+      orphaned_media_file_fixture(%{
+        library_path_id: lp.id,
+        relative_path: "Show B/Season 01/b.mkv"
+      })
+
+    Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id == ^file_a.id),
+      set: [import_group_id: group_a.id]
+    )
+
+    Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id == ^file_b.id),
+      set: [import_group_id: group_b.id]
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    # Expand Group A
+    view |> element("#group-toggle-#{group_a.id}") |> render_click()
+    assert has_element?(view, "#member-#{file_a.id}")
+    assert has_element?(view, "#group-toggle-#{group_a.id} .hero-chevron-down")
+    assert has_element?(view, "#group-toggle-#{group_b.id} .hero-chevron-right")
+
+    # Expand Group B -> Group A collapses, Group B expands
+    view |> element("#group-toggle-#{group_b.id}") |> render_click()
+    assert has_element?(view, "#member-#{file_b.id}")
+    refute has_element?(view, "#member-#{file_a.id}")
+    assert has_element?(view, "#group-toggle-#{group_a.id} .hero-chevron-right")
+    assert has_element?(view, "#group-toggle-#{group_b.id} .hero-chevron-down")
+  end
+
   test "select all matching the filter accepts every ready group", %{conn: conn} do
     lp = library_path_fixture(%{type: "series"})
     for n <- 1..3, do: seed_group(lp, cluster_key: "r#{n}", min_confidence: 1.0)
@@ -443,6 +484,52 @@ defmodule MydiaWeb.ImportMediaReviewTest do
 
     assert has_element?(view, "#group-#{b.id}")
     refute has_element?(view, "#group-#{a.id}")
+  end
+
+  test "navigating with type=movies selects the movie library in review panel", %{conn: conn} do
+    lp1 =
+      library_path_fixture(%{
+        type: "series",
+        path: "/tmp/import_review_lib_a_#{System.unique_integer([:positive])}"
+      })
+
+    lp2 =
+      library_path_fixture(%{
+        type: "movies",
+        path: "/tmp/import_review_lib_b_#{System.unique_integer([:positive])}"
+      })
+
+    a = seed_group(lp1, cluster_key: "a", display_title: "Library A Group")
+    b = seed_group(lp2, cluster_key: "b", display_title: "Library B Group")
+
+    {:ok, view, _html} = live(conn, ~p"/import?type=movies")
+
+    assert has_element?(view, "#group-#{b.id}")
+    refute has_element?(view, "#group-#{a.id}")
+    assert has_element?(view, "#library-picker-#{lp2.id}.btn-primary")
+  end
+
+  test "navigating with type=tv selects the tv library in review panel", %{conn: conn} do
+    lp1 =
+      library_path_fixture(%{
+        type: "movies",
+        path: "/tmp/import_review_lib_a_#{System.unique_integer([:positive])}"
+      })
+
+    lp2 =
+      library_path_fixture(%{
+        type: "series",
+        path: "/tmp/import_review_lib_b_#{System.unique_integer([:positive])}"
+      })
+
+    a = seed_group(lp1, cluster_key: "a", display_title: "Library A Group")
+    b = seed_group(lp2, cluster_key: "b", display_title: "Library B Group")
+
+    {:ok, view, _html} = live(conn, ~p"/import?type=tv")
+
+    assert has_element?(view, "#group-#{b.id}")
+    refute has_element?(view, "#group-#{a.id}")
+    assert has_element?(view, "#library-picker-#{lp2.id}.btn-primary")
   end
 
   test "the page issues no query on the disconnected render", %{conn: conn} do
@@ -636,6 +723,33 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     assert Repo.aggregate(Mydia.Media.MediaItem, :count) == 0
     refute Repo.reload!(file).episode_id
     assert Repo.reload!(group).provider_type != "local"
+  end
+
+  test "readonly users cannot restore selected ignored groups", %{conn: conn} do
+    lp = library_path_fixture(%{type: "series"})
+    group = seed_group(lp, cluster_key: "readonly-restore", status: "ignored")
+
+    readonly_conn = log_in_user(conn, user_fixture(%{role: "readonly"}))
+    {:ok, view, _html} = live(readonly_conn, ~p"/import")
+
+    render_click(view, "select_band", %{"band" => "ignored"})
+    render_click(view, "toggle_group", %{"id" => group.id})
+    render_click(view, "restore_selected", %{})
+
+    assert Repo.reload!(group).status == "ignored"
+  end
+
+  test "readonly users cannot batch rematch", %{conn: conn} do
+    lp = library_path_fixture(%{type: "series"})
+    group = seed_group(lp, cluster_key: "readonly-batch-rematch", provider_id: nil)
+
+    readonly_conn = log_in_user(conn, user_fixture(%{role: "readonly"}))
+    {:ok, view, _html} = live(readonly_conn, ~p"/import")
+
+    render_click(view, "toggle_group", %{"id" => group.id})
+    render_click(view, "rematch_selected", %{})
+
+    assert Repo.reload!(group).provider_id == nil
   end
 
   describe "Change match" do
@@ -867,7 +981,9 @@ defmodule MydiaWeb.ImportMediaReviewTest do
       view |> element("#band-ignored") |> render_click()
 
       assert has_element?(view, "#restore-#{ignored.id}")
-      refute has_element?(view, "#group-#{ignored.id} input[type=checkbox]")
+      assert has_element?(view, "#group-#{ignored.id} input[type=checkbox]")
+      refute has_element?(view, "#change-match-#{ignored.id}")
+      refute has_element?(view, "#create-local-#{ignored.id}")
     end
 
     test "restoring a group returns it to pending and moves it back off the Ignored view",
@@ -912,5 +1028,246 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     render_click(view, "restore_group", %{"id" => group.id})
 
     assert Repo.reload!(group).status == "ignored"
+  end
+
+  describe "member episode editing" do
+    test "renders filename, folder, matched episode badge, and inline S/E inputs", %{conn: conn} do
+      lp = library_path_fixture(%{type: "series"})
+
+      group =
+        seed_group(lp, cluster_key: "ep-edit", display_title: "My Show", min_confidence: 1.0)
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "My Show/Season 01/My.Show.S01E03.1080p.mkv"
+        })
+
+      %Mydia.Library.MatchCandidate{}
+      |> Mydia.Library.MatchCandidate.changeset(%{
+        media_file_id: file.id,
+        rank: 0,
+        provider_type: "tvdb",
+        provider_id: "1",
+        title: "My Show",
+        confidence: 1.0,
+        parsed_info: %{"season" => 1, "episodes" => [3]}
+      })
+      |> Repo.insert!()
+
+      Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id == ^file.id),
+        set: [import_group_id: group.id]
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/import")
+
+      view |> element("#group-toggle-#{group.id}") |> render_click()
+
+      assert has_element?(view, "#member-#{file.id}", "My.Show.S01E03.1080p.mkv")
+      assert has_element?(view, "#member-row-#{file.id}", "My Show/Season 01")
+      assert has_element?(view, "#member-row-#{file.id}", "S01E03")
+      assert has_element?(view, "#member-form-#{file.id} input[name=season][value='1']")
+      assert has_element?(view, "#member-form-#{file.id} input[name=episode][value='3']")
+    end
+
+    test "changing season and episode updates candidate parsed_info and LiveView UI", %{
+      conn: conn
+    } do
+      lp = library_path_fixture(%{type: "series"})
+
+      group =
+        seed_group(lp, cluster_key: "ep-change", display_title: "My Show", min_confidence: 1.0)
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "My Show/Season 01/ep.mkv"
+        })
+
+      Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id == ^file.id),
+        set: [import_group_id: group.id]
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/import")
+      view |> element("#group-toggle-#{group.id}") |> render_click()
+
+      assert has_element?(view, "#member-row-#{file.id}", "No episode")
+
+      view
+      |> element("#member-form-#{file.id}")
+      |> render_change(%{"file_id" => file.id, "season" => "2", "episode" => "8"})
+
+      assert has_element?(view, "#member-row-#{file.id}", "S02E08")
+
+      candidate = Repo.get_by!(Mydia.Library.MatchCandidate, media_file_id: file.id, rank: 0)
+      assert candidate.parsed_info["season"] == 2
+      assert candidate.parsed_info["episodes"] == [8]
+    end
+
+    test "readonly users cannot update member episodes", %{conn: conn} do
+      lp = library_path_fixture(%{type: "series"})
+
+      group =
+        seed_group(lp, cluster_key: "readonly-ep", display_title: "Show", min_confidence: 1.0)
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Show/Season 01/a.mkv"
+        })
+
+      Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id == ^file.id),
+        set: [import_group_id: group.id]
+      )
+
+      readonly_conn = log_in_user(conn, user_fixture(%{role: "readonly"}))
+      {:ok, view, _html} = live(readonly_conn, ~p"/import")
+
+      render_change(view, "update_member_episode", %{
+        "file_id" => file.id,
+        "season" => "1",
+        "episode" => "1"
+      })
+
+      assert is_nil(Repo.get_by(Mydia.Library.MatchCandidate, media_file_id: file.id, rank: 0))
+    end
+
+    test "movie groups do not render season span badges or episode editing forms", %{conn: conn} do
+      lp = library_path_fixture(%{type: "movies"})
+
+      group =
+        seed_group(lp,
+          cluster_key: "movie-1",
+          display_title: "Inception",
+          media_type: "movie",
+          min_confidence: 1.0
+        )
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Inception (2010)/Inception.2010.1080p.mkv"
+        })
+
+      Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id == ^file.id),
+        set: [import_group_id: group.id]
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/import")
+      view |> element("#group-toggle-#{group.id}") |> render_click()
+
+      assert has_element?(view, "#member-#{file.id}", "Inception.2010.1080p.mkv")
+      refute has_element?(view, "#member-form-#{file.id}")
+      refute has_element?(view, "#member-row-#{file.id}", "No episode")
+      refute has_element?(view, "#group-toggle-#{group.id}", "S1")
+    end
+  end
+
+  describe "batch actions" do
+    test "select page selects all visible groups on current page", %{conn: conn} do
+      lp = library_path_fixture(%{type: "series"})
+      g1 = seed_group(lp, cluster_key: "g1", display_title: "Show 1")
+      g2 = seed_group(lp, cluster_key: "g2", display_title: "Show 2")
+
+      {:ok, view, _html} = live(conn, ~p"/import")
+
+      render_click(view, "select_band", %{"band" => "all"})
+      # Clicking select current page
+      render_click(view, "select_current_page", %{})
+
+      assert has_element?(view, "#bulk-bar", "2 group(s) selected")
+      assert has_element?(view, "#group-#{g1.id} input[type=checkbox]:checked")
+      assert has_element?(view, "#group-#{g2.id} input[type=checkbox]:checked")
+    end
+
+    test "ignored view supports selection, select-all, and batch restore", %{conn: conn} do
+      lp = library_path_fixture(%{type: "series"})
+      g1 = seed_group(lp, cluster_key: "ig1", display_title: "Ignored 1", status: "ignored")
+      g2 = seed_group(lp, cluster_key: "ig2", display_title: "Ignored 2", status: "ignored")
+
+      {:ok, view, _html} = live(conn, ~p"/import")
+
+      render_click(view, "select_band", %{"band" => "ignored"})
+
+      assert has_element?(view, "#restore-#{g1.id}")
+      assert has_element?(view, "#restore-#{g2.id}")
+
+      # Toggle individual ignored group
+      render_click(view, "toggle_group", %{"id" => g1.id})
+      assert has_element?(view, "#bulk-bar", "1 group(s) selected")
+      assert has_element?(view, "#restore-selected", "Restore 1")
+      refute has_element?(view, "#accept-selected")
+
+      # Select all matching
+      render_click(view, "select_all_matching", %{})
+      assert has_element?(view, "#bulk-bar", "2 group(s) selected")
+      assert has_element?(view, "#restore-selected", "Restore 2")
+
+      # Click restore selected
+      render_click(view, "restore_selected", %{})
+
+      assert render(view) =~ "Restored 2 group(s) to pending."
+      assert Repo.reload!(g1).status == "pending"
+      assert Repo.reload!(g2).status == "pending"
+    end
+
+    test "local show creation is available per row, not as a batch action", %{conn: conn} do
+      lp = library_path_fixture(%{type: "series", path: "/media/Series"})
+
+      g1 =
+        seed_group(lp,
+          cluster_key: "no-match-1",
+          display_title: "Custom Show One (2020)",
+          provider_id: nil,
+          min_confidence: nil
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/import")
+
+      render_click(view, "select_band", %{"band" => "no_match"})
+      render_click(view, "toggle_group", %{"id" => g1.id})
+
+      refute has_element?(view, "#create-local-selected")
+      assert has_element?(view, "#create-local-#{g1.id}", "Create show from folder")
+    end
+
+    test "batch rematch re-runs matcher on selected groups", %{conn: conn} do
+      lp = library_path_fixture(%{type: "series", path: "/media/Series"})
+
+      g1 =
+        seed_group(lp,
+          cluster_key: "rematch-1",
+          display_title: "Doctor Who (2005)",
+          provider_id: nil,
+          min_confidence: nil
+        )
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Doctor Who (2005)/Season 01/Doctor Who - S01E01.mkv"
+        })
+
+      %Mydia.Library.MatchCandidate{}
+      |> Mydia.Library.MatchCandidate.changeset(%{
+        media_file_id: file.id,
+        rank: 0,
+        last_error: "no_match"
+      })
+      |> Repo.insert!()
+
+      Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id == ^file.id),
+        set: [import_group_id: g1.id]
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/import")
+
+      render_click(view, "toggle_group", %{"id" => g1.id})
+      assert has_element?(view, "#rematch-selected")
+
+      render_click(view, "rematch_selected", %{})
+
+      assert render(view) =~ "Re-matched 1 group(s)."
+    end
   end
 end

--- a/test/mydia_web/live/import_media_review_test.exs
+++ b/test/mydia_web/live/import_media_review_test.exs
@@ -480,7 +480,7 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     assert has_element?(view, "#group-#{a.id}")
     refute has_element?(view, "#group-#{b.id}")
 
-    view |> element("#library-picker-#{lp2.id}") |> render_click()
+    view |> element("#library-tab-#{lp2.id}") |> render_click()
 
     assert has_element?(view, "#group-#{b.id}")
     refute has_element?(view, "#group-#{a.id}")
@@ -506,7 +506,7 @@ defmodule MydiaWeb.ImportMediaReviewTest do
 
     assert has_element?(view, "#group-#{b.id}")
     refute has_element?(view, "#group-#{a.id}")
-    assert has_element?(view, "#library-picker-#{lp2.id}.btn-primary")
+    assert has_element?(view, "#library-tab-#{lp2.id}.tab-active")
   end
 
   test "navigating with type=tv selects the tv library in review panel", %{conn: conn} do
@@ -529,7 +529,7 @@ defmodule MydiaWeb.ImportMediaReviewTest do
 
     assert has_element?(view, "#group-#{b.id}")
     refute has_element?(view, "#group-#{a.id}")
-    assert has_element?(view, "#library-picker-#{lp2.id}.btn-primary")
+    assert has_element?(view, "#library-tab-#{lp2.id}.tab-active")
   end
 
   test "the page issues no query on the disconnected render", %{conn: conn} do

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -255,6 +255,14 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     assert has_element?(view, "#group-#{group.id}")
     assert has_element?(view, "#band-all .badge", "1")
     assert has_element?(view, "#review-section")
+    assert has_element?(view, "#review-heading #scan-complete-status", "Scan complete")
+    refute has_element?(view, "#import-run-control", "Scan complete")
+
+    send(view.pid, {:dismiss_scan_complete, Ecto.UUID.generate()})
+    assert has_element?(view, "#scan-complete-status", "Scan complete")
+
+    Process.sleep(5_100)
+    refute has_element?(view, "#scan-complete-status")
   end
 
   test "starting a run while another tab already started one shows a friendly message and does not create a duplicate",
@@ -378,7 +386,7 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     assert render(view) =~ ":not_found"
   end
 
-  test "outcome panel reports pending groups without a redundant review link",
+  test "a completed scan status is not restored on reload",
        %{
          conn: conn,
          library_path: lp,
@@ -414,16 +422,13 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    assert has_element?(view, "#run-outcome", "Scan complete")
-    assert has_element?(view, "#run-outcome", "1 group ready to review")
-    refute has_element?(view, "#run-outcome", "Import finished")
-    refute has_element?(view, "#run-outcome", "Found")
-    refute has_element?(view, "#run-outcome", "Matched")
-    refute has_element?(view, "#run-outcome", "Added")
-    refute has_element?(view, "#run-outcome a[href='/import']")
+    refute has_element?(view, "#run-outcome")
+    refute has_element?(view, "#scan-complete-status")
+    assert has_element?(view, "#band-all .badge", "1")
+    assert has_element?(view, "#start-run-form")
   end
 
-  test "outcome panel omits the pending summary when there is nothing to review", %{
+  test "a completed scan with nothing to review restores neither outcome nor status", %{
     conn: conn,
     library_path: lp,
     user: user
@@ -442,8 +447,9 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    assert has_element?(view, "#run-outcome")
-    refute has_element?(view, "#run-outcome a[href='/import']")
+    refute has_element?(view, "#run-outcome")
+    refute has_element?(view, "#scan-complete-status")
+    assert has_element?(view, "#start-run-form")
   end
 
   test "clear results removes the selected library's scan outcome and review groups", %{

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -261,7 +261,8 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     send(view.pid, {:dismiss_scan_complete, Ecto.UUID.generate()})
     assert has_element?(view, "#scan-complete-status", "Scan complete")
 
-    Process.sleep(5_100)
+    send(view.pid, {:dismiss_scan_complete, finished.id})
+    render(view)
     refute has_element?(view, "#scan-complete-status")
   end
 
@@ -600,6 +601,13 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
   test "pre-selects movie library tab when type=movies query param is provided", %{
     conn: conn
   } do
+    _default_mixed =
+      library_path_fixture(%{
+        type: "mixed",
+        default_for_movies: true,
+        path: "/tmp/aaa_default_mixed_#{System.unique_integer([:positive])}"
+      })
+
     lp_tv =
       library_path_fixture(%{
         type: "series",

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -11,6 +11,8 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
   alias Mydia.ImportGroups
   alias Mydia.Library
+  alias Mydia.Library.ImportGroup
+  alias Mydia.Repo
 
   setup %{conn: conn} do
     # The app skips Oban entirely in test env (see Mydia.Application), so
@@ -27,11 +29,143 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     {:ok, conn: log_in_user(conn, user), user: user, library_path: library_path}
   end
 
+  defp import_group(library_path, attrs) do
+    defaults = %{
+      library_path_id: library_path.id,
+      anchor_path: "Show",
+      cluster_key: Ecto.UUID.generate(),
+      display_title: "Show",
+      file_count: 1,
+      unresolved_count: 1,
+      status: "pending"
+    }
+
+    %ImportGroup{}
+    |> ImportGroup.changeset(Map.merge(defaults, Map.new(attrs)))
+    |> Repo.insert!()
+  end
+
   test "renders the run control", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/import")
 
     assert has_element?(view, "#import-run-control")
     assert has_element?(view, "#start-run-button")
+  end
+
+  test "uses one library selector for both scanning and review", %{
+    conn: conn,
+    library_path: lp
+  } do
+    {:ok, view, _html} = live(conn, ~p"/import?library_path_id=#{lp.id}")
+
+    assert has_element?(view, "#library-tabs")
+    assert has_element?(view, "#library-tab-#{lp.id}.tab-active")
+
+    assert has_element?(
+             view,
+             "#start-run-form input[type=hidden][name=library_path_id][value='#{lp.id}']"
+           )
+
+    refute has_element?(view, "#start-run-form input[type=radio][name=library_path_id]")
+  end
+
+  test "automatic import is an on-by-default toggle instead of a mode dropdown", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    assert has_element?(
+             view,
+             "#auto-import-toggle[type=checkbox][name=auto_import][value=true][checked]"
+           )
+
+    refute has_element?(view, "#start-run-mode")
+  end
+
+  test "checked automatic import starts an unattended run", %{
+    conn: conn,
+    library_path: lp
+  } do
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    view
+    |> element("#start-run-form")
+    |> render_submit(%{
+      "library_path_id" => lp.id,
+      "mode" => "review",
+      "auto_import" => "true"
+    })
+
+    assert Library.active_import_run(lp.id).mode == :unattended
+  end
+
+  test "disabled automatic import starts a review run", %{
+    conn: conn,
+    library_path: lp
+  } do
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    view
+    |> element("#start-run-form")
+    |> render_submit(%{"library_path_id" => lp.id, "auto_import" => "false"})
+
+    assert Library.active_import_run(lp.id).mode == :review
+  end
+
+  test "an active scan takes focus and hides review controls", %{
+    conn: conn,
+    library_path: lp,
+    user: user
+  } do
+    {:ok, _run} =
+      Library.create_import_run(%{library_path_id: lp.id, user_id: user.id, mode: :review})
+
+    {:ok, view, _html} = live(conn, ~p"/import?library_path_id=#{lp.id}")
+
+    assert has_element?(view, "#run-progress")
+    refute has_element?(view, "#band-all")
+  end
+
+  test "scan state is scoped to the selected library", %{
+    conn: conn,
+    library_path: selected,
+    user: user
+  } do
+    other =
+      library_path_fixture(%{
+        type: "movies",
+        path: "/tmp/other_import_library_#{System.unique_integer([:positive])}"
+      })
+
+    {:ok, _run} =
+      Library.create_import_run(%{
+        library_path_id: other.id,
+        user_id: user.id,
+        mode: :unattended
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/import?library_path_id=#{selected.id}")
+
+    assert has_element?(view, "#start-run-button")
+    refute has_element?(view, "#run-progress")
+  end
+
+  test "start scan cannot target a different library than the selected tab", %{
+    conn: conn,
+    library_path: selected
+  } do
+    other =
+      library_path_fixture(%{
+        type: "series",
+        path: "/tmp/unselected_import_library_#{System.unique_integer([:positive])}"
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/import?library_path_id=#{selected.id}")
+
+    view
+    |> element("#start-run-form")
+    |> render_submit(%{"library_path_id" => other.id, "auto_import" => "true"})
+
+    refute Library.active_import_run(other.id)
+    refute Library.active_import_run(selected.id)
   end
 
   test "starting a run creates it and enqueues the coordinator", %{
@@ -68,7 +202,7 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     assert Library.get_import_run(run.id).status == :stopping
   end
 
-  test "re-attaches to a run in flight after a reload", %{
+  test "re-attaches to a run in flight after a reload without noisy counters", %{
     conn: conn,
     library_path: lp,
     user: user
@@ -80,7 +214,10 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    assert render(view) =~ "4,200"
+    assert has_element?(view, "#run-progress", "Finding files")
+    refute has_element?(view, "#run-progress", "Found")
+    refute has_element?(view, "#run-progress", "Matched")
+    refute has_element?(view, "#run-progress", "Added")
   end
 
   test "a completed run immediately refreshes the review groups", %{
@@ -117,7 +254,7 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     assert has_element?(view, "#group-#{group.id}")
     assert has_element?(view, "#band-all .badge", "1")
-    refute has_element?(view, "details#import-run-control[open]")
+    assert has_element?(view, "#review-section")
   end
 
   test "starting a run while another tab already started one shows a friendly message and does not create a duplicate",
@@ -145,23 +282,17 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     assert Library.active_import_run(lp.id).id == existing.id
   end
 
-  test "a mode the server does not recognise is refused instead of killing the page", %{
+  test "an unrecognised automatic import value safely falls back to review mode", %{
     conn: conn,
     library_path: lp
   } do
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    # A tab left open across a deploy that renamed a mode, a replayed event, or
-    # a crafted one. Converting this straight to an atom raises, and a raise in
-    # a handler takes the LiveView process with it: the user's page closes
-    # instead of answering them.
-    html =
-      view
-      |> element("#start-run-form")
-      |> render_submit(%{"library_path_id" => lp.id, "mode" => "not_a_real_mode_9f3"})
+    view
+    |> element("#start-run-form")
+    |> render_submit(%{"library_path_id" => lp.id, "auto_import" => "not-a-boolean"})
 
-    assert html =~ "That import mode is not available."
-    refute Library.active_import_run(lp.id)
+    assert Library.active_import_run(lp.id).mode == :review
   end
 
   test "stopping a run that finished in the meantime does not lock the path", %{
@@ -185,22 +316,13 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     refute Library.active_import_run(lp.id)
   end
 
-  test "renders one selectable library card per path, with an icon", %{
+  test "renders one selectable library tab per path, with an icon", %{
     conn: conn,
     library_path: lp
   } do
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    assert has_element?(
-             view,
-             "label.card input[type=radio][name=library_path_id][value='#{lp.id}']"
-           )
-
-    # The first path is preselected so the form always submits a real id.
-    assert has_element?(
-             view,
-             "input[type=radio][name=library_path_id][value='#{lp.id}'][checked]"
-           )
+    assert has_element?(view, "#library-tab-#{lp.id}.tab-active .hero-film")
   end
 
   describe "library types that cannot be imported" do
@@ -210,7 +332,7 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     # built -- library_path_fixture validates against the same enum the form
     # reads. What survives is the shape of the check: every type the schema
     # allows is offered, and an id outside the offered set is still refused.
-    test "every type the schema allows is offered in the start form", %{conn: conn} do
+    test "every type the schema allows is offered in the library tabs", %{conn: conn} do
       paths =
         for type <- Ecto.Enum.values(Mydia.Settings.LibraryPath, :type) do
           library_path_fixture(%{type: to_string(type), name: "Lib #{type}"})
@@ -256,7 +378,7 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     assert render(view) =~ ":not_found"
   end
 
-  test "outcome panel shows review CTA when a pending import group exists for the library path",
+  test "outcome panel reports pending groups without a redundant review link",
        %{
          conn: conn,
          library_path: lp,
@@ -274,11 +396,8 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
         confidence: 0.95
       })
 
-    # The CTA reads `import_groups`, same as the page it links to, so the
-    # group has to actually exist -- a bare MatchCandidate (what the old,
-    # `count_inbox_files`-backed CTA read) is no longer enough. This is the
-    # same call `Jobs.ImportRun.execute/2` makes once a real run's match
-    # phase finishes.
+    # The summary reads `import_groups`, same as the review section beneath it,
+    # so a bare MatchCandidate is not enough to produce a review count.
     {:ok, _} = ImportGroups.upsert_for_library(lp)
 
     {:ok, run} =
@@ -295,14 +414,16 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    assert has_element?(
-             view,
-             "#run-outcome a[href='/import']",
-             "Review 1 group(s) that need attention"
-           )
+    assert has_element?(view, "#run-outcome", "Scan complete")
+    assert has_element?(view, "#run-outcome", "1 group ready to review")
+    refute has_element?(view, "#run-outcome", "Import finished")
+    refute has_element?(view, "#run-outcome", "Found")
+    refute has_element?(view, "#run-outcome", "Matched")
+    refute has_element?(view, "#run-outcome", "Added")
+    refute has_element?(view, "#run-outcome a[href='/import']")
   end
 
-  test "outcome panel hides review CTA when no pending import group exists", %{
+  test "outcome panel omits the pending summary when there is nothing to review", %{
     conn: conn,
     library_path: lp,
     user: user
@@ -325,13 +446,115 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     refute has_element?(view, "#run-outcome a[href='/import']")
   end
 
-  test "import control is open by default when there are no items to review", %{conn: conn} do
-    {:ok, view, _html} = live(conn, ~p"/import")
+  test "clear results removes the selected library's scan outcome and review groups", %{
+    conn: conn,
+    library_path: lp,
+    user: user
+  } do
+    media_file = orphaned_media_file_fixture(%{library_path_id: lp.id})
 
-    assert has_element?(view, "details#import-run-control[open]")
+    {:ok, _} =
+      Library.upsert_match_candidate(%{
+        media_file_id: media_file.id,
+        rank: 0,
+        provider_type: "tmdb",
+        provider_id: "603",
+        title: "The Matrix",
+        confidence: 0.95
+      })
+
+    {:ok, _} = ImportGroups.upsert_for_library(lp)
+    {[group], nil} = ImportGroups.page(lp.id)
+
+    {:ok, run} =
+      Library.create_import_run(%{library_path_id: lp.id, user_id: user.id, mode: :review})
+
+    {:ok, _} = Library.update_import_run(run, %{status: :done, phase: :finished})
+
+    {:ok, view, _html} = live(conn, ~p"/import?library_path_id=#{lp.id}")
+
+    assert has_element?(view, "#group-#{group.id}")
+    assert has_element?(view, "#review-section #clear-scan-results")
+    refute has_element?(view, "#start-run-form #clear-scan-results")
+
+    view
+    |> element("#clear-scan-results")
+    |> render_click()
+
+    refute has_element?(view, "#run-outcome")
+    refute has_element?(view, "#group-#{group.id}")
+    assert has_element?(view, "#no-groups", "Nothing to review")
+    refute Library.last_import_run(lp.id)
   end
 
-  test "import control is collapsed by default when there are items to review", %{
+  test "import all accepts every provider-matched result only for the selected library", %{
+    conn: conn,
+    library_path: selected
+  } do
+    confident =
+      import_group(selected,
+        display_title: "Confident",
+        provider_type: "tmdb",
+        provider_id: "1",
+        min_confidence: 0.99
+      )
+
+    uncertain =
+      import_group(selected,
+        display_title: "Uncertain",
+        provider_type: "tmdb",
+        provider_id: "2",
+        min_confidence: 0.55
+      )
+
+    unmatched = import_group(selected, display_title: "Unmatched")
+
+    local =
+      import_group(selected,
+        display_title: "Local",
+        provider_type: "local",
+        provider_id: "local-item"
+      )
+
+    other_library = library_path_fixture(%{type: "movies"})
+
+    other =
+      import_group(other_library,
+        display_title: "Other library",
+        provider_type: "tmdb",
+        provider_id: "3",
+        min_confidence: 0.99
+      )
+
+    {:ok, view, _html} = live(conn, ~p"/import?library_path_id=#{selected.id}")
+
+    assert has_element?(view, "#review-actions #import-all-results")
+    assert has_element?(view, "#review-actions #clear-scan-results")
+
+    view
+    |> element("#import-all-results")
+    |> render_click()
+
+    assert Repo.reload!(confident).status == "accepted"
+    assert Repo.reload!(uncertain).status == "accepted"
+    assert Repo.reload!(unmatched).status == "pending"
+    assert Repo.reload!(local).status == "pending"
+    assert Repo.reload!(other).status == "pending"
+
+    assert_enqueued(
+      worker: Mydia.Jobs.ApplyImportGroups,
+      args: %{"library_path_id" => selected.id}
+    )
+  end
+
+  test "scan controls and review are both visible while idle", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    assert has_element?(view, "#start-run-button")
+    assert has_element?(view, "#review-section")
+  end
+
+  test "scan controls stay compact above review items", %{
     conn: conn,
     library_path: lp
   } do
@@ -351,11 +574,11 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    assert has_element?(view, "details#import-run-control")
-    refute has_element?(view, "details#import-run-control[open]")
+    assert has_element?(view, "#start-run-button")
+    assert has_element?(view, "#review-section")
   end
 
-  test "import control is open by default when an active run is in flight", %{
+  test "an active library tab shows scan activity", %{
     conn: conn,
     library_path: lp,
     user: user
@@ -365,10 +588,10 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    assert has_element?(view, "details#import-run-control[open]")
+    assert has_element?(view, "#library-tab-#{lp.id} .loading-spinner")
   end
 
-  test "pre-selects movie library in start form when type=movies query param is provided", %{
+  test "pre-selects movie library tab when type=movies query param is provided", %{
     conn: conn
   } do
     lp_tv =
@@ -385,11 +608,12 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     {:ok, view, _html} = live(conn, ~p"/import?type=movies")
 
-    assert has_element?(view, "input[name='library_path_id'][value='#{lp_movie.id}'][checked]")
-    refute has_element?(view, "input[name='library_path_id'][value='#{lp_tv.id}'][checked]")
+    assert has_element?(view, "#library-tab-#{lp_movie.id}.tab-active")
+    refute has_element?(view, "#library-tab-#{lp_tv.id}.tab-active")
+    assert has_element?(view, "input[name='library_path_id'][value='#{lp_movie.id}']")
   end
 
-  test "pre-selects tv library in start form when type=tv query param is provided", %{
+  test "pre-selects tv library tab when type=tv query param is provided", %{
     conn: conn
   } do
     lp_movie =
@@ -406,14 +630,15 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     {:ok, view, _html} = live(conn, ~p"/import?type=tv")
 
-    assert has_element?(view, "input[name='library_path_id'][value='#{lp_tv.id}'][checked]")
-    refute has_element?(view, "input[name='library_path_id'][value='#{lp_movie.id}'][checked]")
+    assert has_element?(view, "#library-tab-#{lp_tv.id}.tab-active")
+    refute has_element?(view, "#library-tab-#{lp_movie.id}.tab-active")
+    assert has_element?(view, "input[name='library_path_id'][value='#{lp_tv.id}']")
   end
 
-  test "changing library in start form triggers select_library and updates selected library", %{
+  test "changing the library tab updates scan and review selection", %{
     conn: conn
   } do
-    lp1 =
+    _lp1 =
       library_path_fixture(%{
         type: "series",
         path: "/tmp/lib_1_#{System.unique_integer([:positive])}"
@@ -427,10 +652,9 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     {:ok, view, _html} = live(conn, ~p"/import")
 
-    view
-    |> element("#start-run-form")
-    |> render_change(%{"library_path_id" => lp2.id})
+    view |> element("#library-tab-#{lp2.id}") |> render_click()
 
-    assert has_element?(view, "input[name='library_path_id'][value='#{lp2.id}'][checked]")
+    assert has_element?(view, "#library-tab-#{lp2.id}.tab-active")
+    assert has_element?(view, "input[name='library_path_id'][value='#{lp2.id}']")
   end
 end

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -599,14 +599,10 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
   end
 
   test "pre-selects movie library tab when type=movies query param is provided", %{
-    conn: conn
+    conn: conn,
+    library_path: setup_library
   } do
-    _default_mixed =
-      library_path_fixture(%{
-        type: "mixed",
-        default_for_movies: true,
-        path: "/tmp/aaa_default_mixed_#{System.unique_integer([:positive])}"
-      })
+    {:ok, _setup_library} = Mydia.Settings.update_library_path(setup_library, %{type: "series"})
 
     lp_tv =
       library_path_fixture(%{

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -83,6 +83,43 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     assert render(view) =~ "4,200"
   end
 
+  test "a completed run immediately refreshes the review groups", %{
+    conn: conn,
+    library_path: lp,
+    user: user
+  } do
+    {:ok, run} =
+      Library.create_import_run(%{library_path_id: lp.id, user_id: user.id, mode: :review})
+
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    media_file = orphaned_media_file_fixture(%{library_path_id: lp.id})
+
+    {:ok, _} =
+      Library.upsert_match_candidate(%{
+        media_file_id: media_file.id,
+        rank: 0,
+        provider_type: "tmdb",
+        provider_id: "603",
+        title: "The Matrix",
+        confidence: 0.95
+      })
+
+    {:ok, _} = ImportGroups.upsert_for_library(lp, import_run_id: run.id)
+    {[group], nil} = ImportGroups.page(lp.id)
+
+    refute has_element?(view, "#group-#{group.id}")
+
+    {:ok, finished} =
+      Library.update_import_run(run, %{status: :done, phase: :finished, files_matched: 1})
+
+    send(view.pid, {:import_run_progress, finished})
+
+    assert has_element?(view, "#group-#{group.id}")
+    assert has_element?(view, "#band-all .badge", "1")
+    refute has_element?(view, "details#import-run-control[open]")
+  end
+
   test "starting a run while another tab already started one shows a friendly message and does not create a duplicate",
        %{conn: conn, library_path: lp, user: user} do
     {:ok, view, _html} = live(conn, ~p"/import")
@@ -286,5 +323,114 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
 
     assert has_element?(view, "#run-outcome")
     refute has_element?(view, "#run-outcome a[href='/import']")
+  end
+
+  test "import control is open by default when there are no items to review", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    assert has_element?(view, "details#import-run-control[open]")
+  end
+
+  test "import control is collapsed by default when there are items to review", %{
+    conn: conn,
+    library_path: lp
+  } do
+    media_file = orphaned_media_file_fixture(%{library_path_id: lp.id})
+
+    {:ok, _} =
+      Library.upsert_match_candidate(%{
+        media_file_id: media_file.id,
+        rank: 0,
+        provider_type: "tmdb",
+        provider_id: "603",
+        title: "The Matrix",
+        confidence: 0.95
+      })
+
+    {:ok, _} = ImportGroups.upsert_for_library(lp)
+
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    assert has_element?(view, "details#import-run-control")
+    refute has_element?(view, "details#import-run-control[open]")
+  end
+
+  test "import control is open by default when an active run is in flight", %{
+    conn: conn,
+    library_path: lp,
+    user: user
+  } do
+    {:ok, _run} =
+      Library.create_import_run(%{library_path_id: lp.id, user_id: user.id, mode: :review})
+
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    assert has_element?(view, "details#import-run-control[open]")
+  end
+
+  test "pre-selects movie library in start form when type=movies query param is provided", %{
+    conn: conn
+  } do
+    lp_tv =
+      library_path_fixture(%{
+        type: "series",
+        path: "/tmp/lib_tv_#{System.unique_integer([:positive])}"
+      })
+
+    lp_movie =
+      library_path_fixture(%{
+        type: "movies",
+        path: "/tmp/lib_movie_#{System.unique_integer([:positive])}"
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/import?type=movies")
+
+    assert has_element?(view, "input[name='library_path_id'][value='#{lp_movie.id}'][checked]")
+    refute has_element?(view, "input[name='library_path_id'][value='#{lp_tv.id}'][checked]")
+  end
+
+  test "pre-selects tv library in start form when type=tv query param is provided", %{
+    conn: conn
+  } do
+    lp_movie =
+      library_path_fixture(%{
+        type: "movies",
+        path: "/tmp/lib_movie_#{System.unique_integer([:positive])}"
+      })
+
+    lp_tv =
+      library_path_fixture(%{
+        type: "series",
+        path: "/tmp/lib_tv_#{System.unique_integer([:positive])}"
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/import?type=tv")
+
+    assert has_element?(view, "input[name='library_path_id'][value='#{lp_tv.id}'][checked]")
+    refute has_element?(view, "input[name='library_path_id'][value='#{lp_movie.id}'][checked]")
+  end
+
+  test "changing library in start form triggers select_library and updates selected library", %{
+    conn: conn
+  } do
+    lp1 =
+      library_path_fixture(%{
+        type: "series",
+        path: "/tmp/lib_1_#{System.unique_integer([:positive])}"
+      })
+
+    lp2 =
+      library_path_fixture(%{
+        type: "movies",
+        path: "/tmp/lib_2_#{System.unique_integer([:positive])}"
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    view
+    |> element("#start-run-form")
+    |> render_change(%{"library_path_id" => lp2.id})
+
+    assert has_element?(view, "input[name='library_path_id'][value='#{lp2.id}'][checked]")
   end
 end

--- a/test/mydia_web/live/media_live/index_test.exs
+++ b/test/mydia_web/live/media_live/index_test.exs
@@ -83,6 +83,14 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       assert has_element?(view, "input[name='search']")
     end
 
+    test "import files button includes type param on movies and tv pages", %{conn: conn} do
+      {:ok, movies_view, _html} = live(conn, ~p"/movies")
+      assert has_element?(movies_view, "a[href='/import?type=movies']", "Import Files")
+
+      {:ok, tv_view, _html} = live(conn, ~p"/tv")
+      assert has_element?(tv_view, "a[href='/import?type=tv']", "Import Files")
+    end
+
     test "search filters by title (case-insensitive)", %{
       conn: conn,
       movie1: _movie1,

--- a/test/support/metadata_stub_provider.ex
+++ b/test/support/metadata_stub_provider.ex
@@ -33,6 +33,7 @@ defmodule Mydia.MetadataStubProvider do
 
   @movie_title "Stub Movie"
   @series_title "Stub Series"
+  @season_fetch_block_key {__MODULE__, :season_fetch_block}
 
   @doc "TMDB id of the catalog movie."
   def movie_tmdb_id, do: @movie_tmdb_id
@@ -48,6 +49,21 @@ defmodule Mydia.MetadataStubProvider do
 
   @doc "Title of the catalog series."
   def series_title, do: @series_title
+
+  @doc "Blocks the next season fetch until the calling test releases it."
+  def block_next_season_fetch(owner) when is_pid(owner) do
+    ref = make_ref()
+    :persistent_term.put(@season_fetch_block_key, {owner, ref})
+    ref
+  end
+
+  @doc "Clears a pending season-fetch block installed by a test."
+  def clear_season_fetch_block(ref) do
+    case :persistent_term.get(@season_fetch_block_key, nil) do
+      {_owner, ^ref} -> :persistent_term.erase(@season_fetch_block_key)
+      _other -> :ok
+    end
+  end
 
   @impl true
   def test_connection(_config), do: {:ok, %{status: "ok"}}
@@ -81,6 +97,8 @@ defmodule Mydia.MetadataStubProvider do
 
   @impl true
   def fetch_season(_config, _provider_id, season_number, _opts) do
+    maybe_block_season_fetch()
+
     {:ok,
      %SeasonData{
        season_number: season_number,
@@ -110,6 +128,23 @@ defmodule Mydia.MetadataStubProvider do
   def fetch_trending(_config, _opts), do: {:ok, []}
 
   ## Catalog
+
+  defp maybe_block_season_fetch do
+    case :persistent_term.get(@season_fetch_block_key, nil) do
+      {owner, ref} ->
+        :persistent_term.erase(@season_fetch_block_key)
+        send(owner, {:metadata_season_fetch_started, ref, self()})
+
+        receive do
+          {:release_metadata_season_fetch, ^ref} -> :ok
+        after
+          5_000 -> raise "timed out waiting to release the blocked metadata season fetch"
+        end
+
+      nil ->
+        :ok
+    end
+  end
 
   defp movie_search_result do
     %SearchResult{

--- a/test/support/metadata_stub_provider.ex
+++ b/test/support/metadata_stub_provider.ex
@@ -190,14 +190,20 @@ defmodule Mydia.MetadataStubProvider do
       poster_path: "/stub-series-poster.jpg",
       imdb_id: "tt0000081",
       original_language: "en",
-      number_of_seasons: 1,
-      number_of_episodes: 2,
+      number_of_seasons: 2,
+      number_of_episodes: 4,
       vote_average: 9.0,
       seasons: [
         %SeasonInfo{
           season_number: 1,
           name: "Season 1",
           overview: "Stub season.",
+          episode_count: 2
+        },
+        %SeasonInfo{
+          season_number: 2,
+          name: "Season 2",
+          overview: "Stub season 2.",
           episode_count: 2
         }
       ]


### PR DESCRIPTION
## What changed

- move the successful scan status beside Review
- dismiss it automatically after five seconds
- keep completed scans from restoring the status after reload or library switches
- preserve persistent failed and stopped scan details

This keeps the scan controls focused on starting the next scan while still acknowledging completion where the results appear.

## Testing

- `./dev mix test test/mydia_web/live/import_media_run_control_test.exs test/mydia_web/live/import_media_review_test.exs`
- `./dev test` (8,386 tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned import workflow with library selection, clearer scan controls, filtering, pagination, and bulk actions.
  - Added restore, rematch, import-all, clear-results, and local-show creation actions.
  - Expand groups to review and edit season and episode details.
  - Movie and TV imports use type-specific workflows.
  - Import preferences persist between sessions.

- **Bug Fixes**
  - Loose movie files are matched independently.
  - Scan failures no longer block other files.
  - Library switching and completed scans refresh results more reliably.
  - Ignored and pending groups retain their status during review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->