### PR TITLE
fix(player): stop treating a leading HLS_COPY candidate as direct-playable

### DIFF
--- a/player/lib/core/player/hls_strategy_selection.dart
+++ b/player/lib/core/player/hls_strategy_selection.dart
@@ -20,8 +20,8 @@ library;
 /// incompatible codec into a compatible one. Requesting it here would hand
 /// an old server's leading `HLS_COPY` candidate straight to the streaming
 /// session and reproduce the "Could not open codec." failure this function
-/// exists to avoid: a Fire HD 10's HEVC Main 10-only decoder choking on an
-/// HEVC Main 10 source it was told to stream untouched.
+/// exists to avoid: a Fire HD 10, whose HEVC decoder is Main 8-bit only,
+/// choking on an HEVC Main 10 source it was told to stream untouched.
 ///
 /// This holds against both an old server, which always leads
 /// `:needs_transcoding` with `HLS_COPY`, and one carrying the #564 fix,

--- a/player/lib/core/player/hls_strategy_selection.dart
+++ b/player/lib/core/player/hls_strategy_selection.dart
@@ -1,0 +1,50 @@
+/// Chooses which HLS delivery strategy to request from the server.
+///
+/// Extracted as a free function so it can be unit-tested without a widget
+/// tree, following the same pattern as `shouldOfferResume` in
+/// [resume_plan.dart] and the helpers in [playback_error.dart].
+library;
+
+/// Picks the HLS strategy to request from the streaming-session mutation,
+/// given the priority-ordered strategy values from `streamingCandidates`
+/// (best first).
+///
+/// [strategyValues] is the plain-string form of each candidate's `strategy`
+/// (`candidate.strategy.toJson()`), in the order the server returned them.
+///
+/// A leading `HLS_COPY` is the server's `:needs_transcoding` verdict.
+/// `Mydia.Streaming.Candidates.build_streaming_candidates/2` only ever
+/// reaches for `HLS_COPY` ahead of `TRANSCODE` from that branch, where every
+/// such entry still carries the file's original video codec — `HLS_COPY`
+/// repackages a stream without re-encoding it, so it can never turn an
+/// incompatible codec into a compatible one. Requesting it here would hand
+/// an old server's leading `HLS_COPY` candidate straight to the streaming
+/// session and reproduce the "Could not open codec." failure this function
+/// exists to avoid: a Fire HD 10's HEVC Main 10-only decoder choking on an
+/// HEVC Main 10 source it was told to stream untouched.
+///
+/// This holds against both an old server, which always leads
+/// `:needs_transcoding` with `HLS_COPY`, and one carrying the #564 fix,
+/// which omits `HLS_COPY` from that branch entirely once the client's
+/// declared codecs reject the source. Either way, an `HLS_COPY` that
+/// survives to the front of the list is never one this function may
+/// request.
+///
+/// A later `HLS_COPY` — behind a leading `DIRECT_PLAY` or `REMUX` — is a
+/// different situation: the `:needs_remux` branch leads with `REMUX` and
+/// lists `HLS_COPY` second (`[REMUX, HLS_COPY, TRANSCODE]`), and in that
+/// branch the codecs are already known compatible; only the container
+/// isn't. That `HLS_COPY` is genuine and safe to request.
+///
+/// Falls back to `TRANSCODE` — the one strategy that is always safe to ask
+/// for — whenever no qualifying `HLS_COPY` entry exists.
+String pickHlsStrategy(List<String> strategyValues) {
+  final leadsWithHlsCopy =
+      strategyValues.isNotEmpty && strategyValues.first == 'HLS_COPY';
+
+  if (!leadsWithHlsCopy && strategyValues.contains('HLS_COPY')) {
+    return 'HLS_COPY';
+  }
+
+  return 'TRANSCODE';
+}

