### PR TITLE
feat(downloads): per-client opt-out for adopting external torrents

### DIFF
--- a/docs/using/reference/environment-variables.md
+++ b/docs/using/reference/environment-variables.md
@@ -109,6 +109,7 @@ Configure multiple clients using numbered variables (`<N>` = 1, 2, 3, etc.):
 | `DOWNLOAD_CLIENT_<N>_PASSWORD` | Auth password | - |
 | `DOWNLOAD_CLIENT_<N>_API_KEY` | API key (SABnzbd, debrid, qBittorrent 5.2+) | - |
 | `DOWNLOAD_CLIENT_<N>_CATEGORY` | Default category | - |
+| `DOWNLOAD_CLIENT_<N>_EXTERNAL_TORRENTS` | What to do with torrents Mydia did not add: `auto`, `adopt`, `category_only`, `ignore`. `category_only` is not valid for rqbit. | `auto` |
 | `DOWNLOAD_CLIENT_<N>_DOWNLOAD_DIRECTORY` | Download directory | - |
 | `DOWNLOAD_CLIENT_<N>_PROVIDER` | Debrid provider (debrid only) | `real_debrid` |
 | `DOWNLOAD_CLIENT_<N>_WATCH_FOLDER` | Watch folder (blackhole only) | `/downloads/watch` |

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -346,6 +346,11 @@ defmodule Mydia.Config.Loader do
       |> put_if_present(:password, System.get_env("#{prefix}PASSWORD"))
       |> put_if_present(:api_key, System.get_env("#{prefix}API_KEY"))
       |> put_if_present(:category, System.get_env("#{prefix}CATEGORY"))
+      |> put_if_present(
+        :external_torrents,
+        System.get_env("#{prefix}EXTERNAL_TORRENTS"),
+        &parse_atom/1
+      )
       |> put_if_present(:download_directory, System.get_env("#{prefix}DOWNLOAD_DIRECTORY"))
       |> put_download_client_connection_settings(prefix)
     end)

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -349,7 +349,7 @@ defmodule Mydia.Config.Loader do
       |> put_if_present(
         :external_torrents,
         System.get_env("#{prefix}EXTERNAL_TORRENTS"),
-        &parse_atom/1
+        &parse_external_torrents/1
       )
       |> put_if_present(:download_directory, System.get_env("#{prefix}DOWNLOAD_DIRECTORY"))
       |> put_download_client_connection_settings(prefix)
@@ -629,6 +629,32 @@ defmodule Mydia.Config.Loader do
   end
 
   defp parse_atom(_), do: :error
+
+  # A fixed enum rather than parse_atom/1, which falls back to
+  # String.to_atom/1 and would mint an atom from an environment variable.
+  # Atoms are never garbage collected, and the project rule is explicit: no
+  # String.to_atom/1 on user input.
+  #
+  # An unrecognised value maps to :invalid rather than returning :error.
+  # Returning :error makes put_if_present/4 drop the key, which would fall
+  # back to :auto: an operator who typed "ignor" would get the adoption they
+  # were explicitly trying to switch off, which is the exact silent behaviour
+  # this setting exists to remove. :invalid is not a member of the Ecto.Enum,
+  # so config validation rejects it by name. That matches how a bad
+  # DOWNLOAD_CLIENT_<N>_TYPE already behaves, minus the atom leak.
+  defp parse_external_torrents(value) when is_atom(value), do: {:ok, value}
+
+  defp parse_external_torrents(value) when is_binary(value) do
+    case value |> String.trim() |> String.downcase() do
+      "auto" -> {:ok, :auto}
+      "adopt" -> {:ok, :adopt}
+      "category_only" -> {:ok, :category_only}
+      "ignore" -> {:ok, :ignore}
+      _unrecognised -> {:ok, :invalid}
+    end
+  end
+
+  defp parse_external_torrents(_), do: :error
 
   defp parse_string_list(value) when is_list(value), do: {:ok, value}
 

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -248,6 +248,12 @@ defmodule Mydia.Config.Schema do
       field :category, :string
       field :download_directory, :string
       field :connection_settings, :map, default: %{}
+
+      # What Mydia does with torrents in this client that it did not add.
+      # See `Mydia.Downloads.ExternalPolicy` and issue #531.
+      field :external_torrents, Ecto.Enum,
+        values: [:auto, :adopt, :category_only, :ignore],
+        default: :auto
     end
 
     embeds_many :indexers, Indexer, on_replace: :delete, primary_key: false do
@@ -581,7 +587,8 @@ defmodule Mydia.Config.Schema do
       :api_key,
       :category,
       :download_directory,
-      :connection_settings
+      :connection_settings,
+      :external_torrents
     ])
     |> validate_required([:name, :type])
     |> validate_inclusion(:type, [
@@ -596,6 +603,7 @@ defmodule Mydia.Config.Schema do
       :debrid
     ])
     |> validate_download_client_by_type()
+    |> validate_external_torrents()
     |> validate_number(:port, greater_than: 0, less_than: 65536)
     |> validate_number(:priority, greater_than: 0)
   end
@@ -614,6 +622,25 @@ defmodule Mydia.Config.Schema do
 
       _network_client ->
         validate_required(changeset, [:host, :port])
+    end
+  end
+
+  # Mirrors DownloadClientConfig.validate_external_torrents/1. The two layers
+  # must agree: a combination the admin UI refuses must not be reachable
+  # through YAML or an environment variable.
+  defp validate_external_torrents(changeset) do
+    capable = Mydia.Settings.DownloadClientConfig.category_capable_types()
+    type = get_field(changeset, :type)
+
+    if get_field(changeset, :external_torrents) == :category_only and type not in capable do
+      add_error(
+        changeset,
+        :external_torrents,
+        "category_only is not supported for #{type} clients, which do not report categories " <>
+          "(supported: #{Enum.join(capable, ", ")})"
+      )
+    else
+      changeset
     end
   end
 

--- a/lib/mydia/downloads/client/qbittorrent.ex
+++ b/lib/mydia/downloads/client/qbittorrent.ex
@@ -567,9 +567,17 @@ defmodule Mydia.Downloads.Client.QBittorrent do
       save_path: save_path,
       files: content_files(save_path, torrent["content_path"]),
       added_at: Helpers.parse_timestamp_unix(torrent["added_on"]),
-      completed_at: Helpers.parse_timestamp_unix(torrent["completion_on"])
+      completed_at: Helpers.parse_timestamp_unix(torrent["completion_on"]),
+      categories: parse_categories(torrent["category"])
     })
   end
+
+  # qBittorrent has one category per torrent and sends "" for an uncategorised
+  # one rather than omitting the key. Read back by
+  # `Mydia.Downloads.ExternalPolicy` to tell a torrent Mydia added from one the
+  # operator added by hand.
+  defp parse_categories(category) when is_binary(category) and category != "", do: [category]
+  defp parse_categories(_absent_or_blank), do: []
 
   # `save_path` is the *containing* directory, so a single-file torrent reports
   # the shared download root verbatim — and MediaImport's fallback recursively

--- a/lib/mydia/downloads/client/transmission.ex
+++ b/lib/mydia/downloads/client/transmission.ex
@@ -391,8 +391,30 @@ defmodule Mydia.Downloads.Client.Transmission do
     arguments
     |> add_optional_arg("download-dir", opts[:save_path])
     |> add_optional_arg("paused", opts[:paused])
-    |> add_optional_arg("labels", opts[:tags])
+    |> add_optional_arg("labels", labels_for(opts))
     |> add_optional_arg("bandwidthPriority", map_priority(opts[:priority], config))
+  end
+
+  # Transmission's labels are what every other adapter calls a category, and
+  # `Mydia.Downloads.Queue` sends `:category`. Before this the only source was
+  # `:tags`, which nothing in Mydia ever passes, so every Transmission torrent
+  # Mydia added went in unlabelled. That made the client's own torrents
+  # indistinguishable from foreign ones, which is exactly what
+  # `Mydia.Downloads.ExternalPolicy` needs to tell apart.
+  #
+  # An explicit `:tags` list still wins, so a caller that wants several labels
+  # can say so.
+  defp labels_for(opts) do
+    case opts[:tags] do
+      [_ | _] = tags ->
+        tags
+
+      _ ->
+        case opts[:category] do
+          category when is_binary(category) and category != "" -> [category]
+          _ -> nil
+        end
+    end
   end
 
   # Resolves a Priority atom into Transmission's `bandwidthPriority` value.

--- a/lib/mydia/downloads/client/transmission.ex
+++ b/lib/mydia/downloads/client/transmission.ex
@@ -445,9 +445,20 @@ defmodule Mydia.Downloads.Client.Transmission do
       save_path: save_path,
       files: resolve_torrent_files(download_dir, torrent["files"]),
       added_at: Helpers.parse_timestamp_unix(torrent["addedDate"]),
-      completed_at: Helpers.parse_timestamp_unix(torrent["doneDate"])
+      completed_at: Helpers.parse_timestamp_unix(torrent["doneDate"]),
+      categories: parse_labels(torrent["labels"])
     })
   end
+
+  # Transmission labels are plural and free-form, and are what every other
+  # adapter calls a category. `labels` is already in the torrent-get field
+  # list, so reading them costs no extra request. Read back by
+  # `Mydia.Downloads.ExternalPolicy`.
+  defp parse_labels(labels) when is_list(labels) do
+    Enum.filter(labels, &(is_binary(&1) and &1 != ""))
+  end
+
+  defp parse_labels(_absent_or_malformed), do: []
 
   # Transmission's `files[].name` is already the path relative to
   # `downloadDir` (it includes the torrent's own subfolder for multi-file

--- a/lib/mydia/downloads/client/transmission.ex
+++ b/lib/mydia/downloads/client/transmission.ex
@@ -148,6 +148,10 @@ defmodule Mydia.Downloads.Client.Transmission do
       "downloadDir",
       "addedDate",
       "doneDate",
+      # Kept in step with the list_torrents/2 field list. Without it a
+      # single-torrent fetch reports categories: [] even for a labelled
+      # torrent, so a caller could reasonably conclude it carries no category.
+      "labels",
       "files"
     ]
 

