### PR TITLE
chore(metadata-relay): prepare v0.14.0 release

### DIFF
--- a/metadata-relay/mix.exs
+++ b/metadata-relay/mix.exs
@@ -4,7 +4,7 @@ defmodule MetadataRelay.MixProject do
   def project do
     [
       app: :metadata_relay,
-      version: "0.13.0",
+      version: "0.14.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Version bump ahead of the metadata-relay-v0.14.0 deploy tag, per metadata-relay/CLAUDE.md's release steps. This release ships the security audit fixes from #544 (13 root causes closed: unauthenticated abuse paths, atom exhaustion, etc.) plus the SubDL source-naming and cache-key changes merged since 0.13.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->