### PR TITLE
Only offer season orderings TVDB publishes

### DIFF
--- a/lib/mydia/media/season_order.ex
+++ b/lib/mydia/media/season_order.ex
@@ -77,6 +77,43 @@ defmodule Mydia.Media.SeasonOrder do
   def effective(%MediaItem{season_order: order}), do: order
 
   @doc """
+  The orderings this show can actually be put into: the ones TVDB publishes
+  for it, narrowed to the ones `season_order` can store, plus whichever one
+  the show is in right now.
+
+  Meant to drive the ordering selector. Offering an ordering TVDB does not
+  publish buys a guaranteed `{:error, :no_alternative_ordering}` from
+  `switch/3`, since `Relay.fetch_ordering_episodes/4` finds no season stubs
+  of that type and returns an empty list. Not offering it is the fix.
+
+  `effective/1` is included unconditionally. A show recorded as `:dvd` whose
+  TVDB payload no longer lists a dvd ordering would otherwise render a
+  selector with no matching option, which misreports where the show is and
+  leaves no way back.
+
+  TVDB publishes types outside `@values` for some series ("alternate",
+  "regional"). They are dropped: `media_items.season_order` is an
+  `Ecto.Enum` restricted to `@values` and cannot store them.
+  """
+  @spec available(MediaItem.t(), map()) :: {:ok, [atom()]} | {:error, term()}
+  def available(%MediaItem{tvdb_id: nil}, _config), do: {:error, :missing_tvdb_id}
+
+  def available(%MediaItem{} = media_item, config) do
+    provider_id = to_string(media_item.tvdb_id)
+    current = effective(media_item)
+
+    with {:ok, raw_seasons} <- Relay.fetch_raw_seasons(config, provider_id) do
+      published = raw_seasons |> Relay.available_orderings() |> Map.keys()
+
+      # Filtering `@values` rather than mapping the payload's keys does three
+      # jobs in one pass: it drops types the enum cannot store, it fixes the
+      # option order independently of the map's key order, and it never calls
+      # `String.to_atom/1` on a provider-supplied string.
+      {:ok, Enum.filter(@values, &(&1 == current or Atom.to_string(&1) in published))}
+    end
+  end
+
+  @doc """
   Looks up TVDB's alternative ("dvd") ordering for a show and, if it exists,
   the real per-season episode counts (specials excluded) — the numbers a
   suggestion banner needs to name the alternative concretely rather than

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -177,7 +177,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> SegmentEvents.assign_segment_status(media_item)
      |> FranchiseEvents.maybe_load()
      |> RecommendationEvents.maybe_load()
-     |> MediaItemEvents.maybe_load_season_order_suggestion()
+     |> MediaItemEvents.maybe_load_season_order_info()
      |> assign_target_library(media_item)
      |> stream_configure(:search_results, dom_id: &generate_positioned_id/1)
      |> stream(:search_results, [])}
@@ -688,8 +688,8 @@ defmodule MydiaWeb.MediaLive.Show do
   def handle_async(:load_recommendations, result, socket),
     do: RecommendationEvents.handle_load_result(result, socket)
 
-  def handle_async(:load_season_order_suggestion, result, socket),
-    do: MediaItemEvents.handle_season_order_suggestion_result(result, socket)
+  def handle_async(:load_season_order_info, result, socket),
+    do: MediaItemEvents.handle_season_order_info_result(result, socket)
 
   def handle_async({:add_recommendation, tmdb_id}, result, socket),
     do: RecommendationEvents.handle_add_result(tmdb_id, result, socket)

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -231,6 +231,7 @@
             segment_statuses={@segment_statuses}
             segment_detection_available={@segment_detection_available}
             season_order_suggestion={@season_order_suggestion}
+            season_order_options={@season_order_options}
             can_update_media={@can_update_media}
           />
           <%!-- Media Files Section --%>

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -453,6 +453,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :segment_statuses, :map, default: %{}
   attr :segment_detection_available, :boolean, default: true
   attr :season_order_suggestion, :any, default: nil
+  attr :season_order_options, :any, default: nil
   attr :can_update_media, :boolean, required: true
 
   def episodes_section(assigns) do
@@ -536,6 +537,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           <SeasonOrderComponents.season_order_controls
             media_item={@media_item}
             season_order_suggestion={@season_order_suggestion}
+            options={@season_order_options}
             can_update_media={@can_update_media}
           />
         </div>

--- a/lib/mydia_web/live/media_live/show/media_item_events.ex
+++ b/lib/mydia_web/live/media_live/show/media_item_events.ex
@@ -273,7 +273,7 @@ defmodule MydiaWeb.MediaLive.Show.MediaItemEvents do
          put_flash(
            socket,
            :error,
-           "TVDB does not offer a #{SeasonOrder.label(target)} ordering for this show."
+           "TVDB does not list #{SeasonOrder.label(target)} for this show."
          )}
 
       {:error, :missing_tvdb_id} ->

--- a/lib/mydia_web/live/media_live/show/media_item_events.ex
+++ b/lib/mydia_web/live/media_live/show/media_item_events.ex
@@ -91,35 +91,72 @@ defmodule MydiaWeb.MediaLive.Show.MediaItemEvents do
   # Season ordering
 
   @doc """
