### PR TITLE
ci: configure Dependabot version updates and scan every lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,96 @@
+version: 2
+
+# Alerts were on but version updates were not, so 68 advisories accumulated
+# with nothing able to open a pull request for them. Everything here is
+# grouped: ungrouped, the site tree alone would open around thirty PRs.
+#
+# Hex (mix.lock) and pub (player/pubspec.lock) are absent because Dependabot
+# does not support those ecosystems. ci-security.yml covers them instead.
+
+updates:
+  # The marketing site. Its tree drifted two majors behind and accounted for
+  # 44 of the 68 alerts in the August 2026 backlog.
+  - package-ecosystem: npm
+    directory: /site
+    schedule:
+      interval: weekly
+    groups:
+      site:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /assets
+    schedule:
+      interval: weekly
+    groups:
+      assets:
+        patterns: ["*"]
+
+  # metadata-relay is developed in this repo and deployed separately. Its
+  # asset tree is small but nothing updates it today.
+  - package-ecosystem: npm
+    directory: /metadata-relay/assets
+    schedule:
+      interval: weekly
+    groups:
+      metadata-relay-assets:
+        patterns: ["*"]
+
+  - package-ecosystem: uv
+    directory: /docs
+    schedule:
+      interval: weekly
+    groups:
+      docs:
+        patterns: ["*"]
+
+  - package-ecosystem: bundler
+    directory: /player/ios
+    schedule:
+      interval: weekly
+    groups:
+      fastlane-ios:
+        patterns: ["*"]
+
+  - package-ecosystem: bundler
+    directory: /player/android
+    schedule:
+      interval: weekly
+    groups:
+      fastlane-android:
+        patterns: ["*"]
+
+  # server/ is a workspace, so one entry covers every crate under crates/.
+  - package-ecosystem: cargo
+    directory: /server
+    schedule:
+      interval: weekly
+    groups:
+      server:
+        patterns: ["*"]
+
+  # The remaining Cargo.lock files are separate workspaces. `directories`
+  # takes a list, which avoids one block per crate.
+  - package-ecosystem: cargo
+    directories:
+      - /native/mydia_p2p
+      - /native/mydia_p2p_core
+      - /native/mydia_plugin_sdk
+      - /player/rust/mydia_player_p2p
+      - /plugins/simkl_sync
+      - /plugins/webhook_notifier
+    schedule:
+      interval: weekly
+    groups:
+      rust:
+        patterns: ["*"]
+
+  # Nothing updates the action versions themselves. The repository is pinned
+  # at actions/checkout@v4 throughout.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,40 @@
 version: 2
 
-# Alerts were on but version updates were not, so 68 advisories accumulated
-# with nothing able to open a pull request for them. Everything here is
-# grouped: ungrouped, the site tree alone would open around thirty PRs.
-#
-# Hex (mix.lock) and pub (player/pubspec.lock) are absent because Dependabot
-# does not support those ecosystems. ci-security.yml covers them instead.
+# Security updates were on, but version updates were not, so dependencies
+# drifted until the advisory fix was a major bump the security updater would
+# never offer. That is how 44 site alerts accumulated behind an Astro 5 tree
+# whose patches all landed in 6.x and 7.x. Everything here is grouped:
+# ungrouped, the site tree alone would open around thirty PRs.
 
 updates:
+  # mix.lock and player/pubspec.lock have never produced a single Dependabot
+  # alert, while OSV-Scanner finds real advisories in mix.lock. Version
+  # updates for these ecosystems do work, so run them here and keep
+  # ci-security.yml as the advisory net.
+  - package-ecosystem: mix
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      elixir:
+        patterns: ["*"]
+
+  - package-ecosystem: mix
+    directory: /metadata-relay
+    schedule:
+      interval: weekly
+    groups:
+      metadata-relay:
+        patterns: ["*"]
+
+  - package-ecosystem: pub
+    directory: /player
+    schedule:
+      interval: weekly
+    groups:
+      player:
+        patterns: ["*"]
+
   # The marketing site. Its tree drifted two majors behind and accounted for
   # 44 of the 68 alerts in the August 2026 backlog.
   - package-ecosystem: npm
