### PR TITLE
fix(streaming): validate the whole playback profile, not just codec names

### DIFF
--- a/lib/mydia/streaming/codec_profile.ex
+++ b/lib/mydia/streaming/codec_profile.ex
@@ -1,0 +1,111 @@
+defmodule Mydia.Streaming.CodecProfile do
+  @moduledoc """
+  The constraints attached to one codec a client claims.
+
+  A client says "I decode hevc" with `DeviceProfile.video_codecs`, and says
+  *which* hevc with a codec profile: the conditions here all have to hold for a
+  stream in that codec to be handed over untouched.
+
+  Matching the codec uses the same substring rule as the flat allowlists, so a
+  profile written for `"hevc"` also covers the `"hevc (Main 10)"` shapes ffprobe
+  display strings arrive in.
+
+  Conditions are ANDed. An empty condition list means the codec is claimed
+  unconditionally, which is exactly what the flat allowlists meant on their own
+  and is why an old client that sends no codec profiles keeps working.
+  """
+
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Streaming.ProfileCondition
+
+  @enforce_keys [:type, :codec]
+  defstruct [:type, :codec, conditions: []]
+
+  @type stream_type :: :video | :audio
+
+  @type t :: %__MODULE__{
+          type: stream_type(),
+          codec: String.t(),
+          conditions: [ProfileCondition.t()]
+        }
+
+  @max_conditions 32
+
+  @doc """
+  Builds a codec profile from a decoded JSON map.
+
+  Returns `:error` when the type or codec is unusable, or when any condition
+  fails to parse. A codec profile that silently lost a condition would claim
+  more than the client meant, so a bad entry rejects the whole profile and the
+  caller treats the payload as absent.
+  """
+  @spec from_map(term()) :: {:ok, t()} | :error
+  def from_map(%{} = map) do
+    with {:ok, type} <- parse_type(Map.get(map, "type")),
+         {:ok, codec} <- parse_codec(Map.get(map, "codec")),
+         {:ok, conditions} <- parse_conditions(Map.get(map, "conditions", [])) do
+      {:ok, %__MODULE__{type: type, codec: codec, conditions: conditions}}
+    end
+  end
+
+  def from_map(_other), do: :error
+
+  defp parse_type(type) when is_binary(type) do
+    case type |> String.trim() |> String.downcase() do
+      "video" -> {:ok, :video}
+      "audio" -> {:ok, :audio}
+      _ -> :error
+    end
+  end
+
+  defp parse_type(_type), do: :error
+
+  defp parse_codec(codec) when is_binary(codec) do
+    normalized = codec |> String.trim() |> String.downcase()
+
+    # An empty codec would substring-match every stream, turning one client's
+    # constraint into a global one. Same trap the flat allowlists guard.
+    if normalized == "" or String.length(normalized) > 64 do
+      :error
+    else
+      {:ok, normalized}
+    end
+  end
+
+  defp parse_codec(_codec), do: :error
+
+  defp parse_conditions(conditions) when is_list(conditions) do
+    if length(conditions) > @max_conditions do
+      :error
+    else
+      Enum.reduce_while(conditions, {:ok, []}, fn entry, {:ok, acc} ->
+        case ProfileCondition.from_map(entry) do
+          {:ok, condition} -> {:cont, {:ok, [condition | acc]}}
+          :error -> {:halt, :error}
+        end
+      end)
+      |> case do
+        {:ok, parsed} -> {:ok, Enum.reverse(parsed)}
+        :error -> :error
+      end
+    end
+  end
+
+  defp parse_conditions(_conditions), do: :error
+
+  @doc "Whether this profile governs `codec` for streams of `type`."
+  @spec applies?(t(), stream_type(), String.t() | nil) :: boolean()
+  def applies?(%__MODULE__{type: type, codec: codec}, type, actual) when is_binary(actual) do
+    actual |> String.downcase() |> String.contains?(codec)
+  end
+
+  def applies?(%__MODULE__{}, _type, _actual), do: false
+
+  @doc """
+  Whether `stream` satisfies every condition on this profile.
+  """
+  @spec satisfied?(t(), StreamInfo.t() | nil) :: boolean()
+  def satisfied?(%__MODULE__{conditions: conditions}, stream) do
+    Enum.all?(conditions, &ProfileCondition.satisfied?(&1, stream))
+  end
+end

--- a/lib/mydia/streaming/compatibility.ex
+++ b/lib/mydia/streaming/compatibility.ex
@@ -14,6 +14,7 @@ defmodule Mydia.Streaming.Compatibility do
   """
 
   alias Mydia.Library.MediaFile
+  alias Mydia.Library.Structs.FileMetadata
   alias Mydia.Streaming.DeviceProfile
 
   @type streaming_mode :: :direct_play | :needs_remux | :needs_transcoding
@@ -58,11 +59,13 @@ defmodule Mydia.Streaming.Compatibility do
     video_codec = media_file.codec
     audio_codec = media_file.audio_codec
 
+    streams = stream_pair(media_file)
+
     cond do
-      client_can_play?(profile, container, video_codec, audio_codec) ->
+      client_can_play?(profile, container, video_codec, audio_codec, streams) ->
         :direct_play
 
-      remux_eligible?(profile, container, video_codec, audio_codec) ->
+      remux_eligible?(profile, container, video_codec, audio_codec, streams) ->
         :needs_remux
 
       true ->
@@ -70,19 +73,32 @@ defmodule Mydia.Streaming.Compatibility do
     end
   end
 
+  # The first video and first audio stream, which are the two the `codec` and
+  # `audio_codec` columns describe. Read from `metadata.streams` and never from
+  # FileMetadata's flat codec-detail fields (`hevc_profile_idc`, `bit_depth`):
+  # the analyzer declares those but does not write them, so on a real library
+  # they are nil on every row while the per-stream values are present on all of
+  # them. Sourcing conditions from the flat fields would make every constraint
+  # unresolvable and quietly approve everything.
+  defp stream_pair(media_file) do
+    streams = (media_file.metadata || FileMetadata.empty()).streams || []
+
+    {Enum.find(streams, &(&1.type == :video)), Enum.find(streams, &(&1.type == :audio))}
+  end
+
   # The client can open this container and decode every stream in it as-is.
-  defp client_can_play?(profile, container, video_codec, audio_codec) do
+  defp client_can_play?(profile, container, video_codec, audio_codec, streams) do
     DeviceProfile.container_allowed?(profile, container) and
-      codecs_playable?(profile, video_codec, audio_codec)
+      codecs_playable?(profile, video_codec, audio_codec, streams)
   end
 
   # The codecs are fine but the container is not, so ffmpeg can stream-copy into
   # fMP4 without re-encoding. `remuxable_container?/1` stays hardcoded because it
   # describes what ffmpeg can repackage, which is a server capability and does
   # not vary by client.
-  defp remux_eligible?(profile, container, video_codec, audio_codec) do
+  defp remux_eligible?(profile, container, video_codec, audio_codec, streams) do
     remuxable_container?(container) and
-      codecs_playable?(profile, video_codec, audio_codec)
+      codecs_playable?(profile, video_codec, audio_codec, streams)
   end
 
   # HDR is deliberately NOT checked here yet.
@@ -99,9 +115,11 @@ defmodule Mydia.Streaming.Compatibility do
   # Activate this against Mydia.Library.Hdr.profile_tokens/1 when it lands,
   # matching any-member-of rather than equality. DeviceProfile still parses and
   # caps `hdr_formats` so the wire format does not have to change then.
-  defp codecs_playable?(profile, video_codec, audio_codec) do
+  defp codecs_playable?(profile, video_codec, audio_codec, {video_stream, audio_stream}) do
     DeviceProfile.video_codec_allowed?(profile, video_codec) and
-      DeviceProfile.audio_codec_allowed_or_absent?(profile, audio_codec)
+      DeviceProfile.codec_conditions_met?(profile, :video, video_codec, video_stream) and
+      DeviceProfile.audio_codec_allowed_or_absent?(profile, audio_codec) and
+      DeviceProfile.codec_conditions_met?(profile, :audio, audio_codec, audio_stream)
   end
 
   # Containers that can be remuxed to fMP4 without transcoding.

--- a/lib/mydia/streaming/device_profile.ex
+++ b/lib/mydia/streaming/device_profile.ex
@@ -1,11 +1,26 @@
 defmodule Mydia.Streaming.DeviceProfile do
   @moduledoc """
