### PR TITLE
fix(discover): make the library picker a dialog so nothing can cover it

### DIFF
--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -440,8 +440,12 @@ defmodule Mydia.Metadata do
   @doc """
   Gets the metadata relay base URL.
 
-  The base URL can be configured via the METADATA_RELAY_URL environment variable,
-  defaulting to the self-hosted relay if not set.
+  Resolved in order of precedence:
+
+    1. `Application.get_env(:mydia, :metadata_relay_url)` — set directly in
+       config, or in tests to point the relay at a local `Bypass` instance.
+    2. The `METADATA_RELAY_URL` environment variable.
+    3. The default, the self-hosted relay at `https://relay.mydia.dev`.
 
   ## Examples
 

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -449,7 +449,8 @@ defmodule Mydia.Metadata do
       "https://relay.mydia.dev"
   """
   def metadata_relay_url do
-    System.get_env("METADATA_RELAY_URL", "https://relay.mydia.dev")
+    Application.get_env(:mydia, :metadata_relay_url) ||
+      System.get_env("METADATA_RELAY_URL", "https://relay.mydia.dev")
   end
 
   @doc """

--- a/lib/mydia/metadata.ex
+++ b/lib/mydia/metadata.ex
@@ -529,9 +529,11 @@ defmodule Mydia.Metadata do
   This provides a ready-to-use configuration for the metadata-relay service
   that doesn't require an API key.
 
-  The base URL can be configured via the METADATA_RELAY_URL environment variable,
-  defaulting to the self-hosted relay at relay.mydia.dev if not set. The metadata
-  language can be configured via the METADATA_LANGUAGE environment variable.
+  The base URL follows `metadata_relay_url/0`'s precedence: application env
+  (`:mydia, :metadata_relay_url`), then the METADATA_RELAY_URL environment
+  variable, then the default self-hosted relay at relay.mydia.dev. The
+  metadata language can be configured via the METADATA_LANGUAGE environment
+  variable.
 
   ## Examples
 
@@ -557,9 +559,11 @@ defmodule Mydia.Metadata do
   @doc """
   Gets the default TVDB relay configuration.
 
-  The base URL can be configured via the METADATA_RELAY_URL environment variable,
-  defaulting to the self-hosted relay at relay.mydia.dev if not set. The metadata
-  language can be configured via the METADATA_LANGUAGE environment variable.
+  The base URL follows `metadata_relay_url/0`'s precedence: application env
+  (`:mydia, :metadata_relay_url`), then the METADATA_RELAY_URL environment
+  variable, then the default self-hosted relay at relay.mydia.dev. The
+  metadata language can be configured via the METADATA_LANGUAGE environment
+  variable.
 
   ## Examples
 

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -322,11 +322,11 @@ defmodule MydiaWeb.DiscoverComponents do
               <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
             <% end %>
           </button>
-          <LibraryComponents.library_picker_menu
+          <LibraryComponents.library_picker_button
             libraries={@libraries}
-            event={@add_event}
             tmdb_id={@item.provider_id}
             media_type={@media_type}
+            title={@item.title}
           />
         </div>
       <% @item.in_library -> %>

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -185,9 +185,11 @@ defmodule MydiaWeb.DiscoverComponents do
   attr :current_user, :map, required: true
   attr :adding_ids, MapSet, default: MapSet.new()
   attr :requesting_item_id, :string, default: nil
-  # No libraries attr on purpose. The rail is a horizontal scroll container, so
-  # a library picker dropdown cannot escape it at any placement (#465). Rail
-  # cards add to the default library.
+  # The rail is a horizontal scroll container, so the old anchored dropdown
+  # could not escape it at any placement and was withdrawn here (#465). The
+  # picker is now a page-level dialog, which no ancestor's overflow can clip,
+  # so the attr is back. A host that passes nothing still gets no caret.
+  attr :libraries, :list, default: []
 
   attr :id, :string, default: "media-rail"
   attr :title, :string, default: "More like this"
@@ -264,6 +266,7 @@ defmodule MydiaWeb.DiscoverComponents do
             adding_ids={@adding_ids}
             current={Map.get(item, :current, false)}
             requesting_item_id={@requesting_item_id}
