### PR TITLE
ci: grant the fork OSV job security-events, unbreaking CI / Security

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -25,6 +25,14 @@ permissions:
 # want of security-events: write. Passing an expression to upload-sarif is not
 # an option: the reusable workflow types it as a boolean, and an expression
 # reaches it as a string.
+#
+# Both jobs must still declare security-events: write. The reusable workflow
+# hard-codes that permission on its own job, and a called workflow may not
+# request more than the calling job granted. GitHub checks that while it builds
+# the run graph, before any if: is evaluated, so withholding it on the fork job
+# failed the entire run at startup even on same-repo pull requests where that
+# job never ran. On a fork the token stays read-only regardless of what is
+# declared here, and upload-sarif: false keeps the upload step from running.
 jobs:
   scan:
     name: Scan lockfiles
@@ -52,3 +60,4 @@ jobs:
     permissions:
       actions: read
       contents: read
+      security-events: write

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -31,8 +31,12 @@ permissions:
 # request more than the calling job granted. GitHub checks that while it builds
 # the run graph, before any if: is evaluated, so withholding it on the fork job
 # failed the entire run at startup even on same-repo pull requests where that
-# job never ran. On a fork the token stays read-only regardless of what is
-# declared here, and upload-sarif: false keeps the upload step from running.
+# job never ran. Declaring it hands a fork nothing under the default Actions
+# policy, which downgrades every write permission to read on a fork pull
+# request. That downgrade is the whole protection, so leave "Send write tokens
+# to workflows from pull requests" disabled for the org; enabling it would make
+# this a real grant. upload-sarif: false is a separate guard that stops the
+# upload step from running, and it has no bearing on the token.
 jobs:
   scan:
     name: Scan lockfiles


### PR DESCRIPTION
`CI / Security` has startup-failed on every run since the fork split landed on Aug 26, nineteen in a row. It has effectively never run: exactly one run has ever succeeded, the single-job version from before that commit.

A startup failure produces no jobs and no logs, which is why it reads as an opaque red X on unrelated pull requests rather than pointing at itself.

## Root cause

`osv-scanner-reusable.yml` hard-codes `security-events: write` on its own `osv-scan` job. A called workflow may not request more permission than the calling job granted, and `scan-fork` granted only `actions: read` and `contents: read`.

GitHub checks that subset while it builds the run graph, before any `if:` is evaluated, so the whole run died at startup even on same-repo pull requests where `scan-fork` is skipped and never would have run.

## Fix

Declare `security-events: write` on `scan-fork` too. This costs nothing at runtime and does not weaken the guard the split exists for:

- A fork pull request gets a read-only `GITHUB_TOKEN` whatever this block says.
- `upload-sarif: false` already keeps the code-scanning upload step from running on that job.

The two-job split still earns its place: `upload-sarif` is typed as a boolean, so it cannot take an expression.

## Verification

`actionlint` is clean, and this pull request is itself the test. The `CI / Security` check reaching a real conclusion instead of a startup failure is the proof, and it is the first time that will have happened since Aug 26.

Non-blocking either way: `master` has no required status checks and `fail-on-vuln: false` stands, so the check reports without walling off merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified permission requirements for reusable security workflows.
  * Documented token restrictions for forked contributions and the organization setting that enables write access.
  * Documented safeguards for security report uploads.

* **Bug Fixes**
  * Updated security scan permissions to support workflow validation and security report uploads where permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->