### PR TITLE
fix(player): keep the subtitle button alive in direct play

### DIFF
--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1538,10 +1538,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     // detection pass below would otherwise be lost — which is the whole
     // failure this guards against.
     await _tracksSubscription?.cancel();
-    _tracksSubscription = watchAudioTracks(
-      player.stream.tracks,
-      _onAudioTracksDetected,
-    );
+    _tracksSubscription = watchTracks(player.stream.tracks, _onTracksChanged);
 
     // Before `open`, deliberately: mpv chooses its audio track while loading
     // the file, so a preference applied afterwards does not reselect and the
@@ -2081,6 +2078,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     _selectedSubtitleTrack = applied;
     _pendingSubtitleSelection = applied;
     _subtitleSelectionGeneration++;
+  }
+
+  /// Adopt a track list media_kit published, whether sampled directly after
+  /// `open()` or delivered later by [watchTracks].
+  void _onTracksChanged(Tracks tracks) {
+    _onAudioTracksDetected(detectAudioTracks(tracks.audio));
   }
 
   /// Adopt a track list media_kit published after playback opened.
@@ -4749,23 +4752,24 @@ AudioTrackDetection detectAudioTracks(List<AudioTrack> mkTracks) {
   return AudioTrackDetection(tracks: tracks, byId: byId);
 }
 
-/// Reports an [AudioTrackDetection] every time media_kit revises [tracks].
+/// Reports media_kit's track list every time it is revised.
 ///
 /// mpv discovers tracks asynchronously while it probes the file, and revises
 /// the list afterwards, so sampling it once at a fixed moment after `open()`
-/// races the probe. On a slow enough source the sample lands before any audio
-/// track exists and the selector is left permanently empty. Driving detection
-/// off the stream instead means a late arrival still reaches the UI.
+/// races the probe. On a slow enough source the sample lands before any
+/// track exists and the selectors are left permanently empty. Driving
+/// detection off the stream instead means a late arrival still reaches the
+/// UI.
 ///
 /// `player.stream.tracks` is a plain broadcast stream with no replay, so
 /// callers must subscribe before opening the media and still run a detection
 /// pass afterwards to cover anything emitted in between.
 @visibleForTesting
-StreamSubscription<Tracks> watchAudioTracks(
+StreamSubscription<Tracks> watchTracks(
   Stream<Tracks> tracks,
-  void Function(AudioTrackDetection detection) onDetected,
+  void Function(Tracks tracks) onTracks,
 ) {
-  return tracks.listen((t) => onDetected(detectAudioTracks(t.audio)));
+  return tracks.listen(onTracks);
 }
 
 /// Converts the wire's 0.0-1.0 volume level to media_kit's 0-100 scale, used

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, listEquals;
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -338,6 +338,24 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   GraphQLClient? _graphQLClient;
 
   // Track selection state
+  /// The subtitle tracks the *server* reported for this file, exactly as
+  /// `MediaFileFragment` delivered them: embedded tracks ffprobe found, plus
+  /// sidecars from the database.
+  ///
+  /// The source of truth, and never overwritten by track detection.
+  /// [_subtitleTracks] is derived from this together with whatever media_kit
+  /// has probed (see [_applySubtitleTracks]).
+  ///
+  /// Keeping the two apart is what makes detection re-runnable. The
+  /// direct-play branch used to assign media_kit's own list straight over
+  /// the one field, so a probe that finished after the fixed sample taken
+  /// just after `open()` left an empty list with the server's tracks already
+  /// discarded, and nothing could rebuild it.
+  List<app_models.SubtitleTrack> _serverSubtitleTracks = [];
+
+  /// The tracks actually offered to the viewer, and the list
+  /// `subtitleTrackCount` gates the subtitle button on. Derived: never
+  /// assigned outside [_applySubtitleTracks].
   List<app_models.SubtitleTrack> _subtitleTracks = [];
   app_models.SubtitleTrack? _selectedSubtitleTrack;
   List<app_models_audio.AudioTrack> _audioTracks = [];
@@ -1848,12 +1866,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       if (file.id == widget.fileId) {
         final subtitles = file.subtitles;
         if (subtitles != null) {
-          _subtitleTracks = subtitles
+          _serverSubtitleTracks = subtitles
               .whereType<Fragment$MediaFileFragment$subtitles>()
               .map((sub) => app_models.SubtitleTrack.fromGraphQL(sub))
               .toList();
-          debugPrint(
-              'Extracted ${_subtitleTracks.length} subtitle tracks from GraphQL');
+          _refreshSubtitleTracks();
+          debugPrint('Extracted ${_serverSubtitleTracks.length} subtitle '
+              'tracks from GraphQL');
         }
         break;
       }
@@ -1947,70 +1966,17 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     }
   }
 
