### PR TITLE
ci(web): build the player for web, deploy it on release

### DIFF
--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -91,6 +91,73 @@ jobs:
           echo "Browser tests: $files"
           flutter test --platform chrome $files
 
+  # Nothing compiled the player for the web until this job existed. The matrix
+  # below covers Windows, macOS, Linux and Android, and `icons` only diffs the
+  # generated SVG set, so 183 commits landed on player/ between the public web
+  # player merging and its first deploy without one of them being checked
+  # against the web target. That gap is only visible at deploy time, where it
+  # would now break a release: deploy-web-player.yml runs from release.yml.
+  #
+  # This builds the same bundle the deploy builds, with the same flags, minus
+  # the wasm module. The Rust half needs nix, wasm-pack and a
+  # flutter_rust_bridge codegen install (player/tool/build_web.sh), which is
+  # roughly twelve minutes and too much for every player PR. The split is
+  # deliberate rather than lazy: ci.yml already compiles
+  # native/mydia_p2p_core for wasm32-unknown-unknown, so the crate reaching
+  # wasm is covered, and what stays uncovered here is wasm-pack's packaging
+  # step, whose inputs are pinned toolchain versions that move only on a
+  # deliberate bump. Dart source, which every PR touches, is what this catches.
+  #
+  # MYDIA_WEB_P2P=true matters even without the module present: it selects the
+  # public-web branch in main.dart, so this compiles the code path the deploy
+  # actually ships rather than the instance-hosted one.
+  build-web:
+    name: Build / Web
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: player
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version-file: player/.fvmrc
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run code generation
+        run: flutter pub run build_runner build
+
+      - name: Build the web bundle
+        run: |
+          flutter build web --release --base-href / \
+            --no-web-resources-cdn \
+            --pwa-strategy=none \
+            --dart-define=MYDIA_WEB_P2P=true
+
+      # Same assertion build_web.sh makes, moved forward to PR time. Without
+      # _headers the deployed page never becomes cross-origin isolated, there
+      # is no SharedArrayBuffer, and RustLib.init() throws in every browser.
+      # Flutter copies web/ across verbatim, so this fails only if that file
+      # is deleted or renamed, which is exactly the change worth catching in
+      # review rather than in a browser.
+      - name: Check _headers survived the build
+        run: |
+          [ -f build/web/_headers ] || {
+            echo "::error::_headers did not make it into build/web. The deployed page" >&2
+            echo "         would not be cross-origin isolated and the p2p module would" >&2
+            echo "         fail to instantiate in every browser." >&2
+            exit 1
+          }
+
   build:
     name: Build / ${{ matrix.platform }}
     strategy:

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -115,6 +115,13 @@ jobs:
     name: Build / Web
     runs-on: ubuntu-latest
 
+    # Reading the tree is all this job does. Scoped to this job rather than
+    # added file-wide, which would be its own sweep: the steps below run
+    # third-party code (pub packages, via `flutter pub get` and build_runner),
+    # so it is the one job here where least privilege has something to bite on.
+    permissions:
+      contents: read
+
     defaults:
       run:
         working-directory: player
@@ -122,6 +129,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Nothing in this job runs a git command, so the token has no reason
+          # to stay in .git/config where a package's build hook could read it.
+          persist-credentials: false
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -143,20 +154,31 @@ jobs:
             --pwa-strategy=none \
             --dart-define=MYDIA_WEB_P2P=true
 
-      # Same assertion build_web.sh makes, moved forward to PR time. Without
-      # _headers the deployed page never becomes cross-origin isolated, there
-      # is no SharedArrayBuffer, and RustLib.init() throws in every browser.
-      # Flutter copies web/ across verbatim, so this fails only if that file
-      # is deleted or renamed, which is exactly the change worth catching in
-      # review rather than in a browser.
+      # build_web.sh asserts this file reached build/web; this also asserts it
+      # still says what it has to say. Both directives are load-bearing:
+      # without them the deployed page is not cross-origin isolated, there is
+      # no SharedArrayBuffer, and RustLib.init() throws in every browser.
+      # Checking only for the file's presence would wave through a _headers
+      # whose directives had been edited away, which breaks identically and is
+      # the likelier edit of the two.
       - name: Check _headers survived the build
         run: |
-          [ -f build/web/_headers ] || {
-            echo "::error::_headers did not make it into build/web. The deployed page" >&2
-            echo "         would not be cross-origin isolated and the p2p module would" >&2
-            echo "         fail to instantiate in every browser." >&2
+          set -euo pipefail
+          headers=build/web/_headers
+          if [ ! -f "$headers" ]; then
+            echo "::error::_headers did not make it into build/web." >&2
             exit 1
-          }
+          fi
+          for directive in \
+            "Cross-Origin-Opener-Policy: same-origin" \
+            "Cross-Origin-Embedder-Policy: require-corp"; do
+            if ! grep -qF "$directive" "$headers"; then
+              echo "::error::$headers no longer sets '$directive'. The deployed page" >&2
+              echo "         would not be cross-origin isolated, so the p2p wasm module" >&2
+              echo "         could not instantiate in any browser." >&2
+              exit 1
+            fi
+          done
 
   build:
     name: Build / ${{ matrix.platform }}

