### PR TITLE
Request posters and detail popup

### DIFF
--- a/lib/mydia/media/media_request.ex
+++ b/lib/mydia/media/media_request.ex
@@ -17,6 +17,7 @@ defmodule Mydia.Media.MediaRequest do
           tmdb_id: integer() | nil,
           tvdb_id: integer() | nil,
           imdb_id: String.t() | nil,
+          poster_path: String.t() | nil,
           status: String.t(),
           requester_notes: String.t() | nil,
           admin_notes: String.t() | nil,
@@ -41,6 +42,7 @@ defmodule Mydia.Media.MediaRequest do
     field :tmdb_id, :integer
     field :tvdb_id, :integer
     field :imdb_id, :string
+    field :poster_path, :string
     field :status, :string, default: "pending"
     field :requester_notes, :string
     field :admin_notes, :string
@@ -68,6 +70,7 @@ defmodule Mydia.Media.MediaRequest do
       :tmdb_id,
       :tvdb_id,
       :imdb_id,
+      :poster_path,
       :requester_notes,
       :requester_id
     ])
@@ -112,6 +115,35 @@ defmodule Mydia.Media.MediaRequest do
   Returns the list of valid media types.
   """
   def valid_media_types, do: @media_types
+
+  @doc """
+  Returns the provider and id this request can be resolved with, or nil.
+
+  TMDB wins when both ids are present: it is the id the request flow stores by
+  default, and `MediaAddHelpers.fetch_detail_metadata/2` already resolves a
+  TMDB show to TVDB when the instance is configured that way.
+  """
+  @spec external_ref(t()) :: {:tmdb, integer()} | {:tvdb, integer()} | nil
+  def external_ref(%__MODULE__{tmdb_id: tmdb_id}) when is_integer(tmdb_id), do: {:tmdb, tmdb_id}
+  def external_ref(%__MODULE__{tvdb_id: tvdb_id}) when is_integer(tvdb_id), do: {:tvdb, tvdb_id}
+  def external_ref(%__MODULE__{}), do: nil
+
+  @doc """
+  Whether this request can be resolved against a metadata provider.
+
+  False for an IMDb-only request, which `validate_at_least_one_external_id/1`
+  permits. Gates the poster backfill, the clickable title and the detail popup
+  together so those three never disagree about which rows are usable.
+  """
+  @spec detailable?(t()) :: boolean()
+  def detailable?(%__MODULE__{} = request), do: external_ref(request) != nil
+
+  @doc """
+  The stored `media_type` string as the atom the metadata and card APIs take.
+  """
+  @spec media_type_atom(t()) :: :movie | :tv_show
+  def media_type_atom(%__MODULE__{media_type: "tv_show"}), do: :tv_show
+  def media_type_atom(%__MODULE__{}), do: :movie
 
   # Ensure at least one external ID (TMDB, TVDB, or IMDB) is provided
   defp validate_at_least_one_external_id(changeset) do

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -71,6 +71,21 @@ defmodule Mydia.MediaRequests do
   end
 
   @doc """
+  Stores the poster path for a request.
+
+  Used by the request list backfill for rows created before the column
+  existed. Deliberately a bare write with no duplicate checks: the poster is
+  presentation data and never changes which media the request refers to.
+  """
+  @spec update_poster_path(MediaRequest.t(), String.t()) ::
+          {:ok, MediaRequest.t()} | {:error, Ecto.Changeset.t()}
+  def update_poster_path(%MediaRequest{} = request, poster_path) when is_binary(poster_path) do
+    request
+    |> Ecto.Changeset.change(poster_path: poster_path)
+    |> Repo.update()
+  end
+
+  @doc """
   Approves a media request and creates the corresponding media item.
 
   Provider metadata is fetched before the transaction opens, so the media item

