### PR TITLE
fix: TV media files card, and SQLite foreign key errors

### DIFF
--- a/lib/mydia/collections.ex
+++ b/lib/mydia/collections.ex
@@ -392,16 +392,41 @@ defmodule Mydia.Collections do
   Adds multiple items to a manual collection.
 
   Items are added at the end in the order provided.
-  Returns {:ok, count} where count is the number of items added.
+  Returns `{:ok, count}` where count is the number of items added, or
+  `{:error, :not_found}` if any id does not reference an existing media item.
   """
   @spec add_items(Collection.t(), [binary()]) ::
-          {:ok, non_neg_integer()} | {:error, :smart_collection}
+          {:ok, non_neg_integer()} | {:error, :smart_collection | :not_found}
   def add_items(%Collection{type: "smart"}, _media_item_ids) do
     {:error, :smart_collection}
   end
 
   def add_items(%Collection{type: "manual"} = collection, media_item_ids)
       when is_list(media_item_ids) do
+    if all_media_items_exist?(media_item_ids) do
+      do_add_items(collection, media_item_ids)
+    else
+      {:error, :not_found}
+    end
+  end
+
+  # Repo.insert_all/3 takes no changeset, so Mydia.Repo.ForeignKeyGuard cannot
+  # turn a foreign key violation below into a changeset error: on SQLite it
+  # raises. Check the ids up front instead. `on_conflict: :nothing` tolerates a
+  # duplicate, but a reference to something that does not exist is a different
+  # thing and should not be dropped silently.
+  defp all_media_items_exist?(media_item_ids) do
+    ids = Enum.uniq(media_item_ids)
+    found = Repo.all(from(m in MediaItem, where: m.id in ^ids, select: m.id)) |> MapSet.new()
+
+    Enum.all?(ids, &MapSet.member?(found, &1))
+  rescue
+    # PostgreSQL raises while binding a non-UUID-shaped id. It certainly does
+    # not exist.
+    Ecto.Query.CastError -> false
+  end
+
+  defp do_add_items(collection, media_item_ids) do
     max_position =
       Repo.one(
         from(ci in CollectionItem,

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -646,10 +646,39 @@ defmodule Mydia.Media do
   Updates multiple media items with the given attributes in a transaction.
 
   Only updates non-nil attributes. Returns `{:ok, count}` on success
-  where count is the number of updated items.
+  where count is the number of updated items, or `{:error, :not_found}` if
+  `attrs` references a quality profile or library path that does not exist.
   """
-  @spec update_media_items_batch([binary()], map()) :: {:ok, non_neg_integer()} | {:error, term()}
+  @spec update_media_items_batch([binary()], map()) ::
+          {:ok, non_neg_integer()} | {:error, :not_found | term()}
   def update_media_items_batch(ids, attrs) when is_list(ids) and is_map(attrs) do
