### PR TITLE
feat(events): scope the activity feed and title timeline for guest accounts

### DIFF
--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -10,6 +10,7 @@ defmodule Mydia.Events do
   alias Mydia.Repo
   alias Mydia.Events.Event
   alias Mydia.Events.Presentation
+  alias Mydia.Events.Visibility
   alias Mydia.Events.Writer
   alias Phoenix.PubSub
 
@@ -110,10 +111,32 @@ defmodule Mydia.Events do
   """
   def list_events(opts \\ []) do
     Event
+    |> query_events(opts)
+    |> Repo.all()
+  end
+
+  @doc """
+  Lists the events `user` is allowed to read.
+
+  Accepts the same options as `list_events/1`. Viewer scoping is applied in
+  SQL before pagination, so `:limit` and `:offset` stay correct: filtering
+  after the query would make a page-sized fetch return fewer rows than it
+  claims, and break the caller's "is there another page" check.
+
+  `list_events/1` stays unrestricted for system and admin callers.
+  """
+  def list_visible_events(user, opts \\ []) do
+    Event
+    |> Visibility.scope(user)
+    |> query_events(opts)
+    |> Repo.all()
+  end
+
+  defp query_events(query, opts) do
+    query
     |> apply_filters(opts)
     |> apply_pagination(opts)
     |> order_by([e], desc: e.inserted_at, desc: e.id)
-    |> Repo.all()
   end
 
   @doc """
@@ -131,6 +154,20 @@ defmodule Mydia.Events do
       |> Keyword.put(:resource_id, resource_id)
 
     list_events(opts)
+  end
+
+  @doc """
+  Events for a resource, restricted to what `user` is allowed to read.
+
+  The viewer-scoped counterpart of `get_resource_events/3`.
+  """
+  def get_visible_resource_events(user, resource_type, resource_id, opts \\ []) do
+    opts =
+      opts
+      |> Keyword.put(:resource_type, resource_type)
+      |> Keyword.put(:resource_id, resource_id)
+
+    list_visible_events(user, opts)
   end
 
   @doc """

--- a/lib/mydia/events/visibility.ex
+++ b/lib/mydia/events/visibility.ex
@@ -14,26 +14,13 @@ defmodule Mydia.Events.Visibility do
 
   alias Mydia.Accounts.User
   alias Mydia.Events.Event
+  alias Mydia.Events.Visibility.Policy
 
-  defmodule Policy do
-    @moduledoc """
-    A restricted viewer's allowlist.
-
-    `types` are visible whoever caused them. `own_types` are visible only when
-    the event's actor is the viewer. `categories` names the categories those
-    types are recorded under, so the UI can drop filter chips that could never
-    match. It is declared rather than derived: the type-to-category mapping
-    lives in the `Mydia.Events` writer functions, not in the type registry.
-    """
-
-    defstruct types: [], own_types: [], categories: []
-
-    @type t :: %__MODULE__{
-            types: [String.t()],
-            own_types: [String.t()],
-            categories: [String.t()]
-          }
-  end
+  @guest_policy %Policy{
+    types: ["media_item.added", "media_item.removed"],
+    own_types: ["playback.started", "playback.finished", "playback.unwatched"],
+    categories: ["media", "playback"]
+  }
 
   @doc """
   Returns the visibility policy for a viewer.
@@ -43,21 +30,8 @@ defmodule Mydia.Events.Visibility do
   """
   @spec policy_for(User.t() | nil) :: :unrestricted | :none | Policy.t()
   def policy_for(nil), do: :none
-  def policy_for(%User{role: "guest"}), do: guest_policy()
+  def policy_for(%User{role: "guest"}), do: @guest_policy
   def policy_for(%User{}), do: :unrestricted
-
-  # A function rather than a module attribute: this compiler rejects a
-  # `@guest_policy %Policy{...}` module attribute that references the nested
-  # Policy struct, because the attribute is evaluated in the same compilation
-  # context that is still defining that struct. A function body runs after
-  # both modules have finished compiling, so it has no such restriction.
-  defp guest_policy do
-    %Policy{
-      types: ["media_item.added", "media_item.removed"],
-      own_types: ["playback.started", "playback.finished", "playback.unwatched"],
-      categories: ["media", "playback"]
-    }
-  end
 
   @doc """
   Restricts an event query to the rows the viewer may read.