--- a/lib/mydia_web/components/media_request_components.ex
+++ b/lib/mydia_web/components/media_request_components.ex
@@ -1,0 +1,139 @@
+defmodule MydiaWeb.MediaRequestComponents do
+  @moduledoc """
+  Card chrome shared by the two media request pages.
+
+  Imported by `MydiaWeb.AdminRequestsLive.Index` and
+  `MydiaWeb.MyRequestsLive.Index` rather than added to `html_helpers`: the
+  project reserves global imports for components used by three or more
+  LiveViews, which is how `MydiaWeb.DiscoverComponents` is wired.
+
+  Everything the two pages disagree about lives in the `:badges`, `:details`
+  and `:actions` slots, so neither page needs a flag for the other's chrome.
+  """
+  use Phoenix.Component
+
+  alias Mydia.Media.MediaRequest
+  alias Mydia.Metadata.ImageUrl
+
+  @placeholder_poster "/images/no-poster.svg"
+  @poster_size "w185"
+
+  @doc """
+  Renders one request as a card with a poster and a clickable title.
+
+  The poster and the title both fire `on_select` with the request id, matching
+  how a Discovery card behaves. A request with no TMDB or TVDB id cannot be
+  resolved against a provider, so it renders as static text with no click
+  target.
+  """
+  attr :request, MediaRequest, required: true
+  attr :on_select, :string, default: "show_details"
+
+  slot :badges, doc: "Extra badges rendered beside the status and media type."
+  slot :details, doc: "The page-specific body: requester, timestamps, notes."
+  slot :actions, doc: "The page-specific footer buttons."
+
+  def request_card(assigns) do
+    assigns =
+      assigns
+      |> assign(:detailable, MediaRequest.detailable?(assigns.request))
+      |> assign(:poster_src, poster_src(assigns.request))
+
+    ~H"""
+    <div class="card bg-base-100 shadow-lg" id={"request-#{@request.id}"}>
+      <div class="card-body">
+        <div class="flex gap-4">
+          <%= if @detailable do %>
+            <button
+              type="button"
+              phx-click={@on_select}
+              phx-value-id={@request.id}
+              aria-label={"View details for #{@request.title}"}
+              class="shrink-0 w-16 md:w-24 rounded-lg overflow-hidden transition hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-primary"
+            >
+              <img
+                src={@poster_src}
+                alt=""
+                loading="lazy"
+                class="w-full aspect-[2/3] object-cover bg-base-300"
+              />
+            </button>
+          <% else %>
+            <div class="shrink-0 w-16 md:w-24 rounded-lg overflow-hidden">
+              <img
+                src={@poster_src}
+                alt=""
+                loading="lazy"
+                class="w-full aspect-[2/3] object-cover bg-base-300"
+              />
+            </div>
+          <% end %>
+
+          <div class="flex-1 min-w-0">
+            <h3 class="card-title">
+              <%= if @detailable do %>
+                <button
+                  type="button"
+                  phx-click={@on_select}
+                  phx-value-id={@request.id}
+                  class="link link-hover text-left"
+                >
+                  {@request.title}
+                </button>
+              <% else %>
+                <span>{@request.title}</span>
+              <% end %>
+              <%= if @request.year do %>
+                <span class="text-base-content/70 font-normal">({@request.year})</span>
+              <% end %>
+            </h3>
+
+            <div class="flex flex-wrap items-center gap-2 mt-1">
+              <span class={["badge badge-sm", status_badge_class(@request.status)]}>
+                {status_text(@request.status)}
+              </span>
+              <span class="badge badge-sm badge-ghost">
+                {media_type_text(@request.media_type)}
+              </span>
+              {render_slot(@badges)}
+            </div>
+
+            <div :if={@details != []} class="mt-4 space-y-2 text-sm">
+              {render_slot(@details)}
+            </div>
+
+            <div :if={@actions != []} class="card-actions mt-4">
+              {render_slot(@actions)}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc "DaisyUI badge modifier for a request status."
+  def status_badge_class("pending"), do: "badge-warning"
+  def status_badge_class("approved"), do: "badge-success"
+  def status_badge_class("rejected"), do: "badge-error"
+  def status_badge_class(_), do: "badge-ghost"
+
+  @doc "Human label for a request status."
+  def status_text("pending"), do: "Pending Review"
+  def status_text("approved"), do: "Approved"
+  def status_text("rejected"), do: "Rejected"
+  def status_text(_), do: "Unknown"
+
+  @doc "Formats a request timestamp, or \"N/A\" when it is nil."
+  def format_date(nil), do: "N/A"
+  def format_date(%DateTime{} = dt), do: Calendar.strftime(dt, "%b %d, %Y at %I:%M %p")
+
+  defp media_type_text(media_type) do
+    media_type
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp poster_src(%MediaRequest{poster_path: nil}), do: @placeholder_poster
+  defp poster_src(%MediaRequest{poster_path: path}), do: ImageUrl.poster_url(path, @poster_size)
+end

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -1,7 +1,10 @@
 defmodule MydiaWeb.AdminRequestsLive.Index do
   use MydiaWeb, :live_view
 
+  import MydiaWeb.MediaRequestComponents
+
   alias Mydia.MediaRequests
+  alias MydiaWeb.Live.Helpers.MediaRequestHelpers
   require Logger
 
   @impl true
@@ -140,6 +143,16 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     end
   end
 
+  @impl true
+  def handle_info({:backfill_posters, requests}, socket) do
+    MediaRequestHelpers.backfill_poster_paths(requests)
+
+    # Re-read through load_requests/1 so the refreshed rows and the active
+    # filter stay in agreement. needs_poster?/1 is false for every row it just
+    # filled, so this does not loop.
+    {:noreply, load_requests(socket)}
+  end
+
   ## Private Helpers
 
   defp apply_filters(socket, params) do
@@ -161,7 +174,19 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
 
     requests = MediaRequests.list_requests(opts)
 
-    assign(socket, :requests, requests)
+    socket
+    |> assign(:requests, requests)
+    |> maybe_backfill_posters(requests)
+  end
+
+  # Sent to self rather than fetched here: a relay round trip inside mount/3 or
+  # a handle_event would freeze the LiveView while its page is on screen.
+  defp maybe_backfill_posters(socket, requests) do
+    if connected?(socket) and Enum.any?(requests, &MediaRequestHelpers.needs_poster?/1) do
+      send(self(), {:backfill_posters, requests})
+    end
+
+    socket
   end
 
   defp assign_approve_form(socket) do
@@ -218,20 +243,4 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     |> Ecto.Changeset.cast(params, Map.keys(types))
     |> Ecto.Changeset.validate_required([:rejection_reason])
   end
-
-  defp format_date(nil), do: "N/A"
-
-  defp format_date(%DateTime{} = dt) do
-    Calendar.strftime(dt, "%b %d, %Y at %I:%M %p")
-  end
-
-  defp status_badge_class("pending"), do: "badge-warning"
-  defp status_badge_class("approved"), do: "badge-success"
-  defp status_badge_class("rejected"), do: "badge-error"
-  defp status_badge_class(_), do: "badge-ghost"
-
-  defp status_text("pending"), do: "Pending Review"
-  defp status_text("approved"), do: "Approved"
-  defp status_text("rejected"), do: "Rejected"
-  defp status_text(_), do: "Unknown"
 end

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -211,6 +211,7 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
 
     socket
     |> assign(:filter_status, status)
+    |> close_details()
     |> load_requests()
   end
 

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -123,14 +123,13 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     item = request && MediaRequestHelpers.to_search_result(request)
 
     if item do
-      send(self(), {:fetch_request_metadata, request})
-
       {:noreply,
        socket
        |> assign(:detail_request, request)
        |> assign(:detail_item, item)
        |> assign(:detail_metadata, nil)
-       |> assign(:detail_loading, true)}
+       |> assign(:detail_loading, true)
+       |> fetch_request_metadata_async(request)}
     else
       {:noreply, socket}
     end
@@ -173,23 +172,29 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
   end
 
   @impl true
-  def handle_info({:backfill_posters, requests}, socket) do
-    MediaRequestHelpers.backfill_poster_paths(requests)
-
+  def handle_async(:backfill_posters, {:ok, :ok}, socket) do
     # Re-read through load_requests/1 so the refreshed rows and the active
-    # filter stay in agreement. Every id in `requests` was already added to
-    # :poster_backfill_attempted before this message was sent (see
-    # maybe_backfill_posters/2), so this cannot re-send for them even when the
-    # fetch above left poster_path nil.
+    # filter stay in agreement. Every id in the batch was already added to
+    # :poster_backfill_attempted before start_async was called (see
+    # maybe_backfill_posters/2), so this cannot re-trigger a backfill for them
+    # even when the fetch above left poster_path nil.
     {:noreply, load_requests(socket)}
   end
 
-  @impl true
-  def handle_info({:fetch_request_metadata, request}, socket) do
+  def handle_async(:backfill_posters, {:exit, reason}, socket) do
+    Logger.warning("Poster backfill crashed: #{inspect(reason)}")
+    {:noreply, load_requests(socket)}
+  end
+
+  def handle_async(:fetch_request_metadata, {:ok, {request_id, result}}, socket) do
     # Drop a fetch the user has already navigated away from, so a slow relay
-    # cannot repopulate a popup that was closed or replaced.
-    if socket.assigns.detail_request && socket.assigns.detail_request.id == request.id do
-      case MediaRequestHelpers.fetch_request_metadata(request) do
+    # cannot repopulate a popup that was closed or switched away from.
+    # Comparing by id here (rather than relying only on start_async's
+    # same-key replacement) also covers the popup being closed outright:
+    # close_details/1 does not start a new task under this key, so the
+    # in-flight one's result would otherwise still land here.
+    if socket.assigns.detail_request && socket.assigns.detail_request.id == request_id do
+      case result do
         {:ok, metadata} ->
           {:noreply,
            socket
@@ -202,6 +207,11 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     else
       {:noreply, socket}
     end
+  end
+
+  def handle_async(:fetch_request_metadata, {:exit, reason}, socket) do
+    Logger.warning("Request metadata fetch crashed: #{inspect(reason)}")
+    {:noreply, assign(socket, :detail_loading, false)}
   end
 
   ## Private Helpers
@@ -231,19 +241,24 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     |> maybe_backfill_posters(requests)
   end
 
-  # Sent to self rather than fetched here: a relay round trip inside mount/3 or
-  # a handle_event would freeze the LiveView while its page is on screen.
+  # Runs through start_async rather than inline: backfill_poster_paths/1 makes
+  # a relay round trip per row, and doing that in mount/3, a handle_event, or
+  # a handle_info would block the LiveView process while its page is already
+  # on screen. Deferring only to handle_info (as this used to) merely lets the
+  # first render paint -- the process is still blocked for every event
+  # afterward (Close, Approve, Reject) while the batch runs, so start_async is
+  # what actually keeps the page responsive.
   #
   # Ids are marked attempted at send time, not after the fetch completes.
-  # handle_info/2 re-reads through load_requests/1, and LiveView calls
+  # handle_async/3 re-reads through load_requests/1, and LiveView calls
   # handle_params/3 (which also reaches load_requests/1) immediately after
   # mount/3 on the first connected render, so this runs at least twice per
   # page view. needs_poster?/1 never goes false for a row whose fetch cannot
   # succeed (relay down, 404, or metadata with no poster), so marking on
-  # completion would resend that row to self() forever for as long as the
-  # socket stays connected. Marking at send time bounds every id to at most
-  # one attempt per connected socket; a permanently-failing row is retried on
-  # the next page visit, which starts with a fresh MapSet.
+  # completion would resend that row forever for as long as the socket stays
+  # connected. Marking at send time bounds every id to at most one attempt per
+  # connected socket; a permanently-failing row is retried on the next page
+  # visit, which starts with a fresh MapSet.
   defp maybe_backfill_posters(socket, requests) do
     attempted = socket.assigns.poster_backfill_attempted
 
@@ -253,13 +268,28 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
       end)
 
     if connected?(socket) and pending != [] do
-      send(self(), {:backfill_posters, pending})
-
       pending_ids = MapSet.new(pending, & &1.id)
-      assign(socket, :poster_backfill_attempted, MapSet.union(attempted, pending_ids))
+
+      socket
+      |> assign(:poster_backfill_attempted, MapSet.union(attempted, pending_ids))
+      |> start_async(:backfill_posters, fn ->
+        MediaRequestHelpers.backfill_poster_paths(pending)
+      end)
     else
       socket
     end
+  end
+
+  # Runs through start_async rather than inline: fetch_request_metadata/1
+  # makes a relay round trip (TMDB via MediaAddHelpers.fetch_detail_metadata/2,
+  # or TVDB via Metadata.fetch_by_id/3), and doing that in the handle_event
+  # would block the LiveView process while the popup is already on screen --
+  # close_details and the Approve/Reject buttons would queue behind the fetch
+  # and the modal would look frozen.
+  defp fetch_request_metadata_async(socket, request) do
+    start_async(socket, :fetch_request_metadata, fn ->
+      {request.id, MediaRequestHelpers.fetch_request_metadata(request)}
+    end)
   end
 
   defp close_details(socket) do

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -16,6 +16,7 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
      |> assign(:show_approve_modal, false)
      |> assign(:show_reject_modal, false)
      |> assign(:selected_request, nil)
+     |> assign(:poster_backfill_attempted, MapSet.new())
      |> load_requests()}
   end
 
@@ -148,8 +149,10 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     MediaRequestHelpers.backfill_poster_paths(requests)
 
     # Re-read through load_requests/1 so the refreshed rows and the active
-    # filter stay in agreement. needs_poster?/1 is false for every row it just
-    # filled, so this does not loop.
+    # filter stay in agreement. Every id in `requests` was already added to
+    # :poster_backfill_attempted before this message was sent (see
+    # maybe_backfill_posters/2), so this cannot re-send for them even when the
+    # fetch above left poster_path nil.
     {:noreply, load_requests(socket)}
   end
 
@@ -181,12 +184,33 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
 
   # Sent to self rather than fetched here: a relay round trip inside mount/3 or
   # a handle_event would freeze the LiveView while its page is on screen.
+  #
+  # Ids are marked attempted at send time, not after the fetch completes.
+  # handle_info/2 re-reads through load_requests/1, and LiveView calls
+  # handle_params/3 (which also reaches load_requests/1) immediately after
+  # mount/3 on the first connected render, so this runs at least twice per
+  # page view. needs_poster?/1 never goes false for a row whose fetch cannot
+  # succeed (relay down, 404, or metadata with no poster), so marking on
+  # completion would resend that row to self() forever for as long as the
+  # socket stays connected. Marking at send time bounds every id to at most
+  # one attempt per connected socket; a permanently-failing row is retried on
+  # the next page visit, which starts with a fresh MapSet.
   defp maybe_backfill_posters(socket, requests) do
-    if connected?(socket) and Enum.any?(requests, &MediaRequestHelpers.needs_poster?/1) do
-      send(self(), {:backfill_posters, requests})
-    end
+    attempted = socket.assigns.poster_backfill_attempted
 
-    socket
+    pending =
+      Enum.filter(requests, fn request ->
+        MediaRequestHelpers.needs_poster?(request) and request.id not in attempted
+      end)
+
+    if connected?(socket) and pending != [] do
+      send(self(), {:backfill_posters, pending})
+
+      pending_ids = MapSet.new(pending, & &1.id)
+      assign(socket, :poster_backfill_attempted, MapSet.union(attempted, pending_ids))
+    else
+      socket
+    end
   end
 
   defp assign_approve_form(socket) do

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -17,6 +17,10 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
      |> assign(:show_reject_modal, false)
      |> assign(:selected_request, nil)
      |> assign(:poster_backfill_attempted, MapSet.new())
+     |> assign(:detail_request, nil)
+     |> assign(:detail_item, nil)
+     |> assign(:detail_metadata, nil)
+     |> assign(:detail_loading, false)
      |> load_requests()}
   end
 
@@ -37,6 +41,7 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
 
     {:noreply,
      socket
+     |> close_details()
      |> assign(:show_approve_modal, true)
      |> assign(:selected_request, request)
      |> assign_approve_form()}
@@ -54,6 +59,7 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
 
     {:noreply,
      socket
+     |> close_details()
      |> assign(:show_reject_modal, true)
      |> assign(:selected_request, request)
      |> assign_reject_form()}
@@ -112,6 +118,28 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     end
   end
 
+  def handle_event("show_details", %{"id" => id}, socket) do
+    request = Enum.find(socket.assigns.requests, &(&1.id == id))
+    item = request && MediaRequestHelpers.to_search_result(request)
+
+    if item do
+      send(self(), {:fetch_request_metadata, request})
+
+      {:noreply,
+       socket
+       |> assign(:detail_request, request)
+       |> assign(:detail_item, item)
+       |> assign(:detail_metadata, nil)
+       |> assign(:detail_loading, true)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("close_details", _params, socket) do
+    {:noreply, close_details(socket)}
+  end
+
   def handle_event("validate_reject", %{"reject" => reject_params}, socket) do
     changeset = validate_reject(reject_params)
 
@@ -154,6 +182,26 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     # maybe_backfill_posters/2), so this cannot re-send for them even when the
     # fetch above left poster_path nil.
     {:noreply, load_requests(socket)}
+  end
+
+  @impl true
+  def handle_info({:fetch_request_metadata, request}, socket) do
+    # Drop a fetch the user has already navigated away from, so a slow relay
+    # cannot repopulate a popup that was closed or replaced.
+    if socket.assigns.detail_request && socket.assigns.detail_request.id == request.id do
+      case MediaRequestHelpers.fetch_request_metadata(request) do
+        {:ok, metadata} ->
+          {:noreply,
+           socket
+           |> assign(:detail_metadata, metadata)
+           |> assign(:detail_loading, false)}
+
+        {:error, _reason} ->
+          {:noreply, assign(socket, :detail_loading, false)}
+      end
+    else
+      {:noreply, socket}
+    end
   end
 
   ## Private Helpers
@@ -211,6 +259,14 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     else
       socket
     end
+  end
+
+  defp close_details(socket) do
+    socket
+    |> assign(:detail_request, nil)
+    |> assign(:detail_item, nil)
+    |> assign(:detail_metadata, nil)
+    |> assign(:detail_loading, false)
   end
 
   defp assign_approve_form(socket) do

--- a/lib/mydia_web/live/admin_requests_live/index.html.heex
+++ b/lib/mydia_web/live/admin_requests_live/index.html.heex
@@ -144,6 +144,47 @@
       </div>
     <% end %>
 
+    <%!-- Detail popup. picker_open is false because this page never opens the
+          library picker, and libraries is empty for the same reason. --%>
+    <.live_component
+      module={MydiaWeb.Live.Components.TrendingDetailModal}
+      id="request-detail-modal"
+      item={@detail_item}
+      metadata={@detail_metadata}
+      loading={@detail_loading}
+      current_user={@current_user}
+      open={@detail_item != nil}
+      libraries={[]}
+      picker_open={false}
+    >
+      <:actions>
+        <button class="btn btn-ghost" phx-click="close_details">Close</button>
+        <.link
+          :if={@detail_request && @detail_request.media_item}
+          navigate={~p"/media/#{@detail_request.media_item.id}"}
+          class="btn btn-primary"
+        >
+          <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" /> View in Library
+        </.link>
+        <%= if @detail_request && @detail_request.status == "pending" do %>
+          <button
+            class="btn btn-error"
+            phx-click="open_reject_modal"
+            phx-value-id={@detail_request.id}
+          >
+            <.icon name="hero-x-mark" class="w-4 h-4" /> Reject
+          </button>
+          <button
+            class="btn btn-success"
+            phx-click="open_approve_modal"
+            phx-value-id={@detail_request.id}
+          >
+            <.icon name="hero-check" class="w-4 h-4" /> Approve
+          </button>
+        <% end %>
+      </:actions>
+    </.live_component>
+
     <%!-- Approve Modal --%>
     <%= if @show_approve_modal and @selected_request do %>
       <div class="modal modal-open">

--- a/lib/mydia_web/live/admin_requests_live/index.html.heex
+++ b/lib/mydia_web/live/admin_requests_live/index.html.heex
@@ -63,118 +63,83 @@
       <%!-- Requests List --%>
       <div class="space-y-4">
         <%= for request <- @requests do %>
-          <div class="card bg-base-100 shadow-lg">
-            <div class="card-body">
-              <div class="flex gap-4">
-                <div class="flex-1">
-                  <div class="flex items-start justify-between">
-                    <div>
-                      <h3 class="card-title">
-                        {request.title}
-                        <%= if request.year do %>
-                          <span class="text-base-content/70 font-normal">({request.year})</span>
-                        <% end %>
-                      </h3>
-                      <div class="flex items-center gap-2 mt-1">
-                        <span class={"badge badge-sm " <> status_badge_class(request.status)}>
-                          {status_text(request.status)}
-                        </span>
-                        <span class="badge badge-sm badge-ghost">
-                          {String.replace(request.media_type, "_", " ") |> String.capitalize()}
-                        </span>
-                        <%= if request.tvdb_id do %>
-                          <span class="badge badge-sm badge-ghost">TVDB: {request.tvdb_id}</span>
-                        <% end %>
-                        <%= if request.tmdb_id do %>
-                          <span class="badge badge-sm badge-ghost">TMDB: {request.tmdb_id}</span>
-                        <% end %>
-                      </div>
-                    </div>
+          <.request_card request={request}>
+            <:badges>
+              <span :if={request.tvdb_id} class="badge badge-sm badge-ghost">
+                TVDB: {request.tvdb_id}
+              </span>
+              <span :if={request.tmdb_id} class="badge badge-sm badge-ghost">
+                TMDB: {request.tmdb_id}
+              </span>
+            </:badges>
+
+            <:details>
+              <div class="flex items-center gap-2 text-base-content/70">
+                <.icon name="hero-user" class="w-4 h-4" />
+                <span>
+                  Requested by {request.requester.email} on {format_date(request.inserted_at)}
+                </span>
+              </div>
+              <div
+                :if={request.requester_notes}
+                class="flex items-start gap-2 text-base-content/70"
+              >
+                <.icon name="hero-chat-bubble-left-right" class="w-4 h-4 mt-0.5" />
+                <span>{request.requester_notes}</span>
+              </div>
+              <div :if={request.status == "approved"} class="flex items-start gap-2 text-success">
+                <.icon name="hero-check-circle" class="w-4 h-4 mt-0.5" />
+                <div>
+                  <div>
+                    Approved by {request.approved_by.email} on {format_date(request.approved_at)}
                   </div>
-                  <%!-- Request Details --%>
-                  <div class="mt-4 space-y-2 text-sm">
-                    <div class="flex items-center gap-2 text-base-content/70">
-                      <.icon name="hero-user" class="w-4 h-4" />
-                      <span>
-                        Requested by {request.requester.email} on {format_date(
-                          request.inserted_at
-                        )}
-                      </span>
-                    </div>
-                    <%= if request.requester_notes do %>
-                      <div class="flex items-start gap-2 text-base-content/70">
-                        <.icon name="hero-chat-bubble-left-right" class="w-4 h-4 mt-0.5" />
-                        <span>{request.requester_notes}</span>
-                      </div>
-                    <% end %>
-                    <%= if request.status == "approved" do %>
-                      <div class="flex items-start gap-2 text-success">
-                        <.icon name="hero-check-circle" class="w-4 h-4 mt-0.5" />
-                        <div>
-                          <div>
-                            Approved by {request.approved_by.email} on {format_date(
-                              request.approved_at
-                            )}
-                          </div>
-                          <%= if request.admin_notes do %>
-                            <div class="text-xs mt-1">Admin notes: {request.admin_notes}</div>
-                          <% end %>
-                        </div>
-                      </div>
-                      <%= if request.media_item do %>
-                        <div class="mt-2">
-                          <.link
-                            navigate={~p"/media/#{request.media_item.id}"}
-                            class="btn btn-sm btn-success"
-                          >
-                            <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" />
-                            View in Library
-                          </.link>
-                        </div>
-                      <% end %>
-                    <% end %>
-                    <%= if request.status == "rejected" do %>
-                      <div class="flex items-start gap-2 text-error">
-                        <.icon name="hero-x-circle" class="w-4 h-4 mt-0.5" />
-                        <div>
-                          <div>
-                            Rejected by {request.approved_by.email} on {format_date(
-                              request.rejected_at
-                            )}
-                          </div>
-                          <%= if request.rejection_reason do %>
-                            <div class="text-xs mt-1">Reason: {request.rejection_reason}</div>
-                          <% end %>
-                          <%= if request.admin_notes do %>
-                            <div class="text-xs mt-1">Admin notes: {request.admin_notes}</div>
-                          <% end %>
-                        </div>
-                      </div>
-                    <% end %>
+                  <div :if={request.admin_notes} class="text-xs mt-1">
+                    Admin notes: {request.admin_notes}
                   </div>
-                  <%!-- Actions --%>
-                  <%= if request.status == "pending" do %>
-                    <div class="card-actions mt-4">
-                      <button
-                        class="btn btn-success btn-sm"
-                        phx-click="open_approve_modal"
-                        phx-value-id={request.id}
-                      >
-                        <.icon name="hero-check" class="w-4 h-4" /> Approve
-                      </button>
-                      <button
-                        class="btn btn-error btn-sm"
-                        phx-click="open_reject_modal"
-                        phx-value-id={request.id}
-                      >
-                        <.icon name="hero-x-mark" class="w-4 h-4" /> Reject
-                      </button>
-                    </div>
-                  <% end %>
                 </div>
               </div>
-            </div>
-          </div>
+              <div :if={request.status == "rejected"} class="flex items-start gap-2 text-error">
+                <.icon name="hero-x-circle" class="w-4 h-4 mt-0.5" />
+                <div>
+                  <div>
+                    Rejected by {request.approved_by.email} on {format_date(request.rejected_at)}
+                  </div>
+                  <div :if={request.rejection_reason} class="text-xs mt-1">
+                    Reason: {request.rejection_reason}
+                  </div>
+                  <div :if={request.admin_notes} class="text-xs mt-1">
+                    Admin notes: {request.admin_notes}
+                  </div>
+                </div>
+              </div>
+            </:details>
+
+            <:actions>
+              <%= if request.status == "pending" do %>
+                <button
+                  class="btn btn-success btn-sm"
+                  phx-click="open_approve_modal"
+                  phx-value-id={request.id}
+                >
+                  <.icon name="hero-check" class="w-4 h-4" /> Approve
+                </button>
+                <button
+                  class="btn btn-error btn-sm"
+                  phx-click="open_reject_modal"
+                  phx-value-id={request.id}
+                >
+                  <.icon name="hero-x-mark" class="w-4 h-4" /> Reject
+                </button>
+              <% end %>
+              <.link
+                :if={request.status == "approved" and request.media_item}
+                navigate={~p"/media/#{request.media_item.id}"}
+                class="btn btn-sm btn-success"
+              >
+                <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" /> View in Library
+              </.link>
+            </:actions>
+          </.request_card>
         <% end %>
       </div>
     <% end %>

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -196,48 +196,54 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
             {render_slot(@rail)}
           </div>
 
-          <%!-- Footer actions --%>
+          <%!-- Footer actions. A caller that passes :actions owns the footer
+               outright; the request pages do, because Add to Library there
+               would create the media item while leaving the request pending. --%>
           <div class="p-4 md:p-6 border-t border-base-300 bg-base-100 flex justify-end gap-2">
-            <button class="btn btn-ghost" phx-click="close_details">
-              Close
-            </button>
-            <%= if not in_library?(@item) do %>
-              <%= if @current_user && @current_user.role == "guest" do %>
-                <button
-                  phx-click="request_media"
-                  phx-value-tmdb_id={@item.provider_id}
-                  phx-value-media_type={media_type_string(@item)}
-                  disabled={Map.get(@item, :request_status) != nil}
-                  class="btn btn-primary"
-                >
-                  <%= if Map.get(@item, :request_status) do %>
-                    <.icon name="hero-check" class="w-4 h-4" /> Requested
-                  <% else %>
-                    <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
-                  <% end %>
-                </button>
-              <% else %>
-                <div class="join">
+            <%= if @actions != [] do %>
+              {render_slot(@actions)}
+            <% else %>
+              <button class="btn btn-ghost" phx-click="close_details">
+                Close
+              </button>
+              <%= if not in_library?(@item) do %>
+                <%= if @current_user && @current_user.role == "guest" do %>
                   <button
-                    phx-click="add_to_library"
+                    phx-click="request_media"
                     phx-value-tmdb_id={@item.provider_id}
                     phx-value-media_type={media_type_string(@item)}
-                    class="btn btn-primary join-item"
+                    disabled={Map.get(@item, :request_status) != nil}
+                    class="btn btn-primary"
                   >
-                    <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
+                    <%= if Map.get(@item, :request_status) do %>
+                      <.icon name="hero-check" class="w-4 h-4" /> Requested
+                    <% else %>
+                      <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
+                    <% end %>
                   </button>
-                  <.library_picker_button
-                    libraries={@libraries}
-                    tmdb_id={@item.provider_id}
-                    media_type={media_type_string(@item)}
-                    title={@item.title}
-                  />
-                </div>
+                <% else %>
+                  <div class="join">
+                    <button
+                      phx-click="add_to_library"
+                      phx-value-tmdb_id={@item.provider_id}
+                      phx-value-media_type={media_type_string(@item)}
+                      class="btn btn-primary join-item"
+                    >
+                      <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
+                    </button>
+                    <.library_picker_button
+                      libraries={@libraries}
+                      tmdb_id={@item.provider_id}
+                      media_type={media_type_string(@item)}
+                      title={@item.title}
+                    />
+                  </div>
+                <% end %>
+              <% else %>
+                <.link navigate={library_path(@item)} class="btn btn-ghost">
+                  <.icon name="hero-arrow-right" class="w-4 h-4" /> Go to {media_type_label(@item)}
+                </.link>
               <% end %>
-            <% else %>
-              <.link navigate={library_path(@item)} class="btn btn-ghost">
-                <.icon name="hero-arrow-right" class="w-4 h-4" /> Go to {media_type_label(@item)}
-              </.link>
             <% end %>
           </div>
         </div>
@@ -261,7 +267,9 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
      |> assign_new(:metadata, fn -> nil end)
      |> assign_new(:libraries, fn -> [] end)
      # Optional slot: the dashboard renders this modal without one.
-     |> assign_new(:rail, fn -> [] end)}
+     |> assign_new(:rail, fn -> [] end)
+     # Optional slot: Dashboard and Discovery render the default footer.
+     |> assign_new(:actions, fn -> [] end)}
   end
 
   # Helper functions for accessing data from either SearchResult (item) or MediaMetadata

--- a/lib/mydia_web/live/helpers/media_request_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_request_helpers.ex
@@ -156,9 +156,13 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   @doc """
   Resolves and stores posters for requests that have none.
 
