### PR TITLE
feat(ui): dashboard tile links, media page layout, discover modal, poster hover

### DIFF
--- a/lib/mydia/accounts/user_preference.ex
+++ b/lib/mydia/accounts/user_preference.ex
@@ -18,7 +18,8 @@ defmodule Mydia.Accounts.UserPreference do
     "interface_language" => "en",
     "theme" => "system",
     "close_manual_search_after_grab" => false,
-    "grid_density" => "comfortable"
+    "grid_density" => "comfortable",
+    "recommendations_expanded" => false
   }
 
   # Valid values for each preference
@@ -83,6 +84,17 @@ defmodule Mydia.Accounts.UserPreference do
   end
 
   @doc """
+  Whether the More Like This rail on a show's detail page starts open.
+
+  Only shows collapse the rail. `MydiaWeb.DiscoverComponents.media_rail/1`
+  computes `open? = not collapsible or expanded`, and the rail is collapsible
+  only for a tv_show, so a movie ignores this value.
+  """
+  def recommendations_expanded(%__MODULE__{preferences: prefs}) do
+    Map.get(prefs, "recommendations_expanded", @defaults["recommendations_expanded"])
+  end
+
+  @doc """
   Changeset for creating or updating user preferences.
 
   The `preferences` param should be a map with string keys, e.g.:
@@ -118,6 +130,7 @@ defmodule Mydia.Accounts.UserPreference do
     |> validate_preference_value("interface_language", @valid_languages)
     |> validate_preference_value("close_manual_search_after_grab", [true, false])
     |> validate_preference_value("grid_density", @valid_densities)
+    |> validate_preference_value("recommendations_expanded", [true, false])
   end
 
   defp validate_preference_value(changeset, key, valid_values) do

--- a/lib/mydia_web/components/collection_components.ex
+++ b/lib/mydia_web/components/collection_components.ex
@@ -191,7 +191,7 @@ defmodule MydiaWeb.CollectionComponents do
 
   defp poster_collage(%{poster_paths: []} = assigns) do
     ~H"""
-    <div class="w-full h-full flex flex-col items-center justify-center bg-gradient-to-br from-base-200 to-base-300">
+    <div class="w-full h-full flex flex-col items-center justify-center bg-gradient-to-br from-base-200 to-base-300 group-hover:scale-105 transition-transform duration-300">
       <.icon
         name={if @collection_type == "smart", do: "hero-sparkles", else: "hero-folder"}
         class="w-16 h-16 text-base-content/20"
@@ -220,7 +220,7 @@ defmodule MydiaWeb.CollectionComponents do
       |> assign(:url2, tmdb_poster_url(path2))
 
     ~H"""
-    <div class="grid grid-cols-2 w-full h-full">
+    <div class="grid grid-cols-2 w-full h-full group-hover:scale-105 transition-transform duration-300">
       <img src={@url1} alt="" class="w-full h-full object-cover" loading="lazy" />
       <img src={@url2} alt="" class="w-full h-full object-cover" loading="lazy" />
     </div>
@@ -235,7 +235,7 @@ defmodule MydiaWeb.CollectionComponents do
       |> assign(:url3, tmdb_poster_url(path3))
 
     ~H"""
-    <div class="grid grid-cols-2 w-full h-full">
+    <div class="grid grid-cols-2 w-full h-full group-hover:scale-105 transition-transform duration-300">
       <img src={@url1} alt="" class="w-full h-full object-cover row-span-2" loading="lazy" />
       <div class="flex flex-col">
         <img src={@url2} alt="" class="w-full h-1/2 object-cover" loading="lazy" />
@@ -256,7 +256,7 @@ defmodule MydiaWeb.CollectionComponents do
       |> assign(:url4, tmdb_poster_url(path4))
 
     ~H"""
-    <div class="grid grid-cols-2 grid-rows-2 w-full h-full">
+    <div class="grid grid-cols-2 grid-rows-2 w-full h-full group-hover:scale-105 transition-transform duration-300">
       <img src={@url1} alt="" class="w-full h-full object-cover" loading="lazy" />
       <img src={@url2} alt="" class="w-full h-full object-cover" loading="lazy" />
       <img src={@url3} alt="" class="w-full h-full object-cover" loading="lazy" />

--- a/lib/mydia_web/components/core_components.ex
+++ b/lib/mydia_web/components/core_components.ex
@@ -494,7 +494,13 @@ defmodule MydiaWeb.CoreComponents do
         loading={@loading}
         class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
       />
-      <div :if={is_nil(@src)} class="w-full h-full flex items-center justify-center">
+      <%!-- The fallback carries the same hover transform as the img above. A card
+            whose poster is missing is still a link, and a grid where only some
+            cards lift on hover reads as broken rather than as a distinction. --%>
+      <div
+        :if={is_nil(@src)}
+        class="w-full h-full flex items-center justify-center group-hover:scale-105 transition-transform duration-300"
+      >
         <.icon name={@fallback_icon} class="w-16 h-16 text-base-content/20" />
       </div>
       {render_slot(@overlay)}

--- a/lib/mydia_web/components/core_components.ex
+++ b/lib/mydia_web/components/core_components.ex
@@ -449,6 +449,59 @@ defmodule MydiaWeb.CoreComponents do
     """
   end
 
+  @doc """
+  A 2:3 poster in a hover-scaling figure.
+
+  The hover transform used to be hand-written at every poster grid in the app,
+  which is why three of them had it and five did not. It lives here now so a
+  new grid gets it by construction.
+
+  The `group` class stays on the caller's own wrapper rather than moving in
+  here. Those wrappers differ per page: some are a plain `relative group`, the
+  Libraries grid's also carries `phx-click` and a `data-selected` attribute,
+  and a presentation component has no business owning them.
+
+  `loading` accepts nil to render no attribute at all. See the note on
+  `MydiaWeb.DiscoverComponents.trending_card/1`'s `:loading` attr: lazy-loading
+  an above-the-fold poster is what starved the Dashboard's LCP poster under 40
+  competing requests.
+
+  ## Examples
+
+      <div class="group">
+        <.poster_figure src={poster_url(item)} alt={item.title} class="rounded-t-box">
+          <:overlay>
+            <span class="badge badge-warning absolute top-2 left-2">8.1</span>
+          </:overlay>
+        </.poster_figure>
+      </div>
+  """
+  attr :src, :string, default: nil
+  attr :alt, :string, required: true
+  attr :loading, :string, default: "lazy"
+  attr :fallback_icon, :string, default: "hero-film"
+  attr :class, :string, default: nil
+
+  slot :overlay, doc: "badges, progress bars and other chrome layered over the poster"
+
+  def poster_figure(assigns) do
+    ~H"""
+    <figure class={["relative aspect-[2/3] overflow-hidden bg-base-300", @class]}>
+      <img
+        :if={@src}
+        src={@src}
+        alt={@alt}
+        loading={@loading}
+        class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+      />
+      <div :if={is_nil(@src)} class="w-full h-full flex items-center justify-center">
+        <.icon name={@fallback_icon} class="w-16 h-16 text-base-content/20" />
+      </div>
+      {render_slot(@overlay)}
+    </figure>
+    """
+  end
+
   ## JS Commands
 
   def show(js \\ %JS{}, selector) do

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -5,7 +5,7 @@ defmodule MydiaWeb.DiscoverComponents do
   """
   use Phoenix.Component
 
-  import MydiaWeb.CoreComponents, only: [icon: 1]
+  import MydiaWeb.CoreComponents, only: [icon: 1, poster_figure: 1]
 
   alias Mydia.Metadata.ImageUrl
   alias MydiaWeb.LibraryComponents
@@ -71,7 +71,7 @@ defmodule MydiaWeb.DiscoverComponents do
 
     ~H"""
     <div class={[
-      "card bg-base-100 shadow-sm hover:shadow-md transition-shadow relative",
+      "card bg-base-100 shadow-sm hover:shadow-md transition-shadow relative group",
       @current && "ring-2 ring-primary"
     ]}>
       <%= if (vote = Map.get(@item, :vote_average)) && vote > 0 do %>
@@ -98,18 +98,16 @@ defmodule MydiaWeb.DiscoverComponents do
       <%= cond do %>
         <% @navigate -> %>
           <.link navigate={@navigate} class="block">
-            <figure class="aspect-[2/3] bg-base-300 cursor-pointer overflow-hidden rounded-t-box">
-              <.card_poster
-                item={@item}
-                media_type={@media_type}
-                loading={@loading}
-                poster_size={@poster_size}
-              />
-            </figure>
+            <.card_poster
+              item={@item}
+              media_type={@media_type}
+              loading={@loading}
+              poster_size={@poster_size}
+              class="cursor-pointer rounded-t-box"
+            />
           </.link>
         <% @on_select -> %>
-          <figure
-            class="aspect-[2/3] bg-base-300 cursor-pointer overflow-hidden rounded-t-box"
+          <div
             phx-click={@on_select}
             phx-value-id={@item.provider_id}
             phx-value-type={@media_type}
@@ -119,17 +117,17 @@ defmodule MydiaWeb.DiscoverComponents do
               media_type={@media_type}
               loading={@loading}
               poster_size={@poster_size}
+              class="cursor-pointer rounded-t-box"
             />
-          </figure>
+          </div>
         <% true -> %>
-          <figure class="aspect-[2/3] bg-base-300 overflow-hidden rounded-t-box">
-            <.card_poster
-              item={@item}
-              media_type={@media_type}
-              loading={@loading}
-              poster_size={@poster_size}
-            />
-          </figure>
+          <.card_poster
+            item={@item}
+            media_type={@media_type}
+            loading={@loading}
+            poster_size={@poster_size}
+            class="rounded-t-box"
+          />
       <% end %>
       <div class="card-body p-3">
         <h3 class="font-semibold text-sm line-clamp-2" title={@item.title}>
@@ -363,24 +361,17 @@ defmodule MydiaWeb.DiscoverComponents do
   # :loading attr for why that matters for an above-the-fold grid.
   attr :loading, :string, default: nil
   attr :poster_size, :string, default: "w500"
+  attr :class, :string, default: nil
 
   defp card_poster(assigns) do
     ~H"""
-    <%= if @item.poster_path do %>
-      <img
-        src={ImageUrl.poster_url(@item.poster_path, @poster_size)}
-        alt={@item.title}
-        loading={@loading}
-        class="w-full h-full object-cover"
-      />
-    <% else %>
-      <div class="flex items-center justify-center w-full h-full">
-        <.icon
-          name={if(@media_type == :movie, do: "hero-film", else: "hero-tv")}
-          class="w-16 h-16 text-base-content/20"
-        />
-      </div>
-    <% end %>
+    <.poster_figure
+      src={@item.poster_path && ImageUrl.poster_url(@item.poster_path, @poster_size)}
+      alt={@item.title}
+      loading={@loading}
+      fallback_icon={if(@media_type == :movie, do: "hero-film", else: "hero-tv")}
+      class={@class}
+    />
     """
   end
 end

--- a/lib/mydia_web/live/add_media_live/index.html.heex
+++ b/lib/mydia_web/live/add_media_live/index.html.heex
@@ -160,28 +160,24 @@
             <% media_item_id = Map.get(@added_item_ids, tmdb_id) %>
             <% is_added = !is_nil(media_item_id) %>
             <% is_adding = @adding_index == index %>
-            <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow overflow-hidden">
-              <figure class="relative aspect-[2/3] overflow-hidden bg-base-300">
-                <img
-                  src={get_poster_url(result)}
-                  alt={result.title || result.name}
-                  class="w-full h-full object-cover"
-                  loading="lazy"
-                />
-                <%= if result.vote_average do %>
-                  <div class="badge badge-primary badge-sm absolute top-2 right-2">
-                    <.icon name="hero-star-solid" class="w-3 h-3 mr-1" />
-                    {format_rating(result.vote_average)}
-                  </div>
-                <% end %>
-                <%= if is_added do %>
-                  <div class="absolute inset-0 bg-success/20 flex items-center justify-center">
-                    <div class="badge badge-success gap-1">
-                      <.icon name="hero-check" class="w-4 h-4" /> Added
+            <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow overflow-hidden group">
+              <.poster_figure src={get_poster_url(result)} alt={result.title || result.name}>
+                <:overlay>
+                  <%= if result.vote_average do %>
+                    <div class="badge badge-primary badge-sm absolute top-2 right-2">
+                      <.icon name="hero-star-solid" class="w-3 h-3 mr-1" />
+                      {format_rating(result.vote_average)}
                     </div>
-                  </div>
-                <% end %>
-              </figure>
+                  <% end %>
+                  <%= if is_added do %>
+                    <div class="absolute inset-0 bg-success/20 flex items-center justify-center">
+                      <div class="badge badge-success gap-1">
+                        <.icon name="hero-check" class="w-4 h-4" /> Added
+                      </div>
+                    </div>
+                  <% end %>
+                </:overlay>
+              </.poster_figure>
               <div class="card-body p-3">
                 <h3 class="card-title text-sm line-clamp-2 h-10">
                   {result.title || result.name}

--- a/lib/mydia_web/live/collection_live/show.ex
+++ b/lib/mydia_web/live/collection_live/show.ex
@@ -234,21 +234,7 @@ defmodule MydiaWeb.CollectionLive.Show do
 
             <.link navigate={item_href(item)} class="block">
               <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
-                <figure class="relative aspect-[2/3] overflow-hidden bg-base-300">
-                  <img
-                    :if={item.poster_url}
-                    src={item.poster_url}
-                    alt={item.title}
-                    class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                    loading="lazy"
-                  />
-                  <div
-                    :if={!item.poster_url}
-                    class="w-full h-full flex items-center justify-center"
-                  >
-                    <.icon name="hero-film" class="w-12 h-12 text-base-content/20" />
-                  </div>
-                </figure>
+                <.poster_figure src={item.poster_url} alt={item.title} />
                 <div class="card-body p-3">
                   <h3 class="card-title text-sm line-clamp-2">{item.title}</h3>
                   <span class="text-xs text-base-content/70">{item.year}</span>

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -76,9 +76,12 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
               <div class="w-full h-full bg-gradient-to-br from-primary/20 to-secondary/20"></div>
             <% end %>
 
