### PR TITLE
fix(subtitles): make the Search Subtitles dialog mobile friendly

### DIFF
--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -769,83 +769,31 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                 id={id}
                 class="list-row hover:bg-base-200/50 transition-colors px-4 py-3 border-b border-base-200 last:border-b-0"
               >
+                <% profile? = Keyword.get(@manual_ranking_opts, :quality_profile) != nil %>
+                <% score_data = profile? && profile_score_breakdown(result, @manual_ranking_opts) %>
+                <% breakdown = score_data && score_data.breakdown %>
+                <% score = (score_data && score_data.score) || 0 %>
+                <% ring_value = max(0, trunc(score)) %>
+                <% has_penalty =
+                  profile? and breakdown != nil and
+                    (breakdown.size_penalty < 0.0 or breakdown.seeder_penalty < 0.0 or
+                       breakdown.identity_penalty < 0.0) %>
                 <%!-- Score display --%>
-                <%= if Keyword.get(@manual_ranking_opts, :quality_profile) do %>
-                  <%!-- Unified ranker score with breakdown dropdown --%>
-                  <% score_data = profile_score_breakdown(result, @manual_ranking_opts) %>
-                  <% breakdown = score_data.breakdown %>
-                  <% score = score_data.score %>
-                  <% ring_value = max(0, trunc(score)) %>
-                  <% has_penalty =
-                    breakdown.size_penalty < 0.0 or breakdown.seeder_penalty < 0.0 or
-                      breakdown.identity_penalty < 0.0 %>
-                  <div class="dropdown dropdown-hover dropdown-right">
-                    <div
-                      tabindex="0"
-                      role="button"
-                      class={[
-                        "radial-progress text-sm font-bold cursor-pointer",
-                        score >= 80 && "text-success",
-                        score >= 50 && score < 80 && "text-warning",
-                        score < 50 && "text-error"
-                      ]}
-                      style={"--value:#{ring_value}; --size:3rem; --thickness:4px;"}
-                      title="Hover for score breakdown"
-                    >
-                      {trunc(score)}
-                    </div>
-                    <div
-                      tabindex="0"
-                      class="dropdown-content z-50 card card-compact bg-base-200 shadow-xl w-72 ml-2"
-                    >
-                      <div class="card-body p-3">
-                        <h4 class="card-title text-sm mb-2">Score Breakdown</h4>
-                        <div class="space-y-1.5 text-xs">
-                          <.score_row
-                            label="Resolution"
-                            value={score_data.detected[:resolution]}
-                            score={breakdown.quality}
-                            weight={60}
-                          />
-                          <.score_row
-                            label="Title match"
-                            value={nil}
-                            score={breakdown.title_match}
-                            weight={10}
-                          />
-                          <.score_row
-                            label="File Size"
-                            value={
-                              if(score_data.detected[:size_mb],
-                                do: "#{score_data.detected[:size_mb]} MB",
-                                else: nil
-                              )
-                            }
-                            score={breakdown.size}
-                            weight={5}
-                          />
-                          <div class="divider my-1 text-xs opacity-50">Availability</div>
-                          <.score_row
-                            label="Seeders"
-                            value={"#{result.seeders} peers"}
-                            score={breakdown.seeders}
-                            weight={30}
-                          />
-                        </div>
-                        <%= if has_penalty do %>
-                          <div class="divider my-1 text-xs opacity-50">Penalties</div>
-                          <div class="space-y-1.5 text-xs">
-                            <.penalty_row label="Size penalty" score={breakdown.size_penalty} />
-                            <.penalty_row label="Seeder penalty" score={breakdown.seeder_penalty} />
-                            <.penalty_row
-                              label="Identity mismatch"
-                              score={breakdown.identity_penalty}
-                            />
-                          </div>
-                        <% end %>
-                      </div>
-                    </div>
-                  </div>
+                <%= if profile? do %>
+                  <.score_trigger
+                    id={"#{id}-score-badge"}
+                    panel_id={"#{id}-score-breakdown"}
+                    class={[
+                      "radial-progress text-sm font-bold cursor-pointer",
+                      score >= 80 && "text-success",
+                      score >= 50 && score < 80 && "text-warning",
+                      score < 50 && "text-error"
+                    ]}
+                    style={"--value:#{ring_value}; --size:3rem; --thickness:4px;"}
+                    title="Show score breakdown"
+                  >
+                    {trunc(score)}
+                  </.score_trigger>
                 <% else %>
                   <%!-- No profile - just show seeders count (sorted by most seeders) --%>
                   <div
@@ -914,6 +862,44 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
                   <%= if reason = Map.get(result, :grab_failed) do %>
                     <div class="text-xs text-error mt-1 line-clamp-2">{reason}</div>
                   <% end %>
+                  <.score_panel :if={profile?} id={"#{id}-score-breakdown"}>
+                    <.score_row
+                      label="Resolution"
+                      value={score_data.detected[:resolution]}
+                      score={breakdown.quality}
+                      weight={60}
+                    />
+                    <.score_row
+                      label="Title match"
+                      value={nil}
+                      score={breakdown.title_match}
+                      weight={10}
+                    />
+                    <.score_row
+                      label="File Size"
+                      value={
+                        if(score_data.detected[:size_mb],
+                          do: "#{score_data.detected[:size_mb]} MB",
+                          else: nil
+                        )
+                      }
+                      score={breakdown.size}
+                      weight={5}
+                    />
+                    <div class="divider my-1 text-xs opacity-50">Availability</div>
+                    <.score_row
+                      label="Seeders"
+                      value={"#{result.seeders} peers"}
+                      score={breakdown.seeders}
+                      weight={30}
+                    />
+                    <%= if has_penalty do %>
+                      <div class="divider my-1 text-xs opacity-50">Penalties</div>
+                      <.penalty_row label="Size penalty" score={breakdown.size_penalty} />
+                      <.penalty_row label="Seeder penalty" score={breakdown.seeder_penalty} />
+                      <.penalty_row label="Identity mismatch" score={breakdown.identity_penalty} />
+                    <% end %>
+                  </.score_panel>
                 </div>
                 <%!-- Download Action --%>
                 <div class="flex items-center">

