### PR TITLE
fix(player): un-skip the remote-control e2e, guard two more disposal races

### DIFF
--- a/player/integration_test/helpers/test_bootstrap.dart
+++ b/player/integration_test/helpers/test_bootstrap.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:media_kit/media_kit.dart';
+import 'package:player/app.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/native/frb_generated.dart';
 
 /// One-time initialization shared by every integration test file.
@@ -50,18 +54,56 @@ Future<void> _runBootstrap() async {
 /// the container: `ProviderScope` is mounted once and lives for the life of
 /// the process. Repeated mount/unmount is something only this suite does.
 ///
-/// [settle] is a ceiling, not a sleep — the loop stops as soon as the tree
-/// stops scheduling frames.
+/// Waits on the providers themselves rather than on `hasScheduledFrame`. That
+/// flag reports pending *frames*; a provider blocked on secure storage or a
+/// network round trip schedules none, so a frame-based loop exits immediately
+/// and settles nothing. Only the provider's own `AsyncValue` answers the
+/// question that matters here.
+///
+/// [settle] is a ceiling, not a sleep. Exceeding it unmounts anyway and logs,
+/// because a test that has already failed should report its own reason rather
+/// than hang here for the full timeout.
 Future<void> unmountApp(
   WidgetTester tester, {
-  Duration settle = const Duration(seconds: 5),
+  Duration settle = const Duration(seconds: 15),
 }) async {
-  final deadline = DateTime.now().add(settle);
-  while (DateTime.now().isBefore(deadline)) {
-    await tester.pump(const Duration(milliseconds: 100));
-    if (!WidgetsBinding.instance.hasScheduledFrame) break;
+  final appFinder = find.byType(MyApp);
+  if (appFinder.evaluate().isNotEmpty) {
+    final container = ProviderScope.containerOf(
+      tester.element(appFinder.first),
+      listen: false,
+    );
+
+    final deadline = DateTime.now().add(settle);
+    while (_startupLoading(container) && DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    if (_startupLoading(container)) {
+      debugPrint('[unmountApp] startup providers still loading after '
+          '${settle.inSeconds}s; unmounting anyway');
+    }
   }
 
   await tester.pumpWidget(const SizedBox.shrink());
   await tester.pump(const Duration(milliseconds: 100));
+}
+
+/// Whether a provider the app reads `.future` on during startup is still
+/// loading, and would therefore raise on disposal.
+///
+/// Gated on `exists` so this never *starts* a provider that the test did not
+/// already use. Reading one to find out whether it is loading would begin a
+/// chain that, on an unauthenticated app, never resolves, which is the exact
+/// state this is trying to avoid being in at disposal.
+bool _startupLoading(ProviderContainer container) {
+  if (container.exists(asyncGraphqlClientProvider) &&
+      container.read(asyncGraphqlClientProvider).isLoading) {
+    return true;
+  }
+  if (container.exists(castSessionManagerProvider) &&
+      container.read(castSessionManagerProvider).isLoading) {
+    return true;
+  }
+  return false;
 }

--- a/player/integration_test/helpers/test_bootstrap.dart
+++ b/player/integration_test/helpers/test_bootstrap.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:player/native/frb_generated.dart';
@@ -18,4 +20,48 @@ Future<void> _runBootstrap() async {
   await RustLib.init();
   MediaKit.ensureInitialized();
   await initHiveForFlutter();
+}
+
+/// Replaces the app with an empty widget, after giving its startup work time
+/// to settle.
+///
+/// Every suite that mounts `MyApp` has to unmount it before the test function
+/// returns, or pending async work runs on into the next test. Doing that
+/// straight away is what broke the shared-isolate run:
+///
+/// `MyApp`'s startup reads `asyncGraphqlClientProvider.future` (remote-control
+/// init and the cast-session restore both do). Unmounting replaces the
+/// `ProviderScope`, which disposes the whole `ProviderContainer`. If that
+/// provider is still in its loading state at that moment, Riverpod raises
+/// `StateError: The provider ... was disposed during loading state, yet no
+/// value could be emitted` **synchronously** out of
+/// `ElementWithFuture.dispose`, inside `StatefulElement.unmount` inside
+/// `drawFrame`. Flutter reports that against whichever test happens to be
+/// running, and it corrupts `TestAsyncUtils`' pump guard for the rest of the
+/// isolate, so every later suite dies on "Guarded function conflict" without
+/// running a line of its own body. That is how one teardown took out four
+/// unrelated files.
+///
+/// Pumping first lets the chain reach a resolved state (data or error) so
+/// disposal has something to emit. Both outcomes are fine; only *loading* at
+/// dispose time throws.
+///
+/// This is a harness concern rather than an app bug. Production never disposes
+/// the container: `ProviderScope` is mounted once and lives for the life of
+/// the process. Repeated mount/unmount is something only this suite does.
+///
+/// [settle] is a ceiling, not a sleep — the loop stops as soon as the tree
+/// stops scheduling frames.
+Future<void> unmountApp(
+  WidgetTester tester, {
+  Duration settle = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(settle);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (!WidgetsBinding.instance.hasScheduledFrame) break;
+  }
+
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pump(const Duration(milliseconds: 100));
 }

--- a/player/integration_test/pairing_flow_test.dart
+++ b/player/integration_test/pairing_flow_test.dart
@@ -138,9 +138,11 @@ void main() {
       final pairingSucceeded = await waitForPairingComplete(tester);
 
       // Cleanup first - replace app widget to stop all pending async operations
-      // This prevents the "inTest is not true" error from async providers
-      await tester.pumpWidget(const SizedBox.shrink());
-      await tester.pump(const Duration(milliseconds: 100));
+      // This prevents the "inTest is not true" error from async providers.
+      // Settles first: pairing has just authenticated, so the graphql client
+      // chain is mid-flight, and disposing the container while it loads throws
+      // out of unmount. See `unmountApp`.
+      await unmountApp(tester);
 
       // Now run assertions after cleanup
       expect(

--- a/player/integration_test/pairing_flow_test.dart
+++ b/player/integration_test/pairing_flow_test.dart
@@ -107,6 +107,11 @@ void main() {
           reason: 'E2E_CLAIM_CODE must be set via --dart-define');
       debugPrint('Using pre-generated claim code: $claimCode');
 
+      // Registered before the mount so a failure anywhere below still tears
+      // the app down. See `unmountApp` for why an un-settled teardown breaks
+      // every later suite in the shared isolate.
+      addTearDown(() => unmountApp(tester));
+
       // Launch the app using pumpWidget with proper Riverpod scope
       await tester.pumpWidget(
         const ProviderScope(

--- a/player/integration_test/remote_control_test.dart
+++ b/player/integration_test/remote_control_test.dart
@@ -385,9 +385,7 @@ void main() {
     await adminApi.login();
   });
 
-  testWidgets(
-      'QUARANTINED (no remote-control integration coverage) — '
-      'one player drives another end to end', (tester) async {
+  testWidgets('one player drives another end to end', (tester) async {
     final movie = await _fetchTestMovie(adminApi);
 
     // --- Player B: headless, real p2p host + real pairing (steps 1 & 2) ---
@@ -643,48 +641,5 @@ void main() {
     // returns.
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump(const Duration(milliseconds: 100));
-  },
-      timeout: const Timeout(Duration(minutes: 8)),
-      // SKIPPED, and not because of anything in this file.
-      //
-      // Three consecutive CI runs each died BEFORE this test's body ran, from
-      // three unrelated async-disposal races in the shared-isolate harness:
-      //   32455230401 — the process-wide AuthStorage left paired by
-      //                 pairing_flow_test.dart (fixed, 514236a54)
-      //   32458915516 — castSessionProvider, a StreamProvider disposed
-      //                 mid-load (fixed, ce65b7e25)
-      //   32464761435 — ConnectionNotifier._loadStoredState, disposed during
-      //                 its AuthStorage reads (fixed alongside this skip)
-      // None of the three was in this file, and the third died inside
-      // simple_test.dart, two suites earlier.
-      //
-      // The cause is structural rather than a run of bad luck. all_tests.dart
-      // runs every suite in ONE isolate, and this harness mounts and unmounts
-      // a real, fully-wired MyApp() repeatedly inside it — which production
-      // never does, since the app mounts once and lives for the session. That
-      // makes it an effective fuzzer for every provider in the app that starts
-      // async work after build() without an `ref.mounted` guard, and it finds
-      // a different one each run. `Future.microtask`/`scheduleMicrotask` under
-      // lib/core and lib/presentation still turns up several unaudited
-      // candidates, so a fourth run would most likely just find the next one
-      // rather than reach step 1 of this test.
-      //
-      // What this test would add over what already ships: proof that the
-      // pieces still agree once real bytes cross a real socket. The pieces
-      // themselves are unit-covered — RemoteControlReceiver,
-      // RemoteTargetController, MydiaCastBackend, and CastSessionManager's
-      // adoption fork all have their own suites. So this is a bounded,
-      // documented gap in integration coverage, not an untested feature.
-      //
-      // To re-enable: audit the app's async providers for the `ref.mounted`
-      // guard (the convention is already used in compatibility_provider.dart
-      // and login_controller.dart), or give each suite its own isolate. Then
-      // drop this `skip` and dispatch `CI / Player E2E` by hand — it does not
-      // run on pull requests, only on push to master.
-      // `testWidgets` types `skip` as `bool?`, unlike plain `test()` where it
-      // is `dynamic` and a reason string would print in the run output. So the
-      // quarantine is carried in the test NAME above instead — a bare
-      // "skipped" line is exactly how a disabled test starts reading as a
-      // covered one.
-      skip: true);
+  }, timeout: const Timeout(Duration(minutes: 8)));
 }

--- a/player/integration_test/remote_control_test.dart
+++ b/player/integration_test/remote_control_test.dart
@@ -638,8 +638,7 @@ void main() {
 
     // Cleanup, matching the existing integration tests' pattern: replace the
     // app widget to stop pending async work before the test function
-    // returns.
-    await tester.pumpWidget(const SizedBox.shrink());
-    await tester.pump(const Duration(milliseconds: 100));
+    // returns. Settles first; see `unmountApp`.
+    await unmountApp(tester);
   }, timeout: const Timeout(Duration(minutes: 8)));
 }

--- a/player/integration_test/remote_control_test.dart
+++ b/player/integration_test/remote_control_test.dart
@@ -464,6 +464,12 @@ void main() {
     // earlier keeps the reset adjacent to the mount it exists to protect.
     await getAuthStorage().deleteAll();
 
+    // Registered before the mount so any of the seven steps below failing
+    // still tears the app down. This test has the most assertions of any
+    // suite, so it is the most likely to exit early; see `unmountApp` for why
+    // an un-settled teardown takes out every later suite.
+    addTearDown(() => unmountApp(tester));
+
     await tester.pumpWidget(const ProviderScope(child: MyApp()));
     final aClaimCode = await _generateClaimCode(adminApi, 'A');
     await _pairPlayerA(tester, aClaimCode);

--- a/player/integration_test/simple_test.dart
+++ b/player/integration_test/simple_test.dart
@@ -33,7 +33,6 @@ void main() {
 
     expect(find.byType(MaterialApp), findsOneWidget);
 
-    await tester.pumpWidget(const SizedBox.shrink());
-    await tester.pump(const Duration(milliseconds: 100));
+    await unmountApp(tester);
   });
 }

--- a/player/integration_test/simple_test.dart
+++ b/player/integration_test/simple_test.dart
@@ -28,11 +28,15 @@ void main() {
   setUpAll(ensureTestBootstrap);
   testWidgets('App boots with the native bridge initialized',
       (WidgetTester tester) async {
+    // Registered before the mount, not called at the end of the body: a
+    // failing expect below would skip a terminal call, leaving the app mounted
+    // for the framework to dispose later, which is the exact teardown this
+    // helper exists to make safe.
+    addTearDown(() => unmountApp(tester));
+
     await tester.pumpWidget(const ProviderScope(child: MyApp()));
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(find.byType(MaterialApp), findsOneWidget);
-
-    await unmountApp(tester);
   });
 }

--- a/player/lib/core/connection/connection_diagnostics_provider.dart
+++ b/player/lib/core/connection/connection_diagnostics_provider.dart
@@ -192,6 +192,12 @@ class ConnectionDiagnosticsNotifier
         }
       }
 
+      // The container can be disposed while the reads above are in flight —
+      // `build` fires this off with an unawaited `Future.microtask`, so
+      // nothing holds the provider open for it. Same guard, same reason, as
+      // `connection_provider.dart` and `compatibility_provider.dart`.
+      if (!ref.mounted) return;
+
       // Get current connection state
       final connectionState = ref.read(connectionProvider);
 
@@ -204,6 +210,10 @@ class ConnectionDiagnosticsNotifier
       );
     } catch (e) {
       debugPrint('[ConnectionDiagnostics] Error loading diagnostics: $e');
+      // Guarded for a second reason beyond the one above: without it a
+      // disposal that threw out of the try lands here and throws again from
+      // the handler, which turns a caught error into an unhandled async one.
+      if (!ref.mounted) return;
       state = state.copyWith(isLoading: false);
     }
   }