-            <%!-- Close button --%>
+            <%!-- Close button. Icon-only (and, since the footer's labeled Close
+                 button was removed, the sole click-based way to close the
+                 modal), so aria-label carries its accessible name. --%>
             <button
               phx-click="close_details"
+              aria-label="Close"
               class="btn btn-circle btn-ghost btn-sm absolute top-4 right-4 z-10 bg-base-100/50 hover:bg-base-100"
             >
               <.icon name="hero-x-mark" class="w-5 h-5" />

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -19,6 +19,10 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
         picker_open={@library_picker != nil}
       />
 
+  The box is a flex column: a fixed header, then one scrolling child. Any new
+  content belongs inside `#trending-detail-modal-body`, not as a sibling of it,
+  or it will sit outside the scroll region and be unreachable.
+
   ## Events
 
   The component emits these events to the parent LiveView:
@@ -30,11 +34,12 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
 
   Both host LiveViews also render `MydiaWeb.Components.LibraryComponents.library_picker_dialog/1`
   once per page, at `z-[1000]`, above this modal's `z-999`. That dialog can be
-  opened from this modal's footer, and both dialogs bind `phx-window-keydown`
-  with `phx-key="Escape"` as a workaround for `open`-attribute dialogs getting
-  no native Escape handling. `phx-window-keydown` is not scoped by visual
-  stacking, so without `picker_open` a single Escape press would close both
-  layers at once instead of only the top one.
+  opened from this modal's header actions, and both dialogs bind
+  `phx-window-keydown` with `phx-key="Escape"` as a workaround for
+  `open`-attribute dialogs getting no native Escape handling.
+  `phx-window-keydown` is not scoped by visual stacking, so without
+  `picker_open` a single Escape press would close both layers at once instead
+  of only the top one.
 
   Every caller must pass `picker_open` (whether the library picker dialog is
   currently open for this LiveView). There is deliberately no default — a
@@ -56,9 +61,9 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
       phx-key="Escape"
     >
       <%= if @open do %>
-        <div class="modal-box max-w-5xl w-11/12 max-h-[90vh] p-0 overflow-y-auto">
+        <div class="modal-box max-w-5xl w-11/12 max-h-[90vh] p-0 flex flex-col overflow-hidden">
           <%!-- Header with backdrop --%>
-          <div class="relative h-48 md:h-64 bg-base-300">
+          <div class="relative h-48 md:h-64 bg-base-300 shrink-0">
             <%= if backdrop_path(@item, @metadata) do %>
               <img
                 src={ImageUrl.backdrop_url(backdrop_path(@item, @metadata), "w1280")}
@@ -81,7 +86,7 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
 
             <%!-- Title overlay --%>
             <div class="absolute bottom-0 left-0 right-0 p-4 md:p-6">
-              <div class="flex items-end gap-4">
+              <div class="flex flex-wrap items-end gap-4">
                 <%= if poster_path(@item, @metadata) do %>
                   <img
                     src={ImageUrl.poster_url(poster_path(@item, @metadata), "w185")}
@@ -119,126 +124,132 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
                     <% end %>
                   </div>
                 </div>
+                <div
+                  id="trending-detail-modal-actions"
+                  class="flex flex-wrap items-center gap-2 shrink-0"
+                >
+                  <%= if not in_library?(@item) do %>
+                    <%= if @current_user && @current_user.role == "guest" do %>
+                      <button
+                        phx-click="request_media"
+                        phx-value-tmdb_id={@item.provider_id}
+                        phx-value-media_type={media_type_string(@item)}
+                        disabled={Map.get(@item, :request_status) != nil}
+                        class="btn btn-primary"
+                      >
+                        <%= if Map.get(@item, :request_status) do %>
+                          <.icon name="hero-check" class="w-4 h-4" /> Requested
+                        <% else %>
+                          <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
+                        <% end %>
+                      </button>
+                    <% else %>
+                      <div class="join">
+                        <button
+                          phx-click="add_to_library"
+                          phx-value-tmdb_id={@item.provider_id}
+                          phx-value-media_type={media_type_string(@item)}
+                          class="btn btn-primary join-item"
+                        >
+                          <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
+                        </button>
+                        <.library_picker_button
+                          libraries={@libraries}
+                          tmdb_id={@item.provider_id}
+                          media_type={media_type_string(@item)}
+                          title={@item.title}
+                        />
+                      </div>
+                    <% end %>
+                  <% else %>
+                    <.link navigate={library_path(@item)} class="btn btn-ghost">
+                      <.icon name="hero-arrow-right" class="w-4 h-4" />
+                      Go to {media_type_label(@item)}
+                    </.link>
+                  <% end %>
+                </div>
               </div>
             </div>
           </div>
 
-          <%!-- Body content --%>
-          <div class="p-4 md:p-6">
-            <%= if @loading do %>
-              <div class="flex items-center justify-center py-12">
-                <span class="loading loading-spinner loading-lg"></span>
-                <span class="ml-3 text-base-content/70">Loading details...</span>
-              </div>
-            <% else %>
-              <div class="space-y-6">
-                <%!-- Trailer --%>
-                <%= if first_trailer(@metadata) do %>
-                  <div>
-                    <h3 class="text-lg font-semibold mb-3">Trailer</h3>
-                    <div class="aspect-video rounded-lg overflow-hidden bg-base-300">
-                      <iframe
-                        src={Video.youtube_embed_url(first_trailer(@metadata)) <> "?rel=0&modestbranding=1"}
-                        title="Trailer"
-                        class="w-full h-full"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowfullscreen
-                      ></iframe>
-                    </div>
-                  </div>
-                <% end %>
-
-                <%!-- Synopsis --%>
-                <%= if overview(@item, @metadata) do %>
-                  <div>
-                    <h3 class="text-lg font-semibold mb-2">Synopsis</h3>
-                    <p class="text-base-content/80 leading-relaxed">{overview(@item, @metadata)}</p>
-                  </div>
-                <% end %>
-
-                <%!-- Cast --%>
-                <%= if cast(@metadata) != [] do %>
-                  <div>
-                    <h3 class="text-lg font-semibold mb-3">Cast</h3>
-                    <div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
-                      <%= for member <- Enum.take(cast(@metadata), 6) do %>
-                        <div class="text-center">
-                          <%= if member.profile_path do %>
-                            <img
-                              src={ImageUrl.profile_url(member.profile_path)}
-                              alt={member.name}
-                              class="w-16 h-16 md:w-20 md:h-20 rounded-full object-cover mx-auto mb-2"
-                            />
-                          <% else %>
-                            <div class="w-16 h-16 md:w-20 md:h-20 rounded-full bg-base-300 flex items-center justify-center mx-auto mb-2">
-                              <.icon name="hero-user" class="w-8 h-8 text-base-content/30" />
-                            </div>
-                          <% end %>
-                          <p class="text-sm font-medium line-clamp-1">{member.name}</p>
-                          <%= if member.character do %>
-                            <p class="text-xs text-base-content/60 line-clamp-1">
-                              {member.character}
-                            </p>
-                          <% end %>
-                        </div>
-                      <% end %>
-                    </div>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
-
-          <%!-- Optional trailing content, e.g. a recommendations rail. Rendered
-               inside the modal box so it scrolls with the body; a rail placed
-               beside the <dialog> would sit behind the backdrop. --%>
-          <div :if={@rail != []} class="px-4 md:px-6 pb-4">
-            {render_slot(@rail)}
-          </div>
-
-          <%!-- Footer actions --%>
-          <div class="p-4 md:p-6 border-t border-base-300 bg-base-100 flex justify-end gap-2">
-            <button class="btn btn-ghost" phx-click="close_details">
-              Close
-            </button>
-            <%= if not in_library?(@item) do %>
-              <%= if @current_user && @current_user.role == "guest" do %>
-                <button
-                  phx-click="request_media"
-                  phx-value-tmdb_id={@item.provider_id}
-                  phx-value-media_type={media_type_string(@item)}
-                  disabled={Map.get(@item, :request_status) != nil}
-                  class="btn btn-primary"
-                >
-                  <%= if Map.get(@item, :request_status) do %>
-                    <.icon name="hero-check" class="w-4 h-4" /> Requested
-                  <% else %>
-                    <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
-                  <% end %>
-                </button>
+          <div id="trending-detail-modal-body" class="flex-1 overflow-y-auto">
+            <%!-- Body content --%>
+            <div class="p-4 md:p-6">
+              <%= if @loading do %>
+                <div class="flex items-center justify-center py-12">
+                  <span class="loading loading-spinner loading-lg"></span>
+                  <span class="ml-3 text-base-content/70">Loading details...</span>
+                </div>
               <% else %>
-                <div class="join">
-                  <button
-                    phx-click="add_to_library"
-                    phx-value-tmdb_id={@item.provider_id}
-                    phx-value-media_type={media_type_string(@item)}
-                    class="btn btn-primary join-item"
-                  >
-                    <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
-                  </button>
-                  <.library_picker_button
-                    libraries={@libraries}
-                    tmdb_id={@item.provider_id}
-                    media_type={media_type_string(@item)}
-                    title={@item.title}
-                  />
+                <div class="space-y-6">
+                  <%!-- Trailer --%>
+                  <%= if first_trailer(@metadata) do %>
+                    <div>
+                      <h3 class="text-lg font-semibold mb-3">Trailer</h3>
+                      <div class="aspect-video rounded-lg overflow-hidden bg-base-300">
+                        <iframe
+                          src={
+                            Video.youtube_embed_url(first_trailer(@metadata)) <>
+                              "?rel=0&modestbranding=1"
+                          }
+                          title="Trailer"
+                          class="w-full h-full"
+                          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                          allowfullscreen
+                        ></iframe>
+                      </div>
+                    </div>
+                  <% end %>
+
+                  <%!-- Synopsis --%>
+                  <%= if overview(@item, @metadata) do %>
+                    <div>
+                      <h3 class="text-lg font-semibold mb-2">Synopsis</h3>
+                      <p class="text-base-content/80 leading-relaxed">
+                        {overview(@item, @metadata)}
+                      </p>
+                    </div>
+                  <% end %>
+
+                  <%!-- Cast --%>
+                  <%= if cast(@metadata) != [] do %>
+                    <div>
+                      <h3 class="text-lg font-semibold mb-3">Cast</h3>
+                      <div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
+                        <%= for member <- Enum.take(cast(@metadata), 6) do %>
+                          <div class="text-center">
+                            <%= if member.profile_path do %>
+                              <img
+                                src={ImageUrl.profile_url(member.profile_path)}
+                                alt={member.name}
+                                class="w-16 h-16 md:w-20 md:h-20 rounded-full object-cover mx-auto mb-2"
+                              />
+                            <% else %>
+                              <div class="w-16 h-16 md:w-20 md:h-20 rounded-full bg-base-300 flex items-center justify-center mx-auto mb-2">
+                                <.icon name="hero-user" class="w-8 h-8 text-base-content/30" />
+                              </div>
+                            <% end %>
+                            <p class="text-sm font-medium line-clamp-1">{member.name}</p>
+                            <%= if member.character do %>
+                              <p class="text-xs text-base-content/60 line-clamp-1">
+                                {member.character}
+                              </p>
+                            <% end %>
+                          </div>
+                        <% end %>
+                      </div>
+                    </div>
+                  <% end %>
                 </div>
               <% end %>
-            <% else %>
-              <.link navigate={library_path(@item)} class="btn btn-ghost">
-                <.icon name="hero-arrow-right" class="w-4 h-4" /> Go to {media_type_label(@item)}
-              </.link>
-            <% end %>
+            </div>
+
+            <%!-- Optional trailing content, e.g. a recommendations rail. Rendered
+                 inside the scrolling body so it scrolls with it; a rail placed
+                 beside the <dialog> would sit behind the backdrop. --%>
+            <div :if={@rail != []} class="px-4 md:px-6 pb-4">
+              {render_slot(@rail)}
+            </div>
           </div>
         </div>
 

--- a/lib/mydia_web/live/dashboard_live/components.ex
+++ b/lib/mydia_web/live/dashboard_live/components.ex
@@ -12,7 +12,7 @@ defmodule MydiaWeb.DashboardLive.Components do
   use Phoenix.Component
   use MydiaWeb, :verified_routes
 
-  import MydiaWeb.CoreComponents, only: [icon: 1]
+  import MydiaWeb.CoreComponents, only: [icon: 1, poster_figure: 1]
 
   alias MydiaWeb.Live.Helpers.MediaImages
 
@@ -39,22 +39,22 @@ defmodule MydiaWeb.DashboardLive.Components do
           id={"#{@id}-item-#{entry.media_item.id}"}
           class="snap-start flex-shrink-0 w-36"
         >
-          <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
+          <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden group">
             <.link navigate={~p"/media/#{entry.media_item.id}"}>
-              <figure class="relative aspect-[2/3] overflow-hidden bg-base-300">
-                <img
-                  src={MediaImages.poster_url(entry.media_item, "w342")}
-                  alt={entry.media_item.title}
-                  class="w-full h-full object-cover"
-                  loading={if index < 6, do: nil, else: "lazy"}
-                />
-                <span
-                  :if={new_episode_label(entry)}
-                  class="absolute bottom-1 left-1 right-1 badge badge-primary badge-sm justify-center truncate"
-                >
-                  {new_episode_label(entry)}
-                </span>
-              </figure>
+              <.poster_figure
+                src={MediaImages.poster_url(entry.media_item, "w342")}
+                alt={entry.media_item.title}
+                loading={if(index < 6, do: nil, else: "lazy")}
+              >
+                <:overlay>
+                  <span
+                    :if={new_episode_label(entry)}
+                    class="absolute bottom-1 left-1 right-1 badge badge-primary badge-sm justify-center truncate"
+                  >
+                    {new_episode_label(entry)}
+                  </span>
+                </:overlay>
+              </.poster_figure>
             </.link>
             <div class="card-body p-3">
               <h3 class="card-title text-sm line-clamp-2" title={entry.media_item.title}>

--- a/lib/mydia_web/live/dashboard_live/components.ex
+++ b/lib/mydia_web/live/dashboard_live/components.ex
@@ -12,6 +12,8 @@ defmodule MydiaWeb.DashboardLive.Components do
   use Phoenix.Component
   use MydiaWeb, :verified_routes
 
