### PR TITLE
fix(quality): stop PreDVD releases from resolving to the DVD source

### DIFF
--- a/lib/mydia/quality/sources.ex
+++ b/lib/mydia/quality/sources.ex
@@ -32,6 +32,20 @@ defmodule Mydia.Quality.Sources do
   through, which is the pre-existing behavior anyway. A false positive means a
   legitimate release is silently refused with no way for the operator to find
   out why. Precision wins.
+
+  ## Why some source names have to dodge each other
+
+  Several source tokens contain another source's token: `DVDScr`, `DVDRip`,
+  `PDVD` and `PreDVD` all contain `dvd`. Because `patterns/0` is first-wins, a
+  broad pattern placed above them swallows the longer name and reports the
+  wrong source. `DVDRip` and `Screener` avoid it by sitting above `DVD` in the
+  table; `PDVD`/`PreDVD` avoid it with lookbehinds on the `DVD` pattern,
+  because reordering would have put a cam-tier source above a good one.
+
+  Getting this wrong is quiet and expensive. A `PreDVD` release reported as
+  `DVD` passes every profile's `excluded_sources` list, scores like a real
+  digital source, and gets grabbed. Any new source token added below a broader
+  one needs a test proving the broader one does not claim it first.
   """
 
   @cam_tier ["CAM", "Telesync", "Telecine", "Screener", "Workprint"]
@@ -115,7 +129,13 @@ defmodule Mydia.Quality.Sources do
       {"DVDRip", ~r/dvd[\-\s]?rip|dvdrip/i},
       # Screener must precede DVD so DVDScr does not match the bare dvd pattern.
       {"Screener", ~r/\b(?:dvd|bd|web)scr(?:eener)?\b|\bscreener\b|#{delimited("scr")}/i},
-      {"DVD", ~r/dvd/i},
+      # The lookbehinds keep this from swallowing the `dvd` inside `PDVD` and
+      # `PreDVD`, which are Telesync tokens listed below. Without them the bare
+      # pattern matches first and a cam-tier release resolves to `DVD`, which
+      # no `excluded_sources` list rejects. Solved here rather than by moving
+      # Telesync above DVD so the "good sources before cam-tier" rule below
+      # stays true and no legitimate DVD release becomes a false positive.
+      {"DVD", ~r/(?<!p)(?<!pre)dvd/i},
       {"Telecine", ~r/\btelecine\b|\bhd\-?tc\b|#{delimited("tc")}/i},
       {"Telesync", ~r/\btelesync\b|\bhd\-?ts\b|\bpdvd\b|\bpredvd\b|#{delimited("ts")}/i},
       {"CAM", ~r/\bhd\-?cam\b|\bcam\-?rip\b|\bhqcam\b|#{delimited("cam")}/i},

--- a/test/mydia/quality/sources_test.exs
+++ b/test/mydia/quality/sources_test.exs
@@ -47,7 +47,17 @@ defmodule Mydia.Quality.SourcesTest do
     "Movie.2026.WORKPRINT.x264",
     "Movie 2026 CAM x264",
     "Movie.2026.TC.x264-GRP",
-    "Odyseja - The Odyssey 2026 [HGL HDR SDR] [1080p.TELESYNC.H264-AS76-FT] [ENG-Lektor PL AI] [Alusia]"
+    "Odyseja - The Odyssey 2026 [HGL HDR SDR] [1080p.TELESYNC.H264-AS76-FT] [ENG-Lektor PL AI] [Alusia]",
+    # Real releases the production instance grabbed automatically on
+    # 2026-08-12 and 2026-08-26. Both resolved to "DVD" because the bare `dvd`
+    # pattern claimed the `dvd` inside `PreDVD` before the Telesync entry that
+    # carries \bpredvd\b was ever tried, so no excluded_sources list rejected
+    # them and each became its movie's only copy.
+    "www.1TamilMV.top - Spider-Man Brand New Day (2026) HQ PreDVD - 1080p - x264 - [Tam + Tel + Hin + Eng] - HQ Clean - 5GB",
+    "www.1TamilMV.ing - Insidious Out of the Further (2026) HQ PreDVD - 1080p - x264 - [Tam + Hin + Eng] - HQ Clean - AAC - 2GB",
+    "Movie.2026.1080p.PreDVD.x264",
+    "Movie.2026.1080p.PDVD.x264",
+    "Movie 2026 HQ PreDVD 1080p x264"
   ]
 
   describe "cam_tier/0" do
@@ -99,6 +109,21 @@ defmodule Mydia.Quality.SourcesTest do
 
     test "first-wins keeps an explicit good source ahead of a group suffix" do
       assert Sources.detect("Movie.2026.1080p.BluRay.x264-TS") == "BluRay"
+    end
+
+    test "PDVD and PreDVD resolve Telesync, not the bare DVD pattern" do
+      assert Sources.detect("Movie.2026.1080p.PDVD.x264") == "Telesync"
+      assert Sources.detect("Movie.2026.1080p.PreDVD.x264") == "Telesync"
+      assert Sources.detect("Movie 2026 HQ PreDVD - 1080p - x264") == "Telesync"
+    end
+
+    test "the DVD lookbehinds do not cost a real DVD release its source" do
+      assert Sources.detect("Movie.2026.DVD.x264") == "DVD"
+      assert Sources.detect("Movie 2026 DVD x264") == "DVD"
+      assert Sources.detect("Movie.2026.DVD5.x264") == "DVD"
+      assert Sources.detect("Movie.2026.DVD9.x264") == "DVD"
+      assert Sources.detect("Movie.2026.DVD-R.x264") == "DVD"
+      assert Sources.detect("DVD.Movie.2026.x264") == "DVD"
     end
 
     test "good sources still resolve correctly" do


### PR DESCRIPTION
## The bug

`Mydia.Quality.Sources.patterns/0` is a first-wins table, and the bare `{"DVD", ~r/dvd/i}` entry sits above `Telesync`. It therefore claims the `dvd` inside `PDVD` and `PreDVD` before the `Telesync` entry that carries `\bpdvd\b|\bpredvd\b` is ever tried. Those two alternatives have never been reachable.

Verified against the real module, before this change:

```
"DVD"  cam_tier?=false  <- www.1TamilMV.ing - Insidious Out of the Further (2026) HQ PreDVD - 1080p ...
"DVD"  cam_tier?=false  <- Some.Movie.2026.1080p.PDVD.x264
```

## Why it matters

A cam-tier release reported as `DVD` passes `ReleaseRanker.reject_excluded_sources/2`, and that hard removal is the only thing standing between a theatrical-window capture and the library. `movie_min_size_mb` does not help: size is a scaled soft penalty capped at −15, not a gate.

The production instance grabbed two 1TamilMV "HQ PreDVD" releases through the fully automatic path, on 2026-08-12 (*Spider-Man: Brand New Day*) and 2026-08-26 (*Insidious: Out of the Further*). Each is now its movie's only copy. Its own event log shows the misclassification scoring like a real digital source:

```
20:00:48  search.completed   quality:76.3  size_penalty:-0.34  total:71.26  results_count:15
20:00:48  download.initiated www.1TamilMV.ing - Insidious ... HQ PreDVD ...
```

and the download row persisted `"quality":{"source":"DVD","resolution":"1080p",...}`.

All eight profiles on that instance list the full cam-tier exclusion, and both movies resolve to `HD-1080p`. **Configuration was correct.** That is precisely why this went unnoticed: the exclusion never fired because detection never reported a cam-tier source.

## The fix

Lookbehinds on the `DVD` pattern: `~r/(?<!p)(?<!pre)dvd/i`.

Moving `Telesync` above `DVD` also works and would match the existing `Screener` precedent, but it puts a cam-tier source ahead of a good one and could refuse a legitimate DVD release that happens to carry a delimited `ts`/`tc` token. The module states it prefers false negatives to false positives ("Precision wins"), so the hole is closed where it opens rather than by reordering.

The moduledoc now names the hazard class — several source tokens contain another source's token — and states the rule for anyone adding a token below a broader one.

## Tests

Added to `sources_test.exs`:

- both real production titles, plus `PreDVD`/`PDVD` synthetic forms, to `@always_cam_tier`
- `PDVD and PreDVD resolve Telesync, not the bare DVD pattern`
- `the DVD lookbehinds do not cost a real DVD release its source`, covering `DVD`, `DVD5`, `DVD9`, `DVD-R`, space-delimited, and string-initial forms

Every one of these fails on `master` for the PreDVD cases and passes here.

```
286 tests, 0 failures
```
across `sources_test`, `quality_parser_test`, `release_ranker_test`, `quality_profile_engine_test` and `upgrades/attrs_test` — every consumer of `Sources`. `mix credo --strict` on the changed module: no issues.

## Not covered here

The two other cam-tier files on that instance (`Avatar.Fire.and.Ash.2025.1080p.TS` and a `TELESYNC` Mario) were never grabbed by Mydia — they have no download provenance and were picked up by a library scan of files already on disk. Detection already handles both correctly. Nothing in this PR changes what the scanner imports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-quality detection for `PDVD` and `PreDVD` formats.
  * These releases are now correctly classified as Telesync rather than DVD.
  * Genuine DVD formats, including DVD5, DVD9, DVD-R, and title-initial DVD releases, continue to be classified correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->