-  Callers run this from `handle_info`, never inline: a relay round trip inside
-  `mount/3` or a `handle_event` would freeze the LiveView process while its
-  page is already on screen.
+  Callers run this inside a `start_async/3` task, never inline: a relay round
+  trip per row inside `mount/3`, `handle_event`, or `handle_info` would block
+  the LiveView process while its page is already on screen. Deferring only to
+  `handle_info` (as this used to) merely lets the first render paint -- the
+  process is still blocked for every event afterward (Close, Approve, Reject)
+  while the batch runs, so `start_async/3` is what actually keeps it
+  responsive.
 
   A failed or timed-out fetch leaves `poster_path` nil, so the card falls back
   to the placeholder and the next visit to the page retries. There is
@@ -179,14 +183,18 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   end
 
   defp backfill_one(request) do
-    # `Task.async_stream/3` links each task to the caller, which here is the
-    # user's connected AdminRequestsLive or MyRequestsLive process running
-    # this synchronously inside `handle_info`. `fetch_request_metadata/1`
+    # `Task.async_stream/3` links each task to the caller, which is the
+    # `start_async/3` task that AdminRequestsLive/MyRequestsLive spawn from
+    # `maybe_backfill_posters/2` (see their `handle_async(:backfill_posters,
+    # ...)`), not the LiveView process itself. `fetch_request_metadata/1`
     # parses an upstream JSON payload this code does not control (via
     # `MediaAddHelpers.fetch_detail_metadata/2` and `Metadata.fetch_by_id/3`
     # into the relay provider), so a malformed response raising here is
-    # realistic, and an uncaught raise would crash that page's process over
-    # one bad row. Catch it here, matching
+    # realistic. An uncaught raise here would still be isolated from the
+    # LiveView process -- `start_async/3` reports it to `handle_async/3` as
+    # `{:exit, reason}` rather than crashing the page -- but it would also
+    # abort every other row still in flight in this batch. Catch it here
+    # instead, matching
     # `Mydia.Metadata.Provider.Relay.fetch_all_season_episodes/3`, which
     # rescues at the same kind of single-relay-call-per-task boundary.
     try do

--- a/lib/mydia_web/live/helpers/media_request_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_request_helpers.ex
@@ -179,12 +179,26 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   end
 
   defp backfill_one(request) do
-    with {:ok, metadata} <- fetch_request_metadata(request),
-         path when is_binary(path) <- metadata.poster_path,
-         {:ok, _updated} <- MediaRequests.update_poster_path(request, path) do
-      :ok
-    else
-      _ -> :ok
+    # `Task.async_stream/3` links each task to the caller, which here is the
+    # user's connected AdminRequestsLive or MyRequestsLive process running
+    # this synchronously inside `handle_info`. `fetch_request_metadata/1`
+    # parses an upstream JSON payload this code does not control (via
+    # `MediaAddHelpers.fetch_detail_metadata/2` and `Metadata.fetch_by_id/3`
+    # into the relay provider), so a malformed response raising here is
+    # realistic, and an uncaught raise would crash that page's process over
+    # one bad row. Catch it here, matching
+    # `Mydia.Metadata.Provider.Relay.fetch_all_season_episodes/3`, which
+    # rescues at the same kind of single-relay-call-per-task boundary.
+    try do
+      with {:ok, metadata} <- fetch_request_metadata(request),
+           path when is_binary(path) <- metadata.poster_path,
+           {:ok, _updated} <- MediaRequests.update_poster_path(request, path) do
+        :ok
+      else
+        _ -> :ok
+      end
+    rescue
+      _exception -> :ok
     end
   end
 end

--- a/lib/mydia_web/live/helpers/media_request_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_request_helpers.ex
@@ -63,6 +63,7 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
       title: item.title,
       year: Map.get(item, :year),
       tmdb_id: tmdb_id,
+      poster_path: Map.get(item, :poster_path),
       requester_id: requester_id
     }
 

--- a/lib/mydia_web/live/helpers/media_request_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_request_helpers.ex
@@ -8,7 +8,11 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   """
 
   alias Mydia.Media.Add
+  alias Mydia.Media.MediaRequest
   alias Mydia.MediaRequests
+  alias Mydia.Metadata
+  alias Mydia.Metadata.Structs.SearchResult
+  alias MydiaWeb.Live.Helpers.MediaAddHelpers
 
   # Statuses that should keep the request button disabled. A rejected request
   # leaves the button enabled so a guest can ask again.
@@ -70,6 +74,67 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
     case MediaRequests.create_request(attrs) do
       {:ok, request} -> {:ok, request, %{tmdb_id => request.status}}
       {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Resolves provider metadata for a request.
+
+  Lives here rather than in `Mydia.MediaRequests` because the TMDB branch
+  delegates to `MediaAddHelpers.fetch_detail_metadata/2`, which is already a
+  web helper. Putting it in the context would point a context module at
+  `MydiaWeb`.
+
+  The TMDB branch reuses the Discovery helper so both surfaces show the same
+  metadata for the same title, including its TMDB-to-TVDB resolution for TV.
+  The TVDB branch mirrors `Mydia.Media.Add.fetch_tvdb_series/2` and exists
+  because a TV request made on a TVDB-configured instance stores no tmdb_id.
+  """
+  @spec fetch_request_metadata(MediaRequest.t()) ::
+          {:ok, Mydia.Metadata.Structs.MediaMetadata.t()} | {:error, term()}
+  def fetch_request_metadata(%MediaRequest{} = request) do
+    case MediaRequest.external_ref(request) do
+      {:tmdb, tmdb_id} ->
+        MediaAddHelpers.fetch_detail_metadata(
+          to_string(tmdb_id),
+          MediaRequest.media_type_atom(request)
+        )
+
+      {:tvdb, tvdb_id} ->
+        Metadata.fetch_by_id(
+          Metadata.default_relay_config(),
+          to_string(tvdb_id),
+          media_type: :tv_show,
+          provider: :tvdb
+        )
+
+      nil ->
+        {:error, :no_provider_id}
+    end
+  end
+
+  @doc """
+  Builds the `SearchResult` that `TrendingDetailModal` reads for its header.
+
+  Returns nil for a request with no external ref, which is the same set of rows
+  that render a non-clickable title.
+  """
+  @spec to_search_result(MediaRequest.t()) :: SearchResult.t() | nil
+  def to_search_result(%MediaRequest{} = request) do
+    case MediaRequest.external_ref(request) do
+      nil ->
+        nil
+
+      {provider, id} ->
+        %SearchResult{
+          provider_id: to_string(id),
+          provider: provider,
+          media_type: MediaRequest.media_type_atom(request),
+          id: id,
+          title: request.title,
+          year: request.year,
+          poster_path: request.poster_path
+        }
     end
   end
 end

--- a/lib/mydia_web/live/helpers/media_request_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_request_helpers.ex
@@ -18,6 +18,12 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   # leaves the button enabled so a guest can ask again.
   @outstanding ~w(pending approved)
 