+            libraries={@libraries}
             on_select={@on_select}
             navigate={Map.get(item, :navigate)}
             add_event={@add_event}

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -610,4 +610,107 @@ defmodule MydiaWeb.LibraryComponents do
     </div>
     """
   end
+
+  @doc """
+  The caret half of the "Add to Library" split button.
+
+  Renders nothing when there are fewer than two candidates, so a
+  single-library install sees the plain add button exactly as before.
+
+  This is a real `<button>` rather than a `div[role="button"]` because it no
+  longer drives a CSS `:focus` dropdown. It pushes an event and the host opens
+  `library_picker_dialog/1`.
+  """
+  attr :libraries, :list, required: true
+  attr :tmdb_id, :any, default: nil
+  attr :media_type, :any, default: nil
+  attr :title, :string, default: ""
+
+  def library_picker_button(assigns) do
+    ~H"""
+    <button
+      :if={length(@libraries) > 1}
+      type="button"
+      data-test="library-picker-caret"
+      class="btn btn-primary btn-sm join-item px-2"
+      title="Choose a library"
+      phx-click="open_library_picker"
+      phx-value-tmdb_id={@tmdb_id}
+      phx-value-media_type={@media_type}
+      phx-value-title={@title}
+    >
+      <.icon name="hero-chevron-down" class="w-3 h-3" />
+    </button>
+    """
+  end
+
+  @doc """
+  The library chooser, rendered once per host LiveView.
+
+  An anchored dropdown inside the card cannot work here. The sidebar is
+  `z-40`, the mobile dock is `z-50` and the sticky header is `z-30`, so any
+  value a card claims either loses to the chrome or paints over it during
+  ordinary browsing, and a horizontal rail's `overflow` clips the menu
+  whatever its z-index. A page-level `.modal` is `position: fixed; inset: 0;
+  z-index: 999`, which sidesteps both problems.
+
+  The explicit `z-[1000]` puts the picker above the trending detail modal,
+  which is also a `.modal` at 999, without depending on which of the two
+  happens to come later in the DOM.
+
+  Libraries have no `name` column, only `path`, so each entry shows the
+  basename with the full path as secondary text.
+  """
+  attr :picker, :map,
+    default: nil,
+    doc: "nil, or %{tmdb_id:, media_type:, title:, libraries:} for the card being added"
+
+  attr :event, :string, default: "add_to_library"
+  attr :on_cancel, :string, default: "close_library_picker"
+
+  def library_picker_dialog(assigns) do
+    ~H"""
+    <dialog
+      id="library-picker-dialog"
+      class="modal z-[1000]"
+      open={@picker != nil}
+      phx-window-keydown={@picker && @on_cancel}
+      phx-key="Escape"
+    >
+      <div :if={@picker} class="modal-box max-w-md">
+        <h3 class="font-bold text-lg">Add to which library?</h3>
+        <p class="text-sm text-base-content/60 mt-1 truncate">{@picker.title}</p>
+
+        <ul class="menu w-full mt-4 p-0">
+          <li :for={library <- @picker.libraries}>
+            <button
+              type="button"
+              data-test="library-picker-option"
+              phx-click={@event}
+              phx-value-library_path_id={library.id}
+              phx-value-tmdb_id={@picker.tmdb_id}
+              phx-value-media_type={@picker.media_type}
+              class="flex-col items-start gap-0"
+            >
+              <span class="font-medium">{Path.basename(library.path)}</span>
+              <span class="text-xs text-base-content/50 truncate w-full">{library.path}</span>
+            </button>
+          </li>
+        </ul>
+
+        <div class="modal-action">
+          <button type="button" class="btn btn-ghost" phx-click={@on_cancel}>Cancel</button>
+        </div>
+      </div>
+
+      <%!-- A <dialog> opened through the `open` attribute rather than
+           showModal() gets no ::backdrop and no Escape handling, which is why
+           the keydown above and this click target both exist. Same approach
+           as TrendingDetailModal. --%>
+      <div class="modal-backdrop bg-black/70">
+        <button type="button" phx-click={@on_cancel}>close</button>
+      </div>
+    </dialog>
+    """
+  end
 end

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -554,64 +554,6 @@ defmodule MydiaWeb.LibraryComponents do
   end
 
   @doc """
-  A caret button opening a menu of target libraries.
-
-  Renders nothing when there are fewer than two candidates, so a single-library
-  install sees the plain add button exactly as before.
-
-  Libraries have no `name` column, only `path`, so each entry shows the
-  basename with the full path as secondary text.
-  """
-  attr :libraries, :list, required: true
-  attr :event, :string, required: true
-  attr :tmdb_id, :any, default: nil
-  attr :media_type, :any, default: nil
-  attr :selected_id, :string, default: nil
-
-  # A host that has no room below the caret opens the menu upward instead. An
-  # atom with `values:` rather than a pass-through class string, so a typo is a
-  # compile error and daisyUI class names stay inside this component.
-  attr :placement, :atom, default: :bottom, values: [:bottom, :top]
-
-  def library_picker_menu(assigns) do
-    ~H"""
-    <div
-      :if={length(@libraries) > 1}
-      class={["dropdown dropdown-end z-20", @placement == :top && "dropdown-top"]}
-    >
-      <div
-        tabindex="0"
-        role="button"
-        data-test="library-picker-caret"
-        class="btn btn-primary btn-sm join-item px-2"
-        title="Choose a library"
-      >
-        <.icon name="hero-chevron-down" class="w-3 h-3" />
-      </div>
-      <ul
-        tabindex="0"
-        class="dropdown-content menu p-2 shadow-lg bg-base-100 rounded-box w-60 border border-base-300"
-      >
-        <li class="menu-title text-xs">Add to library</li>
-        <li :for={library <- @libraries}>
-          <button
-            type="button"
-            phx-click={@event}
-            phx-value-library_path_id={library.id}
-            phx-value-tmdb_id={@tmdb_id}
-            phx-value-media_type={@media_type}
-            class="flex-col items-start gap-0"
-          >
-            <span class="font-medium">{Path.basename(library.path)}</span>
-            <span class="text-xs text-base-content/50 truncate w-full">{library.path}</span>
-          </button>
-        </li>
-      </ul>
-    </div>
-    """
-  end
-
-  @doc """
   The caret half of the "Add to Library" split button.
 
   Renders nothing when there are fewer than two candidates, so a

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -208,12 +208,11 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
                   >
                     <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
                   </button>
-                  <.library_picker_menu
+                  <.library_picker_button
                     libraries={@libraries}
-                    event="add_to_library"
                     tmdb_id={@item.provider_id}
                     media_type={media_type_string(@item)}
-                    placement={:top}
+                    title={@item.title}
                   />
                 </div>
               <% end %>

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -14,6 +14,9 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
         metadata={@selected_metadata}
         loading={@detail_loading}
         current_user={@current_user}
+        open={@selected_item != nil}
+        libraries={@libraries}
+        picker_open={@library_picker != nil}
       />
 
   ## Events
@@ -22,6 +25,21 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
 
   - `close_details` - When user closes the modal
   - `add_to_library` - When user clicks "Add to Library" (with tmdb_id and media_type params)
