### PR TITLE
fix(player): let the sidebar scroll on touch by gating reorder behind an edit mode

### DIFF
--- a/player/lib/core/navigation/sidebar_layout_providers.dart
+++ b/player/lib/core/navigation/sidebar_layout_providers.dart
@@ -47,6 +47,33 @@ Future<List<NavDestination>> sidebarDestinations(Ref ref) async {
   return layout.reconcile(downloadSupported: isDownloadSupported);
 }
 
+/// Whether the sidebar is in edit mode.
+///
+/// Presentation state, never persisted: a relaunch always starts in normal
+/// mode. It lives in a provider rather than widget state because the desktop
+/// sidebar and the mobile drawer each build their own `SidebarContent`, and
+/// `Scaffold.drawer` keeps its child mounted while closed, so local state would
+/// leave the drawer in edit mode the next time it opened.
+@Riverpod(keepAlive: true)
+class SidebarEditMode extends _$SidebarEditMode {
+  @override
+  bool build() => false;
+
+  void toggle() => state = !state;
+
+  void exit() => state = false;
+}
+
+/// The middle rows edit mode arranges, hidden ones included.
+///
+/// Distinct from [sidebarDestinations], which drops hidden rows and keeps
+/// anchors. Edit mode needs the opposite of both.
+@riverpod
+Future<List<SidebarEditRow>> sidebarEditRows(Ref ref) async {
+  final layout = await ref.watch(sidebarLayoutProvider.future);
+  return layout.reconcileForEditing(downloadSupported: isDownloadSupported);
+}
+
 @riverpod
 SidebarLayoutController sidebarLayoutController(Ref ref) =>
     SidebarLayoutController(ref);
@@ -83,5 +110,18 @@ class SidebarLayoutController {
   Future<void> deleteFilter(String id) =>
       _mutate((layout) => layout.withoutFilter(id));
 
-  Future<void> resetToDefaults() => _mutate((_) => SidebarLayout.defaults);
+  /// Restores default order and unhides everything, keeping saved filters.
+  ///
+  /// `SidebarLayout.defaults` carries `filters: const {}`, so assigning it
+  /// wholesale would delete every saved filter rather than rearranging. Filters
+  /// are user-created content and the reset affordance is about arrangement.
+  /// Rule 3 in `reconcileLayout` appends the preserved filters back onto the
+  /// default order, so they return at the bottom of the list.
+  Future<void> resetToDefaults() => _mutate(
+        (layout) => SidebarLayout(
+          order: SidebarLayout.defaults.order,
+          hidden: const {},
+          filters: layout.filters,
+        ),
+      );
 }

--- a/player/lib/domain/navigation/sidebar_layout.dart
+++ b/player/lib/domain/navigation/sidebar_layout.dart
@@ -126,6 +126,31 @@ class SidebarLayout {
     );
   }
 
+  /// The middle rows edit mode arranges, hidden ones included.
+  ///
+  /// Anchors are excluded entirely. They cannot be reordered or hidden, and
+  /// `SidebarContent` renders them outside the reorderable region, so putting
+  /// them in this list would misalign every index the reorder callback reports.
+  List<SidebarEditRow> reconcileForEditing({required bool downloadSupported}) {
+    final layout = reconcileLayout(downloadSupported: downloadSupported);
+
+    final rows = <SidebarEditRow>[];
+    for (final id in layout.order) {
+      final NavDestination? destination =
+          _builtinsById[id] ?? layout.filters[id];
+      if (destination == null) continue;
+      if (destination.isAnchored) continue;
+
+      rows.add(
+        SidebarEditRow(
+          destination: destination,
+          hidden: layout.hidden.contains(id),
+        ),
+      );
+    }
+    return rows;
+  }
+
   /// Where [destination] belongs in [ids]: after the last builtin with a lower
   /// `defaultIndex`. Filters and unknown ids do not move the insertion point.
   static int _insertionPoint(
@@ -232,4 +257,28 @@ class SidebarLayout {
   @override
   String toString() =>
       'SidebarLayout(order: $order, hidden: $hidden, filters: ${filters.keys})';
+}
+
+/// One middle row as edit mode sees it.
+///
+/// Edit mode renders hidden rows in place so the user can see where a restored
+/// row will land, which is why it cannot reuse [SidebarLayout.reconcile]'s
+/// output: that drops hidden rows entirely.
+class SidebarEditRow {
+  const SidebarEditRow({required this.destination, required this.hidden});
+
+  final NavDestination destination;
+  final bool hidden;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SidebarEditRow &&
+      other.destination.id == destination.id &&
+      other.hidden == hidden;
+
+  @override
+  int get hashCode => Object.hash(destination.id, hidden);
+
+  @override
+  String toString() => 'SidebarEditRow(${destination.id}, hidden: $hidden)';
 }

--- a/player/lib/domain/navigation/sidebar_layout.dart
+++ b/player/lib/domain/navigation/sidebar_layout.dart
@@ -151,6 +151,52 @@ class SidebarLayout {
     return rows;
   }
 
+  /// The full stored order after edit mode moves one middle row.
+  ///
+  /// [oldIndex] and [newIndex] index [reconcileForEditing]'s output, and the
+  /// middle list here is built from that same call so the two cannot drift.
+  ///
+  /// `ReorderableListView` reports [newIndex] as a position in the list
+  /// *before* the dragged row is removed, so it is decremented when it sits
+  /// past [oldIndex]. Dropping that adjustment is an off-by-one that appears
+  /// only on downward drags.
+  ///
+  /// Anchors are reassembled around the result rather than carried through the
+  /// move. Their relative order does not matter here because [reconcile] sorts
+  /// anchors by `defaultIndex` at render time regardless of stored order.
+  List<String> orderAfterReorder({
+    required int oldIndex,
+    required int newIndex,
+    required bool downloadSupported,
+  }) {
+    final layout = reconcileLayout(downloadSupported: downloadSupported);
+
+    final middle = reconcileForEditing(downloadSupported: downloadSupported)
+        .map((row) => row.destination.id)
+        .toList();
+    final middleIds = middle.toSet();
+
+    final leading = <String>[];
+    final trailing = <String>[];
+    for (final id in layout.order) {
+      if (middleIds.contains(id)) continue;
+      final builtin = _builtinsById[id];
+      if (builtin != null && _anchorsToTop(builtin)) {
+        leading.add(id);
+      } else {
+        trailing.add(id);
+      }
+    }
+
+    var target = newIndex;
+    if (target > oldIndex) target -= 1;
+
+    final moved = middle.removeAt(oldIndex);
+    middle.insert(target, moved);
+
+    return [...leading, ...middle, ...trailing];
+  }
+
   /// Where [destination] belongs in [ids]: after the last builtin with a lower
   /// `defaultIndex`. Filters and unknown ids do not move the insertion point.
   static int _insertionPoint(

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -7,6 +7,7 @@ import '../../core/config/web_config.dart';
 import '../../core/downloads/collection_auto_sync.dart';
 import '../../core/downloads/download_service.dart' show isDownloadSupported;
 import '../../core/graphql/graphql_provider.dart';
+import '../../core/navigation/sidebar_layout_providers.dart';
 import '../../core/playback/playback_progress_providers.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/theme/colors.dart';
@@ -139,6 +140,25 @@ class AppShell extends ConsumerStatefulWidget {
           child: child,
         ),
       );
+
+  /// Reacts to the mobile drawer opening or closing.
+  ///
+  /// Edit mode is ephemeral, and `Scaffold.drawer` keeps its child mounted
+  /// while closed, so without this the drawer reopens in whatever mode it was
+  /// left in. Order changes persist on every drop, so exiting loses nothing.
+  ///
+  /// Public and `@visibleForTesting` for the reason [castOverlay] and
+  /// [contentGutter] are: a test can exercise the exact call the shell makes,
+  /// rather than a mirror that would stay green if the wiring below were
+  /// deleted.
+  @visibleForTesting
+  static void onDrawerVisibilityChanged({
+    required bool isOpen,
+    required WidgetRef ref,
+  }) {
+    if (isOpen) return;
+    ref.read(sidebarEditModeProvider.notifier).exit();
+  }
 
   @override
   ConsumerState<AppShell> createState() => _AppShellState();
@@ -323,7 +343,9 @@ class _AppShellState extends ConsumerState<AppShell>
       backgroundColor: Colors.transparent,
       extendBody: true,
       onDrawerChanged: (isOpen) {
-        if (mounted) setState(() => _drawerOpen = isOpen);
+        if (!mounted) return;
+        setState(() => _drawerOpen = isOpen);
+        AppShell.onDrawerVisibilityChanged(isOpen: isOpen, ref: ref);
       },
       drawer: MobileDrawer(
         location: location,

--- a/player/lib/presentation/widgets/nav/nav_badges.dart
+++ b/player/lib/presentation/widgets/nav/nav_badges.dart
@@ -11,11 +11,19 @@ class SettingsSidebarRow extends ConsumerWidget {
   final bool isDisabled;
   final VoidCallback onTap;
 
+  /// Forwarded to the wrapped [SidebarRow]. See its docs.
+  final bool isEditing;
+  final bool isHidden;
+  final Widget? editingTrailing;
+
   const SettingsSidebarRow({
     super.key,
     required this.isSelected,
     required this.isDisabled,
     required this.onTap,
+    this.isEditing = false,
+    this.isHidden = false,
+    this.editingTrailing,
   });
 
   @override
@@ -28,6 +36,9 @@ class SettingsSidebarRow extends ConsumerWidget {
       isDisabled: isDisabled,
       onTap: onTap,
       badge: const ConnectionStatusDot(),
+      isEditing: isEditing,
+      isHidden: isHidden,
+      editingTrailing: editingTrailing,
     );
   }
 }

--- a/player/lib/presentation/widgets/nav/sidebar_content.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_content.dart
@@ -121,11 +121,9 @@ class SidebarContent extends ConsumerWidget {
           ),
         ),
         if (editing)
