### PR TITLE
Honour the chosen library on the detail page rails

### DIFF
--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -283,15 +283,46 @@ defmodule MydiaWeb.DashboardLive.Index do
   end
 
   def handle_info({:add_media_to_library, provider_id, media_type, library_path_id}, socket) do
-    # Comes from client params, so a blank string is possible. "" is truthy in
-    # Elixir and would reach the changeset as library_path_id: "", failing the
-    # foreign key instead of falling back to normal resolution.
-    opts =
-      case library_path_id do
-        id when is_binary(id) and id != "" -> [library_path_id: id]
-        _ -> []
-      end
+    case MediaAddHelpers.library_path_opts(library_path_id, media_type) do
+      {:error, :unknown_library} ->
+        {:noreply,
+         socket
+         |> clear_adding(provider_id)
+         |> put_flash(:error, "That library is no longer available. Nothing was added.")}
 
+      {:ok, opts} ->
+        add_with_opts(provider_id, media_type, opts, socket)
+    end
+  end
+
+  def handle_info({:request_media, provider_id, media_type}, socket) do
+    trending = socket.assigns.trending_movies ++ socket.assigns.trending_tv
+
+    case Enum.find(trending, &(to_string(&1.provider_id) == provider_id)) do
+      nil ->
+        {:noreply, assign(socket, :requesting_item_id, nil)}
+
+      item ->
+        {:noreply, submit_request(socket, item, media_type)}
+    end
+  end
+
+  # Grab outcomes are broadcast on the "downloads" topic and handled by
+  # MediaLive.Show, which owns the manual-search UI. Ignore them quietly here
+  # so the catch-all below keeps meaning "genuinely unexpected message".
+  def handle_info({:grab_completed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_failed, _payload}, socket), do: {:noreply, socket}
+  def handle_info({:grab_duplicate, _payload}, socket), do: {:noreply, socket}
+
+  def handle_info(msg, socket) do
+    # Catch-all for unhandled messages to prevent crashes
+    Logger.warning("Unhandled message in DashboardLive.Index: #{inspect(msg)}")
+    {:noreply, socket}
+  end
+
+  ## Private Helpers
+
+  defp add_with_opts(provider_id, media_type, opts, socket) do
     case MediaAddHelpers.handle_add_media_to_library(
            provider_id,
            media_type,
@@ -354,33 +385,6 @@ defmodule MydiaWeb.DashboardLive.Index do
          |> put_flash(:error, "Failed to fetch metadata: #{inspect(reason)}")}
     end
   end
-
-  def handle_info({:request_media, provider_id, media_type}, socket) do
-    trending = socket.assigns.trending_movies ++ socket.assigns.trending_tv
-
-    case Enum.find(trending, &(to_string(&1.provider_id) == provider_id)) do
-      nil ->
-        {:noreply, assign(socket, :requesting_item_id, nil)}
-
-      item ->
-        {:noreply, submit_request(socket, item, media_type)}
-    end
-  end
-
-  # Grab outcomes are broadcast on the "downloads" topic and handled by
-  # MediaLive.Show, which owns the manual-search UI. Ignore them quietly here
-  # so the catch-all below keeps meaning "genuinely unexpected message".
-  def handle_info({:grab_completed, _payload}, socket), do: {:noreply, socket}
-  def handle_info({:grab_failed, _payload}, socket), do: {:noreply, socket}
-  def handle_info({:grab_duplicate, _payload}, socket), do: {:noreply, socket}
-
-  def handle_info(msg, socket) do
-    # Catch-all for unhandled messages to prevent crashes
-    Logger.warning("Unhandled message in DashboardLive.Index: #{inspect(msg)}")
-    {:noreply, socket}
-  end
-
-  ## Private Helpers
 
   # Four completion clauses all retire the same id. A MapSet rather than a
   # single id so a second add cannot blank the first one's spinner (#459).

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -399,15 +399,36 @@ defmodule MydiaWeb.DiscoverLive.Index do
   end
 
   def handle_info({:add_media_to_library, provider_id, media_type, library_path_id}, socket) do
-    # Comes from client params, so a blank string is possible. "" is truthy in
-    # Elixir and would reach the changeset as library_path_id: "", failing the
-    # foreign key instead of falling back to normal resolution.
-    opts =
-      case library_path_id do
-        id when is_binary(id) and id != "" -> [library_path_id: id]
-        _ -> []
-      end
+    case MediaAddHelpers.library_path_opts(library_path_id, media_type) do
+      {:error, :unknown_library} ->
+        {:noreply,
+         socket
+         |> clear_adding(provider_id)
+         |> put_flash(:error, "That library is no longer available. Nothing was added.")}
 
+      {:ok, opts} ->
+        add_with_opts(provider_id, media_type, opts, socket)
+    end
+  end
+
+  def handle_info({:request_media, provider_id, media_type}, socket) do
+    # Also resolves against the recommendations rail. A rail title is not in
+    # `items`, so searching only that list made a guest's Request click from
+    # inside the modal silently do nothing.
+    case find_selectable_item(
+           socket.assigns.items,
+           socket.assigns.selected_recommendations,
+           provider_id
+         ) do
+      nil ->
+        {:noreply, assign(socket, :requesting_item_id, nil)}
+
+      item ->
+        {:noreply, submit_request(socket, item, media_type)}
+    end
+  end
+
+  defp add_with_opts(provider_id, media_type, opts, socket) do
     case MediaAddHelpers.handle_add_media_to_library(
            provider_id,
            media_type,
@@ -465,23 +486,6 @@ defmodule MydiaWeb.DiscoverLive.Index do
          socket
          |> clear_adding(provider_id)
          |> put_flash(:error, "Failed to fetch metadata: #{inspect(reason)}")}
-    end
-  end
-
-  def handle_info({:request_media, provider_id, media_type}, socket) do
-    # Also resolves against the recommendations rail. A rail title is not in
-    # `items`, so searching only that list made a guest's Request click from
-    # inside the modal silently do nothing.
-    case find_selectable_item(
-           socket.assigns.items,
-           socket.assigns.selected_recommendations,
-           provider_id
-         ) do
-      nil ->
-        {:noreply, assign(socket, :requesting_item_id, nil)}
-
-      item ->
-        {:noreply, submit_request(socket, item, media_type)}
     end
   end
 

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -79,6 +79,13 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   worth telling the user about, and #458 was filed because a silently ignored
   choice is worse than no picker at all.
 
+  Only `nil` and `""` mean "no choice was made". `nil` is what an ordinary
+  "Add to Library" click sends, since the form has no picker to include a
+  `library_path_id` at all; `""` is the picker's own placeholder option. Any
+  other shape, including a non-binary value such as a map, list, or integer,
+  is a malformed target and is rejected rather than silently treated as "no
+  choice".
+
   The blank-string clause is the reason this function exists. `""` is truthy in
   Elixir, so without it the value reaches the changeset as
   `library_path_id: ""` and fails the foreign key rather than falling back to
@@ -92,6 +99,9 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
           {:ok, keyword()} | {:error, :unknown_library}
   def library_path_opts(library_path_id, media_type)
 
