### PR TITLE
Remove from Continue Watching

### DIFF
--- a/lib/mydia/playback.ex
+++ b/lib/mydia/playback.ex
@@ -503,15 +503,37 @@ defmodule Mydia.Playback do
         |> Keyword.get(:now, DateTime.utc_now())
         |> DateTime.truncate(:second)
 
-      %Dismissal{user_id: user_id, media_item_id: media_item_id}
-      |> Dismissal.changeset(%{dismissed_at: now})
-      |> Repo.insert(
-        on_conflict: {:replace, [:dismissed_at, :updated_at]},
-        conflict_target: [:user_id, :media_item_id]
-      )
+      insert_dismissal(user_id, media_item_id, now)
     else
       {:error, :not_found}
     end
+  end
+
+  # The lookup above cannot close the window on its own: a media item deleted
+  # between the check and this insert takes the foreign key with it. Postgres
+  # names the constraint so the changeset carries the error, SQLite does not and
+  # `Repo.insert/2` raises, so the rescue is what makes the two agree. Either
+  # way the answer is the one the check gives for an id that never existed.
+  defp insert_dismissal(user_id, media_item_id, now) do
+    %Dismissal{user_id: user_id, media_item_id: media_item_id}
+    |> Dismissal.changeset(%{dismissed_at: now})
+    |> Repo.insert(
+      on_conflict: {:replace, [:dismissed_at, :updated_at]},
+      conflict_target: [:user_id, :media_item_id]
+    )
+    |> case do
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if missing_parent?(changeset), do: {:error, :not_found}, else: {:error, changeset}
+
+      other ->
+        other
+    end
+  rescue
+    Ecto.ConstraintError -> {:error, :not_found}
+  end
+
+  defp missing_parent?(%Ecto.Changeset{errors: errors}) do
+    Keyword.has_key?(errors, :media_item_id) or Keyword.has_key?(errors, :user_id)
   end
 
   # Checked here rather than left to the foreign key, because the two adapters

--- a/lib/mydia/playback.ex
+++ b/lib/mydia/playback.ex
@@ -8,6 +8,7 @@ defmodule Mydia.Playback do
   alias Mydia.Media.Episode
   alias Mydia.Media.MediaItem
   alias Mydia.Repo
+  alias Mydia.Playback.Dismissal
   alias Mydia.Playback.Progress
 
   # Throttle for `playback.progressed` emission (R19): a `progressed` event is
@@ -465,6 +466,69 @@ defmodule Mydia.Playback do
   """
   @spec on_deck(binary(), keyword()) :: [Mydia.Playback.OnDeckEntry.t()]
   defdelegate on_deck(user_id, opts \\ []), to: Mydia.Playback.OnDeck, as: :list
+
+  @doc """
+  Hides a title from the user's Continue Watching rail.
+
+  `media_item_id` is the movie, or for a series the *show* — never an episode.
+  `Mydia.Playback.OnDeck` emits one card per show, so the show is the only unit
+  a "remove this card" gesture can mean.
+
+  This hides; it does not unwatch. The progress row is left alone, so the
+  resume point survives, and **no event is emitted**. That silence is
+  deliberate: `delete_progress/3` emits `playback.unwatched`, which
+  `Mydia.WatchSync` forwards to Plex and Jellyfin, and taking a card off a rail
+  must not tell another media server that a watched title was unwatched.
+
+  An upsert rather than an insert. A dismissed show comes back the moment it is
+  played again, so dismissing the same title twice is ordinary use and has to
+  re-stamp rather than fail on the unique index.
+
+  ## Options
+
+    * `:now` - the clock, injectable so tests need not manipulate real time
+
+  ## Examples
+
+      iex> dismiss_from_on_deck(user_id, movie_id)
+      {:ok, %Dismissal{}}
+
+  """
+  @spec dismiss_from_on_deck(binary(), binary(), keyword()) ::
+          {:ok, Dismissal.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+  def dismiss_from_on_deck(user_id, media_item_id, opts \\ []) do
+    if media_item_exists?(media_item_id) do
+      now =
+        opts
+        |> Keyword.get(:now, DateTime.utc_now())
+        |> DateTime.truncate(:second)
+
+      %Dismissal{user_id: user_id, media_item_id: media_item_id}
+      |> Dismissal.changeset(%{dismissed_at: now})
+      |> Repo.insert(
+        on_conflict: {:replace, [:dismissed_at, :updated_at]},
+        conflict_target: [:user_id, :media_item_id]
+      )
+    else
+      {:error, :not_found}
+    end
+  end
+
+  # Checked here rather than left to the foreign key, because the two adapters
+  # disagree about what a violation looks like: Postgres names the constraint
+  # so Ecto can turn it into a changeset error, while SQLite reports no name at
+  # all and `Repo.insert/2` raises `Ecto.ConstraintError` straight through the
+  # resolver. An explicit lookup behaves the same on both.
+  #
+  # The near miss this guards is an episode id, which the rail invites: its
+  # cards are episodes but its dismissals are shows.
+  defp media_item_exists?(media_item_id) do
+    Repo.exists?(from(m in MediaItem, where: m.id == ^media_item_id))
+  rescue
+    # A client is free to send any string as a GraphQL ID. One that is not a
+    # UUID names nothing, which is the same answer as a UUID that names nothing.
+    Ecto.Query.CastError -> false
+  end
 
   @doc """
   Lists recent watch history for all users.

--- a/lib/mydia/playback/dismissal.ex
+++ b/lib/mydia/playback/dismissal.ex
@@ -1,0 +1,68 @@
+defmodule Mydia.Playback.Dismissal do
+  @moduledoc """
+  One viewer taking one title off the Continue Watching rail.
+
+  Written when someone picks "Remove from Continue Watching" on a card, and
+  read back by `Mydia.Playback.OnDeck` on every rail build.
+
+  Scoped to the media item, so for a series this is the show rather than the
+  episode. `OnDeck` emits at most one card per show, and dismissing only the
+  episode behind that card would hand the show straight back with the next
+  one.
+
+  A dismissal hides; it does not unwatch. The `Mydia.Playback.Progress` row
+  survives untouched, so the resume point is still there when the viewer comes
+  back to the title from a detail page. That separation is the whole reason
+  this table exists rather than the feature reusing `delete_progress/3`, which
+  would both discard the resume point and emit a `playback.unwatched` event
+  that `Mydia.WatchSync` pushes out to Plex and Jellyfin.
+
+  `dismissed_at` is a timestamp rather than a boolean because the hide expires
+  on its own: `OnDeck` shows the title again as soon as its most recent watch
+  is newer than this stamp, so playing the title is all it takes to undo, and
+  no job ever has to sweep this table.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          dismissed_at: DateTime.t(),
+          user_id: binary(),
+          media_item_id: binary(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "continue_watching_dismissals" do
+    field :dismissed_at, :utc_datetime
+
+    belongs_to :user, Mydia.Accounts.User
+    belongs_to :media_item, Mydia.Media.MediaItem
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Builds a changeset for a dismissal.
+
+  `user_id` and `media_item_id` are set programmatically by the context rather
+  than cast, so a client cannot hide a title on another account's rail.
+  """
+  def changeset(dismissal, attrs) do
+    dismissal
+    |> cast(attrs, [:dismissed_at])
+    |> validate_required([:dismissed_at])
+    |> unique_constraint([:user_id, :media_item_id])
+    # Backstop only. SQLite reports a foreign key violation with no constraint
+    # name, so Ecto cannot match these and raises instead; the context checks
+    # the media item exists up front for that reason. These still earn their
+    # place on Postgres, where they turn the insert-after-delete race into a
+    # changeset error rather than a five hundred.
+    |> foreign_key_constraint(:media_item_id)
+    |> foreign_key_constraint(:user_id)
+  end
+end

--- a/lib/mydia/playback/on_deck.ex
+++ b/lib/mydia/playback/on_deck.ex
@@ -17,6 +17,11 @@ defmodule Mydia.Playback.OnDeck do
 
   The exact thresholds are the `@default_min_position_seconds` and
   `@default_max_age_days` attributes below, overridable per call.
