### PR TITLE
fix(media): put a movie's files above the discovery rails

### DIFF
--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -17,7 +17,7 @@ defmodule MydiaWeb.MediaLive.Show do
   alias MydiaWeb.MediaLive.Show.SegmentEvents
   alias MydiaWeb.MediaLive.Show.FranchiseEvents
   alias MydiaWeb.MediaLive.Show.RecommendationEvents
-  alias MydiaWeb.DiscoverComponents
+  alias MydiaWeb.MediaLive.Show.RecommendationComponents
 
   # Import helper modules
   import MydiaWeb.MediaLive.Show.Formatters

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -192,17 +192,11 @@
           <% end %>
           <%!-- Overview Section --%>
           <Components.overview_section media_item={@media_item} />
-          <%!-- Franchise Section (Movies in the same TMDB collection) --%>
-          <FranchiseComponents.franchise_section
-            :if={@franchise}
-            franchise={@franchise}
-            can_add={@can_create_media}
-            current_user={@current_user}
-            adding_tmdb_ids={@adding_franchise_tmdb_ids}
-          />
-          <%!-- Collapsed by default on shows, so the episode list below is not
-                pushed under a strip of other titles. Movies render it open. --%>
+          <%!-- Recommendations, TV placement. A show renders this collapsed, so
+                it costs one row and pushes the episode list down by nothing.
+                Movies get it at the bottom of the page instead: see below. --%>
           <RecommendationComponents.recommendations_section
+            :if={@media_item.type == "tv_show"}
             media_item={@media_item}
             items={@recommendations}
             expanded={@recommendations_expanded}
@@ -240,6 +234,30 @@
           />
           <%!-- Timeline Section --%>
           <Components.timeline_section timeline_events={@timeline_events} />
+          <%!-- Everything below here is about other titles, not this one.
+                Franchise Section (Movies in the same TMDB collection) --%>
+          <FranchiseComponents.franchise_section
+            :if={@franchise}
+            franchise={@franchise}
+            can_add={@can_create_media}
+            current_user={@current_user}
+            adding_tmdb_ids={@adding_franchise_tmdb_ids}
+          />
+          <%!-- Recommendations, movie placement. Expanded here, so it sits below
+                the file list: 500px of posters between the overview and the file
+                the user owns buried the thing they came to the page for. The two
+                guards are mutually exclusive and jointly total, so the rail
+                always renders in exactly one place. --%>
+          <RecommendationComponents.recommendations_section
+            :if={@media_item.type != "tv_show"}
+            media_item={@media_item}
+            items={@recommendations}
+            expanded={@recommendations_expanded}
+            current_user={@current_user}
+            adding_ids={@adding_recommendation_tmdb_ids}
+            requesting_item_id={@requesting_recommendation_id}
+            can_add={@can_create_media}
+          />
         </div>
       </div>
     </div>

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -202,20 +202,14 @@
           />
           <%!-- Collapsed by default on shows, so the episode list below is not
                 pushed under a strip of other titles. Movies render it open. --%>
-          <DiscoverComponents.media_rail
-            id="recommendations-rail"
-            collapsible={@media_item.type == "tv_show"}
-            expanded={@recommendations_expanded}
-            toggle_event="toggle_recommendations"
+          <RecommendationComponents.recommendations_section
+            media_item={@media_item}
             items={@recommendations}
-            media_type={if @media_item.type == "tv_show", do: :tv_show, else: :movie}
+            expanded={@recommendations_expanded}
             current_user={@current_user}
             adding_ids={@adding_recommendation_tmdb_ids}
             requesting_item_id={@requesting_recommendation_id}
             can_add={@can_create_media}
-            on_select={nil}
-            add_event="add_recommendation"
-            request_event="request_recommendation"
           />
           <%!-- Episodes Section (TV Shows Only) --%>
           <Components.episodes_section

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -463,7 +463,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
       <% grouped_seasons = group_episodes_by_season(@media_item.episodes)
       derived_preset = Mydia.Media.derive_monitoring_preset(@media_item.episodes) %>
 
