### PR TITLE
feat(prune): review and trash redundant duplicate media files

### DIFF
--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -525,6 +525,8 @@ defmodule Mydia.Events do
       resource_id: resource_id,
       severity: :info,
       metadata: %{
+        "title" => media_item.title,
+        "media_type" => media_item.type,
         "kept" => keeper.relative_path,
         "kept_id" => keeper.id,
         "trashed" => Enum.map(losers, & &1.relative_path),

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -505,6 +505,36 @@ defmodule Mydia.Events do
   end
 
   @doc """
+  Records a media_file.pruned event: redundant copies were trashed and one file
+  was kept.
+
+  ## Examples
+
+      iex> files_pruned(keeper, [loser], media_item, "admin")
+      :ok
+  """
+  def files_pruned(keeper, losers, media_item, actor_id) do
+    {resource_type, resource_id} = upgrade_resource(keeper, media_item)
+
+    create_event_async(%{
+      category: "media",
+      type: "media_file.pruned",
+      actor_type: :user,
+      actor_id: actor_id,
+      resource_type: resource_type,
+      resource_id: resource_id,
+      severity: :info,
+      metadata: %{
+        "kept" => keeper.relative_path,
+        "kept_id" => keeper.id,
+        "trashed" => Enum.map(losers, & &1.relative_path),
+        "trashed_ids" => Enum.map(losers, & &1.id),
+        "bytes_reclaimed" => losers |> Enum.map(&(&1.size || 0)) |> Enum.sum()
+      }
+    })
+  end
+
+  @doc """
   Records a media_file.upgrade_rejected event — the counterpart to
   `file_upgraded/4` for when the candidate release did not actually deliver
   the quality it claimed. The originating release is blacklisted separately

--- a/lib/mydia/events/presentation.ex
+++ b/lib/mydia/events/presentation.ex
@@ -101,6 +101,12 @@ defmodule Mydia.Events.Presentation do
       color: "text-warning",
       title: "Upgrade rejected"
     },
+    %{
+      type: "media_file.pruned",
+      icon: "hero-trash",
+      color: "text-info",
+      title: "Duplicate pruned"
+    },
 
     # download.*
     %{

--- a/lib/mydia/events/presentation.ex
+++ b/lib/mydia/events/presentation.ex
@@ -384,7 +384,7 @@ defmodule Mydia.Events.Presentation do
     trashed = metadata["trashed"] || []
     count = length(trashed)
     suffix = if count == 1, do: "file", else: "files"
-    base = "#{count} #{suffix} trashed"
+    base = "#{title_of(metadata)}, #{count} #{suffix} trashed"
 
     case metadata["bytes_reclaimed"] do
       bytes when is_integer(bytes) and bytes > 0 ->

--- a/lib/mydia/events/presentation.ex
+++ b/lib/mydia/events/presentation.ex
@@ -380,6 +380,21 @@ defmodule Mydia.Events.Presentation do
     if metadata["blacklisted"], do: "#{base}, release blacklisted", else: base
   end
 
+  def detail(%Event{type: "media_file.pruned", metadata: metadata}) do
+    trashed = metadata["trashed"] || []
+    count = length(trashed)
+    suffix = if count == 1, do: "file", else: "files"
+    base = "#{count} #{suffix} trashed"
+
+    case metadata["bytes_reclaimed"] do
+      bytes when is_integer(bytes) and bytes > 0 ->
+        "#{base}, #{humanize_bytes(bytes)} reclaimed"
+
+      _ ->
+        base
+    end
+  end
+
   @plain_download_types ~w(
     download.initiated download.completed download.cancelled
     download.paused download.resumed download.unstalled
@@ -590,6 +605,14 @@ defmodule Mydia.Events.Presentation do
   end
 
   defp pad(number), do: String.pad_leading("#{number}", 2, "0")
+
+  defp humanize_bytes(bytes) when bytes >= 1_073_741_824,
+    do: "#{Float.round(bytes / 1_073_741_824, 1)} GB"
+
+  defp humanize_bytes(bytes) when bytes >= 1_048_576,
+    do: "#{Float.round(bytes / 1_048_576, 1)} MB"
+
+  defp humanize_bytes(bytes), do: "#{bytes} B"
 
   defp search_subject(metadata), do: title_of(metadata) <> episode_part(metadata)
 

--- a/lib/mydia/library/prune.ex
+++ b/lib/mydia/library/prune.ex
@@ -9,13 +9,14 @@ defmodule Mydia.Library.Prune do
 
   Nothing here runs on a schedule. An operator reviews a plan and confirms it.
 
-  ## Why execute/2 re-verifies
+  ## Why execute/3 re-verifies
 
-  `execute/2` does not trust the ids it is handed. It rebuilds the plan and
-  drops any id that is not a current loser of a currently eligible group. The
-  page can be minutes stale, a scan can have changed the group underneath it,
-  and a caller can reach this function without going through the UI at all.
-  The UI is not the security boundary; this function is.
+  `execute/3` does not trust the ids it is handed. It rebuilds the plan
+  (honoring the same `keepers` overrides the operator's plan was built from)
+  and drops any id that is not a current loser of a currently eligible group.
+  The page can be minutes stale, a scan can have changed the group underneath
+  it, and a caller can reach this function without going through the UI at
+  all. The UI is not the security boundary; this function is.
   """
 
   alias Mydia.Events
@@ -53,19 +54,25 @@ defmodule Mydia.Library.Prune do
   Trashes the given files, after re-verifying that each one is a current loser
   of a currently eligible group.
 
+  `keepers` must be the same override map the operator's plan was built from
+  (see `plan/1`). Without it, `execute/3` would silently re-rank every group
+  with the default keeper, discarding whatever override the operator chose
+  before confirming.
+
   Returns which files were trashed, which failed to move, and which were
   aborted by re-verification. Partial failure is reported rather than rolled
   back: `Mydia.Library.TrashStore` has already moved bytes by the time a row
   update can fail, so a global rollback would be a lie.
   """
-  @spec execute([String.t()], String.t()) :: %{
+  @spec execute([String.t()], String.t(), %{optional(String.t()) => String.t()}) :: %{
           trashed: [MediaFile.t()],
           failed: [{String.t(), term()}],
           aborted: [{String.t(), atom()}]
         }
-  def execute(file_ids, actor_id) when is_list(file_ids) and is_binary(actor_id) do
+  def execute(file_ids, actor_id, keepers \\ %{})
+      when is_list(file_ids) and is_binary(actor_id) and is_map(keepers) do
     requested = MapSet.new(file_ids)
-    %{decisions: decisions, refusals: refusals} = plan()
+    %{decisions: decisions, refusals: refusals} = plan(keepers)
 
     refused_ids =
       for {group, reason, _detail} <- refusals,

--- a/lib/mydia/library/prune.ex
+++ b/lib/mydia/library/prune.ex
@@ -1,0 +1,133 @@
+defmodule Mydia.Library.Prune do
+  @moduledoc """
+  Removes redundant duplicate copies of an episode or movie.
+
+  Most items holding more than one file are not holding duplicates. They are
+  holding misidentified files, one file registered twice, or a feature plus its
+  bonus content. `Mydia.Library.Prune.Eligibility` refuses all of those, and
+  this module only ever acts on what survives that gate.
+
+  Nothing here runs on a schedule. An operator reviews a plan and confirms it.
+
+  ## Why execute/2 re-verifies
+
+  `execute/2` does not trust the ids it is handed. It rebuilds the plan and
+  drops any id that is not a current loser of a currently eligible group. The
+  page can be minutes stale, a scan can have changed the group underneath it,
+  and a caller can reach this function without going through the UI at all.
+  The UI is not the security boundary; this function is.
+  """
+
+  alias Mydia.Events
+  alias Mydia.Library
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.Prune.{Decision, Eligibility, Group, Grouping, Ranker}
+
+  require Logger
+
+  @type refusal :: {Group.t(), atom(), map()}
+  @type plan :: %{decisions: [Decision.t()], refusals: [refusal()]}
+
+  @doc """
+  Builds the current plan: what can be pruned, and what was refused and why.
+
+  `keepers` optionally maps a group's `subject_id` to a file id the operator
+  chose instead of the ranked keeper.
+  """
+  @spec plan(%{optional(String.t()) => String.t()}) :: plan()
+  def plan(keepers \\ %{}) do
+    checked = Enum.map(Grouping.list_groups(), fn group -> {group, Eligibility.check(group)} end)
+
+    decisions =
+      for {_group, {:ok, eligible}} <- checked,
+          do: Ranker.decide(eligible, Map.get(keepers, eligible.subject_id))
+
+    refusals =
+      for {group, {:refused, reason, detail}} <- checked,
+          do: {group, reason, detail}
+
+    %{decisions: decisions, refusals: refusals}
+  end
+
+  @doc """
+  Trashes the given files, after re-verifying that each one is a current loser
+  of a currently eligible group.
+
+  Returns which files were trashed, which failed to move, and which were
+  aborted by re-verification. Partial failure is reported rather than rolled
+  back: `Mydia.Library.TrashStore` has already moved bytes by the time a row
+  update can fail, so a global rollback would be a lie.
+  """
+  @spec execute([String.t()], String.t()) :: %{
+          trashed: [MediaFile.t()],
+          failed: [{String.t(), term()}],
+          aborted: [{String.t(), atom()}]
+        }
+  def execute(file_ids, actor_id) when is_list(file_ids) and is_binary(actor_id) do
+    requested = MapSet.new(file_ids)
+    %{decisions: decisions, refusals: refusals} = plan()
+
+    refused_ids =
+      for {group, reason, _detail} <- refusals,
+          file <- group.files,
+          MapSet.member?(requested, file.id),
+          do: {file.id, reason}
+
+    {selected, aborted_keepers} =
+      Enum.reduce(decisions, {[], []}, fn %Decision{} = decision, {selected, aborted} ->
+        losers = Enum.filter(decision.losers, &MapSet.member?(requested, &1.id))
+
+        aborted =
+          if MapSet.member?(requested, decision.keeper.id) do
+            [{decision.keeper.id, :would_leave_no_file} | aborted]
+          else
+            aborted
+          end
+
+        {[{decision, losers} | selected], aborted}
+      end)
+
+    known_ids =
+      decisions
+      |> Enum.flat_map(fn d -> [d.keeper.id | Enum.map(d.losers, & &1.id)] end)
+      |> MapSet.new()
+
+    unknown =
+      for id <- file_ids,
+          not MapSet.member?(known_ids, id),
+          not List.keymember?(refused_ids, id, 0),
+          do: {id, :not_in_any_group}
+
+    {trashed, failed} =
+      selected
+      |> Enum.reject(fn {_decision, losers} -> losers == [] end)
+      |> Enum.reduce({[], []}, fn {decision, losers}, {ok, bad} ->
+        {group_ok, group_bad} = trash_all(losers)
+
+        if group_ok != [] do
+          Events.files_pruned(decision.keeper, group_ok, decision.group.media_item, actor_id)
+        end
+
+        {ok ++ group_ok, bad ++ group_bad}
+      end)
+
+    %{trashed: trashed, failed: failed, aborted: refused_ids ++ aborted_keepers ++ unknown}
+  end
+
+  defp trash_all(files) do
+    Enum.reduce(files, {[], []}, fn file, {ok, bad} ->
+      case Library.trash_media_file(file) do
+        {:ok, trashed} ->
+          {ok ++ [trashed], bad}
+
+        {:error, reason} ->
+          Logger.error("Prune could not trash media file",
+            media_file_id: file.id,
+            reason: inspect(reason)
+          )
+
+          {ok, bad ++ [{file.id, reason}]}
+      end
+    end)
+  end
+end

--- a/lib/mydia/library/prune/decision.ex
+++ b/lib/mydia/library/prune/decision.ex
@@ -1,0 +1,20 @@
+defmodule Mydia.Library.Prune.Decision do
+  @moduledoc """
+  The proposed outcome for one eligible group: which file to keep, which to
+  trash, and why.
+  """
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.Prune.Group
+
+  @enforce_keys [:group, :keeper, :losers, :ranker, :reason]
+  defstruct [:group, :keeper, :losers, :ranker, :reason]
+
+  @type t :: %__MODULE__{
+          group: Group.t(),
+          keeper: MediaFile.t(),
+          losers: [MediaFile.t()],
+          ranker: :profile | :fallback,
+          reason: String.t()
+        }
+end

--- a/lib/mydia/library/prune/eligibility.ex
+++ b/lib/mydia/library/prune/eligibility.ex
@@ -1,0 +1,116 @@
+defmodule Mydia.Library.Prune.Eligibility do
+  @moduledoc """
+  Decides whether a group of files is provably the same content.
+
+  This is the module that keeps prune from destroying media. Most multi-file
+  items in a real library are not redundant copies: they are misidentified
+  files, one file registered twice, or a feature plus its bonus content.
+  Ranking those by quality and trashing the losers deletes real media.
+
+  A group passes only if every check passes. There is no partial prune: a
+  group is prunable as a whole or refused as a whole.
+
+  Checks run in the order below and the first failure is the reported reason.
+  The order is chosen so the reported reason is the most actionable one. Two
+  rows pointing at the same path trivially agree on duration, so the scanner
+  bug has to be named before the duration check can call them identical.
+
+    1. `:duplicate_registration` - two rows share library_path_id + relative_path
+    2. `:unanalyzed` - a file has no usable duration
+    3. `:duration_mismatch` - durations spread wider than 2%
+    4. `:name_mismatch` - a filename does not bind to the subject
+    5. `:episode_mismatch` - parsed season/episode disagrees with the row
+    6. `:nothing_to_prune` - fewer than two files survive
+
+  Checks 4 and 5 live in this module too but are added by the parser task.
+  """
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.Prune.Group
+
+  # Measured against production: 1% admits 164 of 228 candidates, 2% admits
+  # 177, 5% admits 199. The step from 2% to 5% is where extended cuts and
+  # alternate edits start being admitted, so 2% is the last conservative step.
+  @duration_tolerance 0.02
+
+  @type refusal_reason ::
+          :duplicate_registration
+          | :unanalyzed
+          | :duration_mismatch
+          | :name_mismatch
+          | :episode_mismatch
+          | :nothing_to_prune
+
+  @doc """
+  Returns `{:ok, group}` when the group is provably the same content, or
+  `{:refused, reason, detail}` naming the first failed check.
+  """
+  @spec check(Group.t()) :: {:ok, Group.t()} | {:refused, refusal_reason(), map()}
+  def check(%Group{} = group) do
+    with :ok <- check_duplicate_registration(group),
+         :ok <- check_analyzed(group),
+         :ok <- check_duration_agreement(group),
+         :ok <- check_enough_files(group) do
+      {:ok, group}
+    end
+  end
+
+  @doc """
+  The duration tolerance, exposed so the UI can explain the refusal.
+  """
+  @spec duration_tolerance() :: float()
+  def duration_tolerance, do: @duration_tolerance
+
+  defp check_duplicate_registration(%Group{files: files}) do
+    keys = Enum.map(files, &{&1.library_path_id, &1.relative_path})
+
+    case keys -- Enum.uniq(keys) do
+      [] ->
+        :ok
+
+      [{_library_path_id, path} | _] ->
+        {:refused, :duplicate_registration, %{path: path}}
+    end
+  end
+
+  defp check_analyzed(%Group{files: files}) do
+    unanalyzed = Enum.filter(files, &(duration_of(&1) == nil))
+
+    if unanalyzed == [] do
+      :ok
+    else
+      {:refused, :unanalyzed,
+       %{
+         unanalyzed_count: length(unanalyzed),
+         paths: Enum.map(unanalyzed, & &1.relative_path)
+       }}
+    end
+  end
+
+  defp check_duration_agreement(%Group{files: files}) do
+    durations = Enum.map(files, &duration_of/1)
+    longest = Enum.max(durations)
+    shortest = Enum.min(durations)
+    spread = (longest - shortest) / longest
+
+    if spread <= @duration_tolerance do
+      :ok
+    else
+      {:refused, :duration_mismatch,
+       %{spread: spread, tolerance: @duration_tolerance, longest: longest, shortest: shortest}}
+    end
+  end
+
+  defp check_enough_files(%Group{files: files}) do
+    if length(files) >= 2, do: :ok, else: {:refused, :nothing_to_prune, %{count: length(files)}}
+  end
+
+  # A zero or negative duration is treated as absent rather than as a real
+  # value: it is never a usable comparison and it would divide by zero in
+  # check_duration_agreement/1.
+  defp duration_of(%MediaFile{metadata: %{duration: duration}})
+       when is_number(duration) and duration > 0,
+       do: duration
+
+  defp duration_of(_file), do: nil
+end

--- a/lib/mydia/library/prune/eligibility.ex
+++ b/lib/mydia/library/prune/eligibility.ex
@@ -84,6 +84,11 @@ defmodule Mydia.Library.Prune.Eligibility do
     end
   end
 
+  # An empty group has no durations to compare. Deferring to
+  # check_enough_files/1 keeps the reported reason the documented
+  # :nothing_to_prune refusal instead of raising on Enum.max/1.
+  defp check_duration_agreement(%Group{files: []}), do: :ok
+
   defp check_duration_agreement(%Group{files: files}) do
     durations = Enum.map(files, &duration_of/1)
     longest = Enum.max(durations)

--- a/lib/mydia/library/prune/eligibility.ex
+++ b/lib/mydia/library/prune/eligibility.ex
@@ -58,12 +58,6 @@ defmodule Mydia.Library.Prune.Eligibility do
     end
   end
 
-  @doc """
-  The duration tolerance, exposed so the UI can explain the refusal.
-  """
-  @spec duration_tolerance() :: float()
-  def duration_tolerance, do: @duration_tolerance
-
   defp check_duplicate_registration(%Group{files: files}) do
     keys = Enum.map(files, &{&1.library_path_id, &1.relative_path})
 
@@ -120,8 +114,7 @@ defmodule Mydia.Library.Prune.Eligibility do
       Enum.filter(files, fn file ->
         flags =
           file.relative_path
-          |> Path.basename()
-          |> ReleaseParser.parse(target: target)
+          |> ReleaseParser.parse_with_path(target: target)
           |> Map.get(:engine_flags)
           |> Kernel.||(%{})
 
@@ -146,10 +139,7 @@ defmodule Mydia.Library.Prune.Eligibility do
 
     mismatched =
       Enum.filter(group.files, fn file ->
-        parsed =
-          file.relative_path
-          |> Path.basename()
-          |> ReleaseParser.parse(target: target)
+        parsed = ReleaseParser.parse_with_path(file.relative_path, target: target)
 
         season_disagrees?(parsed.season, episode.season_number) or
           episode_disagrees?(parsed.episodes, episode.episode_number)

--- a/lib/mydia/library/prune/eligibility.ex
+++ b/lib/mydia/library/prune/eligibility.ex
@@ -21,12 +21,13 @@ defmodule Mydia.Library.Prune.Eligibility do
     4. `:name_mismatch` - a filename does not bind to the subject
     5. `:episode_mismatch` - parsed season/episode disagrees with the row
     6. `:nothing_to_prune` - fewer than two files survive
-
-  Checks 4 and 5 live in this module too but are added by the parser task.
   """
 
   alias Mydia.Library.MediaFile
   alias Mydia.Library.Prune.Group
+  alias Mydia.Library.ReleaseParser
+  alias Mydia.Library.ReleaseParser.TargetContext
+  alias Mydia.Media.Episode
 
   # Measured against production: 1% admits 164 of 228 candidates, 2% admits
   # 177, 5% admits 199. The step from 2% to 5% is where extended cuts and
@@ -50,6 +51,8 @@ defmodule Mydia.Library.Prune.Eligibility do
     with :ok <- check_duplicate_registration(group),
          :ok <- check_analyzed(group),
          :ok <- check_duration_agreement(group),
+         :ok <- check_names(group),
+         :ok <- check_episode_numbers(group),
          :ok <- check_enough_files(group) do
       {:ok, group}
     end
@@ -100,6 +103,79 @@ defmodule Mydia.Library.Prune.Eligibility do
        %{spread: spread, tolerance: @duration_tolerance, longest: longest, shortest: shortest}}
     end
   end