+    if referenced_foreign_keys_exist?(attrs) do
+      do_update_media_items_batch(ids, attrs)
+    else
+      {:error, :not_found}
+    end
+  end
+
+  # Repo.update_all/3 takes no changeset, so Mydia.Repo.ForeignKeyGuard cannot
+  # turn a foreign key violation below into a changeset error: it raises on
+  # both SQLite and PostgreSQL, unlike the changeset-backed writes elsewhere
+  # in this branch. Check the referenced rows up front instead.
+  defp referenced_foreign_keys_exist?(attrs) do
+    reference_exists?(Mydia.Settings.QualityProfile, attrs[:quality_profile_id]) and
+      reference_exists?(Mydia.Settings.LibraryPath, attrs[:library_path_id])
+  end
+
+  defp reference_exists?(_schema, nil), do: true
+
+  defp reference_exists?(schema, id) do
+    Repo.exists?(from(r in schema, where: r.id == ^id))
+  rescue
+    # PostgreSQL raises while binding a non-UUID-shaped id. It certainly does
+    # not exist.
+    Ecto.Query.CastError -> false
+  end
+
+  defp do_update_media_items_batch(ids, attrs) do
     Repo.transaction(fn ->
       # Build the update list, only including non-nil values
       updates =

--- a/lib/mydia/repo.ex
+++ b/lib/mydia/repo.ex
@@ -7,8 +7,52 @@ defmodule Mydia.Repo do
   - `Ecto.Adapters.Postgres` - PostgreSQL database
 
   Set DATABASE_TYPE=postgres environment variable to use PostgreSQL.
+
+  ## Foreign key errors
+
+  `insert/1,2`, `update/1,2` and `insert_or_update/1,2` are wrapped by
+  `Mydia.Repo.ForeignKeyGuard`, which turns SQLite's nameless foreign key
+  violations into `{:error, changeset}` rather than a raised
+  `Ecto.ConstraintError`. See that module for why SQLite needs it and why the
+  wrapper is a no-op on PostgreSQL. `Ecto.Multi` steps are covered, since Multi
+  dispatches through these functions.
+
+  `insert_all/3` is **not** covered and cannot be: it takes no changeset, so
+  there is nothing to attach an error to, and a foreign key violation there
+  still raises on SQLite. A caller passing client-supplied ids to
+  `insert_all/3` has to check them itself. `Mydia.Collections.add_items/2` is
+  the worked example.
   """
   use Ecto.Repo,
     otp_app: :mydia,
     adapter: Application.compile_env(:mydia, :database_adapter, Ecto.Adapters.SQLite3)
+
+  alias Mydia.Repo.ForeignKeyGuard
+
+  # Ecto blesses only default_options/1, prepare_query/3 and
+  # prepare_transaction/2 as overridable, but `use Ecto.Repo` defines these in
+  # this module, so defoverridable and super apply normally. Both arities are
+  # declared and defined explicitly rather than relying on a default-argument
+  # head, so there is no ambiguity about which definition a local call reaches.
+  defoverridable insert: 1,
+                 insert: 2,
+                 update: 1,
+                 update: 2,
+                 insert_or_update: 1,
+                 insert_or_update: 2
+
+  def insert(subject), do: insert(subject, [])
+
+  def insert(subject, opts),
+    do: ForeignKeyGuard.run(fn -> super(subject, opts) end, subject, :insert)
+
+  def update(subject), do: update(subject, [])
+
+  def update(subject, opts),
+    do: ForeignKeyGuard.run(fn -> super(subject, opts) end, subject, :update)
+
+  def insert_or_update(changeset), do: insert_or_update(changeset, [])
+
+  def insert_or_update(changeset, opts),
+    do: ForeignKeyGuard.run(fn -> super(changeset, opts) end, changeset, :insert_or_update)
 end

--- a/lib/mydia/repo/foreign_key_guard.ex
+++ b/lib/mydia/repo/foreign_key_guard.ex
@@ -1,0 +1,143 @@
+defmodule Mydia.Repo.ForeignKeyGuard do
+  @moduledoc """
+  Turns SQLite's nameless foreign key violations into changeset errors.
+
+  `ecto_sqlite3` cannot recover which constraint failed from SQLite's error
+  message, so its `to_constraints/2` maps every foreign key violation to
+  `[foreign_key: nil]`. Ecto matches a changeset's declared constraints by
+  name, a nil name matches nothing, and Ecto raises `Ecto.ConstraintError`
+  instead of returning `{:error, changeset}`.
+
+  Without this, any write taking a client-supplied id returns a clean error on
+  PostgreSQL and raises a 500 on SQLite, which is the default adapter for
+  self-hosted installs. Two id shapes land there: a malformed id, because a
+  `binary_id` is TEXT on SQLite so no cast error fires, and the more common
+  case of a well-formed id whose row was deleted.
+
+  This is a strict no-op on PostgreSQL. `run/3` only handles an error that is
+  both `type: :foreign_key` and `constraint: nil`, and only `ecto_sqlite3`
+  produces a nil name. PostgreSQL always reports a real one, which Ecto has
+  already tried and failed to match, meaning the changeset genuinely never
+  declared it. That is a live bug on both adapters and stays loud.
+
+  `Ecto.Multi` is covered, because it dispatches through the repo functions
+  this wraps. `Repo.insert_all/3` is not covered and cannot be: it takes no
+  changeset, so there is nothing to attach an error to, and a violation there
+  still raises.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  require Logger
+
+  @type action :: :insert | :update | :insert_or_update
+
+  @doc """
+  Runs `fun`, converting a nameless foreign key violation into
+  `{:error, changeset}` attributed to the reference that is actually missing.
+
+  Reraises anything it cannot attribute, so an undeclared constraint or a race
+  stays as loud as it is today.
+  """
+  @spec run((-> result), term(), action()) :: result when result: term()
+  def run(fun, subject, action) do
+    fun.()
+  rescue
+    error in Ecto.ConstraintError ->
+      case attribute(error, subject, action) do
+        {:ok, changeset} ->
+          {:error, changeset}
+
+        :not_ours ->
+          reraise error, __STACKTRACE__
+
+        {:unattributable, schema, fields} ->
+          Logger.warning(
+            "unattributable foreign key violation on #{inspect(schema)}: every " <>
+              "declared foreign key in #{inspect(fields)} resolves, so the failing " <>
+              "reference is either undeclared or was deleted concurrently"
+          )
+
+          reraise error, __STACKTRACE__
+      end
+  end
+
+  defp attribute(
+         %Ecto.ConstraintError{type: :foreign_key, constraint: nil},
+         %Ecto.Changeset{} = changeset,
+         action
+       ) do
+    schema = changeset.data.__struct__
+    declared = declared_foreign_keys(changeset, schema)
+
+    case Enum.filter(declared, &missing?(changeset, &1)) do
+      [] ->
+        {:unattributable, schema, Enum.map(declared, & &1.constraint.field)}
+
+      missing ->
+        {:ok, add_errors(changeset, missing, resolve_action(action, changeset))}
+    end
+  end
+
+  defp attribute(_error, _subject, _action), do: :not_ours
+
+  # Pairs each declared foreign_key constraint with the belongs_to whose
+  # owner_key it names. `no_assoc_constraint/3` also declares
+  # `type: :foreign_key`, but its field is an association name with no matching
+  # owner_key, so it drops out here. That is correct: delete/2 is out of scope.
+  defp declared_foreign_keys(changeset, schema) do
+    belongs_to =
+      schema.__schema__(:associations)
+      |> Enum.map(&schema.__schema__(:association, &1))
+      |> Enum.filter(&match?(%Ecto.Association.BelongsTo{}, &1))
+      |> Map.new(&{&1.owner_key, &1})
+
+    changeset.constraints
+    |> Enum.filter(&(&1.type == :foreign_key))
+    |> Enum.flat_map(fn constraint ->
+      case Map.fetch(belongs_to, constraint.field) do
+        {:ok, assoc} -> [%{constraint: constraint, assoc: assoc}]
+        :error -> []
+      end
+    end)
+  end
+
+  defp missing?(changeset, %{constraint: constraint, assoc: assoc}) do
+    case Ecto.Changeset.get_field(changeset, constraint.field) do
+      nil ->
+        # A nil foreign key cannot violate the constraint.
+        false
+
+      value ->
+        related = assoc.related
+        related_key = assoc.related_key
+
+        not Mydia.Repo.exists?(from(r in related, where: field(r, ^related_key) == ^value))
+    end
+  rescue
+    # Unreachable on SQLite, the only adapter that reaches this module, but an
+    # id the adapter cannot cast certainly does not exist.
+    Ecto.Query.CastError -> true
+  end
+
+  # Rebuilt from the constraint entry itself, so the caller sees the
+  # byte-identical changeset PostgreSQL would have produced, honouring any
+  # custom `message:` the schema passed.
+  defp add_errors(changeset, missing, action) do
+    changeset =
+      Enum.reduce(missing, changeset, fn %{constraint: constraint}, acc ->
+        Ecto.Changeset.add_error(acc, constraint.field, constraint.error_message,
+          constraint: constraint.error_type,
+          constraint_name: constraint.constraint
+        )
+      end)
+
+    %{changeset | action: action}
+  end
+
+  defp resolve_action(:insert_or_update, %Ecto.Changeset{data: %{__meta__: %{state: :loaded}}}),
+    do: :update
+
+  defp resolve_action(:insert_or_update, _changeset), do: :insert
+  defp resolve_action(action, _changeset), do: action
+end

--- a/lib/mydia/subtitles/track_settings.ex
+++ b/lib/mydia/subtitles/track_settings.ex
@@ -9,9 +9,8 @@ defmodule Mydia.Subtitles.TrackSettings do
   A malformed media file id returns the same answer as an absent row rather
   than raising. Both `Delivery.content/3` and the GraphQL resolver call this on
   ids that arrive from a client, and a cast failure there is a missing setting,
-  not a server error. `set_offset/3` applies the same rule on the write side,
-  reporting a bad id as a changeset error instead of raising; see its doc for
-  why that needs two rescue clauses rather than one.
+  not a server error. `set_offset/3` applies the same rule on the write side;
+  see its doc for how the two adapters get there differently.
   """
 
   import Ecto.Query
@@ -37,28 +36,19 @@ defmodule Mydia.Subtitles.TrackSettings do
   @doc """
   Stores `offset_ms` for a track, replacing any previous value.
 
-  A `media_file_id` that does not reference an existing media file is
-  reported as a changeset error rather than raising. The GraphQL `ID!`
-  scalar does not validate UUID shape, so a client-supplied id can be
-  malformed, and the two adapters fail that in different ways:
+  A `media_file_id` that does not reference an existing media file is reported
+  as a changeset error rather than raising. The GraphQL `ID!` scalar does not
+  validate UUID shape, so a client-supplied id can be malformed, and the two
+  adapters fail that in different ways:
 
     * On PostgreSQL, a non-UUID-shaped string never reaches the database:
       `Repo.get_by/3` raises `Ecto.Query.CastError` while binding the query
-      parameter.
+      parameter. That is the read this function rescues.
     * On SQLite, any string casts as a valid `:binary_id`, so `Repo.get_by/3`
-      just finds no row and the write proceeds to `Repo.insert_or_update/2`,
-      which fails the foreign key constraint instead. `ecto_sqlite3` cannot
-      recover *which* constraint failed from SQLite's error message (see
-      `to_constraints/2` in its connection module, which maps every foreign
-      key violation to a nameless `nil`), so the changeset's own
-      `foreign_key_constraint/3` can never match it by name and Ecto
-      re-raises as `Ecto.ConstraintError` instead of returning `{:error,
-      changeset}`. The same path also fires for a well-formed but
-      nonexistent id on SQLite, not only a malformed one.
-
-  Catching both keeps callers, including the GraphQL resolver, adapter
-  agnostic: either failure mode becomes a normal `{:error, changeset}`
-  instead of a 500.
+      finds no row and the write proceeds to `Repo.insert_or_update/2`, which
+      fails the foreign key constraint. `Mydia.Repo.ForeignKeyGuard` turns that
+      into a changeset error, covering both a malformed id and a well-formed
+      but nonexistent one.
   """
   @spec set_offset(binary(), String.t(), integer()) ::
           {:ok, TrackSetting.t()} | {:error, Ecto.Changeset.t()}
@@ -77,13 +67,6 @@ defmodule Mydia.Subtitles.TrackSettings do
   rescue
     Ecto.Query.CastError ->
       {:error, missing_media_file_changeset(media_file_id, track_ref, offset_ms)}
-
-    error in Ecto.ConstraintError ->
-      if error.type == :foreign_key do
-        {:error, missing_media_file_changeset(media_file_id, track_ref, offset_ms)}
-      else
-        reraise error, __STACKTRACE__
-      end
   end
 
   defp missing_media_file_changeset(media_file_id, track_ref, offset_ms) do
@@ -128,22 +111,12 @@ defmodule Mydia.Subtitles.TrackSettings do
     )
     |> Repo.insert_or_update()
   rescue
-    # Mirrors set_offset/3 in this module, and for the same reason. A malformed
-    # media_file_id fails differently per adapter: PostgreSQL raises CastError
-    # while binding the query parameter, while SQLite casts any string as a
-    # valid :binary_id and fails later on the foreign key, which ecto_sqlite3
-    # cannot attribute to a named constraint and so re-raises as
-    # ConstraintError. Catching both keeps callers adapter agnostic. Read
-    # set_offset/3's doc before touching these two clauses.
+    # Guards Repo.get_by/3 above: on PostgreSQL a malformed media_file_id
+    # raises while binding the query parameter, before any write. The foreign
+    # key half of this is handled for every write by
+    # Mydia.Repo.ForeignKeyGuard. See set_offset/3's doc.
     Ecto.Query.CastError ->
       {:error, unknown_media_file_changeset(track_ref)}
-
-    error in Ecto.ConstraintError ->
-      if error.type == :foreign_key do
-        {:error, unknown_media_file_changeset(track_ref)}
-      else
-        reraise error, __STACKTRACE__
-      end
   end
 
   defp unknown_media_file_changeset(track_ref) do

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -8,6 +8,7 @@ defmodule MydiaWeb.MediaLive.Index do
   alias Mydia.Search
   alias MydiaWeb.Live.Authorization
   alias MydiaWeb.Live.Helpers.GridDensity
+  alias MydiaWeb.MediaLive.Show.Helpers, as: MediaFileHelpers
 
   import MydiaWeb.GridDensityComponents
 
@@ -791,8 +792,13 @@ defmodule MydiaWeb.MediaLive.Index do
   defp apply_quality_filter(items, nil), do: items
 
   defp apply_quality_filter(items, quality) do
+    # A MediaFile belongs to either media_item_id (movies) or episode_id (TV
+    # episodes), never both, so item.media_files alone is always empty for a
+    # TV show; filtering on it dropped every TV show from a quality-filtered
+    # result regardless of its episodes' actual resolutions.
     Enum.filter(items, fn item ->
-      item.media_files
+      item
+      |> MediaFileHelpers.all_media_files()
       |> Enum.any?(fn file -> file.resolution == quality end)
     end)
   end
@@ -952,7 +958,10 @@ defmodule MydiaWeb.MediaLive.Index do
   defp format_year(year), do: year
 
   defp get_quality_badge(media_item) do
-    case media_item.media_files do
+    # A MediaFile belongs to either media_item_id (movies) or episode_id (TV
+    # episodes), never both, so media_item.media_files alone is always empty
+    # for a TV show and the badge was silently blank on every show card.
+    case MediaFileHelpers.all_media_files(media_item) do
       [] ->
         nil
 
@@ -979,7 +988,11 @@ defmodule MydiaWeb.MediaLive.Index do
   end
 
   defp total_file_size(media_item) do
-    media_item.media_files
+    # Same split as get_quality_badge/1 above: media_item.media_files alone is
+    # always empty for a TV show, so every show reported "0 B" in the list
+    # view's Size column regardless of what was actually on disk.
+    media_item
+    |> MediaFileHelpers.all_media_files()
     |> Enum.map(& &1.size)
     |> Enum.reject(&is_nil/1)
     |> Enum.sum()

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.MediaLive.Index do
   alias Mydia.Metadata.Structs.MediaMetadata
   alias Mydia.Settings
   alias Mydia.Collections
+  alias Mydia.Downloads.DownloadService
   alias Mydia.Search
   alias MydiaWeb.Live.Authorization
   alias MydiaWeb.Live.Helpers.GridDensity
@@ -966,12 +967,14 @@ defmodule MydiaWeb.MediaLive.Index do
         nil
 
       files ->
-        # Get the highest quality from available files
+        # Rank by parsed height rather than lexically. Enum.sort(:desc) on the
+        # raw strings puts "720p" ahead of "2160p", and a show's episodes
+        # routinely mix resolutions, so that is easy to hit now that TV shows
+        # reach this function at all.
         files
         |> Enum.map(& &1.resolution)
         |> Enum.reject(&is_nil/1)
-        |> Enum.sort(:desc)
-        |> List.first()
+        |> Enum.max_by(&DownloadService.parse_resolution_height/1, fn -> nil end)
     end
   end
 

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -653,20 +653,29 @@ defmodule MydiaWeb.MediaLive.Show.Components do
 
   @doc """
   Media files section showing all files for this media item.