-  /// Detect available audio and subtitle tracks from the media_kit player
-  /// and build mappings between app model tracks and media_kit track objects.
+  /// Sample whatever media_kit knows right now.
+  ///
+  /// Covers anything mpv had already published before [watchTracks] went
+  /// live; every later revision arrives through that subscription instead.
+  /// Both paths land in [_onTracksChanged], so there is one code path that
+  /// can change the track lists.
   void _detectTracks() {
     final player = _player;
     if (player == null) return;
 
-    // --- Audio tracks ---
-    final audioDetection = detectAudioTracks(player.state.tracks.audio);
-
-    // --- Subtitle tracks ---
-    final mkSubtitleTracks = player.state.tracks.subtitle;
-    final subtitleMap = <String, SubtitleTrack>{};
-
-    if (_isDirectPlay) {
-      // In direct play the engine already sees every embedded track in the
-      // container, including image-based ones it can render natively. These
-      // need no fetch: media_kit already has them.
-      final embeddedSubs = <app_models.SubtitleTrack>[];
-      for (final mkTrack in mkSubtitleTracks) {
-        if (mkTrack == SubtitleTrack.auto() || mkTrack == SubtitleTrack.no()) {
-          continue;
-        }
-
-        final appTrack = app_models.SubtitleTrack(
-          id: 'mk_${mkTrack.id}',
-          language: mkTrack.language ?? 'und',
-          title: mkTrack.title,
-          embedded: true,
-        );
-        embeddedSubs.add(appTrack);
-        subtitleMap[appTrack.id] = mkTrack;
-      }
-
-      // Sidecars are not in the container, so they still come from the
-      // server. Their body is fetched lazily in
-      // [_resolveMediaKitSubtitleTrack], only if and when the viewer selects
-      // one, rather than built here for every sidecar up front. `deliverable`
-      // is redundant with every sidecar today (they are hardcoded true
-      // server-side, unlike an embedded image track), but this keeps the
-      // client's own filtering honest rather than leaning on that server
-      // invariant silently.
-      final externalSubs =
-          _subtitleTracks.where((s) => !s.embedded && s.deliverable).toList();
-
-      _subtitleTracks = [...embeddedSubs, ...externalSubs];
-    } else {
-      // Streaming: every selectable track's body arrives as content over
-      // GraphQL, fetched lazily in [_resolveMediaKitSubtitleTrack] once the
-      // viewer actually picks a track. This is the one path that works
-      // identically on LAN, direct, p2p and web, because GraphQL is already
-      // tunnelled in every connection mode.
-      _subtitleTracks = selectableTracks(_subtitleTracks, isDirectPlay: false);
-    }
-
-    _audioTracks = audioDetection.tracks;
-    _mediaKitAudioTrackMap = audioDetection.byId;
-    _mediaKitSubtitleTrackMap = subtitleMap;
-
-    _syncSelectedAudioTrack();
-    _syncSelectedSubtitleTrack();
-
-    debugPrint('[PlayerScreen] Detected ${_audioTracks.length} audio tracks, '
-        '${_subtitleTracks.length} subtitle tracks '
-        '(directPlay=$_isDirectPlay)');
+    _onTracksChanged(player.state.tracks);
   }
 
   /// Point [_selectedAudioTrack] at whichever detected track media_kit is
@@ -2081,24 +2047,95 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   }
 
   /// Adopt a track list media_kit published, whether sampled directly after