-  Starts the season-order-suggestion lookup on the connected mount.
+  Starts the season-ordering lookup on the connected mount.
 
-  Eligibility is checked entirely from local data (no network), so the
-  (multi-request) TVDB lookup only ever fires for a TVDB show with no
-  recorded ordering and an official season that actually looks wrong. Every
-  other show never pays for it, and the disconnected (dead) render never
-  does either — same convention as `FranchiseEvents.maybe_load/1`.
+  Two things come out of one TVDB round trip: which orderings the show can be
+  put into (always), and the suggestion banner's per-season counts (only for a
+  show that qualifies for a banner). Both read `Relay.fetch_raw_seasons/2`,
+  which is cached for 24 hours, so the second half costs no extra
+  series-level request.
+
+  One task rather than two: `Mydia.Metadata.Cache.fetch/3` is a plain
+  get/miss/put with no locking, so two concurrent tasks would both miss on a
+  cold cache and issue the same request twice.
+
+  Eligibility is checked entirely from local data (no network) and includes
+  `can_update_media`, because `change_season_order` is authorization-gated and
+  a viewer who cannot act on the result should not pay for the lookup. The
+  disconnected (dead) render never runs it either, same convention as
+  `FranchiseEvents.maybe_load/1`.
   """
-  def maybe_load_season_order_suggestion(socket) do
-    socket = assign(socket, :season_order_suggestion, nil)
+  def maybe_load_season_order_info(socket) do
+    socket =
+      socket
+      |> assign(:season_order_suggestion, nil)
+      |> assign(:season_order_options, nil)
+
     media_item = socket.assigns.media_item
 
-    if connected?(socket) and eligible_for_season_order_suggestion?(media_item) do
+    if connected?(socket) and eligible_for_season_order_lookup?(socket) do
       config = socket.assigns.metadata_config
+      suggest? = eligible_for_season_order_suggestion?(media_item)
 
-      start_async(socket, :load_season_order_suggestion, fn ->
-        SeasonOrder.suggest_alternative(media_item, config)
+      start_async(socket, :load_season_order_info, fn ->
+        load_season_order_info(media_item, config, suggest?)
       end)
     else
       socket
     end
   end
 
-  def handle_season_order_suggestion_result({:ok, {:ok, counts}}, socket) do
-    {:noreply, assign(socket, :season_order_suggestion, %{order: :dvd, counts: counts})}
+  defp load_season_order_info(media_item, config, suggest?) do
+    case SeasonOrder.available(media_item, config) do
+      {:ok, available} ->
+        {:ok, %{available: available, suggestion: suggestion(media_item, config, suggest?)}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
-  def handle_season_order_suggestion_result({:ok, {:error, reason}}, socket) do
-    Logger.debug("No season order suggestion",
+  defp suggestion(_media_item, _config, false), do: nil
+
+  defp suggestion(media_item, config, true) do
+    case SeasonOrder.suggest_alternative(media_item, config) do
+      {:ok, counts} -> %{order: :dvd, counts: counts}
+      {:error, _reason} -> nil
+    end
+  end
+
+  def handle_season_order_info_result({:ok, {:ok, info}}, socket) do
+    {:noreply,
+     socket
+     |> assign(:season_order_options, info.available)
+     |> assign(:season_order_suggestion, info.suggestion)}
+  end
+
+  def handle_season_order_info_result({:ok, {:error, reason}}, socket) do
+    Logger.debug("No season order info",
       media_item_id: socket.assigns.media_item.id,
       reason: inspect(reason)
     )
@@ -127,13 +164,21 @@ defmodule MydiaWeb.MediaLive.Show.MediaItemEvents do
     {:noreply, socket}
   end
 
-  def handle_season_order_suggestion_result({:exit, reason}, socket) do
-    Logger.warning("Season order suggestion lookup crashed",
+  def handle_season_order_info_result({:exit, reason}, socket) do
+    Logger.warning("Season order lookup crashed",
       media_item_id: socket.assigns.media_item.id,
       reason: inspect(reason)
     )
 
     {:noreply, socket}
+  end
+
+  defp eligible_for_season_order_lookup?(socket) do
+    media_item = socket.assigns.media_item
+
+    socket.assigns.can_update_media and
+      media_item.type == "tv_show" and
+      media_item.metadata_source == :tvdb
   end
 
   defp eligible_for_season_order_suggestion?(media_item) do

--- a/lib/mydia_web/live/media_live/show/season_order_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_order_components.ex
@@ -17,21 +17,30 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderComponents do
 
   @doc """
   Season-ordering controls for a TVDB-sourced TV show: a persistent selector
