### PR TITLE
fix(player): ship the VC++ runtime with Windows builds

### DIFF
--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -304,6 +304,17 @@ jobs:
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build ${{ matrix.platform_dir }} --release
 
+      # A release build links against the VC++ runtime, which a clean Windows
+      # install does not ship, so the app dies on launch with "msvcp140.dll was
+      # not found". This runner already has the runtime, which is exactly why
+      # nothing here catches it. The script copies the DLLs into the Release
+      # directory that both this artifact and the installer are built from, and
+      # fails the job if they are missing afterwards.
+      - name: Bundle VC++ runtime
+        if: matrix.platform == 'Windows' && steps.check_platform.outputs.enabled == 'true'
+        shell: pwsh
+        run: pwsh ${{ env.PLAYER_PATH }}/tool/bundle_windows_runtime.ps1
+
       # Do NOT point artifact_path at the .app directory and let upload-artifact
       # zip it. Its zip implementation replaces every symlink with a full copy of
       # the target, which flattens all 25 frameworks in the bundle:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -941,6 +941,14 @@ jobs:
         working-directory: ${{ env.PLAYER_PATH }}
         run: flutter build windows --release
 
+      # Must run before the installer is packaged: installer.iss globs the same
+      # Release directory, so the DLLs are only in the shipped installer if they
+      # are on disk by now. Without this every clean Windows machine fails to
+      # launch with "msvcp140.dll was not found".
+      - name: Bundle VC++ runtime
+        shell: pwsh
+        run: pwsh ${{ env.PLAYER_PATH }}/tool/bundle_windows_runtime.ps1
+
       - name: Build installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.4
         with:

--- a/compose.windows.yml
+++ b/compose.windows.yml
@@ -52,9 +52,15 @@ services:
       - /dev/net/tun
     cap_add:
       - NET_ADMIN
+    # Bound to loopback on purpose. Omitting the host IP would publish on every
+    # interface, and this VM pairs a fixed default password with a read-write
+    # share of the repo, so anyone who can reach the host could take both. It is
+    # a local testing VM; reaching it from another machine is not a goal worth
+    # that. If you do need remote access, tunnel over SSH rather than widening
+    # the binding, and change PASSWORD first.
     ports:
-      - "8006:8006" # Web viewer
-      - "3389:3389" # RDP
+      - "127.0.0.1:8006:8006" # Web viewer
+      - "127.0.0.1:3389:3389" # RDP
     volumes:
       - windows_data:/storage
       - ./player:/data:rw

--- a/compose.windows.yml
+++ b/compose.windows.yml
@@ -1,0 +1,66 @@
+# Windows VM for testing the Flutter player locally.
+#
+#   docker compose -f compose.windows.yml up -d
+#   open http://localhost:8006      (web viewer; RDP is on 3389)
+#
+# Windows installs itself unattended on first boot; expect ~15-25 minutes,
+# almost all of it downloading the ISO. The disk lives in a named volume, so
+# subsequent boots are fast and survive `down`.
+#
+# The player build is reached from inside the VM at \\host.lan\Data. The
+# quickest way to get one there is the CI artifact rather than a toolchain
+# install:
+#
+#   gh run download <run-id> -n mydia-player-windows-release \
+#     -D player/build/windows-ci
+#
+# then run \\host.lan\Data\build\windows-ci\mydia-player.exe. That bundle
+# carries its own flutter_windows.dll, libmpv-2.dll and mydia_player_p2p.dll,
+# so nothing needs to be compiled inside Windows.
+#
+# On btrfs, disable copy-on-write for the storage volume before Windows Setup
+# writes to the disk image, or the install runs very slowly and can corrupt.
+# The image warns about this on startup. `chattr +C` only applies to files
+# created afterwards, so the existing image has to go -- the cached ISO next to
+# it does not, so this costs no re-download:
+#
+#   docker compose -f compose.windows.yml stop
+#   V=$(docker volume inspect mydia-windows_windows_data --format '{{.Mountpoint}}')
+#   sudo chattr +C "$V" && sudo rm -f "$V/data.img"
+#   docker compose -f compose.windows.yml up -d
+#
+# To build from source in the VM instead, uncomment the /oem mount below.
+# player/windows-vm-scripts/install.bat runs on first boot and pulls in
+# Chocolatey, Git, Flutter and the VS 2022 C++ build tools, which adds roughly
+# 20 minutes to the install.
+
+name: mydia-windows
+
+services:
+  windows-vm:
+    image: dockurr/windows
+    container_name: mydia_windows_vm
+    environment:
+      VERSION: "11"
+      RAM_SIZE: "8G"
+      CPU_CORES: "4"
+      DISK_SIZE: "64G"
+      USERNAME: "Docker"
+      PASSWORD: "password"
+    devices:
+      - /dev/kvm
+      - /dev/net/tun
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - "8006:8006" # Web viewer
+      - "3389:3389" # RDP
+    volumes:
+      - windows_data:/storage
+      - ./player:/data:rw
+      # - ./player/windows-vm-scripts:/oem
+    stop_grace_period: 2m
+    restart: on-failure
+
+volumes:
+  windows_data:

--- a/player/tool/bundle_windows_runtime.ps1
+++ b/player/tool/bundle_windows_runtime.ps1
@@ -1,0 +1,85 @@
+# Copies the Visual C++ runtime DLLs into the Flutter Windows release bundle.
+#
+# A release build links against the VC++ 2015-2022 runtime, which is not part of
+# a clean Windows install. Without this the app dies on launch with
+# "msvcp140.dll was not found" on any machine that has never had a VC++
+# redistributable. Developer machines and GitHub's windows-latest runners both
+# have it, so nothing catches this before a user does.
+#
+# Deploying the DLLs next to the executable ("app-local deployment") is the
+# option that fits: installer.iss is a per-user install with
+# PrivilegesRequired=lowest, so it cannot run vc_redist.x64.exe, which needs
+# admin. Microsoft's redistributable rights permit app-local deployment.
+#
+# Run this after `flutter build windows --release` and before packaging. The
+# installer's [Files] section globs the same Release directory, so both the raw
+# CI artifact and the Inno Setup installer pick the DLLs up with no further
+# changes.
+#
+#   pwsh player/tool/bundle_windows_runtime.ps1
+#
+# Optional -ReleaseDir overrides the default build output location.
+
+[CmdletBinding()]
+param(
+    [string]$ReleaseDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $ReleaseDir) {
+    $playerRoot = Split-Path -Parent $PSScriptRoot
+    $ReleaseDir = Join-Path $playerRoot 'build\windows\x64\runner\Release'
+}
+
+if (-not (Test-Path -LiteralPath $ReleaseDir)) {
+    throw "Release directory not found: $ReleaseDir. Run 'flutter build windows --release' first."
+}
+
+$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path -LiteralPath $vswhere)) {
+    throw "vswhere.exe not found at $vswhere. Visual Studio with the C++ workload is required."
+}
+
+$vsPath = & $vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+if ([string]::IsNullOrWhiteSpace($vsPath)) {
+    throw 'No Visual Studio installation with the C++ tools was found.'
+}
+
+# The version file is the documented way to find the current redist, but it can
+# name a version whose directory was never laid down. Fall back to whatever CRT
+# directories are actually present and take the newest.
+$crtDir = $null
+$versionFile = Join-Path $vsPath 'VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt'
+if (Test-Path -LiteralPath $versionFile) {
+    $version = (Get-Content -LiteralPath $versionFile -Raw).Trim()
+    $crtDir = Get-ChildItem -Path (Join-Path $vsPath "VC\Redist\MSVC\$version\x64") `
+        -Filter 'Microsoft.VC*.CRT' -Directory -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+}
+
+if (-not $crtDir) {
+    $crtDir = Get-ChildItem -Path (Join-Path $vsPath 'VC\Redist\MSVC') `
+        -Filter 'Microsoft.VC*.CRT' -Directory -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match '\\x64\\' } |
+        Sort-Object FullName |
+        Select-Object -Last 1
+}
+
+if (-not $crtDir) {
+    throw "No x64 Microsoft.VC*.CRT redistributable directory found under $vsPath."
+}
+
+Write-Host "Copying VC++ runtime from $($crtDir.FullName)"
+Copy-Item -Path (Join-Path $crtDir.FullName '*.dll') -Destination $ReleaseDir -Force
+
+# Fail loudly rather than shipping a bundle that only works on machines which
+# happen to already have the runtime.
+$required = @('msvcp140.dll', 'vcruntime140.dll', 'vcruntime140_1.dll')
+$missing = $required | Where-Object { -not (Test-Path -LiteralPath (Join-Path $ReleaseDir $_)) }
+if ($missing) {
+    throw "VC++ runtime missing from the bundle after copy: $($missing -join ', ')"
+}
+
+Write-Host "Bundled VC++ runtime into $ReleaseDir"
+Get-ChildItem -LiteralPath $ReleaseDir -Filter '*140*.dll' | ForEach-Object { Write-Host "  $($_.Name)" }