--- a/lib/mydia_web/live/media_live/show/score_breakdown.ex
+++ b/lib/mydia_web/live/media_live/show/score_breakdown.ex
@@ -123,12 +123,16 @@ defmodule MydiaWeb.MediaLive.Show.ScoreBreakdown do
   @doc """
   Trigger button for a score breakdown panel.
 
-  An inline disclosure rather than a daisyUI `dropdown`, because a `dropdown`
-  cannot work here. daisyUI hides a `dropdown-hover` panel whenever its trigger
-  has `:focus` without `:focus-visible`, which is exactly what a finger tap
-  produces, so the panel was unreachable on touch. And `.dropdown-content` is
-  absolutely positioned, so the modal box's own `overflow-y: auto` clipped it
-  regardless of z-index. A plain hidden sibling has neither problem.
+  An inline disclosure rather than a daisyUI `dropdown`, because a hover-driven
+  panel is not a dependable touch affordance. daisyUI hides a `dropdown-hover`
+  panel whenever its trigger has `:focus` without `:focus-visible`, so the only
+  thing keeping it open after a tap is the sticky `:hover` the tap happens to
+  leave behind, which no touch platform guarantees and which any scroll can
+  clear. Focus, the one state a tap reliably leaves, is excluded by that rule.
+
+  A hidden sibling opens on an explicit tap and stays open until tapped again.
+  It also spans the row rather than a fixed `w-64`, and because it is in flow it
+  grows its scrolling ancestor's scroll extent instead of overhanging it.
 
   The toggle is a client-side `JS` command, not a server event, so it costs no
   round-trip and does not fight the release dialog's `phx-update="stream"` list.

--- a/lib/mydia_web/live/media_live/show/score_breakdown.ex
+++ b/lib/mydia_web/live/media_live/show/score_breakdown.ex
@@ -11,6 +11,8 @@ defmodule MydiaWeb.MediaLive.Show.ScoreBreakdown do
   """
   use Phoenix.Component
 
+  alias Phoenix.LiveView.JS
+
   @doc """
   One factor of a score breakdown.
 
@@ -116,5 +118,68 @@ defmodule MydiaWeb.MediaLive.Show.ScoreBreakdown do
       score / max >= 0.5 -> "text-warning"
       true -> "text-error"
     end
+  end
+
+  @doc """
+  Trigger button for a score breakdown panel.
+
+  An inline disclosure rather than a daisyUI `dropdown`, because a `dropdown`
+  cannot work here. daisyUI hides a `dropdown-hover` panel whenever its trigger
+  has `:focus` without `:focus-visible`, which is exactly what a finger tap
+  produces, so the panel was unreachable on touch. And `.dropdown-content` is
+  absolutely positioned, so the modal box's own `overflow-y: auto` clipped it
+  regardless of z-index. A plain hidden sibling has neither problem.
+
+  The toggle is a client-side `JS` command, not a server event, so it costs no
+  round-trip and does not fight the release dialog's `phx-update="stream"` list.
+  """
+  attr :id, :string, required: true
+  attr :panel_id, :string, required: true
+  attr :class, :any, default: nil
+  attr :style, :string, default: nil
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def score_trigger(assigns) do
+    ~H"""
+    <button
+      type="button"
+      id={@id}
+      class={@class}
+      style={@style}
+      aria-expanded="false"
+      aria-controls={@panel_id}
+      phx-click={
+        JS.toggle(to: "##{@panel_id}")
+        |> JS.toggle_attribute({"aria-expanded", "true", "false"}, to: "##{@id}")
+      }
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </button>
+    """
+  end
+
+  @doc """
+  The panel a `score_trigger/1` opens, hidden until it is toggled.
+
+  Carries no width of its own. It is placed by its caller inside the row's
+  content column, so it spans that column instead of floating as a fixed-width
+  card anchored to a badge.
+  """
+  attr :id, :string, required: true
+  attr :title, :string, default: "Score breakdown"
+  attr :class, :any, default: nil
+  slot :inner_block, required: true
+
+  def score_panel(assigns) do
+    ~H"""
+    <div id={@id} role="region" class={["hidden mt-2 rounded-box bg-base-200 p-3", @class]}>
+      <h4 class="text-sm font-semibold mb-2">{@title}</h4>
+      <div class="space-y-1.5 text-xs">
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
   end
 end

--- a/lib/mydia_web/live/media_live/show/score_breakdown.ex
+++ b/lib/mydia_web/live/media_live/show/score_breakdown.ex
@@ -170,6 +170,13 @@ defmodule MydiaWeb.MediaLive.Show.ScoreBreakdown do
   Carries no width of its own. It is placed by its caller inside the row's
   content column, so it spans that column instead of floating as a fixed-width
   card anchored to a badge.