--- a/lib/mydia/downloads/external_policy.ex
+++ b/lib/mydia/downloads/external_policy.ex
@@ -1,0 +1,156 @@
+defmodule Mydia.Downloads.ExternalPolicy do
+  @moduledoc """
+  What Mydia does with a torrent sitting in a download client that Mydia did
+  not add.
+
+  Mydia adopts and imports foreign torrents that match a library item. That is
+  intentional, and for most operators it is what they want: a release grabbed
+  by hand still lands in the library. It is also the behaviour reported in
+  issue #531, where an operator keeps several copies of one film side by side
+  to compare them and Mydia files each finished copy into the library folder.
+
+  This module is the whole opt-out rule.
+
+  ## The modes
+
+    * `:adopt` — every foreign torrent matching a library item is adopted
+    * `:category_only` — adopt only torrents carrying one of this client's
+      configured categories
+    * `:ignore` — never adopt; foreign torrents stay visible under Downloads,
+      External
+    * `:auto` — the stored default, resolved rather than frozen
+
+  `:auto` resolves to `:category_only` when the client has a category
+  configured and can report one back, and to `:adopt` otherwise. Resolving it
+  at read time rather than stamping a value at migration time is deliberate: a
+  client that gains a category later tightens on its own, and an operator who
+  never used categories keeps exactly the behaviour they had before.
+
+  ## Why it is pure
+
+  No database, no network, every input an argument, in the same spirit as
+  `Mydia.Downloads.ClientAdoption`. Two callers depend on this rule and must
+  never disagree about it:
+
+    * `Mydia.Downloads.UntrackedMatcher` decides whether to adopt
+    * `Mydia.Downloads.ExternalTorrents` decides whether a torrent renders as
+      something to fix (Issues) or something deliberately left alone (External)
+
+  If those two drifted apart, a torrent could be refused by one and filed as a
+  problem by the other, which is the confusing state this module exists to make
+  impossible. Being pure means the whole edge-case suite lives in its tests.
+  """
+
+  alias Mydia.Downloads.Structs.DownloadStatus
+  alias Mydia.Settings.DownloadClientConfig
+
+  @typedoc """
+  Why a torrent was or was not adopted.
+
+  The two exclusion reasons are distinct because they render differently:
+  `:excluded_by_category` still gets library suggestions computed, since the
+  operator plausibly wants a one-off manual pull, while `:excluded_by_ignore`
+  does not, because scoring every foreign torrent every couple of minutes is
+  work the operator explicitly asked Mydia not to do.
+  """
+  @type decision :: :adopt | :excluded_by_category | :excluded_by_ignore
+
+  @type mode :: :adopt | :category_only | :ignore
+
+  @doc """
+  Whether this client type reports a category or label Mydia can read back.
+
+  Delegates to `Mydia.Settings.DownloadClientConfig` so the runtime rule and
+  the write-time validation cannot disagree about which clients qualify.
+  """
+  @spec supports_categories?(atom()) :: boolean()
+  def supports_categories?(type) do
+    type in DownloadClientConfig.category_capable_types()
+  end
+
+  @doc """
+  Every category configured for a client, from both the per-content-type map
+  and the legacy single field.
+
+  Blank and whitespace-only values are dropped: an empty category input is the
+  operator saying "none", and treating it as a real category would silence the
+  client entirely under `:category_only`.
+  """
+  @spec configured_categories(DownloadClientConfig.t()) :: MapSet.t(String.t())
+  def configured_categories(config) do
+    from_map =
+      case Map.get(config, :categories) do
+        map when is_map(map) -> Map.values(map)
+        _ -> []
+      end
+
+    [Map.get(config, :category) | from_map]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> MapSet.new()
+  end
+
+  @doc """
+  The mode actually in force for a client, with `:auto` resolved.
+
+  A `nil` mode is treated as `:auto` so a struct built without the field, which
+  happens in tests and in older serialised runtime config, still resolves
+  rather than crashing.
+  """
+  @spec effective_mode(DownloadClientConfig.t()) :: mode()
+  def effective_mode(config) do
+    case Map.get(config, :external_torrents) do
+      mode when mode in [:adopt, :category_only, :ignore] -> mode
+      _auto_or_nil -> resolve_auto(config)
+    end
+  end
+
+  @doc """
+  Whether to adopt this torrent from this client, and why not when the answer
+  is no.
+  """
+  @spec decide(DownloadClientConfig.t(), DownloadStatus.t()) :: decision()
+  def decide(config, %DownloadStatus{} = status) do
+    case effective_mode(config) do
+      :ignore ->
+        :excluded_by_ignore
+
+      :adopt ->
+        :adopt
+
+      :category_only ->
+        if category_match?(config, status), do: :adopt, else: :excluded_by_category
+    end
+  end
+
+  @doc """
+  Whether to adopt this torrent from this client.
+  """
+  @spec adopt?(DownloadClientConfig.t(), DownloadStatus.t()) :: boolean()
+  def adopt?(config, %DownloadStatus{} = status), do: decide(config, status) == :adopt
+
+  ## Private
+
+  defp resolve_auto(config) do
+    capable? = supports_categories?(Map.get(config, :type))
+
+    if capable? and not Enum.empty?(configured_categories(config)) do
+      :category_only
+    else
+      :adopt
+    end
+  end
+
+  # Exact match, never a prefix. "mydia" and "mydia-movies" are two different
+  # categories in every client that has them, and matching loosely would adopt
+  # from a category the operator deliberately kept separate.
+  defp category_match?(config, status) do
+    configured = configured_categories(config)
+
+    status
+    |> Map.get(:categories)
+    |> List.wrap()
+    |> Enum.any?(&MapSet.member?(configured, &1))
+  end
+end

--- a/lib/mydia/downloads/external_torrents.ex
+++ b/lib/mydia/downloads/external_torrents.ex
@@ -26,6 +26,7 @@ defmodule Mydia.Downloads.ExternalTorrents do
   require Logger
 
   alias Mydia.Downloads
+  alias Mydia.Downloads.ExternalPolicy
   alias Mydia.Downloads.ExternalTorrents.Classifier
   alias Mydia.Downloads.Structs.{CandidatePool, DownloadStatus, ExternalScan, ExternalTorrent}
   alias Mydia.Library
@@ -103,11 +104,12 @@ defmodule Mydia.Downloads.ExternalTorrents do
   """
   @spec scan() :: ExternalScan.t()
   def scan do
-    {listings, failed_clients} = fetch_all()
+    {listings, failed_clients, configs_by_name} = fetch_all()
 
     {needs_matching, external} =
       listings
       |> subtract_known()
+      |> decide_all(configs_by_name)
       |> Classifier.classify(CandidatePool.load())
 
     %ExternalScan{
@@ -116,6 +118,25 @@ defmodule Mydia.Downloads.ExternalTorrents do
       scanned_at: DateTime.utc_now(),
       failed_clients: failed_clients
     }
+  end
+
+  # Attaches each entry's adoption decision. Every configured client is still
+  # listed, including one set to `:ignore`: the External tab is where its
+  # torrents are supposed to be visible, and skipping the listing would be the
+  # obvious optimisation and the wrong one. See issue #531.
+  defp decide_all(entries, configs_by_name) do
+    Enum.map(entries, fn {client_name, status} ->
+      case Map.fetch(configs_by_name, client_name) do
+        {:ok, config} ->
+          {client_name, status, ExternalPolicy.decide(config, status)}
+
+        :error ->
+          # The client disappeared between fetch and classify. With no config
+          # there is no policy to apply, so keep the pre-existing behaviour
+          # rather than silently moving the torrent to a different tab.
+          {client_name, status, :adopt}
+      end
+    end)
   end
 
   @doc """
@@ -165,6 +186,8 @@ defmodule Mydia.Downloads.ExternalTorrents do
       Settings.list_download_client_configs()
       |> Enum.filter(&(&1.enabled and &1.type in @torrent_client_types))
 
+    configs_by_name = Map.new(clients, &{&1.name, &1})
+
     results =
       clients
       |> Task.async_stream(&fetch_one/1, timeout: :infinity, max_concurrency: 10)
@@ -184,7 +207,7 @@ defmodule Mydia.Downloads.ExternalTorrents do
     listings = for {:ok, client_name, statuses} <- results, do: {client_name, statuses}
     failed = for {:error, client_name} <- results, do: client_name
 
-    {listings, failed}
+    {listings, failed, configs_by_name}
   end
 
   defp fetch_one(config) do

--- a/lib/mydia/downloads/external_torrents/classifier.ex
+++ b/lib/mydia/downloads/external_torrents/classifier.ex
@@ -6,15 +6,18 @@ defmodule Mydia.Downloads.ExternalTorrents.Classifier do
   or the library. `Mydia.Downloads.ExternalTorrents` is the I/O shell that
   fetches, subtracts, and feeds it.
 
-  The split is the parsed type and nothing else. `%ParsedFileInfo{type: :movie}`
-  and `:tv_show` are things Mydia can plausibly own; `:unknown` and names the
-  release validator rejects are not. There is no confidence threshold, so a
-  media release for a show that is not in the library still lands in
+  The split is the parsed type and the client's external-torrent policy. A
+  `%ParsedFileInfo{type: :movie}` or `:tv_show` from a client Mydia is allowed
+  to adopt from lands in `:needs_matching`; `:unknown`, names the release
+  validator rejects, and anything from a client the operator told Mydia to
+  leave alone land in `:external`. There is no confidence threshold, so a media
+  release for a show that is not in the library still lands in
   `:needs_matching` rather than being silently reclassified as junk.
   """
 
   require Logger
 
+  alias Mydia.Downloads.ExternalPolicy
   alias Mydia.Downloads.ReleaseIntake
   alias Mydia.Downloads.Structs.{CandidatePool, DownloadStatus, ExternalTorrent}
   alias Mydia.Downloads.TorrentMatcher
@@ -23,17 +26,27 @@ defmodule Mydia.Downloads.ExternalTorrents.Classifier do
   @max_suggestions 3
 
   @doc """
-  Classifies `{client_name, status}` entries into `{needs_matching, external}`.
+  Classifies `{client_name, status, decision}` entries into
+  `{needs_matching, external}`.
+
+  `decision` comes from `Mydia.Downloads.ExternalPolicy.decide/2`. Only
+  `:adopt` entries can reach `:needs_matching`: a torrent Mydia was told not to
+  adopt is not a problem to solve, so it renders on the neutral External tab
+  rather than under Issues.
   """
-  @spec classify([{String.t(), DownloadStatus.t()}], CandidatePool.t()) ::
-          {[ExternalTorrent.t()], [ExternalTorrent.t()]}
+  @spec classify(
+          [{String.t(), DownloadStatus.t(), ExternalPolicy.decision()}],
+          CandidatePool.t()
+        ) :: {[ExternalTorrent.t()], [ExternalTorrent.t()]}
   def classify(entries, %CandidatePool{} = pool) do
     entries
-    |> Enum.map(fn {client_name, status} -> build(client_name, status, pool) end)
+    |> Enum.map(fn {client_name, status, decision} ->
+      build(client_name, status, decision, pool)
+    end)
     |> Enum.split_with(&(&1.kind == :needs_matching))
   end
 
-  defp build(client_name, %DownloadStatus{} = status, pool) do
+  defp build(client_name, %DownloadStatus{} = status, decision, pool) do
     base = %ExternalTorrent{
       id: stable_id(client_name, status.id),
       client_name: client_name,
@@ -48,16 +61,17 @@ defmodule Mydia.Downloads.ExternalTorrents.Classifier do
       ratio: status.ratio,
       save_path: status.save_path,
       parsed: nil,
-      suggestions: []
+      suggestions: [],
+      excluded_by_policy: decision != :adopt
     }
 
     case ReleaseIntake.parse_release(status.name) do
       {:ok, %ParsedFileInfo{type: type} = parsed} when type in [:movie, :tv_show] ->
         %{
           base
-          | kind: :needs_matching,
+          | kind: kind_for(decision),
             parsed: parsed,
-            suggestions: suggestions(parsed, pool)
+            suggestions: suggestions_for(decision, parsed, pool)
         }
 
       {:ok, %ParsedFileInfo{} = parsed} ->
@@ -70,6 +84,16 @@ defmodule Mydia.Downloads.ExternalTorrents.Classifier do
         base
     end
   end
+
+  defp kind_for(:adopt), do: :needs_matching
+  defp kind_for(_excluded), do: :external
+
+  # A category-scoped exclusion still gets suggestions: the operator plausibly
+  # wants a one-off manual pull, and the External tab's match control is right
+  # there. An ignored client does not: scoring every foreign torrent on every
+  # scan is exactly the work `:ignore` asks Mydia to stop doing.
+  defp suggestions_for(:excluded_by_ignore, _parsed, _pool), do: []
+  defp suggestions_for(_decision, parsed, pool), do: suggestions(parsed, pool)
 
   defp suggestions(parsed, pool) do
     TorrentMatcher.find_top_candidates_in(pool, parsed, max_results: @max_suggestions)

--- a/lib/mydia/downloads/structs/download_status.ex
+++ b/lib/mydia/downloads/structs/download_status.ex
@@ -62,7 +62,15 @@ defmodule Mydia.Downloads.Structs.DownloadStatus do
     # rtorrent a single `base_path`, either of which is usually the torrent's
     # root DIRECTORY. Anything that needs to know what is actually inside a
     # torrent must use `Mydia.Downloads.Client.list_files/3` instead.
-    files: nil
+    files: nil,
+    # Categories or labels the client reports for this item, as the client
+    # spells them. Empty for a client with no such concept (rqbit) and for
+    # every adapter that does not report them.
+    #
+    # A list rather than a single value because Transmission labels are plural
+    # and a torrent can carry several. `Mydia.Downloads.ExternalPolicy` treats
+    # any one match as a match.
+    categories: []
   ]
 
   @state_values [
@@ -103,7 +111,8 @@ defmodule Mydia.Downloads.Structs.DownloadStatus do
           added_at: DateTime.t() | nil,
           completed_at: DateTime.t() | nil,
           failure_category: FailureCategory.t() | nil,
-          failure_detail: String.t() | nil
+          failure_detail: String.t() | nil,
+          categories: [String.t()]
         }
 
   @doc """

