### PR TITLE
Align and de-weight the episode row toolbar

### DIFF
--- a/lib/mydia_web/live/media_live/show/helpers.ex
+++ b/lib/mydia_web/live/media_live/show/helpers.ex
@@ -286,6 +286,8 @@ defmodule MydiaWeb.MediaLive.Show.Helpers do
 
   def episode_status_icon(status), do: AvailabilityStatus.icon(status)
 
+  def episode_status_label(status), do: AvailabilityStatus.label(status)
+
   @doc "Human-readable label for a TV metadata provider."
   def provider_label(:tvdb), do: "TheTVDB"
   def provider_label(:tmdb), do: "TMDB"

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -131,34 +131,45 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
     <%= for episode <- @episodes do %>
       <% has_files = length(episode.media_files) > 0
       is_expanded = MapSet.member?(@expanded_episodes, episode.id)
-      status = get_episode_status(episode) %>
+      status = get_episode_status(episode)
+      quality = get_episode_quality_badge(episode) %>
 
       <div class={["py-2 px-3", has_files && "border-l-2 border-l-success"]}>
-        <%!-- Mobile: two rows. Desktop: single row --%>
-        <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
-          <%!-- Row 1: Episode number + Title --%>
-          <div class="flex items-center gap-1 flex-1 min-w-0">
-            <%!-- Episode number with expand toggle --%>
+        <%!-- Mobile keeps two stacked rows. From sm up every wrapper collapses to
+              `display: contents`, which dissolves the boxes and promotes the cells
+              to items of one grid with fixed tracks. That is what makes quality,
+              air date and status form columns down the whole season instead of
+              drifting with each row's content. --%>
+        <div class={[
+          "flex flex-col gap-1",
+          "sm:grid sm:items-center sm:gap-x-3 sm:gap-y-0",
+          "sm:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_2rem_auto]",
+          "lg:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_7rem_auto]"
+        ]}>
+          <div class="flex items-center gap-1 flex-1 min-w-0 sm:contents">
+            <%!-- Chevron and number share one cell so they stay a single
+                  toggle_episode_expanded target. ml-auto right-aligns the number,
+                  which keeps two- and three-digit episodes in column: the chunk
+                  threshold is 50, and TVDB puts 170 Black Clover episodes in one
+                  season. --%>
             <div
               class={[
-                "flex items-center flex-shrink-0",
-                has_files && "gap-1 cursor-pointer hover:text-primary"
+                "flex items-center gap-1 flex-shrink-0 sm:w-full",
+                has_files && "cursor-pointer hover:text-primary"
               ]}
               phx-click={has_files && "toggle_episode_expanded"}
               phx-value-episode-id={episode.id}
             >
-              <%= if has_files do %>
-                <.icon
-                  name={if is_expanded, do: "hero-chevron-down", else: "hero-chevron-right"}
-                  class="w-3 h-3 text-base-content/40"
-                />
-              <% end %>
-              <span class="font-mono text-sm font-medium text-base-content/70">
+              <.icon
+                :if={has_files}
+                name={if is_expanded, do: "hero-chevron-down", else: "hero-chevron-right"}
+                class="w-3 h-3 text-base-content/40"
+              />
+              <span class="font-mono text-sm font-medium text-base-content/70 tabular-nums sm:ml-auto">
                 {episode.episode_number}
               </span>
             </div>
 
-            <%!-- Title --%>
             <div
               class={["flex-1 min-w-0", has_files && "cursor-pointer"]}
               phx-click={has_files && "toggle_episode_expanded"}
@@ -173,84 +184,128 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             </div>
           </div>
 
-          <%!-- Row 2 on mobile / inline on desktop: metadata + actions --%>
-          <div class="flex items-center justify-between sm:justify-end gap-2 sm:pl-0">
-            <%!-- Metadata: quality + air date --%>
-            <div class="flex items-center gap-2 text-xs text-base-content/50">
-              <%= if quality = get_episode_quality_badge(episode) do %>
-                <span class="badge badge-primary badge-xs">{quality}</span>
-              <% end %>
-              <%= if episode.air_date do %>
-                <span>{format_date(episode.air_date)}</span>
-              <% end %>
-            </div>
-
-            <%!-- Status + Actions --%>
-            <div class="flex items-center gap-1 flex-shrink-0">
-              <%!-- Status indicator --%>
-              <div class="tooltip tooltip-left" data-tip={episode_status_tooltip(episode)}>
-                <span class={["badge badge-xs", episode_status_color(status)]}>
-                  <.icon name={episode_status_icon(status)} class="w-3 h-3" />
+          <div class="flex items-center justify-between gap-2 sm:contents">
+            <div class="flex items-center gap-2 sm:contents">
+              <div class="flex items-center sm:justify-end">
+                <span :if={quality} class="badge badge-sm badge-ghost font-mono tabular-nums">
+                  {quality}
                 </span>
               </div>