+  import MydiaWeb.CoreComponents, only: [icon: 1]
+
   alias MydiaWeb.Live.Helpers.MediaImages
 
   @doc """
@@ -77,4 +79,56 @@ defmodule MydiaWeb.DashboardLive.Components do
   end
 
   defp new_episode_label(_entry), do: nil
+
+  @doc """
+  One dashboard stat card, optionally a link.
+
+  `navigate` is nil for a tile with no destination, which renders the plain
+  card the dashboard had before. The caller decides whether a destination is
+  allowed for the current viewer: the Storage tile's target is admin-only and
+  this row renders for every role, so keeping the role test at the call site
+  keeps authorization out of a presentation component.
+  """
+  attr :id, :string, required: true
+  attr :icon, :string, required: true
+  attr :label, :string, required: true
+  attr :value, :any, required: true
+  attr :caption, :string, required: true
+  attr :navigate, :string, default: nil
+
+  def stat_tile(assigns) do
+    ~H"""
+    <.link
+      :if={@navigate}
+      id={@id}
+      navigate={@navigate}
+      class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow"
+    >
+      <.stat_tile_body icon={@icon} label={@label} value={@value} caption={@caption} />
+    </.link>
+    <div :if={is_nil(@navigate)} id={@id} class="card bg-base-100 shadow-sm">
+      <.stat_tile_body icon={@icon} label={@label} value={@value} caption={@caption} />
+    </div>
+    """
+  end
+
+  # The body is repeated across both branches of stat_tile/1 by way of this
+  # component rather than inline, because HEEx cannot swap a tag name and the
+  # link and non-link branches need different elements.
+  attr :icon, :string, required: true
+  attr :label, :string, required: true
+  attr :value, :any, required: true
+  attr :caption, :string, required: true
+
+  defp stat_tile_body(assigns) do
+    ~H"""
+    <div class="card-body">
+      <h2 class="card-title">
+        <.icon name={@icon} class="w-6 h-6 text-primary" /> {@label}
+      </h2>
+      <p class="text-3xl font-bold">{@value}</p>
+      <p class="text-sm text-base-content/60">{@caption}</p>
+    </div>
+    """
+  end
 end

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -28,50 +28,40 @@
   </a>
 
   <!-- Stats Cards -->
+  <% admin? = @current_user && @current_user.role == "admin" %>
   <div class="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4 mb-6 md:mb-8">
-    <!-- Movies Card -->
-    <div class="card bg-base-100 shadow-sm">
-      <div class="card-body">
-        <h2 class="card-title">
-          <.icon name="hero-film" class="w-6 h-6 text-primary" /> Movies
-        </h2>
-        <p class="text-3xl font-bold">{@movie_count}</p>
-        <p class="text-sm text-base-content/60">Total movies</p>
-      </div>
-    </div>
-
-    <!-- TV Shows Card -->
-    <div class="card bg-base-100 shadow-sm">
-      <div class="card-body">
-        <h2 class="card-title">
-          <.icon name="hero-tv" class="w-6 h-6 text-primary" /> TV Shows
-        </h2>
-        <p class="text-3xl font-bold">{@tv_show_count}</p>
-        <p class="text-sm text-base-content/60">Total series</p>
-      </div>
-    </div>
-
-    <!-- Downloads Card -->
-    <div class="card bg-base-100 shadow-sm">
-      <div class="card-body">
-        <h2 class="card-title">
-          <.icon name="hero-arrow-down-tray" class="w-6 h-6 text-primary" /> Downloads
-        </h2>
-        <p class="text-3xl font-bold">{@active_downloads_count}</p>
-        <p class="text-sm text-base-content/60">Active downloads</p>
-      </div>
-    </div>
-
-    <!-- Storage Card -->
-    <div class="card bg-base-100 shadow-sm">
-      <div class="card-body">
-        <h2 class="card-title">
-          <.icon name="hero-circle-stack" class="w-6 h-6 text-primary" /> Storage
-        </h2>
-        <p class="text-3xl font-bold">{@total_storage}</p>
-        <p class="text-sm text-base-content/60">Total storage used</p>
-      </div>
-    </div>
+    <Components.stat_tile
+      id="stat-tile-movies"
+      icon="hero-film"
+      label="Movies"
+      value={@movie_count}
+      caption="Total movies"
+      navigate={~p"/movies"}
+    />
+    <Components.stat_tile
+      id="stat-tile-tv-shows"
+      icon="hero-tv"
+      label="TV Shows"
+      value={@tv_show_count}
+      caption="Total series"
+      navigate={~p"/tv"}
+    />
+    <Components.stat_tile
+      id="stat-tile-downloads"
+      icon="hero-arrow-down-tray"
+      label="Downloads"
+      value={@active_downloads_count}
+      caption="Active downloads"
+      navigate={~p"/downloads"}
+    />
+    <Components.stat_tile
+      id="stat-tile-storage"
+      icon="hero-circle-stack"
+      label="Storage"
+      value={@total_storage}
+      caption="Total storage used"
+      navigate={if(admin?, do: ~p"/admin/config/library-paths", else: nil)}
+    />
   </div>
 
   <!-- Quick Actions -->

--- a/lib/mydia_web/live/helpers/recommendations_expanded.ex
+++ b/lib/mydia_web/live/helpers/recommendations_expanded.ex
@@ -1,0 +1,61 @@
+defmodule MydiaWeb.Live.Helpers.RecommendationsExpanded do
+  @moduledoc """
+  Reads and persists whether the More Like This rail on a media detail page is
+  open.
+
+  Modelled on `MydiaWeb.Live.Helpers.GridDensity`, which solves the same
+  problem for the shared poster-grid density. The rail used to reset to
+  collapsed on every mount, so a user who wanted it open had to reopen it on
+  every page load.
+
+  A guest or unauthenticated render has no preference row to read: it gets the
+  default, and its toggle clicks change the current view without being
+  persisted.
+  """
+
+  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.LiveView, only: [put_flash: 3]
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.UserPreference
+
+  @assign :recommendations_expanded
+
+  @doc """
+  Assigns the viewer's stored value, or the default when there is no user.
+  """
+  def assign_current(socket) do
+    assign(socket, @assign, current(socket))
+  end
+
+  @doc """
+  The viewer's stored value, or the default when there is no user.
+  """
+  def current(socket) do
+    case socket.assigns[:current_user] do
+      nil -> UserPreference.defaults()["recommendations_expanded"]
+      user -> user |> Accounts.get_user_preference!() |> UserPreference.recommendations_expanded()
+    end
+  end
+
+  @doc """
+  Persists the value for the viewer and reassigns it.
+
+  A rejected changeset leaves the stored value alone and flashes, rather than
+  silently showing a rail state that will not survive a reload.
+  """
+  def put(socket, expanded) when is_boolean(expanded) do
+    case socket.assigns[:current_user] do
+      nil ->
+        assign(socket, @assign, expanded)
+
+      user ->
+        preference = Accounts.get_user_preference!(user)
+
+        case Accounts.update_preference(preference, %{"recommendations_expanded" => expanded}) do
+          {:ok, _} -> assign(socket, @assign, expanded)
+          {:error, _changeset} -> put_flash(socket, :error, "Could not save that rail state")
+        end
+    end
+  end
+end

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -354,24 +354,19 @@
 
             <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
               <.link navigate={~p"/media/#{item.id}"}>
-                <figure class="relative aspect-[2/3] overflow-hidden bg-base-300">
-                  <img
-                    src={get_poster_url(item)}
-                    alt={item.title}
-                    class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                    loading="lazy"
-                  />
-                  <%!-- Progress indicators --%>
-                  <% progress = get_progress(item) %>
-                  <.progress_bar :if={progress} progress={progress} class="hide-on-select" />
-                  <%!-- Playback status and quality, stacked in one top-right container --%>
-                  <.poster_badges
-                    id={"poster-badges-#{item.id}"}
-                    progress={progress}
-                    quality={get_quality_badge(item)}
-                    class="hide-on-select"
-                  />
-                </figure>
+                <% progress = get_progress(item) %>
+                <.poster_figure src={get_poster_url(item)} alt={item.title}>
+                  <:overlay>
+                    <.progress_bar :if={progress} progress={progress} class="hide-on-select" />
+                    <%!-- Playback status and quality, stacked in one top-right container --%>
+                    <.poster_badges
+                      id={"poster-badges-#{item.id}"}
+                      progress={progress}
+                      quality={get_quality_badge(item)}
+                      class="hide-on-select"
+                    />
+                  </:overlay>
+                </.poster_figure>
               </.link>
               <div class="card-body p-3">
                 <h3 class="card-title text-sm line-clamp-2" title={item.title}>

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -20,6 +20,7 @@ defmodule MydiaWeb.MediaLive.Show do
   alias MydiaWeb.MediaLive.Show.RecommendationEvents
   alias MydiaWeb.MediaLive.Show.RecommendationComponents
   alias MydiaWeb.MediaLive.Show.LibraryPickerEvents
+  alias MydiaWeb.Live.Helpers.RecommendationsExpanded
 
   # Import helper modules
   import MydiaWeb.MediaLive.Show.Formatters
@@ -142,7 +143,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:adding_franchise_tmdb_ids, MapSet.new())
      # Recommendations rail state
      |> assign(:recommendations, [])
-     |> assign(:recommendations_expanded, false)
+     |> RecommendationsExpanded.assign_current()
      |> assign(:adding_recommendation_tmdb_ids, MapSet.new())
      |> assign(:requesting_recommendation_id, nil)
      |> assign_new(:metadata_config, fn -> Mydia.Metadata.default_relay_config() end)

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -183,7 +183,13 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:show_target_library_modal, false)
      # Trailer modal state
      |> assign(:show_trailer_modal, false)
-     # Collection state
+     # Collection state. show_add_to_collection_modal is initialized here,
+     # not inside load_collection_data/2: that helper also runs after every
+     # add/remove/favorite toggle to refresh the read model, and it must NOT
+     # force the modal closed on those refreshes, or picking more than one
+     # collection in a single sitting becomes impossible (the modal would
+     # slam shut after the very first pick). See CollectionEvents for detail.
+     |> assign(:show_add_to_collection_modal, false)
      |> CollectionEvents.load_collection_data(media_item)
      |> SegmentEvents.assign_segment_status(media_item)
      |> FranchiseEvents.maybe_load()

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -174,6 +174,13 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:show_category_modal, false)
      |> assign(:category_form, nil)
      |> assign(:available_categories, available_categories_for(media_item.type))
+     # Quality profile picker modal state. A page-level modal rather than an
+     # anchored dropdown because the hero column it lives in is
+     # `overflow-y-auto` (see Components.hero_section/1), and an anchored
+     # `.dropdown-content` gets clipped by that ancestor's overflow box.
+     |> assign(:show_quality_profile_modal, false)
+     # Target library picker modal state, same reasoning as above.
+     |> assign(:show_target_library_modal, false)
      # Trailer modal state
      |> assign(:show_trailer_modal, false)
      # Collection state
@@ -411,8 +418,20 @@ defmodule MydiaWeb.MediaLive.Show do
   def handle_event("reset_category_to_auto", params, socket),
     do: CategoryEvents.reset_category_to_auto(params, socket)
 
+  def handle_event("show_quality_profile_modal", params, socket),
+    do: CategoryEvents.show_quality_profile_modal(params, socket)
+
+  def handle_event("hide_quality_profile_modal", params, socket),
+    do: CategoryEvents.hide_quality_profile_modal(params, socket)
+
   def handle_event("update_quality_profile", params, socket),
     do: CategoryEvents.update_quality_profile(params, socket)
+
+  def handle_event("show_target_library_modal", params, socket),
+    do: LibraryEvents.show_target_library_modal(params, socket)
+
+  def handle_event("hide_target_library_modal", params, socket),
+    do: LibraryEvents.hide_target_library_modal(params, socket)
 
   def handle_event("update_target_library", params, socket),
     do: LibraryEvents.update_target_library(params, socket)

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -273,8 +273,23 @@
               serves both layouts, so there is no hidden/xl:block duplicate.
 
               Sticky for the same reason and with the same caveats as the hero
-              column: see the note there on self-start and the inner scroll. --%>
-        <aside class="md:col-span-2 xl:col-span-1 xl:col-start-3 xl:row-start-1 xl:sticky xl:top-4 xl:self-start xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto">
+              column: see the note there on self-start and the inner scroll.
+
+              The :if here is load-bearing alongside the grid template's own
+              @timeline_events == [] conditional above, and neither one makes
+              the other redundant: this aside carries xl:col-start-3 and
+              xl:row-start-1 unconditionally, so even when the grid template
+              picks the two-track layout, a rendered-but-empty aside would
+              still force Grid to open an implicit third column (and, below
+              xl, an implicit row) to satisfy that placement, and gap-4/gap-6
+              still applies to a track that exists but is empty. The template
+              conditional stops the 22rem column from being reserved; this
+              :if stops the aside from existing in the grid at all when there
+              is nothing to place, which is what actually removes the gap. --%>
+        <aside
+          :if={@timeline_events != []}
+          class="md:col-span-2 xl:col-span-1 xl:col-start-3 xl:row-start-1 xl:sticky xl:top-4 xl:self-start xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto"
+        >
           <Components.timeline_section timeline_events={@timeline_events} />
         </aside>
       </div>

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -368,6 +368,23 @@
       <Modals.trailer_modal trailer_url={trailer_url} title={@media_item.title} />
     <% end %>
   <% end %>
+  <%= if @show_quality_profile_modal do %>
+    <Modals.quality_profile_modal
+      media_item={@media_item}
+      quality_profiles={@quality_profiles}
+      default_quality_profile_name={@default_quality_profile_name}
+    />
+  <% end %>
+  <%= if @show_target_library_modal do %>
+    <Modals.target_library_modal media_item={@media_item} libraries={@target_library_candidates} />
+  <% end %>
+  <%= if @show_add_to_collection_modal do %>
+    <Modals.add_to_collection_modal
+      media_item={@media_item}
+      user_collections={@user_collections}
+      item_collections={@item_collections}
+    />
+  <% end %>
 
   <MydiaWeb.LibraryComponents.library_picker_dialog
     picker={@library_picker}

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -15,7 +15,7 @@
     <% end %>
     <%!-- Content Container --%>
     <div class="relative pt-8 md:pt-16 pb-8 px-3 sm:px-4 md:px-6 lg:px-8">
-      <div class="flex flex-col md:flex-row gap-4 md:gap-6">
+      <div class="grid gap-4 md:gap-6 grid-cols-1 md:grid-cols-[16rem_minmax(0,1fr)] lg:grid-cols-[20rem_minmax(0,1fr)]">
         <%!-- Left Column: Hero Section (Poster & Quick Actions) --%>
         <Components.hero_section
           media_item={@media_item}
@@ -34,7 +34,7 @@
           target_library_candidates={@target_library_candidates}
         />
         <%!-- Right Column: Main Content --%>
-        <div class="flex-1 min-w-0">
+        <div class="min-w-0">
           <%!-- Title and Basic Info --%>
           <div class="mb-4 md:mb-6">
             <div class="flex items-start justify-between gap-2 md:gap-4 mb-2">

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -15,7 +15,13 @@
     <% end %>
     <%!-- Content Container --%>
     <div class="relative pt-8 md:pt-16 pb-8 px-3 sm:px-4 md:px-6 lg:px-8">
-      <div class="grid gap-4 md:gap-6 grid-cols-1 md:grid-cols-[16rem_minmax(0,1fr)] lg:grid-cols-[20rem_minmax(0,1fr)]">
+      <div class={[
+        "grid gap-4 md:gap-6 grid-cols-1 md:grid-cols-[16rem_minmax(0,1fr)] lg:grid-cols-[20rem_minmax(0,1fr)]",
+        if(@timeline_events == [],
+          do: "xl:grid-cols-[20rem_minmax(0,1fr)]",
+          else: "xl:grid-cols-[20rem_minmax(0,1fr)_22rem]"
+        )
+      ]}>
         <%!-- Left Column: Hero Section (Poster & Quick Actions) --%>
         <Components.hero_section
           media_item={@media_item}
@@ -234,8 +240,6 @@
             media_item={@media_item}
             media_file_subtitles={@media_file_subtitles}
           />
-          <%!-- Timeline Section --%>
-          <Components.timeline_section timeline_events={@timeline_events} />
           <%!-- Everything below here is about other titles, not this one.
                 Franchise Section (Movies in the same TMDB collection) --%>
           <FranchiseComponents.franchise_section
@@ -263,6 +267,16 @@
             libraries={@target_library_candidates}
           />
         </div>
+        <%!-- History. A sibling of the main column rather than part of it: at
+              xl it is the third grid column, and below xl md:col-span-2 drops
+              it to a full-width row under both other columns. One DOM node
+              serves both layouts, so there is no hidden/xl:block duplicate.
+
+              Sticky for the same reason and with the same caveats as the hero
+              column: see the note there on self-start and the inner scroll. --%>
+        <aside class="md:col-span-2 xl:col-span-1 xl:col-start-3 xl:row-start-1 xl:sticky xl:top-4 xl:self-start xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto">
+          <Components.timeline_section timeline_events={@timeline_events} />
+        </aside>
       </div>
     </div>
   </div>

--- a/lib/mydia_web/live/media_live/show/category_events.ex
+++ b/lib/mydia_web/live/media_live/show/category_events.ex
@@ -102,6 +102,14 @@ defmodule MydiaWeb.MediaLive.Show.CategoryEvents do
     end
   end
 
+  def show_quality_profile_modal(_params, socket) do
+    {:noreply, assign(socket, :show_quality_profile_modal, true)}
+  end
+
+  def hide_quality_profile_modal(_params, socket) do
+    {:noreply, assign(socket, :show_quality_profile_modal, false)}
+  end
+
   def update_quality_profile(%{"profile-id" => profile_id}, socket) do
     with :ok <- Authorization.authorize_update_media(socket) do
       media_item = socket.assigns.media_item
@@ -118,10 +126,14 @@ defmodule MydiaWeb.MediaLive.Show.CategoryEvents do
           {:noreply,
            socket
            |> assign(:media_item, reloaded_item)
+           |> assign(:show_quality_profile_modal, false)
            |> put_flash(:info, "Quality profile updated")}
 
         {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to update quality profile")}
+          {:noreply,
+           socket
+           |> assign(:show_quality_profile_modal, false)
+           |> put_flash(:error, "Failed to update quality profile")}
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}

--- a/lib/mydia_web/live/media_live/show/collection_events.ex
+++ b/lib/mydia_web/live/media_live/show/collection_events.ex
@@ -49,10 +49,13 @@ defmodule MydiaWeb.MediaLive.Show.CollectionEvents do
       collection ->
         case Collections.add_item(collection, media_item.id) do
           {:ok, _item} ->
+            # Deliberately does not close the modal: a user picking several
+            # collections for one item in a single sitting needs the picker
+            # to stay open between picks. It closes only from the explicit
+            # Close/Cancel/backdrop actions (close_add_to_collection_modal).
             {:noreply,
              socket
              |> load_collection_data(media_item)
-             |> assign(:show_add_to_collection_modal, false)
              |> put_flash(:info, "Added to #{collection.name}")}
 
           {:error, :smart_collection} ->
@@ -92,6 +95,16 @@ defmodule MydiaWeb.MediaLive.Show.CollectionEvents do
     end
   end
 
+  @doc """
+  Refreshes the favorite/collection read model.
+
+  Called at mount and again after every favorite toggle and collection
+  add/remove, so it must never touch `:show_add_to_collection_modal`: doing
+  so would force the picker modal closed on its own first successful pick,
+  making it impossible to add an item to more than one collection in a
+  single sitting. That assign is owned by `open_add_to_collection_modal/2`,
+  `close_add_to_collection_modal/2`, and mount's own initial `false`.
+  """
   def load_collection_data(socket, media_item) do
     user = socket.assigns.current_scope.user
     is_favorite = Collections.is_favorite?(user, media_item.id)
@@ -102,6 +115,5 @@ defmodule MydiaWeb.MediaLive.Show.CollectionEvents do
     |> assign(:is_favorite, is_favorite)
     |> assign(:item_collections, item_collections)
     |> assign(:user_collections, user_collections)
-    |> assign(:show_add_to_collection_modal, false)
   end
 end

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -55,9 +55,25 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           830px at lg (a 320px poster at 2:3 is 480px, plus about 350px of
           actions and info cards), which is taller than most laptop viewports.
           Plain sticky on a taller-than-viewport element makes its bottom
-          permanently unreachable, so the Path and Target Library rows would
-          never be visible. --%>
-    <div class="md:sticky md:top-4 md:self-start md:max-h-[calc(100vh-2rem)] md:overflow-y-auto">
+          permanently unreachable, so the Target Library and Path rows would
+          never be visible.
+
+          The top offset is NOT a flat top-4 across the whole md+ range.
+          `Layouts.app/1` renders a `lg:hidden sticky top-0 z-30` mobile
+          header, visible from 0 up to just under lg (1024px) - the entire md
+          band this column starts pinning in. Two siblings sharing the page's
+          scroll context both being sticky means whichever pins lower in the
+          DOM and has no z-index (this column; z-index: auto) paints under
+          the one that does (the header; z-30) wherever their boxes overlap.
+          Measured on the running page at 900px wide: with both pinned, the
+          header (0-64px) and the column (16-769px) overlap by 48px, and
+          elementFromPoint over that band hits the header, not the column -
+          the column's top ~48px (through the top of the poster card) is
+          genuinely covered while scrolled. So below lg the column pins
+          beneath the header's 64px instead of at top-4, and max-h shrinks by
+          the same amount so the bottom stays reachable inside the viewport;
+          at lg the header is gone and both revert to the plain top-4. --%>
+    <div class="md:sticky md:self-start md:overflow-y-auto md:top-20 md:max-h-[calc(100vh-6rem)] lg:top-4 lg:max-h-[calc(100vh-2rem)]">
       <%!-- Poster - centered and smaller on mobile --%>
       <div class="card bg-base-100 shadow-xl mb-4 mx-auto w-48 sm:w-56 md:w-full">
         <figure class="aspect-[2/3] bg-base-300 overflow-hidden rounded-t-2xl">
@@ -155,62 +171,21 @@ defmodule MydiaWeb.MediaLive.Show.Components do
             <span class="hidden sm:inline">{if @is_favorite, do: "Favorited", else: "Favorite"}</span>
           </button>
 
-          <div class="dropdown dropdown-end">
-            <div tabindex="0" role="button" class="btn btn-outline w-full">
-              <.icon name="hero-folder-plus" class="w-5 h-5" />
-              <span class="hidden sm:inline">Collection</span>
-              <.icon name="hero-chevron-down" class="w-3 h-3 opacity-70" />
-            </div>
-            <ul
-              tabindex="0"
-              class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-56 border border-base-300"
-            >
-              <%= if Enum.empty?(@user_collections) do %>
-                <li class="menu-title px-2 py-1 text-base-content/50 text-sm">
-                  No collections yet
-                </li>
-                <li>
-                  <.link navigate={~p"/collections"} class="justify-start">
-                    <.icon name="hero-plus" class="w-4 h-4" /> Create Collection
-                  </.link>
-                </li>
-              <% else %>
-                <li class="menu-title px-2 py-1 text-base-content/50 text-xs uppercase">
-                  Your Collections
-                </li>
-                <%= for collection <- @user_collections do %>
-                  <% is_in_collection = Enum.any?(@item_collections, &(&1.id == collection.id)) %>
-                  <li>
-                    <button
-                      type="button"
-                      phx-click={
-                        if is_in_collection, do: "remove_from_collection", else: "add_to_collection"
-                      }
-                      phx-value-collection-id={collection.id}
-                      class="justify-between"
-                    >
-                      <span class="flex items-center gap-2">
-                        <.icon
-                          name={if collection.is_system, do: "hero-star", else: "hero-folder"}
-                          class="w-4 h-4"
-                        />
-                        {collection.name}
-                      </span>
-                      <%= if is_in_collection do %>
-                        <.icon name="hero-check" class="w-4 h-4 text-success" />
-                      <% end %>
-                    </button>
-                  </li>
-                <% end %>
-                <div class="divider my-1"></div>
-                <li>
-                  <.link navigate={~p"/collections"} class="justify-start">
-                    <.icon name="hero-folder-open" class="w-4 h-4" /> Manage Collections
-                  </.link>
-                </li>
-              <% end %>
-            </ul>
-          </div>
+          <%!-- Opens a page-level modal (Modals.add_to_collection_modal/1) rather
+                than an anchored dropdown, because this button lives inside the
+                hero column's overflow-y-auto wrapper (see the note at the top
+                of this function), which clips a `.dropdown-content` menu the
+                moment its content is taller than the column's remaining
+                headroom. Confirmed by measuring the real page: see the
+                UI polish fix wave report. --%>
+          <button
+            type="button"
+            phx-click="open_add_to_collection_modal"
+            class="btn btn-outline w-full"
+          >
+            <.icon name="hero-folder-plus" class="w-5 h-5" />
+            <span class="hidden sm:inline">Collection</span>
+          </button>
         </div>
 
         <%!-- Secondary actions --%>
@@ -226,70 +201,38 @@ defmodule MydiaWeb.MediaLive.Show.Components do
 
         <%!-- Info Cards --%>
         <div class="rounded-box bg-base-200/50 p-2 space-y-1 mt-3">
-          <%!-- Quality Profile --%>
-          <div class="dropdown dropdown-end w-full">
-            <div
-              tabindex="0"
-              role="button"
-              class="flex items-center gap-2.5 px-2 py-1.5 rounded-lg cursor-pointer hover:bg-base-300/50 transition-colors w-full group"
-              title="Click to change quality profile"
-            >
-              <div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
-                <.icon name="hero-adjustments-horizontal" class="w-4 h-4 text-primary" />
-              </div>
-              <div class="flex-1 min-w-0">
-                <div class="text-xs text-base-content/50">Quality Profile</div>
-                <div class="text-sm font-medium truncate">
-                  <%= if @media_item.quality_profile do %>
-                    {@media_item.quality_profile.name}
-                  <% else %>
-                    <span class="text-base-content/40">Not Set</span>
-                  <% end %>
-                </div>
-              </div>
-              <.icon
-                name="hero-chevron-right"
-                class="w-4 h-4 text-base-content/30 group-hover:text-base-content/60 transition-colors flex-shrink-0"
-              />
+          <%!-- Quality Profile. A button opening a page-level modal
+                (Modals.quality_profile_modal/1) rather than an anchored
+                dropdown, for the same reason as the Collection button above:
+                the hero column's overflow-y-auto wrapper clips a
+                `.dropdown-content` list once it runs past the column's
+                remaining headroom, which a real quality-profile list (a
+                handful of profiles) reliably does. Measured, not assumed:
+                see the UI polish fix wave report. --%>
+          <button
+            type="button"
+            phx-click="show_quality_profile_modal"
+            class="flex items-center gap-2.5 px-2 py-1.5 rounded-lg cursor-pointer hover:bg-base-300/50 transition-colors w-full group"
+            title="Click to change quality profile"
+          >
+            <div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+              <.icon name="hero-adjustments-horizontal" class="w-4 h-4 text-primary" />
             </div>
-            <ul
-              tabindex="0"
-              class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-52 border border-base-300"
-            >
-              <li>
-                <button
-                  type="button"
-                  phx-click="update_quality_profile"
-                  phx-value-profile-id=""
-                  class={[
-                    "justify-between",
-                    is_nil(@media_item.quality_profile_id) && "active"
-                  ]}
-                >
-                  {default_quality_profile_label(@default_quality_profile_name)}
-                  <%= if is_nil(@media_item.quality_profile_id) do %>
-                    <.icon name="hero-check" class="w-4 h-4" />
-                  <% end %>
-                </button>
-              </li>
-              <li :for={profile <- @quality_profiles}>
-                <button
-                  type="button"
-                  phx-click="update_quality_profile"
-                  phx-value-profile-id={profile.id}
-                  class={[
-                    "justify-between",
-                    @media_item.quality_profile_id == profile.id && "active"
-                  ]}
-                >
-                  {profile.name}
-                  <%= if @media_item.quality_profile_id == profile.id do %>
-                    <.icon name="hero-check" class="w-4 h-4" />
-                  <% end %>
-                </button>
-              </li>
-            </ul>
-          </div>
+            <div class="flex-1 min-w-0 text-left">
+              <div class="text-xs text-base-content/50">Quality Profile</div>
+              <div class="text-sm font-medium truncate">
+                <%= if @media_item.quality_profile do %>
+                  {@media_item.quality_profile.name}
+                <% else %>
+                  <span class="text-base-content/40">Not Set</span>
+                <% end %>
+              </div>
+            </div>
+            <.icon
+              name="hero-chevron-right"
+              class="w-4 h-4 text-base-content/30 group-hover:text-base-content/60 transition-colors flex-shrink-0"
+            />
+          </button>
 
           <LibraryComponents.target_library_row
             media_item={@media_item}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -918,6 +918,13 @@ defmodule MydiaWeb.MediaLive.Show.Components do
 
   @doc """
   Timeline section showing history of events.
