### PR TITLE
fix(tv): let an ordering switch work on shows that predate provider ids

### DIFF
--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1276,6 +1276,10 @@ defmodule Mydia.Media do
       - `:config` - Metadata relay config. Defaults to `Metadata.default_relay_config/0`.
         Callers that inject a Bypass (or any non-default relay) must pass it;
         otherwise the refresh silently uses the global default.
+      - `:force` - Fetch even when `seasons_refreshed_at` is inside the throttle
+        window. Defaults to `false`. Pass it whenever a person asked for this
+        show specifically; leave it off for sweeps. See
+        `should_skip_season_refresh?/1`.
 
   ## Returns
     - `{:ok, count}` - Number of episodes created
@@ -1350,7 +1354,7 @@ defmodule Mydia.Media do
       {:error, :missing_provider_id}
     else
       # Check if we should skip season refresh based on threshold
-      if should_skip_season_refresh?(media_item) do
+      if not Keyword.get(opts, :force, false) and should_skip_season_refresh?(media_item) do
         Logger.info(
           "Skipping season refresh for #{media_item.title} - recently refreshed at #{media_item.seasons_refreshed_at}"
         )

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -32,6 +32,15 @@ defmodule Mydia.Media.Refresh do
     * `:recover_by_title` - when no provider id can be resolved, search the
       provider by title to re-identify the item. Defaults to `false`, because
       fuzzy re-identification is surprising when triggered from a UI button.
