### PR TITLE
fix(db): stop SQLite Database busy on events and oban_jobs writes

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -41,7 +41,11 @@ case database_adapter do
       synchronous: :normal,
       foreign_keys: :on,
       # Increased busy_timeout to handle concurrent writes during library scans
-      busy_timeout: 30_000
+      busy_timeout: 30_000,
+      # BEGIN IMMEDIATE rather than BEGIN DEFERRED. A deferred transaction that
+      # reads before it writes gets SQLITE_BUSY_SNAPSHOT under WAL with no busy
+      # handler invoked, so busy_timeout above never applies to it. See #283.
+      default_transaction_mode: :immediate
 end
 
 # For development, we disable any cache and enable

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -96,7 +96,9 @@ if config_env() == :prod do
         synchronous: :normal,
         foreign_keys: :on,
         # Increased busy_timeout to handle concurrent writes during library scans
-        busy_timeout: 30_000
+        busy_timeout: 30_000,
+        # BEGIN IMMEDIATE rather than BEGIN DEFERRED. See #283.
+        default_transaction_mode: :immediate
   end
 
   # The secret key base is used to sign/encrypt cookies and other secrets.

--- a/config/test.exs
+++ b/config/test.exs
@@ -42,7 +42,11 @@ case database_adapter do
       pool_timeout: 60_000,
       timeout: 60_000,
       # Increase busy timeout to handle concurrent writes
-      busy_timeout: 30_000
+      busy_timeout: 30_000,
+      # See config/dev.exs. The SQL sandbox begins with mode: :transaction,
+      # which exqlite maps to a plain BEGIN, so this does not change how the
+      # sandbox wraps tests.
+      default_transaction_mode: :immediate
 end
 
 # We run a server during test for Wallaby browser-based feature tests.

--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -103,7 +103,8 @@ defmodule Mydia.Application do
       {Phoenix.PubSub, name: Mydia.PubSub},
       # Owns every asynchronous event insert. Must sit after the repo and
       # PubSub, which it uses, and therefore stops before them on shutdown so
-      # its terminate/2 can flush what is still buffered.
+      # its terminate/2 has a chance to flush what is still buffered (best
+      # effort, not a guarantee; see the writer's moduledoc).
       Mydia.Events.Writer,
       Mydia.Downloads.Client.Registry,
       # Owns the ETS table holding the derived set of client torrents Mydia