-      <div class="card bg-base-200 shadow-lg">
+      <div id="seasons-episodes-section" class="card bg-base-200 shadow-lg">
         <%!-- Card header with stats --%>
         <div class="card-body p-4 pb-0">
           <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
@@ -705,7 +705,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   def media_files_section(assigns) do
     ~H"""
     <%= if length(@media_item.media_files) > 0 do %>
-      <div class="card bg-base-200 shadow-lg mb-4 md:mb-6">
+      <div id="media-files-section" class="card bg-base-200 shadow-lg mb-4 md:mb-6">
         <div class="card-body p-4 md:p-6">
           <h2 class="card-title text-lg md:text-xl mb-3 md:mb-4">Media Files</h2>
           <%!-- DaisyUI list component --%>
@@ -912,7 +912,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   def timeline_section(assigns) do
     ~H"""
     <%= if length(@timeline_events) > 0 do %>
-      <div class="card bg-base-200 shadow-lg mb-4 md:mb-6">
+      <div id="timeline-section" class="card bg-base-200 shadow-lg mb-4 md:mb-6">
         <div class="card-body p-4 md:p-6">
           <h2 class="card-title text-lg md:text-xl mb-3 md:mb-4">History</h2>
           <%!-- Horizontal scrollable timeline container --%>
