### PR TITLE
fix(downloads): stop a download deleted mid-flight from crashing jobs and LiveViews

### DIFF
--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -122,6 +122,15 @@ defmodule Mydia.Downloads do
   defdelegate get_download(id, opts \\ []), to: Mydia.Downloads.History
 
   @doc """
+  Whether a changeset from a download write failed because the row was gone,
+  rather than because the write was invalid.
+
+  See `Mydia.Downloads.History.stale_changeset?/1`.
+  """
+  @spec stale_changeset?(Ecto.Changeset.t()) :: boolean()
+  defdelegate stale_changeset?(changeset), to: Mydia.Downloads.History
+
+  @doc """
   Gets a single download.
 
   ## Options

--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -107,12 +107,31 @@ defmodule Mydia.Downloads do
   defdelegate list_downloads_with_status(opts \\ []), to: Mydia.Downloads.History
 
   @doc """
+  Gets a single download, or `nil` if it no longer exists.
+
+  ## Options
+    - `:preload` - List of associations to preload
+
+  Prefer this over `get_download!/2` anywhere the row can be deleted underneath
+  you: background jobs, client pollers, PubSub handlers, and any LiveView event
+  handler acting on an id the browser sent. A download disappearing between the
+  read that produced its id and the read that acts on it is an ordinary race, not
+  an exceptional condition (issue #281).
+  """
+  @spec get_download(binary(), keyword()) :: Download.t() | nil
+  defdelegate get_download(id, opts \\ []), to: Mydia.Downloads.History
+
+  @doc """
   Gets a single download.
 
   ## Options
     - `:preload` - List of associations to preload
 
   Raises `Ecto.NoResultsError` if the download does not exist.
+
+  This is for tests and assertions, where a missing row should fail loudly.
+  Application code under `lib/` must use `get_download/2` instead — enforced by
+  `Mydia.Downloads.NoRaisingDownloadGetterTest`.
   """
   @spec get_download!(binary(), keyword()) :: Download.t()
   defdelegate get_download!(id, opts \\ []), to: Mydia.Downloads.History

--- a/lib/mydia/downloads/client/debrid/fetcher.ex
+++ b/lib/mydia/downloads/client/debrid/fetcher.ex
@@ -267,9 +267,18 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
           descriptor
       end)
 
-    download = History.get_download!(state.download_id)
-    new_metadata = Map.merge(download.metadata || %{}, %{"debrid_urls" => persisted})
-    History.update_download(download, %{metadata: new_metadata})
+    case History.get_download(state.download_id) do
+      nil ->
+        # Cancelled or deleted while we were resolving. Report it as an ordinary
+        # fetch failure so the caller's error path runs, rather than raising out
+        # of the GenServer and bypassing both the retry back-off and
+        # `fail_download/2` (issue #281).
+        {:error, Error.api_error("download row no longer exists")}
+
+      download ->
+        new_metadata = Map.merge(download.metadata || %{}, %{"debrid_urls" => persisted})
+        History.update_download(download, %{metadata: new_metadata})
+    end
   end
 
   defp stream_all(urls, download_dir, state, download) do
@@ -452,15 +461,22 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
     # forever and the file sits in staging without ever being imported.
     # The cron's `handle_completed_download/2` is what should stamp
     # completed_at — right before it enqueues the import job.
-    download = History.get_download!(state.download_id)
+    case History.get_download(state.download_id) do
+      # Cancelled or deleted while the payload was streaming (issue #281). There
+      # is no row left to point at the staging directory, so report it rather
+      # than raising out of the GenServer.
+      nil ->
+        {:error, Error.api_error("download row no longer exists")}
 
-    save_path = download_dir!(state)
+      download ->
+        save_path = download_dir!(state)
 
-    new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
+        new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
 
-    case History.update_download(download, %{metadata: new_metadata}) do
-      {:ok, _} -> {:ok, state}
-      {:error, cs} -> {:error, Error.unknown("failed to finalize download: #{inspect(cs)}")}
+        case History.update_download(download, %{metadata: new_metadata}) do
+          {:ok, _} -> {:ok, state}
+          {:error, cs} -> {:error, Error.unknown("failed to finalize download: #{inspect(cs)}")}
+        end
     end
   end
 
@@ -517,17 +533,19 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
       "Debrid fetcher failed for download_id=#{state.download_id}: #{Error.message(error)}"
     )
 
-    case History.get_download!(state.download_id) do
+    case History.get_download(state.download_id) do
       %Download{} = d ->
         History.update_download(d, %{
           import_failed_at: DateTime.utc_now(),
           import_last_error: "fetch_failed: #{Error.message(error)}"
         })
 
-      _ ->
+      # The row is already gone — nothing to record the failure on.
+      nil ->
         :ok
     end
   rescue
+    # Recording the failure must never itself fail the fetcher.
     _ -> :ok
   end
 

--- a/lib/mydia/downloads/client/debrid/fetcher.ex
+++ b/lib/mydia/downloads/client/debrid/fetcher.ex
@@ -149,6 +149,20 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
       {:ok, new_state} ->
         {:stop, :normal, new_state}
 
+      # The row was deleted while we were fetching (cancelled from the UI, an
+      # import that cleaned up). Terminal, and deliberately ahead of the retry
+      # clause: there is nothing left to fetch for and nothing to mark failed,
+      # while each retry would re-resolve provider URLs — and past `finalize/2`,
+      # re-download the entire payload — against a row that is already gone
+      # (issue #281).
+      :download_deleted ->
+        Logger.info(
+          "Debrid fetcher stopping: download row no longer exists " <>
+            "(download_id=#{state.download_id})"
+        )
+
+        {:stop, :normal, state}
+
       {:error, reason} when state.retries_left > 0 ->
         Logger.warning(
           "Debrid fetcher attempt failed for download_id=#{state.download_id} " <>
@@ -268,17 +282,15 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
       end)
 
     case History.get_download(state.download_id) do
-      nil ->
-        # Cancelled or deleted while we were resolving. Report it as an ordinary
-        # fetch failure so the caller's error path runs, rather than raising out
-        # of the GenServer and bypassing both the retry back-off and
-        # `fail_download/2` (issue #281).
-        {:error, Error.api_error("download row no longer exists")}
-
-      download ->
-        new_metadata = Map.merge(download.metadata || %{}, %{"debrid_urls" => persisted})
-        History.update_download(download, %{metadata: new_metadata})
+      # Cancelled or deleted while we were resolving (issue #281). Terminal, not
+      # an error: see the `:download_deleted` clause in `handle_info/2`.
+      nil -> :download_deleted
+      download -> persist_metadata(download, %{"debrid_urls" => persisted})
     end
+  end
+
+  defp persist_metadata(download, attrs) do
+    History.update_download(download, %{metadata: Map.merge(download.metadata || %{}, attrs)})
   end
 
   defp stream_all(urls, download_dir, state, download) do
@@ -463,17 +475,14 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
     # completed_at — right before it enqueues the import job.
     case History.get_download(state.download_id) do
       # Cancelled or deleted while the payload was streaming (issue #281). There
-      # is no row left to point at the staging directory, so report it rather
-      # than raising out of the GenServer.
+      # is no row left to point at the staging directory. Terminal rather than
+      # an error, because this runs *after* the whole payload has transferred:
+      # a retry would re-resolve provider URLs and download all of it again.
       nil ->
-        {:error, Error.api_error("download row no longer exists")}
+        :download_deleted
 
       download ->
-        save_path = download_dir!(state)
-
-        new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
-
-        case History.update_download(download, %{metadata: new_metadata}) do
+        case persist_metadata(download, %{"save_path" => download_dir!(state)}) do
           {:ok, _} -> {:ok, state}
           {:error, cs} -> {:error, Error.unknown("failed to finalize download: #{inspect(cs)}")}
         end

--- a/lib/mydia/downloads/client/debrid/fetcher.ex
+++ b/lib/mydia/downloads/client/debrid/fetcher.ex
@@ -289,8 +289,23 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
     end
   end
 
+  # Writes `attrs` into the row's metadata, collapsing "the row was deleted
+  # between the lookup above and this write" into the same terminal
+  # `:download_deleted` the nil lookup returns. Same race, narrower window, and
+  # retrying it is just as pointless (issue #281). An ordinary changeset error
+  # still surfaces as `{:error, _}` and stays retryable.
   defp persist_metadata(download, attrs) do
-    History.update_download(download, %{metadata: Map.merge(download.metadata || %{}, attrs)})
+    case History.update_download(download, %{
+           metadata: Map.merge(download.metadata || %{}, attrs)
+         }) do
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if History.stale_changeset?(changeset),
+          do: :download_deleted,
+          else: {:error, changeset}
+
+      ok ->
+        ok
+    end
   end
 
   defp stream_all(urls, download_dir, state, download) do
@@ -484,6 +499,7 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
       download ->
         case persist_metadata(download, %{"save_path" => download_dir!(state)}) do
           {:ok, _} -> {:ok, state}
+          :download_deleted -> :download_deleted
           {:error, cs} -> {:error, Error.unknown("failed to finalize download: #{inspect(cs)}")}
         end
     end

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -210,6 +210,24 @@ defmodule Mydia.Downloads.History do
     end
   end
 
+  @doc """
+  Whether a changeset from a download write failed because the row was gone.
+
+  The companion to `@stale_opts`: those turn Ecto's `Ecto.StaleEntryError` into a
+  changeset error, and this tells that error apart from an ordinary validation
+  failure. Ecto tags it `stale: true` (see `Ecto.Repo.Schema.apply/4`), which is
+  what this reads — not the message text, so rewording `@stale_opts` cannot
+  silently break it.
+
+  Callers that must distinguish "this download no longer exists" from "this write
+  was invalid" need it: retrying the first is pointless and sometimes expensive,
+  while retrying the second may be right (issue #281).
+  """
+  @spec stale_changeset?(Ecto.Changeset.t()) :: boolean()
+  def stale_changeset?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn {_field, {_message, opts}} -> Keyword.get(opts, :stale, false) end)
+  end
+
   def get_download(id, opts \\ []), do: opts |> download_query() |> Repo.get(id)
 
   def get_download!(id, opts \\ []), do: opts |> download_query() |> Repo.get!(id)

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -26,6 +26,19 @@ defmodule Mydia.Downloads.History do
   # considered a crashed/abandoned grab and derives to "failed".
   @grab_timeout_minutes 10
 
+  # A download row can be deleted between a caller reading it and writing it back:
+  # an operator deleting from the UI, a concurrent import, or DownloadMonitor's own
+  # reject path. `Repo.update/2` and `Repo.delete/2` filter by primary key
+  # unconditionally, and raise `Ecto.StaleEntryError` when that filter matches zero
+  # rows — this is the default for every write, not something `optimistic_lock`
+  # opts you into, and the non-bang variants raise just the same.
+  #
+  # `:stale_error_field` turns that raise into the `{:error, changeset}` shape every
+  # caller here already handles, so a vanished row reads as an ordinary failed write
+  # instead of crashing the job that happened to be holding the struct. Applied at
+  # this choke point rather than at the ~40 call sites (issue #281).
+  @stale_opts [stale_error_field: :id, stale_error_message: "no longer exists"]
+
   ## Public Functions
 
   @doc """
@@ -197,11 +210,11 @@ defmodule Mydia.Downloads.History do
     end
   end
 
-  def get_download!(id, opts \\ []) do
-    Download
-    |> maybe_preload(opts[:preload])
-    |> Repo.get!(id)
-  end
+  def get_download(id, opts \\ []), do: opts |> download_query() |> Repo.get(id)
+
+  def get_download!(id, opts \\ []), do: opts |> download_query() |> Repo.get!(id)
+
+  defp download_query(opts), do: maybe_preload(Download, opts[:preload])
 
   def create_download(attrs \\ %{}) do
     result =
@@ -223,7 +236,7 @@ defmodule Mydia.Downloads.History do
     result =
       download
       |> Download.changeset(attrs)
-      |> Repo.update()
+      |> Repo.update(@stale_opts)
 
     case result do
       {:ok, updated_download} ->
@@ -289,17 +302,17 @@ defmodule Mydia.Downloads.History do
   def mark_download_completed(%Download{} = download) do
     download
     |> Download.changeset(%{completed_at: DateTime.utc_now()})
-    |> Repo.update()
+    |> Repo.update(@stale_opts)
   end
 
   def mark_download_failed(%Download{} = download, error_message) do
     download
     |> Download.changeset(%{error_message: error_message})
-    |> Repo.update()
+    |> Repo.update(@stale_opts)
   end
 
   def delete_download(%Download{} = download) do
-    result = Repo.delete(download)
+    result = Repo.delete(download, @stale_opts)
 
     case result do
       {:ok, deleted_download} ->

--- a/lib/mydia/downloads/seedbox/fetcher.ex
+++ b/lib/mydia/downloads/seedbox/fetcher.ex
@@ -374,13 +374,21 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
   end
 
   defp finalize(state) do
-    download = History.get_download!(state.download_id)
-    save_path = local_download_dir(state)
-    new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
+    case History.get_download(state.download_id) do
+      # Cancelled or deleted while the payload was being pulled (issue #281).
+      # There is no row left to point at the staging directory, so report it
+      # rather than raising out of the GenServer and skipping `fail_download/2`.
+      nil ->
+        {:error, :download_deleted}
 
-    case History.update_download(download, %{metadata: new_metadata}) do
-      {:ok, _} -> {:ok, :done}
-      {:error, changeset} -> {:error, {:finalize_failed, changeset}}
+      download ->
+        save_path = local_download_dir(state)
+        new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
+
+        case History.update_download(download, %{metadata: new_metadata}) do
+          {:ok, _} -> {:ok, :done}
+          {:error, changeset} -> {:error, {:finalize_failed, changeset}}
+        end
     end
   end
 
@@ -392,17 +400,19 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
       "Seedbox fetch failed for download_id=#{state.download_id}: #{inspect(reason)}"
     )
 
-    case History.get_download!(state.download_id) do
+    case History.get_download(state.download_id) do
       %Download{} = d ->
         History.update_download(d, %{
           import_failed_at: DateTime.utc_now(),
           import_last_error: "seedbox_fetch_failed: #{inspect(reason)}"
         })
 
-      _ ->
+      # The row is already gone — nothing to record the failure on.
+      nil ->
         :ok
     end
   rescue
+    # Recording the failure must never itself fail the fetcher.
     _ -> :ok
   end
 end

--- a/lib/mydia/downloads/seedbox/fetcher.ex
+++ b/lib/mydia/downloads/seedbox/fetcher.ex
@@ -400,8 +400,16 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
         new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
 
         case History.update_download(download, %{metadata: new_metadata}) do
-          {:ok, _} -> {:ok, :done}
-          {:error, changeset} -> {:error, {:finalize_failed, changeset}}
+          {:ok, _} ->
+            {:ok, :done}
+
+          # Deleted between the lookup above and this write — same race, narrower
+          # window, and just as terminal (issue #281). An ordinary changeset
+          # error still surfaces as retryable.
+          {:error, changeset} ->
+            if History.stale_changeset?(changeset),
+              do: :download_deleted,
+              else: {:error, {:finalize_failed, changeset}}
         end
     end
   end

--- a/lib/mydia/downloads/seedbox/fetcher.ex
+++ b/lib/mydia/downloads/seedbox/fetcher.ex
@@ -102,6 +102,19 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
       {:ok, _} ->
         {:stop, :normal, state}
 
+      # The row was deleted while we were pulling (cancelled from the UI, an
+      # import that cleaned up). Terminal, and deliberately ahead of the retry
+      # clause: there is nothing left to fetch for and nothing to mark failed,
+      # and `run/1` has already deleted the remote source by this point, so a
+      # retry would re-open SFTP for a path that is gone (issue #281).
+      :download_deleted ->
+        Logger.info(
+          "Seedbox fetcher stopping: download row no longer exists " <>
+            "(download_id=#{state.download_id})"
+        )
+
+        {:stop, :normal, state}
+
       {:error, reason} when state.retries_left > 0 ->
         Logger.warning(
           "Seedbox fetch attempt failed for download_id=#{state.download_id} " <>
@@ -376,10 +389,11 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
   defp finalize(state) do
     case History.get_download(state.download_id) do
       # Cancelled or deleted while the payload was being pulled (issue #281).
-      # There is no row left to point at the staging directory, so report it
-      # rather than raising out of the GenServer and skipping `fail_download/2`.
+      # Terminal rather than an error: this runs after `transfer_all/2` has
+      # copied everything and `maybe_delete_remote/2` has removed the source, so
+      # a retry would re-open SFTP for a remote path that no longer exists.
       nil ->
-        {:error, :download_deleted}
+        :download_deleted
 
       download ->
         save_path = local_download_dir(state)

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -53,6 +53,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   require Logger
   alias Mydia.Downloads
   alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.Download
   alias Mydia.Downloads.Client
   alias Mydia.Downloads.ClientAdoption
   alias Mydia.Downloads.Client.FailureCategory
@@ -282,6 +283,60 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
   ## Private Functions
 
+  # Reloads the row a poll snapshot named and hands the fresh struct to `fun`.
+  #
+  # Two distinct hazards, one boundary:
+  #
+  #   * The row is gone. `list_downloads_with_status/1` reads every download from
+  #     the database and only then polls each client over HTTP, so seconds elapse
+  #     before these handlers run on its result. A manual delete, a concurrent
+  #     import, or this very poll's reject path can remove the row inside that
+  #     window. That is an expected race, not a failure — hence a plain `nil` from
+  #     `get_download/2` and a :debug log, rather than the `Ecto.NoResultsError`
+  #     that used to abort the whole job (issue #281).
+  #
+  #   * The handler itself faults. Containing that here is the issue #278 lesson:
+  #     without it, one bad download aborts `perform/1` and every *later* handler
+  #     silently stops running for that poll. The stacktrace is kept deliberately
+  #     so a genuine bug is locatable rather than a silently dead subsystem. Stays
+  #     local: Tower runs `log_level: :none`, so this never reaches the relay.
+  #
+  # All six `Enum.each` passes in `perform/1` discard their result, so `:ok` is a
+  # safe universal return.
+  defp with_download(download_map, label, opts, fun) do
+    case Downloads.get_download(download_map.id, opts) do
+      nil ->
+        Logger.debug("Download disappeared mid-poll; skipping #{label}",
+          download_id: download_map.id
+        )
+
+        :ok
+
+      %Download{} = download ->
+        fun.(download)
+        :ok
+    end
+  rescue
+    exception ->
+      Logger.error("#{label} failed for download; continuing poll",
+        download_id: download_map.id,
+        error: Exception.format(:error, exception, __STACKTRACE__)
+      )
+
+      :ok
+  catch
+    # `rescue` matches raises only. A saturated Ecto pool checkout and a
+    # `GenServer.call` timeout inside an event broadcast are exits, and without
+    # this clause they still abort the poll.
+    :exit, reason ->
+      Logger.error("#{label} exited for download; continuing poll",
+        download_id: download_map.id,
+        error: inspect(reason)
+      )
+
+      :ok
+  end
+
   defp handle_completion(download_map) do
     Logger.info("Handling completed download",
       download_id: download_map.id,
@@ -289,32 +344,36 @@ defmodule Mydia.Jobs.DownloadMonitor do
       save_path: download_map.save_path
     )
 
-    # Get the download struct from database (with media_item preloaded)
-    download = Downloads.get_download!(download_map.id, preload: [:media_item])
+    with_download(download_map, :handle_completion, [preload: [:media_item]], fn download ->
+      # Mark download as completed in database (prevents reprocessing on next monitor run)
+      case Downloads.mark_download_completed(download) do
+        {:ok, download} ->
+          # Track completion event
+          Events.download_completed(download, media_item: download.media_item)
 
-    # Mark download as completed in database (prevents reprocessing on next monitor run)
-    {:ok, download} = Downloads.mark_download_completed(download)
+          # Enqueue import job - it will delete the download record after successful import
+          case enqueue_import_job(download, download_map) do
+            {:ok, _job} ->
+              Logger.info("Import job enqueued for completed download",
+                download_id: download.id
+              )
 
-    # Track completion event
-    Events.download_completed(download, media_item: download.media_item)
+            {:error, reason} ->
+              Logger.error("Failed to enqueue import job",
+                download_id: download.id,
+                reason: inspect(reason)
+              )
+          end
 
-    # Enqueue import job - it will delete the download record after successful import
-    case enqueue_import_job(download, download_map) do
-      {:ok, _job} ->
-        Logger.info("Import job enqueued for completed download",
-          download_id: download.id
-        )
-
-        :ok
-
-      {:error, reason} ->
-        Logger.error("Failed to enqueue import job",
-          download_id: download.id,
-          reason: inspect(reason)
-        )
-
-        :ok
-    end
+        {:error, changeset} ->
+          # The row was deleted between the reload above and this write. Skipping
+          # the import is correct: there is no longer a download to import.
+          Logger.info("Could not mark download completed; skipping import",
+            download_id: download.id,
+            errors: inspect(changeset.errors)
+          )
+      end
+    end)
   end
 
   defp handle_failure(download_map) do
@@ -337,47 +396,42 @@ defmodule Mydia.Jobs.DownloadMonitor do
       error: error_msg
     )
 
-    # Get the download struct from database (with media_item preloaded)
-    download = Downloads.get_download!(download_map.id, preload: [:media_item])
+    with_download(download_map, :handle_failure, [preload: [:media_item]], fn download ->
+      # Bound once and used for both the event and the blacklist row below, so
+      # the activity feed and the admin blacklist page can never disagree about
+      # why this release failed (issue #237).
+      failure_slug = FailureCategory.slug(download_map.client_failure_category)
 
-    # Bound once and used for both the event and the blacklist row below, so
-    # the activity feed and the admin blacklist page can never disagree about
-    # why this release failed (issue #237).
-    failure_slug = FailureCategory.slug(download_map.client_failure_category)
+      # Track failure event before deletion. This metadata is what the activity
+      # feed and the media-item history render, so the composed message is the
+      # operator's only lasting record. The Download row is deleted below.
+      Events.download_failed(download, error_msg,
+        media_item: download.media_item,
+        failure_category: failure_slug,
+        failure_detail: download_map.client_error_detail
+      )
 
-    # Track failure event before deletion. This metadata is what the activity
-    # feed and the media-item history render, so the composed message is the
-    # operator's only lasting record. The Download row is deleted below.
-    Events.download_failed(download, error_msg,
-      media_item: download.media_item,
-      failure_category: failure_slug,
-      failure_detail: download_map.client_error_detail
-    )
+      # Blacklist the release so the next search excludes it (issue #123).
+      # The reason is the provider's own classification when we have one
+      # (issue #237), falling back to the pre-existing generic slug.
+      # This MUST NOT block failure handling, so wrap in try/rescue and log.
+      record_blacklist_entry(download, failure_slug)
 
-    # Blacklist the release so the next search excludes it (issue #123).
-    # The reason is the provider's own classification when we have one
-    # (issue #237), falling back to the pre-existing generic slug.
-    # This MUST NOT block failure handling, so wrap in try/rescue and log.
-    record_blacklist_entry(download, failure_slug)
+      # Delete the download record - downloads table is ephemeral
+      case Downloads.delete_download(download) do
+        {:ok, _deleted} ->
+          Logger.info("Download removed from queue (failed)",
+            download_id: download_map.id,
+            error: error_msg
+          )
 
-    # Delete the download record - downloads table is ephemeral
-    case Downloads.delete_download(download) do
-      {:ok, _deleted} ->
-        Logger.info("Download removed from queue (failed)",
-          download_id: download_map.id,
-          error: error_msg
-        )
-
-        :ok
-
-      {:error, changeset} ->
-        Logger.error("Failed to delete failed download",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
-        )
-
-        :ok
-    end
+        {:error, changeset} ->
+          Logger.error("Failed to delete failed download",
+            download_id: download.id,
+            errors: inspect(changeset.errors)
+          )
+      end
+    end)
   end
 
   # --- Pre-completion content check --------------------------------------
@@ -443,15 +497,13 @@ defmodule Mydia.Jobs.DownloadMonitor do
   @bad_content_log_sample 10
 
   defp reject_bad_content(download_map) do
-    download = Downloads.get_download!(download_map.id, preload: [:media_item])
-
-    if auto_reject_exhausted?(download.media_item_id) do
-      suppress_auto_reject(download, download_map)
-    else
-      do_reject_bad_content(download, download_map)
-    end
-  rescue
-    Ecto.NoResultsError -> :ok
+    with_download(download_map, :reject_bad_content, [preload: [:media_item]], fn download ->
+      if auto_reject_exhausted?(download.media_item_id) do
+        suppress_auto_reject(download, download_map)
+      else
+        do_reject_bad_content(download, download_map)
+      end
+    end)
   end
 
   # A media item with no id (an unbound download) has no counter to consult,
@@ -627,28 +679,28 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # `Mydia.Downloads.History`). The `download_client` write is then a no-op and
   # only the orphan state clears.
   defp adopt_download(download_map) do
-    download = Downloads.get_download!(download_map.id)
+    with_download(download_map, :adopt_download, [], fn download ->
+      attrs =
+        %{download_client: download_map.adoptable_client}
+        |> maybe_clear_orphan_state(download)
 
-    attrs =
-      %{download_client: download_map.adoptable_client}
-      |> maybe_clear_orphan_state(download)
+      if attrs == %{download_client: download.download_client} do
+        # Nothing to persist: the row already names this client and carries no
+        # orphan state to clear. Writing anyway would broadcast a download update
+        # on every single poll, and every open Downloads view re-polls all its
+        # clients on that broadcast. Only reachable if the row changed between
+        # the poll's snapshot and this write.
+        :ok
+      else
+        Logger.info("Adopting download onto reconfigured client",
+          download_id: download_map.id,
+          previous_client: download.download_client,
+          adopted_client: download_map.adoptable_client
+        )
 
-    if attrs == %{download_client: download.download_client} do
-      # Nothing to persist: the row already names this client and carries no
-      # orphan state to clear. Writing anyway would broadcast a download update
-      # on every single poll, and every open Downloads view re-polls all its
-      # clients on that broadcast. Only reachable if the row changed between
-      # the poll's snapshot and this write.
-      :ok
-    else
-      Logger.info("Adopting download onto reconfigured client",
-        download_id: download_map.id,
-        previous_client: download.download_client,
-        adopted_client: download_map.adoptable_client
-      )
-
-      persist_adoption(download, download_map, attrs)
-    end
+        persist_adoption(download, download_map, attrs)
+      end
+    end)
   end
 
   defp persist_adoption(download, download_map, attrs) do
@@ -713,20 +765,18 @@ defmodule Mydia.Jobs.DownloadMonitor do
       client_config_state: download_map.client_config_state
     )
 
