### PR TITLE
fix(player): make sign out actually sign out on macOS

### DIFF
--- a/player/lib/core/auth/cert_storage.dart
+++ b/player/lib/core/auth/cert_storage.dart
@@ -8,7 +8,11 @@ import 'auth_storage.dart';
 /// certificate fingerprints for each Mydia instance. This enables
 /// certificate pinning for self-signed certificates.
 class CertStorage {
-  final AuthStorage _storage = getAuthStorage();
+  /// [storage] is injectable for tests and for session teardown, which builds
+  /// every credential store over one storage instance.
+  CertStorage({AuthStorage? storage}) : _storage = storage ?? getAuthStorage();
+
+  final AuthStorage _storage;
 
   static const _fingerprintsKey = 'cert_fingerprints';
 

--- a/player/lib/core/auth/session_teardown.dart
+++ b/player/lib/core/auth/session_teardown.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart' show debugPrint;
 
 import '../channels/pairing_service.dart';
+import '../connection/connection_diagnostics_provider.dart';
 import '../settings/settings_service.dart';
 import 'auth_service.dart';
 import 'auth_storage.dart';
@@ -43,10 +44,12 @@ class SessionTeardown {
 
   final AuthStorage _storage;
 
-  /// Wipes the session, the pairing, the pinned certificates and the settings.
+  /// Wipes the session, the pairing, the pinned certificates, the settings
+  /// and the connection diagnostics.
   ///
-  /// Steps are independent. The session goes first because it is the wipe that
-  /// matters most, so it lands before anything else can misbehave.
+  /// Each step is wrapped in [bestEffort], so no step's outcome depends on
+  /// any other's and none can block the ones after it. The order below is a
+  /// priority ordering only; it provides no safety guarantee on its own.
   Future<void> run() async {
     final auth = AuthService(storage: _storage);
 
@@ -60,6 +63,10 @@ class SessionTeardown {
     await bestEffort(
       'settings',
       SettingsService(storage: _storage).clearSettings,
+    );
+    await bestEffort(
+      'diagnostics',
+      () => clearConnectionDiagnostics(_storage),
     );
   }
 }

--- a/player/lib/core/auth/session_teardown.dart
+++ b/player/lib/core/auth/session_teardown.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart' show debugPrint;
+
+import '../channels/pairing_service.dart';
+import '../settings/settings_service.dart';
+import 'auth_service.dart';
+import 'auth_storage.dart';
+import 'cert_storage.dart';
+
+/// How long a single cleanup step may take before it is abandoned.
+///
+/// The macOS keychain can block on an access prompt that nobody is there to
+/// answer. Without a ceiling, that prompt keeps the user signed in.
+const _stepTimeout = Duration(seconds: 5);
+
+/// Runs [step], swallowing failure and refusing to wait forever.
+///
+/// Sign-out has to finish even when storage is uncooperative, so a step that
+/// throws or hangs is logged and skipped. The alternative is leaving the user
+/// signed in, which is the bug this exists to prevent.
+Future<void> bestEffort(
+  String label,
+  Future<void> Function() step, {
+  Duration timeout = _stepTimeout,
+}) async {
+  try {
+    await step().timeout(timeout);
+  } catch (e) {
+    debugPrint('[SessionTeardown] $label cleanup failed: $e');
+  }
+}
+
+/// Erases every credential this device holds for the server it was signed into.
+///
+/// Deliberately leaves `device_id` alone. That is this installation's stable
+/// identity, and regenerating it makes the next pairing create a second device
+/// row on the server and orphan the first. It is also why this wipes an
+/// explicit key list rather than calling [AuthStorage.deleteAll].
+class SessionTeardown {
+  /// [storage] is injectable for tests. Production callers use the default,
+  /// which is the platform-appropriate implementation.
+  SessionTeardown({AuthStorage? storage})
+      : _storage = storage ?? getAuthStorage();
+
+  final AuthStorage _storage;
+
+  /// Wipes the session, the pairing, the pinned certificates and the settings.
+  ///
+  /// Steps are independent. The session goes first because it is the wipe that
+  /// matters most, so it lands before anything else can misbehave.
+  Future<void> run() async {
+    final auth = AuthService(storage: _storage);
+
+    await bestEffort('session', auth.clearSession);
+    await bestEffort('relay url', auth.clearRelayUrl);
+    await bestEffort(
+      'pairing',
+      PairingService(authStorage: _storage).clearCredentials,
+    );
+    await bestEffort('certs', CertStorage(storage: _storage).clearAll);
+    await bestEffort(
+      'settings',
+      SettingsService(storage: _storage).clearSettings,
+    );
+  }
+}

--- a/player/lib/core/channels/pairing_service.dart
+++ b/player/lib/core/channels/pairing_service.dart
@@ -185,8 +185,10 @@ class PairingService {
     try {
       final devicePlatform = platform ?? _detectPlatform();
       debugPrint('[PairingService] === PAIRING VIA CLAIM CODE ===');
+      // The claim code authenticates a pairing request, so it stays out of
+      // the logs. Device metadata is enough to follow a pairing through.
       debugPrint(
-          '[PairingService] claimCode=$claimCode, deviceName=$deviceName, platform=$devicePlatform');
+          '[PairingService] deviceName=$deviceName, platform=$devicePlatform');
 
       // Use the injected P2P service - it must be provided and initialized
       final p2pService = _p2pService;
@@ -296,8 +298,8 @@ class PairingService {
       final devicePlatform = platform ?? _detectPlatform();
       debugPrint('[PairingService] === PAIRING VIA QR CODE ===');
       debugPrint('[PairingService] instanceId=${qrData.instanceId}');
-      debugPrint(
-          '[PairingService] claimCode=${qrData.claimCode}, deviceName=$deviceName');
+      // Claim code deliberately omitted; see the note in the claim-code path.
+      debugPrint('[PairingService] deviceName=$deviceName');
 
       final p2pService = _p2pService;
       if (p2pService == null) {

--- a/player/lib/core/channels/pairing_service.dart
+++ b/player/lib/core/channels/pairing_service.dart
@@ -402,28 +402,32 @@ class PairingService {
 
   /// Clears stored pairing credentials.
   ///
-  /// The deletes run concurrently, not sequentially. A sequence of awaits
-  /// means one refused delete aborts every delete after it, and
+  /// The deletes run concurrently, not sequentially, and each is wrapped in
+  /// [Future.sync] so a delete that throws before it even returns a Future
+  /// cannot abort the list before it starts. Either failure mode, sequential
+  /// awaits or an eagerly-built list that a synchronous throw cuts short,
+  /// would let one bad delete strand every key after it, and
   /// [_StorageKeys.deviceToken] mints fresh access tokens through a
   /// deliberately unauthenticated server mutation, so stranding it would
   /// leave the server reachable after the user signed out. `Future.wait`
   /// starts every delete and, with its default `eagerError: false`, waits
-  /// for all of them to settle before reporting failure, so a refused key
-  /// cannot strand the rest.
+  /// for all of them to settle before reporting failure, so neither an
+  /// asynchronous rejection nor a synchronous throw from any one key can
+  /// strand the rest.
   Future<void> clearCredentials() async {
     await Future.wait([
-      _authStorage.delete(_StorageKeys.serverUrl),
-      _authStorage.delete(_StorageKeys.deviceId),
-      _authStorage.delete(_StorageKeys.mediaToken),
-      _authStorage.delete(_StorageKeys.mediaTokenExpiry),
-      _authStorage.delete(_StorageKeys.accessToken),
-      _authStorage.delete(_StorageKeys.deviceToken),
-      _authStorage.delete(_StorageKeys.directUrls),
-      _authStorage.delete(_StorageKeys.certFingerprint),
-      _authStorage.delete(_StorageKeys.instanceName),
-      _authStorage.delete(_StorageKeys.serverPublicKey),
-      _authStorage.delete(_StorageKeys.instanceId),
-      _authStorage.delete(_StorageKeys.serverNodeAddr),
+      Future.sync(() => _authStorage.delete(_StorageKeys.serverUrl)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.deviceId)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.mediaToken)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.mediaTokenExpiry)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.accessToken)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.deviceToken)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.directUrls)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.certFingerprint)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.instanceName)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.serverPublicKey)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.instanceId)),
+      Future.sync(() => _authStorage.delete(_StorageKeys.serverNodeAddr)),
     ]);
   }
 }