-  What a client can decode, as four allowlists.
+  What a client can decode: four allowlists, plus the constraints on them.
 
   A profile arrives per request in the `X-Mydia-Device-Profile` header and
   parameterizes `Mydia.Streaming.Compatibility`. It is deliberately not
   persisted: a stored profile goes stale silently when the viewer changes OS,
   display, or hardware decode availability, which is the failure this replaces.
+
+  ## Why codec names alone are not enough
+
+  The allowlists answer "which codecs", and that turned out to be the wrong
+  question on its own. A tablet whose MediaCodec decoder opens HEVC Main and
+  refuses HEVC Main 10 still advertised `hevc`, because the native client reads
+  libmpv's `decoder-list` — a libavcodec *build* list, blind to profile and bit
+  depth. The server direct-played a 10-bit stream at it and playback died on
+  "Could not open codec." with no recoverable path.
+
+  `codec_profiles` carries the rest: per-codec `Mydia.Streaming.ProfileCondition`
+  sets over bit depth, profile, level, resolution, frame rate and channel count,
+  evaluated against the file's real per-stream metadata. A codec with no
+  conditions is claimed unconditionally, so a client that sends none behaves
+  exactly as it did before conditions existed.
 
   ## Matching
 
@@ -29,6 +44,9 @@ defmodule Mydia.Streaming.DeviceProfile do
 
   import Ecto.Changeset
 
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Streaming.CodecProfile
+
   @max_entries 64
   @max_entry_length 64
   @max_encoded_bytes 4096
@@ -37,7 +55,8 @@ defmodule Mydia.Streaming.DeviceProfile do
           containers: [String.t()],
           video_codecs: [String.t()],
           audio_codecs: [String.t()],
-          hdr_formats: [String.t()]
+          hdr_formats: [String.t()],
+          codec_profiles: [CodecProfile.t()]
         }
 
   @primary_key false
@@ -46,6 +65,12 @@ defmodule Mydia.Streaming.DeviceProfile do
     field(:video_codecs, {:array, :string}, default: [])
     field(:audio_codecs, {:array, :string}, default: [])
     field(:hdr_formats, {:array, :string}, default: [])
+
+    # Parsed by hand rather than cast, because these are nested structs and the
+    # "one bad entry rejects the payload" rule below is stricter than a
+    # changeset's per-field errors express. Virtual so the embedded schema stays
+    # the flat, castable shape the four allowlists need.
+    field(:codec_profiles, :any, virtual: true, default: [])
   end
 
   @doc """
@@ -101,13 +126,37 @@ defmodule Mydia.Streaming.DeviceProfile do
       |> downcase_list(:audio_codecs)
       |> downcase_list(:hdr_formats)
 
-    case apply_action(changeset, :insert) do
-      {:ok, profile} -> {:ok, profile}
-      {:error, _changeset} -> :error
+    with {:ok, profile} <- apply_action(changeset, :insert),
+         {:ok, codec_profiles} <- parse_codec_profiles(Map.get(map, "codecProfiles", [])) do
+      {:ok, %{profile | codec_profiles: codec_profiles}}
+    else
+      _ -> :error
     end
   end
 
   def from_map(_other), do: :error
+
+  # A malformed codec profile rejects the whole payload rather than being
+  # dropped. A dropped constraint is indistinguishable from a client that never
+  # had one, and that difference is the direction that widens direct play.
+  defp parse_codec_profiles(entries) when is_list(entries) do
+    if length(entries) > @max_entries do
+      :error
+    else
+      Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, acc} ->
+        case CodecProfile.from_map(entry) do
+          {:ok, codec_profile} -> {:cont, {:ok, [codec_profile | acc]}}
+          :error -> {:halt, :error}
+        end
+      end)
+      |> case do
+        {:ok, parsed} -> {:ok, Enum.reverse(parsed)}
+        :error -> :error
+      end
+    end
+  end
+
+  defp parse_codec_profiles(_entries), do: :error
 
   @doc """
   Decodes a raw device profile header value into a profile.
@@ -175,6 +224,33 @@ defmodule Mydia.Streaming.DeviceProfile do
   end
 
   def audio_codec_allowed_or_absent?(%__MODULE__{}, _codec), do: false
+
+  @doc """
+  Whether `stream` satisfies every codec profile this client attached to `codec`.
+
+  A codec the client attached no conditions to is unconstrained, which is what
+  the flat allowlist meant on its own — so a client that sends no codec profiles
+  behaves exactly as it did before conditions existed.
+
+  Note this answers only the *conditions*. Whether the codec is claimed at all
+  is still `video_codec_allowed?/2` and `audio_codec_allowed_or_absent?/2`;
+  both have to hold.
+  """
+  @spec codec_conditions_met?(
+          t(),
+          CodecProfile.stream_type(),
+          String.t() | nil,
+          StreamInfo.t() | nil
+        ) ::
+          boolean()
+  def codec_conditions_met?(%__MODULE__{codec_profiles: profiles}, type, codec, stream)
+      when is_list(profiles) do
+    profiles
+    |> Enum.filter(&CodecProfile.applies?(&1, type, codec))
+    |> Enum.all?(&CodecProfile.satisfied?(&1, stream))
+  end
+
+  def codec_conditions_met?(%__MODULE__{}, _type, _codec, _stream), do: true
 
   defp contains_any?(list, value) do
     normalized = String.downcase(value)