+
+  ## `picker_open`
+
+  Both host LiveViews also render `MydiaWeb.Components.LibraryComponents.library_picker_dialog/1`
+  once per page, at `z-[1000]`, above this modal's `z-999`. That dialog can be
+  opened from this modal's footer, and both dialogs bind `phx-window-keydown`
+  with `phx-key="Escape"` as a workaround for `open`-attribute dialogs getting
+  no native Escape handling. `phx-window-keydown` is not scoped by visual
+  stacking, so without `picker_open` a single Escape press would close both
+  layers at once instead of only the top one.
+
+  Every caller must pass `picker_open` (whether the library picker dialog is
+  currently open for this LiveView). There is deliberately no default — a
+  future caller that forgets to pass it fails loudly at render instead of
+  silently regressing Escape handling.
   """
   use MydiaWeb, :live_component
 
@@ -34,7 +52,7 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
       id={@id}
       class="modal"
       open={@open}
-      phx-window-keydown={@open && "close_details"}
+      phx-window-keydown={@open && not @picker_open && "close_details"}
       phx-key="Escape"
     >
       <%= if @open do %>

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -39,6 +39,7 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:detail_loading, false)
         |> assign(:movie_libraries, MediaAddHelpers.candidate_libraries(:movie))
         |> assign(:show_libraries, MediaAddHelpers.candidate_libraries(:tv_show))
+        |> assign(:library_picker, nil)
         |> load_dashboard_data()
       else
         socket
@@ -63,6 +64,7 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:detail_loading, false)
         |> assign(:movie_libraries, [])
         |> assign(:show_libraries, [])
+        |> assign(:library_picker, nil)
       end
 
     {:ok, socket}
@@ -130,11 +132,21 @@ defmodule MydiaWeb.DashboardLive.Index do
   end
 
   @impl true
+  def handle_event("open_library_picker", params, socket) do
+    {:noreply, MediaAddHelpers.put_library_picker(socket, params)}
+  end
+
+  def handle_event("close_library_picker", _params, socket) do
+    {:noreply, MediaAddHelpers.clear_library_picker(socket)}
+  end
+
   def handle_event(
         "add_to_library",
         %{"tmdb_id" => provider_id, "media_type" => media_type} = params,
         socket
       ) do
+    socket = MediaAddHelpers.clear_library_picker(socket)
+
     case parse_event_media_type(media_type) do
       {:ok, media_type_atom} ->
         # An impatient double-click sends the event twice before the first

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -375,6 +375,7 @@
         else: @movie_libraries
       )
     }
+    picker_open={@library_picker != nil}
   />
 
   <%!-- Rendered once per page rather than once per card. See

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -376,4 +376,8 @@
       )
     }
   />
+
+  <%!-- Rendered once per page rather than once per card. See
+        library_picker_dialog/1 for why an anchored menu cannot work here. --%>
+  <.library_picker_dialog picker={@library_picker} />
 </Layouts.app>

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -62,6 +62,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
       |> assign(:load_error, nil)
       |> assign(:detail_loading, false)
       |> assign(:libraries, [])
+      |> assign(:library_picker, nil)
       |> GridDensity.assign_current()
 
     {:ok, socket}
@@ -147,7 +148,8 @@ defmodule MydiaWeb.DiscoverLive.Index do
        |> assign(:selected_year, nil)
        |> assign(:min_rating, nil)
        |> assign(:sort_by, "popularity.desc")
-       |> assign(:libraries, MediaAddHelpers.candidate_libraries(:movie))}
+       |> assign(:libraries, MediaAddHelpers.candidate_libraries(:movie))
+       |> assign(:library_picker, nil)}
     end
   end
 
@@ -210,11 +212,21 @@ defmodule MydiaWeb.DiscoverLive.Index do
     end
   end
 
+  def handle_event("open_library_picker", params, socket) do
+    {:noreply, MediaAddHelpers.put_library_picker(socket, params)}
+  end
+
+  def handle_event("close_library_picker", _params, socket) do
+    {:noreply, MediaAddHelpers.clear_library_picker(socket)}
+  end
+
   def handle_event(
         "add_to_library",
         %{"tmdb_id" => provider_id, "media_type" => media_type} = params,
         socket
       ) do
+    socket = MediaAddHelpers.clear_library_picker(socket)
+
     case parse_event_media_type(media_type) do
       {:ok, media_type_atom} ->
         # An impatient double-click sends the event twice before the first

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -220,4 +220,8 @@
       />
     </:rail>
   </.live_component>
+
+  <%!-- Rendered once per page rather than once per card. See
+        library_picker_dialog/1 for why an anchored menu cannot work here. --%>
+  <.library_picker_dialog picker={@library_picker} />
 </Layouts.app>

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -207,6 +207,7 @@
     current_user={@current_user}
     open={@selected_item != nil}
     libraries={@libraries}
+    picker_open={@library_picker != nil}
   >
     <:rail>
       <.media_rail

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -217,6 +217,7 @@
         current_user={@current_user}
         adding_ids={@adding_item_ids}
         requesting_item_id={@requesting_item_id}
+        libraries={@libraries}
       />
     </:rail>
   </.live_component>

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -33,6 +33,44 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   end
 
   @doc """