+
+  Covers episode media files as well as the item's own, via
+  `all_media_files/1`: a movie's files live at `media_item.media_files`, but a
+  `MediaFile` belongs to either `media_item_id` or `episode_id`, never both, so
+  that list is always empty for a TV show. Without this the card was
+  permanently empty on every TV show page, sitting beside a Subtitles card that
+  reaches into both.
   """
   attr :media_item, :map, required: true
   attr :refreshing_file_metadata, :boolean, required: true
   attr :transcode_jobs, :map, default: %{}
 
   def media_files_section(assigns) do
+    assigns = assign(assigns, :files, all_media_files(assigns.media_item))
+
     ~H"""
-    <%= if length(@media_item.media_files) > 0 do %>
+    <%= if @files != [] do %>
       <div id="media-files-section" class="card bg-base-200 shadow-lg mb-4 md:mb-6">
         <div class="card-body p-4 md:p-6">
           <h2 class="card-title text-lg md:text-xl mb-3 md:mb-4">Media Files</h2>
           <%!-- DaisyUI list component --%>
           <ul class="menu bg-base-100 rounded-box p-0">
-            <li :for={file <- @media_item.media_files}>
+            <li :for={file <- @files}>
               <div class="flex flex-col gap-3 p-4 hover:bg-base-200 rounded-none transition-colors">
                 <div class="flex items-start justify-between gap-4">
                   <%!-- Left side: File info --%>