-              <%= if @playback_enabled && has_files do %>
-                <% episode_best_file = get_best_media_file(episode.media_files) %>
-                <a
-                  href={
-                    flutter_player_url("episode", episode.id,
-                      file_id: episode_best_file.id,
-                      title: episode.title
-                    )
-                  }
-                  class="btn btn-success btn-sm btn-square"
-                  title="Play"
+              <div class="text-xs text-base-content/50 tabular-nums sm:text-right">
+                {episode.air_date && format_date(episode.air_date)}
+              </div>
+            </div>
+
+            <div class="flex items-center gap-2 sm:contents">
+              <%!-- badge-sm (24px), not badge-xs (16px), and carrying its label at
+                    lg and up. The tooltip stays: the label names the state, the
+                    tooltip still lists the filenames. It wraps the chip from the
+                    outside, never a join-item. --%>
+              <div
+                class="tooltip tooltip-left min-w-0 sm:justify-self-end"
+                data-tip={episode_status_tooltip(episode)}
+              >
+                <span
+                  id={"episode-#{episode.id}-status"}
+                  class={["badge badge-sm gap-1 max-w-full", episode_status_color(status)]}
                 >
-                  <.icon name="hero-play-solid" class="w-4 h-4" />
-                </a>
-              <% end %>
-              <button
-                type="button"
-                phx-click="auto_search_episode"
-                phx-value-episode-id={episode.id}
-                class="btn btn-primary btn-sm btn-square"
-                disabled={@auto_searching_episode == episode.id}
-                title="Auto search"
-              >
-                <%= if @auto_searching_episode == episode.id do %>
-                  <span class="loading loading-spinner loading-sm"></span>
-                <% else %>
-                  <.icon name="hero-bolt" class="w-4 h-4" />
-                <% end %>
-              </button>
-              <button
-                type="button"
-                phx-click="search_episode"
-                phx-value-episode-id={episode.id}
-                class="btn btn-ghost btn-sm btn-square"
-                title="Manual search"
-              >
-                <.icon name="hero-magnifying-glass" class="w-4 h-4" />
-              </button>
-              <button
-                type="button"
-                phx-click="toggle_episode_monitored"
-                phx-value-episode-id={episode.id}
-                class={[
-                  "btn btn-sm btn-square",
-                  if(episode.monitored, do: "btn-ghost", else: "btn-ghost opacity-40")
-                ]}
-                title={if episode.monitored, do: "Stop monitoring", else: "Start monitoring"}
-              >
-                <.icon
-                  name={if episode.monitored, do: "hero-bookmark-solid", else: "hero-bookmark"}
-                  class="w-4 h-4"
-                />
-              </button>
+                  <.icon name={episode_status_icon(status)} class="w-3 h-3 shrink-0" />
+                  <span class="hidden lg:inline truncate">{episode_status_label(status)}</span>
+                </span>
+              </div>
+
+              <%!-- One toolbar, not four loose squares. The divider rule lives on
+                    the container because btn-ghost has no border of its own and
+                    the first item varies: the play slot is absent whenever
+                    playback is off. --%>
+              <div class="flex-shrink-0 sm:justify-self-end sm:border-l sm:border-base-300 sm:pl-3">
+                <div class="join border border-base-300 rounded-lg [&>*:not(:first-child)]:border-l [&>*:not(:first-child)]:border-base-300">
+                  <%= if @playback_enabled do %>
+                    <%= if has_files do %>
+                      <% best_file = get_best_media_file(episode.media_files) %>
+                      <a
+                        id={"episode-#{episode.id}-play"}
+                        href={
+                          flutter_player_url("episode", episode.id,
+                            file_id: best_file.id,
+                            title: episode.title
+                          )
+                        }
+                        class="join-item btn btn-sm btn-square btn-ghost"
+                        title="Play"
+                        aria-label="Play"
+                      >
+                        <.icon name="hero-play-solid" class="w-4 h-4" />
+                      </a>
+                    <% else %>
+                      <%!-- `disabled` does nothing on an anchor, so the two states
+                            are different elements filling the same 32px box. --%>
+                      <button
+                        id={"episode-#{episode.id}-play"}
+                        type="button"
+                        class="join-item btn btn-sm btn-square btn-ghost"
+                        disabled
+                        title="No file yet"
+                        aria-label="Play, no file yet"
+                      >
+                        <.icon name="hero-play-solid" class="w-4 h-4" />
+                      </button>
+                    <% end %>
+                  <% end %>
+
+                  <button
+                    id={"episode-#{episode.id}-auto-search"}
+                    type="button"
+                    phx-click="auto_search_episode"
+                    phx-value-episode-id={episode.id}
+                    class="join-item btn btn-sm btn-square btn-ghost"
+                    disabled={@auto_searching_episode == episode.id}
+                    title="Auto search"
+                    aria-label="Auto search"
+                  >
+                    <%= if @auto_searching_episode == episode.id do %>
+                      <span class="loading loading-spinner loading-sm"></span>
+                    <% else %>
+                      <.icon name="hero-bolt" class="w-4 h-4 text-primary" />
+                    <% end %>
+                  </button>
+
+                  <button
+                    id={"episode-#{episode.id}-manual-search"}
+                    type="button"
+                    phx-click="search_episode"
+                    phx-value-episode-id={episode.id}
+                    class="join-item btn btn-sm btn-square btn-ghost"
+                    title="Manual search"
+                    aria-label="Manual search"
+                  >
+                    <.icon name="hero-magnifying-glass" class="w-4 h-4" />
+                  </button>
+
+                  <%!-- Muting moves to the icon. opacity-40 on the button dimmed
+                        the focus ring with it. --%>
+                  <button
+                    id={"episode-#{episode.id}-monitor"}
+                    type="button"
+                    phx-click="toggle_episode_monitored"
+                    phx-value-episode-id={episode.id}
+                    class="join-item btn btn-sm btn-square btn-ghost"
+                    title={if episode.monitored, do: "Stop monitoring", else: "Start monitoring"}
+                    aria-label={if episode.monitored, do: "Stop monitoring", else: "Start monitoring"}
+                  >
+                    <.icon
+                      name={if episode.monitored, do: "hero-bookmark-solid", else: "hero-bookmark"}
+                      class={
+                        if episode.monitored, do: "w-4 h-4", else: "w-4 h-4 text-base-content/40"
+                      }
+                    />
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
 