--- a/player/lib/core/channels/pairing_service.dart
+++ b/player/lib/core/channels/pairing_service.dart
@@ -401,18 +401,29 @@ class PairingService {
   }
 
   /// Clears stored pairing credentials.
+  ///
+  /// The deletes run concurrently, not sequentially. A sequence of awaits
+  /// means one refused delete aborts every delete after it, and
+  /// [_StorageKeys.deviceToken] mints fresh access tokens through a
+  /// deliberately unauthenticated server mutation, so stranding it would
+  /// leave the server reachable after the user signed out. `Future.wait`
+  /// starts every delete and, with its default `eagerError: false`, waits
+  /// for all of them to settle before reporting failure, so a refused key
+  /// cannot strand the rest.
   Future<void> clearCredentials() async {
-    await _authStorage.delete(_StorageKeys.serverUrl);
-    await _authStorage.delete(_StorageKeys.deviceId);
-    await _authStorage.delete(_StorageKeys.mediaToken);
-    await _authStorage.delete(_StorageKeys.mediaTokenExpiry);
-    await _authStorage.delete(_StorageKeys.accessToken);
-    await _authStorage.delete(_StorageKeys.deviceToken);
-    await _authStorage.delete(_StorageKeys.directUrls);
-    await _authStorage.delete(_StorageKeys.certFingerprint);
-    await _authStorage.delete(_StorageKeys.instanceName);
-    await _authStorage.delete(_StorageKeys.serverPublicKey);
-    await _authStorage.delete(_StorageKeys.instanceId);
-    await _authStorage.delete(_StorageKeys.serverNodeAddr);
+    await Future.wait([
+      _authStorage.delete(_StorageKeys.serverUrl),
+      _authStorage.delete(_StorageKeys.deviceId),
+      _authStorage.delete(_StorageKeys.mediaToken),
+      _authStorage.delete(_StorageKeys.mediaTokenExpiry),
+      _authStorage.delete(_StorageKeys.accessToken),
+      _authStorage.delete(_StorageKeys.deviceToken),
+      _authStorage.delete(_StorageKeys.directUrls),
+      _authStorage.delete(_StorageKeys.certFingerprint),
+      _authStorage.delete(_StorageKeys.instanceName),
+      _authStorage.delete(_StorageKeys.serverPublicKey),
+      _authStorage.delete(_StorageKeys.instanceId),
+      _authStorage.delete(_StorageKeys.serverNodeAddr),
+    ]);
   }
 }

--- a/player/lib/core/channels/pairing_service.dart
+++ b/player/lib/core/channels/pairing_service.dart
@@ -65,6 +65,7 @@ abstract class _StorageKeys {
   static const serverUrl = 'pairing_server_url';
   static const deviceId = 'pairing_device_id';
   static const mediaToken = 'pairing_media_token';
+  static const mediaTokenExpiry = 'pairing_media_token_expiry';
   static const accessToken = 'pairing_access_token';
   static const deviceToken = 'pairing_device_token';
   static const directUrls = 'pairing_direct_urls';
@@ -91,8 +92,10 @@ class PairingResult {
     this.isP2PMode = false,
   });
 