+  # A relay round trip per row, so bounded. Four at a time keeps a large
+  # pending queue from opening a connection storm while still finishing a
+  # typical page in one round trip's time.
+  @backfill_concurrency 4
+  @backfill_timeout 30_000
+
   @doc """
   Maps `tmdb_id` to request status for every outstanding request.
 
@@ -135,6 +141,50 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
           year: request.year,
           poster_path: request.poster_path
         }
+    end
+  end
+
+  @doc """
+  Whether this request should be resolved for a poster.
+  """
+  @spec needs_poster?(MediaRequest.t()) :: boolean()
+  def needs_poster?(%MediaRequest{poster_path: nil} = request),
+    do: MediaRequest.detailable?(request)
+
+  def needs_poster?(%MediaRequest{}), do: false
+
+  @doc """
+  Resolves and stores posters for requests that have none.
+
+  Callers run this from `handle_info`, never inline: a relay round trip inside
+  `mount/3` or a `handle_event` would freeze the LiveView process while its
+  page is already on screen.
+
+  A failed or timed-out fetch leaves `poster_path` nil, so the card falls back
+  to the placeholder and the next visit to the page retries. There is
+  deliberately no retry inside a single pass.
+  """
+  @spec backfill_poster_paths([MediaRequest.t()]) :: :ok
+  def backfill_poster_paths(requests) when is_list(requests) do
+    requests
+    |> Enum.filter(&needs_poster?/1)
+    |> Task.async_stream(&backfill_one/1,
+      max_concurrency: @backfill_concurrency,
+      timeout: @backfill_timeout,
+      on_timeout: :kill_task
+    )
+    |> Stream.run()
+
+    :ok
+  end
+
+  defp backfill_one(request) do
+    with {:ok, metadata} <- fetch_request_metadata(request),
+         path when is_binary(path) <- metadata.poster_path,
+         {:ok, _updated} <- MediaRequests.update_poster_path(request, path) do
+      :ok
+    else
+      _ -> :ok
     end
   end
 end

--- a/lib/mydia_web/live/my_requests_live/index.ex
+++ b/lib/mydia_web/live/my_requests_live/index.ex
@@ -1,7 +1,10 @@
 defmodule MydiaWeb.MyRequestsLive.Index do
   use MydiaWeb, :live_view
 
+  import MydiaWeb.MediaRequestComponents
+
   alias Mydia.MediaRequests
+  alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
   @impl true
   def mount(_params, _session, socket) do
@@ -22,6 +25,16 @@ defmodule MydiaWeb.MyRequestsLive.Index do
   @impl true
   def handle_event("filter", %{"status" => status}, socket) do
     {:noreply, push_patch(socket, to: ~p"/requests?status=#{status}")}
+  end
+
+  @impl true
+  def handle_info({:backfill_posters, requests}, socket) do
+    MediaRequestHelpers.backfill_poster_paths(requests)
+
+    # Re-read through load_requests/1 so the refreshed rows and the active
+    # filter stay in agreement. needs_poster?/1 is false for every row it just
+    # filled, so this does not loop.
+    {:noreply, load_requests(socket)}
   end
 
   ## Private Helpers
@@ -50,22 +63,18 @@ defmodule MydiaWeb.MyRequestsLive.Index do
 
     requests = MediaRequests.list_requests(opts)
 
-    assign(socket, :requests, requests)
+    socket
+    |> assign(:requests, requests)
+    |> maybe_backfill_posters(requests)
   end
 
-  defp format_date(nil), do: "N/A"
+  # Sent to self rather than fetched here: a relay round trip inside mount/3 or
+  # a handle_event would freeze the LiveView while its page is on screen.
+  defp maybe_backfill_posters(socket, requests) do
+    if connected?(socket) and Enum.any?(requests, &MediaRequestHelpers.needs_poster?/1) do
+      send(self(), {:backfill_posters, requests})
+    end
 
-  defp format_date(%DateTime{} = dt) do
-    Calendar.strftime(dt, "%b %d, %Y at %I:%M %p")
+    socket
   end
-
-  defp status_badge_class("pending"), do: "badge-warning"
-  defp status_badge_class("approved"), do: "badge-success"
-  defp status_badge_class("rejected"), do: "badge-error"
-  defp status_badge_class(_), do: "badge-ghost"
-
-  defp status_text("pending"), do: "Pending Review"
-  defp status_text("approved"), do: "Approved"
-  defp status_text("rejected"), do: "Rejected"
-  defp status_text(_), do: "Unknown"
 end

--- a/lib/mydia_web/live/my_requests_live/index.ex
+++ b/lib/mydia_web/live/my_requests_live/index.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.MyRequestsLive.Index do
 
   alias Mydia.MediaRequests
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
+  require Logger
 
   @impl true
   def mount(_params, _session, socket) do
@@ -37,14 +38,13 @@ defmodule MydiaWeb.MyRequestsLive.Index do
     item = request && MediaRequestHelpers.to_search_result(request)
 
     if item do
-      send(self(), {:fetch_request_metadata, request})
-
       {:noreply,
        socket
        |> assign(:detail_request, request)
        |> assign(:detail_item, item)
        |> assign(:detail_metadata, nil)
-       |> assign(:detail_loading, true)}
+       |> assign(:detail_loading, true)
+       |> fetch_request_metadata_async(request)}
     else
       {:noreply, socket}
     end
@@ -55,23 +55,29 @@ defmodule MydiaWeb.MyRequestsLive.Index do
   end
 
   @impl true
-  def handle_info({:backfill_posters, requests}, socket) do
-    MediaRequestHelpers.backfill_poster_paths(requests)
-
+  def handle_async(:backfill_posters, {:ok, :ok}, socket) do
     # Re-read through load_requests/1 so the refreshed rows and the active
-    # filter stay in agreement. Every id in `requests` was already added to
-    # :poster_backfill_attempted before this message was sent (see
-    # maybe_backfill_posters/2), so this cannot re-send for them even when the
-    # fetch above left poster_path nil.
+    # filter stay in agreement. Every id in the batch was already added to
+    # :poster_backfill_attempted before start_async was called (see
+    # maybe_backfill_posters/2), so this cannot re-trigger a backfill for them
+    # even when the fetch above left poster_path nil.
     {:noreply, load_requests(socket)}
   end
 
-  @impl true
-  def handle_info({:fetch_request_metadata, request}, socket) do
+  def handle_async(:backfill_posters, {:exit, reason}, socket) do
+    Logger.warning("Poster backfill crashed: #{inspect(reason)}")
+    {:noreply, load_requests(socket)}
+  end
+
+  def handle_async(:fetch_request_metadata, {:ok, {request_id, result}}, socket) do
     # Drop a fetch the user has already navigated away from, so a slow relay
-    # cannot repopulate a popup that was closed or replaced.
-    if socket.assigns.detail_request && socket.assigns.detail_request.id == request.id do
-      case MediaRequestHelpers.fetch_request_metadata(request) do
+    # cannot repopulate a popup that was closed or switched away from.
+    # Comparing by id here (rather than relying only on start_async's
+    # same-key replacement) also covers the popup being closed outright:
+    # close_details/1 does not start a new task under this key, so the
+    # in-flight one's result would otherwise still land here.
+    if socket.assigns.detail_request && socket.assigns.detail_request.id == request_id do
+      case result do
         {:ok, metadata} ->
           {:noreply,
            socket
@@ -84,6 +90,11 @@ defmodule MydiaWeb.MyRequestsLive.Index do
     else
       {:noreply, socket}
     end
+  end
+
+  def handle_async(:fetch_request_metadata, {:exit, reason}, socket) do
+    Logger.warning("Request metadata fetch crashed: #{inspect(reason)}")
+    {:noreply, assign(socket, :detail_loading, false)}
   end
 
   ## Private Helpers
@@ -118,19 +129,24 @@ defmodule MydiaWeb.MyRequestsLive.Index do
     |> maybe_backfill_posters(requests)
   end
 
-  # Sent to self rather than fetched here: a relay round trip inside mount/3 or
-  # a handle_event would freeze the LiveView while its page is on screen.
+  # Runs through start_async rather than inline: backfill_poster_paths/1 makes
+  # a relay round trip per row, and doing that in mount/3, a handle_event, or
+  # a handle_info would block the LiveView process while its page is already
+  # on screen. Deferring only to handle_info (as this used to) merely lets the
+  # first render paint -- the process is still blocked for every event
+  # afterward (Close) while the batch runs, so start_async is what actually
+  # keeps the page responsive.
   #
   # Ids are marked attempted at send time, not after the fetch completes.
-  # handle_info/2 re-reads through load_requests/1, and LiveView calls
+  # handle_async/3 re-reads through load_requests/1, and LiveView calls
   # handle_params/3 (which also reaches load_requests/1) immediately after
   # mount/3 on the first connected render, so this runs at least twice per
   # page view. needs_poster?/1 never goes false for a row whose fetch cannot
   # succeed (relay down, 404, or metadata with no poster), so marking on
-  # completion would resend that row to self() forever for as long as the
-  # socket stays connected. Marking at send time bounds every id to at most
-  # one attempt per connected socket; a permanently-failing row is retried on
-  # the next page visit, which starts with a fresh MapSet.
+  # completion would resend that row forever for as long as the socket stays
+  # connected. Marking at send time bounds every id to at most one attempt per
+  # connected socket; a permanently-failing row is retried on the next page
+  # visit, which starts with a fresh MapSet.
   defp maybe_backfill_posters(socket, requests) do
     attempted = socket.assigns.poster_backfill_attempted
 
@@ -140,13 +156,28 @@ defmodule MydiaWeb.MyRequestsLive.Index do
       end)
 
     if connected?(socket) and pending != [] do
-      send(self(), {:backfill_posters, pending})
-
       pending_ids = MapSet.new(pending, & &1.id)
-      assign(socket, :poster_backfill_attempted, MapSet.union(attempted, pending_ids))
+
+      socket
+      |> assign(:poster_backfill_attempted, MapSet.union(attempted, pending_ids))
+      |> start_async(:backfill_posters, fn ->
+        MediaRequestHelpers.backfill_poster_paths(pending)
+      end)
     else
       socket
     end
+  end
+
+  # Runs through start_async rather than inline: fetch_request_metadata/1
+  # makes a relay round trip (TMDB via MediaAddHelpers.fetch_detail_metadata/2,
+  # or TVDB via Metadata.fetch_by_id/3), and doing that in the handle_event
+  # would block the LiveView process while the popup is already on screen --
+  # close_details would queue behind the fetch and the modal would look
+  # frozen.
+  defp fetch_request_metadata_async(socket, request) do
+    start_async(socket, :fetch_request_metadata, fn ->
+      {request.id, MediaRequestHelpers.fetch_request_metadata(request)}
+    end)
   end
 
   defp close_details(socket) do

--- a/lib/mydia_web/live/my_requests_live/index.ex
+++ b/lib/mydia_web/live/my_requests_live/index.ex
@@ -93,6 +93,7 @@ defmodule MydiaWeb.MyRequestsLive.Index do
 
     socket
     |> assign(:filter_status, status)
+    |> close_details()
     |> load_requests()
   end
 

--- a/lib/mydia_web/live/my_requests_live/index.ex
+++ b/lib/mydia_web/live/my_requests_live/index.ex
@@ -12,6 +12,7 @@ defmodule MydiaWeb.MyRequestsLive.Index do
      socket
      |> assign(:page_title, "My Requests")
      |> assign(:filter_status, "all")
+     |> assign(:poster_backfill_attempted, MapSet.new())
      |> load_requests()}
   end
 
@@ -32,8 +33,10 @@ defmodule MydiaWeb.MyRequestsLive.Index do
     MediaRequestHelpers.backfill_poster_paths(requests)
 
     # Re-read through load_requests/1 so the refreshed rows and the active
-    # filter stay in agreement. needs_poster?/1 is false for every row it just
-    # filled, so this does not loop.
+    # filter stay in agreement. Every id in `requests` was already added to
+    # :poster_backfill_attempted before this message was sent (see
+    # maybe_backfill_posters/2), so this cannot re-send for them even when the
+    # fetch above left poster_path nil.
     {:noreply, load_requests(socket)}
   end
 
@@ -70,11 +73,32 @@ defmodule MydiaWeb.MyRequestsLive.Index do
 
   # Sent to self rather than fetched here: a relay round trip inside mount/3 or
   # a handle_event would freeze the LiveView while its page is on screen.
+  #
+  # Ids are marked attempted at send time, not after the fetch completes.
+  # handle_info/2 re-reads through load_requests/1, and LiveView calls
+  # handle_params/3 (which also reaches load_requests/1) immediately after
+  # mount/3 on the first connected render, so this runs at least twice per
+  # page view. needs_poster?/1 never goes false for a row whose fetch cannot
+  # succeed (relay down, 404, or metadata with no poster), so marking on
+  # completion would resend that row to self() forever for as long as the
+  # socket stays connected. Marking at send time bounds every id to at most
+  # one attempt per connected socket; a permanently-failing row is retried on
+  # the next page visit, which starts with a fresh MapSet.
   defp maybe_backfill_posters(socket, requests) do
-    if connected?(socket) and Enum.any?(requests, &MediaRequestHelpers.needs_poster?/1) do
-      send(self(), {:backfill_posters, requests})
-    end
+    attempted = socket.assigns.poster_backfill_attempted
 
-    socket
+    pending =
+      Enum.filter(requests, fn request ->
+        MediaRequestHelpers.needs_poster?(request) and request.id not in attempted
+      end)
+
+    if connected?(socket) and pending != [] do
+      send(self(), {:backfill_posters, pending})
+
+      pending_ids = MapSet.new(pending, & &1.id)
+      assign(socket, :poster_backfill_attempted, MapSet.union(attempted, pending_ids))
+    else
+      socket
+    end
   end
 end

--- a/lib/mydia_web/live/my_requests_live/index.ex
+++ b/lib/mydia_web/live/my_requests_live/index.ex
@@ -13,6 +13,10 @@ defmodule MydiaWeb.MyRequestsLive.Index do
      |> assign(:page_title, "My Requests")
      |> assign(:filter_status, "all")
      |> assign(:poster_backfill_attempted, MapSet.new())
+     |> assign(:detail_request, nil)
+     |> assign(:detail_item, nil)
+     |> assign(:detail_metadata, nil)
+     |> assign(:detail_loading, false)
      |> load_requests()}
   end
 
@@ -28,6 +32,28 @@ defmodule MydiaWeb.MyRequestsLive.Index do
     {:noreply, push_patch(socket, to: ~p"/requests?status=#{status}")}
   end
 
+  def handle_event("show_details", %{"id" => id}, socket) do
+    request = Enum.find(socket.assigns.requests, &(&1.id == id))
+    item = request && MediaRequestHelpers.to_search_result(request)
+
+    if item do
+      send(self(), {:fetch_request_metadata, request})
+
+      {:noreply,
+       socket
+       |> assign(:detail_request, request)
+       |> assign(:detail_item, item)
+       |> assign(:detail_metadata, nil)
+       |> assign(:detail_loading, true)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("close_details", _params, socket) do
+    {:noreply, close_details(socket)}
+  end
+
   @impl true
   def handle_info({:backfill_posters, requests}, socket) do
     MediaRequestHelpers.backfill_poster_paths(requests)
@@ -38,6 +64,26 @@ defmodule MydiaWeb.MyRequestsLive.Index do
     # maybe_backfill_posters/2), so this cannot re-send for them even when the
     # fetch above left poster_path nil.
     {:noreply, load_requests(socket)}
+  end
+
+  @impl true
+  def handle_info({:fetch_request_metadata, request}, socket) do
+    # Drop a fetch the user has already navigated away from, so a slow relay
+    # cannot repopulate a popup that was closed or replaced.
+    if socket.assigns.detail_request && socket.assigns.detail_request.id == request.id do
+      case MediaRequestHelpers.fetch_request_metadata(request) do
+        {:ok, metadata} ->
+          {:noreply,
+           socket
+           |> assign(:detail_metadata, metadata)
+           |> assign(:detail_loading, false)}
+
+        {:error, _reason} ->
+          {:noreply, assign(socket, :detail_loading, false)}
+      end
+    else
+      {:noreply, socket}
+    end
   end
 
   ## Private Helpers
@@ -100,5 +146,13 @@ defmodule MydiaWeb.MyRequestsLive.Index do
     else
       socket
     end
+  end
+
+  defp close_details(socket) do
+    socket
+    |> assign(:detail_request, nil)
+    |> assign(:detail_item, nil)
+    |> assign(:detail_metadata, nil)
+    |> assign(:detail_loading, false)
   end
 end

--- a/lib/mydia_web/live/my_requests_live/index.html.heex
+++ b/lib/mydia_web/live/my_requests_live/index.html.heex
@@ -128,5 +128,30 @@
         <% end %>
       </div>
     <% end %>
+
+    <%!-- Detail popup. picker_open is false because this page never opens the
+          library picker, and libraries is empty for the same reason. --%>
+    <.live_component
+      module={MydiaWeb.Live.Components.TrendingDetailModal}
+      id="request-detail-modal"
+      item={@detail_item}
+      metadata={@detail_metadata}
+      loading={@detail_loading}
+      current_user={@current_user}
+      open={@detail_item != nil}
+      libraries={[]}
+      picker_open={false}
+    >
+      <:actions>
+        <button class="btn btn-ghost" phx-click="close_details">Close</button>
+        <.link
+          :if={@detail_request && @detail_request.media_item}
+          navigate={~p"/media/#{@detail_request.media_item.id}"}
+          class="btn btn-primary"
+        >
+          <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" /> View in Library
+        </.link>
+      </:actions>
+    </.live_component>
   </div>
 </Layouts.app>

--- a/lib/mydia_web/live/my_requests_live/index.html.heex
+++ b/lib/mydia_web/live/my_requests_live/index.html.heex
@@ -79,81 +79,52 @@
       <%!-- Requests List --%>
       <div class="space-y-4">
         <%= for request <- @requests do %>
-          <div class="card bg-base-100 shadow-lg">
-            <div class="card-body">
-              <div class="flex gap-4">
-                <div class="flex-1">
-                  <div class="flex items-start justify-between">
-                    <div>
-                      <h3 class="card-title">
-                        {request.title}
-                        <%= if request.year do %>
-                          <span class="text-base-content/70 font-normal">({request.year})</span>
-                        <% end %>
-                      </h3>
-                      <div class="flex items-center gap-2 mt-1">
-                        <span class={"badge badge-sm " <> status_badge_class(request.status)}>
-                          {status_text(request.status)}
-                        </span>
-                        <span class="badge badge-sm badge-ghost">
-                          {String.replace(request.media_type, "_", " ") |> String.capitalize()}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <%!-- Request Details --%>
-                  <div class="mt-4 space-y-2 text-sm">
-                    <div class="flex items-center gap-2 text-base-content/70">
-                      <.icon name="hero-calendar" class="w-4 h-4" />
-                      <span>Requested on {format_date(request.inserted_at)}</span>
-                    </div>
-                    <%= if request.requester_notes do %>
-                      <div class="flex items-start gap-2 text-base-content/70">
-                        <.icon name="hero-chat-bubble-left-right" class="w-4 h-4 mt-0.5" />
-                        <span>{request.requester_notes}</span>
-                      </div>
-                    <% end %>
-                    <%= if request.status == "approved" do %>
-                      <div class="flex items-start gap-2 text-success">
-                        <.icon name="hero-check-circle" class="w-4 h-4 mt-0.5" />
-                        <div>
-                          <div>Approved on {format_date(request.approved_at)}</div>
-                          <%= if request.admin_notes do %>
-                            <div class="text-xs mt-1">Admin notes: {request.admin_notes}</div>
-                          <% end %>
-                        </div>
-                      </div>
-                      <%= if request.media_item do %>
-                        <div class="mt-2">
-                          <.link
-                            navigate={~p"/media/#{request.media_item.id}"}
-                            class="btn btn-sm btn-success"
-                          >
-                            <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" />
-                            View in Library
-                          </.link>
-                        </div>
-                      <% end %>
-                    <% end %>
-                    <%= if request.status == "rejected" do %>
-                      <div class="flex items-start gap-2 text-error">
-                        <.icon name="hero-x-circle" class="w-4 h-4 mt-0.5" />
-                        <div>
-                          <div>Rejected on {format_date(request.rejected_at)}</div>
-                          <%= if request.rejection_reason do %>
-                            <div class="text-xs mt-1">Reason: {request.rejection_reason}</div>
-                          <% end %>
-                          <%= if request.admin_notes do %>
-                            <div class="text-xs mt-1">Admin notes: {request.admin_notes}</div>
-                          <% end %>
-                        </div>
-                      </div>
-                    <% end %>
+          <.request_card request={request}>
+            <:details>
+              <div class="flex items-center gap-2 text-base-content/70">
+                <.icon name="hero-calendar" class="w-4 h-4" />
+                <span>Requested on {format_date(request.inserted_at)}</span>
+              </div>
+              <div
+                :if={request.requester_notes}
+                class="flex items-start gap-2 text-base-content/70"
+              >
+                <.icon name="hero-chat-bubble-left-right" class="w-4 h-4 mt-0.5" />
+                <span>{request.requester_notes}</span>
+              </div>
+              <div :if={request.status == "approved"} class="flex items-start gap-2 text-success">
+                <.icon name="hero-check-circle" class="w-4 h-4 mt-0.5" />
+                <div>
+                  <div>Approved on {format_date(request.approved_at)}</div>
+                  <div :if={request.admin_notes} class="text-xs mt-1">
+                    Admin notes: {request.admin_notes}
                   </div>
                 </div>
               </div>
-            </div>
-          </div>
+              <div :if={request.status == "rejected"} class="flex items-start gap-2 text-error">
+                <.icon name="hero-x-circle" class="w-4 h-4 mt-0.5" />
+                <div>
+                  <div>Rejected on {format_date(request.rejected_at)}</div>
+                  <div :if={request.rejection_reason} class="text-xs mt-1">
+                    Reason: {request.rejection_reason}
+                  </div>
+                  <div :if={request.admin_notes} class="text-xs mt-1">
+                    Admin notes: {request.admin_notes}
+                  </div>
+                </div>
+              </div>
+            </:details>
+
+            <:actions>
+              <.link
+                :if={request.status == "approved" and request.media_item}
+                navigate={~p"/media/#{request.media_item.id}"}
+                class="btn btn-sm btn-success"
+              >
+                <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4" /> View in Library
+              </.link>
+            </:actions>
+          </.request_card>
         <% end %>
       </div>
     <% end %>

--- a/lib/mydia_web/live/request_media_live/index.ex
+++ b/lib/mydia_web/live/request_media_live/index.ex
@@ -188,6 +188,7 @@ defmodule MydiaWeb.RequestMediaLive.Index do
       original_title: result.original_title || result.original_name,
       year: extract_year(result),
       imdb_id: result.imdb_id,
+      poster_path: result.poster_path,
       requester_notes: params["requester_notes"],
       requester_id: assigns.current_user.id
     }

--- a/priv/repo/migrations/20260825001815_add_poster_path_to_media_requests.exs
+++ b/priv/repo/migrations/20260825001815_add_poster_path_to_media_requests.exs
@@ -1,0 +1,12 @@
+defmodule Mydia.Repo.Migrations.AddPosterPathToMediaRequests do
+  use Ecto.Migration
+
+  def change do
+    # :text rather than :string. A bare :string is varchar(255) on PostgreSQL
+    # and unconstrained TEXT on SQLite, and TVDB stores a full artwork URL
+    # here rather than a short relative path.
+    alter table(:media_requests) do
+      add :poster_path, :text
+    end
+  end
+end

--- a/test/mydia/media_requests/poster_path_test.exs
+++ b/test/mydia/media_requests/poster_path_test.exs
@@ -1,0 +1,76 @@
+defmodule Mydia.MediaRequests.PosterPathTest do
+  use Mydia.DataCase
+
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Media.MediaRequest
+  alias Mydia.MediaRequests
+
+  describe "poster_path column" do
+    test "create_changeset casts poster_path" do
+      changeset =
+        MediaRequest.create_changeset(%MediaRequest{}, %{
+          media_type: "movie",
+          title: "Stub Movie",
+          tmdb_id: 550,
+          poster_path: "/stub-movie-poster.jpg",
+          requester_id: Ecto.UUID.generate()
+        })
+
+      assert Ecto.Changeset.get_change(changeset, :poster_path) == "/stub-movie-poster.jpg"
+    end
+
+    test "update_poster_path/2 persists the path" do
+      request = pending_request_fixture()
+
+      assert {:ok, updated} = MediaRequests.update_poster_path(request, "/later.jpg")
+      assert updated.poster_path == "/later.jpg"
+      assert Repo.get!(MediaRequest, request.id).poster_path == "/later.jpg"
+    end
+  end
+
+  describe "external_ref/1" do
+    test "prefers tmdb_id when both ids are present" do
+      assert MediaRequest.external_ref(%MediaRequest{tmdb_id: 550, tvdb_id: 81_189}) ==
+               {:tmdb, 550}
+    end
+
+    test "falls back to tvdb_id" do
+      assert MediaRequest.external_ref(%MediaRequest{tvdb_id: 81_189}) == {:tvdb, 81_189}
+    end
+
+    test "returns nil for an imdb-only request" do
+      request = %MediaRequest{imdb_id: "tt0137523"}
+
+      assert MediaRequest.external_ref(request) == nil
+      refute MediaRequest.detailable?(request)
+    end
+
+    test "detailable? is true whenever an external ref exists" do
+      assert MediaRequest.detailable?(%MediaRequest{tmdb_id: 550})
+      assert MediaRequest.detailable?(%MediaRequest{tvdb_id: 81_189})
+    end
+  end
+
+  describe "media_type_atom/1" do
+    test "maps the stored string to an atom" do
+      assert MediaRequest.media_type_atom(%MediaRequest{media_type: "tv_show"}) == :tv_show
+      assert MediaRequest.media_type_atom(%MediaRequest{media_type: "movie"}) == :movie
+    end
+  end
+
+  defp pending_request_fixture do
+    user = user_fixture(%{role: "guest"})
+
+    {:ok, request} =
+      MediaRequests.create_request(%{
+        media_type: "movie",
+        title: "Stub Movie",
+        year: 1999,
+        tmdb_id: 550,
+        requester_id: user.id
+      })
+
+    request
+  end
+end

--- a/test/mydia_web/components/media_request_components_test.exs
+++ b/test/mydia_web/components/media_request_components_test.exs
@@ -1,0 +1,115 @@
+defmodule MydiaWeb.MediaRequestComponentsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Media.MediaRequest
+  alias MydiaWeb.MediaRequestComponents
+
+  defp render_card(request, opts \\ []) do
+    assigns = Enum.into(opts, %{request: request})
+
+    render_component(&MediaRequestComponents.request_card/1, assigns)
+    |> LazyHTML.from_fragment()
+  end
+
+  defp movie_request(attrs \\ %{}) do
+    struct!(
+      %MediaRequest{
+        id: "11111111-1111-1111-1111-111111111111",
+        media_type: "movie",
+        title: "Stub Movie",
+        year: 1999,
+        status: "pending",
+        tmdb_id: 550
+      },
+      attrs
+    )
+  end
+
+  test "renders the poster at w185 when a path is stored" do
+    doc = render_card(movie_request(%{poster_path: "/stub-movie-poster.jpg"}))
+
+    assert [_ | _] =
+             LazyHTML.query(
+               doc,
+               ~s(img[src="https://image.tmdb.org/t/p/w185/stub-movie-poster.jpg"])
+             )
+             |> Enum.to_list()
+  end
+
+  test "falls back to the placeholder when there is no poster" do
+    doc = render_card(movie_request())
+
+    assert [_ | _] = LazyHTML.query(doc, ~s(img[src="/images/no-poster.svg"])) |> Enum.to_list()
+  end
+
+  test "passes a full TVDB artwork URL through untouched" do
+    doc = render_card(movie_request(%{poster_path: "https://artworks.thetvdb.com/p.jpg"}))
+
+    assert [_ | _] =
+             LazyHTML.query(doc, ~s(img[src="https://artworks.thetvdb.com/p.jpg"]))
+             |> Enum.to_list()
+  end
+
+  test "the title is a click target for a resolvable request" do
+    doc = render_card(movie_request())
+
+    assert [_ | _] =
+             LazyHTML.query(
+               doc,
+               ~s(button[phx-click="show_details"][phx-value-id="11111111-1111-1111-1111-111111111111"])
+             )
+             |> Enum.to_list()
+  end
+
+  test "an imdb-only request has no click target" do
+    doc = render_card(movie_request(%{tmdb_id: nil, imdb_id: "tt0137523"}))
+
+    assert [] = LazyHTML.query(doc, ~s(button[phx-click="show_details"])) |> Enum.to_list()
+  end
+
+  test "renders the badges, details and actions slots" do
+    doc =
+      render_component(&MediaRequestComponents.request_card/1, %{
+        request: movie_request(),
+        badges: [
+          %{
+            __slot__: :badges,
+            inner_block: fn _, _ -> {:safe, ~s(<span id="slot-badge"></span>)} end
+          }
+        ],
+        details: [
+          %{
+            __slot__: :details,
+            inner_block: fn _, _ -> {:safe, ~s(<span id="slot-detail"></span>)} end
+          }
+        ],
+        actions: [
+          %{
+            __slot__: :actions,
+            inner_block: fn _, _ -> {:safe, ~s(<span id="slot-action"></span>)} end
+          }
+        ]
+      })
+      |> LazyHTML.from_fragment()
+
+    assert [_] = LazyHTML.query(doc, "#slot-badge") |> Enum.to_list()
+    assert [_] = LazyHTML.query(doc, "#slot-detail") |> Enum.to_list()
+    assert [_] = LazyHTML.query(doc, "#slot-action") |> Enum.to_list()
+  end
+
+  test "status helpers cover every stored status" do
+    assert MediaRequestComponents.status_text("pending") == "Pending Review"
+    assert MediaRequestComponents.status_text("approved") == "Approved"
+    assert MediaRequestComponents.status_text("rejected") == "Rejected"
+    assert MediaRequestComponents.status_badge_class("pending") == "badge-warning"
+    assert MediaRequestComponents.status_badge_class("approved") == "badge-success"
+    assert MediaRequestComponents.status_badge_class("rejected") == "badge-error"
+  end
+
+  test "format_date handles a missing timestamp" do
+    assert MediaRequestComponents.format_date(nil) == "N/A"
+    assert MediaRequestComponents.format_date(~U[2026-08-24 15:04:05Z]) =~ "Aug 24, 2026"
+  end
+end

--- a/test/mydia_web/live/components/trending_detail_modal_actions_test.exs
+++ b/test/mydia_web/live/components/trending_detail_modal_actions_test.exs
@@ -1,0 +1,65 @@
+defmodule MydiaWeb.Live.Components.TrendingDetailModalActionsTest do
+  @moduledoc """
+  The requests pages need their own footer. Dashboard and Discovery must keep
+  the default one, so the slot has to be genuinely optional.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Metadata.Structs.SearchResult
+  alias MydiaWeb.Live.Components.TrendingDetailModal
+
+  defp item do
+    %SearchResult{
+      provider_id: "550",
+      provider: :tmdb,
+      media_type: :movie,
+      id: 550,
+      title: "Stub Movie",
+      year: 1999
+    }
+  end
+
+  defp base_assigns do
+    %{
+      id: "detail-modal",
+      item: item(),
+      metadata: nil,
+      loading: false,
+      current_user: %{role: "admin"},
+      open: true,
+      libraries: [],
+      picker_open: false
+    }
+  end
+
+  test "renders the default footer when no actions slot is given" do
+    doc = base_assigns() |> render_component_doc()
+
+    # Enum.to_list/1 because LazyHTML.query/2 returns a %LazyHTML{} struct,
+    # not a list, so a bare list pattern can never match it.
+    assert [_] = LazyHTML.query(doc, ~s(button[phx-click="add_to_library"])) |> Enum.to_list()
+  end
+
+  test "an actions slot replaces the default footer" do
+    doc =
+      base_assigns()
+      |> Map.put(:actions, [
+        %{
+          __slot__: :actions,
+          inner_block: fn _, _ -> {:safe, ~s(<button id="request-approve"></button>)} end
+        }
+      ])
+      |> render_component_doc()
+
+    assert [_] = LazyHTML.query(doc, "#request-approve") |> Enum.to_list()
+    assert [] = LazyHTML.query(doc, ~s(button[phx-click="add_to_library"])) |> Enum.to_list()
+  end
+
+  defp render_component_doc(assigns) do
+    TrendingDetailModal
+    |> render_component(assigns)
+    |> LazyHTML.from_fragment()
+  end
+end