+
+  Deliberately not a `role="region"`. That role is a landmark, and one result
+  list renders a panel per row, so it would add a dozen identically named
+  "Score breakdown" landmarks to a single page and make landmark navigation
+  worse rather than better. The disclosure contract is already complete without
+  it: the trigger carries `aria-expanded` and `aria-controls`, and the heading
+  names the content.
   """
   attr :id, :string, required: true
   attr :title, :string, default: "Score breakdown"
@@ -178,7 +185,7 @@ defmodule MydiaWeb.MediaLive.Show.ScoreBreakdown do
 
   def score_panel(assigns) do
     ~H"""
-    <div id={@id} role="region" class={["hidden mt-2 rounded-box bg-base-200 p-3", @class]}>
+    <div id={@id} class={["hidden mt-2 rounded-box bg-base-200 p-3", @class]}>
       <h4 class="text-sm font-semibold mb-2">{@title}</h4>
       <div class="space-y-1.5 text-xs">
         {render_slot(@inner_block)}

--- a/lib/mydia_web/live/media_live/show/subtitle_modal.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_modal.ex
@@ -10,6 +10,7 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModal do
   import MydiaWeb.MediaLive.Show.ScoreBreakdown
 
   alias Mydia.Library.MediaFile
+  alias Phoenix.LiveView.JS
 
   @doc """
   Subtitle search modal for searching and downloading subtitles.
@@ -91,29 +92,36 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModal do
                 aria-label={label}
                 checked={code in @selected_languages}
               />
+              <input
+                :for={{code, label} <- @more_languages}
+                class="btn btn-sm subtitle-lang-extra hidden"
+                type="checkbox"
+                name="languages[]"
+                value={code}
+                aria-label={label}
+                checked={code in @selected_languages}
+              />
             </div>
 
-            <div class="dropdown dropdown-end">
-              <div tabindex="0" role="button" class="btn btn-sm btn-ghost">
-                +{length(@more_languages)} more <.icon name="hero-chevron-down" class="w-4 h-4" />
-              </div>
-              <ul
-                tabindex="0"
-                class="dropdown-content menu bg-base-100 rounded-box z-10 w-52 p-2 shadow-sm max-h-64 flex-nowrap overflow-y-auto"
-              >
-                <li :for={{code, label} <- @more_languages}>
-                  <label class="label cursor-pointer justify-start gap-2">
-                    <input
-                      type="checkbox"
-                      class="checkbox checkbox-sm"
-                      name="languages[]"
-                      value={code}
-                    />
-                    <span class="label-text">{label}</span>
-                  </label>
-                </li>
-              </ul>
-            </div>
+            <button
+              type="button"
+              id="subtitle-language-more-toggle"
+              class="btn btn-sm btn-ghost"
+              aria-expanded="false"
+              aria-controls="subtitle-language-form"
+              phx-click={
+                JS.toggle(to: "#subtitle-language-form .subtitle-lang-extra", display: "inline-flex")
+                |> JS.toggle_attribute({"aria-expanded", "true", "false"},
+                  to: "#subtitle-language-more-toggle"
+                )
+                |> JS.toggle(to: "#subtitle-language-more-label", display: "inline")
+                |> JS.toggle(to: "#subtitle-language-fewer-label", display: "inline")
+              }
+            >
+              <span id="subtitle-language-more-label">+{length(@more_languages)} more</span>
+              <span id="subtitle-language-fewer-label" class="hidden">Show fewer</span>
+              <.icon name="hero-chevron-down" class="w-4 h-4" />
+            </button>
 
             <div class="flex-1"></div>
 

--- a/lib/mydia_web/live/media_live/show/subtitle_modal.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_modal.ex
@@ -26,8 +26,8 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModal do
     common = MydiaWeb.Languages.common()
     common_codes = Enum.map(common, &elem(&1, 0))
 
-    # A selected language always gets a chip, even an uncommon one, so the
-    # current selection is never hidden behind the dropdown.
+    # A selected language always gets a visible chip, even an uncommon one, so
+    # the current selection is never hidden behind the "+N more" toggle.
     extra_chips =
       assigns.selected_languages
       |> Enum.reject(&(&1 in common_codes))

--- a/lib/mydia_web/live/media_live/show/subtitle_modal.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_modal.ex
@@ -248,40 +248,25 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModal do
                           >
                             <span class="badge badge-outline badge-sm">HI</span>
                           </div>
-                          <div class="dropdown dropdown-hover dropdown-end">
-                            <div
-                              tabindex="0"
-                              role="button"
-                              id={"subtitle-score-badge-#{index}"}
-                              class={[
-                                "badge badge-sm cursor-pointer",
-                                score_badge_class(result.score)
-                              ]}
-                              title="Hover for score breakdown"
-                            >
-                              Score {result.score}
-                            </div>
-                            <div
-                              tabindex="0"
-                              id={"subtitle-score-breakdown-#{index}"}
-                              class="dropdown-content z-50 card card-compact bg-base-200 shadow-xl w-64"
-                            >
-                              <div class="card-body p-3">
-                                <h4 class="card-title text-sm mb-2">Score breakdown</h4>
-                                <div class="space-y-1.5 text-xs">
-                                  <.score_row
-                                    :for={factor <- result.score_breakdown}
-                                    label={factor.label}
-                                    value={factor.detail}
-                                    score={factor.points}
-                                    max={factor.max}
-                                    zero_is_absent={true}
-                                  />
-                                </div>
-                              </div>
-                            </div>
-                          </div>
+                          <.score_trigger
+                            id={"subtitle-score-badge-#{index}"}
+                            panel_id={"subtitle-score-breakdown-#{index}"}
+                            class={["badge badge-sm cursor-pointer", score_badge_class(result.score)]}
+                            title="Show score breakdown"
+                          >
+                            Score {result.score}
+                          </.score_trigger>
                         </div>
+                        <.score_panel id={"subtitle-score-breakdown-#{index}"}>
+                          <.score_row
+                            :for={factor <- result.score_breakdown}
+                            label={factor.label}
+                            value={factor.detail}
+                            score={factor.points}
+                            max={factor.max}
+                            zero_is_absent={true}
+                          />
+                        </.score_panel>
                         <div class="text-xs text-base-content/60 mt-1 flex gap-3">
                           <span :if={result.rating}>★ {result.rating}/10</span>
                           <span :if={result.download_count}>

--- a/lib/mydia_web/live/media_live/show/subtitle_modal.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_modal.ex
@@ -43,10 +43,10 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModal do
       |> assign(:more_languages, more)
 
     ~H"""