+  def library_path_opts(nil, _media_type), do: {:ok, []}
+  def library_path_opts("", _media_type), do: {:ok, []}
+
   def library_path_opts(id, media_type) when is_binary(id) and id != "" do
     if Enum.any?(candidate_libraries(media_type), &(to_string(&1.id) == id)) do
       {:ok, [library_path_id: id]}
@@ -100,7 +110,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
     end
   end
 
-  def library_path_opts(_library_path_id, _media_type), do: {:ok, []}
+  def library_path_opts(_library_path_id, _media_type), do: {:error, :unknown_library}
 
   @doc """
   Enriches a list of search result items with library status information.

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -71,6 +71,38 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   end
 
   @doc """
+  Add options for a client-supplied `library_path_id`.
+
+  Three cases have to stay distinct, which is why this returns a tagged tuple
+  rather than a bare keyword list: no choice was made, a valid choice was made,
+  or a choice was made that this server will not honour. Only the third is
+  worth telling the user about, and #458 was filed because a silently ignored
+  choice is worse than no picker at all.
+
+  The blank-string clause is the reason this function exists. `""` is truthy in
+  Elixir, so without it the value reaches the changeset as
+  `library_path_id: ""` and fails the foreign key rather than falling back to
+  normal target resolution.
+
+  The candidate check is authorization, not convenience. This value arrives in
+  event params, so without it a crafted event can name any `library_paths` row,
+  including one of the wrong type for the media being added.
+  """
+  @spec library_path_opts(term(), :movie | :tv_show) ::
+          {:ok, keyword()} | {:error, :unknown_library}
+  def library_path_opts(library_path_id, media_type)
+
+  def library_path_opts(id, media_type) when is_binary(id) and id != "" do
+    if Enum.any?(candidate_libraries(media_type), &(to_string(&1.id) == id)) do
+      {:ok, [library_path_id: id]}
+    else
+      {:error, :unknown_library}
+    end
+  end
+
+  def library_path_opts(_library_path_id, _media_type), do: {:ok, []}
+
+  @doc """
   Enriches a list of search result items with library status information.
 
   For each item, adds `:in_library`, `:monitored`, and `:id` fields

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -18,6 +18,7 @@ defmodule MydiaWeb.MediaLive.Show do
   alias MydiaWeb.MediaLive.Show.FranchiseEvents
   alias MydiaWeb.MediaLive.Show.RecommendationEvents
   alias MydiaWeb.MediaLive.Show.RecommendationComponents
+  alias MydiaWeb.MediaLive.Show.LibraryPickerEvents
 
   # Import helper modules
   import MydiaWeb.MediaLive.Show.Formatters
@@ -144,6 +145,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:adding_recommendation_tmdb_ids, MapSet.new())
      |> assign(:requesting_recommendation_id, nil)
      |> assign_new(:metadata_config, fn -> Mydia.Metadata.default_relay_config() end)