-    download = Downloads.get_download!(download_map.id)
+    with_download(download_map, :tag_legacy_orphan, [], fn download ->
+      case Downloads.update_download(download, %{import_failure_reason: "no_client"}) do
+        {:ok, _updated} ->
+          :ok
 
-    case Downloads.update_download(download, %{import_failure_reason: "no_client"}) do
-      {:ok, _updated} ->
-        :ok
-
-      {:error, changeset} ->
-        Logger.warning("Failed to tag pre-existing orphaned download",
-          download_id: download_map.id,
-          errors: inspect(changeset.errors)
-        )
-
-        :ok
-    end
+        {:error, changeset} ->
+          Logger.warning("Failed to tag pre-existing orphaned download",
+            download_id: download_map.id,
+            errors: inspect(changeset.errors)
+          )
+      end
+    end)
   end
 
   defp handle_missing(download_map) do
@@ -737,48 +787,44 @@ defmodule Mydia.Jobs.DownloadMonitor do
       client_config_state: download_map.client_config_state
     )
 
-    # Get the download struct from database (with media_item preloaded)
-    download = Downloads.get_download!(download_map.id, preload: [:media_item])
-
     error_msg = missing_error_message(download_map)
 
-    # `Download` has no `:status` field — status is derived at read time from the
-    # client poll (see `Downloads.list_downloads_with_status/1`). Persisting
-    # `error_message` is what moves the row into the Issues tab, and what drops
-    # it out of `Download.occupying/1` so the target is released.
-    #
-    # For an orphan we also persist the grouping tag the Issues tab bulk-clear
-    # keys on. It is deliberately the same tag `MediaImport` emits for
-    # `:no_client`, so a still-downloading orphan and one that died in import
-    # group together.
-    attrs =
-      case download_map.client_config_state do
-        state when state in [:removed, :disabled] ->
-          %{error_message: error_msg, import_failure_reason: "no_client"}
+    with_download(download_map, :handle_missing, [preload: [:media_item]], fn download ->
+      # `Download` has no `:status` field — status is derived at read time from the
+      # client poll (see `Downloads.list_downloads_with_status/1`). Persisting
+      # `error_message` is what moves the row into the Issues tab, and what drops
+      # it out of `Download.occupying/1` so the target is released.
+      #
+      # For an orphan we also persist the grouping tag the Issues tab bulk-clear
+      # keys on. It is deliberately the same tag `MediaImport` emits for
+      # `:no_client`, so a still-downloading orphan and one that died in import
+      # group together.
+      attrs =
+        case download_map.client_config_state do
+          state when state in [:removed, :disabled] ->
+            %{error_message: error_msg, import_failure_reason: "no_client"}
 
-        _present_or_unassigned ->
-          %{error_message: error_msg}
+          _present_or_unassigned ->
+            %{error_message: error_msg}
+        end
+
+      case Downloads.update_download(download, attrs) do
+        {:ok, _updated} ->
+          Logger.info("Download marked as missing (preserved for Issues tab)",
+            download_id: download_map.id,
+            client: download_map.download_client
+          )
+
+          # Track event for user visibility
+          Events.download_failed(download, error_msg, media_item: download.media_item)
+
+        {:error, changeset} ->
+          Logger.error("Failed to mark download as missing",
+            download_id: download.id,
+            errors: inspect(changeset.errors)
+          )
       end
-
-    case Downloads.update_download(download, attrs) do
-      {:ok, _updated} ->
-        Logger.info("Download marked as missing (preserved for Issues tab)",
-          download_id: download_map.id,
-          client: download_map.download_client
-        )
-
-        # Track event for user visibility
-        Events.download_failed(download, error_msg, media_item: download.media_item)
-        :ok
-
-      {:error, changeset} ->
-        Logger.error("Failed to mark download as missing",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
-        )
-
-        :ok
-    end
+    end)
   end
 
   @doc false