+
+  Vertical, and positioned by the page grid rather than by its place in the
+  main column: at xl and up it is the third grid column, and below xl it falls
+  to a full-width row under the other two. See show.html.heex for the grid.
+
+  It renders nothing at all on an item with no events, which is why the page
+  grid picks its column template from `@timeline_events != []`.
   """
   attr :timeline_events, :list, required: true
 
@@ -927,81 +934,70 @@ defmodule MydiaWeb.MediaLive.Show.Components do
       <div id="timeline-section" class="card bg-base-200 shadow-lg mb-4 md:mb-6">
         <div class="card-body p-4 md:p-6">
           <h2 class="card-title text-lg md:text-xl mb-3 md:mb-4">History</h2>
-          <%!-- Horizontal scrollable timeline container --%>
-          <div class="w-full overflow-x-auto scroll-smooth pb-4 -mx-4 px-4">
-            <div class="flex gap-0 min-w-max relative">
-              <%!-- Horizontal timeline line --%>
-              <div class="absolute top-[32px] left-0 right-0 h-0.5 bg-base-300 z-0"></div>
+          <div class="relative">
+            <%!-- The spine. Inset to the centre of the 40px icon nodes below
+                  (left-5 is 20px), so every node sits on it. --%>
+            <div class="absolute left-5 top-0 bottom-0 w-0.5 bg-base-300"></div>
 
-              <%!-- Timeline events --%>
-              <%= for {event, index} <- Enum.with_index(@timeline_events) do %>
-                <div class="relative flex flex-col items-center z-10 min-w-[280px] md:min-w-[280px]">
-                  <%!-- Time above timeline --%>
-                  <time
-                    class="text-xs text-base-content/60 mb-2 whitespace-nowrap"
-                    title={format_absolute_time(event.timestamp)}
-                  >
-                    {format_relative_time(event.timestamp)}
-                  </time>
-
-                  <%!-- Timeline node and connector --%>
-                  <div class="relative flex items-center justify-center">
-                    <%!-- Icon node on timeline --%>
-                    <div class="w-10 h-10 rounded-full bg-base-200 flex items-center justify-center border-2 border-base-300 z-20">
-                      <.icon name={event.icon} class={"w-5 h-5 #{event.color}"} />
-                    </div>
-                  </div>
-
-                  <%!-- Event card below timeline --%>
-                  <div
-                    class="card bg-base-100 shadow-md mt-4 w-64 md:w-64 hover:shadow-xl transition-shadow"
-                    title={format_absolute_time(event.timestamp)}
-                  >
-                    <div class="card-body p-4">
-                      <div class="font-bold text-sm mb-2">{event.title}</div>
-                      <div class="text-sm text-base-content/80 mb-2 line-clamp-2">
-                        {event.description}
-                      </div>
-                      <%= if event.metadata do %>
-                        <div class="flex flex-wrap gap-1">
-                          <%= if event.metadata[:quality] do %>
-                            <span class="badge badge-primary badge-xs">
-                              {format_download_quality(event.metadata.quality)}
-                            </span>
-                          <% end %>
-                          <%= if event.metadata[:indexer] do %>
-                            <span class="badge badge-outline badge-xs">
-                              {event.metadata.indexer}
-                            </span>
-                          <% end %>
-                          <%= if event.metadata[:resolution] do %>
-                            <span class="badge badge-primary badge-xs">
-                              {event.metadata.resolution}
-                            </span>
-                          <% end %>
-                          <%= if event.metadata[:size] do %>
-                            <span class="badge badge-ghost badge-xs">
-                              {format_file_size(event.metadata.size)}
-                            </span>
-                          <% end %>
-                          <%= if event.metadata[:error] do %>
-                            <div class="text-xs text-error mt-1 line-clamp-2">
-                              <.icon name="hero-exclamation-circle" class="w-3 h-3 inline" />
-                              {event.metadata.error}
-                            </div>
-                          <% end %>
-                        </div>
-                      <% end %>
-                    </div>
-                  </div>
-
-                  <%!-- Connecting line to next event --%>
-                  <%= if index < length(@timeline_events) - 1 do %>
-                    <div class={"absolute top-[32px] left-1/2 w-[280px] h-0.5 #{event.color} z-0"}>
-                    </div>
-                  <% end %>
+            <div class="flex flex-col gap-4">
+              <div
+                :for={event <- @timeline_events}
+                class="relative flex items-start gap-3"
+              >
+                <%!-- Icon node on the spine --%>
+                <div class="w-10 h-10 rounded-full bg-base-200 flex items-center justify-center border-2 border-base-300 shrink-0 z-10">
+                  <.icon name={event.icon} class={"w-5 h-5 #{event.color}"} />
                 </div>
-              <% end %>
+
+                <%!-- Event card, filling the rest of the column --%>
+                <div
+                  class="card bg-base-100 shadow-md flex-1 min-w-0 hover:shadow-xl transition-shadow"
+                  title={format_absolute_time(event.timestamp)}
+                >
+                  <div class="card-body p-3">
+                    <time
+                      class="text-xs text-base-content/60 whitespace-nowrap"
+                      title={format_absolute_time(event.timestamp)}
+                    >
+                      {format_relative_time(event.timestamp)}
+                    </time>
+                    <div class="font-bold text-sm">{event.title}</div>
+                    <div class="text-sm text-base-content/80 line-clamp-2">
+                      {event.description}
+                    </div>
+                    <%= if event.metadata do %>
+                      <div class="flex flex-wrap gap-1">
+                        <%= if event.metadata[:quality] do %>
+                          <span class="badge badge-primary badge-xs">
+                            {format_download_quality(event.metadata.quality)}
+                          </span>
+                        <% end %>
+                        <%= if event.metadata[:indexer] do %>
+                          <span class="badge badge-outline badge-xs">
+                            {event.metadata.indexer}
+                          </span>
+                        <% end %>
+                        <%= if event.metadata[:resolution] do %>
+                          <span class="badge badge-primary badge-xs">
+                            {event.metadata.resolution}
+                          </span>
+                        <% end %>
+                        <%= if event.metadata[:size] do %>
+                          <span class="badge badge-ghost badge-xs">
+                            {format_file_size(event.metadata.size)}
+                          </span>
+                        <% end %>
+                        <%= if event.metadata[:error] do %>
+                          <div class="text-xs text-error mt-1 line-clamp-2">
+                            <.icon name="hero-exclamation-circle" class="w-3 h-3 inline" />
+                            {event.metadata.error}
+                          </div>
+                        <% end %>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -47,7 +47,17 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   def hero_section(assigns) do
     ~H"""
     <%!-- Left Column: Poster and Quick Actions --%>