--- a/test/mydia_web/live/helpers/media_request_backfill_test.exs
+++ b/test/mydia_web/live/helpers/media_request_backfill_test.exs
@@ -73,6 +73,32 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestBackfillTest do
       assert :ok = MediaRequestHelpers.backfill_poster_paths([request])
       assert reload(request).poster_path == "/keep.jpg"
     end
+
+    test "a raise resolving one row does not crash the caller or stop siblings", %{user: user} do
+      # Task.async_stream/3 links each task to the caller. This test calls
+      # backfill_poster_paths/1 directly from the test process, so if the
+      # per-row raise below were not caught, it would crash this test
+      # process via the link instead of merely failing an assertion --
+      # proving the containment, not just describing it.
+      crashing = request_fixture(user, %{tmdb_id: MetadataStubProvider.movie_tmdb_id()})
+
+      sibling =
+        request_fixture(user, %{
+          media_type: "tv_show",
+          title: "Stub Series",
+          tmdb_id: nil,
+          tvdb_id: MetadataStubProvider.series_tvdb_id()
+        })
+
+      provider_id = to_string(MetadataStubProvider.movie_tmdb_id())
+      ref = MetadataStubProvider.raise_on_fetch_by_id(provider_id)
+      on_exit(fn -> MetadataStubProvider.clear_raise_on_fetch_by_id(ref) end)
+
+      assert :ok = MediaRequestHelpers.backfill_poster_paths([crashing, sibling])
+
+      assert is_nil(reload(crashing).poster_path)
+      assert reload(sibling).poster_path == "/stub-series-poster.jpg"
+    end
   end
 
   defp request_fixture(user, attrs) do