@@ -905,19 +951,20 @@ defmodule Mydia.Jobs.DownloadMonitor do
 
     {apply_progress_decision(download, decision, now), 0}
   rescue
-    # The row was deleted between the poll's status snapshot and this write
-    # (e.g. a concurrent import that deletes the download, or a manual delete).
-    # Skip it — the rest of the poll must still run. This is an expected race
-    # rather than a failure, so it deliberately does not count toward
-    # `stall_update_failures`; counting it would fill the summary with noise.
-    Ecto.NoResultsError ->
-      Logger.debug("Download disappeared mid-poll; skipping stall update",
-        download_id: download.id
-      )
-
-      {0, 0}
-
-    # Any other failure is contained to this one download. Issue #278 is the
+    # A row deleted between the poll's snapshot and this write no longer reaches
+    # here: every reload below it goes through `Downloads.get_download/2` and
+    # returns a plain `nil`, which each decision branch handles as "nothing to
+    # do" (issue #281). It stays out of `stall_update_failures` for the same
+    # reason it always did — an expected race is not a failure to report.
+    #
+    # This is deliberately *not* the `with_download/4` boundary the six
+    # `Enum.each` handlers share. That helper reloads first and returns `:ok`;
+    # this path evaluates the in-memory struct first (`StallDetector.evaluate/7`
+    # can raise before any database access), reloads only inside some decision
+    # branches, and must return a counted `{stalled, failures}` tuple. Unifying
+    # the two would mean restructuring this for no behavioural gain.
+    #
+    # Any failure is contained to this one download. Issue #278 is the
     # cautionary case: one un-encodable byte count aborted the whole reduce, so
     # stall detection stopped for every download on the instance and the Oban
     # job retried forever.
@@ -1013,23 +1060,29 @@ defmodule Mydia.Jobs.DownloadMonitor do
       message: message
     )
 
-    db_download = Downloads.get_download!(download.id, preload: [:media_item])
-
-    case Downloads.update_download(db_download, %{
-           stalled_since: now,
-           last_observed_at: now
-         }) do
-      {:ok, updated} ->
-        Events.download_stalled(updated, message, media_item: updated.media_item)
-        1
-
-      {:error, changeset} ->
-        Logger.error("Failed to flag soft-stalled download",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
-        )
-
+    case Downloads.get_download(download.id, preload: [:media_item]) do
+      # Deleted since the poll's snapshot — nothing to flag, and nothing newly
+      # stalled to count (issue #281).
+      nil ->
         0
+
+      db_download ->
+        case Downloads.update_download(db_download, %{
+               stalled_since: now,
+               last_observed_at: now
+             }) do
+          {:ok, updated} ->
+            Events.download_stalled(updated, message, media_item: updated.media_item)
+            1
+
+          {:error, changeset} ->
+            Logger.error("Failed to flag soft-stalled download",
+              download_id: download.id,
+              errors: inspect(changeset.errors)
+            )
+
+            0
+        end
     end
   end
 
@@ -1040,12 +1093,17 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # fields and left the torrent running, which read to operators as "Mydia
   # says this failed but it is still downloading".
   defp apply_progress_decision(download, {:escalate, error_message, _at}, _now) do
-    db_download = Downloads.get_download!(download.id, preload: [:media_item])
+    case Downloads.get_download(download.id, preload: [:media_item]) do
+      # Already gone — the escalation has nothing left to reject (issue #281).
+      nil ->
+        0
 
-    if auto_reject_exhausted?(db_download.media_item_id) do
-      suppress_stall_reject(db_download, error_message)
-    else
-      do_reject_stalled(db_download, error_message)
+      db_download ->
+        if auto_reject_exhausted?(db_download.media_item_id) do
+          suppress_stall_reject(db_download, error_message)
+        else
+          do_reject_stalled(db_download, error_message)
+        end
     end
   end
 
@@ -1141,20 +1199,26 @@ defmodule Mydia.Jobs.DownloadMonitor do
     if is_nil(download.stalled_since) do
       update_progress(download, attrs)
     else
-      db_download = Downloads.get_download!(download.id, preload: [:media_item])
-
-      case Downloads.update_download(db_download, attrs) do
-        {:ok, updated} ->
-          Events.download_unstalled(updated, media_item: updated.media_item)
+      case Downloads.get_download(download.id, preload: [:media_item]) do
+        # Deleted since the snapshot — there is no soft-stall left to clear
+        # (issue #281).
+        nil ->
           :ok
 
-        {:error, changeset} ->
-          Logger.warning("Failed to clear soft-stall on download",
-            download_id: download.id,
-            errors: inspect(changeset.errors)
-          )
+        db_download ->
+          case Downloads.update_download(db_download, attrs) do
+            {:ok, updated} ->
+              Events.download_unstalled(updated, media_item: updated.media_item)
+              :ok
 
-          :ok
+            {:error, changeset} ->
+              Logger.warning("Failed to clear soft-stall on download",
+                download_id: download.id,
+                errors: inspect(changeset.errors)
+              )
+
+              :ok
+          end
       end
     end
   end
@@ -1170,19 +1234,24 @@ defmodule Mydia.Jobs.DownloadMonitor do
   end
 
   defp update_progress(download, attrs) do