+  Opens the library picker dialog for one card.
+
+  The candidate list is read here rather than carried from mount, so a library
+  added or unmonitored since the page loaded cannot show up as a stale option.
+
+  An unrecognised media type returns the socket untouched: the caret only ever
+  sends "movie" or "tv_show", so anything else is a forged event and opening a
+  dialog with an empty list would be worse than doing nothing.
+  """
+  @spec put_library_picker(Phoenix.LiveView.Socket.t(), map()) :: Phoenix.LiveView.Socket.t()
+  def put_library_picker(socket, %{"tmdb_id" => tmdb_id, "media_type" => media_type} = params) do
+    case media_type do
+      "movie" -> assign_library_picker(socket, tmdb_id, :movie, params["title"])
+      "tv_show" -> assign_library_picker(socket, tmdb_id, :tv_show, params["title"])
+      _ -> socket
+    end
+  end
+
+  def put_library_picker(socket, _params), do: socket
+
+  @doc """
+  Closes the library picker dialog.
+  """
+  @spec clear_library_picker(Phoenix.LiveView.Socket.t()) :: Phoenix.LiveView.Socket.t()
+  def clear_library_picker(socket) do
+    Phoenix.Component.assign(socket, :library_picker, nil)
+  end
+
+  defp assign_library_picker(socket, tmdb_id, media_type, title) do
+    Phoenix.Component.assign(socket, :library_picker, %{
+      tmdb_id: tmdb_id,
+      media_type: media_type,
+      title: title || "",
+      libraries: candidate_libraries(media_type)
+    })
+  end
+
+  @doc """
   Enriches a list of search result items with library status information.
 
   For each item, adds `:in_library`, `:monitored`, and `:id` fields

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -172,16 +172,24 @@ defmodule MydiaWeb.DiscoverComponentsTest do
   end
 
   # The rail is a horizontal scroll container (overflow-x-auto, which makes
-  # overflow-y compute to auto as well) and is one card tall, so a dropdown
-  # cannot escape it at any placement. The picker is withdrawn there rather
-  # than shipped broken: the plain add button still works against the default
-  # library. See #465.
-  describe "media_rail picker suppression" do
-    test "a rail renders the add button but never a library picker" do
+  # overflow-y compute to auto as well) and is one card tall. That is why the
+  # old anchored dropdown was withdrawn here: it could not escape the
+  # container at any placement. The picker is now a page-level dialog, which
+  # the container cannot clip, so rail cards can target a chosen library
+  # again. See #465.
+  describe "media_rail library picker" do
+    test "a rail card offers the picker when the host supplies several libraries" do
       html =
         rail(%{
           libraries: [%{id: "a", path: "/m/a"}, %{id: "b", path: "/m/b"}]
         })
+
+      assert html =~ "Add to Library"
+      assert html =~ "library-picker-caret"
+    end
+
+    test "a rail card offers no picker when the host supplies none" do
+      html = rail(%{})
 
       assert html =~ "Add to Library"
       refute html =~ "library-picker-caret"

--- a/test/mydia_web/components/library_components_test.exs
+++ b/test/mydia_web/components/library_components_test.exs
@@ -11,72 +11,111 @@ defmodule MydiaWeb.LibraryComponentsTest do
     for i <- 1..count, do: %{id: "lib-#{i}", path: "/media/movies-#{i}"}
   end
 
-  defp picker(overrides \\ %{}) do
+  defp picker_button(overrides \\ %{}) do
     assigns =
       Map.merge(
-        %{libraries: libraries(2), event: "add_to_library"},
+        %{
+          libraries: libraries(2),
+          tmdb_id: "693134",
+          media_type: :movie,
+          title: "Dune: Part Two"
+        },
         overrides
       )
 
-    render_component(&LibraryComponents.library_picker_menu/1, assigns)
+    render_component(&LibraryComponents.library_picker_button/1, assigns)
   end
 
-  describe "library_picker_menu/1" do
+  defp picker_dialog(overrides \\ %{}) do
+    assigns =
+      Map.merge(
+        %{
+          picker: %{
+            tmdb_id: "693134",
+            media_type: :movie,
+            title: "Dune: Part Two",
+            libraries: libraries(2)
+          }
+        },
+        overrides
+      )
+
+    render_component(&LibraryComponents.library_picker_dialog/1, assigns)
+  end
+
+  describe "library_picker_button/1" do
     test "renders nothing when there is only one candidate library" do
-      html = picker(%{libraries: libraries(1)})
-
-      refute html =~ "library-picker-caret"
+      refute picker_button(%{libraries: libraries(1)}) =~ "library-picker-caret"
     end
 
-    test "renders a caret and one entry per library when there are several" do
-      html = picker()
-
-      assert html =~ ~s(data-test="library-picker-caret")
-      assert html =~ "movies-1"
-      assert html =~ "movies-2"
-    end
-
-    # Regression for #465: the menu sat at z-[1] while the trending card's
-    # rating and in-library badges sit at z-10, so even the unclipped sliver
-    # rendered underneath them.
-    #
-    # daisyUI's `.join > :where(:focus, :has(:focus))` rule stamps z-index: 1
-    # on the `.dropdown` wrapper the moment the caret is focused (the same
-    # condition that opens the menu), which creates a stacking context on
-    # that `position: relative` div. A z-index on the inner `<ul>` is then
-    # confined below that context regardless of its value, so the wrapper
-    # itself must carry the z-index, not the menu list.
-    test "the menu stacks above the trending card badges" do
-      html = picker()
+    test "renders a real button that opens the dialog, carrying the card's identity" do
+      html = picker_button()
       document = LazyHTML.from_fragment(html)
 
-      # The `.dropdown` div is the root node of this component's output, so
-      # filter/2 (root nodes only) is correct here.
-      wrapper_class =
-        document
-        |> LazyHTML.filter("div.dropdown")
-        |> LazyHTML.attribute("class")
-        |> List.first()
+      caret = LazyHTML.query(document, ~s(button[data-test="library-picker-caret"]))
 
-      assert wrapper_class =~ "z-20"
+      assert LazyHTML.attribute(caret, "phx-click") == ["open_library_picker"]
+      assert LazyHTML.attribute(caret, "phx-value-tmdb_id") == ["693134"]
+      assert LazyHTML.attribute(caret, "phx-value-media_type") == ["movie"]
+      assert LazyHTML.attribute(caret, "phx-value-title") == ["Dune: Part Two"]
+    end
+  end
 
