### PR TITLE
fix(streaming): stop offering HLS_COPY for a stream the client rejected

### DIFF
--- a/lib/mydia/streaming/candidates.ex
+++ b/lib/mydia/streaming/candidates.ex
@@ -132,10 +132,24 @@ defmodule Mydia.Streaming.Candidates do
         ]
 
       :needs_transcoding ->
+        # HLS_COPY repackages without re-encoding, so it carries the original
+        # video codec. Offering it to a client whose stated conditions just
+        # rejected that codec hands back the same undecodable bytes in a new
+        # container, and the player takes it: `_canDirectPlay` treats a leading
+        # HLS_COPY as playable, which inverted this verdict into direct play and
+        # put "Could not open codec." on screen for every 10-bit HEVC file.
+        #
+        # Only conditions suppress it, never a codec's mere absence from the
+        # allowlist. A browser that judges codec strings itself still gets the
+        # stream-copy rungs it has always been offered.
         native_candidates =
-          Enum.map(video_variants, fn video_variant ->
-            build_candidate("HLS_COPY", "ts", video_variant, audio_codec_str)
-          end)
+          if Compatibility.conditions_reject?(media_file, profile) do
+            []
+          else
+            Enum.map(video_variants, fn video_variant ->
+              build_candidate("HLS_COPY", "ts", video_variant, audio_codec_str)
+            end)
+          end
 
         transcode_candidate =
           build_candidate("TRANSCODE", "ts", "avc1.640028", "mp4a.40.2")

--- a/lib/mydia/streaming/compatibility.ex
+++ b/lib/mydia/streaming/compatibility.ex
@@ -86,6 +86,35 @@ defmodule Mydia.Streaming.Compatibility do
     {Enum.find(streams, &(&1.type == :video)), Enum.find(streams, &(&1.type == :audio))}
   end
 
+  @doc """
+  Whether the client's own stated conditions rule this file's streams out.
+
+  Distinct from "the codec is not on the allowlist". A codec merely absent from
+  the lists means the client never claimed it, which historically still left
+  stream-copy candidates on the table for a client that could judge codec
+  strings itself — a browser calling `canPlayType`, most of it. A codec that is
+  claimed but whose *conditions* fail is a different statement: the client
+  looked at this exact shape of stream and said no.
+
+  Callers use this to drop candidates that preserve the offending stream.
+  `HLS_COPY` repackages without re-encoding, so offering it to a client whose
+  conditions just rejected the codec hands back the same undecodable bytes in a
+  new container. Returns `false` for a client that stated no conditions, so
+  nothing about the pre-conditions candidate lists changes for it.
+  """
+  @spec conditions_reject?(MediaFile.t(), DeviceProfile.t()) :: boolean()
+  def conditions_reject?(%MediaFile{} = media_file, %DeviceProfile{} = profile) do
+    {video_stream, audio_stream} = stream_pair(media_file)
+
+    not (DeviceProfile.codec_conditions_met?(profile, :video, media_file.codec, video_stream) and
+           DeviceProfile.codec_conditions_met?(
+             profile,
+             :audio,
+             media_file.audio_codec,
+             audio_stream
+           ))
+  end
+
   # The client can open this container and decode every stream in it as-is.
   defp client_can_play?(profile, container, video_codec, audio_codec, streams) do
     DeviceProfile.container_allowed?(profile, container) and

--- a/test/mydia/streaming/codec_profile_compatibility_test.exs
+++ b/test/mydia/streaming/codec_profile_compatibility_test.exs
@@ -13,7 +13,7 @@ defmodule Mydia.Streaming.CodecProfileCompatibilityTest do
 
   alias Mydia.Library.MediaFile
   alias Mydia.Library.Structs.{FileMetadata, StreamInfo}
-  alias Mydia.Streaming.{Compatibility, DeviceProfile}
+  alias Mydia.Streaming.{Candidates, Compatibility, DeviceProfile}
 
   # The real file, as the production analyzer recorded it.
   defp lanterns_media_file do
@@ -131,6 +131,50 @@ defmodule Mydia.Streaming.CodecProfileCompatibilityTest do
       profile = profile_claiming_hevc([bit_depth_at_most(8)])
 
       assert Compatibility.check_compatibility(bare, profile) == :needs_transcoding
