### PR TITLE
fix(import): make clearing scan results actually clear them

### DIFF
--- a/lib/mydia/import_groups.ex
+++ b/lib/mydia/import_groups.ex
@@ -12,6 +12,7 @@ defmodule Mydia.ImportGroups do
 
   require Logger
 
+  alias Mydia.Library
   alias Mydia.Library.ImportGroup
   alias Mydia.Library.ImportRun
   alias Mydia.Library.MatchCandidate
@@ -47,11 +48,20 @@ defmodule Mydia.ImportGroups do
   @doc """
   Clears the derived scan and review state for one library path.
 
-  Imported media files are preserved. Active scans are refused so their
-  coordinator cannot recreate groups while the clear is in progress.
+  That means the cached match candidates as well as the groups rolled up from
+  them, so the next scan re-matches from scratch instead of reproducing the
+  previous scan's verdicts. Clearing the groups alone did the latter, which is
+  how a shipped matcher fix could fail to reach an already-scanned library.
+
+  Imported media files are preserved, links and all: a completed import is not
+  scan state. Active scans are refused so their coordinator cannot recreate
+  groups while the clear is in progress.
+
+  Returns the number of groups and candidates removed.
   """
   @spec clear_for_library(binary()) ::
-          {:ok, non_neg_integer()} | {:error, :active_run}
+          {:ok, %{groups: non_neg_integer(), candidates: non_neg_integer()}}
+          | {:error, :active_run}
   def clear_for_library(library_path_id) do
     result =
       Repo.transaction(fn ->
@@ -65,6 +75,12 @@ defmodule Mydia.ImportGroups do
           Repo.rollback(:active_run)
         end
 
+        # Before the groups, because the groups are only a rollup of these.
+        # Leaving them behind is what made a clear-then-rescan reproduce the
+        # previous scan's verdicts exactly -- see
+        # `Library.delete_match_candidates_for_library/1`.
+        {candidate_count, _} = Library.delete_match_candidates_for_library(library_path_id)
+
         {group_count, _} =
           ImportGroup
           |> where([g], g.library_path_id == ^library_path_id)
@@ -74,16 +90,16 @@ defmodule Mydia.ImportGroups do
         |> where([r], r.library_path_id == ^library_path_id)
         |> Repo.delete_all()
 
-        group_count
+        %{groups: group_count, candidates: candidate_count}
       end)
 
-    with {:ok, group_count} <- result do
+    with {:ok, counts} <- result do
       Phoenix.PubSub.broadcast(Mydia.PubSub, "import_groups:#{library_path_id}", {
         :import_groups_changed,
         library_path_id
       })
 
