### PR TITLE
fix(downloads): finish the deleted-row handling #505 left behind

### DIFF
--- a/lib/mydia/downloads/grabber.ex
+++ b/lib/mydia/downloads/grabber.ex
@@ -138,7 +138,19 @@ defmodule Mydia.Downloads.Grabber do
 
       {:error, changeset} ->
         # The torrent IS in the client, but we couldn't persist the link.
-        fail_grab(download, {:record_update_failed, changeset.errors})
+        if History.stale_changeset?(changeset) do
+          # Nothing left to mark failed, and broadcasting `:grab_failed` for a
+          # row the operator already removed would resurrect it in the UI as an
+          # error they cannot clear.
+          Logger.warning(
+            "Download row removed mid-grab; the torrent is in the client but is no longer tracked",
+            download_id: download.id
+          )
+
+          :error
+        else
+          fail_grab(download, {:record_update_failed, changeset.errors})
+        end
     end
   end
 
@@ -152,19 +164,31 @@ defmodule Mydia.Downloads.Grabber do
         {:ok, updated}
 
       {:error, changeset} ->
-        case find_conflicting_download(client_name, client_id, download.id) do
-          nil ->
-            {:error, changeset}
-
-          stale ->
-            Logger.info("Deleting stale download record before grab finalize",
-              download_id: stale.id,
-              title: stale.title
-            )
-
-            History.delete_download(stale)
-            History.update_download(download, attrs)
+        # Our own row is the one that is gone (cancelled from the UI, or reaped
+        # as a stale grab). There is no unique-constraint conflict to resolve,
+        # and the row this would find and delete belongs to somebody else —
+        # deleting it on a dead row's behalf is destructive (issue #285).
+        if History.stale_changeset?(changeset) do
+          {:error, changeset}
+        else
+          resolve_client_assignment_conflict(download, attrs, client_name, client_id, changeset)
         end
+    end
+  end
+
+  defp resolve_client_assignment_conflict(download, attrs, client_name, client_id, changeset) do
+    case find_conflicting_download(client_name, client_id, download.id) do
+      nil ->
+        {:error, changeset}
+
+      stale ->
+        Logger.info("Deleting stale download record before grab finalize",
+          download_id: stale.id,
+          title: stale.title
+        )
+
+        History.delete_download(stale)
+        History.update_download(download, attrs)
     end
   end
 

--- a/lib/mydia/jobs/media_rematch.ex
+++ b/lib/mydia/jobs/media_rematch.ex
@@ -174,9 +174,26 @@ defmodule Mydia.Jobs.MediaRematch do
       {:ok, updated} ->
         # Provenance is part of the re-match contract; a failed stamp must roll
         # back the relink so callers can retry rather than half-update.
+        #
+        # One exception: the download row being gone. The stamp is an audit
+        # trail, and there is nothing left to attach it to. Rolling back would
+        # discard a correct, disk-verified relink over bookkeeping, and since the
+        # row stays gone every retry fails identically until the job is
+        # discarded — leaving the media file permanently mis-linked (issue #285).
         case stamp_provenance(download, old_media_file) do
-          {:ok, _} -> updated
-          {:error, changeset} -> Repo.rollback({:provenance_failed, changeset})
+          {:ok, _} ->
+            updated
+
+          {:error, changeset} ->
+            if Downloads.stale_changeset?(changeset) do
+              Logger.info("Download row removed before provenance stamp; keeping the relink",
+                download_id: download.id
+              )
+
+              updated
+            else
+              Repo.rollback({:provenance_failed, changeset})
+            end
         end
 
       {:error, changeset} ->

--- a/lib/mydia/jobs/movie_search.ex
+++ b/lib/mydia/jobs/movie_search.ex
@@ -750,7 +750,24 @@ defmodule Mydia.Jobs.MovieSearch do
   # an existing download.
   defp attach_upgrade_target(%Download{} = download, %MediaFile{} = file) do
     metadata = Map.put(download.metadata || %{}, "upgrade_target_media_file_id", file.id)
-    Downloads.update_download(download, %{metadata: metadata})
+
+    case Downloads.update_download(download, %{metadata: metadata}) do
+      {:error, changeset} ->
+        # See the twin in `Mydia.Jobs.TvShowSearch`: the grab already succeeded,
+        # so a vanished row must not be reported as a failed initiate (#285).
+        if Downloads.stale_changeset?(changeset) do
+          Logger.debug("Download row removed before the upgrade target could be stamped",
+            download_id: download.id
+          )
+
+          {:ok, download}
+        else
+          {:error, changeset}
+        end
+
+      other ->
+        other
+    end
   end
 
   ## Private Functions - Search Delay

