### PR TITLE
fix(nix): bump npmDeps.hash for the resynced package-lock

### DIFF
--- a/nix/packages/flake-module.nix
+++ b/nix/packages/flake-module.nix
@@ -181,7 +181,7 @@
       # Pre-fetch npm dependencies (required for sandbox build)
       npmDeps = pkgs.fetchNpmDeps {
         src = ../../assets;
-        hash = "sha256-DhOg4p37GgILp0IzzgqyoiyTBx6saHz6j4624/+Smj4=";
+        hash = "sha256-Bbuu/Xu0TRODd9a2ai2ZQqv0xFK4NF+wELFasIQp99g=";
       };
 
       # Tailwind CSS v4 standalone binary. nixpkgs does ship tailwindcss_4, but


### PR DESCRIPTION
f00681d22 resynced `assets/package-lock.json` but left `npmDeps.hash` at the value from the July typescript bump (5217140e7). `fetchNpmDeps` then fails its fixed-output check, so every Nix job fails regardless of which branch it is building.

One line, `nix/packages/flake-module.nix`:

```
-        hash = "sha256-DhOg4p37GgILp0IzzgqyoiyTBx6saHz6j4624/+Smj4=";
+        hash = "sha256-Bbuu/Xu0TRODd9a2ai2ZQqv0xFK4NF+wELFasIQp99g=";
```

## Verification

- `prefetch-npm-deps assets/package-lock.json` returns the new hash.
- The `fetchNpmDeps` FOD builds under the flake's own pinned nixpkgs, not just the version that computed the hash: `/nix/store/np79r2xr0cf2l2nsalgbjkjbfr5j3jl1-npm-deps`.
- `nix build --dry-run .#default` and `.#postgres` both evaluate, and the resulting `mydia-0.0.0-dev.drv` references that npm-deps path, so the package consumes the store path that actually builds from the current lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration metadata to keep application builds and installations reliable.
  * Maintained reproducible build behavior without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->