### PR TITLE
feat(search): show that a search is still running in the indexer bar

### DIFF
--- a/lib/mydia_web/components/indexer_components.ex
+++ b/lib/mydia_web/components/indexer_components.ex
@@ -19,6 +19,10 @@ defmodule MydiaWeb.IndexerComponents do
   completion count, and a failed count — with an expandable `<details>` list of
   one row per indexer.
 
+  While any indexer is still outstanding the summary carries a spinner and a
+  determinate progress bar, so an in-flight search is obvious without expanding
+  the list. Both are replaced by a success check once every indexer settles.
+
   `progress` is a map of `indexer_id => %IndexerProgress{}`. Pass `retry_event`
   to render a retry button on failed and timed-out indexers; the button sends
   that event with `phx-value-id` set to the indexer id.
@@ -45,13 +49,34 @@ defmodule MydiaWeb.IndexerComponents do
       |> assign(:done, done)
       |> assign(:total, total)
       |> assign(:failed, failed)
+      # Derived rather than passed in: a row is :pending until it settles, and
+      # a retry puts a settled row back to :pending, so this tracks a retry's
+      # in-flight window too.
+      |> assign(:searching, done < total)
 
     ~H"""
-    <div :if={@rows != []} id="indexer-search-status" class="mb-4">
+    <div :if={@rows != []} id="indexer-search-status" class="mb-4" aria-busy={to_string(@searching)}>
       <details class="collapse collapse-arrow bg-base-200/50 border border-base-300">
-        <summary class="collapse-title text-sm font-medium flex items-center gap-2">
+        <summary class="collapse-title text-sm font-medium flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span
+            :if={@searching}
+            class="loading loading-spinner loading-xs text-primary shrink-0"
+            aria-hidden="true"
+          ></span>
+          <.icon
+            :if={!@searching}
+            name="hero-check-circle"
+            class="w-4 h-4 shrink-0 text-success"
+          />
+          <span :if={@searching} class="sr-only">Searching indexers</span>
           <span>{@total_results} results · {@done}/{@total} indexers</span>
           <span :if={@failed > 0} class="badge badge-sm badge-error">{@failed} failed</span>
+          <progress
+            :if={@searching}
+            class="progress progress-primary w-full h-1"
+            value={@done}
+            max={@total}
+          ></progress>
         </summary>
         <div class="collapse-content">
           <ul class="menu w-full">

--- a/test/mydia_web/components/indexer_components_test.exs
+++ b/test/mydia_web/components/indexer_components_test.exs
@@ -75,8 +75,92 @@ defmodule MydiaWeb.IndexerComponentsTest do
 
     document = LazyHTML.from_fragment(html)
 
-    assert LazyHTML.query(document, "#indexer-search-status .loading") |> Enum.count() == 1
+    assert LazyHTML.query(document, "#indexer-search-status ul li .loading") |> Enum.count() == 1
     assert LazyHTML.query(document, "#indexer-search-status button") |> Enum.empty?()
+  end
+
+  test "the summary spins and shows a determinate progress bar while indexers are outstanding" do
+    progress =
+      progress_map([
+        %IndexerProgress{
+          indexer: "Alpha",
+          indexer_id: "a",
+          status: :ok,
+          result_count: 5,
+          duration_ms: 400,
+          total: 3
+        },
+        %IndexerProgress{indexer: "Beta", indexer_id: "b", status: :pending, total: 3},
+        %IndexerProgress{
+          indexer: "Gamma",
+          indexer_id: "c",
+          status: :error,
+          error: "boom",
+          total: 3
+        }
+      ])
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: progress)
+
+    document = LazyHTML.from_fragment(html)
+
+    assert LazyHTML.query(document, "#indexer-search-status summary .loading-spinner")
+           |> Enum.count() == 1
+
+    bar = LazyHTML.query(document, "#indexer-search-status summary progress")
+
+    assert LazyHTML.attribute(bar, "value") == ["2"]
+    assert LazyHTML.attribute(bar, "max") == ["3"]
+
+    # The success check belongs to the settled state, not this one.
+    assert LazyHTML.query(document, "#indexer-search-status summary .hero-check-circle")
+           |> Enum.empty?()
+
+    assert LazyHTML.query(document, "#indexer-search-status")
+           |> LazyHTML.attribute("aria-busy") == ["true"]
+  end
+
+  test "the summary drops the spinner and progress bar once every indexer settles" do
+    progress =
+      progress_map([
+        %IndexerProgress{
+          indexer: "Alpha",
+          indexer_id: "a",
+          status: :ok,
+          result_count: 5,
+          duration_ms: 400,
+          total: 3
+        },
+        %IndexerProgress{
+          indexer: "Beta",
+          indexer_id: "b",
+          status: :timeout,
+          error: "Timed out",
+          total: 3
+        },
+        %IndexerProgress{
+          indexer: "Gamma",
+          indexer_id: "c",
+          status: :error,
+          error: "boom",
+          total: 3
+        }
+      ])
+
+    html =
+      render_component(&MydiaWeb.IndexerComponents.indexer_search_status/1, progress: progress)
+
+    document = LazyHTML.from_fragment(html)
+
+    assert LazyHTML.query(document, "#indexer-search-status summary .loading") |> Enum.empty?()
+    assert LazyHTML.query(document, "#indexer-search-status summary progress") |> Enum.empty?()
+
+    assert LazyHTML.query(document, "#indexer-search-status summary .hero-check-circle")
+           |> Enum.count() == 1
+
+    assert LazyHTML.query(document, "#indexer-search-status")
+           |> LazyHTML.attribute("aria-busy") == ["false"]
   end
 
   test "a failed indexer shows its error and a retry button when the event is given" do


### PR DESCRIPTION
## Problem

The collapsed indexer bar reads `12 results · 2/5 indexers` whether the search is halfway through or finished. Both call sites (the search page and the manual-search modal) render a large "Searching indexers…" card, but only while no indexer has reported yet. The moment the first one lands, that card disappears and the bar is the only thing on screen, looking identical to a completed search. You had to expand the `<details>` list to see the per-row spinners and tell the difference.

## Change

While any indexer is still outstanding, the summary row carries a daisyUI `loading loading-spinner` plus a determinate `progress progress-primary` bar over `done`/`total`. Once every indexer settles, both give way to a `hero-check-circle` in the same slot, so the text does not shift horizontally when the search finishes.

```
┌──────────────────────────────────────────────┐
│ ◜ 12 results · 2/5 indexers      [1 failed] ⌄│
│ ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
└──────────────────────────────────────────────┘
         ↓ when all indexers settle
┌──────────────────────────────────────────────┐
│ ✓ 27 results · 5/5 indexers      [1 failed] ⌄│
└──────────────────────────────────────────────┘
```

The summary text itself is unchanged.

## Notes

- The in-flight state is derived (`done < total`) from rows the component already folds, so there is no new attr and no LiveView change. A retried indexer is set back to `:pending` by `handle_event("retry_indexer", ...)`, so the indicator correctly returns for a retry's in-flight window.
- Summary children stay phrasing-level (`<span>`, `<progress>`, `<.icon>`) since `<summary>`'s content model has no room for a block `<div>`. daisyUI's `collapse-title` already reserves `padding-inline-end` for the `collapse-arrow`, so the full-width bar stops short of it.
- `aria-busy` on the wrapper, `aria-hidden` on the decorative spinner, and an `sr-only` "Searching indexers" label.

## Verification

- `mix test test/mydia_web/components/indexer_components_test.exs` — 11 tests, 0 failures. Two new tests cover the in-flight and settled summaries; the existing pending-row spinner assertion is scoped to the row list so it keeps testing what it meant to.
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, and `mix credo --strict` on the touched files all clean.
- Rendered both states and confirmed the markup, and confirmed `mix assets.build` emits daisyUI's `.progress` and `.progress-primary` rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear visual feedback while indexing is in progress, including a spinner, progress bar, and busy accessibility state.
  * Added a success indicator when indexing completes.
  * Improved status layout to accommodate progress indicators on smaller screens.

* **Accessibility**
  * Added `aria-busy` status information to communicate indexing activity to assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->