-    db_download = Downloads.get_download!(download.id)
-
-    case Downloads.update_download(db_download, attrs) do
-      {:ok, _} ->
+    case Downloads.get_download(download.id) do
+      # Deleted since the snapshot — no progress left to track (issue #281).
+      nil ->
         :ok
 
-      {:error, changeset} ->
-        Logger.warning("Failed to update download progress tracking",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
-        )
+      db_download ->
+        case Downloads.update_download(db_download, attrs) do
+          {:ok, _} ->
+            :ok
 
-        :ok
+          {:error, changeset} ->
+            Logger.warning("Failed to update download progress tracking",
+              download_id: download.id,
+              errors: inspect(changeset.errors)
+            )
+
+            :ok
+        end
     end
   end
 

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -229,12 +229,12 @@ defmodule Mydia.Jobs.MediaImport do
   defp terminal_failure?(_reason, _attempt), do: false
 
   defp fetch_download(download_id) do
-    {:ok,
-     Downloads.get_download!(download_id,
-       preload: [{:media_item, :episodes}, :episode, :library_path]
-     )}
-  rescue
-    Ecto.NoResultsError -> :not_found
+    case Downloads.get_download(download_id,
+           preload: [{:media_item, :episodes}, :episode, :library_path]
+         ) do
+      nil -> :not_found
+      download -> {:ok, download}
+    end
   end
 
   defp handle_incomplete_download(download, args, attempt, raw_args) do
@@ -465,9 +465,10 @@ defmodule Mydia.Jobs.MediaImport do
   defp snapshot_candidates_on_failure(result, _download, _files, _library_path), do: result
 
   defp fetch_current_download(download_id) do
-    {:ok, Downloads.get_download!(download_id)}
-  rescue
-    Ecto.NoResultsError -> :not_found
+    case Downloads.get_download(download_id) do
+      nil -> :not_found
+      download -> {:ok, download}
+    end
   end
 
   defp do_process_import(download, files, library_path, args) do
@@ -483,11 +484,15 @@ defmodule Mydia.Jobs.MediaImport do
         # so future re-imports and reporting can recognize it.
         partial_pack_status = detect_partial_pack(download, imported_files)
 
-        # Reload download to check if it was flagged as having unresolved files
+        # Reload download to check if it was flagged as having unresolved files.
+        # Falling back to the pre-import struct covers the row being deleted
+        # between the file placement above and this read (issue #281): the files
+        # are already on disk, so aborting here would be strictly worse than
+        # reading a `match_status` written seconds ago by this same call stack.
         updated_download =
-          Downloads.get_download!(download.id,
+          Downloads.get_download(download.id,
             preload: [{:media_item, :episodes}, :episode, :library_path]
-          )
+          ) || download
 
         has_unresolved = updated_download.match_status == "unresolved_files"
 

--- a/lib/mydia/jobs/media_rematch.ex
+++ b/lib/mydia/jobs/media_rematch.ex
@@ -57,11 +57,9 @@ defmodule Mydia.Jobs.MediaRematch do
   end
 
   defp fetch_download(download_id) do
