### PR TITLE
ci: auto-merge Dependabot pull requests once their checks pass

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,37 @@
+name: Dependabot auto-merge
+
+# pull_request_target rather than pull_request, because a Dependabot pull
+# request gets a read-only token on the pull_request event and cannot enable
+# auto-merge. The job checks out nothing and runs no code from the branch, so
+# the usual pull_request_target hazard does not apply here.
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-metadata is the supported way to read what a Dependabot pull
+      # request changed. Parsing the branch name or title is not.
+      - name: Fetch metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # --auto queues the merge behind every required check on the Master
+      # ruleset, which since #581 includes Site build and both Load lanes
+      # contexts. Those gates report on every pull request rather than being
+      # path-filtered, precisely so this wait means something.
+      #
+      # Rebase because squash merge is disabled on this repository.
+      - name: Enable auto-merge
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,8 +2,9 @@ name: Dependabot auto-merge
 
 # pull_request_target rather than pull_request, because a Dependabot pull
 # request gets a read-only token on the pull_request event and cannot enable
-# auto-merge. The job checks out nothing and runs no code from the branch, so
-# the usual pull_request_target hazard does not apply here.
+# auto-merge. The job checks out nothing, runs no code from the branch, and
+# uses no third-party actions, so it does not take on the usual
+# pull_request_target hazard.
 on: pull_request_target
 
 permissions:
@@ -13,23 +14,26 @@ permissions:
 jobs:
   auto-merge:
     name: Enable auto-merge
-    if: github.actor == 'dependabot[bot]'
+    # The pull request AUTHOR, not github.actor. github.actor is whoever
+    # triggered the event, so a maintainer reopening or synchronising a
+    # Dependabot pull request would fail this gate and silently skip the
+    # auto-merge. The author is dependabot on every Dependabot pull request
+    # and cannot be spoofed.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      # fetch-metadata is the supported way to read what a Dependabot pull
-      # request changed. Parsing the branch name or title is not.
-      - name: Fetch metadata
-        id: meta
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       # --auto queues the merge behind every required check on the Master
-      # ruleset, which since #581 includes Site build and both Load lanes
-      # contexts. Those gates report on every pull request rather than being
+      # ruleset, which now includes Site build and both Load lanes contexts.
+      # Those gates report on every pull request rather than being
       # path-filtered, precisely so this wait means something.
       #
       # Rebase because squash merge is disabled on this repository.
+      #
+      # dependabot/fetch-metadata is deliberately absent. It is the right way
+      # to read what a Dependabot pull request changed, but nothing here needs
+      # to know: every update auto-merges on green, so there is no policy to
+      # branch on. Leaving it out keeps a job holding contents: write on
+      # pull_request_target free of third-party actions entirely.
       - name: Enable auto-merge
         run: gh pr merge --auto --rebase "$PR_URL"
         env:


### PR DESCRIPTION
Final piece of the dependency remediation.

Dependabot now opens grouped weekly pull requests across twelve trees (#574). Merging each by hand is exactly the friction that lets a backlog re-form, which is how 68 alerts accumulated in the first place.

## Why the wait is meaningful now

`gh pr merge --auto` queues the merge behind every **required** check on the `Master` ruleset. That set is now:

| Context | Added |
|---|---|
| `Test` | pre-existing |
| `Test / PostgreSQL` | pre-existing |
| `Test / E2E Browser` | pre-existing |
| `Site build` | after #570 / #581 |
| `Load lanes (ios)` | after #570 / #581 |
| `Load lanes (android)` | after #570 / #581 |

This ordering was the whole point of the sequence. Before it, a site-only pull request went green on the Elixir suite having never built the site, because `ci.yml` has no path filter and the required checks were all its. Auto-merging on that would have been auto-merging on a check set that never touched the changed code.

#581 was the prerequisite: the site and fastlane gates had to report on **every** pull request before they could be required, since a workflow skipped by a `paths:` filter leaves its check Pending forever and blocks the PR.

## Implementation notes

**`pull_request_target`, not `pull_request`.** A Dependabot pull request carries a read-only `GITHUB_TOKEN` on `pull_request` and cannot enable auto-merge. The usual `pull_request_target` hazard is executing branch code with an elevated token; this job checks out nothing and runs nothing from the branch, so it does not take that on.

**`--rebase`, not `--squash`.** Squash merge is disabled on this repository (`allow_squash_merge: false`).

**`dependabot/fetch-metadata`** is the supported way to read what the PR changed, rather than parsing branch names or titles.

`allow_auto_merge` is already enabled on the repo, and the `Master` ruleset requires no human approval, so no settings changes are needed.

## What to watch on the first real one

Confirm `autoMergeRequest` is non-null once a grouped PR lands:

```
gh pr list --author "app/dependabot" --json number,title,autoMergeRequest
```

If it comes back null, the usual cause is the repository's default workflow permissions being read-only (Settings → Actions → General).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated handling for eligible software update pull requests.
  * Eligible updates can now be automatically queued for merging after required checks pass.
  * This streamlines routine maintenance and helps deliver approved updates more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->