--- a/player/lib/domain/models/quality_delivery_subtitle.dart
+++ b/player/lib/domain/models/quality_delivery_subtitle.dart
@@ -42,10 +42,11 @@ String cappedRungDeliverySubtitle(int? maxBitrateKbps) {
 /// repackages a stream without re-encoding it — so a leading `HLS_COPY`
 /// always still carries the exact video codec the server just said this
 /// device cannot decode. Treating it as direct-playable let a Fire HD 10
-/// (whose HEVC decoder is Main 10 only) stream an HEVC Main 10 file
-/// untouched, straight into mpv's "Could not open codec." `REMUX` stays
-/// accepted: it only repackages a codec the compatibility check already
-/// found acceptable into a different container.
+/// (whose HEVC decoder is Main 8-bit only, with no Main 10 support) stream
+/// an HEVC Main 10 file untouched, straight into mpv's "Could not open
+/// codec." `REMUX` stays accepted: it only repackages a codec the
+/// compatibility check already found acceptable into a different
+/// container.
 ///
 /// Platform gating (`!kIsWeb`) is intentionally left to the caller — this
 /// only inspects strategy ordering.

--- a/player/lib/domain/models/quality_delivery_subtitle.dart
+++ b/player/lib/domain/models/quality_delivery_subtitle.dart
@@ -34,7 +34,18 @@ String cappedRungDeliverySubtitle(int? maxBitrateKbps) {
 }
 
 /// Whether the first candidate strategy is one `PlayerScreen._canDirectPlay`
-/// would accept (DIRECT_PLAY, REMUX, or HLS_COPY).
+/// would accept (DIRECT_PLAY or REMUX).
+///
+/// `HLS_COPY` is deliberately excluded, even when it leads the list.
+/// `Mydia.Streaming.Candidates.build_streaming_candidates/2` only ever leads
+/// with `HLS_COPY` from its `:needs_transcoding` branch, and `HLS_COPY`
+/// repackages a stream without re-encoding it — so a leading `HLS_COPY`
+/// always still carries the exact video codec the server just said this
+/// device cannot decode. Treating it as direct-playable let a Fire HD 10
+/// (whose HEVC decoder is Main 10 only) stream an HEVC Main 10 file
+/// untouched, straight into mpv's "Could not open codec." `REMUX` stays
+/// accepted: it only repackages a codec the compatibility check already
+/// found acceptable into a different container.
 ///
 /// Platform gating (`!kIsWeb`) is intentionally left to the caller — this
 /// only inspects strategy ordering.
@@ -42,7 +53,7 @@ bool firstStrategyAllowsDirectPlay(Iterable<String> strategyValues) {
   final iterator = strategyValues.iterator;
   if (!iterator.moveNext()) return false;
   final first = iterator.current;
-  return first == 'DIRECT_PLAY' || first == 'REMUX' || first == 'HLS_COPY';
+  return first == 'DIRECT_PLAY' || first == 'REMUX';
 }
 
 /// Whether any candidate is a no-re-encode delivery (HLS_COPY or REMUX).

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1778,20 +1778,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   /// without re-encoding it, so it still carries the exact video codec the
   /// server just said this device cannot decode. Treating a leading
   /// HLS_COPY as direct-playable is what let a Fire HD 10 — whose HEVC
-  /// decoder is Main 10 only — stream an HEVC Main 10 file untouched,
-  /// straight into mpv's "Could not open codec.".
+  /// decoder is Main 8-bit only, with no Main 10 support — stream an HEVC
+  /// Main 10 file untouched, straight into mpv's "Could not open codec.".
   ///
   /// This guard used to stay permissive on the theory that the native
   /// device profile the server checks against hadn't been validated on real
   /// hardware and might under-report a device's true decoder support. That
-  /// hedge no longer applies: an Android `MediaCodecList` probe against a
-  /// Fire HD 10 confirmed its decoder is exactly as limited as the server's
-  /// verdict assumed — `video/hevc` capped at 8-bit, `video/vp9` capped at
-  /// 10-bit — so a `:needs_transcoding` verdict for a codec this device
-  /// cannot decode is trustworthy, and HLS_COPY must not be used to
-  /// second-guess it. REMUX stays accepted because it only repackages a
-  /// codec the compatibility check already found acceptable into a
-  /// different container — an unrelated case.
+  /// hedge no longer applies: `android_codec_capabilities.dart`'s
+  /// `MediaCodecList` probe against a Fire HD 10 confirmed its decoder is
+  /// exactly as limited as the server's verdict assumed — `video/hevc`
+  /// capped at 8-bit, `video/vp9` capped at 10-bit — so a
+  /// `:needs_transcoding` verdict for a codec this device cannot decode is
+  /// trustworthy, and HLS_COPY must not be used to second-guess it. REMUX
+  /// stays accepted because it only repackages a codec the compatibility
+  /// check already found acceptable into a different container — an
+  /// unrelated case.
   bool _canDirectPlay(
     List<Query$StreamingCandidates$streamingCandidates$candidates> candidates,
   ) {

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -76,6 +76,7 @@ import '../../../core/p2p/media_proxy.dart';
 import '../../../core/p2p/media_proxy_factory.dart';
 import '../../../core/window/desktop_window.dart';
 import '../../../core/window/player_window_sizer.dart';
+import '../../../core/player/hls_strategy_selection.dart';
 import '../../../core/player/resume_plan.dart';
 import '../../../core/remote/remote_control_intent.dart';
 import '../../../core/remote/remote_target_controller.dart';
@@ -1441,18 +1442,21 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
 
   /// Pick the best HLS strategy from streaming candidates.
   ///
-  /// Prefers HLS_COPY (no transcoding) if available, falls back to TRANSCODE.
+  /// Delegates to [pickHlsStrategy], which reads the leading candidate as
+  /// the server's compatibility verdict for this file: a leading `HLS_COPY`
+  /// means `:needs_transcoding`, and `HLS_COPY` never re-encodes, so it is
+  /// never a safe choice in that case. See that function's doc comment for
+  /// why this is correct against both an old server and one carrying the
+  /// #564 fix.
   Enum$StreamingStrategy _pickHlsStrategy(
     List<Query$StreamingCandidates$streamingCandidates$candidates>? candidates,
   ) {
-    if (candidates != null) {
-      for (final c in candidates) {
-        if (c.strategy == Enum$StreamingCandidateStrategy.HLS_COPY) {
-          return Enum$StreamingStrategy.HLS_COPY;
-        }
-      }
-    }
-    return Enum$StreamingStrategy.TRANSCODE;
+    final values = candidates?.map((c) => c.strategy.toJson()).toList() ??
+        const <String>[];
+
+    return pickHlsStrategy(values) == 'HLS_COPY'
+        ? Enum$StreamingStrategy.HLS_COPY
+        : Enum$StreamingStrategy.TRANSCODE;
   }
 
   /// Rebuilds the quality ladder for the file about to play and settles which
@@ -1767,25 +1771,32 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
 
   /// Check if the first candidate supports direct play on native.
   ///
-  /// On native desktop, FFmpeg handles virtually all codecs/containers,
-  /// so DIRECT_PLAY, REMUX, and HLS_COPY are all direct-playable.
+  /// Delegates to [firstStrategyAllowsDirectPlay], which accepts only
+  /// DIRECT_PLAY and REMUX. HLS_COPY is deliberately excluded even when it
+  /// leads the list: the server only ever leads with HLS_COPY from its
+  /// `:needs_transcoding` branch, and HLS_COPY repackages the stream
+  /// without re-encoding it, so it still carries the exact video codec the
+  /// server just said this device cannot decode. Treating a leading
+  /// HLS_COPY as direct-playable is what let a Fire HD 10 — whose HEVC
+  /// decoder is Main 10 only — stream an HEVC Main 10 file untouched,
+  /// straight into mpv's "Could not open codec.".
   ///
-  /// This stays deliberately permissive even now that the server answers
-  /// against a real device profile. The native profile narrows a static
-  /// table with an mpv probe that has not been validated on hardware, so it
-  /// can under-report. Narrowing this guard to DIRECT_PLAY on top of an
-  /// under-reporting profile would refuse files the player handles fine.
-  /// Narrow it once the probe is confirmed on a device.
+  /// This guard used to stay permissive on the theory that the native
+  /// device profile the server checks against hadn't been validated on real
+  /// hardware and might under-report a device's true decoder support. That
+  /// hedge no longer applies: an Android `MediaCodecList` probe against a
+  /// Fire HD 10 confirmed its decoder is exactly as limited as the server's
+  /// verdict assumed — `video/hevc` capped at 8-bit, `video/vp9` capped at
+  /// 10-bit — so a `:needs_transcoding` verdict for a codec this device
+  /// cannot decode is trustworthy, and HLS_COPY must not be used to
+  /// second-guess it. REMUX stays accepted because it only repackages a
+  /// codec the compatibility check already found acceptable into a
+  /// different container — an unrelated case.
   bool _canDirectPlay(
     List<Query$StreamingCandidates$streamingCandidates$candidates> candidates,
   ) {
-    if (candidates.isEmpty) return false;
-
-    final first = candidates.first;
-    // On native desktop, FFmpeg can handle any format directly
-    return first.strategy == Enum$StreamingCandidateStrategy.DIRECT_PLAY ||
-        first.strategy == Enum$StreamingCandidateStrategy.REMUX ||
-        first.strategy == Enum$StreamingCandidateStrategy.HLS_COPY;
+    final values = candidates.map((c) => c.strategy.toJson()).toList();
+    return firstStrategyAllowsDirectPlay(values);
   }
 
   /// Cache the Original-rung delivery subtitle from resolved candidates.

--- a/player/test/core/player/hls_strategy_selection_test.dart
+++ b/player/test/core/player/hls_strategy_selection_test.dart
@@ -1,0 +1,72 @@
+// `pickHlsStrategy` is what `PlayerScreen._pickHlsStrategy` delegates to. A
+// leading HLS_COPY candidate is the server's :needs_transcoding verdict
+// (Mydia.Streaming.Candidates.build_streaming_candidates/2), and HLS_COPY
+// never re-encodes, so it must never be requested in that case — that
+// inversion is what let a Fire HD 10 (HEVC Main 10-only decoder) stream an
+// HEVC Main 10 file untouched and hit mpv's "Could not open codec.".
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/hls_strategy_selection.dart';
+
+void main() {
+  group('pickHlsStrategy', () {
+    test(
+        'a leading HLS_COPY (old-server :needs_transcoding shape) forces '
+        'TRANSCODE', () {
+      expect(
+        pickHlsStrategy(['HLS_COPY', 'TRANSCODE']),
+        'TRANSCODE',
+      );
+    });
+
+    test(
+        'multiple leading HLS_COPY variants (one per video codec variant) '
+        'still force TRANSCODE', () {
+      expect(
+        pickHlsStrategy(['HLS_COPY', 'HLS_COPY', 'HLS_COPY', 'TRANSCODE']),
+        'TRANSCODE',
+      );
+    });
+
+    test('a later HLS_COPY behind REMUX (:needs_remux shape) is used', () {
+      expect(
+        pickHlsStrategy(['REMUX', 'HLS_COPY', 'TRANSCODE']),
+        'HLS_COPY',
+      );
+    });
+
+    test('a DIRECT_PLAY list with no HLS_COPY falls back to TRANSCODE', () {
+      expect(
+        pickHlsStrategy(['DIRECT_PLAY', 'TRANSCODE']),
+        'TRANSCODE',
+      );
+    });
+
+    test('a TRANSCODE-only list stays TRANSCODE', () {
+      expect(
+        pickHlsStrategy(['TRANSCODE']),
+        'TRANSCODE',
+      );
+    });
+
+    test('an empty list falls back to TRANSCODE', () {
+      expect(
+        pickHlsStrategy(const []),
+        'TRANSCODE',
+      );
+    });
+
+    test(
+        'a server carrying the #564 fix that omits HLS_COPY outright still '
+        'yields TRANSCODE', () {
+      // PR #564 (server-side) omits HLS_COPY from the :needs_transcoding
+      // branch entirely once the client's declared codecs reject the
+      // source, so the list a fixed server sends here for that case has no
+      // HLS_COPY entry at all.
+      expect(
+        pickHlsStrategy(['TRANSCODE']),
+        'TRANSCODE',
+      );
+    });
+  });
+}

--- a/player/test/core/player/hls_strategy_selection_test.dart
+++ b/player/test/core/player/hls_strategy_selection_test.dart
@@ -2,8 +2,9 @@
 // leading HLS_COPY candidate is the server's :needs_transcoding verdict
 // (Mydia.Streaming.Candidates.build_streaming_candidates/2), and HLS_COPY
 // never re-encodes, so it must never be requested in that case — that
-// inversion is what let a Fire HD 10 (HEVC Main 10-only decoder) stream an
-// HEVC Main 10 file untouched and hit mpv's "Could not open codec.".
+// inversion is what let a Fire HD 10 (HEVC decoder is Main 8-bit only, no
+// Main 10 support) stream an HEVC Main 10 file untouched and hit mpv's
+// "Could not open codec.".
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/player/hls_strategy_selection.dart';

--- a/player/test/domain/models/quality_delivery_subtitle_test.dart
+++ b/player/test/domain/models/quality_delivery_subtitle_test.dart
@@ -55,7 +55,7 @@ void main() {
   });
 
   group('firstStrategyAllowsDirectPlay', () {
-    test('true when first is DIRECT_PLAY, REMUX, or HLS_COPY', () {
+    test('true when first is DIRECT_PLAY or REMUX', () {
       expect(
         firstStrategyAllowsDirectPlay(['DIRECT_PLAY', 'TRANSCODE']),
         isTrue,
@@ -64,9 +64,17 @@ void main() {
         firstStrategyAllowsDirectPlay(['REMUX', 'HLS_COPY', 'TRANSCODE']),
         isTrue,
       );
+    });
+
+    test('false when first is HLS_COPY, even with nothing else ahead of it',
+        () {
+      // A leading HLS_COPY is the server's :needs_transcoding verdict
+      // (Mydia.Streaming.Candidates.build_streaming_candidates/2) and
+      // HLS_COPY never re-encodes, so it still carries a codec the device
+      // was just told it cannot decode.
       expect(
         firstStrategyAllowsDirectPlay(['HLS_COPY', 'TRANSCODE']),
-        isTrue,
+        isFalse,
       );
     });
 


### PR DESCRIPTION
## The bug

A Fire HD 10 tablet cannot decode HEVC Main 10 (its MediaCodec HEVC decoder is 8-bit only). The server correctly classifies such a file as `:needs_transcoding`. Playback still failed with mpv's "Could not open codec." because the player inverted that verdict.

`Mydia.Streaming.Candidates.build_streaming_candidates/2` returns a priority-ordered candidate list (best first). Its `:needs_transcoding` branch leads with one `HLS_COPY` entry per video codec variant, ahead of a terminal `TRANSCODE` entry:

```elixir
:needs_transcoding ->
  native_candidates = Enum.map(video_variants, &build_candidate("HLS_COPY", "ts", &1, audio_codec_str))
  native_candidates ++ [transcode_candidate]
```

`HLS_COPY` repackages a stream without re-encoding it, so every one of those entries still carries the file's original, undecodable video codec. Two places in `player_screen.dart` treated a leading `HLS_COPY` as safe anyway:

- `_canDirectPlay(candidates)` inspected `candidates.first` and accepted `DIRECT_PLAY`, `REMUX`, **or `HLS_COPY`** — so it enabled direct play on a leading `HLS_COPY`, handing the client the untouched, undecodable original file.
- `_pickHlsStrategy(candidates)` returned `HLS_COPY` if **any** candidate was `HLS_COPY` — which also matches a leading one, so even the HLS fallback path would request a stream-copy of a codec the server had just said this device cannot decode.

`domain/models/quality_delivery_subtitle.dart`'s `firstStrategyAllowsDirectPlay` had the identical bug — it exists specifically to mirror `_canDirectPlay`'s gate for the Original-rung subtitle label, so it shared the same three-strategy acceptance list.

## The fix

Both checks now key off one rule: **a leading `HLS_COPY` is the signal for the `:needs_transcoding` verdict, and is never selected** — regardless of whether `HLS_COPY` appears later in the list.

- `firstStrategyAllowsDirectPlay` (already extracted, in `quality_delivery_subtitle.dart`) now accepts only `DIRECT_PLAY` or `REMUX`. `_canDirectPlay` delegates to it directly instead of duplicating the strategy check, so the playback gate and the displayed Original-rung subtitle can never disagree again.
- A new `pickHlsStrategy` free function (`core/player/hls_strategy_selection.dart`) treats a leading `HLS_COPY` as disqualifying: it only returns `HLS_COPY` when the list does *not* lead with it. `_pickHlsStrategy` delegates to it and maps the result back to the generated `Enum$StreamingStrategy`.

This is correct against both server versions:

- **Old server** (current `candidates.ex`): `:needs_transcoding` always leads with `HLS_COPY` (there is always at least one video codec variant), so it is always rejected. `:needs_remux` leads with `REMUX` and lists `HLS_COPY` second (`[REMUX, HLS_COPY, TRANSCODE]`) — that `HLS_COPY` is untouched by this fix and stays selectable, correctly, since `:needs_remux` means the codecs are already known compatible and only the container needs to change.
- **New server** (#564, server-side, not part of this PR): omits `HLS_COPY` from the `:needs_transcoding` branch entirely once the client's declared codecs reject the source, so that branch's list has no `HLS_COPY` at all — the "any `HLS_COPY`" fallback in `pickHlsStrategy` simply never matches, same end result.

`Enum$StreamingStrategy` (the mutation input type) only has two values, `HLS_COPY` and `TRANSCODE` — verified against `lib/graphql/schema.graphql` before relying on it, no values were invented.

`_canDirectPlay`'s docstring previously said the guard stayed "deliberately permissive" because the native device profile "narrows a static table with an mpv probe that has not been validated on hardware." That hedge is stale: `android_codec_capabilities.dart`'s `MediaCodecList` probe (landed in #563, on `dev.mydia.player/codecs`) against the Fire HD 10 confirmed its decoder matches the server's verdict exactly (`video/hevc` capped at 8-bit, `video/vp9` capped at 10-bit), so a `:needs_transcoding` verdict for an unsupported codec is trustworthy and must not be second-guessed by falling through to `HLS_COPY`. Updated the docstring accordingly.

Not changed:
- `REMUX` acceptance in `_canDirectPlay` — unaffected by this bug, no justification found to narrow it further.
- Elixir server code — the other half of this fix is #564.
- Web behavior — `_canDirectPlay` stays gated on `!kIsWeb`.
- The quality-rung veto (`_selectedQuality.isOriginal`) — untouched.

## Tests

Extracted both checks into pure, testable free functions rather than testing the private `State` methods directly, following the existing `resume_plan.dart`/`playback_error.dart` pattern.

- `player/test/core/player/hls_strategy_selection_test.dart` (new): leading `HLS_COPY` (single and multi-variant), `HLS_COPY` behind `REMUX` (`:needs_remux` shape, still selected), `DIRECT_PLAY`-only, `TRANSCODE`-only, empty list, and the #564 shape (`HLS_COPY` already absent).
- `player/test/domain/models/quality_delivery_subtitle_test.dart` (updated): `firstStrategyAllowsDirectPlay` no longer treats a leading `HLS_COPY` as direct-playable.
- Ran the existing player_screen widget tests that stub streaming candidates end to end (`player_honors_selected_file_test.dart`, `direct_play_resume_prompt_test.dart`, `player_screen_stale_candidates_test.dart`, `quality_choice_test.dart`, `offline_sentinel_streaming_fallback_test.dart`, `player_screen_quality_caps_test.dart`) to confirm nothing regressed — none of them stub a leading `HLS_COPY`, so all were unaffected and still pass.

### Commands run

```
./dev player setup
devenv shell -- bash -c 'cd player && dart format --line-length 80 <changed files>'
devenv shell -- bash -c 'cd player && dart analyze --fatal-warnings'
./dev flutter test --concurrency=1 test/core/player/hls_strategy_selection_test.dart test/domain/models/quality_delivery_subtitle_test.dart
./dev flutter test --concurrency=1 test/presentation/screens/player/player_honors_selected_file_test.dart test/presentation/screens/player/direct_play_resume_prompt_test.dart test/presentation/screens/player/player_screen_stale_candidates_test.dart test/presentation/screens/player/quality_choice_test.dart test/presentation/screens/player/offline_sentinel_streaming_fallback_test.dart test/presentation/screens/player/player_screen_quality_caps_test.dart

# after merging origin/master (brings in #563's MediaCodecList probe) and
# correcting the inverted wording:
devenv shell -- git fetch origin master
devenv shell -- git merge origin/master
devenv shell -- bash -c 'cd player && dart format --line-length 80 <changed files>'
devenv shell -- bash -c 'cd player && dart analyze --fatal-warnings'
./dev flutter test --concurrency=1 test/core/player/hls_strategy_selection_test.dart test/domain/models/quality_delivery_subtitle_test.dart test/core/player/android_codec_capabilities_test.dart
./dev flutter test --concurrency=1 test/presentation/screens/player/player_honors_selected_file_test.dart test/presentation/screens/player/direct_play_resume_prompt_test.dart test/presentation/screens/player/player_screen_stale_candidates_test.dart test/presentation/screens/player/quality_choice_test.dart test/presentation/screens/player/offline_sentinel_streaming_fallback_test.dart test/presentation/screens/player/player_screen_quality_caps_test.dart
```

`dart analyze --fatal-warnings` reports only pre-existing info-level issues (none in the touched or new files); the pre-commit hook's own `dart analyze` and `dart format` checks passed on commit.

### Update: merged master, corrected inverted wording

This branch was originally cut before #563 (the Android `MediaCodecList` probe) merged, so an earlier revision of this PR both (a) could not name the in-repo probe it relied on for the hardware-confirmation claim, and (b) had the Fire HD 10's decoder limitation backwards in several comments — it said the decoder was "Main 10 only" when the decoder is actually **Main 8-bit only, with no Main 10 support at all**; the 10-bit source is what it refuses to open. That inversion has since been corrected in every comment it appeared in (`hls_strategy_selection.dart`, `quality_delivery_subtitle.dart`, `player_screen.dart`, and the test file), and confirmed against `android_codec_capabilities.dart`'s own moduledoc: "a Fire HD 10 whose MediaTek decoder opens HEVC Main and refuses Main 10." `origin/master` (including #563) has since been merged into this branch so the hardware-confirmation comment can name `android_codec_capabilities.dart` directly instead of describing an unnamed probe.

### What I did not do

- Did not run the full player test suite (too slow to be worth it here) — only the targeted files above, plus `android_codec_capabilities_test.dart` and the widget tests most likely to exercise `_canDirectPlay`/`_pickHlsStrategy`, all re-run after the master merge.
- Did not touch `strategiesAllowLosslessDelivery` — it answers a different question ("is any candidate a no-re-encode delivery") that stays correct regardless of position.
- Did not touch the Elixir side of #563 (`codec_profile.ex`, `profile_condition.ex`, `device_profile.ex`) or the Kotlin `MainActivity.kt` channel handler — all came in via the master merge, not authored here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HLS playback strategy selection for more reliable handling of direct play, remuxing, copying, and transcoding.
  * Prevented HLS copy candidates from being treated as directly playable when they appear first.
  * Ensured incompatible candidate orderings correctly fall back to transcoding.

* **Tests**
  * Added comprehensive coverage for HLS strategy selection and direct-play eligibility across supported candidate combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
