### PR TITLE
fix(downloads): tolerate a download row deleted mid-flight

### DIFF
--- a/lib/mydia/downloads.ex
+++ b/lib/mydia/downloads.ex
@@ -118,6 +118,24 @@ defmodule Mydia.Downloads do
   defdelegate get_download!(id, opts \\ []), to: Mydia.Downloads.History
 
   @doc """
+  Gets a single download, or `nil` if it no longer exists.
+
+  Prefer this over `get_download!/2` in background jobs and LiveView handlers,
+  which act on an id captured earlier and must tolerate the row having been
+  imported, cleared, or deleted in the meantime (issue #281).
+  """
+  @spec get_download(binary(), keyword()) :: Download.t() | nil
+  defdelegate get_download(id, opts \\ []), to: Mydia.Downloads.History
+
+  @doc """
+  True when a write failed because the download row no longer exists.
+
+  See `Mydia.Downloads.History.stale_error?/1`.
+  """
+  @spec stale_error?(term()) :: boolean()
+  defdelegate stale_error?(changeset), to: Mydia.Downloads.History
+
+  @doc """
   Creates a download.
   """
   @spec create_download(map()) :: {:ok, Download.t()} | {:error, Ecto.Changeset.t()}
@@ -125,6 +143,9 @@ defmodule Mydia.Downloads do
 
   @doc """
   Updates a download.
+
+  Returns `{:error, changeset}` if the row no longer exists; `stale_error?/1`
+  distinguishes that from a validation failure.
   """
   @spec update_download(Download.t(), map()) :: {:ok, Download.t()} | {:error, Ecto.Changeset.t()}
   defdelegate update_download(download, attrs), to: Mydia.Downloads.History
@@ -148,6 +169,8 @@ defmodule Mydia.Downloads do
 
   @doc """
   Marks a download as completed by storing the completion time.
+
+  Returns `{:error, changeset}` if the row no longer exists; see `stale_error?/1`.
   """
   @spec mark_download_completed(Download.t()) ::
           {:ok, Download.t()} | {:error, Ecto.Changeset.t()}
@@ -155,6 +178,8 @@ defmodule Mydia.Downloads do
 
   @doc """
   Records an error message for a download.
+
+  Returns `{:error, changeset}` if the row no longer exists; see `stale_error?/1`.
   """
   @spec mark_download_failed(Download.t(), String.t()) ::
           {:ok, Download.t()} | {:error, Ecto.Changeset.t()}
@@ -162,6 +187,8 @@ defmodule Mydia.Downloads do
 
   @doc """
   Deletes a download.
+
+  Idempotent: a row another process already deleted still returns `{:ok, download}`.
   """
   @spec delete_download(Download.t()) :: {:ok, Download.t()} | {:error, Ecto.Changeset.t()}
   defdelegate delete_download(download), to: Mydia.Downloads.History

--- a/lib/mydia/downloads/client/debrid/fetcher.ex
+++ b/lib/mydia/downloads/client/debrid/fetcher.ex
@@ -149,6 +149,15 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
       {:ok, new_state} ->
         {:stop, :normal, new_state}
 
+      # The download was cancelled while this fetcher was working. Terminal, not
+      # retryable: there is nothing left to fetch for (issue #281).
+      :deleted ->
+        Logger.info(
+          "Debrid fetch stopping: download_id=#{state.download_id} was removed mid-fetch"
+        )
+
+        {:stop, :normal, state}
+
       {:error, reason} when state.retries_left > 0 ->
         Logger.warning(
           "Debrid fetcher attempt failed for download_id=#{state.download_id} " <>
@@ -270,13 +279,25 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
     # The operator can cancel a download while its fetcher is still running, so a
     # missing row is an ordinary outcome here, not a reason to crash the
     # GenServer mid-fetch (issue #281).
+    #
+    # `:deleted` is deliberately neither `{:ok, _}` nor `{:error, _}`: it exits
+    # `run/1`'s `with` and lands on the terminal clause in `handle_info/2`. An
+    # `{:error, _}` here would instead be retried, re-resolving provider URLs and
+    # re-transferring a payload for a download nobody is tracking any more.
     case History.get_download(state.download_id) do
       nil ->
-        :ok
+        :deleted
 
       download ->
         new_metadata = Map.merge(download.metadata || %{}, %{"debrid_urls" => persisted})
-        History.update_download(download, %{metadata: new_metadata})
+
+        case History.update_download(download, %{metadata: new_metadata}) do
+          {:error, changeset} ->
+            if History.stale_error?(changeset), do: :deleted, else: {:error, changeset}
+
+          ok ->
+            ok
+        end
     end
   end
 
@@ -464,7 +485,7 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
       # Cancelled mid-fetch. The bytes are staged but nothing tracks them any
       # more, so stop cleanly rather than crashing the fetcher (issue #281).
       nil ->
-        {:ok, state}
+        :deleted
 
       download ->
         save_path = download_dir!(state)
@@ -477,7 +498,7 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
 
           {:error, cs} ->
             if History.stale_error?(cs) do
-              {:ok, state}
+              :deleted
             else
               {:error, Error.unknown("failed to finalize download: #{inspect(cs)}")}
             end

--- a/lib/mydia/downloads/client/debrid/fetcher.ex
+++ b/lib/mydia/downloads/client/debrid/fetcher.ex
@@ -267,9 +267,17 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
           descriptor
       end)
 
-    download = History.get_download!(state.download_id)
-    new_metadata = Map.merge(download.metadata || %{}, %{"debrid_urls" => persisted})
-    History.update_download(download, %{metadata: new_metadata})
+    # The operator can cancel a download while its fetcher is still running, so a
+    # missing row is an ordinary outcome here, not a reason to crash the
+    # GenServer mid-fetch (issue #281).
+    case History.get_download(state.download_id) do
+      nil ->
+        :ok
+
+      download ->
+        new_metadata = Map.merge(download.metadata || %{}, %{"debrid_urls" => persisted})
+        History.update_download(download, %{metadata: new_metadata})
+    end
   end
 
   defp stream_all(urls, download_dir, state, download) do
@@ -452,15 +460,28 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
     # forever and the file sits in staging without ever being imported.
     # The cron's `handle_completed_download/2` is what should stamp
     # completed_at — right before it enqueues the import job.
-    download = History.get_download!(state.download_id)
+    case History.get_download(state.download_id) do
+      # Cancelled mid-fetch. The bytes are staged but nothing tracks them any
+      # more, so stop cleanly rather than crashing the fetcher (issue #281).
+      nil ->
+        {:ok, state}
 
-    save_path = download_dir!(state)
+      download ->
+        save_path = download_dir!(state)
 
-    new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
+        new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
 
-    case History.update_download(download, %{metadata: new_metadata}) do
-      {:ok, _} -> {:ok, state}
-      {:error, cs} -> {:error, Error.unknown("failed to finalize download: #{inspect(cs)}")}
+        case History.update_download(download, %{metadata: new_metadata}) do
+          {:ok, _} ->
+            {:ok, state}
+
+          {:error, cs} ->
+            if History.stale_error?(cs) do
+              {:ok, state}
+            else
+              {:error, Error.unknown("failed to finalize download: #{inspect(cs)}")}
+            end
+        end
     end
   end
 
@@ -517,7 +538,7 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
       "Debrid fetcher failed for download_id=#{state.download_id}: #{Error.message(error)}"
     )
 