--- a/lib/mydia/jobs/tv_show_search.ex
+++ b/lib/mydia/jobs/tv_show_search.ex
@@ -1742,7 +1742,27 @@ defmodule Mydia.Jobs.TVShowSearch do
   # one it supersedes. Mirrors Mydia.Jobs.MovieSearch.attach_upgrade_target/2.
   defp attach_upgrade_target(%Download{} = download, %MediaFile{} = file) do
     metadata = Map.put(download.metadata || %{}, "upgrade_target_media_file_id", file.id)
-    Downloads.update_download(download, %{metadata: metadata})
+
+    case Downloads.update_download(download, %{metadata: metadata}) do
+      {:error, changeset} ->
+        # This runs as `after_grab`, inside a `with` whose else branch reports
+        # "Failed to initiate download". The grab already succeeded — a torrent
+        # is in the client. If the row vanished before this bookkeeping stamp
+        # landed, reporting failure would be a lie, and one that invites the
+        # caller to grab a second copy of the same release (issue #285).
+        if Downloads.stale_changeset?(changeset) do
+          Logger.debug("Download row removed before the upgrade target could be stamped",
+            download_id: download.id
+          )
+
+          {:ok, download}
+        else
+          {:error, changeset}
+        end
+
+      other ->
+        other
+    end
   end
 
   ## Private Functions - Helpers

--- a/test/mydia/jobs/media_rematch_test.exs
+++ b/test/mydia/jobs/media_rematch_test.exs
@@ -129,6 +129,71 @@ defmodule Mydia.Jobs.MediaRematchTest do
     end
   end
 