--- a/test/mydia_web/live/helpers/media_request_backfill_test.exs
+++ b/test/mydia_web/live/helpers/media_request_backfill_test.exs
@@ -1,0 +1,91 @@
+defmodule MydiaWeb.Live.Helpers.MediaRequestBackfillTest do
+  @moduledoc """
+  Requests created before the poster_path column existed fill in on first view.
+  A failed fetch must leave the row alone so the card falls back to the
+  placeholder and the next visit retries.
+  """
+
+  # async: false: setup_metadata_stub swaps the global Provider.Registry, and
+  # a shared sandbox is what lets the backfill's Tasks reach the Repo.
+  use Mydia.DataCase, async: false
+
+  import Mydia.AccountsFixtures
+  import Mydia.MetadataStub
+
+  alias Mydia.Media.MediaRequest
+  alias Mydia.MediaRequests
+  alias Mydia.MetadataStubProvider
+  alias MydiaWeb.Live.Helpers.MediaRequestHelpers
+
+  setup :setup_metadata_stub
+
+  setup do
+    %{user: user_fixture(%{role: "guest"})}
+  end
+
+  describe "needs_poster?/1" do
+    test "true only for a resolvable request with no poster yet" do
+      assert MediaRequestHelpers.needs_poster?(%MediaRequest{tmdb_id: 550, poster_path: nil})
+      refute MediaRequestHelpers.needs_poster?(%MediaRequest{tmdb_id: 550, poster_path: "/p.jpg"})
+      refute MediaRequestHelpers.needs_poster?(%MediaRequest{imdb_id: "tt1", poster_path: nil})
+    end
+  end
+
+  describe "backfill_poster_paths/1" do
+    test "fills a movie request from its tmdb_id", %{user: user} do
+      request = request_fixture(user, %{tmdb_id: MetadataStubProvider.movie_tmdb_id()})
+
+      assert :ok = MediaRequestHelpers.backfill_poster_paths([request])
+      assert reload(request).poster_path == "/stub-movie-poster.jpg"
+    end
+
+    test "fills a series request that only has a tvdb_id", %{user: user} do
+      request =
+        request_fixture(user, %{
+          media_type: "tv_show",
+          title: "Stub Series",
+          tvdb_id: MetadataStubProvider.series_tvdb_id()
+        })
+
+      assert :ok = MediaRequestHelpers.backfill_poster_paths([request])
+      assert reload(request).poster_path == "/stub-series-poster.jpg"
+    end
+
+    test "leaves an imdb-only request untouched", %{user: user} do
+      request = request_fixture(user, %{tmdb_id: nil, imdb_id: "tt0137523"})
+
+      assert :ok = MediaRequestHelpers.backfill_poster_paths([request])
+      assert is_nil(reload(request).poster_path)
+    end
+
+    test "leaves the row alone when the provider fails", %{user: user} do
+      request = request_fixture(user, %{tmdb_id: MetadataStubProvider.missing_id()})
+
+      assert :ok = MediaRequestHelpers.backfill_poster_paths([request])
+      assert is_nil(reload(request).poster_path)
+    end
+
+    test "does not overwrite a poster that is already set", %{user: user} do
+      request = request_fixture(user, %{tmdb_id: MetadataStubProvider.movie_tmdb_id()})
+      {:ok, request} = MediaRequests.update_poster_path(request, "/keep.jpg")
+
+      assert :ok = MediaRequestHelpers.backfill_poster_paths([request])
+      assert reload(request).poster_path == "/keep.jpg"
+    end
+  end
+
+  defp request_fixture(user, attrs) do
+    base = %{
+      media_type: "movie",
+      title: "Stub Movie",
+      year: 1999,
+      tmdb_id: MetadataStubProvider.movie_tmdb_id(),
+      requester_id: user.id
+    }
+
+    {:ok, request} = MediaRequests.create_request(Map.merge(base, attrs))
+    request
+  end
+
+  defp reload(request), do: Repo.get!(MediaRequest, request.id)
+end

--- a/test/mydia_web/live/helpers/media_request_backfill_test.exs
+++ b/test/mydia_web/live/helpers/media_request_backfill_test.exs
@@ -44,6 +44,7 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestBackfillTest do
         request_fixture(user, %{
           media_type: "tv_show",
           title: "Stub Series",
+          tmdb_id: nil,
           tvdb_id: MetadataStubProvider.series_tvdb_id()
         })
 

--- a/test/mydia_web/live/helpers/media_request_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_request_helpers_test.exs
@@ -1,37 +1,109 @@
 defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
-  use Mydia.DataCase
+  use Mydia.DataCase, async: true
 
-  import Mydia.AccountsFixtures
-
+  alias Mydia.{Accounts, MediaRequests}
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
+  defp guest do
+    id = System.unique_integer([:positive])
+
+    {:ok, user} =
+      Accounts.create_user(%{
+        username: "guest#{id}",
+        email: "guest#{id}@example.com",
+        password: "passwordpassword",
+        role: "guest"
+      })
+
+    user
+  end
+
+  defp item(tmdb_id, title \\ "Card Movie") do
+    %{provider_id: to_string(tmdb_id), title: title, year: 2024}
+  end
+
   describe "handle_request_media/3" do
+    test "creates a pending request and returns it in the updated map" do
+      user = guest()
+      tmdb_id = System.unique_integer([:positive])
+
+      assert {:ok, request, map} =
+               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
+
+      assert request.tmdb_id == tmdb_id
+      assert request.status == "pending"
+      assert request.requester_id == user.id
+      assert map[tmdb_id] == "pending"
+    end
+
+    test "reports a duplicate when a pending request already exists" do
+      user = guest()
+      tmdb_id = System.unique_integer([:positive])
+
+      assert {:ok, _request, _map} =
+               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
+
+      assert {:error, :duplicate_request} =
+               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
+    end
+
     test "stores the card's poster path on the request" do
-      user = user_fixture(%{role: "guest"})
+      user = guest()
+      tmdb_id = System.unique_integer([:positive])
+      poster_item = Map.put(item(tmdb_id), :poster_path, "/stub-movie-poster.jpg")
 
-      item = %{
-        provider_id: "550",
-        title: "Stub Movie",
-        year: 1999,
-        poster_path: "/stub-movie-poster.jpg"
-      }
-
-      assert {:ok, request, _statuses} =
-               MediaRequestHelpers.handle_request_media(item, :movie, user.id)
+      assert {:ok, request, _map} =
+               MediaRequestHelpers.handle_request_media(poster_item, :movie, user.id)
 
       assert request.poster_path == "/stub-movie-poster.jpg"
-      assert request.tmdb_id == 550
     end
 
     test "leaves poster_path nil when the card has no poster" do
-      user = user_fixture(%{role: "guest"})
+      user = guest()
+      tmdb_id = System.unique_integer([:positive])
 
-      item = %{provider_id: "550", title: "Stub Movie", year: 1999, poster_path: nil}
-
-      assert {:ok, request, _statuses} =
-               MediaRequestHelpers.handle_request_media(item, :movie, user.id)
+      assert {:ok, request, _map} =
+               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
 
       assert is_nil(request.poster_path)
+    end
+  end
+
+  describe "request_status_map/0" do
+    test "includes pending requests from any requester" do
+      first = guest()
+      second = guest()
+      tmdb_id = System.unique_integer([:positive])
+
+      {:ok, _request} =
+        MediaRequests.create_request(%{
+          media_type: "movie",
+          title: "Someone Else's Pick",
+          tmdb_id: tmdb_id,
+          requester_id: first.id
+        })
+
+      # The second guest must see it as already requested: create_request/1
+      # rejects duplicates globally, so an enabled button would only error.
+      assert MediaRequestHelpers.request_status_map()[tmdb_id] == "pending"
+      assert second.id != first.id
+    end
+  end
+
+  describe "enrich_with_request_status/2" do
+    test "stamps the status onto matching items and nil onto the rest" do
+      requested = System.unique_integer([:positive])
+      untouched = System.unique_integer([:positive])
+      map = %{requested => "pending"}
+
+      [a, b] =
+        MediaRequestHelpers.enrich_with_request_status(
+          [item(requested), item(untouched)],
+          map
+        )
+
+      assert a.request_status == "pending"
+      assert b.request_status == nil
     end
   end
 end

--- a/test/mydia_web/live/helpers/media_request_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_request_helpers_test.exs
@@ -1,88 +1,37 @@
 defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
-  use Mydia.DataCase, async: true
+  use Mydia.DataCase
 
-  alias Mydia.{Accounts, MediaRequests}
+  import Mydia.AccountsFixtures
+
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
-  defp guest do
-    id = System.unique_integer([:positive])
-
-    {:ok, user} =
-      Accounts.create_user(%{
-        username: "guest#{id}",
-        email: "guest#{id}@example.com",
-        password: "passwordpassword",
-        role: "guest"
-      })
-
-    user
-  end
-
-  defp item(tmdb_id, title \\ "Card Movie") do
-    %{provider_id: to_string(tmdb_id), title: title, year: 2024}
-  end
-
   describe "handle_request_media/3" do
-    test "creates a pending request and returns it in the updated map" do
-      user = guest()
-      tmdb_id = System.unique_integer([:positive])
+    test "stores the card's poster path on the request" do
+      user = user_fixture(%{role: "guest"})
 
-      assert {:ok, request, map} =
-               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
+      item = %{
+        provider_id: "550",
+        title: "Stub Movie",
+        year: 1999,
+        poster_path: "/stub-movie-poster.jpg"
+      }
 
-      assert request.tmdb_id == tmdb_id
-      assert request.status == "pending"
-      assert request.requester_id == user.id
-      assert map[tmdb_id] == "pending"
+      assert {:ok, request, _statuses} =
+               MediaRequestHelpers.handle_request_media(item, :movie, user.id)
+
+      assert request.poster_path == "/stub-movie-poster.jpg"
+      assert request.tmdb_id == 550
     end
 