-  factory PairingResult.success(PairingCredentials credentials, {bool isP2PMode = false}) {
-    return PairingResult._(success: true, credentials: credentials, isP2PMode: isP2PMode);
+  factory PairingResult.success(PairingCredentials credentials,
+      {bool isP2PMode = false}) {
+    return PairingResult._(
+        success: true, credentials: credentials, isP2PMode: isP2PMode);
   }
 
   factory PairingResult.error(String error) {
@@ -182,19 +185,22 @@ class PairingService {
     try {
       final devicePlatform = platform ?? _detectPlatform();
       debugPrint('[PairingService] === PAIRING VIA CLAIM CODE ===');
-      debugPrint('[PairingService] claimCode=$claimCode, deviceName=$deviceName, platform=$devicePlatform');
+      debugPrint(
+          '[PairingService] claimCode=$claimCode, deviceName=$deviceName, platform=$devicePlatform');
 
       // Use the injected P2P service - it must be provided and initialized
       final p2pService = _p2pService;
       if (p2pService == null) {
-        return PairingResult.error('P2P service not available. Please try again.');
+        return PairingResult.error(
+            'P2P service not available. Please try again.');
       }
 
       // 1. Resolve claim code via relay API to get server's EndpointAddr
       onStatusUpdate?.call('Resolving pairing code...');
       final relayClient = RelayApiClient();
       final resolveResult = await relayClient.resolveClaimCode(claimCode);
-      debugPrint('[PairingService] Resolved node_addr: ${resolveResult.nodeAddr}');
+      debugPrint(
+          '[PairingService] Resolved node_addr: ${resolveResult.nodeAddr}');
 
       // 2. Initialize the P2P host
       onStatusUpdate?.call('Initializing secure connection...');
@@ -207,12 +213,14 @@ class PairingService {
         debugPrint('[PairingService] Dialed server successfully');
       } catch (e) {
         debugPrint('[PairingService] Failed to dial server: $e');
-        return PairingResult.error('Could not connect to server. Please check your network connection.');
+        return PairingResult.error(
+            'Could not connect to server. Please check your network connection.');
       }
 
       final peerId = _extractNodeId(resolveResult.nodeAddr);
       if (peerId == null) {
-        debugPrint('[PairingService] Could not extract node ID from resolved node_addr');
+        debugPrint(
+            '[PairingService] Could not extract node ID from resolved node_addr');
         return PairingResult.error('Pairing failed: server address is invalid');
       }
       debugPrint('[PairingService] Using peer node ID: $peerId');
@@ -237,7 +245,8 @@ class PairingService {
       // Store credentials
       await _authStorage.write(_StorageKeys.accessToken, accessToken);
       await _authStorage.write(_StorageKeys.mediaToken, mediaToken);
-      await _authStorage.write(_StorageKeys.serverNodeAddr, resolveResult.nodeAddr);
+      await _authStorage.write(
+          _StorageKeys.serverNodeAddr, resolveResult.nodeAddr);
       if (deviceToken != null) {
         await _authStorage.write(_StorageKeys.deviceToken, deviceToken);
       }
@@ -287,11 +296,13 @@ class PairingService {
       final devicePlatform = platform ?? _detectPlatform();
       debugPrint('[PairingService] === PAIRING VIA QR CODE ===');
       debugPrint('[PairingService] instanceId=${qrData.instanceId}');
-      debugPrint('[PairingService] claimCode=${qrData.claimCode}, deviceName=$deviceName');
+      debugPrint(
+          '[PairingService] claimCode=${qrData.claimCode}, deviceName=$deviceName');
 
       final p2pService = _p2pService;
       if (p2pService == null) {
-        return PairingResult.error('P2P service not available. Please try again.');
+        return PairingResult.error(
+            'P2P service not available. Please try again.');
       }
 
       // Initialize the host
@@ -305,13 +316,16 @@ class PairingService {
         debugPrint('[PairingService] Dialed server successfully');
       } catch (e) {
         debugPrint('[PairingService] Failed to dial server: $e');
-        return PairingResult.error('Could not connect to server. Please check your network connection.');
+        return PairingResult.error(
+            'Could not connect to server. Please check your network connection.');
       }
 
       final peerId = _extractNodeId(qrData.nodeAddr);
       if (peerId == null) {
-        debugPrint('[PairingService] Could not extract node ID from QR node_addr');
-        return PairingResult.error('Pairing failed: QR code contains an invalid server address');
+        debugPrint(
+            '[PairingService] Could not extract node ID from QR node_addr');
+        return PairingResult.error(
+            'Pairing failed: QR code contains an invalid server address');
       }
       debugPrint('[PairingService] Using peer node ID: $peerId');
 
@@ -391,6 +405,7 @@ class PairingService {
     await _authStorage.delete(_StorageKeys.serverUrl);
     await _authStorage.delete(_StorageKeys.deviceId);
     await _authStorage.delete(_StorageKeys.mediaToken);
+    await _authStorage.delete(_StorageKeys.mediaTokenExpiry);
     await _authStorage.delete(_StorageKeys.accessToken);
     await _authStorage.delete(_StorageKeys.deviceToken);
     await _authStorage.delete(_StorageKeys.directUrls);

--- a/player/lib/core/connection/connection_diagnostics_provider.dart
+++ b/player/lib/core/connection/connection_diagnostics_provider.dart
@@ -28,8 +28,12 @@ abstract class _DiagnosticsKeys {
 /// server's direct URLs, which should not outlive the session that
 /// produced them.
 Future<void> clearConnectionDiagnostics(AuthStorage storage) async {
-  await storage.delete(_DiagnosticsKeys.lastDirectAttempt);
-  await storage.delete(_DiagnosticsKeys.directUrlErrors);
+  // Concurrent, not sequential: one refused delete must not strand the
+  // other key.
+  await Future.wait([
+    storage.delete(_DiagnosticsKeys.lastDirectAttempt),
+    storage.delete(_DiagnosticsKeys.directUrlErrors),
+  ]);
 }
 
 /// Simple result type for URL attempts.

--- a/player/lib/core/connection/connection_diagnostics_provider.dart
+++ b/player/lib/core/connection/connection_diagnostics_provider.dart
@@ -22,6 +22,16 @@ abstract class _DiagnosticsKeys {
   static const directUrlErrors = 'diagnostics_direct_url_errors';
 }
 
+/// Erases stored connection diagnostics.
+///
+/// Called from sign-out teardown: the recorded attempts include the
+/// server's direct URLs, which should not outlive the session that
+/// produced them.
+Future<void> clearConnectionDiagnostics(AuthStorage storage) async {
+  await storage.delete(_DiagnosticsKeys.lastDirectAttempt);
+  await storage.delete(_DiagnosticsKeys.directUrlErrors);
+}
+
 /// Simple result type for URL attempts.
 class UrlProbeResult {
   final String url;

--- a/player/lib/core/connection/connection_diagnostics_provider.dart
+++ b/player/lib/core/connection/connection_diagnostics_provider.dart
@@ -28,11 +28,12 @@ abstract class _DiagnosticsKeys {
 /// server's direct URLs, which should not outlive the session that
 /// produced them.
 Future<void> clearConnectionDiagnostics(AuthStorage storage) async {
-  // Concurrent, not sequential: one refused delete must not strand the
-  // other key.
+  // Concurrent, not sequential, and each delete is wrapped in Future.sync:
+  // one refused delete, whether it rejects its Future or throws before
+  // returning one at all, must not strand the other key.
   await Future.wait([
-    storage.delete(_DiagnosticsKeys.lastDirectAttempt),
-    storage.delete(_DiagnosticsKeys.directUrlErrors),
+    Future.sync(() => storage.delete(_DiagnosticsKeys.lastDirectAttempt)),
+    Future.sync(() => storage.delete(_DiagnosticsKeys.directUrlErrors)),
   ]);
 }
 

--- a/player/lib/core/graphql/graphql_provider.dart
+++ b/player/lib/core/graphql/graphql_provider.dart
@@ -292,9 +292,11 @@ class AuthStateNotifier extends Notifier<AsyncValue<AuthStatus>> {
 
     // Read through the provider rather than the teardown: clear() also resets
     // the in-memory connection state, which wiping storage alone would not.
+    // The read happens inside the closure, not while building the argument
+    // list, so a throw from it is caught by bestEffort too.
     await bestEffort(
       'connection',
-      ref.read(connectionProvider.notifier).clear,
+      () => ref.read(connectionProvider.notifier).clear(),
     );
 
     // Last, because this is what redirects the router to /login.

--- a/player/lib/core/graphql/graphql_provider.dart
+++ b/player/lib/core/graphql/graphql_provider.dart
@@ -4,6 +4,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import '../auth/auth_service.dart';
 import '../auth/auth_status.dart';
 import '../auth/media_token_service.dart';
+import '../auth/session_teardown.dart';
 import '../config/web_config.dart';
 import '../connection/connection_provider.dart';
 import '../p2p/p2p_service.dart';
@@ -280,9 +281,23 @@ class AuthStateNotifier extends Notifier<AsyncValue<AuthStatus>> {
     await _checkAuth();
   }
 
-  /// Logout and clear all session data.
+  /// Sign out: erase this device's credentials, then send the router to login.
+  ///
+  /// This used to be sequenced from the Settings widget with the state flip
+  /// last, so one refused keychain delete left the user signed in with nothing
+  /// shown. It lives here because this notifier outlives the redirect that
+  /// unmounts that screen.
   Future<void> logout() async {
-    await authService.clearSession();
+    await SessionTeardown().run();
+
+    // Read through the provider rather than the teardown: clear() also resets
+    // the in-memory connection state, which wiping storage alone would not.
+    await bestEffort(
+      'connection',
+      ref.read(connectionProvider.notifier).clear,
+    );
+
+    // Last, because this is what redirects the router to /login.
     state = const AsyncValue.data(AuthStatus.unauthenticated);
   }
 

--- a/player/lib/core/settings/settings_service.dart
+++ b/player/lib/core/settings/settings_service.dart
@@ -1,16 +1,19 @@
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
-import '../storage/secure_storage_options.dart';
+import '../auth/auth_storage.dart';
 
 /// Service for managing user settings and preferences.
 ///
-/// Uses secure storage to persist user preferences like default quality,
-/// intro skipping, and per-library sort order.
+/// Storage goes through [AuthStorage] rather than `FlutterSecureStorage`
+/// directly, so every call inherits the platform hardening in
+/// `NativeAuthStorage`. Reaching for the plugin directly is what made
+/// `clearSettings` throw on the macOS legacy keychain and abort sign-out
+/// before it reached the step that ends the session.
 class SettingsService {
-  static const _storage = FlutterSecureStorage(
-    aOptions: kAndroidSecureStorageOptions,
-    mOptions: kMacOsSecureStorageOptions,
-  );
+  /// [storage] is injectable for tests. Production callers use the default,
+  /// which is the platform-appropriate implementation.
+  SettingsService({AuthStorage? storage})
+      : _storage = storage ?? getAuthStorage();
+
+  final AuthStorage _storage;
 
   static const _defaultQualityKey = 'default_quality';
   static const _autoSkipSegmentsKey = 'auto_skip_segments';
@@ -18,13 +21,13 @@ class SettingsService {
 
   /// Get the default quality setting.
   Future<String> getDefaultQuality() async {
-    final quality = await _storage.read(key: _defaultQualityKey);
+    final quality = await _storage.read(_defaultQualityKey);
     return quality ?? 'auto';
   }
 
   /// Set the default quality setting.
   Future<void> setDefaultQuality(String quality) async {
-    await _storage.write(key: _defaultQualityKey, value: quality);
+    await _storage.write(_defaultQualityKey, quality);
   }
 
   /// Get the automatic intro and credits skipping setting.
@@ -32,13 +35,13 @@ class SettingsService {
   /// Defaults to disabled: a wrong detection that silently jumps the viewer out
   /// of content is far more annoying than a button they can ignore.
   Future<bool> getAutoSkipSegments() async {
-    final value = await _storage.read(key: _autoSkipSegmentsKey);
+    final value = await _storage.read(_autoSkipSegmentsKey);
     return value == 'true';
   }
 
   /// Set the automatic intro and credits skipping setting.
   Future<void> setAutoSkipSegments(bool enabled) async {
-    await _storage.write(key: _autoSkipSegmentsKey, value: enabled.toString());
+    await _storage.write(_autoSkipSegmentsKey, enabled.toString());
   }
 
   /// Get the remembered sort for a library, as its encoded string.
@@ -48,24 +51,21 @@ class SettingsService {
   /// Returns null when nothing has been stored yet; decoding, including the
   /// default, belongs to the caller.
   Future<String?> getLibrarySort(String libraryKey) async {
-    return _storage.read(key: '$_librarySortKeyPrefix$libraryKey');
+    return _storage.read('$_librarySortKeyPrefix$libraryKey');
   }
 
   /// Set the remembered sort for a library, as its encoded string.
   Future<void> setLibrarySort(String libraryKey, String encoded) async {
-    await _storage.write(
-      key: '$_librarySortKeyPrefix$libraryKey',
-      value: encoded,
-    );
+    await _storage.write('$_librarySortKeyPrefix$libraryKey', encoded);
   }
 
   /// Clear all settings.
   Future<void> clearSettings() async {
     await Future.wait([
-      _storage.delete(key: _defaultQualityKey),
-      _storage.delete(key: _autoSkipSegmentsKey),
-      _storage.delete(key: '${_librarySortKeyPrefix}movies'),
-      _storage.delete(key: '${_librarySortKeyPrefix}tvShows'),
+      _storage.delete(_defaultQualityKey),
+      _storage.delete(_autoSkipSegmentsKey),
+      _storage.delete('${_librarySortKeyPrefix}movies'),
+      _storage.delete('${_librarySortKeyPrefix}tvShows'),
     ]);
   }
 }

--- a/player/lib/presentation/screens/settings/settings_controller.dart
+++ b/player/lib/presentation/screens/settings/settings_controller.dart
@@ -60,18 +60,4 @@ class SettingsController extends _$SettingsController {
       return currentSettings.copyWith(autoSkipSegments: enabled);
     });
   }
-
-  /// Logout the user and clear all data.
-  Future<void> logout() async {
-    final authService = AuthService();
-    final settingsService = ref.read(settingsServiceProvider);
-
-    await Future.wait([
-      authService.clearSession(),
-      settingsService.clearSettings(),
-    ]);
-
-    // Invalidate the auth state to trigger navigation
-    ref.invalidate(settingsControllerProvider);
-  }
 }

--- a/player/lib/presentation/screens/settings/settings_screen.dart
+++ b/player/lib/presentation/screens/settings/settings_screen.dart
@@ -127,13 +127,10 @@ class SettingsScreen extends ConsumerWidget {
 
     if (confirmed != true || !context.mounted) return;
 
-    // Clear settings and connection state BEFORE changing auth state, since the
-    // auth state change triggers a router redirect that unmounts this widget.
-    await ref.read(settingsServiceProvider).clearSettings();
-    await ref.read(connectionProvider.notifier).clear();
-
-    // Last, because this sets auth state to unauthenticated, which redirects to
-    // /login. No explicit context.go() needed.
+    // One call. AuthStateNotifier.logout() owns the whole teardown and
+    // outlives the router redirect that unmounts this screen, which is why
+    // the ordering this used to juggle no longer matters. No explicit
+    // context.go() needed.
     await ref.read(authStateProvider.notifier).logout();
   }
 }

--- a/player/test/core/auth/cert_storage_test.dart
+++ b/player/test/core/auth/cert_storage_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/cert_storage.dart';
+
+import '../../test_utils/mock_auth_storage.dart';
+
+void main() {
+  test('clearAll removes the pinned fingerprints', () async {
+    final storage = MockAuthStorage();
+    final certs = CertStorage(storage: storage);
+
+    await certs.storeFingerprint('instance-1', 'aa:bb:cc');
+
+    await certs.clearAll();
+
+    expect(storage.containsKey('cert_fingerprints'), isFalse);
+  });
+}

--- a/player/test/core/auth/session_teardown_test.dart
+++ b/player/test/core/auth/session_teardown_test.dart
@@ -29,6 +29,8 @@ const _signedIn = {
   'auto_skip_segments': 'true',
   'library_sort_movies': 'YEAR:ASC',
   'library_sort_tvShows': 'RATING:DESC',
+  'diagnostics_last_direct_attempt': '2026-01-01T00:00:00.000Z',
+  'diagnostics_direct_url_errors': '{"https://mydia.local":{}}',
   'device_id': 'stable-id',
 };
 

--- a/player/test/core/auth/session_teardown_test.dart
+++ b/player/test/core/auth/session_teardown_test.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/session_teardown.dart';
+
+import '../../test_utils/mock_auth_storage.dart';
+
+/// Every key a signed-in, paired device holds, plus the one that must survive.
+const _signedIn = {
+  'auth_token': 'tok',
+  'server_url': 'https://mydia.local',
+  'user_id': 'u1',
+  'username': 'admin',
+  'relay_url': 'https://relay.mydia.dev',
+  'pairing_server_url': 'p2p://server',
+  'pairing_device_id': 'dev-1',
+  'pairing_media_token': 'media-tok',
+  'pairing_media_token_expiry': '2026-01-01T00:00:00.000Z',
+  'pairing_access_token': 'access-tok',
+  'pairing_device_token': 'device-tok',
+  'pairing_direct_urls': '["https://mydia.local"]',
+  'pairing_cert_fingerprint': 'aa:bb:cc',
+  'pairing_instance_name': 'Home',
+  'server_public_key': 'pubkey',
+  'instance_id': 'inst-1',
+  'server_node_addr': 'node-addr',
+  'cert_fingerprints': '{"inst-1":"aa:bb:cc"}',
+  'default_quality': '1080p',
+  'auto_skip_segments': 'true',
+  'library_sort_movies': 'YEAR:ASC',
+  'library_sort_tvShows': 'RATING:DESC',
+  'device_id': 'stable-id',
+};
+
+void main() {
+  group('bestEffort', () {
+    test('swallows a step that throws', () async {
+      await expectLater(
+        bestEffort('boom', () async => throw Exception('keyring unavailable')),
+        completes,
+      );
+    });
+
+    test('gives up on a step that never completes', () async {
+      final stuck = Completer<void>();
+
+      await expectLater(
+        bestEffort('stuck', () => stuck.future,
+            timeout: const Duration(milliseconds: 50)),
+        completes,
+      );
+
+      expect(stuck.isCompleted, isFalse);
+    });
+  });
+
+  group('SessionTeardown', () {
+    test('erases every server-scoped credential', () async {
+      final storage = MockAuthStorage()..seedData(_signedIn);
+
+      await SessionTeardown(storage: storage).run();
+
+      expect(storage.contents, {'device_id': 'stable-id'});
+    });
+
+    test('keeps going when the keychain refuses one delete', () async {
+      // The macOS failure mode. One refused delete must not strand the rest.
+      final storage = MockAuthStorage()
+        ..seedData(_signedIn)
+        ..failDeleteKeys.add('library_sort_movies');
+
+      await SessionTeardown(storage: storage).run();
+
+      expect(storage.containsKey('pairing_device_token'), isFalse);
+      expect(storage.containsKey('auth_token'), isFalse);
+      expect(storage.containsKey('device_id'), isTrue);
+    });
+
+    test('erases the pairing even when the session step fails entirely',
+        () async {
+      final storage = MockAuthStorage()
+        ..seedData(_signedIn)
+        ..failDeleteKeys.addAll({'auth_token', 'server_url'});
+
+      await SessionTeardown(storage: storage).run();
+
+      expect(storage.containsKey('pairing_device_token'), isFalse);
+    });
+  });
+}

--- a/player/test/core/channels/pairing_service_clear_test.dart
+++ b/player/test/core/channels/pairing_service_clear_test.dart
@@ -36,4 +36,39 @@ void main() {
 
     expect(storage.contents, {'device_id': 'stable-id'});
   });
+
+  test(
+      'an early refused delete does not strand pairing_device_token '
+      '(the key that mints fresh access tokens)', () async {
+    final storage = MockAuthStorage()
+      ..seedData({
+        'pairing_server_url': 'p2p://server',
+        'pairing_device_id': 'dev-1',
+        'pairing_media_token': 'media-tok',
+        'pairing_media_token_expiry': '2026-01-01T00:00:00.000Z',
+        'pairing_access_token': 'access-tok',
+        'pairing_device_token': 'device-tok',
+        'pairing_direct_urls': '["https://mydia.local"]',
+        'pairing_cert_fingerprint': 'aa:bb:cc',
+        'pairing_instance_name': 'Home',
+        'server_public_key': 'pubkey',
+        'instance_id': 'inst-1',
+        'server_node_addr': 'node-addr',
+      })
+      // The first delete in the sequence refuses. Sequential awaits would
+      // abort here and strand every key after it, pairing_device_token
+      // included.
+      ..failDeleteKeys.add('pairing_server_url');
+
+    // The aggregate rejection is expected. Production wraps this call in
+    // bestEffort; the test only cares what happened to storage before the
+    // rejection surfaced.
+    await expectLater(
+      PairingService(authStorage: storage).clearCredentials(),
+      throwsA(anything),
+    );
+
+    expect(storage.containsKey('pairing_device_token'), isFalse);
+    expect(storage.contents.keys.toSet(), {'pairing_server_url'});
+  });
 }

--- a/player/test/core/channels/pairing_service_clear_test.dart
+++ b/player/test/core/channels/pairing_service_clear_test.dart
@@ -1,7 +1,52 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_storage.dart';
 import 'package:player/core/channels/pairing_service.dart';
 
 import '../../test_utils/mock_auth_storage.dart';
+
+/// An [AuthStorage] whose `delete` is deliberately not `async`, so a throw
+/// for the chosen key happens synchronously, before any Future is returned
+/// at all. `MockAuthStorage.delete` is `async`, so Dart converts its throws
+/// into a rejected Future automatically; this double exists to reach the
+/// code path that guard does not cover, where `Future.wait([...])` would
+/// otherwise abort list construction before it even starts.
+class _SyncThrowingAuthStorage implements AuthStorage {
+  final Map<String, String> _storage = {};
+  final String _failKey;
+
+  _SyncThrowingAuthStorage(this._failKey);
+
+  @override
+  bool get degraded => false;
+
+  @override
+  Future<String?> read(String key) async => _storage[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    _storage[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) {
+    if (key == _failKey) {
+      throw Exception('keyring refused delete of $key synchronously');
+    }
+    _storage.remove(key);
+    return Future.value();
+  }
+
+  @override
+  Future<void> deleteAll() async {
+    _storage.clear();
+  }
+
+  void seedData(Map<String, String> data) => _storage.addAll(data);
+
+  Map<String, String> get contents => Map.unmodifiable(_storage);
+
+  bool containsKey(String key) => _storage.containsKey(key);
+}
 
 void main() {
   test('clearCredentials removes every pairing key', () async {
@@ -63,6 +108,37 @@ void main() {
     // The aggregate rejection is expected. Production wraps this call in
     // bestEffort; the test only cares what happened to storage before the
     // rejection surfaced.
+    await expectLater(
+      PairingService(authStorage: storage).clearCredentials(),
+      throwsA(anything),
+    );
+
+    expect(storage.containsKey('pairing_device_token'), isFalse);
+    expect(storage.contents.keys.toSet(), {'pairing_server_url'});
+  });
+
+  test(
+      'a synchronous throw building the delete list does not strand '
+      'pairing_device_token either', () async {
+    final storage = _SyncThrowingAuthStorage('pairing_server_url')
+      ..seedData({
+        'pairing_server_url': 'p2p://server',
+        'pairing_device_id': 'dev-1',
+        'pairing_media_token': 'media-tok',
+        'pairing_media_token_expiry': '2026-01-01T00:00:00.000Z',
+        'pairing_access_token': 'access-tok',
+        'pairing_device_token': 'device-tok',
+        'pairing_direct_urls': '["https://mydia.local"]',
+        'pairing_cert_fingerprint': 'aa:bb:cc',
+        'pairing_instance_name': 'Home',
+        'server_public_key': 'pubkey',
+        'instance_id': 'inst-1',
+        'server_node_addr': 'node-addr',
+      });
+
+    // pairing_server_url is the first key in clearCredentials' list, so an
+    // unwrapped synchronous throw there would abort list construction
+    // before any later delete, pairing_device_token included, ever runs.
     await expectLater(
       PairingService(authStorage: storage).clearCredentials(),
       throwsA(anything),

--- a/player/test/core/channels/pairing_service_clear_test.dart
+++ b/player/test/core/channels/pairing_service_clear_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/channels/pairing_service.dart';
+
+import '../../test_utils/mock_auth_storage.dart';
+
+void main() {
+  test('clearCredentials removes every pairing key', () async {
+    final storage = MockAuthStorage()
+      ..seedData({
+        'pairing_server_url': 'p2p://server',
+        'pairing_device_id': 'dev-1',
+        'pairing_media_token': 'media-tok',
+        'pairing_media_token_expiry': '2026-01-01T00:00:00.000Z',
+        'pairing_access_token': 'access-tok',
+        'pairing_device_token': 'device-tok',
+        'pairing_direct_urls': '["https://mydia.local"]',
+        'pairing_cert_fingerprint': 'aa:bb:cc',
+        'pairing_instance_name': 'Home',
+        'server_public_key': 'pubkey',
+        'instance_id': 'inst-1',
+        'server_node_addr': 'node-addr',
+      });
+
+    await PairingService(authStorage: storage).clearCredentials();
+
+    expect(storage.contents, isEmpty);
+  });
+
+  test('clearCredentials leaves the device identity alone', () async {
+    // device_id is this installation's stable identity. Wiping it makes the
+    // next pairing create a second device row on the server.
+    final storage = MockAuthStorage()
+      ..seedData({'device_id': 'stable-id', 'pairing_device_token': 'tok'});
+
+    await PairingService(authStorage: storage).clearCredentials();
+
+    expect(storage.contents, {'device_id': 'stable-id'});
+  });
+}

--- a/player/test/core/graphql/auth_state_logout_test.dart
+++ b/player/test/core/graphql/auth_state_logout_test.dart
@@ -23,6 +23,22 @@ class _ThrowingConnectionNotifier extends ConnectionNotifier {
   Future<void> clear() async => throw Exception('keyring unavailable');
 }
 
+/// A connection notifier whose construction itself throws, standing in for
+/// the failure mode where `ref.read(connectionProvider.notifier)` throws
+/// synchronously, before clear() ever runs. Riverpod calls the constructor
+/// while resolving `.notifier`, so this (unlike a throwing `build()`, which
+/// Riverpod defers until the provider's *value* is read) reproduces a throw
+/// from the read itself, which has to happen inside bestEffort's guard and
+/// not while building its argument list.
+class _ThrowingConstructorConnectionNotifier extends ConnectionNotifier {
+  _ThrowingConstructorConnectionNotifier() {
+    throw Exception('connection provider unavailable');
+  }
+
+  @override
+  ConnectionState build() => const ConnectionState(type: ConnectionType.direct);
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -56,6 +72,36 @@ void main() {
 
     expect(await storage.read('pairing_device_token'), isNull);
     // And the throwing connection step did not prevent the sign-out itself.
+    expect(container.read(authStateProvider).value, AuthStatus.unauthenticated);
+    expect(await storage.read('auth_token'), isNull);
+  });
+
+  test(
+      'logout still signs out when reading the connection notifier throws synchronously',
+      () async {
+    final container = ProviderContainer(overrides: [
+      connectionProvider
+          .overrideWith(_ThrowingConstructorConnectionNotifier.new),
+    ]);
+    addTearDown(container.dispose);
+
+    final storage = getAuthStorage();
+    await storage.write('pairing_device_token', 'device-tok');
+
+    final notifier = container.read(authStateProvider.notifier);
+    await notifier.login(
+      serverUrl: 'https://mydia.local',
+      token: 'tok',
+      userId: 'u1',
+      username: 'admin',
+    );
+    expect(container.read(authStateProvider).value, AuthStatus.authenticated);
+
+    await notifier.logout();
+
+    expect(await storage.read('pairing_device_token'), isNull);
+    // The connection notifier blew up on read, before clear() ever ran, and
+    // the state flip still has to land.
     expect(container.read(authStateProvider).value, AuthStatus.unauthenticated);
     expect(await storage.read('auth_token'), isNull);
   });

--- a/player/test/core/graphql/auth_state_logout_test.dart
+++ b/player/test/core/graphql/auth_state_logout_test.dart
@@ -1,0 +1,62 @@
+// No material.dart import here on purpose: it exports its own ConnectionState,
+// which would clash with the app's.
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/auth/auth_storage.dart';
+// Only NativeAuthStorage is needed here: getAuthStorage() from
+// auth_storage.dart would otherwise clash with the one this file also
+// exports.
+import 'package:player/core/auth/auth_storage_native.dart'
+    show NativeAuthStorage;
+import 'package:player/core/connection/connection_provider.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+
+/// A connection notifier whose clear() fails, standing in for any cleanup step
+/// that throws part-way through sign-out.
+class _ThrowingConnectionNotifier extends ConnectionNotifier {
+  @override
+  ConnectionState build() => const ConnectionState(type: ConnectionType.direct);
+
+  @override
+  Future<void> clear() async => throw Exception('keyring unavailable');
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    NativeAuthStorage.resetForTest();
+  });
+
+  test('logout forgets the pairing, even when a cleanup step throws', () async {
+    final container = ProviderContainer(overrides: [
+      connectionProvider.overrideWith(_ThrowingConnectionNotifier.new),
+    ]);
+    addTearDown(container.dispose);
+
+    // The credential that matters most. It mints fresh access tokens through
+    // an intentionally unauthenticated mutation, and the old logout left it in
+    // place.
+    final storage = getAuthStorage();
+    await storage.write('pairing_device_token', 'device-tok');
+
+    final notifier = container.read(authStateProvider.notifier);
+    await notifier.login(
+      serverUrl: 'https://mydia.local',
+      token: 'tok',
+      userId: 'u1',
+      username: 'admin',
+    );
+    expect(container.read(authStateProvider).value, AuthStatus.authenticated);
+
+    await notifier.logout();
+
+    expect(await storage.read('pairing_device_token'), isNull);
+    // And the throwing connection step did not prevent the sign-out itself.
+    expect(container.read(authStateProvider).value, AuthStatus.unauthenticated);
+    expect(await storage.read('auth_token'), isNull);
+  });
+}

--- a/player/test/core/settings/settings_service_clear_test.dart
+++ b/player/test/core/settings/settings_service_clear_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_storage_native.dart';
+import 'package:player/core/settings/settings_service.dart';
+
+import '../../test_utils/mock_auth_storage.dart';
+
+/// A keychain that refuses every call, the way the macOS legacy keychain
+/// refuses a delete for a key that was never written.
+class _FailingBackend implements SecretBackend {
+  @override
+  Future<String?> read(String key) async =>
+      throw Exception('keyring unavailable');
+
+  @override
+  Future<void> write(String key, String value) async =>
+      throw Exception('keyring unavailable');
+
+  @override
+  Future<void> delete(String key) async =>
+      throw Exception('keyring unavailable');
+
+  @override
+  Future<void> deleteAll() async => throw Exception('keyring unavailable');
+}
+
+void main() {
+  setUp(NativeAuthStorage.resetForTest);
+
+  test('clearSettings removes every settings key', () async {
+    final storage = MockAuthStorage();
+    final service = SettingsService(storage: storage);
+
+    await service.setDefaultQuality('1080p');
+    await service.setAutoSkipSegments(true);
+    await service.setLibrarySort('movies', 'YEAR:ASC');
+    await service.setLibrarySort('tvShows', 'RATING:DESC');
+
+    await service.clearSettings();
+
+    expect(storage.contents, isEmpty);
+  });
+
+  test('clearSettings completes when the keychain refuses every delete',
+      () async {
+    // The macOS sign-out bug. SettingsService talked to FlutterSecureStorage
+    // directly, so a refused delete threw and aborted sign-out before it
+    // reached the step that ends the session.
+    final service = SettingsService(
+      storage: NativeAuthStorage(backend: _FailingBackend()),
+    );
+
+    await expectLater(service.clearSettings(), completes);
+  });
+}

--- a/player/test/core/settings/settings_service_sort_test.dart
+++ b/player/test/core/settings/settings_service_sort_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:player/core/auth/auth_storage_native.dart';
 import 'package:player/core/settings/settings_service.dart';
 
 void main() {
@@ -7,6 +8,7 @@ void main() {
 
   setUp(() {
     FlutterSecureStorage.setMockInitialValues({});
+    NativeAuthStorage.resetForTest();
   });
 
   test('an unset library sort reads back as null', () async {

--- a/player/test/presentation/screens/settings/settings_screen_test.dart
+++ b/player/test/presentation/screens/settings/settings_screen_test.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart' hide ConnectionState;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/connection/connection_provider.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/core/p2p/p2p_service.dart';
 import 'package:player/core/update/update_provider.dart';
 import 'package:player/domain/models/user_settings.dart';
@@ -19,6 +21,26 @@ class _FakeConnectionNotifier extends ConnectionNotifier {
 
   @override
   ConnectionState build() => _state;
+
+  /// Sign-out used to call this before ending the session, so a throw here
+  /// left the user signed in. Nothing else on this screen calls it.
+  @override
+  Future<void> clear() async => throw Exception('keyring unavailable');
+}
+
+/// Reports a signed-in session and records logout calls, without touching
+/// storage. The real teardown is covered in session_teardown_test.dart.
+class _RecordingAuthNotifier extends AuthStateNotifier {
+  static int logoutCalls = 0;
+
+  @override
+  AsyncValue<AuthStatus> build() =>
+      const AsyncValue.data(AuthStatus.authenticated);
+
+  @override
+  Future<void> logout() async {
+    logoutCalls++;
+  }
 }
 
 class _FakeP2pStatusNotifier extends P2pStatusNotifier {
@@ -100,6 +122,7 @@ Future<void> _pump(
         updateProvider.overrideWith(
           () => _FakeUpdateNotifier(UpdateState(currentVersion: version)),
         ),
+        authStateProvider.overrideWith(_RecordingAuthNotifier.new),
       ],
       child: MaterialApp.router(
         routerConfig: GoRouter(
@@ -159,6 +182,37 @@ void main() {
     final title = tester.widget<Text>(find.text('Sign out'));
 
     expect(title.style?.color, Theme.of(context).colorScheme.error);
+  });
+
+  testWidgets('confirming sign out signs the user out', (tester) async {
+    _RecordingAuthNotifier.logoutCalls = 0;
+    await _pump(tester);
+
+    await tester.ensureVisible(find.byKey(const Key('settings-sign-out')));
+    await tester.tap(find.byKey(const Key('settings-sign-out')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.widgetWithText(TextButton, 'Sign out'),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(_RecordingAuthNotifier.logoutCalls, 1);
+  });
+
+  testWidgets('cancelling sign out leaves the session alone', (tester) async {
+    _RecordingAuthNotifier.logoutCalls = 0;
+    await _pump(tester);
+
+    await tester.ensureVisible(find.byKey(const Key('settings-sign-out')));
+    await tester.tap(find.byKey(const Key('settings-sign-out')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(_RecordingAuthNotifier.logoutCalls, 0);
   });
 
   testWidgets('the footer names the running version', (tester) async {

--- a/player/test/test_utils/mock_auth_storage.dart
+++ b/player/test/test_utils/mock_auth_storage.dart
@@ -9,6 +9,12 @@ class MockAuthStorage implements AuthStorage {
   /// Set by tests that need to simulate storage that cannot persist.
   bool degradedValue = false;
 
+  /// Keys whose delete throws, simulating a keychain that refuses the call.
+  final Set<String> failDeleteKeys = <String>{};
+
+  /// When true, every delete throws.
+  bool failAllDeletes = false;
+
   @override
   bool get degraded => degradedValue;
 
@@ -24,6 +30,9 @@ class MockAuthStorage implements AuthStorage {
 
   @override
   Future<void> delete(String key) async {
+    if (failAllDeletes || failDeleteKeys.contains(key)) {
+      throw Exception('keyring refused delete of $key');
+    }
     _storage.remove(key);
   }
 


### PR DESCRIPTION
On macOS, Sign out did nothing. The app stayed on the Settings screen, still signed in, with no error shown.

## Cause

`_handleSignOut` ran three awaits with the session-ending one last:

```dart
await ref.read(settingsServiceProvider).clearSettings();   // 1
await ref.read(connectionProvider.notifier).clear();       // 2
await ref.read(authStateProvider.notifier).logout();       // 3
```

`SettingsService.clearSettings()` fired four `FlutterSecureStorage.delete()` calls with no error handling, and two of those keys (`library_sort_movies`, `library_sort_tvShows`) are absent unless the user changed a library sort. On the macOS legacy keychain, deleting an absent key throws. `auth_storage_native.dart` already documents this: `NativeAuthStorage._withFallback` exists precisely because of it. `SettingsService` was the one credential store that bypassed that hardening.

So step 1 threw, steps 2 and 3 never ran, and the exception disappeared into a dropped `VoidCallback` Future. An unanswered macOS keychain prompt produces the same symptom by hanging instead.

## Also fixed: sign-out forgot almost nothing

`clearSession()` cleared four keys and left the entire pairing credential set in the keychain, including `pairing_device_token`. That token mints fresh access tokens through `refreshAccessToken`, which is deliberately unauthenticated on the server because the device token is itself the proof of identity. `PairingService.clearCredentials()` already existed to delete exactly those keys and was never called from anywhere.

## Changes

- `SettingsService` takes an injectable `AuthStorage` instead of holding a private `FlutterSecureStorage`, so its deletes degrade rather than throw.
- New `SessionTeardown` erases every server-scoped credential behind one storage instance: session, relay URL, twelve pairing keys, pinned certs, connection diagnostics, settings.
- New `bestEffort` guard wraps each step, swallowing failures and timing out hangs, so no single uncooperative keychain call can abort sign-out.
- `AuthStateNotifier.logout()` owns the whole sequence. It outlives the router redirect that unmounts the Settings screen, which is why the ordering the widget used to juggle no longer matters.
- `CertStorage` gains an injectable storage; `clearCredentials()` picks up the `pairing_media_token_expiry` it was missing.
- The Settings screen shrinks to a confirmation plus one call.

`device_id` is deliberately retained. It is this installation's stable identity, and regenerating it would make the next pairing create a second device row on the server and orphan the first. That is also why the wipe uses an explicit key list rather than `AuthStorage.deleteAll()`.

## Tests

2474 passing, 9 new. The tap path had no coverage at all before, which is how this shipped.

- `clearSettings()` completes against a real `NativeAuthStorage` wrapping a failing backend, which is the macOS bug reproduced.
- `SessionTeardown` erases every server-scoped key and leaves `device_id`, asserted by exact equality.
- Teardown continues when the keychain refuses a delete, and gives up on a step that never completes.
- `logout()` reaches `unauthenticated` even when a cleanup step throws, covering both the async path and a synchronous throw from `ref.read`.
- Tapping Sign out and confirming actually signs out; cancelling does not.

## Not included

Server-side `revokeDevice`. The mutation exists and the player still never calls it, so a signed-out device stays listed and trusted under Remote Access. Deliberately out of scope here.

## Verification gap

Manual macOS verification has not been done: the development host is Linux. The bug is macOS-only, so this wants a real run of sign out, quit, relaunch on a Mac before it ships to users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive sign-out cleanup for session data, credentials, certificates, settings, and connection diagnostics.
  * Preserves the device identity during sign-out.
  * Added media-token expiry cleanup when pairing credentials are cleared.
  * Sign-out cleanup continues despite individual failures or timeouts.

* **Bug Fixes**
  * Ensured users reach the signed-out state even when cleanup errors occur.
  * Removed claim codes from pairing logs.

* **Tests**
  * Added coverage for cleanup, failure handling, credential removal, device ID preservation, and sign-out confirmation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->