+     |> assign_new(:library_picker, fn -> nil end)
      |> assign(
        :can_create_media,
        Mydia.Accounts.Authorization.can_create_media?(socket.assigns.current_user)
@@ -449,6 +451,15 @@ defmodule MydiaWeb.MediaLive.Show do
   @impl true
   def handle_event("request_recommendation", params, socket),
     do: RecommendationEvents.request_recommendation(params, socket)
+
+  def handle_event("open_library_picker", params, socket),
+    do: LibraryPickerEvents.open_library_picker(params, socket)
+
+  def handle_event("close_library_picker", params, socket),
+    do: LibraryPickerEvents.close_library_picker(params, socket)
+
+  def handle_event("add_from_library_picker", params, socket),
+    do: LibraryPickerEvents.add_from_library_picker(params, socket)
 
   @impl true
   def handle_info({:download_created, download}, socket) do

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -204,6 +204,7 @@
             adding_ids={@adding_recommendation_tmdb_ids}
             requesting_item_id={@requesting_recommendation_id}
             can_add={@can_create_media}
+            libraries={@target_library_candidates}
           />
           <%!-- Episodes Section (TV Shows Only) --%>
           <Components.episodes_section
@@ -243,6 +244,7 @@
             can_add={@can_create_media}
             current_user={@current_user}
             adding_tmdb_ids={@adding_franchise_tmdb_ids}
+            libraries={@target_library_candidates}
           />
           <%!-- Recommendations, movie placement. Expanded here, so it sits below
                 the file list: 500px of posters between the overview and the file
@@ -258,6 +260,7 @@
             adding_ids={@adding_recommendation_tmdb_ids}
             requesting_item_id={@requesting_recommendation_id}
             can_add={@can_create_media}
+            libraries={@target_library_candidates}
           />
         </div>
       </div>
@@ -336,4 +339,9 @@
       <Modals.trailer_modal trailer_url={trailer_url} title={@media_item.title} />
     <% end %>
   <% end %>
+
+  <MydiaWeb.LibraryComponents.library_picker_dialog
+    picker={@library_picker}
+    event="add_from_library_picker"
+  />
 </Layouts.app>

--- a/lib/mydia_web/live/media_live/show/franchise_components.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_components.ex
@@ -22,6 +22,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
   attr :can_add, :boolean, required: true
   attr :adding_tmdb_ids, MapSet, required: true
   attr :current_user, :map, required: true
+  attr :libraries, :list, default: []
 
   def franchise_section(assigns) do
     assigns = assign(assigns, :items, items(assigns.franchise))
@@ -35,6 +36,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
       current_user={@current_user}
       can_add={@can_add}
       adding_ids={@adding_tmdb_ids}
+      libraries={@libraries}
       on_select={nil}
       add_event="add_franchise_movie"
       request_event="request_franchise_movie"

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -64,17 +64,23 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   cancels a task under an existing key, which would silently drop the first
   result.
   """
-  def add_franchise_movie(%{"tmdb_id" => tmdb_id}, socket) do
-    with :ok <- Authorization.authorize_create_media(socket) do
-      start_add(tmdb_id, socket)
+  def add_franchise_movie(%{"tmdb_id" => tmdb_id} = params, socket) do
+    with :ok <- Authorization.authorize_create_media(socket),
+         {:ok, opts} <- MediaAddHelpers.library_path_opts(params["library_path_id"], :movie) do
+      start_add(tmdb_id, opts, socket)
     else
-      {:unauthorized, socket} -> {:noreply, socket}
+      {:unauthorized, socket} ->
+        {:noreply, socket}
+
+      {:error, :unknown_library} ->
+        {:noreply,
+         put_flash(socket, :error, "That library is no longer available. Nothing was added.")}
     end
   end
 
-  defp start_add(tmdb_id, socket) do
+  defp start_add(tmdb_id, opts, socket) do
     case Integer.parse(tmdb_id) do
-      {tmdb_id, ""} -> dispatch_add(tmdb_id, socket)
+      {tmdb_id, ""} -> dispatch_add(tmdb_id, opts, socket)
       _ -> {:noreply, socket}
     end
   end
@@ -82,7 +88,9 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   # An impatient double-click sends the event twice. The second add would hit the
   # tmdb_id unique index and flash a failure for a row the first add just
   # created, so a repeat for an id already in flight is dropped.
-  defp dispatch_add(tmdb_id, socket) do
+  #
+  # The in-flight set stays keyed on tmdb_id alone and `opts` rides beside it.
+  defp dispatch_add(tmdb_id, opts, socket) do
     if MapSet.member?(socket.assigns.adding_franchise_tmdb_ids, tmdb_id) do
       {:noreply, socket}
     else
@@ -93,7 +101,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
         socket
         |> mark_in_flight(tmdb_id)
         |> start_async({:add_franchise_movie, tmdb_id}, fn ->
-          perform_add(media_item, tmdb_id, config)
+          perform_add(media_item, tmdb_id, config, opts)
         end)
 
       {:noreply, socket}
@@ -104,14 +112,16 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   Performs the add. Public so it can be exercised directly in tests without a
   live process.
   """
-  def perform_add(media_item, tmdb_id, config) do
+  def perform_add(media_item, tmdb_id, config, opts \\ []) do
     MediaAddHelpers.handle_add_media_to_library(
       to_string(tmdb_id),
       :movie,
       %{},
       config,
-      monitored: media_item.monitored,
-      quality_profile_id: media_item.quality_profile_id
+      Keyword.merge(
+        [monitored: media_item.monitored, quality_profile_id: media_item.quality_profile_id],
+        opts
+      )
     )
     |> case do
       {:ok, added, _status_map} -> {:ok, added}

--- a/lib/mydia_web/live/media_live/show/library_picker_events.ex
+++ b/lib/mydia_web/live/media_live/show/library_picker_events.ex
@@ -1,0 +1,60 @@
+defmodule MydiaWeb.MediaLive.Show.LibraryPickerEvents do
+  @moduledoc """
+  Routes the detail page's single library-picker dialog to the right rail.
+
+  `library_picker_dialog/1` is page-level and fires one event per host, but
+  this page has two rails with different add handlers. Rather than teach the
+  shared dialog about sources, the event lands here and is dispatched by
+  franchise membership.
+
+  When the same movie sits in both rails (#460) the franchise strip wins and
+  the recommendations card stays stale. A later click on that stale card
+  resolves to `:already_in_library`, which both `perform_add` functions map to
+  an informational result rather than an error.
+  """
+
+  alias Mydia.Media.FranchiseEntry
+  alias MydiaWeb.Live.Helpers.MediaAddHelpers
+  alias MydiaWeb.MediaLive.Show.FranchiseEvents
+  alias MydiaWeb.MediaLive.Show.RecommendationEvents
+
+  @doc """
+  Opens the picker for one card.
+  """
+  def open_library_picker(params, socket) do
+    {:noreply, MediaAddHelpers.put_library_picker(socket, params)}
+  end
+
+  @doc """
+  Closes the picker.
+  """
+  def close_library_picker(_params, socket) do
+    {:noreply, MediaAddHelpers.clear_library_picker(socket)}
+  end
+
+  @doc """
+  Dispatches a chosen library to the rail the card belongs to.
+
+  The dialog is closed first, unconditionally: leaving it open while an async
+  add runs would let a second choice queue behind the first.
+  """
+  def add_from_library_picker(%{"tmdb_id" => tmdb_id} = params, socket) do
+    socket = MediaAddHelpers.clear_library_picker(socket)
+
+    if franchise_entry?(socket.assigns[:franchise], tmdb_id) do
+      FranchiseEvents.add_franchise_movie(params, socket)
+    else
+      RecommendationEvents.add_recommendation(params, socket)
+    end
+  end
+
+  defp franchise_entry?(nil, _tmdb_id), do: false
+
+  defp franchise_entry?(%{entries: entries}, tmdb_id) do
+    Enum.any?(entries, fn %FranchiseEntry{} = entry ->
+      to_string(entry.tmdb_id) == to_string(tmdb_id)
+    end)
+  end
+
+  defp franchise_entry?(_franchise, _tmdb_id), do: false
+end

--- a/lib/mydia_web/live/media_live/show/recommendation_components.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_components.ex
@@ -29,6 +29,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationComponents do
   attr :adding_ids, MapSet, required: true
   attr :requesting_item_id, :string, default: nil
   attr :can_add, :boolean, required: true
+  attr :libraries, :list, default: []
 
   def recommendations_section(assigns) do
     tv_show? = assigns.media_item.type == "tv_show"
@@ -50,6 +51,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationComponents do
       adding_ids={@adding_ids}
       requesting_item_id={@requesting_item_id}
       can_add={@can_add}
+      libraries={@libraries}
       on_select={nil}
       add_event="add_recommendation"
       request_event="request_recommendation"

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -81,21 +81,33 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   overwrites rather than cancels under an existing key, which would silently drop
   the first result.
   """
-  def add_recommendation(%{"tmdb_id" => tmdb_id}, socket) do
-    with :ok <- Authorization.authorize_create_media(socket) do
+  def add_recommendation(%{"tmdb_id" => tmdb_id} = params, socket) do
+    media_type = if socket.assigns.media_item.type == "tv_show", do: :tv_show, else: :movie
+
+    with :ok <- Authorization.authorize_create_media(socket),
+         {:ok, opts} <- MediaAddHelpers.library_path_opts(params["library_path_id"], media_type) do
       case Integer.parse(tmdb_id) do
-        {parsed, ""} -> dispatch_add(parsed, socket)
+        {parsed, ""} -> dispatch_add(parsed, opts, socket)
         _ -> {:noreply, socket}
       end
     else
-      {:unauthorized, socket} -> {:noreply, socket}
+      {:unauthorized, socket} ->
+        {:noreply, socket}
+
+      {:error, :unknown_library} ->
+        {:noreply,
+         put_flash(socket, :error, "That library is no longer available. Nothing was added.")}
     end
   end
 
   # An impatient double-click sends the event twice. The second add would hit the
   # tmdb_id unique index and flash a failure for a row the first add just
   # created, so a repeat for an id already in flight is dropped.
-  defp dispatch_add(tmdb_id, socket) do
+  #
+  # The in-flight set stays keyed on tmdb_id alone and `opts` rides beside it.
+  # Folding the library into the key would let a double-click through two
+  # different libraries past this guard and onto the unique index.
+  defp dispatch_add(tmdb_id, opts, socket) do
     if MapSet.member?(socket.assigns.adding_recommendation_tmdb_ids, tmdb_id) do
       {:noreply, socket}
     else
@@ -106,7 +118,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
         socket
         |> mark_in_flight(tmdb_id)
         |> start_async({:add_recommendation, tmdb_id}, fn ->
-          perform_add(media_item, tmdb_id, config)
+          perform_add(media_item, tmdb_id, config, opts)
         end)
 
       {:noreply, socket}
@@ -168,7 +180,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   Performs the add. Public so it can be exercised directly in tests without a
   live process.
   """
-  def perform_add(media_item, tmdb_id, config) do
+  def perform_add(media_item, tmdb_id, config, opts \\ []) do
     media_type = if media_item.type == "tv_show", do: :tv_show, else: :movie
 
     MediaAddHelpers.handle_add_media_to_library(
@@ -176,11 +188,17 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
       media_type,
       %{},
       config,
-      monitored: media_item.monitored,
-      quality_profile_id: media_item.quality_profile_id
+      Keyword.merge(
+        [monitored: media_item.monitored, quality_profile_id: media_item.quality_profile_id],
+        opts
+      )
     )
     |> case do
       {:ok, added, _status_map} -> {:ok, added}
+      # Reachable when the same title sits in both rails (#460): adding from
+      # one leaves the other's card stale, and a click there lands here. Without
+      # this clause it raises CaseClauseError and takes the page down.
+      {:already_in_library, added, _status_map} -> {:already_in_library, added}
       {:error, reason} -> {:error, reason}
     end
   end
@@ -191,6 +209,16 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
      |> clear_in_flight(tmdb_id)
      |> assign(:recommendations, mark_owned(socket.assigns.recommendations, added))
      |> put_flash(:info, "Added #{added.title} to your library")}