-    <div class="modal modal-open" id="subtitle-search-modal">
-      <div class="modal-box max-w-3xl max-h-[85vh] flex flex-col p-0">
+    <div class="modal modal-bottom sm:modal-middle modal-open" id="subtitle-search-modal">
+      <div class="modal-box max-w-none sm:max-w-3xl max-h-[92dvh] sm:max-h-[85vh] flex flex-col overflow-hidden p-0">
         <%!-- Header --%>
-        <div class="sticky top-0 z-10 bg-base-100 border-b border-base-300 p-4 sm:p-6">
+        <div class="bg-base-100 border-b border-base-300 p-4 sm:p-6">
           <div class="flex items-start justify-between gap-4">
             <div class="min-w-0">
               <h3 class="text-xl sm:text-2xl font-bold">Search Subtitles</h3>
@@ -128,7 +128,7 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModal do
             <button
               type="button"
               phx-click="perform_subtitle_search"
-              class="btn btn-primary btn-sm"
+              class="btn btn-primary btn-sm btn-block sm:w-auto"
               disabled={@subtitle_search_state == :searching or @selected_languages == []}
             >
               <%= if @subtitle_search_state == :searching do %>
@@ -234,68 +234,73 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModal do
                       :for={{result, index} <- Enum.with_index(@subtitle_search_results)}
                       class="list-row hover:bg-base-200/50 transition-colors"
                     >
-                      <div class="list-col-grow min-w-0">
-                        <div class="font-medium truncate">
-                          {result.file_name || MydiaWeb.Languages.name(result.language)}
-                        </div>
-                        <div class="flex flex-wrap items-center gap-1.5 mt-1">
-                          <span class="badge badge-sm">
-                            {MydiaWeb.Languages.name(result.language)}
-                          </span>
-                          <span class="badge badge-ghost badge-sm">{result.format}</span>
-                          <span :if={result.provider_name} class="badge badge-ghost badge-sm">
-                            {result.provider_name}
-                          </span>
-                          <span :if={result.moviehash_match} class="badge badge-success badge-sm">
-                            Exact match
-                          </span>
-                          <div
-                            :if={result.hearing_impaired}
-                            class="tooltip"
-                            data-tip="Includes hearing impaired captions"
-                          >
-                            <span class="badge badge-outline badge-sm">HI</span>
+                      <div class="list-col-grow min-w-0 flex flex-col sm:flex-row sm:items-center gap-3">
+                        <div class="min-w-0 flex-1">
+                          <div class="font-medium truncate">
+                            {result.file_name || MydiaWeb.Languages.name(result.language)}
                           </div>
-                          <.score_trigger
-                            id={"subtitle-score-badge-#{index}"}
-                            panel_id={"subtitle-score-breakdown-#{index}"}
-                            class={["badge badge-sm cursor-pointer", score_badge_class(result.score)]}
-                            title="Show score breakdown"
-                          >
-                            Score {result.score}
-                          </.score_trigger>
+                          <div class="flex flex-wrap items-center gap-1.5 mt-1">
+                            <span class="badge badge-sm">
+                              {MydiaWeb.Languages.name(result.language)}
+                            </span>
+                            <span class="badge badge-ghost badge-sm">{result.format}</span>
+                            <span :if={result.provider_name} class="badge badge-ghost badge-sm">
+                              {result.provider_name}
+                            </span>
+                            <span :if={result.moviehash_match} class="badge badge-success badge-sm">
+                              Exact match
+                            </span>
+                            <div
+                              :if={result.hearing_impaired}
+                              class="tooltip"
+                              data-tip="Includes hearing impaired captions"
+                            >
+                              <span class="badge badge-outline badge-sm">HI</span>
+                            </div>
+                            <.score_trigger
+                              id={"subtitle-score-badge-#{index}"}
+                              panel_id={"subtitle-score-breakdown-#{index}"}
+                              class={[
+                                "badge badge-sm cursor-pointer",
+                                score_badge_class(result.score)
+                              ]}
+                              title="Show score breakdown"
+                            >
+                              Score {result.score}
+                            </.score_trigger>
+                          </div>
+                          <.score_panel id={"subtitle-score-breakdown-#{index}"}>
+                            <.score_row
+                              :for={factor <- result.score_breakdown}
+                              label={factor.label}
+                              value={factor.detail}
+                              score={factor.points}
+                              max={factor.max}
+                              zero_is_absent={true}
+                            />
+                          </.score_panel>
+                          <div class="text-xs text-base-content/60 mt-1 flex gap-3">
+                            <span :if={result.rating}>★ {result.rating}/10</span>
+                            <span :if={result.download_count}>
+                              {result.download_count} downloads
+                            </span>
+                          </div>
                         </div>