--- a/.github/workflows/deploy-web-player.yml
+++ b/.github/workflows/deploy-web-player.yml
@@ -1,26 +1,34 @@
 name: Deploy Web Player
 
-# Manual dispatch only, on purpose. There is no `push` trigger yet.
+# web.mydia.dev ships on a release, plus manual dispatch for a hotfix or a
+# rehearsal. release.yml calls this workflow after it publishes, so the public
+# player moves in step with the tag, the Docker :latest image and the docs.
 #
-# Nothing in this stack has been exercised end to end even once: every browser
-# test covering it uses a fake P2pService, so the wasm iroh transport, dialing
-# over the relay, pairing, and GraphQL over p2p have never run anywhere. An
-# automatic deploy would publish that straight to web.mydia.dev, and merging
-# the branch that adds the workflow would be enough to do it.
+# Deliberately not `push: branches: [master]`, which an earlier revision of
+# this file carried. There is one public player and no staging copy of it, so
+# a push trigger would put every intermediate master commit in front of every
+# viewer, and the browser matrix that qualifies this stack is per-release work
+# (docs/superpowers/sdd-web-player/MANUAL-VERIFICATION.md) rather than
+# something CI can stand in for.
 #
-# Restoring it is one deliberate block, to be added back under `on:` once the
-# manual browser matrix has been run and relay capacity has been reviewed:
-#
-#   push:
-#     branches: [master]
-#     paths:
-#       - "player/**"
-#       # player/rust/mydia_player_p2p depends on ../../native/mydia_p2p_core
-#       # by relative path. A core change alters the wasm bundle even when no
-#       # Flutter file moves, so it must trigger a redeploy on its own.
-#       - "native/mydia_p2p_core/**"
+# The `ref` input exists because a release does not necessarily build master's
+# tip: release.yml pins its draft to a commit SHA and every job checks that
+# same SHA out, so the tag, the images and this bundle all describe one commit.
+# Defaulting to github.sha keeps a bare dispatch behaving as it always has.
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: Commit SHA to build and deploy.
+        type: string
+        required: true
+      branch:
+        description: >-
+          What wrangler reports as the deploy's branch. Reaches web.mydia.dev
+          only when it matches the Pages project's production branch.
+        type: string
+        required: true
 
 concurrency:
   group: web-player
@@ -33,6 +41,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Empty on a bare dispatch, where github.sha is already the tip of
+          # whichever ref was picked, so this matches the previous behaviour.
+          ref: ${{ inputs.ref || github.sha }}
 
       # The devenv/Cachix/Nix steps below are copied from the `rust` job in
       # ci.yml, which already builds native/mydia_p2p_core for
@@ -119,18 +131,19 @@ jobs:
       # relying on it auto-detecting the checkout (which actions/checkout only
       # gives a real local branch for on a branch push; workflow_dispatch has
       # no branch of its own to detect). This deploy is only ever "production"
-      # if that value matches the Pages project's configured production
-      # branch, which does NOT default to master on a new project (see the
-      # human setup steps below), and a mismatch there still deploys
-      # successfully to a preview URL with no failure anywhere in this job,
-      # so getting the project setting right is what actually matters; this
-      # flag only removes the auto-detection half of the risk.
+      # if that value matches the `mydia-web` Pages project's production
+      # branch, which is `master`. A mismatch is the quiet failure worth
+      # knowing about: it still deploys successfully, to a preview URL, with
+      # nothing in this job reporting a problem and web.mydia.dev unchanged.
       #
-      # github.ref_name rather than a literal `master`: the dispatch UI lets a
-      # human pick any ref, and a hardcoded master would let a run from a
-      # feature branch claim to be production and overwrite web.mydia.dev with
-      # unreviewed code. A dispatch from a branch now deploys to that branch's
-      # preview URL, which is what a human picking it meant.
+      # The release path passes `master` explicitly. It cannot use
+      # github.ref_name, because a release checks out the SHA its draft pins
+      # rather than a branch, and it cannot infer the name from that SHA.
+      #
+      # A bare dispatch still falls back to github.ref_name so that a run from
+      # a feature branch publishes to that branch's preview instead of
+      # overwriting the public player with unreviewed code. A hardcoded
+      # `master` here would remove that protection.
       #
       # Passed through the environment rather than interpolated into the
       # command: a ref name is attacker-influencable text and git permits `$`,