+    end
+  end
+
+  describe "candidate list" do
+    # The second half of the original bug. The server correctly answered
+    # :needs_transcoding, but that branch led with HLS_COPY variants, and the
+    # player's `_canDirectPlay` treats a leading HLS_COPY as playable. So the
+    # verdict was inverted client-side and the untouched 10-bit file was streamed
+    # anyway. HLS_COPY stream-copies the video, so it was never a real option.
+    test "offers no HLS_COPY when the client's conditions rejected the codec" do
+      profile = profile_claiming_hevc([bit_depth_at_most(8)])
+
+      strategies =
+        lanterns_media_file()
+        |> Candidates.build_streaming_candidates(profile)
+        |> Enum.map(& &1.strategy)
+
+      assert Compatibility.check_compatibility(lanterns_media_file(), profile) ==
+               :needs_transcoding
+
+      refute "HLS_COPY" in strategies
+      assert List.first(strategies) == "TRANSCODE"
+    end
+
+    test "keeps HLS_COPY for a client that stated no conditions" do
+      # A browser judges codec strings itself, so the stream-copy rungs it has
+      # always been offered must survive. Only conditions suppress them.
+      profile = %DeviceProfile{
+        containers: ["mp4"],
+        video_codecs: ["h264"],
+        audio_codecs: ["aac"],
+        hdr_formats: [],
+        codec_profiles: []
+      }
+
+      strategies =
+        lanterns_media_file()
+        |> Candidates.build_streaming_candidates(profile)
+        |> Enum.map(& &1.strategy)
+
+      assert Compatibility.check_compatibility(lanterns_media_file(), profile) ==
+               :needs_transcoding
+
+      assert "HLS_COPY" in strategies
     end
   end
 


### PR DESCRIPTION
## Why playback still failed after #563

#563 made the server answer `:needs_transcoding` for 10-bit HEVC on a device that cannot decode it, and it does. Confirmed against production, same file and same server:

```
DECISION (hevc VideoBitDepth <= 8)  = :needs_transcoding
DECISION (no conditions)            = :direct_play
```

The tablet still direct-played the file and still showed **"Could not open codec."** The verdict was inverted again on the way out.

`build_streaming_candidates/2` leads the `:needs_transcoding` branch with `HLS_COPY` variants:

```elixir
:needs_transcoding ->
  native_candidates = Enum.map(video_variants, &build_candidate("HLS_COPY", ...))
  native_candidates ++ [transcode_candidate]
```

and the player's `_canDirectPlay` (player_screen.dart:1688) returns true for a leading `HLS_COPY`, so `canDirect` came back true and the untouched 10-bit file was streamed. `_pickHlsStrategy` would have made the same mistake on the other branch: it returns `HLS_COPY` whenever *any* candidate is one.

## The fix

`HLS_COPY` repackages without re-encoding, so it carries the original video codec. It was never a real option here: handing it to a client whose stated conditions just rejected that codec returns the same undecodable bytes in a new container.

`Compatibility.conditions_reject?/2` answers "the client's own conditions rule this stream out", and `Candidates` drops the stream-copy rungs when it does.

**Only conditions suppress those rungs, never a codec's mere absence from the allowlist.** That distinction is the whole reason this is safe: a codec missing from the lists means the client never *claimed* it, which historically still left stream-copy on the table for a client that judges codec strings itself. Safari playing HEVC keeps the rungs it has always been offered, and a client that states no conditions sees no change.

## Why server-side

Fixing this in `Candidates` rather than in `_canDirectPlay` means it takes effect without shipping a new player, and it holds for every client instead of the one whose gate we happened to narrow.

The player's permissive `_canDirectPlay` / `_pickHlsStrategy` are still worth tightening on their own. Both predate hardware-confirmed capability probing, and `_canDirectPlay`'s docstring asks for exactly that once the probe is validated on a device, which it now is. Left out here to keep this change deployable without a client release.

## Tests

361 streaming tests green, including two new ones: the rejected-codec list must not contain `HLS_COPY` and must lead with `TRANSCODE`, and a no-conditions client must still be offered `HLS_COPY`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming candidate selection for devices with incompatible video or audio codec requirements.
  * Clients that reject a media file now receive a transcoding option instead of incompatible direct-play options.
  * Devices without codec restrictions continue to receive available direct-play variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->