-    test "reports a duplicate when a pending request already exists" do
-      user = guest()
-      tmdb_id = System.unique_integer([:positive])
+    test "leaves poster_path nil when the card has no poster" do
+      user = user_fixture(%{role: "guest"})
 
-      assert {:ok, _request, _map} =
-               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
+      item = %{provider_id: "550", title: "Stub Movie", year: 1999, poster_path: nil}
 
-      assert {:error, :duplicate_request} =
-               MediaRequestHelpers.handle_request_media(item(tmdb_id), :movie, user.id)
-    end
-  end
+      assert {:ok, request, _statuses} =
+               MediaRequestHelpers.handle_request_media(item, :movie, user.id)
 
-  describe "request_status_map/0" do
-    test "includes pending requests from any requester" do
-      first = guest()
-      second = guest()
-      tmdb_id = System.unique_integer([:positive])
-
-      {:ok, _request} =
-        MediaRequests.create_request(%{
-          media_type: "movie",
-          title: "Someone Else's Pick",
-          tmdb_id: tmdb_id,
-          requester_id: first.id
-        })
-
-      # The second guest must see it as already requested: create_request/1
-      # rejects duplicates globally, so an enabled button would only error.
-      assert MediaRequestHelpers.request_status_map()[tmdb_id] == "pending"
-      assert second.id != first.id
-    end
-  end
-
-  describe "enrich_with_request_status/2" do
-    test "stamps the status onto matching items and nil onto the rest" do
-      requested = System.unique_integer([:positive])
-      untouched = System.unique_integer([:positive])
-      map = %{requested => "pending"}
-
-      [a, b] =
-        MediaRequestHelpers.enrich_with_request_status(
-          [item(requested), item(untouched)],
-          map
-        )
-
-      assert a.request_status == "pending"
-      assert b.request_status == nil
+      assert is_nil(request.poster_path)
     end
   end
 end

--- a/test/mydia_web/live/helpers/media_request_metadata_test.exs
+++ b/test/mydia_web/live/helpers/media_request_metadata_test.exs
@@ -1,0 +1,96 @@
+defmodule MydiaWeb.Live.Helpers.MediaRequestMetadataTest do
+  @moduledoc """
+  A TV request made while the instance is on TVDB metadata stores only a
+  tvdb_id, so resolution has to route on whichever id the row carries.
+  """
+
+  # async: false: setup_metadata_stub swaps the global Provider.Registry.
+  use Mydia.DataCase, async: false
+
+  import Mydia.MetadataStub
+
+  alias Mydia.Media.MediaRequest
+  alias Mydia.Metadata.Structs.SearchResult
+  alias Mydia.MetadataStubProvider
+  alias MydiaWeb.Live.Helpers.MediaRequestHelpers
+
+  setup :setup_metadata_stub
+
+  describe "fetch_request_metadata/1" do
+    test "resolves a movie by tmdb_id" do
+      request = %MediaRequest{
+        media_type: "movie",
+        title: "Stub Movie",
+        tmdb_id: MetadataStubProvider.movie_tmdb_id()
+      }
+
+      assert {:ok, metadata} = MediaRequestHelpers.fetch_request_metadata(request)
+      assert metadata.title == MetadataStubProvider.movie_title()
+      assert metadata.poster_path == "/stub-movie-poster.jpg"
+    end
+
+    test "resolves a series that only has a tvdb_id" do
+      request = %MediaRequest{
+        media_type: "tv_show",
+        title: "Stub Series",
+        tvdb_id: MetadataStubProvider.series_tvdb_id()
+      }
+
+      assert {:ok, metadata} = MediaRequestHelpers.fetch_request_metadata(request)
+      assert metadata.title == MetadataStubProvider.series_title()
+      assert metadata.poster_path == "/stub-series-poster.jpg"
+    end
+
+    test "returns :no_provider_id for an imdb-only request" do
+      request = %MediaRequest{media_type: "movie", title: "Old One", imdb_id: "tt0137523"}
+
+      assert {:error, :no_provider_id} = MediaRequestHelpers.fetch_request_metadata(request)
+    end
+
+    test "passes a provider failure through" do
+      request = %MediaRequest{
+        media_type: "movie",
+        title: "Missing",
+        tmdb_id: MetadataStubProvider.missing_id()
+      }
+
+      assert {:error, _reason} = MediaRequestHelpers.fetch_request_metadata(request)
+    end
+  end
+
+  describe "to_search_result/1" do
+    test "builds the item shape the detail popup reads" do
+      request = %MediaRequest{
+        media_type: "movie",
+        title: "Stub Movie",
+        year: 1999,
+        tmdb_id: 550,
+        poster_path: "/stub-movie-poster.jpg"
+      }
+
+      assert %SearchResult{} = item = MediaRequestHelpers.to_search_result(request)
+      assert item.provider_id == "550"
+      assert item.provider == :tmdb
+      assert item.media_type == :movie
+      assert item.title == "Stub Movie"
+      assert item.year == 1999
+      assert item.poster_path == "/stub-movie-poster.jpg"
+    end
+
+    test "tags a tvdb-only series with the tvdb provider" do
+      request = %MediaRequest{media_type: "tv_show", title: "Stub Series", tvdb_id: 81_189}
+
+      assert %SearchResult{provider: :tvdb, provider_id: "81189", media_type: :tv_show} =
+               MediaRequestHelpers.to_search_result(request)
+    end
+
+    test "returns nil when there is nothing to resolve" do
+      assert is_nil(
+               MediaRequestHelpers.to_search_result(%MediaRequest{
+                 media_type: "movie",
+                 imdb_id: "tt0137523"
+               })
+             )
+    end
+  end
+end