@@ -236,6 +246,8 @@ class ConnectionDiagnosticsNotifier
       DateTime.now().toIso8601String(),
     );
 
+    if (!ref.mounted) return;
+
     state = state.copyWith(
       urlAttempts: newAttempts,
       lastDirectAttempt: DateTime.now(),
@@ -261,6 +273,8 @@ class ConnectionDiagnosticsNotifier
       DateTime.now().toIso8601String(),
     );
 
+    if (!ref.mounted) return;
+
     state = state.copyWith(
       urlAttempts: newAttempts,
       lastDirectAttempt: DateTime.now(),
@@ -271,6 +285,7 @@ class ConnectionDiagnosticsNotifier
   Future<void> clear() async {
     await _authStorage.delete(_DiagnosticsKeys.lastDirectAttempt);
     await _authStorage.delete(_DiagnosticsKeys.directUrlErrors);
+    if (!ref.mounted) return;
     state = const ConnectionDiagnosticsState(isLoading: false);
   }
 

--- a/player/lib/core/graphql/graphql_provider.dart
+++ b/player/lib/core/graphql/graphql_provider.dart
@@ -221,9 +221,18 @@ class AuthStateNotifier extends Notifier<AsyncValue<AuthStatus>> {
       // Check if we have stored credentials
       final isAuth = await authService.isAuthenticated();
 
+      // `build` calls this without awaiting it, so nothing holds the provider
+      // open across the secure-storage read above. Same guard, same reason, as
+      // `connection_provider.dart` and `compatibility_provider.dart`.
+      if (!ref.mounted) return;
+
       state = AsyncValue.data(
           isAuth ? AuthStatus.authenticated : AuthStatus.unauthenticated);
     } catch (e, st) {
+      // Guarded because a disposal that threw out of the try lands here and
+      // throws again from the handler, turning a caught error into an
+      // unhandled async one.
+      if (!ref.mounted) return;
       state = AsyncValue.error(e, st);
     }
   }
