### PR TITLE
fix(prune): rebuild the prune page on the admin standard, preselect duplicates

### DIFF
--- a/lib/mydia_web/components/admin_components.ex
+++ b/lib/mydia_web/components/admin_components.ex
@@ -76,7 +76,7 @@ defmodule MydiaWeb.AdminComponents do
       </.tab_link>
       <.tab_link
         active={@active_tab == :prune}
-        to="/admin/library/prune"
+        to="/admin/config/prune"
         icon="hero-document-duplicate"
       >
         Prune duplicates

--- a/lib/mydia_web/live/admin_library_prune_live/components.ex
+++ b/lib/mydia_web/live/admin_library_prune_live/components.ex
@@ -8,49 +8,181 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Components do
 
   alias Mydia.Library.MediaFile
 
+  @doc """
+  Renders the Prune Duplicates tab content.
+  """
+  attr :decisions, :list, required: true
+  attr :refusals, :list, required: true
+  attr :selected, :any, required: true
+  attr :reclaimable, :integer, required: true
+  attr :retention_days, :integer, required: true
+
+  def prune_tab(assigns) do
+    total_losers =
+      Enum.reduce(assigns.decisions, 0, fn decision, acc -> acc + length(decision.losers) end)
+
+    assigns = assign(assigns, :all_selected?, MapSet.size(assigns.selected) == total_losers)
+
+    ~H"""
+    <div class="p-4 sm:p-6 space-y-4">
+      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <.icon name="hero-document-duplicate" class="w-5 h-5 opacity-60" /> Duplicate Files
+          <span class="badge badge-ghost">{length(@decisions)}</span>
+        </h2>
+        <div class="join">
+          <button
+            :if={not @all_selected?}
+            id="prune-select-all"
+            type="button"
+            class="btn btn-sm btn-ghost join-item"
+            phx-click="select_all_prune_files"
+          >
+            <.icon name="hero-check-circle" class="w-4 h-4" /> Select all
+          </button>
+          <button
+            id="prune-trash-selected"
+            type="button"
+            class="btn btn-sm btn-error join-item"
+            disabled={MapSet.size(@selected) == 0}
+            phx-click="open_prune_modal"
+          >
+            <.icon name="hero-trash" class="w-4 h-4" />
+            Trash {file_count(MapSet.size(@selected))} ({humanize_bytes(@reclaimable)})
+          </button>
+        </div>
+      </div>
+
+      <p class="text-sm text-base-content/60">
+        Items holding more than one file, where every copy is proven to be the same content.
+        The lower-quality copies are already selected, so one click on Trash clears them all.
+        The radio marks the file that stays. Trashed files are kept for {@retention_days} days before permanent deletion.
+      </p>
+
+      <%= if @decisions == [] do %>
+        <div class="alert alert-info">
+          <.icon name="hero-information-circle" class="w-5 h-5" />
+          <span :if={@refusals == []}>
+            No item holds more than one file. There is nothing to prune.
+          </span>
+          <span :if={@refusals != []}>
+            Nothing can be pruned safely right now. Every item below needs attention first.
+          </span>
+        </div>
+      <% else %>
+        <div class="bg-base-200 rounded-box divide-y divide-base-300">
+          <.decision_row :for={decision <- @decisions} decision={decision} selected={@selected} />
+        </div>
+      <% end %>
+
+      <%= if @refusals != [] do %>
+        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 pt-2">
+          <h2 class="text-lg font-semibold flex items-center gap-2">
+            <.icon name="hero-exclamation-triangle" class="w-5 h-5 opacity-60" /> Needs Attention
+            <span class="badge badge-ghost">{length(@refusals)}</span>
+          </h2>
+        </div>
+
+        <p class="text-sm text-base-content/60">
+          These were not pruned. Each one is a matching or scanning problem rather than a
+          duplicate, and acting on them would remove real media.
+        </p>
+
+        <div class="bg-base-200 rounded-box divide-y divide-base-300">
+          <.refusal_row
+            :for={{group, reason, detail} <- @refusals}
+            group={group}
+            reason={reason}
+            detail={detail}
+          />
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
   attr :decision, :map, required: true
   attr :selected, :any, required: true
 
-  def decision_group(assigns) do
-    ~H"""
-    <div
-      class="card bg-base-100 border border-base-300"
-      id={"prune-group-#{@decision.group.subject_id}"}
-    >
-      <div class="card-body gap-3">
-        <h3 class="card-title text-base">{subject_label(@decision.group)}</h3>
-        <p class="text-sm opacity-70">{@decision.reason}</p>
+  defp decision_row(assigns) do
+    selected_count = Enum.count(assigns.decision.losers, &MapSet.member?(assigns.selected, &1.id))
 