-  (any TVDB show, any time) and a dismissible suggestion banner (only when
-  the show has never been asked and its official season looks wrong).
+  (whenever TVDB publishes more than one ordering for the show) and a
+  dismissible suggestion banner (only when the show has never been asked and
+  its official season looks wrong).
 
-  Absent entirely for non-TVDB shows — there is nothing to switch between —
-  and for a viewer who cannot update media, since `change_season_order` is
-  authorization-gated: showing a control that will be refused is worse than
-  not showing it.
+  Absent entirely for non-TVDB shows, for a viewer who cannot update media
+  (`change_season_order` is authorization-gated, and a control that will be
+  refused is worse than no control), and for a show whose `options` hold
+  fewer than two orderings, where every choice but the current one would
+  fail.
   """
   attr :media_item, :map, required: true
   attr :season_order_suggestion, :any, default: nil
+  attr :options, :any, default: nil
   attr :can_update_media, :boolean, required: true
 
   def season_order_controls(assigns) do
     ~H"""
-    <div :if={tvdb_show?(@media_item) and @can_update_media} class="mb-4 space-y-3">
+    <div
+      :if={
+        tvdb_show?(@media_item) and @can_update_media and
+          (@season_order_suggestion || switchable?(@options))
+      }
+      class="mb-4 space-y-3"
+    >
       <div
         :if={@season_order_suggestion}
         id="season-order-suggestion"
@@ -67,6 +76,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderComponents do
       </div>
 
       <form
+        :if={switchable?(@options)}
         id="season-order-form"
         phx-change="change_season_order"
         class="flex items-center gap-2"
@@ -76,7 +86,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderComponents do
         </label>
         <select id="season-order-select" name="order" class="select select-xs select-bordered w-auto">
           <option
-            :for={order <- SeasonOrder.values()}
+            :for={order <- @options}
             value={order}
             selected={current_season_order(@media_item) == order}
           >
@@ -90,6 +100,13 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderComponents do
 
   defp tvdb_show?(media_item),
     do: media_item.type == "tv_show" and media_item.metadata_source == :tvdb
+
+  # nil means the lookup has not landed or has failed, which reads the same as
+  # "nothing to switch to": hide the control rather than offer a choice
+  # `switch/3` would refuse. A single-entry list is the show's current
+  # ordering and nothing else, so it is not a choice either.
+  defp switchable?(options) when is_list(options), do: length(options) > 1
+  defp switchable?(_options), do: false
 
   defp current_season_order(media_item), do: SeasonOrder.effective(media_item)
 

--- a/test/mydia/media/season_order_test.exs
+++ b/test/mydia/media/season_order_test.exs
@@ -198,4 +198,87 @@ defmodule Mydia.Media.SeasonOrderTest do
     |> Enum.map(&{&1.provider_episode_id, &1.season_number, &1.episode_number})
     |> Enum.sort()
   end