--- a/lib/mydia_web/live/media_live/show/file_events.ex
+++ b/lib/mydia_web/live/media_live/show/file_events.ex
@@ -14,7 +14,12 @@ defmodule MydiaWeb.MediaLive.Show.FileEvents do
     only: [load_media_item: 1, load_transcode_jobs: 1]
 
   import MydiaWeb.MediaLive.Show.Helpers,
-    only: [get_season_media_files: 2, refresh_files: 1, provider_label: 1]
+    only: [
+      all_media_files: 1,
+      get_season_media_files: 2,
+      refresh_files: 1,
+      provider_label: 1
+    ]
 
   require Logger
 
@@ -184,7 +189,10 @@ defmodule MydiaWeb.MediaLive.Show.FileEvents do
 
   def refresh_all_file_metadata(_params, socket) do
     media_item = socket.assigns.media_item
-    media_files = media_item.media_files
+    # A MediaFile belongs to either media_item_id or episode_id, never both, so
+    # media_item.media_files is empty for a TV show and this button was dead on
+    # every show page.
+    media_files = all_media_files(media_item)
 
     if Enum.empty?(media_files) do
       {:noreply, put_flash(socket, :info, "No media files to refresh")}

--- a/test/mydia/collections_test.exs
+++ b/test/mydia/collections_test.exs
@@ -260,6 +260,18 @@ defmodule Mydia.CollectionsTest do
       assert length(collection_items) == 3
     end
 