--- a/lib/mydia/streaming/profile_condition.ex
+++ b/lib/mydia/streaming/profile_condition.ex
@@ -1,0 +1,251 @@
+defmodule Mydia.Streaming.ProfileCondition do
+  @moduledoc """
+  One constraint a client places on a codec it claims to decode.
+
+  A codec name alone cannot answer "can this device play this file". A tablet
+  whose MediaCodec decodes HEVC Main happily rejects the same codec at Main 10,
+  and libmpv's `decoder-list` — which is what the native client probes — reports
+  what libavcodec was *compiled* with, so it says "hevc" either way. Conditions
+  are how a client says the rest of it: bit depth, profile, level, resolution,
+  frame rate, channel count.
+
+  The shape mirrors Jellyfin's `ProfileCondition` (and Plex's device profiles)
+  rather than inventing a Mydia dialect, so the vocabulary is one an operator
+  may already know and a future importer can map onto directly.
+
+  ## Evaluating against absent metadata
+
+  A condition whose property cannot be resolved from the file's stream data is
+  **not** silently satisfied. `required: true` (the default) fails closed, which
+  is the only safe direction: the alternative hands the client a stream it never
+  approved and dead-ends playback on an error screen it cannot recover from.
+  `required: false` marks a preference that an unknown value may pass.
+
+  Read the property values from `Mydia.Library.Structs.StreamInfo`, never from
+  the flat `FileMetadata` codec-detail fields (`hevc_profile_idc`, `bit_depth`).
+  Those are declared but never written by the analyzer — across a 1291-file
+  production HEVC library they are populated on zero rows, while the per-stream
+  values are populated on all of them. A condition sourced from the flat fields
+  would resolve to `nil` everywhere and, under `required: false`, pass
+  everything while appearing to validate.
+  """
+
+  alias Mydia.Library.Structs.StreamInfo
+
+  @enforce_keys [:property, :condition, :value]
+  defstruct [:property, :condition, :value, required: true]
+
+  @type property ::
+          :video_bit_depth
+          | :video_profile
+          | :video_level
+          | :width
+          | :height
+          | :video_framerate
+          | :audio_channels
+          | :audio_sample_rate
+          | :audio_profile
+
+  @type condition ::
+          :equals | :not_equals | :less_than_equal | :greater_than_equal | :equals_any
+
+  @type t :: %__MODULE__{
+          property: property(),
+          condition: condition(),
+          value: String.t(),
+          required: boolean()
+        }
+
+  # Fixed enums, looked up rather than converted. The payload is
+  # attacker-controlled and these read exactly like atom names, which is the
+  # shape that invites an unsafe String.to_atom/1 and a memory leak with it.
+  # An unrecognized name resolves to :invalid, never to a minted atom.
+  @properties %{
+    "videobitdepth" => :video_bit_depth,
+    "videoprofile" => :video_profile,
+    "videolevel" => :video_level,
+    "width" => :width,
+    "height" => :height,
+    "videoframerate" => :video_framerate,
+    "audiochannels" => :audio_channels,
+    "audiosamplerate" => :audio_sample_rate,
+    "audioprofile" => :audio_profile
+  }
+
+  @conditions %{
+    "equals" => :equals,
+    "notequals" => :not_equals,
+    "lessthanequal" => :less_than_equal,
+    "greaterthanequal" => :greater_than_equal,
+    "equalsany" => :equals_any
+  }
+
+  # Properties compared as numbers. Everything else compares as a
+  # case-insensitive string, which is what "Main 10" needs.
+  @numeric [
+    :video_bit_depth,
+    :video_level,
+    :width,
+    :height,
+    :video_framerate,
+    :audio_channels,
+    :audio_sample_rate
+  ]
+
+  @doc "Parses a property name. Unrecognized names return `:invalid`."
+  @spec parse_property(term()) :: property() | :invalid
+  def parse_property(name) when is_binary(name) do
+    Map.get(@properties, name |> String.trim() |> String.downcase(), :invalid)
+  end
+
+  def parse_property(_name), do: :invalid
+
+  @doc "Parses a condition name. Unrecognized names return `:invalid`."
+  @spec parse_condition(term()) :: condition() | :invalid
+  def parse_condition(name) when is_binary(name) do
+    Map.get(@conditions, name |> String.trim() |> String.downcase(), :invalid)
+  end
+
+  def parse_condition(_name), do: :invalid
+
+  @doc """
+  Builds a condition from a decoded JSON map.
+
+  Returns `:error` for an unknown property or condition rather than dropping the
+  entry. A silently dropped constraint is indistinguishable from a client that
+  never had one, which would widen direct play instead of narrowing it.
+  """
+  @spec from_map(term()) :: {:ok, t()} | :error
+  def from_map(%{} = map) do
+    property = parse_property(Map.get(map, "property"))
+    condition = parse_condition(Map.get(map, "condition"))
+    value = Map.get(map, "value")
+
+    cond do
+      property == :invalid -> :error
+      condition == :invalid -> :error
+      not is_binary(value) or value == "" -> :error
+      true -> {:ok, build(property, condition, value, Map.get(map, "isRequired", true))}
+    end
+  end
+
+  def from_map(_other), do: :error
+
+  defp build(property, condition, value, required) do
+    %__MODULE__{
+      property: property,
+      condition: condition,
+      value: value,
+      # Anything that is not an explicit `false` keeps the fail-closed default.
+      required: required != false
+    }
+  end
+
+  @doc """
+  Whether `stream` satisfies this condition.
+
+  An unresolvable property fails when `required` is set, and passes when it is
+  not. See the moduledoc for why the default leans that way.
+  """
+  @spec satisfied?(t(), StreamInfo.t() | nil) :: boolean()
+  def satisfied?(%__MODULE__{} = condition, stream) do
+    case resolve(condition.property, stream) do
+      nil -> not condition.required
+      actual -> compare(condition, actual)
+    end
+  end
+
+  defp resolve(_property, nil), do: nil
+  defp resolve(:video_bit_depth, %StreamInfo{bit_depth: value}), do: value
+  defp resolve(:video_profile, %StreamInfo{profile: value}), do: value
+  defp resolve(:video_level, %StreamInfo{level: value}), do: value
+  defp resolve(:width, %StreamInfo{width: value}), do: value
+  defp resolve(:height, %StreamInfo{height: value}), do: value
+  defp resolve(:video_framerate, %StreamInfo{frame_rate: value}), do: value
+  defp resolve(:audio_channels, %StreamInfo{channels: value}), do: value
+  defp resolve(:audio_sample_rate, %StreamInfo{sample_rate: value}), do: value
+  defp resolve(:audio_profile, %StreamInfo{profile: value}), do: value
+  defp resolve(_property, _stream), do: nil
+
+  # Handled before the single-number parse below: an `equals_any` value is a
+  # "8|10" list, which never parses as one number and would otherwise be
+  # rejected as malformed.
+  defp compare(%__MODULE__{property: property, condition: :equals_any} = condition, actual)
+       when property in @numeric do
+    case to_number(actual) do
+      {:ok, actual} ->
+        condition.value
+        |> split_any()
+        |> Enum.any?(&match?({:ok, ^actual}, to_number(&1)))
+
+      :error ->
+        not condition.required
+    end
+  end
+
+  defp compare(%__MODULE__{property: property} = condition, actual)
+       when property in @numeric do
+    with {:ok, expected} <- to_number(condition.value),
+         {:ok, actual} <- to_number(actual) do
+      numeric_compare(condition, expected, actual)
+    else
+      # A non-numeric value on a numeric property is a malformed condition, and
+      # a malformed constraint must not widen direct play.
+      :error -> not condition.required
+    end
+  end
+
+  defp compare(condition, actual), do: string_compare(condition, actual)
+
+  defp numeric_compare(%__MODULE__{condition: :equals}, expected, actual),
+    do: actual == expected
+
+  defp numeric_compare(%__MODULE__{condition: :not_equals}, expected, actual),
+    do: actual != expected
+
+  defp numeric_compare(%__MODULE__{condition: :less_than_equal}, expected, actual),
+    do: actual <= expected
+
+  defp numeric_compare(%__MODULE__{condition: :greater_than_equal}, expected, actual),
+    do: actual >= expected
+
+  defp string_compare(%__MODULE__{condition: :equals_any} = condition, actual) do
+    normalized = normalize(actual)
+
+    condition.value
+    |> split_any()
+    |> Enum.any?(&(normalize(&1) == normalized))
+  end
+
+  defp string_compare(%__MODULE__{condition: :equals} = condition, actual),
+    do: normalize(actual) == normalize(condition.value)
+
+  defp string_compare(%__MODULE__{condition: :not_equals} = condition, actual),
+    do: normalize(actual) != normalize(condition.value)
+
+  # Ordering comparisons are meaningless on a free-text profile name. Treat them
+  # as malformed rather than inventing a lexicographic answer that would read as
+  # a real capability check.
+  defp string_compare(%__MODULE__{} = condition, _actual), do: not condition.required
+
+  defp split_any(value) do
+    value
+    |> String.split("|")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp normalize(value) when is_binary(value), do: value |> String.trim() |> String.downcase()
+  defp normalize(value), do: value |> to_string() |> String.trim() |> String.downcase()
+
+  defp to_number(value) when is_integer(value) or is_float(value), do: {:ok, value * 1.0}
+
+  defp to_number(value) when is_binary(value) do
+    case Float.parse(String.trim(value)) do
+      {number, ""} -> {:ok, number}
+      _ -> :error
+    end
+  end
+
+  defp to_number(_value), do: :error
+end

--- a/player/android/app/src/main/kotlin/dev/mydia/player/MainActivity.kt
+++ b/player/android/app/src/main/kotlin/dev/mydia/player/MainActivity.kt
@@ -3,6 +3,8 @@ package dev.mydia.player
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
 import android.net.wifi.WifiManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