+
+  describe "available/2" do
+    setup do
+      %{config: Mydia.Metadata.default_relay_config()}
+    end
+
+    test "offers the orderings TVDB publishes", %{config: config} do
+      tvdb_id = System.unique_integer([:positive])
+      show = tvdb_show(tvdb_id)
+      seed_raw_seasons(tvdb_id, [{"official", 1}, {"dvd", 4}])
+
+      assert {:ok, [:official, :dvd]} = SeasonOrder.available(show, config)
+    end
+
+    test "drops ordering types season_order cannot store", %{config: config} do
+      tvdb_id = System.unique_integer([:positive])
+      show = tvdb_show(tvdb_id)
+      seed_raw_seasons(tvdb_id, [{"official", 1}, {"alternate", 3}, {"regional", 2}])
+
+      assert {:ok, [:official]} = SeasonOrder.available(show, config)
+    end
+
+    # The option order must not depend on the payload's key order, or the
+    # selector would reshuffle itself between shows.
+    test "returns the orderings in values/0 order", %{config: config} do
+      tvdb_id = System.unique_integer([:positive])
+      show = tvdb_show(tvdb_id)
+      seed_raw_seasons(tvdb_id, [{"absolute", 1}, {"dvd", 4}, {"official", 1}])
+
+      assert {:ok, [:official, :dvd, :absolute]} = SeasonOrder.available(show, config)
+    end
+
+    # A show sitting on an ordering TVDB no longer publishes would otherwise
+    # render a selector with no matching option, misreporting where it is and
+    # offering no way back.
+    test "always includes the ordering the show is already in", %{config: config} do
+      tvdb_id = System.unique_integer([:positive])
+      show = tvdb_show(tvdb_id, %{season_order: :dvd})
+      seed_raw_seasons(tvdb_id, [{"official", 1}])
+
+      assert {:ok, [:official, :dvd]} = SeasonOrder.available(show, config)
+    end
+
+    test "refuses a show with no TVDB id", %{config: config} do
+      show = media_item_fixture(%{type: "tv_show", title: "No Id", metadata_source: :tvdb})
+
+      assert {:error, :missing_tvdb_id} = SeasonOrder.available(show, config)
+    end
+  end
+
+  defp tvdb_show(tvdb_id, attrs \\ %{}) do
+    media_item_fixture(
+      Map.merge(
+        %{
+          type: "tv_show",
+          title: "Ordering #{tvdb_id}",
+          tvdb_id: tvdb_id,
+          metadata_source: :tvdb
+        },
+        attrs
+      )
+    )
+  end
+
+  # Seeds the cache key `Relay.fetch_raw_seasons/2` reads, so the lookup never
+  # makes an HTTP request. `Mydia.Metadata.Cache` is a shared ETS table, but the
+  # key carries a unique tvdb_id per test, so this stays safe under async: true.
+  defp seed_raw_seasons(tvdb_id, types) do
+    seasons =
+      Enum.flat_map(types, fn {type, season_count} ->
+        Enum.map(1..season_count, fn number ->
+          %{
+            "id" => System.unique_integer([:positive]),
+            "number" => number,
+            "type" => %{"type" => type}
+          }
+        end)
+      end)
+
+    Mydia.Metadata.Cache.put("tvdb_raw_seasons:#{tvdb_id}", seasons, ttl: :timer.hours(1))
+
+    :ok
+  end
 end

--- a/test/mydia_web/live/media_live/show/season_order_ui_test.exs
+++ b/test/mydia_web/live/media_live/show/season_order_ui_test.exs
@@ -117,25 +117,90 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderUiTest do
     refute has_element?(view, "#season-order-suggestion")
   end
 