-  /// `open()` or delivered later by [watchTracks].
+  /// `open()` by [_detectTracks] or delivered later by [watchTracks].
   void _onTracksChanged(Tracks tracks) {
-    _onAudioTracksDetected(detectAudioTracks(tracks.audio));
-  }
-
-  /// Adopt a track list media_kit published after playback opened.
-  ///
-  /// The audio button is gated on `audioTrackCount > 0`, so until this lands
-  /// a late-probing file leaves it disabled with no way to reach a second
-  /// language.
-  void _onAudioTracksDetected(AudioTrackDetection detection) {
     if (!mounted) return;
 
     setState(() {
-      _audioTracks = detection.tracks;
-      _mediaKitAudioTrackMap = detection.byId;
+      final audio = detectAudioTracks(tracks.audio);
+      _audioTracks = audio.tracks;
+      _mediaKitAudioTrackMap = audio.byId;
       _syncSelectedAudioTrack();
+
+      _applySubtitleTracks(tracks.subtitle);
     });
+
+    debugPrint('[PlayerScreen] Detected ${_audioTracks.length} audio tracks, '
+        '${_subtitleTracks.length} subtitle tracks '
+        '(directPlay=$_isDirectPlay)');
+  }
+
+  /// Rebuild [_subtitleTracks] from [_serverSubtitleTracks] and whatever
+  /// media_kit has probed so far.
+  ///
+  /// Call inside a `setState`; this does not call one itself, so the audio
+  /// and subtitle halves of [_onTracksChanged] share a single rebuild.
+  ///
+  /// Returns early when the derived list is unchanged, which is
+  /// load-bearing rather than an optimisation: [_syncSelectedSubtitleTrack]
+  /// bumps [_subtitleSelectionGeneration], and a bump makes
+  /// [shouldApplySubtitleSelection] discard whatever selection the viewer
+  /// has in flight. media_kit revises its track list more than once per
+  /// playback, so an unguarded rebuild would swallow a tap every time it
+  /// did.
+  ///
+  /// The comparison is by id, since `SubtitleTrack.operator ==` is
+  /// id-based. That is the right granularity: the button's gate and every
+  /// selection path key on id, so a revision that changes only a title
+  /// genuinely does not need a rebuild.
+  void _applySubtitleTracks(List<SubtitleTrack> mkTracks) {
+    final mpvTracks = <app_models.SubtitleTrack>[];
+    final mpvById = <String, SubtitleTrack>{};
+
+    for (final mkTrack in mkTracks) {
+      if (mkTrack == SubtitleTrack.auto() || mkTrack == SubtitleTrack.no()) {
+        continue;
+      }
+
+      final appTrack = app_models.SubtitleTrack(
+        id: 'mk_${mkTrack.id}',
+        language: mkTrack.language ?? 'und',
+        title: mkTrack.title,
+        embedded: true,
+      );
+      mpvTracks.add(appTrack);
+      mpvById[appTrack.id] = mkTrack;
+    }
+
+    final derived = resolveSubtitleTracks(
+      serverTracks: _serverSubtitleTracks,
+      mpvTracks: mpvTracks,
+      isDirectPlay: _isDirectPlay,
+    );
+
+    if (listEquals(derived, _subtitleTracks)) return;
+
+    _subtitleTracks = derived;
+
+    // Only the `mk_` half of this map is media_kit's to republish. The rest
+    // is the lazily fetched `SubtitleTrack.data` bodies
+    // [_resolveMediaKitSubtitleTrack] caches by server track id. Assigning
+    // the whole map, as detection used to, would drop that cache and refetch
+    // -- re-running a server-side ffmpeg extraction -- for every track the
+    // viewer had already selected this session.
+    _mediaKitSubtitleTrackMap
+      ..removeWhere((id, _) => id.startsWith('mk_'))
+      ..addAll(mpvById);
+
+    _syncSelectedSubtitleTrack();
+  }
+
+  /// Re-derive [_subtitleTracks] after the *server's* list changed, against
+  /// whatever media_kit has already published.
+  ///
+  /// The counterpart to [_onTracksChanged]: that one runs when media_kit
+  /// revises its side, this one when [_extractSubtitlesFromFiles] or a
+  /// freshly downloaded sidecar revises the server's.
+  void _refreshSubtitleTracks() {
+    if (!mounted) return;
+
+    final mkTracks = _player?.state.tracks.subtitle ?? const <SubtitleTrack>[];
+    setState(() => _applySubtitleTracks(mkTracks));
   }
 
   Future<void> _fetchSeasonEpisodes(GraphQLClient client) async {
@@ -3311,14 +3348,22 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       Mutation$DownloadSubtitle.fromJson(data).downloadSubtitle,
     );
 