--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -101,6 +101,10 @@ defmodule Mydia.Application do
       Mydia.Jobs.ImportRunReconciler,
       {DNSCluster, query: Application.get_env(:mydia, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Mydia.PubSub},
+      # Owns every asynchronous event insert. Must sit after the repo and
+      # PubSub, which it uses, and therefore stops before them on shutdown so
+      # its terminate/2 can flush what is still buffered.
+      Mydia.Events.Writer,
       Mydia.Downloads.Client.Registry,
       # Owns the ETS table holding the derived set of client torrents Mydia
       # does not manage. init/1 only creates the table (no I/O), so unlike

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -266,7 +266,14 @@ defmodule Mydia.Events do
   @spec unsubscribe() :: :ok
   def unsubscribe, do: PubSub.unsubscribe(@pubsub_name, @events_topic)
 
-  defp broadcast_event(event) do
+  @doc """
+  Broadcasts an event to subscribers of the global event feed.
+
+  Public because `Mydia.Events.Writer` broadcasts the rows it inserts, and
+  duplicating the topic name in two modules is how they drift apart.
+  """
+  @spec broadcast_event(Event.t()) :: :ok | {:error, term()}
+  def broadcast_event(event) do
     PubSub.broadcast(@pubsub_name, @events_topic, {:event_created, event})
   end
 

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -10,6 +10,7 @@ defmodule Mydia.Events do
   alias Mydia.Repo
   alias Mydia.Events.Event
   alias Mydia.Events.Presentation
+  alias Mydia.Events.Writer
   alias Phoenix.PubSub
 
   @pubsub_name Mydia.PubSub
@@ -47,8 +48,10 @@ defmodule Mydia.Events do
   @doc """
   Creates an event asynchronously without blocking the caller.
 
-  This is a fire-and-forget operation that returns immediately.
-  Errors are logged but don't affect the calling process.
+  This is a fire-and-forget operation that returns immediately. Outside the SQL
+  sandbox the event is validated in the caller and handed to
+  `Mydia.Events.Writer`, which batches inserts. Errors are logged but never
+  affect the caller.
 
   Useful for tracking events in hot code paths where performance matters.
 
@@ -58,10 +61,10 @@ defmodule Mydia.Events do
       :ok
   """
   def create_event_async(attrs) do
-    repo_config = Mydia.Repo.config()
-
-    if repo_config[:pool] == Ecto.Adapters.SQL.Sandbox do
-      # In test environment with sandbox, run synchronously to avoid connection issues
+    if sandbox_pool?() do
+      # Under the SQL sandbox the test process owns the connection. A cast to
+      # the long-lived writer would insert on a connection the test cannot see
+      # or roll back, so stay synchronous here.
       case create_event(attrs) do
         {:ok, event} ->
           Logger.debug("Event created asynchronously: #{event.type}")
@@ -69,21 +72,14 @@ defmodule Mydia.Events do
         {:error, changeset} ->
           Logger.error("Failed to create event asynchronously: #{inspect(changeset.errors)}")
       end
+
+      :ok
     else
-      # In production, run asynchronously
-      Task.Supervisor.start_child(Mydia.TaskSupervisor, fn ->
-        case create_event(attrs) do
-          {:ok, event} ->
-            Logger.debug("Event created asynchronously: #{event.type}")
-
-          {:error, changeset} ->
-            Logger.error("Failed to create event asynchronously: #{inspect(changeset.errors)}")
-        end
-      end)
+      Writer.enqueue(attrs)
     end
-
-    :ok
   end
+
+  defp sandbox_pool?, do: Repo.config()[:pool] == Ecto.Adapters.SQL.Sandbox
 
   ## Event Queries
 

--- a/lib/mydia/events/writer.ex
+++ b/lib/mydia/events/writer.ex
@@ -17,8 +17,19 @@ defmodule Mydia.Events.Writer do
   drops oldest on overflow, and a failed insert is logged and dropped rather
   than retried, because retrying reintroduces the contention this module exists
   to remove.
+
+  On shutdown, `terminate/2` makes a best-effort flush of the buffer through
+  `Repo.insert_all/2`. A shutdown that lands during heavy write contention can
+  still exceed the shutdown timeout and drop the buffer, which is consistent
+  with the activity-log contract above: these events are not a durable
+  record.
   """
-  use GenServer
+  # terminate/2 flushes through Repo.insert_all, which can block on the
+  # SQLite write lock, so the default 5 second shutdown timeout is too tight.
+  # 30 seconds would match busy_timeout exactly, but that would hold a
+  # container restart hostage well past the typical grace period for what is
+  # an activity log, so 10 seconds is the compromise.
+  use GenServer, shutdown: 10_000
 
   require Logger
 

--- a/lib/mydia/events/writer.ex
+++ b/lib/mydia/events/writer.ex
@@ -13,10 +13,18 @@ defmodule Mydia.Events.Writer do
   contended for a lock their own caller was holding and surfaced
   `Exqlite.Error{message: "Database busy"}`. See issue #283.
 
-  Events are an activity log, not a durable record. The buffer is bounded and
-  drops oldest on overflow, and a failed insert is logged and dropped rather
-  than retried, because retrying reintroduces the contention this module exists
-  to remove.
+  Events are an activity log, not a durable record. Total pending events are
+  bounded by two limits stacked in front of each other. The mailbox limit
+  caps messages waiting in the writer's own inbox, which matters because
+  `Repo.insert_all/2` can block the writer for the SQLite busy_timeout under
+  write contention while callers keep casting. The buffer limit caps
+  validated events waiting to be flushed once the writer has caught up on its
+  inbox. On overflow the buffer drops the oldest event, since the writer owns
+  the buffer and can pop from either end; the mailbox limit instead drops the
+  newest event, the one a caller is trying to enqueue right now, because a
+  caller has no way to reach into another process's mailbox and evict an
+  older message. A failed insert is logged and dropped rather than retried,
+  because retrying reintroduces the contention this module exists to remove.
 
   On shutdown, `terminate/2` makes a best-effort flush of the buffer through
   `Repo.insert_all/2`. A shutdown that lands during heavy write contention can
@@ -40,6 +48,16 @@ defmodule Mydia.Events.Writer do
   @max_batch 100
   @flush_interval_ms 200
   @max_buffer 5_000
+  @max_mailbox 10_000
+
+  # `enqueue/2` runs in the caller's process and must never block on the
+  # writer, so it cannot ask the writer's own state for the configured
+  # mailbox limit (a GenServer.call would queue up behind the very backlog
+  # it is trying to detect). Instead the writer stashes the limit and a
+  # shared drop counter in its own process dictionary at init, where
+  # `Process.info/2` can read them from any process without sending the
+  # writer a message, even while it is busy.
+  @mailbox_guard_key :mydia_events_writer_mailbox_guard
 
   ## Client
 
@@ -60,12 +78,17 @@ defmodule Mydia.Events.Writer do
   changeset is attributed to the caller and never occupies buffer space. An
   invalid changeset is logged and dropped, matching the fire-and-forget
   contract of `Mydia.Events.create_event_async/1`.
+
+  The event is dropped instead of cast when the writer's mailbox is already
+  at its configured limit. This bounds total pending events (mailbox plus
+  buffer) even though the writer can be blocked in `Repo.insert_all/2` for
+  seconds at a time under write contention while casts keep arriving.
   """
   @spec enqueue(map(), GenServer.server()) :: :ok
   def enqueue(attrs, server \\ __MODULE__) do
     case build(attrs) do
       {:ok, event} ->
-        GenServer.cast(server, {:event, event})
+        cast_or_drop(server, event)
 
       {:error, changeset} ->
         Logger.error("Failed to create event asynchronously: #{inspect(changeset.errors)}")
@@ -78,6 +101,40 @@ defmodule Mydia.Events.Writer do
   """
   @spec flush(GenServer.server()) :: :ok
   def flush(server \\ __MODULE__), do: GenServer.call(server, :flush)
+
+  # Resolves `server` to a pid and checks its mailbox before casting. An atom
+  # that is not currently registered resolves to no pid, in which case this
+  # casts unconditionally: GenServer.cast/2 to an unregistered name is
+  # already a silent no-op, and short-circuiting here would change that
+  # existing behavior. A pid whose mailbox guard is missing (for example a
+  # process that is not a Mydia.Events.Writer at all) also just casts.
+  defp cast_or_drop(server, event) do
+    case resolve_pid(server) do
+      nil ->
+        GenServer.cast(server, {:event, event})
+
+      pid ->
+        case Process.info(pid, [:message_queue_len, :dictionary]) do
+          [{:message_queue_len, len}, {:dictionary, dict}] ->
+            case Keyword.get(dict, @mailbox_guard_key) do
+              {max_mailbox, drop_counter} when len >= max_mailbox ->
+                :counters.add(drop_counter, 1, 1)
+                :ok
+
+              _ ->
+                GenServer.cast(server, {:event, event})
+            end
+
+          # Process.info/2 returns nil for a pid that is no longer alive.
+          nil ->
+            GenServer.cast(server, {:event, event})
+        end
+    end
+  end
+
+  defp resolve_pid(pid) when is_pid(pid), do: pid
+  defp resolve_pid(name) when is_atom(name), do: Process.whereis(name)
+  defp resolve_pid(_other), do: nil
 
   # Repo.insert_all/2 autogenerates neither the primary key nor the timestamp,
   # so both are filled here. :utc_datetime is second precision.
@@ -104,6 +161,9 @@ defmodule Mydia.Events.Writer do
   @impl true
   def init(opts) do
     Process.flag(:trap_exit, true)
+
+    max_mailbox = Keyword.get(opts, :max_mailbox, @max_mailbox)
+    Process.put(@mailbox_guard_key, {max_mailbox, :counters.new(1, [])})
 
     {:ok,
      %{
@@ -155,11 +215,15 @@ defmodule Mydia.Events.Writer do
 
   defp schedule_flush(state), do: state
 
-  defp do_flush(%{size: 0} = state), do: cancel_timer(state)
+  defp do_flush(%{size: 0} = state) do
+    log_mailbox_dropped()
+    cancel_timer(state)
+  end
 
   defp do_flush(state) do
     events = :queue.to_list(state.buffer)
     log_dropped(state.dropped)
+    log_mailbox_dropped()
 
     case insert_batch(events) do
       :ok -> Enum.each(events, &Events.broadcast_event/1)
@@ -200,6 +264,25 @@ defmodule Mydia.Events.Writer do
 
   defp log_dropped(count) do
     Logger.warning("Events.Writer buffer full, dropped #{count} event(s)")
+  end
+
+  # Runs on the writer's own flush cadence rather than per drop, so a mailbox
+  # stall logs at most once per flush interval instead of flooding at exactly
+  # the moment logging would be least welcome. Reads and zeroes the counter
+  # that cast_or_drop/2 increments from arbitrary caller processes.
+  defp log_mailbox_dropped do
+    case Process.get(@mailbox_guard_key) do
+      {_max_mailbox, drop_counter} ->
+        count = :counters.get(drop_counter, 1)
+
+        if count > 0 do
+          :counters.sub(drop_counter, 1, count)
+          Logger.warning("Events.Writer mailbox full, dropped #{count} event(s)")
+        end
+
+      nil ->
+        :ok
+    end
   end
 
   defp cancel_timer(%{timer: nil} = state), do: state

--- a/lib/mydia/events/writer.ex
+++ b/lib/mydia/events/writer.ex
@@ -1,0 +1,200 @@
+defmodule Mydia.Events.Writer do
+  @moduledoc """
+  Single owner of asynchronous event inserts.
+
+  Every `Mydia.Events.create_event_async/1` call outside the SQL sandbox routes
+  here. The writer buffers validated events and flushes them as one
+  `Repo.insert_all/2`, so a burst costs one write transaction and one pool
+  checkout instead of one of each per event.
+
+  This replaced a `Task` per event. A bulk operation such as
+  `Mydia.Media.update_media_items_monitored/3` fires one event per item from
+  inside a transaction that already holds the SQLite write lock, so those tasks
+  contended for a lock their own caller was holding and surfaced
+  `Exqlite.Error{message: "Database busy"}`. See issue #283.
+
+  Events are an activity log, not a durable record. The buffer is bounded and
+  drops oldest on overflow, and a failed insert is logged and dropped rather
+  than retried, because retrying reintroduces the contention this module exists
+  to remove.
+  """
+  use GenServer
+
+  require Logger
+
+  alias Mydia.Events
+  alias Mydia.Events.Event
+  alias Mydia.Repo
+
+  @max_batch 100
+  @flush_interval_ms 200
+  @max_buffer 5_000
+
+  ## Client
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    # `name: nil` starts an unregistered writer. GenServer rejects a literal
+    # `name: nil`, so the option is omitted entirely in that case. Tests use it
+    # to run their own writer alongside the supervised one.
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, gen_opts)
+  end
+
+  @doc """
+  Validates `attrs` and queues the resulting event for insertion.
+
+  Always returns `:ok`. Validation runs in the calling process so an invalid
+  changeset is attributed to the caller and never occupies buffer space. An
+  invalid changeset is logged and dropped, matching the fire-and-forget
+  contract of `Mydia.Events.create_event_async/1`.
+  """
+  @spec enqueue(map(), GenServer.server()) :: :ok
+  def enqueue(attrs, server \\ __MODULE__) do
+    case build(attrs) do
+      {:ok, event} ->
+        GenServer.cast(server, {:event, event})
+
+      {:error, changeset} ->
+        Logger.error("Failed to create event asynchronously: #{inspect(changeset.errors)}")
+        :ok
+    end
+  end
+
+  @doc """
+  Flushes the buffer synchronously, returning after the insert and broadcasts.
+  """
+  @spec flush(GenServer.server()) :: :ok
+  def flush(server \\ __MODULE__), do: GenServer.call(server, :flush)
+
+  # Repo.insert_all/2 autogenerates neither the primary key nor the timestamp,
+  # so both are filled here. :utc_datetime is second precision.
+  defp build(attrs) do
+    %Event{}
+    |> Event.changeset(attrs)
+    |> Ecto.Changeset.apply_action(:insert)
+    |> case do
+      {:ok, event} ->
+        {:ok,
+         %{
+           event
+           | id: Ecto.UUID.generate(),
+             inserted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+         }}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  ## Server
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    {:ok,
+     %{
+       buffer: :queue.new(),
+       size: 0,
+       dropped: 0,
+       timer: nil,
+       max_batch: Keyword.get(opts, :max_batch, @max_batch),
+       flush_interval_ms: Keyword.get(opts, :flush_interval_ms, @flush_interval_ms),
+       max_buffer: Keyword.get(opts, :max_buffer, @max_buffer)
+     }}
+  end
+
+  @impl true
+  def handle_cast({:event, event}, state) do
+    {:noreply, state |> buffer(event) |> maybe_flush()}
+  end
+
+  @impl true
+  def handle_call(:flush, _from, state), do: {:reply, :ok, do_flush(state)}
+
+  @impl true
+  def handle_info(:flush, state), do: {:noreply, do_flush(state)}
+
+  @impl true
+  def terminate(_reason, state) do
+    do_flush(state)
+    :ok
+  end
+
+  ## Internals
+
+  defp buffer(%{size: size, max_buffer: max} = state, event) when size >= max do
+    # :queue is FIFO, so the front is the oldest event.
+    {_oldest, queue} = :queue.out(state.buffer)
+    %{state | buffer: :queue.in(event, queue), dropped: state.dropped + 1}
+  end
+
+  defp buffer(state, event) do
+    %{state | buffer: :queue.in(event, state.buffer), size: state.size + 1}
+  end
+
+  defp maybe_flush(%{size: size, max_batch: max} = state) when size >= max, do: do_flush(state)
+  defp maybe_flush(state), do: schedule_flush(state)
+
+  defp schedule_flush(%{timer: nil, size: size} = state) when size > 0 do
+    %{state | timer: Process.send_after(self(), :flush, state.flush_interval_ms)}
+  end
+
+  defp schedule_flush(state), do: state
+
+  defp do_flush(%{size: 0} = state), do: cancel_timer(state)
+
+  defp do_flush(state) do
+    events = :queue.to_list(state.buffer)
+    log_dropped(state.dropped)
+
+    case insert_batch(events) do
+      :ok -> Enum.each(events, &Events.broadcast_event/1)
+      :error -> :ok
+    end
+
+    %{cancel_timer(state) | buffer: :queue.new(), size: 0, dropped: 0}
+  end
+
+  defp insert_batch(events) do
+    Repo.insert_all(Event, Enum.map(events, &row/1))
+    :ok
+  rescue
+    error ->
+      Logger.error(
+        "Events.Writer dropped #{length(events)} event(s): #{Exception.message(error)}"
+      )
+
+      :error
+  end
+
+  defp row(%Event{} = event) do
+    %{
+      id: event.id,
+      category: event.category,
+      type: event.type,
+      actor_type: event.actor_type,
+      actor_id: event.actor_id,
+      resource_type: event.resource_type,
+      resource_id: event.resource_id,
+      severity: event.severity,
+      metadata: event.metadata,
+      inserted_at: event.inserted_at
+    }
+  end
+
+  defp log_dropped(0), do: :ok
+
+  defp log_dropped(count) do
+    Logger.warning("Events.Writer buffer full, dropped #{count} event(s)")
+  end
+
+  defp cancel_timer(%{timer: nil} = state), do: state
+
+  defp cancel_timer(%{timer: ref} = state) do
+    Process.cancel_timer(ref)
+    %{state | timer: nil}
+  end
+end

--- a/lib/mydia/events/writer.ex
+++ b/lib/mydia/events/writer.ex
@@ -17,14 +17,22 @@ defmodule Mydia.Events.Writer do
   bounded by two limits stacked in front of each other. The mailbox limit
   caps messages waiting in the writer's own inbox, which matters because
   `Repo.insert_all/2` can block the writer for the SQLite busy_timeout under
-  write contention while callers keep casting. The buffer limit caps
-  validated events waiting to be flushed once the writer has caught up on its
-  inbox. On overflow the buffer drops the oldest event, since the writer owns
-  the buffer and can pop from either end; the mailbox limit instead drops the
-  newest event, the one a caller is trying to enqueue right now, because a
-  caller has no way to reach into another process's mailbox and evict an
-  older message. A failed insert is logged and dropped rather than retried,
-  because retrying reintroduces the contention this module exists to remove.
+  write contention while callers keep casting. That check and the cast it
+  guards run as separate steps, so the bound is soft rather than exact:
+  callers enqueuing at the same instant can each observe room under the
+  limit and all cast, overshooting by at most one event per concurrent
+  caller. What it reliably closes is the unbounded case, a single process
+  casting in a loop while the writer is stalled, since a serial loop
+  re-reads the mailbox length on every iteration; the residual overshoot is
+  bounded by concurrency, not by how long the writer stays blocked. The
+  buffer limit caps validated events waiting to be flushed once the writer
+  has caught up on its inbox. On overflow the buffer drops the oldest event,
+  since the writer owns the buffer and can pop from either end; the mailbox
+  limit instead drops the newest event, the one a caller is trying to
+  enqueue right now, because a caller has no way to reach into another
+  process's mailbox and evict an older message. A failed insert is logged
+  and dropped rather than retried, because retrying reintroduces the
+  contention this module exists to remove.
 
   On shutdown, `terminate/2` makes a best-effort flush of the buffer through
   `Repo.insert_all/2`. A shutdown that lands during heavy write contention can
@@ -80,9 +88,13 @@ defmodule Mydia.Events.Writer do
   contract of `Mydia.Events.create_event_async/1`.
 
   The event is dropped instead of cast when the writer's mailbox is already
-  at its configured limit. This bounds total pending events (mailbox plus
-  buffer) even though the writer can be blocked in `Repo.insert_all/2` for
-  seconds at a time under write contention while casts keep arriving.
+  at its configured limit. This bound is soft, not exact: the mailbox check
+  and the cast it guards are separate steps, so callers enqueuing at the
+  same instant can each see room under the limit and all cast, overshooting
+  by at most one event per concurrent caller. What it reliably prevents is
+  the unbounded case, a single process casting in a loop while the writer is
+  blocked in `Repo.insert_all/2` for seconds under write contention, because
+  that loop re-reads the mailbox length before every cast.
   """
   @spec enqueue(map(), GenServer.server()) :: :ok
   def enqueue(attrs, server \\ __MODULE__) do

--- a/test/mydia/events/writer_test.exs
+++ b/test/mydia/events/writer_test.exs
@@ -91,6 +91,68 @@ defmodule Mydia.Events.WriterTest do
       types = Event |> Repo.all() |> Enum.map(& &1.type) |> Enum.sort()
       assert types == ["download.completed", "download.initiated"]
     end
+
+    test "the mailbox bound is soft under concurrent enqueue/2 callers" do
+      # cast_or_drop/2 reads Process.info/2 and then calls GenServer.cast/2 as
+      # two separate steps. That is fine against a single caller looping,
+      # since each iteration re-reads the mailbox length before casting, but
+      # concurrent callers can each observe room under max_mailbox before any
+      # of them casts. The result is not a hard cap: it can overshoot by up
+      # to one event per caller enqueuing at the same instant. Closing that
+      # gap exactly would need something like :atomics.compare_exchange/4
+      # (a plain :counters get-then-add is just as racy) plus reconciling
+      # that counter against buffer-overflow drops and writer restarts, and a
+      # bug in that accounting either wedges every future event or silently
+      # removes the bound, which is worse than a small overshoot for a
+      # droppable activity log. So this test documents the real, soft
+      # guarantee instead of asserting a hard cap the implementation does
+      # not provide.
+      #
+      # caller_count is deliberately much larger than this machine's core
+      # count. A small burst (say 32) can race entirely within one wave of
+      # true parallelism and land every event, which would make the "some
+      # events get dropped" assertion below flaky. A few hundred concurrent
+      # callers cannot all be scheduled at once, so later callers reliably
+      # observe an already-elevated mailbox length and get dropped, even
+      # though which ones do is nondeterministic.
+      caller_count = 300
+      max_mailbox = 2
+      writer = start_writer(max_batch: 1000, flush_interval_ms: 60_000, max_mailbox: max_mailbox)
+
+      # :sys.suspend/1 halts the writer's own receive loop without touching
+      # its real mailbox, so casts pile up there exactly as they would while
+      # the writer is genuinely blocked inside Repo.insert_all/2.
+      :sys.suspend(writer)
+
+      test_pid = self()
+
+      callers =
+        for n <- 1..caller_count do
+          spawn(fn ->
+            send(test_pid, :ready)
+            receive do: (:go -> :ok)
+            Writer.enqueue(attrs("download.initiated"), writer)
+            send(test_pid, {:done, n})
+          end)
+        end
+
+      for _ <- callers, do: assert_receive(:ready)
+      for pid <- callers, do: send(pid, :go)
+      for _ <- callers, do: assert_receive({:done, _}, 5_000)
+
+      {:message_queue_len, len} = Process.info(writer, :message_queue_len)
+
+      # The bound still did real work: well under every offered event landed.
+      assert len < caller_count
+      # The bound is soft, not exact: the theoretical worst case is every
+      # caller landing between the check and the cast, i.e. max_mailbox
+      # plus caller_count. Actual runs land nowhere near that, but the test
+      # only asserts what is actually guaranteed.
+      assert len <= max_mailbox + caller_count
+
+      :sys.resume(writer)
+      Writer.flush(writer)
+    end
   end
 
   describe "flush/1" do

--- a/test/mydia/events/writer_test.exs
+++ b/test/mydia/events/writer_test.exs
@@ -65,6 +65,32 @@ defmodule Mydia.Events.WriterTest do
       types = Event |> Repo.all() |> Enum.map(& &1.type) |> Enum.sort()
       assert types == ["download.completed", "download.failed"]
     end
+
+    test "drops newly enqueued events once the mailbox is full" do
+      writer = start_writer(max_batch: 100, flush_interval_ms: 60_000, max_mailbox: 2)
+
+      # :sys.suspend/1 halts the writer's own receive loop without touching
+      # its real mailbox, so casts pile up there exactly as they would while
+      # the writer is genuinely blocked inside Repo.insert_all/2.
+      :sys.suspend(writer)
+
+      Writer.enqueue(attrs("download.initiated"), writer)
+      Writer.enqueue(attrs("download.completed"), writer)
+      Writer.enqueue(attrs("download.failed"), writer)
+      Writer.enqueue(attrs("download.paused"), writer)
+
+      # The mailbox bound held: only the first two casts made it in, the rest
+      # were shed at enqueue/2 instead of piling up further.
+      assert Process.info(writer, :message_queue_len) == {:message_queue_len, 2}
+
+      :sys.resume(writer)
+
+      log = capture_log(fn -> Writer.flush(writer) end)
+
+      assert log =~ "Events.Writer mailbox full, dropped 2 event(s)"
+      types = Event |> Repo.all() |> Enum.map(& &1.type) |> Enum.sort()
+      assert types == ["download.completed", "download.initiated"]
+    end
   end
 
   describe "flush/1" do

--- a/test/mydia/events/writer_test.exs
+++ b/test/mydia/events/writer_test.exs
@@ -127,6 +127,26 @@ defmodule Mydia.Events.WriterTest do
     end
   end
 
+  describe "supervision" do
+    test "starts after the repo and PubSub" do
+      children = Mydia.Application.children()
+
+      repo = Enum.find_index(children, &(&1 == Mydia.Repo))
+      pubsub = Enum.find_index(children, &match?({Phoenix.PubSub, _}, &1))
+      writer = Enum.find_index(children, &(&1 == Mydia.Events.Writer))
+
+      assert repo, "expected a Mydia.Repo child"
+      assert pubsub, "expected a Phoenix.PubSub child"
+      assert writer, "expected a Mydia.Events.Writer child"
+
+      # It inserts through the repo and broadcasts through PubSub, so both must
+      # already be up when it starts, and it must stop before them on shutdown
+      # so terminate/2 can still flush.
+      assert repo < writer
+      assert pubsub < writer
+    end
+  end
+
   # The writer inserts from its own process, so a cast is not observable the
   # instant enqueue/2 returns. Poll instead of sleeping a fixed amount.
   defp eventually(fun, attempts \\ 100) do

--- a/test/mydia/events/writer_test.exs
+++ b/test/mydia/events/writer_test.exs
@@ -1,0 +1,142 @@
+defmodule Mydia.Events.WriterTest do
+  use Mydia.DataCase
+
+  import ExUnit.CaptureLog
+
+  alias Mydia.Events.Event
+  alias Mydia.Events.Writer
+  alias Phoenix.PubSub
+
+  # Small, explicit limits so tests do not depend on the production defaults.
+  # `name: nil` starts the writer unregistered, so it never collides with the
+  # supervised one that Task 4 adds to the application tree.
+  defp start_writer(opts) do
+    pid = start_supervised!({Writer, Keyword.put(opts, :name, nil)}, id: :writer_under_test)
+    Ecto.Adapters.SQL.Sandbox.allow(Mydia.Repo, self(), pid)
+    pid
+  end
+
+  defp attrs(type \\ "download.initiated") do
+    %{category: "downloads", type: type, metadata: %{"title" => "Test"}}
+  end
+
+  describe "enqueue/2" do
+    test "flushes when the buffer reaches max_batch" do
+      writer = start_writer(max_batch: 3, flush_interval_ms: 60_000)
+
+      for _ <- 1..3, do: Writer.enqueue(attrs(), writer)
+
+      # No explicit flush: reaching max_batch must trigger one on its own.
+      # A short poll avoids racing the cast.
+      assert eventually(fn -> Repo.aggregate(Event, :count) == 3 end)
+    end
+
+    test "flushes when the interval elapses below max_batch" do
+      writer = start_writer(max_batch: 100, flush_interval_ms: 50)
+
+      Writer.enqueue(attrs(), writer)
+
+      assert eventually(fn -> Repo.aggregate(Event, :count) == 1 end)
+    end
+
+    test "logs and drops an invalid changeset without inserting" do
+      writer = start_writer(max_batch: 1, flush_interval_ms: 60_000)
+
+      log =
+        capture_log(fn ->
+          assert :ok = Writer.enqueue(%{category: "Invalid"}, writer)
+          Writer.flush(writer)
+        end)
+
+      assert log =~ "Failed to create event asynchronously"
+      assert Repo.aggregate(Event, :count) == 0
+    end
+
+    test "drops the oldest events when the buffer overflows" do
+      writer = start_writer(max_batch: 100, flush_interval_ms: 60_000, max_buffer: 2)
+
+      Writer.enqueue(attrs("download.initiated"), writer)
+      Writer.enqueue(attrs("download.completed"), writer)
+      Writer.enqueue(attrs("download.failed"), writer)
+
+      log = capture_log(fn -> Writer.flush(writer) end)
+
+      assert log =~ "buffer full"
+      types = Event |> Repo.all() |> Enum.map(& &1.type) |> Enum.sort()
+      assert types == ["download.completed", "download.failed"]
+    end
+  end
+
+  describe "flush/1" do
+    test "inserts the pending buffer and broadcasts each event" do
+      writer = start_writer(max_batch: 100, flush_interval_ms: 60_000)
+      PubSub.subscribe(Mydia.PubSub, "events:all")
+
+      Writer.enqueue(attrs(), writer)
+      assert Repo.aggregate(Event, :count) == 0
+
+      assert :ok = Writer.flush(writer)
+
+      assert Repo.aggregate(Event, :count) == 1
+      assert_received {:event_created, %Event{type: "download.initiated"}}
+    end
+
+    test "logs, survives, and does not broadcast when the insert fails" do
+      writer = start_writer(max_batch: 100, flush_interval_ms: 60_000)
+      PubSub.subscribe(Mydia.PubSub, "events:all")
+
+      # `metadata` is a Mydia.Settings.JsonMapType, whose dump/1 returns :error
+      # for anything that is not a map, so Repo.insert_all raises
+      # Ecto.ChangeError while dumping, before any SQL is sent. That matters:
+      # a constraint violation would poison the surrounding sandbox transaction
+      # on PostgreSQL and break every assertion after it.
+      #
+      # Casting the struct directly is deliberate. enqueue/2 validates through
+      # the changeset, which rejects this, so it is the only way to reach the
+      # rescue clause without a live database failure.
+      bad = %Event{
+        id: Ecto.UUID.generate(),
+        category: "downloads",
+        type: "download.initiated",
+        severity: :info,
+        metadata: "not a map",
+        inserted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      }
+
+      GenServer.cast(writer, {:event, bad})
+
+      log = capture_log(fn -> Writer.flush(writer) end)
+
+      assert log =~ "Events.Writer dropped 1 event(s)"
+      assert Process.alive?(writer)
+      assert Repo.aggregate(Event, :count) == 0
+      refute_received {:event_created, _}
+    end
+  end
+
+  describe "termination" do
+    test "flushes the pending buffer on terminate" do
+      writer = start_writer(max_batch: 100, flush_interval_ms: 60_000)
+
+      Writer.enqueue(attrs(), writer)
+      assert Repo.aggregate(Event, :count) == 0
+
+      :ok = stop_supervised(:writer_under_test)
+
+      assert Repo.aggregate(Event, :count) == 1
+    end
+  end
+
+  # The writer inserts from its own process, so a cast is not observable the
+  # instant enqueue/2 returns. Poll instead of sleeping a fixed amount.
+  defp eventually(fun, attempts \\ 100) do
+    Enum.reduce_while(1..attempts, false, fn _, _ ->
+      if fun.() do
+        {:halt, true}
+      else
+        Process.sleep(10)
+        {:cont, false}
+      end
+    end)
+  end
+end

--- a/test/mydia/events_test.exs
+++ b/test/mydia/events_test.exs
@@ -158,6 +158,18 @@ defmodule Mydia.EventsTest do
       end)
       |> Task.await()
     end