-  test "the persistent selector is present on a normally sized TVDB show", %{conn: conn} do
-    show = media_item_fixture(%{type: "tv_show", title: "Normal", metadata_source: :tvdb})
+  test "no selector when TVDB publishes only the official ordering", %{conn: conn} do
+    tvdb_id = System.unique_integer([:positive])
+
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Official Only",
+        tvdb_id: tvdb_id,
+        metadata_source: :tvdb
+      })
+
+    for n <- 1..12 do
+      episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: n})
+    end
+
+    stub_tvdb_orderings(tvdb_id, official: 12)
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    refute has_element?(view, "#season-order-suggestion")
+    refute has_element?(view, "#season-order-select")
+  end
+
+  test "the selector offers exactly the orderings TVDB publishes", %{conn: conn} do
+    tvdb_id = System.unique_integer([:positive])
+    show = oversized_show(tvdb_id)
+    stub_tvdb_orderings(tvdb_id, official: 170, dvd: [51, 51, 52, 16])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, "#season-order-select option[value=official]", "Aired order")
+    assert has_element?(view, "#season-order-select option[value=dvd]", "DVD order")
+    assert has_element?(view, "#season-order-select option[value=official][selected]")
+
+    # The whole point: absolute is in SeasonOrder.values/0 but not in this
+    # show's TVDB payload, and picking it could only ever produce an error.
+    refute has_element?(view, "#season-order-select option[value=absolute]")
+  end
+
+  # The mirror of the test above. Without it, a filter that simply hard-coded
+  # "drop absolute" would pass everything else in this file.
+  test "an absolute ordering TVDB does publish is offered", %{conn: conn} do
+    tvdb_id = System.unique_integer([:positive])
+    show = oversized_show(tvdb_id)
+    stub_tvdb_orderings(tvdb_id, official: 170, absolute: [170])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, "#season-order-select option[value=absolute]", "Absolute order")
+    refute has_element?(view, "#season-order-select option[value=dvd]")
+  end
+
+  # The failed-lookup branch, exercised through the one failure that needs no
+  # network: available/2 refuses a nil tvdb_id before it fetches anything. A
+  # relay outage lands on the same {:error, reason} handler. There is no seam
+  # to point the LiveView's own relay config at Bypass, so an outage cannot be
+  # simulated here without a real outbound request.
+  test "no selector when the show has no TVDB id to look orderings up with", %{conn: conn} do
+    show = media_item_fixture(%{type: "tv_show", title: "No Tvdb Id", metadata_source: :tvdb})
 
     for n <- 1..12 do
       episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: n})
     end
 
     {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
 
-    refute has_element?(view, "#season-order-suggestion")
-    assert has_element?(view, "#season-order-select")
+    refute has_element?(view, "#season-order-select")
+  end
 
-    # The options' `value`s are the ordering atoms rendered as plain option
-    # values (`:official` -> "official", etc), and the show's nil
-    # `season_order` (never asked) selects "official", not nothing.
+  test "the selector still lists the ordering the show is already in", %{conn: conn} do
+    tvdb_id = System.unique_integer([:positive])
+    show = oversized_show(tvdb_id)
+    {:ok, _show} = Media.update_media_item(show, %{season_order: :dvd})
+    stub_tvdb_orderings(tvdb_id, official: 170)
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, "#season-order-select option[value=dvd][selected]", "DVD order")
     assert has_element?(view, "#season-order-select option[value=official]", "Aired order")
-    assert has_element?(view, "#season-order-select option[value=dvd]", "DVD order")
-    assert has_element?(view, "#season-order-select option[value=absolute]", "Absolute order")
-    assert has_element?(view, "#season-order-select option[value=official][selected]")
   end
 
   test "picking a different ordering from the persistent selector switches to it", %{conn: conn} do
@@ -407,21 +472,27 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderUiTest do
   # do not include the base URL, so the LiveView's later call against the
   # real default config reads the stubbed data back with no outbound
   # request — same trick as `FranchiseSectionTest.warm_collection_cache/2`.
-  defp stub_tvdb_orderings(tvdb_id, official: official_count, dvd: dvd_counts) do
+  defp stub_tvdb_orderings(tvdb_id, opts) do
     bypass = Bypass.open()
 
     relay = Mydia.Metadata.default_relay_config()
     bypass_config = %{relay | base_url: "http://localhost:#{bypass.port}"}
 
+    official_count = Keyword.fetch!(opts, :official)
+    dvd_counts = Keyword.get(opts, :dvd, [])
+    absolute_counts = Keyword.get(opts, :absolute, [])
+
     official_season_id = System.unique_integer([:positive])
     dvd_season_ids = Enum.map(dvd_counts, fn _ -> System.unique_integer([:positive]) end)
+
+    absolute_season_ids =
+      Enum.map(absolute_counts, fn _ -> System.unique_integer([:positive]) end)
 
     Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
       seasons =
         [season_stub(official_season_id, 1, "official")] ++
-          (dvd_season_ids
-           |> Enum.with_index(1)
-           |> Enum.map(fn {id, number} -> season_stub(id, number, "dvd") end))
+          typed_season_stubs(dvd_season_ids, "dvd") ++
+          typed_season_stubs(absolute_season_ids, "absolute")
 
       json(conn, %{"data" => %{"id" => tvdb_id, "seasons" => seasons}})
     end)
