### PR TITLE
fix(remote-access): show devices that are actually online

### DIFF
--- a/lib/mydia/auth/guardian.ex
+++ b/lib/mydia/auth/guardian.ex
@@ -47,9 +47,24 @@ defmodule Mydia.Auth.Guardian do
   Verifies and decodes a token, returning the user.
   """
   def verify_token(token) do
-    case decode_and_verify(token) do
-      {:ok, claims} -> resource_from_claims(claims)
+    case verify_token_with_claims(token) do
+      {:ok, user, _claims} -> {:ok, user}
       {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Verifies and decodes a token, returning the user alongside the raw claims.
+
+  Device access tokens minted by `Mydia.RemoteAccess.Pairing` carry a
+  `"device_id"` claim, and `resource_from_claims/1` drops it on the way to a
+  `User`. Callers that need to know *which* paired device is talking, rather
+  than only who it belongs to, use this instead.
+  """
+  def verify_token_with_claims(token) do
+    with {:ok, claims} <- decode_and_verify(token),
+         {:ok, user} <- resource_from_claims(claims) do
+      {:ok, user, claims}
     end
   end
 

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -8,7 +8,9 @@ defmodule Mydia.P2p.Server do
   use GenServer
   require Logger
 
+  alias Mydia.Auth.Guardian
   alias Mydia.P2p
+  alias Mydia.RemoteAccess
   alias Mydia.RemoteAccess.DirectUrls
   alias Mydia.RemoteAccess.Pairing
   alias Mydia.Streaming.HlsSession
@@ -550,7 +552,14 @@ defmodule Mydia.P2p.Server do
   defp verify_hls_auth(nil), do: {:error, :no_token}
 
   defp verify_hls_auth(auth_token) when is_binary(auth_token) do
-    Mydia.Auth.Guardian.verify_token(auth_token)
+    case Guardian.verify_token_with_claims(auth_token) do
+      {:ok, user, claims} ->
+        RemoteAccess.touch_device_from_claims(claims)
+        {:ok, user}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   defp lookup_hls_session(session_id) do
@@ -787,8 +796,13 @@ defmodule Mydia.P2p.Server do
   defp build_graphql_context(auth_token, source, peer_connection_type)
        when is_binary(auth_token) do
     # Use Guardian to verify the token and get the user
-    case Mydia.Auth.Guardian.verify_token(auth_token) do
-      {:ok, user} ->
+    case Guardian.verify_token_with_claims(auth_token) do
+      {:ok, user, claims} ->
+        # Paired players reach the backend over p2p and nowhere else, so this is
+        # the only place device liveness can be observed. The remote access admin
+        # page reads it back as "Online now".
+        RemoteAccess.touch_device_from_claims(claims)
+
         %{current_user: user, source: source, peer_connection_type: peer_connection_type}
 
       {:error, _reason} ->

--- a/lib/mydia/remote_access.ex
+++ b/lib/mydia/remote_access.ex
@@ -358,6 +358,43 @@ defmodule Mydia.RemoteAccess do
     :ok
   end
 
+  @doc """
+  Records liveness for the device named in a verified access token's claims.
+
+  The remote access admin page derives "online" entirely from `last_seen_at`,
+  so without this a player streaming over p2p right now still reads as never
+  connected. Claims without a `"device_id"` (a plain user login rather than a
+  paired device) are ignored.
+  """
+  def touch_device_from_claims(%{"device_id" => device_id}) when is_binary(device_id) do
+    touch_device_if_stale(device_id)
+    :ok
+  end
+
+  def touch_device_from_claims(_claims), do: :ok
+
+  @doc """
+  Updates `last_seen_at` unless it was already written inside the throttle window.
+
+  Accepts a loaded device or a device id. Synchronous: callers on a request path
+  are already holding a database connection, and the throttle keeps this to one
+  write per device per #{@touch_throttle_seconds} seconds.
+  """
+  def touch_device_if_stale(device_id) when is_binary(device_id) do
+    case get_device(device_id) do
+      nil -> {:error, :not_found}
+      device -> touch_device_if_stale(device)
+    end
+  end
+
+  def touch_device_if_stale(%RemoteDevice{} = device) do
+    if should_touch_device?(device) do
+      touch_device(device)
+    else
+      {:ok, device}
+    end
+  end
+
   defp should_touch_device?(%{last_seen_at: nil}), do: true
 
   defp should_touch_device?(%{last_seen_at: last_seen_at}) do