+
+    test "returns :ok and inserts nothing for an invalid changeset" do
+      before = Repo.aggregate(Event, :count)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok = Events.create_event_async(%{category: "Invalid"})
+        end)
+
+      assert log =~ "Failed to create event asynchronously"
+      assert Repo.aggregate(Event, :count) == before
+    end
   end
 
   describe "list_events/1" do

--- a/test/mydia/repo/sqlite_write_contention_test.exs
+++ b/test/mydia/repo/sqlite_write_contention_test.exs
@@ -1,0 +1,89 @@
+defmodule Mydia.Repo.SQLiteWriteContentionTest do
+  @moduledoc """
+  Demonstrates why the SQLite repo runs in IMMEDIATE transaction mode.
+
+  Under WAL, a DEFERRED transaction takes a read snapshot on its first SELECT.
+  If another connection commits before that transaction upgrades to a write,
+  SQLite returns SQLITE_BUSY_SNAPSHOT immediately and does NOT invoke the busy
+  handler, because sleeping can never resolve the conflict. That is how issue
+  #283 produced "Database busy" on instances configured with a 30 second
+  busy_timeout.
+
+  IMMEDIATE mode takes the write lock at BEGIN, so contention goes through the
+  busy handler and busy_timeout applies.
+
+  This test uses its own throwaway repo rather than Mydia.Repo, because the SQL
+  sandbox wraps each test in a transaction of its own.
+  """
+  use ExUnit.Case, async: false
+
+  alias Mydia.MigrationTestRepo, as: TestRepo
+
+  @writers 8
+  @iterations 20
+  # Deliberately short. A long timeout would make the IMMEDIATE arm take
+  # minutes to fail if this test ever regresses, and the DEFERRED arm does not
+  # consult the busy handler at all.
+  @busy_timeout_ms 2_000
+
+  # No adapter guard: MigrationTestRepo is always SQLite (see its moduledoc),
+  # so this runs meaningfully even on a PostgreSQL suite run.
+
+  @tag :tmp_dir
+  test "DEFERRED transactions surface Database busy under concurrent writers", %{tmp_dir: tmp_dir} do
+    errors = run_contention(tmp_dir, "deferred.db", :deferred)
+
+    assert "Database busy" in errors,
+           """
+           Expected at least one SQLITE_BUSY_SNAPSHOT from concurrent deferred
+           read-then-write transactions, got: #{inspect(Enum.uniq(errors))}.
+           If this stopped reproducing, raise @writers or @iterations before
+           concluding the mechanism is gone.
+           """
+  end
+
+  @tag :tmp_dir
+  test "IMMEDIATE transactions do not", %{tmp_dir: tmp_dir} do
+    assert run_contention(tmp_dir, "immediate.db", :immediate) == []
+  end
+
+  defp run_contention(tmp_dir, filename, mode) do
+    start_supervised!(
+      {TestRepo,
+       database: Path.join(tmp_dir, filename),
+       pool_size: @writers,
+       journal_mode: :wal,
+       synchronous: :normal,
+       busy_timeout: @busy_timeout_ms,
+       default_transaction_mode: mode}
+    )
+
+    TestRepo.query!("CREATE TABLE counter (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)")
+    TestRepo.query!("INSERT INTO counter (id, value) VALUES (1, 0)")
+
+    1..@writers
+    |> Task.async_stream(fn _ -> writer_loop() end,
+      max_concurrency: @writers,
+      timeout: :infinity
+    )
+    |> Enum.flat_map(fn {:ok, errors} -> errors end)
+  end
+
+  defp writer_loop do
+    Enum.flat_map(1..@iterations, fn _ -> one_transaction() end)
+  end
+
+  # Read, yield to widen the window between snapshot and write, then write.
+  # This is the shape of every Repo.transaction site in lib/mydia.
+  defp one_transaction do
+    TestRepo.transaction(fn ->
+      TestRepo.query!("SELECT value FROM counter WHERE id = 1")
+      Process.sleep(1)
+      TestRepo.query!("UPDATE counter SET value = value + 1 WHERE id = 1")
+    end)
+
+    []
+  rescue
+    error in Exqlite.Error -> [error.message]
+  end
+end