@@ -69,8 +96,15 @@ updates:
       server:
         patterns: ["*"]
 
-  # The remaining Cargo.lock files are separate workspaces. `directories`
-  # takes a list, which avoids one block per crate.
+  # The remaining shipped Cargo.lock files are separate workspaces.
+  # `directories` takes a list, which avoids one block per crate.
+  #
+  # Deliberately excluded, because updating them buys nothing and adds PR
+  # noise: native/mydia_plugin_sdk/examples/minimal is a documentation
+  # example, and test/support/fixtures/plugins/{host_fns,host_test}_fixture
+  # are test fixtures whose whole purpose is a pinned, reproducible build.
+  # ci-security.yml still scans all three, so a real advisory in them
+  # surfaces even though nothing auto-bumps them.
   - package-ecosystem: cargo
     directories:
       - /native/mydia_p2p

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -31,7 +31,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.0"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@8deb546fdb875b9996d27d4950be7312dac076a1" # v2.5.0
     with:
       fail-on-vuln: false
       upload-sarif: true
@@ -45,7 +45,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.0"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@8deb546fdb875b9996d27d4950be7312dac076a1" # v2.5.0
     with:
       fail-on-vuln: false
       upload-sarif: false

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -1,0 +1,33 @@
+name: CI / Security
+
+on:
+  pull_request:
+  schedule:
+    # Monday 12:30 UTC, ahead of the weekly Dependabot run.
+    - cron: "30 12 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  # OSV-Scanner reads mix.lock and player/pubspec.lock, which Dependabot does
+  # not scan at all, plus the eight Cargo.lock files outside server/. Between
+  # them that is the Elixir application and the Flutter player, which are the
+  # two artifacts users actually run.
+  #
+  # Non-blocking for now. Neither of those trees has ever been scanned, so the
+  # baseline is unknown, and a required check here could wall off every PR in
+  # the repository on day one. Promote to fail-on-vuln once the baseline is
+  # triaged.
+  scan:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.0"
+    with:
+      fail-on-vuln: false
+      upload-sarif: true
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -12,17 +12,25 @@ permissions:
   contents: read
   security-events: write
 
+# OSV-Scanner reads every lockfile in the repository, including the eight
+# Cargo.lock files outside server/ and the two test-fixture crates nothing
+# auto-bumps. It is the advisory net behind Dependabot's version updates.
+#
+# Non-blocking for now. mix.lock had never been scanned before this landed, so
+# a required check here could wall off every PR in the repository. Promote to
+# fail-on-vuln once the baseline is triaged.
+#
+# Split into two jobs on purpose. A fork pull request gets a read-only
+# GITHUB_TOKEN, so the SARIF upload inside the reusable workflow would fail for
+# want of security-events: write. Passing an expression to upload-sarif is not
+# an option: the reusable workflow types it as a boolean, and an expression
+# reaches it as a string.
 jobs:
-  # OSV-Scanner reads mix.lock and player/pubspec.lock, which Dependabot does
-  # not scan at all, plus the eight Cargo.lock files outside server/. Between
-  # them that is the Elixir application and the Flutter player, which are the
-  # two artifacts users actually run.
-  #
-  # Non-blocking for now. Neither of those trees has ever been scanned, so the
-  # baseline is unknown, and a required check here could wall off every PR in
-  # the repository on day one. Promote to fail-on-vuln once the baseline is
-  # triaged.
   scan:
+    name: Scan lockfiles
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.0"
     with:
       fail-on-vuln: false
@@ -31,3 +39,16 @@ jobs:
       actions: read
       contents: read
       security-events: write
+
+  scan-fork:
+    name: Scan lockfiles (fork)
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.0"
+    with:
+      fail-on-vuln: false
+      upload-sarif: false
+    permissions:
+      actions: read
+      contents: read


### PR DESCRIPTION
## The headline

