### PR TITLE
ci: make the site and fastlane gates report on every pull request

### DIFF
--- a/.github/workflows/ci-fastlane.yml
+++ b/.github/workflows/ci-fastlane.yml
@@ -1,15 +1,11 @@
 name: CI / Fastlane
 
+# Deliberately NOT path-filtered. See the note in ci-site.yml: a workflow
+# skipped by a paths: filter never reports, so a required check pointing at it
+# blocks the pull request forever. Both matrix legs are registered in the
+# Master ruleset, so both have to report on every pull request.
 on:
   pull_request:
-    paths:
-      - 'player/ios/Gemfile'
-      - 'player/ios/Gemfile.lock'
-      - 'player/ios/fastlane/**'
-      - 'player/android/Gemfile'
-      - 'player/android/Gemfile.lock'
-      - 'player/android/fastlane/**'
-      - '.github/workflows/ci-fastlane.yml'
 
 concurrency:
   group: "ci-fastlane-${{ github.ref }}"
@@ -35,17 +31,38 @@ jobs:
       run:
         working-directory: player/${{ matrix.platform }}
     steps:
-      # bundle install builds native extensions and fastlane executes the
+      # bundle install builds native gem extensions and fastlane executes the
       # pull request's own Fastfile, so the job must not leave the token
       # sitting in .git/config. Nothing here needs git credentials.
