### PR TITLE
fix: Run CI when draft pull requests become ready

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -2,6 +2,7 @@ name: CI / Documentation
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master, main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -20,6 +20,7 @@ on:
       - "priv/graphql/schema.graphql"
       - ".github/workflows/ci-player.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "player/**"
       - "native/**"

--- a/.github/workflows/ci-relay.yml
+++ b/.github/workflows/ci-relay.yml
@@ -9,6 +9,7 @@ on:
       - "metadata-relay/**"
       - ".github/workflows/ci-relay.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "**"
     paths:

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -13,6 +13,7 @@ on:
       - "priv/graphql/schema.graphql"
       - ".github/workflows/ci-server.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "server/**"
       # See the push.paths comment above: this entry is inert for the same

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - master
       - main
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "**"
   workflow_dispatch:

--- a/test/ci/workflow_triggers_test.exs
+++ b/test/ci/workflow_triggers_test.exs
@@ -1,0 +1,45 @@
+defmodule Mydia.CI.WorkflowTriggersTest do
+  use ExUnit.Case, async: true
+
+  @required_pull_request_types ~w(opened synchronize reopened ready_for_review)
+  @workflow_patterns [".github/workflows/*.yml", ".github/workflows/*.yaml"]
+
+  test "pull request workflows run for every required activity type" do
+    workflow_paths =
+      @workflow_patterns
+      |> Enum.flat_map(&Path.wildcard(repo_path(&1)))
+      |> Enum.filter(&pull_request_workflow?/1)
+
+    assert workflow_paths != [], "expected to find at least one pull request workflow"
+
+    Enum.each(workflow_paths, fn workflow_path ->
+      workflow = read_workflow!(workflow_path)
+      pull_request = triggers(workflow)["pull_request"] || %{}
+      configured_types = Map.get(pull_request, "types", [])
+      missing_types = @required_pull_request_types -- configured_types
+      relative_path = Path.relative_to(workflow_path, repo_path("."))
+
+      assert missing_types == [],
+             "#{relative_path} is missing pull_request types: #{Enum.join(missing_types, ", ")}"
+    end)
+  end
+
+  defp pull_request_workflow?(workflow_path) do
+    workflow_path
+    |> read_workflow!()
+    |> triggers()
+    |> Map.has_key?("pull_request")
+  end
+
+  # YAML 1.1 parsers resolve the unquoted GitHub Actions `on` key as a boolean.
+  defp triggers(workflow), do: Map.get(workflow, "on") || Map.fetch!(workflow, true)
+
+  defp read_workflow!(workflow_path) do
+    case YamlElixir.read_from_file(workflow_path) do
+      {:ok, workflow} -> workflow
+      {:error, reason} -> raise "failed to parse #{workflow_path}: #{inspect(reason)}"
+    end
+  end
+
+  defp repo_path(path), do: Path.expand(Path.join([__DIR__, "../..", path]))
+end


### PR DESCRIPTION
A pull request can appear blocked without any CI runs, leaving reviewers unable to distinguish a permanently untested change from checks that are merely queued. The repository-verifiable failure is that every current PR-facing CI workflow relies on GitHub's default pull-request activity types, which exclude `ready_for_review`. As a result, converting a draft pull request to ready does not schedule CI until another event, such as a new push, occurs. The separately reported absence of runs for the initial `opened` event has no local configuration diagnosis and remains outside this partial plan.

## Summary

Add an explicit pull-request activity-type list containing `opened`, `synchronize`, `reopened`, and `ready_for_review` to each of the six workflows that currently listens for pull requests. Preserve every existing branch and path filter so the change expands only the accepted activity types, not which files or target branches qualify for each workflow. Add a repository-level regression test that reads all PR-facing workflow definitions and verifies the required activity types while allowing each workflow's existing filters and any additional intentional types.

## Verification

- A draft pull request with changes matching a workflow's existing filters becomes ready, and that workflow's configuration accepts the `ready_for_review` activity.
- Newly opened, synchronized, and reopened pull requests remain accepted after replacing the implicit defaults with an explicit type list.
- The Player, Server, Relay, and Documentation workflows retain their existing path filters, while CI and Relay retain their existing branch filters.
- The regression test discovers every workflow that has a `pull_request` trigger and fails with the workflow path and missing activity type if one omits any required type.
- Push-only workflows such as CI / Docker and CI / Player E2E remain outside the assertion and do not regain pull-request execution.

Closes #322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Pull-request checks now run for opened, synchronized, reopened, and ready-for-review events.
  - This standardizes when automated validation is triggered across project workflows.

- **Tests**
  - Added automated coverage to verify pull-request workflow trigger settings and detect configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->