+    * `:force` - refresh episodes even when `seasons_refreshed_at` is inside
+      the throttle window. Defaults to `false`.
+
+      The throttle exists to keep the weekly sweep off the relay, and it is
+      right for a sweep. It is wrong for a person: someone who clicked
+      "Refresh metadata" is asking for the work to happen now, and the throttle
+      silently declines the episode half of it for 24 hours, or 168 once the
+      show has ended, while the item row still updates and the flash still
+      says it worked. Every UI-initiated refresh passes `force: true`.
   """
   @spec run(MediaItem.t(), keyword()) :: {:ok, MediaItem.t()} | {:error, term()}
   def run(%MediaItem{} = media_item, opts \\ []) do
@@ -49,7 +58,7 @@ defmodule Mydia.Media.Refresh do
         with {:ok, metadata} <- fetch(item, provider_id, media_type, source, config),
              {:ok, updated} <- apply_metadata(item, metadata, source) do
           reclassified = reclassify_after_refresh(updated)
-          post_update(reclassified, media_type, fetch_episodes, config)
+          post_update(reclassified, media_type, fetch_episodes, config, opts)
           {:ok, reclassified}
         end
     end
@@ -169,8 +178,10 @@ defmodule Mydia.Media.Refresh do
   # `config` is threaded through rather than re-derived: refresh_episodes_for_tv_show/2
   # falls back to Metadata.default_relay_config/0, so dropping it here sent the
   # episode leg of an injected-config refresh at the real relay.
-  defp post_update(updated, :tv_show, true, config) do
-    case Media.refresh_episodes_for_tv_show(updated, config: config) do
+  defp post_update(updated, :tv_show, true, config, opts) do
+    force = Keyword.get(opts, :force, false)
+
+    case Media.refresh_episodes_for_tv_show(updated, config: config, force: force) do
       {:ok, _count} ->
         :ok
 
@@ -185,7 +196,7 @@ defmodule Mydia.Media.Refresh do
     :ok
   end
 
-  defp post_update(updated, _media_type, _fetch_episodes, _config) do
+  defp post_update(updated, _media_type, _fetch_episodes, _config, _opts) do
     NfoWriter.maybe_write_nfos(updated)
     :ok
   end

--- a/lib/mydia/media/season_order.ex
+++ b/lib/mydia/media/season_order.ex
@@ -18,6 +18,24 @@ defmodule Mydia.Media.SeasonOrder do
 
   @values [:official, :dvd, :absolute]
 
+  # Specials. TVDB files them under every ordering separately and the lists do
+  # not agree: Black Clover has 19 specials in its official ordering, 27 in its
+  # DVD ordering and none at all in its absolute one, while all three agree on
+  # the same 170 numbered episodes. Treating specials as part of a switch
+  # therefore refuses the switch outright — an ordering that "does not account
+  # for every episode" — for a disagreement that has nothing to do with the
+  # seasons the user is choosing between. Worse, two orderings' specials lists
+  # routinely assign the same (0, n) coordinates to different episodes, so
+  # remapping them anyway collides.
+  #
+  # So a switch reorders the numbered seasons and leaves specials exactly where
+  # they are, on both sides: no special is moved, and no ordering is asked to
+  # account for one. This is the same line `fetch_alternative_counts/3` already
+  # draws when it counts the seasons the suggestion banner offers — the banner
+  # promises "51, 51, 52, 16", never anything about specials, and the switch now
+  # delivers exactly that.
+  @specials_season 0
+
   # Season numbers are validated non-negative and no real series approaches
   # 1000 seasons, so parking rows here cannot collide with live data. What
   # actually carries the correctness is that one statement parks every row in
@@ -123,8 +141,17 @@ defmodule Mydia.Media.SeasonOrder do
   exists for — the ones where the aired-order confirmation option can't be
   allowed to depend on the network working.
 
+  Episodes whose `provider_episode_id` is still NULL — every row written
+  before that column existed — are tagged first, from the ordering the show
+  is already in. Without that, this refuses via `remap/3` and sends the user
+  to a metadata refresh that a throttle can silently decline to run for a
+  week. See `backfill_provider_ids/4`.
+
+  Specials are out of scope on both sides: none is moved, and no ordering is
+  asked to account for one. See `@specials_season`.
+
   When it isn't a no-op, refuses (without writing anything) if the fetched
-  ordering does not account for every one of the show's episodes —
+  ordering does not account for every one of the show's numbered episodes —
   `{:error, {:incomplete_ordering, missing_count}}`. TVDB sometimes lists an
   ordering that only covers part of a series; remapping just the covered
   subset would silently strand the rest at their old numbers under a
@@ -160,6 +187,7 @@ defmodule Mydia.Media.SeasonOrder do
     provider_id = to_string(media_item.tvdb_id)
 
     with {:ok, raw_seasons} <- Relay.fetch_raw_seasons(config, provider_id),
+         :ok <- backfill_provider_ids(media_item, provider_id, raw_seasons, config),
          {:ok, episodes} <-
            Relay.fetch_ordering_episodes(config, provider_id, tvdb_type(target), raw_seasons) do
       case episodes do
@@ -169,7 +197,7 @@ defmodule Mydia.Media.SeasonOrder do
         episodes ->
           mapping =
             episodes
-            |> Enum.filter(& &1.provider_episode_id)
+            |> Enum.filter(&(&1.provider_episode_id && &1.season_number != @specials_season))
             |> Map.new(&{&1.provider_episode_id, {&1.season_number, &1.episode_number}})
 
           case missing_from_mapping(media_item, mapping) do
@@ -180,14 +208,114 @@ defmodule Mydia.Media.SeasonOrder do
     end
   end
 
+  # Tags episodes that have no `provider_episode_id`, using the ordering the
+  # show's rows are already in.
+  #
+  # Every episode row written before that column existed holds NULL, and the
+  # only other writer is a metadata refresh, which
+  # `Media.should_skip_season_refresh?/1` throttles for up to a week on an
+  # ended show. So `remap/3`'s `:missing_provider_ids` refusal used to send the
+  # user to a "refresh the metadata" remedy that silently does nothing, with no
+  # way out of it from the UI — the state every show imported before the column
+  # shipped is in, which is to say nearly all of them.
+  #
+  # Identifying an untagged row by its coordinates is the same call
+  # `Media.find_existing_episode/2` already makes on every refresh: an untagged
+  # row at a given (season, episode) is that ordering's episode at those
+  # coordinates. It reads the *current* ordering, not the target, precisely so
+  # that identification holds — the local rows are laid out in the ordering
+  # `effective/1` names.
+  #
+  # A failed fetch propagates rather than falling through to an untagged remap:
+  # a partially tagged show must not be moved, and `remap/3`'s refusal is the
+  # only thing standing between a half-identified show and a silent half-remap.
+  defp backfill_provider_ids(%MediaItem{} = media_item, provider_id, raw_seasons, config) do
+    case untagged_episodes(media_item) do
+      [] ->
+        :ok
+
+      untagged ->
+        tag_from_current_ordering(media_item, untagged, provider_id, raw_seasons, config)
+    end
+  end
+
+  defp untagged_episodes(%MediaItem{id: id}) do
+    Repo.all(from(e in Episode, where: e.media_item_id == ^id and is_nil(e.provider_episode_id)))
+  end
+
+  defp tag_from_current_ordering(media_item, untagged, provider_id, raw_seasons, config) do
+    current = tvdb_type(effective(media_item))
+
+    case Relay.fetch_ordering_episodes(config, provider_id, current, raw_seasons) do
+      {:ok, ordering} ->
+        write_tags(media_item, untagged, ordering)
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp write_tags(media_item, untagged, ordering) do
+    by_coordinates =
+      ordering
+      |> Enum.filter(& &1.provider_episode_id)
+      |> Map.new(&{{&1.season_number, &1.episode_number}, &1.provider_episode_id})
+
+    # An id another row of this show already carries is skipped rather than
+    # written. Reachable only when the rows have drifted out of the ordering
+    # `season_order` claims they are in, and the unique index on
+    # (media_item_id, provider_episode_id) turns it into a raised constraint
+    # error inside a LiveView `handle_event` rather than a flash. Leaving the
+    # row untagged instead lands on `remap/3`'s refusal, which is the outcome
+    # this whole path is here to make honest.
+    taken = MapSet.new(tagged_ids(media_item))
+
+    Repo.transaction(fn ->
+      Enum.reduce(untagged, taken, fn episode, seen ->
+        case Map.get(by_coordinates, {episode.season_number, episode.episode_number}) do
+          nil ->
+            seen
+
+          id ->
+            if MapSet.member?(seen, id) do
+              seen
+            else
+              tag(episode, id)
+              MapSet.put(seen, id)
+            end
+        end
+      end)
+    end)
+  end
+
+  defp tagged_ids(%MediaItem{id: id}) do
+    Episode
+    |> where([e], e.media_item_id == ^id and not is_nil(e.provider_episode_id))
+    |> select([e], e.provider_episode_id)
+    |> Repo.all()
+  end
+
+  defp tag(%Episode{id: id}, provider_episode_id) do
+    Repo.update_all(
+      from(e in Episode, where: e.id == ^id),
+      set: [provider_episode_id: provider_episode_id]
+    )
+  end
+
   # Local episodes with a provider id that the fetched ordering never
   # mentioned. Episodes with no provider id at all are excluded here on
   # purpose — that is `remap/3`'s own `:missing_provider_ids` refusal to
   # raise, not this one's, and counting them here would misreport a
   # provider-id problem as an incomplete-ordering problem.
+  #
+  # Specials are excluded for the reason `@specials_season` gives: they are not
+  # part of what a switch moves, so an ordering is not incomplete for omitting
+  # them. A special the target ordering *does* place in a numbered season still
+  # moves — it is in `mapping` — it just is not required to be there.
   defp missing_from_mapping(%MediaItem{id: id}, mapping) do
     Episode
-    |> where([e], e.media_item_id == ^id)
+    |> where([e], e.media_item_id == ^id and e.season_number != @specials_season)
     |> select([e], e.provider_episode_id)
     |> Repo.all()
     |> Enum.reject(&(is_nil(&1) or Map.has_key?(mapping, &1)))

--- a/lib/mydia/media/season_order.ex
+++ b/lib/mydia/media/season_order.ex
@@ -147,8 +147,8 @@ defmodule Mydia.Media.SeasonOrder do
   to a metadata refresh that a throttle can silently decline to run for a
   week. See `backfill_provider_ids/4`.
 
-  Specials are out of scope on both sides: none is moved, and no ordering is
-  asked to account for one. See `@specials_season`.
+  Specials are out of scope on both sides: no ordering is asked to account for
+  one, and an untagged one cannot block the switch. See `@specials_season`.
 
   When it isn't a no-op, refuses (without writing anything) if the fetched
   ordering does not account for every one of the show's numbered episodes —
@@ -200,7 +200,20 @@ defmodule Mydia.Media.SeasonOrder do
             |> Enum.filter(&(&1.provider_episode_id && &1.season_number != @specials_season))
             |> Map.new(&{&1.provider_episode_id, {&1.season_number, &1.episode_number}})
 
-          case missing_from_mapping(media_item, mapping) do
+          # "Accounted for" and "moved" are different questions, so they are
+          # asked of different sets. An episode the target ordering files as a
+          # special is accounted for — the ordering knows about it — but is not
+          # moved, because `mapping` holds only numbered destinations. Judging
+          # completeness against `mapping` instead would report every such
+          # episode as missing and refuse the switch over a reclassification the
+          # user did not ask about.
+          accounted =
+            episodes
+            |> Enum.map(& &1.provider_episode_id)
+            |> Enum.reject(&is_nil/1)
+            |> MapSet.new()
+
+          case unaccounted_episodes(media_item, accounted) do
             [] -> remap(media_item, target, mapping)
             missing -> {:error, {:incomplete_ordering, length(missing)}}
           end
@@ -313,12 +326,12 @@ defmodule Mydia.Media.SeasonOrder do
   # part of what a switch moves, so an ordering is not incomplete for omitting
   # them. A special the target ordering *does* place in a numbered season still
   # moves — it is in `mapping` — it just is not required to be there.
-  defp missing_from_mapping(%MediaItem{id: id}, mapping) do
+  defp unaccounted_episodes(%MediaItem{id: id}, accounted) do
     Episode
     |> where([e], e.media_item_id == ^id and e.season_number != @specials_season)
     |> select([e], e.provider_episode_id)
     |> Repo.all()
-    |> Enum.reject(&(is_nil(&1) or Map.has_key?(mapping, &1)))
+    |> Enum.reject(&(is_nil(&1) or MapSet.member?(accounted, &1)))
   end
 
   @doc """
