### PR TITLE
test(player): re-quarantine the remote-control e2e, with the real cause

### DIFF
--- a/player/integration_test/remote_control_test.dart
+++ b/player/integration_test/remote_control_test.dart
@@ -50,7 +50,9 @@
 // screen answers commands correctly — that is `PlayerScreen`'s own
 // `RemotePlayerBinding` implementation, exercised by unit tests instead.
 //
-// Coverage against the plan's 7 steps:
+// Coverage against the plan's 7 steps — all of it currently DORMANT: this
+// test is quarantined at step 3 (see the `skip` at the bottom of the file),
+// so none of the following is actually being verified on any run.
 //   1. Pair two players to the same account; confirm both node IDs reached
 //      the server.                                            — COVERED
 //   2. Start playback locally on player B, without involving player A.
@@ -385,7 +387,9 @@ void main() {
     await adminApi.login();
   });
 
-  testWidgets('one player drives another end to end', (tester) async {
+  testWidgets(
+      'QUARANTINED (no remote-control integration coverage) — '
+      'one player drives another end to end', (tester) async {
     final movie = await _fetchTestMovie(adminApi);
 
     // --- Player B: headless, real p2p host + real pairing (steps 1 & 2) ---
@@ -646,5 +650,36 @@ void main() {
     // app widget to stop pending async work before the test function
     // returns. Settles first; see `unmountApp`.
     await unmountApp(tester);
-  }, timeout: const Timeout(Duration(minutes: 8)));
+  },
+      timeout: const Timeout(Duration(minutes: 8)),
+      // QUARANTINED at step 3, and the reason is a product bug this test
+      // found rather than anything wrong with the harness.
+      //
+      // `MydiaCastBackend._probe` sends `Hello` to a bare node ID read out of
+      // `RemoteRoster`. That lands in `handle_send_request`
+      // (`native/mydia_p2p_core/src/lib.rs`), which looks the peer up in
+      // `connected_peers` and returns "Not connected to peer" when it is
+      // absent — it never dials. Nothing else dials a peer either: every
+      // `P2pService.dial`/`ensureConnected` call site in the player targets
+      // the *server* (`core/channels/pairing_service.dart`,
+      // `core/graphql/p2p_link.dart`). So A holds no connection to B, every
+      // probe fails the instant it is made, and B can never be offered in A's
+      // picker.
+      //
+      // That makes casting to another player non-functional in general, not
+      // only under CI, which is the finding worth keeping. `probeBudget` is
+      // not the limit — no budget rescues a call that never dials — so do not
+      // re-diagnose this as discovery latency and raise a timeout.
+      //
+      // Re-enable once `send_request` establishes a connection on demand.
+      // Note `handle_command` awaits inline in the host event loop, so a dial
+      // added there must not be allowed to stall every other command while an
+      // unreachable peer times out.
+      //
+      // `testWidgets` types `skip` as `bool?`, unlike plain `test()` where it
+      // is `dynamic` and a reason string would print in the run output. So the
+      // quarantine is carried in the test NAME above instead — a bare
+      // "skipped" line is exactly how a disabled test starts reading as a
+      // covered one.
+      skip: true);
 }


### PR DESCRIPTION
Puts `remote_control one player drives another end to end` back in quarantine, so `CI / Player E2E` on master is green again. Un-skipping it in #526 is what turned that check red.

## Why it cannot pass

Not a harness problem, and not CI timing. Player-to-player remote control does not work at all.

`MydiaCastBackend._probe` sends `Hello` to a bare node ID read out of `RemoteRoster`. That reaches `handle_send_request` (`native/mydia_p2p_core/src/lib.rs`), which looks the peer up in `connected_peers` and returns `"Not connected to peer: <id>"` when it is absent. **It never dials.** The only path that calls `endpoint.connect(...)` is `Command::Dial` → `handle_dial`.

Nothing else dials a peer either. Every `P2pService.dial` / `ensureConnected` call site in the player targets the **server**:

- `player/lib/core/channels/pairing_service.dart:214,317`
- `player/lib/core/graphql/p2p_link.dart:186`

So A holds no connection to B, every probe fails the instant it is made, and B can never be offered in A's picker. The same gap exists on the Dart side: `P2pService._normalizePeerForRequest` given a bare node ID only calls `_waitForConnectedPeer` (a 10s poll) and dials only when handed a full EndpointAddr JSON.

The 3-second `probeBudget` is a red herring — no budget rescues a call that never dials. The two theories in #527's body were both wrong, and the second is worth retiring explicitly: `RemoteRoster.allows()` self-heals, since an unknown peer earns one throttled refetch before it is refused.

## What the runs show

On master (pre-#527) the test died at step 1 from the `serverUrl=null` bug #527 fixed. With that fix in, it reaches step 3 and fails there — `Player B (...) never appeared in the cast picker after 4 sweeps` — then hangs to the 8-minute timeout ([run 32509361820](https://github.com/getmydia/mydia/actions/runs/32509361820)). Suite score was `+8 ~2 -1`; with this skip it should be `+8 ~3`.

## Fixing it for real

Make `send_request` establish a connection on demand. One caveat for whoever picks it up: `handle_command` awaits inline in the host event loop, so a dial added there must not be allowed to stall every other command while an unreachable peer times out.

That is a shared-Rust change affecting the Elixir server as well as the player, so it wants its own PR rather than riding along here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Quarantined and skipped the remote-control integration test.
  * Documented that the test remains dormant until peer connection support is available.
  * Preserved the existing eight-minute timeout for future re-enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->