-        <ul class="menu bg-base-200 rounded-box w-full">
-          <li :for={file <- [@decision.keeper | @decision.losers]}>
-            <div class="flex items-center gap-3">
-              <input
-                type="radio"
-                class="radio radio-sm radio-primary"
-                id={"prune-keeper-#{file.id}"}
-                name={"keeper-#{@decision.group.subject_id}"}
-                checked={file.id == @decision.keeper.id}
-                aria-label={"Keep #{file.relative_path}"}
-                phx-click="choose_keeper"
-                phx-value-subject={@decision.group.subject_id}
-                phx-value-file={file.id}
-              />
-              <span class="flex-1 truncate">{file.relative_path}</span>
-              <span class="badge badge-ghost badge-sm">{quality_label(file)}</span>
-              <span class="text-xs opacity-60">{humanize_bytes(file.size)}</span>
-              <input
-                :if={file.id != @decision.keeper.id}
-                type="checkbox"
-                class="checkbox checkbox-sm checkbox-error"
-                id={"prune-loser-#{file.id}"}
-                checked={MapSet.member?(@selected, file.id)}
-                aria-label={"Trash #{file.relative_path}"}
-                phx-click="toggle_loser"
-                phx-value-file={file.id}
-              />
-            </div>
-          </li>
-        </ul>
+    assigns = assign(assigns, :selected_count, selected_count)
+
+    ~H"""
+    <div class="p-3 sm:p-4" id={"prune-group-#{@decision.group.subject_id}"}>
+      <div class="flex items-center gap-3">
+        <div class="flex-1 min-w-0">
+          <div class="font-medium truncate">{subject_label(@decision.group)}</div>
+          <div class="text-xs opacity-60 truncate">{@decision.reason}</div>
+        </div>
+
+        <span class="badge badge-sm badge-outline hidden sm:inline-flex">
+          {file_count(length(@decision.losers) + 1)}
+        </span>
+        <span :if={@selected_count > 0} class="badge badge-sm badge-outline badge-error">
+          {@selected_count} to trash
+        </span>
+        <span :if={@selected_count == 0} class="badge badge-sm badge-outline">Skipped</span>
+
+        <div class="join ml-auto sm:ml-2">
+          <button
+            id={"prune-group-toggle-#{@decision.group.subject_id}"}
+            type="button"
+            class="btn btn-sm btn-ghost join-item"
+            title={
+              if @selected_count > 0,
+                do: "Keep every file in this group",
+                else: "Trash every duplicate in this group"
+            }
+            aria-label={
+              if @selected_count > 0,
+                do: "Keep every file in #{subject_label(@decision.group)}",
+                else: "Trash every duplicate in #{subject_label(@decision.group)}"
+            }
+            phx-click="toggle_prune_group"
+            phx-value-subject={@decision.group.subject_id}
+          >
+            <.icon
+              name={if @selected_count > 0, do: "hero-x-mark", else: "hero-check"}
+              class="w-4 h-4"
+            />
+          </button>
+        </div>
+      </div>
+
+      <div class="bg-base-100 rounded-box divide-y divide-base-300 mt-3">
+        <div
+          :for={file <- [@decision.keeper | @decision.losers]}
+          class="flex items-center gap-3 px-3 py-2"
+        >
+          <input
+            type="radio"
+            class="radio radio-sm radio-primary shrink-0"
+            id={"prune-keeper-#{file.id}"}
+            name={"keeper-#{@decision.group.subject_id}"}
+            checked={file.id == @decision.keeper.id}
+            aria-label={"Keep #{file.relative_path}"}
+            phx-click="choose_prune_keeper"
+            phx-value-subject={@decision.group.subject_id}
+            phx-value-file={file.id}
+          />
+          <span class="flex-1 min-w-0 truncate text-sm">{file.relative_path}</span>
+          <span class="badge badge-ghost badge-sm">{quality_label(file)}</span>
+          <span class="text-xs opacity-60 whitespace-nowrap">{humanize_bytes(file.size)}</span>
+          <div class="w-5 flex justify-end shrink-0">
+            <input
+              :if={file.id != @decision.keeper.id}
+              type="checkbox"
+              class="checkbox checkbox-sm checkbox-error"
+              id={"prune-loser-#{file.id}"}
+              checked={MapSet.member?(@selected, file.id)}
+              aria-label={"Trash #{file.relative_path}"}
+              phx-click="toggle_prune_file"
+              phx-value-file={file.id}
+            />
+          </div>
+        </div>
       </div>
     </div>
     """