-    Downloads.get_download!(download_id,
+    Downloads.get_download(download_id,
       preload: [:media_item, :episode, :library_path]
     )
-  rescue
-    Ecto.NoResultsError -> nil
   end
 
   defp run(download) do
@@ -232,11 +230,17 @@ defmodule Mydia.Jobs.MediaRematch do
   end
 
   defp record_pending_source_delete(download_id, source_path) do
-    with %_{} = download <- Downloads.get_download!(download_id) do
-      metadata = Map.put(download.metadata || %{}, "rematch_pending_source_delete", source_path)
-      Downloads.update_download(download, %{metadata: metadata})
+    case Downloads.get_download(download_id) do
+      nil ->
+        :ok
+
+      download ->
+        metadata = Map.put(download.metadata || %{}, "rematch_pending_source_delete", source_path)
+        Downloads.update_download(download, %{metadata: metadata})
     end
   rescue
+    # Best-effort bookkeeping: the reload's missing-row case is handled above,
+    # but this must never take down a re-match that otherwise succeeded.
     _ -> :ok
   end
 

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -2,6 +2,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
   use MydiaWeb, :live_view
   alias Mydia.Downloads
   alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.Download
   alias Mydia.Downloads.ExternalTorrents
   alias Mydia.Downloads.ImportCandidates
   alias Mydia.Downloads.StallDetector
@@ -193,18 +194,18 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("cancel_download", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
+      with_download(socket, id, fn download ->
+        case Downloads.cancel_download(download, delete_files: false) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Download cancelled and removed from client")
+             |> load_downloads()}
 
-      case Downloads.cancel_download(download, delete_files: false) do
-        {:ok, _} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Download cancelled and removed from client")
-           |> load_downloads()}
-
-        {:error, reason} ->
-          {:noreply, put_flash(socket, :error, "Failed to cancel download: #{inspect(reason)}")}
-      end
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, "Failed to cancel download: #{inspect(reason)}")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -212,18 +213,18 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("pause_download", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
+      with_download(socket, id, fn download ->
+        case Downloads.pause_download(download) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Download paused")
+             |> load_downloads()}
 
-      case Downloads.pause_download(download) do
-        {:ok, _} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Download paused")
-           |> load_downloads()}
-
-        {:error, reason} ->
-          {:noreply, put_flash(socket, :error, "Failed to pause download: #{inspect(reason)}")}
-      end
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, "Failed to pause download: #{inspect(reason)}")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -231,18 +232,18 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("resume_download", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
+      with_download(socket, id, fn download ->
+        case Downloads.resume_download(download) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Download resumed")
+             |> load_downloads()}
 
-      case Downloads.resume_download(download) do
-        {:ok, _} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Download resumed")
-           |> load_downloads()}
-
-        {:error, reason} ->
-          {:noreply, put_flash(socket, :error, "Failed to resume download: #{inspect(reason)}")}
-      end
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, "Failed to resume download: #{inspect(reason)}")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -250,49 +251,49 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("retry_download", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id, preload: [:media_item, :episode])
+      with_download(socket, id, [preload: [:media_item, :episode]], fn download ->
+        # Clear error message if any
+        case Downloads.update_download(download, %{error_message: nil}) do
+          {:ok, updated} ->
+            # Convert metadata to struct for type-safe access
+            metadata = DownloadMetadata.from_map(updated.metadata)
 
-      # Clear error message if any
-      case Downloads.update_download(download, %{error_message: nil}) do
-        {:ok, updated} ->
-          # Convert metadata to struct for type-safe access
-          metadata = DownloadMetadata.from_map(updated.metadata)
+            # Re-add to client using the original download URL
+            search_result = %Mydia.Indexers.SearchResult{
+              download_url: updated.download_url,
+              title: updated.title,
+              indexer: updated.indexer,
+              size: metadata.size,
+              seeders: metadata.seeders,
+              leechers: metadata.leechers,
+              quality: metadata.quality
+            }
 
-          # Re-add to client using the original download URL
-          search_result = %Mydia.Indexers.SearchResult{
-            download_url: updated.download_url,
-            title: updated.title,
-            indexer: updated.indexer,
-            size: metadata.size,
-            seeders: metadata.seeders,
-            leechers: metadata.leechers,
-            quality: metadata.quality
-          }
+            opts =
+              []
+              |> maybe_add_opt(:media_item_id, updated.media_item_id)
+              |> maybe_add_opt(:episode_id, updated.episode_id)
+              |> maybe_add_opt(:client_name, updated.download_client)
 
-          opts =
-            []
-            |> maybe_add_opt(:media_item_id, updated.media_item_id)
-            |> maybe_add_opt(:episode_id, updated.episode_id)
-            |> maybe_add_opt(:client_name, updated.download_client)
+            # Delete old download record and create new one
+            Downloads.delete_download(updated)
 
-          # Delete old download record and create new one
-          Downloads.delete_download(updated)
+            case Downloads.initiate_download(search_result, opts) do
+              {:ok, _new_download} ->
+                {:noreply,
+                 socket
+                 |> put_flash(:info, "Download re-initiated")
+                 |> load_downloads()}
 
-          case Downloads.initiate_download(search_result, opts) do
-            {:ok, _new_download} ->
-              {:noreply,
-               socket
-               |> put_flash(:info, "Download re-initiated")
-               |> load_downloads()}
+              {:error, reason} ->
+                {:noreply,
+                 put_flash(socket, :error, "Failed to retry download: #{inspect(reason)}")}
+            end
 
-            {:error, reason} ->
-              {:noreply,
-               put_flash(socket, :error, "Failed to retry download: #{inspect(reason)}")}
-          end
-
-        {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to update download")}
-      end
+          {:error, _changeset} ->
+            {:noreply, put_flash(socket, :error, "Failed to update download")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -337,35 +338,35 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("retry_import", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id, preload: [:media_item, :episode])
+      with_download(socket, id, [preload: [:media_item, :episode]], fn download ->
+        # Clear retry metadata and trigger immediate import
+        case Downloads.update_download(download, %{
+               import_retry_count: 0,
+               import_last_error: nil,
+               import_next_retry_at: nil,
+               import_failed_at: nil
+             }) do
+          {:ok, updated} ->
+            # Enqueue import job with immediate execution
+            %{
+              "download_id" => updated.id,
+              "save_path" => nil,
+              "cleanup_client" => true,
+              "use_hardlinks" => true,
+              "move_files" => false
+            }
+            |> Mydia.Jobs.MediaImport.new()
+            |> Oban.insert()
 
-      # Clear retry metadata and trigger immediate import
-      case Downloads.update_download(download, %{
-             import_retry_count: 0,
-             import_last_error: nil,
-             import_next_retry_at: nil,
-             import_failed_at: nil
-           }) do
-        {:ok, updated} ->
-          # Enqueue import job with immediate execution
-          %{
-            "download_id" => updated.id,
-            "save_path" => nil,
-            "cleanup_client" => true,
-            "use_hardlinks" => true,
-            "move_files" => false
-          }
-          |> Mydia.Jobs.MediaImport.new()
-          |> Oban.insert()
+            {:noreply,
+             socket
+             |> put_flash(:info, "Import retry initiated")
+             |> load_downloads()}
 
-          {:noreply,
-           socket
-           |> put_flash(:info, "Import retry initiated")
-           |> load_downloads()}
-
-        {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to retry import")}
-      end
+          {:error, _changeset} ->
+            {:noreply, put_flash(socket, :error, "Failed to retry import")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -373,22 +374,22 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("delete_download", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
+      with_download(socket, id, fn download ->
+        # First try to remove from client (ignore errors if already removed)
+        _ = Downloads.cancel_download(download, delete_files: true)
 
-      # First try to remove from client (ignore errors if already removed)
-      _ = Downloads.cancel_download(download, delete_files: true)
+        # Then delete from database
+        case Downloads.delete_download(download) do
+          {:ok, _deleted} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Download removed")
+             |> load_downloads()}
 
-      # Then delete from database
-      case Downloads.delete_download(download) do
-        {:ok, _deleted} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Download removed")
-           |> load_downloads()}
-
-        {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to delete download")}
-      end
+          {:error, _changeset} ->
+            {:noreply, put_flash(socket, :error, "Failed to delete download")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -401,53 +402,14 @@ defmodule MydiaWeb.DownloadsLive.Index do
       results =
         Enum.map(selected_ids, fn id ->
           try do
-            download = Downloads.get_download!(id, preload: [:media_item, :episode])
+            case Downloads.get_download(id, preload: [:media_item, :episode]) do
+              # Deleted while the selection sat open — nothing left to retry, so
+              # it is not counted as a success (issue #281).
+              nil ->
+                {:error, :not_found}
 
-            # Check if this is an import failure or download failure
-            if download.import_last_error do
-              # Import failure - retry import
-              case Downloads.update_download(download, %{
-                     import_retry_count: 0,
-                     import_last_error: nil,
-                     import_next_retry_at: nil,
-                     import_failed_at: nil
-                   }) do
-                {:ok, updated} ->
-                  %{
-                    "download_id" => updated.id,
-                    "save_path" => nil,
-                    "cleanup_client" => true,
-                    "use_hardlinks" => true,
-                    "move_files" => false
-                  }
-                  |> Mydia.Jobs.MediaImport.new()
-                  |> Oban.insert()
-
-                error ->
-                  error
-              end
-            else
-              # Download failure - retry download
-              metadata = DownloadMetadata.from_map(download.metadata)
-
-              search_result = %Mydia.Indexers.SearchResult{
-                download_url: download.download_url,
-                title: download.title,
-                indexer: download.indexer,
-                size: metadata.size,
-                seeders: metadata.seeders,
-                leechers: metadata.leechers,
-                quality: metadata.quality
-              }
-
-              opts =
-                []
-                |> maybe_add_opt(:media_item_id, download.media_item_id)
-                |> maybe_add_opt(:episode_id, download.episode_id)
-                |> maybe_add_opt(:client_name, download.download_client)
-
-              Downloads.delete_download(download)
-              Downloads.initiate_download(search_result, opts)
+              download ->
+                batch_retry_one(download)
             end
           rescue
             _ -> {:error, :failed}
@@ -474,11 +436,19 @@ defmodule MydiaWeb.DownloadsLive.Index do
       results =
         Enum.map(selected_ids, fn id ->
           try do
-            download = Downloads.get_download!(id)
-            # Try to remove from client (ignore errors)
-            _ = Downloads.cancel_download(download, delete_files: true)
-            # Delete from database
-            Downloads.delete_download(download)
+            case Downloads.get_download(id) do
+              # Already gone. The operator asked for it removed and it is
+              # removed, so this counts toward the total rather than reading as
+              # a failure they need to act on (issue #281).
+              nil ->
+                {:ok, :already_removed}
+
+              download ->
+                # Try to remove from client (ignore errors)
+                _ = Downloads.cancel_download(download, delete_files: true)
+                # Delete from database
+                Downloads.delete_download(download)
+            end
           rescue
             _ -> {:error, :failed}
           end
@@ -545,18 +515,18 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("clear_single_completed", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
+      with_download(socket, id, fn download ->
+        case Downloads.clear_completed(download) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Download cleared from history")
+             |> load_downloads()}
 
-      case Downloads.clear_completed(download) do
-        {:ok, _} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Download cleared from history")
-           |> load_downloads()}
-
-        {:error, reason} ->
-          {:noreply, put_flash(socket, :error, "Failed to clear download: #{inspect(reason)}")}
-      end
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, "Failed to clear download: #{inspect(reason)}")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -723,35 +693,35 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("open_match_files", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id, preload: [:media_item, :library_path])
+      with_download(socket, id, [preload: [:media_item, :library_path]], fn download ->
+        case ImportCandidates.load(download) do
+          {:ok, source, candidates} ->
+            episodes =
+              if download.media_item && download.media_item.type == "tv_show" do
+                Media.list_episodes(download.media_item.id)
+              else
+                []
+              end
 
-      case ImportCandidates.load(download) do
-        {:ok, source, candidates} ->
-          episodes =
-            if download.media_item && download.media_item.type == "tv_show" do
-              Media.list_episodes(download.media_item.id)
-            else
-              []
-            end
+            {:noreply,
+             socket
+             |> assign(:match_files_error, nil)
+             |> assign(:match_files_modal, %{
+               download: download,
+               source: source,
+               candidates: candidates,
+               episodes: episodes
+             })}
 
-          {:noreply,
-           socket
-           |> assign(:match_files_error, nil)
-           |> assign(:match_files_modal, %{
-             download: download,
-             source: source,
-             candidates: candidates,
-             episodes: episodes
-           })}
-
-        {:error, :unavailable} ->
-          {:noreply,
-           put_flash(
-             socket,
-             :error,
-             "Mydia could not read this download's folder and has no recorded listing for it."
-           )}
-      end
+          {:error, :unavailable} ->
+            {:noreply,
+             put_flash(
+               socket,
+               :error,
+               "Mydia could not read this download's folder and has no recorded listing for it."
+             )}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -765,18 +735,22 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   def handle_event("match_files_import", params, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      %{download: modal_download, candidates: candidates} = socket.assigns.match_files_modal
+    %{download: modal_download, candidates: candidates} = socket.assigns.match_files_modal
 
-      # Re-read the download at submit time rather than trusting the assign
-      # captured when the modal opened. The modal has no way to notice a
-      # re-bind: the separate match/re-match modal can rebind this download to
-      # a different show while this one stays open, and process_targeted_import/3
-      # must build destinations from the CURRENT media_item — trusting the
-      # stale struct would link an episode from the OLD show onto files
-      # imported under the NEW one.
-      download = Downloads.get_download!(modal_download.id, preload: [:media_item])
-
+    # Re-read the download at submit time rather than trusting the assign
+    # captured when the modal opened. The modal has no way to notice a
+    # re-bind: the separate match/re-match modal can rebind this download to
+    # a different show while this one stays open, and process_targeted_import/3
+    # must build destinations from the CURRENT media_item — trusting the
+    # stale struct would link an episode from the OLD show onto files
+    # imported under the NEW one.
+    #
+    # That same re-read is where the row can turn out to be gone entirely — the
+    # modal can sit open across an import that deletes it (issue #281) — so the
+    # `nil` branch below closes the modal instead of crashing the socket.
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         %Download{} = download <-
+           Downloads.get_download(modal_download.id, preload: [:media_item]) do
       # Defense in depth: a disabled <select> only stops a normal browser. Never
       # trust a submitted path or target purely from client state — re-derive
       # what's actually allowed from the socket's own candidate list and the
@@ -869,35 +843,39 @@ defmodule MydiaWeb.DownloadsLive.Index do
           end
       end
     else
-      {:unauthorized, socket} -> {:noreply, socket}
+      {:unauthorized, socket} ->
+        {:noreply, socket}
+
+      nil ->
+        {:noreply, download_vanished(socket)}
     end
   end
 
   def handle_event("reject_release", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
+      with_download(socket, id, fn download ->
+        case Downloads.reject_release(download) do
+          {:ok, :rejected} ->
+            flash =
+              case Blacklists.extract_key(download) do
+                {:ok, _indexer, _guid} ->
+                  "Release blacklisted and a new search was queued"
 
-      case Downloads.reject_release(download) do
-        {:ok, :rejected} ->
-          flash =
-            case Blacklists.extract_key(download) do
-              {:ok, _indexer, _guid} ->
-                "Release blacklisted and a new search was queued"
+                {:error, _} ->
+                  "Download removed and a new search was queued"
+              end
 
-              {:error, _} ->
-                "Download removed and a new search was queued"
-            end
+            {:noreply,
+             socket
+             |> assign(:match_files_modal, nil)
+             |> assign(:match_files_error, nil)
+             |> put_flash(:info, flash)
+             |> load_downloads()}
 
-          {:noreply,
-           socket
-           |> assign(:match_files_modal, nil)
-           |> assign(:match_files_error, nil)
-           |> put_flash(:info, flash)
-           |> load_downloads()}
-
-        {:error, _reason} ->
-          {:noreply, assign(socket, :match_files_error, "Failed to reject the release.")}
-      end
+          {:error, _reason} ->
+            {:noreply, assign(socket, :match_files_error, "Failed to reject the release.")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -908,21 +886,21 @@ defmodule MydiaWeb.DownloadsLive.Index do
   # operator gets warned again.
   def handle_event("keep_waiting", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
+      with_download(socket, id, fn download ->
+        case Downloads.update_download(download, %{
+               stalled_since: nil,
+               last_progress_at: DateTime.utc_now()
+             }) do
+          {:ok, _updated} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Stall timer reset. Mydia will keep waiting on this download.")
+             |> load_downloads()}
 
-      case Downloads.update_download(download, %{
-             stalled_since: nil,
-             last_progress_at: DateTime.utc_now()
-           }) do
-        {:ok, _updated} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, "Stall timer reset. Mydia will keep waiting on this download.")
-           |> load_downloads()}
-
-        {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Could not reset the stall timer")}
-      end
+          {:error, _changeset} ->
+            {:noreply, put_flash(socket, :error, "Could not reset the stall timer")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -930,15 +908,15 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("dismiss_download", %{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
+      with_download(socket, id, fn download ->
+        case Downloads.dismiss_download(download) do
+          {:ok, _} ->
+            {:noreply, load_downloads(socket)}
 
-      case Downloads.dismiss_download(download) do
-        {:ok, _} ->
-          {:noreply, load_downloads(socket)}
-
-        {:error, _} ->
-          {:noreply, put_flash(socket, :error, "Failed to dismiss download")}
-      end
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Failed to dismiss download")}
+        end
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -1085,6 +1063,85 @@ defmodule MydiaWeb.DownloadsLive.Index do
         downloads = get_current_downloads(socket)
         stream(socket, :downloads, downloads, reset: true)
     end
+  end
+
+  # Retries one selected row: an import failure re-runs the import, a download
+  # failure re-grabs the release. Returns the `{status, _}` shape the batch
+  # tally counts.
+  defp batch_retry_one(download) do
+    if download.import_last_error do
+      # Import failure - retry import
+      case Downloads.update_download(download, %{
+             import_retry_count: 0,
+             import_last_error: nil,
+             import_next_retry_at: nil,
+             import_failed_at: nil
+           }) do
+        {:ok, updated} ->
+          %{
+            "download_id" => updated.id,
+            "save_path" => nil,
+            "cleanup_client" => true,
+            "use_hardlinks" => true,
+            "move_files" => false
+          }
+          |> Mydia.Jobs.MediaImport.new()
+          |> Oban.insert()
+
+        error ->
+          error
+      end
+    else
+      # Download failure - retry download
+      metadata = DownloadMetadata.from_map(download.metadata)
+
+      search_result = %Mydia.Indexers.SearchResult{
+        download_url: download.download_url,
+        title: download.title,
+        indexer: download.indexer,
+        size: metadata.size,
+        seeders: metadata.seeders,
+        leechers: metadata.leechers,
+        quality: metadata.quality
+      }
+
+      opts =
+        []
+        |> maybe_add_opt(:media_item_id, download.media_item_id)
+        |> maybe_add_opt(:episode_id, download.episode_id)
+        |> maybe_add_opt(:client_name, download.download_client)
+
+      Downloads.delete_download(download)
+      Downloads.initiate_download(search_result, opts)
+    end
+  end
+
+  # Loads the download an event names and hands it to `fun`.
+  #
+  # The id came from the rendered page, so it can name a row that is already
+  # gone by the time the click lands: another tab, another operator, an import
+  # that completed, or DownloadMonitor's own reject path deletes rows while a
+  # Downloads view sits open. `get_download!/2` turned that ordinary race into a
+  # crashed LiveView; tell the operator and re-render instead (issue #281).
+  defp with_download(socket, id, opts \\ [], fun) do
+    case Downloads.get_download(id, opts) do
+      nil ->
+        {:noreply, download_vanished(socket)}
+
+      download ->
+        fun.(download)
+    end
+  end
+
+  # Any modal still open is about the row that just turned out to be gone, so
+  # close it rather than leaving the operator acting on a stale struct.
+  defp download_vanished(socket) do
+    socket
+    |> assign(:match_files_modal, nil)
+    |> assign(:match_files_error, nil)
+    |> assign(:match_modal, nil)
+    |> put_flash(:info, "That download no longer exists.")
+    |> load_downloads()
   end
 
   defp maybe_add_opt(opts, _key, nil), do: opts
@@ -1342,34 +1399,37 @@ defmodule MydiaWeb.DownloadsLive.Index do
   defp submit_match(socket, media_item_id, episode_id) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
       modal = socket.assigns.match_modal
-      download = Downloads.get_download!(modal.download_id)
 
-      {flash_kind, message} =
-        case modal.mode do
-          :inflight ->
-            case Downloads.manually_match_download(download, media_item_id, episode_id) do
-              {:ok, _} -> {:info, "Match updated — the import will use the corrected match."}
-              {:error, _} -> {:error, "Failed to update the match."}
-            end
+      # The match modal can sit open across a delete (issue #281), so close it
+      # and say so rather than crashing the socket on submit.
+      with_download(socket, modal.download_id, fn download ->
+        {flash_kind, message} =
+          case modal.mode do
+            :inflight ->
+              case Downloads.manually_match_download(download, media_item_id, episode_id) do
+                {:ok, _} -> {:info, "Match updated — the import will use the corrected match."}
+                {:error, _} -> {:error, "Failed to update the match."}
+              end
 
-          :postimport ->
-            case Downloads.rematch_imported_download(download, media_item_id, episode_id) do
-              {:ok, :enqueued} ->
-                {:info, "Re-match queued — the file will be moved and relinked."}
+            :postimport ->
+              case Downloads.rematch_imported_download(download, media_item_id, episode_id) do
+                {:ok, :enqueued} ->
+                  {:info, "Re-match queued — the file will be moved and relinked."}
 
-              {:ok, :unchanged} ->
-                {:info, "Already matched to that title."}
+                {:ok, :unchanged} ->
+                  {:info, "Already matched to that title."}
 
-              {:error, reason} ->
-                {:error, friendly_rematch_error(reason)}
-            end
-        end
+                {:error, reason} ->
+                  {:error, friendly_rematch_error(reason)}
+              end
+          end
 
-      {:noreply,
-       socket
-       |> assign(:match_modal, nil)
-       |> put_flash(flash_kind, message)
-       |> load_downloads()}
+        {:noreply,
+         socket
+         |> assign(:match_modal, nil)
+         |> put_flash(flash_kind, message)
+         |> load_downloads()}
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end

--- a/lib/mydia_web/live/media_live/show/download_events.ex
+++ b/lib/mydia_web/live/media_live/show/download_events.ex
@@ -15,13 +15,40 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
 
   require Logger
 
-  def show_download_cancel_confirm(%{"download-id" => download_id}, socket) do
-    download = Downloads.get_download!(download_id)
+  # Loads the download an event names and hands it to `fun`.
+  #
+  # The id came from the rendered page, so it can name a row that is already
+  # gone by the time the click lands — an import that completed, another tab, or
+  # DownloadMonitor's own reject path. `get_download!/2` turned that ordinary
+  # race into a crashed LiveView; tell the operator and re-render (issue #281).
+  defp with_download(socket, id, opts \\ [], fun) do
+    case Downloads.get_download(id, opts) do
+      nil ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "That download no longer exists.")
+         |> refresh_downloads()}
 
-    {:noreply,
-     socket
-     |> assign(:show_download_cancel_confirm, true)
-     |> assign(:download_to_cancel, download)}
+      download ->
+        fun.(download)
+    end
+  end
+
+  defp refresh_downloads(socket) do
+    assign(
+      socket,
+      :downloads_with_status,
+      load_downloads_with_status(socket.assigns.media_item)
+    )
+  end
+
+  def show_download_cancel_confirm(%{"download-id" => download_id}, socket) do
+    with_download(socket, download_id, fn download ->
+      {:noreply,
+       socket
+       |> assign(:show_download_cancel_confirm, true)
+       |> assign(:download_to_cancel, download)}
+    end)
   end
 
   def hide_download_cancel_confirm(_params, socket) do
@@ -52,12 +79,12 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
   end
 
   def show_download_delete_confirm(%{"download-id" => download_id}, socket) do
-    download = Downloads.get_download!(download_id)
-
-    {:noreply,
-     socket
-     |> assign(:show_download_delete_confirm, true)
-     |> assign(:download_to_delete, download)}
+    with_download(socket, download_id, fn download ->
+      {:noreply,
+       socket
+       |> assign(:show_download_delete_confirm, true)
+       |> assign(:download_to_delete, download)}
+    end)
   end
 
   def hide_download_delete_confirm(_params, socket) do
@@ -89,12 +116,12 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
   end
 
   def show_download_details(%{"download-id" => download_id}, socket) do
-    download = Downloads.get_download!(download_id)
-
-    {:noreply,
-     socket
-     |> assign(:show_download_details_modal, true)
-     |> assign(:download_details, download)}
+    with_download(socket, download_id, fn download ->
+      {:noreply,
+       socket
+       |> assign(:show_download_details_modal, true)
+       |> assign(:download_details, download)}
+    end)
   end
 
   def hide_download_details(_params, socket) do
@@ -105,39 +132,40 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
   end
 
   def retry_download(%{"download-id" => download_id}, socket) do
-    download = Downloads.get_download!(download_id, preload: [:media_item, :episode])
+    with_download(socket, download_id, [preload: [:media_item, :episode]], fn download ->
+      case Downloads.update_download(download, %{error_message: nil}) do
+        {:ok, updated} ->
+          search_result = %SearchResult{
+            download_url: updated.download_url,
+            title: updated.title,
+            indexer: updated.indexer,
+            size: updated.metadata["size"],
+            seeders: updated.metadata["seeders"],
+            leechers: updated.metadata["leechers"],
+            quality: updated.metadata["quality"]
+          }
 
-    case Downloads.update_download(download, %{error_message: nil}) do
-      {:ok, updated} ->
-        search_result = %SearchResult{
-          download_url: updated.download_url,
-          title: updated.title,
-          indexer: updated.indexer,
-          size: updated.metadata["size"],
-          seeders: updated.metadata["seeders"],
-          leechers: updated.metadata["leechers"],
-          quality: updated.metadata["quality"]
-        }
+          opts =
+            []
+            |> maybe_add_opt(:media_item_id, updated.media_item_id)
+            |> maybe_add_opt(:episode_id, updated.episode_id)
+            |> maybe_add_opt(:client_name, updated.download_client)
 
-        opts =
-          []
-          |> maybe_add_opt(:media_item_id, updated.media_item_id)
-          |> maybe_add_opt(:episode_id, updated.episode_id)
-          |> maybe_add_opt(:client_name, updated.download_client)
+          Downloads.delete_download(updated)
 
-        Downloads.delete_download(updated)
+          case Downloads.initiate_download(search_result, opts) do
+            {:ok, _new_download} ->
+              {:noreply, put_flash(socket, :info, "Download re-initiated")}
 
-        case Downloads.initiate_download(search_result, opts) do
-          {:ok, _new_download} ->
-            {:noreply, put_flash(socket, :info, "Download re-initiated")}
+            {:error, reason} ->
+              {:noreply,
+               put_flash(socket, :error, "Failed to retry download: #{inspect(reason)}")}
+          end
 
-          {:error, reason} ->
-            {:noreply, put_flash(socket, :error, "Failed to retry download: #{inspect(reason)}")}
-        end
-
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Failed to update download")}
-    end
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, "Failed to update download")}
+      end
+    end)
   end
 
   @doc false
@@ -145,15 +173,23 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
   # record never reached a client, so there is nothing to clean up remotely.
   def dismiss_failed_grab(%{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-      {:ok, _} = Downloads.delete_download(download)
+      with_download(socket, id, fn download ->
+        # A failed grab another tab already dismissed reads as `{:error, _}` now
+        # that a vanished row no longer raises (issue #281). Either way the row
+        # is gone, which is what the operator asked for, so re-render and move on.
+        case Downloads.delete_download(download) do
+          {:ok, _} ->
+            :ok
 
-      {:noreply,
-       assign(
-         socket,
-         :downloads_with_status,
-         load_downloads_with_status(socket.assigns.media_item)
-       )}
+          {:error, changeset} ->
+            Logger.info("Failed grab already dismissed",
+              download_id: id,
+              errors: inspect(changeset.errors)
+            )
+        end
+
+        {:noreply, refresh_downloads(socket)}
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end

--- a/test/mydia/downloads/client/debrid/fetcher_test.exs
+++ b/test/mydia/downloads/client/debrid/fetcher_test.exs
@@ -272,6 +272,38 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
     end
   end
 
+  describe "the download row is deleted mid-fetch" do
+    # Issue #281. A missing row must be terminal, not a retryable error: every
+    # retry re-runs run/1 from the top, which makes a fresh provider call to
+    # re-resolve URLs, and past finalize/2 would re-download the entire payload
+    # — all against a row that no longer exists.
+    test "stops instead of consuming the retry budget", %{staging: staging} do
+      download = insert_download()
+
+      StubProvider.set(:get_download_urls, {:ok, ["http://127.0.0.1:65535/never-fetched.bin"]})
+      StubProvider.set(:rate_limit_budget, {100, 60})
+
+      # persist_urls/2 runs before any streaming, so the URL above is never
+      # fetched — the fetcher should be gone before it gets that far.
+      Repo.delete!(download)
+
+      :ok =
+        Fetcher.claim(
+          download_id: download.id,
+          config: config(staging),
+          provider_job: fake_provider_job(download.download_client_id),
+          provider_module: StubProvider,
+          jitter_ms: 0,
+          download_dir: staging
+        )
+
+      # 20 attempts × 100ms = a 2s budget. The first retry sleeps 5s before
+      # re-running, so exiting inside this window is the proof that the missing
+      # row was treated as terminal rather than retried.
+      :ok = wait_for_fetcher_exit(download.id, 20)
+    end
+  end
+
   # Polls the Fetcher's Registry entry until it's gone (or times out.)
   # Default budget is 30s — the Fetcher's retry-with-exponential-backoff
   # path (max_retries=3 with growing waits) needs more than the original

--- a/test/mydia/downloads/no_raising_download_getter_test.exs
+++ b/test/mydia/downloads/no_raising_download_getter_test.exs
@@ -1,0 +1,80 @@
+defmodule Mydia.Downloads.NoRaisingDownloadGetterTest do
+  @moduledoc """
+  Application code must load downloads with `Downloads.get_download/2`, never the
+  raising `get_download!/2`.
+
+  A download row is deleted routinely and from several directions: an operator
+  deleting from the UI, an import that finishes and cleans up, `Queue`/`Grabber`
+  stale-record cleanup, and `DownloadMonitor`'s own reject path. Anything holding
+  an id across a gap — an Oban job between enqueue and run, a poll between its
+  database snapshot and its per-row handler, a LiveView between render and click —
+  can find the row gone. That is an ordinary race, not an exceptional condition.
+
+  Issue #281 is what happens when the only getter raises: `Ecto.NoResultsError`
+  crashed `DownloadMonitor.perform/1` 356 times across two instances in five
+  weeks, and because the crash aborted the whole job, every handler queued behind
+  the failing one silently stopped running for that poll.
+
+  The deeper problem was that nil-safety was opt-in. Six call sites hand-rolled
+  `rescue Ecto.NoResultsError` around the bang getter and five forgot, with
+  nothing in the signature to say which was which. This guard removes the choice:
+  `get_download/2` returns `nil` and the compiler-visible return type forces the
+  caller to say what that means.
+
+  `get_download!/2` deliberately survives for tests, where a row that vanished
+  unexpectedly *should* fail loudly. It just may not be called from `lib/`.
+  """
+  use ExUnit.Case, async: true
+
+  # The definition, its delegate, and its `@spec` — the only places the name may
+  # legitimately appear under lib/. Everything else is a call site.
+  @definition_sites [
+    "lib/mydia/downloads.ex",
+    "lib/mydia/downloads/history.ex"
+  ]
+
+  test "no application code under lib/ calls the raising download getter" do
+    offenders =
+      "lib/**/*.ex"
+      |> Path.wildcard()
+      |> Enum.reject(&(&1 in @definition_sites))
+      |> Enum.flat_map(&raising_calls/1)
+
+    assert offenders == [], """
+    These call sites use the raising `get_download!/2` (issue #281):
+
+    #{Enum.map_join(offenders, "\n", fn {file, line, text} -> "  #{file}:#{line}  #{text}" end)}
+
+    Use `Mydia.Downloads.get_download/2` and handle `nil` explicitly. A download
+    row can be deleted between the read that produced its id and the read that
+    acts on it; that is expected, and raising there takes down the job or the
+    LiveView around it.
+    """
+  end
+
+  test "the definition sites expose a non-bang getter alongside the bang one" do
+    # Guards the guard: if `get_download/2` were ever removed, every call site
+    # above would have to go back to the bang version and the test above would
+    # still pass on an empty codebase-wide search.
+    for file <- @definition_sites do
+      source = File.read!(file)
+
+      assert source =~ "get_download(",
+             "#{file} must keep a non-bang `get_download/2` for lib/ to call"
+    end
+  end
+
+  # Strips comments before matching so the prose in this fix's own explanatory
+  # comments does not trip the guard. Matches a qualified call
+  # (`Downloads.get_download!(`) rather than the bare name, which would also hit
+  # `def`/`defdelegate`/`@spec`.
+  defp raising_calls(file) do
+    file
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.with_index(1)
+    |> Enum.reject(fn {line, _no} -> String.trim_leading(line) |> String.starts_with?("#") end)
+    |> Enum.filter(fn {line, _no} -> line =~ ~r/\.get_download!\(/ end)
+    |> Enum.map(fn {line, no} -> {file, no, String.trim(line)} end)
+  end
+end

--- a/test/mydia/downloads/no_raising_download_getter_test.exs
+++ b/test/mydia/downloads/no_raising_download_getter_test.exs
@@ -26,8 +26,11 @@ defmodule Mydia.Downloads.NoRaisingDownloadGetterTest do
   """
   use ExUnit.Case, async: true
 
-  # The definition, its delegate, and its `@spec` — the only places the name may
-  # legitimately appear under lib/. Everything else is a call site.
+  # Where the definition, its delegate, and its `@spec` live. Only the second
+  # test below uses this: the scan itself covers these files too, since
+  # `raising_calls/1` matches a *qualified* call and so cannot be tripped by
+  # `def`, `defdelegate`, or `@spec`. Excluding them would have blinded the guard
+  # to a real call added to either file later.
   @definition_sites [
     "lib/mydia/downloads.ex",
     "lib/mydia/downloads/history.ex"
@@ -37,7 +40,6 @@ defmodule Mydia.Downloads.NoRaisingDownloadGetterTest do
     offenders =
       "lib/**/*.ex"
       |> Path.wildcard()
-      |> Enum.reject(&(&1 in @definition_sites))
       |> Enum.flat_map(&raising_calls/1)
 
     assert offenders == [], """

--- a/test/mydia/downloads/seedbox/fetcher_test.exs
+++ b/test/mydia/downloads/seedbox/fetcher_test.exs
@@ -397,6 +397,35 @@ defmodule Mydia.Downloads.Seedbox.FetcherTest do
     assert File.exists?(remote_file)
   end
 
+  # Issue #281. finalize/1 runs after transfer_all/2 has copied everything and
+  # maybe_delete_remote/2 has removed the source, so a missing row must be
+  # terminal: retrying would re-open SFTP for a remote path that no longer
+  # exists, three times over.
+  test "a download deleted mid-fetch stops the fetcher instead of retrying", %{
+    remote_root: remote_root,
+    local_root: local_root,
+    port: port
+  } do
+    download = insert_download!("seedbox-qbit")
+    remote_file = Path.join(remote_root, "release.mkv")
+    File.write!(remote_file, "hello world")
+
+    Repo.delete!(download)
+
+    assert :ok =
+             Fetcher.claim(
+               download_id: download.id,
+               client_name: "seedbox-qbit",
+               remote_fetch: remote_fetch_config(port),
+               remote_path: remote_file,
+               download_directory: local_root
+             )
+
+    # 20 attempts × 100ms = a 2s budget, against a 5s first retry delay. Exiting
+    # inside this window is the proof that the missing row was terminal.
+    wait_for_fetcher_exit(download.id, 20)
+  end
+
   defp wait_for_fetcher_exit(download_id, attempts \\ 100)
   defp wait_for_fetcher_exit(_download_id, 0), do: flunk("fetcher did not exit in time")
 

--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -539,6 +539,31 @@ defmodule Mydia.DownloadsTest do
     end
   end
 
+  describe "stale_changeset?/1" do
+    # Callers have to tell "this row is gone" apart from "this write was
+    # invalid": retrying the first is pointless and, in the fetchers, expensive
+    # enough to re-download a whole payload. Reads Ecto's `stale: true` tag
+    # rather than the message text, so rewording the error cannot break it.
+    test "is true for a write against a deleted row" do
+      download = download_fixture()
+      Repo.delete_all(from(d in Download, where: d.id == ^download.id))
+
+      {:error, changeset} = Downloads.update_download(download, %{title: "Nope"})
+
+      assert Downloads.stale_changeset?(changeset)
+    end
+
+    test "is false for an ordinary validation failure" do
+      download = download_fixture()
+
+      # `title` is required, so blanking it is a plain validation error on a row
+      # that is still very much present.
+      {:error, changeset} = Downloads.update_download(download, %{title: nil})
+
+      refute Downloads.stale_changeset?(changeset)
+    end
+  end
+
   describe "mark_download_completed/1 and mark_download_failed/2" do
     # These two write through `Repo.update/2` directly rather than through
     # `update_download/2`, so they need the same stale handling. `DownloadMonitor`

--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -452,6 +452,36 @@ defmodule Mydia.DownloadsTest do
     end
   end
 
+  describe "get_download/2" do
+    test "returns the download with given id" do
+      download = download_fixture()
+      assert Downloads.get_download(download.id).id == download.id
+    end
+
+    # The whole point of the non-bang getter (issue #281): every caller in lib/
+    # holds an id across a gap during which the row can be deleted, so "gone" has
+    # to be an ordinary return value rather than an exception.
+    test "returns nil rather than raising when the row no longer exists" do
+      download = download_fixture()
+      {:ok, _} = Downloads.delete_download(download)
+
+      assert Downloads.get_download(download.id) == nil
+      assert Downloads.get_download(Ecto.UUID.generate()) == nil
+    end
+
+    test "applies the requested preloads" do
+      # The local `download_fixture/1` leaves `media_item_id` nil, so bind one
+      # explicitly — otherwise a preloaded association reads as nil whether or
+      # not the preload was applied, and the assertion proves nothing.
+      media_item = media_item_fixture()
+      download = download_fixture(%{media_item_id: media_item.id})
+
+      loaded = Downloads.get_download(download.id, preload: [:media_item])
+
+      assert loaded.media_item.id == media_item.id
+    end
+  end
+
   describe "create_download/1" do
     test "creates a download with valid attributes" do
       attrs = %{
@@ -474,6 +504,22 @@ defmodule Mydia.DownloadsTest do
 
       assert updated.title == "Updated Title"
     end
+
+    # The write half of issue #281. `Repo.update/2` filters by primary key on
+    # every write and raises `Ecto.StaleEntryError` when that matches no rows —
+    # this is the default, not something `optimistic_lock` opts you into. Holding
+    # a struct across a delete is routine here (a poll's snapshot, a confirm
+    # modal), so the context converts it to the `{:error, changeset}` callers
+    # already handle.
+    test "returns an error rather than raising when the row was deleted" do
+      download = download_fixture()
+      Repo.delete_all(from(d in Download, where: d.id == ^download.id))
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Downloads.update_download(download, %{title: "Updated Title"})
+
+      assert "no longer exists" in errors_on(changeset).id
+    end
   end
 
   describe "delete_download/1" do
@@ -482,6 +528,28 @@ defmodule Mydia.DownloadsTest do
 
       assert {:ok, %Download{}} = Downloads.delete_download(download)
       assert_raise Ecto.NoResultsError, fn -> Downloads.get_download!(download.id) end
+    end
+
+    test "returns an error rather than raising when the row is already gone" do
+      download = download_fixture()
+      Repo.delete_all(from(d in Download, where: d.id == ^download.id))
+
+      assert {:error, %Ecto.Changeset{} = changeset} = Downloads.delete_download(download)
+      assert "no longer exists" in errors_on(changeset).id
+    end
+  end
+
+  describe "mark_download_completed/1 and mark_download_failed/2" do
+    # These two write through `Repo.update/2` directly rather than through
+    # `update_download/2`, so they need the same stale handling. `DownloadMonitor`
+    # calls `mark_download_completed/1` on every download a client reports
+    # finished, which is exactly where the race bites.
+    test "return an error rather than raising when the row was deleted" do
+      download = download_fixture()
+      Repo.delete_all(from(d in Download, where: d.id == ^download.id))
+
+      assert {:error, %Ecto.Changeset{}} = Downloads.mark_download_completed(download)
+      assert {:error, %Ecto.Changeset{}} = Downloads.mark_download_failed(download, "boom")
     end
   end
 

--- a/test/mydia/jobs/download_monitor_race_test.exs
+++ b/test/mydia/jobs/download_monitor_race_test.exs
@@ -1,0 +1,125 @@
+defmodule Mydia.Jobs.DownloadMonitorRaceTest do
+  @moduledoc """
+  Issue #281: a download deleted mid-poll must not crash `DownloadMonitor` or
+  stop the rest of the batch from being handled.
+
+  `perform/1` calls `Downloads.list_downloads_with_status/1`, which reads every
+  download row from the database and only *then* polls each configured client
+  over HTTP. The six `Enum.each` passes that follow re-load each row by id. In
+  production, seconds pass in between — long enough for an operator delete, a
+  concurrent import, or the monitor's own reject path to remove a row. The
+  reload then raised `Ecto.NoResultsError`, which aborted `perform/1` outright:
+  356 occurrences across two instances in five weeks, each one also silently
+  skipping every handler queued behind the failing one.
+
+  The reproduction below needs no sleeps and cannot flake. Because the database
+  read strictly precedes the HTTP call, deleting the row *inside the Bypass
+  handler that answers the client poll* lands in that window on every single
+  run.
+
+  `async: false` is load-bearing, not incidental: `Mydia.DataCase` starts the
+  sandbox with `shared: not tags[:async]`, and the Bypass handler runs in its
+  own process, so only a shared connection lets it touch the database at all.
+  """
+  use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  import Ecto.Query
+
+  alias Mydia.Downloads
+  alias Mydia.Jobs.DownloadMonitor
+
+  import Mydia.MediaFixtures
+  import Mydia.DownloadsFixtures
+  import Mydia.SettingsFixtures
+
+  setup do
+    bypass = Bypass.open()
+
+    client_config =
+      download_client_config_fixture(%{
+        name: "race-client",
+        type: "qbittorrent",
+        host: "localhost",
+        port: bypass.port
+      })
+
+    Bypass.stub(bypass, "POST", "/api/v2/auth/login", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("set-cookie", "SID=test-sid; HttpOnly")
+      |> Plug.Conn.resp(200, "Ok.")
+    end)
+
+    {:ok, bypass: bypass, client: client_config}
+  end
+
+  test "a download deleted mid-poll neither crashes the job nor stops the batch", %{
+    bypass: bypass,
+    client: client
+  } do
+    media_item = media_item_fixture()
+
+    vanishing = download_for(media_item, client, "vanishing-hash")
+    survivor = download_for(media_item, client, "survivor-hash")
+
+    delete_during_poll(bypass, vanishing)
+
+    # Pre-fix this raises Ecto.NoResultsError straight out of perform_job/2.
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    assert Downloads.get_download(vanishing.id) == nil
+
+    # The assertion that actually matters. "Did not crash" alone would still pass
+    # if the poll bailed out after the vanished row; this proves the rest of the
+    # batch was handled. Persisting `error_message` is what moves a row into the
+    # Issues tab, so it is the observable outcome of `handle_missing/1`.
+    reloaded = Downloads.get_download(survivor.id)
+    refute is_nil(reloaded), "the surviving download was deleted by the poll"
+    refute is_nil(reloaded.error_message), "the surviving download was never handled"
+  end
+
+  test "a poll where every download vanishes still completes", %{
+    bypass: bypass,
+    client: client
+  } do
+    media_item = media_item_fixture()
+    doomed = download_for(media_item, client, "only-hash")
+
+    delete_during_poll(bypass, doomed)
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+    assert Downloads.get_download(doomed.id) == nil
+  end
+
+  defp download_for(media_item, client, hash) do
+    download_fixture(%{
+      media_item_id: media_item.id,
+      download_client: client.name,
+      download_client_id: hash
+    })
+  end
+
+  # Answers the client poll with an empty torrent list — so every download reads
+  # as "missing" and lands in `handle_missing/1` — and deletes `download` on the
+  # way past. That deletion is the whole point: it happens after the monitor has
+  # already read the rows and before any handler reloads one.
+  #
+  # `delete_all` rather than `delete!/1`: a single poll fans this endpoint out to
+  # several readers (`UntrackedMatcher` and `ExternalTorrents` alongside the
+  # monitor itself), so the stub runs more than once and the deletion has to be
+  # idempotent. `delete!/1` on the second pass raises `Ecto.StaleEntryError`
+  # inside the Bypass process and fails the test for the wrong reason.
+  defp delete_during_poll(bypass, download) do
+    test_pid = self()
+    id = download.id
+
+    Bypass.stub(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+      Ecto.Adapters.SQL.Sandbox.allow(Mydia.Repo, test_pid, self())
+      Mydia.Repo.delete_all(from(d in Mydia.Downloads.Download, where: d.id == ^id))
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, "[]")
+    end)
+  end
+end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -655,5 +655,33 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       # Nothing left to retry, so it is not reported as retried.
       assert render_click(view, "batch_retry", %{}) =~ "0 item(s) retried"
     end
+
+    # `match_files_import` is the one handler that already re-read its download
+    # at submit time (so a re-bind from the other modal cannot strand it on a
+    # stale media_item). That same re-read is where the row can turn out to be
+    # gone: the modal can sit open across an import that deletes it.
+    test "match_files_import closes the modal instead of crashing", %{conn: conn} do
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          metadata: %{
+            "import_candidates" => [
+              %{"path" => "/nope/ep01.mkv", "name" => "ep01.mkv", "size" => 1}
+            ]
+          }
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      # Opens from the stored candidate snapshot — no live listing needed.
+      render_click(view, "open_match_files", %{"id" => download.id})
+
+      {:ok, _} = Downloads.delete_download(download)
+
+      assert render_click(view, "match_files_import", %{}) =~
+               "That download no longer exists."
+    end
   end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -604,4 +604,56 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
         updated
     end
   end
+
+  # Issue #281: every one of these handlers loaded the download with the raising
+  # `get_download!/2`, so clicking a row that had been deleted since the page
+  # rendered — by an import that finished, by DownloadMonitor's reject path, or
+  # from another tab — took down the LiveView process instead of saying so. The
+  # row is deleted in setup, which is exactly the state a stale browser is in.
+  describe "acting on a download that no longer exists" do
+    setup do
+      media_item = media_item_fixture()
+      download = download_fixture(%{media_item_id: media_item.id})
+      {:ok, _} = Downloads.delete_download(download)
+
+      %{stale_id: download.id}
+    end
+
+    for event <- ~w(
+          cancel_download pause_download resume_download retry_download retry_import
+          delete_download clear_single_completed open_match_files reject_release
+          keep_waiting dismiss_download
+        ) do
+      test "#{event} tells the operator instead of crashing the socket", %{
+        conn: conn,
+        stale_id: stale_id
+      } do
+        {:ok, view, _html} = live(conn, ~p"/downloads")
+
+        assert render_click(view, unquote(event), %{"id" => stale_id}) =~
+                 "That download no longer exists."
+      end
+    end
+
+    test "batch_delete counts an already-deleted row rather than failing it", %{
+      conn: conn,
+      stale_id: stale_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      render_click(view, "toggle_select", %{"id" => stale_id})
+
+      # The operator asked for it removed and it is removed, so it counts.
+      assert render_click(view, "batch_delete", %{}) =~ "1 download(s) removed"
+    end
+
+    test "batch_retry does not count an already-deleted row", %{conn: conn, stale_id: stale_id} do
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+
+      render_click(view, "toggle_select", %{"id" => stale_id})
+
+      # Nothing left to retry, so it is not reported as retried.
+      assert render_click(view, "batch_retry", %{}) =~ "0 item(s) retried"
+    end
+  end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -677,11 +677,16 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
 
       # Opens from the stored candidate snapshot — no live listing needed.
       render_click(view, "open_match_files", %{"id" => download.id})
+      assert has_element?(view, "#match-files-modal")
 
       {:ok, _} = Downloads.delete_download(download)
 
       assert render_click(view, "match_files_import", %{}) =~
                "That download no longer exists."
+
+      # The flash alone would pass even if the modal stayed open on a download
+      # that no longer exists, leaving the operator submitting into nothing.
+      refute has_element?(view, "#match-files-modal")
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/download_events_missing_row_test.exs
+++ b/test/mydia_web/live/media_live/show/download_events_missing_row_test.exs
@@ -1,0 +1,63 @@
+defmodule MydiaWeb.MediaLive.Show.DownloadEventsMissingRowTest do
+  @moduledoc """
+  Issue #281: the download-related events on the media detail page loaded their
+  row with the raising `get_download!/2`.
+
+  The id comes from the rendered page, so it can name a row that is already gone
+  by the time the click lands — an import that finished and cleaned up, another
+  tab, or `DownloadMonitor`'s reject path. That crashed the LiveView process
+  rather than telling the operator anything.
+
+  The row is deleted in setup, which is exactly the state a stale browser tab is
+  in when the operator clicks.
+  """
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import Mydia.DownloadsFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Downloads
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    conn = log_in_user(conn, admin)
+    movie = media_item_fixture(%{type: "movie", title: "Some Movie", year: 2020})
+
+    download = download_fixture(%{media_item_id: movie.id})
+    {:ok, _} = Downloads.delete_download(download)
+
+    %{conn: conn, movie: movie, stale_id: download.id}
+  end
+
+  for event <- ~w(show_download_cancel_confirm show_download_delete_confirm
+                  show_download_details retry_download) do
+    test "#{event} tells the operator instead of crashing the socket", %{
+      conn: conn,
+      movie: movie,
+      stale_id: stale_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+
+      assert render_click(view, unquote(event), %{"download-id" => stale_id}) =~
+               "That download no longer exists."
+    end
+  end
+
+  # Keyed on "id" rather than "download-id", and it is the one that carried a
+  # strict `{:ok, _} = delete_download(...)` match — which, now that a vanished
+  # row returns `{:error, changeset}` instead of raising `Ecto.StaleEntryError`,
+  # would have become a MatchError.
+  test "dismiss_failed_grab survives a row another tab already dismissed", %{
+    conn: conn,
+    movie: movie,
+    stale_id: stale_id
+  } do
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+
+    assert render_click(view, "dismiss_failed_grab", %{"id" => stale_id}) =~
+             "That download no longer exists."
+  end
+end


### PR DESCRIPTION
Fixes #281.

## What was happening

`DownloadMonitor.perform/1` reads every download row from the database, *then* polls each configured client over HTTP, then fans the result out over six `Enum.each` passes that each reload their row by id. In production seconds pass between the snapshot and the reload — long enough for an operator delete, a concurrent import, `Queue`/`Grabber` cleanup, or the monitor's own reject path to remove the row.

Five of those six handlers used the raising `get_download!/2` with no guard, so a row deleted inside that window raised `Ecto.NoResultsError` and aborted the whole job. Every handler queued behind the failing one was silently skipped for that poll. That is the same amplification #278 fixed for the stall-detection reduce, in the same file, in the passes it did not cover.

356 occurrences across two instances between 2026-06-26 and 2026-07-31, ongoing. The reported query's `preload: [:media_item]` is a usable fingerprint: it matches `handle_completion`, `handle_failure`, `reject_bad_content` and `handle_missing` exactly, and among all other call sites in the repo only `downloads_live/index.ex`'s `match_files_import`.

## The root cause was the missing primitive

`Mydia.Downloads` exposed only `get_download!/2`. Nil-safety was therefore opt-in: six call sites hand-rolled `rescue Ecto.NoResultsError` around the bang getter and five forgot, with nothing in the signature to say which was which. Sprinkling a sixth rescue would have left the next call site exactly as exposed.

So this adds `get_download/2` — the same shape as the existing `Library.get_media_file/2` and `Collections.get_collection_by_id/2` — and converts every one of the 43 call sites in `lib/`, deleting the ad-hoc rescues as it goes.

## The write half was broken too

`Repo.update/2` and `Repo.delete/2` filter by primary key on every write and raise `Ecto.StaleEntryError` when that matches zero rows. This is the default for any write, **not** something `optimistic_lock` opts you into, and the non-bang variants raise just the same. So `update_download/2` and `delete_download/1` raised if the row vanished between a caller's reload and its write — an exposure wider than #281, covering every `update_download` caller including `handle_stale_grab/1`, which writes a struct from `list_stale_grabs/1` with no reload at all.

Fixed at the choke point with Ecto's own `:stale_error_field`, which converts the raise into the `{:error, changeset}` every caller already handles. Four lines in one file; no call site needed changing. Two strict `{:ok, _} =` matches that would have become `MatchError` got real error branches.

## LiveViews

All 20 download reads in the web layer sit in `handle_event` handlers — none in `mount` or `handle_params`, where raising a 404 would be correct. So every one was a crash-the-socket bug: delete a download in one tab, click it in another, and the second tab's LiveView process died. Each module gets a `with_download` helper that flashes and re-renders instead, closing any modal that was about the now-deleted row.

The two batch handlers differ, since they iterate a selection: `batch_delete` counts an already-deleted row as removed (the operator asked for it gone and it is gone), while `batch_retry` does not count it (nothing left to retry).

## Tests

The race reproduction is deterministic and needs no sleeps. `list_downloads_with_status/1` reads the rows before it calls any client, so deleting a row **inside the Bypass handler that answers the client poll** lands in the exact window on every run.

I verified the test earns its keep by reverting `DownloadMonitor` to the raising reload: both race tests fail with `Ecto.NoResultsError`, and pass again with the fix. The load-bearing assertion is that the *other* download in the same batch was still handled — asserting only that `perform/1` returns `:ok` would pass even if the poll bailed out early.

Also adds a guard test asserting `get_download!` appears nowhere under `lib/`. The function stays for tests, where a row that vanished unexpectedly should fail loudly; it just may not be called from application code. Without it this fix erodes the same way the bug arrived.

## Verification

- `mix test test/mydia/downloads_test.exs test/mydia/downloads/ test/mydia/jobs/` — 1628 tests, 0 failures
- `mix test test/mydia_web/live/downloads_live/ test/mydia_web/live/media_live/` — 334 tests, 1 failure
- `mix precommit`

The one web failure is `ManualSearchInfoLinkTest`, which is unrelated and pre-existing: it fails in isolation at `--seed 0` with this branch's `lib/` changes reverted to master's, and a different manual-search test fails at other seeds. Nothing in this diff touches manual search.

## Note for review

`evaluate_and_apply/3` keeps its own containment rather than being folded into the new `with_download/4`. It evaluates the in-memory struct before touching the database (`StallDetector.evaluate/7` can raise first), reloads only inside some decision branches, and must return a counted `{stalled, failures}` tuple rather than `:ok`. Its now-unreachable `Ecto.NoResultsError` clause is gone; the broad rescue and the `catch :exit` from #278 stay. There is a comment saying so, so nobody force-unifies the two later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Download actions now handle records deleted during processing without crashing.
  * Monitoring, retrying, deleting, importing, matching, and rejecting downloads continue safely when downloads disappear.
  * Background transfers stop normally instead of retrying deleted downloads.
  * Stale dialogs and actions refresh appropriately and display a clear “That download no longer exists.” message.
  * Concurrent updates and deletions return recoverable errors instead of raising unexpected exceptions.

* **Tests**
  * Added regression coverage for deleted downloads across monitoring, background processing, batch actions, and LiveView interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->