+
+  # Binds every filename to the item the files are attached to. The parser
+  # already knows how to say "this release name does not belong to this show":
+  # `:binding_suspect` and `:parsed_title_unbound` are exactly that signal, and
+  # `Mydia.Downloads.TorrentMatcher` uses the same two flags as a wrong-show
+  # guard.
+  #
+  # `:season_out_of_range` is deliberately not consulted here. It fires when a
+  # season is absent from the item's known seasons, which check_episode_numbers/1
+  # below already covers more precisely against the actual episode row.
+  defp check_names(%Group{media_item: media_item, files: files}) do
+    target = TargetContext.from_media_item(media_item)
+
+    unbound =
+      Enum.filter(files, fn file ->
+        flags =
+          file.relative_path
+          |> Path.basename()
+          |> ReleaseParser.parse(target: target)
+          |> Map.get(:engine_flags)
+          |> Kernel.||(%{})
+
+        Map.get(flags, :binding_suspect) || Map.get(flags, :parsed_title_unbound)
+      end)
+
+    if unbound == [] do
+      :ok
+    else
+      {:refused, :name_mismatch, %{paths: Enum.map(unbound, & &1.relative_path)}}
+    end
+  end
+
+  # Movies have no season or episode number to compare, so this check applies
+  # to episodes only.
+  defp check_episode_numbers(%Group{subject_type: :movie}), do: :ok
+
+  defp check_episode_numbers(
+         %Group{subject_type: :episode, subject: %Episode{} = episode} = group
+       ) do
+    target = TargetContext.from_media_item(group.media_item)
+
+    mismatched =
+      Enum.filter(group.files, fn file ->
+        parsed =
+          file.relative_path
+          |> Path.basename()
+          |> ReleaseParser.parse(target: target)
+
+        season_disagrees?(parsed.season, episode.season_number) or
+          episode_disagrees?(parsed.episodes, episode.episode_number)
+      end)
+
+    if mismatched == [] do
+      :ok
+    else
+      {:refused, :episode_mismatch,
+       %{
+         expected: {episode.season_number, episode.episode_number},
+         paths: Enum.map(mismatched, & &1.relative_path)
+       }}
+    end
+  end
+
+  # A parse that produced no season or no episode number is not evidence of a
+  # mismatch, so it does not refuse here. `check_names/1` has already rejected
+  # the filenames that fail to bind at all.
+  defp season_disagrees?(nil, _expected), do: false
+  defp season_disagrees?(parsed, expected), do: parsed != expected
+
+  defp episode_disagrees?(nil, _expected), do: false
+  defp episode_disagrees?([], _expected), do: false
+  defp episode_disagrees?(parsed, expected) when is_list(parsed), do: expected not in parsed
+  defp episode_disagrees?(parsed, expected), do: parsed != expected
 
   defp check_enough_files(%Group{files: files}) do
     if length(files) >= 2, do: :ok, else: {:refused, :nothing_to_prune, %{count: length(files)}}

--- a/lib/mydia/library/prune/group.ex
+++ b/lib/mydia/library/prune/group.ex
@@ -1,0 +1,26 @@
+defmodule Mydia.Library.Prune.Group do
+  @moduledoc """
+  One media item that holds more than one active file.
+
+  A group is the unit the prune feature reasons about. `subject` is the thing
+  that owns the files: an `%Episode{}` for TV, a `%MediaItem{}` for a movie.
+  `media_item` is always the owning movie or show, which is what carries the
+  quality profile and what `TargetContext.from_media_item/1` needs.
+  """
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.{Episode, MediaItem}
+
+  @enforce_keys [:subject_type, :subject_id, :subject, :media_item, :files]
+  defstruct [:subject_type, :subject_id, :subject, :media_item, :files]
+
+  @type subject_type :: :episode | :movie
+
+  @type t :: %__MODULE__{
+          subject_type: subject_type(),
+          subject_id: String.t(),
+          subject: Episode.t() | MediaItem.t(),
+          media_item: MediaItem.t(),
+          files: [MediaFile.t()]
+        }
+end