@@ -13,6 +15,7 @@ import io.flutter.plugin.common.MethodChannel
 class MainActivity : FlutterActivity() {
     private val channelName = "dev.mydia.player/notifications"
     private val multicastChannelName = "dev.mydia.player/multicast"
+    private val codecChannelName = "dev.mydia.player/codecs"
 
     /**
      * Held only while cast discovery is running.
@@ -44,6 +47,14 @@ class MainActivity : FlutterActivity() {
                 }
             }
 
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, codecChannelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "videoDecoderCapabilities" -> result.success(videoDecoderCapabilities())
+                    else -> result.notImplemented()
+                }
+            }
+
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
             .setMethodCallHandler { call, result ->
                 when (call.method) {
@@ -64,6 +75,121 @@ class MainActivity : FlutterActivity() {
                     else -> result.notImplemented()
                 }
             }
+    }
+
+    /**
+     * What this device's video decoders can actually open.
+     *
+     * libmpv's `decoder-list`, which the player probes for its device profile,
+     * reports what libavcodec was *compiled* with. It says "hevc" on a tablet
+     * whose MediaCodec decoder opens HEVC Main and refuses Main 10, so the
+     * server direct-plays a 10-bit stream and playback dies on "Could not open
+     * codec." with no recoverable path. This asks the platform the question
+     * that actually matters.
+     *
+     * Only decoders are considered, and a codec is reported only if some
+     * decoder claims its MIME type. Anything that throws is skipped rather than
+     * failing the whole probe: a single vendor codec with a broken capability
+     * table must not cost the device its entire profile.
+     */
+    private fun videoDecoderCapabilities(): List<Map<String, Any>> {
+        val best = mutableMapOf<String, MutableMap<String, Any>>()
+
+        val infos = try {
+            MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos
+        } catch (error: Exception) {
+            return emptyList()
+        }
+
+        for (info in infos) {
+            if (info.isEncoder) continue
+
+            for (mime in info.supportedTypes) {
+                val codec = codecNameFor(mime.lowercase()) ?: continue
+
+                try {
+                    val capabilities = info.getCapabilitiesForType(mime)
+                    val video = capabilities.videoCapabilities ?: continue
+
+                    val depth = maxBitDepthFor(mime.lowercase(), capabilities.profileLevels)
+                    val width = video.supportedWidths.upper
+                    val height = video.supportedHeights.upper
+
+                    val entry = best.getOrPut(codec) {
+                        mutableMapOf(
+                            "codec" to codec,
+                            "maxBitDepth" to 8,
+                            "maxWidth" to 0,
+                            "maxHeight" to 0
+                        )
+                    }
+
+                    entry["maxBitDepth"] = maxOf(entry["maxBitDepth"] as Int, depth)
+                    entry["maxWidth"] = maxOf(entry["maxWidth"] as Int, width)
+                    entry["maxHeight"] = maxOf(entry["maxHeight"] as Int, height)
+                } catch (error: Exception) {
+                    continue
+                }
+            }
+        }
+
+        return best.values.map { it.toMap() }
+    }
+
+    private fun codecNameFor(mime: String): String? = when (mime) {
+        "video/avc" -> "h264"
+        "video/hevc" -> "hevc"
+        "video/x-vnd.on2.vp8" -> "vp8"
+        "video/x-vnd.on2.vp9" -> "vp9"
+        "video/av01" -> "av1"
+        "video/mp4v-es" -> "mpeg4"
+        "video/mpeg2" -> "mpeg2"
+        else -> null
+    }
+
+    /**
+     * The deepest bit depth any advertised profile for [mime] implies.
+     *
+     * Defaults to 8 rather than to "unknown": a decoder that lists no profile
+     * this build recognizes is treated as 8-bit only, which is the direction
+     * that asks the server to transcode instead of handing over a stream the
+     * device may not open.
+     */
+    private fun maxBitDepthFor(mime: String, profiles: Array<MediaCodecInfo.CodecProfileLevel>): Int {
+        var depth = 8
+
+        for (level in profiles) {
+            val candidate = when (mime) {
+                "video/hevc" -> when (level.profile) {
+                    MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10,
+                    MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10,
+                    MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10Plus -> 10
+                    else -> 8
+                }
+                "video/avc" -> when (level.profile) {
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileHigh10 -> 10
+                    else -> 8
+                }
+                "video/x-vnd.on2.vp9" -> when (level.profile) {
+                    MediaCodecInfo.CodecProfileLevel.VP9Profile2,
+                    MediaCodecInfo.CodecProfileLevel.VP9Profile3,
+                    MediaCodecInfo.CodecProfileLevel.VP9Profile2HDR,
+                    MediaCodecInfo.CodecProfileLevel.VP9Profile3HDR -> 10
+                    else -> 8
+                }
+                "video/av01" -> when (level.profile) {
+                    MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10,
+                    MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10,
+                    MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10Plus -> 10
+                    else -> 8
+                }
+                else -> 8
+            }
+
+            if (candidate > depth) depth = candidate
+        }
+
+        return depth
     }
 
     private fun acquireMulticastLock() {

--- a/player/lib/core/player/android_codec_capabilities.dart
+++ b/player/lib/core/player/android_codec_capabilities.dart
@@ -1,0 +1,101 @@
+/// What Android's MediaCodec can actually open, as profile conditions.
+///
+/// This exists because libmpv's `decoder-list` cannot answer the question the
+/// server asks. That list is libavcodec's *build* configuration: it reports
+/// `hevc` on any build compiled with the HEVC decoder, which is every build
+/// Mydia ships. On a Fire HD 10 whose MediaTek decoder opens HEVC Main and
+/// refuses Main 10, the client still claimed `hevc`, the server direct-played a
+/// 10-bit stream, and mpv failed at `avcodec_open2` with "Could not open
+/// codec." — audio decoded fine, so sound played under an error screen.
+///
+/// Software decoding is deliberately not treated as a rescue. mpv can decode
+/// 10-bit HEVC in software, but not at 1080p on the class of SoC that lacks a
+/// Main 10 hardware decoder, so advertising it would trade an error screen for
+/// unwatchable stutter. Asking the server to transcode is the better answer,
+/// and it is the answer this client gave before device profiles existed.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'codec_profile.dart';
+
+const MethodChannel _channel = MethodChannel('dev.mydia.player/codecs');
+
+/// Builds codec profiles from the platform's decoder capability tables.
+///
+/// Returns an empty list on any failure, which leaves the codec claims
+/// unconstrained — the behavior that shipped before this probe existed. That is
+/// the wrong direction for safety, but the right one for availability: a device
+/// whose capability table cannot be read should still be able to watch
+/// something, and a wrong `hevc` claim is recoverable in a way that refusing
+/// every codec is not.
+Future<List<CodecProfile>> probeAndroidCodecProfiles({
+  MethodChannel channel = _channel,
+}) async {
+  try {
+    final raw =
+        await channel.invokeListMethod<dynamic>('videoDecoderCapabilities');
+    if (raw == null || raw.isEmpty) return const [];
+
+    final profiles = <CodecProfile>[];
+
+    for (final entry in raw) {
+      if (entry is! Map) continue;
+
+      final codec = entry['codec'];
+      if (codec is! String || codec.isEmpty) continue;
+
+      final conditions = _conditionsFor(entry);
+      if (conditions.isEmpty) continue;
+
+      profiles.add(CodecProfile.video(codec, conditions));
+    }
+
+    return profiles;
+  } catch (error, stackTrace) {
+    debugPrint(
+        'MediaCodec probe failed, leaving codec claims unconstrained: $error');
+    debugPrintStack(stackTrace: stackTrace);
+    return const [];
+  }
+}
+
+List<ProfileCondition> _conditionsFor(Map<dynamic, dynamic> entry) {
+  final conditions = <ProfileCondition>[];
+
+  final depth = _positiveInt(entry['maxBitDepth']);
+  if (depth != null) {
+    conditions.add(
+      ProfileCondition.atMost(ProfileProperty.videoBitDepth, '$depth'),
+    );
+  }
+
+  // Resolution ceilings are advisory rather than required: a decoder's reported
+  // maximum is per-codec and vendors under-report it, and a file that merely
+  // exceeds a soft cap usually still plays. Marking them optional means a file
+  // with no width/height recorded is not pushed to a transcode over a limit
+  // nobody could check.
+  final width = _positiveInt(entry['maxWidth']);
+  if (width != null) {
+    conditions.add(
+      ProfileCondition.atMost(ProfileProperty.width, '$width',
+          isRequired: false),
+    );
+  }
+
+  final height = _positiveInt(entry['maxHeight']);
+  if (height != null) {
+    conditions.add(
+      ProfileCondition.atMost(ProfileProperty.height, '$height',
+          isRequired: false),
+    );
+  }
+
+  return conditions;
+}
+
+int? _positiveInt(Object? value) {
+  if (value is int && value > 0) return value;
+  return null;
+}

--- a/player/lib/core/player/codec_profile.dart
+++ b/player/lib/core/player/codec_profile.dart
@@ -1,0 +1,108 @@
+/// Per-codec constraints a client attaches to a codec it claims to decode.
+///
+/// A codec name alone cannot answer "can this device play this file". The
+/// tablet that motivated these decodes HEVC Main and refuses HEVC Main 10, and
+/// libmpv's `decoder-list` — the native profile's source — reports what
+/// libavcodec was *compiled* with, so it says "hevc" for both.
+///
+/// The vocabulary mirrors Jellyfin's `ProfileCondition` and Plex's device
+/// profiles rather than inventing a Mydia dialect. The server parses the same
+/// names in `Mydia.Streaming.ProfileCondition`.
+library;
+
+/// The properties the server knows how to resolve from a stream.
+///
+/// Kept as constants rather than free strings so a typo is a compile error here
+/// instead of a constraint the server rejects at runtime — a rejected payload
+/// is treated as *absent*, which silently widens direct play rather than
+/// narrowing it.
+abstract final class ProfileProperty {
+  static const videoBitDepth = 'VideoBitDepth';
+  static const videoProfile = 'VideoProfile';
+  static const videoLevel = 'VideoLevel';
+  static const width = 'Width';
+  static const height = 'Height';
+  static const videoFramerate = 'VideoFramerate';
+  static const audioChannels = 'AudioChannels';
+  static const audioSampleRate = 'AudioSampleRate';
+  static const audioProfile = 'AudioProfile';
+}
+
+/// The comparisons the server implements.
+abstract final class ProfileComparison {
+  static const equals = 'Equals';
+  static const notEquals = 'NotEquals';
+  static const lessThanEqual = 'LessThanEqual';
+  static const greaterThanEqual = 'GreaterThanEqual';
+
+  /// Value is a `|`-separated list, e.g. `'Main|Main 10'`.
+  static const equalsAny = 'EqualsAny';
+}
+
+/// One constraint on one codec.
+class ProfileCondition {
+  final String property;
+  final String condition;
+  final String value;
+
+  /// When true (the default), a stream whose value for [property] is unknown
+  /// fails this condition. That is the safe direction: the alternative hands
+  /// the client a stream it never approved.
+  final bool isRequired;
+
+  const ProfileCondition({
+    required this.property,
+    required this.condition,
+    required this.value,
+    this.isRequired = true,
+  });
+
+  /// `property <= value`, the common shape for a ceiling.
+  const ProfileCondition.atMost(this.property, this.value,
+      {this.isRequired = true})
+      : condition = ProfileComparison.lessThanEqual;
+
+  Map<String, dynamic> toJson() => {
+        'property': property,
+        'condition': condition,
+        'value': value,
+        'isRequired': isRequired,
+      };
+
+  @override
+  String toString() => 'ProfileCondition($property $condition $value)';
+}
+
+/// The constraints attached to one codec.
+///
+/// Conditions are ANDed. An empty list claims the codec unconditionally.
+class CodecProfile {
+  /// `'video'` or `'audio'`.
+  final String type;
+
+  /// The codec name, matched as a substring by the server so `'hevc'` also
+  /// covers the display strings ffprobe produces.
+  final String codec;
+
+  final List<ProfileCondition> conditions;
+
+  const CodecProfile({
+    required this.type,
+    required this.codec,
+    this.conditions = const [],
+  });
+
+  const CodecProfile.video(this.codec, this.conditions) : type = 'video';
+
+  const CodecProfile.audio(this.codec, this.conditions) : type = 'audio';
+
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'codec': codec,
+        'conditions': conditions.map((c) => c.toJson()).toList(),
+      };
+
+  @override
+  String toString() =>
+      'CodecProfile($type/$codec, ${conditions.length} condition(s))';
+}

--- a/player/lib/core/player/codec_profile.dart
+++ b/player/lib/core/player/codec_profile.dart
@@ -103,6 +103,14 @@ class CodecProfile {
       };
 
   @override
-  String toString() =>
-      'CodecProfile($type/$codec, ${conditions.length} condition(s))';
+  String toString() {
+    final detail = conditions.isEmpty
+        ? 'unconstrained'
+        : conditions
+            .map((c) =>
+                '${c.property}${c.isRequired ? '' : '?'} ${c.condition} ${c.value}')
+            .join(' AND ');
+
+    return '$type/$codec[$detail]';
+  }
 }

