### PR TITLE
fix(player): refresh cached session reads after pairing

### DIFF
--- a/player/lib/presentation/screens/login/login_controller.dart
+++ b/player/lib/presentation/screens/login/login_controller.dart
@@ -232,6 +232,15 @@ class LoginController extends _$LoginController {
         userId: credentials.deviceId, // Use device ID as user ID for now
         username: 'Device ${credentials.deviceId.substring(0, 8)}',
       );
+
+      // `setSession` awaits storage writes, so this Ref may have been disposed
+      // while it ran. Riverpod 3 throws `UnmountedRefException` on any use of a
+      // disposed Ref, invalidation included.
+      if (!ref.mounted) {
+        debugPrint(
+            '[LoginController] Not mounted after setSession, returning early');
+        return;
+      }
       _invalidateStoredSessionProviders(ref);
       debugPrint('[LoginController] Credentials stored');
 
@@ -417,6 +426,9 @@ class LoginController extends _$LoginController {
         userId: credentials.deviceId,
         username: 'Device ${credentials.deviceId.substring(0, 8)}',
       );
+
+      // See the claim-code path: a disposed Ref throws on invalidate too.
+      if (!ref.mounted) return;
       _invalidateStoredSessionProviders(ref);
 
       // Set connection mode

--- a/player/lib/presentation/screens/login/login_controller.dart
+++ b/player/lib/presentation/screens/login/login_controller.dart
@@ -16,6 +16,30 @@ export '../../../core/p2p/p2p_service.dart'
 
 part 'login_controller.g.dart';
 
+/// Drops the cached reads of everything [AuthService.setSession] just wrote.
+///
+/// `serverUrlProvider`, `authTokenProvider` and `isAuthenticatedProvider` each
+/// read storage once and cache the result. Pairing writes that storage, so
+/// without this they keep serving the values from before the user paired.
+///
+/// Invalidating `asyncGraphqlClientProvider` alone is not enough and was the
+/// bug: it rebuilds, re-watches the *same cached* `serverUrlProvider`, sees
+/// null again, and can never produce a client for the rest of the session.
+/// Worse than a plain failure, it does not settle — the throw for a null
+/// server URL sits after another await, so the provider sits in `loading`,
+/// which is also what made teardown in the E2E suites raise from
+/// `ElementWithFuture.dispose`.
+///
+/// Ordered dependencies-first so the client rebuilds against fresh values
+/// rather than re-reading stale ones on its way past.
+void _invalidateStoredSessionProviders(Ref ref) {
+  ref.invalidate(serverUrlProvider);
+  ref.invalidate(authTokenProvider);
+  ref.invalidate(isAuthenticatedProvider);
+  ref.invalidate(graphqlClientProvider);
+  ref.invalidate(asyncGraphqlClientProvider);
+}
+
 /// Connection mode for the login flow.
 enum ConnectionMode {
   /// Initial mode selection screen
@@ -208,6 +232,7 @@ class LoginController extends _$LoginController {
         userId: credentials.deviceId, // Use device ID as user ID for now
         username: 'Device ${credentials.deviceId.substring(0, 8)}',
       );
+      _invalidateStoredSessionProviders(ref);
       debugPrint('[LoginController] Credentials stored');
 
       // Set connection mode
@@ -392,6 +417,7 @@ class LoginController extends _$LoginController {
         userId: credentials.deviceId,
         username: 'Device ${credentials.deviceId.substring(0, 8)}',
       );
+      _invalidateStoredSessionProviders(ref);
 
       // Set connection mode
       if (result.isP2PMode && credentials.serverNodeAddr != null) {


### PR DESCRIPTION
A real product bug, found while chasing the E2E failures from #526.

## After pairing, the GraphQL client never builds again

`serverUrlProvider`, `authTokenProvider` and `isAuthenticatedProvider` each read secure storage once and cache the result. Pairing writes that storage through `AuthService.setSession`, but `LoginController` only invalidated `asyncGraphqlClientProvider` afterwards. So it rebuilds, re-watches the **same cached** `serverUrlProvider`, reads the pre-pairing `null` again, and fails identically for the rest of the session. Anything depending on that provider stays broken until the app is restarted, at which point storage is read fresh and everything works.

Run 32489079480 shows it directly. `[serverUrlProvider] storedUrl=null` appears **twice**; `[asyncGraphqlClientProvider] serverUrl=null` repeats on every one of its **29** restarts. The dependency was never re-read.

It also does not settle into an error. The `serverUrl == null` throw sits after one more `await`, so the provider sits in `loading`. A provider stuck loading when its container is disposed is what raises `StateError` out of `ElementWithFuture.dispose`, which is the crash that has been taking down the E2E suites. #526's settle loop was not wrong; it correctly timed out, because nothing can settle a provider that never resolves.

That also explains the timing. `CI / Player E2E` went red on master at #524 rather than earlier because that PR added `_initRemoteControlIfEnabled`, which reads `asyncGraphqlClientProvider.future` during startup and so materialized a completer with nothing to complete it.

The fix invalidates the dependencies first, then the client, on both pairing paths.

## Verification

Dispatched by hand against this branch, since `CI / Player E2E` does not run on pull requests: https://github.com/getmydia/mydia/actions/runs/32509361820

| | master before #526 | after #526 | this branch |
|---|---|---|---|
| Passing | 1 | 7 | **8** |
| Failing | 7 | 2 | **1** |

`serverUrl=p2p://mydia` on all 14 reads, where it was `null` on all 29 before. `pairing_flow` now passes, and the disposal crash is gone from the run entirely.

Player unit suite green at 2733/2733 with `--concurrency=1`.

## Still failing, and not fixed here

`remote_control one player drives another end to end` now gets through step 1 (both node IDs registered on the server) and fails at step 3: player B never appears in A's cast picker after 4 sweeps.

`MydiaCastBackend` only offers a device that answers a `Hello` probe within `probeBudget`, which is 3 seconds. A↔B is a cold iroh dial with no warm connection and no cached discovery record, which the test file's own comment already calls out. The two candidates are that budget being too short in CI, or B's `RemoteRoster` having cached its device list before A registered and refusing A on `allows()`. The refusal path logs nothing, so the run cannot currently distinguish them. Needs one more round with a log on that branch rather than a guess.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling after claim-code and QR pairing sign-ins.
  * Ensured refreshed credentials are used immediately when rebuilding connected services.
  * Prevented disposed sign-in flows from incorrectly refreshing session data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->