--- a/lib/mydia/library/prune/grouping.ex
+++ b/lib/mydia/library/prune/grouping.ex
@@ -1,0 +1,93 @@
+defmodule Mydia.Library.Prune.Grouping do
+  @moduledoc """
+  Finds media items that hold more than one active file.
+
+  Two separate queries, because a TV `media_file` carries `episode_id` with
+  `media_item_id` NULL. A single join from `media_items` would silently return
+  nothing for shows.
+  """
+
+  import Ecto.Query
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.Prune.Group
+  alias Mydia.Media.{Episode, MediaItem}
+  alias Mydia.Repo
+
+  @doc """
+  Every group in the library, episodes and movies together.
+
+  Files come back with `:library_path` preloaded so `MediaFile.absolute_path/1`
+  resolves without a second query per file.
+  """
+  @spec list_groups() :: [Group.t()]
+  def list_groups do
+    episode_groups() ++ movie_groups()
+  end
+
+  defp episode_groups do
+    ids = multi_file_ids(:episode_id)
+
+    if ids == [] do
+      []
+    else
+      episodes =
+        Episode
+        |> where([e], e.id in ^ids)
+        |> preload([:media_item])
+        |> Repo.all()
+
+      files_by_subject = files_for(:episode_id, ids)
+
+      for episode <- episodes, files = Map.get(files_by_subject, episode.id, []), files != [] do
+        %Group{
+          subject_type: :episode,
+          subject_id: episode.id,
+          subject: episode,
+          media_item: episode.media_item,
+          files: files
+        }
+      end
+    end
+  end
+
+  defp movie_groups do
+    ids = multi_file_ids(:media_item_id)
+
+    if ids == [] do
+      []
+    else
+      items = MediaItem |> where([m], m.id in ^ids) |> Repo.all()
+      files_by_subject = files_for(:media_item_id, ids)
+
+      for item <- items, files = Map.get(files_by_subject, item.id, []), files != [] do
+        %Group{
+          subject_type: :movie,
+          subject_id: item.id,
+          subject: item,
+          media_item: item,
+          files: files
+        }
+      end
+    end
+  end
+
+  # `count(mf.id)` rather than `count()` over a boolean or a nullable column:
+  # boolean aggregates pass on SQLite and crash on PostgreSQL.
+  defp multi_file_ids(field) do
+    MediaFile
+    |> where([mf], is_nil(mf.trashed_at) and not is_nil(field(mf, ^field)))
+    |> group_by([mf], field(mf, ^field))
+    |> having([mf], count(mf.id) > 1)
+    |> select([mf], field(mf, ^field))
+    |> Repo.all()
+  end
+
+  defp files_for(field, ids) do
+    MediaFile
+    |> where([mf], is_nil(mf.trashed_at) and field(mf, ^field) in ^ids)
+    |> preload([:library_path])
+    |> Repo.all()
+    |> Enum.group_by(&Map.fetch!(&1, field))
+  end
+end

--- a/lib/mydia/library/prune/grouping.ex
+++ b/lib/mydia/library/prune/grouping.ex
@@ -34,7 +34,7 @@ defmodule Mydia.Library.Prune.Grouping do
       episodes =
         Episode
         |> where([e], e.id in ^ids)
-        |> preload([:media_item])
+        |> preload(media_item: :episodes)
         |> Repo.all()
 
       files_by_subject = files_for(:episode_id, ids)
@@ -57,7 +57,7 @@ defmodule Mydia.Library.Prune.Grouping do
     if ids == [] do
       []
     else
-      items = MediaItem |> where([m], m.id in ^ids) |> Repo.all()
+      items = MediaItem |> where([m], m.id in ^ids) |> preload([:episodes]) |> Repo.all()
       files_by_subject = files_for(:media_item_id, ids)
 
       for item <- items, files = Map.get(files_by_subject, item.id, []), files != [] do

--- a/lib/mydia/library/prune/grouping.ex
+++ b/lib/mydia/library/prune/grouping.ex
@@ -34,7 +34,7 @@ defmodule Mydia.Library.Prune.Grouping do
       episodes =
         Episode
         |> where([e], e.id in ^ids)
-        |> preload(media_item: :episodes)
+        |> preload(media_item: [:episodes, :quality_profile])
         |> Repo.all()
 
       files_by_subject = files_for(:episode_id, ids)
@@ -57,7 +57,12 @@ defmodule Mydia.Library.Prune.Grouping do
     if ids == [] do
       []
     else
-      items = MediaItem |> where([m], m.id in ^ids) |> preload([:episodes]) |> Repo.all()
+      items =
+        MediaItem
+        |> where([m], m.id in ^ids)
+        |> preload([:episodes, :quality_profile])
+        |> Repo.all()
+
       files_by_subject = files_for(:media_item_id, ids)
 
       for item <- items, files = Map.get(files_by_subject, item.id, []), files != [] do