-    <div class="w-full md:w-64 lg:w-80 flex-shrink-0">
+    <%!-- self-start is load-bearing. Without it this grid item stretches to the
+          full row height, position: sticky has no travel room inside its own
+          box, and the column silently does not pin.
+
+          The inner scroll is not optional either. The column runs roughly
+          830px at lg (a 320px poster at 2:3 is 480px, plus about 350px of
+          actions and info cards), which is taller than most laptop viewports.
+          Plain sticky on a taller-than-viewport element makes its bottom
+          permanently unreachable, so the Path and Target Library rows would
+          never be visible. --%>
+    <div class="md:sticky md:top-4 md:self-start md:max-h-[calc(100vh-2rem)] md:overflow-y-auto">
       <%!-- Poster - centered and smaller on mobile --%>
       <div class="card bg-base-100 shadow-xl mb-4 mx-auto w-48 sm:w-56 md:w-full">
         <figure class="aspect-[2/3] bg-base-300 overflow-hidden rounded-t-2xl">

--- a/lib/mydia_web/live/media_live/show/library_components.ex
+++ b/lib/mydia_web/live/media_live/show/library_components.ex
@@ -11,9 +11,19 @@ defmodule MydiaWeb.MediaLive.Show.LibraryComponents do
   @doc """
   Renders the resolved target library.
 
-  With two or more candidates this is a dropdown writing
+  With two or more candidates this is a button opening a page-level picker
+  modal (`MydiaWeb.MediaLive.Show.Modals.target_library_modal/1`) that writes
   `media_items.library_path_id`; with one it is static text. Selecting
   "Automatic" clears the column and returns the item to dynamic resolution.
+
+  This used to be an anchored daisyUI dropdown, but this row lives inside the
+  hero column's `overflow-y-auto` wrapper (see the note at the top of
+  `MydiaWeb.MediaLive.Show.Components.hero_section/1`), and a
+  `.dropdown-content` menu gets clipped by that ancestor's overflow box the
+  moment it runs past the column's remaining headroom, exactly the failure
+  mode issue #465 already fixed once for a different surface. Confirmed by
+  measuring the real page with a realistic library count, not assumed from
+  the CSS alone.
   """
   attr :media_item, :map, required: true
   attr :target_library, :map, default: nil
@@ -22,74 +32,62 @@ defmodule MydiaWeb.MediaLive.Show.LibraryComponents do
 
   def target_library_row(assigns) do
     ~H"""
-    <div class="dropdown dropdown-end w-full" data-test="target-library">
-      <div
-        tabindex="0"
-        role={if length(@libraries) > 1, do: "button", else: nil}
-        class={[
-          "flex items-center gap-2.5 px-2 py-1.5 rounded-lg w-full group transition-colors",
-          length(@libraries) > 1 && "cursor-pointer hover:bg-base-300/50"
-        ]}
-        title={if length(@libraries) > 1, do: "Click to change the download library", else: nil}
+    <%= if length(@libraries) > 1 do %>
+      <button
+        type="button"
+        phx-click="show_target_library_modal"
+        data-test="target-library"
+        class="flex items-center gap-2.5 px-2 py-1.5 rounded-lg w-full group transition-colors cursor-pointer hover:bg-base-300/50"
+        title="Click to change the download library"
       >
-        <div class="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center flex-shrink-0">
-          <.icon name="hero-folder" class="w-4 h-4 text-accent" />
-        </div>
-        <div class="flex-1 min-w-0">
-          <div class="text-xs text-base-content/50">Library</div>
-          <div class="text-sm font-medium truncate">
-            <%= if @target_library do %>
-              {Path.basename(@target_library.path)}
-              <span class="text-xs font-normal text-base-content/50">
-                {reason_label(@target_reason)}
-              </span>
-            <% else %>
-              <span class="text-base-content/40">No compatible library</span>
-            <% end %>
-          </div>
-        </div>
-        <.icon
-          :if={length(@libraries) > 1}
-          name="hero-chevron-right"
-          class="w-4 h-4 text-base-content/30 group-hover:text-base-content/60 transition-colors flex-shrink-0"
+        <.target_library_row_content
+          target_library={@target_library}
+          target_reason={@target_reason}
+          interactive?={true}
+        />
+      </button>
+    <% else %>
+      <div
+        data-test="target-library"
+        class="flex items-center gap-2.5 px-2 py-1.5 rounded-lg w-full group transition-colors"
+      >
+        <.target_library_row_content
+          target_library={@target_library}
+          target_reason={@target_reason}
+          interactive?={false}
         />
       </div>
-      <ul
-        :if={length(@libraries) > 1}
-        tabindex="0"
-        class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-64 border border-base-300"
-      >
-        <li>
-          <button
-            type="button"
-            phx-click="update_target_library"
-            phx-value-library-path-id=""
-            class={["justify-between", is_nil(@media_item.library_path_id) && "active"]}
-          >
-            Automatic
-            <.icon :if={is_nil(@media_item.library_path_id)} name="hero-check" class="w-4 h-4" />
-          </button>
-        </li>
-        <li :for={library <- @libraries}>
-          <button
-            type="button"
-            phx-click="update_target_library"
-            phx-value-library-path-id={library.id}
-            class={["justify-between", @media_item.library_path_id == library.id && "active"]}
-          >
-            {Path.basename(library.path)}
-            <.icon
-              :if={@media_item.library_path_id == library.id}
-              name="hero-check"
-              class="w-4 h-4"
-            />
-          </button>
-        </li>
-        <li class="menu-title text-xs pt-2">
-          Changing this affects future downloads. Files already on disk stay where they are.
-        </li>
-      </ul>
+    <% end %>
+    """
+  end
+
+  attr :target_library, :map, default: nil
+  attr :target_reason, :atom, default: nil
+  attr :interactive?, :boolean, required: true
+
+  defp target_library_row_content(assigns) do
+    ~H"""
+    <div class="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center flex-shrink-0">
+      <.icon name="hero-folder" class="w-4 h-4 text-accent" />
     </div>
+    <div class="flex-1 min-w-0 text-left">
+      <div class="text-xs text-base-content/50">Library</div>
+      <div class="text-sm font-medium truncate">
+        <%= if @target_library do %>
+          {Path.basename(@target_library.path)}
+          <span class="text-xs font-normal text-base-content/50">
+            {reason_label(@target_reason)}
+          </span>
+        <% else %>
+          <span class="text-base-content/40">No compatible library</span>
+        <% end %>
+      </div>
+    </div>
+    <.icon
+      :if={@interactive?}
+      name="hero-chevron-right"
+      class="w-4 h-4 text-base-content/30 group-hover:text-base-content/60 transition-colors flex-shrink-0"
+    />
     """
   end
 

