### PR TITLE
feat(release): send the changelog's Player notes to TestFlight

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -93,6 +93,25 @@ jobs:
       - name: Assert every Apple deployment target agrees
         run: ./scripts/check-apple-deployment-targets.sh
 
+  testflight-notes:
+    name: Check / TestFlight Notes
+    runs-on: ubuntu-latest
+
+    steps:
+      # fetch-depth: 0 because the commit-log fallback resolves a previous tag
+      # and walks a commit range. A shallow checkout has neither.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # The notes this produces become TestFlight's "What to Test", which Apple
+      # caps at 4000 characters and rejects when empty. Both properties are
+      # invisible until a release is dispatched, so they are asserted here
+      # against every bundled changelog instead. Needs only the checkout.
+      - name: Assert the store release notes hold their contract
+        run: ./scripts/check-testflight-notes.sh
+
   # Both NixOS VM tests run on push only. They are the slowest and least
   # reliable jobs in CI, combining a QEMU boot with a full Nix build on top of
   # the FlakeHub cache 503s that can hit any Nix job, and breaking the NixOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -640,12 +640,23 @@ jobs:
           bundler-cache: true
           working-directory: ${{ env.PLAYER_PATH }}/ios
 
+      # The notes reach the shell through env, never through ${{ }} substitution
+      # into this body: changelog text contains backticks and $, which would be
+      # both an injection risk and a corruption bug.
+      - name: Write TestFlight notes
+        if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          NOTES: ${{ needs.prepare.outputs.testflight_notes }}
+        run: printf '%s' "$NOTES" > "$RUNNER_TEMP/testflight-notes.txt"
+
       - name: Upload to TestFlight
         if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          TESTFLIGHT_CHANGELOG_PATH: ${{ runner.temp }}/testflight-notes.txt
         working-directory: ${{ env.PLAYER_PATH }}/ios
         run: bundle exec fastlane beta
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,15 +192,20 @@ jobs:
       # job's checkout is shallow and pinned. Runs on a dry run too, so the
       # rehearsal exercises it, and echoes the result into the step summary so
       # the notes can be read before any platform build finishes.
+      #
+      # The three values arrive through env rather than ${{ }} substitution into
+      # the script body. The tag is a dispatch input, so a tag containing $(...)
+      # would otherwise be parsed as command substitution here.
       - name: Compute store release notes
         id: testflight_notes
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+          NOTES_SHA: ${{ steps.get_version.outputs.sha }}
+          TAG: ${{ steps.get_version.outputs.tag }}
         run: |
           set -euo pipefail
 
-          NOTES=$(./scripts/testflight-notes.sh \
-            "${{ steps.get_version.outputs.version }}" \
-            "${{ steps.get_version.outputs.sha }}" \
-            "${{ steps.get_version.outputs.tag }}")
+          NOTES=$(./scripts/testflight-notes.sh "$VERSION" "$NOTES_SHA" "$TAG")
 
           # A random delimiter: a fixed one appearing in the notes would
           # terminate the value early.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
       version_code: ${{ steps.get_version.outputs.version_code }}
       is_prerelease: ${{ steps.get_version.outputs.is_prerelease }}
       sha: ${{ steps.get_version.outputs.sha }}