-    // Added to the list the sheet was opened with so it survives the sheet
-    // closing: the pick that follows is applied against `_subtitleTracks`,
-    // and the controls' track count and the next open of the sheet both
-    // read from it. Guarded on identity because the server returns the
-    // existing row when the same subtitle is downloaded twice, and a
-    // duplicate entry would render the track twice in the list.
-    if (mounted && !_subtitleTracks.any((t) => t.id == track.id)) {
-      setState(() => _subtitleTracks = [..._subtitleTracks, track]);
+    // Added to the server list so it survives the sheet closing: the pick
+    // that follows is applied against `_subtitleTracks`, and the controls'
+    // track count and the next open of the sheet both read from it.
+    // Guarded on identity because the server returns the existing row when
+    // the same subtitle is downloaded twice, and a duplicate entry would
+    // render the track twice in the list.
+    //
+    // Written to `_serverSubtitleTracks` rather than `_subtitleTracks`
+    // because the latter is derived: a later media_kit revision rebuilds it
+    // from this list, so an append made directly to the derived list would
+    // vanish at the next revision. A downloaded sidecar is `embedded:
+    // false, deliverable: true`, so every branch of `resolveSubtitleTracks`
+    // keeps it.
+    if (mounted && !_serverSubtitleTracks.any((t) => t.id == track.id)) {
+      _serverSubtitleTracks = [..._serverSubtitleTracks, track];
+      _refreshSubtitleTracks();
     }
 
     return track;

--- a/player/lib/presentation/screens/player/subtitle_track_builder.dart
+++ b/player/lib/presentation/screens/player/subtitle_track_builder.dart
@@ -21,6 +21,51 @@ List<SubtitleTrack> selectableTracks(
   return tracks.where((t) => t.deliverable).toList();
 }
 
+/// The subtitle tracks to offer the viewer, given both places they can come
+/// from.
+///
+/// [serverTracks] is what `MediaFileFragment` reported: embedded tracks
+/// ffprobe found, plus sidecars from the database. [mpvTracks] is what
+/// media_kit has probed out of the container so far, already mapped onto
+/// this app's model with `mk_`-prefixed ids.
+///
+/// Three cases:
+///
+///  - **Streaming.** The server is the only source that means anything --
+///    every body arrives as text over GraphQL -- so media_kit's list is
+///    ignored and image tracks are filtered out.
+///  - **Direct play, media_kit has tracks.** Its tracks win: it reads them
+///    from the container at no fetch cost, including image-based ones it
+///    renders natively. Sidecars are not in the container, so those still
+///    come from [serverTracks].
+///  - **Direct play, media_kit has nothing yet.** Fall back to the server's
+///    deliverable tracks. mpv discovers tracks asynchronously while it
+///    probes, so on a remote file the probe routinely finishes after the
+///    fixed sample taken just after `open()`. Before this fallback existed
+///    that left the list empty and `panel_controls.dart`'s
+///    `subtitleTrackCount > 0` gate rendered the subtitle button
+///    permanently dead. Selecting one of these fetches its body over the
+///    `SubtitleContent` query, the same path sidecars already take; image
+///    tracks are dropped because there is no body to fetch for a bitmap.
+///
+/// The two lists are never merged into one. ffprobe stream indices and
+/// media_kit's own track ids do not correspond, so a merge would list every
+/// embedded track twice.
+List<SubtitleTrack> resolveSubtitleTracks({
+  required List<SubtitleTrack> serverTracks,
+  required List<SubtitleTrack> mpvTracks,
+  required bool isDirectPlay,
+}) {
+  if (isDirectPlay && mpvTracks.isNotEmpty) {
+    return [
+      ...mpvTracks,
+      ...serverTracks.where((t) => !t.embedded && t.deliverable),
+    ];
+  }
+
+  return selectableTracks(serverTracks, isDirectPlay: false);
+}
+
 /// Whether an in-flight subtitle selection's result should still be applied
 /// to the player, once its async work (a media_kit "Off" call, or a
 /// `SubtitleContent` fetch) finishes.

--- a/player/test/presentation/screens/player/audio_track_detection_test.dart
+++ b/player/test/presentation/screens/player/audio_track_detection_test.dart
@@ -1,4 +1,4 @@
-// Unit coverage for `detectAudioTracks` and `watchAudioTracks`, the pure
+// Unit coverage for `detectAudioTracks` and `watchTracks`, the pure
 // pieces extracted from `_PlayerScreenState._detectTracks`.
 //
 // Extracted (rather than tested through a fully mounted `PlayerScreen`) for
@@ -27,6 +27,9 @@ import 'package:player/presentation/screens/player/player_screen.dart';
 /// `Silo.S03E03.A.Dark.Web.2160p...ENG.ITA...mkv`.
 const _italian = AudioTrack('1', null, 'ita', isDefault: true);
 const _english = AudioTrack('2', null, 'eng');
+
+/// A single embedded subtitle track, as media_kit reports one.
+const _englishSubtitle = SubtitleTrack('1', null, 'eng');
 
 /// What media_kit reports before it has probed the file: sentinels only.
 const _sentinelsOnly = Tracks();
@@ -96,35 +99,56 @@ void main() {
     });
   });
 