+    test "returns :not_found when a media item id does not exist" do
+      user = user_fixture()
+      collection = collection_fixture(%{user: user})
+      movie = media_item_fixture(%{type: "movie"})
+
+      assert {:error, :not_found} =
+               Collections.add_items(collection, [movie.id, Ecto.UUID.generate()])
+
+      # Nothing was inserted: the valid id must not slip through either.
+      assert Collections.list_collection_items(collection) == []
+    end
+
     test "remove_item/2 removes item from collection" do
       user = user_fixture()
       collection = collection_fixture(%{user: user})

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -282,6 +282,29 @@ defmodule Mydia.MediaTest do
       episodes = Media.list_episodes(media_item.id, preload: [:media_files])
       assert Media.derive_monitoring_preset(episodes) == :custom
     end
+
+    test "update_media_items_batch/2 rejects a nonexistent quality_profile_id" do
+      media_item = media_item_fixture(%{type: "movie"})
+
+      assert {:error, :not_found} =
+               Media.update_media_items_batch([media_item.id], %{
+                 quality_profile_id: Ecto.UUID.generate()
+               })
+
+      assert Media.get_media_item!(media_item.id).quality_profile_id == nil
+    end
+
+    test "update_media_items_batch/2 applies a valid quality_profile_id" do
+      media_item = media_item_fixture(%{type: "movie"})
+      profile = quality_profile_fixture()
+
+      assert {:ok, 1} =
+               Media.update_media_items_batch([media_item.id], %{
+                 quality_profile_id: profile.id
+               })
+
+      assert Media.get_media_item!(media_item.id).quality_profile_id == profile.id
+    end
   end
 
   # Nested describe is invalid in ExUnit. These live as siblings of "media_items"

--- a/test/mydia/repo/foreign_key_guard_test.exs
+++ b/test/mydia/repo/foreign_key_guard_test.exs
@@ -1,0 +1,131 @@
+defmodule Mydia.Repo.ForeignKeyGuardTest do
+  # Every case but one asserts the same result on SQLite and PostgreSQL. That
+  # parity is the point: ecto_sqlite3 reports foreign key violations with no
+  # constraint name, so without the guard these raise on SQLite and return a
+  # changeset error on PostgreSQL. The one exception is the malformed-id case
+  # below, which hits a genuinely different failure (a dump-time type error,
+  # not a foreign key violation) on PostgreSQL and documents why this guard
+  # does not and should not paper over it.
+  use Mydia.DataCase, async: true
+
+  import Mydia.CollectionsFixtures
+  import Mydia.MediaFixtures
+
+  alias Mydia.Collections.CollectionItem
+  alias Mydia.Subtitles.TrackSetting
+
+  defp track_setting_changeset(media_file_id) do
+    TrackSetting.changeset(%TrackSetting{}, %{
+      media_file_id: media_file_id,
+      track_ref: "3",
+      offset_ms: 0
+    })
+  end
+
+  describe "insert/2, one declared foreign key" do
+    test "a valid insert is untouched" do
+      media_file = media_file_fixture()
+
+      assert {:ok, setting} = Repo.insert(track_setting_changeset(media_file.id))
+      assert setting.offset_ms == 0
+    end
+
+    test "a well-formed but nonexistent id becomes a changeset error" do
+      assert {:error, changeset} = Repo.insert(track_setting_changeset(Ecto.UUID.generate()))
+
+      assert %{media_file_id: ["does not exist"]} = errors_on(changeset)
+      assert changeset.action == :insert
+    end
+
+    test "a malformed id diverges by adapter, neither route through the guard alone" do
+      # Ecto.Type.cast/2 for :binary_id is a bare binary check (cast_binary/1
+      # in deps/ecto/lib/ecto/type.ex), not a UUID format check, on both
+      # adapters: the changeset itself is valid regardless of adapter. What
+      # differs is what happens next.
+      #
+      # On SQLite a binary_id is TEXT, so "garbage" is written as-is, fails
+      # the foreign key, and this guard catches it.
+      #
+      # On PostgreSQL the column is a native uuid, so the same changeset
+      # instead fails at dump time inside Ecto.Repo.Schema.do_insert with
+      # Ecto.ChangeError: an adapter-inherent type-validation failure that has
+      # nothing to do with foreign keys. It is raised by super/2 before
+      # ForeignKeyGuard.run/3's `rescue error in Ecto.ConstraintError` clause
+      # ever sees it, so this guard neither causes nor papers over it; it is
+      # pre-existing Ecto/Postgrex behaviour.
+      case Repo.__adapter__() do
+        Ecto.Adapters.Postgres ->
+          assert_raise Ecto.ChangeError, fn ->
+            Repo.insert(track_setting_changeset("garbage"))
+          end
+
+        _ ->
+          assert {:error, changeset} = Repo.insert(track_setting_changeset("garbage"))
+          assert %{media_file_id: [_ | _]} = errors_on(changeset)
+      end
+    end
+  end
+
+  describe "insert/2, two declared foreign keys" do
+    test "blames only the reference that is actually missing" do
+      collection = collection_fixture()
+
+      changeset =
+        %CollectionItem{
+          collection_id: collection.id,
+          media_item_id: Ecto.UUID.generate()
+        }
+        |> CollectionItem.changeset(%{position: 0})
+
+      assert {:error, changeset} = Repo.insert(changeset)
+      errors = errors_on(changeset)
+
+      assert %{media_item_id: ["does not exist"]} = errors
+      refute Map.has_key?(errors, :collection_id)
+    end
+  end
+
+  describe "update/2" do
+    test "a nonexistent id becomes a changeset error" do
+      media_file = media_file_fixture()
+      {:ok, setting} = Repo.insert(track_setting_changeset(media_file.id))
+
+      changeset = TrackSetting.changeset(setting, %{media_file_id: Ecto.UUID.generate()})
+
+      assert {:error, changeset} = Repo.update(changeset)
+      assert %{media_file_id: ["does not exist"]} = errors_on(changeset)
+      assert changeset.action == :update
+    end
+  end
+
+  describe "insert_or_update/2" do
+    test "a nonexistent id becomes a changeset error" do
+      assert {:error, changeset} =
+               Repo.insert_or_update(track_setting_changeset(Ecto.UUID.generate()))
+
+      assert %{media_file_id: ["does not exist"]} = errors_on(changeset)
+      assert changeset.action == :insert
+    end
+  end
+
+  describe "escape hatches" do
+    test "a violation the changeset never declared still raises" do
+      # Stripping the declared constraint leaves the guard nothing to attribute
+      # to on SQLite, and leaves Ecto's own matcher nothing to match on
+      # PostgreSQL. Both must stay loud: an undeclared constraint is a real bug.
+      changeset = %{track_setting_changeset(Ecto.UUID.generate()) | constraints: []}
+
+      assert_raise Ecto.ConstraintError, fn -> Repo.insert(changeset) end
+    end
+
+    test "an Ecto.Multi step halts instead of raising" do
+      result =
+        Ecto.Multi.new()
+        |> Ecto.Multi.insert(:setting, track_setting_changeset(Ecto.UUID.generate()))
+        |> Repo.transaction()
+
+      assert {:error, :setting, changeset, %{}} = result
+      assert %{media_file_id: ["does not exist"]} = errors_on(changeset)
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/index_test.exs
+++ b/test/mydia_web/live/media_live/index_test.exs
@@ -1113,6 +1113,25 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       assert has_element?(view, "#{container} .badge-neutral", "720p")
     end
 