--- a/lib/mydia/events/visibility.ex
+++ b/lib/mydia/events/visibility.ex
@@ -1,0 +1,124 @@
+defmodule Mydia.Events.Visibility do
+  @moduledoc """
+  Decides which events a viewer is allowed to read.
+
+  The rule lives here once, as data, and is compiled into the two forms the
+  application needs: an Ecto `where` clause for paginated queries (`scope/2`)
+  and a boolean check for events arriving over PubSub (`visible?/2`). A single
+  source is the point. `MydiaWeb.ActivityLive.Index` already maintains its
+  live-insert check as a hand-written mirror of its SQL filter, and that mirror
+  is exactly what drifts.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Mydia.Accounts.User
+  alias Mydia.Events.Event
+
+  defmodule Policy do
+    @moduledoc """
+    A restricted viewer's allowlist.
+
+    `types` are visible whoever caused them. `own_types` are visible only when
+    the event's actor is the viewer. `categories` names the categories those
+    types are recorded under, so the UI can drop filter chips that could never
+    match. It is declared rather than derived: the type-to-category mapping
+    lives in the `Mydia.Events` writer functions, not in the type registry.
+    """
+
+    defstruct types: [], own_types: [], categories: []
+
+    @type t :: %__MODULE__{
+            types: [String.t()],
+            own_types: [String.t()],
+            categories: [String.t()]
+          }
+  end
+
+  @doc """
+  Returns the visibility policy for a viewer.
+
+  `:unrestricted` for admin, user and readonly; the guest policy for a guest;
+  `:none` when there is no viewer.
+  """
+  @spec policy_for(User.t() | nil) :: :unrestricted | :none | Policy.t()
+  def policy_for(nil), do: :none
+  def policy_for(%User{role: "guest"}), do: guest_policy()
+  def policy_for(%User{}), do: :unrestricted
+
+  # A function rather than a module attribute: this compiler rejects a
+  # `@guest_policy %Policy{...}` module attribute that references the nested
+  # Policy struct, because the attribute is evaluated in the same compilation
+  # context that is still defining that struct. A function body runs after
+  # both modules have finished compiling, so it has no such restriction.
+  defp guest_policy do
+    %Policy{
+      types: ["media_item.added", "media_item.removed"],
+      own_types: ["playback.started", "playback.finished", "playback.unwatched"],
+      categories: ["media", "playback"]
+    }
+  end
+
+  @doc """
+  Restricts an event query to the rows the viewer may read.
+
+  Applied before pagination so `:limit` and `:offset` stay correct.
+  """
+  @spec scope(Ecto.Queryable.t(), User.t() | nil) :: Ecto.Query.t()
+  def scope(query, user) do
+    case policy_for(user) do
+      :unrestricted ->
+        query
+
+      :none ->
+        # An explicit contradiction rather than an `actor_id == ^nil`
+        # comparison. The latter compiles to `= NULL`, which is never true on
+        # either adapter, so it would give the right answer through a mechanism
+        # no reader can see.
+        where(query, [_e], fragment("1 = 0"))
+
+      %Policy{types: types, own_types: own_types} ->
+        viewer_id = user.id
+
+        where(
+          query,
+          [e],
+          e.type in ^types or
+            (e.type in ^own_types and e.actor_type == ^:user and e.actor_id == ^viewer_id)
+        )
+    end
+  end
+
+  @doc """
+  Whether a single in-memory event is visible to the viewer.
+
+  The PubSub counterpart of `scope/2`. Both read the same policy.
+  """
+  @spec visible?(Event.t(), User.t() | nil) :: boolean()
+  def visible?(%Event{} = event, user) do
+    case policy_for(user) do
+      :unrestricted -> true
+      :none -> false
+      %Policy{} = policy -> matches?(event, policy, user.id)
+    end
+  end
+
+  @doc """
+  The event categories a viewer can encounter, or `:all` when unrestricted.
+
+  Consumers use this to drop filter controls that could never match a row.
+  """
+  @spec visible_categories(User.t() | nil) :: :all | [String.t()]
+  def visible_categories(user) do
+    case policy_for(user) do
+      :unrestricted -> :all
+      :none -> []
+      %Policy{categories: categories} -> categories
+    end
+  end
+
+  defp matches?(%Event{type: type} = event, %Policy{} = policy, viewer_id) do
+    type in policy.types or
+      (type in policy.own_types and event.actor_type == :user and event.actor_id == viewer_id)
+  end
+end

--- a/lib/mydia/events/visibility/policy.ex
+++ b/lib/mydia/events/visibility/policy.ex
@@ -1,0 +1,19 @@
+defmodule Mydia.Events.Visibility.Policy do
+  @moduledoc """
+  A restricted viewer's allowlist.
+
+  `types` are visible whoever caused them. `own_types` are visible only when
+  the event's actor is the viewer. `categories` names the categories those
+  types are recorded under, so the UI can drop filter chips that could never
+  match. It is declared rather than derived: the type-to-category mapping
+  lives in the `Mydia.Events` writer functions, not in the type registry.
+  """
+
+  defstruct types: [], own_types: [], categories: []
+
+  @type t :: %__MODULE__{
+          types: [String.t()],
+          own_types: [String.t()],
+          categories: [String.t()]
+        }
+end

--- a/lib/mydia_web/live/activity_live/index.ex
+++ b/lib/mydia_web/live/activity_live/index.ex
@@ -2,6 +2,7 @@ defmodule MydiaWeb.ActivityLive.Index do
   use MydiaWeb, :live_view
   alias Mydia.Events
   alias Mydia.Events.Presentation
+  alias Mydia.Events.Visibility
   alias Phoenix.PubSub
 
   @page_size 50
@@ -77,6 +78,10 @@ defmodule MydiaWeb.ActivityLive.Index do
     # This check must mirror build_filter_opts/2, which applies it in SQL.
     feed_visible = event.type not in Presentation.feed_hidden_types()
 
+    # Viewer scoping needs no mirroring: this predicate and the SQL clause
+    # applied by Events.list_visible_events/2 are compiled from the same policy.
+    viewer_visible = Visibility.visible?(event, socket.assigns.current_user)
+
     # Only add event if it matches current category filter
     matches_category =
       case category_filter do
@@ -89,7 +94,7 @@ defmodule MydiaWeb.ActivityLive.Index do
     matches_date = event_matches_date_filter?(event.inserted_at, date_filter)
 
     socket =
-      if feed_visible && matches_category && matches_date do
+      if feed_visible && viewer_visible && matches_category && matches_date do
         socket
         |> assign(:events_empty?, false)
         |> stream_insert(:events, event, at: 0)
@@ -109,7 +114,11 @@ defmodule MydiaWeb.ActivityLive.Index do
     filter_opts = build_filter_opts(category_filter, date_filter)
 
     # Request one more than page_size to check if there are more results
-    events = Events.list_events(filter_opts ++ [limit: @page_size + 1, offset: 0])
+    events =
+      Events.list_visible_events(
+        socket.assigns.current_user,
+        filter_opts ++ [limit: @page_size + 1, offset: 0]
+      )
 
     has_more? = length(events) > @page_size
     events = Enum.take(events, @page_size)
@@ -129,7 +138,11 @@ defmodule MydiaWeb.ActivityLive.Index do
     offset = page * @page_size
 
     # Request one more than page_size to check if there are more results
-    events = Events.list_events(filter_opts ++ [limit: @page_size + 1, offset: offset])
+    events =
+      Events.list_visible_events(
+        socket.assigns.current_user,
+        filter_opts ++ [limit: @page_size + 1, offset: offset]
+      )
 
     has_more? = length(events) > @page_size
     events = Enum.take(events, @page_size)

--- a/lib/mydia_web/live/activity_live/index.ex
+++ b/lib/mydia_web/live/activity_live/index.ex
@@ -7,6 +7,70 @@ defmodule MydiaWeb.ActivityLive.Index do
 
   @page_size 50
 
+  # The chip catalog lives here rather than in Mydia.Events.Visibility so that
+  # daisyUI classes and hero icon names stay out of a context module. Visibility
+  # answers which categories a viewer can encounter; this decides how they look.
+  # "all" and "errors" are not categories: "all" clears the filter and "errors"
+  # filters on severity, so only "all" survives for a restricted viewer.
+  @chips [
+    %{
+      value: "all",
+      label: "All",
+      icon: "hero-squares-2x2",
+      active_class: "btn-primary",
+      idle_class: "btn-ghost"
+    },
+    %{
+      value: "media",
+      label: "Media",
+      icon: "hero-film",
+      active_class: "btn-primary",
+      idle_class: "btn-ghost"
+    },
+    %{
+      value: "downloads",
+      label: "Downloads",
+      icon: "hero-arrow-down-tray",
+      active_class: "btn-primary",
+      idle_class: "btn-ghost"
+    },
+    %{
+      value: "search",
+      label: "Search",
+      icon: "hero-magnifying-glass",
+      active_class: "btn-primary",
+      idle_class: "btn-ghost"
+    },
+    %{
+      value: "system",
+      label: "System",
+      icon: "hero-cog-6-tooth",
+      active_class: "btn-primary",
+      idle_class: "btn-ghost"
+    },
+    %{
+      value: "playback",
+      label: "Playback",
+      icon: "hero-play",
+      active_class: "btn-primary",
+      idle_class: "btn-ghost"
+    },
+    %{
+      value: "plugin",
+      label: "Plugins",
+      icon: "hero-puzzle-piece",
+      active_class: "btn-primary",
+      idle_class: "btn-ghost"
+    },
+    %{
+      value: "errors",
+      label: "Errors",
+      icon: "hero-exclamation-triangle",
+      active_class: "btn-error",
+      idle_class: "btn-ghost text-error/70 hover:text-error"
+    }
+  ]
+
   @impl true
   def mount(_params, _session, socket) do
     socket =
@@ -17,6 +81,7 @@ defmodule MydiaWeb.ActivityLive.Index do
         socket
         |> assign(:category_filter, "all")
         |> assign(:date_filter, "all")
+        |> assign(:filter_chips, filter_chips(socket.assigns.current_user))
         |> assign(:page, 0)
         |> assign(:has_more?, false)
         |> assign(:events_empty?, false)
@@ -25,6 +90,7 @@ defmodule MydiaWeb.ActivityLive.Index do
         socket
         |> assign(:category_filter, "all")
         |> assign(:date_filter, "all")
+        |> assign(:filter_chips, filter_chips(socket.assigns.current_user))
         |> assign(:page, 0)
         |> assign(:has_more?, false)
         |> assign(:events_empty?, true)
@@ -106,6 +172,13 @@ defmodule MydiaWeb.ActivityLive.Index do
   end
 
   ## Private Helpers
+
+  defp filter_chips(user) do
+    case Visibility.visible_categories(user) do
+      :all -> @chips
+      categories -> Enum.filter(@chips, &(&1.value == "all" or &1.value in categories))
+    end
+  end
 
   defp load_events(socket) do
     category_filter = socket.assigns.category_filter

--- a/lib/mydia_web/live/activity_live/index.html.heex
+++ b/lib/mydia_web/live/activity_live/index.html.heex
@@ -22,87 +22,18 @@
             </div>
             <div class="flex flex-wrap gap-1">
               <button
+                :for={chip <- @filter_chips}
                 class={[
                   "btn btn-sm gap-1",
-                  if(@category_filter == "all", do: "btn-primary", else: "btn-ghost")
-                ]}
-                phx-click="filter_category"
-                phx-value-category="all"
-              >
-                <.icon name="hero-squares-2x2" class="w-4 h-4" /> All
-              </button>
-              <button
-                class={[
-                  "btn btn-sm gap-1",
-                  if(@category_filter == "media", do: "btn-primary", else: "btn-ghost")
-                ]}
-                phx-click="filter_category"
-                phx-value-category="media"
-              >
-                <.icon name="hero-film" class="w-4 h-4" /> Media
-              </button>
-              <button
-                class={[
-                  "btn btn-sm gap-1",
-                  if(@category_filter == "downloads", do: "btn-primary", else: "btn-ghost")
-                ]}
-                phx-click="filter_category"
-                phx-value-category="downloads"
-              >
-                <.icon name="hero-arrow-down-tray" class="w-4 h-4" /> Downloads
-              </button>
-              <button
-                class={[
-                  "btn btn-sm gap-1",
-                  if(@category_filter == "search", do: "btn-primary", else: "btn-ghost")
-                ]}
-                phx-click="filter_category"
-                phx-value-category="search"
-              >
-                <.icon name="hero-magnifying-glass" class="w-4 h-4" /> Search
-              </button>
-              <button
-                class={[
-                  "btn btn-sm gap-1",
-                  if(@category_filter == "system", do: "btn-primary", else: "btn-ghost")
-                ]}
-                phx-click="filter_category"
-                phx-value-category="system"
-              >
-                <.icon name="hero-cog-6-tooth" class="w-4 h-4" /> System
-              </button>
-              <button
-                class={[
-                  "btn btn-sm gap-1",
-                  if(@category_filter == "playback", do: "btn-primary", else: "btn-ghost")
-                ]}
-                phx-click="filter_category"
-                phx-value-category="playback"
-              >
-                <.icon name="hero-play" class="w-4 h-4" /> Playback
-              </button>
-              <button
-                class={[
-                  "btn btn-sm gap-1",
-                  if(@category_filter == "plugin", do: "btn-primary", else: "btn-ghost")
-                ]}
-                phx-click="filter_category"
-                phx-value-category="plugin"
-              >
-                <.icon name="hero-puzzle-piece" class="w-4 h-4" /> Plugins
-              </button>
-              <button
-                class={[
-                  "btn btn-sm gap-1",
-                  if(@category_filter == "errors",
-                    do: "btn-error",
-                    else: "btn-ghost text-error/70 hover:text-error"
+                  if(@category_filter == chip.value,
+                    do: chip.active_class,
+                    else: chip.idle_class
                   )
                 ]}
                 phx-click="filter_category"
-                phx-value-category="errors"
+                phx-value-category={chip.value}
               >
-                <.icon name="hero-exclamation-triangle" class="w-4 h-4" /> Errors
+                <.icon name={chip.icon} class="w-4 h-4" /> {chip.label}
               </button>
             </div>
           </div>

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -53,7 +53,7 @@ defmodule MydiaWeb.MediaLive.Show do
     user_preference = Mydia.Accounts.get_user_preference!(socket.assigns.current_user)
 
     # Load timeline events from Events system
-    timeline_events = load_timeline_events(media_item)
+    timeline_events = load_timeline_events(media_item, socket.assigns.current_user)
 
     # Load next episode for TV shows
     {next_episode, next_episode_state} = load_next_episode(media_item, socket)
@@ -467,7 +467,7 @@ defmodule MydiaWeb.MediaLive.Show do
     if download_for_media?(download, socket.assigns.media_item) do
       media_item = load_media_item(socket.assigns.media_item.id)
       downloads_with_status = load_downloads_with_status(media_item)
-      timeline_events = load_timeline_events(media_item)
+      timeline_events = load_timeline_events(media_item, socket.assigns.current_user)
 
       # If auto searching was in progress, show success message
       socket =
@@ -505,7 +505,7 @@ defmodule MydiaWeb.MediaLive.Show do
     # Reload media item and downloads with status
     media_item = load_media_item(socket.assigns.media_item.id)
     downloads_with_status = load_downloads_with_status(media_item)
-    timeline_events = load_timeline_events(media_item)
+    timeline_events = load_timeline_events(media_item, socket.assigns.current_user)
 
     {:noreply,
      socket
@@ -598,7 +598,8 @@ defmodule MydiaWeb.MediaLive.Show do
     if event.resource_type == "media_item" &&
          event.resource_id == socket.assigns.media_item.id do
       # Reload timeline events to include the new event
-      timeline_events = load_timeline_events(socket.assigns.media_item)
+      timeline_events =
+        load_timeline_events(socket.assigns.media_item, socket.assigns.current_user)
 
       {:noreply, assign(socket, :timeline_events, timeline_events)}
     else

--- a/lib/mydia_web/live/media_live/show/loaders.ex
+++ b/lib/mydia_web/live/media_live/show/loaders.ex
@@ -43,9 +43,10 @@ defmodule MydiaWeb.MediaLive.Show.Loaders do
     end)
   end
 
-  def load_timeline_events(media_item) do
-    # Get events from Events system for this media item
-    events = Events.get_resource_events("media_item", media_item.id, limit: 50)
+  def load_timeline_events(media_item, user) do
+    # Scoped by viewer: playback events record resource_type "media_item", so an
+    # unscoped read would show a guest every account's watch activity here.
+    events = Events.get_visible_resource_events(user, "media_item", media_item.id, limit: 50)
 
     # Format each event for timeline display
     events

--- a/test/mydia/events/visibility_test.exs
+++ b/test/mydia/events/visibility_test.exs
@@ -1,0 +1,134 @@
+defmodule Mydia.Events.VisibilityTest do
+  use Mydia.DataCase, async: true
+
+  import Ecto.Query, only: [select: 3]
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Events
+  alias Mydia.Events.Event
+  alias Mydia.Events.Visibility
+  alias Mydia.Events.Visibility.Policy
+  alias Mydia.Repo
+
+  describe "policy_for/1" do
+    test "admin, user and readonly are unrestricted" do
+      for role <- ~w(admin user readonly) do
+        assert Visibility.policy_for(user_fixture(%{role: role})) == :unrestricted
+      end
+    end
+
+    test "a guest gets the guest policy" do
+      assert %Policy{types: types, own_types: own_types} =
+               Visibility.policy_for(user_fixture(%{role: "guest"}))
+
+      assert types == ["media_item.added", "media_item.removed"]
+
+      assert own_types == [
+               "playback.started",
+               "playback.finished",
+               "playback.unwatched"
+             ]
+    end
+
+    test "no viewer is denied everything" do
+      assert Visibility.policy_for(nil) == :none
+    end
+  end
+
+  describe "visible?/2" do
+    setup do
+      %{guest: user_fixture(%{role: "guest"}), other: user_fixture(%{role: "guest"})}
+    end
+
+    test "an allowed shared type is visible whoever caused it", %{guest: guest, other: other} do
+      assert Visibility.visible?(event(:system, "media_context", "media_item.added"), guest)
+      assert Visibility.visible?(event(:user, other.id, "media_item.removed"), guest)
+    end
+
+    test "a type outside the policy is hidden", %{guest: guest} do
+      refute Visibility.visible?(event(:system, "download_monitor", "download.completed"), guest)
+      refute Visibility.visible?(event(:system, "media_context", "media_item.updated"), guest)
+      refute Visibility.visible?(event(:system, "media_context", "media_file.imported"), guest)
+    end
+
+    test "an own_type is visible only for the viewer's own events", %{
+      guest: guest,
+      other: other
+    } do
+      assert Visibility.visible?(event(:user, guest.id, "playback.started"), guest)
+      refute Visibility.visible?(event(:user, other.id, "playback.started"), guest)
+    end
+
+    test "an own_type from a non-user actor is hidden", %{guest: guest} do
+      refute Visibility.visible?(event(:system, guest.id, "playback.started"), guest)
+    end
+
+    test "progressed and paused are hidden even for the viewer's own account", %{guest: guest} do
+      refute Visibility.visible?(event(:user, guest.id, "playback.progressed"), guest)
+      refute Visibility.visible?(event(:user, guest.id, "playback.paused"), guest)
+    end
+
+    test "an unrestricted viewer sees everything", %{guest: guest} do
+      admin = admin_user_fixture()
+
+      assert Visibility.visible?(event(:system, "download_monitor", "download.failed"), admin)
+      assert Visibility.visible?(event(:user, guest.id, "playback.progressed"), admin)
+    end
+
+    test "no viewer sees nothing" do
+      refute Visibility.visible?(event(:system, "media_context", "media_item.added"), nil)
+    end
+
+    defp event(actor_type, actor_id, type) do
+      %Event{type: type, actor_type: actor_type, actor_id: actor_id}
+    end
+  end
+
+  describe "scope/2" do
+    test "an unrestricted viewer's query is untouched" do
+      insert_event("download.completed", :system, "download_monitor")
+
+      assert [_] = scoped_types(admin_user_fixture())
+    end
+
+    test "a guest's query returns only allowed rows" do
+      guest = user_fixture(%{role: "guest"})
+      other = user_fixture(%{role: "guest"})
+
+      insert_event("media_item.added", :system, "media_context")
+      insert_event("download.completed", :system, "download_monitor")
+      insert_event("playback.started", :user, guest.id)
+      insert_event("playback.started", :user, other.id)
+      insert_event("playback.progressed", :user, guest.id)
+
+      assert scoped_types(guest) == ["media_item.added", "playback.started"]
+    end
+
+    test "no viewer returns no rows" do
+      insert_event("media_item.added", :system, "media_context")
+
+      assert scoped_types(nil) == []
+    end
+
+    defp insert_event(type, actor_type, actor_id) do
+      {:ok, event} =
+        Events.create_event(%{
+          category: "media",
+          type: type,
+          actor_type: actor_type,
+          actor_id: actor_id,
+          metadata: %{"title" => "Fixture Title"}
+        })
+
+      event
+    end
+
+    defp scoped_types(user) do
+      Event
+      |> Visibility.scope(user)
+      |> select([e], e.type)
+      |> Repo.all()
+      |> Enum.sort()
+    end
+  end
+end

--- a/test/mydia/events_test.exs
+++ b/test/mydia/events_test.exs
@@ -1265,7 +1265,7 @@ defmodule Mydia.EventsTest do
       guest = user_fixture(%{role: "guest"})
       other = user_fixture(%{role: "guest"})
 
-      corpus = seed_registry_corpus([guest, other])
+      corpus = seed_registry_corpus([guest, other], guest)
 
       %{guest: guest, other: other, admin: admin_user_fixture(), corpus: corpus}
     end
@@ -1314,11 +1314,17 @@ defmodule Mydia.EventsTest do
              ]
     end
 
-    # One event per registered type, per actor: each of the given users, plus a
-    # system actor. Driving the list off the registry means a newly registered
-    # type is covered here without anyone remembering to add it.
-    defp seed_registry_corpus(users) do
-      actors = Enum.map(users, &{:user, &1.id}) ++ [{:system, "test_system"}]
+    # One event per registered type, per actor: each of the given users, a
+    # system actor, and a non-user actor whose actor_id spoofs the viewing
+    # guest's own id. That last pairing is what an own_type row looks like if
+    # scope/2 or visible?/2 only compared actor_id and forgot actor_type; it
+    # must stay hidden from the guest. Driving the list off the registry means
+    # a newly registered type is covered here without anyone remembering to
+    # add it.
+    defp seed_registry_corpus(users, guest) do
+      actors =
+        Enum.map(users, &{:user, &1.id}) ++
+          [{:system, "test_system"}, {:system, guest.id}]
 
       for type <- Presentation.known_types(), {actor_type, actor_id} <- actors do
         {:ok, event} =

--- a/test/mydia/events_test.exs
+++ b/test/mydia/events_test.exs
@@ -1,6 +1,8 @@
 defmodule Mydia.EventsTest do
   use Mydia.DataCase
 
+  import Mydia.AccountsFixtures
+
   alias Mydia.Events
   alias Mydia.Events.Event
   alias Phoenix.PubSub
@@ -1160,5 +1162,108 @@ defmodule Mydia.EventsTest do
 
       assert formatted.description == "Event occurred"
     end
+  end
+
+  describe "list_visible_events/2" do
+    setup do
+      guest = user_fixture(%{role: "guest"})
+      other = user_fixture(%{role: "guest"})
+
+      {:ok, added} = seed("media", "media_item.added", :system, "media_context")
+      {:ok, download} = seed("downloads", "download.completed", :system, "download_monitor")
+      {:ok, own_play} = seed("playback", "playback.started", :user, guest.id)
+      {:ok, other_play} = seed("playback", "playback.started", :user, other.id)
+
+      %{
+        guest: guest,
+        added: added,
+        download: download,
+        own_play: own_play,
+        other_play: other_play
+      }
+    end
+
+    test "a guest sees allowed types and only their own playback", ctx do
+      ids = Enum.map(Events.list_visible_events(ctx.guest), & &1.id)
+
+      assert ctx.added.id in ids
+      assert ctx.own_play.id in ids
+      refute ctx.download.id in ids
+      refute ctx.other_play.id in ids
+    end
+
+    test "an admin sees everything", ctx do
+      ids = Enum.map(Events.list_visible_events(admin_user_fixture()), & &1.id)
+
+      assert ctx.added.id in ids
+      assert ctx.download.id in ids
+      assert ctx.other_play.id in ids
+    end
+
+    test "no viewer sees nothing" do
+      assert Events.list_visible_events(nil) == []
+    end
+
+    test "viewer scoping composes with the other filters", ctx do
+      ids =
+        ctx.guest
+        |> Events.list_visible_events(category: "playback")
+        |> Enum.map(& &1.id)
+
+      assert ids == [ctx.own_play.id]
+    end
+
+    test "scoping is applied before pagination", ctx do
+      # Two visible rows exist for the guest. A limit of 1 must return one
+      # visible row, not one row selected from the unscoped set and then
+      # discarded.
+      assert [event] = Events.list_visible_events(ctx.guest, limit: 1)
+      assert event.id in [ctx.added.id, ctx.own_play.id]
+    end
+  end
+
+  describe "get_visible_resource_events/4" do
+    test "restricts a resource's events to what the viewer may read" do
+      guest = user_fixture(%{role: "guest"})
+      other = user_fixture(%{role: "guest"})
+      resource_id = Ecto.UUID.generate()
+
+      {:ok, own} =
+        Events.create_event(%{
+          category: "playback",
+          type: "playback.started",
+          actor_type: :user,
+          actor_id: guest.id,
+          resource_type: "media_item",
+          resource_id: resource_id
+        })
+
+      {:ok, _theirs} =
+        Events.create_event(%{
+          category: "playback",
+          type: "playback.started",
+          actor_type: :user,
+          actor_id: other.id,
+          resource_type: "media_item",
+          resource_id: resource_id
+        })
+
+      ids =
+        guest
+        |> Events.get_visible_resource_events("media_item", resource_id)
+        |> Enum.map(& &1.id)
+
+      assert ids == [own.id]
+    end
+  end
+
+  defp seed(category, type, actor_type, actor_id) do
+    Events.create_event(%{
+      category: category,
+      type: type,
+      actor_type: actor_type,
+      actor_id: actor_id,
+      metadata: %{"title" => "Fixture Title"}
+    })
   end
 end

--- a/test/mydia/events_test.exs
+++ b/test/mydia/events_test.exs
@@ -2,9 +2,12 @@ defmodule Mydia.EventsTest do
   use Mydia.DataCase
 
   import Mydia.AccountsFixtures
+  import Mydia.EventsFixtures
 
   alias Mydia.Events
   alias Mydia.Events.Event
+  alias Mydia.Events.Presentation
+  alias Mydia.Events.Visibility
   alias Phoenix.PubSub
 
   describe "create_event/1" do
@@ -1254,6 +1257,81 @@ defmodule Mydia.EventsTest do
         |> Enum.map(& &1.id)
 
       assert ids == [own.id]
+    end
+  end
+
+  describe "viewer scoping agreement" do
+    setup do
+      guest = user_fixture(%{role: "guest"})
+      other = user_fixture(%{role: "guest"})
+
+      corpus = seed_registry_corpus([guest, other])
+
+      %{guest: guest, other: other, admin: admin_user_fixture(), corpus: corpus}
+    end
+
+    test "the SQL filter and the boolean predicate select the same events", ctx do
+      # list_visible_events/2 defaults :limit to 50 (see apply_pagination/2 in
+      # Mydia.Events). The corpus has ~174 rows, so an unrestricted viewer
+      # (admin, or a guest policy that matched everything) would otherwise be
+      # silently truncated and look like a scope/2 vs visible?/2 disagreement
+      # that is really just pagination. Pass a limit that covers the whole
+      # corpus so this test compares visibility, not page size.
+      corpus_size = length(ctx.corpus)
+
+      for viewer <- [ctx.guest, ctx.other, ctx.admin, nil] do
+        listed =
+          viewer
+          |> Events.list_visible_events(limit: corpus_size)
+          |> Enum.map(& &1.id)
+          |> Enum.sort()
+
+        expected =
+          ctx.corpus
+          |> Enum.filter(&Visibility.visible?(&1, viewer))
+          |> Enum.map(& &1.id)
+          |> Enum.sort()
+
+        assert listed == expected,
+               "scope/2 and visible?/2 disagree for #{inspect(viewer && viewer.role)}"
+      end
+    end
+
+    test "a guest sees exactly five of the registered types", ctx do
+      types =
+        ctx.guest
+        |> Events.list_visible_events()
+        |> Enum.map(& &1.type)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert types == [
+               "media_item.added",
+               "media_item.removed",
+               "playback.finished",
+               "playback.started",
+               "playback.unwatched"
+             ]
+    end
+
+    # One event per registered type, per actor: each of the given users, plus a
+    # system actor. Driving the list off the registry means a newly registered
+    # type is covered here without anyone remembering to add it.
+    defp seed_registry_corpus(users) do
+      actors = Enum.map(users, &{:user, &1.id}) ++ [{:system, "test_system"}]
+
+      for type <- Presentation.known_types(), {actor_type, actor_id} <- actors do
+        {:ok, event} =
+          Events.create_event(%{
+            category: category_for_type(type),
+            type: type,
+            actor_type: actor_type,
+            actor_id: actor_id,
+            metadata: %{"title" => "Fixture Title"}
+          })
+
+        event
+      end
     end
   end
 

--- a/test/mydia_web/live/activity_live/index_test.exs
+++ b/test/mydia_web/live/activity_live/index_test.exs
@@ -3,22 +3,9 @@ defmodule MydiaWeb.ActivityLive.IndexTest do
 
   import Phoenix.LiveViewTest
   import Mydia.AccountsFixtures
+  import Mydia.EventsFixtures
   alias Mydia.Events
   alias Mydia.Events.Presentation
-
-  # The category an event type is actually recorded under by the `Mydia.Events`
-  # helpers. It is not the type's namespace: `media_item.*` is recorded as
-  # "media" and `job.*` as "system", so deriving it from the type would produce
-  # fixtures no code path ever writes.
-  @category_by_namespace %{
-    "download" => "downloads",
-    "job" => "system",
-    "media_file" => "media",
-    "media_item" => "media",
-    "playback" => "playback",
-    "plugin" => "plugin",
-    "search" => "search"
-  }
 
   describe "Activity feed" do
     setup %{conn: conn} do
@@ -248,19 +235,9 @@ defmodule MydiaWeb.ActivityLive.IndexTest do
       types = Presentation.known_types() -- Presentation.feed_hidden_types()
 
       for type <- types do
-        [namespace, _action] = String.split(type, ".")
-
-        category =
-          Map.get_lazy(@category_by_namespace, namespace, fn ->
-            flunk(
-              "no real category mapped for event namespace #{inspect(namespace)}; " <>
-                "add it to @category_by_namespace"
-            )
-          end)
-
         {:ok, _} =
           Events.create_event(%{
-            category: category,
+            category: category_for_type(type),
             type: type,
             actor_type: :system,
             actor_id: "test",

--- a/test/mydia_web/live/activity_live/index_test.exs
+++ b/test/mydia_web/live/activity_live/index_test.exs
@@ -366,4 +366,183 @@ defmodule MydiaWeb.ActivityLive.IndexTest do
       assert html =~ "Plugin update available: tmdb-art 1.0.0 to 1.2.0"
     end
   end
+
+  describe "Activity feed as a guest" do
+    setup %{conn: conn} do
+      guest = user_fixture(%{role: "guest"})
+      other = user_fixture(%{role: "guest"})
+
+      %{conn: log_in_user(conn, guest), guest: guest, other: other}
+    end
+
+    test "shows media additions and removals", %{conn: conn} do
+      {:ok, _} =
+        Events.create_event(%{
+          category: "media",
+          type: "media_item.added",
+          actor_type: :system,
+          actor_id: "media_context",
+          metadata: %{"title" => "Paddington", "media_type" => "movie"}
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/activity")
+
+      assert html =~ "Added to library: Paddington (movie)"
+    end
+
+    test "shows the guest's own playback", %{conn: conn, guest: guest} do
+      {:ok, _} =
+        Events.create_event(%{
+          category: "playback",
+          type: "playback.started",
+          actor_type: :user,
+          actor_id: guest.id,
+          metadata: %{"origin" => "this-guests-player"}
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/activity")
+
+      assert html =~ "this-guests-player"
+    end
+
+    test "hides another user's playback", %{conn: conn, other: other} do
+      {:ok, _} =
+        Events.create_event(%{
+          category: "playback",
+          type: "playback.started",
+          actor_type: :user,
+          actor_id: other.id,
+          metadata: %{"origin" => "someone-elses-player"}
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/activity")
+
+      refute html =~ "someone-elses-player"
+      assert html =~ "No events found"
+    end
+
+    test "hides the guest's own progressed and paused events", %{conn: conn, guest: guest} do
+      for {type, origin} <- [
+            {"playback.progressed", "progress-noise"},
+            {"playback.paused", "pause-noise"}
+          ] do
+        {:ok, _} =
+          Events.create_event(%{
+            category: "playback",
+            type: type,
+            actor_type: :user,
+            actor_id: guest.id,
+            metadata: %{"origin" => origin}
+          })
+      end
+
+      {:ok, _view, html} = live(conn, ~p"/activity")
+
+      refute html =~ "progress-noise"
+      refute html =~ "pause-noise"
+    end
+
+    test "hides downloads, search, jobs and file operations", %{conn: conn} do
+      {:ok, _} =
+        Events.create_event(%{
+          category: "downloads",
+          type: "download.completed",
+          actor_type: :system,
+          actor_id: "download_monitor",
+          metadata: %{"title" => "Hidden.Download.mkv"}
+        })
+
+      {:ok, _} =
+        Events.create_event(%{
+          category: "search",
+          type: "search.completed",
+          actor_type: :system,
+          actor_id: "search_service",
+          metadata: %{"title" => "Hidden Search"}
+        })
+
+      {:ok, _} =
+        Events.create_event(%{
+          category: "system",
+          type: "job.failed",
+          actor_type: :job,
+          actor_id: "hidden_job",
+          severity: :error,
+          metadata: %{"job_name" => "hidden_job", "error_message" => "Hidden Error"}
+        })
+
+      {:ok, _} =
+        Events.create_event(%{
+          category: "media",
+          type: "media_file.imported",
+          actor_type: :system,
+          actor_id: "file_ingest",
+          metadata: %{"title" => "Hidden.Import.mkv"}
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/activity")
+
+      refute html =~ "Hidden.Download.mkv"
+      refute html =~ "Hidden Search"
+      refute html =~ "Hidden Error"
+      refute html =~ "Hidden.Import.mkv"
+      assert html =~ "No events found"
+    end
+
+    test "a hidden event arriving over PubSub is not inserted", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/activity")
+
+      {:ok, _hidden} =
+        Events.create_event(%{
+          category: "downloads",
+          type: "download.completed",
+          actor_type: :system,
+          actor_id: "download_monitor",
+          metadata: %{"title" => "Hidden.Live.mkv"}
+        })
+
+      {:ok, _visible} =
+        Events.create_event(%{
+          category: "media",
+          type: "media_item.added",
+          actor_type: :system,
+          actor_id: "media_context",
+          metadata: %{"title" => "Visible Live Movie", "media_type" => "movie"}
+        })
+
+      # Both broadcasts reach this LiveView in order on the same topic, so once
+      # the second has rendered the first has already been handled. That makes
+      # the refute below a real assertion rather than a race against a sleep.
+      html =
+        Enum.reduce_while(1..20, nil, fn _attempt, _acc ->
+          html = render(view)
+
+          if html =~ "Visible Live Movie" do
+            {:halt, html}
+          else
+            Process.sleep(50)
+            {:cont, html}
+          end
+        end)
+
+      assert html =~ "Visible Live Movie"
+      refute html =~ "Hidden.Live.mkv"
+    end
+
+    test "an admin's feed is unchanged", %{conn: conn} do
+      {:ok, _} =
+        Events.create_event(%{
+          category: "downloads",
+          type: "download.completed",
+          actor_type: :system,
+          actor_id: "download_monitor",
+          metadata: %{"title" => "Admin.Visible.mkv"}
+        })
+
+      admin_conn = log_in_user(conn, admin_user_fixture())
+      {:ok, _view, html} = live(admin_conn, ~p"/activity")
+
+      assert html =~ "Admin.Visible.mkv"
+    end
+  end
 end

--- a/test/mydia_web/live/activity_live/index_test.exs
+++ b/test/mydia_web/live/activity_live/index_test.exs
@@ -231,6 +231,15 @@ defmodule MydiaWeb.ActivityLive.IndexTest do
       assert has_element?(view, "button", "Errors")
     end
 
+    test "an admin keeps every chip", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/activity")
+
+      for category <- ~w(all media downloads search system playback plugin errors) do
+        assert has_element?(view, "button[phx-value-category='#{category}']"),
+               "#{category} chip is missing for an admin"
+      end
+    end
+
     test "labels every feed-visible event type instead of printing its key", %{conn: conn} do
       types = Presentation.known_types() -- Presentation.feed_hidden_types()
 
@@ -543,6 +552,50 @@ defmodule MydiaWeb.ActivityLive.IndexTest do
       {:ok, _view, html} = live(admin_conn, ~p"/activity")
 
       assert html =~ "Admin.Visible.mkv"
+    end
+
+    test "shows only the chips that can match", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/activity")
+
+      for category <- ~w(all media playback) do
+        assert has_element?(view, "button[phx-value-category='#{category}']"),
+               "#{category} chip is missing"
+      end
+
+      for category <- ~w(downloads search system plugin errors) do
+        refute has_element?(view, "button[phx-value-category='#{category}']"),
+               "#{category} chip can never match but is still rendered"
+      end
+    end
+
+    test "the media chip still filters", %{conn: conn, guest: guest} do
+      {:ok, _} =
+        Events.create_event(%{
+          category: "media",
+          type: "media_item.added",
+          actor_type: :system,
+          actor_id: "media_context",
+          metadata: %{"title" => "Paddington", "media_type" => "movie"}
+        })
+
+      {:ok, _} =
+        Events.create_event(%{
+          category: "playback",
+          type: "playback.started",
+          actor_type: :user,
+          actor_id: guest.id,
+          metadata: %{"origin" => "this-guests-player"}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/activity")
+
+      html =
+        view
+        |> element("button[phx-value-category='media']")
+        |> render_click()
+
+      assert html =~ "Paddington"
+      refute html =~ "this-guests-player"
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/timeline_visibility_test.exs
+++ b/test/mydia_web/live/media_live/show/timeline_visibility_test.exs
@@ -1,0 +1,121 @@
+defmodule MydiaWeb.MediaLive.Show.TimelineVisibilityTest do
+  @moduledoc """
+  The per-title timeline reads events by resource, and playback events record
+  `resource_type: "media_item"`. Without viewer scoping a guest sees every
+  other account's watch activity for the title.
+  """
+
+  # Connected LiveView tests must stay sync: the Postgres sandbox is only shared
+  # with the mount process when the case is not async.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import Mydia.MetadataCacheHelpers
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Events
+
+  setup do
+    # The app disables Oban in test (engine: false), so Oban.insert cannot run
+    # from the LiveView process. Start an isolated, manual-mode instance so the
+    # recommendations load can enqueue without a live queue.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+    :ok
+  end
+
+  test "a guest's timeline omits another account's playback", %{conn: conn} do
+    guest = user_fixture(%{role: "guest"})
+    other = user_fixture(%{role: "guest"})
+    show = seed_show()
+
+    playback_event(other, show, "someone-elses-player")
+    playback_event(guest, show, "this-guests-player")
+
+    html =
+      conn
+      |> log_in_user(guest)
+      |> render_show(show)
+
+    assert html =~ "this-guests-player"
+    refute html =~ "someone-elses-player"
+  end
+
+  test "a guest's timeline still shows the title being added", %{conn: conn} do
+    guest = user_fixture(%{role: "guest"})
+    show = seed_show()
+
+    html =
+      conn
+      |> log_in_user(guest)
+      |> render_show(show)
+
+    # media_item_fixture goes through Media.create_media_item/2, which records
+    # media_item.added, and Events.create_event_async/1 writes synchronously
+    # under the SQL sandbox.
+    assert html =~ "Added to library"
+  end
+
+  test "an admin's timeline is unchanged", %{conn: conn} do
+    other = user_fixture(%{role: "guest"})
+    show = seed_show()
+
+    playback_event(other, show, "someone-elses-player")
+
+    html =
+      conn
+      |> log_in_user(admin_user_fixture())
+      |> render_show(show)
+
+    assert html =~ "someone-elses-player"
+  end
+
+  defp seed_show do
+    tmdb_id = unique_provider_id()
+
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Detectorists",
+        year: 2014,
+        tmdb_id: tmdb_id
+      })
+
+    episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+    warm_recommendations_cache(tmdb_id, :tv_show, [
+      %{
+        "id" => unique_provider_id(),
+        "name" => "Rev.",
+        "first_air_date" => "2010-06-28",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    show
+  end
+
+  defp playback_event(user, show, origin) do
+    {:ok, event} =
+      Events.create_event(%{
+        category: "playback",
+        type: "playback.started",
+        actor_type: :user,
+        actor_id: user.id,
+        resource_type: "media_item",
+        resource_id: show.id,
+        metadata: %{"origin" => origin}
+      })
+
+    event
+  end
+
+  defp render_show(conn, show) do
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+    render(view)
+  end
+end

--- a/test/support/fixtures/events_fixtures.ex
+++ b/test/support/fixtures/events_fixtures.ex
@@ -1,0 +1,35 @@
+defmodule Mydia.EventsFixtures do
+  @moduledoc """
+  Test helpers for building events that match what the application records.
+  """
+
+  # The category an event type is actually recorded under by the `Mydia.Events`
+  # writer functions. It is not the type's namespace: `media_item.*` is recorded
+  # as "media" and `job.*` as "system", so deriving it from the type would
+  # produce fixtures no code path ever writes.
+  @category_by_namespace %{
+    "download" => "downloads",
+    "job" => "system",
+    "media_file" => "media",
+    "media_item" => "media",
+    "playback" => "playback",
+    "plugin" => "plugin",
+    "search" => "search"
+  }
+
+  @doc """
+  The category the application records the given event type under.
+
+  Raises when a namespace has no mapping, so a new event namespace fails loudly
+  here rather than producing fixtures that do not match production writes.
+  """
+  def category_for_type(type) when is_binary(type) do
+    [namespace, _action] = String.split(type, ".")
+
+    Map.get_lazy(@category_by_namespace, namespace, fn ->
+      raise ArgumentError,
+            "no category mapped for event namespace #{inspect(namespace)}; " <>
+              "add it to Mydia.EventsFixtures"
+    end)
+  end
+end


### PR DESCRIPTION
Guest accounts could read the entire events system. The activity feed showed them download failures, indexer searches, plugin HTTP traffic and job errors, and the History timeline on a title page showed every other account's playback for it, since playback events record `resource_type: "media_item"`.

A guest now sees `media_item.added` and `media_item.removed` from anyone, plus `playback.started`, `playback.finished` and `playback.unwatched` from their own account only. Admin, user and readonly viewers are unchanged.

## How it works

The rule lives once as data in `Mydia.Events.Visibility` and compiles into two forms: an Ecto `where` clause for paginated queries, and a boolean predicate for events arriving over PubSub. Scoping is applied in SQL before pagination, because the feed fetches `limit: page_size + 1` and derives "is there another page" from the row count, so filtering afterwards would produce short pages that still claim more results.

`list_events/1` and `get_resource_events/3` keep their unrestricted behavior for system and admin callers. The viewer-scoped versions are separately named rather than gated behind an optional `:viewer` key, so a caller cannot silently fail open by forgetting it.

The two forms are hand-written separately, one in Ecto's query macro and one in plain Elixir, because there is no cheap way to share an expression across that boundary. What keeps them honest is a registry-driven agreement test: it builds a corpus from `Presentation.known_types/0` across four actor pairings and asserts both forms select exactly the same rows for every role. Because the corpus comes from the registry, a newly registered event type is checked against the guest policy without anyone remembering to add it. The test is fault-injection-verified: removing either the actor-type check or the ownership check from the SQL form makes it fail.

Under the new policy five of the eight filter chips could never match a row for a guest, so the chip row is now derived from the viewer's policy. The chip catalog stays in the LiveView rather than the context module, so daisyUI classes and icon names do not leak into `Mydia.Events`.

`handle_event("filter_category", ...)` deliberately has no allowlist guard. A guest can post any category from devtools and the SQL scope makes the result empty regardless. The scope is the security boundary; the chips are ergonomics.

## Verification

- `mix compile --warnings-as-errors`: clean
- `mix precommit`: 9079 tests, 0 failures
- PostgreSQL run of the touched suites: 124 tests, 0 failures

No migration, no schema change, no GraphQL change. Nothing exposes events over GraphQL or REST, so the Rust SDL parity gate is not involved.

## Upgrade note

This changes what existing guest accounts see, with no data migration. No events are deleted or altered; only what a guest can read changes.

## Not included

Library-scoped and content-age-rating access controls were requested alongside this. They are a cross-cutting authorization layer over every media read path and need their own design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added viewer-aware event visibility across activity feeds and media timelines.
  * Guests now see permitted shared events and only their own playback activity.
  * Administrators retain access to all events.
  * Activity filters now adapt to the viewer’s available categories.

* **Bug Fixes**
  * Prevented unauthorized events from appearing in paginated feeds, timelines, and real-time updates.
  * Anonymous viewers no longer receive restricted event data.

* **Tests**
  * Added comprehensive coverage for visibility rules, filtering, pagination, real-time updates, and timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->