-    case History.get_download!(state.download_id) do
+    case History.get_download(state.download_id) do
       %Download{} = d ->
         History.update_download(d, %{
           import_failed_at: DateTime.utc_now(),

--- a/lib/mydia/downloads/grabber.ex
+++ b/lib/mydia/downloads/grabber.ex
@@ -138,7 +138,18 @@ defmodule Mydia.Downloads.Grabber do
 
       {:error, changeset} ->
         # The torrent IS in the client, but we couldn't persist the link.
-        fail_grab(download, {:record_update_failed, changeset.errors})
+        if History.stale_error?(changeset) do
+          # Nothing left to mark failed, and broadcasting `:grab_failed` for a row
+          # the operator already removed would resurrect it in the UI as an error.
+          Logger.warning(
+            "Download row removed mid-grab; the torrent is in the client but is no longer tracked",
+            download_id: download.id
+          )
+
+          :error
+        else
+          fail_grab(download, {:record_update_failed, changeset.errors})
+        end
     end
   end
 
@@ -152,19 +163,30 @@ defmodule Mydia.Downloads.Grabber do
         {:ok, updated}
 
       {:error, changeset} ->
-        case find_conflicting_download(client_name, client_id, download.id) do
-          nil ->
-            {:error, changeset}
-
-          stale ->
-            Logger.info("Deleting stale download record before grab finalize",
-              download_id: stale.id,
-              title: stale.title
-            )
-
-            History.delete_download(stale)
-            History.update_download(download, attrs)
+        # Our own row is gone (cancelled from the UI, or reaped as a stale grab).
+        # There is no unique-constraint conflict to resolve, and deleting some
+        # other row on its behalf would be destructive — bail out (issue #285).
+        if History.stale_error?(changeset) do
+          {:error, changeset}
+        else
+          resolve_client_assignment_conflict(download, attrs, client_name, client_id, changeset)
         end
+    end
+  end
+
+  defp resolve_client_assignment_conflict(download, attrs, client_name, client_id, changeset) do
+    case find_conflicting_download(client_name, client_id, download.id) do
+      nil ->
+        {:error, changeset}
+
+      stale ->
+        Logger.info("Deleting stale download record before grab finalize",
+          download_id: stale.id,
+          title: stale.title
+        )
+
+        History.delete_download(stale)
+        History.update_download(download, attrs)
     end
   end
 

--- a/lib/mydia/downloads/history.ex
+++ b/lib/mydia/downloads/history.ex
@@ -26,6 +26,25 @@ defmodule Mydia.Downloads.History do
   # considered a crashed/abandoned grab and derives to "failed".
   @grab_timeout_minutes 10
 
+  # A download row can be deleted while another process still holds a struct for
+  # it: DownloadMonitor's own failure pass deletes rows, MediaImport deletes on
+  # successful import, and an operator can delete/cancel/dismiss from the UI at
+  # any moment. `Repo.update/2` and `Repo.delete/2` filter on the primary key and
+  # raise `Ecto.StaleEntryError` when that filter matches zero rows — the default
+  # for every write, not something `optimistic_lock` opts you into.
+  #
+  # `downloads` has no `lock_version` and no `optimistic_lock`, so a stale error
+  # on this table has exactly one meaning: the row is gone. That is the same
+  # condition `Ecto.NoResultsError` reports on the read side (issue #281), which
+  # is why both are handled here at the choke point rather than at the ~40 call
+  # sites (issues #285, #281).
+  #
+  # `:id` is a safe sentinel field: it is never cast, and the changeset's
+  # constraints are on `media_item_id`/`episode_id`/`library_path_id`. The error
+  # Ecto adds carries `stale: true` metadata, which `stale_error?/1` matches —
+  # never match on the message text, which is configurable.
+  @stale_update_opts [stale_error_field: :id, stale_error_message: "no longer exists"]
+
   ## Public Functions
 
   @doc """
@@ -203,6 +222,38 @@ defmodule Mydia.Downloads.History do
     |> Repo.get!(id)
   end
 
+  @doc """
+  Non-raising sibling of `get_download!/2`, returning `nil` when the row is gone.
+
+  Background jobs and LiveView handlers routinely act on a download id captured
+  moments earlier — a poll snapshot, an Oban job arg, a clicked table row. By the
+  time they run, the row may already have been imported and deleted, or removed
+  by the operator. That is an ordinary outcome, not a fault, so those callers use
+  this and skip cleanly instead of crashing the job (issue #281).
+
+  Use `get_download!/2` only where a missing row genuinely is a bug.
+  """
+  def get_download(id, opts \\ []) do
+    Download
+    |> maybe_preload(opts[:preload])
+    |> Repo.get(id)
+  end
+
+  @doc """
+  True when a write returned `{:error, changeset}` because the row no longer exists.
+
+  Most callers do not need this: the stale result keeps the ordinary
+  `{:error, changeset}` shape, so existing error branches log and continue
+  unchanged. It exists for the call sites whose *behavior* must differ — where
+  the success branch would otherwise emit an event, enqueue a job, or roll back a
+  transaction for a download that is already gone.
+  """
+  def stale_error?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn {_field, {_message, opts}} -> Keyword.get(opts, :stale) == true end)
+  end
+
+  def stale_error?(_other), do: false
+
   def create_download(attrs \\ %{}) do
     result =
       %Download{}
@@ -223,7 +274,7 @@ defmodule Mydia.Downloads.History do
     result =
       download
       |> Download.changeset(attrs)
-      |> Repo.update()
+      |> Repo.update(@stale_update_opts)
 
     case result do
       {:ok, updated_download} ->
@@ -289,17 +340,26 @@ defmodule Mydia.Downloads.History do
   def mark_download_completed(%Download{} = download) do
     download
     |> Download.changeset(%{completed_at: DateTime.utc_now()})
-    |> Repo.update()
+    |> Repo.update(@stale_update_opts)
   end
 
   def mark_download_failed(%Download{} = download, error_message) do
     download
     |> Download.changeset(%{error_message: error_message})
-    |> Repo.update()
+    |> Repo.update(@stale_update_opts)
   end
 
+  @doc """
+  Deletes a download. Idempotent: a row another process already deleted still
+  returns `{:ok, download}`.
+
+  `allow_stale: true` is Ecto's own option for "the struct was deleted from the
+  database before this deletion" — the caller's desired end state is reached
+  either way, so reporting it as a failure would be noise callers cannot act on.
+  The broadcast still fires, so open LiveViews drop the row (issue #285).
+  """
   def delete_download(%Download{} = download) do
-    result = Repo.delete(download)
+    result = Repo.delete(download, allow_stale: true)
 
     case result do
       {:ok, deleted_download} ->

--- a/lib/mydia/downloads/seedbox/fetcher.ex
+++ b/lib/mydia/downloads/seedbox/fetcher.ex
@@ -102,6 +102,15 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
       {:ok, _} ->
         {:stop, :normal, state}
 
+      # The download was cancelled while this fetcher was working. Terminal, not
+      # retryable: there is nothing left to fetch for (issue #281).
+      :deleted ->
+        Logger.info(
+          "Seedbox fetch stopping: download_id=#{state.download_id} was removed mid-fetch"
+        )
+
+        {:stop, :normal, state}
+
       {:error, reason} when state.retries_left > 0 ->
         Logger.warning(
           "Seedbox fetch attempt failed for download_id=#{state.download_id} " <>
@@ -374,10 +383,15 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
   end
 
   defp finalize(state) do
+    # `:deleted` is deliberately neither `{:ok, _}` nor `{:error, _}` so it lands
+    # on the terminal clause in `handle_info/2`. An `{:error, _}` would be
+    # retried, opening fresh SFTP sessions for a download nobody tracks any more
+    # — and the first successful transfer may already have deleted the remote
+    # source (issue #281).
     case History.get_download(state.download_id) do
-      # Cancelled mid-fetch — nothing left to finalize against (issue #281).
+      # Cancelled mid-fetch — nothing left to finalize against.
       nil ->
-        {:ok, :done}
+        :deleted
 
       download ->
         save_path = local_download_dir(state)
@@ -389,7 +403,7 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
 
           {:error, changeset} ->
             if History.stale_error?(changeset) do
-              {:ok, :done}
+              :deleted
             else
               {:error, {:finalize_failed, changeset}}
             end

--- a/lib/mydia/downloads/seedbox/fetcher.ex
+++ b/lib/mydia/downloads/seedbox/fetcher.ex
@@ -374,13 +374,26 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
   end
 
   defp finalize(state) do
-    download = History.get_download!(state.download_id)
-    save_path = local_download_dir(state)
-    new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
+    case History.get_download(state.download_id) do
+      # Cancelled mid-fetch — nothing left to finalize against (issue #281).
+      nil ->
+        {:ok, :done}
 
-    case History.update_download(download, %{metadata: new_metadata}) do
-      {:ok, _} -> {:ok, :done}
-      {:error, changeset} -> {:error, {:finalize_failed, changeset}}
+      download ->
+        save_path = local_download_dir(state)
+        new_metadata = Map.merge(download.metadata || %{}, %{"save_path" => save_path})
+
+        case History.update_download(download, %{metadata: new_metadata}) do
+          {:ok, _} ->
+            {:ok, :done}
+
+          {:error, changeset} ->
+            if History.stale_error?(changeset) do
+              {:ok, :done}
+            else
+              {:error, {:finalize_failed, changeset}}
+            end
+        end
     end
   end
 
@@ -392,7 +405,7 @@ defmodule Mydia.Downloads.Seedbox.Fetcher do
       "Seedbox fetch failed for download_id=#{state.download_id}: #{inspect(reason)}"
     )
 
-    case History.get_download!(state.download_id) do
+    case History.get_download(state.download_id) do
       %Download{} = d ->
         History.update_download(d, %{
           import_failed_at: DateTime.utc_now(),

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -289,29 +289,63 @@ defmodule Mydia.Jobs.DownloadMonitor do
       save_path: download_map.save_path
     )
 
-    # Get the download struct from database (with media_item preloaded)
-    download = Downloads.get_download!(download_map.id, preload: [:media_item])
-
-    # Mark download as completed in database (prevents reprocessing on next monitor run)
-    {:ok, download} = Downloads.mark_download_completed(download)
-
-    # Track completion event
-    Events.download_completed(download, media_item: download.media_item)
-
-    # Enqueue import job - it will delete the download record after successful import
-    case enqueue_import_job(download, download_map) do
-      {:ok, _job} ->
-        Logger.info("Import job enqueued for completed download",
-          download_id: download.id
+    # `downloads` is a snapshot taken at the top of `perform/1`, before minutes of
+    # client polling. The row may already have been imported and deleted, or
+    # removed by the operator, by the time we get here — an ordinary outcome, so
+    # fetch without raising and skip (issue #281).
+    case Downloads.get_download(download_map.id, preload: [:media_item]) do
+      nil ->
+        Logger.debug("Download vanished before completion could be handled",
+          download_id: download_map.id
         )
 
         :ok
 
-      {:error, reason} ->
-        Logger.error("Failed to enqueue import job",
-          download_id: download.id,
-          reason: inspect(reason)
-        )
+      download ->
+        complete_download(download, download_map)
+    end
+  end
+
+  defp complete_download(download, download_map) do
+    # Mark download as completed in database (prevents reprocessing on next monitor run)
+    case Downloads.mark_download_completed(download) do
+      {:ok, download} ->
+        # Track completion event
+        Events.download_completed(download, media_item: download.media_item)
+
+        # Enqueue import job - it will delete the download record after successful import
+        case enqueue_import_job(download, download_map) do
+          {:ok, _job} ->
+            Logger.info("Import job enqueued for completed download",
+              download_id: download.id
+            )
+
+            :ok
+
+          {:error, reason} ->
+            Logger.error("Failed to enqueue import job",
+              download_id: download.id,
+              reason: inspect(reason)
+            )
+
+            :ok
+        end
+
+      {:error, changeset} ->
+        # A concurrent pass deleted the row between the fetch above and this
+        # write. Emitting a completion event or enqueueing an import job for a
+        # row that no longer exists would fabricate history and queue a job that
+        # can only no-op, so stop here (issue #285).
+        if Downloads.stale_error?(changeset) do
+          Logger.debug("Download vanished before it could be marked completed",
+            download_id: download.id
+          )
+        else
+          Logger.error("Failed to mark download as completed",
+            download_id: download.id,
+            errors: inspect(changeset.errors)
+          )
+        end
 
         :ok
     end
@@ -337,9 +371,24 @@ defmodule Mydia.Jobs.DownloadMonitor do
       error: error_msg
     )
 
-    # Get the download struct from database (with media_item preloaded)
-    download = Downloads.get_download!(download_map.id, preload: [:media_item])
+    # Get the download struct from database (with media_item preloaded). A
+    # concurrent pass or an operator may already have removed it, in which case
+    # this failure has been dealt with and there is nothing left to record
+    # (issue #281).
+    case Downloads.get_download(download_map.id, preload: [:media_item]) do
+      nil ->
+        Logger.debug("Download vanished before failure could be handled",
+          download_id: download_map.id
+        )
 
+        :ok
+
+      download ->
+        record_failure(download, download_map, error_msg)
+    end
+  end
+
+  defp record_failure(download, download_map, error_msg) do
     # Bound once and used for both the event and the blacklist row below, so
     # the activity feed and the admin blacklist page can never disagree about
     # why this release failed (issue #237).
@@ -606,11 +655,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
         :ok
 
       {:error, changeset} ->
-        Logger.error("Failed to persist stale grab timeout",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
-        )
-
+        log_write_failure(changeset, download.id, "Failed to persist stale grab timeout")
         :ok
     end
   end
@@ -627,8 +672,13 @@ defmodule Mydia.Jobs.DownloadMonitor do
   # `Mydia.Downloads.History`). The `download_client` write is then a no-op and
   # only the orphan state clears.
   defp adopt_download(download_map) do
-    download = Downloads.get_download!(download_map.id)
+    case Downloads.get_download(download_map.id) do
+      nil -> skip_vanished(download_map.id, "adoption")
+      download -> do_adopt_download(download, download_map)
+    end
+  end
 
+  defp do_adopt_download(download, download_map) do
     attrs =
       %{download_client: download_map.adoptable_client}
       |> maybe_clear_orphan_state(download)
@@ -657,9 +707,11 @@ defmodule Mydia.Jobs.DownloadMonitor do
         :ok
 
       {:error, changeset} ->
-        Logger.warning("Failed to adopt download onto new client",
-          download_id: download_map.id,
-          errors: inspect(changeset.errors)
+        log_write_failure(
+          changeset,
+          download_map.id,
+          "Failed to adopt download onto new client",
+          :warning
         )
 
         :ok
@@ -713,19 +765,25 @@ defmodule Mydia.Jobs.DownloadMonitor do
       client_config_state: download_map.client_config_state
     )
 
-    download = Downloads.get_download!(download_map.id)
+    case Downloads.get_download(download_map.id) do
+      nil ->
+        skip_vanished(download_map.id, "legacy-orphan tagging")
 
-    case Downloads.update_download(download, %{import_failure_reason: "no_client"}) do
-      {:ok, _updated} ->
-        :ok
+      download ->
+        case Downloads.update_download(download, %{import_failure_reason: "no_client"}) do
+          {:ok, _updated} ->
+            :ok
 
-      {:error, changeset} ->
-        Logger.warning("Failed to tag pre-existing orphaned download",
-          download_id: download_map.id,
-          errors: inspect(changeset.errors)
-        )
+          {:error, changeset} ->
+            log_write_failure(
+              changeset,
+              download_map.id,
+              "Failed to tag pre-existing orphaned download",
+              :warning
+            )
 
-        :ok
+            :ok
+        end
     end
   end
 
@@ -737,9 +795,16 @@ defmodule Mydia.Jobs.DownloadMonitor do
       client_config_state: download_map.client_config_state
     )
 
-    # Get the download struct from database (with media_item preloaded)
-    download = Downloads.get_download!(download_map.id, preload: [:media_item])
+    # Get the download struct from database (with media_item preloaded). A row
+    # that is gone is no longer "missing", just absent — nothing to preserve for
+    # the Issues tab (issue #281).
+    case Downloads.get_download(download_map.id, preload: [:media_item]) do
+      nil -> skip_vanished(download_map.id, "missing-download handling")
+      download -> record_missing(download, download_map)
+    end
+  end
 
+  defp record_missing(download, download_map) do
     error_msg = missing_error_message(download_map)
 
     # `Download` has no `:status` field — status is derived at read time from the
@@ -772,11 +837,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
         :ok
 
       {:error, changeset} ->
-        Logger.error("Failed to mark download as missing",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
-        )
-
+        log_write_failure(changeset, download.id, "Failed to mark download as missing")
         :ok
     end
   end
@@ -846,10 +907,10 @@ defmodule Mydia.Jobs.DownloadMonitor do
         enqueue_import_job(updated)
 
       {:error, changeset} ->
-        Logger.error("Failed to flag stuck download",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
-        )
+        # `stuck` is a snapshot from `list_stuck_downloads/1` that is never
+        # re-fetched, so a row resolved in the meantime lands here. Nothing is
+        # stuck any more — skip the failure event and the retry enqueue.
+        log_write_failure(changeset, download.id, "Failed to flag stuck download")
     end
   end
 
@@ -1024,11 +1085,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
         1
 
       {:error, changeset} ->
-        Logger.error("Failed to flag soft-stalled download",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
-        )
-
+        log_write_failure(changeset, download.id, "Failed to flag soft-stalled download")
         0
     end
   end
@@ -1126,9 +1183,10 @@ defmodule Mydia.Jobs.DownloadMonitor do
         :ok
 
       {:error, changeset} ->
-        Logger.error("Failed to reset the stall clock on a suppressed download",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
+        log_write_failure(
+          changeset,
+          download.id,
+          "Failed to reset the stall clock on a suppressed download"
         )
     end
 
@@ -1149,9 +1207,11 @@ defmodule Mydia.Jobs.DownloadMonitor do
           :ok
 
         {:error, changeset} ->
-          Logger.warning("Failed to clear soft-stall on download",
-            download_id: download.id,
-            errors: inspect(changeset.errors)
+          log_write_failure(
+            changeset,
+            download.id,
+            "Failed to clear soft-stall on download",
+            :warning
           )
 
           :ok
@@ -1177,13 +1237,39 @@ defmodule Mydia.Jobs.DownloadMonitor do
         :ok
 
       {:error, changeset} ->
-        Logger.warning("Failed to update download progress tracking",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
+        log_write_failure(
+          changeset,
+          download.id,
+          "Failed to update download progress tracking",
+          :warning
         )
 
         :ok
     end
+  end
+
+  # `perform/1` iterates a snapshot taken before minutes of client polling, and a
+  # second monitor pass (the adaptive fast-followup is deliberately not a
+  # uniqueness duplicate of the cron tick), an import, or the operator can delete
+  # any row in the meantime. That race is expected, so it is logged at :debug and
+  # never counted as a failure — otherwise every handler would report faults for
+  # ordinary concurrency, and the poll would abort partway through its passes
+  # (issues #285, #281).
+  #
+  # A genuine write failure still logs at its original level with the changeset
+  # errors, so `evaluate_and_apply/3`'s broad rescue stays reserved for real bugs.
+  defp log_write_failure(changeset, download_id, message, level \\ :error) do
+    if Downloads.stale_error?(changeset) do
+      Logger.debug("#{message}: download row no longer exists", download_id: download_id)
+    else
+      Logger.log(level, message, download_id: download_id, errors: inspect(changeset.errors))
+    end
+  end
+
+  # The row was gone before we could even read it back.
+  defp skip_vanished(download_id, what) do
+    Logger.debug("Download vanished mid-poll; skipping #{what}", download_id: download_id)
+    :ok
   end
 
   # Resolve the current time from job args (test injection) or fall back to

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -229,12 +229,12 @@ defmodule Mydia.Jobs.MediaImport do
   defp terminal_failure?(_reason, _attempt), do: false
 
   defp fetch_download(download_id) do
-    {:ok,
-     Downloads.get_download!(download_id,
-       preload: [{:media_item, :episodes}, :episode, :library_path]
-     )}
-  rescue
-    Ecto.NoResultsError -> :not_found
+    case Downloads.get_download(download_id,
+           preload: [{:media_item, :episodes}, :episode, :library_path]
+         ) do
+      nil -> :not_found
+      download -> {:ok, download}
+    end
   end
 
   defp handle_incomplete_download(download, args, attempt, raw_args) do
@@ -465,9 +465,10 @@ defmodule Mydia.Jobs.MediaImport do
   defp snapshot_candidates_on_failure(result, _download, _files, _library_path), do: result
 
   defp fetch_current_download(download_id) do
-    {:ok, Downloads.get_download!(download_id)}
-  rescue
-    Ecto.NoResultsError -> :not_found
+    case Downloads.get_download(download_id) do
+      nil -> :not_found
+      download -> {:ok, download}
+    end
   end
 
   defp do_process_import(download, files, library_path, args) do
@@ -483,11 +484,14 @@ defmodule Mydia.Jobs.MediaImport do
         # so future re-imports and reporting can recognize it.
         partial_pack_status = detect_partial_pack(download, imported_files)
 
-        # Reload download to check if it was flagged as having unresolved files
+        # Reload download to check if it was flagged as having unresolved files.
+        # The files are already on disk at this point, so a row deleted mid-import
+        # must not crash the job: Oban would retry and import them a second time.
+        # Fall back to the struct we already hold (issue #281).
         updated_download =
-          Downloads.get_download!(download.id,
+          Downloads.get_download(download.id,
             preload: [{:media_item, :episodes}, :episode, :library_path]
-          )
+          ) || download
 
         has_unresolved = updated_download.match_status == "unresolved_files"
 
@@ -553,10 +557,20 @@ defmodule Mydia.Jobs.MediaImport do
             )
 
           {:error, changeset} ->
-            Logger.warning("Failed to mark download as imported",
-              download_id: download.id,
-              errors: inspect(changeset.errors)
-            )
+            # The import itself succeeded — the files are on disk. Losing the
+            # bookkeeping stamp because an operator cleared the row mid-import
+            # must not read as an import failure (issue #285).
+            if Downloads.stale_error?(changeset) do
+              Logger.info(
+                "Import succeeded but the download row was removed before it could be marked imported",
+                download_id: download.id
+              )
+            else
+              Logger.warning("Failed to mark download as imported",
+                download_id: download.id,
+                errors: inspect(changeset.errors)
+              )
+            end
         end
 
         # Write NFO metadata files if enabled for this library path
@@ -1937,7 +1951,7 @@ defmodule Mydia.Jobs.MediaImport do
       import_failed_at: import_failed_at
     }
 
-    case update_retry_metadata(download, attrs) do
+    case Downloads.update_download(download, attrs) do
       {:ok, _updated} ->
         if terminal? do
           Logger.warning("Import failed terminally — no further retries",
@@ -1957,32 +1971,23 @@ defmodule Mydia.Jobs.MediaImport do
         :ok
 
       {:error, changeset} ->
-        Logger.error("Failed to update retry metadata",
-          download_id: download.id,
-          errors: inspect(changeset.errors)
-        )
-
-        :ok
-
-      :not_found ->
-        # The row this whole job is about was deleted while the job was
-        # running (e.g. an operator dismissed it mid-import). `Repo.update/1`
-        # raises `Ecto.StaleEntryError` when the struct's primary key no
-        # longer matches any row — there is no retry metadata left to
-        # attach it to, and the job already self-heals next attempt via
+        # The row this whole job is about can be deleted while the job runs
+        # (e.g. an operator dismissed it mid-import). There is no retry metadata
+        # left to attach it to, and the job self-heals next attempt via
         # `fetch_download/1`'s `:not_found` guard, so skip rather than crash.
-        Logger.info("Skipping retry-metadata update: download row no longer exists",
-          download_id: download.id
-        )
+        if Downloads.stale_error?(changeset) do
+          Logger.info("Skipping retry-metadata update: download row no longer exists",
+            download_id: download.id
+          )
+        else
+          Logger.error("Failed to update retry metadata",
+            download_id: download.id,
+            errors: inspect(changeset.errors)
+          )
+        end
 
         :ok
     end
-  end
-
-  defp update_retry_metadata(download, attrs) do
-    Downloads.update_download(download, attrs)
-  rescue
-    Ecto.StaleEntryError -> :not_found
   end
 
   # Structured failure classification persisted alongside the human message, so
@@ -2195,10 +2200,18 @@ defmodule Mydia.Jobs.MediaImport do
           :ok
 
         {:error, changeset} ->
-          Logger.warning("Failed to clear retry metadata",
-            download_id: download.id,
-            errors: inspect(changeset.errors)
-          )
+          # Same race as the retry-metadata write above: the import finished and
+          # the row was cleared before the bookkeeping could be reset.
+          if Downloads.stale_error?(changeset) do
+            Logger.info("Skipping retry-metadata clear: download row no longer exists",
+              download_id: download.id
+            )
+          else
+            Logger.warning("Failed to clear retry metadata",
+              download_id: download.id,
+              errors: inspect(changeset.errors)
+            )
+          end
 
           :ok
       end

--- a/lib/mydia/jobs/media_rematch.ex
+++ b/lib/mydia/jobs/media_rematch.ex
@@ -57,11 +57,7 @@ defmodule Mydia.Jobs.MediaRematch do
   end
 
   defp fetch_download(download_id) do
-    Downloads.get_download!(download_id,
-      preload: [:media_item, :episode, :library_path]
-    )
-  rescue
-    Ecto.NoResultsError -> nil
+    Downloads.get_download(download_id, preload: [:media_item, :episode, :library_path])
   end
 
   defp run(download) do
@@ -176,9 +172,26 @@ defmodule Mydia.Jobs.MediaRematch do
       {:ok, updated} ->
         # Provenance is part of the re-match contract; a failed stamp must roll
         # back the relink so callers can retry rather than half-update.
+        #
+        # The one exception is the download row having been deleted underneath
+        # us: the stamp is an audit trail, and there is nothing left to attach it
+        # to. Rolling back would discard a correct, disk-verified relink over
+        # bookkeeping, and every retry would fail identically until the job is
+        # discarded — leaving the media file permanently mis-linked (issue #285).
         case stamp_provenance(download, old_media_file) do
-          {:ok, _} -> updated
-          {:error, changeset} -> Repo.rollback({:provenance_failed, changeset})
+          {:ok, _} ->
+            updated
+
+          {:error, changeset} ->
+            if Downloads.stale_error?(changeset) do
+              Logger.info("Download row removed before provenance stamp; keeping the relink",
+                download_id: download.id
+              )
+
+              updated
+            else
+              Repo.rollback({:provenance_failed, changeset})
+            end
         end
 
       {:error, changeset} ->
@@ -232,7 +245,7 @@ defmodule Mydia.Jobs.MediaRematch do
   end
 
   defp record_pending_source_delete(download_id, source_path) do
-    with %_{} = download <- Downloads.get_download!(download_id) do
+    with %_{} = download <- Downloads.get_download(download_id) do
       metadata = Map.put(download.metadata || %{}, "rematch_pending_source_delete", source_path)
       Downloads.update_download(download, %{metadata: metadata})
     end

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -750,7 +750,27 @@ defmodule Mydia.Jobs.MovieSearch do
   # an existing download.
   defp attach_upgrade_target(%Download{} = download, %MediaFile{} = file) do
     metadata = Map.put(download.metadata || %{}, "upgrade_target_media_file_id", file.id)
-    Downloads.update_download(download, %{metadata: metadata})
+
+    case Downloads.update_download(download, %{metadata: metadata}) do
+      {:error, changeset} ->
+        # This runs as `after_grab`, inside a `with` whose else branch reports
+        # "Failed to initiate download". The grab already succeeded — a torrent
+        # is in the client. If the row vanished before the upgrade link could be
+        # stamped, reporting failure would be a lie that invites the caller to
+        # grab a second copy of the same release (issue #285).
+        if Downloads.stale_error?(changeset) do
+          Logger.debug("Download row removed before the upgrade target could be stamped",
+            download_id: download.id
+          )
+
+          {:ok, download}
+        else
+          {:error, changeset}
+        end
+
+      other ->
+        other
+    end
   end
 
   ## Private Functions - Search Delay

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -1742,7 +1742,24 @@ defmodule Mydia.Jobs.TVShowSearch do
   # one it supersedes. Mirrors Mydia.Jobs.MovieSearch.attach_upgrade_target/2.
   defp attach_upgrade_target(%Download{} = download, %MediaFile{} = file) do
     metadata = Map.put(download.metadata || %{}, "upgrade_target_media_file_id", file.id)
-    Downloads.update_download(download, %{metadata: metadata})
+
+    case Downloads.update_download(download, %{metadata: metadata}) do
+      {:error, changeset} ->
+        # See the twin in `Mydia.Jobs.MovieSearch`: the grab already succeeded, so
+        # a vanished row must not be reported as a failed initiate (issue #285).
+        if Downloads.stale_error?(changeset) do
+          Logger.debug("Download row removed before the upgrade target could be stamped",
+            download_id: download.id
+          )
+
+          {:ok, download}
+        else
+          {:error, changeset}
+        end
+
+      other ->
+        other
+    end
   end
 
   ## Private Functions - Helpers

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -192,9 +192,8 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   def handle_event("cancel_download", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id) do
       case Downloads.cancel_download(download, delete_files: false) do
         {:ok, _} ->
           {:noreply,
@@ -207,13 +206,13 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
   def handle_event("pause_download", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id) do
       case Downloads.pause_download(download) do
         {:ok, _} ->
           {:noreply,
@@ -226,13 +225,13 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
   def handle_event("resume_download", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id) do
       case Downloads.resume_download(download) do
         {:ok, _} ->
           {:noreply,
@@ -245,13 +244,13 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
   def handle_event("retry_download", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id, preload: [:media_item, :episode])
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id, preload: [:media_item, :episode]) do
       # Clear error message if any
       case Downloads.update_download(download, %{error_message: nil}) do
         {:ok, updated} ->
@@ -295,6 +294,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
@@ -336,9 +336,8 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   def handle_event("retry_import", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id, preload: [:media_item, :episode])
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id, preload: [:media_item, :episode]) do
       # Clear retry metadata and trigger immediate import
       case Downloads.update_download(download, %{
              import_retry_count: 0,
@@ -368,13 +367,13 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
   def handle_event("delete_download", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id) do
       # First try to remove from client (ignore errors if already removed)
       _ = Downloads.cancel_download(download, delete_files: true)
 
@@ -391,6 +390,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
@@ -544,9 +544,8 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   def handle_event("clear_single_completed", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id) do
       case Downloads.clear_completed(download) do
         {:ok, _} ->
           {:noreply,
@@ -559,6 +558,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
@@ -722,9 +722,8 @@ defmodule MydiaWeb.DownloadsLive.Index do
   # --- Match files modal (manual file matching on import failure) ---
 
   def handle_event("open_match_files", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id, preload: [:media_item, :library_path])
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id, preload: [:media_item, :library_path]) do
       case ImportCandidates.load(download) do
         {:ok, source, candidates} ->
           episodes =
@@ -754,6 +753,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
@@ -765,17 +765,19 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   def handle_event("match_files_import", params, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      %{download: modal_download, candidates: candidates} = socket.assigns.match_files_modal
+    %{download: modal_download} = socket.assigns.match_files_modal
 
-      # Re-read the download at submit time rather than trusting the assign
-      # captured when the modal opened. The modal has no way to notice a
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(modal_download.id, preload: [:media_item]) do
+      %{candidates: candidates} = socket.assigns.match_files_modal
+
+      # `download` above is re-read at submit time rather than trusting the
+      # assign captured when the modal opened. The modal has no way to notice a
       # re-bind: the separate match/re-match modal can rebind this download to
       # a different show while this one stays open, and process_targeted_import/3
       # must build destinations from the CURRENT media_item — trusting the
       # stale struct would link an episode from the OLD show onto files
       # imported under the NEW one.
-      download = Downloads.get_download!(modal_download.id, preload: [:media_item])
 
       # Defense in depth: a disabled <select> only stops a normal browser. Never
       # trust a submitted path or target purely from client state — re-derive
@@ -870,13 +872,13 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
   def handle_event("reject_release", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id) do
       case Downloads.reject_release(download) do
         {:ok, :rejected} ->
           flash =
@@ -900,6 +902,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
@@ -907,9 +910,8 @@ defmodule MydiaWeb.DownloadsLive.Index do
   # buys a full fresh grace-then-escalation window. If it stalls again the
   # operator gets warned again.
   def handle_event("keep_waiting", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id) do
       case Downloads.update_download(download, %{
              stalled_since: nil,
              last_progress_at: DateTime.utc_now()
@@ -925,13 +927,13 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
   def handle_event("dismiss_download", %{"id" => id}, socket) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(id) do
       case Downloads.dismiss_download(download) do
         {:ok, _} ->
           {:noreply, load_downloads(socket)}
@@ -941,6 +943,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
@@ -1340,10 +1343,10 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   defp submit_match(socket, media_item_id, episode_id) do
-    with :ok <- Authorization.authorize_manage_downloads(socket) do
-      modal = socket.assigns.match_modal
-      download = Downloads.get_download!(modal.download_id)
+    modal = socket.assigns.match_modal
 
+    with :ok <- Authorization.authorize_manage_downloads(socket),
+         {:ok, download} <- fetch_download(modal.download_id) do
       {flash_kind, message} =
         case modal.mode do
           :inflight ->
@@ -1372,6 +1375,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
        |> load_downloads()}
     else
       {:unauthorized, socket} -> {:noreply, socket}
+      :gone -> download_gone(socket)
     end
   end
 
@@ -1789,5 +1793,23 @@ defmodule MydiaWeb.DownloadsLive.Index do
       diff < 86400 -> "in #{div(diff, 3600)}h"
       true -> "in #{div(diff, 86400)}d"
     end
+  end
+
+  # A row the operator clicked can be gone by the time the click lands: the
+  # monitor deletes rows the client reported failed, and an import deletes the
+  # row it just imported. Nothing went wrong, so re-render and say so plainly
+  # rather than crashing the LiveView (issue #281).
+  defp fetch_download(id, opts \\ []) do
+    case Downloads.get_download(id, opts) do
+      nil -> :gone
+      download -> {:ok, download}
+    end
+  end
+
+  defp download_gone(socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, "That download is no longer in the queue")
+     |> load_downloads()}
   end
 end

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -289,8 +289,12 @@ defmodule MydiaWeb.DownloadsLive.Index do
                put_flash(socket, :error, "Failed to retry download: #{inspect(reason)}")}
           end
 
-        {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to update download")}
+        {:error, changeset} ->
+          if Downloads.stale_error?(changeset) do
+            download_gone(socket)
+          else
+            {:noreply, put_flash(socket, :error, "Failed to update download")}
+          end
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
@@ -362,8 +366,12 @@ defmodule MydiaWeb.DownloadsLive.Index do
            |> put_flash(:info, "Import retry initiated")
            |> load_downloads()}
 
-        {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to retry import")}
+        {:error, changeset} ->
+          if Downloads.stale_error?(changeset) do
+            download_gone(socket)
+          else
+            {:noreply, put_flash(socket, :error, "Failed to retry import")}
+          end
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
@@ -922,8 +930,12 @@ defmodule MydiaWeb.DownloadsLive.Index do
            |> put_flash(:info, "Stall timer reset. Mydia will keep waiting on this download.")
            |> load_downloads()}
 
-        {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Could not reset the stall timer")}
+        {:error, changeset} ->
+          if Downloads.stale_error?(changeset) do
+            download_gone(socket)
+          else
+            {:noreply, put_flash(socket, :error, "Could not reset the stall timer")}
+          end
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}
@@ -1807,9 +1819,15 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   defp download_gone(socket) do
+    # `match_files_import` and `submit_match` land here from an open modal, so
+    # the modal state has to go with the row — otherwise the operator is left
+    # looking at a match dialog for a download that no longer exists.
     {:noreply,
      socket
      |> put_flash(:info, "That download is no longer in the queue")
+     |> assign(:match_files_modal, nil)
+     |> assign(:match_files_error, nil)
+     |> assign(:match_modal, nil)
      |> load_downloads()}
   end
 end

--- a/lib/mydia_web/live/media_live/show/download_events.ex
+++ b/lib/mydia_web/live/media_live/show/download_events.ex
@@ -16,12 +16,16 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
   require Logger
 
   def show_download_cancel_confirm(%{"download-id" => download_id}, socket) do
-    download = Downloads.get_download!(download_id)
+    case Downloads.get_download(download_id) do
+      nil ->
+        download_gone(socket)
 
-    {:noreply,
-     socket
-     |> assign(:show_download_cancel_confirm, true)
-     |> assign(:download_to_cancel, download)}
+      download ->
+        {:noreply,
+         socket
+         |> assign(:show_download_cancel_confirm, true)
+         |> assign(:download_to_cancel, download)}
+    end
   end
 
   def hide_download_cancel_confirm(_params, socket) do
@@ -52,12 +56,16 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
   end
 
   def show_download_delete_confirm(%{"download-id" => download_id}, socket) do
-    download = Downloads.get_download!(download_id)
+    case Downloads.get_download(download_id) do
+      nil ->
+        download_gone(socket)
 
-    {:noreply,
-     socket
-     |> assign(:show_download_delete_confirm, true)
-     |> assign(:download_to_delete, download)}
+      download ->
+        {:noreply,
+         socket
+         |> assign(:show_download_delete_confirm, true)
+         |> assign(:download_to_delete, download)}
+    end
   end
 
   def hide_download_delete_confirm(_params, socket) do
@@ -89,12 +97,16 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
   end
 
   def show_download_details(%{"download-id" => download_id}, socket) do
-    download = Downloads.get_download!(download_id)
+    case Downloads.get_download(download_id) do
+      nil ->
+        download_gone(socket)
 
-    {:noreply,
-     socket
-     |> assign(:show_download_details_modal, true)
-     |> assign(:download_details, download)}
+      download ->
+        {:noreply,
+         socket
+         |> assign(:show_download_details_modal, true)
+         |> assign(:download_details, download)}
+    end
   end
 
   def hide_download_details(_params, socket) do
@@ -105,8 +117,13 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
   end
 
   def retry_download(%{"download-id" => download_id}, socket) do
-    download = Downloads.get_download!(download_id, preload: [:media_item, :episode])
+    case Downloads.get_download(download_id, preload: [:media_item, :episode]) do
+      nil -> download_gone(socket)
+      download -> do_retry_download(download, socket)
+    end
+  end
 
+  defp do_retry_download(download, socket) do
     case Downloads.update_download(download, %{error_message: nil}) do
       {:ok, updated} ->
         search_result = %SearchResult{
@@ -135,8 +152,12 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
             {:noreply, put_flash(socket, :error, "Failed to retry download: #{inspect(reason)}")}
         end
 
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Failed to update download")}
+      {:error, changeset} ->
+        if Downloads.stale_error?(changeset) do
+          download_gone(socket)
+        else
+          {:noreply, put_flash(socket, :error, "Failed to update download")}
+        end
     end
   end
 
@@ -145,8 +166,13 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
   # record never reached a client, so there is nothing to clean up remotely.
   def dismiss_failed_grab(%{"id" => id}, socket) do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      download = Downloads.get_download!(id)
-      {:ok, _} = Downloads.delete_download(download)
+      # `delete_download/1` is idempotent, so a row another process already
+      # removed still succeeds here; only a row gone before the read needs a
+      # guard.
+      case Downloads.get_download(id) do
+        nil -> :already_gone
+        download -> Downloads.delete_download(download)
+      end
 
       {:noreply,
        assign(
@@ -157,5 +183,23 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
+  end
+
+  # A download the operator clicked can be gone by the time the click lands: the
+  # monitor deletes rows the client reported failed, and an import deletes the
+  # row it just imported. Nothing went wrong, so say so plainly and re-render
+  # rather than showing an error (issue #281).
+  defp download_gone(socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, "That download is no longer in the queue")
+     |> assign(:show_download_cancel_confirm, false)
+     |> assign(:download_to_cancel, nil)
+     |> assign(:show_download_delete_confirm, false)
+     |> assign(:download_to_delete, nil)
+     |> assign(
+       :downloads_with_status,
+       load_downloads_with_status(socket.assigns.media_item)
+     )}
   end
 end

--- a/lib/mydia_web/live/media_live/show/download_events.ex
+++ b/lib/mydia_web/live/media_live/show/download_events.ex
@@ -168,18 +168,28 @@ defmodule MydiaWeb.MediaLive.Show.DownloadEvents do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
       # `delete_download/1` is idempotent, so a row another process already
       # removed still succeeds here; only a row gone before the read needs a
-      # guard.
-      case Downloads.get_download(id) do
-        nil -> :already_gone
-        download -> Downloads.delete_download(download)
-      end
+      # guard. A genuine delete failure is still worth surfacing — silently
+      # reloading would leave the row on screen with no explanation.
+      result =
+        case Downloads.get_download(id) do
+          nil -> :already_gone
+          download -> Downloads.delete_download(download)
+        end
 
-      {:noreply,
-       assign(
-         socket,
-         :downloads_with_status,
-         load_downloads_with_status(socket.assigns.media_item)
-       )}
+      socket =
+        assign(
+          socket,
+          :downloads_with_status,
+          load_downloads_with_status(socket.assigns.media_item)
+        )
+
+      case result do
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, "Failed to dismiss download")}
+
+        _ok_or_already_gone ->
+          {:noreply, socket}
+      end
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end

--- a/test/mydia/downloads/client/debrid/fetcher_test.exs
+++ b/test/mydia/downloads/client/debrid/fetcher_test.exs
@@ -142,10 +142,14 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
     test "stops the fetcher without streaming or retrying", %{staging: staging} do
       bypass = Bypass.open()
 
+      # Bound out here on purpose: the stub runs in Bypass's handler process, so
+      # `self()` inside it is that process and the refute below would never fail.
+      test_pid = self()
+
       # If the fetcher retried instead of stopping, it would resolve URLs again
       # and hit this endpoint. Never being called is the assertion.
       Bypass.stub(bypass, "GET", "/file.bin", fn conn ->
-        send(self(), :unexpected_stream)
+        send(test_pid, :unexpected_stream)
         Plug.Conn.resp(conn, 200, "payload")
       end)
 

--- a/test/mydia/downloads/client/debrid/fetcher_test.exs
+++ b/test/mydia/downloads/client/debrid/fetcher_test.exs
@@ -132,6 +132,60 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
     end
   end
 
+  describe "download cancelled mid-fetch" do
+    # Regression for #281/#285. A row deleted while the fetcher is working must
+    # be terminal, not retryable: the missing-row branch used to return a bare
+    # `:ok`, which is neither of `handle_info/2`'s clauses and crashed the
+    # GenServer with CaseClauseError. Returning `{:error, _}` instead would be
+    # just as wrong — it would burn the retry budget re-resolving provider URLs
+    # and re-transferring a payload nothing is tracking any more.
+    test "stops the fetcher without streaming or retrying", %{staging: staging} do
+      bypass = Bypass.open()
+
+      # If the fetcher retried instead of stopping, it would resolve URLs again
+      # and hit this endpoint. Never being called is the assertion.
+      Bypass.stub(bypass, "GET", "/file.bin", fn conn ->
+        send(self(), :unexpected_stream)
+        Plug.Conn.resp(conn, 200, "payload")
+      end)
+
+      download = insert_download()
+      url = "http://127.0.0.1:#{bypass.port}/file.bin"
+      StubProvider.set(:get_download_urls, {:ok, [url]})
+      StubProvider.set(:rate_limit_budget, {100, 60})
+
+      # The operator cancels before the fetcher gets to persist its URLs.
+      Repo.delete!(download)
+
+      # A crash and a clean stop both deregister the process, so "it exited" is
+      # not the assertion — the exit *reason* is. The small jitter leaves room to
+      # attach the monitor before `:begin` is handled.
+      :ok =
+        Fetcher.claim(
+          download_id: download.id,
+          config: config(staging),
+          provider_job: fake_provider_job(download.download_client_id),
+          provider_module: StubProvider,
+          jitter_ms: 50,
+          download_dir: staging
+        )
+
+      {:ok, pid} = Fetcher.whereis(download.id)
+      ref = Process.monitor(pid)
+
+      # Generous window: a retry would only fire after 5s, so anything within it
+      # also proves the fetcher did not schedule one.
+      assert_receive {:DOWN, ^ref, :process, ^pid, reason}, 4_000
+      assert reason == :normal
+
+      refute_received :unexpected_stream
+
+      # Registry deregistration trails process death, so poll rather than
+      # reading `whereis/1` straight after the :DOWN.
+      :ok = wait_for_fetcher_exit(download.id)
+    end
+  end
+
   describe "atomic claim" do
     test "two concurrent claim calls produce one running fetcher", %{staging: staging} do
       bypass = Bypass.open()

--- a/test/mydia/downloads_test.exs
+++ b/test/mydia/downloads_test.exs
@@ -452,6 +452,20 @@ defmodule Mydia.DownloadsTest do
     end
   end
 
+  describe "get_download/2" do
+    test "returns the download with given id" do
+      download = download_fixture()
+      assert Downloads.get_download(download.id).id == download.id
+    end
+
+    test "returns nil instead of raising when the row no longer exists (#281)" do
+      download = download_fixture()
+      {:ok, _} = Downloads.delete_download(download)
+
+      assert Downloads.get_download(download.id) == nil
+    end
+  end
+
   describe "create_download/1" do
     test "creates a download with valid attributes" do
       attrs = %{
@@ -474,6 +488,43 @@ defmodule Mydia.DownloadsTest do
 
       assert updated.title == "Updated Title"
     end
+
+    # Before #285 this raised Ecto.StaleEntryError and crashed whichever job or
+    # LiveView happened to be holding the struct.
+    test "returns a stale changeset instead of raising when the row was deleted" do
+      download = download_fixture()
+      {:ok, _} = Downloads.delete_download(download)
+
+      assert {:error, changeset} = Downloads.update_download(download, %{title: "Updated"})
+      assert Downloads.stale_error?(changeset)
+    end
+
+    test "a validation failure is not reported as stale" do
+      download = download_fixture()
+
+      assert {:error, changeset} = Downloads.update_download(download, %{title: nil})
+      refute Downloads.stale_error?(changeset)
+    end
+  end
+
+  describe "mark_download_completed/1" do
+    test "returns a stale changeset instead of raising when the row was deleted" do
+      download = download_fixture()
+      {:ok, _} = Downloads.delete_download(download)
+
+      assert {:error, changeset} = Downloads.mark_download_completed(download)
+      assert Downloads.stale_error?(changeset)
+    end
+  end
+
+  describe "mark_download_failed/2" do
+    test "returns a stale changeset instead of raising when the row was deleted" do
+      download = download_fixture()
+      {:ok, _} = Downloads.delete_download(download)
+
+      assert {:error, changeset} = Downloads.mark_download_failed(download, "boom")
+      assert Downloads.stale_error?(changeset)
+    end
   end
 
   describe "delete_download/1" do
@@ -482,6 +533,20 @@ defmodule Mydia.DownloadsTest do
 
       assert {:ok, %Download{}} = Downloads.delete_download(download)
       assert_raise Ecto.NoResultsError, fn -> Downloads.get_download!(download.id) end
+    end
+
+    # Two DownloadMonitor passes can both decide to delete the same failed row.
+    # The second one has still achieved what it asked for (#285).
+    test "is idempotent when the row was already deleted, and still broadcasts" do
+      download = download_fixture()
+      {:ok, _} = Downloads.delete_download(download)
+
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "downloads")
+
+      assert {:ok, %Download{} = deleted} = Downloads.delete_download(download)
+      assert deleted.id == download.id
+      assert_received {:download_updated, download_id}
+      assert download_id == download.id
     end
   end
 

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -2340,6 +2340,10 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
   # Telemetry handlers are global and run in the emitting process, so the pid
   # guard stops a concurrent Postgres test from stealing the handler and
   # deleting on a sandbox connection where this row does not exist.
+  #
+  # The SQL match stops at `."id" = ` because the placeholder that follows is
+  # adapter-specific — `?` on SQLite, `$1` on Postgres. Matching the SQLite form
+  # would leave these tests silently never firing on the Postgres CI job.
   defp delete_on_primary_key_read(download, tag) do
     handler_id = {__MODULE__, tag, download.id}
     test_pid = self()
@@ -2349,7 +2353,7 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       [:mydia, :repo, :query],
       fn _event, _measurements, metadata, _config ->
         if self() == test_pid and metadata.source == "downloads" and
-             String.contains?(metadata.query, ~s|."id" = ?|) do
+             String.contains?(metadata.query, ~s|."id" = |) do
           :telemetry.detach(handler_id)
           {:ok, _} = Downloads.delete_download(download)
           send(test_pid, {:deleted_mid_poll, download.id})

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -985,6 +985,111 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
     end
   end
 
+  # Two monitor passes can execute at once: the adaptive fast-followup carries a
+  # distinct `fast_chain_position` arg, so Oban's uniqueness deliberately does
+  # not treat it as a duplicate of the cron tick. One pass deleting a row the
+  # other is writing used to abort the whole poll with Ecto.StaleEntryError
+  # (#285) or Ecto.NoResultsError (#281).
+  describe "a download deleted mid-poll" do
+    test "does not crash the completion pass" do
+      {bypass, client_config} = start_sabnzbd_bypass()
+
+      mock_sabnzbd_queue(bypass, [],
+        history: [
+          sabnzbd_history_item("nzo-vanish-complete", "Show.S01E01.nzb", "Completed")
+        ]
+      )
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Show.S01E01",
+          download_client: client_config.name,
+          download_client_id: "nzo-vanish-complete"
+        })
+
+      delete_on_primary_key_read(download, :vanish_during_completion)
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+      assert_raced(download)
+      assert Downloads.get_download(download.id) == nil
+    end
+
+    test "does not crash the failure pass" do
+      {bypass, client_config} = start_sabnzbd_bypass()
+
+      mock_sabnzbd_queue(bypass, [],
+        history: [
+          sabnzbd_history_item("nzo-vanish-failed", "Show.S01E02.nzb", "Failed")
+        ]
+      )
+
+      media_item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Show.S01E02",
+          indexer: "nzbhydra2",
+          download_client: client_config.name,
+          download_client_id: "nzo-vanish-failed",
+          metadata: %{indexer: "nzbhydra2", guid: "vanishing-guid"}
+        })
+
+      delete_on_primary_key_read(download, :vanish_during_failure)
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+      assert_raced(download)
+      assert Downloads.get_download(download.id) == nil
+    end
+
+    test "one vanished row does not stop the rest of the poll" do
+      {bypass, client_config} = start_sabnzbd_bypass()
+
+      mock_sabnzbd_queue(bypass, [],
+        history: [
+          sabnzbd_history_item("nzo-vanish-first", "Vanishing.S01E01.nzb", "Failed"),
+          sabnzbd_history_item("nzo-survivor", "Survivor.S01E01.nzb", "Failed")
+        ]
+      )
+
+      media_item = media_item_fixture()
+
+      vanishing =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Vanishing.S01E01",
+          indexer: "nzbhydra2",
+          download_client: client_config.name,
+          download_client_id: "nzo-vanish-first",
+          metadata: %{indexer: "nzbhydra2", guid: "vanishing-guid"}
+        })
+
+      survivor =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          title: "Survivor.S01E01",
+          indexer: "nzbhydra2",
+          download_client: client_config.name,
+          download_client_id: "nzo-survivor",
+          metadata: %{indexer: "nzbhydra2", guid: "survivor-guid"}
+        })
+
+      delete_on_primary_key_read(vanishing, :vanish_mid_pass)
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+      assert_raced(vanishing)
+
+      # The survivor still went through the full failure path: blacklisted and
+      # removed from the queue. Before the fix, the vanished row raised out of
+      # `Enum.each` and every later row in the pass was skipped.
+      assert Blacklists.blacklisted?("nzbhydra2", "survivor-guid")
+      assert Downloads.get_download(survivor.id) == nil
+    end
+  end
+
   describe "release blacklist on failure (#123)" do
     test "writes a (indexer, guid) row when a download is reported failed" do
       {bypass, client_config} = start_sabnzbd_bypass()
@@ -2220,6 +2325,48 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
       "storage" => "/downloads",
       "added" => System.system_time(:second)
     }
+  end
+
+  # Deletes `download` the moment the poll re-reads it by primary key — the
+  # `Downloads.get_download/2` inside `handle_completion/1` / `handle_failure/1`.
+  #
+  # Telemetry fires *after* the query executes, so the handler still receives the
+  # row and the very next write is the one that finds it gone. That is exactly
+  # the production race in #285, and it is targeted by matching the SQL rather
+  # than by counting `downloads` queries: `perform/1` issues several of those
+  # (the status listing, stale grabs, stuck downloads) and their order shifts
+  # with the fixtures, so a counter silently tests the wrong window.
+  #
+  # Telemetry handlers are global and run in the emitting process, so the pid
+  # guard stops a concurrent Postgres test from stealing the handler and
+  # deleting on a sandbox connection where this row does not exist.
+  defp delete_on_primary_key_read(download, tag) do
+    handler_id = {__MODULE__, tag, download.id}
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:mydia, :repo, :query],
+      fn _event, _measurements, metadata, _config ->
+        if self() == test_pid and metadata.source == "downloads" and
+             String.contains?(metadata.query, ~s|."id" = ?|) do
+          :telemetry.detach(handler_id)
+          {:ok, _} = Downloads.delete_download(download)
+          send(test_pid, {:deleted_mid_poll, download.id})
+        end
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  # The handlers under test delete the row themselves on some paths, so
+  # "the row is gone afterwards" proves nothing. Assert the injected delete
+  # actually fired, or these tests pass without ever exercising the race.
+  defp assert_raced(download) do
+    assert_received {:deleted_mid_poll, id}
+    assert id == download.id
   end
 
   defp sabnzbd_history_item(nzo_id, filename, status) do

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -2465,6 +2465,9 @@ defmodule Mydia.Jobs.MediaImportTest do
       # disappearance exactly in the window the stamp writes into. Telemetry
       # fires after the query runs, so the reload still returns a row and it is
       # the write that finds it gone.
+      #
+      # The SQL match stops at `."id" = ` because the placeholder that follows is
+      # adapter-specific (`?` on SQLite, `$1` on Postgres).
       handler_id = {__MODULE__, :delete_after_files_land, download.id}
       test_pid = self()
       reads = :counters.new(1, [])
@@ -2474,7 +2477,7 @@ defmodule Mydia.Jobs.MediaImportTest do
         [:mydia, :repo, :query],
         fn _event, _measurements, metadata, _config ->
           if self() == test_pid and metadata.source == "downloads" and
-               String.contains?(metadata.query, ~s|."id" = ?|) do
+               String.contains?(metadata.query, ~s|."id" = |) do
             :counters.add(reads, 1, 1)
 
             if :counters.get(reads, 1) == 2 do

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -2421,5 +2421,86 @@ defmodule Mydia.Jobs.MediaImportTest do
 
       refute Mydia.Search.get_backoff_info("auto_reject", media_item.id)
     end
+
+    test "an import whose download row is deleted after the files land still succeeds",
+         %{tmp_dir: tmp_dir} do
+      # Regression for #285. `do_process_import/4` stamps `imported_at` *after*
+      # `organize_and_import_files/4` has already moved the bytes into the
+      # library. If an operator clears the download in that window, the stamp
+      # used to raise Ecto.StaleEntryError and crash the job — so Oban retried
+      # and imported the same files a second time.
+      _library_path = create_test_library_path(tmp_dir, :movies)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+      video_file = Path.join(download_dir, "Vanishing.Row.2024.1080p.mkv")
+      File.write!(video_file, "fake video content")
+
+      media_item = media_item_fixture(%{type: "movie", title: "Vanishing Row Movie", year: 2024})
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "VanishingImportClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "VanishingImportClient",
+          download_client_id: "vanishing-import"
+        })
+
+      # The job reads the download by primary key twice: once at start
+      # (`fetch_download/1`) and once as `do_process_import/4`'s reload, after the
+      # files are on disk. Deleting on the *second* read puts the row's
+      # disappearance exactly in the window the stamp writes into. Telemetry
+      # fires after the query runs, so the reload still returns a row and it is
+      # the write that finds it gone.
+      handler_id = {__MODULE__, :delete_after_files_land, download.id}
+      test_pid = self()
+      reads = :counters.new(1, [])
+
+      :telemetry.attach(
+        handler_id,
+        [:mydia, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          if self() == test_pid and metadata.source == "downloads" and
+               String.contains?(metadata.query, ~s|."id" = ?|) do
+            :counters.add(reads, 1, 1)
+
+            if :counters.get(reads, 1) == 2 do
+              :telemetry.detach(handler_id)
+              {:ok, _} = Mydia.Downloads.delete_download(download)
+              send(test_pid, :deleted_after_files_landed)
+            end
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert {:ok, :imported} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => download_dir
+               })
+
+      # Without this the test would pass even if the delete never fired, and so
+      # would never have exercised the race.
+      assert_received :deleted_after_files_landed
+
+      # The import itself must still have completed: the file is in the library.
+      assert [_media_file] = Mydia.Library.list_media_files(media_item_id: media_item.id)
+    end
   end
 end


### PR DESCRIPTION
Closes #285. Closes #281.

Two crash reports turned out to be the same bug seen from two sides: a `downloads` row is deleted by one process while another still holds a struct for it.

`Mydia.Downloads.Download` has no `optimistic_lock` and no `lock_version`, so Ecto's `UPDATE ... WHERE id = $1` can never fail because of a concurrent *field* update. On this table `Ecto.StaleEntryError` has exactly one meaning: **the row is gone** — the same condition `Ecto.NoResultsError` reports on the read side. That is why both issues share call sites and are fixed together at one choke point rather than at the ~40 call sites.

### Where it actually crashed

Recovered from the relay's crash store as full stacktraces, not inferred:

| Crash | Call site | Hits |
|---|---|---|
| NoResultsError | `download_monitor.ex handle_completion/1` | 382 + 7 |
| NoResultsError | `download_monitor.ex handle_failure/1` | 66 + 2 |
| NoResultsError | `media_import.ex` import path | 85 |
| StaleEntryError (update) | `media_import.ex do_process_import` | 9 |
| StaleEntryError (update) | `download_monitor.ex update_progress/2` | 7 |
| StaleEntryError (update) | `download_monitor.ex handle_completion/1` | 6 |
| StaleEntryError (delete) | `download_monitor.ex handle_failure/1` | 6 |
| StaleEntryError (delete) | `queue.ex create_download_record_with_retry/4` | 1 |
| NoResultsError | Downloads / media LiveViews | 5 |

Rows vanish because `DownloadMonitor.perform/1` iterates a snapshot taken before minutes of client polling, while a second monitor pass (the adaptive fast-followup deliberately is not a uniqueness duplicate of the cron tick), `MediaImport`, or the operator deletes rows underneath it. Preventing that overlap was considered and rejected: an operator deleting from the UI causes the identical race, so the writes have to tolerate it regardless.

### The fix

Both halves are off-the-shelf Ecto options, so behaviour is identical on SQLite and Postgres (staleness is decided by rows-affected in shared `Ecto.Adapters.SQL` code).

In `Mydia.Downloads.History`:

- `update_download/2`, `mark_download_completed/1`, `mark_download_failed/2` pass `stale_error_field: :id`. A vanished row now returns the ordinary `{:error, changeset}` shape every caller already handles instead of raising, and new `stale_error?/1` distinguishes it from a validation failure. Keeping it a real changeset matters: ~15 callers do `inspect(changeset.errors)` in their error branch, so returning a bare atom would have traded `StaleEntryError` for `UndefinedFunctionError`.
- `delete_download/1` passes `allow_stale: true` and is now **idempotent** — a row another process already deleted still returns `{:ok, download}` and still broadcasts, so open LiveViews drop it. This removes the delete-stale crash class with no change at any of the 16 delete call sites, including one that hard-matches `{:ok, _} =`.
- New non-raising `get_download/2`, the sibling of `get_download!/2`.

Call sites whose *behaviour* had to change, not just their logging:

- `handle_completion/1` no longer hard-matches `{:ok, _} = mark_download_completed/1`, and skips the completion event and import job when the row is gone.
- The stall path reports a vanished row at debug rather than counting it in `stall_update_failures`, leaving `evaluate_and_apply/3`'s broad rescue for genuine bugs.
- `MediaImport` treats a vanished row after a successful import as success — the files are already on disk, and crashing there made Oban retry and import them twice.
- `MediaRematch` keeps a correct, disk-verified relink instead of rolling it back over an audit-only provenance stamp it can no longer write.
- `attach_upgrade_target/2` no longer reports a grab that actually succeeded as a failed initiate, which could provoke a duplicate grab.
- `Grabber` skips conflict resolution when its own row is the missing one, rather than deleting an unrelated row on its behalf.
- The debrid and seedbox fetchers stop cleanly when a download is cancelled mid-fetch instead of crashing the GenServer.
- LiveView handlers say the download is no longer in the queue and re-render instead of crashing.

Three `rescue`-based one-offs (`MediaImport`'s `Ecto.StaleEntryError` guard and two `Ecto.NoResultsError` fetch helpers) are folded into the new return values, so there is one mechanism rather than several.

### Testing

- Choke-point contract covered directly: stale update returns a `stale: true` changeset, a validation error is *not* misflagged, delete is idempotent and still broadcasts, `get_download/2` returns `nil`.
- Job-level regressions for the three confirmed crash sites, driven by a telemetry handler that deletes the row at the poll's primary-key read. It matches on the SQL rather than counting `downloads` queries — `perform/1` issues several and their order shifts with fixtures, so a counter silently tests the wrong window. Each asserts the injected delete actually fired, so they cannot pass without exercising the race. One asserts the rest of the poll still runs, and one asserts the file still reaches the library.
- Reverting `lib/` makes 11 of the new tests fail; with it, `mix test` is 8446 tests / 0 failures. `mix format --check-formatted` and `mix credo --strict` are clean.

The remaining `get_download!/2` call sites are all inside existing rescues with correct semantics (the stall path, the batch loops, `reject_bad_content/1`) and were left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when downloads are deleted during processing, transfers, imports, or status updates.
  - Prevented unnecessary retries, errors, and failure notifications for downloads that no longer exist.
  - Download actions now show an informational message and refresh the list when a record is unavailable.
  - Deletion is safely repeatable and remains synchronized across the interface.
  - Improved resilience when download updates become outdated during concurrent changes.

- **Tests**
  - Added coverage for concurrent deletion scenarios across fetching, monitoring, and media imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->