+  describe "download deleted mid-job" do
+    test "keeps the relink when the provenance stamp finds no row", %{tmp_dir: tmp} do
+      # Regression for #285. The provenance stamp is an audit trail written at
+      # the end of the relink transaction. If an operator clears the download
+      # while the job is moving the file, that write finds no row — and rolling
+      # the transaction back would throw away a correct, disk-verified relink
+      # over bookkeeping. Because the row stays gone, every retry would fail the
+      # same way until the job is discarded, leaving the file mis-linked for good.
+      library = movies_library(tmp)
+      old_movie = media_item_fixture(%{type: "movie", title: "Wrong Movie", year: 2020})
+      new_movie = media_item_fixture(%{type: "movie", title: "Right Movie", year: 2021})
+
+      {_abs, size} = write_source(library, "Wrong Movie (2020)/movie.mkv", "video-bytes")
+
+      download =
+        download_fixture(%{
+          media_item_id: new_movie.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, media_file} =
+        Library.create_media_file(%{
+          relative_path: "Wrong Movie (2020)/movie.mkv",
+          library_path_id: library.id,
+          media_item_id: old_movie.id,
+          size: size,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      # Delete the row on the job's opening read of it, which is well before the
+      # relink transaction opens. The match stops before the placeholder because
+      # that is adapter-specific (`?` on SQLite, `$1` on Postgres) — matching one
+      # form would leave this test silently inert on the other adapter.
+      handler_id = {__MODULE__, :delete_before_provenance, download.id}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:mydia, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          if self() == test_pid and metadata.source == "downloads" and
+               String.contains?(metadata.query, ~s|."id" = |) do
+            :telemetry.detach(handler_id)
+            {:ok, _} = Mydia.Downloads.delete_download(download)
+            send(test_pid, :download_deleted_mid_job)
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert {:ok, :rematched} = perform_job(MediaRematch, %{"download_id" => download.id})
+
+      # Without this the test would pass even if the delete never fired.
+      assert_received :download_deleted_mid_job
+
+      # The relink survived: parent flipped and the bytes are at the new path.
+      reloaded = Repo.get(MediaFile, media_file.id)
+      assert reloaded.media_item_id == new_movie.id
+      assert reloaded.relative_path == "Right Movie (2021)/movie.mkv"
+      assert File.exists?(Path.join(library.path, "Right Movie (2021)/movie.mkv"))
+    end
+  end
+
   describe "concurrency + idempotency" do
     test "adopts a scanner-created duplicate at the destination (no duplicate row)", %{
       tmp_dir: tmp

--- a/test/mydia/jobs/movie_search_test.exs
+++ b/test/mydia/jobs/movie_search_test.exs
@@ -594,6 +594,59 @@ defmodule Mydia.Jobs.MovieSearchTest do
       assert download.media_item_id == movie.id
     end
 
+    test "a grab whose row is deleted before the upgrade tag lands is not reported as failed", %{
+      library_path: library_path
+    } do
+      # Regression for #285. `attach_upgrade_target/2` runs as `after_grab`,
+      # inside a `with` whose else branch logs "Failed to initiate download".
+      # The grab itself has already succeeded by then — a torrent is in the
+      # client — so if the row vanishes before the bookkeeping stamp lands,
+      # returning an error is a lie that can send the caller off to grab a
+      # second copy of the same release.
+      {movie, media_file} = upgrade_target(library_path)
+
+      # Delete the row the instant it is inserted, which is after the grab and
+      # before the tag write. The match avoids the bind placeholder because that
+      # is adapter-specific (`?` on SQLite, `$1` on Postgres).
+      handler_id = {__MODULE__, :delete_before_upgrade_tag}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:mydia, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          if self() == test_pid and metadata.source == "downloads" and
+               String.starts_with?(metadata.query, "INSERT") do
+            :telemetry.detach(handler_id)
+
+            Enum.each(Mydia.Downloads.list_downloads(), &Mydia.Downloads.delete_download/1)
+            send(test_pid, :download_deleted_before_tag)
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      # The job returns `:ok` down both paths, so the return value proves
+      # nothing here — the misreport is what to assert on, and it logs at
+      # :error, which the test logger's :warning threshold does let through.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok =
+                   perform_job(MovieSearch, %{
+                     "mode" => "upgrade",
+                     "media_item_id" => movie.id,
+                     "media_file_id" => media_file.id
+                   })
+        end)
+
+      # Without this the test would pass even if the delete never fired.
+      assert_received :download_deleted_before_tag
+
+      refute log =~ "Failed to initiate download"
+    end
+
     # Proves the Comparator genuinely gates the grab rather than merely being
     # called for show: same movie, same file, same mocked indexer results as
     # the "grabs a genuine upgrade candidate" test above (proven there to


### PR DESCRIPTION
Follow-up to #505, which made download writes tolerate a row deleted mid-flight. Three call sites still treat "the row is gone" as a failure and act on it. None of them crash, which is why they survived that pass — they are behaviour bugs, and two are destructive.

### 1. `MediaRematch` discards a correct relink over an audit stamp

`stamp_provenance/2` is the last step inside the relink transaction. If an operator clears the download while the job is moving the file, that write finds no row and `Repo.rollback({:provenance_failed, _})` throws away a relink that **already succeeded on disk**.

The row stays gone, so all ten Oban attempts fail identically and the job is discarded — leaving the media file permanently pointed at the wrong item, even though nothing was ever wrong with the relink itself. The stamp is an audit trail with nothing left to attach to, so the relink is kept and the miss is logged.

### 2. `Grabber` resolves a unique-constraint conflict that isn't one

When its *own* row is the missing one, `store_client_assignment/3` still looks for a conflicting `(download_client, download_client_id)` record and **deletes whatever it finds** — a row belonging to something else, removed on a dead row's behalf. It then calls `fail_grab/2`, which writes to the vanished row and broadcasts a `:grab_failed` the operator cannot clear.

Both paths now bail out when the changeset is stale. The conflict-resolution branch is extracted so the stale check reads as the guard it is.

### 3. The search jobs report a successful grab as a failure

`attach_upgrade_target/2` runs as the `after_grab` callback inside a `with` whose else branch logs `"Failed to initiate download"`. By the time it runs the grab has already succeeded — a torrent is in the client — so a vanished row turns a real grab into a reported failure. That can send the caller back to grab a **second copy of the same release**. Stale is swallowed into `{:ok, download}`, degrading to "no upgrade link stamped".

### Testing

A regression test per fix, each verified to fail with its fix reverted:

- `media_rematch_test.exs` — deletes the row on the job's opening read, then asserts the parent flip and the moved file survive.
- `movie_search_test.exs` — deletes the row on the download INSERT, between the grab and the tag write.

Two details worth flagging, both learned the hard way on this branch:

- The `movie_search` test asserts on the **error log**, not the return value. That job returns `:ok` down both paths, so an `assert :ok` proves nothing — my first version passed against the bug.
- The telemetry matchers stop before the bind placeholder. It is adapter-specific (`?` on SQLite, `$1` on Postgres), and matching one form leaves the test silently inert on the other adapter — which is exactly how the earlier round of these tests passed locally and did nothing on the Postgres CI job. Both tests also assert the injected delete actually fired, so they cannot pass without exercising the race.

`mix format --check-formatted`, `mix compile --warnings-as-errors` and `mix credo --strict` are clean, and the affected suites pass. My local full-suite run was cut short by machine load rather than by a failure (an earlier run over this same code reached 4857 tests with 0 failures); CI is the authoritative check on both adapters.

No new `get_download!/2` call sites, so the guard test #505 added stays satisfied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when download records are removed during media rematching or upgrade processing.
  * Prevented stale download updates from deleting or affecting other downloads.
  * Jobs now complete successfully when their related download is deleted concurrently, while continuing to report genuine failures.
  * Preserved successful media relinking and file movement during concurrent deletion scenarios.

* **Tests**
  * Added regression coverage for concurrent download deletion during rematching and upgrade workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->