-          // Reset arrives in Task 9, together with its confirmation dialog.
-          // Omitted rather than stubbed, so this commit ships no destructive
-          // control that skips confirming.
           SidebarEditBar(
             onDone: () => ref.read(sidebarEditModeProvider.notifier).exit(),
+            onReset: () => _confirmReset(context, ref),
           ),
         Expanded(
           child: Padding(
@@ -218,6 +216,46 @@ class SidebarContent extends ConsumerWidget {
     );
 
     ref.read(sidebarLayoutControllerProvider).reorder(newOrder);
+  }
+
+  /// Confirms before resetting, because reset is the one destructive action in
+  /// edit mode. It restores default order and unhides every row. Saved
+  /// filters survive (see `SidebarLayoutController.resetToDefaults`) but
+  /// return to the bottom of the list, which the copy says plainly.
+  Future<void> _confirmReset(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: AppColors.surfaceVariant,
+        title: const Text('Reset sidebar?'),
+        content: const Text(
+          'Restores the default order and shows every hidden row. Saved '
+          'filters are kept, but move to the bottom of the list.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Reset'),
+          ),
+        ],
+      ),
+    );
+
+    // sidebarLayoutControllerProvider is plain @riverpod (autoDispose) with no
+    // watcher anywhere, so a controller captured before the dialog's await
+    // does not survive it: the provider is torn down once its listener count
+    // hits zero, and calling a method on the stale instance afterwards throws
+    // UnmountedRefException. Reading it fresh here, mirroring onDelete above
+    // and showFilterEditor's onSave, rebuilds the (stateless) controller on
+    // demand instead of reusing a possibly-disposed one. The context.mounted
+    // guard covers the SidebarContent-unmounted-during-the-dialog case.
+    if ((confirmed ?? false) && context.mounted) {
+      await ref.read(sidebarLayoutControllerProvider).resetToDefaults();
+    }
   }
 
   Widget _buildRow({

--- a/player/lib/presentation/widgets/nav/sidebar_content.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_content.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -12,6 +11,8 @@ import '../../../domain/navigation/sidebar_layout.dart';
 import '../../screens/filter/filter_editor_sheet.dart';
 import '../mydia_logo.dart';
 import 'nav_badges.dart';
+import 'sidebar_edit_bar.dart';
+import 'sidebar_middle_list.dart';
 import 'sidebar_row.dart';
 
 /// Shared sidebar navigation content used by both the desktop sidebar and the
@@ -52,76 +53,22 @@ class SidebarContent extends ConsumerWidget {
     return best;
   }
 
-  /// Builds the full stored order after a middle-section reorder.
-  ///
-  /// Visible middle rows are reordered among themselves; hidden middle ids
-  /// stay at their relative slots in the stored middle list.
-  @visibleForTesting
-  static List<String> orderAfterMiddleReorder({
-    required SidebarLayout layout,
-    required List<String> visibleMiddleIds,
-    required int oldIndex,
-    required int newIndex,
-    required bool downloadSupported,
-  }) {
-    var adjustedNewIndex = newIndex;
-    if (adjustedNewIndex > oldIndex) adjustedNewIndex -= 1;
-
-    final reorderedVisible = List<String>.from(visibleMiddleIds);
-    final moved = reorderedVisible.removeAt(oldIndex);
-    reorderedVisible.insert(adjustedNewIndex, moved);
-
-    final reconciled =
-        layout.reconcileLayout(downloadSupported: downloadSupported);
-    final storedOrder = reconciled.order;
-
-    final leadingIds =
-        storedOrder.where((id) => _isLeadingAnchorId(id)).toList();
-    final trailingIds =
-        storedOrder.where((id) => _isTrailingAnchorId(id)).toList();
-    final storedMiddleIds = storedOrder
-        .where((id) => !_isLeadingAnchorId(id) && !_isTrailingAnchorId(id))
-        .toList();
-
-    final newMiddleIds = _mergeMiddleOrder(
-      storedMiddleIds: storedMiddleIds,
-      hiddenIds: reconciled.hidden,
-      reorderedVisibleIds: reorderedVisible,
-    );
-
-    return [...leadingIds, ...newMiddleIds, ...trailingIds];
-  }
-
-  static bool _isLeadingAnchorId(String id) => id == 'search';
-
-  static bool _isTrailingAnchorId(String id) =>
-      id == 'downloads' || id == 'settings';
-
-  static List<String> _mergeMiddleOrder({
-    required List<String> storedMiddleIds,
-    required Set<String> hiddenIds,
-    required List<String> reorderedVisibleIds,
-  }) {
-    final result = <String>[];
-    var visibleIndex = 0;
-
-    for (final id in storedMiddleIds) {
-      if (hiddenIds.contains(id)) {
-        result.add(id);
-      } else {
-        result.add(reorderedVisibleIds[visibleIndex++]);
-      }
-    }
-
-    return result;
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final editing = ref.watch(sidebarEditModeProvider);
+
     final asyncDestinations = ref.watch(sidebarDestinationsProvider);
     final destinations = switch (asyncDestinations) {
       AsyncData(:final value) => value,
       _ => SidebarLayout.defaults.reconcile(
+          downloadSupported: isDownloadSupported,
+        ),
+    };
+
+    final asyncEditRows = ref.watch(sidebarEditRowsProvider);
+    final editRows = switch (asyncEditRows) {
+      AsyncData(:final value) => value,
+      _ => SidebarLayout.defaults.reconcileForEditing(
           downloadSupported: isDownloadSupported,
         ),
     };
@@ -131,7 +78,6 @@ class SidebarContent extends ConsumerWidget {
         destinations.where((d) => d.isAnchored && d.id == 'search').toList();
     final trailing =
         destinations.where((d) => d.isAnchored && d.id != 'search').toList();
-    final middle = destinations.where((d) => !d.isAnchored).toList();
 
     final hasBackWidget = backToMydiaWidget != null;
 
@@ -144,7 +90,7 @@ class SidebarContent extends ConsumerWidget {
             child: backToMydiaWidget!,
           ),
         Padding(
-          padding: EdgeInsets.fromLTRB(20, hasBackWidget ? 16 : 20, 20, 24),
+          padding: EdgeInsets.fromLTRB(20, hasBackWidget ? 16 : 20, 12, 16),
           child: Row(
             children: [
               const MydiaLogo(size: 36),
@@ -160,9 +106,27 @@ class SidebarContent extends ConsumerWidget {
                       ),
                 ),
               ),
+              IconButton(
+                onPressed: () =>
+                    ref.read(sidebarEditModeProvider.notifier).toggle(),
+                tooltip: 'Edit sidebar',
+                visualDensity: VisualDensity.compact,
+                icon: Icon(
+                  Icons.edit_outlined,
+                  size: 20,
+                  color: editing ? AppColors.primary : AppColors.textSecondary,
+                ),
+              ),
             ],
           ),
         ),
+        if (editing)
+          // Reset arrives in Task 9, together with its confirmation dialog.
+          // Omitted rather than stubbed, so this commit ships no destructive
+          // control that skips confirming.
+          SidebarEditBar(
+            onDone: () => ref.read(sidebarEditModeProvider.notifier).exit(),
+          ),
         Expanded(
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12),
@@ -174,55 +138,44 @@ class SidebarContent extends ConsumerWidget {
                     context: context,
                     destination: destination,
                     selected: selected,
+                    isEditing: editing,
                   ),
                   const SizedBox(height: 2),
                 ],
-                // The reorderable region owns the leftover vertical space and
-                // scrolls inside it. It must not size to its content: the flat
-                // list renders every destination at once, where the old tree
-                // kept Library collapsed, so on a short viewport the column
-                // overflowed by ~100px and the render library threw. Anchors
-                // stay outside this so Downloads and Settings never scroll
-                // away, Settings being the only route back from a hidden row.
                 Expanded(
-                  child: ReorderableListView.builder(
-                    buildDefaultDragHandles: false,
-                    itemCount: middle.length,
+                  child: SidebarMiddleList(
+                    editing: editing,
+                    rows: editRows,
+                    buildRow: (row, {editingTrailing}) => _buildRow(
+                      ref: ref,
+                      context: context,
+                      destination: row.destination,
+                      selected: selected,
+                      isEditing: editing,
+                      isHidden: row.hidden,
+                      editingTrailing: editingTrailing,
+                    ),
                     onReorder: (oldIndex, newIndex) => _onReorder(
                       ref: ref,
-                      middle: middle,
                       oldIndex: oldIndex,
                       newIndex: newIndex,
                     ),
-                    itemBuilder: (context, index) {
-                      final destination = middle[index];
-                      return ReorderableDragStartListener(
-                        key: ValueKey(destination.id),
-                        index: index,
-                        child: Padding(
-                          padding: const EdgeInsets.only(bottom: 2),
-                          child: _buildRow(
-                            ref: ref,
-                            context: context,
-                            destination: destination,
-                            selected: selected,
-                          ),
-                        ),
-                      );
-                    },
+                    onRestore: (id) =>
+                        ref.read(sidebarLayoutControllerProvider).unhide(id),
                   ),
                 ),
-                SidebarRow(
-                  icon: Icons.add_rounded,
-                  selectedIcon: Icons.add_rounded,
-                  label: '+ New filter',
-                  isSelected: false,
-                  onTap: () => showFilterEditor(
-                    context: context,
-                    ref: ref,
-                    initialFilter: MediaFilter.allMovies,
+                if (!editing)
+                  SidebarRow(
+                    icon: Icons.add_rounded,
+                    selectedIcon: Icons.add_rounded,
+                    label: '+ New filter',
+                    isSelected: false,
+                    onTap: () => showFilterEditor(
+                      context: context,
+                      ref: ref,
+                      initialFilter: MediaFilter.allMovies,
+                    ),
                   ),
-                ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8),
                   child: Divider(
@@ -237,6 +190,7 @@ class SidebarContent extends ConsumerWidget {
                     context: context,
                     destination: destination,
                     selected: selected,
+                    isEditing: editing,
                   ),
                   const SizedBox(height: 2),
                 ],
@@ -251,17 +205,13 @@ class SidebarContent extends ConsumerWidget {
 
   void _onReorder({
     required WidgetRef ref,
-    required List<NavDestination> middle,
     required int oldIndex,
     required int newIndex,
   }) {
     final layout =
         ref.read(sidebarLayoutStoreProvider).get() ?? SidebarLayout.defaults;
-    final visibleMiddleIds = middle.map((d) => d.id).toList();
 
-    final newOrder = orderAfterMiddleReorder(
-      layout: layout,
-      visibleMiddleIds: visibleMiddleIds,
+    final newOrder = layout.orderAfterReorder(
       oldIndex: oldIndex,
       newIndex: newIndex,
       downloadSupported: isDownloadSupported,
@@ -275,16 +225,32 @@ class SidebarContent extends ConsumerWidget {
     required BuildContext context,
     required NavDestination destination,
     required NavDestination? selected,
+    bool isEditing = false,
+    bool isHidden = false,
+    Widget? editingTrailing,
   }) {
     final isSelected = selected?.id == destination.id;
     final isDisabled = isOffline && destination.id != 'downloads';
     final canCustomise = !destination.isAnchored;
+
+    // Anchors read as locked while editing so they do not look draggable.
+    // They cannot move, and saying so is more honest than leaving them bare.
+    final Widget? trailing = isEditing && !canCustomise
+        ? const Icon(
+            Icons.lock_outline_rounded,
+            size: 17,
+            color: AppColors.textDisabled,
+          )
+        : editingTrailing;
 
     if (destination.id == 'settings') {
       return SettingsSidebarRow(
         isSelected: isSelected,
         isDisabled: isDisabled,
         onTap: () => onNavigate(destination.route),
+        isEditing: isEditing,
+        isHidden: isHidden,
+        editingTrailing: trailing,
       );
     }
 
@@ -317,6 +283,9 @@ class SidebarContent extends ConsumerWidget {
             context.go('/');
           }
         },
+        isEditing: isEditing,
+        isHidden: isHidden,
+        editingTrailing: trailing,
       );
     }
 
@@ -331,6 +300,9 @@ class SidebarContent extends ConsumerWidget {
       onHide: canCustomise
           ? () => ref.read(sidebarLayoutControllerProvider).hide(destination.id)
           : null,
+      isEditing: isEditing,
+      isHidden: isHidden,
+      editingTrailing: trailing,
     );
   }
 }

--- a/player/lib/presentation/widgets/nav/sidebar_edit_bar.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_edit_bar.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/colors.dart';
+
+/// The bar shown below the sidebar's brand row while edit mode is active.
+///
+/// Presentational: it owns no state and makes no decisions. The reset
+/// confirmation lives with the caller, which has the provider access to act on
+/// the answer.
+class SidebarEditBar extends StatelessWidget {
+  const SidebarEditBar({
+    super.key,
+    required this.onDone,
+    this.onReset,
+  });
+
+  final VoidCallback onDone;
+
+  /// Null while the confirmation dialog does not exist yet, and in any caller
+  /// that has no business offering a destructive reset. The control is omitted
+  /// rather than disabled, so no commit ships a reset that skips its
+  /// confirmation.
+  final VoidCallback? onReset;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(12, 0, 12, 6),
+      padding: const EdgeInsets.fromLTRB(14, 6, 6, 6),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: AppColors.primary.withValues(alpha: 0.28),
+        ),
+      ),
+      child: Row(
+        children: [
+          const Expanded(
+            child: Text(
+              'Editing',
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.6,
+                color: AppColors.primary,
+              ),
+            ),
+          ),
+          if (onReset != null) ...[
+            IconButton(
+              onPressed: onReset,
+              tooltip: 'Reset sidebar',
+              visualDensity: VisualDensity.compact,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints.tightFor(width: 32, height: 32),
+              icon: const Icon(
+                Icons.settings_backup_restore_rounded,
+                size: 19,
+                color: AppColors.textSecondary,
+              ),
+            ),
+            const SizedBox(width: 4),
+          ],
+          TextButton(
+            onPressed: onDone,
+            style: TextButton.styleFrom(
+              backgroundColor: AppColors.primary,
+              foregroundColor: AppColors.onPrimary,
+              minimumSize: const Size(0, 30),
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              shape: const StadiumBorder(),
+              textStyle: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            child: const Text('Done'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/nav/sidebar_edit_bar.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_edit_bar.dart
@@ -22,6 +22,13 @@ class SidebarEditBar extends StatelessWidget {
   /// confirmation.
   final VoidCallback? onReset;
 
+  /// Minimum interactive (tap/click) region for the reset control, in
+  /// logical pixels. Kept at Material's 48dp-adjacent minimum touch target
+  /// guidance (also WCAG 2.5.5 and Apple HIG territory) even though the
+  /// glyph itself stays small — this guards a destructive action, so a
+  /// cramped hit target is a real usability defect, not polish.
+  static const double resetControlTapSize = 44;
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -53,12 +60,14 @@ class SidebarEditBar extends StatelessWidget {
             IconButton(
               onPressed: onReset,
               tooltip: 'Reset sidebar',
-              visualDensity: VisualDensity.compact,
+              iconSize: 19,
               padding: EdgeInsets.zero,
-              constraints: const BoxConstraints.tightFor(width: 32, height: 32),
+              constraints: const BoxConstraints.tightFor(
+                width: resetControlTapSize,
+                height: resetControlTapSize,
+              ),
               icon: const Icon(
                 Icons.settings_backup_restore_rounded,
-                size: 19,
                 color: AppColors.textSecondary,
               ),
             ),
@@ -69,7 +78,7 @@ class SidebarEditBar extends StatelessWidget {
             style: TextButton.styleFrom(
               backgroundColor: AppColors.primary,
               foregroundColor: AppColors.onPrimary,
-              minimumSize: const Size(0, 30),
+              minimumSize: const Size(0, 40),
               padding: const EdgeInsets.symmetric(horizontal: 12),
               shape: const StadiumBorder(),
               textStyle: const TextStyle(

--- a/player/lib/presentation/widgets/nav/sidebar_middle_list.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_middle_list.dart
@@ -50,6 +50,13 @@ class SidebarMiddleList extends StatelessWidget {
 
   final void Function(String id) onRestore;
 
+  /// Minimum interactive (tap/click) region for the restore control, in
+  /// logical pixels. Kept at Material's 48dp-adjacent minimum touch target
+  /// guidance even though the glyph itself stays small — restore is tapped
+  /// repeatedly while a user cleans up a long hidden list on a phone, so a
+  /// cramped hit target is a real usability defect, not polish.
+  static const double _restoreControlTapSize = 44;
+
   @override
   Widget build(BuildContext context) {
     if (!editing) {
@@ -84,13 +91,14 @@ class SidebarMiddleList extends StatelessWidget {
             ? IconButton(
                 onPressed: () => onRestore(row.destination.id),
                 tooltip: 'Restore ${row.destination.label}',
-                visualDensity: VisualDensity.compact,
+                iconSize: 20,
                 padding: EdgeInsets.zero,
-                constraints:
-                    const BoxConstraints.tightFor(width: 32, height: 32),
+                constraints: const BoxConstraints.tightFor(
+                  width: _restoreControlTapSize,
+                  height: _restoreControlTapSize,
+                ),
                 icon: const Icon(
                   Icons.add_circle_outline_rounded,
-                  size: 20,
                   color: AppColors.primary,
                 ),
               )

--- a/player/lib/presentation/widgets/nav/sidebar_middle_list.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_middle_list.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/colors.dart';
+import '../../../domain/navigation/sidebar_layout.dart';
+
+/// The sidebar's scrolling middle region, in one of two renderings.
+///
+/// Normal mode is a plain [ListView] that constructs no drag recognizer at
+/// all. That is the whole point: [ReorderableDragStartListener] uses an
+/// immediate multi-drag recognizer, so wrapping every row in one meant a touch
+/// drag won the gesture arena the moment the finger moved and the scrollable
+/// never saw it. The sidebar could not be scrolled on any touch device.
+///
+/// Edit mode is a [ReorderableListView] whose drag listener wraps only the
+/// grip, and which additionally renders hidden rows in place so the user can
+/// see where a restored row will land.
+///
+/// This region must own the leftover vertical space and scroll inside it. It
+/// must not size to its content: the flat list renders every destination at
+/// once, where the old tree kept Library collapsed, so on a short viewport the
+/// column overflowed by ~100px and the render library threw. Anchors stay
+/// outside this widget so Downloads and Settings never scroll away, Settings
+/// being the only route back from a hidden row.
+class SidebarMiddleList extends StatelessWidget {
+  const SidebarMiddleList({
+    super.key,
+    required this.editing,
+    required this.rows,
+    required this.buildRow,
+    required this.onReorder,
+    required this.onRestore,
+  });
+
+  /// Whether edit mode is active.
+  final bool editing;
+
+  /// Every middle row, hidden ones included. Normal mode filters them out
+  /// here rather than at the call site, so the caller passes one list
+  /// regardless of mode.
+  final List<SidebarEditRow> rows;
+
+  /// Builds the row body. [editingTrailing] is null outside edit mode.
+  final Widget Function(SidebarEditRow row, {Widget? editingTrailing}) buildRow;
+
+  /// Raw `ReorderableListView` indices into [rows], passed through with no
+  /// arithmetic. `SidebarLayout.orderAfterReorder` performs the
+  /// newIndex-past-oldIndex adjustment itself; doing it here too would be a
+  /// second adjustment and an off-by-one on downward drags.
+  final void Function(int oldIndex, int newIndex) onReorder;
+
+  final void Function(String id) onRestore;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!editing) {
+      final visible = rows.where((row) => !row.hidden).toList();
+
+      return ListView.builder(
+        padding: EdgeInsets.zero,
+        itemCount: visible.length,
+        itemBuilder: (context, index) {
+          final row = visible[index];
+          return Padding(
+            key: ValueKey(row.destination.id),
+            padding: const EdgeInsets.only(bottom: 2),
+            child: buildRow(row),
+          );
+        },
+      );
+    }
+
+    return ReorderableListView.builder(
+      padding: EdgeInsets.zero,
+      buildDefaultDragHandles: false,
+      itemCount: rows.length,
+      onReorder: onReorder,
+      itemBuilder: (context, index) {
+        final row = rows[index];
+
+        // A hidden row gets a restore control instead of a grip, so it cannot
+        // be dragged. Visible rows can still be dropped either side of it,
+        // which is what keeps its stored slot meaningful.
+        final Widget trailing = row.hidden
+            ? IconButton(
+                onPressed: () => onRestore(row.destination.id),
+                tooltip: 'Restore ${row.destination.label}',
+                visualDensity: VisualDensity.compact,
+                padding: EdgeInsets.zero,
+                constraints:
+                    const BoxConstraints.tightFor(width: 32, height: 32),
+                icon: const Icon(
+                  Icons.add_circle_outline_rounded,
+                  size: 20,
+                  color: AppColors.primary,
+                ),
+              )
+            : ReorderableDragStartListener(
+                index: index,
+                child: const Icon(
+                  Icons.drag_indicator,
+                  size: 20,
+                  color: AppColors.textSecondary,
+                ),
+              );
+
+        return Padding(
+          key: ValueKey(row.destination.id),
+          padding: const EdgeInsets.only(bottom: 2),
+          child: buildRow(row, editingTrailing: trailing),
+        );
+      },
+    );
+  }
+}

--- a/player/lib/presentation/widgets/nav/sidebar_middle_list.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_middle_list.dart
@@ -19,8 +19,9 @@ import '../../../domain/navigation/sidebar_layout.dart';
 /// must not size to its content: the flat list renders every destination at
 /// once, where the old tree kept Library collapsed, so on a short viewport the
 /// column overflowed by ~100px and the render library threw. Anchors stay
-/// outside this widget so Downloads and Settings never scroll away, Settings
-/// being the only route back from a hidden row.
+/// outside this widget so Downloads and Settings never scroll away. The
+/// route back from a hidden row is the edit-mode pencil plus this list's
+/// own per-row restore control, not Settings.
 class SidebarMiddleList extends StatelessWidget {
   const SidebarMiddleList({
     super.key,
@@ -50,12 +51,34 @@ class SidebarMiddleList extends StatelessWidget {
 
   final void Function(String id) onRestore;
 
-  /// Minimum interactive (tap/click) region for the restore control, in
-  /// logical pixels. Kept at Material's 48dp-adjacent minimum touch target
-  /// guidance even though the glyph itself stays small — restore is tapped
+  /// Minimum interactive (tap/click) height for the restore control, in
+  /// logical pixels. Kept at the WCAG 2.5.5 / Apple HIG minimum touch target
+  /// size even though the glyph itself stays small — restore is tapped
   /// repeatedly while a user cleans up a long hidden list on a phone, so a
   /// cramped hit target is a real usability defect, not polish.
-  static const double _restoreControlTapSize = 44;
+  ///
+  /// Height only, deliberately. This control renders as `SidebarRow`'s
+  /// `editingTrailing` inside its shared trailing slot (`_menuWidth` in
+  /// sidebar_row.dart), which every customisable row's overflow menu also
+  /// occupies at 36px wide. Declaring a width here would not even be a
+  /// no-op: `IconButton` fills its own slot horizontally only because
+  /// Material's default `MaterialTapTargetSize.padded` behaviour pads a
+  /// small icon out to its 48dp minimum and then `BoxConstraints.enforce`
+  /// clamps that padding down into whatever the ambient slot allows: 36px
+  /// here, not 48. Requesting a tight 44px width instead would shrink the
+  /// button back down to its unpadded icon size (about 20px) and leave a
+  /// gap in the slot, which is worse than the width this finding's
+  /// predecessor complained about. Widening the slot itself to reach a
+  /// clean 44px target on both axes was rejected too: the slot is shared
+  /// with normal mode's row layout, and widening it would shift rows there
+  /// too, breaking the "nothing shifts between the two modes" guarantee
+  /// `sidebar_row_editing_test.dart` covers.
+  ///
+  /// The honest result: this control fills its 36px-wide slot exactly (via
+  /// the padding mechanism above, not this constant), and is at least this
+  /// tall — in practice 48px, since height is the one dimension nothing
+  /// upstream constrains, so Material's own padded minimum applies in full.
+  static const double _restoreControlTapHeight = 44;
 
   @override
   Widget build(BuildContext context) {
@@ -94,8 +117,7 @@ class SidebarMiddleList extends StatelessWidget {
                 iconSize: 20,
                 padding: EdgeInsets.zero,
                 constraints: const BoxConstraints.tightFor(
-                  width: _restoreControlTapSize,
-                  height: _restoreControlTapSize,
+                  height: _restoreControlTapHeight,
                 ),
                 icon: const Icon(
                   Icons.add_circle_outline_rounded,

--- a/player/lib/presentation/widgets/nav/sidebar_row.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_row.dart
@@ -74,14 +74,22 @@ class _SidebarRowState extends State<SidebarRow> {
   @override
   Widget build(BuildContext context) {
     final isSelected = widget.isSelected && !widget.isDisabled;
-    final iconColor = widget.isDisabled || widget.isHidden
+
+    // An anchor cannot be reordered or hidden, so while editing it reads as
+    // locked: dimmed the same way a hidden row is, plus the lock glyph
+    // `SidebarContent` adds in its trailing slot.
+    final isLockedWhileEditing = widget.isEditing && !widget.canCustomise;
+
+    final isDimmed =
+        widget.isDisabled || widget.isHidden || isLockedWhileEditing;
+    final iconColor = isDimmed
         ? AppColors.textDisabled
         : isSelected
             ? AppColors.primary
             : _isHovered
                 ? AppColors.textPrimary
                 : AppColors.textSecondary;
-    final textColor = widget.isDisabled || widget.isHidden
+    final textColor = isDimmed
         ? AppColors.textDisabled
         : isSelected
             ? AppColors.textPrimary
@@ -105,9 +113,16 @@ class _SidebarRowState extends State<SidebarRow> {
         _isHovered = false;
         _isLongPressed = false;
       }),
+      // Scoped to anchors only: every row's tap is suppressed while editing,
+      // but only an anchor's cursor changes here. A customisable row is still
+      // draggable and its overflow menu still exists just outside edit mode,
+      // so a click cursor there is arguably still wrong too — left alone as a
+      // separate call, not part of this fix.
       cursor: widget.isDisabled
           ? SystemMouseCursors.forbidden
-          : SystemMouseCursors.click,
+          : isLockedWhileEditing
+              ? SystemMouseCursors.basic
+              : SystemMouseCursors.click,
       child: GestureDetector(
         onTap: widget.isEditing ? null : widget.onTap,
         onLongPress: widget.canCustomise && !widget.isEditing

--- a/player/lib/presentation/widgets/nav/sidebar_row.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_row.dart
@@ -24,6 +24,25 @@ class SidebarRow extends StatefulWidget {
   /// Invoked when the user chooses Delete. Null for builtins.
   final VoidCallback? onDelete;
 
+  /// Whether the sidebar is in edit mode.
+  ///
+  /// Suppresses the tap handler, the overflow menu, and the hover and
+  /// long-press reveal that opens it. Navigation is suspended across the whole
+  /// sidebar while editing, so a mistimed tap cannot navigate away mid-drag.
+  final bool isEditing;
+
+  /// Whether the user has hidden this row.
+  ///
+  /// Only ever true while editing, because edit mode is the only place hidden
+  /// rows render at all.
+  final bool isHidden;
+
+  /// Rendered in the trailing slot in place of the overflow menu while editing.
+  ///
+  /// The parent supplies it because building a `ReorderableDragStartListener`
+  /// needs the item's index, which belongs to the list rather than the row.
+  final Widget? editingTrailing;
+
   const SidebarRow({
     super.key,
     required this.icon,
@@ -37,6 +56,9 @@ class SidebarRow extends StatefulWidget {
     this.onHide,
     this.onEdit,
     this.onDelete,
+    this.isEditing = false,
+    this.isHidden = false,
+    this.editingTrailing,
   });
 
   @override
@@ -52,14 +74,14 @@ class _SidebarRowState extends State<SidebarRow> {
   @override
   Widget build(BuildContext context) {
     final isSelected = widget.isSelected && !widget.isDisabled;
-    final iconColor = widget.isDisabled
+    final iconColor = widget.isDisabled || widget.isHidden
         ? AppColors.textDisabled
         : isSelected
             ? AppColors.primary
             : _isHovered
                 ? AppColors.textPrimary
                 : AppColors.textSecondary;
-    final textColor = widget.isDisabled
+    final textColor = widget.isDisabled || widget.isHidden
         ? AppColors.textDisabled
         : isSelected
             ? AppColors.textPrimary
@@ -67,7 +89,15 @@ class _SidebarRowState extends State<SidebarRow> {
                 ? AppColors.textPrimary
                 : AppColors.textSecondary;
 
-    final showMenu = widget.canCustomise && (_isHovered || _isLongPressed);
+    final showMenu = widget.canCustomise &&
+        !widget.isEditing &&
+        (_isHovered || _isLongPressed);
+
+    // In edit mode the 36px slot the overflow menu already reserves becomes
+    // the grip or restore slot, so nothing shifts between the two modes.
+    final Widget? trailing = widget.isEditing
+        ? widget.editingTrailing
+        : (widget.canCustomise ? _overflowMenu(showMenu: showMenu) : null);
 
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
@@ -79,8 +109,8 @@ class _SidebarRowState extends State<SidebarRow> {
           ? SystemMouseCursors.forbidden
           : SystemMouseCursors.click,
       child: GestureDetector(
-        onTap: widget.onTap,
-        onLongPress: widget.canCustomise
+        onTap: widget.isEditing ? null : widget.onTap,
+        onLongPress: widget.canCustomise && !widget.isEditing
             ? () => setState(() => _isLongPressed = true)
             : null,
         child: AnimatedContainer(
@@ -125,59 +155,56 @@ class _SidebarRowState extends State<SidebarRow> {
                     fontSize: 15,
                     fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
                     color: textColor,
+                    decoration:
+                        widget.isHidden ? TextDecoration.lineThrough : null,
+                    decorationColor: AppColors.textDisabled,
                   ),
                 ),
               ),
-              if (widget.canCustomise)
+              if (trailing != null)
                 SizedBox(
                   width: _menuWidth,
-                  child: Opacity(
-                    opacity: showMenu ? 1 : 0,
-                    child: IgnorePointer(
-                      ignoring: !showMenu,
-                      child: PopupMenuButton<String>(
-                        padding: EdgeInsets.zero,
-                        icon: Icon(
-                          Icons.more_vert,
-                          size: 20,
-                          color: AppColors.textSecondary,
-                        ),
-                        onSelected: (value) {
-                          setState(() => _isLongPressed = false);
-                          switch (value) {
-                            case 'hide':
-                              widget.onHide?.call();
-                            case 'edit':
-                              widget.onEdit?.call();
-                            case 'delete':
-                              widget.onDelete?.call();
-                          }
-                        },
-                        onCanceled: () =>
-                            setState(() => _isLongPressed = false),
-                        itemBuilder: (context) => [
-                          if (widget.onHide != null)
-                            const PopupMenuItem(
-                              value: 'hide',
-                              child: Text('Hide'),
-                            ),
-                          if (widget.onEdit != null)
-                            const PopupMenuItem(
-                              value: 'edit',
-                              child: Text('Edit'),
-                            ),
-                          if (widget.onDelete != null)
-                            const PopupMenuItem(
-                              value: 'delete',
-                              child: Text('Delete'),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
+                  child: Center(child: trailing),
                 ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget _overflowMenu({required bool showMenu}) {
+    return Opacity(
+      opacity: showMenu ? 1 : 0,
+      child: IgnorePointer(
+        ignoring: !showMenu,
+        child: PopupMenuButton<String>(
+          padding: EdgeInsets.zero,
+          icon: Icon(
+            Icons.more_vert,
+            size: 20,
+            color: AppColors.textSecondary,
+          ),
+          onSelected: (value) {
+            setState(() => _isLongPressed = false);
+            switch (value) {
+              case 'hide':
+                widget.onHide?.call();
+              case 'edit':
+                widget.onEdit?.call();
+              case 'delete':
+                widget.onDelete?.call();
+            }
+          },
+          onCanceled: () => setState(() => _isLongPressed = false),
+          itemBuilder: (context) => [
+            if (widget.onHide != null)
+              const PopupMenuItem(value: 'hide', child: Text('Hide')),
+            if (widget.onEdit != null)
+              const PopupMenuItem(value: 'edit', child: Text('Edit')),
+            if (widget.onDelete != null)
+              const PopupMenuItem(value: 'delete', child: Text('Delete')),
+          ],
         ),
       ),
     );

--- a/player/lib/presentation/widgets/nav/sidebar_row.dart
+++ b/player/lib/presentation/widgets/nav/sidebar_row.dart
@@ -161,10 +161,13 @@ class _SidebarRowState extends State<SidebarRow> {
                   ),
                 ),
               ),
-              if (trailing != null)
+              // The slot stays reserved for the whole time the row is
+              // editing, even when the caller withholds editingTrailing, so
+              // the row's width never shifts mid-edit.
+              if (trailing != null || widget.isEditing)
                 SizedBox(
                   width: _menuWidth,
-                  child: Center(child: trailing),
+                  child: Center(child: trailing ?? const SizedBox.shrink()),
                 ),
             ],
           ),

--- a/player/test/core/navigation/sidebar_layout_providers_test.dart
+++ b/player/test/core/navigation/sidebar_layout_providers_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/navigation/sidebar_layout_providers.dart';
 import 'package:player/core/navigation/sidebar_layout_store.dart';
+import 'package:player/domain/navigation/media_filter.dart';
+import 'package:player/domain/navigation/nav_destination.dart';
 import 'package:player/domain/navigation/sidebar_layout.dart';
 
 ProviderContainer _container(SidebarLayoutStore store) {
@@ -59,5 +61,93 @@ void main() {
       await container.read(sidebarLayoutProvider.future),
       SidebarLayout.defaults,
     );
+  });
+
+  group('sidebarEditMode', () {
+    test('starts off, toggles, and exits', () {
+      final container = ProviderContainer(
+        overrides: [
+          sidebarLayoutStoreProvider
+              .overrideWithValue(InMemorySidebarLayoutStore()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(sidebarEditModeProvider), isFalse);
+
+      container.read(sidebarEditModeProvider.notifier).toggle();
+      expect(container.read(sidebarEditModeProvider), isTrue);
+
+      container.read(sidebarEditModeProvider.notifier).exit();
+      expect(container.read(sidebarEditModeProvider), isFalse);
+    });
+
+    test('exit is idempotent', () {
+      final container = ProviderContainer(
+        overrides: [
+          sidebarLayoutStoreProvider
+              .overrideWithValue(InMemorySidebarLayoutStore()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.read(sidebarEditModeProvider.notifier).exit();
+      expect(container.read(sidebarEditModeProvider), isFalse);
+    });
+  });
+
+  group('sidebarEditRows', () {
+    test('includes hidden rows that sidebarDestinations drops', () async {
+      final store = InMemorySidebarLayoutStore();
+      await store.save(SidebarLayout.defaults.withHidden('collections'));
+
+      final container = ProviderContainer(
+        overrides: [sidebarLayoutStoreProvider.overrideWithValue(store)],
+      );
+      addTearDown(container.dispose);
+
+      final destinations =
+          await container.read(sidebarDestinationsProvider.future);
+      expect(
+        destinations.map((d) => d.id),
+        isNot(contains('collections')),
+      );
+
+      final rows = await container.read(sidebarEditRowsProvider.future);
+      final collections =
+          rows.firstWhere((r) => r.destination.id == 'collections');
+      expect(collections.hidden, isTrue);
+    });
+  });
+
+  group('resetToDefaults', () {
+    test('restores order and unhides without deleting saved filters', () async {
+      final filter = FilterDestination(
+        id: 'filter_keep_me',
+        label: 'Keep me',
+        filter: MediaFilter.allMovies,
+      );
+
+      final store = InMemorySidebarLayoutStore();
+      await store.save(
+        SidebarLayout.defaults.withFilter(filter).withHidden('collections'),
+      );
+
+      final container = ProviderContainer(
+        overrides: [sidebarLayoutStoreProvider.overrideWithValue(store)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(sidebarLayoutControllerProvider).resetToDefaults();
+
+      final after = store.get()!;
+      expect(after.hidden, isEmpty);
+      expect(after.filters.keys, contains('filter_keep_me'));
+
+      final destinations =
+          await container.read(sidebarDestinationsProvider.future);
+      expect(destinations.map((d) => d.id), contains('filter_keep_me'));
+      expect(destinations.map((d) => d.id), contains('collections'));
+    });
   });
 }

--- a/player/test/domain/navigation/sidebar_layout_test.dart
+++ b/player/test/domain/navigation/sidebar_layout_test.dart
@@ -179,4 +179,77 @@ void main() {
       expect(hidden.withUnhidden('movies').hidden, isNot(contains('movies')));
     });
   });
+
+  group('reconcileForEditing', () {
+    test('keeps hidden rows in place, flagged', () {
+      final layout = SidebarLayout.defaults.withHidden('collections');
+
+      final rows = layout.reconcileForEditing(downloadSupported: true);
+      final ids = rows.map((r) => r.destination.id).toList();
+
+      expect(ids, contains('collections'));
+
+      final collections = rows.firstWhere(
+        (r) => r.destination.id == 'collections',
+      );
+      expect(collections.hidden, isTrue);
+
+      final movies = rows.firstWhere((r) => r.destination.id == 'movies');
+      expect(movies.hidden, isFalse);
+    });
+
+    test('holds a hidden row at its stored slot', () {
+      final visible = SidebarLayout.defaults
+          .reconcileForEditing(downloadSupported: true)
+          .map((r) => r.destination.id)
+          .toList();
+      final expectedIndex = visible.indexOf('collections');
+
+      final hiddenLayout = SidebarLayout.defaults.withHidden('collections');
+      final rows = hiddenLayout.reconcileForEditing(downloadSupported: true);
+
+      expect(
+        rows.map((r) => r.destination.id).toList().indexOf('collections'),
+        expectedIndex,
+      );
+    });
+
+    test('excludes anchors', () {
+      final rows =
+          SidebarLayout.defaults.reconcileForEditing(downloadSupported: true);
+      final ids = rows.map((r) => r.destination.id).toList();
+
+      expect(ids, isNot(contains('search')));
+      expect(ids, isNot(contains('downloads')));
+      expect(ids, isNot(contains('settings')));
+    });
+
+    test('drops ids matching no builtin and no stored filter', () {
+      final layout = SidebarLayout(
+        order: [...SidebarLayout.defaults.order, 'ghost_id'],
+        hidden: const {},
+        filters: const {},
+      );
+
+      final ids = layout
+          .reconcileForEditing(downloadSupported: true)
+          .map((r) => r.destination.id);
+
+      expect(ids, isNot(contains('ghost_id')));
+    });
+
+    test('is unaffected by download support', () {
+      // The only download-gated destination is `downloads`, and it is
+      // anchored, so it never reaches the middle list either way.
+      final supported =
+          SidebarLayout.defaults.reconcileForEditing(downloadSupported: true);
+      final unsupported =
+          SidebarLayout.defaults.reconcileForEditing(downloadSupported: false);
+
+      expect(
+        unsupported.map((r) => r.destination.id).toList(),
+        supported.map((r) => r.destination.id).toList(),
+      );
+    });
+  });
 }

--- a/player/test/domain/navigation/sidebar_layout_test.dart
+++ b/player/test/domain/navigation/sidebar_layout_test.dart
@@ -252,4 +252,88 @@ void main() {
       );
     });
   });
+
+  group('orderAfterReorder', () {
+    List<String> middleOf(SidebarLayout layout) => layout
+        .reconcileForEditing(downloadSupported: true)
+        .map((r) => r.destination.id)
+        .toList();
+
+    test('moves a row upward to the front', () {
+      final layout = SidebarLayout.defaults;
+      final middle = middleOf(layout);
+      final moviesIndex = middle.indexOf('movies');
+
+      final order = layout.orderAfterReorder(
+        oldIndex: moviesIndex,
+        newIndex: 0,
+        downloadSupported: true,
+      );
+
+      final newMiddle = order
+          .where(
+              (id) => id != 'search' && id != 'downloads' && id != 'settings')
+          .toList();
+      expect(newMiddle.first, 'movies');
+    });
+
+    test('moves a row downward, applying the pre-removal index adjustment', () {
+      // ReorderableListView reports newIndex against the list BEFORE the
+      // dragged row is removed. Without the decrement this lands one slot too
+      // early, which only shows on downward drags.
+      final layout = SidebarLayout.defaults;
+      final middle = middleOf(layout);
+
+      final order = layout.orderAfterReorder(
+        oldIndex: 0,
+        newIndex: 3,
+        downloadSupported: true,
+      );
+
+      final newMiddle = order
+          .where(
+              (id) => id != 'search' && id != 'downloads' && id != 'settings')
+          .toList();
+
+      final expected = List<String>.from(middle);
+      final moved = expected.removeAt(0);
+      expected.insert(2, moved);
+
+      expect(newMiddle, expected);
+    });
+
+    test('keeps anchors pinned at the edges', () {
+      final layout = SidebarLayout.defaults;
+      final middle = middleOf(layout);
+
+      final order = layout.orderAfterReorder(
+        oldIndex: middle.length - 1,
+        newIndex: 0,
+        downloadSupported: true,
+      );
+
+      expect(order.first, 'search');
+      expect(order.sublist(order.length - 2), ['downloads', 'settings']);
+    });
+
+    test('carries a hidden row along as an ordinary middle row', () {
+      final layout = SidebarLayout.defaults.withHidden('collections');
+      final middle = middleOf(layout);
+      final collectionsIndex = middle.indexOf('collections');
+
+      final order = layout.orderAfterReorder(
+        oldIndex: collectionsIndex,
+        newIndex: 0,
+        downloadSupported: true,
+      );
+
+      final newMiddle = order
+          .where(
+              (id) => id != 'search' && id != 'downloads' && id != 'settings')
+          .toList();
+
+      expect(newMiddle.first, 'collections');
+      expect(order, contains('collections'));
+    });
+  });
 }

--- a/player/test/presentation/widgets/app_shell_edit_mode_reset_test.dart
+++ b/player/test/presentation/widgets/app_shell_edit_mode_reset_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/navigation/sidebar_layout_providers.dart';
+import 'package:player/core/navigation/sidebar_layout_store.dart';
+import 'package:player/presentation/widgets/app_shell.dart';
+
+/// Pumps a bare `Consumer` and hands back its ref.
+///
+/// [AppShell.onDrawerVisibilityChanged] takes a `WidgetRef`, and mounting the
+/// whole shell to obtain one would drag in auth, GraphQL, connection and
+/// compatibility stubs for the sake of a two-line handler.
+Future<WidgetRef> _pumpRef(
+  WidgetTester tester,
+  ProviderContainer container,
+) async {
+  late WidgetRef captured;
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        home: Consumer(
+          builder: (context, ref, _) {
+            captured = ref;
+            return const SizedBox();
+          },
+        ),
+      ),
+    ),
+  );
+  return captured;
+}
+
+void main() {
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        sidebarLayoutStoreProvider
+            .overrideWithValue(InMemorySidebarLayoutStore()),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  testWidgets('a closing drawer exits edit mode', (tester) async {
+    final container = makeContainer();
+    final ref = await _pumpRef(tester, container);
+
+    container.read(sidebarEditModeProvider.notifier).toggle();
+    expect(container.read(sidebarEditModeProvider), isTrue);
+
+    AppShell.onDrawerVisibilityChanged(isOpen: false, ref: ref);
+    await tester.pump();
+
+    expect(container.read(sidebarEditModeProvider), isFalse);
+  });
+
+  testWidgets('an opening drawer leaves edit mode alone', (tester) async {
+    final container = makeContainer();
+    final ref = await _pumpRef(tester, container);
+
+    container.read(sidebarEditModeProvider.notifier).toggle();
+
+    AppShell.onDrawerVisibilityChanged(isOpen: true, ref: ref);
+    await tester.pump();
+
+    expect(container.read(sidebarEditModeProvider), isTrue);
+  });
+}

--- a/player/test/presentation/widgets/nav/sidebar_content_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_content_test.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart' hide ConnectionState;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/connection/connection_provider.dart';
-import 'package:player/core/downloads/download_service.dart'
-    show isDownloadSupported;
 import 'package:player/core/navigation/sidebar_layout_providers.dart';
 import 'package:player/core/navigation/sidebar_layout_store.dart';
 import 'package:player/domain/navigation/sidebar_layout.dart';
@@ -150,76 +148,86 @@ void main() {
     expect(downloads.isDisabled, isFalse);
   });
 
-  test('reorder preserves hidden middle ids in stored order', () async {
+  testWidgets('the header offers an edit control', (tester) async {
+    await _pump(tester, location: '/');
+
+    expect(find.byTooltip('Edit sidebar'), findsOneWidget);
+    expect(find.text('Editing'), findsNothing);
+  });
+
+  testWidgets('tapping edit reveals grips and hidden rows', (tester) async {
     final store = InMemorySidebarLayoutStore();
     await store.save(SidebarLayout.defaults.withHidden('collections'));
 
-    final container = ProviderContainer(
-      overrides: [sidebarLayoutStoreProvider.overrideWithValue(store)],
-    );
-    addTearDown(container.dispose);
+    await _pump(tester, location: '/', store: store);
+    expect(find.text('Collections'), findsNothing);
 
-    await container.read(sidebarLayoutProvider.future);
+    await tester.tap(find.byTooltip('Edit sidebar'));
+    await tester.pumpAndSettle();
 
-    final layoutBefore = store.get()!;
-    final middleBefore = layoutBefore.order
-        .where(
-          (id) => id != 'search' && id != 'downloads' && id != 'settings',
-        )
-        .toList();
-    final collectionsIndexBefore = middleBefore.indexOf('collections');
-    expect(collectionsIndexBefore, greaterThan(0));
-    final neighborBefore = middleBefore[collectionsIndexBefore - 1];
+    expect(find.text('Editing'), findsOneWidget);
+    expect(find.text('Collections'), findsOneWidget);
+    expect(find.byType(ReorderableDragStartListener), findsWidgets);
+  });
 
-    final visibleMiddle =
-        (await container.read(sidebarDestinationsProvider.future))
-            .where((d) => !d.isAnchored)
-            .map((d) => d.id)
-            .toList();
-    final moviesIndex = visibleMiddle.indexOf('movies');
+  testWidgets('a row tap does not navigate while editing', (tester) async {
+    final routes = <String>[];
+    await _pump(tester, location: '/', onNavigate: routes.add);
 
-    final newOrder = SidebarContent.orderAfterMiddleReorder(
-      layout: layoutBefore,
-      visibleMiddleIds: visibleMiddle,
-      oldIndex: moviesIndex,
-      newIndex: 0,
-      downloadSupported: isDownloadSupported,
-    );
+    await tester.tap(find.byTooltip('Edit sidebar'));
+    await tester.pumpAndSettle();
 
-    await container.read(sidebarLayoutControllerProvider).reorder(newOrder);
+    await tester.tap(find.text('Movies'));
+    await tester.pumpAndSettle();
 
-    final layoutAfterReorder = store.get()!;
-    expect(layoutAfterReorder.order, contains('collections'));
-    expect(layoutAfterReorder.hidden, contains('collections'));
+    expect(routes, isEmpty);
+  });
 
-    final middleAfterReorder = layoutAfterReorder.order
-        .where(
-          (id) => id != 'search' && id != 'downloads' && id != 'settings',
-        )
-        .toList();
-    expect(
-      middleAfterReorder.indexOf('collections'),
-      collectionsIndexBefore,
-    );
-    expect(middleAfterReorder[collectionsIndexBefore - 1], neighborBefore);
+  testWidgets('Done leaves edit mode', (tester) async {
+    await _pump(tester, location: '/');
 
-    await container.read(sidebarLayoutControllerProvider).unhide('collections');
+    await tester.tap(find.byTooltip('Edit sidebar'));
+    await tester.pumpAndSettle();
+    expect(find.text('Editing'), findsOneWidget);
 
-    final destinations =
-        await container.read(sidebarDestinationsProvider.future);
-    expect(destinations.map((d) => d.id), contains('collections'));
+    await tester.tap(find.text('Done'));
+    await tester.pumpAndSettle();
 
-    final middleAfterUnhide = store
-        .get()!
-        .order
-        .where(
-          (id) => id != 'search' && id != 'downloads' && id != 'settings',
-        )
-        .toList();
-    expect(
-      middleAfterUnhide.indexOf('collections'),
-      collectionsIndexBefore,
-    );
-    expect(middleAfterUnhide[collectionsIndexBefore - 1], neighborBefore);
+    expect(find.text('Editing'), findsNothing);
+    expect(find.byType(ReorderableDragStartListener), findsNothing);
+  });
+
+  testWidgets('the New filter row is hidden while editing', (tester) async {
+    await _pump(tester, location: '/');
+    expect(find.text('+ New filter'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Edit sidebar'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('+ New filter'), findsNothing);
+  });
+
+  testWidgets('restoring a hidden row unhides it', (tester) async {
+    final store = InMemorySidebarLayoutStore();
+    await store.save(SidebarLayout.defaults.withHidden('collections'));
+
+    await _pump(tester, location: '/', store: store);
+
+    await tester.tap(find.byTooltip('Edit sidebar'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Restore Collections'));
+    await tester.pumpAndSettle();
+
+    expect(store.get()!.hidden, isNot(contains('collections')));
+  });
+
+  testWidgets('edit mode offers no reset until it can confirm', (tester) async {
+    await _pump(tester, location: '/');
+
+    await tester.tap(find.byTooltip('Edit sidebar'));
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('Reset sidebar'), findsNothing);
   });
 }

--- a/player/test/presentation/widgets/nav/sidebar_content_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_content_test.dart
@@ -222,12 +222,42 @@ void main() {
     expect(store.get()!.hidden, isNot(contains('collections')));
   });
 
-  testWidgets('edit mode offers no reset until it can confirm', (tester) async {
-    await _pump(tester, location: '/');
+  testWidgets('reset asks before it acts, and cancel changes nothing',
+      (tester) async {
+    final store = InMemorySidebarLayoutStore();
+    await store.save(SidebarLayout.defaults.withHidden('collections'));
+
+    await _pump(tester, location: '/', store: store);
 
     await tester.tap(find.byTooltip('Edit sidebar'));
     await tester.pumpAndSettle();
 
-    expect(find.byTooltip('Reset sidebar'), findsNothing);
+    await tester.tap(find.byTooltip('Reset sidebar'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Reset sidebar?'), findsOneWidget);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(store.get()!.hidden, contains('collections'));
+  });
+
+  testWidgets('confirming reset unhides everything', (tester) async {
+    final store = InMemorySidebarLayoutStore();
+    await store.save(SidebarLayout.defaults.withHidden('collections'));
+
+    await _pump(tester, location: '/', store: store);
+
+    await tester.tap(find.byTooltip('Edit sidebar'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Reset sidebar'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Reset'));
+    await tester.pumpAndSettle();
+
+    expect(store.get()!.hidden, isEmpty);
   });
 }

--- a/player/test/presentation/widgets/nav/sidebar_content_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_content_test.dart
@@ -222,6 +222,35 @@ void main() {
     expect(store.get()!.hidden, isNot(contains('collections')));
   });
 
+  testWidgets(
+      'the restore control fills its shared 36px slot, and keeps at least a '
+      '44px tap height', (tester) async {
+    // SidebarRow's trailing slot is a fixed 36px, shared with normal mode's
+    // overflow menu; widening it would shift row layout there too. So the
+    // restore control's live hit target is 36 wide, exactly the slot, not
+    // the 44 its own BoxConstraints requests for height alone — width comes
+    // from Material's own default tap-target padding being clamped down
+    // into the slot, not from this widget's constraints. Height is at least
+    // the requested 44 and, since nothing upstream bounds it, actually lands
+    // at Material's own 48px padded minimum.
+    final store = InMemorySidebarLayoutStore();
+    await store.save(SidebarLayout.defaults.withHidden('collections'));
+
+    await _pump(tester, location: '/', store: store);
+
+    await tester.tap(find.byTooltip('Edit sidebar'));
+    await tester.pumpAndSettle();
+
+    final button = find.ancestor(
+      of: find.byTooltip('Restore Collections'),
+      matching: find.byType(IconButton),
+    );
+    final size = tester.getSize(button);
+
+    expect(size.width, 36);
+    expect(size.height, greaterThanOrEqualTo(44));
+  });
+
   testWidgets('reset asks before it acts, and cancel changes nothing',
       (tester) async {
     final store = InMemorySidebarLayoutStore();

--- a/player/test/presentation/widgets/nav/sidebar_edit_bar_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_edit_bar_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/nav/sidebar_edit_bar.dart';
+
+Future<void> _pumpBar(
+  WidgetTester tester, {
+  required VoidCallback onDone,
+  VoidCallback? onReset,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 260,
+          child: SidebarEditBar(onDone: onDone, onReset: onReset),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('Done calls onDone', (tester) async {
+    var done = 0;
+    await _pumpBar(tester, onDone: () => done++, onReset: () {});
+
+    await tester.tap(find.text('Done'));
+    await tester.pumpAndSettle();
+
+    expect(done, 1);
+  });
+
+  testWidgets('the reset action calls onReset', (tester) async {
+    var reset = 0;
+    await _pumpBar(tester, onDone: () {}, onReset: () => reset++);
+
+    await tester.tap(find.byTooltip('Reset sidebar'));
+    await tester.pumpAndSettle();
+
+    expect(reset, 1);
+  });
+
+  testWidgets('labels the mode', (tester) async {
+    await _pumpBar(tester, onDone: () {}, onReset: () {});
+
+    expect(find.text('Editing'), findsOneWidget);
+  });
+
+  testWidgets('omits the reset control when onReset is null', (tester) async {
+    await _pumpBar(tester, onDone: () {});
+
+    expect(find.byTooltip('Reset sidebar'), findsNothing);
+    expect(find.text('Done'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/widgets/nav/sidebar_edit_bar_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_edit_bar_test.dart
@@ -53,4 +53,20 @@ void main() {
     expect(find.byTooltip('Reset sidebar'), findsNothing);
     expect(find.text('Done'), findsOneWidget);
   });
+
+  testWidgets('the reset control keeps an accessible tap target',
+      (tester) async {
+    await _pumpBar(tester, onDone: () {}, onReset: () {});
+
+    final tapTargetSize = tester.getSize(find.byTooltip('Reset sidebar'));
+
+    expect(
+      tapTargetSize.width,
+      greaterThanOrEqualTo(SidebarEditBar.resetControlTapSize),
+    );
+    expect(
+      tapTargetSize.height,
+      greaterThanOrEqualTo(SidebarEditBar.resetControlTapSize),
+    );
+  });
 }

--- a/player/test/presentation/widgets/nav/sidebar_middle_list_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_middle_list_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/navigation/sidebar_layout.dart';
+import 'package:player/presentation/widgets/nav/sidebar_middle_list.dart';
+
+List<SidebarEditRow> _rows({Set<String> hidden = const {}}) {
+  return SidebarLayout.defaults
+      .reconcileForEditing(downloadSupported: true)
+      .map(
+        (row) => SidebarEditRow(
+          destination: row.destination,
+          hidden: hidden.contains(row.destination.id),
+        ),
+      )
+      .toList();
+}
+
+Future<void> _pumpList(
+  WidgetTester tester, {
+  required bool editing,
+  List<SidebarEditRow>? rows,
+  void Function(int, int)? onReorder,
+  void Function(String)? onRestore,
+  double height = 220,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 260,
+          height: height,
+          child: SidebarMiddleList(
+            editing: editing,
+            rows: rows ?? _rows(),
+            buildRow: (row, {editingTrailing}) => SizedBox(
+              height: 46,
+              child: Row(
+                children: [
+                  Expanded(child: Text(row.destination.label)),
+                  if (editingTrailing != null) editingTrailing,
+                ],
+              ),
+            ),
+            onReorder: onReorder ?? (_, __) {},
+            onRestore: onRestore ?? (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('normal mode scrolls when a row is dragged', (tester) async {
+    // The bug this whole change exists for. A ReorderableDragStartListener uses
+    // an immediate drag recognizer, so wrapping every row in one meant a touch
+    // drag started a reorder and the list never scrolled.
+    await _pumpList(tester, editing: false);
+
+    final scrollable = find.descendant(
+      of: find.byType(SidebarMiddleList),
+      matching: find.byType(Scrollable),
+    );
+    final before = tester.state<ScrollableState>(scrollable).position.pixels;
+
+    await tester.drag(find.text('Home'), const Offset(0, -140));
+    await tester.pumpAndSettle();
+
+    final after = tester.state<ScrollableState>(scrollable).position.pixels;
+    expect(after, greaterThan(before));
+  });
+
+  testWidgets('normal mode builds no drag machinery at all', (tester) async {
+    await _pumpList(tester, editing: false);
+
+    expect(find.byType(ReorderableDragStartListener), findsNothing);
+    expect(find.byType(ReorderableListView), findsNothing);
+  });
+
+  testWidgets('normal mode omits hidden rows', (tester) async {
+    await _pumpList(
+      tester,
+      editing: false,
+      rows: _rows(hidden: {'movies'}),
+      height: 900,
+    );
+
+    expect(find.text('Movies'), findsNothing);
+    expect(find.text('Home'), findsOneWidget);
+  });
+
+  testWidgets('edit mode shows hidden rows and builds grips', (tester) async {
+    await _pumpList(
+      tester,
+      editing: true,
+      rows: _rows(hidden: {'movies'}),
+      height: 900,
+    );
+
+    expect(find.text('Movies'), findsOneWidget);
+    expect(find.byType(ReorderableDragStartListener), findsWidgets);
+  });
+
+  testWidgets('edit mode gives a hidden row a restore control, not a grip',
+      (tester) async {
+    var restored = <String>[];
+    await _pumpList(
+      tester,
+      editing: true,
+      rows: _rows(hidden: {'movies'}),
+      onRestore: restored.add,
+      height: 900,
+    );
+
+    await tester.tap(find.byTooltip('Restore Movies'));
+    await tester.pumpAndSettle();
+
+    expect(restored, ['movies']);
+  });
+}

--- a/player/test/presentation/widgets/nav/sidebar_middle_list_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_middle_list_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/domain/navigation/sidebar_layout.dart';
@@ -117,5 +118,53 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(restored, ['movies']);
+  });
+
+  testWidgets(
+      'edit mode passes the raw ReorderableListView indices straight '
+      'through, unmodified', (tester) async {
+    // `_rows()` (no hidden ids) puts Home at index 0, Continue Watching at
+    // 1, Movies at 2 — see SidebarLayout.defaults' builtin ordering.
+    final captured = <(int, int)>[];
+    await _pumpList(
+      tester,
+      editing: true,
+      onReorder: (oldIndex, newIndex) => captured.add((oldIndex, newIndex)),
+      height: 900,
+    );
+
+    // Drag Home's grip down until the drag proxy settles past Movies (row
+    // index 2). Every row occupies a fixed 48px slot (46px content from
+    // `_pumpList`'s `buildRow` plus this widget's own 2px bottom padding),
+    // so rows sit at [0,48), [48,96), [96,144)... Dragging down by 84px
+    // puts the dragged proxy's trailing edge at 132px, inside Movies'
+    // ending half (its midpoint-to-end span is 120-144px). Per
+    // `_dragUpdateItems` in the Flutter SDK's
+    // `packages/flutter/lib/src/widgets/reorderable_list.dart`, landing in
+    // an item's ending half sets `newIndex = item.index + 1`, i.e. 3 —
+    // NOT 2. That "+1" is Flutter's documented pre-removal semantics:
+    // ReorderableListView reports newIndex as the insertion point in the
+    // list *before* the dragged row is removed, one past where the row
+    // actually lands once removal happens. `SidebarLayout
+    // .orderAfterReorder` performs exactly that one adjustment itself.
+    //
+    // If this widget "helpfully" pre-adjusted newIndex too (reintroducing
+    // a second `-= 1`), this test would observe (0, 2) here instead of
+    // (0, 3) — precisely the off-by-one-on-downward-drags failure mode
+    // the brief warns about by name.
+    final grip = find.descendant(
+      of: find.byKey(const ValueKey('home')),
+      matching: find.byType(ReorderableDragStartListener),
+    );
+    final gesture = await tester.startGesture(tester.getCenter(grip));
+    await tester.pump(kPressTimeout);
+    for (var i = 0; i < 4; i++) {
+      await gesture.moveBy(const Offset(0, 21));
+      await tester.pump();
+    }
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(captured, [(0, 3)]);
   });
 }

--- a/player/test/presentation/widgets/nav/sidebar_row_editing_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_row_editing_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/theme/colors.dart';
+import 'package:player/presentation/widgets/nav/sidebar_row.dart';
+
+Future<void> _pumpRow(
+  WidgetTester tester, {
+  required bool isEditing,
+  bool isHidden = false,
+  Widget? editingTrailing,
+  VoidCallback? onTap,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 260,
+          child: SidebarRow(
+            icon: Icons.movie_outlined,
+            selectedIcon: Icons.movie,
+            label: 'Movies',
+            isSelected: false,
+            canCustomise: true,
+            isEditing: isEditing,
+            isHidden: isHidden,
+            editingTrailing: editingTrailing,
+            onTap: onTap ?? () {},
+            onHide: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('editing suppresses the row tap', (tester) async {
+    var taps = 0;
+    await _pumpRow(tester, isEditing: true, onTap: () => taps++);
+
+    await tester.tap(find.text('Movies'));
+    await tester.pumpAndSettle();
+
+    expect(taps, 0);
+  });
+
+  testWidgets('a normal row still taps', (tester) async {
+    var taps = 0;
+    await _pumpRow(tester, isEditing: false, onTap: () => taps++);
+
+    await tester.tap(find.text('Movies'));
+    await tester.pumpAndSettle();
+
+    expect(taps, 1);
+  });
+
+  testWidgets('editing renders editingTrailing instead of the menu',
+      (tester) async {
+    await _pumpRow(
+      tester,
+      isEditing: true,
+      editingTrailing: const Icon(Icons.drag_indicator, key: Key('grip')),
+    );
+
+    expect(find.byKey(const Key('grip')), findsOneWidget);
+    expect(find.byType(PopupMenuButton<String>), findsNothing);
+  });
+
+  testWidgets('a normal customizable row keeps its overflow menu',
+      (tester) async {
+    await _pumpRow(tester, isEditing: false);
+
+    expect(find.byType(PopupMenuButton<String>), findsOneWidget);
+  });
+
+  testWidgets('a hidden row strikes its label and dims it', (tester) async {
+    await _pumpRow(
+      tester,
+      isEditing: true,
+      isHidden: true,
+      editingTrailing: const Icon(Icons.add_circle, key: Key('restore')),
+    );
+
+    final text = tester.widget<Text>(find.text('Movies'));
+    expect(text.style?.decoration, TextDecoration.lineThrough);
+    expect(text.style?.color, AppColors.textDisabled);
+  });
+
+  testWidgets('editing does not long-press into the menu', (tester) async {
+    await _pumpRow(
+      tester,
+      isEditing: true,
+      editingTrailing: const Icon(Icons.drag_indicator, key: Key('grip')),
+    );
+
+    await tester.longPress(find.text('Movies'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hide'), findsNothing);
+  });
+}

--- a/player/test/presentation/widgets/nav/sidebar_row_editing_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_row_editing_test.dart
@@ -134,4 +134,25 @@ void main() {
     expect(find.byKey(const Key('grip')), findsOneWidget);
     expect(find.byType(PopupMenuButton<String>), findsNothing);
   });
+
+  testWidgets('an anchor dims its icon and label while editing',
+      (tester) async {
+    await _pumpRow(tester, isEditing: true, canCustomise: false);
+
+    final text = tester.widget<Text>(find.text('Movies'));
+    final icon = tester.widget<Icon>(find.byIcon(Icons.movie_outlined));
+
+    expect(text.style?.color, AppColors.textDisabled);
+    expect(icon.color, AppColors.textDisabled);
+    // Unlike a hidden row, an anchor is never struck through — it is locked,
+    // not removed.
+    expect(text.style?.decoration, isNot(TextDecoration.lineThrough));
+  });
+
+  testWidgets('an anchor is not dimmed outside edit mode', (tester) async {
+    await _pumpRow(tester, isEditing: false, canCustomise: false);
+
+    final text = tester.widget<Text>(find.text('Movies'));
+    expect(text.style?.color, isNot(AppColors.textDisabled));
+  });
 }

--- a/player/test/presentation/widgets/nav/sidebar_row_editing_test.dart
+++ b/player/test/presentation/widgets/nav/sidebar_row_editing_test.dart
@@ -7,6 +7,7 @@ Future<void> _pumpRow(
   WidgetTester tester, {
   required bool isEditing,
   bool isHidden = false,
+  bool canCustomise = true,
   Widget? editingTrailing,
   VoidCallback? onTap,
 }) async {
@@ -20,7 +21,7 @@ Future<void> _pumpRow(
             selectedIcon: Icons.movie,
             label: 'Movies',
             isSelected: false,
-            canCustomise: true,
+            canCustomise: canCustomise,
             isEditing: isEditing,
             isHidden: isHidden,
             editingTrailing: editingTrailing,
@@ -33,6 +34,11 @@ Future<void> _pumpRow(
   );
   await tester.pumpAndSettle();
 }
+
+/// The 36px trailing slot every customisable row already reserves for its
+/// overflow menu. Edit mode reuses this same width for the grip/restore
+/// slot, so a slot of exactly this width must persist while editing.
+const _menuWidth = 36.0;
 
 void main() {
   testWidgets('editing suppresses the row tap', (tester) async {
@@ -98,5 +104,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Hide'), findsNothing);
+  });
+
+  testWidgets(
+      'editing reserves the trailing slot even when editingTrailing is '
+      'omitted', (tester) async {
+    await _pumpRow(tester, isEditing: true);
+
+    final slot = tester.widget<SizedBox>(
+      find.byWidgetPredicate(
+        (widget) => widget is SizedBox && widget.width == _menuWidth,
+      ),
+    );
+
+    expect(slot.width, _menuWidth);
+    expect(find.byType(PopupMenuButton<String>), findsNothing);
+  });
+
+  testWidgets(
+      'a non-customisable row still shows a supplied editingTrailing while '
+      'editing', (tester) async {
+    await _pumpRow(
+      tester,
+      isEditing: true,
+      canCustomise: false,
+      editingTrailing: const Icon(Icons.drag_indicator, key: Key('grip')),
+    );
+
+    expect(find.byKey(const Key('grip')), findsOneWidget);
+    expect(find.byType(PopupMenuButton<String>), findsNothing);
   });
 }


### PR DESCRIPTION
## The bug

The player sidebar could not be scrolled by touch. `ReorderableListView` with `buildDefaultDragHandles: false` wrapped every nav row in a `ReorderableDragStartListener`, and that listener uses an immediate drag recognizer, so it wins the gesture arena the moment a finger moves. The scrollable never received the drag, which left the middle section frozen wherever it happened to sit on any phone.

Two small fixes ruled themselves out. Swapping in `ReorderableDelayedDragStartListener` collides with `sidebar_row.dart`, where long press already opens the Hide / Edit / Delete menu and is the only way to reach it on touch. An always-visible per-row grip would have to share the row's single 36px trailing slot with that menu.

## The fix

Reordering now lives behind an explicit edit mode, entered from a pencil in the sidebar header. Normal mode is a plain `ListView` that constructs no drag machinery at all, which is what hands the gesture back to the scrollable. Edit mode is a `ReorderableListView` whose drag listener wraps only a per-row grip. While editing, row taps are suspended across the whole sidebar, so a mistimed tap cannot navigate away mid-rearrange, which matters on mobile where navigating closes the drawer.

## Two fixes that ride along

**Hiding a row was permanent.** `SidebarLayoutController.unhide` and `resetToDefaults` existed and were called from nowhere in `lib/`; no unhide affordance existed anywhere in the app. `sidebar_layout.dart` even documented that `reconcileLayout` was split out so a UI could list hidden rows and offer to restore them, but that UI was never built. Edit mode now shows hidden rows in place, dimmed and struck through, with a restore control in the trailing slot. Showing them in position is the point: you can see where a restored row will land.

**`resetToDefaults` deleted every saved filter.** It assigned `SidebarLayout.defaults` wholesale, and `defaults` carries `filters: const {}`, so calling it destroyed user-created filters rather than just rearranging. That was invisible because nothing called it. This branch adds the first caller, so the controller was corrected first, to reset `order` and `hidden` while preserving `filters`. The preserved filters return via the existing Rule 3 in `reconcileLayout`, and the confirmation dialog says so.

## Net effect on the code

This removes more than it adds in the widget layer. `SidebarContent.orderAfterMiddleReorder` and `_mergeMiddleOrder` existed only to merge a visible-only reorder back against stored order, because hidden rows were invisible during a drag. In edit mode every middle row is on screen, so a reorder became a plain move over the full list. Those two, plus `_isLeadingAnchorId` and `_isTrailingAnchorId` (which restated anchor placement that `SidebarLayout` already encoded), are gone. Reorder assembly moved into the domain layer as `SidebarLayout.orderAfterReorder`, where it is testable without mounting a widget, and anchor placement is now expressed in one file instead of two.

## Design decisions worth knowing

- One interaction model on desktop and mobile, rather than a platform branch. Desktop pays one click to enter edit mode and drags as before.
- Inline edit mode rather than a `/settings/sidebar` screen. A settings screen splits more cleanly but puts you editing one list while looking at a different one, and turns desktop reordering into a trip through Settings.
- Hide stays on the normal-mode overflow menu while restore lives in edit mode. Hiding is done to a row you are already looking at; restoring first requires seeing what is hidden.
- Edit mode is ephemeral and never persisted. It also resets when the mobile drawer closes, since `Scaffold.drawer` keeps its child mounted and the drawer would otherwise reopen in a forgotten mode. Order changes persist on every drop, so nothing is lost.
- The stored `SidebarLayout` shape is unchanged, so existing saved layouts keep loading and no migration is needed.

## Testing

Full player suite: 2777 passing at `--concurrency=1`. `flutter analyze` error count: 0.

The test that matters most is the one whose absence let this ship: in normal mode, on a short viewport, a drag starting on a nav row scrolls the list. It is backed by a structural guard asserting normal mode builds no `ReorderableDragStartListener` or `ReorderableListView` at all, so the two catch the regression from different angles.

Also covered: the raw `(oldIndex, newIndex)` pair reaching the reorder callback, including a downward drag, since the pre-removal index adjustment lives in exactly one place and a second one would be an off-by-one visible only on downward drags. Domain-level cases for `reconcileForEditing` and `orderAfterReorder`. Restore, reset with confirmation and cancel asserted against persisted store state rather than dialog visibility, drawer-close reset, and the reserved-slot and touch-target sizes.

## Manual check worth doing before merge

Widget tests cannot prove the gesture arena behaves on a real touch screen, which is where this bug lived. Narrow the window below 900px, open the drawer, and drag a nav row: the list should scroll. Then tap the pencil and confirm grips appear, hidden rows show struck through, and dragging by a grip reorders and persists.

## Known follow-ups, deliberately not in scope

- In edit mode the cursor still reads as clickable on customizable rows, though row taps are suspended. Anchors were fixed; the rest was left alone to keep the change scoped.
- The Reset and Cancel actions in the confirmation dialog are styled identically, though reset is the destructive one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sidebar editing mode with controls to reorder, hide, and restore navigation items.
  * Added drag-and-drop reordering while keeping fixed navigation items in place.
  * Added Done and optional Reset actions, including reset confirmation.
  * Hidden items are clearly indicated and can be restored directly.
  * Sidebar editing exits automatically when the mobile drawer closes.

* **Bug Fixes**
  * Resetting the sidebar now restores default visibility and order without removing saved filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->