@@ -140,4 +153,4 @@ jobs:
         run: npx wrangler pages deploy player/build/web --project-name=mydia-web --branch="$DEPLOY_BRANCH"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          DEPLOY_BRANCH: ${{ github.ref_name }}
+          DEPLOY_BRANCH: ${{ inputs.branch || github.ref_name }}

--- a/.github/workflows/deploy-web-player.yml
+++ b/.github/workflows/deploy-web-player.yml
@@ -29,6 +29,16 @@ on:
           only when it matches the Pages project's production branch.
         type: string
         required: true
+    # Named rather than left to `secrets: inherit` at the call site, which
+    # would hand this workflow every secret the repository holds: Apple and
+    # Android signing keys, the Flatpak GPG key, R2 credentials. It needs two.
+    # These same names resolve to the repository secrets on a bare dispatch,
+    # so the steps below read `secrets.*` either way.
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+      CLOUDFLARE_API_TOKEN:
+        required: true
 
 concurrency:
   group: web-player
@@ -37,6 +47,13 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    # Checking out the tree is the only thing this needs from GitHub. Cachix
+    # and Cloudflare each authenticate with their own token, so nothing here
+    # wants a writable GITHUB_TOKEN. When release.yml calls this workflow, the
+    # caller's grant and this one intersect, and both are contents: read.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1340,6 +1340,31 @@ jobs:
           uv run --project docs mike deploy --push --update-aliases "$VERSION" latest
           uv run --project docs mike set-default --push latest
 
+  web-player:
+    name: Deploy Web Player
+    # Stable only, matching `docs` above and the Docker :latest tag.
+    # web.mydia.dev is a single public surface with no staging copy, so a
+    # prerelease published there would reach every viewer with no way to opt
+    # in. Betas stay on the installable builds, which a user chooses.
+    if: needs.prepare.outputs.is_prerelease == 'false' && !inputs.dry_run
+    needs:
+      - prepare
+      - publish
+    # Builds and deploys the same bundle a manual dispatch would. Reused
+    # rather than restated here: the build is nine steps of nix, devenv,
+    # Cachix and a pinned flutter_rust_bridge install, and a second copy
+    # would drift from the one that gets exercised between releases.
+    uses: ./.github/workflows/deploy-web-player.yml
+    with:
+      # The commit the draft pins, so the bundle, the tag and the images all
+      # describe one commit even when master has moved past it.
+      ref: ${{ needs.prepare.outputs.sha }}
+      # Literal, and it must equal the `mydia-web` Pages project's production
+      # branch. Anything else deploys green to a preview URL and leaves
+      # web.mydia.dev on the previous release.
+      branch: master
+    secrets: inherit
+
   flatpak-publish:
     name: Publish Flatpak
     # Needs `publish`, which carries !inputs.dry_run, so this is skipped

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1350,6 +1350,8 @@ jobs:
     needs:
       - prepare
       - publish
+    permissions:
+      contents: read
     # Builds and deploys the same bundle a manual dispatch would. Reused
     # rather than restated here: the build is nine steps of nix, devenv,
     # Cachix and a pinned flutter_rust_bridge install, and a second copy
@@ -1363,7 +1365,12 @@ jobs:
       # branch. Anything else deploys green to a preview URL and leaves
       # web.mydia.dev on the previous release.
       branch: master
-    secrets: inherit
+    # Named one by one instead of `secrets: inherit`, which would pass this
+    # workflow every secret the repository holds, signing keys included, to
+    # build a static bundle. These two are what it uses.
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
   flatpak-publish:
     name: Publish Flatpak

--- a/player/web/sw.js
+++ b/player/web/sw.js
@@ -32,14 +32,23 @@ const PREFIX = new URL('p2p/', self.registration.scope).pathname;
 // the handler while this worker keeps controlling the page, because
 // unregister() does not stop a worker already in control.
 //
-// 30s is chosen against what the page does before it replies with a head: one
+// 60s is chosen against what the page does before it replies with a head: one
 // p2p round trip to the instance, which for the first segment of a fresh
 // session waits on the instance's HLS session becoming ready (its own 30s
-// budget, in lib/mydia/p2p/server.ex). Anything under that would abort real,
-// working cold starts over a relay. Nothing legitimate waits on this: the
-// failures it catches are handler-is-missing states that would otherwise wait
-// forever.
-const REPLY_TIMEOUT_MS = 30_000;
+// budget, in lib/mydia/p2p/server.ex).
+//
+// It has to exceed that budget, not match it. At an equal 30s the two
+// deadlines race and a cold start that legitimately uses its full budget
+// loses: the instance answers at the moment this worker gives up, so a
+// working session returns 503. Worse, that 503 is indistinguishable from a
+// genuine transport fault, which makes it the most misleading failure this
+// file can produce. The headroom covers the instance's own wait plus the
+// relay round trip carrying the answer back, and a browser connection never
+// hole-punches, so it always pays relay latency.
+//
+// Nothing legitimate waits on the full 60s: the failures it catches are
+// handler-is-missing states that would otherwise wait forever.
+const REPLY_TIMEOUT_MS = 60_000;
 
 self.addEventListener('install', () => self.skipWaiting());
 self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));