+      #
+      # fetch-depth: 0 so the diff below can reach the base commit.
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Detect fastlane changes
+        id: changes
+        working-directory: ${{ github.workspace }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          if git diff --name-only "$BASE_SHA" HEAD \
+               | grep -qE "^(player/${PLATFORM}/(Gemfile(\.lock)?|fastlane/)|\.github/workflows/ci-fastlane\.yml$)"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to player/${PLATFORM} fastlane files; nothing to load."
+          fi
+
       # Mirrors release.yml, which pins 3.2 with bundler-cache for both
-      # fastlane jobs.
+      # fastlane jobs. The lockfiles are resolved under 3.2 to match, because
+      # bundler discards a lockfile resolved under a newer Ruby and re-resolves
+      # on the runner.
       - name: Set up Ruby
+        if: steps.changes.outputs.relevant == 'true'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
@@ -56,4 +73,5 @@ jobs:
       # Listing lanes proves the resolved gem set installs and that fastlane
       # can parse the Fastfile, which is what a dependency bump can break.
       - name: Load lanes
+        if: steps.changes.outputs.relevant == 'true'
         run: bundle exec fastlane lanes

--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -1,10 +1,14 @@
 name: CI / Site
 
+# Deliberately NOT path-filtered, despite only caring about site/.
+#
+# A workflow skipped by a paths: filter never reports a status at all, so a
+# required check pointing at it sits Pending forever and blocks the pull
+# request. This job is registered in the Master ruleset, so it has to report
+# on every pull request. It detects the change itself instead and exits in a
+# few seconds when site/ is untouched.
 on:
   pull_request:
-    paths:
-      - 'site/**'
-      - '.github/workflows/ci-site.yml'
 
 concurrency:
   group: "ci-site-${{ github.ref }}"
@@ -29,12 +33,30 @@ jobs:
       # npm ci runs whatever install scripts the pull request's lockfile
       # names, so the job must not leave the token sitting in .git/config
       # where that code can read it. Nothing here needs git credentials.
+      #
+      # fetch-depth: 0 so the diff below can reach the base commit.
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Detect site changes
+        id: changes
+        working-directory: ${{ github.workspace }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" HEAD \
+               | grep -qE '^(site/|\.github/workflows/ci-site\.yml$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No changes under site/; nothing to build."
+          fi
+
       - name: Set up Node
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -42,9 +64,11 @@ jobs:
           cache-dependency-path: site/package-lock.json
 
       - name: Install
+        if: steps.changes.outputs.relevant == 'true'
         run: npm ci
 
       - name: Test
+        if: steps.changes.outputs.relevant == 'true'
         run: npm test
 
       # astro build type-checks every page and renders the whole site. It is
@@ -52,4 +76,5 @@ jobs:
       # files, so npm test alone would not catch a dependency bump breaking a
       # component.
       - name: Build
+        if: steps.changes.outputs.relevant == 'true'
         run: npm run build

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -28,7 +28,7 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.8.9",
+      "version": "1.8.13",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "7.29.7",
@@ -49,36 +49,33 @@
       "version": "4.3.0"
     },
     "../deps/phoenix_live_view": {
-      "version": "1.2.8",
+      "version": "1.2.10",
       "license": "MIT",
-      "dependencies": {
-        "morphdom": "github:SteffenDE/morphdom#sd-keyed-root"
-      },
       "devDependencies": {
-        "@babel/cli": "7.27.2",
-        "@babel/core": "7.29.6",
-        "@babel/preset-env": "7.27.2",
-        "@babel/preset-typescript": "^7.27.1",
-        "@eslint/js": "^9.29.0",
-        "@playwright/test": "^1.60.0",
+        "@babel/cli": "8.0.4",
+        "@babel/core": "8.0.1",
+        "@babel/preset-env": "^8.0.2",
+        "@babel/preset-typescript": "^8.0.1",
+        "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.62.0",
         "@types/jest": "^30.0.0",
-        "@types/phoenix": "^1.6.6",
+        "@types/phoenix": "^1.6.7",
         "css.escape": "^1.5.1",
-        "eslint": "9.29.0",
-        "eslint-plugin-jest": "28.14.0",
-        "eslint-plugin-playwright": "^2.2.0",
-        "globals": "^16.2.0",
-        "jest": "^30.0.0",
-        "jest-environment-jsdom": "^30.0.0",
+        "eslint": "^10.8.0",
+        "eslint-plugin-jest": "^29.16.0",
+        "eslint-plugin-playwright": "^2.11.0",
+        "globals": "^17.8.0",
+        "jest": "^30.4.2",
+        "jest-environment-jsdom": "^30.4.1",
         "jest-monocart-coverage": "^1.1.1",
-        "monocart-reporter": "^2.9.21",
-        "phoenix": "1.7.21",
-        "prettier": "3.5.3",
-        "ts-jest": "^29.4.0",
-        "typedoc": "^0.28.19",
-        "typedoc-plugin-missing-exports": "^4.1.3",
-        "typescript": "^5.8.3",
-        "typescript-eslint": "^8.34.0"
+        "monocart-reporter": "^2.12.4",
+        "morphdom": "github:SteffenDE/morphdom#main",
+        "phoenix": "1.8.9",
+        "prettier": "3.9.6",
+        "typedoc": "^0.28.20",
+        "typedoc-plugin-missing-exports": "^4.1.4",
+        "typescript": "^6.0",
+        "typescript-eslint": "^8.65.0"
       }
     },
     "node_modules/@catppuccin/daisyui": {


### PR DESCRIPTION
Prerequisite for registering `Site build`, `Load lanes (ios)` and `Load lanes (android)` as required checks in the `Master` ruleset.

## Why this is needed

They cannot be required while path-filtered. GitHub is explicit about it:

> checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging.

So requiring them as-is would wedge every pull request that does not happen to touch `site/` or the fastlane Gemfiles, which is most of them.

That is also why the current ruleset requires only the three unconditional `ci.yml` checks. Every path-filtered check in the repo (`Test / Player`, the whole `Build / *` matrix, `Flatpak / *`, `ci-server`, `ci-docs`) is deliberately left unrequired. This PR is what lets these three be the exception without that cost.

## What changes

Both workflows now trigger on every `pull_request` and decide for themselves whether there is work to do. A run that touches nothing relevant checks out, diffs against `github.event.pull_request.base.sha`, and finishes in seconds having reported success. A run that does touch those files behaves exactly as before.

Detection is a plain `git diff --name-only` rather than a paths-filter action. Adding another third-party dependency to a workflow whose whole purpose is supply-chain hygiene would work against the point, especially having just SHA-pinned the OSV workflow in #574 for that reason.

`fetch-depth: 0` is needed so the base commit is reachable. `persist-credentials: false` stays.

## Regex coverage

Both patterns are unit-tested against 21 literal path cases, including the two that would hurt most if wrong:

| Case | Expect |
|---|---|
| `site/src/pages/index.astro` | site ✓ |
| `lib/mydia_web/site/thing.ex` | site ✗ (nested path must not count) |
| `server/Cargo.toml`, `docs/uv.lock`, `mix.lock` | site ✗ |
| `player/ios/Gemfile.lock` on the **ios** leg | ✓ |
| `player/ios/Gemfile.lock` on the **android** leg | ✗ (one platform must not trigger the other) |
| `player/android/app/build.gradle` | android ✗ (not a fastlane file) |
| `player/lib/main.dart` | ✗ on both |

All 21 pass.

## Also here

`assets/package-lock.json` resynced with `mix.lock`. `assets/package.json` pulls phoenix, phoenix_html and phoenix_live_view through `file:../deps/...`, so the lockfile records the versions of the Hex packages in `deps/`. #575 moved phoenix to 1.8.13 and phoenix_live_view to 1.2.10 and left this file describing 1.8.9 and 1.2.8.

That is fallout from a change I merged. It did not break CI, since npm tolerates the mismatch on `file:` dependencies, but the lockfile no longer described the tree. Verified with `npm ci --prefix assets` and `mix assets.deploy`, which is what `ci.yml` runs.

## After this merges

Register the three contexts in the `Master` ruleset, then the Dependabot auto-merge workflow has something real to wait on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation for mobile and website changes.
  * Checks now run consistently on all pull requests while skipping unrelated build and test work.
  * Enhanced change detection and full-history access improve the reliability of automated checks.
  * Updated Ruby environment guidance to support lockfiles under Ruby 3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->