--- a/test/mydia/repo/transaction_mode_test.exs
+++ b/test/mydia/repo/transaction_mode_test.exs
@@ -1,0 +1,19 @@
+defmodule Mydia.Repo.TransactionModeTest do
+  @moduledoc """
+  Locks in the SQLite repo's transaction mode.
+
+  Deferred transactions that read before they write get SQLITE_BUSY_SNAPSHOT
+  under WAL without the busy handler ever running, which is how issue #283
+  produced "Database busy" despite a 30 second busy_timeout. See
+  test/mydia/repo/sqlite_write_contention_test.exs for the demonstration.
+  """
+  use ExUnit.Case, async: true
+
+  test "the SQLite repo begins transactions in IMMEDIATE mode" do
+    if Mydia.DB.sqlite?() do
+      assert Mydia.Repo.config()[:default_transaction_mode] == :immediate
+    else
+      assert Mydia.DB.postgres?()
+    end
+  end
+end


### PR DESCRIPTION
Closes #283.

`busy_timeout: 30_000` and `journal_mode: :wal` were already set, and exqlite's busy handler honors the full timeout, so the issue's own suggested fix was already in place. That is why this stayed open. Two other things were causing it.

## Deferred read-then-write transactions

`default_transaction_mode` was never set, so every `Repo.transaction` issued `BEGIN DEFERRED`. All 23 call sites in `lib/mydia` read before they write.