-                        <.score_panel id={"subtitle-score-breakdown-#{index}"}>
-                          <.score_row
-                            :for={factor <- result.score_breakdown}
-                            label={factor.label}
-                            value={factor.detail}
-                            score={factor.points}
-                            max={factor.max}
-                            zero_is_absent={true}
-                          />
-                        </.score_panel>
-                        <div class="text-xs text-base-content/60 mt-1 flex gap-3">
-                          <span :if={result.rating}>★ {result.rating}/10</span>
-                          <span :if={result.download_count}>
-                            {result.download_count} downloads
-                          </span>
-                        </div>
-                      </div>
 
-                      <button
-                        type="button"
-                        phx-click="download_subtitle_result"
-                        phx-value-index={index}
-                        class="btn btn-primary btn-sm"
-                        disabled={@downloading_subtitle_index != nil}
-                      >
-                        <%= if @downloading_subtitle_index == index do %>
-                          <span class="loading loading-spinner loading-xs"></span>
-                        <% else %>
-                          <.icon name="hero-arrow-down-tray" class="w-4 h-4" /> Download
-                        <% end %>
-                      </button>
+                        <button
+                          type="button"
+                          phx-click="download_subtitle_result"
+                          phx-value-index={index}
+                          class="btn btn-primary btn-sm btn-block sm:w-auto"
+                          disabled={@downloading_subtitle_index != nil}
+                        >
+                          <%= if @downloading_subtitle_index == index do %>
+                            <span class="loading loading-spinner loading-xs"></span>
+                          <% else %>
+                            <.icon name="hero-arrow-down-tray" class="w-4 h-4" /> Download
+                          <% end %>
+                        </button>
+                      </div>
                     </li>
                   </ul>
               <% end %>