-        <%!-- Expanded file details --%>
         <%= if is_expanded && has_files do %>
           <div class="mt-2 ml-8 space-y-1">
             <div :for={file <- episode.media_files} class="bg-base-200/50 rounded p-2">

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -385,70 +385,75 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
         <% end %>
       </button>
 
-      <%!-- Season actions: siblings of the toggle, so they never collapse it --%>
-      <div class="flex items-center gap-1">
-        <div class="tooltip tooltip-bottom" data-tip="Auto search season">
-          <button
-            type="button"
-            id={"season-#{@season_number}-auto-search"}
-            phx-click="auto_search_season"
-            phx-value-season-number={@season_number}
-            aria-label="Auto search season"
-            class="btn btn-sm btn-primary"
-            disabled={@auto_searching_season == @season_number}
-          >
-            <%= if @auto_searching_season == @season_number do %>
-              <span class="loading loading-spinner loading-sm"></span>
-            <% else %>
-              <.icon name="hero-bolt" class="w-4 h-4" />
-            <% end %>
-          </button>
-        </div>
-        <div class="tooltip tooltip-bottom" data-tip="Manual search">
-          <button
-            type="button"
-            phx-click="manual_search_season"
-            phx-value-season-number={@season_number}
-            aria-label="Manual search"
-            class="btn btn-sm btn-ghost"
-          >
-            <.icon name="hero-magnifying-glass" class="w-4 h-4" />
-          </button>
-        </div>
-        <div class="tooltip tooltip-bottom" data-tip="Re-scan">
-          <button
-            type="button"
-            phx-click="rescan_season"
-            phx-value-season-number={@season_number}
-            aria-label="Re-scan"
-            class="btn btn-sm btn-ghost"
-            disabled={@rescanning_season == @season_number}
-          >
-            <%= if @rescanning_season == @season_number do %>
-              <span class="loading loading-spinner loading-sm"></span>
-            <% else %>
-              <.icon name="hero-arrow-path" class="w-4 h-4" />
-            <% end %>
-          </button>
-        </div>
-        <div
-          class="tooltip tooltip-bottom"
-          data-tip={season_monitoring_tooltip(@season_state)}
+      <%!-- Season actions: siblings of the toggle, so they never collapse it.
+            One join group, matching the per-episode toolbar. The tooltip wrappers
+            are gone — a div between `join` and its items becomes the join child
+            and breaks daisyUI's sibling radius handling — so the hint moves to
+            `title` beside each button's existing aria-label. --%>
+      <div class="join border border-base-300 rounded-lg [&>*:not(:first-child)]:border-l [&>*:not(:first-child)]:border-base-300">
+        <%!-- This one keeps a text label: it acts on a whole season, so it should
+              outrank the row-level bolt. --%>
+        <button
+          type="button"
+          id={"season-#{@season_number}-auto-search"}
+          phx-click="auto_search_season"
+          phx-value-season-number={@season_number}
+          aria-label="Auto search season"
+          title="Auto search season"
+          class="join-item btn btn-sm btn-ghost gap-1"
+          disabled={@auto_searching_season == @season_number}
         >