### PR DESCRIPTION
Closes the three gaps left open after web.mydia.dev went live. They share one failure mode: a break in the web bundle stayed invisible until someone deployed.

## 1. CI never built the player for web

`ci-player.yml` covers Windows, macOS, Linux and Android, and `icons` only diffs the generated SVG set. Nothing ran `flutter build web`. 183 commits landed on `player/` between the public web player merging (#370, 2026-08-09) and its first deploy without one of them being compiled against the web target.

The new **Build / Web** job runs the deploy's exact flags minus the wasm module. Skipping the Rust half is deliberate rather than lazy: it needs nix, wasm-pack and a pinned `flutter_rust_bridge` install (roughly twelve minutes, too much per player PR), and `ci.yml` already compiles `native/mydia_p2p_core` for `wasm32-unknown-unknown`. What stays uncovered is wasm-pack's packaging step, whose inputs are pinned toolchain versions that move only on a deliberate bump. Dart source, which every PR touches, is what this catches.

It also asserts `build/web/_headers` survived, mirroring `build_web.sh`. Without that file the deployed page is never cross-origin isolated, there is no SharedArrayBuffer, and `RustLib.init()` throws in every browser.

## 2. web.mydia.dev now ships on every stable release

`deploy-web-player.yml` gains a `workflow_call` entry point; `release.yml` calls it after `publish`. The public player now moves in step with the tag, the Docker `:latest` image and the docs.

Reused rather than restated, because the build is nine steps of nix, devenv, Cachix and a pinned codegen install, and a second copy would drift from the one exercised between releases.

Two details worth review:

- **Stable only**, matching the existing `docs` job. web.mydia.dev is a single public surface with no staging copy, so a prerelease published there reaches every viewer with no way to opt in. Betas stay on the installable builds, which a user chooses. Say the word if you would rather betas deploy to a preview URL.
- **`ref` carries the SHA the draft pins**, not master's tip, so the bundle, the tag and the images all describe one commit even after master moves. `branch` is passed explicitly as `master` because a release checks out a commit and has no branch name to infer; it must equal the `mydia-web` Pages project's production branch or the deploy goes green to a preview URL and leaves the site on the previous release. A bare dispatch still falls back to `github.ref_name`, so a feature branch publishes to a preview rather than overwriting the public player.

## 3. The service worker's 503 race

`sw.js` raises `REPLY_TIMEOUT_MS` from 30s to 60s. It was tied exactly with the instance's own HLS readiness budget (`lib/mydia/p2p/server.ex:454`), so a cold start that legitimately used its full budget lost the race and returned 503 on a working session. That 503 is indistinguishable from a genuine transport fault, which made it the most misleading failure the worker could produce. The headroom covers the instance's wait plus the relay round trip carrying the answer back, and a browser connection never hole-punches, so it always pays relay latency.

This was item 0 on `MANUAL-VERIFICATION.md`, flagged as worth fixing before anyone reads browser matrix results.

## Verification

- The new job's exact sequence (`pub get`, `build_runner build`, the web build, the `_headers` assertion) runs green locally. Build takes 51.8s on top of existing setup.
- `node --check player/web/sw.js` passes, and the built `build/web/sw.js` carries `60_000`. Worth checking by hand because Flutter copies `web/` across verbatim, so a syntax error there would not fail a build.
- `actionlint` reports no new findings across the three workflows. The remaining hits (`release.yml` 323-856, `ci-player.yml:84`) are present on master unchanged.
- Reusable-workflow wiring checked structurally: declared inputs and passed inputs match exactly, and `prepare` really does output `sha` and `is_prerelease`.

## Not covered

The browser matrix still has not run, so the wasm iroh transport, relay dial, pairing and GraphQL-over-p2p remain unexercised anywhere. Relay capacity is also still one replica at 256Mi / 500m, and a browser session never hole-punches. Both are tracked in `docs/superpowers/sdd-web-player/MANUAL-VERIFICATION.md` and neither is affected by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Stable releases now automatically deploy the web player to production.
  - Web player deployments support both preview and production release workflows.
  - Preview and release deployments can be initiated with specified source and target branches.

- **Bug Fixes**
  - Increased the web player’s page-loading timeout to 60 seconds, improving reliability during slower cold starts and streamed content initialization.

- **Chores**
  - Added automated web-player build verification to ensure release assets are generated and configured correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->