-      # The `<ul>` is nested inside the wrapper, so it needs query/2, not
-      # filter/2, to be found at all.
-      menu_class =
-        document
-        |> LazyHTML.query("ul.dropdown-content")
-        |> LazyHTML.attribute("class")
-        |> List.first()
+  describe "library_picker_dialog/1" do
+    test "renders a closed dialog when no picker is open" do
+      html = render_component(&LibraryComponents.library_picker_dialog/1, %{picker: nil})
+      document = LazyHTML.from_fragment(html)
 
-      refute menu_class =~ "z-20"
+      dialog = LazyHTML.filter(document, "dialog")
+
+      assert LazyHTML.attribute(dialog, "open") == []
+      refute html =~ "library-picker-option"
     end
 
-    test "opens downward by default" do
-      refute picker() =~ "dropdown-top"
+    # The dialog is a page-level overlay rather than a card descendant, which
+    # is the whole point: the sidebar is z-40 and the mobile dock is z-50, so
+    # no value a card can claim keeps the old anchored menu visible. daisyUI's
+    # .modal is z-999 and the picker takes 1000 so it also wins against the
+    # trending detail modal without depending on DOM order.
+    test "the open dialog sits above every other layer" do
+      document = LazyHTML.from_fragment(picker_dialog())
+
+      dialog = LazyHTML.filter(document, "dialog")
+      [class] = LazyHTML.attribute(dialog, "class")
+
+      assert LazyHTML.attribute(dialog, "open") == [""]
+      assert class =~ "modal"
+      assert class =~ "z-[1000]"
     end
 
-    test "opens upward when placement is :top" do
-      assert picker(%{placement: :top}) =~ "dropdown-top"
+    test "lists every candidate library with the values the add handler needs" do
+      document = LazyHTML.from_fragment(picker_dialog())
+
+      options = LazyHTML.query(document, ~s(button[data-test="library-picker-option"]))
+
+      assert LazyHTML.attribute(options, "phx-click") == ["add_to_library", "add_to_library"]
+      assert LazyHTML.attribute(options, "phx-value-library_path_id") == ["lib-1", "lib-2"]
+      assert LazyHTML.attribute(options, "phx-value-tmdb_id") == ["693134", "693134"]
+      assert LazyHTML.attribute(options, "phx-value-media_type") == ["movie", "movie"]
+    end
+
+    test "shows the basename with the full path underneath" do
+      html = picker_dialog()
+
+      assert html =~ "movies-1"
+      assert html =~ "/media/movies-1"
+    end
+
+    test "names the title being added" do
+      assert picker_dialog() =~ "Dune: Part Two"
+    end
+
+    test "offers cancel and a backdrop that both close the dialog" do
+      document = LazyHTML.from_fragment(picker_dialog())
+
+      closers = LazyHTML.query(document, ~s([phx-click="close_library_picker"]))
+
+      assert Enum.count(closers) >= 2
     end
   end
 

--- a/test/mydia_web/components/library_components_test.exs
+++ b/test/mydia_web/components/library_components_test.exs
@@ -105,10 +105,20 @@ defmodule MydiaWeb.LibraryComponentsTest do
     end
 
     test "shows the basename with the full path underneath" do
-      html = picker_dialog()
+      document = LazyHTML.from_fragment(picker_dialog())
 
-      assert html =~ "movies-1"
-      assert html =~ "/media/movies-1"
+      # `LazyHTML.text/1` on a multi-node match concatenates every node's
+      # text, so map over the spans individually to keep the basename and
+      # the full path as separate assertions. A substring check here
+      # (`html =~ "movies-1"`) would pass even if the basename span vanished,
+      # since "/media/movies-1" itself contains "movies-1".
+      spans =
+        document
+        |> LazyHTML.query(~s(button[data-test="library-picker-option"] span))
+        |> Enum.map(&LazyHTML.text/1)
+
+      assert Enum.at(spans, 0) == "movies-1"
+      assert Enum.at(spans, 1) == "/media/movies-1"
     end
 
     test "names the title being added" do

--- a/test/mydia_web/components/library_components_test.exs
+++ b/test/mydia_web/components/library_components_test.exs
@@ -68,6 +68,11 @@ defmodule MydiaWeb.LibraryComponentsTest do
 
       dialog = LazyHTML.filter(document, "dialog")
 
+      # Guard the cardinality first: `LazyHTML.attribute/2` on a zero-node
+      # match returns `[]` same as a genuinely closed dialog's missing `open`
+      # attribute, so without this the assertion below would pass even if the
+      # "dialog" selector matched nothing at all.
+      assert Enum.count(dialog) == 1
       assert LazyHTML.attribute(dialog, "open") == []
       refute html =~ "library-picker-option"
     end