@@ -60,23 +192,76 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Components do
   attr :reason, :atom, required: true
   attr :detail, :map, required: true
 
-  def refusal_group(assigns) do
+  defp refusal_row(assigns) do
     ~H"""
-    <div
-      class="card bg-base-100 border border-warning/40"
-      id={"prune-refusal-#{@group.subject_id}"}
-    >
-      <div class="card-body gap-2">
-        <div class="flex items-center gap-2">
-          <.icon name="hero-exclamation-triangle" class="w-4 h-4 text-warning" />
-          <h3 class="card-title text-base">{subject_label(@group)}</h3>
-          <span class="badge badge-warning badge-sm">{refusal_label(@reason)}</span>
+    <div class="p-3 sm:p-4" id={"prune-refusal-#{@group.subject_id}"}>
+      <div class="flex items-center gap-3">
+        <div class="flex-1 min-w-0">
+          <div class="font-medium truncate">{subject_label(@group)}</div>
+          <div class="text-xs opacity-60 truncate">{file_count(length(@group.files))}</div>
         </div>
-        <p class="text-sm opacity-70">{refusal_explanation(@reason, @detail)}</p>
-        <ul class="text-xs opacity-60 list-disc pl-5">
-          <li :for={file <- @group.files}>{file.relative_path}</li>
-        </ul>
+        <span class="badge badge-sm badge-outline badge-warning">{refusal_label(@reason)}</span>
       </div>
+
+      <p class="text-sm text-base-content/60 mt-2">{refusal_explanation(@reason, @detail)}</p>
+
+      <ul class="text-xs opacity-60 list-disc pl-5 mt-1">
+        <li :for={file <- @group.files}>{file.relative_path}</li>
+      </ul>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders the trash confirmation modal.
+
+  A `data-confirm` would be enough for a single row, but this button moves
+  every selected duplicate across the whole library in one go. The blast
+  radius (files, items, bytes) is worth showing before it runs.
+  """
+  attr :count, :integer, required: true
+  attr :items, :integer, required: true
+  attr :bytes, :integer, required: true
+  attr :retention_days, :integer, required: true
+
+  def prune_confirm_modal(assigns) do
+    ~H"""
+    <div id="prune-confirm-modal" class="modal modal-open">
+      <div class="modal-box">
+        <div class="flex items-center gap-3 mb-5">
+          <div class="w-10 h-10 rounded-xl bg-error/20 flex items-center justify-center">
+            <.icon name="hero-trash" class="w-5 h-5 text-error" />
+          </div>
+          <div>
+            <h3 class="font-bold text-lg">Trash {file_count(@count)}?</h3>
+            <p class="text-sm text-base-content/60">
+              Across {item_count(@items)}, reclaiming {humanize_bytes(@bytes)}.
+            </p>
+          </div>
+        </div>
+
+        <p class="py-2">
+          Every selected file is a redundant copy of one that stays behind, so each item keeps
+          a playable file. Trashed files are kept for {@retention_days} days before permanent
+          deletion.
+        </p>
+
+        <div class="modal-action mt-6 pt-4 border-t border-base-300">
+          <button id="prune-cancel" type="button" class="btn btn-ghost" phx-click="close_prune_modal">
+            Cancel
+          </button>
+          <button
+            id="prune-confirm"
+            type="button"
+            class="btn btn-error"
+            phx-click="confirm_prune"
+            phx-disable-with="Trashing..."
+          >
+            <.icon name="hero-trash" class="w-4 h-4" /> Move to trash
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop bg-black/50" phx-click="close_prune_modal"></div>
     </div>
     """
   end
@@ -93,6 +278,12 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Components do
   defp quality_label(%MediaFile{} = file) do
     [file.resolution, file.codec] |> Enum.reject(&is_nil/1) |> Enum.join(" ")
   end
+
+  defp file_count(1), do: "1 file"
+  defp file_count(n), do: "#{n} files"
+
+  defp item_count(1), do: "1 item"
+  defp item_count(n), do: "#{n} items"
 
   defp refusal_label(:duplicate_registration), do: "Registered twice"
   defp refusal_label(:unanalyzed), do: "Not analyzed"

