### PR TITLE
fix(subsync): allow a cdylib on musl, unbreaking the Alpine images

### DIFF
--- a/native/mydia_subsync/.cargo/config.toml
+++ b/native/mydia_subsync/.cargo/config.toml
@@ -1,0 +1,19 @@
+[target.'cfg(target_os = "macos")']
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]
+
+# On musl hosts (the Alpine release/e2e images, which now use the rustup
+# toolchain to get the wasm32-wasip2 target for plugin guests) the default
+# crt-static feature forbids producing a cdylib. This NIF is a cdylib
+# dlopen'd by the BEAM, so it must be dynamically linked: turn crt-static off.
+#
+# This mirrors native/mydia_p2p/.cargo/config.toml exactly, and for the same
+# reason. Omitting it is not a subtle degradation: `mix compile` fails outright
+# with "cannot produce cdylib for `mydia_subsync` as the target
+# x86_64-unknown-linux-musl does not support these crate types", which breaks
+# both the release image and the player E2E image while every glibc build
+# (nix, devenv, CI's Rust job) stays green.
+[target.'cfg(target_env = "musl")']
+rustflags = ["-C", "target-feature=-crt-static"]


### PR DESCRIPTION
Master is currently red on `CI / Docker` and `CI / Player E2E`. Both fail the same way, and #588 caused it:

```
error: cannot produce cdylib for `mydia_subsync v0.1.0 (/app/native/mydia_subsync)`
as the target `x86_64-unknown-linux-musl` does not support these crate types
```

`mydia_subsync` shipped without a per-crate cargo config. On musl hosts the default `crt-static` feature forbids producing a cdylib, and the crate is a cdylib NIF that the BEAM dlopens, so `mix compile` fails outright inside the Alpine release image and the player E2E image.

This adds `native/mydia_subsync/.cargo/config.toml`, mirroring `native/mydia_p2p/.cargo/config.toml` exactly. That file already carries the same two blocks for the same reason, and its comment describes this precise failure; the new crate simply never got one.

## Why nothing caught it before merge

Every gate that ran is glibc:

- the full Elixir suite locally and in CI
- `cargo test` / `clippy` / `fmt` for the crate, including the new CI job #588 added
- the nix sandbox build, which I ran locally to completion and which produced a working `mydia_subsync.so`

musl is only exercised by the two Docker image builds, and `CI / Docker` never runs on a pull request. The first musl compile of this crate happened on master, after merge.

## Verification

The failing compile is deterministic rather than flaky: it is a target-capability error, not a download or cache wobble, and it reproduced identically in both image builds. CI on this PR exercises the same `mix compile` path that failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS compatibility for dynamically loaded application components.
  * Improved support for musl-based builds and runtime loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->