@@ -434,25 +505,40 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderUiTest do
       })
     end)
 
-    _final_episode_id =
-      dvd_season_ids
-      |> Enum.zip(dvd_counts)
-      |> Enum.with_index(1)
-      |> Enum.reduce(1, fn {{season_id, count}, season_number}, next_id ->
-        episode_ids = next_id..(next_id + count - 1)
-
-        Bypass.stub(bypass, "GET", "/tvdb/seasons/#{season_id}/extended", fn conn ->
-          episodes = episodes_json(episode_ids, season_number)
-
-          json(conn, %{
-            "data" => %{"id" => season_id, "number" => season_number, "episodes" => episodes}
-          })
-        end)
-
-        next_id + count
-      end)
+    stub_ordering_seasons(bypass, dvd_season_ids, dvd_counts)
+    stub_ordering_seasons(bypass, absolute_season_ids, absolute_counts)
 
     warm_ordering_cache(bypass_config, tvdb_id)
+
+    :ok
+  end
+
+  defp typed_season_stubs(season_ids, type) do
+    season_ids
+    |> Enum.with_index(1)
+    |> Enum.map(fn {id, number} -> season_stub(id, number, type) end)
+  end
+
+  # Every ordering describes the same episode ids (1..sum(counts)), grouped
+  # differently, which is what makes a real TVDB alternative ordering safe to
+  # switch to losslessly.
+  defp stub_ordering_seasons(bypass, season_ids, counts) do
+    season_ids
+    |> Enum.zip(counts)
+    |> Enum.with_index(1)
+    |> Enum.reduce(1, fn {{season_id, count}, season_number}, next_id ->
+      episode_ids = next_id..(next_id + count - 1)
+
+      Bypass.stub(bypass, "GET", "/tvdb/seasons/#{season_id}/extended", fn conn ->
+        episodes = episodes_json(episode_ids, season_number)
+
+        json(conn, %{
+          "data" => %{"id" => season_id, "number" => season_number, "episodes" => episodes}
+        })
+      end)
+
+      next_id + count
+    end)
 
     :ok
   end
@@ -463,8 +549,14 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderUiTest do
     provider_id = to_string(tvdb_id)
 
     {:ok, raw_seasons} = Relay.fetch_raw_seasons(bypass_config, provider_id)
-    {:ok, _} = Relay.fetch_ordering_episodes(bypass_config, provider_id, "official", raw_seasons)
-    {:ok, _} = Relay.fetch_ordering_episodes(bypass_config, provider_id, "dvd", raw_seasons)
+
+    # An ordering with no season stubs short-circuits to {:ok, []} inside
+    # fetch_ordering_episodes/4 without making a request, so asking for all
+    # three is safe whatever the caller stubbed.
+    for type <- ["official", "dvd", "absolute"] do
+      {:ok, _episodes} =
+        Relay.fetch_ordering_episodes(bypass_config, provider_id, type, raw_seasons)
+    end
 
     :ok
   end
@@ -580,13 +672,12 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderUiTest do
     end
 
     test "the ordering controls still render for an admin", %{conn: conn} do