--- a/test/mydia_web/features/library_picker_test.exs
+++ b/test/mydia_web/features/library_picker_test.exs
@@ -1,0 +1,238 @@
+defmodule MydiaWeb.Features.LibraryPickerTest do
+  @moduledoc """
+  Browser regression for #465, the library picker being covered and clipped.
+
+  Three earlier fixes moved a z-index around and the unit test asserted that
+  the class was present, which it always was. What the class could not show is
+  that the sidebar is `z-40`, the mobile dock is `z-50` and the sticky header
+  is `z-30`, so the `z-20` menu lost to all of them, ran off the left edge on
+  first-column cards and hung below the fold on lower rows.
+
+  This test asks the browser what actually paints on top, across the whole
+  picker rectangle, at a desktop and a mobile viewport.
+  """
+
+  use MydiaWeb.FeatureCase, async: false
+
+  @moduletag :feature
+
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Metadata.Cache
+
+  # elementFromPoint answers the exact question the bug is about: given a
+  # point inside the picker, which element does the user's click land on? Any
+  # answer outside the dialog is something painting over it.
+  @probe """
+  const box = document.querySelector('#library-picker-dialog .modal-box');
+  if (!box) { return ['no dialog rendered']; }
+  const r = box.getBoundingClientRect();
+  const vw = document.documentElement.clientWidth;
+  const vh = document.documentElement.clientHeight;
+  const problems = [];
+  if (r.width < 1 || r.height < 1) { return ['dialog has no size']; }
+  if (r.left < 0) problems.push('off-screen left by ' + Math.round(-r.left));
+  if (r.top < 0) problems.push('off-screen top by ' + Math.round(-r.top));
+  if (r.right > vw) problems.push('off-screen right by ' + Math.round(r.right - vw));
+  if (r.bottom > vh) problems.push('off-screen bottom by ' + Math.round(r.bottom - vh));
+  const seen = {};
+  for (let x = r.left + 3; x < r.right - 3; x += 10) {
+    for (let y = r.top + 3; y < r.bottom - 3; y += 10) {
+      const t = document.elementFromPoint(x, y);
+      if (t && !box.contains(t) && t !== box) {
+        const key = t.tagName.toLowerCase() + (t.id ? '#' + t.id : '');
+        if (!seen[key]) { seen[key] = true; problems.push('covered by ' + key); }
+      }
+    }
+  }
+  return problems;
+  """
+
+  # The probe above can never fail on its own: daisyUI centers .modal-box
+  # within the fixed, full-viewport .modal, so at these two content sizes
+  # the box's own rectangle never reaches into the sidebar's or dock's
+  # screen space, regardless of the dialog's z-index (that is Step 4's
+  # finding for this test). What actually competes with the chrome is the
+  # full-viewport .modal LAYER itself, which covers the sidebar and dock
+  # entirely and, per daisyUI, is pointer-events: auto while open. This
+  # probe hit-tests the CENTRE of a given chrome element and asserts the
+  # picker dialog (or one of its descendants, e.g. the modal-backdrop) wins
+  # there instead of the chrome — the comparison a z-index downgrade can
+  # actually break.
+  @chrome_probe """
+  const chromeSelector = arguments[0];
+  const dialog = document.querySelector('#library-picker-dialog');
+  if (!dialog) { return ['no dialog rendered']; }
+  const chromeEl = document.querySelector(chromeSelector);
+  if (!chromeEl) { return ['chrome element not found: ' + chromeSelector]; }
+  const r = chromeEl.getBoundingClientRect();
+  if (r.width < 1 || r.height < 1) { return ['chrome element has no size: ' + chromeSelector]; }
+  const cx = r.left + r.width / 2;
+  const cy = r.top + r.height / 2;
+  const winner = document.elementFromPoint(cx, cy);
+  if (!winner) { return ['nothing returned by elementFromPoint at chrome centre']; }
+  if (winner === dialog || dialog.contains(winner)) { return []; }
+  const key = winner.tagName.toLowerCase() + (winner.id ? '#' + winner.id : '');
+  return ['chrome centre (' + chromeSelector + ') is won by ' + key + ' instead of the picker dialog'];
+  """
+
+  setup do
+    bypass = Bypass.open()
+
+    Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+    Cache.clear()
+
+    on_exit(fn ->
+      Application.delete_env(:mydia, :metadata_relay_url)
+      Cache.clear()
+    end)
+
+    # Bypass returns JSON only if the content type says so; Req leaves the
+    # body as a raw string otherwise and the relay parser then sees no
+    # "results" key and yields an empty grid.
+    Bypass.stub(bypass, "GET", "/tmdb/movies/trending", fn conn ->
+      results =
+        for i <- 1..12 do
+          %{
+            "id" => 900_000 + i,
+            "title" => "Fixture Movie #{i}",
+            "release_date" => "2026-01-01",
+            "vote_average" => 8.0,
+            "poster_path" => nil,
+            "overview" => ""
+          }
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!(%{"page" => 1, "total_pages" => 1, "results" => results})
+      )
+    end)
+
+    # DiscoverLive's genre filter calls Relay.fetch_genres/2, which builds
+    # "/tmdb/genre/movie" (singular, reversed word order from what it looks
+    # like) rather than "/tmdb/movies/genres". Left unstubbed, every request
+    # 500s and Req's `retry: :transient` step retries it three times with
+    # backoff inside the LiveView's synchronous handle_info, which starves
+    # the process long enough for the picker click to miss Wallaby's wait
+    # window.
+    Bypass.stub(bypass, "GET", "/tmdb/genre/movie", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(%{"genres" => []}))
+    end)
+
+    # login_as_admin/1 signs in through the real login form, and the server
+    # redirects to "/" before we ever navigate to /discover. DashboardLive's
+    # mount fires both a trending-movies and a trending-tv load, so the tv
+    # endpoint needs a stub too or the same retry storm happens there instead.
+    Bypass.stub(bypass, "GET", "/tmdb/tv/trending", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(%{"page" => 1, "total_pages" => 1, "results" => []}))
+    end)
+
+    # "choosing a library closes the picker" clicks the first card's
+    # library-picker-option, i.e. id 900001, the first result above. The
+    # dialog closes synchronously, but
+    # MediaAddHelpers.handle_add_media_to_library/5 then fetches that movie's
+    # full TMDB details before writing the media_items row, so that also
+    # needs a stub or the same retry storm follows it. A literal path rather
+    # than a ":id" wildcard, so it cannot also swallow "/tmdb/movies/trending"
+    # and break the stub above.
+    Bypass.stub(bypass, "GET", "/tmdb/movies/900001", fn conn ->
+      body = %{
+        "id" => 900_001,
+        "title" => "Fixture Movie 1",
+        "release_date" => "2026-01-01",
+        "overview" => "",
+        "credits" => %{"cast" => [], "crew" => []},
+        "genres" => []
+      }
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    # The caret only renders with two or more monitored candidates.
+    library_path_fixture(%{path: "/media/picker-a", type: "movies"})
+    library_path_fixture(%{path: "/media/picker-b", type: "movies"})
+
+    :ok
+  end
+
+  # The first card is the leftmost in the top row, which is the geometry that
+  # failed: the old menu opened left into the sidebar and, on mobile, straight
+  # off the edge of the viewport.
+  defp open_first_picker(session) do
+    session
+    |> visit("/discover")
+    |> wait_for_liveview()
+    |> assert_has(Query.css(~s([data-test="library-picker-caret"]), minimum: 1))
+    # Wallaby's native click on this button produces zero DOM click events at
+    # the mobile viewport (confirmed with a document-level click listener: an
+    # empty log after the "click" returned), while it is reliable at the
+    # desktop viewport. js_click/2 is this codebase's existing workaround for
+    # exactly that headless-Chrome unreliability on phx-click buttons (see
+    # guest_test.exs), so it is used here instead of Query-based click.
+    |> js_click(~s([data-test="library-picker-caret"]))
+    |> assert_has(Query.css(~s([data-test="library-picker-option"]), minimum: 2))
+  end
+
+  defp probe(session) do
+    execute_script(session, @probe, [], fn problems -> send(self(), {:probe, problems}) end)
+
+    assert_receive {:probe, problems}, 5_000
+    problems
+  end
+
+  defp chrome_probe(session, chrome_selector) do
+    execute_script(session, @chrome_probe, [chrome_selector], fn problems ->
+      send(self(), {:chrome_probe, problems})
+    end)
+
+    assert_receive {:chrome_probe, problems}, 5_000
+    problems
+  end
+
+  @tag :feature
+  test "the picker is fully visible and unobstructed on a desktop viewport", %{session: session} do
+    session
+    |> login_as_admin()
+    |> resize_window(1400, 1000)
+    |> open_first_picker()
+
+    assert probe(session) == []
+    # The sidebar is always visible at this width (lg:drawer-open), so its
+    # centre is a real point of contention with the full-viewport dialog
+    # layer, not just its centered box.
+    assert chrome_probe(session, ".drawer-side") == []
+  end
+
+  @tag :feature
+  test "the picker is fully visible and unobstructed on a mobile viewport", %{session: session} do
+    session
+    |> login_as_admin()
+    |> resize_window(390, 844)
+    |> open_first_picker()
+
+    assert probe(session) == []
+    # The sidebar drawer is closed (and not hit-testable) by default at this
+    # width, but the mobile dock is a real, painted fixed element here, so
+    # it is the chrome that actually contends with the dialog layer.
+    assert chrome_probe(session, "#mobile-dock") == []
+  end
+
+  @tag :feature
+  test "choosing a library closes the picker", %{session: session} do
+    session
+    |> login_as_admin()
+    |> resize_window(1400, 1000)
+    |> open_first_picker()
+    |> click(Query.css(~s([data-test="library-picker-option"]), count: :any, at: 0))
+    |> refute_has(Query.css(~s([data-test="library-picker-option"])))
+  end
+end

--- a/test/mydia_web/features/library_picker_test.exs
+++ b/test/mydia_web/features/library_picker_test.exs
@@ -79,11 +79,21 @@ defmodule MydiaWeb.Features.LibraryPickerTest do
   setup do
     bypass = Bypass.open()
 
+    # Capture whatever was configured before this test so on_exit can put it
+    # back rather than deleting the key outright. metadata_relay_url/0 now
+    # prefers this application env key over METADATA_RELAY_URL, so a bare
+    # delete_env would erase a real config value for every test that runs
+    # afterwards in this VM if one is ever set.
+    previous_metadata_relay_url = Application.get_env(:mydia, :metadata_relay_url)
     Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
     Cache.clear()
 
     on_exit(fn ->
-      Application.delete_env(:mydia, :metadata_relay_url)
+      case previous_metadata_relay_url do
+        nil -> Application.delete_env(:mydia, :metadata_relay_url)
+        value -> Application.put_env(:mydia, :metadata_relay_url, value)
+      end
+
       Cache.clear()
     end)
 

--- a/test/mydia_web/live/components/trending_detail_modal_test.exs
+++ b/test/mydia_web/live/components/trending_detail_modal_test.exs
@@ -36,8 +36,9 @@ defmodule MydiaWeb.Components.TrendingDetailModalTest do
   # `<%= if @open do %>` (trending_detail_modal.ex:40), so omitting it renders
   # an empty dialog and every assertion below fails for the wrong reason.
   # `rail: []` is an undeclared slot the template calls `render_slot/1` on;
-  # without it the render raises KeyError.
-  defp render_modal(item, metadata) do
+  # without it the render raises KeyError. `picker_open` has no default (see
+  # the moduledoc) so it must always be passed too.
+  defp render_modal(item, metadata, opts \\ []) do
     render_component(TrendingDetailModal,
       id: "trending-detail-modal",
       open: true,
@@ -46,7 +47,8 @@ defmodule MydiaWeb.Components.TrendingDetailModalTest do
       loading: false,
       current_user: %{id: Ecto.UUID.generate(), role: "admin", username: "admin"},
       libraries: [],
-      rail: []
+      rail: [],
+      picker_open: Keyword.get(opts, :picker_open, false)
     )
   end
 
@@ -67,5 +69,35 @@ defmodule MydiaWeb.Components.TrendingDetailModalTest do
     html = render_modal(item(%{media_type: :movie}), metadata(%{number_of_seasons: nil}))
 
     refute html =~ ~r/\d+ seasons?/
+  end
+
+  describe "Escape keydown binding" do
+    # Both this modal and the library picker dialog it can open
+    # (MydiaWeb.Components.LibraryComponents.library_picker_dialog/1) bind
+    # `phx-window-keydown` with `phx-key="Escape"` as a workaround for
+    # `open`-attribute dialogs getting no native Escape handling. That
+    # binding attaches per DOM node rather than by visual stacking order, so
+    # without `picker_open` a single Escape press would fire both handlers
+    # in the same LiveView process and close this modal out from under the
+    # picker instead of only the top layer.
+    test "binds close_details on Escape when no other dialog is on top" do
+      html = render_modal(item(), metadata(%{number_of_seasons: 3}), picker_open: false)
+      document = LazyHTML.from_fragment(html)
+
+      dialog = LazyHTML.filter(document, "dialog")
+
+      assert Enum.count(dialog) == 1
+      assert LazyHTML.attribute(dialog, "phx-window-keydown") == ["close_details"]
+    end
+
+    test "does not bind Escape while the library picker dialog is open" do
+      html = render_modal(item(), metadata(%{number_of_seasons: 3}), picker_open: true)
+      document = LazyHTML.from_fragment(html)
+
+      dialog = LazyHTML.filter(document, "dialog")
+
+      assert Enum.count(dialog) == 1
+      assert LazyHTML.attribute(dialog, "phx-window-keydown") == []
+    end
   end
 end

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -346,4 +346,60 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
       |> Plug.Conn.resp(200, Jason.encode!(body))
     end)
   end