-  group('watchAudioTracks', () {
+  group('watchTracks', () {
     test('reports tracks that media_kit only discovers after playback opens',
         () async {
       final controller = StreamController<Tracks>();
       addTearDown(controller.close);
 
-      final seen = <AudioTrackDetection>[];
-      final subscription = watchAudioTracks(controller.stream, seen.add);
+      final seen = <Tracks>[];
+      final subscription = watchTracks(controller.stream, seen.add);
       addTearDown(subscription.cancel);
 
       // The probe has not finished: this is exactly the state the old fixed
       // 500ms sample could land in.
       controller.add(_sentinelsOnly);
       await pumpEventQueue();
-      expect(seen.last.tracks, isEmpty);
+      expect(detectAudioTracks(seen.last.audio).tracks, isEmpty);
 
       // mpv finishes probing and revises the list.
       controller.add(const Tracks(audio: [_italian, _english]));
       await pumpEventQueue();
 
-      expect(seen.last.tracks.map((t) => t.language), ['ita', 'eng']);
+      expect(
+        detectAudioTracks(seen.last.audio).tracks.map((t) => t.language),
+        ['ita', 'eng'],
+      );
+    });
+
+    test('carries the subtitle tracks too, not only the audio ones', () async {
+      // The whole point of widening this from `watchTracks`. Subtitle
+      // tracks used to be sampled once, 500ms after `open()`, with nothing
+      // watching for a later revision -- so a probe that finished late left
+      // the subtitle button disabled for the entire session.
+      final controller = StreamController<Tracks>();
+      addTearDown(controller.close);
+
+      final seen = <Tracks>[];
+      final subscription = watchTracks(controller.stream, seen.add);
+      addTearDown(subscription.cancel);
+
+      controller.add(const Tracks(subtitle: [_englishSubtitle]));
+      await pumpEventQueue();
+
+      expect(seen.last.subtitle, contains(_englishSubtitle));
     });
 
     test('stops reporting once cancelled', () async {
       final controller = StreamController<Tracks>();
       addTearDown(controller.close);
 
-      final seen = <AudioTrackDetection>[];
-      final subscription = watchAudioTracks(controller.stream, seen.add);
+      final seen = <Tracks>[];
+      final subscription = watchTracks(controller.stream, seen.add);
       await subscription.cancel();
 
       controller.add(const Tracks(audio: [_italian, _english]));

--- a/player/test/presentation/screens/player/subtitle_track_loading_test.dart
+++ b/player/test/presentation/screens/player/subtitle_track_loading_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/domain/models/subtitle_track.dart';
 import 'package:player/presentation/screens/player/subtitle_track_builder.dart';
@@ -25,6 +26,16 @@ void main() {
     language: 'eng',
     title: 'English',
     format: 'srt',
+    embedded: true,
+  );
+
+  /// What `_applySubtitleTracks` builds out of a media_kit track: the `mk_`
+  /// prefix is what keeps mpv's id space apart from the server's ffprobe
+  /// stream indices.
+  const mkTrack = SubtitleTrack(
+    id: 'mk_1',
+    language: 'eng',
+    title: 'English',
     embedded: true,
   );
 
@@ -73,6 +84,81 @@ void main() {
         selectableTracks([embeddedTextTrack], isDirectPlay: false),
         contains(embeddedTextTrack),
       );
+    });
+  });
+
+  group('resolveSubtitleTracks', () {
+    test('ignores media_kit entirely when streaming', () {
+      // Streaming delivers every track's body as text over GraphQL, so the
+      // server's list is the only one that means anything and image tracks
+      // cannot be rendered at all.
+      final tracks = resolveSubtitleTracks(
+        serverTracks: [textTrack, embeddedTextTrack, imageTrack],
+        mpvTracks: [mkTrack],
+        isDirectPlay: false,
+      );
+
+      expect(tracks, [textTrack, embeddedTextTrack]);
+    });
+
+    test('prefers media_kit tracks over the server list in direct play', () {
+      // mpv reads embedded tracks straight from the container, at no fetch
+      // cost, so its own tracks win. Sidecars are not in the container and
+      // still come from the server.
+      final tracks = resolveSubtitleTracks(
+        serverTracks: [textTrack, embeddedTextTrack],
+        mpvTracks: [mkTrack],
+        isDirectPlay: true,
+      );
+
+      expect(tracks, [mkTrack, textTrack]);
+    });
+
+    test(
+        'falls back to the server list when media_kit has probed nothing '
+        'yet in direct play', () {
+      // The regression this whole change exists for. mpv discovers tracks
+      // asynchronously while it probes, and on a remote file the probe
+      // routinely outruns the fixed 500ms sample after `open()`. Dropping
+      // the server's embedded tracks here left `_subtitleTracks` empty and
+      // `panel_controls.dart`'s `subtitleTrackCount > 0` gate rendered the
+      // button dead for the whole session.
+      final tracks = resolveSubtitleTracks(
+        serverTracks: [textTrack, embeddedTextTrack],
+        mpvTracks: const [],
+        isDirectPlay: true,
+      );
+
+      expect(tracks, [textTrack, embeddedTextTrack]);
+    });
+
+    test('drops image tracks from the direct-play fallback', () {
+      // PGS and VobSub are bitmaps. In direct play mpv renders them from the
+      // container; without mpv there is no body to fetch and nothing that
+      // could draw them, so offering one would be a selection that silently
+      // fails.
+      final tracks = resolveSubtitleTracks(
+        serverTracks: [textTrack, imageTrack],
+        mpvTracks: const [],
+        isDirectPlay: true,
+      );
+
+      expect(tracks, isNot(contains(imageTrack)));
+      expect(tracks, contains(textTrack));
+    });
+
+    test('derives an equal list from unchanged inputs', () {
+      // What lets `_applySubtitleTracks` skip the rebuild on a repeated
+      // media_kit emission. That skip is load-bearing:
+      // `_syncSelectedSubtitleTrack` bumps `_subtitleSelectionGeneration`,
+      // and a bump discards whatever selection the viewer has in flight.
+      List<SubtitleTrack> derive() => resolveSubtitleTracks(
+            serverTracks: [textTrack, embeddedTextTrack],
+            mpvTracks: [mkTrack],
+            isDirectPlay: true,
+          );
+
+      expect(listEquals(derive(), derive()), isTrue);
     });
   });
 


### PR DESCRIPTION
On iOS the player's subtitle button renders disabled and stays that way for the whole session, on files that do have subtitles. The same file plays with working subtitles in the web player.

## What was happening

The client learns about subtitle tracks two ways: the `MovieDetail` / `EpisodeDetail` query, and mpv's own probe, sampled once by `_detectTracks` after a fixed 500ms delay following `player.open()`.

In direct play the second source replaced the first. `_subtitleTracks` was reassigned to mpv's embedded tracks plus whichever server tracks were sidecars, so every embedded track the server reported was discarded by construction.

mpv discovers tracks asynchronously while it probes. On a remote file over HTTP the probe routinely outruns the 500ms sample, so the mpv list is still empty when detection reads it and the result is a list of length zero. Nothing ever recomputed it. Audio is protected from this exact race by a `player.stream.tracks` subscription established before `open()`, and the dartdoc on `watchAudioTracks` describes the bug, but subtitles never got the equivalent. `panel_controls.dart` gates the button on `subtitleTrackCount > 0`, so a zero-length list renders a dead control for the rest of the session.

Web is the tell. `canDirect = !kIsWeb && ...`, so the web player can never take the direct-play path, never reaches the branch that discards the server's list, and its subtitle button works. The server and the GraphQL path were healthy all along.

## The fix

`_subtitleTracks` was both the GraphQL result and the merged display list, which is what made detection destructive. Those are now separate. `_serverSubtitleTracks` holds the server's list untouched; `_subtitleTracks` is derived from it together with whatever mpv has probed.

A new pure function, `resolveSubtitleTracks`, makes that decision in three cases:

- Streaming: the server's deliverable tracks. Unchanged.
- Direct play with mpv tracks present: mpv's tracks plus sidecars. Unchanged.
- Direct play with mpv still empty: the server's deliverable tracks. This is the new case. Selecting one fetches its body over `SubtitleContent`, the path sidecars already take. Image tracks are dropped, since there is no body to fetch for a bitmap and nothing to render it.

The two lists are never merged into one. ffprobe stream indices and mpv's own track ids do not correspond, so a merge would list every embedded track twice.

`watchAudioTracks` becomes `watchTracks`, carrying the whole `Tracks` payload so both kinds ride one subscription, and the derived list is recomputed on every revision instead of once.

## Two details worth a look

The rebuild returns early when the derived list is unchanged. That guard is load-bearing rather than an optimisation: `_syncSelectedSubtitleTrack` bumps `_subtitleSelectionGeneration`, a bump makes `shouldApplySubtitleSelection` discard whatever selection is in flight, and mpv revises its track list more than once per playback. Without it, a revision would swallow a viewer's tap.

`_mediaKitSubtitleTrackMap` holds two kinds of entry: mpv-native tracks keyed `mk_*`, and the lazily fetched `SubtitleTrack.data` bodies `_resolveMediaKitSubtitleTrack` caches by server track id. Detection used to assign the whole map. Now that it runs repeatedly it replaces only the `mk_` keys, so a rebuild cannot drop that cache and re-run a server-side ffmpeg extraction for every track the viewer had already selected.

## Verification

- Full player suite, `./dev flutter test --concurrency=1`: 2786 tests, 0 failures
- Focused: `subtitle_track_loading_test.dart` and `audio_track_detection_test.dart`, 29 tests
- `dart analyze --fatal-warnings` over `player/lib/presentation/screens/player/`: clean

New coverage sits on the pure helpers, since `flutter test` cannot construct a real native-backed media_kit `Player`. The regression case is `resolveSubtitleTracks` returning the server's embedded tracks when mpv has probed nothing yet in direct play.

Not yet confirmed on an iOS device. When testing, `[PlayerScreen] Detected N audio tracks, M subtitle tracks (directPlay=true)` should now print more than once per playback, with `M` non-zero on the first line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subtitle and audio track detection as tracks become available during playback.
  - Fixed subtitle updates for embedded and downloaded subtitles discovered after playback begins.
  - Prevented duplicate subtitle entries.
  - Improved subtitle selection for streaming and direct playback, including reliable fallback behavior.
  - Filtered unsupported image-based subtitle tracks from available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->