+    # Ranking resolutions with Enum.sort(:desc) compares the raw strings, so
+    # "720p" sorts above "2160p" and the badge reports the worst episode as the
+    # show's quality. Mixed resolutions across a season are ordinary.
+    test "the quality badge picks the highest episode resolution by height, not by string order",
+         %{conn: conn} do
+      show = media_item_fixture(%{title: "Mixed Show", type: "tv_show"})
+      first = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+      second = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 2})
+      media_file_fixture(%{episode_id: first.id, resolution: "2160p"})
+      media_file_fixture(%{episode_id: second.id, resolution: "720p"})
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      container = "#poster-badges-#{show.id}"
+
+      assert has_element?(view, "#{container} .badge-neutral", "2160p")
+      refute has_element?(view, "#{container} .badge-neutral", "720p")
+    end
+
     test "list view shows a TV show's total episode file size, not zero", %{conn: conn} do
       show = media_item_fixture(%{title: "Size Show", type: "tv_show"})
       episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})

--- a/test/mydia_web/live/media_live/index_test.exs
+++ b/test/mydia_web/live/media_live/index_test.exs
@@ -1072,4 +1072,59 @@ defmodule MydiaWeb.MediaLive.IndexTest do
       refute has_element?(view, "#poster-badges-#{movie.id}")
     end
   end