--- a/player/lib/core/player/device_profile.dart
+++ b/player/lib/core/player/device_profile.dart
@@ -1,7 +1,11 @@
 import 'dart:convert';
 
+import 'codec_profile.dart';
 import 'device_profile_web.dart'
     if (dart.library.io) 'device_profile_native.dart' as platform;
+
+export 'codec_profile.dart'
+    show CodecProfile, ProfileComparison, ProfileCondition, ProfileProperty;
 
 /// What this client can decode, sent to the server on every request.
 ///
@@ -14,12 +18,29 @@ class DeviceProfile {
   final List<String> audioCodecs;
   final List<String> hdrFormats;
 
+  /// Per-codec constraints, for the parts a codec name cannot express.
+  ///
+  /// A codec listed in [videoCodecs] with no entry here is claimed
+  /// unconditionally, which is what the flat lists meant on their own. An entry
+  /// narrows that claim: "hevc, but only up to 8-bit" is the difference between
+  /// a tablet playing its library and a tablet showing "Could not open codec."
+  final List<CodecProfile> codecProfiles;
+
   const DeviceProfile({
     required this.containers,
     required this.videoCodecs,
     required this.audioCodecs,
     required this.hdrFormats,
+    this.codecProfiles = const [],
   });
+
+  DeviceProfile copyWith({List<CodecProfile>? codecProfiles}) => DeviceProfile(
+        containers: containers,
+        videoCodecs: videoCodecs,
+        audioCodecs: audioCodecs,
+        hdrFormats: hdrFormats,
+        codecProfiles: codecProfiles ?? this.codecProfiles,
+      );
 
   /// What browsers decode. Mirrors `DeviceProfile.browser_default/0` on the
   /// server, so a web client asserts nothing the server would not have assumed.
@@ -36,13 +57,21 @@ class DeviceProfile {
           'av01',
         ],
         audioCodecs = const ['aac', 'mp3', 'opus', 'vorbis'],
-        hdrFormats = const [];
+        hdrFormats = const [],
+        // A browser enforces its own codec support at `canPlayType`, and this
+        // client has no capability table to read, so it constrains nothing.
+        codecProfiles = const [];
 
-  Map<String, List<String>> toJson() => {
+  Map<String, dynamic> toJson() => {
         'containers': containers,
         'videoCodecs': videoCodecs,
         'audioCodecs': audioCodecs,
         'hdrFormats': hdrFormats,
+        // Omitted entirely when empty. An older server ignores the key either
+        // way, but sending nothing keeps the header at the size it has always
+        // been for clients with nothing to constrain.
+        if (codecProfiles.isNotEmpty)
+          'codecProfiles': codecProfiles.map((p) => p.toJson()).toList(),
       };
 
   /// Unpadded base64url of the JSON, which is what the server's plug decodes.

--- a/player/lib/core/player/device_profile_native.dart
+++ b/player/lib/core/player/device_profile_native.dart
@@ -3,10 +3,13 @@
 library;
 
 import 'dart:convert';
+import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:media_kit/media_kit.dart';
 
+import 'android_codec_capabilities.dart';
+import 'codec_profile.dart';
 import 'device_profile.dart';
 
 /// What libmpv is built with on every desktop and mobile target Mydia ships.
@@ -88,7 +91,30 @@ const DeviceProfile _staticNativeProfile = DeviceProfile(
 /// Constructs a throwaway [Player] purely to reach mpv's property API; media_kit
 /// exposes no lighter handle for it. The instance is always disposed before
 /// returning, success or failure.
+/// The profile this client advertises.
+///
+/// Two sources, answering two different questions. libmpv's `decoder-list` says
+/// which codecs this build can decode *at all*; Android's MediaCodec tables say
+/// which of them this hardware can actually open, and at what bit depth. Only
+/// the second one would have caught a Fire HD 10 being handed HEVC Main 10 —
+/// `decoder-list` reports `hevc` on every build Mydia ships, Main 10 or not.
+///
+/// The MediaCodec pass only ever *narrows* what the mpv pass claimed, and only
+/// on Android, where hardware decoding is the path that actually runs. Desktop
+/// keeps the unconstrained claim: mpv software-decodes 10-bit HEVC there
+/// perfectly well.
 Future<DeviceProfile> detectDeviceProfile() async {
+  final profile = await _probeMpvProfile();
+
+  if (!Platform.isAndroid) return profile;
+
+  final List<CodecProfile> codecProfiles = await probeAndroidCodecProfiles();
+  if (codecProfiles.isEmpty) return profile;
+
+  return profile.copyWith(codecProfiles: codecProfiles);
+}
+
+Future<DeviceProfile> _probeMpvProfile() async {
   Player? player;
   try {
     player = Player();

--- a/player/lib/core/player/device_profile_native.dart
+++ b/player/lib/core/player/device_profile_native.dart
@@ -109,6 +109,16 @@ Future<DeviceProfile> detectDeviceProfile() async {
   if (!Platform.isAndroid) return profile;
 
   final List<CodecProfile> codecProfiles = await probeAndroidCodecProfiles();
+
+  // Logged because the absence of exactly this line is what made the original
+  // failure so expensive to diagnose: a device claiming a codec it cannot open
+  // looks identical, from every log we had, to a device that can. One line
+  // naming what this client actually advertised turns that into a lookup.
+  debugPrint(
+    '[DeviceProfile] android codec constraints: '
+    '${codecProfiles.isEmpty ? 'none (unconstrained)' : codecProfiles.join(', ')}',
+  );
+
   if (codecProfiles.isEmpty) return profile;
 
   return profile.copyWith(codecProfiles: codecProfiles);

--- a/player/test/core/player/android_codec_capabilities_test.dart
+++ b/player/test/core/player/android_codec_capabilities_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/android_codec_capabilities.dart';
+import 'package:player/core/player/device_profile.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('dev.mydia.player/codecs.test');
+
+  void stub(Object? Function() respond) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, 'videoDecoderCapabilities');
+      return respond();
+    });
+  }
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('probeAndroidCodecProfiles', () {
+    test('turns an 8-bit-only HEVC decoder into a bit-depth ceiling', () async {
+      stub(() => [
+            {
+              'codec': 'hevc',
+              'maxBitDepth': 8,
+              'maxWidth': 1920,
+              'maxHeight': 1088,
+            },
+          ]);
+
+      final profiles = await probeAndroidCodecProfiles(channel: channel);
+
+      expect(profiles, hasLength(1));
+      expect(profiles.single.codec, 'hevc');
+      expect(profiles.single.type, 'video');
+
+      final depth = profiles.single.conditions.firstWhere(
+        (c) => c.property == ProfileProperty.videoBitDepth,
+      );
+      expect(depth.condition, ProfileComparison.lessThanEqual);
+      expect(depth.value, '8');
+      // The whole point: a Main 10 stream must fail this, so it has to be
+      // required rather than skipped when the depth is unknown.
+      expect(depth.isRequired, isTrue);
+    });
+
+    test(
+        'marks resolution ceilings optional so an unknown size does not transcode',
+        () async {
+      stub(() => [
+            {
+              'codec': 'hevc',
+              'maxBitDepth': 10,
+              'maxWidth': 3840,
+              'maxHeight': 2160
+            },
+          ]);
+
+      final profiles = await probeAndroidCodecProfiles(channel: channel);
+      final width = profiles.single.conditions.firstWhere(
+        (c) => c.property == ProfileProperty.width,
+      );
+
+      expect(width.isRequired, isFalse);
+      expect(width.value, '3840');
+    });
+
+    test('returns empty when the platform reports nothing', () async {
+      stub(() => <dynamic>[]);
+
+      expect(await probeAndroidCodecProfiles(channel: channel), isEmpty);
+    });
+
+    test('returns empty rather than throwing when the channel fails', () async {
+      stub(() => throw PlatformException(code: 'boom'));
+
+      expect(await probeAndroidCodecProfiles(channel: channel), isEmpty);
+    });
+
+    test('skips malformed entries instead of emitting a codec with no name',
+        () async {
+      stub(() => [
+            {'maxBitDepth': 8},
+            {'codec': '', 'maxBitDepth': 8},
+            {'codec': 'h264', 'maxBitDepth': 8},
+          ]);
+
+      final profiles = await probeAndroidCodecProfiles(channel: channel);
+
+      expect(profiles.map((p) => p.codec), ['h264']);
+    });
+  });
+
+  group('DeviceProfile wire format', () {
+    test('omits codecProfiles entirely when there are none', () {
+      const profile = DeviceProfile(
+        containers: ['mkv'],
+        videoCodecs: ['hevc'],
+        audioCodecs: ['ac3'],
+        hdrFormats: [],
+      );
+
+      expect(profile.toJson().containsKey('codecProfiles'), isFalse);
+    });
+
+    test('serializes conditions in the shape the server parses', () {
+      const profile = DeviceProfile(
+        containers: ['mkv'],
+        videoCodecs: ['hevc'],
+        audioCodecs: ['ac3'],
+        hdrFormats: [],
+        codecProfiles: [
+          CodecProfile.video('hevc', [
+            ProfileCondition.atMost(ProfileProperty.videoBitDepth, '8'),
+          ]),
+        ],
+      );
+
+      expect(profile.toJson()['codecProfiles'], [
+        {
+          'type': 'video',
+          'codec': 'hevc',
+          'conditions': [
+            {
+              'property': 'VideoBitDepth',
+              'condition': 'LessThanEqual',
+              'value': '8',
+              'isRequired': true,
+            },
+          ],
+        },
+      ]);
+    });
+
+    test('the header stays unpadded base64url', () {
+      const profile = DeviceProfile(
+        containers: ['mkv'],
+        videoCodecs: ['hevc'],
+        audioCodecs: ['ac3'],
+        hdrFormats: [],
+        codecProfiles: [
+          CodecProfile.video('hevc', [
+            ProfileCondition.atMost(ProfileProperty.videoBitDepth, '8'),
+          ]),
+        ],
+      );
+
+      final header = profile.toHeaderValue();
+
+      expect(header, isNot(contains('=')));
+      expect(header, isNot(contains('+')));
+      expect(header, isNot(contains('/')));
+    });
+  });
+}

--- a/test/mydia/streaming/codec_profile_compatibility_test.exs
+++ b/test/mydia/streaming/codec_profile_compatibility_test.exs
@@ -1,0 +1,209 @@
+defmodule Mydia.Streaming.CodecProfileCompatibilityTest do
+  @moduledoc """
+  The regression this module exists for.
+
+  A Fire HD 10 played `Lanterns.2026.S01E02.1080p.x265-ELiTE.mkv` and got
+  "Could not open codec." The client advertised `hevc` because that is what
+  libmpv's `decoder-list` reports — a libavcodec *build* list, blind to profile
+  and bit depth — so the server direct-played a HEVC Main 10 stream at a
+  MediaCodec decoder that only opens Main. Audio (AC3) decoded fine, which is
+  why sound played under the error screen.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.Structs.{FileMetadata, StreamInfo}
+  alias Mydia.Streaming.{Compatibility, DeviceProfile}
+
+  # The real file, as the production analyzer recorded it.
+  defp lanterns_media_file do
+    %MediaFile{
+      codec: "hevc",
+      audio_codec: "ac3",
+      metadata: %FileMetadata{
+        container: "mkv",
+        streams: [
+          %StreamInfo{
+            index: 0,
+            type: :video,
+            codec: "hevc",
+            profile: "Main 10",
+            level: 120,
+            bit_depth: 10,
+            width: 1920,
+            height: 960,
+            frame_rate: 23.976,
+            pixel_format: "yuv420p10le"
+          },
+          %StreamInfo{
+            index: 1,
+            type: :audio,
+            codec: "ac3",
+            channels: 6,
+            channel_layout: "5.1(side)",
+            sample_rate: 48_000
+          }
+        ]
+      },
+      relative_path: "Lanterns/Season 01/Lanterns.2026.S01E02.1080p.x265-ELiTE.mkv",
+      library_path: %Mydia.Settings.LibraryPath{path: "/media/Series"}
+    }
+  end
+
+  # Same container and codecs, but 8-bit Main — what the tablet can actually open.
+  defp main8_media_file do
+    file = lanterns_media_file()
+    [video, audio] = file.metadata.streams
+
+    %{
+      file
+      | metadata: %{
+          file.metadata
+          | streams: [%{video | profile: "Main", bit_depth: 8}, audio]
+        }
+    }
+  end
+
+  defp profile_claiming_hevc(codec_profiles) do
+    %DeviceProfile{
+      containers: ["mkv", "matroska", "mp4"],
+      video_codecs: ["hevc", "h264"],
+      audio_codecs: ["ac3", "aac"],
+      hdr_formats: [],
+      codec_profiles: codec_profiles
+    }
+  end
+
+  defp bit_depth_at_most(depth) do
+    {:ok, codec_profile} =
+      Mydia.Streaming.CodecProfile.from_map(%{
+        "type" => "video",
+        "codec" => "hevc",
+        "conditions" => [
+          %{
+            "property" => "VideoBitDepth",
+            "condition" => "LessThanEqual",
+            "value" => to_string(depth)
+          }
+        ]
+      })
+
+    codec_profile
+  end
+
+  describe "a client that states its HEVC limits" do
+    test "does not get a Main 10 stream direct-played at it" do
+      profile = profile_claiming_hevc([bit_depth_at_most(8)])
+
+      refute Compatibility.check_compatibility(lanterns_media_file(), profile) == :direct_play
+      refute Compatibility.check_compatibility(lanterns_media_file(), profile) == :needs_remux
+
+      assert Compatibility.check_compatibility(lanterns_media_file(), profile) ==
+               :needs_transcoding
+    end
+
+    test "still direct-plays 8-bit HEVC, so the constraint costs nothing it can decode" do
+      profile = profile_claiming_hevc([bit_depth_at_most(8)])
+
+      assert Compatibility.check_compatibility(main8_media_file(), profile) == :direct_play
+    end
+
+    test "gets Main 10 direct-played when it says it can decode 10-bit" do
+      profile = profile_claiming_hevc([bit_depth_at_most(10)])
+
+      assert Compatibility.check_compatibility(lanterns_media_file(), profile) == :direct_play
+    end
+  end
+
+  describe "clients that attach no conditions" do
+    test "keep the unconstrained behavior the flat allowlist always meant" do
+      profile = profile_claiming_hevc([])
+
+      assert Compatibility.check_compatibility(lanterns_media_file(), profile) == :direct_play
+    end
+  end
+
+  describe "conditions and absent stream metadata" do
+    test "a file with no stream detail fails a required condition closed" do
+      file = lanterns_media_file()
+      bare = %{file | metadata: %{file.metadata | streams: []}}
+
+      profile = profile_claiming_hevc([bit_depth_at_most(8)])
+
+      assert Compatibility.check_compatibility(bare, profile) == :needs_transcoding
+    end
+  end
+
+  describe "audio conditions" do
+    test "a channel cap pushes 5.1 AC3 away from direct play" do
+      {:ok, stereo_only} =
+        Mydia.Streaming.CodecProfile.from_map(%{
+          "type" => "audio",
+          "codec" => "ac3",
+          "conditions" => [
+            %{"property" => "AudioChannels", "condition" => "LessThanEqual", "value" => "2"}
+          ]
+        })
+
+      profile = profile_claiming_hevc([stereo_only])
+
+      assert Compatibility.check_compatibility(lanterns_media_file(), profile) ==
+               :needs_transcoding
+    end
+  end
+
+  describe "wire format" do
+    test "a header carrying codec profiles round-trips into a working decision" do
+      encoded =
+        %{
+          "containers" => ["mkv"],
+          "videoCodecs" => ["hevc"],
+          "audioCodecs" => ["ac3"],
+          "hdrFormats" => [],
+          "codecProfiles" => [
+            %{
+              "type" => "video",
+              "codec" => "hevc",
+              "conditions" => [
+                %{
+                  "property" => "VideoBitDepth",
+                  "condition" => "LessThanEqual",
+                  "value" => "8"
+                }
+              ]
+            }
+          ]
+        }
+        |> Jason.encode!()
+        |> Base.url_encode64(padding: false)
+
+      assert %DeviceProfile{} = profile = DeviceProfile.decode_header(encoded)
+      assert [_one] = profile.codec_profiles
+
+      assert Compatibility.check_compatibility(lanterns_media_file(), profile) ==
+               :needs_transcoding
+    end
+
+    test "a payload with a malformed condition is treated as absent, not as trusted" do
+      encoded =
+        %{
+          "containers" => ["mkv"],
+          "videoCodecs" => ["hevc"],
+          "audioCodecs" => ["ac3"],
+          "codecProfiles" => [
+            %{
+              "type" => "video",
+              "codec" => "hevc",
+              "conditions" => [
+                %{"property" => "NotAProperty", "condition" => "Equals", "value" => "8"}
+              ]
+            }
+          ]
+        }
+        |> Jason.encode!()
+        |> Base.url_encode64(padding: false)
+
+      assert DeviceProfile.decode_header(encoded) == nil
+    end
+  end
+end

--- a/test/mydia/streaming/profile_condition_test.exs
+++ b/test/mydia/streaming/profile_condition_test.exs
@@ -1,0 +1,255 @@
+defmodule Mydia.Streaming.ProfileConditionTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Streaming.{CodecProfile, ProfileCondition}
+
+  # The stream that broke playback on a Fire HD 10: HEVC Main 10, 10-bit. The
+  # server direct-played it because the client claimed "hevc", and mpv's
+  # MediaCodec decoder would not open it.
+  defp main10_stream do
+    %StreamInfo{
+      type: :video,
+      codec: "hevc",
+      profile: "Main 10",
+      level: 120,
+      bit_depth: 10,
+      width: 1920,
+      height: 960,
+      frame_rate: 23.976,
+      pixel_format: "yuv420p10le"
+    }
+  end
+
+  defp main8_stream do
+    %StreamInfo{
+      type: :video,
+      codec: "hevc",
+      profile: "Main",
+      level: 120,
+      bit_depth: 8,
+      width: 1920,
+      height: 1080,
+      frame_rate: 23.976,
+      pixel_format: "yuv420p"
+    }
+  end
+
+  defp condition(property, condition, value, opts \\ []) do
+    %ProfileCondition{
+      property: property,
+      condition: condition,
+      value: value,
+      required: Keyword.get(opts, :required, true)
+    }
+  end
+
+  describe "parse_property/1 and parse_condition/1" do
+    test "resolve known names case-insensitively" do
+      assert ProfileCondition.parse_property("VideoBitDepth") == :video_bit_depth
+      assert ProfileCondition.parse_property("  videoprofile ") == :video_profile
+      assert ProfileCondition.parse_condition("LessThanEqual") == :less_than_equal
+    end
+
+    test "return :invalid rather than minting an atom for unknown input" do
+      assert ProfileCondition.parse_property("TotallyMadeUpProperty") == :invalid
+      assert ProfileCondition.parse_condition("Sideways") == :invalid
+      assert ProfileCondition.parse_property(nil) == :invalid
+      assert ProfileCondition.parse_condition(%{}) == :invalid
+    end
+  end
+
+  describe "numeric conditions" do
+    test "less_than_equal rejects the 10-bit stream and accepts the 8-bit one" do
+      cond_ = condition(:video_bit_depth, :less_than_equal, "8")
+
+      refute ProfileCondition.satisfied?(cond_, main10_stream())
+      assert ProfileCondition.satisfied?(cond_, main8_stream())
+    end
+
+    test "greater_than_equal, equals and not_equals compare numerically" do
+      assert ProfileCondition.satisfied?(
+               condition(:width, :less_than_equal, "1920"),
+               main10_stream()
+             )
+
+      refute ProfileCondition.satisfied?(
+               condition(:width, :greater_than_equal, "3840"),
+               main10_stream()
+             )
+
+      assert ProfileCondition.satisfied?(condition(:video_level, :equals, "120"), main10_stream())
+
+      refute ProfileCondition.satisfied?(
+               condition(:video_level, :not_equals, "120"),
+               main10_stream()
+             )
+    end
+
+    test "equals_any matches one of several numbers" do
+      assert ProfileCondition.satisfied?(
+               condition(:video_bit_depth, :equals_any, "8|10"),
+               main10_stream()
+             )
+
+      refute ProfileCondition.satisfied?(
+               condition(:video_bit_depth, :equals_any, "8|12"),
+               main10_stream()
+             )
+    end
+
+    test "a float property compares without truncation surprises" do
+      assert ProfileCondition.satisfied?(
+               condition(:video_framerate, :less_than_equal, "30"),
+               main10_stream()
+             )
+
+      refute ProfileCondition.satisfied?(
+               condition(:video_framerate, :less_than_equal, "23"),
+               main10_stream()
+             )
+    end
+  end
+
+  describe "string conditions" do
+    test "video_profile matches case- and space-insensitively" do
+      assert ProfileCondition.satisfied?(
+               condition(:video_profile, :equals, "main 10"),
+               main10_stream()
+             )
+
+      assert ProfileCondition.satisfied?(
+               condition(:video_profile, :equals_any, "Main|Main 10"),
+               main10_stream()
+             )
+
+      refute ProfileCondition.satisfied?(
+               condition(:video_profile, :equals_any, "Main|Main Still Picture"),
+               main10_stream()
+             )
+    end
+
+    test "an ordering comparison on a profile name is treated as malformed" do
+      # Required, so the malformed constraint fails closed.
+      refute ProfileCondition.satisfied?(
+               condition(:video_profile, :less_than_equal, "Main"),
+               main10_stream()
+             )
+    end
+  end
+
+  describe "absent metadata" do
+    test "a required condition fails closed when the property is missing" do
+      bare = %StreamInfo{type: :video, codec: "hevc"}
+
+      refute ProfileCondition.satisfied?(condition(:video_bit_depth, :less_than_equal, "8"), bare)
+      refute ProfileCondition.satisfied?(condition(:video_bit_depth, :less_than_equal, "8"), nil)
+    end
+
+    test "an optional condition passes when the property is missing" do
+      bare = %StreamInfo{type: :video, codec: "hevc"}
+
+      assert ProfileCondition.satisfied?(
+               condition(:video_bit_depth, :less_than_equal, "8", required: false),
+               bare
+             )
+    end
+
+    test "a non-numeric value on a numeric property does not widen direct play" do
+      refute ProfileCondition.satisfied?(
+               condition(:video_bit_depth, :less_than_equal, "eight"),
+               main10_stream()
+             )
+    end
+  end
+
+  describe "from_map/1" do
+    test "parses a well-formed condition and defaults isRequired to true" do
+      assert {:ok, parsed} =
+               ProfileCondition.from_map(%{
+                 "property" => "VideoBitDepth",
+                 "condition" => "LessThanEqual",
+                 "value" => "8"
+               })
+
+      assert parsed.property == :video_bit_depth
+      assert parsed.condition == :less_than_equal
+      assert parsed.required
+    end
+
+    test "honors an explicit isRequired false" do
+      assert {:ok, parsed} =
+               ProfileCondition.from_map(%{
+                 "property" => "Width",
+                 "condition" => "LessThanEqual",
+                 "value" => "1920",
+                 "isRequired" => false
+               })
+
+      refute parsed.required
+    end
+
+    test "rejects unknown names and empty values instead of dropping them" do
+      assert ProfileCondition.from_map(%{
+               "property" => "Nope",
+               "condition" => "Equals",
+               "value" => "1"
+             }) == :error
+
+      assert ProfileCondition.from_map(%{
+               "property" => "Width",
+               "condition" => "Nope",
+               "value" => "1"
+             }) == :error
+
+      assert ProfileCondition.from_map(%{
+               "property" => "Width",
+               "condition" => "Equals",
+               "value" => ""
+             }) == :error
+    end
+  end
+
+  describe "CodecProfile" do
+    test "the Fire HD 10 profile rejects Main 10 and accepts Main" do
+      {:ok, profile} =
+        CodecProfile.from_map(%{
+          "type" => "video",
+          "codec" => "hevc",
+          "conditions" => [
+            %{"property" => "VideoBitDepth", "condition" => "LessThanEqual", "value" => "8"}
+          ]
+        })
+
+      assert CodecProfile.applies?(profile, :video, "hevc")
+      assert CodecProfile.applies?(profile, :video, "HEVC")
+      refute CodecProfile.applies?(profile, :audio, "hevc")
+      refute CodecProfile.applies?(profile, :video, "h264")
+
+      refute CodecProfile.satisfied?(profile, main10_stream())
+      assert CodecProfile.satisfied?(profile, main8_stream())
+    end
+
+    test "an empty condition list claims the codec unconditionally" do
+      {:ok, profile} = CodecProfile.from_map(%{"type" => "video", "codec" => "hevc"})
+
+      assert CodecProfile.satisfied?(profile, main10_stream())
+    end
+
+    test "one bad condition rejects the whole codec profile" do
+      assert CodecProfile.from_map(%{
+               "type" => "video",
+               "codec" => "hevc",
+               "conditions" => [
+                 %{"property" => "VideoBitDepth", "condition" => "LessThanEqual", "value" => "8"},
+                 %{"property" => "Bogus", "condition" => "Equals", "value" => "1"}
+               ]
+             }) == :error
+    end
+
+    test "rejects an empty codec that would match every stream" do
+      assert CodecProfile.from_map(%{"type" => "video", "codec" => ""}) == :error
+      assert CodecProfile.from_map(%{"type" => "video", "codec" => "   "}) == :error
+    end
+  end
+end


### PR DESCRIPTION
## What broke

Playing `Lanterns.2026.S01E02.1080p.x265-ELiTE.mkv` on a Fire HD 10 (KFTRWI, MediaTek) showed **"Failed to load video / Playback failed: Could not open codec."** Audio kept playing under the error screen.

## Root cause

The file is **HEVC Main 10 (`yuv420p10le`, 10-bit) + AC3 5.1 in MKV**. The server chose direct play for it.

1. The native client builds its device profile from libmpv's `decoder-list`. That is libavcodec's **build** configuration, not a device capability: it reports `hevc` on every build Mydia ships, blind to profile and bit depth.
2. `Compatibility.check_compatibility/2` matched **codec names only**, with no notion of profile, bit depth, or level.
3. So `codec: "hevc"` plus a client claiming `hevc` produced `:direct_play`, and mpv's MediaCodec decoder refused the Main 10 stream at `avcodec_open2`.

Verified on the device itself:

| Decoder | Declares |
| --- | --- |
| `OMX.google.hevc.decoder` (software) | `ProfileMain : MainTierLevel51`, no Main 10 |
| `OMX.MTK.VIDEO.DECODER.HEVC` (hardware) | no profile list, max `2048x1088` |

which is why logcat also carries `W VideoCapabilities: Unrecognized profile 4 for video/hevc`.

This is a regression from #541. `DeviceProfile.browser_default/0` has no `hevc`, so before device profiles every HEVC file was transcoded. On the production library **1220 of 1291 HEVC files (94.5%) are Main 10**, so this affected essentially the whole HEVC catalogue on that tablet.

The candidate list already carried a `TRANSCODE` fallback after `DIRECT_PLAY`, but `_canDirectPlay` only ever inspects `candidates.first`, so it was never consulted. Its own docstring flagged the gap: the probe "has not been validated on hardware, so it can under-report". It guarded only the under-reporting direction; this bug is over-reporting.

## The fix

Codec names cannot answer "can this device play this file", so this stops asking them to, rather than adding a special-case 10-bit gate.

- **`Mydia.Streaming.ProfileCondition`** and **`Mydia.Streaming.CodecProfile`**: per-codec constraints over bit depth, profile, level, resolution, frame rate and channel count. The vocabulary mirrors Jellyfin's `ProfileCondition` and Plex's device profiles instead of inventing a Mydia dialect.
- **`Compatibility`** evaluates them against the file's real per-stream metadata.
- **Android**: the player reads `MediaCodecList` for what the hardware actually opens and emits that as conditions.

### Two things worth reviewing

**Conditions read `metadata.streams`, never FileMetadata's flat codec-detail fields.** The analyzer declares `hevc_profile_idc` and `bit_depth` but does not write them. Across the 1291-file production HEVC library they are populated on **zero** rows, while the per-stream values are populated on **all** of them. A condition sourced from the flat fields would resolve to `nil` everywhere and approve everything while appearing to validate.

**Fail-closed throughout.** A required condition whose property cannot be resolved fails; a malformed condition rejects its whole payload; an empty codec string is refused because substring matching would make it match every stream. Each default is the direction that asks the server to transcode instead of handing over a stream the client never approved.

Software decoding is deliberately not treated as a rescue. mpv decodes 10-bit HEVC in software, but not at 1080p on the class of SoC that lacks a Main 10 decoder, so advertising it would trade an error screen for unwatchable stutter.

## Compatibility

A codec with no conditions stays unconstrained, so clients that send none behave exactly as they did before. `codecProfiles` is omitted from the header entirely when empty, and an older server ignores the key.

Note this needs the server change deployed to take effect; a new player against an old server keeps the old behavior.

## Tests

- 378 Elixir tests green across `streaming/`, the device-profile plug, and schema compatibility, including a regression file built from the exact production stream.
- 147 player Dart tests green in `test/core/player/`.
- `mix credo --strict` clean project-wide (1378 files); `dart analyze --fatal-warnings` exits 0.

## Not covered here

End-to-end playback on the tablet is unverified, because the fix only takes effect once the server side is deployed and prod runs the `:master` image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added codec capability profiles for video and audio playback.
  - Added support for codec-specific limits, including bit depth, resolution, audio channels, and other stream properties.
  - Android devices now detect supported decoder capabilities automatically.
  - Playback compatibility checks use detected device capabilities to select direct playback or transcoding.

- **Bug Fixes**
  - Improved handling of missing, malformed, or unsupported stream metadata and profile conditions.
  - Unrestricted profiles continue to allow compatible playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->