--- a/lib/mydia/downloads/structs/external_torrent.ex
+++ b/lib/mydia/downloads/structs/external_torrent.ex
@@ -9,10 +9,15 @@ defmodule Mydia.Downloads.Structs.ExternalTorrent do
 
   `kind` is the split that decides where it renders:
 
-    * `:needs_matching` — the name parses as a movie or a TV release, so Mydia
-      offers to match it to the library (Issues tab)
-    * `:external` — anything else, most often genuinely unrelated to Mydia
-      (External tab)
+    * `:needs_matching` — the name parses as a movie or a TV release AND the
+      client's policy would have adopted it, so Mydia offers to match it to
+      the library (Issues tab)
+    * `:external` — anything else (External tab). That includes a perfectly
+      parseable release from a client the operator told Mydia to leave alone,
+      which is why `excluded_by_policy` exists: without it an operator sees a
+      matchable film sitting untouched with no way to tell whether Mydia
+      skipped it on purpose or failed at something. See
+      `Mydia.Downloads.ExternalPolicy` and issue #531.
 
   `seeders` / `leechers` are deliberately absent: adapters return
   `Mydia.Downloads.Structs.DownloadStatus`, which does not carry them.
@@ -35,6 +40,7 @@ defmodule Mydia.Downloads.Structs.ExternalTorrent do
     :ratio,
     :save_path,
     :parsed,
+    excluded_by_policy: false,
     suggestions: []
   ]
 
@@ -61,6 +67,7 @@ defmodule Mydia.Downloads.Structs.ExternalTorrent do
           ratio: float() | nil,
           save_path: String.t() | nil,
           parsed: ParsedFileInfo.t() | nil,
+          excluded_by_policy: boolean(),
           suggestions: [suggestion()]
         }
 end

--- a/lib/mydia/downloads/untracked_matcher.ex
+++ b/lib/mydia/downloads/untracked_matcher.ex
@@ -14,11 +14,19 @@ defmodule Mydia.Downloads.UntrackedMatcher do
 
   This dual-matching prevents issues when download clients reuse numeric IDs
   after torrents are removed from the client.
+
+  ## Opting out
+
+  Adoption is per-client, governed by `Mydia.Downloads.ExternalPolicy`. A
+  client set to `:ignore` is never listed here at all, and a client scoped to
+  its own category adopts only torrents carrying it. Anything not adopted is
+  still surfaced by `Mydia.Downloads.ExternalTorrents` under Downloads,
+  External, where it can be matched by hand. See issue #531.
   """
 
   require Logger
   alias Mydia.Downloads
-  alias Mydia.Downloads.{ReleaseIntake, TorrentMatcher}
+  alias Mydia.Downloads.{ExternalPolicy, ReleaseIntake, TorrentMatcher}
   alias Mydia.Library
   alias Mydia.Library.Structs.Quality
   alias Mydia.Settings
@@ -69,11 +77,19 @@ defmodule Mydia.Downloads.UntrackedMatcher do
       Logger.warning("No download clients configured")
       []
     else
-      # Only fetch torrents from torrent clients (not Usenet or HTTP clients)
+      # Only fetch torrents from torrent clients (not Usenet or HTTP clients),
+      # and skip clients the operator told Mydia to keep its hands off.
+      #
+      # The skip is safe here and only here: `Mydia.Downloads.ExternalTorrents`
+      # runs its own listing pass, so an ignored client's torrents are still
+      # visible under Downloads, External. Skipping it there would make them
+      # vanish, which is the opposite of what `:ignore` is asking for.
       torrent_clients =
-        Enum.filter(clients, fn client ->
+        clients
+        |> Enum.filter(fn client ->
           client.type in [:qbittorrent, :transmission, :rqbit]
         end)
+        |> Enum.reject(&(ExternalPolicy.effective_mode(&1) == :ignore))
 
       torrent_clients
       |> Task.async_stream(
@@ -94,15 +110,25 @@ defmodule Mydia.Downloads.UntrackedMatcher do
 
     case Downloads.Client.list_torrents(adapter, config, []) do
       {:ok, torrents} ->
-        # Attach client name to each torrent for later reference
-        Enum.map(torrents, fn torrent ->
-          Map.put(torrent, :client_name, client_config.name)
-        end)
+        adoptable_torrents(client_config, torrents)
 
       {:error, error} ->
         Logger.warning("Failed to fetch torrents from #{client_config.name}: #{inspect(error)}")
         []
     end
+  end
+
+  @doc false
+  # Applies the client's external-torrent policy and attaches the client name
+  # to the survivors.
+  #
+  # Public for the same reason process_untracked_torrent/1 is: the repo has no
+  # download client mock, so find_and_match_untracked/0 cannot be driven end to
+  # end in a test, and this is the whole behavioural change for issue #531.
+  def adoptable_torrents(client_config, torrents) do
+    torrents
+    |> Enum.filter(&ExternalPolicy.adopt?(client_config, &1))
+    |> Enum.map(&Map.put(&1, :client_name, client_config.name))
   end
 
   defp find_untracked_torrents(client_torrents, tracked_downloads) do

--- a/lib/mydia/downloads/untracked_matcher.ex
+++ b/lib/mydia/downloads/untracked_matcher.ex
@@ -218,6 +218,14 @@ defmodule Mydia.Downloads.UntrackedMatcher do
             confidence: match.confidence
           )
 
+          # Put adoption in the activity feed. Without it the only trace is
+          # this log line and a file that moved, which is how issue #531 came
+          # in as a possible bug rather than as recognised behaviour.
+          Mydia.Events.download_adopted(download,
+            media_item: match.media_item,
+            confidence: match.confidence
+          )
+
           {:ok, download}
 
         {:error, reason} ->

--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -685,6 +685,53 @@ defmodule Mydia.Events do
   end
 
   @doc """
+  Records a download.adopted event.
+
+  Emitted when Mydia takes over a torrent it did not add. Before this the only
+  trace of adoption was an info-level log line and a file that had moved, which
+  is how issue #531 came in as a possible bug rather than as recognised
+  behaviour.
+
+  ## Parameters
+    - `download` - The Download struct just created
+    - `opts` - `:media_item` for context, `:confidence` for the match score
+
+  ## Examples
+
+      iex> download_adopted(download, media_item: media_item, confidence: 0.92)
+      :ok
+  """
+  def download_adopted(download, opts \\ []) do
+    media_item = opts[:media_item]
+
+    {resource_type, resource_id} =
+      if media_item do
+        {"media_item", media_item.id}
+      else
+        {"download", download.id}
+      end
+
+    metadata =
+      %{
+        "title" => download.title,
+        "download_client" => download.download_client,
+        "download_id" => download.id,
+        "match_confidence" => opts[:confidence]
+      }
+      |> maybe_add_media_context(media_item)
+
+    create_event_async(%{
+      category: "downloads",
+      type: "download.adopted",
+      actor_type: :system,
+      actor_id: "download_monitor",
+      resource_type: resource_type,
+      resource_id: resource_id,
+      metadata: metadata
+    })
+  end
+
+  @doc """
   Records a download.completed event.
 
   ## Parameters

--- a/lib/mydia/events/presentation.ex
+++ b/lib/mydia/events/presentation.ex
@@ -116,6 +116,12 @@ defmodule Mydia.Events.Presentation do
       title: "Download started"
     },
     %{
+      type: "download.adopted",
+      icon: "hero-inbox-arrow-down",
+      color: "text-info",
+      title: "Adopted from download client"
+    },
+    %{
       type: "download.completed",
       icon: "hero-check-circle",
       color: "text-success",
@@ -398,7 +404,7 @@ defmodule Mydia.Events.Presentation do
   @plain_download_types ~w(
     download.initiated download.completed download.cancelled
     download.paused download.resumed download.unstalled
-    download.auto_reject_suppressed
+    download.auto_reject_suppressed download.adopted
   )
 
   def detail(%Event{type: type, metadata: metadata}) when type in @plain_download_types,

--- a/lib/mydia/settings/download_client_config.ex
+++ b/lib/mydia/settings/download_client_config.ex
@@ -23,6 +23,10 @@ defmodule Mydia.Settings.DownloadClientConfig do
     value (integer or string, varies per adapter). Empty map means adapters
     fall back to their hardcoded default mapping.
   - `incomplete_grace_minutes` — stall detection grace window; defaults to 60.
+  - `external_torrents` — what Mydia does with torrents in this client that it
+    did not add. `:auto` (the default) resolves to `:category_only` when the
+    client has a category configured and can report one back, and to `:adopt`
+    otherwise. See `Mydia.Downloads.ExternalPolicy` and issue #531.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -50,6 +54,7 @@ defmodule Mydia.Settings.DownloadClientConfig do
           download_directory: String.t() | nil,
           connection_settings: map() | nil,
           remove_completed: boolean(),
+          external_torrents: :auto | :adopt | :category_only | :ignore,
           updated_by: Mydia.Accounts.User.t() | nil | Ecto.Association.NotLoaded.t(),
           updated_by_id: binary() | nil,
           inserted_at: DateTime.t(),
@@ -73,6 +78,13 @@ defmodule Mydia.Settings.DownloadClientConfig do
   @remote_fetch_types [:qbittorrent, :transmission, :rqbit, :rtorrent]
   @remote_fetch_auth_methods ~w(password ssh_key)
 
+  @external_torrent_modes [:auto, :adopt, :category_only, :ignore]
+
+  # Client types whose torrents can carry a category or label Mydia can read
+  # back. rqbit has neither, so `:category_only` can never be satisfied there
+  # and is rejected rather than left to fail closed in silence.
+  @category_capable_types [:qbittorrent, :transmission]
+
   schema "download_client_configs" do
     field :name, :string
     field :type, Ecto.Enum, values: @client_types
@@ -92,6 +104,10 @@ defmodule Mydia.Settings.DownloadClientConfig do
     field :download_directory, :string
     field :connection_settings, Mydia.Settings.JsonMapType
     field :remove_completed, :boolean, default: false
+
+    field :external_torrents, Ecto.Enum,
+      values: @external_torrent_modes,
+      default: :auto
 
     belongs_to :updated_by, Mydia.Accounts.User
 
@@ -122,12 +138,14 @@ defmodule Mydia.Settings.DownloadClientConfig do
       :download_directory,
       :connection_settings,
       :remove_completed,
+      :external_torrents,
       :updated_by_id
     ])
     |> validate_required([:name, :type])
     |> validate_inclusion(:type, @client_types)
     |> apply_debrid_grace_default(attrs)
     |> validate_by_type()
+    |> validate_external_torrents()
     |> validate_remote_fetch_config()
     |> validate_number(:priority, greater_than: 0)
     |> validate_number(:incomplete_grace_minutes, greater_than: 0)
@@ -205,6 +223,26 @@ defmodule Mydia.Settings.DownloadClientConfig do
         changeset
         |> validate_required([:host, :port])
         |> validate_number(:port, greater_than: 0, less_than: 65536)