--- a/lib/mydia/remote_access.ex
+++ b/lib/mydia/remote_access.ex
@@ -374,24 +374,34 @@ defmodule Mydia.RemoteAccess do
   def touch_device_from_claims(_claims), do: :ok
 
   @doc """
-  Updates `last_seen_at` unless it was already written inside the throttle window.
+  Records that a device was seen, unless the throttle window has not elapsed.
 
-  Accepts a loaded device or a device id. Synchronous: callers on a request path
-  are already holding a database connection, and the throttle keeps this to one
-  write per device per #{@touch_throttle_seconds} seconds.
+  Accepts a loaded device or a device id. Returns `:recorded` when it wrote and
+  `:skipped` when it did not, which covers both a device seen moments ago and
+  one that no longer exists.
+
+  One conditional `UPDATE` rather than a read followed by a write. A p2p player
+  holds a GraphQL and an HLS connection at once and they are handled in separate
+  processes, so a read-then-write pair lets both sides clear the throttle and
+  write together; here the throttle window is part of the statement, so exactly
+  one of them matches a row. It also keeps the common throttled case to a single
+  statement that touches nothing.
   """
-  def touch_device_if_stale(device_id) when is_binary(device_id) do
-    case get_device(device_id) do
-      nil -> {:error, :not_found}
-      device -> touch_device_if_stale(device)
-    end
-  end
+  @spec touch_device_if_stale(RemoteDevice.t() | binary()) :: :recorded | :skipped
+  def touch_device_if_stale(%RemoteDevice{id: device_id}), do: touch_device_if_stale(device_id)
 