-      show = media_item_fixture(%{type: "tv_show", title: "Normal", metadata_source: :tvdb})
-
-      for n <- 1..12 do
-        episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: n})
-      end
+      tvdb_id = System.unique_integer([:positive])
+      show = oversized_show(tvdb_id)
+      stub_tvdb_orderings(tvdb_id, official: 170, dvd: [51, 51, 52, 16])
 
       {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+      render_async(view, 5000)
 
       assert has_element?(view, "#season-order-select")
     end

--- a/test/mydia_web/live/media_live/show/season_order_ui_test.exs
+++ b/test/mydia_web/live/media_live/show/season_order_ui_test.exs
@@ -222,6 +222,25 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderUiTest do
     assert reloaded.season_order == :dvd
   end
 
+  test "picking an ordering TVDB does not publish flashes instead of switching", %{conn: conn} do
+    tvdb_id = System.unique_integer([:positive])
+    show = oversized_show(tvdb_id)
+    stub_tvdb_orderings(tvdb_id, official: 170, dvd: [51, 51, 52, 16])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    # Fired straight at the handler rather than through the select: the render
+    # gate no longer offers absolute for this show, so this is the stale-cache
+    # path, where TVDB's payload changed between render and submit.
+    render_change(view, "change_season_order", %{"order" => "absolute"})
+
+    assert has_element?(view, "#flash-error", "TVDB does not list Absolute order for this show.")
+
+    reloaded = Media.get_media_item!(show.id)
+    assert reloaded.season_order == nil
+  end
+
   test "no ordering controls for a TMDB-sourced show", %{conn: conn} do
     show = media_item_fixture(%{type: "tv_show", title: "Tmdb Only", metadata_source: :tmdb})
 

--- a/test/mydia_web/live/media_live/show/season_order_ui_test.exs
+++ b/test/mydia_web/live/media_live/show/season_order_ui_test.exs
@@ -542,22 +542,23 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderUiTest do
   # differently, which is what makes a real TVDB alternative ordering safe to
   # switch to losslessly.
   defp stub_ordering_seasons(bypass, season_ids, counts) do
-    season_ids
-    |> Enum.zip(counts)
-    |> Enum.with_index(1)
-    |> Enum.reduce(1, fn {{season_id, count}, season_number}, next_id ->
-      episode_ids = next_id..(next_id + count - 1)
+    _final_episode_id =
+      season_ids
+      |> Enum.zip(counts)
+      |> Enum.with_index(1)
+      |> Enum.reduce(1, fn {{season_id, count}, season_number}, next_id ->
+        episode_ids = next_id..(next_id + count - 1)
 
-      Bypass.stub(bypass, "GET", "/tvdb/seasons/#{season_id}/extended", fn conn ->
-        episodes = episodes_json(episode_ids, season_number)
+        Bypass.stub(bypass, "GET", "/tvdb/seasons/#{season_id}/extended", fn conn ->
+          episodes = episodes_json(episode_ids, season_number)
 
-        json(conn, %{
-          "data" => %{"id" => season_id, "number" => season_number, "episodes" => episodes}
-        })
+          json(conn, %{
+            "data" => %{"id" => season_id, "number" => season_number, "episodes" => episodes}
+          })
+        end)
+
+        next_id + count
       end)
-
-      next_id + count
-    end)
 
     :ok
   end


### PR DESCRIPTION
The TV show page offered all three of `SeasonOrder.values/0` for every TVDB show, with no knowledge of which orderings that show actually has. Most shows only publish an official ordering, so two of the three options were guaranteed failures: picking one landed on `{:error, :no_alternative_ordering}` and the flash "TVDB does not offer a DVD order ordering for this show."

The page now looks up the show's published orderings once on the connected mount, in the same async task that already fetches the suggestion banner's counts, and the selector renders only those. A show with a single ordering, or one whose lookup fails, renders no selector at all.

- `SeasonOrder.available/2` returns the orderings TVDB publishes, narrowed to what the `season_order` enum can store, always including the one the show is currently in
- The mount-time lookup now runs for every TVDB show the viewer can edit rather than only oversized ones, and returns availability and the banner counts together from one task, since `Metadata.Cache.fetch/3` has no locking and two tasks would both miss on a cold cache
- The stale-cache flash is reworded from "does not offer a DVD order ordering" to "does not list DVD order"

A show sitting on an ordering TVDB no longer publishes keeps that option and stays switchable back to aired order, so this cannot strand anyone.

## Testing

- 5 new unit tests for `available/2`, seeded through `Metadata.Cache` so they make no HTTP request and stay `async: true`
- 4 new and 2 rewritten LiveView tests, including a pair that guards against a hard-coded "drop absolute" shortcut passing for the wrong reason
- Full suite green (8521 tests), `--warnings-as-errors` clean, Credo clean
- A `--trace` run of the season-order UI file confirms all 23 tests finish under 700ms, so none reach the live relay


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added season-order options based on supported TVDB orderings.
  * Added a selector for switching between available season-order options.
  * Preserved the current season ordering when available options are displayed.
  * Combined season-order information and alternative-order suggestions into one loading flow.

* **Bug Fixes**
  * Unsupported and invalid ordering types are now excluded.
  * Improved handling for missing TVDB information and unavailable ordering data.
  * Added safeguards for stale submissions and unauthorized changes.

* **Tests**
  * Expanded coverage for ordering availability, filtering, authorization, and UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->