Under WAL, a deferred transaction takes a read snapshot on its first SELECT. If another connection commits before that transaction upgrades to a write, SQLite returns `SQLITE_BUSY_SNAPSHOT` **immediately and does not invoke the busy handler at all**, because sleeping can never resolve the conflict. The 30 second timeout never applied to any of these. That is why the errors looked instantaneous despite a generous timeout.

Fixed by setting `default_transaction_mode: :immediate` on the SQLite repo, so the write lock is taken at BEGIN and contention routes through the busy handler.

## One task per event

`Events.create_event_async/1` spawned one `Task.Supervisor` child per event, and 31 of the 36 event helpers call it. `Media.update_media_items_monitored/3` opens a transaction, takes the write lock with `update_all`, then fires one task per item while still holding that lock. Those tasks piled onto a 5 connection pool contending for a lock their own caller held.

That is the 74 `events` insert failures directly. Starving unrelated autocommit writers is the 6 `oban_jobs` failures, since Oban's `complete_job/2` is a plain `update_all` outside any transaction and depends entirely on winning the write lock within `busy_timeout`.

Fixed by routing every asynchronous event through a single supervised `Mydia.Events.Writer` that buffers and flushes as one `insert_all`. A `GenServer.cast` cannot write inside the caller's transaction, so this is structural rather than a tuning change.