@@ -335,8 +348,14 @@ defmodule Mydia.Media.SeasonOrder do
   worse than one that declines to move: the damage is silent and the user
   cannot tell which episodes shifted.
 
-    * `{:error, :missing_provider_ids}` - some episode has no provider id, so
-      there is no stable identity to remap it by.
+    * `{:error, :missing_provider_ids}` - some numbered episode has no provider
+      id, so there is no stable identity to remap it by. Specials are exempt
+      for the reason `@specials_season` gives: an untagged special is not a row
+      this failed to identify, it is a row that was never in scope, and an
+      importer that created one from a filename would otherwise block every
+      ordering switch on the show for good. Untagged rows still keep their
+      coordinates and are still counted by `conflicting?/2`, so exempting them
+      from identity cannot let one move or collide.
     * `{:error, :conflicting_mapping}` - two episodes would land on the same
       `{season_number, episode_number}`, which the unique index forbids.
   """
@@ -346,7 +365,7 @@ defmodule Mydia.Media.SeasonOrder do
     episodes = Repo.all(from(e in Episode, where: e.media_item_id == ^id))
 
     cond do
-      Enum.any?(episodes, &is_nil(&1.provider_episode_id)) ->
+      Enum.any?(episodes, &untagged_numbered?/1) ->
         {:error, :missing_provider_ids}
 
       conflicting?(episodes, mapping) ->
@@ -356,6 +375,10 @@ defmodule Mydia.Media.SeasonOrder do
         Repo.transaction(fn -> write_ordering(id, episodes, target, mapping) end)
     end
   end
+
+  defp untagged_numbered?(%Episode{season_number: @specials_season}), do: false
+  defp untagged_numbered?(%Episode{provider_episode_id: nil}), do: true
+  defp untagged_numbered?(%Episode{}), do: false
 
   defp conflicting?(episodes, mapping) do
     coordinates = Enum.map(episodes, &target_coordinates(&1, mapping))

--- a/lib/mydia_web/controllers/api/media_controller.ex
+++ b/lib/mydia_web/controllers/api/media_controller.ex
@@ -7,7 +7,7 @@ defmodule MydiaWeb.Api.MediaController do
 
   use MydiaWeb, :controller
 
-  alias Mydia.{Media, Metadata, Repo}
+  alias Mydia.{Media, Metadata}
   alias Mydia.Accounts.Authorization
   alias Mydia.Auth.Guardian
   require Logger
@@ -214,41 +214,43 @@ defmodule MydiaWeb.Api.MediaController do
       })
       |> Map.reject(fn {_k, v} -> is_nil(v) end)
 
-    Repo.transaction(fn ->
-      # Update the media item
-      case Media.update_media_item(media_item, attrs, reason: "Manually matched") do
-        {:ok, updated_media_item} ->
-          # For TV shows, refresh episodes if requested
-          if media_item.type == "tv_show" and fetch_episodes do
-            # `force: true`: the show was just pointed at a different series, so
-            # its episodes are now the wrong ones. Letting the season-refresh
-            # throttle skip them would leave a manually matched show carrying
-            # the previous match's episodes for up to a week.
-            case Media.refresh_episodes_for_tv_show(updated_media_item,
-                   config: config,
-                   force: true
-                 ) do
-              {:ok, _episodes} ->
-                updated_media_item
+    # The episode refresh deliberately runs after the update commits, not inside
+    # a transaction with it. It fetches the series and every one of its seasons
+    # over the network, and SQLite admits one writer at a time, so holding the
+    # write open across that blocks every other writer for the duration. The
+    # transaction that used to wrap both bought nothing anyway: it covered a
+    # single write plus a side effect whose failures are swallowed here, so it
+    # could never roll back for the reason it appeared to guard.
+    case Media.update_media_item(media_item, attrs, reason: "Manually matched") do
+      {:ok, updated_media_item} ->
+        maybe_refresh_episodes(updated_media_item, fetch_episodes, config)
+        {:ok, updated_media_item}
 
-              {:error, reason} ->
-                Logger.warning("Failed to refresh episodes during manual match",
-                  media_item_id: media_item.id,
-                  reason: inspect(reason)
-                )
-
-                # Don't fail the whole operation if episode refresh fails
-                updated_media_item
-            end
-          else
-            updated_media_item
-          end
-
-        {:error, changeset} ->
-          Repo.rollback(changeset)
-      end
-    end)
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
+
+  # `force: true`: the show was just pointed at a different series, so its
+  # episodes are now the wrong ones. Letting the season-refresh throttle skip
+  # them would leave a manually matched show carrying the previous match's
+  # episodes for up to a week.
+  defp maybe_refresh_episodes(%{type: "tv_show"} = media_item, true, config) do
+    case Media.refresh_episodes_for_tv_show(media_item, config: config, force: true) do
+      {:ok, _episodes} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to refresh episodes during manual match",
+          media_item_id: media_item.id,
+          reason: inspect(reason)
+        )
+
+        :ok
+    end
+  end
+
+  defp maybe_refresh_episodes(_media_item, _fetch_episodes, _config), do: :ok
 
   defp extract_year(metadata) do
     cond do

--- a/lib/mydia_web/controllers/api/media_controller.ex
+++ b/lib/mydia_web/controllers/api/media_controller.ex
@@ -220,7 +220,14 @@ defmodule MydiaWeb.Api.MediaController do
         {:ok, updated_media_item} ->
           # For TV shows, refresh episodes if requested
           if media_item.type == "tv_show" and fetch_episodes do
-            case Media.refresh_episodes_for_tv_show(updated_media_item, config: config) do
+            # `force: true`: the show was just pointed at a different series, so
+            # its episodes are now the wrong ones. Letting the season-refresh
+            # throttle skip them would leave a manually matched show carrying
+            # the previous match's episodes for up to a week.
+            case Media.refresh_episodes_for_tv_show(updated_media_item,
+                   config: config,
+                   force: true
+                 ) do
               {:ok, _episodes} ->
                 updated_media_item
 

--- a/lib/mydia_web/live/media_live/show/file_events.ex
+++ b/lib/mydia_web/live/media_live/show/file_events.ex
@@ -149,8 +149,13 @@ defmodule MydiaWeb.MediaLive.Show.FileEvents do
   # this no longer hand-rolls the two-call sequence. Episode-refresh failures
   # are logged there rather than surfaced as a flash: they are best-effort and
   # must not read as a failed metadata refresh.
+  #
+  # `force: true` because a person clicked the button. The season-refresh
+  # throttle is sized for the weekly sweep, and without this it silently
+  # declines the episode half of the refresh for 24 hours — 168 once the show
+  # has ended — while this still flashes "Metadata refreshed".
   defp do_standard_refresh(media_item, socket) do
-    case Media.Refresh.run(media_item) do
+    case Media.Refresh.run(media_item, force: true) do
       {:ok, _updated_item} ->
         {:noreply,
          socket

--- a/test/mydia/media/refresh_season_order_test.exs
+++ b/test/mydia/media/refresh_season_order_test.exs
@@ -14,55 +14,7 @@ defmodule Mydia.Media.RefreshSeasonOrderTest do
   # The ordering is observable through which season ids the refresh then
   # fetches: each ordering's seasons carry their own TVDB season ids.
   describe "refresh_episodes_for_tv_show/2 season ordering" do
-    setup do
-      tvdb_id = System.unique_integer([:positive])
-      official_id = System.unique_integer([:positive])
-      dvd_one = System.unique_integer([:positive])
-      dvd_two = System.unique_integer([:positive])
-
-      bypass = Bypass.open()
-      hits = start_supervised!({Agent, fn -> [] end})
-
-      Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
-        json(conn, %{
-          "data" => %{
-            "id" => tvdb_id,
-            "name" => "Ordered Show",
-            "overview" => "x",
-            "firstAired" => "2023-01-01",
-            "status" => %{"name" => "Continuing"},
-            "genres" => [],
-            "seasons" => [
-              season_stub(official_id, 1, "official"),
-              season_stub(dvd_one, 1, "dvd"),
-              season_stub(dvd_two, 2, "dvd")
-            ]
-          }
-        })
-      end)
-
-      for {id, number} <- [{official_id, 1}, {dvd_one, 1}, {dvd_two, 2}] do
-        Bypass.stub(bypass, "GET", "/tvdb/seasons/#{id}/extended", fn conn ->
-          Agent.update(hits, &[id | &1])
-          json(conn, %{"data" => %{"id" => id, "number" => number, "episodes" => []}})
-        end)
-      end
-
-      config = %{
-        type: :metadata_relay,
-        base_url: "http://localhost:#{bypass.port}",
-        options: %{language: "en-US", include_adult: false}
-      }
-
-      %{
-        config: config,
-        tvdb_id: tvdb_id,
-        official_id: official_id,
-        dvd_one: dvd_one,
-        dvd_two: dvd_two,
-        fetched: fn -> Agent.get(hits, & &1) end
-      }
-    end
+    setup :ordering_stubs
 
     test "a show set to :dvd fetches the DVD ordering's seasons", ctx do
       item = show(ctx.tvdb_id, %{season_order: :dvd})
@@ -101,6 +53,115 @@ defmodule Mydia.Media.RefreshSeasonOrderTest do
       assert ctx.official_id in fetched
       refute ctx.dvd_one in fetched
     end
+  end
+
+  # The throttle keeps the weekly sweep off the relay, which is right for a
+  # sweep and wrong for a person: it also silently declined the episode half of
+  # a refresh someone clicked for, for 24 hours or 168 once the show ended,
+  # while the item row still updated and the flash still said it worked. That
+  # is what made "refresh this show's metadata, then try again" an instruction
+  # nobody could act on.
+  #
+  # Observable the same way as the ordering tests: whether any season was
+  # fetched at all.
+  describe "refresh_episodes_for_tv_show/2 season refresh throttle" do
+    setup :ordering_stubs
+
+    test "skips the episode fetch for a show refreshed moments ago", ctx do
+      item = recently_refreshed(ctx.tvdb_id)
+
+      assert {:ok, _count} = Media.refresh_episodes_for_tv_show(item, config: ctx.config)
+
+      assert ctx.fetched.() == []
+    end
+
+    test "force: true fetches anyway", ctx do
+      item = recently_refreshed(ctx.tvdb_id)
+
+      assert {:ok, _count} =
+               Media.refresh_episodes_for_tv_show(item, config: ctx.config, force: true)
+
+      assert ctx.official_id in ctx.fetched.()
+    end
+
+    test "Refresh.run/2 threads force through to the episode leg", ctx do
+      item = recently_refreshed(ctx.tvdb_id)
+
+      assert {:ok, _updated} = Media.Refresh.run(item, config: ctx.config, force: true)
+
+      assert ctx.official_id in ctx.fetched.()
+    end
+
+    test "Refresh.run/2 without force leaves the throttle in place", ctx do
+      item = recently_refreshed(ctx.tvdb_id)
+
+      assert {:ok, _updated} = Media.Refresh.run(item, config: ctx.config)
+
+      assert ctx.fetched.() == []
+    end
+  end
+
+  # `should_skip_season_refresh?/1` reads the struct it is handed, not the row,
+  # so the stamp has to be reloaded or every one of these tests passes for the
+  # wrong reason.
+  defp recently_refreshed(tvdb_id) do
+    item = show(tvdb_id, %{})
+    Media.stamp_seasons_refreshed(item)
+    reloaded = Repo.get!(Mydia.Media.MediaItem, item.id)
+
+    refute is_nil(reloaded.seasons_refreshed_at)
+
+    reloaded
+  end
+
+  defp ordering_stubs(_context) do
+    tvdb_id = System.unique_integer([:positive])
+    official_id = System.unique_integer([:positive])
+    dvd_one = System.unique_integer([:positive])
+    dvd_two = System.unique_integer([:positive])
+
+    bypass = Bypass.open()
+    hits = start_supervised!({Agent, fn -> [] end})
+
+    Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+      json(conn, %{
+        "data" => %{
+          "id" => tvdb_id,
+          "name" => "Ordered Show",
+          "overview" => "x",
+          "firstAired" => "2023-01-01",
+          "status" => %{"name" => "Continuing"},
+          "genres" => [],
+          "seasons" => [
+            season_stub(official_id, 1, "official"),
+            season_stub(dvd_one, 1, "dvd"),
+            season_stub(dvd_two, 2, "dvd")
+          ]
+        }
+      })
+    end)
+
+    for {id, number} <- [{official_id, 1}, {dvd_one, 1}, {dvd_two, 2}] do
+      Bypass.stub(bypass, "GET", "/tvdb/seasons/#{id}/extended", fn conn ->
+        Agent.update(hits, &[id | &1])
+        json(conn, %{"data" => %{"id" => id, "number" => number, "episodes" => []}})
+      end)
+    end
+
+    config = %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false}
+    }
+
+    %{
+      config: config,
+      tvdb_id: tvdb_id,
+      official_id: official_id,
+      dvd_one: dvd_one,
+      dvd_two: dvd_two,
+      fetched: fn -> Agent.get(hits, & &1) end
+    }
   end
 
   defp show(tvdb_id, extra) do

--- a/test/mydia/media/season_order_switch_test.exs
+++ b/test/mydia/media/season_order_switch_test.exs
@@ -1,0 +1,354 @@
+defmodule Mydia.Media.SeasonOrderSwitchTest do
+  @moduledoc """
+  Covers `SeasonOrder.switch/3` against a relay stub, with the emphasis on
+  shows whose episode rows predate the `provider_episode_id` column.
+
+  Every episode row written before that column existed holds NULL, and the
+  only writer of it is a metadata refresh, which `should_skip_season_refresh?/1`
+  throttles for up to 168 hours on an ended show. So a refusal here pointed the
+  user at a remedy that silently does nothing — observed on production for
+  Black Clover, 189 episodes, none of them tagged.
+  """
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Media
+  alias Mydia.Media.MediaItem
+  alias Mydia.Media.SeasonOrder
+
+  defp config(bypass) do
+    %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false, timeout: 30_000}
+    }
+  end
+
+  defp json(conn, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(200, Jason.encode!(body))
+  end
+
+  # One official season of 4, split into two DVD seasons of 2 — Black Clover's
+  # shape in miniature.
+  defp stub_series(bypass, tvdb_id, official_id, dvd_ids) do
+    [dvd1, dvd2] = dvd_ids
+
+    stub_seasons_list(bypass, tvdb_id, official_id, dvd_ids)
+
+    stub_season(bypass, official_id, [
+      %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+      %{"id" => 1002, "seasonNumber" => 1, "number" => 2},
+      %{"id" => 1003, "seasonNumber" => 1, "number" => 3},
+      %{"id" => 1004, "seasonNumber" => 1, "number" => 4}
+    ])
+
+    stub_season(bypass, dvd1, [
+      %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+      %{"id" => 1002, "seasonNumber" => 1, "number" => 2}
+    ])
+
+    stub_season(bypass, dvd2, [
+      %{"id" => 1003, "seasonNumber" => 2, "number" => 1},
+      %{"id" => 1004, "seasonNumber" => 2, "number" => 2}
+    ])
+  end
+
+  defp stub_seasons_list(bypass, tvdb_id, official_id, [dvd1, dvd2]) do
+    Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+      json(conn, %{
+        "data" => %{
+          "seasons" => [
+            %{"id" => official_id, "number" => 1, "type" => %{"type" => "official"}},
+            %{"id" => dvd1, "number" => 1, "type" => %{"type" => "dvd"}},
+            %{"id" => dvd2, "number" => 2, "type" => %{"type" => "dvd"}}
+          ]
+        }
+      })
+    end)
+  end
+
+  defp stub_season(bypass, season_id, episodes) do
+    Bypass.stub(bypass, "GET", "/tvdb/seasons/#{season_id}/extended", fn conn ->
+      json(conn, %{"data" => %{"episodes" => episodes}})
+    end)
+  end
+
+  defp untagged_show(tvdb_id, count \\ 4) do
+    show = media_item_fixture(%{type: "tv_show", title: "Untagged Show", tvdb_id: tvdb_id})
+
+    for n <- 1..count do
+      episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 1,
+        episode_number: n,
+        provider_episode_id: nil
+      })
+    end
+
+    show
+  end
+
+  defp coordinates(show) do
+    show.id
+    |> Media.list_episodes()
+    |> Enum.map(&{&1.season_number, &1.episode_number})
+    |> Enum.sort()
+  end
+
+  defp provider_ids(show) do
+    show.id
+    |> Media.list_episodes()
+    |> Enum.map(& &1.provider_episode_id)
+    |> Enum.sort()
+  end
+
+  # Unique per test so the 24h relay caches keyed on these ids cannot leak
+  # between async tests.
+  defp unique_ids do
+    base = System.unique_integer([:positive])
+    {base, base * 10, [base * 10 + 1, base * 10 + 2]}
+  end
+
+  describe "switch/3 with episodes that predate provider_episode_id" do
+    test "backfills the ids from the current ordering and completes the switch" do
+      bypass = Bypass.open()
+      {tvdb_id, official_id, dvd_ids} = unique_ids()
+      stub_series(bypass, tvdb_id, official_id, dvd_ids)
+
+      show = untagged_show(tvdb_id)
+      ids_before = show.id |> Media.list_episodes() |> Enum.map(& &1.id) |> Enum.sort()
+
+      assert {:ok, 4} = SeasonOrder.switch(show, :dvd, config(bypass))
+
+      assert coordinates(show) == [{1, 1}, {1, 2}, {2, 1}, {2, 2}]
+      assert provider_ids(show) == ["1001", "1002", "1003", "1004"]
+
+      # Same rows throughout: file links, watch history and monitored flags
+      # ride on these ids.
+      assert show.id |> Media.list_episodes() |> Enum.map(& &1.id) |> Enum.sort() == ids_before
+
+      assert Repo.get!(MediaItem, show.id).season_order == :dvd
+    end
+
+    test "refuses when an episode sits where the current ordering has nothing" do
+      bypass = Bypass.open()
+      {tvdb_id, official_id, dvd_ids} = unique_ids()
+      stub_series(bypass, tvdb_id, official_id, dvd_ids)
+
+      show = untagged_show(tvdb_id)
+
+      # A fifth episode at coordinates the official ordering never mentions:
+      # nothing can tag it, so the switch must still refuse rather than move a
+      # partially tagged show.
+      episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 1,
+        episode_number: 99,
+        provider_episode_id: nil
+      })
+
+      assert {:error, :missing_provider_ids} = SeasonOrder.switch(show, :dvd, config(bypass))
+
+      assert coordinates(show) == [{1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 99}]
+      assert Repo.get!(MediaItem, show.id).season_order == nil
+    end
+
+    test "leaves ids that are already present alone" do
+      bypass = Bypass.open()
+      {tvdb_id, official_id, dvd_ids} = unique_ids()
+      stub_series(bypass, tvdb_id, official_id, dvd_ids)
+
+      show = media_item_fixture(%{type: "tv_show", title: "Half Tagged", tvdb_id: tvdb_id})
+
+      for n <- 1..4 do
+        episode_fixture(%{
+          media_item_id: show.id,
+          season_number: 1,
+          episode_number: n,
+          provider_episode_id: if(n <= 2, do: "#{1000 + n}", else: nil)
+        })
+      end
+
+      assert {:ok, 4} = SeasonOrder.switch(show, :dvd, config(bypass))
+
+      assert provider_ids(show) == ["1001", "1002", "1003", "1004"]
+      assert coordinates(show) == [{1, 1}, {1, 2}, {2, 1}, {2, 2}]
+    end
+
+    test "refuses without writing when the current ordering cannot be fetched" do
+      bypass = Bypass.open()
+      {tvdb_id, official_id, dvd_ids} = unique_ids()
+      [dvd1, dvd2] = dvd_ids
+
+      stub_seasons_list(bypass, tvdb_id, official_id, dvd_ids)
+      stub_season(bypass, dvd1, [%{"id" => 1001, "seasonNumber" => 1, "number" => 1}])
+      stub_season(bypass, dvd2, [%{"id" => 1003, "seasonNumber" => 2, "number" => 1}])
+
+      Bypass.stub(bypass, "GET", "/tvdb/seasons/#{official_id}/extended", fn conn ->
+        Plug.Conn.resp(conn, 500, "")
+      end)
+
+      show = untagged_show(tvdb_id)
+
+      assert {:error, _reason} = SeasonOrder.switch(show, :dvd, config(bypass))
+
+      assert coordinates(show) == [{1, 1}, {1, 2}, {1, 3}, {1, 4}]
+      assert provider_ids(show) == [nil, nil, nil, nil]
+      assert Repo.get!(MediaItem, show.id).season_order == nil
+    end
+
+    # Black Clover's actual shape, verified against relay.mydia.dev for TVDB
+    # 331753: the three orderings agree on all 170 numbered episodes and
+    # disagree on specials — 19 official, 27 DVD, 0 absolute — and two of the
+    # official specials are absent from the DVD ordering while the DVD ordering
+    # hands their (0, 26) and (0, 27) coordinates to different episodes.
+    # Counting specials therefore refused the switch outright, and remapping
+    # them anyway would have collided.
+    test "switches when the target ordering files specials differently" do
+      bypass = Bypass.open()
+      {tvdb_id, official_id, dvd_ids} = unique_ids()
+      [dvd1, dvd2] = dvd_ids
+
+      stub_seasons_list(bypass, tvdb_id, official_id, dvd_ids)
+
+      stub_season(bypass, official_id, [
+        %{"id" => 2001, "seasonNumber" => 0, "number" => 26},
+        %{"id" => 2002, "seasonNumber" => 0, "number" => 27},
+        %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+        %{"id" => 1002, "seasonNumber" => 1, "number" => 2},
+        %{"id" => 1003, "seasonNumber" => 1, "number" => 3},
+        %{"id" => 1004, "seasonNumber" => 1, "number" => 4}
+      ])
+
+      # The DVD ordering knows nothing of 2001/2002 and reuses their
+      # coordinates for two other specials entirely.
+      stub_season(bypass, dvd1, [
+        %{"id" => 3001, "seasonNumber" => 0, "number" => 26},
+        %{"id" => 3002, "seasonNumber" => 0, "number" => 27},
+        %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+        %{"id" => 1002, "seasonNumber" => 1, "number" => 2}
+      ])
+
+      stub_season(bypass, dvd2, [
+        %{"id" => 1003, "seasonNumber" => 2, "number" => 1},
+        %{"id" => 1004, "seasonNumber" => 2, "number" => 2}
+      ])
+
+      show = media_item_fixture(%{type: "tv_show", title: "Has Specials", tvdb_id: tvdb_id})
+
+      for {season, number} <- [{0, 26}, {0, 27}, {1, 1}, {1, 2}, {1, 3}, {1, 4}] do
+        episode_fixture(%{
+          media_item_id: show.id,
+          season_number: season,
+          episode_number: number,
+          provider_episode_id: nil
+        })
+      end
+
+      assert {:ok, 4} = SeasonOrder.switch(show, :dvd, config(bypass))
+
+      # The numbered episodes moved; the specials stayed exactly where they
+      # were rather than being renumbered onto another ordering's specials.
+      assert coordinates(show) == [{0, 26}, {0, 27}, {1, 1}, {1, 2}, {2, 1}, {2, 2}]
+      assert provider_ids(show) == ["1001", "1002", "1003", "1004", "2001", "2002"]
+      assert Repo.get!(MediaItem, show.id).season_order == :dvd
+    end
+
+    test "switches to an ordering that lists no specials at all" do
+      bypass = Bypass.open()
+      {tvdb_id, official_id, _dvd_ids} = unique_ids()
+      absolute_id = official_id + 5
+
+      Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+        json(conn, %{
+          "data" => %{
+            "seasons" => [
+              %{"id" => official_id, "number" => 1, "type" => %{"type" => "official"}},
+              %{"id" => absolute_id, "number" => 1, "type" => %{"type" => "absolute"}}
+            ]
+          }
+        })
+      end)
+
+      stub_season(bypass, official_id, [
+        %{"id" => 2001, "seasonNumber" => 0, "number" => 1},
+        %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+        %{"id" => 1002, "seasonNumber" => 2, "number" => 1}
+      ])
+
+      # Absolute ordering: no specials season at all, which used to refuse
+      # every show that has one.
+      stub_season(bypass, absolute_id, [
+        %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+        %{"id" => 1002, "seasonNumber" => 1, "number" => 2}
+      ])
+
+      show =
+        media_item_fixture(%{type: "tv_show", title: "No Absolute Specials", tvdb_id: tvdb_id})
+
+      for {season, number} <- [{0, 1}, {1, 1}, {2, 1}] do
+        episode_fixture(%{
+          media_item_id: show.id,
+          season_number: season,
+          episode_number: number,
+          provider_episode_id: nil
+        })
+      end
+
+      assert {:ok, 2} = SeasonOrder.switch(show, :absolute, config(bypass))
+
+      assert coordinates(show) == [{0, 1}, {1, 1}, {1, 2}]
+      assert Repo.get!(MediaItem, show.id).season_order == :absolute
+    end
+
+    test "still refuses when the target ordering drops a numbered episode" do
+      bypass = Bypass.open()
+      {tvdb_id, official_id, dvd_ids} = unique_ids()
+      [dvd1, dvd2] = dvd_ids
+
+      stub_seasons_list(bypass, tvdb_id, official_id, dvd_ids)
+
+      stub_season(bypass, official_id, [
+        %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+        %{"id" => 1002, "seasonNumber" => 1, "number" => 2},
+        %{"id" => 1003, "seasonNumber" => 1, "number" => 3},
+        %{"id" => 1004, "seasonNumber" => 1, "number" => 4}
+      ])
+
+      # 1004 is nowhere in the DVD ordering: a numbered episode really left
+      # behind, which is the case the refusal exists for.
+      stub_season(bypass, dvd1, [
+        %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+        %{"id" => 1002, "seasonNumber" => 1, "number" => 2}
+      ])
+
+      stub_season(bypass, dvd2, [%{"id" => 1003, "seasonNumber" => 2, "number" => 1}])
+
+      show = untagged_show(tvdb_id)
+
+      assert {:error, {:incomplete_ordering, 1}} = SeasonOrder.switch(show, :dvd, config(bypass))
+
+      assert coordinates(show) == [{1, 1}, {1, 2}, {1, 3}, {1, 4}]
+      assert Repo.get!(MediaItem, show.id).season_order == nil
+    end
+
+    test "a show already on the target ordering still confirms without any fetch" do
+      bypass = Bypass.open()
+      {tvdb_id, _official_id, _dvd_ids} = unique_ids()
+
+      Bypass.down(bypass)
+
+      show = untagged_show(tvdb_id)
+
+      on_dvd =
+        show
+        |> Ecto.Changeset.change(season_order: :dvd)
+        |> Repo.update!()
+
+      assert {:ok, :confirmed} = SeasonOrder.switch(on_dvd, :dvd, config(bypass))
+    end
+  end
+end

--- a/test/mydia/media/season_order_switch_test.exs
+++ b/test/mydia/media/season_order_switch_test.exs
@@ -304,6 +304,68 @@ defmodule Mydia.Media.SeasonOrderSwitchTest do
       assert Repo.get!(MediaItem, show.id).season_order == :absolute
     end
 
+    # The importer creates episode rows from parsed filenames with no provider
+    # id (`ImportGroups.link_local_member/2`), so a stray S00E99 file is enough
+    # to produce a special that nothing can ever tag. Letting that block the
+    # switch would put the show back behind the same unactionable message, for
+    # good this time, over a row the switch does not touch.
+    test "an untagged special does not block the switch" do
+      bypass = Bypass.open()
+      {tvdb_id, official_id, dvd_ids} = unique_ids()
+      stub_series(bypass, tvdb_id, official_id, dvd_ids)
+
+      show = untagged_show(tvdb_id)
+
+      episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 0,
+        episode_number: 99,
+        provider_episode_id: nil
+      })
+
+      assert {:ok, 4} = SeasonOrder.switch(show, :dvd, config(bypass))
+
+      assert coordinates(show) == [{0, 99}, {1, 1}, {1, 2}, {2, 1}, {2, 2}]
+      assert provider_ids(show) == [nil, "1001", "1002", "1003", "1004"]
+      assert Repo.get!(MediaItem, show.id).season_order == :dvd
+    end
+
+    # Accounted for is not the same question as moved. The target ordering knows
+    # this episode, it just files it as a special, and `mapping` holds only
+    # numbered destinations — so judging completeness against `mapping` would
+    # refuse the whole switch over a reclassification nobody asked about.
+    test "an episode the target ordering files as a special is accounted for" do
+      bypass = Bypass.open()
+      {tvdb_id, official_id, dvd_ids} = unique_ids()
+      [dvd1, dvd2] = dvd_ids
+
+      stub_seasons_list(bypass, tvdb_id, official_id, dvd_ids)
+
+      stub_season(bypass, official_id, [
+        %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+        %{"id" => 1002, "seasonNumber" => 1, "number" => 2},
+        %{"id" => 1003, "seasonNumber" => 1, "number" => 3},
+        %{"id" => 1004, "seasonNumber" => 1, "number" => 4}
+      ])
+
+      # 1004 is a numbered episode locally, and a special in the DVD ordering.
+      stub_season(bypass, dvd1, [
+        %{"id" => 1001, "seasonNumber" => 1, "number" => 1},
+        %{"id" => 1002, "seasonNumber" => 1, "number" => 2},
+        %{"id" => 1004, "seasonNumber" => 0, "number" => 3}
+      ])
+
+      stub_season(bypass, dvd2, [%{"id" => 1003, "seasonNumber" => 2, "number" => 1}])
+
+      show = untagged_show(tvdb_id)
+
+      assert {:ok, 3} = SeasonOrder.switch(show, :dvd, config(bypass))
+
+      # It stays where it is rather than being renumbered into specials.
+      assert coordinates(show) == [{1, 1}, {1, 2}, {1, 4}, {2, 1}]
+      assert Repo.get!(MediaItem, show.id).season_order == :dvd
+    end
+
     test "still refuses when the target ordering drops a numbered episode" do
       bypass = Bypass.open()
       {tvdb_id, official_id, dvd_ids} = unique_ids()

--- a/test/mydia_web/live/media_live/show/season_order_ui_test.exs
+++ b/test/mydia_web/live/media_live/show/season_order_ui_test.exs
@@ -306,7 +306,13 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderUiTest do
     assert episode_numbers == Enum.to_list(1..170)
   end
 
-  test "missing provider ids produce an actionable flash instead of a crash", %{conn: conn} do
+  # This used to assert the "refresh this show's metadata" flash, which was the
+  # honest thing to say when nothing could tag these rows. It is the wrong
+  # assertion now: every row written before the `provider_episode_id` column
+  # existed holds NULL, which is nearly every show in an existing library, and
+  # the refresh that flash asked for is throttled for up to a week. The switch
+  # tags them from the ordering they are already in and goes through.
+  test "a show whose episodes predate provider ids switches anyway", %{conn: conn} do
     tvdb_id = System.unique_integer([:positive])
 
     show =
@@ -319,6 +325,52 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderUiTest do
       })
 
     for n <- 1..170 do
+      episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 1,
+        episode_number: n,
+        provider_episode_id: nil
+      })
+    end
+
+    stub_tvdb_orderings(tvdb_id, official: 170, dvd: [51, 51, 52, 16])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    view |> element("#season-order-accept") |> render_click()
+
+    assert has_element?(view, "#flash-info", "Switched to DVD order")
+
+    reloaded = Media.get_media_item!(show.id)
+    assert reloaded.season_order == :dvd
+
+    tagged =
+      Episode
+      |> where([e], e.media_item_id == ^show.id and is_nil(e.provider_episode_id))
+      |> Repo.aggregate(:count)
+
+    assert tagged == 0
+  end
+
+  # The flash still has to exist, and still has to be reachable: an episode the
+  # current ordering never mentions cannot be tagged by anything, and moving a
+  # partially identified show is worse than declining to.
+  test "an episode no ordering can tag still produces an actionable flash", %{conn: conn} do
+    tvdb_id = System.unique_integer([:positive])
+
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Untaggable Episode",
+        tvdb_id: tvdb_id,
+        metadata_source: :tvdb,
+        season_order: nil
+      })
+
+    # 171 local episodes against an official ordering that lists 170, so the
+    # last one sits at coordinates nothing describes.
+    for n <- 1..171 do
       episode_fixture(%{
         media_item_id: show.id,
         season_number: 1,


### PR DESCRIPTION
Switching Black Clover to DVD ordering on galactica refused with "Some of this show's episodes are missing their provider id. Refresh this show's metadata, then try again." Refreshing did nothing, and could not have.

## Root cause

Three things stacked behind that one message. All of it measured against the live instance and relay, not reasoned about.

**1. Every episode row predates `provider_episode_id`.** The column arrived in `20260817161500`, which ran on galactica at `2026-08-18 04:08`, after that show's last season refresh at `2026-08-17 19:09`. All 189 of its episodes hold NULL, so `remap/3` refuses on identity. Library-wide it is 2174 rows out of 2625.

**2. The remedy the message prescribes could not run.** The only writer of that column is `upsert_episodes_from_season/3`, reached through `refresh_episodes_for_tv_show/2`, which gates its whole episode leg behind `should_skip_season_refresh?/1`: a 24 hour throttle that becomes 168 once the metadata blob says the show ended. That throttle applied to the UI button, not just the weekly sweep. The `media_item` row updates, the flash reports success, the episodes are untouched, and nothing says so. Black Clover was 33 hours into a 168 hour window, and its `updated_at` shows the refresh was tried.

**3. Backfilling the ids alone still refuses**, with `{:incomplete_ordering, 2}`. Measured against relay.mydia.dev for TVDB 331753:

| ordering | numbered episodes | specials | seasons |
|---|---|---|---|
| official | 170 | 19 | 1x170 |
| dvd | 170 | 27 | 51, 51, 52, 16 |
| absolute | 170 | **0** | 1x170 |

The 170 numbered episode ids are identical across all three, in both directions. Every disagreement is in season 0. Two official specials ("Sword of the Wizard King", "Jump Festa 2018 Special") are absent from the DVD ordering, which hands their `(0,26)` and `(0,27)` coordinates to different episodes, so remapping them anyway collides on the season and episode unique index. An ordering that lists no specials refused every show that has one, which is every switch to absolute.

## Change

### `SeasonOrder.switch/3` tags what it needs

Untagged rows are backfilled from the ordering the show is already in, before remapping. An untagged row at a given (season, episode) is that ordering's episode at those coordinates, which is the same identification `Media.find_existing_episode/2` already makes on every refresh.

An id another row already carries is skipped rather than written, so a show whose rows have drifted cannot raise a constraint error inside a `handle_event`. A failed fetch propagates instead of falling through to an untagged remap, because a partially tagged show must not be moved.

### Specials are out of scope on both sides

None is moved, and no ordering is asked to account for one. This is the line `fetch_alternative_counts/3` already draws when it counts the seasons the suggestion banner offers: the banner promises "51, 51, 52, 16" and says nothing about specials, so the switch now delivers exactly that. A special the target ordering does place in a numbered season still moves, it just is not required to.

`remap/3`'s contract is unchanged.

### A refresh someone clicked for is a hard refresh

`refresh_episodes_for_tv_show/2` and `Refresh.run/2` take `:force`.

| caller | forces | why |
|---|---|---|
| show page "Refresh metadata" button | yes | a person asked for the work to happen now |
| manual-match API endpoint | yes | the show was just pointed at a different series, so its episodes are the previous match's |
| weekly `MetadataRefresh` sweep | no | the throttle is what it was sized for |

## Verification

Replayed the new logic over live Black Clover data, read-only:

```
rows still untagged after backfill: 0
mapping entries (dvd, specials excluded): 170
incomplete_ordering count (0 means the switch proceeds): 0
would remap/3 refuse with :missing_provider_ids?: false
would remap/3 refuse with :conflicting_mapping?: false
episodes that would be remapped: 170
resulting season layout: [{0, 19}, {1, 51}, {2, 51}, {3, 52}, {4, 16}]
```

`switch/3` had no test coverage at all. The new file covers Black Clover's shape, including an ordering that lists no specials, plus the refusals that have to survive it: a numbered episode the target ordering drops, an episode nothing can tag, an unreachable current ordering that writes nothing, and the already-on-target confirm that still needs no fetch.

The throttle gets its first coverage too, both directions and at both layers, on the existing ordering fixture that already observes which seasons a refresh fetches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a force-refresh option for TV metadata updates, allowing manual refreshes to bypass refresh throttling.
  * Improved season-order switching by handling missing episode IDs and specials more reliably.
* **Bug Fixes**
  * Prevented incomplete or unavailable season orderings from changing existing data.
  * Preserved episode and season-order information when switching orderings fails.
* **Tests**
  * Added coverage for forced refreshes, refresh throttling, season-order switching, specials, and missing metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->