+
+  describe "TV show media files on the index page" do
+    setup %{conn: conn} do
+      admin = admin_user_fixture()
+      %{conn: log_in_user(conn, admin), admin: admin}
+    end
+
+    # A MediaFile belongs to either media_item_id (movies) or episode_id (TV
+    # episodes), never both, so a TV show's own media_files list is always
+    # empty. apply_quality_filter/2, get_quality_badge/1 and
+    # total_file_size/1 all read that list directly and silently gave a wrong
+    # answer for every TV show.
+    test "a quality filter matches on episode resolution, not the item's own empty list", %{
+      conn: conn
+    } do
+      show = media_item_fixture(%{title: "Quality Show", type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+      media_file_fixture(%{episode_id: episode.id, resolution: "1080p"})
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      view
+      |> element("form#library-filter-form")
+      |> render_change(%{"quality" => "1080p"})
+
+      assert has_element?(view, "#grid-item-#{show.id}")
+    end
+
+    test "a TV show with an episode file renders the quality badge", %{conn: conn} do
+      show = media_item_fixture(%{title: "Badge Show", type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+      media_file_fixture(%{episode_id: episode.id, resolution: "720p"})
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      container = "#poster-badges-#{show.id}"
+
+      assert has_element?(view, container)
+      assert has_element?(view, "#{container} .badge-neutral", "720p")
+    end
+
+    test "list view shows a TV show's total episode file size, not zero", %{conn: conn} do
+      show = media_item_fixture(%{title: "Size Show", type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+      media_file_fixture(%{episode_id: episode.id, size: 1_073_741_824})
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      view
+      |> element("button[aria-label='List']")
+      |> render_click()
+
+      assert has_element?(view, "#list-item-#{show.id}", "1.0 GB")
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/show/media_files_section_test.exs
+++ b/test/mydia_web/live/media_live/show/media_files_section_test.exs
@@ -1,0 +1,147 @@
+defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
+  # async: false - the refresh_all_file_metadata/2 block added in Step 6 touches
+  # the Ecto sandbox from a stub socket, which shares the connection with the
+  # test process. That only works in non-async mode on PostgreSQL. The
+  # render_component cases below do not hit the database and would be safe
+  # either way.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Settings.LibraryPath
+  alias MydiaWeb.MediaLive.Show.Components
+  alias MydiaWeb.MediaLive.Show.FileEvents
+  alias MydiaWeb.MediaLive.Show.Loaders
+
+  defp section_html(media_item) do
+    render_component(&Components.media_files_section/1,
+      media_item: media_item,
+      refreshing_file_metadata: false,
+      transcode_jobs: %{}
+    )
+  end
+
+  defp file(id, relative_path) do
+    %MediaFile{
+      id: id,
+      path: nil,
+      relative_path: relative_path,
+      library_path: %LibraryPath{path: "/media"},
+      resolution: "1080p",
+      codec: "h264",
+      audio_codec: "eac3",
+      size: 4_200_000_000
+    }
+  end
+
+  defp stub_socket(media_item) do
+    %Phoenix.LiveView.Socket{
+      assigns: %{__changed__: %{}, flash: %{}, media_item: media_item},
+      private: %{live_temp: %{}},
+      root_pid: self()
+    }
+  end
+
+  describe "media_files_section/1" do
+    test "renders a movie's own files" do
+      media_item = %{
+        media_files: [file("mf-1", "The Matrix (1999)/The.Matrix.1999.1080p.mkv")],
+        episodes: []
+      }
+
+      html = section_html(media_item)
+
+      assert html =~ "The.Matrix.1999.1080p.mkv"
+      assert html =~ ~s|phx-value-file-id="mf-1"|
+    end
+
+    # A MediaFile belongs to either media_item_id (movies) or episode_id (TV
+    # episodes), never both, so media_item.media_files alone is always empty
+    # for a TV show. Episode files live at media_item.episodes[].media_files
+    # instead; the section must reach into both.
+    test "renders files that belong to an episode, not just the item's own" do
+      media_item = %{
+        media_files: [],
+        episodes: [
+          %{media_files: [file("mf-ep-1", "Breaking Bad/Season 01/S01E01.mkv")]},
+          %{media_files: [file("mf-ep-2", "Breaking Bad/Season 01/S01E02.mkv")]}
+        ]
+      }
+
+      html = section_html(media_item)
+
+      assert html =~ "media-files-section"
+      assert html =~ "S01E01.mkv"
+      assert html =~ "S01E02.mkv"
+      assert html =~ ~s|phx-value-file-id="mf-ep-1"|
+      assert html =~ ~s|phx-value-file-id="mf-ep-2"|
+    end
+
+    test "renders nothing when the item has no files anywhere" do
+      html = section_html(%{media_files: [], episodes: [%{media_files: []}]})
+
+      refute html =~ "media-files-section"
+    end
+
+    test "renders a file whose location cannot be resolved instead of crashing" do
+      broken = %MediaFile{
+        id: "mf-broken",
+        path: nil,
+        relative_path: nil,
+        library_path: nil,
+        resolution: nil,
+        codec: nil,
+        audio_codec: nil,
+        size: nil
+      }
+
+      html = section_html(%{media_files: [], episodes: [%{media_files: [broken]}]})
+
+      assert html =~ "Unknown file"
+      assert html =~ ~s|phx-value-file-id="mf-broken"|
+    end
+  end
+
+  describe "refresh_all_file_metadata/2" do
+    test "reports nothing to refresh when a TV show really has no files" do
+      show = media_item_fixture(%{type: "tv_show"})
+      _episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+      loaded = Loaders.load_media_item(show.id)
+
+      {:noreply, socket} = FileEvents.refresh_all_file_metadata(%{}, stub_socket(loaded))
+
+      assert socket.assigns.flash["info"] == "No media files to refresh"
+    end
+
+    # A MediaFile belongs to either media_item_id or episode_id, never both, so
+    # media_item.media_files is empty for a TV show. Reading only that list made
+    # this button dead on every show page.
+    test "refreshes a TV show whose files hang off its episodes" do
+      library_path = library_path_fixture(%{type: "series"})
+      show = media_item_fixture(%{type: "tv_show"})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+      _file =
+        media_file_fixture(%{
+          episode_id: episode.id,
+          library_path_id: library_path.id,
+          relative_path: "Show/Season 01/S01E01.mkv"
+        })
+
+      loaded = Loaders.load_media_item(show.id)
+
+      # The chain the fix depends on: the preload reaches episode files, and the
+      # helper merges them.
+      assert [_ | _] = MydiaWeb.MediaLive.Show.Helpers.all_media_files(loaded)
+
+      {:noreply, socket} = FileEvents.refresh_all_file_metadata(%{}, stub_socket(loaded))
+
+      refute socket.assigns.flash["info"] == "No media files to refresh"
+      assert socket.assigns.refreshing_file_metadata
+    end
+  end
+end


### PR DESCRIPTION
Closes #587. Two unrelated follow-ups from #585, filed together in that issue and shipped together here.

## 1. The Media Files card was permanently empty on TV shows

A `MediaFile` belongs to either `media_item_id` (movies) or `episode_id` (TV episodes), never both, enforced by a check constraint. So `media_item.media_files` is always empty for a TV show, and `media_files_section/1` both gated and iterated on exactly that list. #585 fixed the neighbouring Subtitles card via `Helpers.all_media_files/1`, which left a working card sitting beside a permanently empty one.

The sweep the issue asked for found four more sites with the same root cause, three of them outside the file the issue named:

| Site | Symptom before |
|---|---|
| `show/components.ex` `media_files_section/1` | Card never rendered on a show page |
| `show/file_events.ex` `refresh_all_file_metadata/2` | "No media files to refresh" on every show page |
| `index.ex` `apply_quality_filter/2` | Any active quality filter silently excluded **every** TV show |
| `index.ex` `get_quality_badge/1` | Quality badge always blank on show cards |
| `index.ex` `total_file_size/1` | List view Size column always read "0 B" for shows |

All five now go through `Helpers.all_media_files/1`. The movie path is provably unchanged: `Loaders.build_preload_list/0` always preloads `episodes:`, so a movie's episode list is empty and the helper reduces to the prior list. The index page already preloaded `episodes: [media_files: ...]` on every path that feeds these functions, so this is in-memory work over data the page was loading anyway, with no new queries.

Worth noting for anyone repeating the sweep: grepping `media_item.media_files` misses all three `index.ex` sites, which bind the item to a local called `item`. Grep `.media_files`.

## 2. Foreign key violations raised a 500 on SQLite

`ecto_sqlite3` cannot recover which constraint failed from SQLite's error message, so its `to_constraints/2` maps every foreign key violation to `[foreign_key: nil]`. Ecto matches a changeset's declared constraints by name, a nil name matches nothing, and Ecto raises `Ecto.ConstraintError` instead of returning `{:error, changeset}`. PostgreSQL reports the real name and is unaffected.

The effect: any write taking a client-supplied id returned a clean error on PostgreSQL and raised a 500 on SQLite, which is the default adapter for self-hosted installs. The realistic trigger is not a malformed id but a well-formed one whose row was deleted, held by a stale client.

`Mydia.Repo` now wraps `insert`, `update` and `insert_or_update` with `Mydia.Repo.ForeignKeyGuard`. On a nil-named violation it walks the changeset's declared foreign keys, resolves each to its `belongs_to`, existence-checks the value, and rebuilds the error from the constraint entry so the caller sees the changeset PostgreSQL would have produced. Anything it cannot attribute is logged and reraised, so an undeclared constraint or a race stays as loud as it is today. No call site changed, and `Ecto.Multi` is covered because it dispatches through these functions.

**The guard is a strict no-op on PostgreSQL.** It handles only an error that is both `type: :foreign_key` and `constraint: nil`, and only `ecto_sqlite3` produces a nil name. The green PostgreSQL suite below is the evidence.

### A divergence left in place, deliberately

A *malformed* id, as opposed to a well-formed but nonexistent one, behaves differently and the test says so per adapter rather than papering over it. `Ecto.Type.cast_fun(:binary_id)` is a bare `is_binary` check on both adapters, so `"garbage"` produces a valid changeset either way. SQLite then stores it and fails the foreign key, which the guard converts. PostgreSQL instead fails in the `Ecto.UUID` dumper and raises `Ecto.ChangeError` before any constraint is evaluated. That is a type failure rather than a constraint failure, it predates this work, and the guard neither causes nor hides it.

### What the guard cannot cover

A write that takes no changeset has nothing to attach an error to. The audit went looking for those and found two live ones, both fixed here by checking ids up front:

- `Collections.add_items/2`, via `Repo.insert_all/3` with a client-supplied `media_item_id`.
- `Media.update_media_items_batch/2`, via `Repo.update_all/3` with a client-supplied `quality_profile_id` from the batch edit form. **This one raised on both adapters**, not just SQLite, so it is a plain 500 that predates the SQLite issue and would have outlived a fix aimed only at it. `Repo.update_all` has no changeset for Ecto to translate against, so it surfaced the raw `Exqlite.Error` rather than an `Ecto.ConstraintError`.

`plugins/kv.ex` already carried its own rescue and needed nothing.

### The audit

The issue reported "roughly 17" affected call sites and flagged the number as unverified. Establishing it was the first thing worth doing, and the answer reframes the work: **18 client-facing write paths carry a client-supplied foreign key, and 16 of them needed no edit at all**, because the guard covers them for free. That is the argument for fixing this at the repo level rather than per site. The two exceptions are the changeset-free writes above.

The per-site approach had already failed in practice, which is the clearest evidence available. #585 added the rescue to `set_offset/3`. #588 then added `record_resync/4` the following day with a verbatim copy, its comment noting it mirrors `set_offset/3`. Both are removed here.

## Testing

`test/mydia/repo/foreign_key_guard_test.exs` asserts the same result on both adapters for a nonexistent id, attribution across two foreign keys (a valid `collection_id` with a bogus `media_item_id` blames only the latter), an undeclared constraint still raising, an `Ecto.Multi` step halting rather than raising, and a valid insert being untouched, plus the malformed-id case which asserts each adapter's genuinely different outcome.

The equivalence check for removing #585 and #588's rescues is that `test/mydia/subtitles/track_settings_test.exs` passes **byte-for-byte unmodified** on both adapters: 20/20 before and after.

| | Result |
|---|---|
| SQLite full suite | 9,398 tests + 13 doctests, 0 failures |
| PostgreSQL full suite | 9,399 tests + 13 doctests, 0 failures |
| `mix credo --strict` | No issues, 1,407 files |
| `mix compile --warnings-as-errors` | Clean |

## Risk

`Ecto` marks only `default_options/1`, `prepare_query/3` and `prepare_transaction/2` as overridable. Overriding the write functions works because `use Ecto.Repo` defines them in the calling module, so `defoverridable` and `super` apply normally, but a major Ecto release could change the generated shape. The "a valid insert is untouched" test is first in the guard suite and fails immediately if that happens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TV shows now include episode files in quality filters, badges, file sizes, metadata refreshes, and media-file displays.
  * Missing related records receive clearer validation feedback.

* **Bug Fixes**
  * Invalid collection items and media update references now return errors without partial changes.
  * Foreign-key failures are handled consistently instead of raising unexpected database errors.

* **Tests**
  * Added coverage for collection validation, media updates, foreign keys, and TV episode file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->