### PR TITLE
fix(endpoint): mount the SQL sandbox plug only in test

### DIFF
--- a/lib/mydia_web/endpoint.ex
+++ b/lib/mydia_web/endpoint.ex
@@ -15,9 +15,13 @@ defmodule MydiaWeb.Endpoint do
   ]
 
   # Enable SQL sandbox for browser-based feature tests (Wallaby)
-  # This allows browser requests to participate in the test transaction
-  # The plug only activates when sandbox metadata is present in the request
-  plug Phoenix.Ecto.SQL.Sandbox
+  # This allows browser requests to participate in the test transaction.
+  # This plug deserializes data carried in a request header, so per the
+  # library's own guidance it must be compiled out of every environment
+  # except test.
+  if Application.compile_env(:mydia, :sql_sandbox) do
+    plug Phoenix.Ecto.SQL.Sandbox
+  end
 
   # Trust X-Forwarded-* headers from reverse proxy (Caddy)
   # This ensures conn.scheme reflects the original HTTPS request

--- a/test/mydia_web/endpoint_sandbox_guard_test.exs
+++ b/test/mydia_web/endpoint_sandbox_guard_test.exs
@@ -1,0 +1,47 @@
+defmodule MydiaWeb.EndpointSandboxGuardTest do
+  @moduledoc """
+  Source-level guard for `MydiaWeb.Endpoint`.
+
+  `Phoenix.Ecto.SQL.Sandbox` must only ever be compiled into the test
+  environment: per the library's own documentation it should be wrapped in
+  `if Application.compile_env(:mydia, :sql_sandbox) do ... end` so it is
+  absent from every other build. A behavioural test can't exercise this
+  directly, because in the test environment the plug is legitimately
+  mounted. Instead this reads the endpoint source and asserts the plug
+  declaration is nested inside that guard, and nowhere else unguarded.
+  """
+
+  use ExUnit.Case, async: true
+
+  @endpoint_path Path.expand("../../lib/mydia_web/endpoint.ex", __DIR__)
+  @guard_start ~r/^\s*if\s+Application\.compile_env\(:mydia,\s*:sql_sandbox\)\s+do\s*$/
+  @plug_line ~r/^\s*plug\s+Phoenix\.Ecto\.SQL\.Sandbox\s*$/
+  @block_end ~r/^\s*end\s*$/
+
+  test "the SQL sandbox plug is only mounted behind the sql_sandbox compile-time flag" do
+    lines = @endpoint_path |> File.read!() |> String.split("\n")
+
+    guard_index = Enum.find_index(lines, &String.match?(&1, @guard_start))
+
+    assert guard_index,
+           "expected lib/mydia_web/endpoint.ex to guard the sandbox plug behind " <>
+             "`if Application.compile_env(:mydia, :sql_sandbox) do`"
+
+    remainder = Enum.drop(lines, guard_index + 1)
+    end_offset = Enum.find_index(remainder, &String.match?(&1, @block_end))
+
+    assert end_offset,
+           "expected a matching `end` closing the sql_sandbox guard block"
+
+    guarded_block = Enum.slice(remainder, 0, end_offset)
+
+    assert Enum.any?(guarded_block, &String.match?(&1, @plug_line)),
+           "expected `plug Phoenix.Ecto.SQL.Sandbox` inside the sql_sandbox guard block"
+
+    lines_outside_guard =
+      Enum.slice(lines, 0, guard_index) ++ Enum.slice(remainder, (end_offset + 1)..-1//1)
+
+    refute Enum.any?(lines_outside_guard, &String.match?(&1, @plug_line)),
+           "the sandbox plug must not also be mounted outside the sql_sandbox guard"
+  end
+end


### PR DESCRIPTION
## Summary

`Phoenix.Ecto.SQL.Sandbox` was mounted unconditionally in `MydiaWeb.Endpoint`, so it compiled into every environment including production, even though it exists solely to let browser-based feature tests (Wallaby) join the test's database transaction. The library's own documentation prescribes gating this plug behind a compile-time config flag that is only enabled in test; this PR does that.

- Wraps the plug in `if Application.compile_env(:mydia, :sql_sandbox) do ... end` in `lib/mydia_web/endpoint.ex`.
- `config/test.exs` already sets `sql_sandbox: true`, so the plug continues to be mounted in the test environment exactly as before.
- Adds a source-level regression test (`test/mydia_web/endpoint_sandbox_guard_test.exs`) that reads the endpoint source and fails if the plug is ever unwrapped again.

## Verification

- New guard test passes, and was confirmed to fail with the plug unwrapped (proving it actually catches a regression).
- `mix credo --strict` and `mix format` are clean.
- Feature tests (Wallaby) were run locally both with and without this change. Both runs hit the same 4 pre-existing failures (`library_picker_test.exs`, `guest_test.exs`), confirming those are unrelated flakes and not caused by this change. CI also runs the full Wallaby suite on this PR.

## Test plan

- [x] `mix test test/mydia_web/endpoint_sandbox_guard_test.exs`
- [x] `./dev feature-test` (compared against baseline; no new failures introduced)
- [x] `mix credo --strict`
- [x] `mix format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQL sandbox support is now enabled only when explicitly configured, preventing unintended sandbox behavior in production environments.

* **Tests**
  * Added automated coverage to verify that SQL sandbox integration remains properly configuration-controlled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->