+
+  describe "library picker assigns" do
+    defp socket do
+      %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}, library_picker: nil}}
+    end
+
+    test "opening reads the candidate libraries at open time" do
+      library_path_fixture(%{path: "/media/picker-a", type: "movies"})
+      library_path_fixture(%{path: "/media/picker-b", type: "movies"})
+
+      updated =
+        MediaAddHelpers.put_library_picker(socket(), %{
+          "tmdb_id" => "693134",
+          "media_type" => "movie",
+          "title" => "Dune: Part Two"
+        })
+
+      picker = updated.assigns.library_picker
+
+      assert picker.tmdb_id == "693134"
+      assert picker.media_type == :movie
+      assert picker.title == "Dune: Part Two"
+      assert length(picker.libraries) == 2
+    end
+
+    test "a missing title becomes an empty string rather than nil" do
+      library_path_fixture(%{path: "/media/picker-c", type: "movies"})
+      library_path_fixture(%{path: "/media/picker-d", type: "movies"})
+
+      updated =
+        MediaAddHelpers.put_library_picker(socket(), %{
+          "tmdb_id" => "1",
+          "media_type" => "movie"
+        })
+
+      assert updated.assigns.library_picker.title == ""
+    end
+
+    test "an unrecognised media type opens nothing" do
+      updated =
+        MediaAddHelpers.put_library_picker(socket(), %{
+          "tmdb_id" => "1",
+          "media_type" => "podcast"
+        })
+
+      assert updated.assigns.library_picker == nil
+    end
+
+    test "clearing closes the dialog" do
+      opened = %Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{}, library_picker: %{tmdb_id: "1"}}
+      }
+
+      assert MediaAddHelpers.clear_library_picker(opened).assigns.library_picker == nil
+    end
+  end
 end