+    end
+  end
+
+  # `:category_only` needs a client that reports a category or label back.
+  # rqbit reports neither, so the combination is impossible rather than merely
+  # unusual, and is rejected at write time in both the DB and runtime-config
+  # paths. See `Mydia.Downloads.ExternalPolicy`.
+  defp validate_external_torrents(changeset) do
+    type = get_field(changeset, :type)
+    mode = get_field(changeset, :external_torrents)
+
+    if mode == :category_only and type not in @category_capable_types do
+      add_error(
+        changeset,
+        :external_torrents,
+        "category_only is not supported for #{type} clients, which do not report categories " <>
+          "(supported: #{Enum.join(@category_capable_types, ", ")})"
+      )
+    else
+      changeset
     end
   end
 
@@ -339,4 +377,14 @@ defmodule Mydia.Settings.DownloadClientConfig do
   """
   @spec remote_fetch_auth_methods() :: [String.t()]
   def remote_fetch_auth_methods, do: @remote_fetch_auth_methods
+
+  @doc """
+  Returns the client types that report a category or label Mydia can read back.
+
+  `Mydia.Downloads.ExternalPolicy` and `Mydia.Config.Schema` both read this, so
+  the runtime rule and the two write-time validations cannot disagree about
+  which clients qualify.
+  """
+  @spec category_capable_types() :: [atom()]
+  def category_capable_types, do: @category_capable_types
 end

--- a/lib/mydia/settings/runtime_config.ex
+++ b/lib/mydia/settings/runtime_config.ex
@@ -427,6 +427,7 @@ defmodule Mydia.Settings.RuntimeConfig do
       category: Map.get(map, :category),
       download_directory: Map.get(map, :download_directory),
       connection_settings: Map.get(map, :connection_settings, %{}),
+      external_torrents: Map.get(map, :external_torrents, :auto),
       updated_by_id: nil,
       inserted_at: nil,
       updated_at: nil

--- a/lib/mydia_web/live/admin_download_clients_live/components.ex
+++ b/lib/mydia_web/live/admin_download_clients_live/components.ex
@@ -21,6 +21,22 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
   # no seedbox concept.
   @remote_fetch_types ~w(qbittorrent transmission rqbit rtorrent)
 
+  # Client types the untracked scan actually visits. Usenet, debrid, and
+  # blackhole clients have no concept of a foreign torrent sitting in them, so
+  # the External torrents control is meaningless for them. Mirrors
+  # `@torrent_client_types` in `Mydia.Downloads.ExternalTorrents`.
+  @external_torrent_types ~w(qbittorrent transmission rqbit)
+
+  # `category_only` is omitted for a client that cannot report a category back
+  # (rqbit), rather than offered and left to adopt nothing in silence. The
+  # changeset rejects that combination too, in both config layers.
+  @external_torrent_modes [
+    {"Automatic (recommended)", "auto"},
+    {"Adopt any match", "adopt"},
+    {"Only my category", "category_only"},
+    {"Ignore", "ignore"}
+  ]
+
   # Placeholder hints shown in the per-tier priority profile inputs. Each
   # adapter has its own native priority value domain; the placeholder mirrors
   # the hardcoded default mapping so users see what value they'd get if they
@@ -139,6 +155,11 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
                     </span>
                     <%= if client.category do %>
                       <span class="ml-2">Category: {client.category}</span>
+                    <% end %>
+                    <%!-- Only when the operator changed it. :auto is the
+                          default and says nothing worth a row of chrome. --%>
+                    <%= if client.external_torrents && client.external_torrents != :auto do %>
+                      <span class="ml-2">External: {client.external_torrents}</span>
                     <% end %>
                   </div>
                 </div>
@@ -281,6 +302,16 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
     show_categories? = selected_type in @category_aware_types
     show_priority_profile? = selected_type in @priority_profile_types
     show_remote_fetch? = selected_type in @remote_fetch_types
+    show_external_torrents? = selected_type in @external_torrent_types
+
+    # rqbit reports neither categories nor labels, so scoping to a category can
+    # never match there. Drop the option rather than let it look available.
+    external_torrent_modes =
+      if category_capable_type?(selected_type) do
+        @external_torrent_modes
+      else
+        Enum.reject(@external_torrent_modes, fn {_label, value} -> value == "category_only" end)
+      end
 
     priority_placeholders = Map.get(@priority_profile_placeholders, selected_type, %{})
 
@@ -294,6 +325,9 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
       |> assign(:show_categories?, show_categories?)
       |> assign(:show_priority_profile?, show_priority_profile?)
       |> assign(:show_remote_fetch?, show_remote_fetch?)
+      |> assign(:show_external_torrents?, show_external_torrents?)
+      |> assign(:external_torrent_modes, external_torrent_modes)
+      |> assign(:category_capable_type?, category_capable_type?(selected_type))
       |> assign(:priority_placeholders, priority_placeholders)
       |> assign(:priority_tiers, @priority_tiers)
       |> assign(:content_types, @content_types)
@@ -604,6 +638,53 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
                     />
                   <% end %>
                 </div>
+              </div>
+            <% end %>
+
+            <%!-- What to do with torrents this client already holds that Mydia
+                 did not add. See Mydia.Downloads.ExternalPolicy and #531. --%>
+            <%= if @show_external_torrents? do %>
+              <div class="space-y-3" id="download-client-external-torrents-section">
+                <div class="flex items-center gap-2 text-sm font-medium text-base-content/80">
+                  <.icon name="hero-inbox-stack" class="w-4 h-4" />
+                  <span>External torrents</span>
+                </div>
+
+                <p class="text-xs text-base-content/50">
+                  What Mydia does with torrents already in this client that it did not add.
+                  Anything Mydia does not adopt stays visible under Downloads, External,
+                  where you can match it by hand.
+                </p>
+
+                <.input
+                  field={@download_client_form[:external_torrents]}
+                  id="download-client-external-torrents"
+                  type="select"
+                  label="Mode"
+                  options={@external_torrent_modes}
+                />
+
+                <ul class="text-xs text-base-content/50 space-y-1 list-disc list-inside">
+                  <li>
+                    <span class="font-medium">Automatic</span>
+                    uses your category when you have one set, and adopts any library match
+                    otherwise.
+                  </li>
+                  <li>
+                    <span class="font-medium">Adopt any match</span>
+                    imports every torrent here that matches something in your library.
+                  </li>
+                  <%= if @category_capable_type? do %>
+                    <li>
+                      <span class="font-medium">Only my category</span>
+                      imports only torrents tagged with this client's configured category.
+                    </li>
+                  <% end %>
+                  <li>
+                    <span class="font-medium">Ignore</span>
+                    never imports from this client. Use this for a client you manage yourself.
+                  </li>
+                </ul>
               </div>
             <% end %>
 
@@ -958,6 +1039,16 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
 
   defp auth_method_label("password"), do: "Password"
   defp auth_method_label("ssh_key"), do: "SSH key"
+
+  # Compares as strings rather than round-tripping through
+  # String.to_existing_atom/1: the form's type is a string, and there is no
+  # reason to convert just to compare. Sourced from the schema so the UI and
+  # the two changeset validations cannot disagree about which clients qualify.
+  defp category_capable_type?(type) when is_binary(type) do
+    type in Enum.map(Settings.DownloadClientConfig.category_capable_types(), &Atom.to_string/1)
+  end
+
+  defp category_capable_type?(_type), do: false
 
   # Whether a client's saved connection_settings has remote_fetch enabled,
   # for the row-level "Seedbox" badge in the list. `enabled` is stored as

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -1735,6 +1735,23 @@ defmodule MydiaWeb.DownloadsLive.Index do
     end
   end
 
+  # Whether Mydia adopted this download from a client rather than grabbing it
+  # itself. Written by `UntrackedMatcher.create_download_record/3` (automatic)
+  # and `Queue.adopt_external_torrent/3` (manual); "Added outside Mydia" is
+  # accurate for both.
+  #
+  # `metadata` is a `Mydia.Settings.JsonMapType`, whose `cast/1` passes a map
+  # through unchanged. A struct built in memory therefore carries atom keys
+  # while the same row loaded from the database carries string keys after JSON
+  # decoding. Reading only one form works right after adoption and silently
+  # stops after the next page load.
+  defp adopted_from_client?(%{metadata: metadata}) when is_map(metadata) do
+    Map.get(metadata, "matched_from_client") == true or
+      Map.get(metadata, :matched_from_client) == true
+  end
+
+  defp adopted_from_client?(_download), do: false
+
   defp get_display_title(download) do
     cond do
       # Episode download - show parent show title

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -831,6 +831,15 @@
                   <span>•</span>
                   <span>{format_progress(torrent.progress)}%</span>
                 <% end %>
+                <%!-- Without this, a plainly matchable release sitting here
+                      untouched gives no clue whether Mydia skipped it on
+                      purpose or failed at something. --%>
+                <%= if torrent.excluded_by_policy do %>
+                  <span>•</span>
+                  <span title="This client's External torrents setting tells Mydia not to adopt it">
+                    Not adopted by client setting
+                  </span>
+                <% end %>
               </div>
               <%= if @search_open_for == torrent.id do %>
                 <MydiaWeb.Live.Components.LibrarySearchForm.library_search_form

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -214,6 +214,17 @@
                   {get_episode_details(download)}
                 </span>
               <% end %>
+              <%!-- Mydia did not add this one. Neutral styling on purpose:
+                    adoption is intended behaviour, not a problem. --%>
+              <%= if adopted_from_client?(download) do %>
+                <span
+                  class="badge badge-ghost badge-xs shrink-0"
+                  data-test="adopted-badge"
+                  title="Mydia did not add this torrent. It was already in the download client and matched to your library."
+                >
+                  Added outside Mydia
+                </span>
+              <% end %>
             </div>
             <%!-- Line 2: release title (muted), only when it differs from the display title --%>
             <%= if get_display_title(download) != download.title do %>

--- a/priv/repo/migrations/20260822151843_add_external_torrents_to_download_client_configs.exs
+++ b/priv/repo/migrations/20260822151843_add_external_torrents_to_download_client_configs.exs
@@ -1,0 +1,16 @@
+defmodule Mydia.Repo.Migrations.AddExternalTorrentsToDownloadClientConfigs do
+  use Ecto.Migration
+
+  def change do
+    # :text rather than :string. A bare :string is varchar(255) on PostgreSQL
+    # and unconstrained TEXT on SQLite, which has shipped the same bug twice.
+    #
+    # "auto" rather than "adopt" so existing rows keep resolving through
+    # Mydia.Downloads.ExternalPolicy rather than freezing today's behaviour at
+    # migration time. A client that gains a category later then tightens on its
+    # own, which is the upgrade behaviour agreed for issue #531.
+    alter table(:download_client_configs) do
+      add :external_torrents, :text, default: "auto", null: false
+    end
+  end
+end

--- a/test/mydia/config/loader_test.exs
+++ b/test/mydia/config/loader_test.exs
@@ -456,6 +456,47 @@ defmodule Mydia.Config.LoaderTest do
       assert %{external_torrents: :ignore} = List.first(config.download_clients)
     end
 
+    test "accepts EXTERNAL_TORRENTS case-insensitively with surrounding whitespace" do
+      System.put_env("DOWNLOAD_CLIENT_1_NAME", "EnvClient")
+      System.put_env("DOWNLOAD_CLIENT_1_TYPE", "qbittorrent")
+      System.put_env("DOWNLOAD_CLIENT_1_HOST", "env.host")
+      System.put_env("DOWNLOAD_CLIENT_1_PORT", "8080")
+      System.put_env("DOWNLOAD_CLIENT_1_EXTERNAL_TORRENTS", "  Ignore ")
+
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert %{external_torrents: :ignore} = List.first(config.download_clients)
+    end
+
+    test "rejects an unrecognised EXTERNAL_TORRENTS rather than falling back to auto" do
+      # Dropping the key would silently fall back to :auto, so an operator who
+      # typed "ignor" would get the adoption they were trying to switch off.
+      # Failing loudly matches how a bad DOWNLOAD_CLIENT_<N>_TYPE behaves.
+      System.put_env("DOWNLOAD_CLIENT_1_NAME", "EnvClient")
+      System.put_env("DOWNLOAD_CLIENT_1_TYPE", "qbittorrent")
+      System.put_env("DOWNLOAD_CLIENT_1_HOST", "env.host")
+      System.put_env("DOWNLOAD_CLIENT_1_PORT", "8080")
+      System.put_env("DOWNLOAD_CLIENT_1_EXTERNAL_TORRENTS", "ignor")
+
+      assert {:error, _reason} = Loader.load(config_file: "nonexistent.yml")
+    end
+
+    test "an unrecognised EXTERNAL_TORRENTS does not mint a new atom" do
+      # parse_atom/1 falls back to String.to_atom/1, and atoms are never
+      # garbage collected. The dedicated parser must never reach that path.
+      System.put_env("DOWNLOAD_CLIENT_1_NAME", "EnvClient")
+      System.put_env("DOWNLOAD_CLIENT_1_TYPE", "qbittorrent")
+      System.put_env("DOWNLOAD_CLIENT_1_HOST", "env.host")
+      System.put_env("DOWNLOAD_CLIENT_1_PORT", "8080")
+      System.put_env("DOWNLOAD_CLIENT_1_EXTERNAL_TORRENTS", "definitely_not_a_mode_atom")
+
+      {:error, _reason} = Loader.load(config_file: "nonexistent.yml")
+
+      assert_raise ArgumentError, fn ->
+        String.to_existing_atom("definitely_not_a_mode_atom")
+      end
+    end
+
     test "rejects category_only for an rqbit client, which reports no categories" do
       System.put_env("DOWNLOAD_CLIENT_1_NAME", "EnvRqbit")
       System.put_env("DOWNLOAD_CLIENT_1_TYPE", "rqbit")

--- a/test/mydia/config/loader_test.exs
+++ b/test/mydia/config/loader_test.exs
@@ -433,6 +433,39 @@ defmodule Mydia.Config.LoaderTest do
       assert client.password == "envpass"
     end
 
+    test "defaults external_torrents to :auto when the env var is absent" do
+      System.put_env("DOWNLOAD_CLIENT_1_NAME", "EnvClient")
+      System.put_env("DOWNLOAD_CLIENT_1_TYPE", "qbittorrent")
+      System.put_env("DOWNLOAD_CLIENT_1_HOST", "env.host")
+      System.put_env("DOWNLOAD_CLIENT_1_PORT", "8080")
+
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert %{external_torrents: :auto} = List.first(config.download_clients)
+    end
+
+    test "reads DOWNLOAD_CLIENT_<N>_EXTERNAL_TORRENTS as an atom" do
+      System.put_env("DOWNLOAD_CLIENT_1_NAME", "EnvClient")
+      System.put_env("DOWNLOAD_CLIENT_1_TYPE", "qbittorrent")
+      System.put_env("DOWNLOAD_CLIENT_1_HOST", "env.host")
+      System.put_env("DOWNLOAD_CLIENT_1_PORT", "8080")
+      System.put_env("DOWNLOAD_CLIENT_1_EXTERNAL_TORRENTS", "ignore")
+
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert %{external_torrents: :ignore} = List.first(config.download_clients)
+    end
+
+    test "rejects category_only for an rqbit client, which reports no categories" do
+      System.put_env("DOWNLOAD_CLIENT_1_NAME", "EnvRqbit")
+      System.put_env("DOWNLOAD_CLIENT_1_TYPE", "rqbit")
+      System.put_env("DOWNLOAD_CLIENT_1_HOST", "env.host")
+      System.put_env("DOWNLOAD_CLIENT_1_PORT", "3030")
+      System.put_env("DOWNLOAD_CLIENT_1_EXTERNAL_TORRENTS", "category_only")
+
+      assert {:error, _reason} = Loader.load(config_file: "nonexistent.yml")
+    end
+
     test "keeps YAML connection_settings keys as strings for debrid clients" do
       yaml_content = """
       download_clients:

