### PR TITLE
fix(ui): shrink the episode status chip back to a 16px dot

### DIFF
--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -143,8 +143,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
         <div class={[
           "flex flex-col gap-1",
           "sm:grid sm:items-center sm:gap-x-3 sm:gap-y-0",
-          "sm:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_2rem_auto]",
-          "lg:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_7rem_auto]"
+          "sm:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_1.5rem_auto]"
         ]}>
           <div class="flex items-center gap-1 flex-1 min-w-0 sm:contents">
             <%!-- Chevron and number share one cell so they stay a single
@@ -197,29 +196,25 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             </div>
 
             <div class="flex items-center gap-2 sm:contents">
-              <%!-- badge-sm (24px), not badge-xs (16px), and carrying its label at
-                    lg and up. The tooltip stays: the label names the state, the
-                    tooltip still lists the filenames. It wraps the chip from the
-                    outside, never a join-item. --%>
+              <%!-- A 16px dot of colour, at every width. A visible state label
+                    repeated down 170 rows is noise, and the row already says it
+                    twice: the left border is green when files exist, and the
+                    play control is live rather than disabled. The tooltip names
+                    the state and lists the filenames on hover; the sr-only copy
+                    names it for assistive technology, since the icon is a masked
+                    span and data-tip is CSS content, so neither carries text.
+                    The tooltip wraps the chip from the outside, never a
+                    join-item. --%>
               <div
-                class="tooltip tooltip-left min-w-0 sm:justify-self-end"
+                class="tooltip tooltip-left sm:justify-self-end"
                 data-tip={episode_status_tooltip(episode)}
               >
                 <span
                   id={"episode-#{episode.id}-status"}
-                  class={["badge badge-sm gap-1 max-w-full", episode_status_color(status)]}
+                  class={["badge badge-xs", episode_status_color(status)]}
                 >
                   <.icon name={episode_status_icon(status)} class="w-3 h-3 shrink-0" />
-                  <%!-- `hidden` is display:none, which drops the label out of the
-                        accessibility tree entirely below lg. The icon is a masked
-                        span and data-tip is CSS content, so neither names the
-                        status. Keep an sr-only copy at every breakpoint and hide
-                        the visible one from screen readers to avoid a double
-                        announcement at lg. --%>
                   <span class="sr-only">{episode_status_label(status)}</span>
-                  <span aria-hidden="true" class="hidden lg:inline truncate">
-                    {episode_status_label(status)}
-                  </span>
                 </span>
               </div>
 

--- a/test/mydia_web/live/media_live/show/episode_row_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_row_test.exs
@@ -115,25 +115,27 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeRowTest do
       assert has_selector?(html, "#episode-ep-1-auto-search")
     end
 
-    test "the status chip names the state instead of relying on its tooltip" do
+    test "the status chip stays a 16px dot, with no visible label" do
       html = render_season([episode(air_date: ~D[2024-01-01], media_files: [])])
 
-      label = html |> query("#episode-ep-1-status") |> LazyHTML.text()
+      # badge-xs, not badge-sm: a state word repeated down 170 rows is noise,
+      # and the tooltip already names it on hover.
+      [class] = html |> query("#episode-ep-1-status") |> LazyHTML.attribute("class")
 
-      assert label =~ "Missing"
+      assert class =~ "badge-xs"
+      refute class =~ "badge-sm"
     end
 
     test "the status label reaches assistive technology at every breakpoint" do
       html = render_season([episode(air_date: ~D[2024-01-01], media_files: [])])
 
-      # The visible label is `hidden lg:inline`, and `hidden` is display:none —
-      # it leaves the accessibility tree below lg. An sr-only copy carries the
-      # name at every width; the visible one is aria-hidden so lg does not
-      # announce it twice.
-      sr_only = html |> query("#episode-ep-1-status .sr-only") |> LazyHTML.text()
+      # The icon is a masked span and data-tip is CSS content, so neither names
+      # the state. The sr-only copy is the chip's only text node — asserting on
+      # the whole chip's text catches a visible label creeping back in.
+      chip_text = html |> query("#episode-ep-1-status") |> LazyHTML.text() |> String.trim()
 
-      assert sr_only =~ "Missing"
-      assert has_selector?(html, ~s(#episode-ep-1-status [aria-hidden="true"]))
+      assert chip_text == "Missing"
+      assert html |> query("#episode-ep-1-status .sr-only") |> LazyHTML.text() =~ "Missing"
     end
 
     test "the four actions sit in one join group" do


### PR DESCRIPTION
The episode status chip is back to the 16px icon-only dot it was before #516.

The fixed-track grid work grew it from `badge-xs` to `badge-sm` and gave it a visible label at `lg` and up, so every row down a season spelled out "Downloaded". At 170 episodes in a season that is a column of the same word repeated, and the row already carries the state twice over: the left border is green when files exist, and the play control is a live link rather than a disabled button.

## What changed

- `badge badge-sm gap-1 max-w-full` -> `badge badge-xs`, icon only.
- Dropped the visible `hidden lg:inline` label. The `sr-only` copy added in b256bdc stays, so the accessibility tree keeps its name at every breakpoint, and the tooltip still names the state and lists the filenames on hover.
- Status grid track drops from `7rem` to `1.5rem`, which makes the `lg:` grid override identical to the `sm:` one, so it goes away.

## Tests

`episode_row_test.exs` asserted on the visible label. Both status tests now pin the shape that matters: the chip carries `badge-xs` and not `badge-sm`, and its only text node is the `sr-only` name, so a visible label creeping back in fails the suite.

`./dev mix test test/mydia_web/live/media_live/` passes; the one failure seen was a pre-existing `render_async` 100ms timing flake in `manual_search_info_link_test.exs`, which passes on its own and does not touch this row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Simplified episode status indicators into compact icon dots.
  - Added tooltips and screen-reader labels for clearer status information.
  - Improved episode row spacing by narrowing the status area.
- **Accessibility**
  - Preserved readable status text for assistive technologies.
  - Ensured status indicators remain discoverable without relying on visible labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->