### PR DESCRIPTION
The library picker menu on Discover was covered by the sidebar (`z-40`) and the
mobile dock (`z-50`), ran 34 to 67px off the left edge on first-column cards
below the `lg` breakpoint, and hung up to 191px below the fold on lower rows.
Measured in a real browser on `v0.14.0-beta.1` across seven viewport widths;
every one had at least four of those problems.

Three previous fixes (#465) each moved a z-index. The card cannot win that race:
the layout already occupies 30, 40 and 50, and a card that climbed above them
would paint over the sidebar during ordinary browsing. So the picker now leaves
the stacking hierarchy instead of climbing it. It is a single page-level
`<dialog class="modal">` rendered once per host LiveView, which daisyUI styles
`position: fixed; inset: 0; z-index: 999`, plus an explicit `z-[1000]` so it also
beats the trending detail modal without depending on DOM order.

Because it is no longer a card descendant, no ancestor `overflow` can clip it,
so `media_rail/1` gets its `:libraries` attribute back and rail cards can target
a chosen library again instead of always the default.

## On the test

The old regression test asserted the string `z-20` appeared in the markup. It
stayed green through all four rounds of this bug, including on the build where
the picker was unreadable at every viewport, because a class assertion cannot
see that the sidebar outranks it.

It is replaced by a Wallaby test that asks the browser, via
`document.elementFromPoint`, what actually paints over the picker, at 1400x1000
and 390x844.

That test was itself falsified before being trusted: setting the dialog back to
`z-20` must make it fail. The first version did not fail, because it probed the
centred `.modal-box`, which daisyUI keeps clear of the chrome at any z-index. It
now probes the full-viewport dialog layer, and under `z-20` the desktop test
fails naming a sidebar link and the mobile test fails naming `nav#mobile-dock`.

## Notes

- `Mydia.Metadata.metadata_relay_url/0` now prefers
  `Application.get_env(:mydia, :metadata_relay_url)` before the env var. This
  matches how `remote_access.ex` and `subtitles/client/metadata_relay.ex`
  already resolved the same key, and lets the browser test point the relay at
  Bypass without mutating process-global env.
- `TrendingDetailModal` stops binding Escape while the picker is open, so one
  Escape press closes only the top layer. Both dialogs use the `open` attribute
  rather than `showModal()`, so neither gets native Escape handling.

Refs #465


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a library picker dialog for selecting where movies and TV shows are added.
  - The picker displays available libraries, media titles, and library paths.
  - Added support for opening and closing the picker across Dashboard and Discover views.
  - Improved picker visibility and layering on desktop and mobile layouts.

- **Bug Fixes**
  - Prevented detail modals from closing when the library picker is active.
  - Added configurable relay URL resolution with configuration and environment fallbacks.

- **Tests**
  - Added coverage for picker behavior, responsiveness, selection, and dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->