**Scanning `mix.lock` for the first time finds 17 known vulnerabilities across 8 packages, including CVSS 8.7 in `bandit` (the HTTP server) and 8.2 in `guardian` (the auth library).**

None of these have ever appeared on the security tab. Dependabot alerts do not cover the Hex ecosystem, so the Elixir application, the thing users actually run, has had zero dependency monitoring. The 68 alerts we did have were all build tooling.

The count going up is this working.

(#575 fixes 9 of those 17. The rest are blocked upstream.)

## Why the backlog formed

Dependabot **security updates** are enabled on this repo and do open PRs. They are not the gap. But they have opened only 5 PRs since January against 68 accumulated alerts, and 3 of those were closed unmerged.

The reason they could not clear the backlog is structural: a security update can only propose a fix that exists on the current major. For `site/`, every advisory's patched version was astro 6.x or 7.x while the site sat on 5.17.3, so there was no patch-level fix for Dependabot to offer. 44 alerts sat untouched because the tree had drifted far enough that the fix was a migration, not a bump.

**Version updates** are what prevent that drift, and there was no `.github/dependabot.yml`, so they were never running.

## What this adds

### `.github/dependabot.yml`

Nine trees, weekly, grouped. Grouping matters: ungrouped, the site tree alone would open around thirty PRs.

| Directory | Ecosystem |
|---|---|
| `/site`, `/assets`, `/metadata-relay/assets` | npm |
| `/docs` | uv |
| `/player/ios`, `/player/android` | bundler |
| `/server` | cargo (workspace, covers all `crates/*`) |
| `/native/*`, `/player/rust/*`, `/plugins/*` | cargo (via `directories`) |
| `/` | github-actions |

That last row is new coverage. Nothing updated the action versions before, and the repo is pinned at `actions/checkout@v4` throughout.

### `.github/workflows/ci-security.yml`

OSV-Scanner over the whole repo, on PRs and weekly. It reads all 20 lockfiles, including the ones Dependabot structurally cannot: `mix.lock`, `player/pubspec.lock`, and the eight `Cargo.lock` files outside `server/`.

Non-blocking to start (`fail-on-vuln: false`, SARIF to the Security tab). Making it required on day one would wall off every PR in the repo, since it runs unfiltered on `pull_request`. Promote it once the `mix.lock` findings are dealt with.

## Baseline, scanned locally

| Lockfile | Result |
|---|---|
| `mix.lock` | **17 vulnerabilities, 8 packages** |
| `player/pubspec.lock` | clean (227 packages) |
| `metadata-relay/mix.lock` | clean (42 packages) |

The `mix.lock` findings:

| Package | Version | Fixed in | Top CVSS | Status |
|---|---|---|---|---|
| `bandit` | 1.12.4 | 1.12.5 | 8.7 | fixed in #575 |
| `guardian` | 2.4.0 | 2.4.1 | 8.2 | fixed in #575 |
| `postgrex` | 0.22.3 | 0.22.4 | 5.9 | fixed in #575 |
| `phoenix_live_view` | 1.2.8 | 1.2.9 | 2.1 | fixed in #575 |
| `ymlr` | 5.1.5 | 5.1.6 | 2.1 | fixed in #575 |
| `hackney` | 1.25.0 | 4.0.1 | 8.2 | blocked: `tzdata 1.1.4` pins `hackney ~> 1.17` |
| `cowlib` | 2.19.0 | none published | 6.3 | blocked upstream |
| `earmark` | 1.4.49 | none published | 4.8 | blocked upstream |

## Not included

The Dependabot auto-merge workflow. It has to land after the `Master` ruleset picks up the new site and fastlane check contexts from #570, otherwise auto-merge would proceed on a check set that does not exercise the changed code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Automated weekly dependency update checks across supported project components.
  - Documentation and fixture components are excluded from automatic version bumps while remaining covered by security checks.

- **Security**
  - Added scheduled and on-demand scanning for known vulnerabilities in dependency lockfiles.
  - Security scan results are reported for eligible pull requests, with scans remaining non-blocking to development workflows.
  - Fork-based pull requests are scanned with appropriate safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->