--- a/lib/mydia_web/live/admin_library_prune_live/index.ex
+++ b/lib/mydia_web/live/admin_library_prune_live/index.ex
@@ -5,11 +5,23 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Index do
   The plan is computed on every render rather than cached. It is a couple of
   queries over a few hundred groups, and a stale plan is a correctness problem
   rather than a performance one.
+
+  ## Why the selection is stored as an exclusion set
+
+  Every loser of every eligible group starts selected, so the ordinary path
+  through this page is one click on Trash. Holding the operator's
+  *deselections* rather than their selections is what keeps that true across a
+  re-plan: when the keeper changes, the file that stopped being the keeper
+  becomes a loser and is selected without the operator hunting for it, while
+  everything they explicitly unchecked stays unchecked.
+
+  Selecting by default is only defensible because `Mydia.Library.Prune.Eligibility`
+  has already refused every group that is not proven to be the same content.
+  A group that reaches `:decisions` holds redundant copies of one file; the
+  refused ones are listed separately and have nothing selectable on them.
   """
 
   use MydiaWeb, :live_view
-
-  import MydiaWeb.AdminLibraryPruneLive.Components
 
   alias Mydia.Library.Prune
 
@@ -25,38 +37,67 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Index do
      socket
      |> assign(:page_title, "Configuration - Prune Duplicates")
      |> assign(:active_tab, :prune)
-     |> assign(:selected, MapSet.new())
+     |> assign(:deselected, MapSet.new())
      |> assign(:keepers, %{})
+     |> assign(:show_prune_modal, false)
      |> assign(:retention_days, retention_days)
      |> load_plan()}
   end
 
   @impl true
-  def handle_event("choose_keeper", %{"subject" => subject_id, "file" => file_id}, socket) do
+  def handle_event("choose_prune_keeper", %{"subject" => subject_id, "file" => file_id}, socket) do
     keepers = Map.put(socket.assigns.keepers, subject_id, file_id)
 
-    # The chosen keeper can no longer be a selected loser.
-    selected = MapSet.delete(socket.assigns.selected, file_id)
-
-    {:noreply,
-     socket
-     |> assign(:keepers, keepers)
-     |> assign(:selected, selected)
-     |> load_plan()}
+    # The new keeper drops out of `:losers` on the next plan, so it stops being
+    # selected without touching `:deselected`. The old keeper becomes a loser
+    # and, never having been unchecked, is selected.
+    {:noreply, socket |> assign(:keepers, keepers) |> load_plan()}
   end
 
-  def handle_event("toggle_loser", %{"file" => file_id}, socket) do
-    selected =
-      if MapSet.member?(socket.assigns.selected, file_id) do
-        MapSet.delete(socket.assigns.selected, file_id)
+  def handle_event("toggle_prune_file", %{"file" => file_id}, socket) do
+    deselected =
+      if MapSet.member?(socket.assigns.deselected, file_id) do
+        MapSet.delete(socket.assigns.deselected, file_id)
       else
-        MapSet.put(socket.assigns.selected, file_id)
+        MapSet.put(socket.assigns.deselected, file_id)
       end
 
-    {:noreply, socket |> assign(:selected, selected) |> assign_reclaimable()}
+    {:noreply, socket |> assign(:deselected, deselected) |> assign_selection()}
   end
 
-  def handle_event("confirm", _params, socket) do
+  def handle_event("toggle_prune_group", %{"subject" => subject_id}, socket) do
+    case Enum.find(socket.assigns.decisions, &(&1.group.subject_id == subject_id)) do
+      nil ->
+        {:noreply, socket}
+
+      decision ->
+        loser_ids = Enum.map(decision.losers, & &1.id)
+        selected = socket.assigns.selected
+
+        deselected =
+          if Enum.any?(loser_ids, &MapSet.member?(selected, &1)) do
+            Enum.reduce(loser_ids, socket.assigns.deselected, &MapSet.put(&2, &1))
+          else
+            Enum.reduce(loser_ids, socket.assigns.deselected, &MapSet.delete(&2, &1))
+          end
+
+        {:noreply, socket |> assign(:deselected, deselected) |> assign_selection()}
+    end
+  end
+
+  def handle_event("select_all_prune_files", _params, socket) do
+    {:noreply, socket |> assign(:deselected, MapSet.new()) |> assign_selection()}
+  end
+
+  def handle_event("open_prune_modal", _params, socket) do
+    {:noreply, assign(socket, :show_prune_modal, MapSet.size(socket.assigns.selected) > 0)}
+  end
+
+  def handle_event("close_prune_modal", _params, socket) do
+    {:noreply, assign(socket, :show_prune_modal, false)}
+  end
+
+  def handle_event("confirm_prune", _params, socket) do
     actor_id = to_string(socket.assigns.current_scope.user.id)
 
     # execute/3 must be given the same keeper overrides the plan on screen was
@@ -69,7 +110,8 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Index do
     {:noreply,
      socket
      |> put_flash(:info, flash_for(result))
-     |> assign(:selected, MapSet.new())
+     |> assign(:show_prune_modal, false)
+     |> assign(:deselected, MapSet.new())
      |> load_plan()}
   end
 
@@ -78,13 +120,22 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Index do
 
     socket
     |> assign(decisions: plan.decisions, refusals: plan.refusals)
-    |> assign_reclaimable()
+    |> assign_selection()
   end
 
-  # Recomputed wherever `:selected` or `:decisions` changes, so the byte count
-  # on the confirm button can never disagree with the checkboxes above it.
-  defp assign_reclaimable(socket) do
-    selected = socket.assigns.selected
+  # `:selected` is derived, never stored: every loser of an eligible group is
+  # selected unless the operator unchecked it. Recomputed wherever
+  # `:deselected` or `:decisions` changes, so the counts on the confirm button
+  # can never disagree with the checkboxes above it.
+  defp assign_selection(socket) do
+    deselected = socket.assigns.deselected
+
+    selected =
+      for decision <- socket.assigns.decisions,
+          file <- decision.losers,
+          not MapSet.member?(deselected, file.id),
+          into: MapSet.new(),
+          do: file.id
 
     bytes =
       for decision <- socket.assigns.decisions,
@@ -94,7 +145,15 @@ defmodule MydiaWeb.AdminLibraryPruneLive.Index do
         total -> total + (file.size || 0)
       end
 
-    assign(socket, :reclaimable, bytes)
+    affected =
+      Enum.count(socket.assigns.decisions, fn decision ->
+        Enum.any?(decision.losers, &MapSet.member?(selected, &1.id))
+      end)
+
+    socket
+    |> assign(:selected, selected)
+    |> assign(:reclaimable, bytes)
+    |> assign(:affected_items, affected)
   end
 
   defp flash_for(%{trashed: trashed, failed: failed, aborted: aborted}) do

--- a/lib/mydia_web/live/admin_library_prune_live/index.html.heex
+++ b/lib/mydia_web/live/admin_library_prune_live/index.html.heex
@@ -1,50 +1,21 @@
 <Layouts.app {assigns}>
   <.admin_page active_tab={@active_tab}>
-    <div class="space-y-6">
-      <div>
-        <h1 class="text-2xl font-semibold">Prune duplicate files</h1>
-        <p class="text-sm opacity-70 mt-1">
-          Items holding more than one file. Only groups proven to be the same content
-          can be pruned. Trashed files are kept for {@retention_days} days before permanent deletion.
-        </p>
-      </div>
+    <MydiaWeb.AdminLibraryPruneLive.Components.prune_tab
+      decisions={@decisions}
+      refusals={@refusals}
+      selected={@selected}
+      reclaimable={@reclaimable}
+      retention_days={@retention_days}
+    />
 
-      <div :if={@decisions == [] and @refusals == []} class="alert alert-success">
-        <.icon name="hero-check-circle" class="w-5 h-5" />
-        <span>No item has more than one file.</span>
-      </div>
-
-      <section :if={@decisions != []} class="space-y-3">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-medium">Ready to prune ({length(@decisions)})</h2>
-          <button
-            id="prune-confirm"
-            class="btn btn-error btn-sm"
-            disabled={MapSet.size(@selected) == 0}
-            phx-click="confirm"
-            data-confirm={"Move #{MapSet.size(@selected)} file(s) to trash, reclaiming #{humanize_bytes(@reclaimable)}? They are kept for #{@retention_days} days before permanent deletion."}
-          >
-            Trash selected ({MapSet.size(@selected)}, {humanize_bytes(@reclaimable)})
-          </button>
-        </div>
-
-        <.decision_group :for={decision <- @decisions} decision={decision} selected={@selected} />
-      </section>
-
-      <section :if={@refusals != []} class="space-y-3">
-        <h2 class="text-lg font-medium">Needs attention ({length(@refusals)})</h2>
-        <p class="text-sm opacity-70">
-          These were not pruned. Each one is a matching or scanning problem rather than
-          a duplicate, and acting on them would remove real media.
-        </p>
-
-        <.refusal_group
-          :for={{group, reason, detail} <- @refusals}
-          group={group}
-          reason={reason}
-          detail={detail}
-        />
-      </section>
-    </div>
+    <%!-- Trash Confirmation Modal --%>
+    <%= if @show_prune_modal do %>
+      <MydiaWeb.AdminLibraryPruneLive.Components.prune_confirm_modal
+        count={MapSet.size(@selected)}
+        items={@affected_items}
+        bytes={@reclaimable}
+        retention_days={@retention_days}
+      />
+    <% end %>
   </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/router.ex
+++ b/lib/mydia_web/router.ex
@@ -196,7 +196,7 @@ defmodule MydiaWeb.Router do
       live "/config/indexers", AdminIndexersLive.Index, :index
       live "/subtitle-providers", AdminSubtitleProvidersLive, :index
       live "/config/library-paths", AdminLibraryPathsLive.Index, :index
-      live "/library/prune", AdminLibraryPruneLive.Index, :index
+      live "/config/prune", AdminLibraryPruneLive.Index, :index
       live "/config/media-servers", AdminMediaServersLive.Index, :index
       live "/config/plugins", AdminPluginsLive.Index, :index
       live "/config/path-mappings", AdminPathMappingsLive.Index, :index

--- a/test/mydia_web/live/admin_library_prune_live_test.exs
+++ b/test/mydia_web/live/admin_library_prune_live_test.exs
@@ -25,18 +25,29 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
     %{user: user, token: token}
   end
 
-  defp prunable_episode do
+  @two_files [
+    {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+     %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
+    {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+     %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
+  ]
+
+  # A third copy, so a test can uncheck one duplicate and still have another
+  # left to trash. With only two files, unchecking the single loser empties
+  # the selection and there is nothing left to assert about.
+  @three_files @two_files ++
+                 [
+                   {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.480p.WEBRip.x264.mp4",
+                    %{resolution: "480p", codec: "h264", bitrate: 500_000}}
+                 ]
+
+  defp prunable_episode(specs \\ @two_files) do
     show = media_item_fixture(%{type: "tv_show", title: "Rick and Morty", year: 2013})
     episode = episode_fixture(%{media_item_id: show.id, season_number: 2, episode_number: 3})
     lp = library_path_fixture(%{type: "series"})
 
     files =
-      for {name, attrs} <- [
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
-             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
-             %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
-          ] do
+      for {name, attrs} <- specs do
         attrs
         |> Map.merge(%{
           episode_id: episode.id,
@@ -84,13 +95,13 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
       {_show, _episode, files} = prunable_episode()
       loser = Enum.find(files, &(&1.relative_path =~ "360p"))
 
-      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
 
       assert has_element?(view, "#prune-loser-#{loser.id}")
     end
 
     test "renders the admin tab strip with prune as the active tab", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
 
       assert has_element?(view, "div[role=tablist]")
       assert has_element?(view, "a.tab-active", "Prune duplicates")
@@ -99,10 +110,26 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
       assert has_element?(view, "a[href='/admin/config/library-paths']", "Library")
     end
 
+    test "heads its sections with h2 and leaves the page h1 to the admin shell", %{conn: conn} do
+      prunable_episode()
+      refused_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
+
+      # <.admin_page> already renders the "Configuration" <h1> and the tab
+      # strip. Every other /admin/config tab opens its body with an <h2>
+      # section header carrying a count badge, and adds no <h1> of its own.
+      assert has_element?(view, "h2", "Duplicate Files")
+      assert has_element?(view, "h2", "Needs Attention")
+      assert has_element?(view, "h2 span.badge-ghost")
+      refute has_element?(view, "h1", "Prune")
+      refute has_element?(view, "h1", "Duplicate")
+    end
+
     test "renders a refused group without any selectable file", %{conn: conn} do
       movie = refused_movie()
 
-      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
 
       assert has_element?(view, "#prune-refusal-#{movie.id}")
       refute has_element?(view, "#prune-refusal-#{movie.id} input[type=checkbox]")
@@ -116,7 +143,7 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
       # that they disagreed.
       movie = refused_movie()
 
-      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
 
       group_html = view |> element("#prune-refusal-#{movie.id}") |> render()
 
@@ -124,30 +151,115 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
       assert group_html =~ "2.0%"
     end
 
-    test "trashes the selected loser on confirm", %{conn: conn} do
-      {_show, _episode, files} = prunable_episode()
-      loser = Enum.find(files, &(&1.relative_path =~ "360p"))
+    test "every lower-quality duplicate is checked on arrival", %{conn: conn} do
+      {_show, _episode, files} = prunable_episode(@three_files)
       keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      losers = Enum.reject(files, &(&1.id == keeper.id))
 
-      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
 
-      view |> element("#prune-loser-#{loser.id}") |> render_click()
+      for loser <- losers do
+        assert has_element?(view, "#prune-loser-#{loser.id}[checked]"),
+               "#{loser.relative_path} should be selected without the operator touching it"
+      end
+
+      refute has_element?(view, "#prune-loser-#{keeper.id}")
+    end
+
+    test "trashes every duplicate from a clean load with no checkbox clicks", %{conn: conn} do
+      # This is the one-click path: land on the page, press Trash, confirm.
+      # Nothing on the group is touched in between.
+      {_show, _episode, files} = prunable_episode(@three_files)
+      keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      losers = Enum.reject(files, &(&1.id == keeper.id))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
+
+      view |> element("#prune-trash-selected") |> render_click()
       view |> element("#prune-confirm") |> render_click()
 
-      assert Mydia.Repo.get!(Mydia.Library.MediaFile, loser.id).trashed_at
+      for loser <- losers do
+        assert Mydia.Repo.get!(Mydia.Library.MediaFile, loser.id).trashed_at
+      end
+
       refute Mydia.Repo.get!(Mydia.Library.MediaFile, keeper.id).trashed_at
     end
 
-    test "changing the keeper re-derives the losers", %{conn: conn} do
+    test "unchecking a duplicate leaves it on disk while the rest are trashed", %{conn: conn} do
+      {_show, _episode, files} = prunable_episode(@three_files)
+      keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      spared = Enum.find(files, &(&1.relative_path =~ "480p"))
+      doomed = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
+
+      view |> element("#prune-loser-#{spared.id}") |> render_click()
+      refute has_element?(view, "#prune-loser-#{spared.id}[checked]")
+
+      view |> element("#prune-trash-selected") |> render_click()
+      view |> element("#prune-confirm") |> render_click()
+
+      assert Mydia.Repo.get!(Mydia.Library.MediaFile, doomed.id).trashed_at
+      refute Mydia.Repo.get!(Mydia.Library.MediaFile, spared.id).trashed_at
+      refute Mydia.Repo.get!(Mydia.Library.MediaFile, keeper.id).trashed_at
+    end
+
+    test "the group toggle skips the whole group, and pressing it again restores it",
+         %{conn: conn} do
+      {_show, episode, files} = prunable_episode(@three_files)
+      keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      losers = Enum.reject(files, &(&1.id == keeper.id))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
+
+      view |> element("#prune-group-toggle-#{episode.id}") |> render_click()
+
+      for loser <- losers do
+        refute has_element?(view, "#prune-loser-#{loser.id}[checked]")
+      end
+
+      assert has_element?(view, "#prune-trash-selected[disabled]")
+
+      view |> element("#prune-group-toggle-#{episode.id}") |> render_click()
+
+      for loser <- losers do
+        assert has_element?(view, "#prune-loser-#{loser.id}[checked]")
+      end
+    end
+
+    test "the confirmation modal opens on Trash and closes on Cancel without trashing anything",
+         %{conn: conn} do
+      {_show, _episode, files} = prunable_episode()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
+
+      refute has_element?(view, "#prune-confirm-modal")
+
+      view |> element("#prune-trash-selected") |> render_click()
+      assert has_element?(view, "#prune-confirm-modal")
+
+      view |> element("#prune-cancel") |> render_click()
+      refute has_element?(view, "#prune-confirm-modal")
+
+      for file <- files do
+        refute Mydia.Repo.get!(Mydia.Library.MediaFile, file.id).trashed_at
+      end
+    end
+
+    test "changing the keeper re-derives the losers and selects the demoted file",
+         %{conn: conn} do
       {_show, _episode, files} = prunable_episode()
       low = Enum.find(files, &(&1.relative_path =~ "360p"))
       high = Enum.find(files, &(&1.relative_path =~ "1080p"))
 
-      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
 
       view |> element("#prune-keeper-#{low.id}") |> render_click()
 
-      assert has_element?(view, "#prune-loser-#{high.id}")
+      # The file that stopped being the keeper has to come back selected, or
+      # overriding the keeper would silently leave the operator with an empty
+      # selection and a disabled Trash button.
+      assert has_element?(view, "#prune-loser-#{high.id}[checked]")
       refute has_element?(view, "#prune-loser-#{low.id}")
     end
 
@@ -157,15 +269,16 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
       ranked_keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
       overridden_keeper = Enum.find(files, &(&1.relative_path =~ "360p"))
 
-      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
 
-      # Override the keeper to the lower-quality file, then select the
-      # higher-quality (ranked) file for trashing. If `confirm` ever calls
-      # `Prune.execute/2` instead of `execute/3` with the keepers map, the
-      # ranked keeper gets silently re-derived as 1080p again and this
-      # trashing gets aborted as `:would_leave_no_file` instead of applied.
+      # Override the keeper to the lower-quality file. The higher-quality
+      # (ranked) file becomes the loser and is selected by default. If
+      # `confirm_prune` ever calls `Prune.execute/2` instead of `execute/3`
+      # with the keepers map, the ranked keeper gets silently re-derived as
+      # 1080p again and this trashing gets aborted as `:would_leave_no_file`
+      # instead of applied.
       view |> element("#prune-keeper-#{overridden_keeper.id}") |> render_click()
-      view |> element("#prune-loser-#{ranked_keeper.id}") |> render_click()
+      view |> element("#prune-trash-selected") |> render_click()
       view |> element("#prune-confirm") |> render_click()
 
       assert Mydia.Repo.get!(Mydia.Library.MediaFile, ranked_keeper.id).trashed_at
@@ -178,7 +291,7 @@ defmodule MydiaWeb.AdminLibraryPruneLiveTest do
       keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
       loser = Enum.find(files, &(&1.relative_path =~ "360p"))
 
-      {:ok, view, _html} = live(conn, ~p"/admin/library/prune")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/prune")
 
       group_html = view |> element("#prune-group-#{episode.id}") |> render()
 


### PR DESCRIPTION
Follow-up to #520. Two fixes for the prune duplicates page.

## It did not follow the admin UI standard

The page shipped with its own scaffolding while every other `/admin/config`
tab shares one. It had a page `<h1>` on top of the "Configuration" heading
`<.admin_page>` already renders, `card`/`card-body` groups instead of the
`bg-base-200 rounded-box divide-y` row list, bare event names, and all its
markup inline in the template.

- `index.html.heex` is now a thin shell: `<Layouts.app>` to `<.admin_page>`
  to one call into the sibling `components.ex`, plus the modal behind a flag.
- Sections open with an `h2` + leading icon + `badge-ghost` count. Groups are
  rows in the standard row list, with a `join` action group on the right.
- Events are namespaced (`choose_prune_keeper`, `toggle_prune_file`,
  `confirm_prune`, `open_prune_modal` / `close_prune_modal`), backed by
  `show_prune_modal`.
- The route moves to `/admin/config/prune`, where the rest of that tab strip
  lives. Nothing but the tab link pointed at the old path.

## Every duplicate is now selected on arrival

Landing on the page, pressing Trash, and confirming is the whole flow. The
selection is stored as the operator's *deselections* rather than their
selections, which is what keeps that true across a re-plan: change the keeper
and the file that stopped being the keeper comes back selected without them
hunting for it, while anything they unchecked stays unchecked.

A per-group toggle skips or restores a whole group, and a Select all button
appears once anything is unchecked.

Selecting by default is only safe because `Prune.Eligibility` has already
refused every group that is not proven to be the same content. Those still
land in Needs Attention with nothing selectable on them.

## Confirmation modal

One press can now trash every duplicate in the library, so the `data-confirm`
is replaced by a confirmation modal carrying the file count, item count, and
bytes reclaimed.

## Verification

- 13 tests on the page (up from 8), covering default selection, the one-click
  path with no checkbox clicks, unchecking one duplicate while the rest are
  trashed, the group toggle round trip, modal open/cancel, and the demoted
  keeper coming back selected.
- `mix test test/mydia_web`: 1370 tests, 0 failures.
- `mix credo --strict`: no issues. `mix compile --warnings-as-errors`: clean.
- Rendered against seeded data in a real browser, both the page and the modal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moved the duplicate-pruning page to **Admin → Configuration → Prune**.
  * Added clearer list-based duplicate and refusal views with file counts and reclaimable storage totals.
  * Added bulk selection, group-level controls, keeper overrides, and persistent deselection during replanning.
  * Added a confirmation dialog before moving selected files to trash.

* **Bug Fixes**
  * Improved selection behavior when changing keepers or updating duplicate decisions.
  * Added the ability to cancel pruning without applying changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->