-  def touch_device_if_stale(%RemoteDevice{} = device) do
-    if should_touch_device?(device) do
-      touch_device(device)
-    else
-      {:ok, device}
+  def touch_device_if_stale(device_id) when is_binary(device_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    threshold = DateTime.add(now, -@touch_throttle_seconds, :second)
+
+    query =
+      from d in RemoteDevice,
+        where: d.id == ^device_id,
+        where: is_nil(d.last_seen_at) or d.last_seen_at < ^threshold
+
+    case Repo.update_all(query, set: [last_seen_at: now, updated_at: now]) do
+      {0, _} -> :skipped
+      {_updated, _} -> :recorded
     end
   end
 

--- a/lib/mydia_web/live/admin_remote_access_live/index.ex
+++ b/lib/mydia_web/live/admin_remote_access_live/index.ex
@@ -5,10 +5,17 @@ defmodule MydiaWeb.AdminRemoteAccessLive.Index do
 
   require Logger
 
+  # Which paired devices are online is derived from `last_seen_at` and from the
+  # live p2p peer count, and both move while this page sits open. Without a
+  # timer the page shows whatever was true at mount, so a device connecting a
+  # moment later never appears until someone clicks refresh.
+  @refresh_interval_ms 10_000
+
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(Mydia.PubSub, "remote_access:claims")
+      schedule_refresh()
     end
 
     {:ok,
@@ -55,7 +62,8 @@ defmodule MydiaWeb.AdminRemoteAccessLive.Index do
 
   @impl true
   def handle_info(:refresh_p2p, socket) do
-    {:noreply, load_p2p_status(socket)}
+    schedule_refresh()
+    {:noreply, refresh_status(socket)}
   end
 
   @impl true
@@ -330,7 +338,7 @@ defmodule MydiaWeb.AdminRemoteAccessLive.Index do
   def handle_event("refresh_p2p", _params, socket) do
     {:noreply,
      socket
-     |> load_p2p_status()
+     |> refresh_status()
      |> put_flash(:info, "Status refreshed")}
   end
 
@@ -449,6 +457,18 @@ defmodule MydiaWeb.AdminRemoteAccessLive.Index do
   end
 
   defp format_errors(_), do: "unknown error"
+
+  defp schedule_refresh do
+    Process.send_after(self(), :refresh_p2p, @refresh_interval_ms)
+  end
+
+  # Device liveness lives in `last_seen_at`, so the device list has to be
+  # re-read alongside the p2p status for online badges to move.
+  defp refresh_status(socket) do
+    socket
+    |> load_p2p_status()
+    |> load_devices()
+  end
 
   defp load_config(socket) do
     config = RemoteAccess.get_config()

--- a/test/mydia/remote_access/device_liveness_test.exs
+++ b/test/mydia/remote_access/device_liveness_test.exs
@@ -1,0 +1,114 @@
+defmodule Mydia.RemoteAccess.DeviceLivenessTest do
+  @moduledoc """
+  The remote access admin page decides a device is "online" purely from
+  `last_seen_at`. Every writer of that column belonged to the pre-iroh relay
+  tunnel, so a player actively talking over p2p still rendered as "Never
+  connected". These cover the seam that records liveness from a verified p2p
+  access token.
+  """
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Accounts
+  alias Mydia.Auth.Guardian
+  alias Mydia.RemoteAccess
+  alias Mydia.RemoteAccess.Pairing
+  alias Mydia.RemoteAccess.RemoteDevice
+  alias Mydia.Repo
+
+  setup do
+    user = create_user()
+    %{user: user, device: create_device(user)}
+  end
+
+  describe "touch_device_if_stale/1" do
+    test "records liveness for a device that has never been seen", %{device: device} do
+      assert is_nil(device.last_seen_at)
+
+      assert {:ok, _} = RemoteAccess.touch_device_if_stale(device.id)
+
+      assert Repo.reload!(device).last_seen_at != nil
+    end
+
+    test "refreshes a device last seen longer ago than the throttle window", %{device: device} do
+      stale = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+      device = device |> Ecto.Changeset.change(last_seen_at: stale) |> Repo.update!()
+
+      assert {:ok, _} = RemoteAccess.touch_device_if_stale(device.id)
+
+      assert DateTime.compare(Repo.reload!(device).last_seen_at, stale) == :gt
+    end
+
+    test "leaves a device touched moments ago alone", %{device: device} do
+      fresh = DateTime.utc_now() |> DateTime.truncate(:second)
+      device = device |> Ecto.Changeset.change(last_seen_at: fresh) |> Repo.update!()
+
+      assert {:ok, _} = RemoteAccess.touch_device_if_stale(device.id)
+
+      assert DateTime.compare(Repo.reload!(device).last_seen_at, fresh) == :eq
+    end
+
+    test "accepts a loaded device as well as an id", %{device: device} do
+      assert {:ok, _} = RemoteAccess.touch_device_if_stale(device)
+
+      assert Repo.reload!(device).last_seen_at != nil
+    end
+
+    test "reports an unknown device id rather than raising" do
+      assert {:error, :not_found} = RemoteAccess.touch_device_if_stale(Ecto.UUID.generate())
+    end
+  end
+
+  describe "touch_device_from_claims/1" do
+    test "records liveness for the device named in the claims", %{device: device} do
+      claims = %{"device_id" => device.id}
+
+      assert :ok = RemoteAccess.touch_device_from_claims(claims)
+
+      assert Repo.reload!(device).last_seen_at != nil
+    end
+
+    test "ignores claims that carry no device id", %{device: device} do
+      assert :ok = RemoteAccess.touch_device_from_claims(%{"sub" => device.user_id})
+
+      assert is_nil(Repo.reload!(device).last_seen_at)
+    end
+  end
+
+  describe "access token claims" do
+    test "a device access token carries its device id through verification", %{
+      user: user,
+      device: device
+    } do
+      {:ok, token, _claims} = Pairing.generate_access_token_with_claims(device)
+
+      assert {:ok, verified_user, claims} = Guardian.verify_token_with_claims(token)
+
+      assert verified_user.id == user.id
+      assert claims["device_id"] == device.id
+    end
+  end
+
+  defp create_user do
+    {:ok, user} =
+      Accounts.create_user(%{
+        email: "user-#{System.unique_integer([:positive])}@example.com",
+        username: "user#{System.unique_integer([:positive])}",
+        password: "password123",
+        role: "user"
+      })
+
+    user
+  end
+
+  defp create_device(user) do
+    %RemoteDevice{}
+    |> RemoteDevice.changeset(%{
+      device_name: "Test Device #{System.unique_integer([:positive])}",
+      platform: "ios",
+      device_static_public_key: :crypto.strong_rand_bytes(32),
+      token: "device-token-#{System.unique_integer([:positive])}",
+      user_id: user.id
+    })
+    |> Repo.insert!()
+  end
+end

--- a/test/mydia/remote_access/device_liveness_test.exs
+++ b/test/mydia/remote_access/device_liveness_test.exs
@@ -24,7 +24,7 @@ defmodule Mydia.RemoteAccess.DeviceLivenessTest do
     test "records liveness for a device that has never been seen", %{device: device} do
       assert is_nil(device.last_seen_at)
 
-      assert {:ok, _} = RemoteAccess.touch_device_if_stale(device.id)
+      assert :recorded = RemoteAccess.touch_device_if_stale(device.id)
 
       assert Repo.reload!(device).last_seen_at != nil
     end
@@ -33,7 +33,7 @@ defmodule Mydia.RemoteAccess.DeviceLivenessTest do
       stale = DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
       device = device |> Ecto.Changeset.change(last_seen_at: stale) |> Repo.update!()
 
-      assert {:ok, _} = RemoteAccess.touch_device_if_stale(device.id)
+      assert :recorded = RemoteAccess.touch_device_if_stale(device.id)
 
       assert DateTime.compare(Repo.reload!(device).last_seen_at, stale) == :gt
     end
@@ -42,19 +42,34 @@ defmodule Mydia.RemoteAccess.DeviceLivenessTest do
       fresh = DateTime.utc_now() |> DateTime.truncate(:second)
       device = device |> Ecto.Changeset.change(last_seen_at: fresh) |> Repo.update!()
 
-      assert {:ok, _} = RemoteAccess.touch_device_if_stale(device.id)
+      assert :skipped = RemoteAccess.touch_device_if_stale(device.id)
 
       assert DateTime.compare(Repo.reload!(device).last_seen_at, fresh) == :eq
     end
 
     test "accepts a loaded device as well as an id", %{device: device} do
-      assert {:ok, _} = RemoteAccess.touch_device_if_stale(device)
+      assert :recorded = RemoteAccess.touch_device_if_stale(device)
 
       assert Repo.reload!(device).last_seen_at != nil
     end
 
-    test "reports an unknown device id rather than raising" do
-      assert {:error, :not_found} = RemoteAccess.touch_device_if_stale(Ecto.UUID.generate())
+    test "skips an unknown device id rather than raising" do
+      assert :skipped = RemoteAccess.touch_device_if_stale(Ecto.UUID.generate())
+    end
+
+    test "concurrent requests for one device write exactly once", %{device: device} do
+      # A paired player holds a GraphQL and an HLS connection at once, handled in
+      # separate processes. The throttle window lives inside the UPDATE, so only
+      # one of them can match a row however the two interleave.
+      results =
+        1..4
+        |> Enum.map(fn _ ->
+          Task.async(fn -> RemoteAccess.touch_device_if_stale(device.id) end)
+        end)
+        |> Task.await_many(5_000)
+
+      assert Enum.count(results, &(&1 == :recorded)) == 1
+      assert Enum.count(results, &(&1 == :skipped)) == 3
     end
   end
 

--- a/test/mydia_web/live/admin_remote_access_live_test.exs
+++ b/test/mydia_web/live/admin_remote_access_live_test.exs
@@ -100,4 +100,74 @@ defmodule MydiaWeb.AdminRemoteAccessLiveTest do
       refute url in persisted_config.direct_urls
     end
   end
+
+  describe "Device liveness display" do
+    setup %{conn: conn, token: token, user: user} do
+      start_supervised!(Mydia.Indexers.Health)
+
+      # The devices section only renders once remote access is on.
+      {:ok, _config} = RemoteAccess.initialize_keypair()
+      {:ok, _config} = RemoteAccess.toggle_remote_access(true)
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      %{conn: conn, device: create_device(user)}
+    end
+
+    test "a device seen moments ago renders as online", %{conn: conn, device: device} do
+      touch(device, seconds_ago: 5)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/config/remote-access")
+
+      assert html =~ "Online now"
+    end
+
+    test "a device that comes online after mount is picked up without a manual refresh",
+         %{conn: conn, device: device} do
+      touch(device, seconds_ago: 86_400)
+
+      {:ok, view, html} = live(conn, ~p"/admin/config/remote-access")
+      refute html =~ "Online now"
+
+      touch(device, seconds_ago: 5)
+      send(view.pid, :refresh_p2p)
+
+      assert render(view) =~ "Online now"
+    end
+
+    test "the manual refresh button re-reads device liveness", %{conn: conn, device: device} do
+      touch(device, seconds_ago: 86_400)
+
+      {:ok, view, html} = live(conn, ~p"/admin/config/remote-access")
+      refute html =~ "Online now"
+
+      touch(device, seconds_ago: 5)
+
+      assert render_click(view, "refresh_p2p", %{}) =~ "Online now"
+    end
+  end
+
+  defp create_device(user) do
+    %Mydia.RemoteAccess.RemoteDevice{}
+    |> Mydia.RemoteAccess.RemoteDevice.changeset(%{
+      device_name: "Liveness Device #{System.unique_integer([:positive])}",
+      platform: "ios",
+      device_static_public_key: :crypto.strong_rand_bytes(32),
+      token: "device-token-#{System.unique_integer([:positive])}",
+      user_id: user.id
+    })
+    |> Mydia.Repo.insert!()
+  end
+
+  defp touch(device, seconds_ago: seconds) do
+    seen = DateTime.utc_now() |> DateTime.add(-seconds, :second) |> DateTime.truncate(:second)
+
+    device
+    |> Ecto.Changeset.change(last_seen_at: seen)
+    |> Mydia.Repo.update!()
+  end
 end


### PR DESCRIPTION
The Remote Access admin page could not show a device as online, and would not update itself if one came online while the page was open.

## Devices never registered as online

"Online now" is derived entirely from `remote_devices.last_seen_at` being under 10 minutes old. Nothing had written that column for a connected device since the move to iroh:

- `Pairing.complete_pairing/2` writes it once, at pairing time
- the `refreshAccessToken` mutation writes it only when a JWT ages out
- `MydiaWeb.Plugs.RelayDeviceAuth` writes it on requests carrying `x-relay-tunnel: true`, a header from the old relay tunnel that nothing in the repo sends any more

So a player streaming over p2p right now rendered as "Never connected", or froze at whenever it last paired.

Paired players reach the backend only over p2p, so liveness is now recorded there. The device id was already travelling in the access token, but `Guardian.verify_token/1` resolved claims straight to a `User` and threw it away. `verify_token_with_claims/1` keeps the claims so the p2p GraphQL and HLS paths can touch the right row. The existing 5 minute throttle holds this to one write per device per window, and the touch is synchronous because the GraphQL handler already blocks its GenServer on the whole query.

## The page froze at its mount snapshot

`handle_info(:refresh_p2p, ...)` existed but nothing ever sent it, so the only path to fresh data was the manual refresh button. Both that handler and the button also reloaded p2p status without re-reading the devices whose badges they were supposed to move. Both now re-read devices, on a 10 second timer.

## Tests

- `test/mydia/remote_access/device_liveness_test.exs` covers the touch throttle, the id and struct forms, unknown ids, and that a device access token carries its device id through verification
- three LiveView tests cover a recently seen device rendering as online, a device coming online after mount without a manual refresh, and the refresh button re-reading liveness

Verified: 1206 tests green across `test/mydia_web/live`, `test/mydia/remote_access`, `test/mydia_web/schema`, `test/mydia_web/plugs`, plus the token cache. Clean under `--warnings-as-errors` and `credo --strict`.

## Left alone

`RelayDeviceAuth` is now unreachable dead code. Removing it touches an auth surface, so it is worth its own change rather than riding along here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote-access devices now update their last-seen status when verified tokens are used.
  * The admin remote-access page automatically refreshes every 10 seconds.
  * Device status now reflects online and stale states more accurately.
  * Manual refresh updates both connection status and device liveness.

* **Bug Fixes**
  * Improved token verification while preserving existing invalid-token behavior.
  * Liveness updates now avoid unnecessary writes for recently active devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->