+  end
+
+  # Not an error from here up: the title the user clicked is already in the
+  # library, just under a card this rail had not linked up yet.
+  def handle_add_result(tmdb_id, {:ok, {:already_in_library, added}}, socket) do
+    {:noreply,
+     socket
+     |> clear_in_flight(tmdb_id)
+     |> assign(:recommendations, mark_owned(socket.assigns.recommendations, added))
+     |> put_flash(:info, "#{added.title} is already in your library")}
   end
 
   def handle_add_result(tmdb_id, {:ok, {:error, reason}}, socket) do

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -443,5 +443,20 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
       assert {:error, :unknown_library} =
                MediaAddHelpers.library_path_opts(Ecto.UUID.generate(), :movie)
     end
+
+    test "rejects a map value instead of silently treating it as no choice" do
+      # #458: a crafted event sending a non-binary library_path_id must not be
+      # swallowed by the catch-all as "no library was selected".
+      assert {:error, :unknown_library} =
+               MediaAddHelpers.library_path_opts(%{"id" => "1"}, :movie)
+    end
+
+    test "rejects a list value instead of silently treating it as no choice" do
+      assert {:error, :unknown_library} = MediaAddHelpers.library_path_opts(["1"], :movie)
+    end
+
+    test "rejects an integer value instead of silently treating it as no choice" do
+      assert {:error, :unknown_library} = MediaAddHelpers.library_path_opts(1, :movie)
+    end
   end
 end

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -402,4 +402,46 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
       assert MediaAddHelpers.clear_library_picker(opened).assigns.library_picker == nil
     end
   end
+
+  describe "library_path_opts/2" do
+    test "returns no options when no library was chosen" do
+      assert {:ok, []} = MediaAddHelpers.library_path_opts(nil, :movie)
+    end
+
+    test "returns no options for a blank string" do
+      # "" is truthy in Elixir. Without an explicit clause it reaches the
+      # changeset as library_path_id: "" and fails the foreign key, instead of
+      # falling back to normal target resolution.
+      assert {:ok, []} = MediaAddHelpers.library_path_opts("", :movie)
+    end
+
+    test "keeps an id that is a candidate for this media type" do
+      library = library_path_fixture(%{path: "/media/opts-a", type: "movies"})
+
+      assert {:ok, opts} = MediaAddHelpers.library_path_opts(to_string(library.id), :movie)
+      assert Keyword.fetch!(opts, :library_path_id) == to_string(library.id)
+    end
+
+    test "rejects a library belonging to the other media type" do
+      series = library_path_fixture(%{path: "/media/opts-series", type: "series"})
+
+      assert {:error, :unknown_library} =
+               MediaAddHelpers.library_path_opts(to_string(series.id), :movie)
+    end
+
+    test "rejects an unmonitored library" do
+      unmonitored =
+        library_path_fixture(%{path: "/media/opts-off", type: "movies", monitored: false})
+
+      assert {:error, :unknown_library} =
+               MediaAddHelpers.library_path_opts(to_string(unmonitored.id), :movie)
+    end
+
+    test "rejects an id matching no library at all" do
+      # library_path_id is client input. Without the candidate check a crafted
+      # event can name any row in the table.
+      assert {:error, :unknown_library} =
+               MediaAddHelpers.library_path_opts(Ecto.UUID.generate(), :movie)
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/show/franchise_section_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_section_test.exs
@@ -7,9 +7,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseSectionTest do
   import Mydia.MediaFixtures
   import Mydia.AccountsFixtures
   import MydiaWeb.AuthHelpers
-
-  alias Mydia.Metadata
-  alias Mydia.Metadata.Cache
+  import Mydia.MetadataCacheHelpers
 
   setup %{conn: conn} do
     %{conn: log_in_user(conn, admin_user_fixture())}
@@ -21,7 +19,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseSectionTest do
         type: "tv_show",
         title: "A Show",
         year: 2010,