--- a/test/mydia/downloads/client/qbittorrent_test.exs
+++ b/test/mydia/downloads/client/qbittorrent_test.exs
@@ -1031,6 +1031,59 @@ defmodule Mydia.Downloads.Client.QBittorrentTest do
     end
   end
 
+  describe "category parsing (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      stub_login(bypass)
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "reports the torrent's category as a single-element list", %{
+      bypass: bypass,
+      config: config
+    } do
+      hash = "1111111111111111111111111111111111111111"
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash, category: "mydia")])
+      end)
+
+      assert {:ok, [status]} = QBittorrent.list_torrents(config)
+      assert status.categories == ["mydia"]
+    end
+
+    test "reports an empty list when the category is the empty string", %{
+      bypass: bypass,
+      config: config
+    } do
+      # qBittorrent sends "" rather than omitting the key for an uncategorised
+      # torrent. Treating "" as a category would make it match a client whose
+      # configured category is also blank.
+      hash = "2222222222222222222222222222222222222222"
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash, category: "")])
+      end)
+
+      assert {:ok, [status]} = QBittorrent.list_torrents(config)
+      assert status.categories == []
+    end
+
+    test "reports an empty list when the key is absent entirely", %{
+      bypass: bypass,
+      config: config
+    } do
+      hash = "3333333333333333333333333333333333333333"
+
+      Bypass.expect(bypass, "GET", "/api/v2/torrents/info", fn conn ->
+        json_resp(conn, 200, [torrent_payload(hash)])
+      end)
+
+      assert {:ok, [status]} = QBittorrent.list_torrents(config)
+      assert status.categories == []
+    end
+  end
+
   ## Helpers
 
   defp bypass_config(bypass) do

--- a/test/mydia/downloads/client/transmission_test.exs
+++ b/test/mydia/downloads/client/transmission_test.exs
@@ -616,6 +616,78 @@ defmodule Mydia.Downloads.Client.TransmissionTest do
     end
   end
 
+  describe "category is written as a label (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    defp expect_add(bypass, args_assertion) do
+      stub_rpc(bypass, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn, length: 1_000_000)
+        decoded = Jason.decode!(body)
+        assert decoded["method"] == "torrent-add"
+        args_assertion.(decoded["arguments"])
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          ~s({"result":"success","arguments":{"torrent-added":{"hashString":"abc"}}})
+        )
+      end)
+    end
+
+    test "puts the category into labels", %{bypass: bypass, config: config} do
+      expect_add(bypass, fn args ->
+        assert args["labels"] == ["mydia"]
+      end)
+
+      assert {:ok, "abc"} =
+               Transmission.add_torrent(config, {:magnet, "magnet:?xt=urn:btih:abc"},
+                 category: "mydia"
+               )
+    end
+
+    test "omits labels entirely when no category is configured", %{
+      bypass: bypass,
+      config: config
+    } do
+      expect_add(bypass, fn args ->
+        refute Map.has_key?(args, "labels")
+      end)
+
+      assert {:ok, "abc"} =
+               Transmission.add_torrent(config, {:magnet, "magnet:?xt=urn:btih:abc"}, [])
+    end
+
+    test "omits labels when the category is blank", %{bypass: bypass, config: config} do
+      expect_add(bypass, fn args ->
+        refute Map.has_key?(args, "labels")
+      end)
+
+      assert {:ok, "abc"} =
+               Transmission.add_torrent(config, {:magnet, "magnet:?xt=urn:btih:abc"},
+                 category: ""
+               )
+    end
+
+    test "an explicit tags list still wins, for callers that pass one", %{
+      bypass: bypass,
+      config: config
+    } do
+      expect_add(bypass, fn args ->
+        assert args["labels"] == ["explicit"]
+      end)
+
+      assert {:ok, "abc"} =
+               Transmission.add_torrent(config, {:magnet, "magnet:?xt=urn:btih:abc"},
+                 category: "mydia",
+                 tags: ["explicit"]
+               )
+    end
+  end
+
   # Note: Full integration tests would require either:
   # 1. A real Transmission instance (can be configured via environment variables)
   # 2. HTTP mocking library like Bypass or Mox to simulate Transmission RPC responses

--- a/test/mydia/downloads/client/transmission_test.exs
+++ b/test/mydia/downloads/client/transmission_test.exs
@@ -528,6 +528,94 @@ defmodule Mydia.Downloads.Client.TransmissionTest do
     end
   end
 
+  ## Bypass helpers for the label read path
+  ##
+  ## `bypass_config/1` already exists above, next to the priority-profile tests.
+
+  # Transmission's RPC requires a session-id round trip first: the initial call
+  # gets a 409 carrying the header, and the real call follows with it set.
+  defp stub_rpc(bypass, responder) do
+    Bypass.expect(bypass, "POST", "/transmission/rpc", fn conn ->
+      case Plug.Conn.get_req_header(conn, "x-transmission-session-id") do
+        [] ->
+          conn
+          |> Plug.Conn.put_resp_header("x-transmission-session-id", "test-session-id")
+          |> Plug.Conn.resp(409, "")
+
+        ["test-session-id"] ->
+          responder.(conn)
+      end
+    end)
+  end
+
+  defp transmission_payload(overrides) do
+    Map.merge(
+      %{
+        "hashString" => "abc123",
+        "name" => "Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP",
+        "status" => 6,
+        "percentDone" => 1.0,
+        "rateDownload" => 0,
+        "rateUpload" => 0,
+        "downloadedEver" => 1000,
+        "uploadedEver" => 0,
+        "totalSize" => 1000,
+        "eta" => -1,
+        "uploadRatio" => 0.0,
+        "downloadDir" => "/downloads",
+        "addedDate" => 1_700_000_000,
+        "doneDate" => 1_700_000_100
+      },
+      overrides
+    )
+  end
+
+  defp stub_torrent_get(bypass, torrent) do
+    stub_rpc(bypass, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!(%{"result" => "success", "arguments" => %{"torrents" => [torrent]}})
+      )
+    end)
+  end
+
+  describe "label parsing (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, config: bypass_config(bypass)}
+    end
+
+    test "reports every non-blank label", %{bypass: bypass, config: config} do
+      stub_torrent_get(bypass, transmission_payload(%{"labels" => ["mydia", "seeding"]}))
+
+      assert {:ok, [status]} = Transmission.list_torrents(config)
+      assert status.categories == ["mydia", "seeding"]
+    end
+
+    test "reports an empty list when labels is empty", %{bypass: bypass, config: config} do
+      stub_torrent_get(bypass, transmission_payload(%{"labels" => []}))
+
+      assert {:ok, [status]} = Transmission.list_torrents(config)
+      assert status.categories == []
+    end
+
+    test "reports an empty list when labels is absent", %{bypass: bypass, config: config} do
+      stub_torrent_get(bypass, transmission_payload(%{}))
+
+      assert {:ok, [status]} = Transmission.list_torrents(config)
+      assert status.categories == []
+    end
+
+    test "drops blank labels", %{bypass: bypass, config: config} do
+      stub_torrent_get(bypass, transmission_payload(%{"labels" => ["", "mydia"]}))
+
+      assert {:ok, [status]} = Transmission.list_torrents(config)
+      assert status.categories == ["mydia"]
+    end
+  end
+
   # Note: Full integration tests would require either:
   # 1. A real Transmission instance (can be configured via environment variables)
   # 2. HTTP mocking library like Bypass or Mox to simulate Transmission RPC responses

--- a/test/mydia/downloads/client/transmission_test.exs
+++ b/test/mydia/downloads/client/transmission_test.exs
@@ -614,6 +614,33 @@ defmodule Mydia.Downloads.Client.TransmissionTest do
       assert {:ok, [status]} = Transmission.list_torrents(config)
       assert status.categories == ["mydia"]
     end