--- a/lib/mydia/library/prune/ranker.ex
+++ b/lib/mydia/library/prune/ranker.ex
@@ -1,0 +1,129 @@
+defmodule Mydia.Library.Prune.Ranker do
+  @moduledoc """
+  Picks which file in an eligible group to keep.
+
+  Two rankers. When the item has a quality profile and the files are analyzed,
+  `Mydia.Upgrades.Comparator` scores them, so prune agrees with whatever the
+  operator already configured as better. Otherwise a fixed fallback runs.
+
+  ## Why the fallback puts codec last
+
+  An earlier draft ranked codec right after resolution, reasoning that a more
+  efficient codec is a better file. Against real data that is harmful. Jujutsu
+  Kaisen S03E03 exists as 1080p h264 at 8.8 Mbps (1.58 GB), h264 at 5.0 Mbps,
+  and av1 at 2.9 Mbps (520 MB). Codec-second keeps the 520 MB av1 and trashes
+  the source. Codec efficiency describes quality per bit; it does not make a
+  low-bitrate re-encode better than a high-bitrate source.
+
+  Since the fallback only runs for items with no quality profile, the
+  conservative ordering is the right default. An operator who genuinely prefers
+  av1 says so in a quality profile, which takes the profile path instead.
+
+  The keeper is a proposal. `decide/2` lets the operator name a different one.
+  """
+
+  alias Mydia.Library.{FileRanking, MediaFile}
+  alias Mydia.Library.Prune.{Decision, Group}
+  alias Mydia.Upgrades.Comparator
+
+  # Only a tiebreak, and only among files that already tie on resolution,
+  # bitrate and size.
+  @codec_rank %{"av1" => 4, "hevc" => 3, "h265" => 3, "h264" => 2, "avc" => 2, "mpeg4" => 1}
+
+  @doc """
+  Ranks `group` and returns the decision, keeping the highest-ranked file.
+  """
+  @spec decide(Group.t()) :: Decision.t()
+  def decide(%Group{} = group), do: decide(group, nil)
+
+  @doc """
+  Like `decide/1`, but keeps `keeper_id` when it names a file in the group.
+
+  An id that is not in the group is ignored rather than raising: the page can
+  race a rescan, and silently falling back to the ranked keeper is safer than
+  crashing a LiveView mid-review.
+  """
+  @spec decide(Group.t(), String.t() | nil) :: Decision.t()
+  def decide(%Group{files: files} = group, keeper_id) do
+    {ranker, sorted} = rank(group)
+
+    keeper =
+      Enum.find(files, fn file -> keeper_id != nil and file.id == keeper_id end) || hd(sorted)
+
+    %Decision{
+      group: group,
+      keeper: keeper,
+      losers: Enum.reject(files, &(&1.id == keeper.id)),
+      ranker: ranker,
+      reason: reason_for(ranker, keeper)
+    }
+  end
+
+  defp rank(%Group{media_item: media_item, files: files} = group) do
+    media_type = if group.subject_type == :episode, do: :episode, else: :movie
+
+    profile =
+      case Map.get(media_item, :quality_profile) do
+        %Ecto.Association.NotLoaded{} -> nil
+        other -> other
+      end
+
+    scored =
+      if profile do
+        Enum.map(files, fn file ->
+          case Comparator.score_file(file, profile, media_type) do
+            {:ok, score} -> {file, score}
+            {:error, :unscorable} -> {file, nil}
+          end
+        end)
+      else
+        Enum.map(files, &{&1, nil})
+      end
+
+    if profile && Enum.all?(scored, fn {_file, score} -> score != nil end) do
+      {:profile,
+       scored |> Enum.sort_by(fn {_file, score} -> score end, :desc) |> Enum.map(&elem(&1, 0))}
+    else
+      {:fallback, Enum.sort_by(files, &fallback_key/1, :desc)}
+    end
+  end
+
+  # Sorted descending, so every component is "bigger is better". `inserted_at`
+  # is negated so that a larger key means an *older* file, which keeps the
+  # oldest on a tie. `id` last makes the order total, so two files inserted in
+  # the same second still rank deterministically and a re-run proposes the same
+  # keeper.
+  defp fallback_key(%MediaFile{} = file) do
+    {
+      FileRanking.resolution_pixels(file.resolution),
+      file.bitrate || 0,
+      file.size || 0,
+      codec_rank(file.codec),
+      -DateTime.to_unix(file.inserted_at),
+      file.id
+    }
+  end
+
+  defp codec_rank(nil), do: 0
+
+  defp codec_rank(codec) when is_binary(codec) do
+    Map.get(@codec_rank, String.downcase(String.trim(codec)), 0)
+  end
+
+  defp codec_rank(_other), do: 0
+
+  defp reason_for(:profile, keeper),
+    do: "Highest quality profile score (#{describe(keeper)})"
+
+  defp reason_for(:fallback, keeper),
+    do: "No quality profile, ranked by resolution then bitrate (#{describe(keeper)})"
+
+  defp describe(%MediaFile{} = file) do
+    [file.resolution, file.codec, bitrate_label(file.bitrate)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(", ")
+  end
+
+  defp bitrate_label(nil), do: nil
+  defp bitrate_label(bitrate), do: "#{Float.round(bitrate / 1_000_000, 1)} Mbps"
+end

--- a/lib/mydia_web/components/admin_components.ex
+++ b/lib/mydia_web/components/admin_components.ex
@@ -75,6 +75,13 @@ defmodule MydiaWeb.AdminComponents do
         Library
       </.tab_link>
       <.tab_link
+        active={@active_tab == :prune}
+        to="/admin/library/prune"
+        icon="hero-document-duplicate"
+      >
+        Prune duplicates
+      </.tab_link>
+      <.tab_link
         active={@active_tab == :media_servers}
         to="/admin/config/media-servers"
         icon="hero-server-stack"

--- a/lib/mydia_web/live/admin_library_prune_live/components.ex
+++ b/lib/mydia_web/live/admin_library_prune_live/components.ex
@@ -23,13 +23,14 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Components do
 
         <ul class="menu bg-base-200 rounded-box w-full">
           <li :for={file <- [@decision.keeper | @decision.losers]}>
-            <label class="flex items-center gap-3">
+            <div class="flex items-center gap-3">
               <input
                 type="radio"
                 class="radio radio-sm radio-primary"
                 id={"prune-keeper-#{file.id}"}
                 name={"keeper-#{@decision.group.subject_id}"}
                 checked={file.id == @decision.keeper.id}
+                aria-label={"Keep #{file.relative_path}"}
                 phx-click="choose_keeper"
                 phx-value-subject={@decision.group.subject_id}
                 phx-value-file={file.id}
@@ -43,10 +44,11 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Components do
                 class="checkbox checkbox-sm checkbox-error"
                 id={"prune-loser-#{file.id}"}
                 checked={MapSet.member?(@selected, file.id)}
+                aria-label={"Trash #{file.relative_path}"}
                 phx-click="toggle_loser"
                 phx-value-file={file.id}
               />
-            </label>
+            </div>
           </li>
         </ul>
       </div>

--- a/lib/mydia_web/live/admin_library_prune_live/components.ex
+++ b/lib/mydia_web/live/admin_library_prune_live/components.ex
@@ -1,0 +1,137 @@
+defmodule MydiaWeb.AdminLibraryPruneLive.Components do
+  @moduledoc """
+  Function components for the prune review page. Used only by the sibling
+  LiveView.
+  """
+
+  use MydiaWeb, :html
+
+  alias Mydia.Library.MediaFile
+
+  attr :decision, :map, required: true
+  attr :selected, :any, required: true
+
+  def decision_group(assigns) do
+    ~H"""
+    <div
+      class="card bg-base-100 border border-base-300"
+      id={"prune-group-#{@decision.group.subject_id}"}
+    >
+      <div class="card-body gap-3">
+        <h3 class="card-title text-base">{subject_label(@decision.group)}</h3>
+        <p class="text-sm opacity-70">{@decision.reason}</p>
+
+        <ul class="menu bg-base-200 rounded-box w-full">
+          <li :for={file <- [@decision.keeper | @decision.losers]}>
+            <label class="flex items-center gap-3">
+              <input
+                type="radio"
+                class="radio radio-sm radio-primary"
+                id={"prune-keeper-#{file.id}"}
+                name={"keeper-#{@decision.group.subject_id}"}
+                checked={file.id == @decision.keeper.id}
+                phx-click="choose_keeper"
+                phx-value-subject={@decision.group.subject_id}
+                phx-value-file={file.id}
+              />
+              <span class="flex-1 truncate">{file.relative_path}</span>
+              <span class="badge badge-ghost badge-sm">{quality_label(file)}</span>
+              <span class="text-xs opacity-60">{humanize_bytes(file.size)}</span>
+              <input
+                :if={file.id != @decision.keeper.id}
+                type="checkbox"
+                class="checkbox checkbox-sm checkbox-error"
+                id={"prune-loser-#{file.id}"}
+                checked={MapSet.member?(@selected, file.id)}
+                phx-click="toggle_loser"
+                phx-value-file={file.id}
+              />
+            </label>
+          </li>
+        </ul>
+      </div>
+    </div>
+    """
+  end
+
+  attr :group, :map, required: true
+  attr :reason, :atom, required: true
+  attr :detail, :map, required: true
+
+  def refusal_group(assigns) do
+    ~H"""
+    <div
+      class="card bg-base-100 border border-warning/40"
+      id={"prune-refusal-#{@group.subject_id}"}
+    >
+      <div class="card-body gap-2">
+        <div class="flex items-center gap-2">
+          <.icon name="hero-exclamation-triangle" class="w-4 h-4 text-warning" />
+          <h3 class="card-title text-base">{subject_label(@group)}</h3>
+          <span class="badge badge-warning badge-sm">{refusal_label(@reason)}</span>
+        </div>
+        <p class="text-sm opacity-70">{refusal_explanation(@reason, @detail)}</p>
+        <ul class="text-xs opacity-60 list-disc pl-5">
+          <li :for={file <- @group.files}>{file.relative_path}</li>
+        </ul>
+      </div>
+    </div>
+    """
+  end
+
+  defp subject_label(%{subject_type: :movie, subject: movie}), do: movie.title
+
+  defp subject_label(%{subject_type: :episode, subject: episode, media_item: show}) do
+    "#{show.title} S#{pad(episode.season_number)}E#{pad(episode.episode_number)}"
+  end
+
+  defp pad(nil), do: "??"
+  defp pad(n), do: String.pad_leading(to_string(n), 2, "0")
+
+  defp quality_label(%MediaFile{} = file) do
+    [file.resolution, file.codec] |> Enum.reject(&is_nil/1) |> Enum.join(" ")
+  end
+
+  defp refusal_label(:duplicate_registration), do: "Registered twice"
+  defp refusal_label(:unanalyzed), do: "Not analyzed"
+  defp refusal_label(:duration_mismatch), do: "Different lengths"
+  defp refusal_label(:name_mismatch), do: "Names disagree"
+  defp refusal_label(:episode_mismatch), do: "Wrong episode"
+  defp refusal_label(:nothing_to_prune), do: "Nothing to prune"
+
+  defp refusal_explanation(:duplicate_registration, detail) do
+    "One file on disk is registered twice (#{detail.path}). Trashing a copy would move the only real file. Rescan this library path instead."
+  end
+
+  defp refusal_explanation(:unanalyzed, detail) do
+    "#{detail.unanalyzed_count} file(s) have no duration, so they cannot be compared. Run analysis first."
+  end
+
+  defp refusal_explanation(:duration_mismatch, _detail) do
+    "These files are different lengths, so they are not the same content. This is usually bonus features or a file matched to the wrong item."
+  end
+
+  defp refusal_explanation(:name_mismatch, _detail) do
+    "At least one filename does not belong to this item. Fix the match before pruning."
+  end
+
+  defp refusal_explanation(:episode_mismatch, _detail) do
+    "At least one filename names a different episode than the one it is attached to."
+  end
+
+  defp refusal_explanation(:nothing_to_prune, _detail), do: "Only one file remains."
+
+  @doc """
+  Formats a byte count for display. Public because the page template uses it
+  for the running total on the confirm button.
+  """
+  def humanize_bytes(nil), do: "unknown"
+
+  def humanize_bytes(bytes) when bytes >= 1_073_741_824,
+    do: "#{Float.round(bytes / 1_073_741_824, 1)} GB"
+
+  def humanize_bytes(bytes) when bytes >= 1_048_576,
+    do: "#{Float.round(bytes / 1_048_576, 1)} MB"
+
+  def humanize_bytes(bytes), do: "#{bytes} B"
+end

--- a/lib/mydia_web/live/admin_library_prune_live/components.ex
+++ b/lib/mydia_web/live/admin_library_prune_live/components.ex
@@ -109,8 +109,8 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Components do
     "#{detail.unanalyzed_count} file(s) have no duration, so they cannot be compared. Run analysis first."
   end
 
-  defp refusal_explanation(:duration_mismatch, _detail) do
-    "These files are different lengths, so they are not the same content. This is usually bonus features or a file matched to the wrong item."
+  defp refusal_explanation(:duration_mismatch, detail) do
+    "These files are #{percent(detail.spread)} apart in length, more than the #{percent(detail.tolerance)} allowed, so they are not the same content. This is usually bonus features or a file matched to the wrong item."
   end
 
   defp refusal_explanation(:name_mismatch, _detail) do
@@ -122,6 +122,10 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Components do
   end
 
   defp refusal_explanation(:nothing_to_prune, _detail), do: "Only one file remains."
+
+  # Formats a fraction (0.093) as a percentage string ("9.3%") for the
+  # duration mismatch explanation.
+  defp percent(fraction), do: "#{Float.round(fraction * 100, 1)}%"
 
   @doc """
   Formats a byte count for display. Public because the page template uses it

--- a/lib/mydia_web/live/admin_library_prune_live/index.ex
+++ b/lib/mydia_web/live/admin_library_prune_live/index.ex
@@ -1,0 +1,100 @@
+defmodule MydiaWeb.AdminLibraryPruneLive.Index do
+  @moduledoc """
+  Reviews and confirms pruning of redundant duplicate files.
+
+  The plan is computed on every render rather than cached. It is a couple of
+  queries over a few hundred groups, and a stale plan is a correctness problem
+  rather than a performance one.
+  """
+
+  use MydiaWeb, :live_view
+
+  import MydiaWeb.AdminLibraryPruneLive.Components
+
+  alias Mydia.Library.Prune
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Prune duplicate files")
+     |> assign(:selected, MapSet.new())
+     |> assign(:keepers, %{})
+     |> load_plan()}
+  end
+
+  @impl true
+  def handle_event("choose_keeper", %{"subject" => subject_id, "file" => file_id}, socket) do
+    keepers = Map.put(socket.assigns.keepers, subject_id, file_id)
+
+    # The chosen keeper can no longer be a selected loser.
+    selected = MapSet.delete(socket.assigns.selected, file_id)
+
+    {:noreply,
+     socket
+     |> assign(:keepers, keepers)
+     |> assign(:selected, selected)
+     |> load_plan()}
+  end
+
+  def handle_event("toggle_loser", %{"file" => file_id}, socket) do
+    selected =
+      if MapSet.member?(socket.assigns.selected, file_id) do
+        MapSet.delete(socket.assigns.selected, file_id)
+      else
+        MapSet.put(socket.assigns.selected, file_id)
+      end
+
+    {:noreply, socket |> assign(:selected, selected) |> assign_reclaimable()}
+  end
+
+  def handle_event("confirm", _params, socket) do
+    actor_id = to_string(socket.assigns.current_scope.user.id)
+
+    # execute/3 must be given the same keeper overrides the plan on screen was
+    # built from. Without them, execute/3 silently re-ranks every group with
+    # the default keeper, discarding whatever override the operator chose
+    # before confirming.
+    result =
+      Prune.execute(MapSet.to_list(socket.assigns.selected), actor_id, socket.assigns.keepers)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, flash_for(result))
+     |> assign(:selected, MapSet.new())
+     |> load_plan()}
+  end
+
+  defp load_plan(socket) do
+    plan = Prune.plan(socket.assigns.keepers)
+
+    socket
+    |> assign(decisions: plan.decisions, refusals: plan.refusals)
+    |> assign_reclaimable()
+  end
+
+  # Recomputed wherever `:selected` or `:decisions` changes, so the byte count
+  # on the confirm button can never disagree with the checkboxes above it.
+  defp assign_reclaimable(socket) do
+    selected = socket.assigns.selected
+
+    bytes =
+      for decision <- socket.assigns.decisions,
+          file <- decision.losers,
+          MapSet.member?(selected, file.id),
+          reduce: 0 do
+        total -> total + (file.size || 0)
+      end
+
+    assign(socket, :reclaimable, bytes)
+  end
+
+  defp flash_for(%{trashed: trashed, failed: failed, aborted: aborted}) do
+    base = "Trashed #{length(trashed)} file(s)."
+    base = if failed == [], do: base, else: base <> " #{length(failed)} could not be moved."
+
+    if aborted == [],
+      do: base,
+      else: base <> " #{length(aborted)} were skipped by re-verification."
+  end
+end

--- a/lib/mydia_web/live/admin_library_prune_live/index.ex
+++ b/lib/mydia_web/live/admin_library_prune_live/index.ex
@@ -13,13 +13,20 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Index do
 
   alias Mydia.Library.Prune
 
+  # Mirrors Mydia.Jobs.TrashCleanup's default, so this page never quotes a
+  # retention period that disagrees with what actually purges trashed files.
+  @default_retention_days 30
+
   @impl true
   def mount(_params, _session, socket) do
+    retention_days = Application.get_env(:mydia, :trash_retention_days, @default_retention_days)
+
     {:ok,
      socket
      |> assign(:page_title, "Prune duplicate files")
      |> assign(:selected, MapSet.new())
      |> assign(:keepers, %{})
+     |> assign(:retention_days, retention_days)
      |> load_plan()}
   end
 

--- a/lib/mydia_web/live/admin_library_prune_live/index.ex
+++ b/lib/mydia_web/live/admin_library_prune_live/index.ex
@@ -23,7 +23,8 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Index do
 
     {:ok,
      socket
-     |> assign(:page_title, "Prune duplicate files")
+     |> assign(:page_title, "Configuration - Prune Duplicates")
+     |> assign(:active_tab, :prune)
      |> assign(:selected, MapSet.new())
      |> assign(:keepers, %{})
      |> assign(:retention_days, retention_days)

--- a/lib/mydia_web/live/admin_library_prune_live/index.html.heex
+++ b/lib/mydia_web/live/admin_library_prune_live/index.html.heex
@@ -4,7 +4,7 @@
       <h1 class="text-2xl font-semibold">Prune duplicate files</h1>
       <p class="text-sm opacity-70 mt-1">
         Items holding more than one file. Only groups proven to be the same content
-        can be pruned. Trashed files are kept for 30 days before permanent deletion.
+        can be pruned. Trashed files are kept for {@retention_days} days before permanent deletion.
       </p>
     </div>
 
@@ -21,7 +21,7 @@
           class="btn btn-error btn-sm"
           disabled={MapSet.size(@selected) == 0}
           phx-click="confirm"
-          data-confirm={"Move #{MapSet.size(@selected)} file(s) to trash, reclaiming #{humanize_bytes(@reclaimable)}? They are kept for 30 days before permanent deletion."}
+          data-confirm={"Move #{MapSet.size(@selected)} file(s) to trash, reclaiming #{humanize_bytes(@reclaimable)}? They are kept for #{@retention_days} days before permanent deletion."}
         >
           Trash selected ({MapSet.size(@selected)}, {humanize_bytes(@reclaimable)})
         </button>

--- a/lib/mydia_web/live/admin_library_prune_live/index.html.heex
+++ b/lib/mydia_web/live/admin_library_prune_live/index.html.heex
@@ -1,0 +1,48 @@
+<Layouts.app flash={@flash} current_scope={@current_scope}>
+  <div class="max-w-5xl mx-auto p-4 space-y-6">
+    <div>
+      <h1 class="text-2xl font-semibold">Prune duplicate files</h1>
+      <p class="text-sm opacity-70 mt-1">
+        Items holding more than one file. Only groups proven to be the same content
+        can be pruned. Trashed files are kept for 30 days before permanent deletion.
+      </p>
+    </div>
+
+    <div :if={@decisions == [] and @refusals == []} class="alert alert-success">
+      <.icon name="hero-check-circle" class="w-5 h-5" />
+      <span>No item has more than one file.</span>
+    </div>
+
+    <section :if={@decisions != []} class="space-y-3">
+      <div class="flex items-center justify-between">
+        <h2 class="text-lg font-medium">Ready to prune ({length(@decisions)})</h2>
+        <button
+          id="prune-confirm"
+          class="btn btn-error btn-sm"
+          disabled={MapSet.size(@selected) == 0}
+          phx-click="confirm"
+          data-confirm={"Move #{MapSet.size(@selected)} file(s) to trash, reclaiming #{humanize_bytes(@reclaimable)}? They are kept for 30 days before permanent deletion."}
+        >
+          Trash selected ({MapSet.size(@selected)}, {humanize_bytes(@reclaimable)})
+        </button>
+      </div>
+
+      <.decision_group :for={decision <- @decisions} decision={decision} selected={@selected} />
+    </section>
+
+    <section :if={@refusals != []} class="space-y-3">
+      <h2 class="text-lg font-medium">Needs attention ({length(@refusals)})</h2>
+      <p class="text-sm opacity-70">
+        These were not pruned. Each one is a matching or scanning problem rather than
+        a duplicate, and acting on them would remove real media.
+      </p>
+
+      <.refusal_group
+        :for={{group, reason, detail} <- @refusals}
+        group={group}
+        reason={reason}
+        detail={detail}
+      />
+    </section>
+  </div>
+</Layouts.app>

--- a/lib/mydia_web/live/admin_library_prune_live/index.html.heex
+++ b/lib/mydia_web/live/admin_library_prune_live/index.html.heex
@@ -1,48 +1,50 @@
-<Layouts.app flash={@flash} current_scope={@current_scope}>
-  <div class="max-w-5xl mx-auto p-4 space-y-6">
-    <div>
-      <h1 class="text-2xl font-semibold">Prune duplicate files</h1>
-      <p class="text-sm opacity-70 mt-1">
-        Items holding more than one file. Only groups proven to be the same content
-        can be pruned. Trashed files are kept for {@retention_days} days before permanent deletion.
-      </p>
-    </div>
-
-    <div :if={@decisions == [] and @refusals == []} class="alert alert-success">
-      <.icon name="hero-check-circle" class="w-5 h-5" />
-      <span>No item has more than one file.</span>
-    </div>
-
-    <section :if={@decisions != []} class="space-y-3">
-      <div class="flex items-center justify-between">
-        <h2 class="text-lg font-medium">Ready to prune ({length(@decisions)})</h2>
-        <button
-          id="prune-confirm"
-          class="btn btn-error btn-sm"
-          disabled={MapSet.size(@selected) == 0}
-          phx-click="confirm"
-          data-confirm={"Move #{MapSet.size(@selected)} file(s) to trash, reclaiming #{humanize_bytes(@reclaimable)}? They are kept for #{@retention_days} days before permanent deletion."}
-        >
-          Trash selected ({MapSet.size(@selected)}, {humanize_bytes(@reclaimable)})
-        </button>
+<Layouts.app {assigns}>
+  <.admin_page active_tab={@active_tab}>
+    <div class="space-y-6">
+      <div>
+        <h1 class="text-2xl font-semibold">Prune duplicate files</h1>
+        <p class="text-sm opacity-70 mt-1">
+          Items holding more than one file. Only groups proven to be the same content
+          can be pruned. Trashed files are kept for {@retention_days} days before permanent deletion.
+        </p>
       </div>
 
-      <.decision_group :for={decision <- @decisions} decision={decision} selected={@selected} />
-    </section>
+      <div :if={@decisions == [] and @refusals == []} class="alert alert-success">
+        <.icon name="hero-check-circle" class="w-5 h-5" />
+        <span>No item has more than one file.</span>
+      </div>
 
-    <section :if={@refusals != []} class="space-y-3">
-      <h2 class="text-lg font-medium">Needs attention ({length(@refusals)})</h2>
-      <p class="text-sm opacity-70">
-        These were not pruned. Each one is a matching or scanning problem rather than
-        a duplicate, and acting on them would remove real media.
-      </p>
+      <section :if={@decisions != []} class="space-y-3">
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-medium">Ready to prune ({length(@decisions)})</h2>
+          <button
+            id="prune-confirm"
+            class="btn btn-error btn-sm"
+            disabled={MapSet.size(@selected) == 0}
+            phx-click="confirm"
+            data-confirm={"Move #{MapSet.size(@selected)} file(s) to trash, reclaiming #{humanize_bytes(@reclaimable)}? They are kept for #{@retention_days} days before permanent deletion."}
+          >
+            Trash selected ({MapSet.size(@selected)}, {humanize_bytes(@reclaimable)})
+          </button>
+        </div>
 
-      <.refusal_group
-        :for={{group, reason, detail} <- @refusals}
-        group={group}
-        reason={reason}
-        detail={detail}
-      />
-    </section>
-  </div>
+        <.decision_group :for={decision <- @decisions} decision={decision} selected={@selected} />
+      </section>
+
+      <section :if={@refusals != []} class="space-y-3">
+        <h2 class="text-lg font-medium">Needs attention ({length(@refusals)})</h2>
+        <p class="text-sm opacity-70">
+          These were not pruned. Each one is a matching or scanning problem rather than
+          a duplicate, and acting on them would remove real media.
+        </p>
+
+        <.refusal_group
+          :for={{group, reason, detail} <- @refusals}
+          group={group}
+          reason={reason}
+          detail={detail}
+        />
+      </section>
+    </div>
+  </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/router.ex
+++ b/lib/mydia_web/router.ex
@@ -196,6 +196,7 @@ defmodule MydiaWeb.Router do
       live "/config/indexers", AdminIndexersLive.Index, :index
       live "/subtitle-providers", AdminSubtitleProvidersLive, :index
       live "/config/library-paths", AdminLibraryPathsLive.Index, :index
+      live "/library/prune", AdminLibraryPruneLive.Index, :index
       live "/config/media-servers", AdminMediaServersLive.Index, :index
       live "/config/plugins", AdminPluginsLive.Index, :index
       live "/config/path-mappings", AdminPathMappingsLive.Index, :index

--- a/test/mydia/events/presentation_test.exs
+++ b/test/mydia/events/presentation_test.exs
@@ -266,6 +266,55 @@ defmodule Mydia.Events.PresentationTest do
                )
              ) == "Severance, kept 2160p over 1080p"
     end
+
+    test "pruned reports how many files were trashed and the bytes reclaimed" do
+      assert Presentation.detail(
+               event(
+                 type: "media_file.pruned",
+                 metadata: %{
+                   "kept" => "Arrival/Arrival.2160p.mkv",
+                   "trashed" => ["Arrival/Arrival.1080p.mkv"],
+                   "bytes_reclaimed" => 2_147_483_648
+                 }
+               )
+             ) == "1 file trashed, 2.0 GB reclaimed"
+    end
+
+    test "pruned pluralizes for more than one trashed file" do
+      assert Presentation.detail(
+               event(
+                 type: "media_file.pruned",
+                 metadata: %{
+                   "kept" => "Arrival/Arrival.2160p.mkv",
+                   "trashed" => [
+                     "Arrival/Arrival.1080p.mkv",
+                     "Arrival/Arrival.720p.mkv"
+                   ],
+                   "bytes_reclaimed" => 500_000
+                 }
+               )
+             ) == "2 files trashed, 500000 B reclaimed"
+    end
+
+    test "pruned omits the reclaimed clause when bytes_reclaimed is absent or zero" do
+      assert Presentation.detail(
+               event(
+                 type: "media_file.pruned",
+                 metadata: %{"kept" => "Arrival/Arrival.2160p.mkv", "trashed" => ["a.mkv"]}
+               )
+             ) == "1 file trashed"
+
+      assert Presentation.detail(
+               event(
+                 type: "media_file.pruned",
+                 metadata: %{
+                   "kept" => "Arrival/Arrival.2160p.mkv",
+                   "trashed" => ["a.mkv"],
+                   "bytes_reclaimed" => 0
+                 }
+               )
+             ) == "1 file trashed"
+    end
   end
 
   describe "detail/1 download.*" do

--- a/test/mydia/events/presentation_test.exs
+++ b/test/mydia/events/presentation_test.exs
@@ -272,12 +272,13 @@ defmodule Mydia.Events.PresentationTest do
                event(
                  type: "media_file.pruned",
                  metadata: %{
+                   "title" => "Arrival",
                    "kept" => "Arrival/Arrival.2160p.mkv",
                    "trashed" => ["Arrival/Arrival.1080p.mkv"],
                    "bytes_reclaimed" => 2_147_483_648
                  }
                )
-             ) == "1 file trashed, 2.0 GB reclaimed"
+             ) == "Arrival, 1 file trashed, 2.0 GB reclaimed"
     end
 
     test "pruned pluralizes for more than one trashed file" do
@@ -285,6 +286,7 @@ defmodule Mydia.Events.PresentationTest do
                event(
                  type: "media_file.pruned",
                  metadata: %{
+                   "title" => "Arrival",
                    "kept" => "Arrival/Arrival.2160p.mkv",
                    "trashed" => [
                      "Arrival/Arrival.1080p.mkv",
@@ -293,27 +295,41 @@ defmodule Mydia.Events.PresentationTest do
                    "bytes_reclaimed" => 500_000
                  }
                )
-             ) == "2 files trashed, 500000 B reclaimed"
+             ) == "Arrival, 2 files trashed, 500000 B reclaimed"
     end
 
     test "pruned omits the reclaimed clause when bytes_reclaimed is absent or zero" do
       assert Presentation.detail(
                event(
                  type: "media_file.pruned",
-                 metadata: %{"kept" => "Arrival/Arrival.2160p.mkv", "trashed" => ["a.mkv"]}
+                 metadata: %{
+                   "title" => "Arrival",
+                   "kept" => "Arrival/Arrival.2160p.mkv",
+                   "trashed" => ["a.mkv"]
+                 }
                )
-             ) == "1 file trashed"
+             ) == "Arrival, 1 file trashed"
 
       assert Presentation.detail(
                event(
                  type: "media_file.pruned",
                  metadata: %{
+                   "title" => "Arrival",
                    "kept" => "Arrival/Arrival.2160p.mkv",
                    "trashed" => ["a.mkv"],
                    "bytes_reclaimed" => 0
                  }
                )
-             ) == "1 file trashed"
+             ) == "Arrival, 1 file trashed"
+    end
+
+    test "pruned falls back to Unknown when the title is missing" do
+      assert Presentation.detail(
+               event(
+                 type: "media_file.pruned",
+                 metadata: %{"kept" => "Arrival/Arrival.2160p.mkv", "trashed" => ["a.mkv"]}
+               )
+             ) == "Unknown, 1 file trashed"
     end
   end
 

--- a/test/mydia/library/prune/eligibility_test.exs
+++ b/test/mydia/library/prune/eligibility_test.exs
@@ -1,0 +1,126 @@
+defmodule Mydia.Library.Prune.EligibilityTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library.Prune.{Eligibility, Group}
+
+  # Builds a movie group whose files differ only in the attrs given.
+  defp movie_group(file_attrs) do
+    movie = media_item_fixture(%{type: "movie", title: "Muppets Most Wanted", year: 2014})
+    lp = library_path_fixture(%{type: "movies"})
+
+    files =
+      Enum.map(file_attrs, fn attrs ->
+        attrs
+        |> Map.merge(%{media_item_id: movie.id, library_path_id: lp.id})
+        |> media_file_fixture()
+      end)
+
+    files = Mydia.Repo.preload(files, :library_path)
+
+    %Group{
+      subject_type: :movie,
+      subject_id: movie.id,
+      subject: movie,
+      media_item: movie,
+      files: files
+    }
+  end
+
+  defp duration(seconds), do: %{"container" => "mkv", "duration" => seconds}
+
+  describe "check/1 duplicate registration" do
+    test "refuses two rows sharing library_path_id and relative_path" do
+      group =
+        movie_group([
+          %{relative_path: "Muppets/Muppets.mkv", metadata: duration(6000.0)},
+          %{relative_path: "Muppets/Muppets.mkv", metadata: duration(6000.0)}
+        ])
+
+      assert {:refused, :duplicate_registration, detail} = Eligibility.check(group)
+      assert detail.path == "Muppets/Muppets.mkv"
+    end
+  end
+
+  describe "check/1 analysis" do
+    test "refuses when any file has no duration" do
+      group =
+        movie_group([
+          %{relative_path: "a.mkv", metadata: duration(6000.0)},
+          %{relative_path: "b.avi", metadata: %{"container" => "avi"}}
+        ])
+
+      assert {:refused, :unanalyzed, detail} = Eligibility.check(group)
+      assert detail.unanalyzed_count == 1
+    end
+
+    test "refuses a zero duration rather than dividing by it" do
+      group =
+        movie_group([
+          %{relative_path: "a.mkv", metadata: duration(0.0)},
+          %{relative_path: "b.mkv", metadata: duration(6000.0)}
+        ])
+
+      assert {:refused, :unanalyzed, _} = Eligibility.check(group)
+    end
+  end
+
+  describe "check/1 duration agreement" do
+    test "refuses the Monsters University extras shape" do
+      group =
+        movie_group([
+          %{relative_path: "MU/Monsters University (2013).mkv", metadata: duration(6360.0)},
+          %{relative_path: "MU/Campus Life.mkv", metadata: duration(280.0)}
+        ])
+
+      assert {:refused, :duration_mismatch, detail} = Eligibility.check(group)
+      assert detail.spread > 0.02
+    end
+
+    test "refuses the cross-show shape" do
+      group =
+        movie_group([
+          %{relative_path: "Comme des tetes/S03E24.mkv", metadata: duration(1405.0)},
+          %{relative_path: "Les mots/S03E24.mkv", metadata: duration(120.0)}
+        ])
+
+      assert {:refused, :duration_mismatch, _} = Eligibility.check(group)
+    end
+
+    test "accepts durations inside the 2 percent tolerance" do
+      group =
+        movie_group([
+          %{relative_path: "a.mkv", metadata: duration(6000.0)},
+          %{relative_path: "b.mkv", metadata: duration(5900.0)}
+        ])
+
+      assert {:ok, ^group} = Eligibility.check(group)
+    end
+
+    test "refuses durations just outside the 2 percent tolerance" do
+      group =
+        movie_group([
+          %{relative_path: "a.mkv", metadata: duration(6000.0)},
+          %{relative_path: "b.mkv", metadata: duration(5800.0)}
+        ])
+
+      assert {:refused, :duration_mismatch, _} = Eligibility.check(group)
+    end
+  end
+
+  describe "check/1 refusal ordering" do
+    test "reports duplicate_registration ahead of duration agreement" do
+      # Identical rows trivially agree on duration. The scanner bug is the
+      # more actionable reason, so it must win.
+      group =
+        movie_group([
+          %{relative_path: "same.mkv", metadata: duration(6000.0)},
+          %{relative_path: "same.mkv", metadata: duration(6000.0)}
+        ])
+
+      assert {:refused, :duplicate_registration, _} = Eligibility.check(group)
+    end
+  end
+end

--- a/test/mydia/library/prune/eligibility_test.exs
+++ b/test/mydia/library/prune/eligibility_test.exs
@@ -116,6 +116,14 @@ defmodule Mydia.Library.Prune.EligibilityTest do
     end
   end
 
+  describe "check/1 empty group" do
+    test "refuses nothing_to_prune instead of raising on an empty file list" do
+      group = movie_group([])
+
+      assert {:refused, :nothing_to_prune, %{count: 0}} = Eligibility.check(group)
+    end
+  end
+
   describe "check/1 refusal ordering" do
     test "reports duplicate_registration ahead of duration agreement" do
       # Identical rows trivially agree on duration. The scanner bug is the

--- a/test/mydia/library/prune/eligibility_test.exs
+++ b/test/mydia/library/prune/eligibility_test.exs
@@ -24,7 +24,7 @@ defmodule Mydia.Library.Prune.EligibilityTest do
       subject_type: :movie,
       subject_id: movie.id,
       subject: movie,
-      media_item: movie,
+      media_item: Mydia.Repo.preload(movie, :episodes),
       files: files
     }
   end
@@ -92,8 +92,14 @@ defmodule Mydia.Library.Prune.EligibilityTest do
     test "accepts durations inside the 2 percent tolerance" do
       group =
         movie_group([
-          %{relative_path: "a.mkv", metadata: duration(6000.0)},
-          %{relative_path: "b.mkv", metadata: duration(5900.0)}
+          %{
+            relative_path: "Muppets Most Wanted (2014) 1080p.mkv",
+            metadata: duration(6000.0)
+          },
+          %{
+            relative_path: "Muppets Most Wanted (2014) 720p.mkv",
+            metadata: duration(5900.0)
+          }
         ])
 
       assert {:ok, ^group} = Eligibility.check(group)
@@ -121,6 +127,67 @@ defmodule Mydia.Library.Prune.EligibilityTest do
         ])
 
       assert {:refused, :duplicate_registration, _} = Eligibility.check(group)
+    end
+  end
+
+  describe "check/1 name agreement" do
+    test "refuses the FROM Fray/Crepe shape where two names disagree" do
+      show = media_item_fixture(%{type: "tv_show", title: "FROM", year: 2022})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 4, episode_number: 2})
+      lp = library_path_fixture(%{type: "series"})
+
+      files =
+        for name <- [
+              "FROM/Season 04/From.S04E02.Fray.WEB-DL.1080p.UkrEng.mkv",
+              "FROM/Season 04/From.S04E03.Crepe.1080p.AMZN.WEB-DL.H.264-MeM.mkv"
+            ] do
+          media_file_fixture(%{
+            episode_id: episode.id,
+            library_path_id: lp.id,
+            relative_path: name,
+            metadata: %{"container" => "mkv", "duration" => 3246.0}
+          })
+        end
+
+      group = %Group{
+        subject_type: :episode,
+        subject_id: episode.id,
+        subject: episode,
+        media_item: Mydia.Repo.preload(show, :episodes),
+        files: Mydia.Repo.preload(files, :library_path)
+      }
+
+      assert {:refused, reason, _detail} = Eligibility.check(group)
+      assert reason in [:name_mismatch, :episode_mismatch]
+    end
+
+    test "accepts two releases of the same episode" do
+      show = media_item_fixture(%{type: "tv_show", title: "Rick and Morty", year: 2013})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 2, episode_number: 3})
+      lp = library_path_fixture(%{type: "series"})
+
+      files =
+        for name <- [
+              "Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265-RARBG.mp4",
+              "Rick and Morty/Season 02/Rick.and.Morty.S02E03.480p.WEBRip.x264.mp4"
+            ] do
+          media_file_fixture(%{
+            episode_id: episode.id,
+            library_path_id: lp.id,
+            relative_path: name,
+            metadata: %{"container" => "mp4", "duration" => 1320.0}
+          })
+        end
+
+      group = %Group{
+        subject_type: :episode,
+        subject_id: episode.id,
+        subject: episode,
+        media_item: Mydia.Repo.preload(show, :episodes),
+        files: Mydia.Repo.preload(files, :library_path)
+      }
+
+      assert {:ok, ^group} = Eligibility.check(group)
     end
   end
 end

--- a/test/mydia/library/prune/eligibility_test.exs
+++ b/test/mydia/library/prune/eligibility_test.exs
@@ -189,5 +189,43 @@ defmodule Mydia.Library.Prune.EligibilityTest do
 
       assert {:ok, ^group} = Eligibility.check(group)
     end
+
+    test "recovers the season from folder structure when the filename omits it" do
+      # "E05" alone is anime-style absolute episode numbering with no season
+      # marker: ReleaseParser.parse/2 on the basename defaults it to season 1
+      # (see Resolver.parse_absolute_episode/1), which disagrees with this
+      # episode's real season 3. Only the "Season 03" folder segment carries
+      # the true season, and only ReleaseParser.parse_with_path/2 (fed
+      # file.relative_path, not Path.basename/1) reads it. Before switching
+      # check_episode_numbers/1 to parse_with_path/2, this exact shape parsed
+      # season 1 from the basename and wrongly refused an eligible group as
+      # :episode_mismatch.
+      show = media_item_fixture(%{type: "tv_show", title: "Show Name"})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 3, episode_number: 5})
+      lp = library_path_fixture(%{type: "series"})
+
+      files =
+        for name <- [
+              "Show Name/Season 03/Show.Name.E05.1080p.WEB.mkv",
+              "Show Name/Season 03/Show.Name.E05.720p.WEB.mkv"
+            ] do
+          media_file_fixture(%{
+            episode_id: episode.id,
+            library_path_id: lp.id,
+            relative_path: name,
+            metadata: %{"container" => "mkv", "duration" => 1320.0}
+          })
+        end
+
+      group = %Group{
+        subject_type: :episode,
+        subject_id: episode.id,
+        subject: episode,
+        media_item: Mydia.Repo.preload(show, :episodes),
+        files: Mydia.Repo.preload(files, :library_path)
+      }
+
+      assert {:ok, ^group} = Eligibility.check(group)
+    end
   end
 end

--- a/test/mydia/library/prune/grouping_test.exs
+++ b/test/mydia/library/prune/grouping_test.exs
@@ -1,0 +1,67 @@
+defmodule Mydia.Library.Prune.GroupingTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library.Prune.Grouping
+
+  describe "list_groups/0" do
+    test "returns an episode holding two active files" do
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id})
+      lp = library_path_fixture(%{type: "series"})
+
+      a = media_file_fixture(%{episode_id: episode.id, library_path_id: lp.id})
+      b = media_file_fixture(%{episode_id: episode.id, library_path_id: lp.id})
+
+      assert [group] = Grouping.list_groups()
+      assert group.subject_type == :episode
+      assert group.subject_id == episode.id
+      assert group.media_item.id == show.id
+      assert Enum.map(group.files, & &1.id) |> Enum.sort() == Enum.sort([a.id, b.id])
+    end
+
+    test "returns a movie holding two active files" do
+      movie = media_item_fixture(%{type: "movie"})
+      lp = library_path_fixture(%{type: "movies"})
+
+      media_file_fixture(%{media_item_id: movie.id, library_path_id: lp.id})
+      media_file_fixture(%{media_item_id: movie.id, library_path_id: lp.id})
+
+      assert [group] = Grouping.list_groups()
+      assert group.subject_type == :movie
+      assert group.subject_id == movie.id
+      assert length(group.files) == 2
+    end
+
+    test "ignores items with exactly one file" do
+      movie = media_item_fixture(%{type: "movie"})
+      media_file_fixture(%{media_item_id: movie.id})
+
+      assert Grouping.list_groups() == []
+    end
+
+    test "ignores trashed files when counting" do
+      movie = media_item_fixture(%{type: "movie"})
+      media_file_fixture(%{media_item_id: movie.id})
+      keep = media_file_fixture(%{media_item_id: movie.id})
+
+      {:ok, _} = Mydia.Library.trash_media_file(keep)
+
+      assert Grouping.list_groups() == []
+    end
+
+    test "preloads library_path so absolute_path resolves" do
+      movie = media_item_fixture(%{type: "movie"})
+      media_file_fixture(%{media_item_id: movie.id})
+      media_file_fixture(%{media_item_id: movie.id})
+
+      assert [group] = Grouping.list_groups()
+
+      for file <- group.files do
+        assert is_binary(Mydia.Library.MediaFile.absolute_path(file))
+      end
+    end
+  end
+end

--- a/test/mydia/library/prune/ranker_test.exs
+++ b/test/mydia/library/prune/ranker_test.exs
@@ -26,6 +26,49 @@ defmodule Mydia.Library.Prune.RankerTest do
     }
   end
 
+  # Mirrors Mydia.Upgrades.ComparatorTest's profile/1: a usable profile with
+  # every dimension filled in, so score_file/3 never bails out early.
+  defp quality_profile(overrides \\ %{}) do
+    default_standards = %{
+      preferred_resolutions: ["2160p", "1080p", "720p"],
+      preferred_video_codecs: ["h265", "h264"],
+      preferred_audio_codecs: ["aac", "eac3"],
+      preferred_audio_channels: ["5.1", "2.0"],
+      preferred_sources: ["BluRay", "WEB-DL"],
+      hdr_formats: ["dolby_vision", "hdr10"]
+    }
+
+    attrs =
+      Map.merge(
+        %{quality_standards: default_standards},
+        Map.new(overrides)
+      )
+
+    quality_profile_fixture(attrs)
+  end
+
+  # Like group_of/1, but the movie carries `profile` as its quality profile,
+  # so Ranker.decide/1 can take the :profile path.
+  defp group_with_profile(profile, file_attrs) do
+    movie = media_item_fixture(%{type: "movie", quality_profile_id: profile.id})
+    lp = library_path_fixture(%{type: "movies"})
+
+    files =
+      Enum.map(file_attrs, fn attrs ->
+        attrs
+        |> Map.merge(%{media_item_id: movie.id, library_path_id: lp.id})
+        |> media_file_fixture()
+      end)
+
+    %Group{
+      subject_type: :movie,
+      subject_id: movie.id,
+      subject: movie,
+      media_item: Mydia.Repo.preload(movie, [:episodes, :quality_profile]),
+      files: Mydia.Repo.preload(files, :library_path)
+    }
+  end
+
   describe "decide/1 fallback ranking" do
     test "prefers higher resolution" do
       group =
@@ -162,6 +205,71 @@ defmodule Mydia.Library.Prune.RankerTest do
         ])
 
       assert Ranker.decide(group).keeper.relative_path == "known.mkv"
+    end
+  end
+
+  describe "decide/1 profile ranking" do
+    test "ranks via Upgrades.Comparator when the media item has a quality profile" do
+      profile = quality_profile()
+
+      group =
+        group_with_profile(profile, [
+          %{
+            relative_path: "low.mkv",
+            resolution: "480p",
+            codec: "mpeg4",
+            audio_codec: nil,
+            hdr_format: nil,
+            size: 500_000_000
+          },
+          %{
+            relative_path: "high.mkv",
+            resolution: "4K",
+            codec: "hevc",
+            audio_codec: "aac",
+            hdr_format: "Dolby Vision",
+            size: 20_000_000_000
+          }
+        ])
+
+      decision = Ranker.decide(group)
+
+      assert decision.ranker == :profile
+      assert decision.keeper.relative_path == "high.mkv"
+      assert Enum.map(decision.losers, & &1.relative_path) == ["low.mkv"]
+    end
+
+    test "falls back for the whole group when any file is unscorable, rather than mixing scales" do
+      profile = quality_profile()
+
+      group =
+        group_with_profile(profile, [
+          %{
+            relative_path: "analyzed.mkv",
+            resolution: "1080p",
+            codec: "h264",
+            bitrate: 4_000_000,
+            size: 1_000_000
+          },
+          %{
+            relative_path: "unanalyzed.mkv",
+            resolution: "480p",
+            codec: "mpeg4",
+            bitrate: 500_000,
+            size: 400_000,
+            # No analyzed_at means Comparator.score_file/3 returns
+            # {:error, :unscorable} for this file. A group must never rank
+            # one file on the profile's 0-100 scale and another on the
+            # fallback's raw resolution/bitrate scale, so the whole group
+            # must drop to :fallback.
+            analyzed_at: nil
+          }
+        ])
+
+      decision = Ranker.decide(group)
+
+      assert decision.ranker == :fallback
+      assert decision.keeper.relative_path == "analyzed.mkv"
     end
   end
 

--- a/test/mydia/library/prune/ranker_test.exs
+++ b/test/mydia/library/prune/ranker_test.exs
@@ -1,0 +1,193 @@
+defmodule Mydia.Library.Prune.RankerTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library.Prune.{Group, Ranker}
+
+  defp group_of(file_attrs) do
+    movie = media_item_fixture(%{type: "movie"})
+    lp = library_path_fixture(%{type: "movies"})
+
+    files =
+      Enum.map(file_attrs, fn attrs ->
+        attrs
+        |> Map.merge(%{media_item_id: movie.id, library_path_id: lp.id})
+        |> media_file_fixture()
+      end)
+
+    %Group{
+      subject_type: :movie,
+      subject_id: movie.id,
+      subject: movie,
+      media_item: Mydia.Repo.preload(movie, :episodes),
+      files: Mydia.Repo.preload(files, :library_path)
+    }
+  end
+
+  describe "decide/1 fallback ranking" do
+    test "prefers higher resolution" do
+      group =
+        group_of([
+          %{relative_path: "low.avi", resolution: "360p", codec: "mpeg4", bitrate: 2_006_830},
+          %{relative_path: "high.mp4", resolution: "1080p", codec: "hevc", bitrate: 2_002_656}
+        ])
+
+      decision = Ranker.decide(group)
+
+      assert decision.keeper.relative_path == "high.mp4"
+      assert Enum.map(decision.losers, & &1.relative_path) == ["low.avi"]
+      assert decision.ranker == :fallback
+    end
+
+    test "prefers higher bitrate over a more efficient codec" do
+      # Jujutsu Kaisen S03E03. Ranking codec above bitrate would keep the
+      # 520 MB av1 and trash an 8.8 Mbps source.
+      group =
+        group_of([
+          %{
+            relative_path: "kARiDo.mkv",
+            resolution: "1080p",
+            codec: "h264",
+            bitrate: 8_817_626,
+            size: 1_581_811_675
+          },
+          %{
+            relative_path: "AniDub.mp4",
+            resolution: "1080p",
+            codec: "h264",
+            bitrate: 4_981_199,
+            size: 956_867_074
+          },
+          %{
+            relative_path: "Sokudo.mkv",
+            resolution: "1080p",
+            codec: "av1",
+            bitrate: 2_898_871,
+            size: 520_011_219
+          }
+        ])
+
+      decision = Ranker.decide(group)
+
+      assert decision.keeper.relative_path == "kARiDo.mkv"
+      assert length(decision.losers) == 2
+    end
+
+    test "falls through to size when resolution and bitrate tie" do
+      group =
+        group_of([
+          %{
+            relative_path: "small.mkv",
+            resolution: "1080p",
+            codec: "h264",
+            bitrate: 4_000_000,
+            size: 1_000_000
+          },
+          %{
+            relative_path: "big.mkv",
+            resolution: "1080p",
+            codec: "h264",
+            bitrate: 4_000_000,
+            size: 2_000_000
+          }
+        ])
+
+      assert Ranker.decide(group).keeper.relative_path == "big.mkv"
+    end
+
+    test "falls through to codec only when everything else ties" do
+      group =
+        group_of([
+          %{
+            relative_path: "h264.mkv",
+            resolution: "1080p",
+            codec: "h264",
+            bitrate: 4_000_000,
+            size: 1_000_000
+          },
+          %{
+            relative_path: "av1.mkv",
+            resolution: "1080p",
+            codec: "av1",
+            bitrate: 4_000_000,
+            size: 1_000_000
+          }
+        ])
+
+      assert Ranker.decide(group).keeper.relative_path == "av1.mkv"
+    end
+
+    test "is deterministic across runs on a total tie" do
+      group =
+        group_of([
+          %{
+            relative_path: "a.mkv",
+            resolution: "1080p",
+            codec: "h264",
+            bitrate: 4_000_000,
+            size: 1_000_000
+          },
+          %{
+            relative_path: "b.mkv",
+            resolution: "1080p",
+            codec: "h264",
+            bitrate: 4_000_000,
+            size: 1_000_000
+          }
+        ])
+
+      first = Ranker.decide(group).keeper.id
+      assert Ranker.decide(group).keeper.id == first
+    end
+
+    test "treats a missing resolution as worst rather than best" do
+      group =
+        group_of([
+          %{
+            relative_path: "unknown.avi",
+            resolution: nil,
+            codec: nil,
+            bitrate: nil,
+            size: 900_000_000
+          },
+          %{
+            relative_path: "known.mkv",
+            resolution: "480p",
+            codec: "mpeg4",
+            bitrate: 1_874_724,
+            size: 800_000_000
+          }
+        ])
+
+      assert Ranker.decide(group).keeper.relative_path == "known.mkv"
+    end
+  end
+
+  describe "decide/2 operator override" do
+    test "honours an explicit keeper and re-derives the losers" do
+      group =
+        group_of([
+          %{relative_path: "high.mkv", resolution: "1080p", codec: "hevc", bitrate: 8_000_000},
+          %{relative_path: "low.mkv", resolution: "720p", codec: "h264", bitrate: 2_000_000}
+        ])
+
+      chosen = Enum.find(group.files, &(&1.relative_path == "low.mkv"))
+      decision = Ranker.decide(group, chosen.id)
+
+      assert decision.keeper.id == chosen.id
+      assert Enum.map(decision.losers, & &1.relative_path) == ["high.mkv"]
+    end
+
+    test "ignores a keeper id that is not in the group" do
+      group =
+        group_of([
+          %{relative_path: "high.mkv", resolution: "1080p", codec: "hevc", bitrate: 8_000_000},
+          %{relative_path: "low.mkv", resolution: "720p", codec: "h264", bitrate: 2_000_000}
+        ])
+
+      assert Ranker.decide(group, Ecto.UUID.generate()).keeper.relative_path == "high.mkv"
+    end
+  end
+end

--- a/test/mydia/library/prune_test.exs
+++ b/test/mydia/library/prune_test.exs
@@ -1,0 +1,140 @@
+defmodule Mydia.Library.PruneTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library.Prune
+
+  defp episode_with(file_names, duration) do
+    show = media_item_fixture(%{type: "tv_show", title: "Rick and Morty", year: 2013})
+    episode = episode_fixture(%{media_item_id: show.id, season_number: 2, episode_number: 3})
+    lp = library_path_fixture(%{type: "series"})
+
+    files =
+      Enum.map(file_names, fn {name, attrs} ->
+        attrs
+        |> Map.merge(%{
+          episode_id: episode.id,
+          library_path_id: lp.id,
+          relative_path: name,
+          metadata: %{"container" => "mp4", "duration" => duration}
+        })
+        |> media_file_fixture()
+      end)
+
+    {episode, files}
+  end
+
+  describe "plan/0" do
+    test "separates prunable decisions from refusals" do
+      {_episode, _files} =
+        episode_with(
+          [
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+             %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
+          ],
+          1320.0
+        )
+
+      movie = media_item_fixture(%{type: "movie", title: "Monsters University", year: 2013})
+      lp = library_path_fixture(%{type: "movies"})
+
+      for {name, duration} <- [
+            {"MU/Monsters University (2013).mkv", 6360.0},
+            {"MU/Campus Life.mkv", 280.0}
+          ] do
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: lp.id,
+          relative_path: name,
+          metadata: %{"container" => "mkv", "duration" => duration}
+        })
+      end
+
+      plan = Prune.plan()
+
+      assert [decision] = plan.decisions
+      assert decision.keeper.relative_path =~ "1080p"
+
+      assert [{group, :duration_mismatch, _detail}] = plan.refusals
+      assert group.subject_id == movie.id
+    end
+  end
+
+  describe "execute/2" do
+    test "trashes the selected losers and leaves the keeper active" do
+      {_episode, files} =
+        episode_with(
+          [
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+             %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
+          ],
+          1320.0
+        )
+
+      loser = Enum.find(files, &(&1.relative_path =~ "360p"))
+      keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+
+      result = Prune.execute([loser.id], "admin")
+
+      assert Enum.map(result.trashed, & &1.id) == [loser.id]
+      assert result.failed == []
+      assert result.aborted == []
+
+      assert Mydia.Repo.get!(Mydia.Library.MediaFile, loser.id).trashed_at
+      refute Mydia.Repo.get!(Mydia.Library.MediaFile, keeper.id).trashed_at
+    end
+
+    test "refuses to trash a file from a refused group even when handed its id" do
+      movie = media_item_fixture(%{type: "movie", title: "Monsters University", year: 2013})
+      lp = library_path_fixture(%{type: "movies"})
+
+      files =
+        for {name, duration} <- [
+              {"MU/Monsters University (2013).mkv", 6360.0},
+              {"MU/Campus Life.mkv", 280.0}
+            ] do
+          media_file_fixture(%{
+            media_item_id: movie.id,
+            library_path_id: lp.id,
+            relative_path: name,
+            metadata: %{"container" => "mkv", "duration" => duration}
+          })
+        end
+
+      extra = Enum.find(files, &(&1.relative_path =~ "Campus Life"))
+
+      result = Prune.execute([extra.id], "admin")
+
+      assert result.trashed == []
+      assert [{id, :duration_mismatch}] = result.aborted
+      assert id == extra.id
+      refute Mydia.Repo.get!(Mydia.Library.MediaFile, extra.id).trashed_at
+    end
+
+    test "refuses to trash a proposed keeper" do
+      {_episode, files} =
+        episode_with(
+          [
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+             %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
+          ],
+          1320.0
+        )
+
+      # Selecting every file in a group would leave the item with nothing.
+      ids = Enum.map(files, & &1.id)
+      result = Prune.execute(ids, "admin")
+
+      assert length(result.trashed) == 1
+      assert [{_id, :would_leave_no_file}] = result.aborted
+    end
+  end
+end

--- a/test/mydia/library/prune_test.exs
+++ b/test/mydia/library/prune_test.exs
@@ -137,4 +137,60 @@ defmodule Mydia.Library.PruneTest do
       assert [{_id, :would_leave_no_file}] = result.aborted
     end
   end
+
+  describe "execute/3 with a keeper override" do
+    test "trashes the file the operator selected, honoring the override, not the ranked keeper" do
+      {episode, files} =
+        episode_with(
+          [
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+             %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
+          ],
+          1320.0
+        )
+
+      ranked_keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      overridden_keeper = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      # The operator overrode the keeper to the lower-quality file, then chose
+      # to trash the ranked (higher-quality) one.
+      keepers = %{episode.id => overridden_keeper.id}
+      result = Prune.execute([ranked_keeper.id], "admin", keepers)
+
+      assert Enum.map(result.trashed, & &1.id) == [ranked_keeper.id]
+      assert result.failed == []
+      assert result.aborted == []
+
+      assert Mydia.Repo.get!(Mydia.Library.MediaFile, ranked_keeper.id).trashed_at
+      refute Mydia.Repo.get!(Mydia.Library.MediaFile, overridden_keeper.id).trashed_at
+    end
+
+    test "still refuses to leave a group with zero files under an override" do
+      {episode, files} =
+        episode_with(
+          [
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+             %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
+          ],
+          1320.0
+        )
+
+      ranked_keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      overridden_keeper = Enum.find(files, &(&1.relative_path =~ "360p"))
+      keepers = %{episode.id => overridden_keeper.id}
+
+      ids = Enum.map(files, & &1.id)
+      result = Prune.execute(ids, "admin", keepers)
+
+      assert Enum.map(result.trashed, & &1.id) == [ranked_keeper.id]
+      assert result.aborted == [{overridden_keeper.id, :would_leave_no_file}]
+
+      assert Mydia.Repo.get!(Mydia.Library.MediaFile, ranked_keeper.id).trashed_at
+      refute Mydia.Repo.get!(Mydia.Library.MediaFile, overridden_keeper.id).trashed_at
+    end
+  end
 end

--- a/test/mydia_web/live/admin_library_prune_live_test.exs
+++ b/test/mydia_web/live/admin_library_prune_live_test.exs
@@ -145,5 +145,33 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
       assert Mydia.Repo.get!(Mydia.Library.MediaFile, ranked_keeper.id).trashed_at
       refute Mydia.Repo.get!(Mydia.Library.MediaFile, overridden_keeper.id).trashed_at
     end
+
+    test "the keeper radio and loser checkbox are independently and unambiguously operable",
+         %{conn: conn} do
+      {_show, episode, files} = prunable_episode()
+      keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      loser = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+
+      group_html = view |> element("#prune-group-#{episode.id}") |> render()
+
+      # The keeper radio and the loser checkbox must not be governed by one
+      # shared <label>: a click anywhere in the row would otherwise only
+      # ever activate the first labelable descendant (the keeper radio),
+      # silently reassigning the keeper when the operator meant to toggle
+      # the trash checkbox.
+      refute group_html =~ "<label"
+
+      keeper_match =
+        Regex.run(~r/id="prune-keeper-#{keeper.id}"[^>]*aria-label="([^"]*)"/, group_html)
+
+      loser_match =
+        Regex.run(~r/id="prune-loser-#{loser.id}"[^>]*aria-label="([^"]*)"/, group_html)
+
+      assert [_, keeper_label] = keeper_match
+      assert [_, loser_label] = loser_match
+      assert keeper_label != loser_label
+    end
   end
 end

--- a/test/mydia_web/live/admin_library_prune_live_test.exs
+++ b/test/mydia_web/live/admin_library_prune_live_test.exs
@@ -1,0 +1,149 @@
+defmodule MydiaWeb.AdminLibraryPruneLiveTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Accounts
+
+  # Mirrors test/mydia_web/live/admin_quality_profiles_live_test.exs, which is
+  # the canonical admin LiveView setup in this project.
+  setup do
+    unique_id = System.unique_integer([:positive])
+
+    {:ok, user} =
+      Accounts.create_user(%{
+        email: "admin_#{unique_id}@example.com",
+        username: "admin_#{unique_id}",
+        password_hash: "$2b$12$test",
+        role: "admin"
+      })
+
+    {:ok, token, _claims} = Mydia.Auth.Guardian.encode_and_sign(user)
+
+    %{user: user, token: token}
+  end
+
+  defp prunable_episode do
+    show = media_item_fixture(%{type: "tv_show", title: "Rick and Morty", year: 2013})
+    episode = episode_fixture(%{media_item_id: show.id, season_number: 2, episode_number: 3})
+    lp = library_path_fixture(%{type: "series"})
+
+    files =
+      for {name, attrs} <- [
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
+            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+             %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
+          ] do
+        attrs
+        |> Map.merge(%{
+          episode_id: episode.id,
+          library_path_id: lp.id,
+          relative_path: name,
+          metadata: %{"container" => "mp4", "duration" => 1320.0}
+        })
+        |> media_file_fixture()
+      end
+
+    {show, episode, files}
+  end
+
+  defp refused_movie do
+    movie = media_item_fixture(%{type: "movie", title: "Monsters University", year: 2013})
+    lp = library_path_fixture(%{type: "movies"})
+
+    for {name, duration} <- [
+          {"MU/Monsters University (2013).mkv", 6360.0},
+          {"MU/Campus Life.mkv", 280.0}
+        ] do
+      media_file_fixture(%{
+        media_item_id: movie.id,
+        library_path_id: lp.id,
+        relative_path: name,
+        metadata: %{"container" => "mkv", "duration" => duration}
+      })
+    end
+
+    movie
+  end
+
+  describe "the prune page" do
+    setup %{conn: conn, token: token} do
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      %{conn: conn}
+    end
+
+    test "renders a prunable group with a selectable loser", %{conn: conn} do
+      {_show, _episode, files} = prunable_episode()
+      loser = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+
+      assert has_element?(view, "#prune-loser-#{loser.id}")
+    end
+
+    test "renders a refused group without any selectable file", %{conn: conn} do
+      movie = refused_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+
+      assert has_element?(view, "#prune-refusal-#{movie.id}")
+      refute has_element?(view, "#prune-refusal-#{movie.id} input[type=checkbox]")
+    end
+
+    test "trashes the selected loser on confirm", %{conn: conn} do
+      {_show, _episode, files} = prunable_episode()
+      loser = Enum.find(files, &(&1.relative_path =~ "360p"))
+      keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+
+      view |> element("#prune-loser-#{loser.id}") |> render_click()
+      view |> element("#prune-confirm") |> render_click()
+
+      assert Mydia.Repo.get!(Mydia.Library.MediaFile, loser.id).trashed_at
+      refute Mydia.Repo.get!(Mydia.Library.MediaFile, keeper.id).trashed_at
+    end
+
+    test "changing the keeper re-derives the losers", %{conn: conn} do
+      {_show, _episode, files} = prunable_episode()
+      low = Enum.find(files, &(&1.relative_path =~ "360p"))
+      high = Enum.find(files, &(&1.relative_path =~ "1080p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+
+      view |> element("#prune-keeper-#{low.id}") |> render_click()
+
+      assert has_element?(view, "#prune-loser-#{high.id}")
+      refute has_element?(view, "#prune-loser-#{low.id}")
+    end
+
+    test "confirming after overriding the keeper trashes the operator's chosen file, not the ranked keeper",
+         %{conn: conn} do
+      {_show, _episode, files} = prunable_episode()
+      ranked_keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      overridden_keeper = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+
+      # Override the keeper to the lower-quality file, then select the
+      # higher-quality (ranked) file for trashing. If `confirm` ever calls
+      # `Prune.execute/2` instead of `execute/3` with the keepers map, the
+      # ranked keeper gets silently re-derived as 1080p again and this
+      # trashing gets aborted as `:would_leave_no_file` instead of applied.
+      view |> element("#prune-keeper-#{overridden_keeper.id}") |> render_click()
+      view |> element("#prune-loser-#{ranked_keeper.id}") |> render_click()
+      view |> element("#prune-confirm") |> render_click()
+
+      assert Mydia.Repo.get!(Mydia.Library.MediaFile, ranked_keeper.id).trashed_at
+      refute Mydia.Repo.get!(Mydia.Library.MediaFile, overridden_keeper.id).trashed_at
+    end
+  end
+end

--- a/test/mydia_web/live/admin_library_prune_live_test.exs
+++ b/test/mydia_web/live/admin_library_prune_live_test.exs
@@ -89,6 +89,16 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
       assert has_element?(view, "#prune-loser-#{loser.id}")
     end
 
+    test "renders the admin tab strip with prune as the active tab", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+
+      assert has_element?(view, "div[role=tablist]")
+      assert has_element?(view, "a.tab-active", "Prune duplicates")
+      # Every other admin page's tab must still be reachable from here, or an
+      # operator who lands on this page has no way back to the rest of admin.
+      assert has_element?(view, "a[href='/admin/config/library-paths']", "Library")
+    end
+
     test "renders a refused group without any selectable file", %{conn: conn} do
       movie = refused_movie()
 
@@ -96,6 +106,22 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
 
       assert has_element?(view, "#prune-refusal-#{movie.id}")
       refute has_element?(view, "#prune-refusal-#{movie.id} input[type=checkbox]")
+    end
+
+    test "explains a duration mismatch refusal with the actual spread and tolerance",
+         %{conn: conn} do
+      # refused_movie/0's durations are 6360.0s and 280.0s, a ~95.6% spread
+      # against the 2.0% tolerance. The explanation must show both numbers so
+      # an operator can see how far apart the files actually were, not just
+      # that they disagreed.
+      movie = refused_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+
+      group_html = view |> element("#prune-refusal-#{movie.id}") |> render()
+
+      assert group_html =~ "95.6%"
+      assert group_html =~ "2.0%"
     end
 
     test "trashes the selected loser on confirm", %{conn: conn} do


### PR DESCRIPTION
## What

Adds an operator-reviewed way to trash redundant duplicate copies of an episode or movie, at `/admin/library/prune`.

## Why this is mostly a refusal engine

Measured on a real library (3437 active `media_files`): 518 episodes and 39 movies hold more than one file, but most are not duplicates.

| Category | Episodes |
|---|---:|
| Files from two different show folders (misidentified) | 137 |
| Identical `library_path_id` + `relative_path` (one file registered twice) | 153 |
| Same show, distinct paths (contains the genuine duplicates) | 228 |

For movies, 30 of 39 are bonus features rather than duplicates. Monsters University has 21 files: one 4.6 GB feature plus `Campus Life.mkv`, `Easter Egg.mkv` and trailers, sitting loose in the movie folder where `SampleDetector`'s rules do not catch them.

A naive "keep the best, trash the rest" sweep destroys real media. So the gate refuses anything it cannot prove is the same content, and surfaces the rest as "needs attention" rather than acting on it.

## Design

- `Prune.Grouping` finds items holding more than one active file. Two queries, since a TV `media_file` carries `episode_id` with `media_item_id` NULL.
- `Prune.Eligibility` is a six-check gate. First failure is the reported reason: `:duplicate_registration`, `:unanalyzed`, `:duration_mismatch`, `:name_mismatch`, `:episode_mismatch`, `:nothing_to_prune`.
- `Prune.Ranker` scores against the item's quality profile via `Upgrades.Comparator`, falling back to resolution, then bitrate, then size, then codec.
- `Mydia.Library.Prune` assembles the plan and executes it through the existing `Library.trash_media_file/1`.
- `AdminLibraryPruneLive.Index` is the review page.

No new table and no migration. Nothing runs on a schedule.

### Duration tolerance is 2%

Against the 228-group candidate pool, 1% admits 164, 2% admits 177, 5% admits 199. The step from 2% to 5% is where extended cuts and alternate edits start being admitted, so 2% is the last conservative step.

### Codec ranks last in the fallback, deliberately

Jujutsu Kaisen S03E03 exists three times: 1080p h264 at 8.8 Mbps (1.58 GB), h264 at 5.0 Mbps (957 MB), and av1 at 2.9 Mbps (520 MB). Ranking codec second, the intuitive "av1 is a better codec" ordering, keeps the 520 MB av1 and trashes the 8.8 Mbps source. Codec efficiency describes quality per bit; it does not make a low-bitrate re-encode better than a high-bitrate source. There is a test pinning this shape.

## Safety properties

- `Prune.execute/3` is the boundary, not the UI. It rebuilds the plan from the database on every call and drops any id that is not a current loser of a currently eligible group. A test asserts that handing it a file id from a refused group trashes nothing.
- Deletion goes only through `Library.trash_media_file/1`, which moves the file off the library path into `.mydia-trash` with the configured retention (default 30 days).
- Partial failure is reported per file and not rolled back, since `TrashStore` has already moved bytes by the time a row update can fail.
- The keeper is a proposal. The operator can pick a different one, and the override is threaded through to execution.

## What the gate does to the real data

Refuses all 137 cross-show groups, all 153 double-registrations, the Star Trek trio (no duration on two of three files), the `FROM S04E02` Fray/Crepe pair (different episodes, durations only 34 seconds apart), and Monsters University's extras. Prunes the genuine cases such as Rick and Morty S02E03 as a 360p mpeg4 `.avi` next to a 1080p x265.

## Shared files touched

`lib/mydia/events.ex` gains `files_pruned/4`, and `lib/mydia/events/presentation.ex` gains one `@entries` row plus a `detail/1` clause for `"media_file.pruned"`. Both are additive; no existing event type is modified. The registry entry is required: without it `Event.changeset/2` rejects the write and `create_event_async/1` only logs, so the activity trail would silently no-op.

## Testing

`mix precommit` green: 8566 tests, 0 failures, Credo clean.

## Known follow-up, not fixed here

Hyphen-slug filenames such as `Muppets-Most-Wanted-2014-1080p-BluRay-x264.mkv` fail title extraction in `ReleaseParser`, so `binding_suspect` fires and those movies are refused rather than pruned. Dot-separated, space-separated and parenthesized-year styles all bind correctly. The fix belongs in `ReleaseParser`/`Resolver`, which import, download and matching all share, so it is out of scope here. It fails in the safe direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin workflow to review and prune duplicate media files.
  * Automatically identifies eligible duplicates, recommends a file to keep, and estimates reclaimable storage.
  * Supports keeper overrides, selective file removal, and confirmation before changes are applied.
  * Displays clear explanations for files that cannot be safely pruned.
  * Records pruning activity, including removed files and reclaimed storage.
* **Bug Fixes**
  * Protects selected keeper files and rechecks eligibility before removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->