+
+  On top of that, a viewer can take a title off the rail by hand, which writes
+  a `Mydia.Playback.Dismissal` and hides the entry while the dismissal is newer
+  than its most recent watch. Playing the title again is what brings it back,
+  so nothing has to expire these. See `dismissed?/2`.
   """
 
   import Ecto.Query

--- a/lib/mydia/playback/on_deck.ex
+++ b/lib/mydia/playback/on_deck.ex
@@ -23,7 +23,7 @@ defmodule Mydia.Playback.OnDeck do
 
   alias Mydia.Library.MediaFile
   alias Mydia.Media.{Episode, MediaItem}
-  alias Mydia.Playback.{NextEpisode, OnDeckEntry, Progress}
+  alias Mydia.Playback.{Dismissal, NextEpisode, OnDeckEntry, Progress}
   alias Mydia.Repo
 
   @default_min_position_seconds 120
@@ -54,9 +54,33 @@ defmodule Mydia.Playback.OnDeck do
       |> Repo.all()
       |> Enum.filter(&counting_row?(&1, min_position, cutoff))
 
+    dismissals = load_dismissals(user_id)
+
     (movie_entries(counting) ++ show_entries(counting, user_id))
+    |> Enum.reject(&dismissed?(&1, dismissals))
     |> Enum.sort_by(&sort_key/1, :desc)
     |> Enum.take(limit)
+  end
+
+  # Rejected before `Enum.take/2`, so a hidden title does not silently eat one
+  # of the caller's slots and leave a short rail.
+  #
+  # The comparison is against `sort_at`, the entry's most recent watch, which
+  # is what makes the hide expire without a sweep: playing the title pushes
+  # `sort_at` past `dismissed_at` and the card comes back. For a series
+  # `sort_at` is the newest watch across the whole show, so finishing any
+  # episode brings it back, not only the one the card happens to name.
+  #
+  # `:eq` counts as dismissed. Both columns are `:utc_datetime`, so two actions
+  # in the same second are indistinguishable and one of them has to win. Giving
+  # it to the dismissal keeps the gesture the viewer just made from appearing
+  # to do nothing; the losing case (dismiss, then resume the same title inside
+  # one second) rights itself on the next progress write a few seconds later.
+  defp dismissed?(entry, dismissals) do
+    case Map.get(dismissals, OnDeckEntry.dismissal_key(entry)) do
+      nil -> false
+      dismissed_at -> DateTime.compare(dismissed_at, entry.sort_at) != :lt
+    end
   end
 
   # Sorted on a tuple so entries sharing a timestamp, which a bulk watched
@@ -173,6 +197,18 @@ defmodule Mydia.Playback.OnDeck do
       files: episode.media_files,
       sort_at: sort_at
     }
+  end
+
+  # One query for the whole user, never one per entry: the rail's query count
+  # has to stay flat as a library grows, which `on_deck_query_count_test.exs`
+  # pins down.
+  defp load_dismissals(user_id) do
+    from(d in Dismissal,
+      where: d.user_id == ^user_id,
+      select: {d.media_item_id, d.dismissed_at}
+    )
+    |> Repo.all()
+    |> Map.new()
   end
 
   defp load_media_items([]), do: []

--- a/lib/mydia/playback/on_deck_entry.ex
+++ b/lib/mydia/playback/on_deck_entry.ex
@@ -37,4 +37,19 @@ defmodule Mydia.Playback.OnDeckEntry do
   @spec id(t()) :: binary()
   def id(%__MODULE__{kind: :movie, media_item: %{id: id}}), do: id
   def id(%__MODULE__{kind: :episode, episode: %{id: id}}), do: id
+
+  @doc """
+  The media item a "remove from Continue Watching" gesture on this entry hides:
+  the movie itself, or for an episode entry the **show** it belongs to.
+
+  Deliberately not `id/1`, which returns the episode id. An episode entry is
+  the one card its whole series gets, and both of the states it can be in
+  (`:continue`, `:next`) name a different episode as the series moves along, so
+  a dismissal keyed on the episode would be handing the show back with the next
+  one. Keying on the show is also what lets a `:next` entry be dismissed at
+  all, since it has no progress row of its own to hang anything off.
+  """
+  @spec dismissal_key(t()) :: binary()
+  def dismissal_key(%__MODULE__{kind: :movie, media_item: %{id: id}}), do: id
+  def dismissal_key(%__MODULE__{kind: :episode, show: %{id: id}}), do: id
 end

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -288,6 +288,14 @@ defmodule MydiaWeb.Schema.CommonTypes do
     field :media_item_id, non_null(:id), description: "ID of the media item"
   end
 
+  @desc "Outcome of hiding a title from Continue Watching"
+  object :remove_from_continue_watching_result do
+    field :media_item_id, non_null(:id), description: "ID of the hidden movie or show"
+
+    field :removed, non_null(:boolean),
+      description: "Whether the title is now hidden from Continue Watching"
+  end
+
   @desc "Media access token for direct media requests"
   object :media_token do
     field :token, non_null(:string), description: "JWT token for media access"

--- a/lib/mydia_web/schema/mutation_types.ex
+++ b/lib/mydia_web/schema/mutation_types.ex
@@ -78,6 +78,12 @@ defmodule MydiaWeb.Schema.MutationTypes do
       arg(:media_item_id, non_null(:id))
       resolve(&PlaybackResolver.toggle_favorite/3)
     end
+
+    @desc "Hide a movie or show from Continue Watching until it is played again"
+    field :remove_from_continue_watching, :remove_from_continue_watching_result do
+      arg(:media_item_id, non_null(:id))
+      resolve(&PlaybackResolver.remove_from_continue_watching/3)
+    end
   end
 
   object :remote_access_mutations do

--- a/lib/mydia_web/schema/resolvers/playback_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/playback_resolver.ex
@@ -223,6 +223,36 @@ defmodule MydiaWeb.Schema.Resolvers.PlaybackResolver do
     end
   end
 
+  @doc """
+  Hides a movie or show from the viewer's Continue Watching rail.
+
+  `media_item_id` is the movie, or for a series the *show*. The rail carries
+  one card per show, so an episode id is not a thing this can take.
+
+  A hide, not an unwatch: progress survives, so the title still offers Resume
+  from its detail page, and nothing is pushed out to a media server.
+  """
+  def remove_from_continue_watching(_parent, %{media_item_id: media_item_id}, %{context: context}) do
+    case context[:current_user] do
+      nil ->
+        {:error, "Authentication required"}
+
+      user ->
+        case Playback.dismiss_from_on_deck(user.id, media_item_id) do
+          {:ok, _dismissal} ->
+            {:ok, %{media_item_id: media_item_id, removed: true}}
+
+          # Most often an episode id: the rail's cards are episodes, but a
+          # card stands for its whole show and that is what gets hidden.
+          {:error, :not_found} ->
+            {:error, "Media item not found"}
+
+          {:error, changeset} ->
+            {:error, format_changeset_errors(changeset)}
+        end
+    end
+  end
+
   # Private helper functions
 
   # Safe loaders return an error tuple (not a raised 500) for unknown ids.

--- a/player/lib/core/graphql/watch/invalidation_rules.dart
+++ b/player/lib/core/graphql/watch/invalidation_rules.dart
@@ -125,6 +125,28 @@ abstract final class InvalidationRules {
           QueryKeys.showDetail(showId).target,
       };
 
+  /// A title was hidden from Continue Watching.
+  ///
+  /// Only the two surfaces that render the rail. Nothing else changes: the
+  /// dismissal leaves the progress row alone, so watched state, resume
+  /// positions and unwatched counts everywhere else are exactly as they were,
+  /// and listing the wider set [watchedChanged] carries would refetch a dozen
+  /// screens to show them what they already display.
+  ///
+  /// `home` is here as well as `continueWatchingList` because Continue
+  /// Watching feeds the home hero, not only the rail: removing the first card
+  /// changes which title the backdrop is showing.
+  ///
+  /// Worth knowing at the call site: on `/continue-watching` this is a no-op
+  /// once the viewer has paged, since that watcher sets
+  /// `canRefetch: () => !_hasPaginated` and `refetchAutomatically` then only
+  /// clears the fetch log. The optimistic removal in the controller is what
+  /// the viewer actually sees there.
+  static Set<InvalidationTarget> continueWatchingRemoved() => {
+        QueryKeys.home.target,
+        QueryKeys.continueWatchingList.target,
+      };
+
   /// The 10-second progress sync timer invalidates nothing.
   ///
   /// Wiring it up looks correct, since progress is what `continueWatching`

--- a/player/lib/domain/models/continue_watching_item.dart
+++ b/player/lib/domain/models/continue_watching_item.dart
@@ -55,6 +55,26 @@ class ContinueWatchingItem {
   bool get isEpisode => type.toLowerCase() == 'episode';
   bool get isMovie => type.toLowerCase() == 'movie';
 
+  /// The media item that "Remove from Continue Watching" hides for this card.
+  ///
+  /// For an episode that is the show, not [id]: the rail carries one card per
+  /// series, so the card stands for the series and hiding only this episode
+  /// would hand the show back with the next one. [id] is the episode's own id,
+  /// which the server refuses outright.
+  ///
+  /// Null for an episode whose `showId` the server did not send, which is the
+  /// only case with nothing to hide. Callers treat null as "no removal
+  /// offered" rather than falling back to [id], since falling back would send
+  /// the episode id the server rejects.
+  String? get continueWatchingKey => isEpisode ? showId : id;
+
+  /// Whether this card would be hidden by a dismissal of [key].
+  ///
+  /// The comparison every optimistic removal needs: matching on [id] would
+  /// never remove an episode card, because the id removal is keyed on is its
+  /// show's.
+  bool dismissedBy(String key) => continueWatchingKey == key;
+
   String get displayTitle {
     final show = showTitle;
     final season = seasonNumber;

--- a/player/lib/domain/models/continue_watching_item.dart
+++ b/player/lib/domain/models/continue_watching_item.dart
@@ -14,22 +14,38 @@ import 'progress.dart';
 /// the snapshot can be several changes stale. Putting it back resurrects cards
 /// the server has since hidden.
 ///
-/// So the snapshot is used only for ordering. A card survives if it is still
+/// So the snapshot is used only for *ordering*. A card survives if it is still
 /// in [latest] (nothing else has removed it) or if it is one this failure has
 /// to return. Anything [latest] gained meanwhile — a refetch landing mid-flight
 /// — is kept on the end rather than dropped.
+///
+/// Two details the ordering role makes easy to get wrong:
+///
+/// The card that survives is [latest]'s copy, never the snapshot's. They share
+/// an id but not necessarily a position or a watch state, and preferring the
+/// snapshot would roll a refetch's fresher progress back along with the
+/// removal.
+///
+/// And the failed card goes back only if [latest] has nothing under [key]
+/// already. A show gets one card on the rail, but not always the same episode:
+/// a refetch can replace the one this snapshot holds with its successor, and
+/// restoring the snapshot's copy on top would leave the series showing twice.
 List<ContinueWatchingItem> restoreFailedRemoval({
   required List<ContinueWatchingItem> snapshot,
   required List<ContinueWatchingItem> latest,
   required String key,
 }) {
-  final latestIds = latest.map((item) => item.id).toSet();
+  final latestById = {for (final item in latest) item.id: item};
   final snapshotIds = snapshot.map((item) => item.id).toSet();
+  final latestHasKey = latest.any((item) => item.dismissedBy(key));
 
   return [
-    ...snapshot.where(
-      (item) => latestIds.contains(item.id) || item.dismissedBy(key),
-    ),
+    ...snapshot.expand((item) {
+      final current = latestById[item.id];
+      if (current != null) return [current];
+      if (!latestHasKey && item.dismissedBy(key)) return [item];
+      return const <ContinueWatchingItem>[];
+    }),
     ...latest.where((item) => !snapshotIds.contains(item.id)),
   ];
 }

--- a/player/lib/domain/models/continue_watching_item.dart
+++ b/player/lib/domain/models/continue_watching_item.dart
@@ -2,6 +2,38 @@ import 'artwork.dart';
 import 'media_file.dart';
 import 'progress.dart';
 
+/// Puts the cards a failed removal took back, without undoing anything that
+/// happened while its mutation was in flight.
+///
+/// [snapshot] is the list as it stood before the removal, [latest] the list as
+/// it stands now, and [key] the title whose removal failed.
+///
+/// Restoring [snapshot] wholesale is the obvious move and is wrong: a viewer
+/// can remove a second card before the first mutation answers, and a
+/// successful removal also triggers a refetch, so by the time a failure lands
+/// the snapshot can be several changes stale. Putting it back resurrects cards
+/// the server has since hidden.
+///
+/// So the snapshot is used only for ordering. A card survives if it is still
+/// in [latest] (nothing else has removed it) or if it is one this failure has
+/// to return. Anything [latest] gained meanwhile — a refetch landing mid-flight
+/// — is kept on the end rather than dropped.
+List<ContinueWatchingItem> restoreFailedRemoval({
+  required List<ContinueWatchingItem> snapshot,
+  required List<ContinueWatchingItem> latest,
+  required String key,
+}) {
+  final latestIds = latest.map((item) => item.id).toSet();
+  final snapshotIds = snapshot.map((item) => item.id).toSet();
+
+  return [
+    ...snapshot.where(
+      (item) => latestIds.contains(item.id) || item.dismissedBy(key),
+    ),
+    ...latest.where((item) => !snapshotIds.contains(item.id)),
+  ];
+}
+
 class ContinueWatchingItem {
   final String id;
   final String type;

--- a/player/lib/domain/models/home_data.dart
+++ b/player/lib/domain/models/home_data.dart
@@ -32,6 +32,22 @@ class HomeData {
     );
   }
 
+  /// Exists so an optimistic edit to one rail cannot silently drop the others.
+  /// Hand-constructing a replacement means remembering to carry two unrelated
+  /// lists forward, and forgetting either empties a rail the viewer is looking
+  /// at.
+  HomeData copyWith({
+    List<ContinueWatchingItem>? continueWatching,
+    List<RecentlyAddedItem>? recentlyAdded,
+    List<RecentlyAddedItem>? favorites,
+  }) {
+    return HomeData(
+      continueWatching: continueWatching ?? this.continueWatching,
+      recentlyAdded: recentlyAdded ?? this.recentlyAdded,
+      favorites: favorites ?? this.favorites,
+    );
+  }
+
   bool get isEmpty =>
       continueWatching.isEmpty && recentlyAdded.isEmpty && favorites.isEmpty;
 }

--- a/player/lib/graphql/mutations/remove_from_continue_watching.graphql
+++ b/player/lib/graphql/mutations/remove_from_continue_watching.graphql
@@ -1,0 +1,6 @@
+mutation RemoveFromContinueWatching($mediaItemId: ID!) {
+  removeFromContinueWatching(mediaItemId: $mediaItemId) {
+    mediaItemId
+    removed
+  }
+}

--- a/player/lib/presentation/screens/continue_watching/continue_watching_actions.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_actions.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+import '../../../core/graphql/graphql_provider.dart';
+import '../../../core/graphql/watch/invalidation_rules.dart';
+import '../../../core/graphql/watch/watcher_registry.dart';
+import '../../../graphql/mutations/remove_from_continue_watching.graphql.dart';
+
+/// Hides a movie or show from Continue Watching, server-side.
+///
+/// Shared by the home rail and the `/continue-watching` grid, which both offer
+/// the action and would otherwise each carry their own copy of the mutation,
+/// the invalidation and the ordering rule below.
+///
+/// Deliberately does not touch controller state. Each caller owns its own
+/// optimistic splice and its own revert, because the two hold different shapes
+/// and only the caller knows what to put back on failure.
+///
+/// [mediaItemId] is `ContinueWatchingItem.continueWatchingKey`: the movie, or
+/// for an episode card its *show*. The server refuses an episode id.
+///
+/// Throws whatever the mutation failed with, so the caller reverts and reports.
+Future<void> removeFromContinueWatching(Ref ref, String mediaItemId) async {
+  // Read before the first await, not after. These controllers are auto-dispose,
+  // so a viewer who navigates away while the mutation is in flight tears `ref`
+  // down, and a later read would throw `UnmountedRefException` — swallowing
+  // the invalidation into the caller's revert-on-error path and leaving every
+  // other surface showing a card the server has already hidden.
+  final invalidator = ref.read(invalidatorProvider);
+
+  final client = await ref.read(asyncGraphqlClientProvider.future);
+  final result = await client.mutate(
+    MutationOptions(
+      document: documentNodeMutationRemoveFromContinueWatching,
+      variables: Variables$Mutation$RemoveFromContinueWatching(
+        mediaItemId: mediaItemId,
+      ).toJson(),
+    ),
+  );
+
+  if (result.hasException) {
+    throw result.exception!;
+  }
+
+  await invalidator.invalidate(InvalidationRules.continueWatchingRemoved());
+}
+
+/// Runs [remove] and reports a failure, for the two screens that offer the
+/// action. Shared so the wording cannot drift between them.
+///
+/// Success is silent on purpose. The card disappearing is the confirmation,
+/// and there is no undo to offer in a snackbar: hiding is reversed by playing
+/// the title, the way Plex does it.
+Future<void> reportRemovalFailure(
+  BuildContext context,
+  Future<void> Function() remove,
+) async {
+  // Captured before the await. The card is being removed from under this
+  // context, and on the home rail the widget it belongs to is gone by the time
+  // the mutation answers.
+  final messenger = ScaffoldMessenger.of(context);
+
+  try {
+    await remove();
+  } catch (_) {
+    messenger.showSnackBar(
+      const SnackBar(
+        content: Text('Could not remove from Continue Watching'),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/screens/continue_watching/continue_watching_controller.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_controller.dart
@@ -8,6 +8,7 @@ import '../../../core/graphql/watch/controller_watcher.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/graphql/watch/query_watcher.dart';
 import '../../../domain/models/continue_watching_item.dart';
+import 'continue_watching_actions.dart' as actions;
 
 part 'continue_watching_controller.g.dart';
 
@@ -103,6 +104,20 @@ class ContinueWatchingData {
     required this.hasMore,
     this.endCursor,
   });
+
+  /// Exists so an optimistic edit to [items] cannot silently drop the paging
+  /// state, which would strand the viewer on page one with no way to load more.
+  ContinueWatchingData copyWith({
+    List<ContinueWatchingItem>? items,
+    bool? hasMore,
+    String? endCursor,
+  }) {
+    return ContinueWatchingData(
+      items: items ?? this.items,
+      hasMore: hasMore ?? this.hasMore,
+      endCursor: endCursor ?? this.endCursor,
+    );
+  }
 
   bool get isEmpty => items.isEmpty;
 }
@@ -207,6 +222,35 @@ class ContinueWatchingController extends _$ContinueWatchingController {
       debugPrint('ContinueWatchingController.loadMore failed: $error');
     } finally {
       _loadingMore = false;
+    }
+  }
+
+  /// Hides a title from Continue Watching and drops its card from the grid.
+  ///
+  /// [key] is `ContinueWatchingItem.continueWatchingKey`, the show for an
+  /// episode card. Matching on the item's own id would never remove an episode
+  /// card, since the id being hidden is its show's.
+  ///
+  /// The splice below is doing more work here than on the home rail. Once the
+  /// viewer has paged, `canRefetch` returns false and the invalidation only
+  /// clears the fetch log rather than refetching, so nothing on the server
+  /// side corrects a splice that misses until this screen is torn down.
+  Future<void> removeFromContinueWatching(String key) async {
+    final currentState = state.value;
+    if (currentState == null) return;
+
+    state = AsyncValue.data(
+      currentState.copyWith(
+        items:
+            currentState.items.where((item) => !item.dismissedBy(key)).toList(),
+      ),
+    );
+
+    try {
+      await actions.removeFromContinueWatching(ref, key);
+    } catch (_) {
+      state = AsyncValue.data(currentState);
+      rethrow;
     }
   }
 }

--- a/player/lib/presentation/screens/continue_watching/continue_watching_controller.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_controller.dart
@@ -249,7 +249,16 @@ class ContinueWatchingController extends _$ContinueWatchingController {
     try {
       await actions.removeFromContinueWatching(ref, key);
     } catch (_) {
-      state = AsyncValue.data(currentState);
+      final latest = state.value ?? currentState;
+      state = AsyncValue.data(
+        latest.copyWith(
+          items: restoreFailedRemoval(
+            snapshot: currentState.items,
+            latest: latest.items,
+            key: key,
+          ),
+        ),
+      );
       rethrow;
     }
   }

--- a/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
@@ -9,7 +9,9 @@ import '../../../domain/models/continue_watching_item.dart';
 import '../../../domain/models/watch_status.dart';
 import '../../widgets/browse_grid.dart';
 import '../../widgets/browse_scaffold.dart';
+import '../../widgets/media_context_menu.dart';
 import '../../widgets/media_poster.dart';
+import 'continue_watching_actions.dart' as cw_actions;
 import 'continue_watching_controller.dart';
 
 class ContinueWatchingScreen extends ConsumerStatefulWidget {
@@ -43,6 +45,34 @@ class _ContinueWatchingScreenState
         _scrollController.position.maxScrollExtent - 200) {
       ref.read(continueWatchingControllerProvider.notifier).loadMore();
     }
+  }
+
+  void _openMenu(BuildContext posterContext, ContinueWatchingItem item) {
+    showMediaContextMenu(
+      posterContext,
+      target: MediaContextTarget(
+        id: item.id,
+        type: item.type,
+        showId: item.showId,
+        hasFile: item.files.isNotEmpty,
+        continueWatchingId: item.continueWatchingKey,
+      ),
+      // Unreachable: with `tapPlays` false the menu never offers Play.
+      onPlay: () {},
+      onRemoveFromContinueWatching: () => _handleRemove(item),
+    );
+  }
+
+  Future<void> _handleRemove(ContinueWatchingItem item) async {
+    final key = item.continueWatchingKey;
+    if (key == null) return;
+
+    await cw_actions.reportRemovalFailure(
+      context,
+      () => ref
+          .read(continueWatchingControllerProvider.notifier)
+          .removeFromContinueWatching(key),
+    );
   }
 
   void _handleItemTap(BuildContext context, ContinueWatchingItem item) {
@@ -106,6 +136,12 @@ class _ContinueWatchingScreenState
                     ? null
                     : WatchStatus.fromProgress(item.progress!),
                 onTap: () => _handleItemTap(context, item),
+                // `tapPlays` stays false here: this grid opens the title, it
+                // does not play it. That suppresses the navigation entries,
+                // which would only repeat the tap, and leaves the removal.
+                onContextMenu: (posterContext) =>
+                    _openMenu(posterContext, item),
+                showMenuButton: item.continueWatchingKey != null,
               );
             },
           );

--- a/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
+++ b/player/lib/presentation/screens/continue_watching/continue_watching_screen.dart
@@ -139,8 +139,12 @@ class _ContinueWatchingScreenState
                 // `tapPlays` stays false here: this grid opens the title, it
                 // does not play it. That suppresses the navigation entries,
                 // which would only repeat the tap, and leaves the removal.
-                onContextMenu: (posterContext) =>
-                    _openMenu(posterContext, item),
+                // Null when there is nothing to hide, rather than installing a
+                // gesture that opens an empty menu. An episode the server sent
+                // without a show id is the only card in that position.
+                onContextMenu: item.continueWatchingKey == null
+                    ? null
+                    : (posterContext) => _openMenu(posterContext, item),
                 showMenuButton: item.continueWatchingKey != null,
               );
             },

--- a/player/lib/presentation/screens/home/home_controller.dart
+++ b/player/lib/presentation/screens/home/home_controller.dart
@@ -3,6 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/graphql/watch/controller_watcher.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/graphql/watch/query_watcher.dart';
+import '../../../domain/models/continue_watching_item.dart';
 import '../../../domain/models/home_data.dart';
 import '../continue_watching/continue_watching_actions.dart' as actions;
 
@@ -195,7 +196,16 @@ class HomeController extends _$HomeController {
     try {
       await actions.removeFromContinueWatching(ref, key);
     } catch (_) {
-      state = AsyncValue.data(currentState);
+      final latest = state.value ?? currentState;
+      state = AsyncValue.data(
+        latest.copyWith(
+          continueWatching: restoreFailedRemoval(
+            snapshot: currentState.continueWatching,
+            latest: latest.continueWatching,
+            key: key,
+          ),
+        ),
+      );
       rethrow;
     }
   }

--- a/player/lib/presentation/screens/home/home_controller.dart
+++ b/player/lib/presentation/screens/home/home_controller.dart
@@ -4,6 +4,7 @@ import '../../../core/graphql/watch/controller_watcher.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/graphql/watch/query_watcher.dart';
 import '../../../domain/models/home_data.dart';
+import '../continue_watching/continue_watching_actions.dart' as actions;
 
 part 'home_controller.g.dart';
 
@@ -168,4 +169,34 @@ class HomeController extends _$HomeController {
   }
 
   Future<void> refresh() => _watcher.refetch();
+
+  /// Hides a title from Continue Watching and drops its card from the rail.
+  ///
+  /// [key] is `ContinueWatchingItem.continueWatchingKey`, the show for an
+  /// episode card. Matching on the item's own id would never remove an episode
+  /// card, since the id being hidden is its show's.
+  ///
+  /// The rail is short one card until the next full refetch backfills an
+  /// eleventh: this only ever fetched ten, so there is no local item to
+  /// promote. Refetching here instead would put a spinner over the rail for
+  /// the one card nobody is looking at.
+  Future<void> removeFromContinueWatching(String key) async {
+    final currentState = state.value;
+    if (currentState == null) return;
+
+    state = AsyncValue.data(
+      currentState.copyWith(
+        continueWatching: currentState.continueWatching
+            .where((item) => !item.dismissedBy(key))
+            .toList(),
+      ),
+    );
+
+    try {
+      await actions.removeFromContinueWatching(ref, key);
+    } catch (_) {
+      state = AsyncValue.data(currentState);
+      rethrow;
+    }
+  }
 }

--- a/player/lib/presentation/screens/home_screen.dart
+++ b/player/lib/presentation/screens/home_screen.dart
@@ -10,6 +10,7 @@ import '../../domain/models/continue_watching_item.dart';
 import '../../domain/models/media_file.dart';
 import '../widgets/ambient_backdrop_provider.dart';
 import '../widgets/content_rail.dart';
+import 'continue_watching/continue_watching_actions.dart' as cw_actions;
 import '../widgets/freshness_header.dart';
 import '../widgets/glass_surface.dart';
 import '../widgets/shimmer_card.dart';
@@ -115,6 +116,25 @@ class HomeScreen extends ConsumerWidget {
     }
   }
 
+  /// A card with no show id is an episode the server sent without one. There
+  /// is nothing to hide in that case, and the menu entry is already absent, so
+  /// this only guards the callback against being reached another way.
+  Future<void> _handleRemove(
+    BuildContext context,
+    WidgetRef ref,
+    ContinueWatchingItem item,
+  ) async {
+    final key = item.continueWatchingKey;
+    if (key == null) return;
+
+    await cw_actions.reportRemovalFailure(
+      context,
+      () => ref
+          .read(homeControllerProvider.notifier)
+          .removeFromContinueWatching(key),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final homeData = ref.watch(homeControllerProvider);
@@ -216,6 +236,8 @@ class HomeScreen extends ConsumerWidget {
                                   _handleItemTap(context, id, type),
                               onItemActivate: (item) =>
                                   _handlePlay(context, item),
+                              onRemoveFromContinueWatching: (item) =>
+                                  _handleRemove(context, ref, item),
                             ),
                           if (data.recentlyAdded.isNotEmpty)
                             ContentRail(

--- a/player/lib/presentation/widgets/content_rail.dart
+++ b/player/lib/presentation/widgets/content_rail.dart
@@ -26,6 +26,13 @@ class ContentRail extends StatefulWidget {
   /// item's files and progress, which an (id, type) pair cannot carry.
   final void Function(Object item)? onItemActivate;
 
+  /// Called when a card's menu asks to hide its title from Continue Watching.
+  ///
+  /// Null means the rail offers no such entry, which is every rail but one.
+  /// Passing it is also what puts the visible kebab on these cards: a rail
+  /// whose menu only repeats where a tap already goes does not earn one.
+  final void Function(ContinueWatchingItem item)? onRemoveFromContinueWatching;
+
   /// Turns the header into a disclosure and starts the rail collapsed, so only
   /// the title line is drawn until it is tapped. For rails that are supporting
   /// context rather than the reason the page was opened, an always-open strip
@@ -41,6 +48,7 @@ class ContentRail extends StatefulWidget {
     this.onItemTap,
     this.onSeeAllTap,
     this.onItemActivate,
+    this.onRemoveFromContinueWatching,
     this.collapsible = false,
   });
 
@@ -284,6 +292,11 @@ class _ContentRailState extends State<ContentRail> {
         showId: item.showId,
         hasFile: item.files.isNotEmpty,
         tapPlays: widget.onItemActivate != null,
+        // Null unless this rail can actually act on it, so the entry never
+        // appears where selecting it would do nothing.
+        continueWatchingId: widget.onRemoveFromContinueWatching == null
+            ? null
+            : item.continueWatchingKey,
       );
       return MediaCard(
         posterUrl: item.posterUrl,
@@ -303,6 +316,11 @@ class _ContentRailState extends State<ContentRail> {
             ? widget.onItemActivate!(item)
             : widget.onItemTap?.call(item.id, item.type),
         onContextMenu: (cardContext) => _openMenu(cardContext, target, item),
+        // Asked of the same function that builds the menu, rather than
+        // recomputed from the rail's own state, so the button cannot end up
+        // advertising a menu entry that is not there.
+        showMenuButton: mediaContextActionsFor(target)
+            .contains(MediaContextAction.removeFromContinueWatching),
       );
     } else if (item is RecentlyAddedItem) {
       final target = MediaContextTarget(id: item.id, type: item.type);
@@ -363,6 +381,9 @@ class _ContentRailState extends State<ContentRail> {
       cardContext,
       target: target,
       onPlay: () => widget.onItemActivate?.call(item),
+      onRemoveFromContinueWatching: item is ContinueWatchingItem
+          ? () => widget.onRemoveFromContinueWatching?.call(item)
+          : null,
     );
   }
 }

--- a/player/lib/presentation/widgets/media_card.dart
+++ b/player/lib/presentation/widgets/media_card.dart
@@ -6,6 +6,7 @@ import '../../domain/models/media_file.dart';
 import '../../domain/models/watch_status.dart';
 import 'poster_badge_corner.dart';
 import 'poster_frame.dart';
+import 'poster_menu_button.dart';
 import 'progress_overlay.dart';
 import 'quality_badge.dart';
 import 'watch_indicator.dart';
@@ -46,6 +47,15 @@ class MediaCard extends StatelessWidget {
   /// card so the menu can anchor to it. Null means the card has no menu.
   final void Function(BuildContext cardContext)? onContextMenu;
 
+  /// Whether to show a persistent kebab that opens the same menu as
+  /// [onContextMenu]. Ignored when there is no menu to open.
+  ///
+  /// Off by default: most rails offer only navigation entries a card's own tap
+  /// already reaches, so a visible affordance would be clutter pointing at
+  /// nothing new. Continue Watching turns it on, where the menu carries an
+  /// action nothing else on the card offers.
+  final bool showMenuButton;
+
   /// If true, uses responsive sizing based on screen width.
   final bool responsive;
 
@@ -62,6 +72,7 @@ class MediaCard extends StatelessWidget {
     this.files,
     required this.action,
     this.onContextMenu,
+    this.showMenuButton = false,
     this.responsive = false,
   });
 
@@ -156,6 +167,15 @@ class MediaCard extends StatelessWidget {
                           ),
                       ],
                     ),
+                    // Routed through the same callback as the long-press, so
+                    // the button and the gesture can never offer different
+                    // menus.
+                    if (showMenuButton && contextMenu != null)
+                      Builder(
+                        builder: (buttonContext) => PosterMenuButton(
+                          onPressed: () => contextMenu(buttonContext),
+                        ),
+                      ),
                   ],
                 ),
               ),

--- a/player/lib/presentation/widgets/media_context_menu.dart
+++ b/player/lib/presentation/widgets/media_context_menu.dart
@@ -4,7 +4,13 @@ import 'package:go_router/go_router.dart';
 import '../../core/theme/colors.dart';
 
 /// What a card's long-press menu can offer.
-enum MediaContextAction { play, goToShow, episodeDetails, movieDetails }
+enum MediaContextAction {
+  play,
+  goToShow,
+  episodeDetails,
+  movieDetails,
+  removeFromContinueWatching,
+}
 
 /// The subject of a long-press menu, flattened out of whichever rail item the
 /// card was built from.
@@ -30,12 +36,21 @@ class MediaContextTarget {
   /// be offering a second route to where its own tap goes.
   final bool tapPlays;
 
+  /// The media item to hide when the card sits on a Continue Watching surface,
+  /// or null when it does not.
+  ///
+  /// For a movie this is [id]. For an episode it is the *show*: the rail shows
+  /// one card per series and that card stands for the series, so hiding only
+  /// the episode would hand the show straight back with the next one.
+  final String? continueWatchingId;
+
   const MediaContextTarget({
     required this.id,
     required this.type,
     this.showId,
     this.hasFile = false,
     this.tapPlays = false,
+    this.continueWatchingId,
   });
 
   bool get isEpisode => type.toLowerCase() == 'episode';
@@ -47,19 +62,30 @@ class MediaContextTarget {
 /// Pure, so the visibility rules are unit-testable without pumping a menu.
 /// An empty result means the card gets no menu at all.
 List<MediaContextAction> mediaContextActionsFor(MediaContextTarget target) {
-  // A card whose own tap opens the title earns no menu at all. Gating only
-  // `movieDetails` on this left two holes: an episode target got
+  // A card whose own tap opens the title earns no *navigation* entry. Gating
+  // only `movieDetails` on this left two holes: an episode target got
   // `episodeDetails` regardless, duplicating what its tap already did, and any
   // target with a file got `play` even where the rail had no play handler to
   // run, since `_openMenu` routes Play through a nullable `onItemActivate`.
   // That is a Play entry that silently does nothing.
-  if (!target.tapPlays) return const [];
+  //
+  // The gate stops at navigation. Removing a title is not a second route to
+  // somewhere the tap already goes, and the `/continue-watching` grid opens
+  // details on tap, so gating it here would leave the one surface most in need
+  // of the action without any way to reach it.
+  final navigation = target.tapPlays
+      ? [
+          if (target.hasFile) MediaContextAction.play,
+          if (target.showId != null) MediaContextAction.goToShow,
+          if (target.isEpisode) MediaContextAction.episodeDetails,
+          if (target.isMovie) MediaContextAction.movieDetails,
+        ]
+      : const <MediaContextAction>[];
 
   return [
-    if (target.hasFile) MediaContextAction.play,
-    if (target.showId != null) MediaContextAction.goToShow,
-    if (target.isEpisode) MediaContextAction.episodeDetails,
-    if (target.isMovie) MediaContextAction.movieDetails,
+    ...navigation,
+    if (target.continueWatchingId != null)
+      MediaContextAction.removeFromContinueWatching,
   ];
 }
 
@@ -69,6 +95,8 @@ String mediaContextLabel(MediaContextAction action) => switch (action) {
       MediaContextAction.goToShow => 'Go to show',
       MediaContextAction.episodeDetails => 'Episode details',
       MediaContextAction.movieDetails => 'Movie details',
+      MediaContextAction.removeFromContinueWatching =>
+        'Remove from Continue Watching',
     };
 
 /// Menu glyph for [action].
@@ -77,6 +105,8 @@ IconData mediaContextIcon(MediaContextAction action) => switch (action) {
       MediaContextAction.goToShow => Icons.tv_rounded,
       MediaContextAction.episodeDetails => Icons.info_outline_rounded,
       MediaContextAction.movieDetails => Icons.info_outline_rounded,
+      MediaContextAction.removeFromContinueWatching =>
+        Icons.remove_circle_outline_rounded,
     };
 
 /// Opens the card's secondary menu, anchored under the card.
@@ -88,10 +118,14 @@ IconData mediaContextIcon(MediaContextAction action) => switch (action) {
 /// A [showMenu] popup rather than a modal bottom sheet: this reads correctly at
 /// 400px and at 1600px, and matches the `PopupMenuButton` already used by
 /// `EpisodeRailCard`, `ShowDetailScreen` and `CollectionDetailScreen`.
+/// [onRemoveFromContinueWatching] is only ever called for a target carrying a
+/// [MediaContextTarget.continueWatchingId], and only the surfaces that can act
+/// on it pass one.
 Future<void> showMediaContextMenu(
   BuildContext context, {
   required MediaContextTarget target,
   required VoidCallback onPlay,
+  VoidCallback? onRemoveFromContinueWatching,
 }) async {
   final actions = mediaContextActionsFor(target);
   if (actions.isEmpty) return;
@@ -124,7 +158,11 @@ Future<void> showMediaContextMenu(
                 color: AppColors.textSecondary,
               ),
               const SizedBox(width: 12),
-              Text(mediaContextLabel(action)),
+              // Flexible because the labels are no longer all short. "Remove
+              // from Continue Watching" overflows the menu's own width on a
+              // phone, and a bare Text in a min-size Row paints the overflow
+              // stripes rather than wrapping.
+              Flexible(child: Text(mediaContextLabel(action))),
             ],
           ),
         ),
@@ -143,5 +181,7 @@ Future<void> showMediaContextMenu(
       context.push('/episode/${target.id}');
     case MediaContextAction.movieDetails:
       context.push('/movie/${target.id}');
+    case MediaContextAction.removeFromContinueWatching:
+      onRemoveFromContinueWatching?.call();
   }
 }

--- a/player/lib/presentation/widgets/media_poster.dart
+++ b/player/lib/presentation/widgets/media_poster.dart
@@ -4,6 +4,7 @@ import '../../core/theme/colors.dart';
 import '../../domain/models/watch_status.dart';
 import 'poster_badge_corner.dart';
 import 'poster_frame.dart';
+import 'poster_menu_button.dart';
 import 'progress_overlay.dart';
 import 'rating_badge.dart';
 import 'watch_indicator.dart';
@@ -30,6 +31,16 @@ class MediaPoster extends StatelessWidget {
   final VoidCallback? onTap;
   final bool showTitle;
 
+  /// Called on long press and on secondary tap, with a context inside this
+  /// poster so the menu can anchor to it. Null means the poster has no menu.
+  final void Function(BuildContext posterContext)? onContextMenu;
+
+  /// Whether to show a persistent kebab that opens the same menu as
+  /// [onContextMenu]. Ignored when there is no menu to open. See
+  /// [PosterMenuButton] for why a grid that carries a removal action needs a
+  /// visible affordance and one that does not should stay clean.
+  final bool showMenuButton;
+
   const MediaPoster({
     super.key,
     this.posterUrl,
@@ -41,6 +52,8 @@ class MediaPoster extends StatelessWidget {
     this.isFavorite = false,
     this.onTap,
     this.showTitle = true,
+    this.onContextMenu,
+    this.showMenuButton = false,
   });
 
   static const Widget _placeholder = ColoredBox(
@@ -69,10 +82,16 @@ class MediaPoster extends StatelessWidget {
     //
     // A click cursor and nothing more: tapping opens the title, it does not
     // start playback, so there is no play glyph and no hoverOverlay here.
+    final contextMenu = onContextMenu;
+
     return MouseRegion(
       cursor: onTap != null ? SystemMouseCursors.click : MouseCursor.defer,
       child: GestureDetector(
         onTap: onTap,
+        // Long press for touch, secondary tap for a desktop right-click, the
+        // same pairing `MediaCard` uses on the rails.
+        onLongPress: contextMenu == null ? null : () => contextMenu(context),
+        onSecondaryTap: contextMenu == null ? null : () => contextMenu(context),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -112,6 +131,14 @@ class MediaPoster extends StatelessWidget {
                         ),
                     ],
                   ),
+                  // Routed through the same callback as the long-press, so the
+                  // button and the gesture can never offer different menus.
+                  if (showMenuButton && contextMenu != null)
+                    Builder(
+                      builder: (buttonContext) => PosterMenuButton(
+                        onPressed: () => contextMenu(buttonContext),
+                      ),
+                    ),
                 ],
               ),
             ),

--- a/player/lib/presentation/widgets/poster_menu_button.dart
+++ b/player/lib/presentation/widgets/poster_menu_button.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+/// The kebab that opens a poster card's secondary menu.
+///
+/// A [PosterFrame] overlay, so it positions itself the way that widget's
+/// `overlays` contract requires. Bottom-right rather than top-right, because
+/// `PosterBadgeCorner` already owns the top-right for watch and quality
+/// badges, and inset far enough up to clear a `ProgressOverlay` sitting on the
+/// bottom edge.
+///
+/// This exists because the menu it opens is otherwise reachable only by
+/// long-press or right-click, neither of which a card advertises. Continue
+/// Watching is the surface that needs it: "Remove from Continue Watching" is
+/// the one action on these cards a viewer goes looking for, and an affordance
+/// nobody can see is not one.
+///
+/// Deliberately not a [PopupMenuButton] of its own, unlike
+/// `EpisodeRailCard._buildWatchedMenu` which it is styled after. It calls the
+/// same `onContextMenu` callback the long-press already routes through, so the
+/// two affordances cannot drift into offering different things.
+class PosterMenuButton extends StatelessWidget {
+  /// Opens the menu. The card passes its own context so the menu anchors to
+  /// the card rather than to this button.
+  final VoidCallback onPressed;
+
+  /// Named for the surface, so screen readers do not just say "button".
+  final String tooltip;
+
+  const PosterMenuButton({
+    super.key,
+    required this.onPressed,
+    this.tooltip = 'More actions',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      right: 6,
+      bottom: 10,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.45),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: IconButton(
+          icon: const Icon(
+            Icons.more_vert_rounded,
+            color: Colors.white,
+            size: 20,
+          ),
+          tooltip: tooltip,
+          padding: const EdgeInsets.all(4),
+          constraints: const BoxConstraints(),
+          visualDensity: VisualDensity.compact,
+          style: const ButtonStyle(
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          onPressed: onPressed,
+        ),
+      ),
+    );
+  }
+}

--- a/player/test/domain/models/continue_watching_dismissal_key_test.dart
+++ b/player/test/domain/models/continue_watching_dismissal_key_test.dart
@@ -1,0 +1,92 @@
+// Which media item "Remove from Continue Watching" actually hides.
+//
+// The rail's cards are episodes but its dismissals are shows, and every layer
+// above this — the menu's target, the optimistic splice in both controllers,
+// the mutation argument — reads the answer from here. Getting it wrong is
+// silent: matching on the card's own id simply never removes an episode card,
+// and the server refuses an episode id outright.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/continue_watching_item.dart';
+
+void main() {
+  group('ContinueWatchingItem.continueWatchingKey', () {
+    test('a movie is hidden by its own id', () {
+      const item = ContinueWatchingItem(
+        id: 'mv-1',
+        type: 'movie',
+        title: 'Heat',
+      );
+
+      expect(item.continueWatchingKey, 'mv-1');
+    });
+
+    test('an episode is hidden by its show, not itself', () {
+      const item = ContinueWatchingItem(
+        id: 'ep-1',
+        type: 'episode',
+        title: 'System',
+        showId: 'show-1',
+      );
+
+      expect(item.continueWatchingKey, 'show-1');
+      expect(item.continueWatchingKey, isNot('ep-1'));
+    });
+
+    // Falling back to the episode id here would send the server the one id it
+    // rejects, so a card with no show offers no removal at all.
+    test('an episode with no known show has nothing to hide', () {
+      const item = ContinueWatchingItem(
+        id: 'ep-1',
+        type: 'episode',
+        title: 'System',
+      );
+
+      expect(item.continueWatchingKey, isNull);
+    });
+
+    test('a next-up card keys on its show like any other episode', () {
+      const item = ContinueWatchingItem(
+        id: 'ep-2',
+        type: 'episode',
+        title: 'Sheridan',
+        showId: 'show-1',
+        state: 'next',
+      );
+
+      expect(item.continueWatchingKey, 'show-1');
+    });
+  });
+
+  group('ContinueWatchingItem.dismissedBy', () {
+    const movie = ContinueWatchingItem(
+      id: 'mv-1',
+      type: 'movie',
+      title: 'Heat',
+    );
+
+    const episode = ContinueWatchingItem(
+      id: 'ep-1',
+      type: 'episode',
+      title: 'System',
+      showId: 'show-1',
+    );
+
+    test('an episode card is dismissed by its show id', () {
+      expect(episode.dismissedBy('show-1'), isTrue);
+    });
+
+    test('an episode card is not dismissed by its own id', () {
+      expect(episode.dismissedBy('ep-1'), isFalse);
+    });
+
+    test('a movie card is dismissed by its own id', () {
+      expect(movie.dismissedBy('mv-1'), isTrue);
+    });
+
+    test('an unrelated title is left alone', () {
+      expect(movie.dismissedBy('show-1'), isFalse);
+      expect(episode.dismissedBy('show-2'), isFalse);
+    });
+  });
+}

--- a/player/test/domain/models/continue_watching_dismissal_key_test.dart
+++ b/player/test/domain/models/continue_watching_dismissal_key_test.dart
@@ -89,4 +89,87 @@ void main() {
       expect(episode.dismissedBy('show-2'), isFalse);
     });
   });
+
+  group('restoreFailedRemoval', () {
+    ContinueWatchingItem movie(String id) =>
+        ContinueWatchingItem(id: id, type: 'movie', title: id);
+
+    test('puts the failed card back where it was', () {
+      final snapshot = [movie('a'), movie('b'), movie('c')];
+      final latest = [movie('a'), movie('c')];
+
+      final restored = restoreFailedRemoval(
+        snapshot: snapshot,
+        latest: latest,
+        key: 'b',
+      );
+
+      expect(restored.map((item) => item.id), ['a', 'b', 'c']);
+    });
+
+    // The defect a whole-snapshot restore has: the viewer removed b and then
+    // c, c succeeded, b failed. Restoring the snapshot would bring c back too.
+    test('does not resurrect a card another removal has since dismissed', () {
+      final snapshot = [movie('a'), movie('b'), movie('c')];
+      final latest = [movie('a')];
+
+      final restored = restoreFailedRemoval(
+        snapshot: snapshot,
+        latest: latest,
+        key: 'b',
+      );
+
+      expect(restored.map((item) => item.id), ['a', 'b']);
+      expect(restored.map((item) => item.id), isNot(contains('c')));
+    });
+
+    // A successful removal invalidates and refetches, so the list can gain
+    // cards while a failing mutation is still in flight.
+    test('keeps a card a refetch added meanwhile', () {
+      final snapshot = [movie('a'), movie('b')];
+      final latest = [movie('a'), movie('d')];
+
+      final restored = restoreFailedRemoval(
+        snapshot: snapshot,
+        latest: latest,
+        key: 'b',
+      );
+
+      expect(restored.map((item) => item.id), ['a', 'b', 'd']);
+    });
+
+    test('an episode is restored by its show key', () {
+      final snapshot = [
+        movie('a'),
+        const ContinueWatchingItem(
+          id: 'ep-1',
+          type: 'episode',
+          title: 'System',
+          showId: 'show-1',
+        ),
+      ];
+      final latest = [movie('a')];
+
+      final restored = restoreFailedRemoval(
+        snapshot: snapshot,
+        latest: latest,
+        key: 'show-1',
+      );
+
+      expect(restored.map((item) => item.id), ['a', 'ep-1']);
+    });
+
+    test('nothing to restore leaves the latest list alone', () {
+      final snapshot = [movie('a'), movie('b')];
+      final latest = [movie('a'), movie('b')];
+
+      final restored = restoreFailedRemoval(
+        snapshot: snapshot,
+        latest: latest,
+        key: 'zzz',
+      );
+
+      expect(restored.map((item) => item.id), ['a', 'b']);
+    });
+  });
 }

--- a/player/test/domain/models/continue_watching_dismissal_key_test.dart
+++ b/player/test/domain/models/continue_watching_dismissal_key_test.dart
@@ -8,6 +8,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/domain/models/continue_watching_item.dart';
+import 'package:player/domain/models/progress.dart';
 
 void main() {
   group('ContinueWatchingItem.continueWatchingKey', () {
@@ -157,6 +158,73 @@ void main() {
       );
 
       expect(restored.map((item) => item.id), ['a', 'ep-1']);
+    });
+
+    // A refetch can land while the mutation is in flight, carrying fresher
+    // progress. Keeping the snapshot's copy would roll that back along with
+    // the removal.
+    test('keeps the latest copy of a card, not the snapshot copy', () {
+      const stale = ContinueWatchingItem(
+        id: 'a',
+        type: 'movie',
+        title: 'Heat',
+        progress: Progress(
+          positionSeconds: 100,
+          durationSeconds: 7200,
+          percentage: 1.4,
+          watched: false,
+        ),
+      );
+      const fresh = ContinueWatchingItem(
+        id: 'a',
+        type: 'movie',
+        title: 'Heat',
+        progress: Progress(
+          positionSeconds: 900,
+          durationSeconds: 7200,
+          percentage: 12.5,
+          watched: false,
+        ),
+      );
+
+      final restored = restoreFailedRemoval(
+        snapshot: [stale, movie('b')],
+        latest: [fresh],
+        key: 'b',
+      );
+
+      expect(restored.first.progress?.positionSeconds, 900);
+    });
+
+    // The rail carries one card per show, but not always the same episode. If
+    // a refetch has already replaced the snapshot's episode with its
+    // successor, putting the snapshot's copy back would show the series twice.
+    test('does not restore a show the latest list already covers', () {
+      const episodeOne = ContinueWatchingItem(
+        id: 'ep-1',
+        type: 'episode',
+        title: 'System',
+        showId: 'show-1',
+      );
+      const episodeTwo = ContinueWatchingItem(
+        id: 'ep-2',
+        type: 'episode',
+        title: 'Sheridan',
+        showId: 'show-1',
+      );
+
+      final restored = restoreFailedRemoval(
+        snapshot: [movie('a'), episodeOne],
+        latest: [movie('a'), episodeTwo],
+        key: 'show-1',
+      );
+
+      expect(restored.map((item) => item.id), ['a', 'ep-2']);
+      expect(
+        restored.where((item) => item.continueWatchingKey == 'show-1'),
+        hasLength(1),
+        reason: 'the rail carries one card per show',
+      );
     });
 
     test('nothing to restore leaves the latest list alone', () {

--- a/player/test/presentation/screens/continue_watching/remove_from_continue_watching_test.dart
+++ b/player/test/presentation/screens/continue_watching/remove_from_continue_watching_test.dart
@@ -1,0 +1,219 @@
+// The optimistic removal, on the controller that owns the home rail.
+//
+// Two things here are easy to get wrong and silent when wrong: the splice has
+// to match on the show id for an episode card (matching the card's own id
+// removes nothing), and the revert has to put back the whole HomeData, not
+// just the rail it edited.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/domain/models/home_data.dart';
+import 'package:player/presentation/screens/home/home_controller.dart';
+
+import '../../../test_utils/riverpod_helpers.dart';
+import '../../../test_utils/stub_graphql_client.dart';
+
+Map<String, dynamic> _artwork() => {
+      '__typename': 'Artwork',
+      'posterUrl': null,
+      'backdropUrl': null,
+      'thumbnailUrl': null,
+    };
+
+/// Every field the home query selects. A stub missing one does not error: the
+/// normalized cache returns partial data and the failure surfaces elsewhere.
+Map<String, dynamic> _continueWatching({
+  required String id,
+  required String type,
+  required String title,
+  String? showId,
+}) =>
+    {
+      '__typename': 'ContinueWatchingItem',
+      'id': id,
+      'type': type,
+      'title': title,
+      'state': 'continue',
+      'artwork': _artwork(),
+      'progress': {
+        '__typename': 'Progress',
+        'positionSeconds': 600,
+        'durationSeconds': 3600,
+        'percentage': 16.6,
+        'watched': false,
+        'lastWatchedAt': null,
+      },
+      'showId': showId,
+      'showTitle': showId == null ? null : 'The Bear',
+      'seasonNumber': showId == null ? null : 1,
+      'episodeNumber': showId == null ? null : 2,
+      'files': <dynamic>[],
+    };
+
+Map<String, dynamic> _recentlyAdded() => {
+      '__typename': 'MediaItem',
+      'id': 'ra-1',
+      'type': 'movie',
+      'title': 'Recently Added Movie',
+      'year': 2026,
+      'artwork': _artwork(),
+      'addedAt': '2026-07-01T00:00:00Z',
+      'newEpisodeCount': null,
+      'latestSeasonNumber': null,
+      'latestEpisodeNumber': null,
+      'watchStatus': null,
+    };
+
+Map<String, dynamic> _homeData() => {
+      '__typename': 'Query',
+      'continueWatching': [
+        _continueWatching(id: 'mv-1', type: 'movie', title: 'Heat'),
+        _continueWatching(
+          id: 'ep-1',
+          type: 'episode',
+          title: 'System',
+          showId: 'show-1',
+        ),
+      ],
+      'recentlyAdded': [_recentlyAdded()],
+      'upNext': <dynamic>[],
+      'favorites': <dynamic>[],
+    };
+
+Map<String, dynamic> _removalResult(String mediaItemId) => {
+      '__typename': 'RootMutationType',
+      'removeFromContinueWatching': {
+        '__typename': 'RemoveFromContinueWatchingResult',
+        'mediaItemId': mediaItemId,
+        'removed': true,
+      },
+    };
+
+/// Answers the home query from [_homeData] and the mutation from [onMutation].
+///
+/// Discriminates on the variables, not on `operation.operationName`: that is
+/// null for the codegen'd documents, so keying on it silently routed the
+/// mutation into the query's response and every test here passed or failed for
+/// the wrong reason.
+StubLink _link(Object Function() onMutation) => StubLink((request, _) =>
+    request.variables.containsKey('mediaItemId') ? onMutation() : _homeData());
+
+ProviderContainer _container(StubLink link) {
+  final container = ProviderContainer(
+    overrides: [
+      asyncGraphqlClientProvider.overrideWith((ref) async => stubClient(link)),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Future<HomeData> _settle(ProviderContainer container) => waitForValue<HomeData>(
+      container,
+      homeControllerProvider,
+      (value) => value.continueWatching.length == 2,
+    );
+
+void main() {
+  test('removing a movie drops its card', () async {
+    final container = _container(_link(() => _removalResult('mv-1')));
+    await _settle(container);
+
+    await container
+        .read(homeControllerProvider.notifier)
+        .removeFromContinueWatching('mv-1');
+
+    final ids = container
+        .read(homeControllerProvider)
+        .value!
+        .continueWatching
+        .map((item) => item.id);
+    expect(ids, ['ep-1']);
+  });
+
+  // The bug this pins: an episode card is removed by its show id, and a splice
+  // matching on the card's own id would leave it sitting there.
+  test('removing a show drops its episode card', () async {
+    final container = _container(_link(() => _removalResult('show-1')));
+    await _settle(container);
+
+    await container
+        .read(homeControllerProvider.notifier)
+        .removeFromContinueWatching('show-1');
+
+    final ids = container
+        .read(homeControllerProvider)
+        .value!
+        .continueWatching
+        .map((item) => item.id);
+    expect(ids, ['mv-1']);
+  });
+
+  test('the episode card is not removed by its own id', () async {
+    final container = _container(_link(() => _removalResult('ep-1')));
+    await _settle(container);
+
+    await container
+        .read(homeControllerProvider.notifier)
+        .removeFromContinueWatching('ep-1');
+
+    final ids = container
+        .read(homeControllerProvider)
+        .value!
+        .continueWatching
+        .map((item) => item.id);
+    expect(ids, ['mv-1', 'ep-1']);
+  });
+
+  test('the other rails survive a removal', () async {
+    final container = _container(_link(() => _removalResult('mv-1')));
+    await _settle(container);
+
+    await container
+        .read(homeControllerProvider.notifier)
+        .removeFromContinueWatching('mv-1');
+
+    final data = container.read(homeControllerProvider).value!;
+    expect(data.recentlyAdded, hasLength(1));
+  });
+
+  group('on failure', () {
+    test('the card comes back and the error reaches the caller', () async {
+      final container = _container(
+        _link(() => graphqlErrorResponse('nope')),
+      );
+      await _settle(container);
+
+      await expectLater(
+        container
+            .read(homeControllerProvider.notifier)
+            .removeFromContinueWatching('mv-1'),
+        throwsA(isA<OperationException>()),
+      );
+
+      final ids = container
+          .read(homeControllerProvider)
+          .value!
+          .continueWatching
+          .map((item) => item.id);
+      expect(ids, ['mv-1', 'ep-1']);
+    });
+
+    test('the other rails are restored intact, not emptied', () async {
+      final container = _container(
+        _link(() => graphqlErrorResponse('nope')),
+      );
+      await _settle(container);
+
+      await container
+          .read(homeControllerProvider.notifier)
+          .removeFromContinueWatching('mv-1')
+          .catchError((_) {});
+
+      final data = container.read(homeControllerProvider).value!;
+      expect(data.recentlyAdded, hasLength(1));
+    });
+  });
+}

--- a/player/test/presentation/screens/continue_watching/remove_from_continue_watching_test.dart
+++ b/player/test/presentation/screens/continue_watching/remove_from_continue_watching_test.dart
@@ -1,9 +1,12 @@
 // The optimistic removal, on the controller that owns the home rail.
 //
-// Two things here are easy to get wrong and silent when wrong: the splice has
-// to match on the show id for an episode card (matching the card's own id
-// removes nothing), and the revert has to put back the whole HomeData, not
-// just the rail it edited.
+// Three things here are easy to get wrong and silent when wrong: the splice
+// has to match on the show id for an episode card (matching the card's own id
+// removes nothing), the revert has to carry the rest of HomeData forward, and
+// the revert has to be scoped to the failed key rather than restoring a
+// snapshot that a concurrent removal has already made stale.
+
+import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -100,7 +103,37 @@ Map<String, dynamic> _removalResult(String mediaItemId) => {
 StubLink _link(Object Function() onMutation) => StubLink((request, _) =>
     request.variables.containsKey('mediaItemId') ? onMutation() : _homeData());
 
-ProviderContainer _container(StubLink link) {
+/// Holds the `mv-1` mutation open until [gate] completes, so a second removal
+/// can finish while the first is still in flight. `StubLink`'s handler is
+/// synchronous and cannot await, so this test needs its own link.
+class _GatedLink extends Link {
+  _GatedLink(this.gate);
+
+  final Future<void> gate;
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) async* {
+    final variables = request.variables;
+
+    if (!variables.containsKey('mediaItemId')) {
+      yield Response(data: _homeData(), response: const <String, dynamic>{});
+      return;
+    }
+
+    if (variables['mediaItemId'] == 'mv-1') {
+      await gate;
+      yield graphqlErrorResponse('nope');
+      return;
+    }
+
+    yield Response(
+      data: _removalResult('show-1'),
+      response: const <String, dynamic>{},
+    );
+  }
+}
+
+ProviderContainer _container(Link link) {
   final container = ProviderContainer(
     overrides: [
       asyncGraphqlClientProvider.overrideWith((ref) async => stubClient(link)),
@@ -199,6 +232,31 @@ void main() {
           .continueWatching
           .map((item) => item.id);
       expect(ids, ['mv-1', 'ep-1']);
+    });
+
+    // Two removals in flight at once, the first failing after the second
+    // succeeds. Restoring the pre-removal snapshot would put the second card
+    // back on the rail even though the server has hidden it.
+    test('a failure does not resurrect a card removed since', () async {
+      final gate = Completer<void>();
+      final container = _container(_GatedLink(gate.future));
+      await _settle(container);
+
+      final notifier = container.read(homeControllerProvider.notifier);
+
+      // The movie's mutation is still in flight while the show's completes.
+      final pending = notifier.removeFromContinueWatching('mv-1');
+      await notifier.removeFromContinueWatching('show-1');
+
+      gate.complete();
+      await pending.catchError((_) {});
+
+      final ids = container
+          .read(homeControllerProvider)
+          .value!
+          .continueWatching
+          .map((item) => item.id);
+      expect(ids, ['mv-1'], reason: 'the show stays hidden, the movie returns');
     });
 
     test('the other rails are restored intact, not emptied', () async {

--- a/player/test/presentation/widgets/content_rail_test.dart
+++ b/player/test/presentation/widgets/content_rail_test.dart
@@ -326,6 +326,143 @@ void main() {
     });
   });
 
+  group('ContentRail remove from Continue Watching', () {
+    const movie = ContinueWatchingItem(
+      id: 'mv-1',
+      type: 'movie',
+      title: 'Heat',
+      files: [MediaFile(id: 'f-1', directPlaySupported: true)],
+    );
+
+    const episode = ContinueWatchingItem(
+      id: 'ep-1',
+      type: 'episode',
+      title: 'Pilot',
+      showId: 'show-1',
+      showTitle: 'The Bear',
+      seasonNumber: 1,
+      episodeNumber: 1,
+      files: [MediaFile(id: 'f-2', directPlaySupported: true)],
+    );
+
+    testWidgets('the menu offers removal when the rail can act on it',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(
+          title: 'Continue Watching',
+          items: const [movie],
+          onItemActivate: (_) {},
+          onRemoveFromContinueWatching: (_) {},
+        )),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.byType(MediaCard));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Remove from Continue Watching'), findsOneWidget);
+    });
+
+    // Without a handler the entry would be there to be selected and then do
+    // nothing, which is the trap the Play entry fell into on rails with no
+    // activate handler.
+    testWidgets('the menu omits removal when the rail cannot act on it',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(
+          title: 'Continue Watching',
+          items: const [movie],
+          onItemActivate: (_) {},
+        )),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.byType(MediaCard));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Remove from Continue Watching'), findsNothing);
+    });
+
+    testWidgets('a movie card reports itself as the thing to hide',
+        (tester) async {
+      String? removed;
+
+      await tester.pumpWidget(
+        _host(ContentRail(
+          title: 'Continue Watching',
+          items: const [movie],
+          onItemActivate: (_) {},
+          onRemoveFromContinueWatching: (item) =>
+              removed = item.continueWatchingKey,
+        )),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.byType(MediaCard));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Remove from Continue Watching'));
+      await tester.pumpAndSettle();
+
+      expect(removed, 'mv-1');
+    });
+
+    // The whole point of keying on the show: an episode card stands for its
+    // series, and hiding the episode alone would hand the show back with the
+    // next one.
+    testWidgets('an episode card reports its show as the thing to hide',
+        (tester) async {
+      String? removed;
+
+      await tester.pumpWidget(
+        _host(ContentRail(
+          title: 'Continue Watching',
+          items: const [episode],
+          onItemActivate: (_) {},
+          onRemoveFromContinueWatching: (item) =>
+              removed = item.continueWatchingKey,
+        )),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.byType(MediaCard));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Remove from Continue Watching'));
+      await tester.pumpAndSettle();
+
+      expect(removed, 'show-1');
+      expect(removed, isNot('ep-1'));
+    });
+
+    testWidgets('the kebab opens the same menu as the long press',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(
+          title: 'Continue Watching',
+          items: const [movie],
+          onItemActivate: (_) {},
+          onRemoveFromContinueWatching: (_) {},
+        )),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.more_vert_rounded), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.more_vert_rounded));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Remove from Continue Watching'), findsOneWidget);
+    });
+
+    testWidgets('a rail with nothing to remove draws no kebab', (tester) async {
+      await tester.pumpWidget(
+        _host(ContentRail(title: 'Recently Added', items: _items(1))),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.more_vert_rounded), findsNothing);
+    });
+  });
+
   group('ContentRail watch indicators', () {
     testWidgets('draws an unwatched dot on a recently added movie',
         (tester) async {

--- a/player/test/presentation/widgets/media_context_menu_test.dart
+++ b/player/test/presentation/widgets/media_context_menu_test.dart
@@ -116,4 +116,72 @@ void main() {
       }
     });
   });
+
+  group('mediaContextActionsFor removal', () {
+    test('a card with no dismissal target is offered no removal', () {
+      const target = MediaContextTarget(
+        id: 'mv-1',
+        type: 'movie',
+        hasFile: true,
+        tapPlays: true,
+      );
+
+      expect(
+        mediaContextActionsFor(target),
+        isNot(contains(MediaContextAction.removeFromContinueWatching)),
+      );
+    });
+
+    // The case the tapPlays early return used to swallow. The
+    // `/continue-watching` grid opens the title on tap rather than playing it,
+    // so every target it builds has tapPlays false — and it is the surface
+    // where removal matters most.
+    test('a card that navigates on tap is still offered removal', () {
+      const target = MediaContextTarget(
+        id: 'ep-1',
+        type: 'episode',
+        showId: 'show-1',
+        hasFile: true,
+        continueWatchingId: 'show-1',
+      );
+
+      expect(mediaContextActionsFor(target), [
+        MediaContextAction.removeFromContinueWatching,
+      ]);
+    });
+
+    test('removal comes last, after the navigation entries', () {
+      const target = MediaContextTarget(
+        id: 'ep-1',
+        type: 'episode',
+        showId: 'show-1',
+        hasFile: true,
+        tapPlays: true,
+        continueWatchingId: 'show-1',
+      );
+
+      expect(mediaContextActionsFor(target), [
+        MediaContextAction.play,
+        MediaContextAction.goToShow,
+        MediaContextAction.episodeDetails,
+        MediaContextAction.removeFromContinueWatching,
+      ]);
+    });
+
+    test('a movie card is offered removal keyed on itself', () {
+      const target = MediaContextTarget(
+        id: 'mv-1',
+        type: 'movie',
+        hasFile: true,
+        tapPlays: true,
+        continueWatchingId: 'mv-1',
+      );
+
+      expect(mediaContextActionsFor(target), [
+        MediaContextAction.play,
+        MediaContextAction.movieDetails,
+        MediaContextAction.removeFromContinueWatching,
+      ]);
+    });
+  });
 }

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -119,6 +119,9 @@ type RootMutationType {
   "Toggle favorite status for a media item"
   toggleFavorite(mediaItemId: ID!): ToggleFavoriteResult
 
+  "Hide a movie or show from Continue Watching until it is played again"
+  removeFromContinueWatching(mediaItemId: ID!): RemoveFromContinueWatchingResult
+
   "Refresh a media access token before it expires"
   refreshMediaToken(token: String!): MediaToken
 
@@ -954,6 +957,15 @@ type ToggleFavoriteResult {
 
   "ID of the media item"
   mediaItemId: ID!
+}
+
+"Outcome of hiding a title from Continue Watching"
+type RemoveFromContinueWatchingResult {
+  "ID of the hidden movie or show"
+  mediaItemId: ID!
+
+  "Whether the title is now hidden from Continue Watching"
+  removed: Boolean!
 }
 
 "Media access token for direct media requests"

--- a/priv/repo/migrations/20260819154217_create_continue_watching_dismissals.exs
+++ b/priv/repo/migrations/20260819154217_create_continue_watching_dismissals.exs
@@ -1,0 +1,36 @@
+defmodule Mydia.Repo.Migrations.CreateContinueWatchingDismissals do
+  use Ecto.Migration
+
+  def change do
+    # One row per title a viewer has taken off the Continue Watching rail.
+    #
+    # Keyed on the media item, which for a series means the show and not the
+    # episode. The rail carries at most one card per show, so the show is the
+    # only unit a "remove this card" gesture can honestly mean; dismissing a
+    # single episode would put the show straight back with the next one.
+    #
+    # Note this is a hide, not an unwatch. The `playback_progress` row is left
+    # alone so the resume point survives, and no `playback.unwatched` event is
+    # emitted, which is what keeps `Mydia.WatchSync` from telling Plex or
+    # Jellyfin that a title nobody unwatched was unwatched.
+    create table(:continue_watching_dismissals, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :media_item_id, references(:media_items, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      # Compared against the entry's most recent watch time rather than being
+      # a plain boolean flag. A later play pushes that time past this stamp
+      # and the title returns on its own, so nothing has to sweep this table.
+      add :dismissed_at, :utc_datetime, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    # One dismissal per viewer per title, which is also what lets a repeat
+    # dismissal be an atomic upsert instead of a read-modify-write.
+    create unique_index(:continue_watching_dismissals, [:user_id, :media_item_id])
+  end
+end

--- a/server/crates/api/src/mutation.rs
+++ b/server/crates/api/src/mutation.rs
@@ -154,12 +154,18 @@ impl RootMutationType {
     }
 
     /// Hide a movie or show from Continue Watching until it is played again
+    ///
+    /// An explicit error rather than the `Ok(None)` most stubs here return.
+    /// A caller cannot tell a null from a success: the player removes the card
+    /// optimistically and only reverts on an exception, so a silent null would
+    /// leave the card gone, the rail unchanged on the server, and the title
+    /// back on the next refetch with nothing to explain it.
     async fn remove_from_continue_watching(
         &self,
         _ctx: &Context<'_>,
         _media_item_id: ID,
     ) -> Result<Option<RemoveFromContinueWatchingResult>> {
-        Ok(None)
+        Err(not_implemented("removeFromContinueWatching"))
     }
 
     /// Refresh a media access token before it expires

--- a/server/crates/api/src/mutation.rs
+++ b/server/crates/api/src/mutation.rs
@@ -14,6 +14,7 @@ use crate::types::auth::{
     LoginResult, MediaToken, RevokeDeviceResult, ToggleFavoriteResult, User,
 };
 use crate::types::common::StreamingStrategy;
+use crate::types::discovery::RemoveFromContinueWatchingResult;
 use crate::types::media::{Episode, Movie, Progress, SubtitleTrack, TvShow};
 use crate::types::streaming::{
     AudioLanguagePreferenceResult, CancelDownloadResult, DownloadJobStatus, DownloadOption,
@@ -149,6 +150,15 @@ impl RootMutationType {
         _ctx: &Context<'_>,
         _media_item_id: ID,
     ) -> Result<Option<ToggleFavoriteResult>> {
+        Ok(None)
+    }
+
+    /// Hide a movie or show from Continue Watching until it is played again
+    async fn remove_from_continue_watching(
+        &self,
+        _ctx: &Context<'_>,
+        _media_item_id: ID,
+    ) -> Result<Option<RemoveFromContinueWatchingResult>> {
         Ok(None)
     }
 

--- a/server/crates/api/src/types/discovery.rs
+++ b/server/crates/api/src/types/discovery.rs
@@ -1,9 +1,9 @@
 //! Discovery, search and remote access types.
 //!
 //! Types owned by this module (keep in sync with tests/types_remaining.rs):
-//! ContinueWatchingItem, RecentlyAddedItem, UpNextItem, Collection,
-//! SearchResult, SearchSection, SearchResults, RemoteAccessStatus,
-//! ServerCompatibility.
+//! ContinueWatchingItem, RemoveFromContinueWatchingResult, RecentlyAddedItem,
+//! UpNextItem, Collection, SearchResult, SearchSection, SearchResults,
+//! RemoteAccessStatus, ServerCompatibility.
 
 use async_graphql::{SimpleObject, ID};
 
@@ -28,6 +28,12 @@ pub struct ContinueWatchingItem {
     /// Why this item is on the rail: continue for a resume point, next for the
     /// successor of a finished episode.
     pub state: Option<String>,
+}
+
+#[derive(SimpleObject)]
+pub struct RemoveFromContinueWatchingResult {
+    pub media_item_id: ID,
+    pub removed: bool,
 }
 
 #[derive(SimpleObject)]
@@ -107,6 +113,10 @@ pub fn sdl_fragment() -> String {
     #[Object]
     impl FragmentQuery {
         async fn continue_watching_item(&self) -> ContinueWatchingItem {
+            std::future::pending().await
+        }
+
+        async fn remove_from_continue_watching_result(&self) -> RemoveFromContinueWatchingResult {
             std::future::pending().await
         }
 

--- a/server/crates/api/tests/types_remaining.rs
+++ b/server/crates/api/tests/types_remaining.rs
@@ -31,6 +31,7 @@ const OWNED_STREAMING: &[&str] = &[
 
 const OWNED_DISCOVERY: &[&str] = &[
     "ContinueWatchingItem",
+    "RemoveFromContinueWatchingResult",
     "RecentlyAddedItem",
     "UpNextItem",
     "Collection",

--- a/test/mydia/playback/dismissal_test.exs
+++ b/test/mydia/playback/dismissal_test.exs
@@ -1,0 +1,93 @@
+defmodule Mydia.Playback.DismissalTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
+  alias Mydia.Playback
+  alias Mydia.Playback.Dismissal
+
+  setup do
+    %{user: AccountsFixtures.user_fixture(), movie: MediaFixtures.media_item_fixture()}
+  end
+
+  describe "dismiss_from_on_deck/3" do
+    test "records the dismissal against the user and item", ctx do
+      assert {:ok, dismissal} = Playback.dismiss_from_on_deck(ctx.user.id, ctx.movie.id)
+
+      assert dismissal.user_id == ctx.user.id
+      assert dismissal.media_item_id == ctx.movie.id
+      assert dismissal.dismissed_at
+    end
+
+    # A dismissed title comes back the moment it is played again, so dismissing
+    # the same thing twice is ordinary use, not an error. An insert would fail
+    # the second time on the unique index.
+    test "re-dismissing re-stamps rather than failing on the unique index", ctx do
+      earlier = ~U[2026-08-12 20:00:00Z]
+      later = ~U[2026-08-12 21:00:00Z]
+
+      {:ok, _first} = Playback.dismiss_from_on_deck(ctx.user.id, ctx.movie.id, now: earlier)
+      {:ok, _second} = Playback.dismiss_from_on_deck(ctx.user.id, ctx.movie.id, now: later)
+
+      # Read back rather than trusting the returned struct: an upsert hands
+      # back the id it generated for the insert it did not end up doing.
+      assert Repo.aggregate(Dismissal, :count) == 1
+      assert stored = Repo.get_by(Dismissal, user_id: ctx.user.id, media_item_id: ctx.movie.id)
+      assert DateTime.compare(stored.dismissed_at, later) == :eq
+    end
+
+    test "an id naming no media item is refused, not raised", ctx do
+      assert {:error, :not_found} =
+               Playback.dismiss_from_on_deck(ctx.user.id, Ecto.UUID.generate())
+
+      assert Repo.aggregate(Dismissal, :count) == 0
+    end
+
+    test "an id that is not even a UUID is refused, not raised", ctx do
+      assert {:error, :not_found} = Playback.dismiss_from_on_deck(ctx.user.id, "not-a-uuid")
+
+      assert Repo.aggregate(Dismissal, :count) == 0
+    end
+
+    test "two users dismiss the same title independently", ctx do
+      other = AccountsFixtures.user_fixture()
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, ctx.movie.id)
+      {:ok, _} = Playback.dismiss_from_on_deck(other.id, ctx.movie.id)
+
+      assert Repo.aggregate(Dismissal, :count) == 2
+    end
+
+    test "truncates the stamp to the second, matching last_watched_at", ctx do
+      {:ok, dismissal} = Playback.dismiss_from_on_deck(ctx.user.id, ctx.movie.id)
+
+      assert dismissal.dismissed_at.microsecond == {0, 0}
+    end
+
+    # The reason this is a table of its own rather than a call to
+    # `delete_progress/3`: that emits `playback.unwatched`, which WatchSync
+    # forwards to Plex and Jellyfin. Hiding a card must stay local.
+    #
+    # The unwatch at the end is a positive control. Event writes run
+    # synchronously under the sandbox pool, so without it a broken
+    # subscription would make the `refute_receive` pass for the wrong reason.
+    test "emits no event, where an unwatch would", ctx do
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: ctx.movie.id],
+          %{position_seconds: 900, duration_seconds: 7200}
+        )
+
+      Mydia.Events.subscribe()
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, ctx.movie.id)
+
+      refute_receive {:event_created, %{type: "playback.unwatched"}}, 100
+
+      {:ok, _} = Playback.delete_progress(ctx.user.id, media_item_id: ctx.movie.id)
+
+      assert_receive {:event_created, %{type: "playback.unwatched"}}, 100
+    end
+  end
+end

--- a/test/mydia/playback/dismissal_test.exs
+++ b/test/mydia/playback/dismissal_test.exs
@@ -43,6 +43,18 @@ defmodule Mydia.Playback.DismissalTest do
       assert Repo.aggregate(Dismissal, :count) == 0
     end
 
+    # The lookup and the insert are two statements, so a media item deleted
+    # between them still reaches the foreign key. Postgres names the constraint
+    # and the changeset carries it; SQLite reports no name and Ecto raises. The
+    # caller sees one answer either way.
+    test "a media item deleted before the insert is refused, not raised", ctx do
+      Repo.delete!(ctx.movie)
+
+      assert {:error, :not_found} = Playback.dismiss_from_on_deck(ctx.user.id, ctx.movie.id)
+
+      assert Repo.aggregate(Dismissal, :count) == 0
+    end
+
     test "an id that is not even a UUID is refused, not raised", ctx do
       assert {:error, :not_found} = Playback.dismiss_from_on_deck(ctx.user.id, "not-a-uuid")
 

--- a/test/mydia/playback/on_deck_query_count_test.exs
+++ b/test/mydia/playback/on_deck_query_count_test.exs
@@ -114,7 +114,7 @@ defmodule Mydia.Playback.OnDeckQueryCountTest do
       assert small == large,
              "expected a constant query count, got #{small} for 3 shows and #{large} for 15"
 
-      assert large <= 8, "expected at most 8 queries, got #{large}"
+      assert large <= 9, "expected at most 9 queries, got #{large}"
     end
   end
 end

--- a/test/mydia/playback/on_deck_test.exs
+++ b/test/mydia/playback/on_deck_test.exs
@@ -61,6 +61,21 @@ defmodule Mydia.Playback.OnDeckTest do
     progress
   end
 
+  # A movie with a file, left partway through at `at`.
+  defp in_progress_movie(user, at) do
+    movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+    MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+
+    {:ok, _} =
+      Playback.save_progress(
+        user.id,
+        [media_item_id: movie.id],
+        %{position_seconds: 900, duration_seconds: 7200, last_watched_at: at}
+      )
+
+    movie
+  end
+
   defp now, do: ~U[2026-08-12 20:00:00Z]
   defp ago(seconds), do: DateTime.add(now(), -seconds, :second)
   defp days_ago(days), do: DateTime.add(now(), -days, :day)
@@ -341,6 +356,156 @@ defmodule Mydia.Playback.OnDeckTest do
       assert [entry] = OnDeck.list(ctx.user.id, now: now())
       assert entry.state == :next
       assert entry.episode.id == e2.id
+    end
+  end
+
+  describe "list/2 dismissals" do
+    test "a dismissed movie is hidden", ctx do
+      movie = in_progress_movie(ctx.user, ago(60))
+      assert [_] = OnDeck.list(ctx.user.id, now: now())
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, movie.id, now: now())
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "a dismissed show is hidden in the :continue state", ctx do
+      {show, [e1, _e2]} = show_with_episodes(2)
+      start_watching(ctx.user, e1, 900, ago(60))
+
+      assert [%{state: :continue}] = OnDeck.list(ctx.user.id, now: now())
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, show.id, now: now())
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    # The case a progress-row deletion could never have covered: a `:next`
+    # entry has no progress row of its own, so the show id is the only handle
+    # on it.
+    test "a dismissed show is hidden in the :next state", ctx do
+      {show, [e1, _e2]} = show_with_episodes(2)
+      watch(ctx.user, e1, ago(60))
+
+      assert [%{state: :next}] = OnDeck.list(ctx.user.id, now: now())
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, show.id, now: now())
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "dismissing the show, not the episode, is what hides an episode entry", ctx do
+      {_show, [e1, _e2]} = show_with_episodes(2)
+      watch(ctx.user, e1, ago(60))
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+
+      # `OnDeckEntry.id/1` is the episode id and is only a sort tiebreak. An
+      # episode id names no media item, so it is refused outright rather than
+      # writing a dismissal that would never match anything.
+      assert {:error, :not_found} =
+               Playback.dismiss_from_on_deck(ctx.user.id, OnDeckEntry.id(entry), now: now())
+
+      assert [_] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "a dismissal older than the last watch does not hide", ctx do
+      movie = in_progress_movie(ctx.user, ago(60))
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, movie.id, now: ago(600))
+
+      assert [_] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    # Both columns are second-granularity, so a tie has to break one way. It
+    # breaks toward the dismissal: the gesture the viewer just made always
+    # takes effect, and the losing case rights itself on the next progress
+    # write. Flipping this to a strict `>` would make removal silently no-op.
+    test "a dismissal in the same second as the last watch hides", ctx do
+      movie = in_progress_movie(ctx.user, ago(60))
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, movie.id, now: ago(60))
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "playing a dismissed movie again brings it back", ctx do
+      movie = in_progress_movie(ctx.user, ago(600))
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, movie.id, now: ago(300))
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: movie.id],
+          %{position_seconds: 1200, duration_seconds: 7200, last_watched_at: ago(30)}
+        )
+
+      assert [_] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    # `sort_at` for a show is the newest watch across all its episodes, not
+    # just the one the card names, so any episode brings the series back.
+    test "watching a different episode of a dismissed show brings it back", ctx do
+      {show, [e1, e2, _e3]} = show_with_episodes(3)
+      watch(ctx.user, e1, ago(600))
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, show.id, now: ago(300))
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+
+      start_watching(ctx.user, e2, 900, ago(30))
+
+      assert [_] = OnDeck.list(ctx.user.id, now: now())
+    end
+
+    test "a dismissal only hides its own title", ctx do
+      kept = in_progress_movie(ctx.user, ago(120))
+      dismissed = in_progress_movie(ctx.user, ago(60))
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, dismissed.id, now: now())
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now())
+      assert entry.media_item.id == kept.id
+    end
+
+    test "one user's dismissal does not hide another user's card", ctx do
+      movie = in_progress_movie(ctx.user, ago(60))
+      other = AccountsFixtures.user_fixture()
+
+      {:ok, _} =
+        Playback.save_progress(
+          other.id,
+          [media_item_id: movie.id],
+          %{position_seconds: 900, duration_seconds: 7200, last_watched_at: ago(60)}
+        )
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, movie.id, now: now())
+
+      assert [] = OnDeck.list(ctx.user.id, now: now())
+      assert [_] = OnDeck.list(other.id, now: now())
+    end
+
+    # Rejected before the take, so a hidden title does not eat a slot and hand
+    # back a rail one card shorter than the caller asked for.
+    test "a hidden title does not consume a limit slot", ctx do
+      _oldest = in_progress_movie(ctx.user, ago(300))
+      middle = in_progress_movie(ctx.user, ago(200))
+      newest = in_progress_movie(ctx.user, ago(100))
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, newest.id, now: now())
+
+      assert [entry] = OnDeck.list(ctx.user.id, now: now(), limit: 1)
+      assert entry.media_item.id == middle.id
+    end
+
+    test "dismissing leaves the progress row and its resume point alone", ctx do
+      movie = in_progress_movie(ctx.user, ago(60))
+
+      {:ok, _} = Playback.dismiss_from_on_deck(ctx.user.id, movie.id, now: now())
+
+      progress = Playback.get_progress(ctx.user.id, media_item_id: movie.id)
+      assert progress.position_seconds == 900
     end
   end
 end

--- a/test/mydia_web/schema/continue_watching_test.exs
+++ b/test/mydia_web/schema/continue_watching_test.exs
@@ -200,6 +200,98 @@ defmodule MydiaWeb.Schema.ContinueWatchingTest do
     end
   end
 
+  describe "removeFromContinueWatching" do
+    @remove_mutation """
+    mutation Remove($mediaItemId: ID!) {
+      removeFromContinueWatching(mediaItemId: $mediaItemId) {
+        mediaItemId
+        removed
+      }
+    }
+    """
+
+    test "hides the show behind an episode card", ctx do
+      [e1, _e2, _e3] = ctx.episodes
+      :changed = Playback.ensure_watched(ctx.user.id, episode_id: e1.id)
+
+      assert {:ok, %{data: %{"continueWatching" => [_]}}} =
+               run_query(@query, %{"first" => 10}, ctx.user)
+
+      assert {:ok, %{data: %{"removeFromContinueWatching" => result}}} =
+               run_query(@remove_mutation, %{"mediaItemId" => ctx.show.id}, ctx.user)
+
+      assert result["mediaItemId"] == ctx.show.id
+      assert result["removed"] == true
+
+      assert {:ok, %{data: %{"continueWatching" => []}}} =
+               run_query(@query, %{"first" => 10}, ctx.user)
+    end
+
+    # The rail's own ids are episode ids, so a client that passes the card's id
+    # straight back is the mistake most likely to be made here.
+    test "refuses an episode id rather than silently doing nothing", ctx do
+      [e1, _e2, _e3] = ctx.episodes
+      :changed = Playback.ensure_watched(ctx.user.id, episode_id: e1.id)
+
+      assert {:ok, %{errors: [%{message: message}]}} =
+               run_query(@remove_mutation, %{"mediaItemId" => e1.id}, ctx.user)
+
+      assert message =~ "not found"
+
+      assert {:ok, %{data: %{"continueWatching" => [_]}}} =
+               run_query(@query, %{"first" => 10}, ctx.user)
+    end
+
+    test "the hidden title returns once it is played again", ctx do
+      movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "Some Movie"})
+      MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: movie.id],
+          %{
+            position_seconds: 900,
+            duration_seconds: 7200,
+            last_watched_at: DateTime.add(DateTime.utc_now(), -600, :second)
+          }
+        )
+
+      assert {:ok, %{data: %{"removeFromContinueWatching" => _}}} =
+               run_query(@remove_mutation, %{"mediaItemId" => movie.id}, ctx.user)
+
+      assert {:ok, %{data: %{"continueWatching" => []}}} =
+               run_query(@query, %{"first" => 10}, ctx.user)
+
+      # Stamped a second past the dismissal rather than left to default. The
+      # mutation stamps with the real clock and both columns are
+      # second-granularity, so a test fast enough to replay inside the same
+      # second would be asserting the tie-break, not the return.
+      {:ok, _} =
+        Playback.save_progress(
+          ctx.user.id,
+          [media_item_id: movie.id],
+          %{
+            position_seconds: 1200,
+            duration_seconds: 7200,
+            last_watched_at: DateTime.add(DateTime.utc_now(), 1, :second)
+          }
+        )
+
+      assert {:ok, %{data: %{"continueWatching" => [item]}}} =
+               run_query(@query, %{"first" => 10}, ctx.user)
+
+      assert item["id"] == movie.id
+    end
+
+    test "requires authentication", ctx do
+      assert {:ok, %{errors: [%{message: message}]}} =
+               run_query(@remove_mutation, %{"mediaItemId" => ctx.show.id}, nil)
+
+      assert message =~ "Authentication required"
+    end
+  end
+
   defp run_query(query, variables, user) do
     context = if user, do: %{current_user: user}, else: %{}
     Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: context)


### PR DESCRIPTION
Adds a per-card "Remove from Continue Watching" to the player, the way Plex does it.

The rail had no way out: a film abandoned twenty minutes in, or a series nobody means to finish, sat at the top of the home screen until it crossed 90% watched or aged out after ninety days.

## Why not just reuse `markMovieUnwatched`

Two reasons, either one fatal.

Half the rail is **next-up cards** — the successor of an episode just finished — and by construction those have no `playback_progress` row of their own to delete. Deleting the *previous* episode's row would falsely un-watch an episode the viewer did watch.

And `delete_progress/3` emits `playback.unwatched`, which `Mydia.WatchSync` forwards to Plex and Jellyfin. Taking a card off a rail must not tell another media server that a watched title was unwatched.

## How it works

A new `continue_watching_dismissals` row records "user U hid media item M at time T". It hides; it does not unwatch. The progress row is untouched, so the title still offers Resume from its detail page, and nothing goes out to watch-sync.

The key is always a `media_items.id` — for a series that is the **show**, not the episode. `OnDeck` emits one card per show, so the show is the only unit the gesture can honestly mean, and it is also what lets a next-up card be dismissed at all.

The hide expires on its own. `OnDeck` compares `dismissed_at` against the entry's most recent watch, so playing the title pushes that watch past the stamp and the card comes back — no sweep job, at most one row per hidden title. A tie inside one second goes to the dismissal, since a removal that appears to do nothing is worse than a card that returns a moment late.

## Player

The card menu already existed but was reachable only by long-press or right-click, which a card does not advertise. Removal also gets a kebab in the poster's bottom-right corner (top-right is taken by the watch and quality badges), calling the same callback the long-press does so the two cannot drift apart. Wired on both the home rail and the `/continue-watching` grid.

Two things were silent when wrong and are now pinned by tests:

- The menu's `tapPlays` gate returned an empty list outright, and the grid *opens* titles rather than playing them — so gating removal on it would have left the surface most in need of the action with no way to reach it. The gate now covers only the navigation entries.
- A card's own id is the episode's, while the id being hidden is its show's. A splice matching on the card id would never remove a TV card, and the server refuses the argument anyway. Both rules now live in `ContinueWatchingItem.continueWatchingKey`.

## Notes for review

- **No undo**, matching Plex. Hiding is reversed by playing the title.
- The existence check on the media item is deliberate rather than left to the foreign key: SQLite reports FK violations with no constraint name, so Ecto raises `Ecto.ConstraintError` straight through the resolver instead of producing a changeset error. The explicit lookup behaves the same on both adapters.
- On `/continue-watching` the invalidation is a no-op once the viewer has paged (`canRefetch: () => !_hasPaginated`), so the optimistic splice is what they actually see there. Called out in the code.
- `on_deck_query_count_test.exs`'s ceiling goes 8 → 9. The dismissals load is one user-scoped query, so the count-is-constant assertion still holds.
- Known limitation, accepted: `WatchSync` stamps `last_watched_at` from the remote's own `lastViewedAt`, so a sync importing a new watch with a timestamp older than the dismissal will not un-hide the title.

## Verification

- Full Elixir suite: 8434 tests, 0 failures
- Postgres: migration applies clean; on_deck, dismissal, GraphQL and `no_varchar_columns` tests pass (57)
- `cargo test -p mydia-api`: `sdl_parity` and `types_remaining` green
- Full player suite: 2452 tests, 0 failures; `flutter analyze` adds no new issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to remove movies and shows from Continue Watching.
  * Added removal actions through poster and context menus.
  * Episode entries are removed by their associated show.
  * Playback progress remains preserved when an item is removed.
* **Bug Fixes**
  * Continue Watching updates immediately after removal.
  * Failed removals restore affected entries without undoing successful removals.
  * Dismissed titles reappear after newer playback activity.
  * Removal remains isolated by title and viewer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->