## Notes

- **PostgreSQL behavior is unchanged.** `default_transaction_mode` lives only inside the `Ecto.Adapters.SQLite3` branch of each config file.
- **The SQL sandbox is unaffected.** It begins with `mode: :transaction`, which exqlite maps to a plain `BEGIN`, overriding the new default. `create_event_async/1` also keeps its existing synchronous sandbox branch, because under the sandbox the test process owns the connection and a cast to a long lived writer would insert on a connection the test cannot see or roll back.
- **Events remain a droppable activity log.** The writer's buffer is bounded and drops oldest on overflow, and a failed insert is logged and dropped rather than retried, since retrying reintroduces the contention this removes. The shutdown flush is best effort and says so.
- No migration, no schema change, no operator-visible configuration change.

## Tests

- A config assertion pinning the SQLite repo to IMMEDIATE, so the setting cannot be silently dropped later.
- A contention test using a throwaway repo against a real SQLite file, demonstrating that concurrent deferred read-then-write transactions surface `Exqlite.Error "Database busy"` while immediate ones surface none. This is a characterization test, not a regression gate; it exists so the config setting is not later removed as unexplained.
- Seven unit tests for the writer covering flush on size, flush on interval, overflow dropping oldest, flush on terminate, an insert failure that logs without crashing, and broadcasting only after a successful insert.

Verified locally on both adapters. SQLite precommit green (8423 tests, 0 failures, Credo strict clean). PostgreSQL run green apart from a known pre-existing concurrency flake, confirmed by two full runs failing a different test each time and both passing in isolation.

## Follow-ups found while investigating, deliberately out of scope

1. The `database` section of the YAML and env config is never applied to the repo. Filed separately.
2. `lib/mydia/plugins/logs.ex` still does one `Task.Supervisor` child per row, the same shape fixed here for events.
3. Oban queues sum to 31 concurrent workers against `pool_size: 5`, and `DataCase` forces `async: false` on SQLite specifically to dodge this error class. Both may be worth revisiting now that transactions begin IMMEDIATE.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added asynchronous event processing with buffered, batched persistence and PubSub notifications.
  - Added safeguards for invalid events, insertion failures, and buffer overflow.
  - Events now flush automatically by batch size or time interval.

- **Bug Fixes**
  - Reduced SQLite write contention by using immediate transactions across environments.

- **Tests**
  - Added coverage for event processing, shutdown flushing, failures, overflow handling, and SQLite concurrency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->