--- a/test/mydia_web/live/media_live/show/no_hover_dropdowns_test.exs
+++ b/test/mydia_web/live/media_live/show/no_hover_dropdowns_test.exs
@@ -1,0 +1,44 @@
+defmodule MydiaWeb.MediaLive.Show.NoHoverDropdownsTest do
+  @moduledoc """
+  Neither search dialog may explain a score through a daisyUI `dropdown`.
+
+  Two separate defects made that impossible, and both live in CSS rather than
+  in anything a rendered-HTML assertion can see:
+
+    * `app.css` hides a `dropdown-hover` panel whenever its trigger has
+      `:focus` without `:focus-visible`. That is exactly what a finger tap
+      produces, and a touch device has no `:hover`, so the panel was
+      unreachable on a phone.
+    * `.dropdown-content` is `position: absolute`, and `.modal-box` ships
+      `overflow-y: auto`. Absolute positioning does not escape a scroll
+      container's clip rect, so no z-index could save the panel. It was cut
+      off on desktop too.
+
+  The release dialog's score branch cannot be reached from a component test at
+  all: `manual_search_modal/1` builds its own ranking options from DB-backed
+  resolvers, so there is no seam to inject a quality profile through. A source
+  check is the only honest way to keep that branch from regressing.
+  """
+  use ExUnit.Case, async: true
+
+  @dialogs [
+    "lib/mydia_web/live/media_live/show/subtitle_modal.ex",
+    "lib/mydia_web/live/media_live/show/modals.ex"
+  ]
+
+  test "no search dialog uses a hover dropdown" do
+    for path <- @dialogs do
+      assert File.exists?(path), "expected #{path} to exist"
+
+      source = File.read!(path)
+
+      refute source =~ "dropdown-hover",
+             "#{path} still explains a score through a dropdown-hover, " <>
+               "which cannot be opened by touch"
+
+      refute source =~ "dropdown-content",
+             "#{path} still uses an absolutely positioned dropdown-content, " <>
+               "which its scrolling ancestor clips"
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/no_hover_dropdowns_test.exs
+++ b/test/mydia_web/live/media_live/show/no_hover_dropdowns_test.exs
@@ -2,17 +2,25 @@ defmodule MydiaWeb.MediaLive.Show.NoHoverDropdownsTest do
   @moduledoc """
   Neither search dialog may explain a score through a daisyUI `dropdown`.
 
-  Two separate defects made that impossible, and both live in CSS rather than
-  in anything a rendered-HTML assertion can see:
+  A hover-driven panel cannot be a reliable touch affordance, and the reason is
+  in CSS rather than in anything a rendered-HTML assertion can see. `app.css`
+  ships:
 
-    * `app.css` hides a `dropdown-hover` panel whenever its trigger has
-      `:focus` without `:focus-visible`. That is exactly what a finger tap
-      produces, and a touch device has no `:hover`, so the panel was
-      unreachable on a phone.
-    * `.dropdown-content` is `position: absolute`, and `.modal-box` ships
-      `overflow-y: auto`. Absolute positioning does not escape a scroll
-      container's clip rect, so no z-index could save the panel. It was cut
-      off on desktop too.
+      .dropdown.dropdown-hover:not(:hover)
+        [tabindex]:first-child:focus:not(:focus-visible) ~ .dropdown-content {
+          display: none;
+        }
+
+  Measured in headless Chromium with touch emulation against the real built
+  stylesheet: a tap opens the panel, because the tap leaves sticky `:hover` on
+  the trigger. The moment that hover is lost the panel closes again, with the
+  trigger still focused (`:focus` true, `:focus-visible` false), because the
+  rule above fires. So the panel's visibility is pinned to an emulated hover
+  state that no touch platform guarantees, and focus, the one state a tap
+  reliably leaves behind, is explicitly excluded from holding it open.
+
+  An inline disclosure opens on an explicit tap and stays open until tapped
+  again, on every browser, which is the behavior a touch user can rely on.
 
   The release dialog's score branch cannot be reached from a component test at
   all: `manual_search_modal/1` builds its own ranking options from DB-backed
@@ -33,12 +41,14 @@ defmodule MydiaWeb.MediaLive.Show.NoHoverDropdownsTest do
       source = File.read!(path)
 
       refute source =~ "dropdown-hover",
-             "#{path} still explains a score through a dropdown-hover, " <>
-               "which cannot be opened by touch"
+             "#{path} still explains a score through a dropdown-hover, whose " <>
+               "visibility on touch depends on sticky :hover and which daisyUI " <>
+               "explicitly refuses to hold open on focus alone"
 
       refute source =~ "dropdown-content",
-             "#{path} still uses an absolutely positioned dropdown-content, " <>
-               "which its scrolling ancestor clips"
+             "#{path} still puts a score breakdown in an absolutely positioned " <>
+               "dropdown-content, which cannot grow its scrolling ancestor's " <>
+               "scroll extent and is a fixed width regardless of the row"
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/score_breakdown_test.exs
+++ b/test/mydia_web/live/media_live/show/score_breakdown_test.exs
@@ -2,6 +2,8 @@ defmodule MydiaWeb.MediaLive.Show.ScoreBreakdownTest do
   use ExUnit.Case, async: true
 
   import Phoenix.LiveViewTest
+  import Phoenix.Component
+  import MydiaWeb.MediaLive.Show.ScoreBreakdown
 
   alias MydiaWeb.MediaLive.Show.ScoreBreakdown
 
@@ -97,5 +99,89 @@ defmodule MydiaWeb.MediaLive.Show.ScoreBreakdownTest do
       assert ScoreBreakdown.score_color(nil, 10) == "text-base-content/50"
       assert ScoreBreakdown.score_color(nil, 10, true) == "text-base-content/50"
     end
+  end
+
+  # A local wrapper component, because render_component/2 cannot pass a slot
+  # ergonomically. Rendering the pair together is also what we actually want to
+  # assert: their contract is the link between the two ids.
+  defp disclosure(assigns) do
+    ~H"""
+    <.score_trigger
+      id="subtitle-score-badge-0"
+      panel_id="subtitle-score-breakdown-0"
+      class="badge badge-sm"
+    >
+      Score 95
+    </.score_trigger>
+    <.score_panel id="subtitle-score-breakdown-0">
+      <.score_row label="Resolution" value="1080p" score={30} max={30} />
+    </.score_panel>
+    """
+  end
+
+  defp disclosure_html, do: render_component(&disclosure/1, %{})
+
+  describe "score_trigger/1 and score_panel/1 disclosure contract" do
+    test "the trigger is a real button that points at its panel" do
+      doc = LazyHTML.from_fragment(disclosure_html())
+      trigger = LazyHTML.query_by_id(doc, "subtitle-score-badge-0")
+
+      assert LazyHTML.attribute(trigger, "type") == ["button"]
+      assert LazyHTML.attribute(trigger, "aria-controls") == ["subtitle-score-breakdown-0"]
+      assert LazyHTML.attribute(trigger, "aria-expanded") == ["false"]
+    end
+
+    test "the trigger keeps the caller's styling" do
+      doc = LazyHTML.from_fragment(disclosure_html())
+      trigger = LazyHTML.query_by_id(doc, "subtitle-score-badge-0")
+
+      assert LazyHTML.attribute(trigger, "class") == ["badge badge-sm"]
+      assert LazyHTML.text(trigger) =~ "Score 95"
+    end
+
+    test "the trigger toggles the panel client-side, with no server event" do
+      doc = LazyHTML.from_fragment(disclosure_html())
+      trigger = LazyHTML.query_by_id(doc, "subtitle-score-badge-0")
+      [click] = LazyHTML.attribute(trigger, "phx-click")
+
+      # A JS command list, not an event name. A bare event name would mean a
+      # round-trip, which breaks the release dialog's phx-update="stream" list.
+      assert click =~ "toggle"
+      assert click =~ "subtitle-score-breakdown-0"
+      refute click =~ ~s("push")
+    end
+
+    test "the panel starts hidden and renders its rows" do
+      doc = LazyHTML.from_fragment(disclosure_html())
+      panel = LazyHTML.query_by_id(doc, "subtitle-score-breakdown-0")
+      [class] = LazyHTML.attribute(panel, "class")
+
+      assert class =~ "hidden"
+      assert LazyHTML.text(panel) =~ "Score breakdown"
+      assert LazyHTML.text(panel) =~ "Resolution"
+      assert LazyHTML.text(panel) =~ "1080p"
+    end
+
+    test "the panel is not a positioned dropdown" do
+      html = disclosure_html()
+
+      refute html =~ "dropdown"
+      refute html =~ "dropdown-content"
+    end
+
+    test "the panel title is overridable" do
+      html = render_component(&titled_panel/1, %{})
+
+      assert html =~ "Why this ranked here"
+      refute html =~ "Score breakdown"
+    end
+  end
+
+  defp titled_panel(assigns) do
+    ~H"""
+    <.score_panel id="p" title="Why this ranked here">
+      <span>row</span>
+    </.score_panel>
+    """
   end
 end

--- a/test/mydia_web/live/media_live/show/subtitle_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitle_modal_test.exs
@@ -157,7 +157,7 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModalTest do
       # The badge cluster is the flex-wrap row of badges. If the panel were
       # still inside it the panel would be a wrapping flex item, which is what
       # made it a cramped w-64 card in the first place.
-      assert Enum.count(LazyHTML.query(doc, ".flex-wrap #subtitle-score-breakdown-0")) == 0
+      assert Enum.empty?(LazyHTML.query(doc, ".flex-wrap #subtitle-score-breakdown-0"))
       assert Enum.count(LazyHTML.query_by_id(doc, "subtitle-score-breakdown-0")) == 1
     end
   end

--- a/test/mydia_web/live/media_live/show/subtitle_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitle_modal_test.exs
@@ -278,6 +278,39 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModalTest do
       assert html =~ ~s(aria-label="Finnish")
     end
 
+    test "the dialog is a bottom sheet on mobile and a centered modal from sm up" do
+      html = subtitle_modal_html()
+
+      assert html =~ "modal-bottom"
+      assert html =~ "sm:modal-middle"
+    end
+
+    test "the modal box sizes to the small viewport without the phantom scroll layer" do
+      html = subtitle_modal_html()
+      doc = LazyHTML.from_fragment(html)
+
+      [class] =
+        LazyHTML.query(doc, "#subtitle-search-modal > .modal-box")
+        |> LazyHTML.attribute("class")
+
+      # dvh, not vh: mobile browser chrome eats a vh-measured footer.
+      assert class =~ "max-h-[92dvh]"
+      assert class =~ "sm:max-h-[85vh]"
+      assert class =~ "max-w-none"
+      assert class =~ "sm:max-w-3xl"
+      # .modal-box ships overflow-y:auto, which nothing needs now that no
+      # popover has to escape it, and which made a nested scroll container.
+      assert class =~ "overflow-hidden"
+      # The header's sticky was inert: its parent never scrolls.
+      refute class =~ "sticky"
+    end
+
+    test "the primary actions are full width on mobile" do
+      html = loaded_html([result_fixture()])
+
+      assert html =~ "btn-block sm:w-auto"
+    end
+
     test "disables search when no language is selected" do
       html = subtitle_modal_html(selected_languages: [])
 

--- a/test/mydia_web/live/media_live/show/subtitle_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitle_modal_test.exs
@@ -229,6 +229,55 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModalTest do
       assert subtitle_modal_html(selected_languages: ["fi"]) =~ ~s(aria-label="Finnish")
     end
 
+    test "every language is a chip in the filter group, with the extras hidden" do
+      html = subtitle_modal_html(selected_languages: ["en"])
+      doc = LazyHTML.from_fragment(html)
+
+      # All 20 of Languages.all/0, as direct children of the one filter group.
+      assert Enum.count(LazyHTML.query(doc, ".filter input[type=checkbox]")) == 20
+
+      # Finnish is not common and is not selected, so it is present but hidden.
+      [class] =
+        doc
+        |> LazyHTML.query(~s(.filter input[aria-label="Finnish"]))
+        |> LazyHTML.attribute("class")
+
+      assert class =~ "subtitle-lang-extra"
+      assert class =~ "hidden"
+    end
+
+    test "the language list is inline, not a dropdown" do
+      html = subtitle_modal_html(selected_languages: ["en"])
+
+      refute html =~ "dropdown"
+      refute html =~ "menu bg-base-100"
+    end
+
+    test "the more-languages toggle is a client-side disclosure" do
+      html = subtitle_modal_html(selected_languages: ["en"])
+      doc = LazyHTML.from_fragment(html)
+      toggle = LazyHTML.query_by_id(doc, "subtitle-language-more-toggle")
+      [click] = LazyHTML.attribute(toggle, "phx-click")
+
+      assert LazyHTML.attribute(toggle, "type") == ["button"]
+      assert LazyHTML.attribute(toggle, "aria-expanded") == ["false"]
+      assert click =~ "subtitle-lang-extra"
+      refute click =~ ~s("push")
+    end
+
+    test "a selected uncommon language is visible rather than hidden behind the toggle" do
+      html = subtitle_modal_html(selected_languages: ["fi"])
+      doc = LazyHTML.from_fragment(html)
+
+      [class] =
+        doc
+        |> LazyHTML.query(~s(.filter input[aria-label="Finnish"]))
+        |> LazyHTML.attribute("class")
+
+      refute class =~ "hidden"
+      assert html =~ ~s(aria-label="Finnish")
+    end
+
     test "disables search when no language is selected" do
       html = subtitle_modal_html(selected_languages: [])
 

--- a/test/mydia_web/live/media_live/show/subtitle_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitle_modal_test.exs
@@ -131,6 +131,35 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModalTest do
       assert html =~ ~s(id="subtitle-score-breakdown-0")
       assert html =~ "Release group"
     end
+
+    test "the score badge is a button wired to the breakdown panel, not a dropdown" do
+      html = render_modal([result(%{score: 95, score_breakdown: []})])
+      doc = LazyHTML.from_fragment(html)
+      trigger = LazyHTML.query_by_id(doc, "subtitle-score-badge-0")
+
+      assert LazyHTML.attribute(trigger, "type") == ["button"]
+      assert LazyHTML.attribute(trigger, "aria-controls") == ["subtitle-score-breakdown-0"]
+      assert LazyHTML.attribute(trigger, "aria-expanded") == ["false"]
+    end
+
+    test "no hover dropdown survives anywhere in the dialog" do
+      html = render_modal([result(%{score: 95, score_breakdown: []})])
+
+      refute html =~ "dropdown-hover"
+      refute html =~ "dropdown-content"
+      refute html =~ "dropdown-end"
+    end
+
+    test "the breakdown panel is a sibling of the badge cluster, not inside it" do
+      html = render_modal([result(%{score: 95, score_breakdown: []})])
+      doc = LazyHTML.from_fragment(html)
+
+      # The badge cluster is the flex-wrap row of badges. If the panel were
+      # still inside it the panel would be a wrapping flex item, which is what
+      # made it a cramped w-64 card in the first place.
+      assert Enum.count(LazyHTML.query(doc, ".flex-wrap #subtitle-score-breakdown-0")) == 0
+      assert Enum.count(LazyHTML.query_by_id(doc, "subtitle-score-breakdown-0")) == 1
+    end
   end
 
   describe "subtitle_search_modal/1 shell" do


### PR DESCRIPTION
Makes the Search Subtitles dialog usable on a phone. Its two daisyUI `dropdown` popovers, the `+N more` language list and the score breakdown, become inline disclosures, and the dialog gets a mobile shell and row layout. The release search dialog carried the identical score dropdown, so it gets the same treatment.

## Why not a dropdown

A hover-driven panel is not a dependable touch affordance. `app.css` ships:

```css
.dropdown.dropdown-hover:not(:hover)
  [tabindex]:first-child:focus:not(:focus-visible) ~ .dropdown-content {
    display: none;
  }
```

Measured in headless Chromium with touch emulation, against the real built stylesheet: a tap **does** open the panel, because it leaves sticky `:hover` on the trigger. The moment that hover is lost the panel closes again with the trigger still focused (`:focus` true, `:focus-visible` false). So the panel's visibility is pinned to an emulated hover state that no touch platform guarantees and that any scroll can clear, while focus, the one state a tap reliably leaves behind, is explicitly excluded from holding it open.

An inline disclosure opens on an explicit tap and stays open until tapped again, on every browser.

Two secondary wins: the panel spans the row instead of a fixed `w-64`, and being in flow it grows its scrolling ancestor's scroll extent rather than overhanging it.

### A claim this PR does not make

An earlier draft of this work argued the panel was outright unreachable on touch, and separately that `.dropdown-content` being `position: absolute` inside `.modal-box`'s `overflow-y: auto` left it visibly clipped. Both were derived by reading CSS and both were overstated. Measurement contradicted them: the tap opens the panel, and at 3 and again at 12 results on a 390x844 viewport the old dropdown's bottom landed 1px inside the results pane, fully hit-testable after scrolling. `3720bb694` corrects the rationale that had been written into the component docs and the guard test. This is an improvement to a fragile affordance, not a repair of a broken one.

## What changed

- **`score_breakdown.ex`** gains `score_trigger/1` and `score_panel/1`, a disclosure pair bound by `panel_id` and toggled client-side with `JS.toggle` plus `JS.toggle_attribute`. No new assigns, no new `handle_event`, no round-trip, which also keeps it from fighting the release dialog's `phx-update="stream"` list. The trigger is a real `<button>` with `aria-expanded` and `aria-controls`, replacing a `<div role="button" tabindex="0">`.
- **Language selection** loses its dropdown. All 20 of `Languages.all/0` are now chips in the one `.filter` group, 8 common ones visible and the other 12 revealed by a `+N more` toggle. They finally carry `checked`, which the dropdown's checkboxes never did, so a picked language no longer appears to teleport into the chip row.
- **Mobile shell**: `modal-bottom sm:modal-middle`, `max-h-[92dvh] sm:max-h-[85vh]` so browser chrome does not eat the footer, and `overflow-hidden` to retire the scroll container `.modal-box` ships and nothing needs. The header's `sticky top-0` was inert, its parent never scrolls, and is gone.
- **Result rows** stack on a phone: content and the Download button share one `list-col-grow` wrapper that is `flex-col sm:flex-row`, so the button drops below the metadata instead of squeezing a `1fr` column beside a badge cluster wrapping to three lines. Search and Download are `btn-block sm:w-auto`.

Element ids are unchanged, so no existing test selector churned.

## Verification

- `mix precommit`: **8989 tests, 0 failures**.
- Browser check at 390x844 against the real component output and the real built CSS: bottom sheet flush to the bottom edge at full width, no horizontal page scroll, all 20 chips revealed by the toggle, breakdown panel open at full row width and hit-testable at 25 of 25 sampled points, Download button full width.
- A source-level guard, `no_hover_dropdowns_test.exs`, keeps either dialog from regressing to a `dropdown`. It exists because the release dialog's score branch cannot be reached from a component test at all: `manual_search_modal/1` builds its own ranking options from DB-backed resolvers, so there is no seam to inject a quality profile through, and its existing tests only ever render the no-profile branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Replaced hover-based score explanations with accessible, expandable score breakdown panels.
  * Improved subtitle selection with inline language checkboxes and “Show fewer” controls.
  * Updated subtitle search layouts for better responsiveness, including mobile-friendly action buttons.
  * Added safer score handling when quality profile information is available.

* **Accessibility**
  * Added expandable controls with synchronized expanded-state semantics for screen readers.

* **Tests**
  * Added coverage for score panels, subtitle language controls, responsive layouts, and removal of hover-only dropdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->