@@ -257,10 +266,13 @@ class AuthStateNotifier extends Notifier<AsyncValue<AuthStatus>> {
       debugPrint('[AuthStateNotifier] isAuthenticated() returned: $isAuth');
       final status =
           isAuth ? AuthStatus.authenticated : AuthStatus.unauthenticated;
+      if (!ref.mounted) return;
       state = AsyncValue.data(status);
       debugPrint('[AuthStateNotifier] State set to AsyncValue.data($status)');
     } catch (e, st) {
       debugPrint('[AuthStateNotifier] _checkAuth() error: $e');
+      // Same double-throw guard as `_initAuth`.
+      if (!ref.mounted) return;
       state = AsyncValue.error(e, st);
     }
   }
@@ -299,7 +311,10 @@ class AuthStateNotifier extends Notifier<AsyncValue<AuthStatus>> {
       () => ref.read(connectionProvider.notifier).clear(),
     );
 
-    // Last, because this is what redirects the router to /login.
+    // Last, because this is what redirects the router to /login. Guarded
+    // because the two awaits above are storage work: this notifier outlives
+    // the screen that calls it, but not a teardown of the whole container.
+    if (!ref.mounted) return;
     state = const AsyncValue.data(AuthStatus.unauthenticated);
   }
 

--- a/player/lib/core/graphql/graphql_provider.dart
+++ b/player/lib/core/graphql/graphql_provider.dart
@@ -257,6 +257,12 @@ class AuthStateNotifier extends Notifier<AsyncValue<AuthStatus>> {
   }
 
   Future<void> _checkAuth() async {
+    // Before the `try`, so the guards inside it do not cover this write.
+    // `login()` reaches here after awaiting `setSession`, and `refresh()` and
+    // `retryConnection()` are both called without being awaited, so this can
+    // start after disposal.
+    if (!ref.mounted) return;
+
     debugPrint(
         '[AuthStateNotifier] _checkAuth() called, setting state to loading');
     state = const AsyncValue.loading();

--- a/player/lib/core/p2p/p2p_service.dart
+++ b/player/lib/core/p2p/p2p_service.dart
@@ -39,6 +39,12 @@ class P2pStatusNotifier extends Notifier<P2pStatus> {
     _subscription = service.onStatusChanged.listen((status) {
       debugPrint(
           '[P2pStatusNotifier] Received status update: peerConnectionType=${status.peerConnectionType}');
+      // `onDispose` cancels this subscription, but `cancel()` is async and
+      // does not retract an event already queued for delivery, so one can
+      // still arrive here after the provider is gone. Writing `state` then
+      // throws UnmountedRefException from a stream callback, where nothing
+      // catches it. Same guard, same reason, as `connection_provider.dart`.
+      if (!ref.mounted) return;
       state = status;
     });
 
@@ -60,6 +66,8 @@ class P2pStatusNotifier extends Notifier<P2pStatus> {
 
       // Reinitialize with new relay URL
       await p2pService.initialize(relayUrl: relayUrl);
+
+      if (!ref.mounted) return;
 
       state = p2pService.status;
     } catch (e) {

--- a/player/lib/core/update/update_provider.dart
+++ b/player/lib/core/update/update_provider.dart
@@ -114,6 +114,11 @@ class UpdateNotifier extends Notifier<UpdateState> {
   }
 
   Future<void> _performCheck({required bool force}) async {
+    // Before the `try`, so the guards inside it do not cover this read and
+    // write. Reached unawaited from `_initAndCheck` and from
+    // `checkForUpdate`, either of which can resume after disposal.
+    if (!ref.mounted) return;
+
     if (state.isChecking) return;
 
     state = state.copyWith(isChecking: true, clearError: true);
@@ -145,6 +150,10 @@ class UpdateNotifier extends Notifier<UpdateState> {
 
   /// Download and apply the available update.
   Future<void> applyUpdate() async {
+    // Same reason as `_performCheck`: the reads and the write below sit
+    // outside the `try`.
+    if (!ref.mounted) return;
+
     final update = state.availableUpdate;
     if (update == null || _platformUpdater == null || state.isApplying) return;
 

--- a/player/lib/core/update/update_provider.dart
+++ b/player/lib/core/update/update_provider.dart
@@ -79,6 +79,16 @@ class UpdateNotifier extends Notifier<UpdateState> {
   Future<void> _initAndCheck() async {
     try {
       final info = await PackageInfo.fromPlatform();
+
+      // The container can be disposed while that read is in flight — `build`
+      // fires this off with an unawaited `Future.microtask`, so nothing holds
+      // the provider open for it. Same guard, same reason, as
+      // `connection_provider.dart` and `compatibility_provider.dart`. The
+      // catch below would swallow the UnmountedRefException today, but only
+      // by accident, and it would still be reported as an error the app
+      // cannot act on.
+      if (!ref.mounted) return;
+
       state = state.copyWith(currentVersion: info.version);
 
       // Skip auto-check on web
@@ -114,12 +124,18 @@ class UpdateNotifier extends Notifier<UpdateState> {
         force: force,
       );
 
+      if (!ref.mounted) return;
+
       state = state.copyWith(
         availableUpdate: update,
         isChecking: false,
         clearUpdate: update == null,
       );
     } catch (e) {
+      // Guarded because a disposal that threw out of the try lands here and
+      // throws again from the handler, turning a caught error into an
+      // unhandled async one.
+      if (!ref.mounted) return;
       state = state.copyWith(
         isChecking: false,
         error: 'Failed to check for updates: $e',
@@ -132,19 +148,25 @@ class UpdateNotifier extends Notifier<UpdateState> {
     final update = state.availableUpdate;
     if (update == null || _platformUpdater == null || state.isApplying) return;
 
-    state = state.copyWith(isApplying: true, downloadProgress: 0.0, clearError: true);
+    state = state.copyWith(
+        isApplying: true, downloadProgress: 0.0, clearError: true);
 
     try {
       await _platformUpdater.applyUpdate(
         update,
         onProgress: (progress) {
+          if (!ref.mounted) return;
           state = state.copyWith(downloadProgress: progress);
         },
       );
 
+      if (!ref.mounted) return;
+
       // If we get here, the updater didn't exit the process (e.g. macOS).
       state = state.copyWith(isApplying: false);
     } catch (e) {
+      // Same double-throw guard as `_performCheck`.
+      if (!ref.mounted) return;
       state = state.copyWith(
         isApplying: false,
         error: 'Update failed: $e',


### PR DESCRIPTION
Re-enables the remote-control integration test that #524 shipped as `skip: true`, after doing the provider audit that PR asked for.

## Why it was skipped

Nothing in `remote_control_test.dart` was wrong. Three consecutive CI runs each died *before* its body from a different async-disposal race elsewhere in the app. `all_tests.dart` runs every suite in one isolate, and the harness mounts and unmounts a fully-wired `MyApp()` repeatedly, which production never does. That makes it an effective fuzzer for providers that start async work after `build()` without an `ref.mounted` guard.

The reason one escaped exception takes down four unrelated suites is worth stating plainly: an `UnmountedRefException` escaping as an *unhandled* async error during unmount corrupts `TestAsyncUtils`' pump guard for the rest of the process, so every later suite fails on "Guarded function conflict" without running.

## What this fixes

Two providers kick off async work from `build()` via an unawaited `Future.microtask` and were still unguarded:

- `ConnectionDiagnosticsNotifier._loadDiagnostics`
- `UpdateNotifier._initAndCheck`, and `_performCheck` behind it

Both carried a second, subtler shape of the same bug. The `catch` block itself writes `state`, so a disposal that throws out of the `try` lands in the handler and throws *again*, converting a caught error into an unhandled one. Guarding only the success path would have left that live, which is the part worth reviewing.

Also guarded the identical pattern in `recordAttempt`, `recordBatchAttempts`, `clear` and `applyUpdate`. None is reachable from the e2e (the first three have no callers, the last is user-initiated), but they are the same defect and the audit is worth finishing in one pass.

Guard placement and wording follow `connection_provider.dart` and `compatibility_provider.dart`, which already use this convention.

## Verification

`CI / Player E2E` does not run on pull requests, only on push to master and `workflow_dispatch`, so the PR checks below do **not** cover the thing this PR changes. Dispatched by hand against this branch: https://github.com/getmydia/mydia/actions/runs/32494821458

Result is reported in a comment below rather than assumed.

## Known limit

This is an audit, not a structural fix. The suite still shares one isolate, so a future provider written without the guard can reintroduce exactly this failure, and it will again present as an unrelated suite dying. The durable alternative the test file names is giving each suite its own isolate, which costs one app build per file. Not attempted here.

Follow-ups from #524 are tracked separately in #525.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability during connection diagnostics by preventing updates after related screens or services are closed.
  - Improved update checking, installation, and progress handling when interrupted or dismissed.
  - Prevented disposal-related errors during authentication, logout, and peer-to-peer connection updates.
  - Improved reliability when reinitializing connection services.

- **Tests**
  - Re-enabled the remote-control end-to-end integration test.
  - Improved integration test cleanup, including safer handling of pending startup operations and failed assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->