--- a/lib/mydia_web/live/media_live/show/library_events.ex
+++ b/lib/mydia_web/live/media_live/show/library_events.ex
@@ -9,6 +9,14 @@ defmodule MydiaWeb.MediaLive.Show.LibraryEvents do
   alias Mydia.Media
   alias MydiaWeb.Live.Authorization
 
+  def show_target_library_modal(_params, socket) do
+    {:noreply, assign(socket, :show_target_library_modal, true)}
+  end
+
+  def hide_target_library_modal(_params, socket) do
+    {:noreply, assign(socket, :show_target_library_modal, false)}
+  end
+
   def update_target_library(%{"library-path-id" => raw_id}, socket) do
     with :ok <- Authorization.authorize_update_media(socket) do
       media_item = socket.assigns.media_item
@@ -31,10 +39,14 @@ defmodule MydiaWeb.MediaLive.Show.LibraryEvents do
            socket
            |> assign(:media_item, media_item)
            |> assign_target_library(media_item)
+           |> assign(:show_target_library_modal, false)
            |> put_flash(:info, message)}
 
         {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to update the library")}
+          {:noreply,
+           socket
+           |> assign(:show_target_library_modal, false)
+           |> put_flash(:error, "Failed to update the library")}
       end
     else
       {:unauthorized, socket} -> {:noreply, socket}

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -3,6 +3,7 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
   Modal components for the MediaLive.Show page.
   """
   use Phoenix.Component
+  use MydiaWeb, :verified_routes
   import MydiaWeb.CoreComponents
   import MydiaWeb.IndexerComponents
 
@@ -1197,6 +1198,189 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
         </div>
       </div>
       <div class="modal-backdrop bg-black/80" phx-click="hide_trailer_modal"></div>
+    </div>
+    """
+  end
+
+  @doc """
+  Quality profile picker, opened from the hero column's Quality Profile row.
+
+  A page-level modal rather than an anchored dropdown: the row lives inside
+  the hero column's `overflow-y-auto` wrapper
+  (`MydiaWeb.MediaLive.Show.Components.hero_section/1`), which clips an
+  anchored daisyUI dropdown's menu once it runs past the column's remaining
+  headroom, exactly the failure mode issue #465 already fixed once for a
+  different surface. Confirmed by measuring the real page, not assumed from
+  the CSS alone.
+  """
+  attr :media_item, :map, required: true
+  attr :quality_profiles, :list, required: true
+  attr :default_quality_profile_name, :string, default: nil
+
+  def quality_profile_modal(assigns) do
+    ~H"""
+    <div id="quality-profile-modal" class="modal modal-open">
+      <div class="modal-box max-w-sm">
+        <h3 class="font-bold text-lg mb-2">Quality Profile</h3>
+        <ul class="menu w-full p-0">
+          <li>
+            <button
+              type="button"
+              phx-click="update_quality_profile"
+              phx-value-profile-id=""
+              class={[
+                "justify-between",
+                is_nil(@media_item.quality_profile_id) && "active"
+              ]}
+            >
+              {default_quality_profile_label(@default_quality_profile_name)}
+              <.icon
+                :if={is_nil(@media_item.quality_profile_id)}
+                name="hero-check"
+                class="w-4 h-4"
+              />
+            </button>
+          </li>
+          <li :for={profile <- @quality_profiles}>
+            <button
+              type="button"
+              phx-click="update_quality_profile"
+              phx-value-profile-id={profile.id}
+              class={[
+                "justify-between",
+                @media_item.quality_profile_id == profile.id && "active"
+              ]}
+            >
+              {profile.name}
+              <.icon
+                :if={@media_item.quality_profile_id == profile.id}
+                name="hero-check"
+                class="w-4 h-4"
+              />
+            </button>
+          </li>
+        </ul>
+        <div class="modal-action">
+          <button type="button" phx-click="hide_quality_profile_modal" class="btn btn-ghost">
+            Cancel
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop" phx-click="hide_quality_profile_modal"></div>
+    </div>
+    """
+  end
+
+  @doc """
+  Target library picker, opened from the hero column's Library row.
+
+  Same page-level-modal reasoning as `quality_profile_modal/1` above: see
+  `MydiaWeb.MediaLive.Show.LibraryComponents.target_library_row/1` for the
+  full rationale.
+  """
+  attr :media_item, :map, required: true
+  attr :libraries, :list, default: []
+
+  def target_library_modal(assigns) do
+    ~H"""
+    <div id="target-library-modal" class="modal modal-open">
+      <div class="modal-box max-w-sm">
+        <h3 class="font-bold text-lg mb-2">Download Library</h3>
+        <ul class="menu w-full p-0">
+          <li>
+            <button
+              type="button"
+              phx-click="update_target_library"
+              phx-value-library-path-id=""
+              class={["justify-between", is_nil(@media_item.library_path_id) && "active"]}
+            >
+              Automatic
+              <.icon :if={is_nil(@media_item.library_path_id)} name="hero-check" class="w-4 h-4" />
+            </button>
+          </li>
+          <li :for={library <- @libraries}>
+            <button
+              type="button"
+              phx-click="update_target_library"
+              phx-value-library-path-id={library.id}
+              class={["justify-between", @media_item.library_path_id == library.id && "active"]}
+            >
+              {Path.basename(library.path)}
+              <.icon
+                :if={@media_item.library_path_id == library.id}
+                name="hero-check"
+                class="w-4 h-4"
+              />
+            </button>
+          </li>
+        </ul>
+        <p class="text-xs text-base-content/60 mt-3">
+          Changing this affects future downloads. Files already on disk stay where they are.
+        </p>
+        <div class="modal-action">
+          <button type="button" phx-click="hide_target_library_modal" class="btn btn-ghost">
+            Cancel
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop" phx-click="hide_target_library_modal"></div>
+    </div>
+    """
+  end
+
+  @doc """
+  Add-to-collection picker, opened from the hero column's Collection button.
+
+  Same page-level-modal reasoning as `quality_profile_modal/1` above.
+  """
+  attr :media_item, :map, required: true
+  attr :user_collections, :list, default: []
+  attr :item_collections, :list, default: []
+
+  def add_to_collection_modal(assigns) do
+    ~H"""
+    <div id="add-to-collection-modal" class="modal modal-open">
+      <div class="modal-box max-w-sm">
+        <h3 class="font-bold text-lg mb-2">Add to Collection</h3>
+        <%= if Enum.empty?(@user_collections) do %>
+          <p class="text-sm text-base-content/60 mb-3">No collections yet.</p>
+          <.link navigate={~p"/collections"} class="btn btn-primary btn-sm">
+            <.icon name="hero-plus" class="w-4 h-4" /> Create Collection
+          </.link>
+        <% else %>
+          <ul class="menu w-full p-0">
+            <li :for={collection <- @user_collections}>
+              <% is_in_collection = Enum.any?(@item_collections, &(&1.id == collection.id)) %>
+              <button
+                type="button"
+                phx-click={
+                  if is_in_collection, do: "remove_from_collection", else: "add_to_collection"
+                }
+                phx-value-collection-id={collection.id}
+                class="justify-between"
+              >
+                <span class="flex items-center gap-2">
+                  <.icon
+                    name={if collection.is_system, do: "hero-star", else: "hero-folder"}
+                    class="w-4 h-4"
+                  />
+                  {collection.name}
+                </span>
+                <.icon :if={is_in_collection} name="hero-check" class="w-4 h-4 text-success" />
+              </button>
+            </li>
+          </ul>
+          <.link navigate={~p"/collections"} class="btn btn-ghost btn-sm mt-2">
+            <.icon name="hero-folder-open" class="w-4 h-4" /> Manage Collections
+          </.link>
+        <% end %>
+        <div class="modal-action">
+          <button type="button" phx-click="close_add_to_collection_modal" class="btn btn-ghost">
+            Close
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop" phx-click="close_add_to_collection_modal"></div>
     </div>
     """
   end

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -13,6 +13,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   alias MydiaWeb.Live.Authorization
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
+  alias MydiaWeb.Live.Helpers.RecommendationsExpanded
 
   require Logger
 
@@ -65,12 +66,13 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   Flips the rail open or closed.
 
   The rail opens collapsed on TV shows so the episode list is not pushed below a
-  strip of other titles. State is per mount and deliberately not persisted, so
-  every visit starts closed.
+  strip of other titles. The chosen state is persisted per user so it survives
+  a reload; see `MydiaWeb.Live.Helpers.RecommendationsExpanded`.
   """
   def toggle_expanded(_params, socket) do
-    {:noreply,
-     assign(socket, :recommendations_expanded, !socket.assigns.recommendations_expanded)}
+    expanded = !socket.assigns.recommendations_expanded
+
+    {:noreply, RecommendationsExpanded.put(socket, expanded)}
   end
 
   @doc """

--- a/lib/mydia_web/live/request_media_live/index.html.heex
+++ b/lib/mydia_web/live/request_media_live/index.html.heex
@@ -71,28 +71,24 @@
           <%= for {result, index} <- Enum.with_index(@search_results) do %>
             <% is_requested = MapSet.member?(@requested_items, result.id) %>
             <% is_requesting = @requesting_index == index %>
-            <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow overflow-hidden">
-              <figure class="relative aspect-[2/3] overflow-hidden bg-base-300">
-                <img
-                  src={get_poster_url(result)}
-                  alt={result.title || result.name}
-                  class="w-full h-full object-cover"
-                  loading="lazy"
-                />
-                <%= if result.vote_average do %>
-                  <div class="badge badge-primary badge-sm absolute top-2 right-2">
-                    <.icon name="hero-star-solid" class="w-3 h-3 mr-1" />
-                    {format_rating(result.vote_average)}
-                  </div>
-                <% end %>
-                <%= if is_requested do %>
-                  <div class="absolute inset-0 bg-success/20 flex items-center justify-center">
-                    <div class="badge badge-success gap-1">
-                      <.icon name="hero-check" class="w-4 h-4" /> Requested
+            <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow overflow-hidden group">
+              <.poster_figure src={get_poster_url(result)} alt={result.title || result.name}>
+                <:overlay>
+                  <%= if result.vote_average do %>
+                    <div class="badge badge-primary badge-sm absolute top-2 right-2">
+                      <.icon name="hero-star-solid" class="w-3 h-3 mr-1" />
+                      {format_rating(result.vote_average)}
                     </div>
-                  </div>
-                <% end %>
-              </figure>
+                  <% end %>
+                  <%= if is_requested do %>
+                    <div class="absolute inset-0 bg-success/20 flex items-center justify-center">
+                      <div class="badge badge-success gap-1">
+                        <.icon name="hero-check" class="w-4 h-4" /> Requested
+                      </div>
+                    </div>
+                  <% end %>
+                </:overlay>
+              </.poster_figure>
               <div class="card-body p-3">
                 <h3 class="card-title text-sm line-clamp-2 h-10">
                   {result.title || result.name}

--- a/test/mydia_web/components/poster_figure_test.exs
+++ b/test/mydia_web/components/poster_figure_test.exs
@@ -41,6 +41,16 @@ defmodule MydiaWeb.CoreComponents.PosterFigureTest do
     assert html =~ "hero-tv"
   end
 
+  # The fallback shipped without the transform at first, so a grid mixing
+  # poster-less cards with poster-bearing ones lifted only some of them on
+  # hover. Pinned here because nothing else would catch it coming back.
+  test "the fallback carries the same hover transform as the poster" do
+    html = render_component(&poster_figure/1, src: nil, alt: "A")
+
+    assert html =~ "group-hover:scale-105"
+    assert html =~ "transition-transform"
+  end
+
   test "appends caller classes to the figure" do
     html = render_component(&poster_figure/1, src: "/p.jpg", alt: "A", class: "rounded-t-box")
 

--- a/test/mydia_web/components/poster_figure_test.exs
+++ b/test/mydia_web/components/poster_figure_test.exs
@@ -1,0 +1,62 @@
+defmodule MydiaWeb.CoreComponents.PosterFigureTest do
+  @moduledoc """
+  The hover transform is the assertion that matters. It is the thing that was
+  hand-copied across eight files and drifted, and the only reason this
+  component exists.
+  """
+
+  use ExUnit.Case, async: true
+  use Phoenix.Component
+
+  import Phoenix.LiveViewTest
+  import MydiaWeb.CoreComponents
+
+  test "renders the poster with the shared hover transform" do
+    html =
+      render_component(&poster_figure/1, src: "/p.jpg", alt: "Aftersun")
+
+    assert html =~ ~s(src="/p.jpg")
+    assert html =~ ~s(alt="Aftersun")
+    assert html =~ "group-hover:scale-105"
+    assert html =~ "transition-transform"
+    assert html =~ "aspect-[2/3]"
+  end
+
+  test "lazy loads by default" do
+    html = render_component(&poster_figure/1, src: "/p.jpg", alt: "A")
+
+    assert html =~ ~s(loading="lazy")
+  end
+
+  test "renders no loading attribute when loading is nil" do
+    html = render_component(&poster_figure/1, src: "/p.jpg", alt: "A", loading: nil)
+
+    refute html =~ "loading="
+  end
+
+  test "renders the fallback icon instead of an img when src is nil" do
+    html = render_component(&poster_figure/1, src: nil, alt: "A", fallback_icon: "hero-tv")
+
+    refute html =~ "<img"
+    assert html =~ "hero-tv"
+  end
+
+  test "appends caller classes to the figure" do
+    html = render_component(&poster_figure/1, src: "/p.jpg", alt: "A", class: "rounded-t-box")
+
+    assert html =~ "rounded-t-box"
+  end
+
+  test "renders overlay slot content inside the figure" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <MydiaWeb.CoreComponents.poster_figure src="/p.jpg" alt="A">
+        <:overlay><span id="badge">99</span></:overlay>
+      </MydiaWeb.CoreComponents.poster_figure>
+      """)
+
+    assert html =~ ~s(id="badge")
+  end
+end

--- a/test/mydia_web/live/components/trending_detail_modal_test.exs
+++ b/test/mydia_web/live/components/trending_detail_modal_test.exs
@@ -114,7 +114,12 @@ defmodule MydiaWeb.Components.TrendingDetailModalTest do
       html = render_modal(item(), metadata(%{number_of_seasons: 1}))
 
       assert html =~ ~s(id="trending-detail-modal-actions")
-      refute html =~ ~s(id="trending-detail-modal-footer")
+      # The deleted footer div was the only element carrying this class pair
+      # ("border-t border-base-300 bg-base-100 flex justify-end gap-2", the
+      # footer's own styling). Nothing else in the component uses a top
+      # border, so this proves the footer markup is gone rather than merely
+      # asserting an id that was never on it in the first place.
+      refute html =~ "border-t border-base-300"
     end
 
     test "an owned title offers a link to its page in the header" do

--- a/test/mydia_web/live/components/trending_detail_modal_test.exs
+++ b/test/mydia_web/live/components/trending_detail_modal_test.exs
@@ -100,4 +100,28 @@ defmodule MydiaWeb.Components.TrendingDetailModalTest do
       assert LazyHTML.attribute(dialog, "phx-window-keydown") == []
     end
   end
+
+  describe "sticky header layout" do
+    test "the modal box is a flex column with a single scrolling child" do
+      html = render_modal(item(), metadata(%{number_of_seasons: 1}))
+
+      assert html =~ "flex flex-col"
+      assert html =~ ~s(id="trending-detail-modal-body")
+      assert html =~ "overflow-y-auto"
+    end
+
+    test "the add action lives in the header, not a footer" do
+      html = render_modal(item(), metadata(%{number_of_seasons: 1}))
+
+      assert html =~ ~s(id="trending-detail-modal-actions")
+      refute html =~ ~s(id="trending-detail-modal-footer")
+    end
+
+    test "an owned title offers a link to its page in the header" do
+      html = render_modal(item(%{in_library: true, id: "abc"}), metadata(%{}))
+
+      assert html =~ ~s(id="trending-detail-modal-actions")
+      assert html =~ "Go to Show"
+    end
+  end
 end

--- a/test/mydia_web/live/dashboard_live/stat_tiles_test.exs
+++ b/test/mydia_web/live/dashboard_live/stat_tiles_test.exs
@@ -1,0 +1,54 @@
+defmodule MydiaWeb.DashboardLive.StatTilesTest do
+  @moduledoc """
+  The Storage tile is the reason this file exists. Its destination is
+  admin-only, and the stat row renders for every role, so a regression that
+  links it unconditionally hands a guest a link into a 403.
+  """
+
+  # async: false - the Postgres non-shared sandbox hides these rows from the
+  # LiveView mount process otherwise.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+
+  test "the library and downloads tiles link for a regular user", %{conn: conn} do
+    conn = log_in_user(conn, user_fixture())
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(view, ~s(#stat-tile-movies[href="/movies"]))
+    assert has_element?(view, ~s(#stat-tile-tv-shows[href="/tv"]))
+    assert has_element?(view, ~s(#stat-tile-downloads[href="/downloads"]))
+  end
+
+  test "the storage tile links to library paths for an admin", %{conn: conn} do
+    conn = log_in_user(conn, admin_user_fixture())
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(
+             view,
+             ~s(#stat-tile-storage[href="/admin/config/library-paths"])
+           )
+  end
+
+  test "the storage tile is not a link for a regular user", %{conn: conn} do
+    conn = log_in_user(conn, user_fixture())
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(view, "#stat-tile-storage")
+    refute has_element?(view, "#stat-tile-storage[href]")
+  end
+
+  test "the storage tile is not a link for a guest", %{conn: conn} do
+    conn = log_in_user(conn, user_fixture(%{role: "guest"}))
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(view, "#stat-tile-storage")
+    refute has_element?(view, "#stat-tile-storage[href]")
+  end
+end

--- a/test/mydia_web/live/media_live/show/default_quality_profile_label_test.exs
+++ b/test/mydia_web/live/media_live/show/default_quality_profile_label_test.exs
@@ -12,9 +12,12 @@ defmodule MydiaWeb.MediaLive.Show.DefaultQualityProfileLabelTest do
 
   alias Mydia.Settings
 
-  # The blank "follow the default" choice in the quality-profile dropdown.
-  # It has no DOM id of its own, but phx-value-profile-id="" uniquely
-  # identifies it among the profile buttons.
+  # The blank "follow the default" choice in the quality-profile picker
+  # modal. It has no DOM id of its own, but phx-value-profile-id="" uniquely
+  # identifies it among the profile buttons. The modal only renders once
+  # opened (it is a page-level dialog, not an anchored dropdown: see
+  # MydiaWeb.MediaLive.Show.Components.hero_section/1), so every test here
+  # must open it first.
   @blank_profile_button ~s{button[phx-click="update_quality_profile"][phx-value-profile-id=""]}
 
   setup %{conn: conn} do
@@ -38,6 +41,7 @@ defmodule MydiaWeb.MediaLive.Show.DefaultQualityProfileLabelTest do
     movie = media_item_fixture(%{type: "movie", quality_profile_id: profile_a.id})
 
     {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_click(view, "show_quality_profile_modal", %{})
 
     assert has_element?(view, @blank_profile_button, "Use default (#{profile_b.name})")
     refute has_element?(view, @blank_profile_button, "Use default (#{profile_a.name})")
@@ -49,6 +53,7 @@ defmodule MydiaWeb.MediaLive.Show.DefaultQualityProfileLabelTest do
     movie = media_item_fixture(%{type: "movie"})
 
     {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_click(view, "show_quality_profile_modal", %{})
 
     assert has_element?(view, @blank_profile_button, "No profile")
   end

--- a/test/mydia_web/live/media_live/show/hero_picker_modals_test.exs
+++ b/test/mydia_web/live/media_live/show/hero_picker_modals_test.exs
@@ -1,0 +1,143 @@
+defmodule MydiaWeb.MediaLive.Show.HeroPickerModalsTest do
+  @moduledoc """
+  The hero column's Quality Profile, Library and Collection rows all used to
+  be anchored daisyUI dropdowns. They are now buttons that open page-level
+  modals, because the hero column is `overflow-y-auto` (see
+  `MydiaWeb.MediaLive.Show.Components.hero_section/1`), which clips an
+  anchored `.dropdown-content` menu once it runs past the column's remaining
+  headroom, exactly the failure mode issue #465 already fixed once for a
+  different surface. Confirmed by measuring the real page over CDP, not
+  assumed from the CSS alone.
+
+  These tests exercise the round trip through the actual button element
+  (rather than pushing the underlying event by name), so a typo in the
+  `phx-click` wiring fails loudly.
+  """
+
+  # Connected LiveView tests must stay sync: the Postgres sandbox is only
+  # shared with the mount process when the case is not async.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+  import Mydia.CollectionsFixtures
+  import MydiaWeb.AuthHelpers
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin), admin: admin}
+  end
+
+  describe "quality profile modal" do
+    test "the row is a button that opens the modal, and picking a profile closes it", %{
+      conn: conn
+    } do
+      profile = quality_profile_fixture(%{name: "Profile #{System.unique_integer([:positive])}"})
+      item = media_item_fixture(%{type: "movie", title: "Picker Movie", year: 2024})
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{item.id}")
+
+      refute has_element?(view, "#quality-profile-modal")
+
+      view
+      |> element("button[title='Click to change quality profile']")
+      |> render_click()
+
+      assert has_element?(view, "#quality-profile-modal")
+      assert has_element?(view, "#quality-profile-modal", profile.name)
+
+      view
+      |> element(
+        "#quality-profile-modal button[phx-click='update_quality_profile'][phx-value-profile-id='#{profile.id}']"
+      )
+      |> render_click()
+
+      refute has_element?(view, "#quality-profile-modal")
+      assert Mydia.Repo.get!(Mydia.Media.MediaItem, item.id).quality_profile_id == profile.id
+    end
+
+    test "Cancel closes the modal without changing anything", %{conn: conn} do
+      item = media_item_fixture(%{type: "movie", title: "Cancel Movie", year: 2024})
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{item.id}")
+
+      view
+      |> element("button[title='Click to change quality profile']")
+      |> render_click()
+
+      assert has_element?(view, "#quality-profile-modal")
+
+      view
+      |> element("#quality-profile-modal button", "Cancel")
+      |> render_click()
+
+      refute has_element?(view, "#quality-profile-modal")
+      assert Mydia.Repo.get!(Mydia.Media.MediaItem, item.id).quality_profile_id == nil
+    end
+  end
+
+  describe "add to collection modal" do
+    test "the row is a button that opens the modal", %{conn: conn, admin: admin} do
+      collection = collection_fixture(%{user: admin, name: "My Watchlist"})
+      item = media_item_fixture(%{type: "movie", title: "Collectible Movie", year: 2024})
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{item.id}")
+
+      refute has_element?(view, "#add-to-collection-modal")
+
+      view
+      |> element("button[phx-click='open_add_to_collection_modal']")
+      |> render_click()
+
+      assert has_element?(view, "#add-to-collection-modal")
+      assert has_element?(view, "#add-to-collection-modal", collection.name)
+    end
+
+    test "picking a collection adds the item and closes the modal", %{conn: conn, admin: admin} do
+      collection = collection_fixture(%{user: admin, name: "My Watchlist"})
+      item = media_item_fixture(%{type: "movie", title: "Collectible Movie 2", year: 2024})
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{item.id}")
+
+      view
+      |> element("button[phx-click='open_add_to_collection_modal']")
+      |> render_click()
+
+      view
+      |> element(
+        "#add-to-collection-modal button[phx-click='add_to_collection'][phx-value-collection-id='#{collection.id}']"
+      )
+      |> render_click()
+
+      refute has_element?(view, "#add-to-collection-modal")
+
+      assert Mydia.Collections.collections_for_item(admin, item.id) |> Enum.map(& &1.id) == [
+               collection.id
+             ]
+    end
+
+    test "before any manual collection exists, the picker still lists the auto-provisioned Favorites",
+         %{conn: conn} do
+      # Mydia.Collections gets-or-creates a Favorites system collection (type
+      # "manual", is_system: true) the first time a user's favorite status is
+      # checked, which mount/3 does unconditionally via
+      # CollectionEvents.load_collection_data/2. So a brand new user who has
+      # never created a collection still sees one option here, not the empty
+      # state - that empty state only exists for
+      # Modals.add_to_collection_modal/1's own render_component tests (see
+      # modals_test.exs), never through this LiveView's mount flow.
+      item = media_item_fixture(%{type: "movie", title: "No Collections Movie", year: 2024})
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{item.id}")
+
+      view
+      |> element("button[phx-click='open_add_to_collection_modal']")
+      |> render_click()
+
+      assert has_element?(view, "#add-to-collection-modal", "Favorites")
+      refute has_element?(view, "#add-to-collection-modal", "No collections yet")
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/hero_picker_modals_test.exs
+++ b/test/mydia_web/live/media_live/show/hero_picker_modals_test.exs
@@ -95,7 +95,10 @@ defmodule MydiaWeb.MediaLive.Show.HeroPickerModalsTest do
       assert has_element?(view, "#add-to-collection-modal", collection.name)
     end
 
-    test "picking a collection adds the item and closes the modal", %{conn: conn, admin: admin} do
+    test "picking a collection adds the item and leaves the modal open", %{
+      conn: conn,
+      admin: admin
+    } do
       collection = collection_fixture(%{user: admin, name: "My Watchlist"})
       item = media_item_fixture(%{type: "movie", title: "Collectible Movie 2", year: 2024})
 
@@ -111,11 +114,60 @@ defmodule MydiaWeb.MediaLive.Show.HeroPickerModalsTest do
       )
       |> render_click()
 
-      refute has_element?(view, "#add-to-collection-modal")
+      # Deliberately stays open: see the regression-guard test below for why.
+      assert has_element?(view, "#add-to-collection-modal")
 
       assert Mydia.Collections.collections_for_item(admin, item.id) |> Enum.map(& &1.id) == [
                collection.id
              ]
+    end
+
+    # The regression guard: CollectionEvents.load_collection_data/2 used to
+    # unconditionally force show_add_to_collection_modal to false on every
+    # call, which was dead weight under the old anchored dropdown (nothing
+    # read that assign) but became live and load-bearing the moment the
+    # dropdown became this modal. Left unfixed, the very first pick in a
+    # session would close the picker, making it impossible to add one item to
+    # more than one collection without reopening the modal between every
+    # single pick.
+    test "toggling membership in two collections in one sitting keeps the modal open between picks",
+         %{conn: conn, admin: admin} do
+      collection_a = collection_fixture(%{user: admin, name: "Collection A"})
+      collection_b = collection_fixture(%{user: admin, name: "Collection B"})
+      item = media_item_fixture(%{type: "movie", title: "Multi Collection Movie", year: 2024})
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{item.id}")
+
+      view
+      |> element("button[phx-click='open_add_to_collection_modal']")
+      |> render_click()
+
+      view
+      |> element(
+        "#add-to-collection-modal button[phx-click='add_to_collection'][phx-value-collection-id='#{collection_a.id}']"
+      )
+      |> render_click()
+
+      assert has_element?(view, "#add-to-collection-modal")
+
+      view
+      |> element(
+        "#add-to-collection-modal button[phx-click='add_to_collection'][phx-value-collection-id='#{collection_b.id}']"
+      )
+      |> render_click()
+
+      assert has_element?(view, "#add-to-collection-modal")
+
+      assert Mydia.Collections.collections_for_item(admin, item.id)
+             |> Enum.map(& &1.id)
+             |> Enum.sort() == Enum.sort([collection_a.id, collection_b.id])
+
+      # It does still close, just only from the explicit Close action.
+      view
+      |> element("#add-to-collection-modal button", "Close")
+      |> render_click()
+
+      refute has_element?(view, "#add-to-collection-modal")
     end
 
     test "before any manual collection exists, the picker still lists the auto-provisioned Favorites",
@@ -138,6 +190,36 @@ defmodule MydiaWeb.MediaLive.Show.HeroPickerModalsTest do
 
       assert has_element?(view, "#add-to-collection-modal", "Favorites")
       refute has_element?(view, "#add-to-collection-modal", "No collections yet")
+    end
+  end
+
+  describe "target library modal" do
+    test "the row is a button that opens the modal, and picking a library closes it", %{
+      conn: conn
+    } do
+      library_path_fixture(%{type: "movies", path: "/tmp/hero-target-a"})
+      library = library_path_fixture(%{type: "movies", path: "/tmp/hero-target-b"})
+      item = media_item_fixture(%{type: "movie", title: "Target Library Movie", year: 2024})
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{item.id}")
+
+      refute has_element?(view, "#target-library-modal")
+
+      view
+      |> element("button[data-test='target-library']")
+      |> render_click()
+
+      assert has_element?(view, "#target-library-modal")
+      assert has_element?(view, "#target-library-modal", "hero-target-b")
+
+      view
+      |> element(
+        "#target-library-modal button[phx-click='update_target_library'][phx-value-library-path-id='#{library.id}']"
+      )
+      |> render_click()
+
+      refute has_element?(view, "#target-library-modal")
+      assert Mydia.Repo.get!(Mydia.Media.MediaItem, item.id).library_path_id == library.id
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -212,4 +212,75 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
       assert html =~ "Grabbing…"
     end
   end
+
+  describe "quality_profile_modal/1" do
+    test "lists every profile plus the default choice, marking the active one" do
+      profile_a = %Mydia.Settings.QualityProfile{id: "profile-a", name: "Profile A"}
+      profile_b = %Mydia.Settings.QualityProfile{id: "profile-b", name: "Profile B"}
+
+      html =
+        render_component(&Modals.quality_profile_modal/1,
+          media_item: %Mydia.Media.MediaItem{quality_profile_id: "profile-b"},
+          quality_profiles: [profile_a, profile_b],
+          default_quality_profile_name: "House Default"
+        )
+
+      assert html =~ "Profile A"
+      assert html =~ "Profile B"
+      assert html =~ "Use default (House Default)"
+      assert html =~ ~s(phx-value-profile-id="profile-b")
+      assert html =~ ~s(phx-click="hide_quality_profile_modal")
+    end
+  end
+
+  describe "target_library_modal/1" do
+    test "lists Automatic plus every candidate library, marking the active one" do
+      library = %LibraryPath{id: "lib-a", path: "/media/movies-a"}
+
+      html =
+        render_component(&Modals.target_library_modal/1,
+          media_item: %Mydia.Media.MediaItem{library_path_id: "lib-a"},
+          libraries: [library]
+        )
+
+      assert html =~ "Automatic"
+      assert html =~ "movies-a"
+      assert html =~ ~s(phx-value-library-path-id="lib-a")
+      assert html =~ ~s(phx-click="hide_target_library_modal")
+    end
+  end
+
+  describe "add_to_collection_modal/1" do
+    test "with no collections, offers a create-collection link instead of a list" do
+      html =
+        render_component(&Modals.add_to_collection_modal/1,
+          media_item: %Mydia.Media.MediaItem{},
+          user_collections: [],
+          item_collections: []
+        )
+
+      assert html =~ "No collections yet"
+      assert html =~ "Create Collection"
+      refute html =~ ~s(phx-click="add_to_collection")
+    end
+
+    test "lists collections and marks the ones the item already belongs to" do
+      in_collection = %Mydia.Collections.Collection{id: "c-1", name: "In It", is_system: false}
+      not_in_collection = %Mydia.Collections.Collection{id: "c-2", name: "Not In It"}
+
+      html =
+        render_component(&Modals.add_to_collection_modal/1,
+          media_item: %Mydia.Media.MediaItem{},
+          user_collections: [in_collection, not_in_collection],
+          item_collections: [in_collection]
+        )
+
+      assert html =~ "In It"
+      assert html =~ "Not In It"
+      assert html =~ ~s(phx-click="remove_from_collection")
+      assert html =~ ~s(phx-value-collection-id="c-1")
+      assert html =~ ~s(phx-click="add_to_collection")
+      assert html =~ ~s(phx-value-collection-id="c-2")
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/show/recommendations_expanded_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendations_expanded_test.exs
@@ -1,0 +1,114 @@
+defmodule MydiaWeb.MediaLive.Show.RecommendationsExpandedTest do
+  @moduledoc """
+  The remount is the point. A test that only clicks the toggle and re-reads the
+  same socket passes even when the state never leaves memory, which is exactly
+  the bug this change fixes.
+  """
+
+  # async: false - the Postgres non-shared sandbox hides these rows from the
+  # LiveView mount process otherwise.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+  import Mydia.MetadataCacheHelpers
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.UserPreference
+
+  setup %{conn: conn} do
+    # The app disables Oban in test (engine: false), so Oban.insert cannot run
+    # from the LiveView process. Start an isolated, manual-mode instance so the
+    # recommendations load can enqueue without a live queue.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+    user = admin_user_fixture()
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
+  defp show_with_recommendations do
+    source_tmdb_id = unique_provider_id()
+
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Detectorists",
+        year: 2014,
+        tmdb_id: source_tmdb_id
+      })
+
+    episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+    warm_recommendations_cache(source_tmdb_id, :tv_show, [
+      %{
+        "id" => unique_provider_id(),
+        "name" => "Rev.",
+        "first_air_date" => "2010-06-28",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    show
+  end
+
+  test "the rail starts collapsed for a show", %{conn: conn} do
+    show = show_with_recommendations()
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, ~s(#recommendations-rail-toggle[aria-expanded="false"]))
+  end
+
+  test "opening the rail persists and survives a remount", %{conn: conn, user: user} do
+    show = show_with_recommendations()
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    view |> element("#recommendations-rail-toggle") |> render_click()
+
+    assert user
+           |> Accounts.get_user_preference!()
+           |> UserPreference.recommendations_expanded() == true
+
+    {:ok, remounted, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(remounted, 5000)
+
+    assert has_element?(remounted, ~s(#recommendations-rail-toggle[aria-expanded="true"]))
+  end
+
+  test "closing the rail again persists false", %{conn: conn, user: user} do
+    show = show_with_recommendations()
+
+    {:ok, _} =
+      Accounts.update_preference(
+        Accounts.get_user_preference!(user),
+        %{"recommendations_expanded" => true}
+      )
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+    render_async(view, 5000)
+
+    view |> element("#recommendations-rail-toggle") |> render_click()
+
+    assert user
+           |> Accounts.get_user_preference!()
+           |> UserPreference.recommendations_expanded() == false
+  end
+
+  # Asserts on the changeset directly rather than via errors_on/1: that helper
+  # lives in Mydia.DataCase and MydiaWeb.ConnCase does not import it.
+  test "a non-boolean value is rejected by the changeset", %{user: user} do
+    assert {:error, %Ecto.Changeset{valid?: false} = changeset} =
+             Accounts.update_preference(
+               Accounts.get_user_preference!(user),
+               %{"recommendations_expanded" => "yes"}
+             )
+
+    assert Keyword.has_key?(changeset.errors, :preferences)
+  end
+end

--- a/test/mydia_web/live/media_live/show/section_order_test.exs
+++ b/test/mydia_web/live/media_live/show/section_order_test.exs
@@ -12,6 +12,9 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
   # Every section whose position this page decides. Each case asserts the whole
   # list rather than a pairwise precedence, so a section that stops rendering
   # fails the test instead of passing quietly.
+  #
+  # timeline-section is no longer a member of the main column: it is a sibling
+  # aside placed after it, so it always sorts last in document order.
   @sections "#seasons-episodes-section, #media-files-section, #subtitles-section, " <>
               "#timeline-section, #franchise-section, #recommendations-rail"
 
@@ -58,8 +61,8 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
     assert section_ids(view) == [
              "media-files-section",
              "subtitles-section",
-             "timeline-section",
-             "recommendations-rail"
+             "recommendations-rail",
+             "timeline-section"
            ]
   end
 
@@ -141,19 +144,18 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
     assert section_ids(view) == [
              "media-files-section",
              "subtitles-section",
-             "timeline-section",
              "franchise-section",
-             "recommendations-rail"
+             "recommendations-rail",
+             "timeline-section"
            ]
   end
 
-  # A movie with no file is not left untouched by this reorder: its timeline card
-  # moved above the rails along with the file and subtitle cards. That is the
-  # intended grouping - everything about this copy of the movie, then everything
-  # about other movies - and it holds even when the history is the only thing in
-  # the first group. Pinned here so the placement stays a decision rather than a
-  # side effect of the guards.
-  test "a movie with no media files keeps its history above the rails", %{conn: conn} do
+  # History is no longer part of the main column's ordering decision: it is a
+  # sibling aside, third grid column at xl and a full-width row below it. It
+  # therefore always sorts last in document order regardless of what the main
+  # column contains. Pinned here so a later edit that folds it back into the
+  # flow fails loudly.
+  test "a movie with no media files renders its history outside the main column", %{conn: conn} do
     source_tmdb_id = unique_provider_id()
 
     movie =
@@ -181,8 +183,8 @@ defmodule MydiaWeb.MediaLive.Show.SectionOrderTest do
     # No media-files-section or subtitles-section: both guard on a non-empty
     # media_files. No franchise-section: the fixture carries no collection_id.
     assert section_ids(view) == [
-             "timeline-section",
-             "recommendations-rail"
+             "recommendations-rail",
+             "timeline-section"
            ]
   end
 

--- a/test/mydia_web/live/media_live/show_library_test.exs
+++ b/test/mydia_web/live/media_live/show_library_test.exs
@@ -52,4 +52,40 @@ defmodule MydiaWeb.MediaLive.ShowLibraryTest do
 
     assert Mydia.Repo.get!(Mydia.Media.MediaItem, item.id).library_path_id == nil
   end
+
+  # The row used to be an anchored daisyUI dropdown. It is now a button that
+  # opens a page-level modal, because the row lives inside the hero column's
+  # overflow-y-auto wrapper, which clips an anchored dropdown-content menu
+  # once it runs past the column's remaining headroom (measured on the
+  # running page, not assumed from the CSS: see the UI polish fix wave
+  # report).
+  test "with two or more candidates, the row is a button that opens the picker modal", %{
+    conn: conn
+  } do
+    library_path_fixture(%{type: "movies", path: "/tmp/aaa-first"})
+    library_path_fixture(%{type: "movies", path: "/tmp/zzz-second"})
+    item = media_item_fixture(%{type: "movie", title: "Multi Library", year: 2024})
+
+    {:ok, view, _html} = live(conn, ~p"/movies/#{item.id}")
+
+    refute has_element?(view, "#target-library-modal")
+
+    view
+    |> element("button[data-test='target-library']")
+    |> render_click()
+
+    assert has_element?(view, "#target-library-modal")
+    assert has_element?(view, "#target-library-modal", "aaa-first")
+    assert has_element?(view, "#target-library-modal", "zzz-second")
+  end
+
+  test "with a single candidate, the row is static and not clickable", %{conn: conn} do
+    library_path_fixture(%{type: "movies", path: "/tmp/only-one"})
+    item = media_item_fixture(%{type: "movie", title: "Single Library", year: 2024})
+
+    {:ok, view, _html} = live(conn, ~p"/movies/#{item.id}")
+
+    refute has_element?(view, "button[data-test='target-library']")
+    assert has_element?(view, "div[data-test='target-library']")
+  end
 end


### PR DESCRIPTION
Six UI polish changes, requested together and built as one branch.

## What changed

**Dashboard.** The four stat tiles (Movies, TV Shows, Downloads, Storage) are now links. Storage points at library paths and only renders as a link for admins, since that route is behind `:require_admin` and the stat row renders for every role including guest.

**Media detail page.** The outer layout moves from a flex row to a CSS grid. The poster column pins while you scroll, capped at the viewport height with its own scroll so the Path and Target Library rows stay reachable on a laptop. History changes from a horizontal card scroller buried between Subtitles and the franchise rail into a vertical rail: a third column at `xl` and up, a full-width row below it, one DOM node placed by the grid rather than duplicated markup.

**More Like This.** The rail's open state now persists per user across page loads, instead of resetting to collapsed on every mount. Stored in the existing `user_preferences` map column following the `GridDensity` helper pattern, so there is no migration.

**Discover preview popup.** The modal box becomes a flex column with a pinned header and one scrolling body. The footer is gone and its actions moved up beside the title, so Add to Library stays reachable from the bottom of a long modal.

**Poster hover.** The hover treatment had been hand-copied across poster grids, so three had it and five did not. It is now one `poster_figure/1` in `core_components.ex`, adopted at seven call sites. Adopting it in `discover_components.card_poster/1` alone fixes the Discover grid, More Like This, the franchise rail and the modal rail together.

## Notes for review

Two problems surfaced during review that were not in the original scope, both confirmed by measuring in a browser rather than reading the source:

- The pinned poster column's `overflow-y-auto` clipped the Collection, Quality Profile and Target Library dropdown menus, which daisyUI renders as `position: absolute`. Menus extended 200+px past the wrapper and were confirmed painted over. All three are now page-level modals, matching the fix already used for #465.
- The pinned column overlapped the mobile header by 48px across 768-1023px, where that header is still visible. The column's offset is raised in that band only and reverts at `lg`.

Converting those dropdowns to modals made a previously-dead close path live, which closed the Collection picker after a single toggle. Fixed, with a test that toggles two collections in one session.

The `<.icon>`-only close X in the Discover modal gained an `aria-label`, since dropping the footer left it as the only close control.

## Verification

`mix precommit` green: compile with `--warnings-as-errors`, unused deps, format, Credo `--strict`, and the full suite.

Layout behaviour was measured in a real browser over CDP rather than asserted from the source, at 1920/1440/1280/1024/900/768/375 wide and at short viewport heights, in both themes.

## Known gaps, not introduced here

- `collection_live/show.ex` and `collection_components.ex` have no test coverage anywhere in the repo. This branch modifies both; correctness was verified by reading.
- No test pins the grid and sticky class strings, so an accidental revert would pass the suite silently.
- No test exercises a media item with zero timeline events, because `create_media_item/2` always records one. The empty-state behaviour rests on the browser measurement.
- A horizontal overflow at 1024px from episode-row action buttons predates this branch and is untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page-level pickers for quality profiles, download libraries, and collections.
  * Added persistent “More Like This” expansion preferences for TV shows.
  * Redesigned media history as a responsive timeline sidebar.
  * Added reusable poster displays with loading, fallback, hover, and overlay support.
  * Improved dashboard statistics navigation, including admin-only storage access.

* **Improvements**
  * Collection selection can remain open for multiple additions.
  * Trending details now use a fixed header with scrolling content.
  * Standardized poster behavior across media views and search results.
  * Improved responsive media-page layout and hero controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->