+      testflight_notes: ${{ steps.testflight_notes.outputs.notes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -185,6 +186,38 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           echo "Building version: $VERSION_NUM (code: $VERSION_CODE, prerelease: $IS_PRERELEASE, commit: $SHA)"
+
+      # What testers read in TestFlight's "What to Test". Computed here because
+      # this is the only job with the resolved version and full history; the iOS
+      # job's checkout is shallow and pinned. Runs on a dry run too, so the
+      # rehearsal exercises it, and echoes the result into the step summary so
+      # the notes can be read before any platform build finishes.
+      - name: Compute store release notes
+        id: testflight_notes
+        run: |
+          set -euo pipefail
+
+          NOTES=$(./scripts/testflight-notes.sh \
+            "${{ steps.get_version.outputs.version }}" \
+            "${{ steps.get_version.outputs.sha }}" \
+            "${{ steps.get_version.outputs.tag }}")
+
+          # A random delimiter: a fixed one appearing in the notes would
+          # terminate the value early.
+          DELIM="notes-$(openssl rand -hex 16)"
+          {
+            echo "notes<<${DELIM}"
+            echo "$NOTES"
+            echo "${DELIM}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### TestFlight release notes"
+            echo
+            echo '```'
+            echo "$NOTES"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   docker-build:
     name: Docker / ${{ matrix.db }} / ${{ matrix.arch }}

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -280,6 +280,15 @@ repository. The app compiles that file into the image, and the draft's
 GitHub notes are produced from it too. Nothing is generated from the commit
 range.
 
+The `## Player` section has a second consumer. `scripts/testflight-notes.sh`
+extracts it during the release run and it becomes TestFlight's "What to Test",
+so it is what beta testers read on their phones. Apple caps that field at 4000
+characters; anything longer is trimmed to whole bullets with a link to the
+release page. A prerelease, which ships no bundled file, gets a summary of the
+commit subjects touching `player/` since the previous tag instead. The computed
+text is echoed into the `Prepare` job's step summary on every run, including a
+dry run, so it can be read before the build finishes.
+
 A patch release's GitHub notes carry the preceding minor's notes as well as
 its own, produced by concatenating the two bundled files. The bundled file
 itself holds only the patch's own changes, since the app stacks releases

--- a/player/ios/fastlane/Fastfile
+++ b/player/ios/fastlane/Fastfile
@@ -1,5 +1,18 @@
 default_platform(:ios)
 
+# What testers read in TestFlight. The release workflow writes the release's
+# `## Player` notes to a file and names it here. The literal fallback keeps a
+# local `fastlane beta` working with nothing set up, and degrades a failed write
+# to the old behaviour rather than to a rejected upload: Apple refuses an empty
+# "What to Test" for external distribution.
+def testflight_changelog
+  path = ENV["TESTFLIGHT_CHANGELOG_PATH"]
+  return "Automated beta build." if path.nil? || path.empty? || !File.readable?(path)
+
+  notes = File.read(path).strip
+  notes.empty? ? "Automated beta build." : notes
+end
+
 platform :ios do
   desc "Build and upload to TestFlight"
   lane :beta do
@@ -29,7 +42,7 @@ platform :ios do
     upload_to_testflight(
       distribute_external: true,
       groups: ["Beta"],
-      changelog: "Automated beta build.",
+      changelog: testflight_changelog,
       notify_external_testers: false
     )
   end

--- a/scripts/check-testflight-notes.sh
+++ b/scripts/check-testflight-notes.sh
@@ -25,12 +25,21 @@ for f in priv/changelog/*.md; do
     note_failure "${version}: script exited non-zero: $(cat "$err")"
     continue
   fi
+  source_label="$(sed -n 's/^testflight-notes: source=//p' "$err")"
 
   [ -n "$out" ] || note_failure "${version}: produced no output"
 
   chars="$(printf '%s' "$out" | wc -m | tr -d ' ')"
   if [ "$chars" -gt "$MAX_CHARS" ]; then
     note_failure "${version}: ${chars} characters, over the ${MAX_CHARS} limit"
+  fi
+
+  # Membership is decided here, by grep, not by the script. A renamed heading
+  # or a broken extraction pattern then shows up as a failure instead of a
+  # quiet fall-through to commit subjects, which would still be non-empty,
+  # still under the cap, and still wrong.
+  if grep -qx '## Player' "$f" && [ "$source_label" != "bundled" ]; then
+    note_failure "${version}: has a '## Player' section but reported source=${source_label}"
   fi
 done
 

--- a/scripts/check-testflight-notes.sh
+++ b/scripts/check-testflight-notes.sh
@@ -77,5 +77,21 @@ case "$out" in
   *'(#'*) note_failure "0.13.0: a PR reference survived the plain-text conversion" ;;
 esac
 
+# The commit-log fallback, for a version with no bundled file. The previous tag
+# is pinned so the commit range does not drift as new releases land.
+if out="$(TESTFLIGHT_PREV_TAG=v0.13.0 "$SCRIPT" 9.9.9 HEAD v9.9.9 2>"$err")"; then
+  source_label="$(sed -n 's/^testflight-notes: source=//p' "$err")"
+  [ -n "$out" ] || note_failure "fallback: produced no output"
+  chars="$(printf '%s' "$out" | wc -m | tr -d ' ')"
+  if [ "$chars" -gt "$MAX_CHARS" ]; then
+    note_failure "fallback: ${chars} characters, over the ${MAX_CHARS} limit"
+  fi
+  if [ "$source_label" != "gitlog" ]; then
+    note_failure "fallback: reported source=${source_label}, wanted gitlog"
+  fi
+else
+  note_failure "fallback: script exited non-zero: $(cat "$err")"
+fi
+
 [ "$fail" -eq 0 ] || exit 1
 echo "testflight notes: all $(find priv/changelog -name '*.md' | wc -l | tr -d ' ') bundled changelogs pass"

--- a/scripts/check-testflight-notes.sh
+++ b/scripts/check-testflight-notes.sh
@@ -43,5 +43,32 @@ for f in priv/changelog/*.md; do
   fi
 done
 
+# Plain-text conversion, asserted against a release known to exercise every rule.
+out="$("$SCRIPT" 0.14.0 HEAD v0.14.0 2>/dev/null)"
+
+case "$out" in
+  *'`'*)   note_failure "0.14.0: backticks survived the plain-text conversion" ;;
+esac
+case "$out" in
+  *'**'*)  note_failure "0.14.0: bold markers survived the plain-text conversion" ;;
+esac
+case "$out" in
+  *'(#'*)  note_failure "0.14.0: a PR reference survived the plain-text conversion" ;;
+esac
+case "$out" in
+  *'### '*) note_failure "0.14.0: a subheading kept its hashes" ;;
+esac
+case "$out" in
+  *'Remote control between players'*) : ;;
+  *) note_failure "0.14.0: the subheading text itself was dropped" ;;
+esac
+
+# A trailing sentence period must survive its PR reference being stripped.
+out="$("$SCRIPT" 0.13.0 HEAD v0.13.0 2>/dev/null)"
+case "$out" in
+  *'rendered identically.'*) : ;;
+  *) note_failure "0.13.0: stripping '(#332).' also ate the sentence period" ;;
+esac
+
 [ "$fail" -eq 0 ] || exit 1
 echo "testflight notes: all $(find priv/changelog -name '*.md' | wc -l | tr -d ' ') bundled changelogs pass"

--- a/scripts/check-testflight-notes.sh
+++ b/scripts/check-testflight-notes.sh
@@ -93,5 +93,29 @@ else
   note_failure "fallback: script exited non-zero: $(cat "$err")"
 fi
 
+# Commit subjects reach testers too, so they get the same cleanup the bundled
+# section gets. A squash merge appends its PR number to the subject, so this is a
+# real case rather than a theoretical one.
+#
+# Both ends of this range are immutable, and it is deliberately NOT the range
+# used above: `v0.13.0..HEAD` runs to 120+ subjects, and the marked-up one sits
+# far past the point the 4000-character budget stops keeping lines, so it never
+# reaches the output and the assertion would pass without testing anything.
+# `v0.13.2..7f080ff3` is 46 subjects with the marked-up one first.
+if out="$(TESTFLIGHT_PREV_TAG=v0.13.2 "$SCRIPT" 9.9.9 7f080ff3714f91b186eaa052cf8f721260c6e1ad v9.9.9 2>/dev/null)"; then
+  case "$out" in
+    *'Address PR review feedback'*) : ;;
+    *) note_failure "fallback markup: the fixture subject is missing, so this assertion proves nothing" ;;
+  esac
+  case "$out" in
+    *'(#'*) note_failure "fallback markup: a PR reference survived the plain-text conversion" ;;
+  esac
+  case "$out" in
+    *'`'*)  note_failure "fallback markup: backticks survived the plain-text conversion" ;;
+  esac
+else
+  note_failure "fallback markup: script exited non-zero"
+fi
+
 [ "$fail" -eq 0 ] || exit 1
 echo "testflight notes: all $(find priv/changelog -name '*.md' | wc -l | tr -d ' ') bundled changelogs pass"

--- a/scripts/check-testflight-notes.sh
+++ b/scripts/check-testflight-notes.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Assert scripts/testflight-notes.sh holds its contract against every bundled
+# changelog: non-empty output, and at most 4000 characters once fitted.
+#
+# Length is measured in characters, not bytes. The notes are not pure ASCII.
+set -euo pipefail
+export LC_ALL=C.UTF-8
+
+cd "$(dirname "$0")/.."
+
+readonly SCRIPT="scripts/testflight-notes.sh"
+readonly MAX_CHARS=4000
+
+fail=0
+err="$(mktemp)"
+trap 'rm -f "$err"' EXIT
+
+note_failure() { echo "FAIL: $*" >&2; fail=1; }
+
+for f in priv/changelog/*.md; do
+  version="$(basename "$f" .md)"
+
+  if ! out="$("$SCRIPT" "$version" HEAD "v${version}" 2>"$err")"; then
+    note_failure "${version}: script exited non-zero: $(cat "$err")"
+    continue
+  fi
+
+  [ -n "$out" ] || note_failure "${version}: produced no output"
+
+  chars="$(printf '%s' "$out" | wc -m | tr -d ' ')"
+  if [ "$chars" -gt "$MAX_CHARS" ]; then
+    note_failure "${version}: ${chars} characters, over the ${MAX_CHARS} limit"
+  fi
+done
+
+[ "$fail" -eq 0 ] || exit 1
+echo "testflight notes: all $(find priv/changelog -name '*.md' | wc -l | tr -d ' ') bundled changelogs pass"

--- a/scripts/check-testflight-notes.sh
+++ b/scripts/check-testflight-notes.sh
@@ -70,5 +70,12 @@ case "$out" in
   *) note_failure "0.13.0: stripping '(#332).' also ate the sentence period" ;;
 esac
 
+# 0.13.0 has bullets with more than one parenthetical PR-ref group per line
+# (a mid-sentence group plus a trailing one), which a stripping pattern
+# anchored to end of line only catches the last of.
+case "$out" in
+  *'(#'*) note_failure "0.13.0: a PR reference survived the plain-text conversion" ;;
+esac
+
 [ "$fail" -eq 0 ] || exit 1
 echo "testflight notes: all $(find priv/changelog -name '*.md' | wc -l | tr -d ' ') bundled changelogs pass"

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -25,6 +25,12 @@ readonly VERSION="$1" SHA="$2" TAG="$3"
 
 git cat-file -e "${SHA}^{commit}" 2>/dev/null || die "'${SHA}' is not a commit"
 
+# The heading match is exact. A renamed or whitespace-padded heading extracts
+# nothing and falls through, which check-testflight-notes.sh is what catches.
+extract_player_section() {
+  awk '/^## Player$/ { inside = 1; next } /^## / { inside = 0 } inside { print }'
+}
+
 # Keep whole lines until the budget is spent. Once a line does not fit, every
 # later line is dropped too, so the output never ends mid-bullet.
 # Returns 1 when something was dropped, 0 when everything fit.
@@ -64,6 +70,16 @@ fit_to_budget() {
 notes=""
 source_label=""
 
+# --- Source 1: the bundled `## Player` section --------------------------------
+# Read from the pinned commit, not the working tree: a draft release can target
+# a commit older than the ref this runs on.
+notes_path="priv/changelog/${VERSION}.md"
+if git cat-file -e "${SHA}:${notes_path}" 2>/dev/null; then
+  notes="$(git show "${SHA}:${notes_path}" | extract_player_section)"
+  [ -n "$notes" ] && source_label="bundled"
+fi
+
+# --- Source 3: a line naming the version --------------------------------------
 # External TestFlight distribution rejects empty notes, so this never yields "".
 if [ -z "$notes" ]; then
   notes="Mydia Player ${VERSION}. No app changes in this build."

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -128,10 +128,13 @@ if git cat-file -e "${SHA}:${notes_path}" 2>/dev/null; then
 fi
 
 # --- Source 2: commits touching the app since the previous tag ----------------
+# Subjects go through to_plain_text for the same reason the bundled section does.
+# A squash merge appends its PR number, so "Address PR review feedback (#475)" is
+# a normal subject here, and backticks in a subject are not unusual either.
 if [ -z "$notes" ]; then
   prev="$(previous_tag)"
   if [ -n "$prev" ]; then
-    notes="$(git log --format='- %s' "${prev}..${SHA}" -- player/ || true)"
+    notes="$(git log --format='- %s' "${prev}..${SHA}" -- player/ | to_plain_text || true)"
     [ -n "$notes" ] && source_label="gitlog"
   fi
 fi

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Produce plain-text app release notes for the stores from the bundled changelog.
+#
+#   scripts/testflight-notes.sh <version> <sha> <tag>
+#
+# stdout: the notes. Always non-empty, never more than 4000 characters, which is
+#         the limit App Store Connect applies to a beta build's "What to Test".
+# stderr: one line, `testflight-notes: source=bundled|gitlog|placeholder`.
+#
+# Apple counts characters, not bytes, and the notes are not pure ASCII, so every
+# length here is measured with bash's ${#var} under a UTF-8 locale. Do not switch
+# to awk's length(): mawk, the default awk on some runner images, counts bytes.
+
+set -euo pipefail
+export LC_ALL=C.UTF-8
+
+readonly MAX_CHARS=4000
+readonly REPO_URL="https://github.com/getmydia/mydia"
+
+die() { echo "testflight-notes: $*" >&2; exit 1; }
+
+[ "$#" -eq 3 ] || die "usage: $0 <version> <sha> <tag>"
+readonly VERSION="$1" SHA="$2" TAG="$3"
+
+git cat-file -e "${SHA}^{commit}" 2>/dev/null || die "'${SHA}' is not a commit"
+
+# Keep whole lines until the budget is spent. Once a line does not fit, every
+# later line is dropped too, so the output never ends mid-bullet.
+# Returns 1 when something was dropped, 0 when everything fit.
+fit_to_budget() {
+  local budget="$1" line total=0 truncated=0 i n has_bullet=0
+  local -a kept=()
+
+  while IFS= read -r line; do
+    if [ "$truncated" -eq 1 ]; then continue; fi
+    local len=$(( ${#line} + 1 ))
+    if (( total + len > budget )); then truncated=1; continue; fi
+    total=$(( total + len ))
+    kept+=("$line")
+  done
+
+  n=${#kept[@]}
+  while (( n > 0 )) && [ -z "${kept[$((n-1))]//[[:space:]]/}" ]; do n=$(( n - 1 )); done
+
+  # Only a bullet list can end on a dangling subheading. The placeholder
+  # fallback is a single prose line and must survive this untouched.
+  for (( i = 0; i < n; i++ )); do
+    case "${kept[$i]}" in "- "*) has_bullet=1; break ;; esac
+  done
+  if (( has_bullet )); then
+    while (( n > 0 )); do
+      case "${kept[$((n-1))]}" in
+        "- "*) break ;;
+        *) n=$(( n - 1 )) ;;
+      esac
+    done
+  fi
+
+  if (( n > 0 )); then printf '%s\n' "${kept[@]:0:$n}"; fi
+  return $truncated
+}
+
+notes=""
+source_label=""
+
+# External TestFlight distribution rejects empty notes, so this never yields "".
+if [ -z "$notes" ]; then
+  notes="Mydia Player ${VERSION}. No app changes in this build."
+  source_label="placeholder"
+fi
+
+# The link is only useful when there is a release page to link to, and only
+# earns its characters when something was actually dropped.
+tail_text=""
+case "$TAG" in
+  v*) tail_text=$'\n\n'"Full notes: ${REPO_URL}/releases/tag/${TAG}" ;;
+esac
+
+budget=$(( MAX_CHARS - ${#tail_text} ))
+fitted="$(printf '%s\n' "$notes" | fit_to_budget "$budget")" && truncated=0 || truncated=1
+
+if [ "$truncated" -eq 1 ] && [ -n "$tail_text" ]; then
+  printf '%s%s\n' "$fitted" "$tail_text"
+else
+  printf '%s\n' "$fitted"
+fi
+
+echo "testflight-notes: source=${source_label}" >&2

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -35,6 +35,12 @@ extract_player_section() {
 # bullet above it, so fit_to_budget can only ever cut between whole bullets.
 # Bullets are one line each in every current changelog; this is insurance
 # against a future wrapped one.
+#
+# The PR-reference sed pattern strips every parenthetical group on a line,
+# not just a trailing one: a bullet can carry a mid-sentence group and a
+# trailing group in the same line, e.g. "Poster cards ... (#344). Search
+# posters ... (#347). ... gone (#345)." A sentence period sits outside the
+# parentheses either way, so it is left in place naturally.
 to_plain_text() {
   awk '
     /^[[:space:]]*$/ { if (buf != "") { print buf; buf = "" } print ""; next }
@@ -46,7 +52,7 @@ to_plain_text() {
     s/`([^`]*)`/\1/g
     s/\*\*([^*]*)\*\*/\1/g
     s/\[([^]]*)\]\([^)]*\)/\1/g
-    s/[[:space:]]*\(#[0-9]+(,[[:space:]]*#[0-9]+)*\)([.]?)[[:space:]]*$/\2/
+    s/[[:space:]]*\(#[0-9]+(,[[:space:]]*#[0-9]+)*\)//g
   ' | cat -s \
     | sed -e '/./,$!d' \
     | awk 'NF { last = NR } { lines[NR] = $0 } END { for (i = 1; i <= last; i++) print lines[i] }'

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -105,7 +105,14 @@ previous_tag() {
     echo "$TESTFLIGHT_PREV_TAG"
     return
   fi
-  git tag --sort=-version:refname | grep -v metadata-relay | grep -vFx "$TAG" | head -n1
+  # An empty filtered list (no tag left after excluding metadata-relay tags and
+  # $TAG itself) makes the last grep exit non-zero even though head still runs
+  # and prints nothing. Under pipefail that failing status is the pipeline's
+  # status, and set -e would abort the whole script right here, silently,
+  # before Source 3's placeholder fallback is ever reached. The trailing
+  # `|| true` keeps this a clean empty result so the `if [ -n "$prev" ]` guard
+  # at the call site can handle it. Do not remove this as dead code.
+  git tag --sort=-version:refname | grep -v metadata-relay | grep -vFx "$TAG" | head -n1 || true
 }
 
 notes=""

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -31,6 +31,27 @@ extract_player_section() {
   awk '/^## Player$/ { inside = 1; next } /^## / { inside = 0 } inside { print }'
 }
 
+# Markdown to plain text. The awk pass folds any continuation line onto the
+# bullet above it, so fit_to_budget can only ever cut between whole bullets.
+# Bullets are one line each in every current changelog; this is insurance
+# against a future wrapped one.
+to_plain_text() {
+  awk '
+    /^[[:space:]]*$/ { if (buf != "") { print buf; buf = "" } print ""; next }
+    /^- /            { if (buf != "") print buf; buf = $0; next }
+    /^### /          { if (buf != "") { print buf; buf = "" } sub(/^### /, ""); print; next }
+                     { if (buf != "") buf = buf " " $0; else buf = $0 }
+    END              { if (buf != "") print buf }
+  ' | sed -E '
+    s/`([^`]*)`/\1/g
+    s/\*\*([^*]*)\*\*/\1/g
+    s/\[([^]]*)\]\([^)]*\)/\1/g
+    s/[[:space:]]*\(#[0-9]+(,[[:space:]]*#[0-9]+)*\)([.]?)[[:space:]]*$/\2/
+  ' | cat -s \
+    | sed -e '/./,$!d' \
+    | awk 'NF { last = NR } { lines[NR] = $0 } END { for (i = 1; i <= last; i++) print lines[i] }'
+}
+
 # Keep whole lines until the budget is spent. Once a line does not fit, every
 # later line is dropped too, so the output never ends mid-bullet.
 # Returns 1 when something was dropped, 0 when everything fit.
@@ -75,7 +96,7 @@ source_label=""
 # a commit older than the ref this runs on.
 notes_path="priv/changelog/${VERSION}.md"
 if git cat-file -e "${SHA}:${notes_path}" 2>/dev/null; then
-  notes="$(git show "${SHA}:${notes_path}" | extract_player_section)"
+  notes="$(git show "${SHA}:${notes_path}" | extract_player_section | to_plain_text)"
   [ -n "$notes" ] && source_label="bundled"
 fi
 

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -94,6 +94,20 @@ fit_to_budget() {
   return $truncated
 }
 
+# The tag being built does not exist yet: GitHub creates it when the workflow
+# publishes the draft. So the newest existing tag is the previous release. The
+# grep -vFx is defensive against a re-dispatch where it somehow already does.
+#
+# TESTFLIGHT_PREV_TAG exists for check-testflight-notes.sh, which needs a
+# deterministic commit range. Production never sets it.
+previous_tag() {
+  if [ -n "${TESTFLIGHT_PREV_TAG:-}" ]; then
+    echo "$TESTFLIGHT_PREV_TAG"
+    return
+  fi
+  git tag --sort=-version:refname | grep -v metadata-relay | grep -vFx "$TAG" | head -n1
+}
+
 notes=""
 source_label=""
 
@@ -104,6 +118,15 @@ notes_path="priv/changelog/${VERSION}.md"
 if git cat-file -e "${SHA}:${notes_path}" 2>/dev/null; then
   notes="$(git show "${SHA}:${notes_path}" | extract_player_section | to_plain_text)"
   [ -n "$notes" ] && source_label="bundled"
+fi
+
+# --- Source 2: commits touching the app since the previous tag ----------------
+if [ -z "$notes" ]; then
+  prev="$(previous_tag)"
+  if [ -n "$prev" ]; then
+    notes="$(git log --format='- %s' "${prev}..${SHA}" -- player/ || true)"
+    [ -n "$notes" ] && source_label="gitlog"
+  fi
 fi
 
 # --- Source 3: a line naming the version --------------------------------------


### PR DESCRIPTION
TestFlight's "What to Test" has said `Automated beta build.` to every external beta tester since the iOS lane was written. This replaces it with the release's real notes.

## How it works

`scripts/testflight-notes.sh <version> <sha> <tag>` renders the notes and prints them to stdout, with a `source=bundled|gitlog|placeholder` line on stderr. Three sources, first non-empty wins:

1. The `## Player` section of `priv/changelog/<version>.md`, read from the pinned commit with `git show` rather than the working tree, since a draft release can target an older commit than the ref the workflow runs on.
2. For prereleases, which ship no bundled changelog, commit subjects touching `player/` since the previous tag.
3. A line naming the version. Apple rejects an empty "What to Test" for external distribution, so the output is never empty.

Markdown becomes plain text, because the field renders plain text: subheadings lose their hashes, backticks and bold and links collapse to their content, and `(#524)` references are stripped. Output over Apple's 4000-character cap is trimmed to whole bullets, never mid-sentence, with a link to the release page appended.

`prepare` computes this and publishes it as the `testflight_notes` job output. It is the only job that resolves the version, checks out with `fetch-depth: 0`, and already validates the changelog at the pinned SHA; `player-ios` checks out shallow and pinned. The notes reach the shell through `env:`, never `${{ }}` interpolation into a `run:` body, because they contain backticks and `$`.

The step runs on dry runs too and echoes the result into the job summary, so you can read exactly what testers will see before any platform build finishes.

The Fastfile keeps `Automated beta build.` as a fallback for an unset or unreadable file, so a local `fastlane beta` still works and a failed write degrades to the old behaviour rather than to an upload Apple refuses.

## Verification

`scripts/check-testflight-notes.sh` runs in CI as `Check / TestFlight Notes` and asserts against all 37 bundled changelogs: non-empty, at most 4000 characters, and `source=bundled` for every file that independently greps as containing a `## Player` heading. That last assertion is the load-bearing one. Without it, a broken extraction pattern would fall through to a commit-log summary that is non-empty, under the cap, and wrong.

Current behaviour on real data: 0.13.0 trims from 7334 to 3891 characters with the link tail, 0.13.1 lands at 2194, 0.13.2 at 2628, 0.14.0 at 2054 untrimmed.

Length is counted in characters, not bytes. The notes are not pure ASCII (0.13.0 carries a `·` in a `Watched · Aug 2` badge), and `awk length()` counts characters on gawk but bytes on mawk, which is the default awk on some runner images.

## Two defects caught during review

- The PR-reference stripper was anchored to end of line, so a bullet packing several sentences that each ended in a PR number only had its last one stripped. 0.13.0's notes were shipping `(#344)` and `(#347)` to testers, and the suite could not see it because that assertion was scoped to 0.14.0 only. Now a global strip, with an assertion covering 0.13.0.
- `previous_tag()` aborted the whole script under `set -e` when the filtered tag list came back empty, because `pipefail` propagates `grep`'s exit 1 even though `head` succeeds. It never reached the placeholder fallback. Unreachable in this repository, which has 70 tags, but latent.

## Not included

The Play Store `internal` lane still passes `skip_upload_metadata: true`, so Android release notes remain blank for the same underlying reason. The `prepare` output added here makes that a small follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TestFlight releases now receive automatically generated notes from player changelog updates.
  * Notes are plain text, capped at Apple’s 4,000-character limit, and may include a release link.
  * Prereleases can fall back to player commit summaries when changelog details are unavailable.
  * Release preparation summaries display generated notes, including during dry runs.
  * Added a fallback message when notes cannot be generated or read.

* **Tests**
  * Added automated validation for note generation, formatting, truncation, and fallback behavior in continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->