-          <button
-            type="button"
-            id={"season-#{@season_number}-monitor-toggle"}
-            phx-click={if @season_state == :all, do: "unmonitor_season", else: "monitor_season"}
-            phx-value-season-number={@season_number}
-            aria-label={season_monitoring_tooltip(@season_state)}
-            class={[
-              "btn btn-sm btn-ghost",
-              @season_state == :none && "opacity-60"
-            ]}
-          >
-            <.monitoring_icon state={@season_state} class="w-4 h-4" />
-          </button>
-        </div>
+          <%= if @auto_searching_season == @season_number do %>
+            <span class="loading loading-spinner loading-sm"></span>
+          <% else %>
+            <.icon name="hero-bolt" class="w-4 h-4 text-primary" />
+          <% end %>
+          Auto
+        </button>
+
+        <button
+          type="button"
+          id={"season-#{@season_number}-manual-search"}
+          phx-click="manual_search_season"
+          phx-value-season-number={@season_number}
+          aria-label="Manual search"
+          title="Manual search"
+          class="join-item btn btn-sm btn-square btn-ghost"
+        >
+          <.icon name="hero-magnifying-glass" class="w-4 h-4" />
+        </button>
+
+        <button
+          type="button"
+          id={"season-#{@season_number}-rescan"}
+          phx-click="rescan_season"
+          phx-value-season-number={@season_number}
+          aria-label="Re-scan"
+          title="Re-scan"
+          class="join-item btn btn-sm btn-square btn-ghost"
+          disabled={@rescanning_season == @season_number}
+        >
+          <%= if @rescanning_season == @season_number do %>
+            <span class="loading loading-spinner loading-sm"></span>
+          <% else %>
+            <.icon name="hero-arrow-path" class="w-4 h-4" />
+          <% end %>
+        </button>
+
+        <button
+          type="button"
+          id={"season-#{@season_number}-monitor-toggle"}
+          phx-click={if @season_state == :all, do: "unmonitor_season", else: "monitor_season"}
+          phx-value-season-number={@season_number}
+          aria-label={season_monitoring_tooltip(@season_state)}
+          title={season_monitoring_tooltip(@season_state)}
+          class={[
+            "join-item btn btn-sm btn-square btn-ghost",
+            @season_state == :none && "text-base-content/40"
+          ]}
+        >
+          <.monitoring_icon state={@season_state} class="w-4 h-4" />
+        </button>
       </div>
     </div>
     """

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -228,7 +228,10 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                     the first item varies: the play slot is absent whenever
                     playback is off. --%>
               <div class="flex-shrink-0 sm:justify-self-end sm:border-l sm:border-base-300 sm:pl-3">
-                <div class="join border border-base-300 rounded-lg [&>*:not(:first-child)]:border-l [&>*:not(:first-child)]:border-base-300">
+                <div
+                  id={"episode-#{episode.id}-actions"}
+                  class="join border border-base-300 rounded-lg [&>*:not(:first-child)]:border-l [&>*:not(:first-child)]:border-base-300"
+                >
                   <%= if @playback_enabled do %>
                     <%= if has_files do %>
                       <% best_file = get_best_media_file(episode.media_files) %>

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -210,7 +210,16 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                   class={["badge badge-sm gap-1 max-w-full", episode_status_color(status)]}
                 >
                   <.icon name={episode_status_icon(status)} class="w-3 h-3 shrink-0" />
-                  <span class="hidden lg:inline truncate">{episode_status_label(status)}</span>
+                  <%!-- `hidden` is display:none, which drops the label out of the
+                        accessibility tree entirely below lg. The icon is a masked
+                        span and data-tip is CSS content, so neither names the
+                        status. Keep an sr-only copy at every breakpoint and hide
+                        the visible one from screen readers to avoid a double
+                        announcement at lg. --%>
+                  <span class="sr-only">{episode_status_label(status)}</span>
+                  <span aria-hidden="true" class="hidden lg:inline truncate">
+                    {episode_status_label(status)}
+                  </span>
                 </span>
               </div>
 

--- a/test/mydia_web/live/media_live/show/episode_row_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_row_test.exs
@@ -1,0 +1,32 @@
+defmodule MydiaWeb.MediaLive.Show.EpisodeRowTest do
+  @moduledoc """
+  The episode row's controls are icon-only, so their DOM ids are the only stable
+  handle a test has.
+
+  `episode_rows/1` is private, so these drive the public `season_section/1` with
+  `expanded?: true` instead — the same `render_component/2` approach
+  `season_collapse_test.exs` already uses for `season_header/1`. That path
+  touches neither the database nor a connection, so this file is `async: true`;
+  the `async: false` Postgres-sandbox rule is only for connected LiveView tests.
+  """
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Media.AvailabilityStatus
+  alias MydiaWeb.MediaLive.Show.Helpers
+
+  describe "episode_status_label/1" do
+    test "names the state" do
+      status = %AvailabilityStatus{state: :missing, monitored: true}
+
+      assert Helpers.episode_status_label(status) == "Missing"
+    end
+
+    test "marks an unmonitored item so the faded chip explains itself" do
+      status = %AvailabilityStatus{state: :downloaded, monitored: false}
+
+      assert Helpers.episode_status_label(status) == "Downloaded · Not monitored"
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/episode_row_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_row_test.exs
@@ -129,4 +129,36 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeRowTest do
       assert html |> query(".join > .join-item") |> Enum.count() >= 4
     end
   end
+
+  describe "season header actions" do
+    defp render_header(opts \\ []) do
+      render_component(&SeasonComponents.season_header/1,
+        season_number: 2,
+        episodes: [episode()],
+        expanded?: false,
+        auto_searching_season: Keyword.get(opts, :auto_searching_season),
+        rescanning_season: Keyword.get(opts, :rescanning_season)
+      )
+    end
+
+    test "every header action carries a stable DOM id" do
+      html = render_header()
+
+      for id <- ~w(auto-search manual-search rescan monitor-toggle) do
+        assert has_selector?(html, "#season-2-#{id}"), "expected #season-2-#{id} to render"
+      end
+    end
+
+    test "the header actions sit in one join group" do
+      html = render_header()
+
+      assert html |> query(".join > .join-item") |> Enum.count() == 4
+    end
+
+    test "the season auto search keeps a text label, unlike the row-level bolt" do
+      label = render_header() |> query("#season-2-auto-search") |> LazyHTML.text()
+
+      assert label =~ "Auto"
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/show/episode_row_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_row_test.exs
@@ -29,4 +29,104 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeRowTest do
       assert Helpers.episode_status_label(status) == "Downloaded · Not monitored"
     end
   end
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.Episode
+  alias MydiaWeb.MediaLive.Show.SeasonComponents
+
+  # library_path: nil rather than an unloaded association — MediaFile.absolute_path/1
+  # logs a warning for the unloaded case, once per file per render, which would
+  # bury the real output of every test in this file.
+  defp media_file(attrs \\ []) do
+    struct!(
+      %MediaFile{
+        id: "file-1",
+        resolution: "1080p",
+        library_path: nil,
+        relative_path: "S01E01.mkv"
+      },
+      attrs
+    )
+  end
+
+  defp episode(attrs \\ []) do
+    struct!(
+      %Episode{
+        id: "ep-1",
+        season_number: 1,
+        episode_number: 1,
+        title: "Pilot",
+        monitored: true,
+        air_date: ~D[2024-01-01],
+        media_files: [],
+        downloads: []
+      },
+      attrs
+    )
+  end
+
+  defp render_season(episodes, opts \\ []) do
+    render_component(&SeasonComponents.season_section/1,
+      season_number: 1,
+      episodes: episodes,
+      expanded?: true,
+      expanded_episodes: MapSet.new(),
+      playback_enabled: Keyword.get(opts, :playback_enabled, true),
+      segment_detection_available: false
+    )
+  end
+
+  # LazyHTML.filter/2 matches root nodes only. Every control here is nested, so
+  # this must be query/2.
+  defp query(html, selector) do
+    html |> LazyHTML.from_fragment() |> LazyHTML.query(selector)
+  end
+
+  defp has_selector?(html, selector), do: html |> query(selector) |> Enum.any?()
+
+  describe "episode row controls" do
+    test "every action carries a stable DOM id" do
+      html = render_season([episode(media_files: [media_file()])])
+
+      for suffix <- ~w(status play auto-search manual-search monitor) do
+        assert has_selector?(html, "#episode-ep-1-#{suffix}"),
+               "expected #episode-ep-1-#{suffix} to render"
+      end
+    end
+
+    test "play is a link when the episode has a file" do
+      html = render_season([episode(media_files: [media_file()])])
+
+      assert has_selector?(html, "a#episode-ep-1-play")
+      refute has_selector?(html, "button#episode-ep-1-play")
+    end
+
+    test "play is a disabled button when the episode has no file" do
+      html = render_season([episode(media_files: [])])
+
+      assert has_selector?(html, "button#episode-ep-1-play[disabled]")
+      refute has_selector?(html, "a#episode-ep-1-play")
+    end
+
+    test "the play slot is absent entirely when playback is off, for every row" do
+      html = render_season([episode(media_files: [media_file()])], playback_enabled: false)
+
+      refute has_selector?(html, "#episode-ep-1-play")
+      assert has_selector?(html, "#episode-ep-1-auto-search")
+    end
+
+    test "the status chip names the state instead of relying on its tooltip" do
+      html = render_season([episode(air_date: ~D[2024-01-01], media_files: [])])
+
+      label = html |> query("#episode-ep-1-status") |> LazyHTML.text()
+
+      assert label =~ "Missing"
+    end
+
+    test "the four actions sit in one join group" do
+      html = render_season([episode(media_files: [media_file()])])
+
+      assert html |> query(".join > .join-item") |> Enum.count() >= 4
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/show/episode_row_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_row_test.exs
@@ -139,7 +139,10 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeRowTest do
     test "the four actions sit in one join group" do
       html = render_season([episode(media_files: [media_file()])])
 
-      assert html |> query(".join > .join-item") |> Enum.count() >= 4
+      # Scoped to the episode toolbar's own id. `season_section/1` also renders
+      # the season header's join group, so an unscoped `.join > .join-item`
+      # count passes on the header alone even if this toolbar were removed.
+      assert html |> query("#episode-ep-1-actions > .join-item") |> Enum.count() == 4
     end
   end
 

--- a/test/mydia_web/live/media_live/show/episode_row_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_row_test.exs
@@ -123,6 +123,19 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeRowTest do
       assert label =~ "Missing"
     end
 
+    test "the status label reaches assistive technology at every breakpoint" do
+      html = render_season([episode(air_date: ~D[2024-01-01], media_files: [])])
+
+      # The visible label is `hidden lg:inline`, and `hidden` is display:none —
+      # it leaves the accessibility tree below lg. An sr-only copy carries the
+      # name at every width; the visible one is aria-hidden so lg does not
+      # announce it twice.
+      sr_only = html |> query("#episode-ep-1-status .sr-only") |> LazyHTML.text()
+
+      assert sr_only =~ "Missing"
+      assert has_selector?(html, ~s(#episode-ep-1-status [aria-hidden="true"]))
+    end
+
     test "the four actions sit in one join group" do
       html = render_season([episode(media_files: [media_file()])])
 

--- a/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
+++ b/test/mydia_web/live/media_live/show/monitoring_controls_test.exs
@@ -157,6 +157,6 @@ defmodule MydiaWeb.MediaLive.Show.MonitoringControlsTest do
     {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
 
     assert has_element?(view, "#season-3-monitor-toggle[phx-click='monitor_season']")
-    assert has_element?(view, "#season-3-monitor-toggle.opacity-60")
+    assert has_element?(view, "#season-3-monitor-toggle.text-base-content\\/40")
   end
 end


### PR DESCRIPTION
The per-episode action cluster on the TV show page was crowded and did not line up. Six causes, all in `episode_rows/1`:

1. **Height mismatch.** The status indicator was `badge badge-xs` (16px) sitting inline with three `btn btn-sm btn-square` (32px).
2. **Variable group width.** The play button rendered only when `@playback_enabled && has_files`, so a downloaded episode showed four buttons and a missing one three. Right-aligned, everything slid sideways row to row.
3. **No metadata columns.** Quality badge and air date were variable-width children of that same right-aligned flex, so `Feb 28, 2025` and `2160p` could never form a column.
4. **Repeated primary.** Auto search was `btn-primary` on every row, a stripe of filled blue competing with the `S{n}` badge and with the season header's own primary auto-search.
5. **Disabled-looking monitoring.** `opacity-40` marked an unmonitored episode, which reads as disabled and dimmed the focus ring along with the icon.
6. **Untestable.** No DOM ids on any episode-row control, unlike the season header.

## What changed

**The row is a grid, not a flex.** Fixed tracks for quality, air date and status, so every value lands in the same place on every row. Below `sm` it keeps the existing two-row stack; from `sm` up the wrappers collapse via `display: contents` and the cells become grid items. The status track is deliberately fixed rather than `auto` — `Downloading` is ~6rem wide and `Missing` ~4.5rem, so an `auto` track would push the action group to a different x on every row, which is the original defect wearing a new hat.

**The play slot is always present** when playback is enabled: an `<a>` when the episode has a file, a `disabled <button>` titled "No file yet" when it does not. `disabled` does nothing on an anchor, so these are different elements filling the same 32px box. When playback is off the slot is dropped for every row at once, so alignment still holds.

**The four actions are one `join` group** of ghost buttons. Auto search drops `btn-primary` and keeps only `text-primary` on its icon; the quality badge drops `badge-primary` for `badge-ghost`. No filled buttons remain in the list, which returns the only primary button on the page to the season header where it outranks the row-level actions.

**The status chip grew** from a 16px icon-only `badge-xs` to a 24px `badge-sm` carrying a text label at `lg` and up, separated from the buttons by a hairline. State is now readable without hovering for a tooltip. The tooltip stays and still lists the filenames.

**Monitoring muting moved** from `opacity-40` on the button to a muted colour, so hover and the focus ring stay at full strength.

**The season header gets the same treatment** so the page has one toolbar vocabulary, with its auto search keeping a text label since it acts on a whole season.

## Testing

New `test/mydia_web/live/media_live/show/episode_row_test.exs` drives `season_section/1` through `render_component/2` and asserts via `LazyHTML.query/2` on elements, never raw HTML. It covers the DOM ids, the anchor-vs-disabled-button split, the playback-off case, and the chip's label. Every control now carries an id, which is what makes the row reachable from a `Phoenix.LiveViewTest` selector for the first time.

## Notes for review

- **No behaviour changes.** Every `phx-click` name and `phx-value-*` payload is byte-identical to master; this is markup and CSS only. No context, schema, or GraphQL changes, so no Rust SDL parity work.
- One assertion in `monitoring_controls_test.exs` was updated like-for-like, since the season monitor toggle's dimmed class changed name.
- The long `[&>*:not(:first-child)]:border-l` string is duplicated between the two components on purpose. Tailwind v4 scans source text, so a class reached through a variable or helper is never generated.
- Gates: compile clean with `--warnings-as-errors`, `mix format` no-op, credo 0 issues, full suite 8522/8522.
- **This is a pure UI change and has not been eyeballed in a browser.** The layout was verified structurally (six leaf items matching six grid tracks, two levels of `sm:contents`, all four actions direct children of `.join`) and designed against mockups built from the real theme tokens, but a quick resize check across `sm`/`lg` before merge is worth the minute.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved episode and season controls with clearer labels, accessible actions, and grouped toolbars.
  - Playback controls are disabled when episode files are unavailable.
  - Added responsive episode layouts that align quality, air date, status, and actions on larger screens while preserving mobile stacking.
  - Added consistent status labels, monitoring indicators, and clearer Auto-search labeling.

- **Bug Fixes**
  - Improved visual feedback for inactive monitoring controls.

- **Tests**
  - Added coverage for episode rows and season headers, including playback states, status labels, identifiers, accessibility, and action controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->