+
+    test "get_status/2 requests labels too, so it agrees with list_torrents/2", %{
+      bypass: bypass,
+      config: config
+    } do
+      # get_status/2 keeps its own field list. When the two drift, a
+      # single-torrent fetch reports no categories for a labelled torrent and a
+      # caller could reasonably conclude it carries none.
+      stub_rpc(bypass, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn, length: 1_000_000)
+        decoded = Jason.decode!(body)
+        assert "labels" in decoded["arguments"]["fields"]
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{
+            "result" => "success",
+            "arguments" => %{"torrents" => [transmission_payload(%{"labels" => ["mydia"]})]}
+          })
+        )
+      end)
+
+      assert {:ok, status} = Transmission.get_status(config, "abc123")
+      assert status.categories == ["mydia"]
+    end
   end
 
   describe "category is written as a label (Bypass)" do

--- a/test/mydia/downloads/external_policy_test.exs
+++ b/test/mydia/downloads/external_policy_test.exs
@@ -1,0 +1,210 @@
+defmodule Mydia.Downloads.ExternalPolicyTest do
+  @moduledoc """
+  The whole opt-out rule for torrents Mydia did not add.
+
+  `:auto` is a resolved default rather than a stored one: a client that gains
+  a category later tightens on its own, which is the behaviour agreed for
+  issue #531. Everything else is an explicit operator choice and is returned
+  unchanged.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.ExternalPolicy
+  alias Mydia.Downloads.Structs.DownloadStatus
+  alias Mydia.Settings.DownloadClientConfig
+
+  defp config(overrides \\ %{}) do
+    struct!(
+      %DownloadClientConfig{
+        name: "qbit",
+        type: :qbittorrent,
+        external_torrents: :auto,
+        category: nil,
+        categories: %{}
+      },
+      overrides
+    )
+  end
+
+  defp status(categories \\ []) do
+    %DownloadStatus{
+      id: "hash-a",
+      name: "Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP",
+      state: :seeding,
+      progress: 100.0,
+      categories: categories
+    }
+  end
+
+  describe "configured_categories/1" do
+    test "is empty when neither the map nor the legacy field is set" do
+      assert MapSet.size(ExternalPolicy.configured_categories(config())) == 0
+    end
+
+    test "reads the legacy single category" do
+      assert ExternalPolicy.configured_categories(config(%{category: "mydia"})) ==
+               MapSet.new(["mydia"])
+    end
+
+    test "reads the per-content-type map" do
+      cfg = config(%{categories: %{"movie" => "mydia-movies", "tv" => "mydia-tv"}})
+
+      assert ExternalPolicy.configured_categories(cfg) ==
+               MapSet.new(["mydia-movies", "mydia-tv"])
+    end
+
+    test "unions the map with the legacy field" do
+      cfg = config(%{category: "mydia", categories: %{"movie" => "mydia-movies"}})
+
+      assert ExternalPolicy.configured_categories(cfg) ==
+               MapSet.new(["mydia", "mydia-movies"])
+    end
+
+    test "drops blank and whitespace-only values" do
+      cfg = config(%{category: "   ", categories: %{"movie" => "", "tv" => "mydia-tv"}})
+
+      assert ExternalPolicy.configured_categories(cfg) == MapSet.new(["mydia-tv"])
+    end
+
+    test "trims surrounding whitespace so a stray space cannot silence a client" do
+      assert ExternalPolicy.configured_categories(config(%{category: " mydia "})) ==
+               MapSet.new(["mydia"])
+    end
+  end
+
+  describe "supports_categories?/1" do
+    test "true for qbittorrent and transmission" do
+      assert ExternalPolicy.supports_categories?(:qbittorrent)
+      assert ExternalPolicy.supports_categories?(:transmission)
+    end
+
+    test "false for rqbit, which has no categories or labels" do
+      refute ExternalPolicy.supports_categories?(:rqbit)
+    end
+
+    test "false for an unknown type" do
+      refute ExternalPolicy.supports_categories?(:not_a_client)
+    end
+  end
+
+  describe "effective_mode/1 resolving :auto" do
+    test "resolves to :adopt when no category is configured" do
+      assert ExternalPolicy.effective_mode(config()) == :adopt
+    end
+
+    test "resolves to :category_only when a legacy category is configured" do
+      assert ExternalPolicy.effective_mode(config(%{category: "mydia"})) == :category_only
+    end
+
+    test "resolves to :category_only when the categories map is populated" do
+      cfg = config(%{categories: %{"movie" => "mydia-movies"}})
+
+      assert ExternalPolicy.effective_mode(cfg) == :category_only
+    end
+
+    test "resolves to :adopt for rqbit even with a category configured" do
+      cfg = config(%{type: :rqbit, category: "mydia"})
+
+      assert ExternalPolicy.effective_mode(cfg) == :adopt
+    end
+
+    test "resolves to :adopt when the only configured category is blank" do
+      assert ExternalPolicy.effective_mode(config(%{category: ""})) == :adopt
+    end
+
+    test "treats a nil mode as :auto, so a struct built without the field still resolves" do
+      assert ExternalPolicy.effective_mode(config(%{external_torrents: nil})) == :adopt
+    end
+  end
+
+  describe "effective_mode/1 with an explicit mode" do
+    test "returns each explicit mode unchanged" do
+      for mode <- [:adopt, :category_only, :ignore] do
+        cfg = config(%{external_torrents: mode, category: "mydia"})
+
+        assert ExternalPolicy.effective_mode(cfg) == mode
+      end
+    end
+
+    test "an explicit mode wins over what :auto would have chosen" do
+      # A category is configured, so :auto would say :category_only.
+      cfg = config(%{external_torrents: :adopt, category: "mydia"})
+
+      assert ExternalPolicy.effective_mode(cfg) == :adopt
+    end
+  end
+
+  describe "decide/2" do
+    test "adopts everything in :adopt mode, category or not" do
+      cfg = config(%{external_torrents: :adopt})
+
+      assert ExternalPolicy.decide(cfg, status()) == :adopt
+      assert ExternalPolicy.decide(cfg, status(["someone-elses"])) == :adopt
+    end
+
+    test "refuses everything in :ignore mode, even a matching category" do
+      cfg = config(%{external_torrents: :ignore, category: "mydia"})
+
+      assert ExternalPolicy.decide(cfg, status(["mydia"])) == :excluded_by_ignore
+    end
+
+    test "adopts a torrent carrying the configured category" do
+      cfg = config(%{external_torrents: :category_only, category: "mydia"})
+
+      assert ExternalPolicy.decide(cfg, status(["mydia"])) == :adopt
+    end
+
+    test "adopts when any one of several labels matches" do
+      cfg = config(%{external_torrents: :category_only, category: "mydia"})
+
+      assert ExternalPolicy.decide(cfg, status(["seeding", "mydia"])) == :adopt
+    end
+
+    test "refuses a torrent carrying a different category" do
+      cfg = config(%{external_torrents: :category_only, category: "mydia"})
+
+      assert ExternalPolicy.decide(cfg, status(["manual"])) == :excluded_by_category
+    end
+
+    test "refuses a torrent carrying no category at all" do
+      cfg = config(%{external_torrents: :category_only, category: "mydia"})
+
+      assert ExternalPolicy.decide(cfg, status([])) == :excluded_by_category
+    end
+
+    test "category matching is exact, not a prefix or substring" do
+      cfg = config(%{external_torrents: :category_only, category: "mydia"})
+
+      assert ExternalPolicy.decide(cfg, status(["mydia-movies"])) == :excluded_by_category
+    end
+
+    test "fails closed on a client that cannot report categories" do
+      # Validation blocks this combination at write time. If one ever reaches
+      # the runtime anyway, refusing is the safe residual behaviour: rqbit
+      # reports no categories, so nothing could legitimately match.
+      cfg = config(%{type: :rqbit, external_torrents: :category_only, category: "mydia"})
+
+      assert ExternalPolicy.decide(cfg, status([])) == :excluded_by_category
+    end
+
+    test "tolerates a status struct with no categories field populated" do
+      cfg = config(%{external_torrents: :category_only, category: "mydia"})
+      bare = %DownloadStatus{id: "h", name: "n", state: :seeding, progress: 1.0}
+
+      assert ExternalPolicy.decide(cfg, bare) == :excluded_by_category
+    end
+  end
+
+  describe "adopt?/2" do
+    test "is true only for the :adopt decision" do
+      adopting = config(%{external_torrents: :adopt})
+      ignoring = config(%{external_torrents: :ignore})
+      scoped = config(%{external_torrents: :category_only, category: "mydia"})
+
+      assert ExternalPolicy.adopt?(adopting, status())
+      refute ExternalPolicy.adopt?(ignoring, status())
+      assert ExternalPolicy.adopt?(scoped, status(["mydia"]))
+      refute ExternalPolicy.adopt?(scoped, status(["other"]))
+    end
+  end
+end

--- a/test/mydia/downloads/external_torrents/classifier_test.exs
+++ b/test/mydia/downloads/external_torrents/classifier_test.exs
@@ -20,11 +20,16 @@ defmodule Mydia.Downloads.ExternalTorrents.ClassifierTest do
     )
   end
 
+  # Entries carry the client's adoption decision, from
+  # `Mydia.Downloads.ExternalPolicy.decide/2`. `:adopt` is the default here
+  # because it is what every pre-#531 caller effectively passed.
+  defp entry(name, decision \\ :adopt), do: {"qbit", status(name), decision}
+
   defp empty_pool, do: %CandidatePool{movies: [], tv_shows: []}
 
   describe "classify/2 split rule" do
     test "a movie release goes to needs_matching" do
-      entries = [{"qbit", status("Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP")}]
+      entries = [entry("Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP")]
 
       {needs, external} = Classifier.classify(entries, empty_pool())
 
@@ -33,7 +38,7 @@ defmodule Mydia.Downloads.ExternalTorrents.ClassifierTest do
     end
 
     test "a tv release goes to needs_matching" do
-      entries = [{"qbit", status("The.Bear.S03E02.1080p.WEB-DL.x264-GROUP")}]
+      entries = [entry("The.Bear.S03E02.1080p.WEB-DL.x264-GROUP")]
 
       {needs, external} = Classifier.classify(entries, empty_pool())
 
@@ -42,7 +47,7 @@ defmodule Mydia.Downloads.ExternalTorrents.ClassifierTest do
     end
 
     test "a non-media name goes to external" do
-      entries = [{"qbit", status("ubuntu-24.04-desktop-amd64.iso")}]
+      entries = [entry("ubuntu-24.04-desktop-amd64.iso")]
 
       {needs, external} = Classifier.classify(entries, empty_pool())
 
@@ -51,7 +56,7 @@ defmodule Mydia.Downloads.ExternalTorrents.ClassifierTest do
     end
 
     test "a validator-rejected name goes to external with no parsed info" do
-      entries = [{"qbit", status("From.S04E05.1080p.WEB.h264-ETHEL.exe")}]
+      entries = [entry("From.S04E05.1080p.WEB.h264-ETHEL.exe")]
 
       {needs, external} = Classifier.classify(entries, empty_pool())
 
@@ -60,11 +65,91 @@ defmodule Mydia.Downloads.ExternalTorrents.ClassifierTest do
     end
   end
 
+  describe "classify/2 policy exclusion" do
+    test "a movie from a client set to ignore goes to external, not needs_matching" do
+      entries = [entry("Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP", :excluded_by_ignore)]
+
+      {needs, external} = Classifier.classify(entries, empty_pool())
+
+      assert needs == []
+      assert [%{kind: :external, excluded_by_policy: true}] = external
+    end
+
+    test "a movie excluded by category also goes to external" do
+      entries = [entry("Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP", :excluded_by_category)]
+
+      {needs, external} = Classifier.classify(entries, empty_pool())
+
+      assert needs == []
+      assert [%{kind: :external, excluded_by_policy: true}] = external
+    end
+
+    test "a category-excluded torrent keeps its parsed info so a manual pull stays easy" do
+      entries = [entry("Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP", :excluded_by_category)]
+
+      {_needs, [torrent]} = Classifier.classify(entries, empty_pool())
+
+      assert %{type: :movie} = torrent.parsed
+    end
+
+    test "an ignored torrent keeps parsed info but is not scored for suggestions" do
+      # Scoring every foreign torrent every couple of minutes is work the
+      # operator explicitly asked Mydia not to do.
+      media_item_fixture(%{type: "tv_show", title: "The Bear"})
+
+      entries = [entry("The.Bear.S03E02.1080p.WEB-DL.x264-GROUP", :excluded_by_ignore)]
+
+      {_needs, [torrent]} = Classifier.classify(entries, CandidatePool.load())
+
+      assert %{type: :tv_show} = torrent.parsed
+      assert torrent.suggestions == []
+    end
+
+    test "a category-excluded torrent IS scored, since a manual pull is plausible" do
+      show = media_item_fixture(%{type: "tv_show", title: "The Bear"})
+
+      entries = [entry("The.Bear.S03E02.1080p.WEB-DL.x264-GROUP", :excluded_by_category)]
+
+      {_needs, [torrent]} = Classifier.classify(entries, CandidatePool.load())
+
+      assert [%{media_item_id: id} | _] = torrent.suggestions
+      assert id == show.id
+    end
+
+    test "an adopted torrent is not flagged as excluded" do
+      entries = [entry("Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP", :adopt)]
+
+      {[torrent], _external} = Classifier.classify(entries, empty_pool())
+
+      refute torrent.excluded_by_policy
+    end
+
+    test "a non-media name from an ignored client is external and flagged" do
+      # It would have been :external regardless of policy, since the name does
+      # not parse as media. The flag still records that policy also excluded it.
+      entries = [entry("ubuntu-24.04-desktop-amd64.iso", :excluded_by_ignore)]
+
+      {needs, external} = Classifier.classify(entries, empty_pool())
+
+      assert needs == []
+      assert [%{kind: :external, excluded_by_policy: true, suggestions: []}] = external
+    end
+
+    test "a validator-rejected name from an ignored client is external and flagged" do
+      entries = [entry("From.S04E05.1080p.WEB.h264-ETHEL.exe", :excluded_by_ignore)]
+
+      {needs, external} = Classifier.classify(entries, empty_pool())
+
+      assert needs == []
+      assert [%{kind: :external, excluded_by_policy: true, parsed: nil}] = external
+    end
+  end
+
   describe "classify/2 suggestions" do
     test "media-shaped entries are scored against the pool" do
       show = media_item_fixture(%{type: "tv_show", title: "The Bear"})
       pool = CandidatePool.load()
-      entries = [{"qbit", status("The.Bear.S03E02.1080p.WEB-DL.x264-GROUP")}]
+      entries = [entry("The.Bear.S03E02.1080p.WEB-DL.x264-GROUP")]
 
       {[torrent], []} = Classifier.classify(entries, pool)
 
@@ -74,7 +159,7 @@ defmodule Mydia.Downloads.ExternalTorrents.ClassifierTest do
 
     test "external entries never get suggestions" do
       media_item_fixture(%{type: "tv_show", title: "Ubuntu"})
-      entries = [{"qbit", status("ubuntu-24.04-desktop-amd64.iso")}]
+      entries = [entry("ubuntu-24.04-desktop-amd64.iso")]
 
       {[], [torrent]} = Classifier.classify(entries, CandidatePool.load())
 
@@ -84,10 +169,10 @@ defmodule Mydia.Downloads.ExternalTorrents.ClassifierTest do
 
   describe "classify/2 identity" do
     test "the same torrent gets the same id across two runs" do
-      entry = {"qbit", status("ubuntu-24.04-desktop-amd64.iso")}
+      single = entry("ubuntu-24.04-desktop-amd64.iso")
 
-      {[], [first]} = Classifier.classify([entry], empty_pool())
-      {[], [second]} = Classifier.classify([entry], empty_pool())
+      {[], [first]} = Classifier.classify([single], empty_pool())
+      {[], [second]} = Classifier.classify([single], empty_pool())
 
       assert first.id == second.id
     end
@@ -96,14 +181,17 @@ defmodule Mydia.Downloads.ExternalTorrents.ClassifierTest do
       shared = status("ubuntu-24.04-desktop-amd64.iso")
 
       {[], torrents} =
-        Classifier.classify([{"qbit", shared}, {"transmission", shared}], empty_pool())
+        Classifier.classify(
+          [{"qbit", shared, :adopt}, {"transmission", shared, :adopt}],
+          empty_pool()
+        )
 
       assert [a, b] = torrents
       assert a.id != b.id
     end
 
     test "carries the client fields and live status through" do
-      entries = [{"qbit", status("ubuntu-24.04.iso", %{progress: 12.5, state: :seeding})}]
+      entries = [{"qbit", status("ubuntu-24.04.iso", %{progress: 12.5, state: :seeding}), :adopt}]
 
       {[], [torrent]} = Classifier.classify(entries, empty_pool())
 

--- a/test/mydia/downloads/untracked_matcher_test.exs
+++ b/test/mydia/downloads/untracked_matcher_test.exs
@@ -106,4 +106,98 @@ defmodule Mydia.Downloads.UntrackedMatcherTest do
       assert download.media_item_id == movie.id
     end
   end
+
+  describe "adoptable_torrents/2" do
+    alias Mydia.Downloads.Structs.DownloadStatus
+    alias Mydia.Settings.DownloadClientConfig
+
+    defp client(overrides \\ %{}) do
+      struct!(
+        %DownloadClientConfig{
+          name: "qbit",
+          type: :qbittorrent,
+          external_torrents: :auto,
+          category: nil,
+          categories: %{}
+        },
+        overrides
+      )
+    end
+
+    # Distinct from the module-level torrent/2 helper above, which builds the
+    # plain map shape process_untracked_torrent/1 consumes. This builds what an
+    # adapter actually returns.
+    defp client_torrent(name, categories) do
+      %DownloadStatus{
+        id: "hash-#{System.unique_integer([:positive])}",
+        name: name,
+        state: :seeding,
+        progress: 100.0,
+        categories: categories
+      }
+    end
+
+    test "keeps everything when the client adopts any match" do
+      config = client(%{external_torrents: :adopt})
+
+      torrents = [
+        client_torrent("A.Movie.2024.1080p", []),
+        client_torrent("B.Movie.2024.1080p", ["other"])
+      ]
+
+      assert length(UntrackedMatcher.adoptable_torrents(config, torrents)) == 2
+    end
+
+    test "drops everything when the client ignores external torrents" do
+      config = client(%{external_torrents: :ignore, category: "mydia"})
+      torrents = [client_torrent("A.Movie.2024.1080p", ["mydia"])]
+
+      assert UntrackedMatcher.adoptable_torrents(config, torrents) == []
+    end
+
+    test "keeps only the configured category when scoped" do
+      config = client(%{external_torrents: :category_only, category: "mydia"})
+
+      torrents = [
+        client_torrent("Mine.2024.1080p", ["mydia"]),
+        client_torrent("Theirs.2024.1080p", ["manual"]),
+        client_torrent("Bare.2024.1080p", [])
+      ]
+
+      assert [%{name: "Mine.2024.1080p"}] =
+               UntrackedMatcher.adoptable_torrents(config, torrents)
+    end
+
+    test "auto scopes to the category when one is configured" do
+      config = client(%{category: "mydia"})
+
+      torrents = [
+        client_torrent("Mine.2024.1080p", ["mydia"]),
+        client_torrent("Theirs.2024.1080p", ["manual"])
+      ]
+
+      assert [%{name: "Mine.2024.1080p"}] =
+               UntrackedMatcher.adoptable_torrents(config, torrents)
+    end
+
+    test "auto adopts everything when no category is configured" do
+      config = client()
+
+      torrents = [
+        client_torrent("Mine.2024.1080p", []),
+        client_torrent("Theirs.2024.1080p", ["manual"])
+      ]
+
+      assert length(UntrackedMatcher.adoptable_torrents(config, torrents)) == 2
+    end
+
+    test "attaches the client name to every surviving torrent" do
+      config = client(%{name: "my-qbit", external_torrents: :adopt})
+
+      assert [%{client_name: "my-qbit"}] =
+               UntrackedMatcher.adoptable_torrents(config, [
+                 client_torrent("A.Movie.2024.1080p", [])
+               ])
+    end
+  end
 end

--- a/test/mydia/events_test.exs
+++ b/test/mydia/events_test.exs
@@ -108,6 +108,63 @@ defmodule Mydia.EventsTest do
     end
   end
 
+  describe "download_adopted/2" do
+    test "records the client, confidence, and media context" do
+      media_item = %Mydia.Media.MediaItem{
+        id: Ecto.UUID.generate(),
+        title: "Dune: Part Two",
+        type: "movie"
+      }
+
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP",
+        download_client: "qbit"
+      }
+
+      assert :ok = Events.download_adopted(download, media_item: media_item, confidence: 0.92)
+
+      # create_event_async/1 writes in a task. Process.sleep/1 is what the
+      # "create_event_async/1" describe block below already uses.
+      Process.sleep(100)
+
+      events = Events.list_events(category: "downloads")
+      assert [event] = Enum.filter(events, &(&1.type == "download.adopted"))
+
+      assert event.actor_type == :system
+      assert event.metadata["download_client"] == "qbit"
+      assert event.metadata["match_confidence"] == 0.92
+      assert event.metadata["media_title"] == "Dune: Part Two"
+      assert event.resource_type == "media_item"
+      assert event.resource_id == media_item.id
+    end
+
+    test "falls back to the download as the resource when there is no media item" do
+      download = %Mydia.Downloads.Download{
+        id: Ecto.UUID.generate(),
+        title: "Some.Release.2024",
+        download_client: "qbit"
+      }
+
+      assert :ok = Events.download_adopted(download)
+
+      Process.sleep(100)
+
+      events = Events.list_events(category: "downloads")
+      assert [event] = Enum.filter(events, &(&1.type == "download.adopted"))
+
+      assert event.resource_type == "download"
+      assert event.resource_id == download.id
+    end
+
+    test "the type is registered, so the changeset accepts it" do
+      # Event.changeset/2 rejects any type missing from Mydia.Events.Presentation
+      # with "is not a registered event type". Without registration the event
+      # would be dropped at write time and only a log line would say so.
+      assert "download.adopted" in Mydia.Events.Presentation.known_types()
+    end
+  end
+
   describe "create_event_async/1" do
     test "creates event asynchronously" do
       attrs = %{

--- a/test/mydia/settings/download_client_config_test.exs
+++ b/test/mydia/settings/download_client_config_test.exs
@@ -475,4 +475,62 @@ defmodule Mydia.Settings.DownloadClientConfigTest do
       assert DownloadClientConfig.remote_fetch_auth_methods() == ["password", "ssh_key"]
     end
   end
+
+  describe "external_torrents" do
+    defp base_attrs(overrides \\ %{}) do
+      Map.merge(
+        %{
+          name: "qbit-#{System.unique_integer([:positive])}",
+          type: :qbittorrent,
+          host: "localhost",
+          port: 8080
+        },
+        overrides
+      )
+    end
+
+    test "defaults to :auto" do
+      changeset = DownloadClientConfig.changeset(%DownloadClientConfig{}, base_attrs())
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :external_torrents) == :auto
+    end
+
+    test "accepts every mode for a qbittorrent client" do
+      for mode <- [:auto, :adopt, :category_only, :ignore] do
+        changeset =
+          DownloadClientConfig.changeset(
+            %DownloadClientConfig{},
+            base_attrs(%{external_torrents: mode})
+          )
+
+        assert changeset.valid?, "expected #{mode} to be valid"
+        assert Ecto.Changeset.get_field(changeset, :external_torrents) == mode
+      end
+    end
+
+    test "rejects category_only for rqbit, which has no categories" do
+      changeset =
+        DownloadClientConfig.changeset(
+          %DownloadClientConfig{},
+          base_attrs(%{type: :rqbit, external_torrents: :category_only})
+        )
+
+      refute changeset.valid?
+      assert %{external_torrents: [message]} = errors_on(changeset)
+      assert message =~ "rqbit"
+    end
+
+    test "accepts adopt and ignore for rqbit" do
+      for mode <- [:auto, :adopt, :ignore] do
+        changeset =
+          DownloadClientConfig.changeset(
+            %DownloadClientConfig{},
+            base_attrs(%{type: :rqbit, external_torrents: mode})
+          )
+
+        assert changeset.valid?, "expected #{mode} to be valid for rqbit"
+      end
+    end
+  end
 end

--- a/test/mydia/settings/runtime_download_client_test.exs
+++ b/test/mydia/settings/runtime_download_client_test.exs
@@ -1,0 +1,70 @@
+defmodule Mydia.Settings.RuntimeDownloadClientTest do
+  @moduledoc """
+  `map_to_download_client_config/1` builds a `%DownloadClientConfig{}` from the
+  runtime map field by field. A field missing from that function is silently
+  replaced by the struct default, with no error anywhere: the operator sets an
+  environment variable, Mydia ignores it, and nothing says so. The `categories`
+  map is already dropped for exactly this reason.
+
+  This is the regression test for that class of bug.
+  """
+  # Not async: setup_runtime_config/1 mutates global application env.
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Settings.RuntimeConfig
+
+  defp client_config(overrides) do
+    Enum.into(overrides, %{
+      name: "runtime-qbit",
+      type: :qbittorrent,
+      enabled: true,
+      host: "localhost",
+      port: 8080,
+      use_ssl: false,
+      username: "admin",
+      password: "admin",
+      priority: 1
+    })
+  end
+
+  defp setup_runtime_config(download_clients) do
+    config = %Mydia.Config.Schema{
+      server: %Mydia.Config.Schema.Server{},
+      database: %Mydia.Config.Schema.Database{},
+      auth: %Mydia.Config.Schema.Auth{},
+      media: %Mydia.Config.Schema.Media{},
+      downloads: %Mydia.Config.Schema.Downloads{},
+      logging: %Mydia.Config.Schema.Logging{},
+      oban: %Mydia.Config.Schema.Oban{},
+      download_clients: download_clients
+    }
+
+    previous = Application.get_env(:mydia, :runtime_config)
+    Application.put_env(:mydia, :runtime_config, config)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:mydia, :runtime_config)
+        value -> Application.put_env(:mydia, :runtime_config, value)
+      end
+    end)
+  end
+
+  describe "map_to_download_client_config/1 external_torrents" do
+    test "carries an explicit mode through to the struct" do
+      setup_runtime_config([client_config(%{external_torrents: :ignore})])
+
+      [client] = RuntimeConfig.get_runtime_download_clients()
+
+      assert client.external_torrents == :ignore
+    end
+
+    test "defaults to :auto when the runtime map omits the field" do
+      setup_runtime_config([client_config(%{})])
+
+      [client] = RuntimeConfig.get_runtime_download_clients()
+
+      assert client.external_torrents == :auto
+    end
+  end
+end

--- a/test/mydia_web/live/admin_download_clients_live_test.exs
+++ b/test/mydia_web/live/admin_download_clients_live_test.exs
@@ -548,6 +548,66 @@ defmodule MydiaWeb.AdminDownloadClientsLiveTest do
     end
   end
 
+  describe "Form: External torrents" do
+    setup %{conn: conn, token: token} do
+      start_supervised!(Mydia.Indexers.Health)
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/clients")
+      %{conn: conn, view: view}
+    end
+
+    defp open_new_client_form(view) do
+      view
+      |> element(~s{button[phx-click="new_download_client"]})
+      |> render_click()
+    end
+
+    defp change_type(view, type) do
+      view
+      |> form("#download-client-form", %{"download_client_config" => %{"type" => type}})
+      |> render_change()
+    end
+
+    # The mode select is type-aware. `category_only` is meaningless for rqbit,
+    # which has neither categories nor labels, so it is not offered at all
+    # rather than offered and left to adopt nothing in silence.
+    test "offers every mode for a qbittorrent client", %{view: view} do
+      open_new_client_form(view)
+
+      assert has_element?(view, "#download-client-external-torrents")
+
+      html = change_type(view, "qbittorrent")
+      assert html =~ "External torrents"
+      assert html =~ "category_only"
+      assert html =~ "ignore"
+    end
+
+    test "omits category_only for rqbit", %{view: view} do
+      open_new_client_form(view)
+
+      html = change_type(view, "rqbit")
+
+      # The control is still there, minus the one option rqbit cannot satisfy.
+      assert html =~ "External torrents"
+      refute html =~ "category_only"
+    end
+
+    test "hides the control entirely for a client type the scan never visits", %{view: view} do
+      open_new_client_form(view)
+
+      # Usenet clients have no concept of a foreign torrent sitting in them.
+      html = change_type(view, "sabnzbd")
+
+      refute html =~ "External torrents"
+    end
+  end
+
   describe "Wave-2 Form: Remote seedbox (Test SFTP Connection)" do
     setup %{conn: conn, token: token} do
       start_supervised!(Mydia.Indexers.Health)

--- a/test/mydia_web/live/downloads_live/adopted_badge_test.exs
+++ b/test/mydia_web/live/downloads_live/adopted_badge_test.exs
@@ -1,0 +1,59 @@
+defmodule MydiaWeb.DownloadsLive.AdoptedBadgeTest do
+  @moduledoc """
+  The badge must survive a database round trip.
+
+  `Mydia.Settings.JsonMapType.cast/1` passes a map through unchanged, so a
+  struct built in memory carries atom keys while the same row loaded back
+  carries string keys after JSON decoding. A badge written against atom keys
+  works immediately after adoption and stops working after the next page load,
+  which is the worst possible failure for a feature whose entire purpose is to
+  be visible.
+
+  These downloads are inserted and then re-read through the LiveView, so the
+  string-key path is the one under test.
+  """
+  # Not async: a connected LiveView mount runs in a separate process from the
+  # test. Under PostgreSQL with async: true the sandbox is non-shared, so that
+  # process cannot see the rows this test inserts and the list renders empty.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.DownloadsFixtures
+  import Mydia.MediaFixtures
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin), admin: admin}
+  end
+
+  test "renders the badge for a download adopted from the client", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Dune: Part Two"})
+
+    download_fixture(%{
+      title: "Dune.Part.Two.2024.2160p.WEB-DL.x265-GROUP",
+      media_item_id: media_item.id,
+      download_client: "qbit",
+      metadata: %{matched_from_client: true}
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+
+    assert has_element?(view, "[data-test=adopted-badge]")
+  end
+
+  test "does not render the badge for a download Mydia grabbed itself", %{conn: conn} do
+    media_item = media_item_fixture(%{title: "Some Other Film"})
+
+    download_fixture(%{
+      title: "Some.Other.Film.2024.1080p.WEB-DL.x264-OTHER",
+      media_item_id: media_item.id,
+      download_client: "qbit",
+      metadata: %{size: 1000}
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/downloads")
+
+    refute has_element?(view, "[data-test=adopted-badge]")
+  end
+end


### PR DESCRIPTION
Closes #531.

Mydia adopts and imports torrents sitting in a download client that it did not add. That is intentional, and for most operators it is what they want. It is also undiscoverable, unlabelled, and impossible to turn off, which is how #531 came in as a possible bug rather than as recognised behaviour.

## The setting

Every torrent client gains an **External torrents** mode.

| Mode | Behaviour |
| --- | --- |
| `auto` (default) | Resolves to `category_only` when the client has a category configured and can report one back, `adopt` otherwise |
| `adopt` | Today's behaviour: any foreign torrent matching a library item is adopted and imported |
| `category_only` | Adopt only torrents carrying one of this client's configured categories |
| `ignore` | Never adopt; foreign torrents stay visible under Downloads, External |

`auto` is resolved at read time rather than stamped at migration time, so a client that gains a category later tightens on its own, and an operator who never used categories keeps exactly the behaviour they had before. rqbit only offers `adopt` and `ignore`, since it has no categories or labels; that combination is rejected in both config layers rather than left to fail closed in silence.

Configurable per client via the admin UI, YAML, and `DOWNLOAD_CLIENT_<N>_EXTERNAL_TORRENTS`.

## Two latent bugs found on the way

**Transmission never received Mydia's category.** `add_common_torrent_opts/3` mapped `opts[:tags]` into `labels`, but `Queue.add_torrent_to_client_with_input/4` only ever passes `:category`, so `opts[:tags]` was always nil and every Transmission torrent Mydia added went in unlabelled. Left alone this would have turned the new default into a silent regression: a Transmission client with a category configured resolves to `category_only` and then adopts nothing, because Mydia's own torrents are unlabelled too. Fixed in c534adfa. This also makes the "Categories" claim in `docs/using/reference/download-clients.md` true for the first time.

**`metadata.matched_from_client` was written in two places and rendered in none.** An adopted download was indistinguishable in the UI from one Mydia searched for and grabbed. It is now an "Added outside Mydia" badge.

## Where non-adopted torrents go

`needs_matching` renders under the **Issues** tab. Without routing changes, opting out would file every deliberate exclusion as a problem: the reporter's three comparison copies would become three permanent Issues entries they cannot clear. So the policy decision travels into classification, and a torrent Mydia was told not to adopt lands on the neutral External tab instead, flagged "Not adopted by client setting" and keeping its existing library-search-and-adopt control.

A client set to `ignore` is still scanned. Skipping it would be the obvious optimisation and the wrong one, since External is exactly where its torrents need to stay visible.

## Structure

`Mydia.Downloads.ExternalPolicy` is the single decision surface, pure in the same sense as the existing `ClientAdoption`: no database, no network, every input an argument. Both the adoption path and the classification path call it, so they cannot disagree about what a mode means.

## Testing

Full suite green on both adapters: **SQLite 8696 tests, PostgreSQL 8697 tests, 0 failures.** `mix format`, `mix compile --warnings-as-errors`, and `credo` (1309 files) all clean.

New coverage worth calling out:

- `ExternalPolicy` has 27 pure tests: mode resolution both directions, the category union across the legacy field and the per-content-type map, blank and whitespace values, exact-not-prefix matching, and failing closed on a client that cannot report categories.
- A regression test for `map_to_download_client_config/1` carrying the new field. That function builds the struct field by field, so an omission silently falls back to the default with no error anywhere; the `categories` map is already dropped for exactly this reason.
- A LiveView test asserting the badge renders for a download loaded **from the database**. `JsonMapType.cast/1` passes maps through unchanged, so an in-memory struct carries atom keys while the same row read back carries string keys. A badge written against one form works right after adoption and silently stops after the next page load.

## What this does not fix

An operator with no category configured sees no behaviour change: `auto` resolves to `adopt` as before. They get a switch, a visible badge, and an activity trail, and they need to choose Ignore or configure a category to get the behaviour asked for in #531. Worth saying plainly when replying to the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable handling for torrents created outside Mydia: automatic adoption, category-only adoption, always adopt, or ignore.
  * Added category and label support for compatible download clients, with validation for supported modes.
  * External torrent listings now indicate when adoption is excluded by policy.
  * Adopted downloads display an “Added outside Mydia” badge and generate an activity event.

* **Documentation**
  * Documented environment-variable configuration for external torrent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->