@@ -1007,7 +1007,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   def subtitles_section(assigns) do
     ~H"""
     <%= if length(@media_item.media_files) > 0 do %>
-      <div class="card bg-base-200 shadow-lg mb-4 md:mb-6">
+      <div id="subtitles-section" class="card bg-base-200 shadow-lg mb-4 md:mb-6">
         <div class="card-body p-4 md:p-6">
           <h2 class="card-title text-lg md:text-xl mb-3 md:mb-4">Subtitles</h2>
 

--- a/lib/mydia_web/live/media_live/show/recommendation_components.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_components.ex
@@ -1,0 +1,59 @@
+defmodule MydiaWeb.MediaLive.Show.RecommendationComponents do
+  @moduledoc """
+  The recommendations strip on a media detail page.
+
+  An adapter rather than a renderer, like its sibling `FranchiseComponents`:
+  it maps this page's assigns onto `DiscoverComponents.media_rail/1` and
+  delegates, so a recommendation and a franchise entry draw the same card.
+
+  It exists because the rail has two call sites in `show.html.heex`. A TV show
+  renders it above the episode list, a movie below the file list, and neither
+  should have to repeat eleven attributes or restate the collapse rule.
+  """
+  use MydiaWeb, :html
+
+  alias MydiaWeb.DiscoverComponents
+
+  @doc """
+  Renders the recommendations rail.
+
+  Collapsible only on TV shows, where it stays collapsed until the user opens
+  it so a long episode list is not pushed under a strip of other titles. On a
+  movie `media_rail/1` computes `open? = not collapsible or expanded`, so the
+  rail renders open there and `expanded` is ignored.
+  """
+  attr :media_item, :map, required: true
+  attr :items, :list, required: true
+  attr :expanded, :boolean, required: true
+  attr :current_user, :map, required: true
+  attr :adding_ids, MapSet, required: true
+  attr :requesting_item_id, :string, default: nil
+  attr :can_add, :boolean, required: true
+
+  def recommendations_section(assigns) do
+    tv_show? = assigns.media_item.type == "tv_show"
+
+    assigns =
+      assigns
+      |> assign(:tv_show?, tv_show?)
+      |> assign(:media_type, if(tv_show?, do: :tv_show, else: :movie))
+
+    ~H"""
+    <DiscoverComponents.media_rail
+      id="recommendations-rail"
+      collapsible={@tv_show?}
+      expanded={@expanded}
+      toggle_event="toggle_recommendations"
+      items={@items}
+      media_type={@media_type}
+      current_user={@current_user}
+      adding_ids={@adding_ids}
+      requesting_item_id={@requesting_item_id}
+      can_add={@can_add}
+      on_select={nil}
+      add_event="add_recommendation"
+      request_event="request_recommendation"
+    />
+    """
+  end
+end

--- a/test/mydia_web/live/media_live/show/section_order_test.exs
+++ b/test/mydia_web/live/media_live/show/section_order_test.exs
@@ -63,6 +63,41 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
            ]
   end
 
+  test "a tv show keeps the rail above its episode list", %{conn: conn} do
+    source_tmdb_id = System.unique_integer([:positive])
+
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Detectorists",
+        year: 2014,
+        tmdb_id: source_tmdb_id
+      })
+
+    episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+    warm_recommendations_cache(source_tmdb_id, :tv_show, [
+      %{
+        "id" => System.unique_integer([:positive]),
+        "name" => "Rev.",
+        "first_air_date" => "2010-06-28",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    # No media-files-section or subtitles-section: a show's files hang off its
+    # episodes, so media_item.media_files is always empty here and both cards
+    # guard themselves out.
+    assert section_ids(view) == [
+             "recommendations-rail",
+             "seasons-episodes-section",
+             "timeline-section"
+           ]
+  end
+
   # LazyHTML.query/2, not filter/2: filter matches root nodes only, and these
   # cards are nested inside the layout. query returns matches in document order,
   # which is the whole point of the assertion.

--- a/test/mydia_web/live/media_live/show/section_order_test.exs
+++ b/test/mydia_web/live/media_live/show/section_order_test.exs
@@ -1,0 +1,117 @@
+defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
+  # Connected LiveView tests must stay sync: the Postgres sandbox is only shared
+  # with the mount process when the case is not async.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Metadata
+  alias Mydia.Metadata.Cache
+
+  # Every section whose position this page decides. Each case asserts the whole
+  # list rather than a pairwise precedence, so a section that stops rendering
+  # fails the test instead of passing quietly.
+  @sections "#seasons-episodes-section, #media-files-section, #subtitles-section, " <>
+              "#timeline-section, #franchise-section, #recommendations-rail"
+
+  setup %{conn: conn} do
+    # The app disables Oban in test (engine: false), so Oban.insert cannot run
+    # from the LiveView process. Start an isolated, manual-mode instance so the
+    # recommendations load can enqueue without a live queue.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  test "a movie renders its own files above the recommendations rail", %{conn: conn} do
+    source_tmdb_id = System.unique_integer([:positive])
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Aftersun",
+        year: 2022,
+        tmdb_id: source_tmdb_id
+      })
+
+    media_file_fixture(%{media_item_id: movie.id})
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{
+        "id" => System.unique_integer([:positive]),
+        "title" => "The Eternal Daughter",
+        "release_date" => "2022-12-02",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    # timeline-section is here without seeding an event: media_item_fixture goes
+    # through Media.create_media_item/2, which records media_item.added, and
+    # Events.create_event_async/1 writes synchronously under the SQL sandbox.
+    assert section_ids(view) == [
+             "media-files-section",
+             "subtitles-section",
+             "timeline-section",
+             "recommendations-rail"
+           ]
+  end
+
+  # LazyHTML.query/2, not filter/2: filter matches root nodes only, and these
+  # cards are nested inside the layout. query returns matches in document order,
+  # which is the whole point of the assertion.
+  defp section_ids(view) do
+    view
+    |> render()
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query(@sections)
+    |> LazyHTML.attribute("id")
+  end
+
+  # Populates the shared metadata cache through the real fetch path, with the
+  # relay response coming from Bypass. The cache key does not include the base
+  # URL, so the LiveView's own default config reads this entry back without any
+  # outbound request.
+  defp warm_recommendations_cache(tmdb_id, media_type, results) do
+    bypass = Bypass.open()
+    relay = Metadata.default_relay_config()
+    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
+
+    on_exit(fn ->
+      Cache.delete(
+        "recommendations:#{relay.type}:#{tmdb_id}:#{media_type}:#{relay.options.language}"
+      )
+    end)
+
+    path =
+      if media_type == :tv_show, do: "/tmdb/tv/shows/#{tmdb_id}", else: "/tmdb/movies/#{tmdb_id}"
+
+    Bypass.expect_once(bypass, "GET", path, fn conn ->
+      body = %{
+        "id" => tmdb_id,
+        "title" => "Source",
+        "recommendations" => %{
+          "page" => 1,
+          "results" => results,
+          "total_pages" => 1,
+          "total_results" => length(results)
+        }
+      }
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    {:ok, _results} =
+      Metadata.fetch_recommendations_cached(config, to_string(tmdb_id), media_type: media_type)
+
+    :ok
+  end
+end

--- a/test/mydia_web/live/media_live/show/section_order_test.exs
+++ b/test/mydia_web/live/media_live/show/section_order_test.exs
@@ -17,6 +17,15 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
   @sections "#seasons-episodes-section, #media-files-section, #subtitles-section, " <>
               "#timeline-section, #franchise-section, #recommendations-rail"
 
+  # Provider ids here are offset past this floor rather than taken raw from
+  # System.unique_integer/1, which hands out small positive integers. Those
+  # collide two ways: with real TMDB ids, so any lookup this file forgets to stub
+  # would reach the live relay, and with the many hardcoded ids elsewhere in the
+  # suite, which share the same ETS-backed metadata cache and its keys. Real TMDB
+  # ids are seven digits, and no fixture in the suite reaches nine, so everything
+  # above this floor belongs to this file alone.
+  @provider_id_floor 900_000_000
+
   setup %{conn: conn} do
     # The app disables Oban in test (engine: false), so Oban.insert cannot run
     # from the LiveView process. Start an isolated, manual-mode instance so the
@@ -28,7 +37,7 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
   end
 
   test "a movie renders its own files above the recommendations rail", %{conn: conn} do
-    source_tmdb_id = System.unique_integer([:positive])
+    source_tmdb_id = unique_provider_id()
 
     movie =
       media_item_fixture(%{
@@ -42,7 +51,7 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
 
     warm_recommendations_cache(source_tmdb_id, :movie, [
       %{
-        "id" => System.unique_integer([:positive]),
+        "id" => unique_provider_id(),
         "title" => "The Eternal Daughter",
         "release_date" => "2022-12-02",
         "poster_path" => "/p.jpg"
@@ -66,7 +75,7 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
   end
 
   test "a tv show keeps the rail above its episode list", %{conn: conn} do
-    source_tmdb_id = System.unique_integer([:positive])
+    source_tmdb_id = unique_provider_id()
 
     show =
       media_item_fixture(%{
@@ -80,7 +89,7 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
 
     warm_recommendations_cache(source_tmdb_id, :tv_show, [
       %{
-        "id" => System.unique_integer([:positive]),
+        "id" => unique_provider_id(),
         "name" => "Rev.",
         "first_air_date" => "2010-06-28",
         "poster_path" => "/p.jpg"
@@ -101,9 +110,9 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
   end
 
   test "a movie with a franchise renders both rails below its own files", %{conn: conn} do
-    collection_id = System.unique_integer([:positive])
-    owned_tmdb_id = System.unique_integer([:positive])
-    missing_tmdb_id = System.unique_integer([:positive])
+    collection_id = unique_provider_id()
+    owned_tmdb_id = unique_provider_id()
+    missing_tmdb_id = unique_provider_id()
 
     movie =
       media_item_fixture(%{
@@ -130,7 +139,7 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
 
     warm_recommendations_cache(owned_tmdb_id, :movie, [
       %{
-        "id" => System.unique_integer([:positive]),
+        "id" => unique_provider_id(),
         "title" => "Third",
         "release_date" => "2010-01-01",
         "poster_path" => "/p.jpg"
@@ -156,7 +165,7 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
   # the first group. Pinned here so the placement stays a decision rather than a
   # side effect of the guards.
   test "a movie with no media files keeps its history above the rails", %{conn: conn} do
-    source_tmdb_id = System.unique_integer([:positive])
+    source_tmdb_id = unique_provider_id()
 
     movie =
       media_item_fixture(%{
@@ -168,7 +177,7 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
 
     warm_recommendations_cache(source_tmdb_id, :movie, [
       %{
-        "id" => System.unique_integer([:positive]),
+        "id" => unique_provider_id(),
         "title" => "Something Else",
         "release_date" => "2019-05-01",
         "poster_path" => "/p.jpg"
@@ -187,6 +196,8 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
              "recommendations-rail"
            ]
   end
+
+  defp unique_provider_id, do: @provider_id_floor + System.unique_integer([:positive])
 
   # LazyHTML.query/2, not filter/2: filter matches root nodes only, and these
   # cards are nested inside the layout. query returns matches in document order,

--- a/test/mydia_web/live/media_live/show/section_order_test.exs
+++ b/test/mydia_web/live/media_live/show/section_order_test.exs
@@ -98,6 +98,55 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
            ]
   end
 
+  test "a movie with a franchise renders both rails below its own files", %{conn: conn} do
+    collection_id = System.unique_integer([:positive])
+    owned_tmdb_id = System.unique_integer([:positive])
+    missing_tmdb_id = System.unique_integer([:positive])
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "First",
+        year: 2001,
+        tmdb_id: owned_tmdb_id,
+        metadata: %{
+          "provider_id" => to_string(owned_tmdb_id),
+          "provider" => "metadata_relay",
+          "media_type" => "movie",
+          "title" => "First",
+          "collection_id" => collection_id,
+          "collection_name" => "Test Collection"
+        }
+      })
+
+    media_file_fixture(%{media_item_id: movie.id})
+
+    warm_collection_cache(collection_id, [
+      %{"id" => owned_tmdb_id, "title" => "First", "release_date" => "2001-01-01"},
+      %{"id" => missing_tmdb_id, "title" => "Second", "release_date" => "2004-01-01"}
+    ])
+
+    warm_recommendations_cache(owned_tmdb_id, :movie, [
+      %{
+        "id" => System.unique_integer([:positive]),
+        "title" => "Third",
+        "release_date" => "2010-01-01",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    assert section_ids(view) == [
+             "media-files-section",
+             "subtitles-section",
+             "timeline-section",
+             "franchise-section",
+             "recommendations-rail"
+           ]
+  end
+
   # LazyHTML.query/2, not filter/2: filter matches root nodes only, and these
   # cards are nested inside the layout. query returns matches in document order,
   # which is the whole point of the assertion.
@@ -147,6 +196,31 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
     {:ok, _results} =
       Metadata.fetch_recommendations_cached(config, to_string(tmdb_id), media_type: media_type)
 
+    :ok
+  end
+
+  # Same trick as warm_recommendations_cache/3, for the TMDB collection lookup
+  # behind the franchise strip. fetch_collection_cached/3 keys on the provider
+  # type, collection id and language but not the base URL, so the LiveView reads
+  # this entry back through its own default config with no outbound request.
+  defp warm_collection_cache(collection_id, parts) do
+    bypass = Bypass.open()
+    relay = Metadata.default_relay_config()
+    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
+
+    on_exit(fn ->
+      Cache.delete("collection:#{relay.type}:#{collection_id}:#{relay.options.language}")
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/tmdb/collections/#{collection_id}", fn conn ->
+      body = %{"id" => collection_id, "name" => "Test Collection", "parts" => parts}
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    {:ok, _collection} = Metadata.fetch_collection_cached(config, collection_id)
     :ok
   end
 end

--- a/test/mydia_web/live/media_live/show/section_order_test.exs
+++ b/test/mydia_web/live/media_live/show/section_order_test.exs
@@ -254,12 +254,11 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
   # Any movie whose metadata carries no collection_id sends
   # Franchises.resolve_collection_id/2 down a movie-details lookup, and that has
   # its own cache key ("fetch_by_id:...") entirely separate from the
-  # recommendations one warmed above. Left unwarmed the lookup escapes to the
-  # real relay, and System.unique_integer/1 hands out small integers that collide
-  # with real TMDB movie ids: a movie that turns out to belong to a real
-  # collection sprouts a franchise strip and reorders the page under the test.
-  # Warming it with a collection-less payload makes the lookup resolve to :none
-  # offline, so these assertions depend on nothing but the fixtures.
+  # recommendations one warmed above. Left unwarmed that lookup leaves the VM for
+  # the real relay, which makes the section order depend on the network being up
+  # and on whatever TMDB says about the id. Warming it with a collection-less
+  # payload resolves it to :none offline, so the order under test comes from the
+  # fixtures alone.
   defp warm_movie_details_cache(tmdb_id) do
     bypass = Bypass.open()
     relay = Metadata.default_relay_config()

--- a/test/mydia_web/live/media_live/show/section_order_test.exs
+++ b/test/mydia_web/live/media_live/show/section_order_test.exs
@@ -49,6 +49,8 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
       }
     ])
 
+    warm_movie_details_cache(source_tmdb_id)
+
     {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
     render_async(view, 5000)
 
@@ -147,6 +149,45 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
            ]
   end
 
+  # A movie with no file is not left untouched by this reorder: its timeline card
+  # moved above the rails along with the file and subtitle cards. That is the
+  # intended grouping - everything about this copy of the movie, then everything
+  # about other movies - and it holds even when the history is the only thing in
+  # the first group. Pinned here so the placement stays a decision rather than a
+  # side effect of the guards.
+  test "a movie with no media files keeps its history above the rails", %{conn: conn} do
+    source_tmdb_id = System.unique_integer([:positive])
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Unowned",
+        year: 2019,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{
+        "id" => System.unique_integer([:positive]),
+        "title" => "Something Else",
+        "release_date" => "2019-05-01",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    warm_movie_details_cache(source_tmdb_id)
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    # No media-files-section or subtitles-section: both guard on a non-empty
+    # media_files. No franchise-section: the fixture carries no collection_id.
+    assert section_ids(view) == [
+             "timeline-section",
+             "recommendations-rail"
+           ]
+  end
+
   # LazyHTML.query/2, not filter/2: filter matches root nodes only, and these
   # cards are nested inside the layout. query returns matches in document order,
   # which is the whole point of the assertion.
@@ -195,6 +236,42 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
 
     {:ok, _results} =
       Metadata.fetch_recommendations_cached(config, to_string(tmdb_id), media_type: media_type)
+
+    :ok
+  end
+
+  # Any movie whose metadata carries no collection_id sends
+  # Franchises.resolve_collection_id/2 down a movie-details lookup, and that has
+  # its own cache key ("fetch_by_id:...") entirely separate from the
+  # recommendations one warmed above. Left unwarmed the lookup escapes to the
+  # real relay, and System.unique_integer/1 hands out small integers that collide
+  # with real TMDB movie ids: a movie that turns out to belong to a real
+  # collection sprouts a franchise strip and reorders the page under the test.
+  # Warming it with a collection-less payload makes the lookup resolve to :none
+  # offline, so these assertions depend on nothing but the fixtures.
+  defp warm_movie_details_cache(tmdb_id) do
+    bypass = Bypass.open()
+    relay = Metadata.default_relay_config()
+    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
+
+    # Mirrors the key fetch_by_id_cached/3 builds for these opts: no
+    # append_to_response, so that segment is empty, and a nil season order
+    # normalises to "official".
+    on_exit(fn ->
+      Cache.delete(
+        "fetch_by_id:#{relay.type}:#{tmdb_id}:movie:#{relay.options.language}::official"
+      )
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+      body = %{"id" => tmdb_id, "title" => "Source", "belongs_to_collection" => nil}
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    {:ok, _details} = Metadata.fetch_by_id_cached(config, to_string(tmdb_id), media_type: :movie)
 
     :ok
   end


### PR DESCRIPTION
## What this does

On a movie's detail page, the franchise strip and the recommendations rail both render expanded, sitting between the two-line overview and the Media Files card. That is roughly 500px of other movies between you and the file you actually own. Someone opening a movie page to check which copy they have, what resolution it is, or where it lives on disk scrolls past two strips of posters to get there.

This moves a movie's own sections above those rails. Everything about this copy of the movie comes first, then everything about other movies:

**Movie:** media files, subtitles, timeline, then franchise, then recommendations.

**TV show:** unchanged.

## Why TV is deliberately excluded

The rule is that an expanded rail goes below the operational content, while a collapsed one-row disclosure can sit above it.

On TV the recommendations rail is already that collapsed disclosure. It costs about one row, it is visible without scrolling, and it buries nothing. Moving it below the episode list would kill it, because `default_expanded_seasons/2` opens the season holding the next episode, so a long-running show renders its whole season list plus one expanded season before anything underneath it. That is a real cost with no matching benefit, since the rail was never in the way on TV.

## How it works

Only one section needed to move between the two types. Every other section already guards itself: `episodes_section` renders only for `tv_show`, `media_files_section` and `subtitles_section` only when `media_files` is non-empty (a show's files hang off its episodes, so both are always empty there), and `franchise_section` on `@franchise`, which `FranchiseEvents.maybe_load/1` only ever populates for movies.

So the right column became one flat sequence with the recommendations rail at two guarded positions. The guards are `== "tv_show"` and `!= "tv_show"` rather than two positive equality checks, which makes them mutually exclusive and jointly total: if a third media type ever lands, the rail still renders somewhere instead of silently vanishing.

The rail's eleven-attribute invocation moved into a new `RecommendationComponents` adapter, so neither call site repeats it and the "collapsible on TV only" rule lives in one place. It mirrors the existing `FranchiseComponents`, which is the same kind of adapter over the same `media_rail/1`.

A movie with no media files keeps only its timeline in that first group, so its page is not identical to before: the timeline card moves from below the rails to above them, which is the same grouping applied consistently rather than a special case. That is the right outcome, since with no file to foreground the history of what has been tried is the most relevant thing the page holds about this movie.

## Tests

New `section_order_test.exs` asserts the exact document order for three cases: a movie with files, the same movie with a franchise, and a TV show. Each asserts the whole id list rather than a pairwise precedence, so a section that stops rendering fails instead of passing quietly.

The TV case is a regression lock. It passed on its first run, which is the point.

## Verification

- `mix test`: 13 doctests, 8514 tests, 0 failures, 43 skipped
- `mix credo --strict`: 54 checks over 1289 files, no issues
- `MIX_ENV=test mix compile --warnings-as-errors`: clean
- `mix format` and `mix deps.unlock --unused`: clean

No schema, route, assign, or query changes. Template reorder, four DOM ids, one extracted component, one new test file.

## Review follow-up

CodeRabbit flagged that the no-file movie case was undocumented and untested. It was right that my original description here was wrong (the timeline does move for those movies), and the test it asked for turned up something worse.

Any movie whose metadata carries no `collection_id` sends `Franchises.resolve_collection_id/2` into a movie-details lookup, and `fetch_by_id_cached/3` keys that on `fetch_by_id:...`, separate from the `recommendations:...` key these tests warm. The lookup was therefore escaping to the production relay. `System.unique_integer/1` hands out small integers that collide with real TMDB movie ids, so a fixture landing on a real movie in a real collection grew a franchise strip and reordered the page. The new test failed in the full file and passed in isolation; the pre-existing movie test had the same exposure and was getting lucky.

Fixed by warming the `fetch_by_id` cache with a collection-less payload so the lookup resolves offline. Verified deterministic across seeds 0, 42, 7777 and 12345.

I did not take the proposed guard change. Moving the rail above the files for no-file movies would give movies two different rail placements depending on file presence, which is the shape this change deliberately rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tailored recommendation sections to movie and TV show detail pages.
  - TV recommendations now appear between the overview and episodes.
  - Movie recommendations now appear after the timeline.

- **Improvements**
  - Reorganized franchise information into the “Other Titles” area.
  - Improved the consistency and structure of media detail page sections.
  - Enhanced TV recommendation displays with expandable sections and clearer placement.
  - Refined recommendation presentation to better match each media type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->