-      {:ok, group_count}
+      {:ok, counts}
     end
   end
 

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -2314,6 +2314,29 @@ defmodule Mydia.Library do
   end
 
   @doc """
+  Deletes every cached candidate belonging to one library path, at every rank.
+
+  This is what makes "clear scan results" mean it. Dropping the groups alone
+  leaves each file's verdict behind, and `unmatched_media_files_query/2` skips
+  any file holding a successful rank-0 candidate, so the next scan matches
+  nothing and `ImportGroups.upsert_for_library/2` rebuilds the same groups from
+  the same stale rows -- quickly, which is what makes it look like it worked.
+  A matcher fix cannot reach an already-scanned library without this.
+
+  Scoped with a subquery rather than a join because PostgreSQL has
+  `DELETE ... USING` and SQLite does not, and this repo targets both.
+  """
+  @spec delete_match_candidates_for_library(binary()) :: {integer(), nil}
+  def delete_match_candidates_for_library(library_path_id) do
+    file_ids =
+      from(f in MediaFile, where: f.library_path_id == ^library_path_id, select: f.id)
+
+    MatchCandidate
+    |> where([c], c.media_file_id in subquery(file_ids))
+    |> Repo.delete_all()
+  end
+
+  @doc """
   Applies one match and/or season to the rank-0 candidate of many files.
 
   This is the review inbox's batch edit. It merges into each file's existing

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -220,10 +220,10 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   def handle_event("clear_scan_results", %{"library_path_id" => path_id}, socket) do
     with :ok <- Authorization.authorize_import_media(socket),
          :ok <- authorize_library_path(socket, path_id),
-         {:ok, count} <- ImportGroups.clear_for_library(path_id) do
+         {:ok, counts} <- ImportGroups.clear_for_library(path_id) do
       {:noreply,
        socket
-       |> put_flash(:info, "Cleared #{count} scan result group(s).")
+       |> put_flash(:info, cleared_message(counts))
        |> assign(:outcome_run, nil)
        |> assign(:scan_complete_run_id, nil)
        |> assign(:selection, SelectionScope.new(path_id))
@@ -784,6 +784,18 @@ defmodule MydiaWeb.ImportMediaLive.Index do
         {:unsupported_type,
          put_flash(socket, :error, "Only movie, TV and mixed libraries can be imported.")}
     end
+  end
+
+  # Naming the cached matches matters: without it the operator reads a small
+  # group count and has no idea the next scan will re-match every file and take
+  # as long as the first one did.
+  defp cleared_message(%{groups: groups, candidates: 0}) do
+    "Cleared #{groups} scan result group(s)."
+  end
+
+  defp cleared_message(%{groups: groups, candidates: candidates}) do
+    "Cleared #{groups} scan result group(s) and #{candidates} cached match(es). " <>
+      "The next scan will re-match every file."
   end
 
   defp accept_result(socket, {:ok, count}) do

--- a/test/mydia/import_groups_test.exs
+++ b/test/mydia/import_groups_test.exs
@@ -63,7 +63,7 @@ defmodule Mydia.ImportGroupsTest do
 
       {:ok, _run} = Mydia.Library.update_import_run(run, %{status: :done, phase: :finished})
 
-      assert {:ok, 1} = ImportGroups.clear_for_library(selected.id)
+      assert {:ok, %{groups: 1}} = ImportGroups.clear_for_library(selected.id)
       refute Repo.get(ImportGroup, selected_group.id)
       assert Repo.get(ImportGroup, other_group.id)
       refute Mydia.Library.last_import_run(selected.id)
@@ -78,6 +78,77 @@ defmodule Mydia.ImportGroupsTest do
 
       assert {:error, :active_run} = ImportGroups.clear_for_library(library_path.id)
       assert Repo.get(ImportGroup, import_group.id)
+    end
+
+    test "a cleared library re-matches every file on the next scan" do
+      # The property that matters. Deleting the groups alone leaves each file's
+      # cached verdict behind, and `unmatched_media_files_query/2` skips any
+      # file holding a successful rank-0 candidate -- so the next scan matched
+      # nothing and `upsert_for_library/2` rebuilt the same groups from the same
+      # stale rows. A row count would not catch that; asking the inbox query
+      # whether the file is outstanding again does.
+      lp = library_path_fixture(%{type: "series"})
+      file = matched_file(lp, "Passe-Partout (2018)/Season 01/ep1.mkv", "117091")
+
+      assert Mydia.Library.list_unmatched_media_file_paths(lp.id, 10) == []
+
+      assert {:ok, %{candidates: 1}} = ImportGroups.clear_for_library(lp.id)
+
+      file_id = file.id
+      assert [{^file_id, _path}] = Mydia.Library.list_unmatched_media_file_paths(lp.id, 10)
+    end
+
+    test "clears candidates of every rank, not just the one the inbox reads" do
+      lp = library_path_fixture(%{type: "series"})
+      file = matched_file(lp, "Show/Season 01/ep1.mkv", "111")
+      candidate(file, 1, "222")
+
+      assert {:ok, %{candidates: 2}} = ImportGroups.clear_for_library(lp.id)
+      assert Repo.all(from(c in MatchCandidate, where: c.media_file_id == ^file.id)) == []
+    end
+
+    test "leaves another library's cached matches alone" do
+      selected = library_path_fixture(%{type: "series"})
+      other = library_path_fixture(%{type: "movies"})
+      matched_file(selected, "Show/Season 01/ep1.mkv", "111")
+      kept = matched_file(other, "Film (2020)/film.mkv", "222")
+
+      assert {:ok, %{candidates: 1}} = ImportGroups.clear_for_library(selected.id)
+      assert [%MatchCandidate{provider_id: "222"}] = Mydia.Library.list_match_candidates(kept.id)
+    end
+
+    test "refusing to clear an active library keeps its cached matches" do
+      lp = library_path_fixture(%{type: "series"})
+      file = matched_file(lp, "Show/Season 01/ep1.mkv", "111")
+
+      {:ok, _run} = Mydia.Library.create_import_run(%{library_path_id: lp.id, mode: :review})
+
+      assert {:error, :active_run} = ImportGroups.clear_for_library(lp.id)
+      assert [%MatchCandidate{provider_id: "111"}] = Mydia.Library.list_match_candidates(file.id)
+    end
+
+    defp matched_file(library_path, relative_path, provider_id) do
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: library_path.id,
+          relative_path: relative_path
+        })
+
+      candidate(file, 0, provider_id)
+      file
+    end
+
+    defp candidate(file, rank, provider_id) do
+      %MatchCandidate{}
+      |> MatchCandidate.changeset(%{
+        media_file_id: file.id,
+        rank: rank,
+        provider_type: "tvdb",
+        provider_id: provider_id,
+        title: "Cached",
+        confidence: 0.95
+      })
+      |> Repo.insert!()
     end
   end
 

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -484,14 +484,25 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     assert has_element?(view, "#review-section #clear-scan-results")
     refute has_element?(view, "#start-run-form #clear-scan-results")
 
-    view
-    |> element("#clear-scan-results")
-    |> render_click()
+    assert Library.list_unmatched_media_file_paths(lp.id, 10) == []
+
+    html =
+      view
+      |> element("#clear-scan-results")
+      |> render_click()
 
     refute has_element?(view, "#run-outcome")
     refute has_element?(view, "#group-#{group.id}")
     assert has_element?(view, "#no-groups", "Nothing to review")
     refute Library.last_import_run(lp.id)
+
+    # The point of clearing: the cached verdict goes too, so the next scan
+    # re-matches this file instead of rebuilding the same group from it.
+    assert Library.list_match_candidates(media_file.id) == []
+    file_id = media_file.id
+    assert [{^file_id, _path}] = Library.list_unmatched_media_file_paths(lp.id, 10)
+
+    assert html =~ "cached match(es)"
   end
 
   test "import all accepts every provider-matched result only for the selected library", %{


### PR DESCRIPTION
"Clear scan results" followed by a new scan reproduced the previous scan's verdicts exactly, so a shipped matcher fix could not reach an already-scanned library through the UI. The second scan finished fast and looked like it had worked.

Found while checking galactica after #495 landed. The corrected matcher was live and returned TVDB 356390 for `Passe-Partout` when called directly, while all 15 `import_groups` still showed the pre-fix `117091` across 299 files.

## Root cause

Three pieces combined:

1. `clear_for_library/1` deleted `import_groups` and `import_runs` but left every `media_file_match_candidates` row.
2. `unmatched_media_files_query/2` selects only files with no rank-0 candidate, or whose rank-0 candidate is a *failure* past its retry backoff. A file holding a successful candidate is never re-matched.
3. `upsert_for_library/2` rebuilds groups by rolling up whatever candidates exist.

So after a clear every file still held its old verdict, the match phase selected nothing, and the group rebuild regenerated byte-identical groups from the stale rows.

## Change

`Library.delete_match_candidates_for_library/1`, called from `clear_for_library/1` inside the existing transaction, before the group delete:

```elixir
def delete_match_candidates_for_library(library_path_id) do
  file_ids = from(f in MediaFile, where: f.library_path_id == ^library_path_id, select: f.id)
  MatchCandidate |> where([c], c.media_file_id in subquery(file_ids)) |> Repo.delete_all()
end
```

A subquery rather than a join on purpose: PostgreSQL has `DELETE ... USING` and SQLite does not, and this repo targets both.

## What clear does and doesn't touch

| Data | Cleared | Why |
|---|---|---|
| `media_file_match_candidates` | yes, every rank | the stale verdicts; the point of this PR |
| `import_groups` | yes | already did |
| `import_runs` | yes | already did |
| `media_files.import_group_id` | self-nils | FK is already `on_delete: :nilify_all` |
| `media_files` rows | no | the scan result, not the match result |
| `media_files.media_item_id` / `episode_id` | no | a completed import is not scan state |

Every rank is deleted so alternate candidates do not survive as a partial result. Linked files hold no candidate anyway, since `FileIngest` drops one when it links a file, so scoping by library path is a no-op for them and keeps the rule simple.

## Return shape and flash

`{:ok, group_count}` becomes `{:ok, %{groups: n, candidates: m}}`. One production caller.

The flash gains the candidate count and "The next scan will re-match every file". A bare group count hid that ~1,150 cached matches also went and the next scan had gone from instant to slow. This is after-the-fact reporting, not a confirmation guard; a guard was considered and declined.

## Tests

The one that matters asserts the property, not row counts. A row count would still pass if the skip predicate kept excluding the file:

```elixir
assert Library.list_unmatched_media_file_paths(lp.id, 10) == []
assert {:ok, %{candidates: 1}} = ImportGroups.clear_for_library(lp.id)
assert [{^file_id, _path}] = Library.list_unmatched_media_file_paths(lp.id, 10)
```

Plus every-rank deletion, cross-library scoping, and that a refused clear (active run) leaves candidates intact. The existing LiveView clear test already seeded a candidate and clicked the button without ever checking what happened to it, so it now covers the same ground end to end.

All four context tests fail before the change and pass after.

## Deliberately not included

**Matcher version stamping.** Auto-invalidating candidates when scoring logic changes was considered and declined. It needs a version constant somebody must remember to bump, and forgetting it silently restores exactly this bug. Recovery stays a deliberate operator action, which means galactica still needs one manual clear after this deploys to pick up #495.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Clearing a library’s scan results now also removes cached match suggestions.
  - Media files become unmatched again and can be matched during the next scan.
  - Results report the number of cleared scan groups and cached matches.

- **Bug Fixes**
  - Cached matches in other libraries remain unaffected.
  - Clearing is prevented while a scan is active.
  - Notifications now clearly indicate when cached matches were removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->