-        tmdb_id: System.unique_integer([:positive])
+        tmdb_id: unique_provider_id()
       })
 
     {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
@@ -31,9 +29,9 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseSectionTest do
 
   test "a movie whose franchise resolves renders the strip with its owned count",
        %{conn: conn} do
-    collection_id = System.unique_integer([:positive])
-    owned_tmdb_id = System.unique_integer([:positive])
-    missing_tmdb_id = System.unique_integer([:positive])
+    collection_id = unique_provider_id()
+    owned_tmdb_id = unique_provider_id()
+    missing_tmdb_id = unique_provider_id()
 
     movie =
       media_item_fixture(%{
@@ -72,31 +70,5 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseSectionTest do
              view,
              "#franchise-section-item-#{missing_tmdb_id} [phx-click='add_franchise_movie']"
            )
-  end
-
-  # Populates the shared metadata cache through the real fetch path, with the
-  # relay response coming from Bypass. `fetch_collection_cached/3` keys on the
-  # provider type, collection id and language but not the base URL, so the
-  # LiveView's own default config reads this entry back without any outbound
-  # request: the assertions above passing is itself proof the cache was hit.
-  defp warm_collection_cache(collection_id, parts) do
-    bypass = Bypass.open()
-    relay = Metadata.default_relay_config()
-    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
-
-    on_exit(fn ->
-      Cache.delete("collection:#{relay.type}:#{collection_id}:#{relay.options.language}")
-    end)
-
-    Bypass.expect_once(bypass, "GET", "/tmdb/collections/#{collection_id}", fn conn ->
-      body = %{"id" => collection_id, "name" => "Test Collection", "parts" => parts}
-
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.resp(200, Jason.encode!(body))
-    end)
-
-    {:ok, _collection} = Metadata.fetch_collection_cached(config, collection_id)
-    :ok
   end
 end

--- a/test/mydia_web/live/media_live/show/rail_library_target_test.exs
+++ b/test/mydia_web/live/media_live/show/rail_library_target_test.exs
@@ -1,0 +1,122 @@
+defmodule MydiaWeb.MediaLive.Show.RailLibraryTargetTest do
+  @moduledoc """
+  #458: a library chosen from a rail card must be the library the title lands
+  in.
+
+  Asserted against `perform_add/4` rather than a rendered click. The add path
+  calls the uncached `Metadata.fetch_by_id/3` with the LiveView's
+  `metadata_config`, which `show.ex` builds from `default_relay_config/0`, and
+  that reads global env. There is no seam to inject a Bypass config through
+  `live/2`, and a test must not mutate global env to make one.
+  """
+
+  # Not async: these insert library paths, which candidate_libraries/1 reads
+  # back through the shared sandbox connection.
+  use MydiaWeb.ConnCase, async: false
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+  import Mydia.MetadataCacheHelpers
+
+  alias Mydia.Library.TargetResolver
+  alias Mydia.Metadata
+  alias Mydia.Repo
+  alias MydiaWeb.MediaLive.Show.FranchiseEvents
+  alias MydiaWeb.MediaLive.Show.RecommendationEvents
+
+  # Serves the added title's metadata from Bypass. Unlike the cache helpers
+  # this config is handed straight to perform_add, because the add path does
+  # not go through the ETS cache at all.
+  defp bypass_relay_config(tmdb_id, title) do
+    bypass = Bypass.open()
+
+    Bypass.expect(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+      body = %{
+        "id" => tmdb_id,
+        "title" => title,
+        "release_date" => "2005-01-01",
+        "belongs_to_collection" => nil
+      }
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    relay = Metadata.default_relay_config()
+    %{relay | base_url: "http://localhost:#{bypass.port}"}
+  end
+
+  describe "recommendations rail" do
+    test "adds into the chosen library rather than the resolved default" do
+      _default = library_path_fixture(%{path: "/media/rec-default", type: "movies"})
+      chosen = library_path_fixture(%{path: "/media/rec-chosen", type: "movies"})
+
+      source = media_item_fixture(%{type: "movie", title: "Source", year: 2001})
+      added_tmdb_id = unique_provider_id()
+      config = bypass_relay_config(added_tmdb_id, "Recommended")
+
+      assert {:ok, added} =
+               RecommendationEvents.perform_add(source, added_tmdb_id, config,
+                 library_path_id: to_string(chosen.id)
+               )
+
+      assert Repo.reload!(added).library_path_id == chosen.id
+    end
+
+    test "falls back to normal resolution when no library was chosen" do
+      default = library_path_fixture(%{path: "/media/rec-only", type: "movies"})
+
+      source = media_item_fixture(%{type: "movie", title: "Source", year: 2001})
+      added_tmdb_id = unique_provider_id()
+      config = bypass_relay_config(added_tmdb_id, "Recommended")
+
+      assert {:ok, added} = RecommendationEvents.perform_add(source, added_tmdb_id, config)
+
+      # No library_path_id is written at add time when no choice was made:
+      # `library_path_opts/2` returns `{:ok, []}` for that case, same as
+      # before this change. "Normal resolution" is dynamic, performed by
+      # Mydia.Library.TargetResolver wherever content for the item is placed
+      # (import, rematch, the detail page), not persisted eagerly here.
+      refute Repo.reload!(added).library_path_id
+
+      assert {:ok, resolved, _reason} = TargetResolver.resolve(added)
+      assert resolved.id == default.id
+    end
+  end
+
+  describe "collection strip" do
+    test "adds into the chosen library rather than the resolved default" do
+      _default = library_path_fixture(%{path: "/media/fr-default", type: "movies"})
+      chosen = library_path_fixture(%{path: "/media/fr-chosen", type: "movies"})
+
+      source = media_item_fixture(%{type: "movie", title: "First", year: 2001})
+      added_tmdb_id = unique_provider_id()
+      config = bypass_relay_config(added_tmdb_id, "Second")
+
+      assert {:ok, added} =
+               FranchiseEvents.perform_add(source, added_tmdb_id, config,
+                 library_path_id: to_string(chosen.id)
+               )
+
+      assert Repo.reload!(added).library_path_id == chosen.id
+    end
+
+    test "falls back to normal resolution when no library was chosen" do
+      default = library_path_fixture(%{path: "/media/fr-only", type: "movies"})
+
+      source = media_item_fixture(%{type: "movie", title: "First", year: 2001})
+      added_tmdb_id = unique_provider_id()
+      config = bypass_relay_config(added_tmdb_id, "Second")
+
+      assert {:ok, added} = FranchiseEvents.perform_add(source, added_tmdb_id, config)
+
+      # See the mirrored comment in the recommendations describe block above:
+      # no library_path_id is written at add time when no choice was made.
+      refute Repo.reload!(added).library_path_id
+
+      assert {:ok, resolved, _reason} = TargetResolver.resolve(added)
+      assert resolved.id == default.id
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
+++ b/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
@@ -1,0 +1,114 @@
+defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
+  @moduledoc """
+  The detail page's rails offer a library picker, and its single page-level
+  dialog routes to the correct rail.
+  """
+
+  # Connected LiveView tests must stay sync: the Postgres sandbox is only
+  # shared with the mount process when the case is not async.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
+  import Mydia.SettingsFixtures
+  import MydiaWeb.AuthHelpers
+  import Mydia.MetadataCacheHelpers
+
+  setup %{conn: conn} do
+    # The app disables Oban in test (engine: false), so Oban.insert cannot run
+    # from the LiveView process. Start an isolated, manual-mode instance so the
+    # recommendations load can enqueue without a live queue.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  defp movie_with_recommendation do
+    source_tmdb_id = unique_provider_id()
+    recommended_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Aftersun",
+        year: 2022,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{
+        "id" => recommended_tmdb_id,
+        "title" => "The Eternal Daughter",
+        "release_date" => "2022-12-02",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    warm_movie_details_cache(source_tmdb_id)
+
+    {movie, recommended_tmdb_id}
+  end
+
+  test "a rail card offers the picker when several libraries are configured", %{conn: conn} do
+    library_path_fixture(%{path: "/media/host-a", type: "movies"})
+    library_path_fixture(%{path: "/media/host-b", type: "movies"})
+
+    {movie, _recommended} = movie_with_recommendation()
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, "#recommendations-rail [data-test='library-picker-caret']")
+  end
+
+  test "a single-library install gets no caret", %{conn: conn} do
+    library_path_fixture(%{path: "/media/host-only", type: "movies"})
+
+    {movie, _recommended} = movie_with_recommendation()
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    refute has_element?(view, "#recommendations-rail [data-test='library-picker-caret']")
+  end
+
+  test "opening the picker renders the dialog with both libraries", %{conn: conn} do
+    library_path_fixture(%{path: "/media/host-a", type: "movies"})
+    library_path_fixture(%{path: "/media/host-b", type: "movies"})
+
+    {movie, recommended} = movie_with_recommendation()
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    html =
+      view
+      |> element("#recommendations-rail [data-test='library-picker-caret']")
+      |> render_click()
+
+    assert html =~ "Add to which library?"
+    assert html =~ "host-a"
+    assert html =~ "host-b"
+    assert view |> element("#library-picker-dialog") |> has_element?()
+  end
+
+  test "cancelling closes the dialog", %{conn: conn} do
+    library_path_fixture(%{path: "/media/host-a", type: "movies"})
+    library_path_fixture(%{path: "/media/host-b", type: "movies"})
+
+    {movie, _recommended} = movie_with_recommendation()
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    view
+    |> element("#recommendations-rail [data-test='library-picker-caret']")
+    |> render_click()
+
+    html = render_click(view, "close_library_picker", %{})
+
+    refute html =~ "Add to which library?"
+  end
+end

--- a/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
+++ b/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
@@ -78,7 +78,7 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
     library_path_fixture(%{path: "/media/host-a", type: "movies"})
     library_path_fixture(%{path: "/media/host-b", type: "movies"})
 
-    {movie, recommended} = movie_with_recommendation()
+    {movie, _recommended} = movie_with_recommendation()
 
     {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
     render_async(view, 5000)

--- a/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
+++ b/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
@@ -51,6 +51,87 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
     {movie, recommended_tmdb_id}
   end
 
+  # Mirrors `franchise_section_test.exs`: a movie whose metadata already
+  # carries a `collection_id` skips the movie-details pointer lookup, so no
+  # warm_movie_details_cache call is needed here. `missing_tmdb_id` is not
+  # owned, so its card renders the Add split button the picker hangs off.
+  #
+  # The recommendations cache is warmed empty so the page's unconditional
+  # recommendations load (`RecommendationEvents.maybe_load/1` fires for any
+  # movie with a tmdb_id) resolves offline instead of reaching the live relay.
+  defp movie_with_franchise_entry do
+    collection_id = unique_provider_id()
+    own_tmdb_id = unique_provider_id()
+    missing_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Alien",
+        year: 1979,
+        tmdb_id: own_tmdb_id,
+        metadata: %{
+          "provider_id" => to_string(own_tmdb_id),
+          "provider" => "metadata_relay",
+          "media_type" => "movie",
+          "title" => "Alien",
+          "collection_id" => collection_id,
+          "collection_name" => "Alien Collection"
+        }
+      })
+
+    warm_collection_cache(collection_id, [
+      %{"id" => own_tmdb_id, "title" => "Alien", "release_date" => "1979-05-25"},
+      %{"id" => missing_tmdb_id, "title" => "Aliens", "release_date" => "1986-07-18"}
+    ])
+
+    warm_recommendations_cache(own_tmdb_id, :movie, [])
+
+    {movie, missing_tmdb_id}
+  end
+
+  # The #460 case: `overlap_tmdb_id` is seeded as both a missing franchise
+  # entry and a recommendation, so the same tmdb_id draws a card in both
+  # rails at once. The routing decision in `LibraryPickerEvents` is keyed on
+  # the tmdb_id alone, not on which rail's caret was clicked.
+  defp movie_with_overlapping_entry do
+    collection_id = unique_provider_id()
+    own_tmdb_id = unique_provider_id()
+    overlap_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Alien",
+        year: 1979,
+        tmdb_id: own_tmdb_id,
+        metadata: %{
+          "provider_id" => to_string(own_tmdb_id),
+          "provider" => "metadata_relay",
+          "media_type" => "movie",
+          "title" => "Alien",
+          "collection_id" => collection_id,
+          "collection_name" => "Alien Collection"
+        }
+      })
+
+    warm_collection_cache(collection_id, [
+      %{"id" => own_tmdb_id, "title" => "Alien", "release_date" => "1979-05-25"},
+      %{"id" => overlap_tmdb_id, "title" => "Aliens", "release_date" => "1986-07-18"}
+    ])
+
+    warm_recommendations_cache(own_tmdb_id, :movie, [
+      %{
+        "id" => overlap_tmdb_id,
+        "title" => "Aliens",
+        "release_date" => "1986-07-18",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    {movie, overlap_tmdb_id}
+  end
+
   test "a rail card offers the picker when several libraries are configured", %{conn: conn} do
     library_path_fixture(%{path: "/media/host-a", type: "movies"})
     library_path_fixture(%{path: "/media/host-b", type: "movies"})
@@ -110,5 +191,83 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
     html = render_click(view, "close_library_picker", %{})
 
     refute html =~ "Add to which library?"
+  end
+
+  describe "add_from_library_picker/2 routing" do
+    test "a recommendation-only title routes the add to the recommendations rail",
+         %{conn: conn} do
+      library_path_fixture(%{path: "/media/host-a", type: "movies"})
+      library_path_fixture(%{path: "/media/host-b", type: "movies"})
+
+      {movie, recommended_tmdb_id} = movie_with_recommendation()
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+      render_async(view, 5000)
+
+      view
+      |> element(
+        "#recommendations-rail-item-#{recommended_tmdb_id} [data-test='library-picker-caret']"
+      )
+      |> render_click()
+
+      view
+      |> element("#library-picker-dialog [data-test='library-picker-option']", "host-a")
+      |> render_click()
+
+      # Proof of routing: the recommendations rail registered the in-flight
+      # add (its card now shows the spinner) and there is no franchise strip
+      # at all to have wrongly claimed it.
+      assert has_element?(view, "#recommendations-rail-item-#{recommended_tmdb_id}", "Adding...")
+      refute has_element?(view, "#franchise-section")
+    end
+
+    test "a movie that is a franchise entry routes the add to the franchise rail",
+         %{conn: conn} do
+      library_path_fixture(%{path: "/media/host-a", type: "movies"})
+      library_path_fixture(%{path: "/media/host-b", type: "movies"})
+
+      {movie, missing_tmdb_id} = movie_with_franchise_entry()
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+      render_async(view, 5000)
+
+      view
+      |> element("#franchise-section-item-#{missing_tmdb_id} [data-test='library-picker-caret']")
+      |> render_click()
+
+      view
+      |> element("#library-picker-dialog [data-test='library-picker-option']", "host-a")
+      |> render_click()
+
+      assert has_element?(view, "#franchise-section-item-#{missing_tmdb_id}", "Adding...")
+    end
+
+    test "a title in both rails (#460) routes to the franchise rail even when the click " <>
+           "starts from the recommendations card",
+         %{conn: conn} do
+      library_path_fixture(%{path: "/media/host-a", type: "movies"})
+      library_path_fixture(%{path: "/media/host-b", type: "movies"})
+
+      {movie, overlap_tmdb_id} = movie_with_overlapping_entry()
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+      render_async(view, 5000)
+
+      # Both rails render a card for overlap_tmdb_id. Opening the picker from
+      # the recommendations card is the point: routing is decided by franchise
+      # membership of the tmdb_id, not by which rail's caret fired the event.
+      view
+      |> element(
+        "#recommendations-rail-item-#{overlap_tmdb_id} [data-test='library-picker-caret']"
+      )
+      |> render_click()
+
+      view
+      |> element("#library-picker-dialog [data-test='library-picker-option']", "host-a")
+      |> render_click()
+
+      assert has_element?(view, "#franchise-section-item-#{overlap_tmdb_id}", "Adding...")
+      refute has_element?(view, "#recommendations-rail-item-#{overlap_tmdb_id}", "Adding...")
+    end
   end
 end

--- a/test/mydia_web/live/media_live/show/section_order_test.exs
+++ b/test/mydia_web/live/media_live/show/section_order_test.exs
@@ -7,24 +7,13 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
   import Mydia.MediaFixtures
   import Mydia.AccountsFixtures
   import MydiaWeb.AuthHelpers
-
-  alias Mydia.Metadata
-  alias Mydia.Metadata.Cache
+  import Mydia.MetadataCacheHelpers
 
   # Every section whose position this page decides. Each case asserts the whole
   # list rather than a pairwise precedence, so a section that stops rendering
   # fails the test instead of passing quietly.
   @sections "#seasons-episodes-section, #media-files-section, #subtitles-section, " <>
               "#timeline-section, #franchise-section, #recommendations-rail"
-
-  # Provider ids here are offset past this floor rather than taken raw from
-  # System.unique_integer/1, which hands out small positive integers. Those
-  # collide two ways: with real TMDB ids, so any lookup this file forgets to stub
-  # would reach the live relay, and with the many hardcoded ids elsewhere in the
-  # suite, which share the same ETS-backed metadata cache and its keys. Real TMDB
-  # ids are seven digits, and no fixture in the suite reaches nine, so everything
-  # above this floor belongs to this file alone.
-  @provider_id_floor 900_000_000
 
   setup %{conn: conn} do
     # The app disables Oban in test (engine: false), so Oban.insert cannot run
@@ -197,8 +186,6 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
            ]
   end
 
-  defp unique_provider_id, do: @provider_id_floor + System.unique_integer([:positive])
-
   # LazyHTML.query/2, not filter/2: filter matches root nodes only, and these
   # cards are nested inside the layout. query returns matches in document order,
   # which is the whole point of the assertion.
@@ -208,106 +195,5 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
     |> LazyHTML.from_fragment()
     |> LazyHTML.query(@sections)
     |> LazyHTML.attribute("id")
-  end
-
-  # Populates the shared metadata cache through the real fetch path, with the
-  # relay response coming from Bypass. The cache key does not include the base
-  # URL, so the LiveView's own default config reads this entry back without any
-  # outbound request.
-  defp warm_recommendations_cache(tmdb_id, media_type, results) do
-    bypass = Bypass.open()
-    relay = Metadata.default_relay_config()
-    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
-
-    on_exit(fn ->
-      Cache.delete(
-        "recommendations:#{relay.type}:#{tmdb_id}:#{media_type}:#{relay.options.language}"
-      )
-    end)
-
-    path =
-      if media_type == :tv_show, do: "/tmdb/tv/shows/#{tmdb_id}", else: "/tmdb/movies/#{tmdb_id}"
-
-    Bypass.expect_once(bypass, "GET", path, fn conn ->
-      body = %{
-        "id" => tmdb_id,
-        "title" => "Source",
-        "recommendations" => %{
-          "page" => 1,
-          "results" => results,
-          "total_pages" => 1,
-          "total_results" => length(results)
-        }
-      }
-
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.resp(200, Jason.encode!(body))
-    end)
-
-    {:ok, _results} =
-      Metadata.fetch_recommendations_cached(config, to_string(tmdb_id), media_type: media_type)
-
-    :ok
-  end
-
-  # Any movie whose metadata carries no collection_id sends
-  # Franchises.resolve_collection_id/2 down a movie-details lookup, and that has
-  # its own cache key ("fetch_by_id:...") entirely separate from the
-  # recommendations one warmed above. Left unwarmed that lookup leaves the VM for
-  # the real relay, which makes the section order depend on the network being up
-  # and on whatever TMDB says about the id. Warming it with a collection-less
-  # payload resolves it to :none offline, so the order under test comes from the
-  # fixtures alone.
-  defp warm_movie_details_cache(tmdb_id) do
-    bypass = Bypass.open()
-    relay = Metadata.default_relay_config()
-    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
-
-    # Mirrors the key fetch_by_id_cached/3 builds for these opts: no
-    # append_to_response, so that segment is empty, and a nil season order
-    # normalises to "official".
-    on_exit(fn ->
-      Cache.delete(
-        "fetch_by_id:#{relay.type}:#{tmdb_id}:movie:#{relay.options.language}::official"
-      )
-    end)
-
-    Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
-      body = %{"id" => tmdb_id, "title" => "Source", "belongs_to_collection" => nil}
-
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.resp(200, Jason.encode!(body))
-    end)
-
-    {:ok, _details} = Metadata.fetch_by_id_cached(config, to_string(tmdb_id), media_type: :movie)
-
-    :ok
-  end
-
-  # Same trick as warm_recommendations_cache/3, for the TMDB collection lookup
-  # behind the franchise strip. fetch_collection_cached/3 keys on the provider
-  # type, collection id and language but not the base URL, so the LiveView reads
-  # this entry back through its own default config with no outbound request.
-  defp warm_collection_cache(collection_id, parts) do
-    bypass = Bypass.open()
-    relay = Metadata.default_relay_config()
-    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
-
-    on_exit(fn ->
-      Cache.delete("collection:#{relay.type}:#{collection_id}:#{relay.options.language}")
-    end)
-
-    Bypass.expect_once(bypass, "GET", "/tmdb/collections/#{collection_id}", fn conn ->
-      body = %{"id" => collection_id, "name" => "Test Collection", "parts" => parts}
-
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.resp(200, Jason.encode!(body))
-    end)
-
-    {:ok, _collection} = Metadata.fetch_collection_cached(config, collection_id)
-    :ok
   end
 end

--- a/test/support/metadata_cache_helpers.ex
+++ b/test/support/metadata_cache_helpers.ex
@@ -1,0 +1,143 @@
+defmodule Mydia.MetadataCacheHelpers do
+  @moduledoc """
+  Warms the shared metadata ETS cache through the real fetch path, with the
+  relay response served by Bypass.
+
+  None of these cache keys include the base URL, so a LiveView reading through
+  its own default relay config gets these entries back with no outbound
+  request. Left unwarmed, a detail-page test reaches the live relay and its
+  result depends on the network being up and on whatever TMDB currently says
+  about the id (#530).
+
+  Every helper registers an `on_exit` that deletes the key it wrote. The cache
+  is ETS-backed and process-independent, so an entry left behind leaks into
+  every later test sharing that key.
+
+  These were private helpers duplicated across `section_order_test.exs` and
+  `franchise_section_test.exs`.
+  """
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  alias Mydia.Metadata
+  alias Mydia.Metadata.Cache
+
+  # Provider ids are offset past this floor rather than taken raw from
+  # System.unique_integer/1, which hands out small positive integers. Those
+  # collide two ways: with real TMDB ids, so any lookup a test forgets to warm
+  # would reach the live relay, and with the many hardcoded ids elsewhere in
+  # the suite, which share this same ETS cache and its keys. Real TMDB ids are
+  # seven digits, and no fixture in the suite reaches nine.
+  @provider_id_floor 900_000_000
+
+  @doc """
+  A provider id guaranteed not to collide with a real TMDB id or with a
+  hardcoded id elsewhere in the suite.
+  """
+  def unique_provider_id, do: @provider_id_floor + System.unique_integer([:positive])
+
+  @doc """
+  Populates the recommendations cache for `tmdb_id` with `results`.
+
+  `results` are raw TMDB result maps with string keys, for example
+  `%{"id" => 123, "title" => "X", "release_date" => "2005-01-01"}`.
+  """
+  def warm_recommendations_cache(tmdb_id, media_type, results) do
+    bypass = Bypass.open()
+    relay = Metadata.default_relay_config()
+    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
+
+    on_exit(fn ->
+      Cache.delete(
+        "recommendations:#{relay.type}:#{tmdb_id}:#{media_type}:#{relay.options.language}"
+      )
+    end)
+
+    path =
+      if media_type == :tv_show, do: "/tmdb/tv/shows/#{tmdb_id}", else: "/tmdb/movies/#{tmdb_id}"
+
+    Bypass.expect_once(bypass, "GET", path, fn conn ->
+      body = %{
+        "id" => tmdb_id,
+        "title" => "Source",
+        "recommendations" => %{
+          "page" => 1,
+          "results" => results,
+          "total_pages" => 1,
+          "total_results" => length(results)
+        }
+      }
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    {:ok, _results} =
+      Metadata.fetch_recommendations_cached(config, to_string(tmdb_id), media_type: media_type)
+
+    :ok
+  end
+
+  @doc """
+  Populates the movie-details cache for `tmdb_id` with a collection-less payload.
+
+  A movie whose metadata carries no collection_id sends
+  `Franchises.resolve_collection_id/2` down a movie-details lookup with its own
+  cache key, separate from the recommendations one. Warming it this way
+  resolves that lookup to `:none` offline.
+  """
+  def warm_movie_details_cache(tmdb_id) do
+    bypass = Bypass.open()
+    relay = Metadata.default_relay_config()
+    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
+
+    # Mirrors the key fetch_by_id_cached/3 builds for these opts: no
+    # append_to_response, so that segment is empty, and a nil season order
+    # normalises to "official".
+    on_exit(fn ->
+      Cache.delete(
+        "fetch_by_id:#{relay.type}:#{tmdb_id}:movie:#{relay.options.language}::official"
+      )
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+      body = %{"id" => tmdb_id, "title" => "Source", "belongs_to_collection" => nil}
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    {:ok, _details} = Metadata.fetch_by_id_cached(config, to_string(tmdb_id), media_type: :movie)
+
+    :ok
+  end
+
+  @doc """
+  Populates the TMDB collection cache behind the franchise strip.
+
+  `parts` are raw TMDB result maps with string keys.
+  """
+  def warm_collection_cache(collection_id, parts) do
+    bypass = Bypass.open()
+    relay = Metadata.default_relay_config()
+    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
+
+    on_exit(fn ->
+      Cache.delete("collection:#{relay.type}:#{collection_id}:#{relay.options.language}")
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/tmdb/collections/#{collection_id}", fn conn ->
+      body = %{"id" => collection_id, "name" => "Test Collection", "parts" => parts}
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    {:ok, _collection} = Metadata.fetch_collection_cached(config, collection_id)
+
+    :ok
+  end
+end


### PR DESCRIPTION
Stacked on `worktree-library-picker-dialog`. That branch restored the library picker inside scrolling rails, but wired only the Discover detail-modal rail and left #458 unfixed. This finishes both halves.

Closes #458.

## Why this is needed on top of the dialog branch

The dialog branch's `1fca7d7df` restored `media_rail/1`'s `libraries` attribute and wired `discover_live/index.html.heex`. The media detail page was never wired, so "More like this" and the Collection strip still had no picker. Separately, `add_recommendation/2` and `add_franchise_movie/2` still matched only `%{"tmdb_id" => tmdb_id}` and dropped `library_path_id` on the floor. Wiring the rails without that fix would have made the silent wrong-library failure reachable from two more surfaces.

## What changed

- **The detail page becomes a picker host.** It renders one `library_picker_dialog`, and a new `LibraryPickerEvents` router dispatches its single event to the correct rail by franchise membership. The page has two rails with different add handlers, so rather than teach the shared dialog about sources, the routing lives on the page. Where a movie sits in both rails (#460), the franchise strip wins.
- **#458 is fixed.** Both `perform_add` functions take an `opts` keyword list and honour `:library_path_id`, and both handlers read it from params. An id the server will not honour now flashes instead of silently falling back, which was the whole complaint in that issue.
- **One guard instead of four.** The blank-string guard Discover and Dashboard each held a private copy of is now `MediaAddHelpers.library_path_opts/2`. It also validates the id against `candidate_libraries/1`. That value is client input, so without the check a crafted event could name any `library_paths` row, including one of the wrong type for the media being added.
- **A latent crash is closed.** `RecommendationEvents.perform_add` had no `:already_in_library` clause. Once that shape can reach it, an unmatched result raises `CaseClauseError` and takes the LiveView down.
- **Test infrastructure shared.** The Bypass cache-warming helpers that two detail-page test files each had a private copy of now live in `test/support/metadata_cache_helpers.ex`. `franchise_section_test.exs` also moved off raw `System.unique_integer/1` for provider ids, which collides with real seven-digit TMDB ids and sends unwarmed lookups to the live relay. That may resolve #530.

## Testing

Six unit tests for `library_path_opts/2` covering every outcome, four for both `perform_add` functions persisting the chosen library, and seven LiveView tests covering caret visibility, dialog rendering, cancelling, and the routing itself, including the #460 overlap case where the picker is opened from the recommendations card and the add must land on the franchise rail.

Format, `compile --warnings-as-errors` and `credo --strict` clean. Full suite green on both adapters before the rebase: SQLite 8626 tests, Postgres 8627 tests, 0 failures each. 370 tests re-run green across the touched areas after rebasing onto the current base tip.

## Known gap

The path from event params through `library_path_opts/2` into `dispatch_add` is not covered end to end, because the add calls the uncached `Metadata.fetch_by_id/3` with `socket.assigns.metadata_config`, which `show.ex` builds via `assign_new`. Worth noting that `ef47d68ab` on the base branch has since added an `Application.get_env(:mydia, :metadata_relay_url)` precedence, which would make such a test possible at the cost of mutating global env from a test. That seems worth revisiting deliberately rather than as a drive-by.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared library picker for selecting destinations when adding movies and TV shows.
  - Library selections are available across recommendation, franchise, and discovery rails.
  - Added feedback when a selected library is unavailable or media is already in the library.

- **Bug Fixes**
  - Invalid or unauthorized library selections no longer trigger additions.
  - Add requests correctly resolve items from recommendations and related results.
  - Explicit library selections are honored, while unselected additions use defaults.

- **Tests**
  - Expanded coverage for validation, picker interactions, routing, and rail additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->