--- a/test/mydia_web/live/request_detail_popup_test.exs
+++ b/test/mydia_web/live/request_detail_popup_test.exs
@@ -44,6 +44,11 @@ defmodule MydiaWeb.RequestDetailPopupTest do
     |> element(~s(#request-#{request.id} button.link[phx-click="show_details"]))
     |> render_click()
 
+    # show_details now fetches request metadata through start_async, so
+    # render_async/1 is needed to await it before callers assert on
+    # detail_metadata-derived content.
+    render_async(view)
+
     view
   end
 

--- a/test/mydia_web/live/request_detail_popup_test.exs
+++ b/test/mydia_web/live/request_detail_popup_test.exs
@@ -1,0 +1,135 @@
+defmodule MydiaWeb.RequestDetailPopupTest do
+  @moduledoc """
+  Clicking a request title opens the same detail popup Discovery uses.
+  Approving from inside it must close the popup as the approve dialog opens:
+  TrendingDetailModal binds phx-window-keydown for Escape, which is not scoped
+  by visual stacking, so two open dialogs would share one Escape press.
+  """
+
+  # async: false: setup_metadata_stub swaps the global Provider.Registry, and
+  # connected LiveView mounts run outside the test process.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MetadataStub
+
+  alias Mydia.MediaRequests
+  alias Mydia.MetadataStubProvider
+
+  setup :setup_metadata_stub
+
+  setup do
+    guest = create_test_user(%{role: "guest"})
+    admin = create_admin_user()
+
+    %{guest: guest, admin: admin}
+  end
+
+  defp request_fixture(user, attrs \\ %{}) do
+    base = %{
+      media_type: "movie",
+      title: "Stub Movie",
+      year: 1999,
+      tmdb_id: MetadataStubProvider.movie_tmdb_id(),
+      poster_path: "/stub-movie-poster.jpg",
+      requester_id: user.id
+    }
+
+    {:ok, request} = MediaRequests.create_request(Map.merge(base, attrs))
+    request
+  end
+
+  defp open_details(view, request) do
+    view
+    |> element(~s(#request-#{request.id} button.link[phx-click="show_details"]))
+    |> render_click()
+
+    view
+  end
+
+  test "the admin page opens and closes the popup", %{conn: conn, admin: admin, guest: guest} do
+    request = request_fixture(guest)
+
+    {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
+
+    refute has_element?(view, "#request-detail-modal[open]")
+
+    open_details(view, request)
+
+    assert has_element?(view, "#request-detail-modal[open]")
+    assert render(view) =~ MetadataStubProvider.movie_title()
+
+    # Text filter disambiguates: TrendingDetailModal always renders three
+    # phx-click="close_details" buttons when open (header icon, backdrop, and
+    # this footer button), matching the codebase's idiom for a modal with
+    # multiple same-selector buttons (see import_media_review_test.exs). The
+    # backdrop button's text is lowercase "close", so "Close" targets only
+    # the footer button and not the backdrop as well.
+    view
+    |> element(~s(#request-detail-modal button[phx-click="close_details"]), "Close")
+    |> render_click()
+
+    refute has_element?(view, "#request-detail-modal[open]")
+  end
+
+  test "My Requests opens the popup", %{conn: conn, guest: guest} do
+    request = request_fixture(guest)
+
+    {:ok, view, _html} = live(log_in_user(conn, guest), ~p"/requests")
+
+    open_details(view, request)
+
+    assert has_element?(view, "#request-detail-modal[open]")
+  end
+
+  test "the popup offers approve and reject on a pending request", %{
+    conn: conn,
+    admin: admin,
+    guest: guest
+  } do
+    request = request_fixture(guest)
+
+    {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
+    open_details(view, request)
+
+    assert has_element?(
+             view,
+             ~s(#request-detail-modal button[phx-click="open_approve_modal"][phx-value-id="#{request.id}"])
+           )
+
+    assert has_element?(
+             view,
+             ~s(#request-detail-modal button[phx-click="open_reject_modal"][phx-value-id="#{request.id}"])
+           )
+  end
+
+  test "approving from the popup closes it before the approve dialog opens", %{
+    conn: conn,
+    admin: admin,
+    guest: guest
+  } do
+    request = request_fixture(guest)
+
+    {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
+    open_details(view, request)
+
+    view
+    |> element(~s(#request-detail-modal button[phx-click="open_approve_modal"]))
+    |> render_click()
+
+    refute has_element?(view, "#request-detail-modal[open]")
+    assert has_element?(view, "#approve-form")
+  end
+
+  test "a request with no resolvable id has no title button", %{
+    conn: conn,
+    admin: admin,
+    guest: guest
+  } do
+    request = request_fixture(guest, %{tmdb_id: nil, imdb_id: "tt0137523"})
+
+    {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
+
+    refute has_element?(view, ~s(#request-#{request.id} button[phx-click="show_details"]))
+  end
+end

--- a/test/mydia_web/live/request_detail_popup_test.exs
+++ b/test/mydia_web/live/request_detail_popup_test.exs
@@ -121,6 +121,25 @@ defmodule MydiaWeb.RequestDetailPopupTest do
     assert has_element?(view, "#approve-form")
   end
 
+  test "switching the status filter closes an open popup", %{
+    conn: conn,
+    admin: admin,
+    guest: guest
+  } do
+    request = request_fixture(guest)
+
+    {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
+    open_details(view, request)
+
+    assert has_element?(view, "#request-detail-modal[open]")
+
+    view
+    |> element(~s(button[phx-click="filter"][phx-value-status="all"]))
+    |> render_click()
+
+    refute has_element?(view, "#request-detail-modal[open]")
+  end
+
   test "a request with no resolvable id has no title button", %{
     conn: conn,
     admin: admin,

--- a/test/mydia_web/live/request_media_poster_test.exs
+++ b/test/mydia_web/live/request_media_poster_test.exs
@@ -1,0 +1,61 @@
+defmodule MydiaWeb.RequestMediaPosterTest do
+  @moduledoc """
+  The guest search flow must carry the search result's poster onto the request
+  row, so the request pages have an image without a second provider call.
+  """
+
+  # async: false: setup_metadata_stub swaps the global Provider.Registry, and
+  # connected LiveView mounts run outside the test process.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MetadataStub
+
+  alias Mydia.Media.MediaRequest
+  alias Mydia.MetadataStubProvider
+  alias Mydia.Repo
+
+  setup :setup_metadata_stub
+
+  setup do
+    %{guest: create_test_user(%{role: "guest"})}
+  end
+
+  test "a submitted movie request carries the search result's poster", %{
+    conn: conn,
+    guest: guest
+  } do
+    {:ok, view, _html} = live(log_in_user(conn, guest), ~p"/request/movie?q=stub")
+
+    view
+    |> element(~s(button[phx-click="open_request_modal"][phx-value-index="0"]))
+    |> render_click()
+
+    view
+    |> form("#request-modal-form", request: %{requester_notes: ""})
+    |> render_submit()
+
+    request = Repo.get_by!(MediaRequest, tmdb_id: MetadataStubProvider.movie_tmdb_id())
+
+    assert request.poster_path == "/stub-movie-poster.jpg"
+  end
+
+  test "a submitted series request carries the search result's poster", %{
+    conn: conn,
+    guest: guest
+  } do
+    {:ok, view, _html} = live(log_in_user(conn, guest), ~p"/request/series?q=stub")
+
+    view
+    |> element(~s(button[phx-click="open_request_modal"][phx-value-index="0"]))
+    |> render_click()
+
+    view
+    |> form("#request-modal-form", request: %{requester_notes: ""})
+    |> render_submit()
+
+    request = Repo.get_by!(MediaRequest, tvdb_id: MetadataStubProvider.series_tvdb_id())
+
+    assert request.poster_path == "/stub-series-poster.jpg"
+  end
+end

--- a/test/mydia_web/live/request_pages_poster_test.exs
+++ b/test/mydia_web/live/request_pages_poster_test.exs
@@ -95,4 +95,46 @@ defmodule MydiaWeb.RequestPagesPosterTest do
     assert has_element?(view, ~s(#request-#{request.id} img[src="/images/no-poster.svg"]))
     refute has_element?(view, ~s(#request-#{request.id} button[phx-click="show_details"]))
   end
+
+  test "a permanently-unresolvable request is attempted once, not retried in a loop", %{
+    conn: conn,
+    admin: admin,
+    guest: guest
+  } do
+    # missing_id/0 is detailable (it is a tmdb_id) but its fetch always
+    # errors, which is exactly the row shape that used to loop: mount/3's
+    # load_requests/1 and the handle_params/3 that LiveView calls right after
+    # it both reach maybe_backfill_posters/2, and needs_poster?/1 stays true
+    # forever for a row whose fetch can never succeed.
+    request = request_fixture(guest, %{tmdb_id: MetadataStubProvider.missing_id()})
+    assert is_nil(request.poster_path)
+
+    MetadataStubProvider.reset_fetch_by_id_count!()
+
+    {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
+
+    # render/1 round-trips through the LiveView process, so the one backfill
+    # message queued during mount has been handled by the time it returns. If
+    # handle_info re-sent itself, the process would be mid-loop right now.
+    render(view)
+
+    assert Repo.get!(MediaRequest, request.id).poster_path == nil
+
+    assert MetadataStubProvider.fetch_by_id_count(to_string(MetadataStubProvider.missing_id())) ==
+             1
+
+    # The LiveView process must still be responsive to ordinary events: a
+    # busy resend loop would starve normal message handling. Switching tabs
+    # re-runs load_requests/1 (and therefore maybe_backfill_posters/2) again,
+    # so this also proves an already-attempted id is not retried on a second
+    # pass within the same connected session.
+    view
+    |> element(~s(button[phx-click="filter"][phx-value-status="all"]))
+    |> render_click()
+
+    assert has_element?(view, ~s(#request-#{request.id}))
+
+    assert MetadataStubProvider.fetch_by_id_count(to_string(MetadataStubProvider.missing_id())) ==
+             1
+  end
 end

--- a/test/mydia_web/live/request_pages_poster_test.exs
+++ b/test/mydia_web/live/request_pages_poster_test.exs
@@ -1,0 +1,98 @@
+defmodule MydiaWeb.RequestPagesPosterTest do
+  @moduledoc """
+  Both request pages show a poster. Rows created before the poster_path column
+  existed fill in from the provider on first view.
+  """
+
+  # async: false: setup_metadata_stub swaps the global Provider.Registry, and
+  # connected LiveView mounts run outside the test process.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MetadataStub
+
+  alias Mydia.Media.MediaRequest
+  alias Mydia.MediaRequests
+  alias Mydia.MetadataStubProvider
+  alias Mydia.Repo
+
+  setup :setup_metadata_stub
+
+  setup do
+    guest = create_test_user(%{role: "guest"})
+    admin = create_admin_user()
+
+    %{guest: guest, admin: admin}
+  end
+
+  defp request_fixture(user, attrs \\ %{}) do
+    base = %{
+      media_type: "movie",
+      title: "Stub Movie",
+      year: 1999,
+      tmdb_id: MetadataStubProvider.movie_tmdb_id(),
+      requester_id: user.id
+    }
+
+    {:ok, request} = MediaRequests.create_request(Map.merge(base, attrs))
+    request
+  end
+
+  test "the admin page renders a stored poster", %{conn: conn, admin: admin, guest: guest} do
+    request = request_fixture(guest, %{poster_path: "/stub-movie-poster.jpg"})
+
+    {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
+
+    assert has_element?(
+             view,
+             ~s(#request-#{request.id} img[src="https://image.tmdb.org/t/p/w185/stub-movie-poster.jpg"])
+           )
+  end
+
+  test "My Requests renders a stored poster", %{conn: conn, guest: guest} do
+    request = request_fixture(guest, %{poster_path: "/stub-movie-poster.jpg"})
+
+    {:ok, view, _html} = live(log_in_user(conn, guest), ~p"/requests")
+
+    assert has_element?(
+             view,
+             ~s(#request-#{request.id} img[src="https://image.tmdb.org/t/p/w185/stub-movie-poster.jpg"])
+           )
+  end
+
+  test "a request with no stored poster backfills on first view", %{
+    conn: conn,
+    admin: admin,
+    guest: guest
+  } do
+    request = request_fixture(guest)
+    assert is_nil(request.poster_path)
+
+    {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
+
+    # render/1 round-trips through the LiveView process, so the backfill
+    # message queued during mount has been handled by the time it returns.
+    render(view)
+
+    assert Repo.get!(MediaRequest, request.id).poster_path == "/stub-movie-poster.jpg"
+
+    assert has_element?(
+             view,
+             ~s(#request-#{request.id} img[src="https://image.tmdb.org/t/p/w185/stub-movie-poster.jpg"])
+           )
+  end
+
+  test "an imdb-only request renders the placeholder and no click target", %{
+    conn: conn,
+    admin: admin,
+    guest: guest
+  } do
+    request = request_fixture(guest, %{tmdb_id: nil, imdb_id: "tt0137523"})
+
+    {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
+    render(view)
+
+    assert has_element?(view, ~s(#request-#{request.id} img[src="/images/no-poster.svg"]))
+    refute has_element?(view, ~s(#request-#{request.id} button[phx-click="show_details"]))
+  end
+end

--- a/test/mydia_web/live/request_pages_poster_test.exs
+++ b/test/mydia_web/live/request_pages_poster_test.exs
@@ -70,9 +70,10 @@ defmodule MydiaWeb.RequestPagesPosterTest do
 
     {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
 
-    # render/1 round-trips through the LiveView process, so the backfill
-    # message queued during mount has been handled by the time it returns.
-    render(view)
+    # render_async/1 awaits the start_async task that mount's load_requests/1
+    # kicks off, so the backfill has finished writing poster_path by the time
+    # it returns.
+    render_async(view)
 
     assert Repo.get!(MediaRequest, request.id).poster_path == "/stub-movie-poster.jpg"
 
@@ -113,10 +114,11 @@ defmodule MydiaWeb.RequestPagesPosterTest do
 
     {:ok, view, _html} = live(log_in_user(conn, admin), ~p"/admin/requests")
 
-    # render/1 round-trips through the LiveView process, so the one backfill
-    # message queued during mount has been handled by the time it returns. If
-    # handle_info re-sent itself, the process would be mid-loop right now.
-    render(view)
+    # render_async/1 awaits the start_async task that mount's load_requests/1
+    # kicks off, so the one backfill batch queued during mount has finished by
+    # the time it returns. If maybe_backfill_posters/2 re-triggered itself,
+    # the task would still be mid-loop right now.
+    render_async(view)
 
     assert Repo.get!(MediaRequest, request.id).poster_path == nil
 

--- a/test/support/metadata_stub_provider.ex
+++ b/test/support/metadata_stub_provider.ex
@@ -35,6 +35,7 @@ defmodule Mydia.MetadataStubProvider do
   @series_title "Stub Series"
   @season_fetch_block_key {__MODULE__, :season_fetch_block}
   @fetch_by_id_counts_table :mydia_metadata_stub_fetch_by_id_counts
+  @raise_on_fetch_by_id_key {__MODULE__, :raise_on_fetch_by_id}
 
   @doc "TMDB id of the catalog movie."
   def movie_tmdb_id, do: @movie_tmdb_id
@@ -85,6 +86,32 @@ defmodule Mydia.MetadataStubProvider do
     :ok
   end
 
+  @doc """
+  Makes the next `fetch_by_id/3` call for `provider_id` raise instead of
+  returning the catalog entry.
+
+  Opt-in and self-clearing: the next matching call consumes it and reverts to
+  the normal catalog lookup, so a test that never triggers it (or fails
+  before triggering it) leaves no state behind for later tests other than
+  what `clear_raise_on_fetch_by_id/1` is meant to guard against -- call it
+  from `on_exit/1` regardless of whether the raise fired. Used by
+  `MediaRequestBackfillTest` to prove a raise inside one row of a concurrent
+  backfill does not crash the caller or stop sibling rows.
+  """
+  def raise_on_fetch_by_id(provider_id) do
+    ref = make_ref()
+    :persistent_term.put(@raise_on_fetch_by_id_key, {to_string(provider_id), ref})
+    ref
+  end
+
+  @doc "Clears a pending `raise_on_fetch_by_id/1` installed by a test, if not already consumed."
+  def clear_raise_on_fetch_by_id(ref) do
+    case :persistent_term.get(@raise_on_fetch_by_id_key, nil) do
+      {_provider_id, ^ref} -> :persistent_term.erase(@raise_on_fetch_by_id_key)
+      _other -> :ok
+    end
+  end
+
   @doc "Number of `fetch_by_id/3` calls observed for `provider_id` since the last reset."
   def fetch_by_id_count(provider_id) do
     case :ets.whereis(@fetch_by_id_counts_table) do
@@ -113,6 +140,7 @@ defmodule Mydia.MetadataStubProvider do
   @impl true
   def fetch_by_id(_config, provider_id, opts) do
     count_fetch_by_id_call(provider_id)
+    maybe_raise_on_fetch_by_id(provider_id)
 
     cond do
       provider_id == to_string(@missing_id) ->
@@ -175,6 +203,17 @@ defmodule Mydia.MetadataStubProvider do
     end
 
     :ok
+  end
+
+  defp maybe_raise_on_fetch_by_id(provider_id) do
+    case :persistent_term.get(@raise_on_fetch_by_id_key, nil) do
+      {^provider_id, _ref} ->
+        :persistent_term.erase(@raise_on_fetch_by_id_key)
+        raise "MetadataStubProvider: forced fetch_by_id failure for #{provider_id}"
+
+      _other ->
+        :ok
+    end
   end
 
   defp maybe_block_season_fetch do

--- a/test/support/metadata_stub_provider.ex
+++ b/test/support/metadata_stub_provider.ex
@@ -34,6 +34,7 @@ defmodule Mydia.MetadataStubProvider do
   @movie_title "Stub Movie"
   @series_title "Stub Series"
   @season_fetch_block_key {__MODULE__, :season_fetch_block}
+  @fetch_by_id_counts_table :mydia_metadata_stub_fetch_by_id_counts
 
   @doc "TMDB id of the catalog movie."
   def movie_tmdb_id, do: @movie_tmdb_id
@@ -65,6 +66,39 @@ defmodule Mydia.MetadataStubProvider do
     end
   end
 
+  @doc """
+  Starts (or clears) the `fetch_by_id/3` call counter.
+
+  Opt-in and purely additive: `fetch_by_id/3` only counts a call when this
+  table exists, so tests that never call this function see no behavior
+  change. Used by `request_pages_poster_test.exs` to assert a permanently-
+  unresolvable row is attempted exactly once per backfill pass, not retried
+  in a loop.
+  """
+  def reset_fetch_by_id_count! do
+    if :ets.whereis(@fetch_by_id_counts_table) == :undefined do
+      :ets.new(@fetch_by_id_counts_table, [:named_table, :public, :set])
+    else
+      :ets.delete_all_objects(@fetch_by_id_counts_table)
+    end
+
+    :ok
+  end
+
+  @doc "Number of `fetch_by_id/3` calls observed for `provider_id` since the last reset."
+  def fetch_by_id_count(provider_id) do
+    case :ets.whereis(@fetch_by_id_counts_table) do
+      :undefined ->
+        0
+
+      _tid ->
+        case :ets.lookup(@fetch_by_id_counts_table, provider_id) do
+          [{^provider_id, count}] -> count
+          [] -> 0
+        end
+    end
+  end
+
   @impl true
   def test_connection(_config), do: {:ok, %{status: "ok"}}
 
@@ -78,6 +112,8 @@ defmodule Mydia.MetadataStubProvider do
 
   @impl true
   def fetch_by_id(_config, provider_id, opts) do
+    count_fetch_by_id_call(provider_id)
+
     cond do
       provider_id == to_string(@missing_id) ->
         {:error, Error.not_found("Media not found: #{@missing_id}")}
@@ -128,6 +164,18 @@ defmodule Mydia.MetadataStubProvider do
   def fetch_trending(_config, _opts), do: {:ok, []}
 
   ## Catalog
+
+  defp count_fetch_by_id_call(provider_id) do
+    case :ets.whereis(@fetch_by_id_counts_table) do
+      :undefined ->
+        :ok
+
+      _tid ->
+        :ets.update_counter(@fetch_by_id_counts_table, provider_id, {2, 1}, {provider_id, 0})
+    end
+
+    :ok
+  end
 
   defp maybe_block_season_fetch do
     case :persistent_term.get(@season_fetch_block_key, nil) do


### PR DESCRIPTION
## Summary

When managing media requests, the cards showed only a title, so an admin had nothing to judge a request by and no way to see more without leaving the page. This adds a poster to every request card and makes the title open the same rich detail popup Discovery and the Dashboard already use.

Both `/admin/requests` and `/requests` are covered. They previously duplicated about ninety lines of card markup and three formatting helpers apiece; both now render through one shared component.

## What changed

- **`media_requests.poster_path`** (new nullable `:text` column). Populated at request creation by both existing creation paths, which already had the value and were discarding it. Rows created before the column existed fill in lazily on first view, so no data migration reaches the network at boot.
- **`MydiaWeb.MediaRequestComponents.request_card/1`**, a shared card with `:badges`, `:details` and `:actions` slots. Each page keeps its own differences in slot content rather than the component growing a flag per difference.
- **Metadata resolution routes on whichever id the row stored.** A TV request made while the instance is set to TVDB metadata carries only a `tvdb_id`, so a TMDB-only lookup would have left every TV request on those instances with no poster and no popup.
- **An optional `:actions` slot on `TrendingDetailModal`.** Its default footer renders unchanged when the slot is absent, so the Dashboard and Discovery callers are untouched. The requests pages supply Approve, Reject, View in Library and Close instead, because "Add to Library" there would create the media item while leaving the request stuck in `pending`.
- **Approve and Reject from inside the popup** close the detail dialog in the same render that opens the approve dialog, so two dialogs are never on screen at once. That matters because the modal's `phx-window-keydown` Escape binding is not scoped by visual stacking.

## Notes for review

- A request with only an `imdb_id` is permitted by the schema. Those render the placeholder poster and a non-clickable title; one predicate gates the click target, the backfill and the popup so they cannot disagree.
- The poster backfill marks request ids attempted at send time and runs at most once per row per connected socket. Marking on completion instead would loop forever on any row whose fetch permanently fails, since `poster_path` stays nil and the row keeps qualifying.
- Relay failures degrade to the existing placeholder rather than retrying in a loop; the next page visit retries.

## Testing

- `mix test` on SQLite: 13 doctests, 9089 tests, 0 failures
- `DATABASE_TYPE=postgres mix test` across the touched suites: 76 tests, 0 failures
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`: all clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request detail popups with metadata, actions, and library navigation.
  * Added poster artwork to media requests, including automatic backfilling and placeholders.
  * Improved request cards with status badges, dates, media details, and context-aware actions.
  * Added library links for approved requests with available media.
* **Bug Fixes**
  * Prevented repeated metadata and poster lookups for unresolved requests.
  * Improved handling of requests lacking provider identifiers.
  * Prevented individual metadata or poster failures from interrupting request displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->