--- a/player/windows/installer.iss
+++ b/player/windows/installer.iss
@@ -43,7 +43,13 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-; Copy the entire Flutter release bundle
+; Copy the entire Flutter release bundle.
+;
+; This includes the VC++ runtime DLLs (msvcp140, vcruntime140, vcruntime140_1),
+; which player/tool/bundle_windows_runtime.ps1 places in BuildDir before this
+; script runs. They have to ship with the app: a clean Windows install does not
+; have them, and PrivilegesRequired=lowest below means this installer cannot run
+; vc_redist.x64.exe, which needs admin. Do not narrow this glob.
 Source: "{#BuildDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]


### PR DESCRIPTION
A Flutter Windows release build links against the Visual C++ 2015-2022 runtime, which a clean Windows install does not have. We never shipped it, so `mydia-player.exe` dies on launch with a "msvcp140.dll was not found" dialog on any machine that has never had a VC++ redistributable installed by something else.

`player/windows/installer.iss` copies the Release bundle and nothing more: no `[Run]` entry for `vc_redist.x64.exe`, no bundled DLLs. Grepping the repo for `vc_redist|msvcp140` returned nothing, so the dependency was undocumented as well as unhandled.

This survived because developer machines and GitHub's `windows-latest` runners already have the runtime. Every build and every automated check passes; only a clean end-user machine hits it.

## Repro

Ran the `mydia-player-windows-release` artifact from a green master build on a freshly installed Windows 11 VM. It fails immediately, before any window appears.

## Fix

`player/tool/bundle_windows_runtime.ps1` locates the redist directory through `vswhere` and copies the CRT DLLs into the Flutter Release output, then asserts that `msvcp140.dll`, `vcruntime140.dll` and `vcruntime140_1.dll` are present and fails the job if they are not. A future regression breaks CI rather than someone's install.

Both Windows build paths call it right after `flutter build windows --release`:

- `ci-player.yml` uploads that directory as `mydia-player-windows-release`
- `release.yml` runs it before Inno Setup, whose `[Files]` section globs the same directory

So the artifact and the shipped installer are both covered by one step.

App-local deployment rather than invoking `vc_redist.x64.exe` because `installer.iss` sets `PrivilegesRequired=lowest` for a per-user install with no UAC prompt, and the redistributable installer needs admin. Microsoft's redistributable rights permit shipping these DLLs next to the executable.

## Also here

The first commit restores `compose.windows.yml`, a `dockurr/windows` VM for testing Windows player builds locally. It was added in c3ce4bfd0 and later dropped, which left `player/windows-vm-scripts/install.bat` with nothing to invoke it. This is what surfaced the bug, so it seemed worth keeping in the same PR.

It no longer mounts `/oem`, since the toolchain install that script performs is unnecessary now that CI publishes a self-contained bundle you can just download and run. The header documents that, along with the btrfs copy-on-write workaround the image warns about at startup.

## Verification

The PowerShell parses clean and its argument guards were smoke-tested locally, but the copy itself only runs on Windows, so CI on this PR is the real check. What to look for in the Windows build job:

- the "Bundle VC++ runtime" step lists the DLLs it copied
- the step fails loudly if the redist directory cannot be found, rather than continuing

Worth downloading the resulting artifact and launching it on a Windows machine that has never had the redistributable, since that is the only environment that ever reproduced the bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows desktop releases now include the required Visual C++ runtime files.
  * Added a local Windows 11 virtual machine configuration for player testing.

* **Bug Fixes**
  * Improved Windows installer reliability by bundling runtime components directly with the application, avoiding separate administrator-required installation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->